### PR TITLE
Allow the Input/EditableText widget to scroll horizontally

### DIFF
--- a/sky/packages/sky/lib/rendering.dart
+++ b/sky/packages/sky/lib/rendering.dart
@@ -9,6 +9,7 @@ export 'package:sky/src/rendering/auto_layout.dart';
 export 'package:sky/src/rendering/block.dart';
 export 'package:sky/src/rendering/box.dart';
 export 'package:sky/src/rendering/debug.dart';
+export 'package:sky/src/rendering/editable_paragraph.dart';
 export 'package:sky/src/rendering/error.dart';
 export 'package:sky/src/rendering/flex.dart';
 export 'package:sky/src/rendering/grid.dart';

--- a/sky/packages/sky/lib/src/painting/text_painter.dart
+++ b/sky/packages/sky/lib/src/painting/text_painter.dart
@@ -157,22 +157,33 @@ class TextPainter {
     _layoutRoot.maxHeight = value;
   }
 
+  // Unfortunately, using full precision floating point here causes bad layouts
+  // because floating point math isn't associative. If we add and subtract
+  // padding, for example, we'll get different values when we estimate sizes and
+  // when we actually compute layout because the operations will end up associated
+  // differently. To work around this problem for now, we round fractional pixel
+  // values up to the nearest whole pixel value. The right long-term fix is to do
+  // layout using fixed precision arithmetic.
+  double _applyFloatingPointHack(double layoutValue) {
+    return layoutValue.ceilToDouble();
+  }
+
   /// The width at which decreasing the width of the text would prevent it from painting itself completely within its bounds
   double get minContentWidth {
     assert(!_needsLayout);
-    return _layoutRoot.rootElement.minContentWidth;
+    return _applyFloatingPointHack(_layoutRoot.rootElement.minContentWidth);
   }
 
   /// The width at which increasing the width of the text no longer decreases the height
   double get maxContentWidth {
     assert(!_needsLayout);
-    return _layoutRoot.rootElement.maxContentWidth;
+    return _applyFloatingPointHack(_layoutRoot.rootElement.maxContentWidth);
   }
 
   /// The height required to paint the text completely within its bounds
   double get height {
     assert(!_needsLayout);
-    return _layoutRoot.rootElement.height;
+    return _applyFloatingPointHack(_layoutRoot.rootElement.height);
   }
 
   /// The distance from the top of the text to the first baseline of the given type

