### PR TITLE
Remove deleted header declaration for SaveFrameToSkPicture

### DIFF
--- a/sky/shell/ios/sky_surface.h
+++ b/sky/shell/ios/sky_surface.h
@@ -10,7 +10,3 @@
 -(instancetype) initWithShellView:(sky::shell::ShellView *) shellView;
 
 @end
-
-extern "C" {
-void SaveFrameToSkPicture();
-}


### PR DESCRIPTION
This was the used to generate the traces before the ability to toggle the same was moved to the tracing controller.