### PR TITLE
Allow Stacks with no children or only poisitioned children

### DIFF
--- a/sky/packages/sky/lib/src/rendering/stack.dart
+++ b/sky/packages/sky/lib/src/rendering/stack.dart
@@ -172,14 +172,15 @@ abstract class RenderStackBase extends RenderBox
       child = parentData.nextSibling;
     }
 
-    if (hasNonPositionedChildren)
+    if (hasNonPositionedChildren) {
       size = new Size(width, height);
-    else
+      assert(size.width == constraints.constrainWidth(width));
+      assert(size.height == constraints.constrainHeight(height));
+    } else {
       size = constraints.biggest;
+    }
 
     assert(!size.isInfinite);
-    assert(size.width == constraints.constrainWidth(width));
-    assert(size.height == constraints.constrainHeight(height));
 
     child = firstChild;
     while (child != null) {

--- a/sky/unit/test/widget/stack_test.dart
+++ b/sky/unit/test/widget/stack_test.dart
@@ -10,6 +10,12 @@ void main() {
     });
   });
 
+  test('Can construct an empty Centered Stack', () {
+    testWidgets((WidgetTester tester) {
+      tester.pumpWidget(new Center(child: new Stack([])));
+    });
+  });
+
   test('Can change position data', () {
     testWidgets((WidgetTester tester) {
       Key key = new Key('container');
@@ -105,6 +111,12 @@ void main() {
   test('Can construct an empty IndexedStack', () {
     testWidgets((WidgetTester tester) {
       tester.pumpWidget(new IndexedStack([]));
+    });
+  });
+
+  test('Can construct an empty Centered IndexedStack', () {
+    testWidgets((WidgetTester tester) {
+      tester.pumpWidget(new Center(child: new IndexedStack([])));
     });
   });
 


### PR DESCRIPTION
```/// If there are no non-positioned children, the stack becomes as large as possible.```

I think that's the same as: if there only positioned children, or no children at all, then the stack becomes as large as possible.

Currently creating a centered empty stack causes the asserts I've changed to throw.