### PR TITLE
Change Tab's builder pattern to child pattern

### DIFF
--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -9,6 +9,7 @@ import 'dart:math' as math;
 import 'dart:sky' as sky;
 
 import 'package:sky/animation.dart';
+import 'package:sky/gestures.dart';
 import 'package:sky/material.dart';
 import 'package:sky/painting.dart';
 import 'package:sky/src/fn3.dart';

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -178,27 +178,30 @@ class StockHomeState extends State<StockHome> {
     return stocks.where((stock) => stock.symbol.contains(regexp));
   }
 
-  Widget buildMarketStockList(BuildContext context) {
-    return new Stocklist(stocks: _filterBySearchQuery(config.stocks).toList());
-  }
-
-  Widget buildPortfolioStocklist(BuildContext context) {
-    return new Stocklist(stocks: _filterBySearchQuery(_filterByPortfolio(config.stocks)).toList());
+  Widget buildStockList(BuildContext context, Iterable<Stock> stocks) {
+    return new Stocklist(
+      stocks: stocks.toList(),
+      onAction: (Stock stock) {
+        setState(() {
+          stock.percentChange = 100.0 * (1.0 / stock.lastSale);
+          stock.lastSale += 1.0;
+        });
+      }
+    );
   }
 
   Widget buildTabNavigator() {
-    List<TabNavigatorView> views = <TabNavigatorView>[
-      new TabNavigatorView(
-        label: const TabLabel(text: 'MARKET'),
-        builder: buildMarketStockList
-      ),
-      new TabNavigatorView(
-        label: const TabLabel(text: 'PORTFOLIO'),
-        builder: buildPortfolioStocklist
-      )
-    ];
     return new TabNavigator(
-      views: views,
+      views: <TabNavigatorView>[
+        new TabNavigatorView(
+          label: const TabLabel(text: 'MARKET'),
+          child: buildStockList(context, _filterBySearchQuery(config.stocks))
+        ),
+        new TabNavigatorView(
+          label: const TabLabel(text: 'PORTFOLIO'),
+          child: buildStockList(context, _filterByPortfolio(config.stocks))
+        )
+      ],
       selectedIndex: selectedTabIndex,
       onChanged: (tabIndex) {
         setState(() { selectedTabIndex = tabIndex; } );

--- a/examples/stocks/lib/stock_list.dart
+++ b/examples/stocks/lib/stock_list.dart
@@ -4,10 +4,13 @@
 
 part of stocks;
 
+typedef void StockActionListener(Stock stock);
+
 class Stocklist extends StatelessComponent {
-  Stocklist({ Key key, this.stocks }) : super(key: key);
+  Stocklist({ Key key, this.stocks, this.onAction }) : super(key: key);
 
   final List<Stock> stocks;
+  final StockActionListener onAction;
 
   Widget build(BuildContext context) {
     return new Material(
@@ -15,7 +18,12 @@ class Stocklist extends StatelessComponent {
       child: new ScrollableList<Stock>(
         items: stocks,
         itemExtent: StockRow.kHeight,
-        itemBuilder: (BuildContext context, Stock stock) => new StockRow(stock: stock)
+        itemBuilder: (BuildContext context, Stock stock) {
+          return new StockRow(
+            stock: stock,
+            onPressed: () { onAction(stock); }
+          );
+        }
       )
     );
   }

--- a/examples/stocks/lib/stock_row.dart
+++ b/examples/stocks/lib/stock_row.dart
@@ -5,9 +5,10 @@
 part of stocks;
 
 class StockRow extends StatelessComponent {
-  StockRow({ Stock stock }) : this.stock = stock, super(key: new Key(stock.symbol));
+  StockRow({ Stock stock, this.onPressed }) : this.stock = stock, super(key: new Key(stock.symbol));
 
   final Stock stock;
+  final GestureTapListener onPressed;
 
   static const double kHeight = 79.0;
 
@@ -36,28 +37,31 @@ class StockRow extends StatelessComponent {
       )
     ];
 
-    // TODO(hansmuller): An explicit |height| shouldn't be needed
-    return new Container(
-      padding: const EdgeDims(16.0, 16.0, 20.0, 16.0),
-      height: kHeight,
-      decoration: new BoxDecoration(
-        border: new Border(
-          bottom: new BorderSide(color: Theme.of(context).dividerColor)
+    return new GestureDetector(
+      onTap: onPressed,
+      child: new InkWell(
+        child: new Container(
+          padding: const EdgeDims(16.0, 16.0, 20.0, 16.0),
+          decoration: new BoxDecoration(
+            border: new Border(
+              bottom: new BorderSide(color: Theme.of(context).dividerColor)
+            )
+          ),
+          child: new Row([
+            new Container(
+              child: new StockArrow(percentChange: stock.percentChange),
+              margin: const EdgeDims.only(right: 5.0)
+            ),
+            new Flexible(
+              child: new Row(
+                children,
+                alignItems: FlexAlignItems.baseline,
+                textBaseline: DefaultTextStyle.of(context).textBaseline
+              )
+            )
+          ])
         )
-      ),
-      child: new Row([
-        new Container(
-          child: new StockArrow(percentChange: stock.percentChange),
-          margin: const EdgeDims.only(right: 5.0)
-        ),
-        new Flexible(
-          child: new Row(
-            children,
-            alignItems: FlexAlignItems.baseline,
-            textBaseline: DefaultTextStyle.of(context).textBaseline
-          )
-        )
-      ])
+      )
     );
   }
 }

--- a/examples/widgets/tabs.dart
+++ b/examples/widgets/tabs.dart
@@ -37,7 +37,7 @@ class TabbedNavigatorAppState extends State<TabbedNavigatorApp> {
       .map((text) {
         return new TabNavigatorView(
           label: new TabLabel(text: text),
-          builder: (BuildContext context) => _buildContent(text)
+          child: _buildContent(text)
         );
       });
     return _buildTabNavigator(n, views.toList(), const ValueKey<String>('textLabelsTabNavigator'));
@@ -48,7 +48,7 @@ class TabbedNavigatorAppState extends State<TabbedNavigatorApp> {
       .map((icon_name) {
         return new TabNavigatorView(
           label: new TabLabel(icon: "action/${icon_name}"),
-          builder: (BuildContext context) => _buildContent(icon_name)
+          child: _buildContent(icon_name)
         );
       });
     return _buildTabNavigator(n, views.toList(), const ValueKey<String>('iconLabelsTabNavigator'));
@@ -58,15 +58,15 @@ class TabbedNavigatorAppState extends State<TabbedNavigatorApp> {
     List<TabNavigatorView> views = <TabNavigatorView>[
       new TabNavigatorView(
         label: const TabLabel(text: 'STOCKS', icon: 'action/list'),
-        builder: (BuildContext context) => _buildContent("Stocks")
+        child: _buildContent("Stocks")
       ),
       new TabNavigatorView(
         label: const TabLabel(text: 'PORTFOLIO', icon: 'action/account_circle'),
-        builder: (BuildContext context) => _buildContent("Portfolio")
+        child: _buildContent("Portfolio")
       ),
       new TabNavigatorView(
         label: const TabLabel(text: 'SUMMARY', icon: 'action/assessment'),
-        builder: (BuildContext context) => _buildContent("Summary")
+        child: _buildContent("Summary")
       )
     ];
     return _buildTabNavigator(n, views, const ValueKey<String>('textAndIconLabelsTabNavigator'));
@@ -88,7 +88,7 @@ class TabbedNavigatorAppState extends State<TabbedNavigatorApp> {
       .map((text) {
         return new TabNavigatorView(
           label: new TabLabel(text: text),
-          builder: (BuildContext context) => _buildContent(text)
+          child: _buildContent(text)
         );
       });
     return _buildTabNavigator(n, views.toList(), const ValueKey<String>('scrollableTabNavigator'), isScrollable: true);
@@ -107,19 +107,19 @@ class TabbedNavigatorAppState extends State<TabbedNavigatorApp> {
     List<TabNavigatorView> views = <TabNavigatorView>[
       new TabNavigatorView(
         label: const TabLabel(text: 'TEXT'),
-        builder: (BuildContext context) => _buildCard(context, _buildTextLabelsTabNavigator(0))
+        child: _buildCard(context, _buildTextLabelsTabNavigator(0))
       ),
       new TabNavigatorView(
         label: const TabLabel(text: 'ICONS'),
-        builder: (BuildContext context) => _buildCard(context, _buildIconLabelsTabNavigator(1))
+        child: _buildCard(context, _buildIconLabelsTabNavigator(1))
       ),
       new TabNavigatorView(
         label: const TabLabel(text: 'BOTH'),
-        builder: (BuildContext context) => _buildCard(context, _buildTextAndIconLabelsTabNavigator(2))
+        child: _buildCard(context, _buildTextAndIconLabelsTabNavigator(2))
       ),
       new TabNavigatorView(
         label: const TabLabel(text: 'SCROLL'),
-        builder: (BuildContext context) => _buildCard(context, _buildScrollableTabNavigator(3))
+        child: _buildCard(context, _buildScrollableTabNavigator(3))
       )
     ];
 

--- a/sky/packages/sky/lib/src/fn3/tabs.dart
+++ b/sky/packages/sky/lib/src/fn3/tabs.dart
@@ -572,17 +572,10 @@ class TabBarState extends ScrollableState<TabBar> {
 }
 
 class TabNavigatorView {
-  TabNavigatorView({ this.label, this.builder });
+  TabNavigatorView({ this.label, this.child });
 
   final TabLabel label;
-  final WidgetBuilder builder;
-
-  Widget buildContent(BuildContext context) {
-    assert(builder != null);
-    Widget content = builder(context);
-    assert(content != null);
-    return content;
-  }
+  final Widget child;
 }
 
 class TabNavigator extends StatelessComponent {
@@ -607,15 +600,14 @@ class TabNavigator extends StatelessComponent {
   Widget build(BuildContext context) {
     assert(views != null && views.isNotEmpty);
     assert(selectedIndex >= 0 && selectedIndex < views.length);
-
-    TabBar tabBar = new TabBar(
-      labels: views.map((view) => view.label),
-      onChanged: _handleSelectedIndexChanged,
-      selectedIndex: selectedIndex,
-      isScrollable: isScrollable
-    );
-
-    Widget content = views[selectedIndex].buildContent(context);
-    return new Column([tabBar, new Flexible(child: content)]);
+    return new Column([
+      new TabBar(
+        labels: views.map((view) => view.label),
+        onChanged: _handleSelectedIndexChanged,
+        selectedIndex: selectedIndex,
+        isScrollable: isScrollable
+      ),
+      new Flexible(child: views[selectedIndex].child)
+    ]);
   }
 }


### PR DESCRIPTION
Previously, TabNavigatorView had a "builder" callback to create the
children. However, it's used by a TabNavigator which is stateless, and
therefore never rebuilds except when it's configuration changes. Thus,
using a builder is pointless. We might as well use an explicit child
widget.

Also while I was at it I made the stocks in the stocks demo clickable.