### PR TITLE
Check if invocation of a closure failed due to a compilation error

### DIFF
--- a/sky/engine/tonic/dart_invoke.cc
+++ b/sky/engine/tonic/dart_invoke.cc
@@ -21,8 +21,10 @@ bool DartInvokeAppClosure(Dart_Handle closure,
                           int number_of_arguments,
                           Dart_Handle* arguments) {
   TRACE_EVENT0("sky", "DartInvoke::DartInvokeAppClosure");
-  return LogIfError(
-      Dart_InvokeClosure(closure, number_of_arguments, arguments));
+  Dart_Handle handle = Dart_InvokeClosure(closure, number_of_arguments, arguments);
+  bool result = LogIfError(handle);
+  CHECK(!Dart_IsCompilationError(handle));
+  return result;
 }
 
 }  // namespace blink


### PR DESCRIPTION
This is a fix for bug #1325.  The test framework is running the test code
as a microtask using DartInvokeAppClosure.  If the test causes a compilation
error, the test framework Dart code can not catch it.  The invocation in
sky_shell will return a compilation error handle.  The sky_shell process
will not shut down, and the test framework will hang.

This change will cause sky_shell to shut down on a compilation error in
the test microtask.