### PR TITLE
SkPicture tracing to file follows same path as rendering into the OpenGL context

### DIFF
--- a/sky/shell/gpu/rasterizer.cc
+++ b/sky/shell/gpu/rasterizer.cc
@@ -21,9 +21,6 @@
 #include "ui/gl/gl_surface.h"
 #include "mojo/public/cpp/system/data_pipe.h"
 
-// Set this value to 1 to serialize the layer tree to disk.
-#define SERIALIZE_LAYER_TREE 0
-
 namespace sky {
 namespace shell {
 

--- a/sky/shell/shell_view.cc
+++ b/sky/shell/shell_view.cc
@@ -63,11 +63,5 @@ void ShellView::StopDartTracing(
                             base::Passed(&producer)));
 }
 
-void ShellView::SaveFrameToSkPicture(base::FilePath& destination) {
-  shell_.ui_task_runner()->PostTask(
-      FROM_HERE, base::Bind(&Engine::SaveFrameToSkPicture,
-                            engine_->GetWeakPtr(), destination));
-}
-
 }  // namespace shell
 }  // namespace sky

--- a/sky/shell/shell_view.h
+++ b/sky/shell/shell_view.h
@@ -27,8 +27,6 @@ class ShellView {
   void StartDartTracing();
   void StopDartTracing(mojo::ScopedDataPipeProducerHandle producer);
 
-  void SaveFrameToSkPicture(base::FilePath& destination);
-
  private:
   void CreateEngine();
   void CreatePlatformView();

--- a/sky/shell/tracing_controller.cc
+++ b/sky/shell/tracing_controller.cc
@@ -17,7 +17,8 @@ const char kBaseTraceStart[] = "{\"traceEvents\":[";
 const char kBaseTraceEnd[] = "]}";
 const char kSentinel[] = "\0";
 
-TracingController::TracingController() : view_(nullptr) {}
+TracingController::TracingController()
+    : view_(nullptr), picture_tracing_enabled_(false) {}
 
 TracingController::~TracingController() {}
 
@@ -108,18 +109,27 @@ void TracingController::OnBaseTraceChunk(
   }
 }
 
-void TracingController::SaveFrameToSkPicture(base::FilePath& destination) {
-  if (view_ != nullptr) {
-    view_->SaveFrameToSkPicture(destination);
-  }
-}
-
 void TracingController::RegisterShellView(ShellView* view) {
   view_ = view;
 }
 
 void TracingController::UnregisterShellView(ShellView* view) {
   view_ = nullptr;
+}
+
+TracingController::SkPictureTracingOptions
+TracingController::picture_tracing_options() const {
+  return SkPictureTracingOptions(
+      picture_tracing_path_.length() == 0 ? false : picture_tracing_enabled_,
+      picture_tracing_path_);
+}
+
+void TracingController::set_picture_tracing_path(const std::string& path) {
+  picture_tracing_path_ = path;
+}
+
+void TracingController::set_picture_tracing_enabled(bool enabled) {
+  picture_tracing_enabled_ = enabled;
 }
 
 }  // namespace shell

--- a/sky/shell/tracing_controller.h
+++ b/sky/shell/tracing_controller.h
@@ -35,7 +35,13 @@ class TracingController : public mojo::common::DataPipeDrainer::Client {
   // be merged before viewing in the trace viewer
   void StopTracing(const base::FilePath& path);
 
-  void SaveFrameToSkPicture(base::FilePath& destination);
+  using SkPictureTracingOptions =
+      std::pair<bool /* enabled */, std::string /* path */>;
+  SkPictureTracingOptions picture_tracing_options() const;
+
+  void set_picture_tracing_path(const std::string& path);
+
+  void set_picture_tracing_enabled(bool enabled);
 
  private:
   std::unique_ptr<mojo::common::DataPipeDrainer> drainer_;
@@ -44,6 +50,8 @@ class TracingController : public mojo::common::DataPipeDrainer::Client {
   // the ability to host multiple shell views, references to each must be stored
   // instead and trace data from each serialized to the output trace.
   ShellView* view_;
+  std::string picture_tracing_path_;
+  bool picture_tracing_enabled_;
 
   void StartDartTracing();
   void StartBaseTracing();

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -264,8 +264,5 @@ void Engine::StopDartTracing(mojo::ScopedDataPipeProducerHandle producer) {
   sky_view_->StopDartTracing(producer.Pass());
 }
 
-void Engine::SaveFrameToSkPicture(const base::FilePath& destination) {
-}
-
 }  // namespace shell
 }  // namespace sky

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -60,8 +60,6 @@ class Engine : public UIDelegate,
   void StartDartTracing();
   void StopDartTracing(mojo::ScopedDataPipeProducerHandle producer);
 
-  void SaveFrameToSkPicture(const base::FilePath& destination);
-
  private:
   // UIDelegate implementation:
   void ConnectToEngine(mojo::InterfaceRequest<SkyEngine> request) override;


### PR DESCRIPTION
Tracing to a file is a two step process:
* The platform shell sets the path on disk where trace files need to be written to. This may happen only once when the application launches (via the `tracing_controller()` on `Shell::Shared()`)
* When the user wants to start and stop tracing to file, the same options are specified via the `tracing_controller()`

Gets rid of the `SERIALIZE_LAYER_TREE` macro