### PR TITLE
Rename Scrollbehavior release() to createFlingScrollSimulation()

### DIFF
--- a/sky/packages/sky/lib/src/animation/scroll_behavior.dart
+++ b/sky/packages/sky/lib/src/animation/scroll_behavior.dart
@@ -14,7 +14,7 @@ const double _kScrollDrag = 0.025;
 abstract class ScrollBehavior {
   /// Called when a drag gesture ends. Returns a simulation that
   /// propels the scrollOffset.
-  Simulation release(double position, double velocity) => null;
+  Simulation createFlingScrollSimulation(double position, double velocity) => null;
 
   /// Called when a drag gesture ends and toSnapOffset is specified.
   /// Returns an animation that ends at the snap offset.
@@ -83,7 +83,7 @@ class UnboundedBehavior extends ExtentScrollBehavior {
   UnboundedBehavior({ double contentExtent: 0.0, double containerExtent: 0.0 })
     : super(contentExtent: contentExtent, containerExtent: containerExtent);
 
-  Simulation release(double position, double velocity) {
+  Simulation createFlingScrollSimulation(double position, double velocity) {
     double velocityPerSecond = velocity * 1000.0;
     return new BoundedFrictionSimulation(
       _kScrollDrag, position, velocityPerSecond, double.NEGATIVE_INFINITY, double.INFINITY
@@ -133,7 +133,7 @@ class OverscrollBehavior extends BoundedBehavior {
   OverscrollBehavior({ double contentExtent: 0.0, double containerExtent: 0.0 })
     : super(contentExtent: contentExtent, containerExtent: containerExtent);
 
-  Simulation release(double position, double velocity) {
+  Simulation createFlingScrollSimulation(double position, double velocity) {
     return _createFlingScrollSimulation(position, velocity, minScrollOffset, maxScrollOffset);
   }
 
@@ -162,9 +162,9 @@ class OverscrollBehavior extends BoundedBehavior {
 class OverscrollWhenScrollableBehavior extends OverscrollBehavior {
   bool get isScrollable => contentExtent > containerExtent;
 
-  Simulation release(double position, double velocity) {
+  Simulation createFlingScrollSimulation(double position, double velocity) {
     if (isScrollable || position < minScrollOffset || position > maxScrollOffset)
-      return super.release(position, velocity);
+      return super.createFlingScrollSimulation(position, velocity);
     return null;
   }
 

--- a/sky/packages/sky/lib/src/fn3/scrollable.dart
+++ b/sky/packages/sky/lib/src/fn3/scrollable.dart
@@ -137,7 +137,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
     _stopAnimations();
 
     if (velocity != null && config.snapOffsetCallback != null && _scrollOffsetIsInBounds(scrollOffset)) {
-      Simulation simulation = scrollBehavior.release(scrollOffset, velocity);
+      Simulation simulation = scrollBehavior.createFlingScrollSimulation(scrollOffset, velocity);
       if (simulation == null)
         return;
       double endScrollOffset = simulation.x(double.INFINITY);
@@ -152,7 +152,7 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
       }
     }
 
-    Simulation simulation = scrollBehavior.release(scrollOffset, velocity ?? 0.0);
+    Simulation simulation = scrollBehavior.createFlingScrollSimulation(scrollOffset, velocity ?? 0.0);
     if (simulation == null)
       return;
     _toEndAnimation.start(simulation);

--- a/sky/packages/sky/lib/src/widgets/tabs.dart
+++ b/sky/packages/sky/lib/src/widgets/tabs.dart
@@ -367,7 +367,7 @@ class _TabsScrollBehavior extends BoundedBehavior {
 
   bool isScrollable = true;
 
-  Simulation release(double position, double velocity) {
+  Simulation createFlingScrollSimulation(double position, double velocity) {
     if (!isScrollable)
       return null;
 


### PR DESCRIPTION
The original name was consistent with the pre-Newton particle simulation but it's become somewhat obscure.