--- a/sky/packages/sky/lib/src/rendering/editable_paragraph.dart
+++ b/sky/packages/sky/lib/src/rendering/editable_paragraph.dart
@@ -1,0 +1,126 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:sky/painting.dart';
+import 'package:sky/src/rendering/box.dart';
+import 'package:sky/src/rendering/object.dart';
+import 'package:sky/src/rendering/paragraph.dart';
+import 'package:sky/src/rendering/proxy_box.dart' show SizeChangedCallback;
+
+const _kCursorGap = 1.0; // pixels
+const _kCursorHeightOffset = 2.0; // pixels
+const _kCursorWidth = 1.0; // pixels
+
+/// A render object used by EditableText widgets.  This is similar to
+/// RenderParagraph but also renders a cursor and provides support for
+/// scrolling.
+class RenderEditableParagraph extends RenderParagraph {
+
+  RenderEditableParagraph({
+    TextSpan text,
+    Color cursorColor,
+    bool showCursor,
+    this.onContentSizeChanged,
+    Offset scrollOffset
+  }) : _cursorColor = cursorColor,
+       _showCursor = showCursor,
+       _scrollOffset = scrollOffset,
+       super(text);
+
+  Color _cursorColor;
+  bool _showCursor;
+  SizeChangedCallback onContentSizeChanged;
+  Offset _scrollOffset;
+
+  Size _contentSize;
+
+  Color get cursorColor => _cursorColor;
+  void set cursorColor(Color value) {
+    if (_cursorColor == value)
+      return;
+    _cursorColor = value;
+    markNeedsPaint();
+  }
+
+  bool get showCursor => _showCursor;
+  void set showCursor(bool value) {
+    if (_showCursor == value)
+      return;
+    _showCursor = value;
+    markNeedsPaint();
+  }
+
+  Offset get scrollOffset => _scrollOffset;
+  void set scrollOffset(Offset value) {
+    if (_scrollOffset == value)
+      return;
+    _scrollOffset = value;
+    markNeedsPaint();
+  }
+
+  // Editable text does not support line wrap.
+  bool get allowLineWrap => false;
+
+  double _getIntrinsicWidth(BoxConstraints constraints) {
+    // There should be no difference between the minimum and maximum width
+    // because we only support single-line text.
+    layoutText(constraints);
+    return constraints.constrainWidth(
+      textPainter.maxContentWidth + _kCursorGap + _kCursorWidth
+    );
+  }
+
+  double getMinIntrinsicWidth(BoxConstraints constraints) {
+    return _getIntrinsicWidth(constraints);
+  }
+
+  double getMaxIntrinsicWidth(BoxConstraints constraints) {
+    return _getIntrinsicWidth(constraints);
+  }
+
+  void performLayout() {
+    layoutText(constraints);
+
+    Size newContentSize = new Size(
+      textPainter.maxContentWidth + _kCursorGap + _kCursorWidth,
+      textPainter.height
+    );
+    size = constraints.constrain(newContentSize);
+
+    if (_contentSize == null || _contentSize != newContentSize) {
+      _contentSize = newContentSize;
+      if (onContentSizeChanged != null)
+        onContentSizeChanged(newContentSize);
+    }
+  }
+
+  void paint(PaintingContext context, Offset offset) {
+    layoutText(constraints);
+
+    bool needsClipping = (_contentSize.width > size.width);
+    if (needsClipping) {
+      context.canvas.save();
+      context.canvas.clipRect(offset & size);
+    }
+
+    textPainter.paint(context.canvas, offset - _scrollOffset);
+
+    if (_showCursor) {
+      Rect cursorRect =  new Rect.fromLTWH(
+        textPainter.maxContentWidth + _kCursorGap,
+        _kCursorHeightOffset,
+        _kCursorWidth,
+        size.height - 2.0 * _kCursorHeightOffset
+      );
+      context.canvas.drawRect(
+        cursorRect.shift(offset - _scrollOffset),
+        new Paint()..color = _cursorColor
+      );
+    }
+
+    if (needsClipping)
+      context.canvas.restore();
+  }
+
+}

--- a/sky/packages/sky/lib/src/rendering/paragraph.dart
+++ b/sky/packages/sky/lib/src/rendering/paragraph.dart
@@ -8,66 +8,57 @@ import 'package:sky/src/rendering/object.dart';
 
 export 'package:sky/src/painting/text_painter.dart';
 
