### PR TITLE
Rename ComponentState and use initState().

### DIFF
--- a/examples/widgets/big_switch.dart
+++ b/examples/widgets/big_switch.dart
@@ -10,12 +10,10 @@ class BigSwitch extends StatefulComponent {
 
   final double scale;
 
-  BigSwitchState createState() => new BigSwitchState(this);
+  BigSwitchState createState() => new BigSwitchState();
 }
 
-class BigSwitchState extends ComponentState<BigSwitch> {
-  BigSwitchState(BigSwitch config) : super(config);
-
+class BigSwitchState extends State<BigSwitch> {
   bool _value = false;
 
   void _handleOnChanged(bool value) {

--- a/examples/widgets/date_picker.dart
+++ b/examples/widgets/date_picker.dart
@@ -8,11 +8,12 @@ import 'package:sky/material.dart';
 void main() => runApp(new DatePickerDemo());
 
 class DatePickerDemo extends StatefulComponent {
-  DatePickerDemoState createState() => new DatePickerDemoState(this);
+  DatePickerDemoState createState() => new DatePickerDemoState();
 }
 
-class DatePickerDemoState extends ComponentState<DatePickerDemo> {
-  DatePickerDemoState(DatePickerDemo config) : super(config) {
+class DatePickerDemoState extends State<DatePickerDemo> {
+  void initState(BuildContext context) {
+    super.initState(context);
     DateTime now = new DateTime.now();
     _dateTime = new DateTime(now.year, now.month, now.day);
   }

--- a/examples/widgets/drag_and_drop.dart
+++ b/examples/widgets/drag_and_drop.dart
@@ -17,12 +17,10 @@ class DragData {
 }
 
 class ExampleDragTarget extends StatefulComponent {
-  ExampleDragTargetState createState() => new ExampleDragTargetState(this);
+  ExampleDragTargetState createState() => new ExampleDragTargetState();
 }
 
-class ExampleDragTargetState extends ComponentState<ExampleDragTarget> {
-  ExampleDragTargetState(ExampleDragTarget config) : super(config);
-
+class ExampleDragTargetState extends State<ExampleDragTarget> {
   String _text = 'ready';
 
   void _handleAccept(DragData data) {
@@ -71,9 +69,7 @@ class DragAndDropApp extends StatefulComponent {
   DragAndDropAppState createState() => new DragAndDropAppState(this);
 }
 
-class DragAndDropAppState extends ComponentState<DragAndDropApp> {
-  DragAndDropAppState(DragAndDropApp config) : super(config);
-
+class DragAndDropAppState extends State<DragAndDropApp> {
   DragController _dragController;
   Offset _displacement = Offset.zero;
 

--- a/examples/widgets/navigation.dart
+++ b/examples/widgets/navigation.dart
@@ -61,12 +61,10 @@ List<Route> routes = [
 ];
 
 class NavigationExampleApp extends StatefulComponent {
-  NavigationExampleAppState createState() => new NavigationExampleAppState(this);
+  NavigationExampleAppState createState() => new NavigationExampleAppState();
 }
 
-class NavigationExampleAppState extends ComponentState<NavigationExampleApp> {
-  NavigationExampleAppState(NavigationExampleApp config) : super(config);
-
+class NavigationExampleAppState extends State<NavigationExampleApp> {
   NavigatorHistory _history = new NavigatorHistory(routes);
 
   void onBack() {

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -20,8 +20,9 @@ class PageableListApp extends StatefulComponent {
   PageableListAppState createState() => new PageableListAppState(this);
 }
 
-class PageableListAppState extends ComponentState<PageableListApp> {
-  PageableListAppState(PageableListApp config) : super(config) {
+class PageableListAppState extends State<PageableListApp> {
+  void initState(BuildContext context) {
+    super.initState(context);
     List<Size> cardSizes = [
       [100.0, 300.0], [300.0, 100.0], [200.0, 400.0], [400.0, 400.0], [300.0, 400.0]
     ]

--- a/examples/widgets/progress_indicator.dart
+++ b/examples/widgets/progress_indicator.dart
@@ -10,8 +10,9 @@ class ProgressIndicatorApp extends StatefulComponent {
   ProgressIndicatorAppState createState() => new ProgressIndicatorAppState(this);
 }
 
-class ProgressIndicatorAppState extends ComponentState<ProgressIndicatorApp> {
-  ProgressIndicatorAppState(ProgressIndicatorApp config) : super(config) {
+class ProgressIndicatorAppState extends State<ProgressIndicatorApp> {
+  void initState(BuildContext context) {
+    super.initState(context);
     valueAnimation = new ValueAnimation<double>()
       ..duration = const Duration(milliseconds: 1500)
       ..variable = new AnimatedValue<double>(

--- a/examples/widgets/scale.dart
+++ b/examples/widgets/scale.dart
@@ -10,8 +10,9 @@ class ScaleApp extends StatefulComponent {
   ScaleAppState createState() => new ScaleAppState(this);
 }
 
-class ScaleAppState extends ComponentState<ScaleApp> {
-  ScaleAppState(ScaleApp config) : super(config) {
+class ScaleAppState extends State<ScaleApp> {
+  void initState(BuildContext context) {
+    super.initState(context);
     _offset = Offset.zero;
     _zoom = 1.0;
   }

--- a/sky/packages/sky/lib/src/fn3/animated_component.dart
+++ b/sky/packages/sky/lib/src/fn3/animated_component.dart
@@ -12,8 +12,9 @@ abstract class AnimatedComponent extends StatefulComponent {
   final Direction direction;
 }
 
-abstract class AnimatedComponentState<T extends AnimatedComponent> extends ComponentState<T> {
-  AnimatedComponentState(T config) : super(config) {
+abstract class AnimatedState<T extends AnimatedComponent> extends State<T> {
+  void initState(BuildContext context) {
+    super.initState(context);
     _performance = new AnimationPerformance(duration: config.duration);
     performance.addStatusListener(_handleAnimationStatusChanged);
     if (buildDependsOnPerformance) {

--- a/sky/packages/sky/lib/src/fn3/basic.dart
+++ b/sky/packages/sky/lib/src/fn3/basic.dart
@@ -724,11 +724,12 @@ class ImageListener extends StatefulComponent {
   final ImageFit fit;
   final ImageRepeat repeat;
 
-  ImageListenerState createState() => new ImageListenerState(this);
+  ImageListenerState createState() => new ImageListenerState();
 }
 
-class ImageListenerState extends ComponentState<ImageListener> {
-  ImageListenerState(ImageListener config) : super(config) {
+class ImageListenerState extends State<ImageListener> {
+  void initState(BuildContext context) {
+    super.initState(context);
     config.image.addListener(_handleImageChanged);
   }
 
@@ -742,6 +743,7 @@ class ImageListenerState extends ComponentState<ImageListener> {
 
   void dispose() {
     config.image.removeListener(_handleImageChanged);
+    super.dispose();
   }
 
   void didUpdateConfig(ImageListener oldConfig) {

--- a/sky/packages/sky/lib/src/fn3/button_state.dart
+++ b/sky/packages/sky/lib/src/fn3/button_state.dart
@@ -5,9 +5,7 @@
 import 'package:sky/src/fn3/basic.dart';
 import 'package:sky/src/fn3/framework.dart';
 
-abstract class ButtonState<T extends StatefulComponent> extends ComponentState<T> {
-  ButtonState(T config) : super(config);
-
+abstract class ButtonState<T extends StatefulComponent> extends State<T> {
   bool highlight = false;
 
   void _handlePointerDown(_) {

--- a/sky/packages/sky/lib/src/fn3/date_picker.dart
+++ b/sky/packages/sky/lib/src/fn3/date_picker.dart
@@ -39,12 +39,10 @@ class DatePicker extends StatefulComponent {
   final DateTime firstDate;
   final DateTime lastDate;
 
-  DatePickerState createState() => new DatePickerState(this);
+  DatePickerState createState() => new DatePickerState();
 }
 
-class DatePickerState extends ComponentState<DatePicker> {
-  DatePickerState(DatePicker config) : super(config);
-
+class DatePickerState extends State<DatePicker> {
   DatePickerMode _mode = DatePickerMode.day;
 
   void _handleModeChanged(DatePickerMode mode) {
@@ -292,11 +290,12 @@ class MonthPicker extends ScrollableWidgetList {
   final DateTime firstDate;
   final DateTime lastDate;
 
-  MonthPickerState createState() => new MonthPickerState(this);
+  MonthPickerState createState() => new MonthPickerState();
 }
 
 class MonthPickerState extends ScrollableWidgetListState<MonthPicker> {
-  MonthPickerState(MonthPicker config) : super(config) {
+  void initState(BuildContext context) {
+    super.initState(context);
     _updateCurrentDate();
   }
 
@@ -342,6 +341,7 @@ class MonthPickerState extends ScrollableWidgetListState<MonthPicker> {
   void dispose() {
     if (_timer != null)
       _timer.cancel();
+    super.dispose();
   }
 }
 
@@ -363,12 +363,10 @@ class YearPicker extends ScrollableWidgetList {
   final DateTime firstDate;
   final DateTime lastDate;
 
-  YearPickerState createState() => new YearPickerState(this);
+  YearPickerState createState() => new YearPickerState();
 }
 
 class YearPickerState extends ScrollableWidgetListState<YearPicker> {
-  YearPickerState(YearPicker config) : super(config);
-
   int get itemCount => config.lastDate.year - config.firstDate.year + 1;
 
   List<Widget> buildItems(BuildContext context, int start, int count) {

--- a/sky/packages/sky/lib/src/fn3/dismissable.dart
+++ b/sky/packages/sky/lib/src/fn3/dismissable.dart
@@ -44,11 +44,12 @@ class Dismissable extends StatefulComponent {
   DismissedCallback onDismissed;
   DismissDirection direction;
 
-  DismissableState createState() => new DismissableState(this);
+  DismissableState createState() => new DismissableState();
 }
 
-class DismissableState extends ComponentState<Dismissable> {
-  DismissableState(Dismissable config) : super(config) {
+class DismissableState extends State<Dismissable> {
+  void initState(BuildContext context) {
+    super.initState(context);
     _fadePerformance = new AnimationPerformance(duration: _kCardDismissFadeout);
     _fadePerformance.addStatusListener((AnimationStatus status) {
       if (status == AnimationStatus.completed)

--- a/sky/packages/sky/lib/src/fn3/drag_target.dart
+++ b/sky/packages/sky/lib/src/fn3/drag_target.dart
@@ -25,12 +25,10 @@ class DragTarget<T> extends StatefulComponent {
   final DragTargetWillAccept<T> onWillAccept;
   final DragTargetAccept<T> onAccept;
 
-  DragTargetState<T> createState() => new DragTargetState<T>(this);
+  DragTargetState<T> createState() => new DragTargetState<T>();
 }
 
-class DragTargetState<T> extends ComponentState<DragTarget<T>> {
-  DragTargetState(DragTarget<T> config) : super(config);
-
+class DragTargetState<T> extends State<DragTarget<T>> {
   final List<T> _candidateData = new List<T>();
   final List<dynamic> _rejectedData = new List<dynamic>();
 

--- a/sky/packages/sky/lib/src/fn3/drawer.dart
+++ b/sky/packages/sky/lib/src/fn3/drawer.dart
@@ -53,11 +53,12 @@ class Drawer extends StatefulComponent {
   final DrawerDismissedCallback onDismissed;
   final NavigatorState navigator;
 
-  DrawerState createState() => new DrawerState(this);
+  DrawerState createState() => new DrawerState();
 }
 
-class DrawerState extends ComponentState<Drawer> {
-  DrawerState(Drawer config) : super(config) {
+class DrawerState extends State<Drawer> {
+  void initState(BuildContext context) {
+    super.initState(context);
     _performance = new AnimationPerformance(duration: _kBaseSettleDuration);
     _performance.addStatusListener((AnimationStatus status) {
       if (status == AnimationStatus.dismissed)

--- a/sky/packages/sky/lib/src/fn3/drawer_item.dart
+++ b/sky/packages/sky/lib/src/fn3/drawer_item.dart
@@ -24,12 +24,10 @@ class DrawerItem extends StatefulComponent {
   final GestureTapListener onPressed;
   final bool selected;
 
-  DrawerItemState createState() => new DrawerItemState(this);
+  DrawerItemState createState() => new DrawerItemState();
 }
 
 class DrawerItemState extends ButtonState<DrawerItem> {
-  DrawerItemState(DrawerItem config) : super(config);
-
   TextStyle _getTextStyle(ThemeData themeData) {
     TextStyle result = themeData.text.body2;
     if (config.selected)

--- a/sky/packages/sky/lib/src/fn3/flat_button.dart
+++ b/sky/packages/sky/lib/src/fn3/flat_button.dart
@@ -19,12 +19,10 @@ class FlatButton extends MaterialButton {
              enabled: enabled,
              onPressed: onPressed);
 
-  FlatButtonState createState() => new FlatButtonState(this);
+  FlatButtonState createState() => new FlatButtonState();
 }
 
 class FlatButtonState extends MaterialButtonState<FlatButton> {
-  FlatButtonState(FlatButton config) : super(config);
-
   Color getColor(BuildContext context) {
     if (!config.enabled || !highlight)
       return null;

--- a/sky/packages/sky/lib/src/fn3/floating_action_button.dart
+++ b/sky/packages/sky/lib/src/fn3/floating_action_button.dart
@@ -28,12 +28,10 @@ class FloatingActionButton extends StatefulComponent {
   final Color backgroundColor;
   final GestureTapListener onPressed;
 
-  FloatingActionButtonState createState() => new FloatingActionButtonState(this);
+  FloatingActionButtonState createState() => new FloatingActionButtonState();
 }
 
 class FloatingActionButtonState extends ButtonState<FloatingActionButton> {
-  FloatingActionButtonState(FloatingActionButton config) : super(config);
-
   Widget buildContent(BuildContext context) {
     IconThemeColor iconThemeColor = IconThemeColor.white;
     Color materialColor = config.backgroundColor;

--- a/sky/packages/sky/lib/src/fn3/focus.dart
+++ b/sky/packages/sky/lib/src/fn3/focus.dart
@@ -75,12 +75,10 @@ class Focus extends StatefulComponent {
   final bool autofocus;
   final Widget child;
 
-  FocusState createState() => new FocusState(this);
+  FocusState createState() => new FocusState();
 }
 
-class FocusState extends ComponentState<Focus> {
-  FocusState(Focus config) : super(config);
-
+class FocusState extends State<Focus> {
   GlobalKey _focusedWidget; // when null, the first component to ask if it's focused will get the focus
   GlobalKey _currentlyRegisteredWidgetRemovalListenerKey;
 
@@ -164,6 +162,7 @@ class FocusState extends ComponentState<Focus> {
   void dispose() {
     _updateWidgetRemovalListener(null);
     _updateScopeRemovalListener(null);
+    super.dispose();
   }
 
   Widget build(BuildContext context) {

--- a/sky/packages/sky/lib/src/fn3/gesture_detector.dart
+++ b/sky/packages/sky/lib/src/fn3/gesture_detector.dart
@@ -51,11 +51,12 @@ class GestureDetector extends StatefulComponent {
   final GestureScaleUpdateCallback onScaleUpdate;
   final GestureScaleEndCallback onScaleEnd;
 
-  GestureDetectorState createState() => new GestureDetectorState(this);
+  GestureDetectorState createState() => new GestureDetectorState();
 }
 
-class GestureDetectorState extends ComponentState<GestureDetector> {
-  GestureDetectorState(GestureDetector config) : super(config) {
+class GestureDetectorState extends State<GestureDetector> {
+  void initState(BuildContext context) {
+    super.initState(context);
     didUpdateConfig(null);
   }
 
@@ -120,6 +121,7 @@ class GestureDetectorState extends ComponentState<GestureDetector> {
     _horizontalDrag = _ensureDisposed(_horizontalDrag);
     _pan = _ensureDisposed(_pan);
     _scale = _ensureDisposed(_scale);
+    super.dispose();
   }
 
   void didUpdateConfig(GestureDetector oldConfig) {

--- a/sky/packages/sky/lib/src/fn3/homogeneous_viewport.dart
+++ b/sky/packages/sky/lib/src/fn3/homogeneous_viewport.dart
@@ -52,7 +52,6 @@ class HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewport
   HomogeneousViewportElement(HomogeneousViewport widget) : super(widget);
 
   List<Element> _children = const <Element>[];
-  bool _layoutDirty = true;
   int _layoutFirstIndex;
   int _layoutItemCount;
 

--- a/sky/packages/sky/lib/src/fn3/material_button.dart
+++ b/sky/packages/sky/lib/src/fn3/material_button.dart
@@ -26,8 +26,6 @@ abstract class MaterialButton extends StatefulComponent {
 }
 
 abstract class MaterialButtonState<T extends MaterialButton> extends ButtonState<T> {
-  MaterialButtonState(T config) : super(config);
-
   Color getColor(BuildContext context);
   int get level;
 

--- a/sky/packages/sky/lib/src/fn3/mixed_viewport.dart
+++ b/sky/packages/sky/lib/src/fn3/mixed_viewport.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:collection';
-
 import 'package:sky/rendering.dart';
 import 'package:sky/src/fn3/framework.dart';
 import 'package:sky/src/fn3/basic.dart';
@@ -63,9 +61,9 @@ class _ChildKey {
 }
 
 class MixedViewportElement extends RenderObjectElement<MixedViewport> {
-  MixedViewportElement(MixedViewport config) : super(config) {
-    if (config.onInvalidatorAvailable != null)
-      config.onInvalidatorAvailable(invalidate);
+  MixedViewportElement(MixedViewport widget) : super(widget) {
+    if (widget.onInvalidatorAvailable != null)
+      widget.onInvalidatorAvailable(invalidate);
   }
 
   /// _childOffsets contains the offsets of each child from the top of the list
@@ -269,9 +267,13 @@ class MixedViewportElement extends RenderObjectElement<MixedViewport> {
   double _getOffset(Element element, BoxConstraints innerConstraints) {
     final RenderBox childRenderObject = element.renderObject;
     switch (widget.direction) {
-      case ScrollDirection.vertical: return childRenderObject.getMaxIntrinsicHeight(innerConstraints);
-      case ScrollDirection.horizontal: return childRenderObject.getMaxIntrinsicWidth(innerConstraints);
-      case ScrollDirection.both: assert(false); // we don't support ScrollDirection.both, see issue 888
+      case ScrollDirection.vertical:
+        return childRenderObject.getMaxIntrinsicHeight(innerConstraints);
+      case ScrollDirection.horizontal:
+        return childRenderObject.getMaxIntrinsicWidth(innerConstraints);
+      case ScrollDirection.both:
+        assert(false); // we don't support ScrollDirection.both, see issue 888
+        return double.NAN;
     }
   }
 

--- a/sky/packages/sky/lib/src/fn3/navigator.dart
+++ b/sky/packages/sky/lib/src/fn3/navigator.dart
@@ -90,7 +90,7 @@ class RouteState extends RouteBase {
 
   Function callback;
   RouteBase route;
-  ComponentState owner;
+  State owner;
 
   bool get isOpaque => false;
 
@@ -152,15 +152,13 @@ class Navigator extends StatefulComponent {
 
   final NavigatorHistory history;
 
-  NavigatorState createState() => new NavigatorState(this);
+  NavigatorState createState() => new NavigatorState();
 }
 
-class NavigatorState extends ComponentState<Navigator> {
-  NavigatorState(Navigator config) : super(config);
-
+class NavigatorState extends State<Navigator> {
   RouteBase get currentRoute => config.history.currentRoute;
 
-  void pushState(ComponentState owner, Function callback) {
+  void pushState(State owner, Function callback) {
     RouteBase route = new RouteState(
       owner: owner,
       callback: callback,

--- a/sky/packages/sky/lib/src/fn3/popup_menu.dart
+++ b/sky/packages/sky/lib/src/fn3/popup_menu.dart
@@ -43,11 +43,12 @@ class PopupMenu extends StatefulComponent {
   final NavigatorState navigator;
   final WatchableAnimationPerformance performance;
 
-  PopupMenuState createState() => new PopupMenuState(this);
+  PopupMenuState createState() => new PopupMenuState();
 }
 
-class PopupMenuState extends ComponentState<PopupMenu> {
-  PopupMenuState(PopupMenu config) : super(config) {
+class PopupMenuState extends State<PopupMenu> {
+  void initState(BuildContext context) {
+    super.initState(context);
     _updateBoxPainter();
     config.performance.addListener(_performanceChanged);
   }
@@ -75,6 +76,7 @@ class PopupMenuState extends ComponentState<PopupMenu> {
 
   void dispose() {
     config.performance.removeListener(_performanceChanged);
+    super.dispose();
   }
 
   void _performanceChanged() {

--- a/sky/packages/sky/lib/src/fn3/progress_indicator.dart
+++ b/sky/packages/sky/lib/src/fn3/progress_indicator.dart
@@ -31,11 +31,12 @@ abstract class ProgressIndicator extends StatefulComponent {
 
   Widget _buildIndicator(BuildContext context, double performanceValue);
 
-  ProgressIndicatorState createState() => new ProgressIndicatorState(this);
+  ProgressIndicatorState createState() => new ProgressIndicatorState();
 }
 
-class ProgressIndicatorState extends ComponentState<ProgressIndicator> {
-  ProgressIndicatorState(ProgressIndicator config) : super(config) {
+class ProgressIndicatorState extends State<ProgressIndicator> {
+  void initState(BuildContext context) {
+    super.initState(context);
     _performance = new AnimationPerformance()
       ..duration = const Duration(milliseconds: 1500)
       ..variable = new AnimatedValue<double>(0.0, end: 1.0, curve: ease);
@@ -44,7 +45,6 @@ class ProgressIndicatorState extends ComponentState<ProgressIndicator> {
         _restartAnimation();
     });
     _performance.play();
-
   }
 
   AnimationPerformance _performance;

--- a/sky/packages/sky/lib/src/fn3/radio.dart
+++ b/sky/packages/sky/lib/src/fn3/radio.dart
@@ -28,12 +28,10 @@ class Radio extends StatefulComponent {
   final Object groupValue;
   final RadioValueChanged onChanged;
 
-  RadioState createState() => new RadioState(this);
+  RadioState createState() => new RadioState();
 }
 
-class RadioState extends ComponentState<Radio> {
-  RadioState(Radio config) : super(config);
-
+class RadioState extends State<Radio> {
   Color _getColor(BuildContext context) {
     ThemeData themeData = Theme.of(context);
     if (config.value == config.groupValue)

--- a/sky/packages/sky/lib/src/fn3/raised_button.dart
+++ b/sky/packages/sky/lib/src/fn3/raised_button.dart
@@ -21,12 +21,10 @@ class RaisedButton extends MaterialButton {
     assert(enabled != null);
   }
 
-  RaisedButtonState createState() => new RaisedButtonState(this);
+  RaisedButtonState createState() => new RaisedButtonState();
 }
 
 class RaisedButtonState extends MaterialButtonState<RaisedButton> {
-  RaisedButtonState(RaisedButton config) : super(config);
-
   Color getColor(BuildContext context) {
     if (config.enabled) {
       switch (Theme.of(context).brightness) {

--- a/sky/packages/sky/lib/src/fn3/scrollable.dart
+++ b/sky/packages/sky/lib/src/fn3/scrollable.dart
@@ -9,8 +9,7 @@ import 'dart:sky' as sky;
 import 'package:newton/newton.dart';
 import 'package:sky/animation.dart';
 import 'package:sky/gestures.dart';
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/viewport.dart';
+import 'package:sky/rendering.dart';
 import 'package:sky/src/fn3/basic.dart';
 import 'package:sky/src/fn3/framework.dart';
 import 'package:sky/src/fn3/gesture_detector.dart';
@@ -39,8 +38,9 @@ abstract class Scrollable extends StatefulComponent {
   final ScrollDirection scrollDirection;
 }
 
-abstract class ScrollableState<T extends Scrollable> extends ComponentState<T> {
-  ScrollableState(T config) : super(config) {
+abstract class ScrollableState<T extends Scrollable> extends State<T> {
+  void initState(BuildContext context) {
+    super.initState(context);
     if (config.initialScrollOffset is double)
       _scrollOffset = config.initialScrollOffset;
     _toEndAnimation = new AnimatedSimulation(_setScrollOffset);
@@ -126,6 +126,7 @@ abstract class ScrollableState<T extends Scrollable> extends ComponentState<T> {
 
   void dispose() {
     _stopAnimations();
+    super.dispose();
   }
 
   void _setScrollOffset(double newScrollOffset) {
@@ -220,12 +221,10 @@ class ScrollableViewport extends Scrollable {
 
   final Widget child;
 
-  ScrollableViewportState createState() => new ScrollableViewportState(this);
+  ScrollableViewportState createState() => new ScrollableViewportState();
 }
 
 class ScrollableViewportState extends ScrollableState<ScrollableViewport> {
-  ScrollableViewportState(ScrollableViewport config) : super(config);
-
   ScrollBehavior createScrollBehavior() => new OverscrollWhenScrollableBehavior();
   OverscrollWhenScrollableBehavior get scrollBehavior => super.scrollBehavior;
 
@@ -320,8 +319,6 @@ abstract class ScrollableWidgetList extends Scrollable {
 }
 
 abstract class ScrollableWidgetListState<T extends ScrollableWidgetList> extends ScrollableState<T> {
-  ScrollableWidgetListState(T config) : super(config);
-
   /// Subclasses must implement `get itemCount` to tell ScrollableWidgetList
   /// how many items there are in the list.
   int get itemCount;
@@ -458,12 +455,10 @@ class ScrollableList<T> extends ScrollableWidgetList {
   final List<T> items;
   final ItemBuilder<T> itemBuilder;
 
-  ScrollableListState<T, ScrollableList<T>> createState() => new ScrollableListState<T, ScrollableList<T>>(this);
+  ScrollableListState<T, ScrollableList<T>> createState() => new ScrollableListState<T, ScrollableList<T>>();
 }
 
 class ScrollableListState<T, Config extends ScrollableList<T>> extends ScrollableWidgetListState<Config> {
-  ScrollableListState(Config config) : super(config);
-
   ScrollBehavior createScrollBehavior() {
     return config.itemsWrap ? new UnboundedBehavior() : super.createScrollBehavior();
   }
@@ -512,8 +507,6 @@ class PageableList<T> extends ScrollableList<T> {
 }
 
 class PageableListState<T> extends ScrollableListState<T, PageableList<T>> {
-  PageableListState(PageableList<T> config) : super(config);
-
   double _snapScrollOffset(double newScrollOffset) {
     double scaledScrollOffset = newScrollOffset / config.itemExtent;
     double previousScrollOffset = scaledScrollOffset.floor() * config.itemExtent;

--- a/sky/packages/sky/lib/src/fn3/snack_bar.dart
+++ b/sky/packages/sky/lib/src/fn3/snack_bar.dart
@@ -56,12 +56,10 @@ class SnackBar extends AnimatedComponent {
   final List<SnackBarAction> actions;
   final SnackBarDismissedCallback onDismissed;
 
-  SnackBarState createState() => new SnackBarState(this);
+  SnackBarState createState() => new SnackBarState();
 }
 
-class SnackBarState extends AnimatedComponentState<SnackBar> {
-  SnackBarState(SnackBar config) : super(config);
-
+class SnackBarState extends AnimatedState<SnackBar> {
   void handleDismissed() {
     if (config.onDismissed != null)
       config.onDismissed();

--- a/sky/packages/sky/lib/src/fn3/tabs.dart
+++ b/sky/packages/sky/lib/src/fn3/tabs.dart
@@ -397,11 +397,12 @@ class TabBar extends Scrollable {
   final SelectedIndexChanged onChanged;
   final bool isScrollable;
 
-  TabBarState createState() => new TabBarState(this);
+  TabBarState createState() => new TabBarState();
 }
 
 class TabBarState extends ScrollableState<TabBar> {
-  TabBarState(TabBar config) : super(config) {
+  void initState(BuildContext context) {
+    super.initState(context);
     _indicatorAnimation = new ValueAnimation<Rect>()
       ..duration = _kTabBarScroll
       ..variable = new AnimatedRect(null, curve: ease);

--- a/sky/packages/sky/lib/src/fn3/transitions.dart
+++ b/sky/packages/sky/lib/src/fn3/transitions.dart
@@ -23,11 +23,12 @@ abstract class TransitionComponent extends StatefulComponent {
 
   Widget build(BuildContext context);
 
-  TransitionComponentState createState() => new TransitionComponentState(this);
+  TransitionState createState() => new TransitionState();
 }
 
-class TransitionComponentState extends ComponentState<TransitionComponent> {
-  TransitionComponentState(TransitionComponent config) : super(config) {
+class TransitionState extends State<TransitionComponent> {
+  void initState(BuildContext context) {
+    super.initState(context);
     config.performance.addListener(_performanceChanged);
   }
 
@@ -40,6 +41,7 @@ class TransitionComponentState extends ComponentState<TransitionComponent> {
 
   void dispose() {
     config.performance.removeListener(_performanceChanged);
+    super.dispose();
   }
 
   void _performanceChanged() {

--- a/sky/unit/test/fn3/test_widgets.dart
+++ b/sky/unit/test/fn3/test_widgets.dart
@@ -21,11 +21,10 @@ class FlipComponent extends StatefulComponent {
   final Widget left;
   final Widget right;
 
-  FlipComponentState createState() => new FlipComponentState(this);
+  FlipComponentState createState() => new FlipComponentState();
 }
 
-class FlipComponentState extends ComponentState<FlipComponent> {
-  FlipComponentState(FlipComponent config): super(config);
+class FlipComponentState extends State<FlipComponent> {
   bool _showLeft = true;
 
   void flip() {

--- a/sky/unit/test/fn3/widget_tester.dart
+++ b/sky/unit/test/fn3/widget_tester.dart
@@ -9,8 +9,7 @@ class RootComponent extends StatefulComponent {
   RootComponentState createState() => new RootComponentState(this);
 }
 
-class RootComponentState extends ComponentState<RootComponent> {
-  RootComponentState(RootComponent widget) : super(widget);
+class RootComponentState extends State<RootComponent> {
   Widget _child = new DecoratedBox(decoration: new BoxDecoration());
   Widget get child => _child;
   void set child(Widget value) {


### PR DESCRIPTION
ComponentState becomes State, for brevity.
Instead of overriding its constructor, override initState().
This makes writing States much simpler.