### PR TITLE
Add include of <memory> for std::unique_ptr

### DIFF
--- a/sky/compositor/paint_context.h
+++ b/sky/compositor/paint_context.h
@@ -5,6 +5,8 @@
 #ifndef SKY_COMPOSITOR_PAINT_CONTEXT_CC_
 #define SKY_COMPOSITOR_PAINT_CONTEXT_CC_
 
+#include <memory>
+
 #include "base/macros.h"
 #include "base/logging.h"
 #include "sky/compositor/compositor_options.h"


### PR DESCRIPTION
This produces the following error on linux:

In file included from ../../sky/compositor/paint_context.cc:5:
../../sky/compositor/paint_context.h:32:5: error: no template named 'unique_ptr' in namespace 'std'; did you mean 'skstd::unique_ptr'?
    std::unique_ptr<SkPictureRecorder> trace_recorder_;
    ^~~~~~~~~~~~~~~
    skstd::unique_ptr
../../third_party/skia/include/core/../private/SkUniquePtr.h:36:61: note: 'skstd::unique_ptr' declared here
template <typename T, typename D = default_delete<T>> class unique_ptr {
