### PR TITLE
HomogeneousViewport support for Theme.of()

### DIFF
--- a/sky/packages/sky/lib/src/material/theme_data.dart
+++ b/sky/packages/sky/lib/src/material/theme_data.dart
@@ -79,4 +79,38 @@ class ThemeData {
   Color get accentColor => _accentColor;
 
   final ThemeBrightness accentColorBrightness;
+
+  bool operator==(Object other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    ThemeData otherData = other;
+    return (otherData.brightness == brightness) &&
+           (otherData.primarySwatch == primarySwatch) &&
+           (otherData.canvasColor == canvasColor) &&
+           (otherData.cardColor == cardColor) &&
+           (otherData.dividerColor == dividerColor) &&
+           (otherData.hintColor == hintColor) &&
+           (otherData.highlightColor == highlightColor) &&
+           (otherData.selectedColor == selectedColor) &&
+           (otherData.hintOpacity == hintOpacity) &&
+           (otherData.text == text) &&
+           (otherData.primaryColorBrightness == primaryColorBrightness) &&
+           (otherData.accentColorBrightness == accentColorBrightness);
+  }
+  int get hashCode {
+    int value = 373;
+    value = 37 * value + brightness.hashCode;
+    value = 37 * value + primarySwatch.hashCode;
+    value = 37 * value + canvasColor.hashCode;
+    value = 37 * value + cardColor.hashCode;
+    value = 37 * value + dividerColor.hashCode;
+    value = 37 * value + hintColor.hashCode;
+    value = 37 * value + highlightColor.hashCode;
+    value = 37 * value + selectedColor.hashCode;
+    value = 37 * value + hintOpacity.hashCode;
+    value = 37 * value + text.hashCode;
+    value = 37 * value + primaryColorBrightness.hashCode;
+    value = 37 * value + accentColorBrightness.hashCode;
+    return value;
+  }
 }

--- a/sky/packages/sky/lib/src/widgets/homogeneous_viewport.dart
+++ b/sky/packages/sky/lib/src/widgets/homogeneous_viewport.dart
@@ -37,8 +37,8 @@ class HomogeneousViewport extends RenderObjectWidget {
   RenderBlockViewport createRenderObject() => new RenderBlockViewport();
 
   bool isLayoutDifferentThan(HomogeneousViewport oldWidget) {
+    // changing the builder doesn't imply the layout changed
     return itemsWrap != oldWidget.itemsWrap ||
-           itemsWrap != oldWidget.itemsWrap ||
            itemExtent != oldWidget.itemExtent ||
            itemCount != oldWidget.itemCount ||
            direction != oldWidget.direction ||
@@ -87,6 +87,10 @@ class _HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewpor
       renderObject.markNeedsLayout();
     else
       _updateChildren();
+  }
+
+  void reinvokeBuilders() {
+    _updateChildren();
   }
 
   void layout(BoxConstraints constraints) {

--- a/sky/packages/sky/lib/src/widgets/mixed_viewport.dart
+++ b/sky/packages/sky/lib/src/widgets/mixed_viewport.dart
@@ -164,27 +164,31 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
     if (changes != _ChangeDescription.none || !isValid) {
       renderObject.markNeedsLayout();
     } else {
-      // we just need to redraw our existing widgets as-is
-      if (_childrenByKey.length > 0) {
-        assert(_firstVisibleChildIndex >= 0);
-        assert(renderObject != null);
-        final int startIndex = _firstVisibleChildIndex;
-        int lastIndex = startIndex + _childrenByKey.length - 1;
-        Element nextSibling = null;
-        for (int index = lastIndex; index > startIndex; index -= 1) {
-          final Widget newWidget = _buildWidgetAt(index);
-          final _ChildKey key = new _ChildKey.fromWidget(newWidget);
-          final Element oldElement = _childrenByKey[key];
-          assert(oldElement != null);
-          final Element newElement = updateChild(oldElement, newWidget, nextSibling);
-          assert(newElement != null);
-          _childrenByKey[key] = newElement;
-          // Verify that it hasn't changed size.
-          // If this assertion fires, it means you didn't call "invalidate"
-          // before changing the size of one of your items.
-          assert(_debugIsSameSize(newElement, index, _lastLayoutConstraints));
-          nextSibling = newElement;
-        }
+      reinvokeBuilders();
+    }
+  }
+
+  void reinvokeBuilders() {
+    // we just need to redraw our existing widgets as-is
+    if (_childrenByKey.length > 0) {
+      assert(_firstVisibleChildIndex >= 0);
+      assert(renderObject != null);
+      final int startIndex = _firstVisibleChildIndex;
+      int lastIndex = startIndex + _childrenByKey.length - 1;
+      Element nextSibling = null;
+      for (int index = lastIndex; index >= startIndex; index -= 1) {
+        final Widget newWidget = _buildWidgetAt(index);
+        final _ChildKey key = new _ChildKey.fromWidget(newWidget);
+        final Element oldElement = _childrenByKey[key];
+        assert(oldElement != null);
+        final Element newElement = updateChild(oldElement, newWidget, nextSibling);
+        assert(newElement != null);
+        _childrenByKey[key] = newElement;
+        // Verify that it hasn't changed size.
+        // If this assertion fires, it means you didn't call "invalidate"
+        // before changing the size of one of your items.
+        assert(_debugIsSameSize(newElement, index, _lastLayoutConstraints));
+        nextSibling = newElement;
       }
     }
   }

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -18,7 +18,6 @@ class RouteArguments {
 typedef Widget RouteBuilder(RouteArguments args);
 typedef RouteBuilder RouteGenerator(String name);
 typedef void StateRouteCallback(StateRoute route);
-typedef void _RouteCallback(Route route);
 
 class Navigator extends StatefulComponent {
   Navigator({

--- a/sky/packages/sky/lib/src/widgets/radio.dart
+++ b/sky/packages/sky/lib/src/widgets/radio.dart
@@ -12,7 +12,7 @@ import 'package:sky/src/widgets/theme.dart';
 const sky.Color _kLightOffColor = const sky.Color(0x8A000000);
 const sky.Color _kDarkOffColor = const sky.Color(0xB2FFFFFF);
 
-typedef RadioValueChanged(Object value);
+typedef void RadioValueChanged(Object value);
 
 class Radio extends StatelessComponent {
   Radio({


### PR DESCRIPTION
Previously, RenderObjectElements didn't support being marked dirty. This
is fine, except for MixedViewport and HomogeneousViewport, which have
builder functions to which they hand themselves as a BuildContext. If
those builder functions call, e.g., Theme.of(), then when the theme
changes, the Inherited logic tries to tell the RenderObjectElement
object that its dependencies changed and that doesn't go down well.

This patch fixes this by making RenderObjectElement a BuildableElement,
and making MixedViewport and HomogeneousViewport hook into that to
rebuild themselves appropriately.

Also, this was only found at all because ThemeData didn't implement
operator==, so we were aggressively marking the entire tree dirty all
the time. That's fixed here too.

Also, I changed card_collection.dart to have more features to make this
easier to test. This found bugs #1524, #1522, #1528, #1529, #1530, #1531.