### PR TITLE
fn3: Add a binding for fn3 and sky.

### DIFF
--- a/sky/packages/sky/lib/src/fn3.dart
+++ b/sky/packages/sky/lib/src/fn3.dart
@@ -6,3 +6,4 @@ library fn3;
 
 export 'fn3/basic.dart';
 export 'fn3/framework.dart';
+export 'fn3/binding.dart';

--- a/sky/packages/sky/lib/src/fn3/binding.dart
+++ b/sky/packages/sky/lib/src/fn3/binding.dart
@@ -1,0 +1,92 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:sky' as sky;
+import 'package:sky/animation.dart';
+import 'package:sky/rendering.dart';
+import 'package:sky/src/fn3/framework.dart';
+
+class WidgetSkyBinding extends SkyBinding {
+
+  WidgetSkyBinding({ RenderView renderViewOverride: null })
+    : super(renderViewOverride: renderViewOverride) {
+    BuildableElement.scheduleBuildFor = this.scheduleBuildFor;
+  }
+
+  /// Ensures that there is a SkyBinding object instantiated.
+  static void initWidgetSkyBinding({ RenderView renderViewOverride: null }) {
+    if (SkyBinding.instance == null)
+      new WidgetSkyBinding(renderViewOverride: renderViewOverride);
+    assert(SkyBinding.instance is WidgetSkyBinding);
+  }
+
+  static WidgetSkyBinding get instance => SkyBinding.instance;
+
+  void handleEvent(sky.Event event, BindingHitTestEntry entry) {
+    for (HitTestEntry entry in entry.result.path) {
+      if (entry.target is! RenderObject)
+        continue;
+      for (Widget target in RenderObjectElement.getElementsForRenderObject(entry.target)) {
+        // TODO(ianh): implement event handling
+        // if (target is ListenerElement)
+        //  target.handleEvent(event);
+      }
+    }
+    super.handleEvent(event, entry);
+  }
+
+  void beginFrame(double timeStamp) {
+    buildDirtyElements();
+    super.beginFrame(timeStamp);
+  }
+
+  final List<BuildableElement> _dirtyElements = new List<BuildableElement>();
+
+  int _debugBuildingAtDepth;
+
+  /// Adds an element to the dirty elements list so that it will be rebuilt
+  /// when buildDirtyElements is called.
+  void scheduleBuildFor(BuildableElement element) {
+    assert(_debugBuildingAtDepth == null || element.depth > _debugBuildingAtDepth);
+    assert(!_dirtyElements.contains(element));
+    assert(element.dirty);
+    if (_dirtyElements.isEmpty)
+      scheduler.ensureVisualUpdate();
+    _dirtyElements.add(element);
+  }
+
+  void _absorbDirtyElements(List<BuildableElement> list) {
+    assert(_debugBuildingAtDepth != null);
+    assert(!_dirtyElements.any((element) => element.depth <= _debugBuildingAtDepth));
+    _dirtyElements.sort((BuildableElement a, BuildableElement b) => a.depth - b.depth);
+    list.addAll(_dirtyElements);
+    _dirtyElements.clear();
+  }
+
+  /// Builds all the elements that were marked as dirty using schedule(), in depth order.
+  /// If elements are marked as dirty while this runs, they must be deeper than the algorithm
+  /// has yet reached.
+  /// This is called by beginFrame().
+  void buildDirtyElements() {
+    assert(_debugBuildingAtDepth == null);
+    if (_dirtyElements.isEmpty)
+      return;
+    assert(() { _debugBuildingAtDepth = 0; return true; });
+    List<BuildableElement> sortedDirtyElements = new List<BuildableElement>();
+    int index = 0;
+    do {
+      _absorbDirtyElements(sortedDirtyElements);
+      for (; index < sortedDirtyElements.length; index += 1) {
+        BuildableElement element = sortedDirtyElements[index];
+        assert(() {
+          if (element.depth > _debugBuildingAtDepth)
+            _debugBuildingAtDepth = element.depth;
+          return element.depth == _debugBuildingAtDepth;
+        });
+        element.rebuild();
+      }
+    } while (_dirtyElements.isNotEmpty);
+    assert(() { _debugBuildingAtDepth = null; return true; });
+  }
+}

