### PR TITLE
fn3: Port Card Collection demo

### DIFF
--- a/sky/packages/sky/lib/src/fn3/dismissable.dart
+++ b/sky/packages/sky/lib/src/fn3/dismissable.dart
@@ -102,6 +102,11 @@ class DismissableState extends State<Dismissable> {
         ..addListener(_handleResizeProgressChanged);
       _resizePerformance.play();
     });
+    // Our squash curve (ease) does not return v=0.0 for t=0.0, so we
+    // technically resize on the first frame. To make sure this doesn't confuse
+    // any other widgets (like MixedViewport, which checks for this kind of
+    // thing), we report a resize straight away.
+    _maybeCallOnResized();
   }
 
   void _handleResizeProgressChanged() {
@@ -220,6 +225,9 @@ class DismissableState extends State<Dismissable> {
 
   Widget build(BuildContext context) {
     if (_resizePerformance != null) {
+      // make sure you remove this widget once it's been dismissed!
+      assert(_resizePerformance.status == AnimationStatus.forward);
+
       AnimatedValue<double> squashAxisExtent = new AnimatedValue<double>(
         _directionIsYAxis ? _size.width : _size.height,
         end: 0.0,

--- a/sky/packages/sky/lib/src/fn3/transitions.dart
+++ b/sky/packages/sky/lib/src/fn3/transitions.dart
@@ -9,8 +9,6 @@ import 'package:vector_math/vector_math.dart';
 
 export 'package:sky/animation.dart' show Direction;
 
-// TODO(abarth): TransitionProxy
-
 abstract class TransitionComponent extends StatefulComponent {
   TransitionComponent({
     Key key,


### PR DESCRIPTION
Also:

- Make Dismissable report when it starts squashing, since otherwise we
  don't invalidate the list early enough and it gets mad that it wasn't
  told one of its children had changed size.

- Have Dismissable check that it gets removed after it's dismissed, to
  avoid having lots of redundant widgets around.

- Start tracking the height of each child of a MixedViewport, so that we
  don't accumulate floating point errors when a child jiggles up and down.

- Have _childOffsets reuse its storage space rather than newing up a new
  copy each time we reset the cache.

- Avoid double-updating child sizes when handling mixed viewport invalidations.