### PR TITLE
Prefer a specific provisioning profile when none is explicitly provided

### DIFF
--- a/build/config/ios/find_signing_identity.py
+++ b/build/config/ios/find_signing_identity.py
@@ -27,7 +27,7 @@ def FindValidIdentity():
     res = exp.match(line)
     if res is None:
       continue
-    if "iPhone Developer" in res.group(2):
+    if "iPhone Developer: Google Development" in res.group(2):
       return res.group(1)
   return ""
 


### PR DESCRIPTION
When multiple provisioning profiles are present (check via `xcrun security find-identity -v -p codesigning`), it is sometimes confusing which profile is picked by default. Only look for the Google Development profile. If running via the Xcode harness, an alternate profile can be selected from within Xcode