### PR TITLE
Simplify AnimationPerformance

### DIFF
--- a/sky/packages/sky/lib/src/fn3/checkbox.dart
+++ b/sky/packages/sky/lib/src/fn3/checkbox.dart
@@ -131,7 +131,7 @@ class _RenderCheckbox extends RenderToggleable {
       ..color = uncheckedColor;
 
     // The rrect contracts slightly during the animation
-    double inset = 2.0 - (position.value - _kMidpoint).abs() * 2.0;
+    double inset = 2.0 - (position - _kMidpoint).abs() * 2.0;
     sky.Rect rect = new sky.Rect.fromLTWH(offset.dx + inset, offset.dy + inset,
         _kEdgeSize - inset, _kEdgeSize - inset);
     sky.RRect rrect = new sky.RRect()
@@ -142,19 +142,19 @@ class _RenderCheckbox extends RenderToggleable {
     canvas.drawRRect(rrect, paint);
 
     // Radial gradient that changes size
-    if (position.value > 0) {
+    if (position > 0) {
       paint.setStyle(sky.PaintingStyle.fill);
       paint.setShader(new sky.Gradient.radial(
           new Point(_kEdgeSize / 2.0, _kEdgeSize / 2.0),
-          _kEdgeSize * (_kMidpoint - position.value) * 8.0, [
+          _kEdgeSize * (_kMidpoint - position) * 8.0, [
         const sky.Color(0x00000000),
         uncheckedColor
       ]));
       canvas.drawRRect(rrect, paint);
     }
 
-    if (position.value > _kMidpoint) {
-      double t = (position.value - _kMidpoint) / (1.0 - _kMidpoint);
+    if (position > _kMidpoint) {
+      double t = (position - _kMidpoint) / (1.0 - _kMidpoint);
 
       // Solid filled rrect
       paint.setStyle(sky.PaintingStyle.strokeAndFill);

--- a/sky/packages/sky/lib/src/fn3/ink_well.dart
+++ b/sky/packages/sky/lib/src/fn3/ink_well.dart
@@ -30,11 +30,11 @@ class InkSplash {
     _radius = new AnimatedValue<double>(
         _kSplashInitialSize, end: _targetRadius, curve: easeOut);
 
-    _performance = new AnimationPerformance()
-      ..variable = _radius
-      ..duration = new Duration(milliseconds: (_targetRadius / _kSplashUnconfirmedVelocity).floor())
-      ..addListener(_handleRadiusChange)
-      ..play();
+    _performance = new ValueAnimation<double>(
+      variable: _radius,
+      duration: new Duration(milliseconds: (_targetRadius / _kSplashUnconfirmedVelocity).floor())
+    )..addListener(_handleRadiusChange)
+     ..play();
   }
 
   final int pointer;

--- a/sky/packages/sky/lib/src/fn3/progress_indicator.dart
+++ b/sky/packages/sky/lib/src/fn3/progress_indicator.dart
@@ -35,20 +35,21 @@ abstract class ProgressIndicator extends StatefulComponent {
 }
 
 class ProgressIndicatorState extends State<ProgressIndicator> {
+
+  ValueAnimation<double> _performance;
+
   void initState() {
     super.initState();
-    _performance = new AnimationPerformance()
-      ..duration = const Duration(milliseconds: 1500)
-      ..variable = new AnimatedValue<double>(0.0, end: 1.0, curve: ease);
+    _performance = new ValueAnimation<double>(
+      variable: new AnimatedValue<double>(0.0, end: 1.0, curve: ease),
+      duration: const Duration(milliseconds: 1500)
+    );
     _performance.addStatusListener((AnimationStatus status) {
       if (status == AnimationStatus.completed)
         _restartAnimation();
     });
     _performance.play();
   }
-
-  AnimationPerformance _performance;
-  double get _performanceValue => (_performance.variable as AnimatedValue<double>).value;
 
   void _restartAnimation() {
     _performance.progress = 0.0;
@@ -57,13 +58,13 @@ class ProgressIndicatorState extends State<ProgressIndicator> {
 
   Widget build(BuildContext context) {
     if (config.value != null)
-      return config._buildIndicator(context, _performanceValue);
+      return config._buildIndicator(context, _performance.value);
 
     return new BuilderTransition(
       variables: [_performance.variable],
       performance: _performance.view,
       builder: (BuildContext context) {
-        return config._buildIndicator(context, _performanceValue);
+        return config._buildIndicator(context, _performance.value);
       }
     );
   }

--- a/sky/packages/sky/lib/src/fn3/switch.dart
+++ b/sky/packages/sky/lib/src/fn3/switch.dart
@@ -97,9 +97,9 @@ class _RenderSwitch extends RenderToggleable {
     _radialReaction = new RadialReaction(
       center: new Point(_kSwitchSize.width / 2.0, _kSwitchSize.height / 2.0),
       radius: _kReactionRadius,
-      startPosition: startLocation)
-      ..addListener(markNeedsPaint)
-      ..show();
+      startPosition: startLocation
+    )..addListener(markNeedsPaint)
+     ..show();
   }
 
   Future _hideRadialReaction() async {
@@ -140,10 +140,10 @@ class _RenderSwitch extends RenderToggleable {
     paint.drawLooper = builder.build();
 
     // The thumb contracts slightly during the animation
-    double inset = 2.0 - (position.value - 0.5).abs() * 2.0;
+    double inset = 2.0 - (position - 0.5).abs() * 2.0;
     Point thumbPos = new Point(offset.dx +
             _kTrackRadius +
-            position.value * (_kTrackWidth - _kTrackRadius * 2),
+            position * (_kTrackWidth - _kTrackRadius * 2),
         offset.dy + _kSwitchHeight / 2.0);
     canvas.drawCircle(thumbPos, _kThumbRadius - inset, paint);
   }

--- a/sky/packages/sky/lib/src/painting/radial_reaction.dart
+++ b/sky/packages/sky/lib/src/painting/radial_reaction.dart
@@ -30,16 +30,16 @@ class RadialReaction {
     _outerOpacity = new AnimatedValue<double>(0.0, end: _kMaxOpacity, curve: easeOut);
     _innerCenter = new AnimatedValue<Point>(startPosition, end: center, curve: easeOut);
     _innerRadius = new AnimatedValue<double>(0.0, end: radius, curve: easeOut);
-    _showPerformance = new AnimationPerformance()
-      ..addVariable(_outerOpacity)
-      ..addVariable(_innerCenter)
-      ..addVariable(_innerRadius)
-      ..duration = _kShowDuration;
-
-    _fade = new AnimatedValue(1.0, end: 0.0, curve: easeIn);
-    _hidePerformance = new AnimationPerformance()
-      ..addVariable(_fade)
-      ..duration =_kHideDuration;
+    _showPerformance = new AnimationPerformance(duration: _kShowDuration)
+      ..addListener(() {
+        _showPerformance.updateVariable(_outerOpacity);
+        _showPerformance.updateVariable(_innerCenter);
+        _showPerformance.updateVariable(_innerRadius);
+      });
+    _fade = new ValueAnimation<double>(
+      variable: new AnimatedValue(1.0, end: 0.0, curve: easeIn),
+      duration: _kHideDuration
+    );
   }
 
   /// The center of the circle in which the reaction occurs
@@ -55,8 +55,7 @@ class RadialReaction {
 
   Future _showComplete;
 
-  AnimationPerformance _hidePerformance;
-  AnimatedValue<double> _fade;
+  ValueAnimation<double> _fade;
 
   /// Show the reaction
   ///
@@ -70,13 +69,13 @@ class RadialReaction {
   /// Returns a future that resolves when the reaction is completely hidden.
   Future hide() async {
     await _showComplete;
-    await _hidePerformance.forward();
+    await _fade.forward();
   }
 
   /// Call listener whenever the visual appearance of the reaction changes
   void addListener(Function listener) {
     _showPerformance.addListener(listener);
-    _hidePerformance.addListener(listener);
+    _fade.addListener(listener);
   }
 
   final Paint _outerPaint = new Paint();

--- a/sky/packages/sky/lib/src/rendering/toggleable.dart
+++ b/sky/packages/sky/lib/src/rendering/toggleable.dart
@@ -24,12 +24,17 @@ abstract class RenderToggleable extends RenderConstrainedBox {
       : _value = value,
         _onChanged = onChanged,
         super(additionalConstraints: new BoxConstraints.tight(size)) {
-    _performance = new AnimationPerformance()
-      ..variable = _position
-      ..duration = _kToggleDuration
-      ..progress = _value ? 1.0 : 0.0
-      ..addListener(markNeedsPaint);
+    _performance = new ValueAnimation<double>(
+      variable: new AnimatedValue<double>(0.0, end: 1.0, curve: easeIn, reverseCurve: easeOut),
+      duration: _kToggleDuration,
+      progress: _value ? 1.0 : 0.0
+    )..addListener(markNeedsPaint);
   }
+
+  ValueAnimation<double> get performance => _performance;
+  ValueAnimation<double> _performance;
+
+  double get position => _performance.value;
 
   void handleEvent(sky.Event event, BoxHitTestEntry entry) {
     if (event.type == 'pointerdown')
@@ -68,15 +73,7 @@ abstract class RenderToggleable extends RenderConstrainedBox {
 
   ValueChanged get onChanged => _onChanged;
   ValueChanged _onChanged;
-
   void set onChanged(ValueChanged onChanged) {
     _onChanged = onChanged;
   }
-
-  AnimatedValue<double> get position => _position;
-  final AnimatedValue<double> _position =
-      new AnimatedValue<double>(0.0, end: 1.0, curve: easeIn, reverseCurve: easeOut);
-
-  AnimationPerformance get performance => _performance;
-  AnimationPerformance _performance;
 }


### PR DESCRIPTION
AnimationPerformance had some logic for supporting multiple variables
that was hardly ever used. ValueAnimation, a subclass, has logic for
handling a single variable. I've removed the logic for handling
variables from AnimationPerformance in favour of most call sites instead
using ValueAnimation.