### PR TITLE
Change OverflowBox API to allow min and max values

### DIFF
--- a/sky/packages/sky/lib/src/fn3/basic.dart
+++ b/sky/packages/sky/lib/src/fn3/basic.dart
@@ -230,20 +230,26 @@ class SizedBox extends OneChildRenderObjectWidget {
 }
 
 class OverflowBox extends OneChildRenderObjectWidget {
-  OverflowBox({ Key key, this.width, this.height, Widget child })
+  OverflowBox({ Key key, this.minWidth, this.maxWidth, this.minHeight, this.maxHeight, Widget child })
     : super(key: key, child: child);
 
-  final double width;
-  final double height;
+  final double minWidth;
+  final double maxWidth;
+  final double minHeight;
+  final double maxHeight;
 
   RenderOverflowBox createRenderObject() => new RenderOverflowBox(
-    innerWidth: width,
-    innerHeight: height
+    minWidth: minWidth,
+    maxWidth: maxWidth,
+    minHeight: minHeight,
+    maxHeight: maxHeight
   );
 
   void updateRenderObject(RenderOverflowBox renderObject, OverflowBox oldWidget) {
-    renderObject.innerWidth = width;
-    renderObject.innerHeight = height;
+    renderObject.minWidth = minWidth;
+    renderObject.maxWidth = maxWidth;
+    renderObject.minHeight = minHeight;
+    renderObject.maxHeight = maxHeight;
   }
 }
 

--- a/sky/packages/sky/lib/src/fn3/editable_text.dart
+++ b/sky/packages/sky/lib/src/fn3/editable_text.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:sky' as sky;
 
 import 'package:mojo_services/keyboard/keyboard.mojom.dart';
 import 'package:sky/painting.dart';