--- a/sky/unit/test/fn3/render_object_widget_test.dart
+++ b/sky/unit/test/fn3/render_object_widget_test.dart
@@ -8,6 +8,12 @@ final BoxDecoration kBoxDecorationA = new BoxDecoration();
 final BoxDecoration kBoxDecorationB = new BoxDecoration();
 final BoxDecoration kBoxDecorationC = new BoxDecoration();
 
+class TestComponent extends StatelessComponent {
+  const TestComponent({ this.child });
+  final Widget child;
+  Widget build() => child;
+}
+
 void main() {
   test('RenderObjectWidget smoke test', () {
     WidgetTester tester = new WidgetTester();

--- a/sky/unit/test/fn3/stateful_component_test.dart
+++ b/sky/unit/test/fn3/stateful_component_test.dart
@@ -78,7 +78,8 @@ void main() {
     checkTree(kBoxDecorationB);
 
     flipStatefulComponent(tester);
-    Element.flushBuild();
+
+    tester.pumpFrameWithoutChange();
 
     checkTree(kBoxDecorationA);
 
@@ -105,7 +106,8 @@ void main() {
     expect(TestBuildCounter.buildCount, equals(1));
 
     flipStatefulComponent(tester);
-    Element.flushBuild();
+
+    tester.pumpFrameWithoutChange();
 
     expect(TestBuildCounter.buildCount, equals(1));
   });

--- a/sky/unit/test/fn3/widget_tester.dart
+++ b/sky/unit/test/fn3/widget_tester.dart
@@ -1,15 +1,34 @@
-import 'package:sky/src/fn3/framework.dart';
+import 'package:sky/src/fn3.dart';
 
-class TestComponent extends StatelessComponent {
-  TestComponent({ this.child });
-  final Widget child;
+class RootComponent extends StatefulComponent {
+  RootComponentState createState() => new RootComponentState(this);
+}
+
+class RootComponentState extends ComponentState<RootComponent> {
+  RootComponentState(RootComponent widget) : super(widget);
+  Widget _child = new DecoratedBox(decoration: new BoxDecoration());
+  Widget get child => _child;
+  void set child(Widget value) {
+    if (value != _child) {
+      setState(() {
+        _child = value;
+      });
+    }
+  }
   Widget build() => child;
 }
 
-final Object _rootSlot = new Object();
+const Object _rootSlot = const Object();
 
 class WidgetTester {
-  StatelessComponentElement _rootElement;
+
+  WidgetTester() {
+    WidgetSkyBinding.initWidgetSkyBinding();
+    _rootElement = new StatefulComponentElement(new RootComponent());
+    _rootElement.mount(null, _rootSlot);
+  }
+
+  StatefulComponentElement _rootElement;
 
   void walkElements(ElementVisitor visitor) {
     void walk(Element element) {
@@ -35,12 +54,12 @@ class WidgetTester {
   }
 
   void pumpFrame(Widget widget) {
-    if (_rootElement == null) {
-      _rootElement = new StatelessComponentElement(new TestComponent(child: widget));
-      _rootElement.mount(null, _rootSlot);
-    } else {
-      _rootElement.update(new TestComponent(child: widget));
-    }
+    (_rootElement.state as RootComponentState).child = widget;
+    WidgetSkyBinding.instance.beginFrame(0.0); // TODO(ianh): https://github.com/flutter/engine/issues/1084
+  }
+
+  void pumpFrameWithoutChange() {
+    WidgetSkyBinding.instance.beginFrame(0.0); // TODO(ianh): https://github.com/flutter/engine/issues/1084
   }
 
 }


### PR DESCRIPTION
- I extracted the BuildScheduler into a separate binding.dart file.
- Various changes to expose private members that are needed by
  binding.dart.
- Registering the render objects for event dispatch.
- Convert the tests to use the new binding mechanism.

This doesn't yet have a RenderView or event handling.