### PR TITLE
Changing themes caused crash

### DIFF
--- a/sky/packages/sky/lib/src/widgets/icon.dart
+++ b/sky/packages/sky/lib/src/widgets/icon.dart
@@ -14,6 +14,9 @@ enum IconThemeColor { white, black }
 class IconThemeData {
   const IconThemeData({ this.color });
   final IconThemeColor color;
+
+  bool operator==(other) => other.runtimeType == runtimeType && other.color == color;
+  int get hashCode => color.hashCode;
 }
 
 class IconTheme extends InheritedWidget {


### PR DESCRIPTION
The root cause was that we crawled the tree to mark anyone who depended
on the updated theme dirty _after_ we crawled it to rebuild it. Thus, if
anyone was already marked dirty when the process started, then got
marked clean by the first (rebuild) walk, then got marked dirty again by
the notification, they'd be clean when they got the notification,
despite already being in the dirty list, which would cause an assertion.

Also IconTheme didn't have an operator==, so it was independently too
aggressive about updates.