### PR TITLE
Flush stdout after printing messages from Dart

### DIFF
--- a/sky/engine/bindings/builtin_natives.cc
+++ b/sky/engine/bindings/builtin_natives.cc
@@ -173,6 +173,7 @@ void Logger_PrintString(Dart_NativeArguments args) {
     // Uses fwrite to support printing NUL bytes.
     fwrite(chars, 1, length, stdout);
     fputs("\n", stdout);
+    fflush(stdout);
 #if defined(OS_ANDROID)
     // In addition to writing to the stdout, write to the logcat so that the
     // message is discoverable when running on an unrooted device.


### PR DESCRIPTION
This modifies the Logger_PrintString used to implement Dart's print() to
explicitly fflush stdout after writing. In some contexts stdout may not be line
buffered, such as when launching a process that runs sky using dart:io's
Process.start.