### PR TITLE
Actually notify GlobalKey listeners in fn3

### DIFF
--- a/sky/packages/sky/lib/src/fn3/binding.dart
+++ b/sky/packages/sky/lib/src/fn3/binding.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:sky/animation.dart';
 import 'package:sky/rendering.dart';
 import 'package:sky/src/fn3/framework.dart';
@@ -15,7 +17,7 @@ class WidgetFlutterBinding extends FlutterBinding {
   }
 
   /// Ensures that there is a FlutterBinding object instantiated.
-  static void initBinding() {
+  static void ensureInitialized() {
     if (FlutterBinding.instance == null)
       new WidgetFlutterBinding();
     assert(FlutterBinding.instance is WidgetFlutterBinding);
@@ -38,16 +40,14 @@ class WidgetFlutterBinding extends FlutterBinding {
   void beginFrame(double timeStamp) {
     buildDirtyElements();
     super.beginFrame(timeStamp);
+    scheduleMicrotask(GlobalKey.checkForDuplicatesAndNotifyListeners);
   }
 
-  final List<BuildableElement> _dirtyElements = new List<BuildableElement>();
-
-  int _debugBuildingAtDepth;
+  List<BuildableElement> _dirtyElements = new List<BuildableElement>();
 
   /// Adds an element to the dirty elements list so that it will be rebuilt
   /// when buildDirtyElements is called.
   void scheduleBuildFor(BuildableElement element) {
-    assert(_debugBuildingAtDepth == null || element.depth > _debugBuildingAtDepth);
     assert(!_dirtyElements.contains(element));
     assert(element.dirty);
     if (_dirtyElements.isEmpty)
@@ -55,46 +55,30 @@ class WidgetFlutterBinding extends FlutterBinding {
     _dirtyElements.add(element);
   }
 
-  void _absorbDirtyElements(List<BuildableElement> list) {
-    assert(_debugBuildingAtDepth != null);
-    assert(!_dirtyElements.any((element) => element.depth <= _debugBuildingAtDepth));
-    _dirtyElements.sort((BuildableElement a, BuildableElement b) => a.depth - b.depth);
-    list.addAll(_dirtyElements);
-    _dirtyElements.clear();
-  }
-
   /// Builds all the elements that were marked as dirty using schedule(), in depth order.
   /// If elements are marked as dirty while this runs, they must be deeper than the algorithm
   /// has yet reached.
   /// This is called by beginFrame().
   void buildDirtyElements() {
-    assert(_debugBuildingAtDepth == null);
     if (_dirtyElements.isEmpty)
       return;
-    assert(() { _debugBuildingAtDepth = 0; return true; });
-    List<BuildableElement> sortedDirtyElements = new List<BuildableElement>();
-    int index = 0;
-    do {
-      _absorbDirtyElements(sortedDirtyElements);
-      for (; index < sortedDirtyElements.length; index += 1) {
-        BuildableElement element = sortedDirtyElements[index];
-        assert(() {
-          if (element.depth > _debugBuildingAtDepth)
-            _debugBuildingAtDepth = element.depth;
-          return element.depth == _debugBuildingAtDepth;
-        });
+    BuildableElement.lockState(() {
+      _dirtyElements.sort((BuildableElement a, BuildableElement b) => a.depth - b.depth);
+      for (BuildableElement element in _dirtyElements)
         element.rebuild();
-      }
-    } while (_dirtyElements.isNotEmpty);
-    assert(() { _debugBuildingAtDepth = null; return true; });
+      _dirtyElements.clear();
+    });
+    assert(_dirtyElements.isEmpty);
   }
 }
 
 void runApp(Widget app) {
-  WidgetFlutterBinding.initBinding();
-  WidgetFlutterBinding.instance.renderViewElement.update(
-    WidgetFlutterBinding.instance.describeApp(app)
-  );
+  WidgetFlutterBinding.ensureInitialized();
+  BuildableElement.lockState(() {
+    WidgetFlutterBinding.instance.renderViewElement.update(
+      WidgetFlutterBinding.instance.describeApp(app)
+    );
+  });
 }
 
 /// This class provides a bridge from a RenderObject to an Element tree. The

--- a/sky/packages/sky/lib/src/fn3/homogeneous_viewport.dart
+++ b/sky/packages/sky/lib/src/fn3/homogeneous_viewport.dart
@@ -90,12 +90,14 @@ class HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewport
   }
 
   void layout(BoxConstraints constraints) {
-    // we lock the framework state (meaning that no elements can call markNeedsBuild()) because we are
-    // in the middle of layout and if we allowed people to set state, they'd expect to have that state
-    // reflected immediately, which, if we were to try to honour it, would potentially result in
-    // assertions since you can't normally mutate the render object tree during layout. (If there was
-    // a way to limit this to only descendants of this, it'd be ok, since we are exempt from that
-    // assert since we are actively doing our own layout still.)
+    // We enter a build scope (meaning that markNeedsBuild() is forbidden)
+    // because we are in the middle of layout and if we allowed people to set
+    // state, they'd expect to have that state reflected immediately, which, if
+    // we were to try to honour it, would potentially result in assertions
+    // because you can't normally mutate the render object tree during layout.
+    // (If there were a way to limit these writes to descendants of this, it'd
+    // be ok because we are exempt from that assert since we are still actively
+    // doing our own layout.)
     BuildableElement.lockState(() {
       double mainAxisExtent = widget.direction == ScrollDirection.vertical ? constraints.maxHeight : constraints.maxWidth;
       double offset;

--- a/sky/unit/test/widget/build_scope_test.dart
+++ b/sky/unit/test/widget/build_scope_test.dart
@@ -1,0 +1,126 @@
+import 'package:sky/src/fn3.dart';
+import 'package:test/test.dart';
+
+import '../fn3/widget_tester.dart';
+import '../fn3/test_widgets.dart';
+
+class ProbeWidget extends StatefulComponent {
+  ProbeWidgetState createState() => new ProbeWidgetState();
+}
+
+class ProbeWidgetState extends State<ProbeWidget> {
+  static int buildCount = 0;
+
+  void initState(BuildContext context) {
+    super.initState(context);
+    setState(() {});
+  }
+
+  void didUpdateConfig(ProbeWidget oldConfig) {
+    setState(() {});
+  }
+
+  Widget build(BuildContext context) {
+    setState(() {});
+    buildCount++;
+    return new Container();
+  }
+}
+
+class BadWidget extends StatelessComponent {
+  BadWidget(this.parentState);
+
+  final State parentState;
+
+  Widget build(BuildContext context) {
+    parentState.setState(() {});
+    return new Container();
+  }
+}
+
+class BadWidgetParent extends StatefulComponent {
+  BadWidgetParentState createState() => new BadWidgetParentState();
+}
+
+class BadWidgetParentState extends State<BadWidgetParent> {
+  Widget build(BuildContext context) {
+    return new BadWidget(this);
+  }
+}
+
+class BadDisposeWidget extends StatefulComponent {
+  BadDisposeWidgetState createState() => new BadDisposeWidgetState();
+}
+
+class BadDisposeWidgetState extends State<BadDisposeWidget> {
+  Widget build(BuildContext context) {
+    return new Container();
+  }
+
+  void dispose() {
+    setState(() {});
+    super.dispose();
+  }
+}
+
+void main() {
+  dynamic cachedException;
+
+  setUp(() {
+    assert(cachedException == null);
+    debugWidgetsExceptionHandler = (String context, dynamic exception, StackTrace stack) {
+      cachedException = exception;
+    };
+  });
+
+  tearDown(() {
+    assert(cachedException == null);
+    cachedException = null;
+    debugWidgetsExceptionHandler = null;
+  });
+
+  test('Legal times for setState', () {
+    WidgetTester tester = new WidgetTester();
+
+    GlobalKey flipKey = new GlobalKey();
+    expect(ProbeWidgetState.buildCount, equals(0));
+    tester.pumpFrame(new ProbeWidget());
+    expect(ProbeWidgetState.buildCount, equals(1));
+    tester.pumpFrame(new ProbeWidget());
+    expect(ProbeWidgetState.buildCount, equals(2));
+    tester.pumpFrame(new FlipComponent(
+      key: flipKey,
+      left: new Container(),
+      right: new ProbeWidget()
+    ));
+    expect(ProbeWidgetState.buildCount, equals(2));
+    (flipKey.currentState as FlipComponentState).flip();
+    tester.pumpFrameWithoutChange();
+    expect(ProbeWidgetState.buildCount, equals(3));
+    (flipKey.currentState as FlipComponentState).flip();
+    tester.pumpFrameWithoutChange();
+    expect(ProbeWidgetState.buildCount, equals(3));
+    tester.pumpFrame(new Container());
+    expect(ProbeWidgetState.buildCount, equals(3));
+  });
+
+  test('Setting parent state during build is forbidden', () {
+    WidgetTester tester = new WidgetTester();
+
+    expect(cachedException, isNull);
+    tester.pumpFrame(new BadWidgetParent());
+    expect(cachedException, isNotNull);
+    cachedException = null;
+    tester.pumpFrame(new Container());
+    expect(cachedException, isNull);
+  });
+
+  test('Setting state during dispose is forbidden', () {
+    WidgetTester tester = new WidgetTester();
+
+    tester.pumpFrame(new BadDisposeWidget());
+    expect(() {
+      tester.pumpFrame(new Container());
+    }, throws);
+  });
+}


### PR DESCRIPTION
This patch makes a number of changes:

1) buildDirtyComponents now prevents all calls to setState, not just those
   higher in the tree. This change is necessary for consistency with
   MixedViewport and HomogeneousViewport because those widgets already build
   subwidgets with that restriction. If the "normal" build didn't enforce that
   rule, then some widgets would break when put inside a mixed or homogeneous
   viewport.

2) We now notify global key listeners at the end of each build phase. The
   notification is dispatched in a state that blocks calls to setState, which
   prevents these callbacks from rewinding the state machine.

3) The one consumer of these notifications, Focus, now uses scheduleMicrotask
   to defer calling setState until the next frame. We should see if other
   consumers of GlobalKey removal notifications follow this pattern and, if so,
   we might want to iterate on the design.