### PR TITLE
Provide a way to redo a frame.

### DIFF
--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -295,6 +295,7 @@ class CardCollectionAppState extends State<CardCollectionApp> {
   void _updateCardCollectionSize(Size newSize) {
     setState(() {
       _cardCollectionSize = newSize;
+      WidgetFlutterBinding.instance.rebuildAndRelayoutAllOverAgainBeforePainting(this);
     });
   }
 

--- a/examples/widgets/mimic.dart
+++ b/examples/widgets/mimic.dart
@@ -1,0 +1,100 @@
+import 'package:sky/rendering.dart';
+import 'package:sky/widgets.dart';
+
+void main() {
+  runApp(new MimicExample());
+}
+
+class MimicExample extends StatelessComponent {
+  Widget build(BuildContext context) {
+    MimicOverlay mimicOverlay = new MimicOverlay();
+    final stackElements = <Widget>[
+      mimicOverlay,
+      new Block([
+          new Column([
+            createChild(mimicOverlay, new Color(0xFFFFFF00)),
+            createChild(mimicOverlay, new Color(0xFF00FFFF)),
+            createChild(mimicOverlay, new Color(0xFFFF00FF)),
+            createChild(mimicOverlay, new Color(0xFFFF0F0F)),
+            createChild(mimicOverlay, new Color(0xFFFFFFFF)),
+            createChild(mimicOverlay, new Color(0xFF808080)),
+            createChild(mimicOverlay, new Color(0xFFFF0000)),
+            createChild(mimicOverlay, new Color(0xFF00FF00)),
+            createChild(mimicOverlay, new Color(0xFF0000FF))
+          ])
+        ],
+        onScroll: (offset) { mimicOverlay.currentState.scrollerMoved(offset); }
+      )
+    ];
+    return new GestureDetector(onTap: () {
+      mimicOverlay.currentState.setActiveOverlay(null);
+    }, child: new Stack(stackElements));
+  }
+
+  Widget createChild(MimicOverlay mimicOverlay, Color color) {
+    GlobalKey key = new GlobalKey();
+    return new GestureDetector(onTap: () {
+      mimicOverlay.currentState.setActiveOverlay(key);
+    },
+        child: new Mimicable(
+            key: key,
+            child: new Container(
+                width: 100.0,
+                height: 100.0,
+                decoration: new BoxDecoration(backgroundColor: color))));
+  }
+}
+
+class MimicOverlay extends UniqueComponent<MimicOverlayState> {
+  MimicOverlay(): super(key: new GlobalKey());
+  MimicOverlayState createState() => new MimicOverlayState();
+}
+
+class MimicOverlayState extends State<MimicOverlay> {
+  MimicableKey _activeOverlay;
+
+  void setActiveOverlay(GlobalKey mimicableKey) {
+    setState(() {
+      _activeOverlay?.stopMimic();
+      _activeOverlay = null;
+      if (mimicableKey != null) {
+        _activeOverlay =
+            (mimicableKey.currentState as MimicableState).startMimic();
+      }
+    });
+  }
+
+  Rect _getMimicBounds() {
+    Rect globalBounds = _activeOverlay.globalBounds;
+    assert(globalBounds != null);
+
+    return (context.findRenderObject().parent as RenderBox)
+            .globalToLocal(globalBounds.topLeft) &
+        globalBounds.size;
+  }
+
+  bool _scrolled = false;
+  void scrollerMoved(double offset) {
+    setState(() { _scrolled = true; });
+  }
+
+  Widget build(BuildContext context) {
+    if (_activeOverlay != null) {
+      if (_scrolled) {
+        _scrolled = false;
+        WidgetFlutterBinding.instance.rebuildAndRelayoutAllOverAgainBeforePainting(this);
+      }
+      Rect mimicBounds = _getMimicBounds();
+      return new Container(
+          child: new Positioned(
+              left: mimicBounds.left - 100.0,
+              top: mimicBounds.top,
+              child: new SizedBox(
+                  width: mimicBounds.width,
+                  height: mimicBounds.height,
+                  child: new Mimic(original: _activeOverlay))));
+    }
+
+    return new Container(width: 0.0, height: 0.0);
+  }
+}

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -46,6 +46,7 @@ class PageableListAppState extends State<PageableListApp> {
   void updatePageSize(Size newSize) {
     setState(() {
       pageSize = newSize;
+      WidgetFlutterBinding.instance.rebuildAndRelayoutAllOverAgainBeforePainting(this);
     });
   }
 

--- a/sky/packages/sky/lib/src/widgets/dismissable.dart
+++ b/sky/packages/sky/lib/src/widgets/dismissable.dart
@@ -6,9 +6,10 @@ import 'dart:sky' as sky;
 
 import 'package:sky/animation.dart';
 import 'package:sky/src/widgets/basic.dart';
-import 'package:sky/src/widgets/transitions.dart';
+import 'package:sky/src/widgets/binding.dart';
 import 'package:sky/src/widgets/framework.dart';
 import 'package:sky/src/widgets/gesture_detector.dart';
+import 'package:sky/src/widgets/transitions.dart';
 
 const Duration _kCardDismissFadeout = const Duration(milliseconds: 200);
 const Duration _kCardDismissResize = const Duration(milliseconds: 300);
@@ -212,6 +213,7 @@ class DismissableState extends State<Dismissable> {
   void _handleSizeChanged(Size newSize) {
     setState(() {
       _size = new Size.copy(newSize);
+      WidgetFlutterBinding.instance.rebuildAndRelayoutAllOverAgainBeforePainting(this);
     });
   }
 

--- a/sky/packages/sky/lib/src/widgets/mimic.dart
+++ b/sky/packages/sky/lib/src/widgets/mimic.dart
@@ -4,6 +4,7 @@
 
 import 'package:sky/rendering.dart';
 import 'package:sky/src/widgets/basic.dart';
+import 'package:sky/src/widgets/binding.dart';
 import 'package:sky/src/widgets/framework.dart';
 
 class MimicableKey {
@@ -70,6 +71,7 @@ class MimicableState extends State<Mimicable> {
   void _handleSizeChanged(Size size) {
     setState(() {
       _size = size;
+      WidgetFlutterBinding.instance.rebuildAndRelayoutAllOverAgainBeforePainting(this);
     });
   }
 

--- a/sky/packages/sky/lib/src/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/src/widgets/scrollable.dart
@@ -11,6 +11,7 @@ import 'package:sky/animation.dart';
 import 'package:sky/gestures.dart';
 import 'package:sky/rendering.dart';
 import 'package:sky/src/widgets/basic.dart';
+import 'package:sky/src/widgets/binding.dart';
 import 'package:sky/src/widgets/framework.dart';
 import 'package:sky/src/widgets/gesture_detector.dart';
 import 'package:sky/src/widgets/homogeneous_viewport.dart';
@@ -337,12 +338,13 @@ class ScrollableViewportState extends ScrollableState<ScrollableViewport> {
     });
   }
   void _updateScrollBehaviour() {
-    // if you don't call this from build() or syncConstructorArguments(), you must call it from setState().
+    // if you don't call this from build(), you must call it from setState().
     scrollTo(scrollBehavior.updateExtents(
       contentExtent: _childSize,
       containerExtent: _viewportSize,
       scrollOffset: scrollOffset
     ));
+    WidgetFlutterBinding.instance.rebuildAndRelayoutAllOverAgainBeforePainting(this);
   }
 
   Widget buildContent(BuildContext context) {


### PR DESCRIPTION
This is a really expensive API, but some times you just need to spin the
entire frame loop twice in a frame.

There's no runaway protection here. One can come up with contrived
examples where it can legitimately run three or four times in a row, but
abuse of this API will just cripple performance...