### PR TITLE
Convert Drawer to using navigator

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -66,19 +66,14 @@ class FeedFragmentState extends State<FeedFragment> {
   void _handleFitnessModeChange(FitnessMode value) {
     setState(() {
       _fitnessMode = value;
-      _drawerShowing = false;
     });
+    config.navigator.pop();
   }
 
-  Drawer buildDrawer() {
-    if (_drawerStatus == AnimationStatus.dismissed)
-      return null;
-    return new Drawer(
-      showing: _drawerShowing,
-      level: 3,
-      onDismissed: _handleDrawerDismissed,
+  void _showDrawer() {
+    showDrawer(
       navigator: config.navigator,
-      children: [
+      child: new Block([
         new DrawerHeader(child: new Text('Fitness')),
         new DrawerItem(
           icon: 'action/view_list',
@@ -98,24 +93,8 @@ class FeedFragmentState extends State<FeedFragment> {
         new DrawerItem(
           icon: 'action/help',
           child: new Text('Help & Feedback'))
-      ]
+      ])
     );
-  }
-
-  bool _drawerShowing = false;
-  AnimationStatus _drawerStatus = AnimationStatus.dismissed;
-
-  void _handleOpenDrawer() {
-    setState(() {
-      _drawerShowing = true;
-      _drawerStatus = AnimationStatus.forward;
-    });
-  }
-
-  void _handleDrawerDismissed() {
-    setState(() {
-      _drawerStatus = AnimationStatus.dismissed;
-    });
   }
 
   void _handleShowSettings() {
@@ -135,7 +114,7 @@ class FeedFragmentState extends State<FeedFragment> {
     return new ToolBar(
       left: new IconButton(
         icon: "navigation/menu",
-        onPressed: _handleOpenDrawer),
+        onPressed: _showDrawer),
       center: new Text(fitnessModeTitle)
     );
   }
@@ -262,8 +241,7 @@ class FeedFragmentState extends State<FeedFragment> {
       toolbar: buildToolBar(),
       body: buildBody(),
       snackBar: buildSnackBar(),
-      floatingActionButton: buildFloatingActionButton(),
-      drawer: buildDrawer()
+      floatingActionButton: buildFloatingActionButton()
     );
   }
 }

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -56,22 +56,6 @@ class StockHomeState extends State<StockHome> {
     });
   }
 
-  bool _drawerShowing = false;
-  AnimationStatus _drawerStatus = AnimationStatus.dismissed;
-
-  void _handleOpenDrawer() {
-    setState(() {
-      _drawerShowing = true;
-      _drawerStatus = AnimationStatus.forward;
-    });
-  }
-
-  void _handleDrawerDismissed() {
-    setState(() {
-      _drawerStatus = AnimationStatus.dismissed;
-    });
-  }
-
   bool _autorefresh = false;
   void _handleAutorefreshChanged(bool value) {
     setState(() {
@@ -91,16 +75,10 @@ class StockHomeState extends State<StockHome> {
     );
   }
 
-  Drawer buildDrawer() {
-    if (_drawerStatus == AnimationStatus.dismissed)
-      return null;
-    assert(_drawerShowing); // TODO(mpcomplete): this is always true
-    return new Drawer(
-      level: 3,
-      showing: _drawerShowing,
-      onDismissed: _handleDrawerDismissed,
+  void _showDrawer() {
+    showDrawer(
       navigator: config.navigator,
-      children: [
+      child: new Block([
         new DrawerHeader(child: new Text('Stocks')),
         new DrawerItem(
           icon: 'action/assessment',
@@ -141,7 +119,7 @@ class StockHomeState extends State<StockHome> {
         new DrawerItem(
           icon: 'action/help',
           child: new Text('Help & Feedback'))
-     ]
+      ])
     );
   }
 
@@ -154,7 +132,7 @@ class StockHomeState extends State<StockHome> {
     return new ToolBar(
         left: new IconButton(
           icon: "navigation/menu",
-          onPressed: _handleOpenDrawer
+          onPressed: _showDrawer
         ),
         center: new Text('Stocks'),
         right: [
@@ -276,8 +254,7 @@ class StockHomeState extends State<StockHome> {
       toolbar: _isSearching ? buildSearchBar() : buildToolBar(),
       body: buildTabNavigator(),
       snackBar: buildSnackBar(),
-      floatingActionButton: buildFloatingActionButton(),
-      drawer: buildDrawer()
+      floatingActionButton: buildFloatingActionButton()
     );
   }
 }

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -4,7 +4,6 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/animation.dart';
 import 'package:sky/material.dart';
 import 'package:sky/painting.dart';
 import 'package:sky/widgets.dart';
@@ -18,11 +17,15 @@ class CardModel {
   Key get key => new ObjectKey(this);
 }
 
-class CardCollectionApp extends StatefulComponent {
-  CardCollectionAppState createState() => new CardCollectionAppState();
+class CardCollection extends StatefulComponent {
+  CardCollection({ this.navigator });
+
+  final NavigatorState navigator;
+
+  CardCollectionState createState() => new CardCollectionState();
 }
 
-class CardCollectionAppState extends State<CardCollectionApp> {
+class CardCollectionState extends State<CardCollection> {
 
   static const TextStyle cardLabelStyle =
     const TextStyle(color: Colors.white, fontSize: 18.0, fontWeight: bold);
@@ -37,9 +40,7 @@ class CardCollectionAppState extends State<CardCollectionApp> {
   DismissDirection _dismissDirection = DismissDirection.horizontal;
   bool _snapToCenter = false;
   bool _fixedSizeCards = false;
-  bool _drawerShowing = false;
   bool _sunshine = false;
-  AnimationStatus _drawerStatus = AnimationStatus.dismissed;
   InvalidatorCallback _invalidator;
   Size _cardCollectionSize = new Size(200.0, 200.0);
 
@@ -114,17 +115,23 @@ class CardCollectionAppState extends State<CardCollectionApp> {
     }
   }
 
-  void _handleOpenDrawer() {
-    setState(() {
-      _drawerShowing = true;
-      _drawerStatus = AnimationStatus.forward;
-    });
-  }
-
-  void _handleDrawerDismissed() {
-    setState(() {
-      _drawerStatus = AnimationStatus.dismissed;
-    });
+  void _showDrawer() {
+    showDrawer(
+      navigator: config.navigator,
+      child: new IconTheme(
+        data: const IconThemeData(color: IconThemeColor.black),
+        child: new Block([
+          new DrawerHeader(child: new Text('Options')),
+          buildDrawerCheckbox("Snap fling scrolls to center", _snapToCenter, _toggleSnapToCenter),
+          buildDrawerCheckbox("Fixed size cards", _fixedSizeCards, _toggleFixedSizeCards),
+          buildDrawerCheckbox("Let the sun shine", _sunshine, _toggleSunshine),
+          new DrawerDivider(),
+          buildDrawerRadioItem(DismissDirection.horizontal, 'action/code'),
+          buildDrawerRadioItem(DismissDirection.left, 'navigation/arrow_back'),
+          buildDrawerRadioItem(DismissDirection.right, 'navigation/arrow_forward'),
+        ])
+      )
+    );
   }
 
   String _dismissDirectionText(DismissDirection direction) {
@@ -151,65 +158,41 @@ class CardCollectionAppState extends State<CardCollectionApp> {
     });
   }
 
-  _changeDismissDirection(DismissDirection newDismissDirection) {
+  void _changeDismissDirection(DismissDirection newDismissDirection) {
     setState(() {
       _dismissDirection = newDismissDirection;
-      _drawerStatus = AnimationStatus.dismissed;
     });
+    config.navigator.pop();
   }
 
-  Widget buildDrawer() {
-    if (_drawerStatus == AnimationStatus.dismissed)
-      return null;
+  Widget buildDrawerCheckbox(String label, bool value, Function callback) {
+    return new DrawerItem(
+      onPressed: callback,
+      child: new Row([
+        new Flexible(child: new Text(label)),
+        new Checkbox(value: value, onChanged: (_) { callback(); })
+      ])
+    );
+  }
 
-    Widget buildDrawerCheckbox(String label, bool value, Function callback) {
-      return new DrawerItem(
-        onPressed: callback,
-        child: new Row([
-          new Flexible(child: new Text(label)),
-          new Checkbox(value: value, onChanged: (_) { callback(); })
-        ])
-      );
-    }
-
-    Widget buildDrawerRadioItem(DismissDirection direction, String icon) {
-      return new DrawerItem(
-        icon: icon,
-        onPressed: () { _changeDismissDirection(direction); },
-        child: new Row([
-          new Flexible(child: new Text(_dismissDirectionText(direction))),
-          new Radio(
-            value: direction,
-            onChanged: _changeDismissDirection,
-            groupValue: _dismissDirection
-          )
-        ])
-      );
-    }
-
-    return new IconTheme(
-      data: const IconThemeData(color: IconThemeColor.black),
-      child: new Drawer(
-        level: 3,
-        showing: _drawerShowing,
-        onDismissed: _handleDrawerDismissed,
-        children: [
-          new DrawerHeader(child: new Text('Options')),
-          buildDrawerCheckbox("Snap fling scrolls to center", _snapToCenter, _toggleSnapToCenter),
-          buildDrawerCheckbox("Fixed size cards", _fixedSizeCards, _toggleFixedSizeCards),
-          buildDrawerCheckbox("Let the sun shine", _sunshine, _toggleSunshine),
-          new DrawerDivider(),
-          buildDrawerRadioItem(DismissDirection.horizontal, 'action/code'),
-          buildDrawerRadioItem(DismissDirection.left, 'navigation/arrow_back'),
-          buildDrawerRadioItem(DismissDirection.right, 'navigation/arrow_forward'),
-        ]
-      )
+  Widget buildDrawerRadioItem(DismissDirection direction, String icon) {
+    return new DrawerItem(
+      icon: icon,
+      onPressed: () { _changeDismissDirection(direction); },
+      child: new Row([
+        new Flexible(child: new Text(_dismissDirectionText(direction))),
+        new Radio(
+          value: direction,
+          onChanged: _changeDismissDirection,
+          groupValue: _dismissDirection
+        )
+      ])
     );
   }
 
   Widget buildToolBar() {
     return new ToolBar(
-      left: new IconButton(icon: "navigation/menu", onPressed: _handleOpenDrawer),
+      left: new IconButton(icon: "navigation/menu", onPressed: _showDrawer),
       center: new Text('Swipe Away'),
       right: [
         new Text(_dismissDirectionText(_dismissDirection))
@@ -358,24 +341,23 @@ class CardCollectionAppState extends State<CardCollectionApp> {
       body = new Stack([body, indicator]);
     }
 
-    return new Theme(
-      data: new ThemeData(
-        brightness: ThemeBrightness.light,
-        primarySwatch: Colors.blue,
-        accentColor: Colors.redAccent[200]
-      ),
-      child: new Title(
-        title: 'Cards',
-        child: new Scaffold(
-          toolbar: buildToolBar(),
-          drawer: buildDrawer(),
-          body: body
-        )
-      )
+    return new Scaffold(
+      toolbar: buildToolBar(),
+      body: body
     );
   }
 }
 
 void main() {
-  runApp(new CardCollectionApp());
+  runApp(new App(
+    title: 'Cards',
+    theme: new ThemeData(
+      brightness: ThemeBrightness.light,
+      primarySwatch: Colors.blue,
+      accentColor: Colors.redAccent[200]
+    ),
+    routes: {
+      '/': (NavigatorState navigator, Route route) => new CardCollection(navigator: navigator),
+    }
+  ));
 }

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/animation.dart';
 import 'package:sky/material.dart';
 import 'package:sky/painting.dart';
 import 'package:sky/widgets.dart';
@@ -17,6 +16,10 @@ class CardModel {
 }
 
 class PageableListApp extends StatefulComponent {
+  PageableListApp({ this.navigator });
+
+  final NavigatorState navigator;
+
   PageableListAppState createState() => new PageableListAppState();
 }
 
@@ -85,31 +88,10 @@ class PageableListAppState extends State<PageableListApp> {
     });
   }
 
-  bool _drawerShowing = false;
-  AnimationStatus _drawerStatus = AnimationStatus.dismissed;
-
-  void _handleOpenDrawer() {
-    setState(() {
-      _drawerShowing = true;
-      _drawerStatus = AnimationStatus.forward;
-    });
-  }
-
-  void _handleDrawerDismissed() {
-    setState(() {
-      _drawerStatus = AnimationStatus.dismissed;
-    });
-  }
-
-  Drawer buildDrawer() {
-    if (_drawerStatus == AnimationStatus.dismissed)
-      return null;
-
-    return new Drawer(
-      level: 3,
-      showing: _drawerShowing,
-      onDismissed: _handleDrawerDismissed,
-      children: [
+  void _showDrawer() {
+    showDrawer(
+      navigator: config.navigator,
+      child: new Block([
         new DrawerHeader(child: new Text('Options')),
         new DrawerItem(
           icon: 'navigation/more_horiz',
@@ -130,14 +112,13 @@ class PageableListAppState extends State<PageableListApp> {
             new Checkbox(value: itemsWrap)
           ])
         )
-      ]
+      ])
     );
-
   }
 
   Widget buildToolBar() {
     return new ToolBar(
-      left: new IconButton(icon: "navigation/menu", onPressed: _handleOpenDrawer),
+      left: new IconButton(icon: "navigation/menu", onPressed: _showDrawer),
       center: new Text('PageableList'),
       right: [
         new Text(scrollDirection == ScrollDirection.horizontal ? "horizontal" : "vertical")
@@ -167,25 +148,24 @@ class PageableListAppState extends State<PageableListApp> {
   Widget build(BuildContext context) {
     return new IconTheme(
       data: const IconThemeData(color: IconThemeColor.white),
-      child: new Theme(
-        data: new ThemeData(
-          brightness: ThemeBrightness.light,
-          primarySwatch: Colors.blue,
-          accentColor: Colors.redAccent[200]
-        ),
-        child: new Title(
-          title: 'PageableList',
-          child: new Scaffold(
-            drawer: buildDrawer(),
-            toolbar: buildToolBar(),
-            body: buildBody(context)
-          )
-        )
+      child: new Scaffold(
+        toolbar: buildToolBar(),
+        body: buildBody(context)
       )
     );
   }
 }
 
 void main() {
-  runApp(new PageableListApp());
+  runApp(new App(
+    title: 'PageableList',
+    theme: new ThemeData(
+      brightness: ThemeBrightness.light,
+      primarySwatch: Colors.blue,
+      accentColor: Colors.redAccent[200]
+    ),
+    routes: {
+      '/': (NavigatorState navigator, Route route) => new PageableListApp(navigator: navigator),
+    }
+  ));
 }

--- a/sky/packages/sky/lib/src/animation/animation_performance.dart
+++ b/sky/packages/sky/lib/src/animation/animation_performance.dart
@@ -79,9 +79,6 @@ class AnimationPerformance implements WatchableAnimationPerformance {
   /// If non-null, animate with this timing instead of a linear timing
   AnimationTiming timing;
 
-  /// If non-null, animate with this force instead of a zero-to-one timeline.
-  Force attachedForce;
-
   /// The progress of this performance along the timeline
   ///
   /// Note: Setting this value stops the current animation.
@@ -136,12 +133,6 @@ class AnimationPerformance implements WatchableAnimationPerformance {
 
   /// Start running this animation in the most recently direction
   Future resume() {
-    if (attachedForce != null) {
-      return fling(
-        velocity: _direction == Direction.forward ? 1.0 : -1.0,
-        force: attachedForce
-      );
-    }
     return _animateTo(_direction == Direction.forward ? 1.0 : 0.0);
   }
 


### PR DESCRIPTION
This patch converts drawer to using the "openDialog" pattern for managing its
state. Currently, the drawer entrance and exit animation aren't integrated with
the navigator's animation system because the drawer's animations can be stopped
and reversed, which the navigator can't yet understand. That means dismissing
the drawer via the system back button causes the drawer to be removed
instanteously.

Fixes #715