--- a/sky/packages/sky/lib/src/fn3/snack_bar.dart
+++ b/sky/packages/sky/lib/src/fn3/snack_bar.dart
@@ -90,7 +90,8 @@ class SnackBarState extends AnimatedState<SnackBar> {
       ),
       child: new ClipRect(
         child: new OverflowBox(
-          height: kSnackHeight,
+          minHeight: kSnackHeight,
+          maxHeight: kSnackHeight,
           child: new Material(
             level: 2,
             color: kSnackBackground,

--- a/sky/packages/sky/lib/src/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/src/rendering/proxy_box.dart
@@ -150,57 +150,81 @@ class RenderConstrainedBox extends RenderProxyBox {
 ///
 /// A render overflow box proxies most functions in the render box protocol to
 /// its child, except that when laying out its child, it passes constraints
-/// based on the innerWidth and innerHeight fields instead of just passing the
-/// parent's constraints in. It then sizes itself based on the parent's
-/// constraints' maxWidth and maxHeight, ignoring the child's dimensions.
+/// based on the minWidth, maxWidth, minHeight, and maxHeight fields instead of
+/// just passing the parent's constraints in. Specifically, it overrides any of
+/// the equivalent fields on the constraints given by the parent with the
+/// constraints given by these fields for each such field that is not null. It
+/// then sizes itself based on the parent's constraints' maxWidth and maxHeight,
+/// ignoring the child's dimensions.
 ///
-/// For example, if you wanted a box to always render 50x50, regardless of where
-/// it was rendered, you would wrap it in a RenderOverflow with innerWidth and
-/// innerHeight members set to 50.0. Generally speaking, to avoid confusing
+/// For example, if you wanted a box to always render 50 pixels high, regardless
+/// of where it was rendered, you would wrap it in a RenderOverflow with
+/// minHeight and maxHeight set to 50.0. Generally speaking, to avoid confusing
 /// behaviour around hit testing, a RenderOverflowBox should usually be wrapped
 /// in a RenderClipRect.
 ///
 /// The child is positioned at the top left of the box. To position a smaller
 /// child inside a larger parent, use [RenderPositionedBox] and
 /// [RenderConstrainedBox] rather than RenderOverflowBox.
-///
-/// If you pass null for innerWidth or innerHeight, the constraints from the
-/// parent are passed instead.
 class RenderOverflowBox extends RenderProxyBox {
   RenderOverflowBox({
     RenderBox child,
-    double innerWidth,
-    double innerHeight
-  }) : _innerWidth = innerWidth, _innerHeight = innerHeight, super(child);
+    double minWidth,
+    double maxWidth,
+    double minHeight,
+    double maxHeight
+  }) : _minWidth = minWidth, _maxWidth = maxWidth, _minHeight = minHeight, _maxHeight = maxHeight, super(child);
 
-  /// The tight width constraint to give the child. Set this to null (the
-  /// default) to use the constraints from the parent instead.
-  double get innerWidth => _innerWidth;
-  double _innerWidth;
-  void set innerWidth (double value) {
-    if (_innerWidth == value)
+  /// The minimum width constraint to give the child. Set this to null (the
+  /// default) to use the constraint from the parent instead.
+  double get minWidth => _minWidth;
+  double _minWidth;
+  void set minWidth (double value) {
+    if (_minWidth == value)
       return;
-    _innerWidth = value;
+    _minWidth = value;
     markNeedsLayout();
   }
 
-  /// The tight height constraint to give the child. Set this to null (the
-  /// default) to use the constraints from the parent instead.
-  double get innerHeight => _innerHeight;
-  double _innerHeight;
-  void set innerHeight (double value) {
-    if (_innerHeight == value)
+  /// The maximum width constraint to give the child. Set this to null (the
+  /// default) to use the constraint from the parent instead.
+  double get maxWidth => _maxWidth;
+  double _maxWidth;
+  void set maxWidth (double value) {
+    if (_maxWidth == value)
       return;
-    _innerHeight = value;
+    _maxWidth = value;
+    markNeedsLayout();
+  }
+
+  /// The minimum height constraint to give the child. Set this to null (the
+  /// default) to use the constraint from the parent instead.
+  double get minHeight => _minHeight;
+  double _minHeight;
+  void set minHeight (double value) {
+    if (_minHeight == value)
+      return;
+    _minHeight = value;
+    markNeedsLayout();
+  }
+
+  /// The maximum height constraint to give the child. Set this to null (the
+  /// default) to use the constraint from the parent instead.
+  double get maxHeight => _maxHeight;
+  double _maxHeight;
+  void set maxHeight (double value) {
+    if (_maxHeight == value)
+      return;
+    _maxHeight = value;
     markNeedsLayout();
   }
 
   BoxConstraints childConstraints(BoxConstraints constraints) {
     return new BoxConstraints(
-      minWidth: _innerWidth ?? constraints.minWidth,
-      maxWidth: _innerWidth ?? constraints.maxWidth,
-      minHeight: _innerHeight ?? constraints.minHeight,
-      maxHeight: _innerHeight ?? constraints.maxHeight
+      minWidth: _minWidth ?? constraints.minWidth,
+      maxWidth: _maxWidth ?? constraints.maxWidth,
+      minHeight: _minHeight ?? constraints.minHeight,
+      maxHeight: _maxHeight ?? constraints.maxHeight
     );
   }
 
@@ -233,8 +257,10 @@ class RenderOverflowBox extends RenderProxyBox {
 
   String debugDescribeSettings(String prefix) {
     return '${super.debugDescribeSettings(prefix)}' + 
-           '${prefix}innerWidth: ${innerWidth ?? "use parent width constraints"}\n' +
-           '${prefix}innerHeight: ${innerHeight ?? "use parent height constraints"}\n';
+           '${prefix}minWidth: ${minWidth ?? "use parent minWidth constraint"}\n' +
+           '${prefix}maxWidth: ${maxWidth ?? "use parent maxWidth constraint"}\n' +
+           '${prefix}minHeight: ${minHeight ?? "use parent minHeight constraint"}\n' + 
+           '${prefix}maxHeight: ${maxHeight ?? "use parent maxHeight constraint"}\n';
   }
 }
 


### PR DESCRIPTION
Previously OverflowBox was only useful to set a tight constraint on the
child. Now it can be used to set any constraint, it just overrides any
constraint from the parent that is not set to null on the
RenderOverflowBox object when giving the constraints to the child.