### PR TITLE
fn3: Binding to RenderView

### DIFF
--- a/sky/unit/test/fn3/stateful_component_test.dart
+++ b/sky/unit/test/fn3/stateful_component_test.dart
@@ -57,6 +57,7 @@ void main() {
     WidgetTester tester = new WidgetTester();
     tester.pumpFrame(
       new FlipComponent(
+        key: new Key('rebuild test'), // this is so we don't get the state from the TestComponentConfig in the last test, but instead instantiate a new element with a new state.
         left: new TestBuildCounter(),
         right: new DecoratedBox(decoration: kBoxDecorationB)
       )

--- a/sky/unit/test/fn3/widget_tester.dart
+++ b/sky/unit/test/fn3/widget_tester.dart
@@ -22,21 +22,12 @@ const Object _rootSlot = const Object();
 
 class WidgetTester {
 
-  WidgetTester() {
-    WidgetSkyBinding.initWidgetSkyBinding();
-    _rootElement = new StatefulComponentElement(new RootComponent());
-    _rootElement.mount(null, _rootSlot);
-  }
-
-  StatefulComponentElement _rootElement;
-
   void walkElements(ElementVisitor visitor) {
     void walk(Element element) {
       visitor(element);
       element.visitChildren(walk);
     }
-
-    _rootElement.visitChildren(walk);
+    WidgetFlutterBinding.instance.renderViewElement.visitChildren(walk);
   }
 
   Element findElement(bool predicate(Element widget)) {
@@ -54,12 +45,12 @@ class WidgetTester {
   }
 
   void pumpFrame(Widget widget) {
-    (_rootElement.state as RootComponentState).child = widget;
-    WidgetSkyBinding.instance.beginFrame(0.0); // TODO(ianh): https://github.com/flutter/engine/issues/1084
+    runApp(widget);
+    WidgetFlutterBinding.instance.beginFrame(0.0); // TODO(ianh): https://github.com/flutter/engine/issues/1084
   }
 
   void pumpFrameWithoutChange() {
-    WidgetSkyBinding.instance.beginFrame(0.0); // TODO(ianh): https://github.com/flutter/engine/issues/1084
+    WidgetFlutterBinding.instance.beginFrame(0.0); // TODO(ianh): https://github.com/flutter/engine/issues/1084
   }
 
 }


### PR DESCRIPTION
In the old world, we had two ways to bind a Widget tree to a
RenderObject node, one way for RenderView and one mostly untested way
for other cases (it's only tested by the spinning_mixed.dart demo). For
fn3, I made these the same code path.

This patch also introduces GlobalKey, though the GlobalKey logic isn't
hooked in yet.

This is Hello World in the new world:

```dart
import 'package:sky/src/fn3.dart';

void main() {
  runApp(new Text('Hello World!'));
}
```