-// Unfortunately, using full precision floating point here causes bad layouts
-// because floating point math isn't associative. If we add and subtract
-// padding, for example, we'll get different values when we estimate sizes and
-// when we actually compute layout because the operations will end up associated
-// differently. To work around this problem for now, we round fractional pixel
-// values up to the nearest whole pixel value. The right long-term fix is to do
-// layout using fixed precision arithmetic.
-double _applyFloatingPointHack(double layoutValue) {
-  return layoutValue.ceilToDouble();
-}
-
 /// A render object that displays a paragraph of text
 class RenderParagraph extends RenderBox {
 
-  RenderParagraph(TextSpan text) : _textPainter = new TextPainter(text) {
+  RenderParagraph(
+    TextSpan text
+  ) : textPainter = new TextPainter(text) {
     assert(text != null);
   }
 
-  TextPainter _textPainter;
+  final TextPainter textPainter;
 
   BoxConstraints _constraintsForCurrentLayout; // when null, we don't have a current layout
 
   /// The text to display
-  TextSpan get text => _textPainter.text;
+  TextSpan get text => textPainter.text;
   void set text(TextSpan value) {
-    if (_textPainter.text == value)
+    if (textPainter.text == value)
       return;
-    _textPainter.text = value;
+    textPainter.text = value;
     _constraintsForCurrentLayout = null;
     markNeedsLayout();
   }
 
-  void _layout(BoxConstraints constraints) {
+  // Whether the text should be allowed to wrap to multiple lines.
+  bool get allowLineWrap => true;
+
+  void layoutText(BoxConstraints constraints) {
     assert(constraints != null);
     if (_constraintsForCurrentLayout == constraints)
       return; // already cached this layout
-    _textPainter.maxWidth = constraints.maxWidth;
-    _textPainter.minWidth = constraints.minWidth;
-    _textPainter.minHeight = constraints.minHeight;
-    _textPainter.maxHeight = constraints.maxHeight;
-    _textPainter.layout();
+    textPainter.maxWidth = allowLineWrap ? constraints.maxWidth : double.INFINITY;
+    textPainter.minWidth = constraints.minWidth;
+    textPainter.minHeight = constraints.minHeight;
+    textPainter.maxHeight = constraints.maxHeight;
+    textPainter.layout();
     _constraintsForCurrentLayout = constraints;
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
-    _layout(constraints);
-    return constraints.constrainWidth(
-        _applyFloatingPointHack(_textPainter.minContentWidth));
+    layoutText(constraints);
+    return constraints.constrainWidth(textPainter.minContentWidth);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
-    _layout(constraints);
-    return constraints.constrainWidth(
-        _applyFloatingPointHack(_textPainter.maxContentWidth));
+    layoutText(constraints);
+    return constraints.constrainWidth(textPainter.maxContentWidth);
   }
 
   double _getIntrinsicHeight(BoxConstraints constraints) {
-    _layout(constraints);
-    return constraints.constrainHeight(
-        _applyFloatingPointHack(_textPainter.height));
+    layoutText(constraints);
+    return constraints.constrainHeight(textPainter.height);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
@@ -80,15 +71,18 @@ class RenderParagraph extends RenderBox {
 
   double computeDistanceToActualBaseline(TextBaseline baseline) {
     assert(!needsLayout);
-    _layout(constraints);
-    return _textPainter.computeDistanceToActualBaseline(baseline);
+    layoutText(constraints);
+    return textPainter.computeDistanceToActualBaseline(baseline);
   }
 
   void performLayout() {
-    _layout(constraints);
-    // _paragraphPainter.width always expands to fill, use maxContentWidth instead.
-    size = constraints.constrain(new Size(_applyFloatingPointHack(_textPainter.maxContentWidth),
-                                          _applyFloatingPointHack(_textPainter.height)));
+    layoutText(constraints);
+
+    // We use textPainter.maxContentWidth here, rather that textPainter.width,
+    // because the latter is the width that it used to wrap the text, whereas
+    // the former is the actual width of the text.
+    size = constraints.constrain(new Size(textPainter.maxContentWidth,
+                                          textPainter.height));
   }
 
   void paint(PaintingContext context, Offset offset) {
@@ -99,8 +93,8 @@ class RenderParagraph extends RenderBox {
     //
     // TODO(abarth): Make computing the min/max intrinsic width/height
     // a non-destructive operation.
-    _layout(constraints);
-    _textPainter.paint(context.canvas, offset);
+    layoutText(constraints);
+    textPainter.paint(context.canvas, offset);
   }
 
   // we should probably expose a way to do precise (inter-glpyh) hit testing


### PR DESCRIPTION
EditableText is now rendered using a custom RenderObject
(RenderEditableParagraph).  RenderEditableParagraph draws the cursor,
handles scroll offsets, and provides feedback about the size of the text for
use by the scroll behavior.