### PR TITLE
Don't dump stacks when app fails to start

### DIFF
--- a/sky/engine/core/script/dart_controller.cc
+++ b/sky/engine/core/script/dart_controller.cc
@@ -80,8 +80,10 @@ void DartController::DidLoadMainLibrary(String name) {
   CHECK(!LogIfError(Dart_FinalizeLoading(true)));
 
   Dart_Handle library = Dart_LookupLibrary(StringToDart(dart_state(), name));
-  CHECK(!LogIfError(library));
-  CHECK(!DartInvokeAppField(library, ToDart("main"), 0, nullptr));
+  if (LogIfError(library))
+    exit(1);
+  if (DartInvokeAppField(library, ToDart("main"), 0, nullptr))
+    exit(1);
 }
 
 void DartController::DidLoadSnapshot() {


### PR DESCRIPTION
Instead of producing a C++ stack dump when the Dart app fails to start, we just
exit with an error code.