### PR TITLE
More dartdoc for fn3, and sundry changes.

### DIFF
--- a/sky/unit/test/fn3/widget_tester.dart
+++ b/sky/unit/test/fn3/widget_tester.dart
@@ -37,7 +37,7 @@ class WidgetTester {
   void pumpFrame(Widget widget) {
     if (_rootElement == null) {
       _rootElement = new StatelessComponentElement(new TestComponent(child: widget));
-      _rootElement.mount(_rootSlot);
+      _rootElement.mount(null, _rootSlot);
     } else {
       _rootElement.update(new TestComponent(child: widget));
     }


### PR DESCRIPTION
- move _uniqueChild earlier since the docs now mention it earlier.
- make uniqueChild public since in theory other subclasses could use it.
- reorder methods in Element to more closely reflect call order.
- change mount to be the place that sets the parent pointer, for consistency.
- make the lifecycleState a purely debug-time thing for consistency.
- make BuildableElement.unmount set dirty to false so that we won't
  build unmounted objects.
- rename "updated" to "newWidget" for clarity.