### PR TITLE
customize the generated dartdoc to look like flutter.io

### DIFF
--- a/sky/packages/sky/doc/firebase.json
+++ b/sky/packages/sky/doc/firebase.json
@@ -1,9 +1,0 @@
-{
-  "firebase": "skydocs",
-  "public": "api",
-  "ignore": [
-    "firebase.json",
-    "**/.*",
-    "**/node_modules/**"
-  ]
-}

--- a/sky/packages/sky/doc/styles.html
+++ b/sky/packages/sky/doc/styles.html
@@ -1,0 +1,31 @@
+<!-- style overrides for dartdoc -->
+<style>
+  header {
+    background-color: #917FFF;
+  }
+
+  body {
+    font-size: 16px;
+    line-height: 1.5;
+    color: #111;
+    background-color: #fdfdfd;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 300;
+  }
+
+  h1 {
+    font-size: 42px !important;
+    letter-spacing: -1px;
+    line-height: 1;
+  }
+
+  h2 {
+    font-size: 32px;
+  }
+
+  pre > code {
+    font-size: 14px;
+  }
+</style>

--- a/sky/packages/sky/lib/gestures.dart
+++ b/sky/packages/sky/lib/gestures.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// The Flutter gesture recognizers
+/// The Flutter gesture recognizers.
 library gestures;
 
 export 'src/gestures/arena.dart';

--- a/sky/packages/sky/lib/material.dart
+++ b/sky/packages/sky/lib/material.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter widgets implementing Material Design
+/// Flutter widgets implementing Material Design.
 ///
 /// See https://www.google.com/design/spec/material-design/introduction.html
 library material;

--- a/sky/packages/sky/lib/painting.dart
+++ b/sky/packages/sky/lib/painting.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// The Flutter painting library
+/// The Flutter painting library.
 ///
 /// This library includes a variety of classes that wrap the Flutter
 /// engine's painting API for more specialised purposes, such as painting scaled

--- a/sky/packages/sky/lib/rendering.dart
+++ b/sky/packages/sky/lib/rendering.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// The Flutter rendering tree
+/// The Flutter rendering tree.
 library rendering;
 
 export 'package:sky/src/rendering/auto_layout.dart';

--- a/sky/packages/sky/lib/services.dart
+++ b/sky/packages/sky/lib/services.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// System services exposed to Flutter apps
+/// System services exposed to Flutter apps.
 ///
 /// For example, this library includes [fetch], which fetches data from the
 /// network.

--- a/sky/tools/skydoc.py
+++ b/sky/tools/skydoc.py
@@ -28,6 +28,7 @@ def main():
 
     cmd = [
         DARTDOC,
+        '--header', os.path.join(SKY_PACKAGE, 'doc', 'styles.html'),
         '--input', SKY_PACKAGE,
         '--output', doc_dir
     ]


### PR DESCRIPTION
- make the generated documentation have similar styling to flutter.io
- also, add periods to the ends of the library descriptions - without, the library overview page looks inconsistent:

<img width="318" alt="screen shot 2015-09-28 at 11 00 35 am" src="https://cloud.githubusercontent.com/assets/1269969/10144047/43f30f74-65d0-11e5-97c3-ee401d19fe68.png">
