### PR TITLE
ToolBar with a TabBar shouldn't have a shadow

### DIFF
--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -126,22 +126,23 @@ class StockHomeState extends State<StockHome> {
 
   Widget buildToolBar() {
     return new ToolBar(
-        left: new IconButton(
-          icon: "navigation/menu",
-          onPressed: _showDrawer
+      level: 0,
+      left: new IconButton(
+        icon: "navigation/menu",
+        onPressed: _showDrawer
+      ),
+      center: new Text('Stocks'),
+      right: [
+        new IconButton(
+          icon: "action/search",
+          onPressed: _handleSearchBegin
         ),
-        center: new Text('Stocks'),
-        right: [
-          new IconButton(
-            icon: "action/search",
-            onPressed: _handleSearchBegin
-          ),
-          new IconButton(
-            icon: "navigation/more_vert",
-            onPressed: _handleMenuShow
-          )
-        ]
-      );
+        new IconButton(
+          icon: "navigation/more_vert",
+          onPressed: _handleMenuShow
+        )
+      ]
+    );
   }
 
   int selectedTabIndex = 0;

--- a/sky/packages/sky/lib/src/material/constants.dart
+++ b/sky/packages/sky/lib/src/material/constants.dart
@@ -17,7 +17,8 @@ const double kToolBarHeight = 56.0;
 
 const double kMaterialDrawerHeight = 140.0;
 const double kScrollbarSize = 10.0;
-const double kScrollbarFadeDuration = 250.0;
-const double kScrollbarFadeDelay = 300.0;
+const Duration kScrollbarFadeDuration = const Duration(milliseconds: 250);
+const Duration kScrollbarFadeDelay = const Duration(milliseconds: 300);
 const double kFadingEdgeLength = 12.0;
-const double kPressedStateDuration = 64.0;
+const double kPressedStateDuration = 64.0; // units?
+const Duration kThemeChangeDuration = const Duration(milliseconds: 200);

--- a/sky/packages/sky/lib/src/widgets/material.dart
+++ b/sky/packages/sky/lib/src/widgets/material.dart
@@ -67,7 +67,7 @@ class Material extends StatelessComponent {
       style: Theme.of(context).text.body1,
       child: new AnimatedContainer(
         curve: ease,
-        duration: const Duration(milliseconds: 200),
+        duration: kThemeChangeDuration,
         decoration: new BoxDecoration(
           backgroundColor: _getBackgroundColor(context),
           borderRadius: _kEdges[type],

--- a/sky/packages/sky/lib/src/widgets/tool_bar.dart
+++ b/sky/packages/sky/lib/src/widgets/tool_bar.dart
@@ -4,35 +4,36 @@
 
 import 'package:sky/material.dart';
 import 'package:sky/painting.dart';
+import 'package:sky/src/widgets/animated_container.dart';
 import 'package:sky/src/widgets/basic.dart';
 import 'package:sky/src/widgets/framework.dart';
 import 'package:sky/src/widgets/icon.dart';
 import 'package:sky/src/widgets/theme.dart';
-import 'package:sky/src/rendering/flex.dart';
 
 class ToolBar extends StatelessComponent {
-
   ToolBar({
     Key key,
     this.left,
     this.center,
     this.right,
+    this.level: 2,
     this.backgroundColor
   }) : super(key: key);
 
   final Widget left;
   final Widget center;
   final List<Widget> right;
+  final int level;
   final Color backgroundColor;
 
   Widget build(BuildContext context) {
-    Color toolbarColor = backgroundColor;
+    Color color = backgroundColor;
     IconThemeData iconThemeData;
     TextStyle centerStyle = Typography.white.title;
     TextStyle sideStyle = Typography.white.body1;
-    if (toolbarColor == null) {
+    if (color == null) {
       ThemeData themeData = Theme.of(context);
-      toolbarColor = themeData.primaryColor;
+      color = themeData.primaryColor;
       if (themeData.primaryColorBrightness == ThemeBrightness.light) {
         centerStyle = Typography.black.title;
         sideStyle = Typography.black.body2;
@@ -44,11 +45,9 @@ class ToolBar extends StatelessComponent {
 
     List<Widget> children = new List<Widget>();
 
-    // left children
     if (left != null)
       children.add(left);
 
-    // center children (left-aligned, but takes all remaining space)
     children.add(
       new Flexible(
         child: new Padding(
@@ -58,11 +57,16 @@ class ToolBar extends StatelessComponent {
       )
     );
 
-    // right children
     if (right != null)
       children.addAll(right);
 
-    Widget content = new Container(
+    Widget content = new AnimatedContainer(
+      duration: kThemeChangeDuration,
+      padding: new EdgeDims.symmetric(horizontal: 8.0),
+      decoration: new BoxDecoration(
+        backgroundColor: color,
+        boxShadow: level == 0 ? null : shadows[2]
+      ),
       child: new DefaultTextStyle(
         style: sideStyle,
         child: new Column([
@@ -73,11 +77,6 @@ class ToolBar extends StatelessComponent {
           ],
           justifyContent: FlexJustifyContent.end
         )
-      ),
-      padding: new EdgeDims.symmetric(horizontal: 8.0),
-      decoration: new BoxDecoration(
-        backgroundColor: toolbarColor,
-        boxShadow: shadows[2]
       )
     );
 


### PR DESCRIPTION
This patch makes the level of the ToolBar configurable. I've also cleaned up
the Tab code slightly.

For some reason, there's still a hairline between the ToolBar and the TabBar.
We might need to rethink how we draw the background a bit here.

Fixes #1454