### PR TITLE
SnackBar throws exception on creation

### DIFF
--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -245,6 +245,10 @@ abstract class Route {
 }
 
 abstract class PerformanceRoute extends Route {
+  PerformanceRoute() {
+    _performance = createPerformance();
+  }
+
   PerformanceView get performance => _performance?.view;
   Performance _performance;
 
@@ -261,7 +265,6 @@ abstract class PerformanceRoute extends Route {
   Widget build(NavigatorState navigator, PerformanceView nextRoutePerformance);
 
   void didPush(NavigatorState navigator) {
-    _performance = createPerformance();
     super.didPush(navigator);
     _performance?.forward();
   }

--- a/sky/unit/test/widget/snack_bar_test.dart
+++ b/sky/unit/test/widget/snack_bar_test.dart
@@ -1,0 +1,40 @@
+import 'package:sky/widgets.dart';
+import 'package:test/test.dart';
+
+import 'widget_tester.dart';
+
+void main() {
+  test('SnackBar control test', () {
+    testWidgets((WidgetTester tester) {
+      String helloSnackBar = 'Hello SnackBar';
+      GlobalKey<PlaceholderState> placeholderKey = new GlobalKey<PlaceholderState>();
+      Key tapTarget = new Key('tap-target');
+
+      tester.pumpWidget(new App(
+        routes: {
+          '/': (RouteArguments args) {
+            return new GestureDetector(
+              onTap: () {
+                showSnackBar(
+                  navigator: args.navigator,
+                  placeholderKey: placeholderKey,
+                  content: new Text(helloSnackBar)
+                );
+              },
+              child: new Center(
+                key: tapTarget,
+                child: new Placeholder(key: placeholderKey)
+              )
+            );
+          }
+        }
+      ));
+
+      tester.tap(tester.findElementByKey(tapTarget));
+
+      expect(tester.findText(helloSnackBar), isNull);
+      tester.pump();
+      expect(tester.findText(helloSnackBar), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
It was trying to grab the route's performance before it was created. Now we
create the performance eagerly again.