### PR TITLE
Rename RouteState to StateRoute

### DIFF
--- a/sky/packages/sky/lib/src/widgets/drawer.dart
+++ b/sky/packages/sky/lib/src/widgets/drawer.dart
@@ -123,8 +123,8 @@ class DrawerState extends State<Drawer> {
 
   void _handleDismissed() {
     if (config.navigator != null &&
-        config.navigator.currentRoute is RouteState &&
-        (config.navigator.currentRoute as RouteState).owner == this) // TODO(ianh): remove cast once analyzer is cleverer
+        config.navigator.currentRoute is StateRoute &&
+        (config.navigator.currentRoute as StateRoute).owner == this) // TODO(ianh): remove cast once analyzer is cleverer
       config.navigator.pop();
     if (config.onDismissed != null)
       config.onDismissed();

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -10,7 +10,7 @@ import 'package:sky/src/widgets/transitions.dart';
 
 typedef Widget RouteBuilder(NavigatorState navigator, Route route);
 typedef RouteBuilder RouteGenerator(String name);
-typedef void RouteStateCallback(RouteState route);
+typedef void StateRouteCallback(StateRoute route);
 typedef void NotificationCallback();
 
 class Navigator extends StatefulComponent {
@@ -48,7 +48,7 @@ class NavigatorState extends State<Navigator> {
   }
 
   void pushState(State owner, Function callback) {
-    push(new RouteState(
+    push(new StateRoute(
       route: currentRoute,
       owner: owner,
       callback: callback
@@ -275,12 +275,12 @@ class PageRoute extends Route {
   }
 }
 
-class RouteState extends Route {
-  RouteState({ this.route, this.owner, this.callback });
+class StateRoute extends Route {
+  StateRoute({ this.route, this.owner, this.callback });
 
   Route route;
   State owner;
-  RouteStateCallback callback;
+  StateRouteCallback callback;
 
   bool get hasContent => false;
   bool get modal => false;


### PR DESCRIPTION
...for consistency with the other Route subclasses:
```
  dialog.dart:      class DialogRoute extends Route
  drag_target.dart: class DragRoute extends Route
  navigator.dart:   class PageRoute extends Route
  navigator.dart:   class StateRoute extends Route
  popup_menu.dart:  class MenuRoute extends Route
```