### PR TITLE
Heroes: Pass next Performance to route builders

### DIFF
--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -899,6 +899,9 @@ class IgnorePointer extends OneChildRenderObjectWidget {
   }
 }
 
+
+// UTILITY NODES
+
 class MetaData extends OneChildRenderObjectWidget {
   MetaData({ Key key, Widget child, this.metaData })
     : super(key: key, child: child);
@@ -910,4 +913,13 @@ class MetaData extends OneChildRenderObjectWidget {
   void updateRenderObject(RenderMetaData renderObject, MetaData oldWidget) {
     renderObject.metaData = metaData;
   }
+}
+
+class KeyedSubtree extends StatelessComponent {
+  KeyedSubtree({ Key key, this.child })
+    : super(key: key);
+
+  final Widget child;
+
+  Widget build(BuildContext context) => child;
 }

--- a/sky/packages/sky/lib/src/widgets/dialog.dart
+++ b/sky/packages/sky/lib/src/widgets/dialog.dart
@@ -140,7 +140,7 @@ class DialogRoute extends Route {
 
   Duration get transitionDuration => _kTransitionDuration;
   bool get opaque => false;
-  Widget build(Key key, NavigatorState navigator) {
+  Widget build(NavigatorState navigator, WatchableAnimationPerformance nextRoutePerformance) {
     return new FadeTransition(
       performance: performance,
       opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: easeOut),

--- a/sky/packages/sky/lib/src/widgets/drag_target.dart
+++ b/sky/packages/sky/lib/src/widgets/drag_target.dart
@@ -5,6 +5,7 @@
 import 'dart:collection';
 import 'dart:sky' as sky;
 
+import 'package:sky/animation.dart';
 import 'package:sky/rendering.dart';
 import 'package:sky/src/widgets/basic.dart';
 import 'package:sky/src/widgets/binding.dart';
@@ -199,10 +200,10 @@ class DragRoute extends Route {
 
   bool get ephemeral => true;
   bool get modal => false;
-
-  Duration get transitionDuration => const Duration();
   bool get opaque => false;
-  Widget build(Key key, NavigatorState navigator) {
+  Duration get transitionDuration => const Duration();
+
+  Widget build(NavigatorState navigator, WatchableAnimationPerformance nextRoutePerformance) {
     return new Positioned(
       left: _lastOffset.dx,
       top: _lastOffset.dy,

--- a/sky/packages/sky/lib/src/widgets/popup_menu.dart
+++ b/sky/packages/sky/lib/src/widgets/popup_menu.dart
@@ -169,10 +169,10 @@ class MenuRoute extends Route {
 
   bool get ephemeral => false; // we could make this true, but then we'd have to use popRoute(), not pop(), in menus
   bool get modal => true;
-
-  Duration get transitionDuration => _kMenuDuration;
   bool get opaque => false;
-  Widget build(Key key, NavigatorState navigator) {
+  Duration get transitionDuration => _kMenuDuration;
+
+  Widget build(NavigatorState navigator, WatchableAnimationPerformance nextRoutePerformance) {
     return new Positioned(
       top: position?.top,
       right: position?.right,
@@ -182,7 +182,6 @@ class MenuRoute extends Route {
         key: new GlobalObjectKey(this),
         autofocus: true,
         child: new PopupMenu(
-          key: key,
           items: builder != null ? builder(navigator) : const <PopupMenuItem>[],
           level: level,
           navigator: navigator,


### PR DESCRIPTION
This is step 1 in making it possible to have hero transitions between
routes. To make it possible for a route to have an "exit" animation when
a new route has been pushed on top of it, we provide the next route's
AnimationPerformance to the build function. It's null if there is no
next route or if the next route has no performance.

Also we move the responsibility for having each route be keyed from the route generators to the navigator, since it turns out all the implementations were getting it wrong or not doing it at all.