### PR TITLE
Remove PopupMenu margin

### DIFF
--- a/examples/stocks/lib/stock_menu.dart
+++ b/examples/stocks/lib/stock_menu.dart
@@ -6,12 +6,14 @@ part of stocks;
 
 enum _MenuItems { autorefresh, autorefreshCheckbox, add, remove }
 
+const double _kMenuMargin = 16.0; // 24.0 on tablet
+
 Future showStockMenu(NavigatorState navigator, { bool autorefresh, ValueChanged onAutorefreshChanged }) async {
   switch (await showMenu(
     navigator: navigator,
     position: new MenuPosition(
-      right: sky.view.paddingRight,
-      top: sky.view.paddingTop
+      right: sky.view.paddingRight + _kMenuMargin,
+      top: sky.view.paddingTop + _kMenuMargin
     ),
     builder: (NavigatorState navigator) {
       return <PopupMenuItem>[

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -63,16 +63,11 @@ class NavigatorState extends State<Navigator> {
   }
 
   void pushNamed(String name) {
-    RouteBuilder builder;
-    if (!config.routes.containsKey(name)) {
+    RouteBuilder generateRoute() {
       assert(config.onGenerateRoute != null);
-      builder = config.onGenerateRoute(name);
-    } else {
-      builder = config.routes[name];
+      return config.onGenerateRoute(name);
     }
-    if (builder == null)
-      builder = config.onUnknownRoute; // 404!
-    assert(builder != null); // 404 getting your 404!
+    RouteBuilder builder = config.routes[name] ?? generateRoute() ?? config.onUnknownRoute;
     push(new PageRoute(builder));
   }
 
@@ -87,7 +82,6 @@ class NavigatorState extends State<Navigator> {
     assert(!_debugCurrentlyHaveRoute(route));
     setState(() {
       while (currentRoute.ephemeral) {
-        assert(currentRoute.ephemeral);
         currentRoute.didPop(null);
         _currentPosition -= 1;
       }

--- a/sky/packages/sky/lib/src/widgets/popup_menu.dart
+++ b/sky/packages/sky/lib/src/widgets/popup_menu.dart
@@ -21,7 +21,6 @@ import 'package:sky/src/widgets/transitions.dart';
 const Duration _kMenuDuration = const Duration(milliseconds: 300);
 const double _kMenuCloseIntervalEnd = 2.0 / 3.0;
 const double _kMenuWidthStep = 56.0;
-const double _kMenuMargin = 16.0; // 24.0 on tablet
 const double _kMenuMinWidth = 2.0 * _kMenuWidthStep;
 const double _kMenuMaxWidth = 5.0 * _kMenuWidthStep;
 const double _kMenuHorizontalPadding = 16.0;
@@ -75,39 +74,36 @@ class PopupMenu extends StatelessComponent {
     return new FadeTransition(
       performance: performance,
       opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, 1.0 / 3.0)),
-      child: new Container(
-        margin: new EdgeDims.all(_kMenuMargin),
-        child: new BuilderTransition(
-          performance: performance,
-          variables: [width, height],
-          builder: (BuildContext context) {
-            return new CustomPaint(
-              callback: (sky.Canvas canvas, Size size) {
-                double widthValue = width.value * size.width;
-                double heightValue = height.value * size.height;
-                painter.paint(canvas, new Rect.fromLTWH(size.width - widthValue, 0.0, widthValue, heightValue));
-              },
-              child: new ConstrainedBox(
-                constraints: new BoxConstraints(
-                  minWidth: _kMenuMinWidth,
-                  maxWidth: _kMenuMaxWidth
-                ),
-                child: new IntrinsicWidth(
-                  stepWidth: _kMenuWidthStep,
-                  child: new ScrollableViewport(
-                    child: new Container(
-                      padding: const EdgeDims.symmetric(
-                        horizontal: _kMenuHorizontalPadding,
-                        vertical: _kMenuVerticalPadding
-                      ),
-                      child: new BlockBody(children)
-                    )
+      child: new BuilderTransition(
+        performance: performance,
+        variables: [width, height],
+        builder: (BuildContext context) {
+          return new CustomPaint(
+            callback: (sky.Canvas canvas, Size size) {
+              double widthValue = width.value * size.width;
+              double heightValue = height.value * size.height;
+              painter.paint(canvas, new Rect.fromLTWH(size.width - widthValue, 0.0, widthValue, heightValue));
+            },
+            child: new ConstrainedBox(
+              constraints: new BoxConstraints(
+                minWidth: _kMenuMinWidth,
+                maxWidth: _kMenuMaxWidth
+              ),
+              child: new IntrinsicWidth(
+                stepWidth: _kMenuWidthStep,
+                child: new ScrollableViewport(
+                  child: new Container(
+                    padding: const EdgeDims.symmetric(
+                      horizontal: _kMenuHorizontalPadding,
+                      vertical: _kMenuVerticalPadding
+                    ),
+                    child: new BlockBody(children)
                   )
                 )
               )
-            );
-          }
-        )
+            )
+          );
+        }
       )
     );
   }


### PR DESCRIPTION
The margins make using showMenu's menuPosition argument difficult and they're not really needed.

I also made a few small gratuitous changes in navigator.dart.
