### PR TITLE
Make the checkbox in the stocks popup menu work.

### DIFF
--- a/examples/stocks/lib/stock_menu.dart
+++ b/examples/stocks/lib/stock_menu.dart
@@ -4,7 +4,7 @@
 
 part of stocks;
 
-enum _MenuItems { add, remove, autorefresh }
+enum _MenuItems { autorefresh, autorefreshCheckbox, add, remove }
 
 Future showStockMenu(NavigatorState navigator, { bool autorefresh, ValueChanged onAutorefreshChanged }) async {
   switch (await showMenu(
@@ -16,6 +16,22 @@ Future showStockMenu(NavigatorState navigator, { bool autorefresh, ValueChanged 
     builder: (NavigatorState navigator) {
       return <PopupMenuItem>[
         new PopupMenuItem(
+          value: _MenuItems.autorefresh,
+          child: new Row([
+              new Flexible(child: new Text('Autorefresh')),
+              new Checkbox(
+                value: autorefresh,
+                onChanged: (bool value) {
+                  navigator.setState(() {
+                    autorefresh = value;
+                  });
+                  navigator.pop(_MenuItems.autorefreshCheckbox);
+                }
+              )
+            ]
+          )
+        ),
+        new PopupMenuItem(
           value: _MenuItems.add,
           child: new Text('Add stock')
         ),
@@ -23,22 +39,17 @@ Future showStockMenu(NavigatorState navigator, { bool autorefresh, ValueChanged 
           value: _MenuItems.remove,
           child: new Text('Remove stock')
         ),
-        new PopupMenuItem(
-          value: _MenuItems.autorefresh,
-          child: new Row([
-              new Flexible(child: new Text('Autorefresh')),
-              new Checkbox(
-                value: autorefresh,
-                onChanged: onAutorefreshChanged
-              )
-            ]
-          )
-        ),
       ];
     }
   )) {
     case _MenuItems.autorefresh:
-      onAutorefreshChanged(!autorefresh);
+      navigator.setState(() {
+        autorefresh = !autorefresh;
+      });
+      continue autorefreshNotify;
+    autorefreshNotify:
+    case _MenuItems.autorefreshCheckbox:
+      onAutorefreshChanged(autorefresh);
       break;
     case _MenuItems.add:
     case _MenuItems.remove:

--- a/sky/packages/sky/lib/src/fn3/checkbox.dart
+++ b/sky/packages/sky/lib/src/fn3/checkbox.dart
@@ -17,7 +17,6 @@ const sky.Color _kLightUncheckedColor = const sky.Color(0x8A000000);
 const sky.Color _kDarkUncheckedColor = const sky.Color(0xB2FFFFFF);
 const double _kEdgeSize = 20.0;
 const double _kEdgeRadius = 1.0;
-const Duration _kCheckDuration = const Duration(milliseconds: 200);
 
 /// A material design checkbox
 ///

--- a/sky/packages/sky/lib/src/fn3/switch.dart
+++ b/sky/packages/sky/lib/src/fn3/switch.dart
@@ -23,7 +23,6 @@ const double _kTrackHeight = 14.0;
 const double _kTrackRadius = _kTrackHeight / 2.0;
 const double _kTrackWidth =
     _kSwitchWidth - (_kThumbRadius - _kTrackRadius) * 2.0;
-const Duration _kCheckDuration = const Duration(milliseconds: 200);
 const Size _kSwitchSize = const Size(_kSwitchWidth + 2.0, _kSwitchHeight + 2.0);
 const double _kReactionRadius = _kSwitchWidth / 2.0;
 

--- a/sky/packages/sky/lib/src/rendering/toggleable.dart
+++ b/sky/packages/sky/lib/src/rendering/toggleable.dart
@@ -53,29 +53,30 @@ abstract class RenderToggleable extends RenderConstrainedBox {
   }
 
   void _handleTap() {
-    _onChanged(!_value);
+    if (_onChanged != null)
+      _onChanged(!_value);
   }
 
-  bool _value;
   bool get value => _value;
-
+  bool _value;
   void set value(bool value) {
-    if (value == _value) return;
+    if (value == _value)
+      return;
     _value = value;
     performance.play(value ? Direction.forward : Direction.reverse);
   }
 
-  ValueChanged _onChanged;
   ValueChanged get onChanged => _onChanged;
+  ValueChanged _onChanged;
 
   void set onChanged(ValueChanged onChanged) {
     _onChanged = onChanged;
   }
 
+  AnimatedValue<double> get position => _position;
   final AnimatedValue<double> _position =
       new AnimatedValue<double>(0.0, end: 1.0, curve: easeIn, reverseCurve: easeOut);
-  AnimatedValue<double> get position => _position;
 
-  AnimationPerformance _performance;
   AnimationPerformance get performance => _performance;
+  AnimationPerformance _performance;
 }


### PR DESCRIPTION
Tapping on the menu item didn't animate the checkbox because the menu
takes 300ms to animate entirely away while the checkbox takes 200ms to
animate checked, and since the item with the checkbox was at the bottom,
we were only seeing about 60ms of the entire checkbox animation, which
isn't enough to notice it. So I moved it to the top of the menu.

Tapping on the checkbox didn't animate because nothing caused the menu
to rebuild when the callback was invoked. To trigger a rebuild, I now
call navigator.setState() explicitly, after changing out local state.

To make tapping the checkbox remove the menu, I also explicitly call
navigator.pop() in the code that handles the check. (I still explicitly
change the checkbox to show that that's possible. In principle one could
just treat the checkbox as an inert widget that happens to trigger pop,
and do all the checking/unchecking in the switch statement.)

I also made some minor style tweaks to files I was looking at while
dealing with this issue.