### PR TITLE
Require giving a GlobalKey to UniqueComponent

### DIFF
--- a/sky/packages/sky/lib/src/fn3/unique_component.dart
+++ b/sky/packages/sky/lib/src/fn3/unique_component.dart
@@ -5,7 +5,9 @@
 import 'package:sky/src/fn3.dart';
 
 abstract class UniqueComponent<T extends State> extends StatefulComponent {
-  UniqueComponent({ GlobalKey key }) : super(key: key ?? new GlobalKey());
+  UniqueComponent({ GlobalKey key }) : super(key: key) {
+    assert(key != null);
+  }
 
   T createState();
 


### PR DESCRIPTION
Having UniqueComponent automatically generate its own key is a trap. If
anyone ever creates a UniqueComponent in a build function (rather than
ahead of time) and forgets to pass a key, then that entire subtree is
going to be rebuilt, including layout, every time it's updated. Since
there's basically no way for us to catch this, we should at least force
the author to see the explicit "new GlobalKey()" call in their code.