### PR TITLE
Defunct DismissableState should not have live animations

### DIFF
--- a/sky/packages/sky/lib/src/widgets/dismissable.dart
+++ b/sky/packages/sky/lib/src/widgets/dismissable.dart
@@ -64,6 +64,12 @@ class _DismissableState extends State<Dismissable> {
   double _dragExtent = 0.0;
   bool _dragUnderway = false;
 
+  void dispose() {
+    _fadePerformance?.stop();
+    _resizePerformance?.stop();
+    super.dispose();
+  }
+
   bool get _directionIsYAxis {
     return
       config.direction == DismissDirection.vertical ||


### PR DESCRIPTION
This change is intended to address https://github.com/flutter/engine/issues/1548
