### PR TITLE
fn3: Minor cleanup

### DIFF
--- a/sky/packages/sky/lib/src/fn3/binding.dart
+++ b/sky/packages/sky/lib/src/fn3/binding.dart
@@ -12,7 +12,7 @@ class WidgetFlutterBinding extends SkyBinding {
   WidgetFlutterBinding() {
     BuildableElement.scheduleBuildFor = scheduleBuildFor;
     _renderViewElement = new RenderObjectToWidgetElement<RenderBox>(describeApp(null));
-    _renderViewElement.mount(null, this);
+    _renderViewElement.mount(null, null);
   }
 
   /// Ensures that there is a SkyBinding object instantiated.
@@ -34,19 +34,6 @@ class WidgetFlutterBinding extends SkyBinding {
       container: instance.renderView,
       child: app
     );
-  }
-
-  void handleEvent(sky.Event event, BindingHitTestEntry entry) {
-    for (HitTestEntry entry in entry.result.path) {
-      if (entry.target is! RenderObject)
-        continue;
-      for (Widget target in RenderObjectElement.getElementsForRenderObject(entry.target)) {
-        // TODO(ianh): implement event handling
-        // if (target is ListenerElement)
-        //  target.handleEvent(event);
-      }
-    }
-    super.handleEvent(event, entry);
   }
 
   void beginFrame(double timeStamp) {
@@ -150,9 +137,9 @@ class RenderObjectToWidgetElement<T extends RenderObject> extends RenderObjectEl
       visitor(_child);
   }
 
-  void mount(Element parent, dynamic slot) {
+  void mount(Element parent, dynamic newSlot) {
     assert(parent == null);
-    super.mount(parent, slot);
+    super.mount(parent, newSlot);
     _child = updateChild(_child, widget.child, _rootChild);
   }
 

--- a/sky/unit/test/fn3/widget_tester.dart
+++ b/sky/unit/test/fn3/widget_tester.dart
@@ -18,8 +18,6 @@ class RootComponentState extends ComponentState<RootComponent> {
   Widget build(BuildContext context) => child;
 }
 
-const Object _rootSlot = const Object();
-
 class WidgetTester {
 
   void walkElements(ElementVisitor visitor) {


### PR DESCRIPTION
- Remove the unique objects used as slots since we decided 'null' was
  fine after all
- Rename 'slot' to 'newSlot' when it's used as an argument to change the
  _slot field, to clarify which variable has the newer value
- Remove the RenderObject registry since we'll do listeners a different
  way. This also removes handleEvent for the same reason.
- Remove the TODOs for mount/unmount becoming didMount/didUnmount since
  the methods do in fact do the mounting/unmounting.