### PR TITLE
Make the FAB move up when a Snack Bar slides in.

### DIFF
--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -236,7 +236,6 @@ class StockHomeState extends State<StockHome> {
     if (_snackBarStatus == AnimationStatus.dismissed)
       return null;
     return new SnackBar(
-      transitionKey: snackBarKey,
       showing: _isSnackBarShowing,
       content: new Text("Stock purchased!"),
       actions: [new SnackBarAction(label: "UNDO", onPressed: _handleUndo)],

--- a/sky/packages/sky/lib/src/fn3/basic.dart
+++ b/sky/packages/sky/lib/src/fn3/basic.dart
@@ -211,7 +211,9 @@ class SizedBox extends OneChildRenderObjectWidget {
   final double width;
   final double height;
 
-  RenderConstrainedBox createRenderObject() => new RenderConstrainedBox(additionalConstraints: _additionalConstraints);
+  RenderConstrainedBox createRenderObject() => new RenderConstrainedBox(
+    additionalConstraints: _additionalConstraints
+  );
 
   BoxConstraints get _additionalConstraints {
     BoxConstraints result = const BoxConstraints();
@@ -224,6 +226,24 @@ class SizedBox extends OneChildRenderObjectWidget {
 
   void updateRenderObject(RenderConstrainedBox renderObject, SizedBox oldWidget) {
     renderObject.additionalConstraints = _additionalConstraints;
+  }
+}
+
+class OverflowBox extends OneChildRenderObjectWidget {
+  OverflowBox({ Key key, this.width, this.height, Widget child })
+    : super(key: key, child: child);
+
+  final double width;
+  final double height;
+
+  RenderOverflowBox createRenderObject() => new RenderOverflowBox(
+    innerWidth: width,
+    innerHeight: height
+  );
+
+  void updateRenderObject(RenderOverflowBox renderObject, OverflowBox oldWidget) {
+    renderObject.innerWidth = width;
+    renderObject.innerHeight = height;
   }
 }
 

--- a/sky/packages/sky/lib/src/fn3/scaffold.dart
+++ b/sky/packages/sky/lib/src/fn3/scaffold.dart
@@ -102,6 +102,7 @@ class RenderScaffold extends RenderBox {
   void performLayout() {
     double bodyHeight = size.height;
     double bodyPosition = 0.0;
+    double fabOffset = 0.0;
     if (_slots[ScaffoldSlots.statusBar] != null) {
       RenderBox statusBar = _slots[ScaffoldSlots.statusBar];
       statusBar.layout(new BoxConstraints.tight(new Size(size.width, kStatusBarHeight)));
@@ -127,18 +128,20 @@ class RenderScaffold extends RenderBox {
     if (_slots[ScaffoldSlots.snackBar] != null) {
       RenderBox snackBar = _slots[ScaffoldSlots.snackBar];
       // TODO(jackson): On tablet/desktop, minWidth = 288, maxWidth = 568
-      snackBar.layout(new BoxConstraints(minWidth: size.width, maxWidth: size.width, minHeight: 0.0, maxHeight: size.height),
-                      parentUsesSize: true);
+      snackBar.layout(
+        new BoxConstraints(minWidth: size.width, maxWidth: size.width, minHeight: 0.0, maxHeight: bodyHeight),
+        parentUsesSize: true
+      );
       assert(snackBar.parentData is BoxParentData);
-      // Position it off-screen. SnackBar slides in with an animation.
-      snackBar.parentData.position = new Point(0.0, size.height);
+      snackBar.parentData.position = new Point(0.0, bodyPosition + bodyHeight - snackBar.size.height);
+      fabOffset += snackBar.size.height;
     }
     if (_slots[ScaffoldSlots.floatingActionButton] != null) {
       RenderBox floatingActionButton = _slots[ScaffoldSlots.floatingActionButton];
       Size area = new Size(size.width - kButtonX, size.height - kButtonY);
       floatingActionButton.layout(new BoxConstraints.loose(area), parentUsesSize: true);
       assert(floatingActionButton.parentData is BoxParentData);
-      floatingActionButton.parentData.position = (area - floatingActionButton.size).toPoint();
+      floatingActionButton.parentData.position = (area - floatingActionButton.size).toPoint() + new Offset(0.0, -fabOffset);
     }
     if (_slots[ScaffoldSlots.drawer] != null) {
       RenderBox drawer = _slots[ScaffoldSlots.drawer];

--- a/sky/packages/sky/lib/src/fn3/snack_bar.dart
+++ b/sky/packages/sky/lib/src/fn3/snack_bar.dart
@@ -17,7 +17,10 @@ import 'package:sky/src/fn3/transitions.dart';
 typedef void SnackBarDismissedCallback();
 
 const Duration _kSlideInDuration = const Duration(milliseconds: 200);
-// TODO(ianh): factor out some of the constants below
+const double kSnackHeight = 52.0;
+const double kSideMargins = 24.0;
+const double kVerticalPadding = 14.0;
+const Color kSnackBackground = const Color(0xFF323232);
 
 class SnackBarAction extends StatelessComponent {
   SnackBarAction({Key key, this.label, this.onPressed }) : super(key: key) {
@@ -31,8 +34,8 @@ class SnackBarAction extends StatelessComponent {
     return new GestureDetector(
       onTap: onPressed,
       child: new Container(
-        margin: const EdgeDims.only(left: 24.0),
-        padding: const EdgeDims.only(top: 14.0, bottom: 14.0),
+        margin: const EdgeDims.only(left: kSideMargins),
+        padding: const EdgeDims.symmetric(vertical: kVerticalPadding),
         child: new Text(label)
       )
     );
@@ -42,7 +45,6 @@ class SnackBarAction extends StatelessComponent {
 class SnackBar extends AnimatedComponent {
   SnackBar({
     Key key,
-    this.transitionKey,
     this.content,
     this.actions,
     bool showing,
@@ -51,7 +53,6 @@ class SnackBar extends AnimatedComponent {
     assert(content != null);
   }
 
-  final Key transitionKey;
   final Widget content;
   final List<SnackBarAction> actions;
   final SnackBarDismissedCallback onDismissed;
@@ -69,7 +70,7 @@ class SnackBarState extends AnimatedState<SnackBar> {
     List<Widget> children = [
       new Flexible(
         child: new Container(
-          margin: const EdgeDims.symmetric(vertical: 14.0),
+          margin: const EdgeDims.symmetric(vertical: kVerticalPadding),
           child: new DefaultTextStyle(
             style: Typography.white.subhead,
             child: config.content
@@ -79,24 +80,28 @@ class SnackBarState extends AnimatedState<SnackBar> {
     ];
     if (config.actions != null)
       children.addAll(config.actions);
-    return new SlideTransition(
-      key: config.transitionKey,
+    return new SquashTransition(
       performance: performance.view,
-      position: new AnimatedValue<Point>(
-        Point.origin,
-        end: const Point(0.0, -52.0),
+      height: new AnimatedValue<double>(
+        0.0,
+        end: kSnackHeight,
         curve: easeIn,
         reverseCurve: easeOut
       ),
-      child: new Material(
-        level: 2,
-        color: const Color(0xFF323232),
-        type: MaterialType.canvas,
-        child: new Container(
-          margin: const EdgeDims.symmetric(horizontal: 24.0),
-          child: new DefaultTextStyle(
-            style: new TextStyle(color: Theme.of(context).accentColor),
-            child: new Row(children)
+      child: new ClipRect(
+        child: new OverflowBox(
+          height: kSnackHeight,
+          child: new Material(
+            level: 2,
+            color: kSnackBackground,
+            type: MaterialType.canvas,
+            child: new Container(
+              margin: const EdgeDims.symmetric(horizontal: kSideMargins),
+              child: new DefaultTextStyle(
+                style: new TextStyle(color: Theme.of(context).accentColor),
+                child: new Row(children)
+              )
+            )
           )
         )
       )


### PR DESCRIPTION
This changes how SnackBar works so you can use it anywhere, not just on
the bottom edge of the screen (it used to rely on overflowing its bounds
and having negative offsets... I'm not really sure how hit testing
worked on it before!).

To do this I introduced a new RenderBox, RenderOverflowBox, that lets
you set your child's size independent of your own. I needed this so that
the snack bar could use a SquashTransition to change its size, while not
affecting the layout of its child. This is exposed as OverflowBox in
fn3. I'm not sure if it's the best API. It doesn't let you position the
child (which is an issue if the size you give is smaller), it doesn't
let you give a loose constraint (which maybe you might want?). But it
handles this use case, so for now it's probably ok.

Making the FAB get repositioned out of the way of the Snack Bar is now
done in the Scaffold, which is in charge of positioning both of those
and is the place that knows that both exist.