### PR TITLE
Regression test for #1215

### DIFF
--- a/sky/packages/sky/lib/src/widgets/framework.dart
+++ b/sky/packages/sky/lib/src/widgets/framework.dart
@@ -181,7 +181,11 @@ abstract class Widget {
   /// Inflates this configuration to a concrete instance.
   Element createElement();
 
-  String toString() => '$runtimeType';
+  String toString() {
+    if (key == null)
+      return '$runtimeType';
+    return '$runtimeType-$key';
+  }
 }
 
 /// RenderObjectWidgets provide the configuration for [RenderObjectElement]s,


### PR DESCRIPTION
I'm not sure this specific incarnation of the test ever crashed, since
the original test depended on user interaction and now works fine, but
just in case, here's a regression test for it so I can close that issue.

This also slightly changes the Widget.toString() output to include the
key since that will make debugging easier.