### PR TITLE
Remove BuildContext argument to initState

### DIFF
--- a/examples/mine_digger/lib/main.dart
+++ b/examples/mine_digger/lib/main.dart
@@ -54,8 +54,8 @@ class MineDiggerState extends State<MineDigger> {
   // |uiState| keeps track of the visible player progess.
   List<List<CellState>> uiState;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     resetGame();
   }
 

--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -34,8 +34,8 @@ class StocksAppState extends State<StocksApp> {
   final Map<String, Stock> _stocks = <String, Stock>{};
   final List<String> _symbols = <String>[];
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     new StockDataFetcher((StockData data) {
       setState(() {
         data.appendTo(_stocks, _symbols);

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -65,8 +65,8 @@ class CardCollectionAppState extends State<CardCollectionApp> {
       _initVariableSizedCardModels();
   }
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _initCardModels();
   }
 
@@ -264,7 +264,6 @@ class CardCollectionAppState extends State<CardCollectionApp> {
     })
     .toList();
 
-    double offset;
     for (int i = 0; i <  cumulativeHeights.length; i++) {
       if (cumulativeHeights[i] >= scrollOffset)
         return 12.0 + (margins + _cardModels[i].height) / 2.0 + ((i == 0) ? 0.0 : cumulativeHeights[i - 1]);

--- a/examples/widgets/date_picker.dart
+++ b/examples/widgets/date_picker.dart
@@ -12,8 +12,8 @@ class DatePickerDemo extends StatefulComponent {
 }
 
 class DatePickerDemoState extends State<DatePickerDemo> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     DateTime now = new DateTime.now();
     _dateTime = new DateTime(now.year, now.month, now.day);
   }

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -21,8 +21,8 @@ class PageableListApp extends StatefulComponent {
 }
 
 class PageableListAppState extends State<PageableListApp> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     List<Size> cardSizes = [
       [100.0, 300.0], [300.0, 100.0], [200.0, 400.0], [400.0, 400.0], [300.0, 400.0]
     ]

--- a/examples/widgets/progress_indicator.dart
+++ b/examples/widgets/progress_indicator.dart
@@ -11,8 +11,8 @@ class ProgressIndicatorApp extends StatefulComponent {
 }
 
 class ProgressIndicatorAppState extends State<ProgressIndicatorApp> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     valueAnimation = new ValueAnimation<double>()
       ..duration = const Duration(milliseconds: 1500)
       ..variable = new AnimatedValue<double>(

--- a/examples/widgets/scale.dart
+++ b/examples/widgets/scale.dart
@@ -11,8 +11,8 @@ class ScaleApp extends StatefulComponent {
 }
 
 class ScaleAppState extends State<ScaleApp> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _offset = Offset.zero;
     _zoom = 1.0;
   }

--- a/examples/widgets/styled_text.dart
+++ b/examples/widgets/styled_text.dart
@@ -11,8 +11,8 @@ class StyledTextApp extends StatefulComponent {
 }
 
 class StyledTextAppState extends State<StyledTextApp> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     toText = toStyledText;
     nameLines = dialogText
       .split('\n')

--- a/sky/packages/sky/lib/src/fn3/animated_component.dart
+++ b/sky/packages/sky/lib/src/fn3/animated_component.dart
@@ -13,8 +13,8 @@ abstract class AnimatedComponent extends StatefulComponent {
 }
 
 abstract class AnimatedState<T extends AnimatedComponent> extends State<T> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _performance = new AnimationPerformance(duration: config.duration);
     performance.addStatusListener(_handleAnimationStatusChanged);
     if (buildDependsOnPerformance) {

--- a/sky/packages/sky/lib/src/fn3/app.dart
+++ b/sky/packages/sky/lib/src/fn3/app.dart
@@ -46,8 +46,8 @@ class AppState extends State<App> {
 
   GlobalObjectKey _navigator;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _navigator = new GlobalObjectKey(this);
     WidgetFlutterBinding.instance.addEventListener(_backHandler);
   }

--- a/sky/packages/sky/lib/src/fn3/basic.dart
+++ b/sky/packages/sky/lib/src/fn3/basic.dart
@@ -754,8 +754,8 @@ class ImageListener extends StatefulComponent {
 }
 
 class ImageListenerState extends State<ImageListener> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     config.image.addListener(_handleImageChanged);
   }
 

--- a/sky/packages/sky/lib/src/fn3/date_picker.dart
+++ b/sky/packages/sky/lib/src/fn3/date_picker.dart
@@ -294,8 +294,8 @@ class MonthPicker extends ScrollableWidgetList {
 }
 
 class MonthPickerState extends ScrollableWidgetListState<MonthPicker> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _updateCurrentDate();
   }
 

--- a/sky/packages/sky/lib/src/fn3/dismissable.dart
+++ b/sky/packages/sky/lib/src/fn3/dismissable.dart
@@ -48,8 +48,8 @@ class Dismissable extends StatefulComponent {
 }
 
 class DismissableState extends State<Dismissable> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _fadePerformance = new AnimationPerformance(duration: _kCardDismissFadeout);
     _fadePerformance.addStatusListener((AnimationStatus status) {
       if (status == AnimationStatus.completed)

--- a/sky/packages/sky/lib/src/fn3/drawer.dart
+++ b/sky/packages/sky/lib/src/fn3/drawer.dart
@@ -57,8 +57,8 @@ class Drawer extends StatefulComponent {
 }
 
 class DrawerState extends State<Drawer> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _performance = new AnimationPerformance(duration: _kBaseSettleDuration);
     _performance.addStatusListener((AnimationStatus status) {
       if (status == AnimationStatus.dismissed)

--- a/sky/packages/sky/lib/src/fn3/focus.dart
+++ b/sky/packages/sky/lib/src/fn3/focus.dart
@@ -152,8 +152,8 @@ class FocusState extends State<Focus> {
     }
   }
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     if (config.autofocus)
       FocusState._moveScopeTo(context, config);
     _updateWidgetRemovalListener(_focusedWidget);

--- a/sky/packages/sky/lib/src/fn3/framework.dart
+++ b/sky/packages/sky/lib/src/fn3/framework.dart
@@ -306,8 +306,8 @@ abstract class State<T extends StatefulComponent> {
   /// object was inserted into the tree or on the widget configuration object.
   ///
   /// If you override this, make sure your method starts with a call to
-  /// super.initState(context).
-  void initState(BuildContext context) {
+  /// super.initState().
+  void initState() {
     assert(_debugLifecycleState == _StateLifecycle.created);
     assert(() { _debugLifecycleState = _StateLifecycle.initialized; return true; });
   }
@@ -834,7 +834,7 @@ class StatefulComponentElement extends BuildableElement<StatefulComponent> {
     assert(_state._debugLifecycleState == _StateLifecycle.created);
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
-      _state.initState(this);
+      _state.initState();
     } finally {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(false);
     }

--- a/sky/packages/sky/lib/src/fn3/gesture_detector.dart
+++ b/sky/packages/sky/lib/src/fn3/gesture_detector.dart
@@ -55,8 +55,8 @@ class GestureDetector extends StatefulComponent {
 }
 
 class GestureDetectorState extends State<GestureDetector> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     didUpdateConfig(null);
   }
 

--- a/sky/packages/sky/lib/src/fn3/input.dart
+++ b/sky/packages/sky/lib/src/fn3/input.dart
@@ -50,8 +50,8 @@ class InputState extends ScrollableState<Input> {
   double _contentWidth = 0.0;
   double _containerWidth = 0.0;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _value = config.initialValue;
     _editableValue = new EditableString(
       text: _value,

--- a/sky/packages/sky/lib/src/fn3/navigator.dart
+++ b/sky/packages/sky/lib/src/fn3/navigator.dart
@@ -39,8 +39,8 @@ class NavigatorState extends State<Navigator> {
   Route get currentRoute => _history[_currentPosition];
   bool get hasPreviousRoute => _history.length > 1;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     PageRoute route = new PageRoute(config.routes['/']);
     assert(route != null);
     assert(!route.ephemeral);
@@ -187,7 +187,7 @@ abstract class Route {
   /// ephemeral, modal, and opaque are ignored. This is useful if the route
   /// represents some state handled by another widget. See
   /// NavigatorState.pushState().
-  /// 
+  ///
   /// Set hasContent to false if you have nothing useful to return from build().
   ///
   /// modal must be false if hasContent is false, since otherwise any
@@ -229,7 +229,7 @@ abstract class Route {
   /// Set this to true if there's no reason to build and paint the route behind
   /// you when your transition is finished, and set it to false if you do not
   /// cover the entire application surface or are in any way semi-transparent.
-  bool get opaque => false; 
+  bool get opaque => false;
 
   /// If this is set to a non-zero [Duration], then an [AnimationPerformance]
   /// object, available via the performance field, will be created when the

--- a/sky/packages/sky/lib/src/fn3/popup_menu.dart
+++ b/sky/packages/sky/lib/src/fn3/popup_menu.dart
@@ -50,8 +50,8 @@ class PopupMenu extends StatefulComponent {
 }
 
 class PopupMenuState extends State<PopupMenu> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     config.performance.addListener(_performanceChanged);
   }
 

--- a/sky/packages/sky/lib/src/fn3/progress_indicator.dart
+++ b/sky/packages/sky/lib/src/fn3/progress_indicator.dart
@@ -35,8 +35,8 @@ abstract class ProgressIndicator extends StatefulComponent {
 }
 
 class ProgressIndicatorState extends State<ProgressIndicator> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _performance = new AnimationPerformance()
       ..duration = const Duration(milliseconds: 1500)
       ..variable = new AnimatedValue<double>(0.0, end: 1.0, curve: ease);

--- a/sky/packages/sky/lib/src/fn3/scrollable.dart
+++ b/sky/packages/sky/lib/src/fn3/scrollable.dart
@@ -47,8 +47,8 @@ abstract class Scrollable extends StatefulComponent {
 }
 
 abstract class ScrollableState<T extends Scrollable> extends State<T> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     if (config.initialScrollOffset is double)
       _scrollOffset = config.initialScrollOffset;
     _toEndAnimation = new AnimatedSimulation(_setScrollOffset);
@@ -672,8 +672,8 @@ class ScrollableMixedWidgetList extends Scrollable {
 }
 
 class ScrollableMixedWidgetListState extends ScrollableState<ScrollableMixedWidgetList> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     scrollBehavior.updateExtents(
       contentExtent: double.INFINITY
     );

--- a/sky/packages/sky/lib/src/fn3/tabs.dart
+++ b/sky/packages/sky/lib/src/fn3/tabs.dart
@@ -401,8 +401,8 @@ class TabBar extends Scrollable {
 }
 
 class TabBarState extends ScrollableState<TabBar> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _indicatorAnimation = new ValueAnimation<Rect>()
       ..duration = _kTabBarScroll
       ..variable = new AnimatedRect(null, curve: ease);

--- a/sky/packages/sky/lib/src/fn3/transitions.dart
+++ b/sky/packages/sky/lib/src/fn3/transitions.dart
@@ -25,8 +25,8 @@ abstract class TransitionComponent extends StatefulComponent {
 }
 
 class TransitionState extends State<TransitionComponent> {
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     config.performance.addListener(_performanceChanged);
   }
 

--- a/sky/unit/test/widget/build_scope_test.dart
+++ b/sky/unit/test/widget/build_scope_test.dart
@@ -11,8 +11,8 @@ class ProbeWidget extends StatefulComponent {
 class ProbeWidgetState extends State<ProbeWidget> {
   static int buildCount = 0;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     setState(() {});
   }
 

--- a/sky/unit/test/widget/scrollable_list_hit_testing_test.dart
+++ b/sky/unit/test/widget/scrollable_list_hit_testing_test.dart
@@ -1,4 +1,3 @@
-import 'package:quiver/testing/async.dart';
 import 'package:sky/rendering.dart';
 import 'package:sky/src/fn3.dart';
 import 'package:test/test.dart';
@@ -7,10 +6,6 @@ import '../fn3/widget_tester.dart';
 
 const List<int> items = const <int>[0, 1, 2, 3, 4, 5];
 List<int> tapped = <int>[];
-
-Widget buildFrame() {
-  return ;
-}
 
 void main() {
   double t = 0.0;

--- a/sky/unit/test/widget/scrollable_list_horizontal_test.dart
+++ b/sky/unit/test/widget/scrollable_list_horizontal_test.dart
@@ -1,4 +1,3 @@
-import 'package:quiver/testing/async.dart';
 import 'package:sky/rendering.dart';
 import 'package:sky/src/fn3.dart';
 import 'package:test/test.dart';

--- a/sky/unit/test/widget/scrollable_list_vertical_test.dart
+++ b/sky/unit/test/widget/scrollable_list_vertical_test.dart
@@ -1,4 +1,3 @@
-import 'package:quiver/testing/async.dart';
 import 'package:sky/src/fn3.dart';
 import 'package:test/test.dart';
 

--- a/sky/unit/test/widget/set_state_3_test.dart
+++ b/sky/unit/test/widget/set_state_3_test.dart
@@ -20,8 +20,8 @@ class Changer extends StatefulComponent {
 class ChangerState extends State<Changer> {
   bool _state = false;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     changer = this;
   }
 

--- a/sky/unit/test/widget/stateful_components_test.dart
+++ b/sky/unit/test/widget/stateful_components_test.dart
@@ -11,8 +11,8 @@ class InnerComponent extends StatefulComponent {
 class InnerComponentState extends State<InnerComponent> {
   bool _didInitState = false;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     _didInitState = true;
   }
 

--- a/sky/unit/test/widget/syncing_test.dart
+++ b/sky/unit/test/widget/syncing_test.dart
@@ -18,8 +18,8 @@ class TestWidgetState extends State<TestWidget> {
   int syncedState;
   int updates = 0;
 
-  void initState(BuildContext context) {
-    super.initState(context);
+  void initState() {
+    super.initState();
     persistentState = config.persistentState;
     syncedState = config.syncedState;
   }


### PR DESCRIPTION
This argument isn't needed anymore now that State has a getter for context.