### PR TITLE
Visualize frame times over the past few seconds in the form of a graph

### DIFF
--- a/sky/compositor/compositor_options.h
+++ b/sky/compositor/compositor_options.h
@@ -16,6 +16,7 @@ class CompositorOptions {
   using OptionType = unsigned int;
   enum class Option : OptionType {
     DisplayFrameStatistics,
+    VisualizeFrameStatistics,
 
     TerminationSentinel,
   };

--- a/sky/compositor/instrumentation.cc
+++ b/sky/compositor/instrumentation.cc
@@ -3,12 +3,66 @@
 // found in the LICENSE file.
 
 #include "sky/compositor/instrumentation.h"
+#include "third_party/skia/include/core/SkPath.h"
 
 namespace sky {
 namespace compositor {
 namespace instrumentation {
 
-//
+static const size_t kMaxSamples = 120;
+
+Stopwatch::Stopwatch()
+    : _start(base::TimeTicks::Now()), _lastLap(), _current_sample(0) {
+  const base::TimeDelta delta;
+  _laps.resize(kMaxSamples, delta);
+}
+
+void Stopwatch::start() {
+  _start = base::TimeTicks::Now();
+  _current_sample = (_current_sample + 1) % kMaxSamples;
+}
+
+void Stopwatch::stop() {
+  _lastLap = base::TimeTicks::Now() - _start;
+  _laps[_current_sample] = _lastLap;
+}
+
+void Stopwatch::visualize(SkCanvas& canvas, const SkRect& rect) const {
+  SkAutoCanvasRestore save(&canvas, false);
+
+  SkPaint paint;
+
+  // Paint the background
+  paint.setColor(0xAAFFFFFF);
+  canvas.drawRect(rect, paint);
+
+  // Paint the graph
+  SkPath path;
+  auto width = rect.width();
+  auto height = rect.height();
+
+  path.moveTo(0, 0);
+  path.lineTo(0, height * (_laps[0].InMillisecondsF() / 16.0));
+  for (size_t i = 0; i < kMaxSamples; i++) {
+    path.lineTo(width * ((double)i / kMaxSamples),
+                height * (_laps[i].InMillisecondsF() / 16.0));
+  }
+  path.lineTo(width, 0);
+  path.lineTo(0, 0);
+  path.close();
+
+  paint.setColor(0xAA0000FF);
+  canvas.drawPath(path, paint);
+
+  // Paint the marker
+  paint.setColor(0xFF00FF00);
+  paint.setStrokeWidth(3);
+  paint.setStyle(SkPaint::Style::kStroke_Style);
+  auto sampleX = width * ((double)_current_sample / kMaxSamples);
+  canvas.drawLine(sampleX, 0, sampleX, height, paint);
+}
+
+Stopwatch::~Stopwatch() = default;
 
 }  // namespace instrumentation
 }  // namespace compositor

--- a/sky/compositor/instrumentation.h
+++ b/sky/compositor/instrumentation.h
@@ -7,6 +7,9 @@
 
 #include "base/macros.h"
 #include "base/time/time.h"
+#include "third_party/skia/include/core/SkCanvas.h"
+
+#include <vector>
 
 namespace sky {
 namespace compositor {
@@ -28,19 +31,24 @@ class Stopwatch {
     DISALLOW_COPY_AND_ASSIGN(ScopedLap);
   };
 
-  explicit Stopwatch() : _start(base::TimeTicks::Now()), _lastLap() {}
+  explicit Stopwatch();
+  ~Stopwatch();
 
   const base::TimeDelta& lastLap() const { return _lastLap; }
 
   base::TimeDelta currentLap() const { return base::TimeTicks::Now() - _start; }
 
-  void start() { _start = base::TimeTicks::Now(); }
+  void visualize(SkCanvas& canvas, const SkRect& rect) const;
 
-  void stop() { _lastLap = base::TimeTicks::Now() - _start; }
+  void start();
+
+  void stop();
 
  private:
   base::TimeTicks _start;
+  std::vector<base::TimeDelta> _laps;
   base::TimeDelta _lastLap;
+  size_t _current_sample;
 
   DISALLOW_COPY_AND_ASSIGN(Stopwatch);
 };

--- a/sky/compositor/statistics_layer.cc
+++ b/sky/compositor/statistics_layer.cc
@@ -23,11 +23,16 @@ static void PaintContext_DrawStatisticsText(SkCanvas& canvas,
 }
 
 void StatisticsLayer::Paint(PaintContext::ScopedFrame& frame) {
-  const int x = 10;
-  int y = 20;
+  const int x = 8;
+  int y = 70;
   static const int kLineSpacing = 18;
 
   const PaintContext& context = frame.context();
+
+  if (options_.isEnabled(CompositorOptions::Option::VisualizeFrameStatistics)) {
+    SkRect visualizationRect = SkRect::MakeWH(paint_bounds().width(), 80);
+    context.frame_time().visualize(frame.canvas(), visualizationRect);
+  }
 
   if (options_.isEnabled(CompositorOptions::Option::DisplayFrameStatistics)) {
     // Frame (2032): 3.26ms


### PR DESCRIPTION
Visualizing the frame times adds a constant overhead to rendering the same. If this is undesirable, you can selectively disable the same. Working on making this faster. For now, the results look like https://www.youtube.com/watch?v=c7EYnaWqUpI&feature=youtu.be