### PR TITLE
Remove workarounds that avoided 'super' in mixins

### DIFF
--- a/sky/packages/sky/lib/src/rendering/box.dart
+++ b/sky/packages/sky/lib/src/rendering/box.dart
@@ -631,7 +631,8 @@ abstract class RenderBox extends RenderObject {
   String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}size: ${size}\n';
 }
 
-/// A mixin that provides useful default behaviors for boxes with children managed by the [ContainerRenderObjectMixin] mixin
+/// A mixin that provides useful default behaviors for boxes with children
+/// managed by the [ContainerRenderObjectMixin] mixin.
 ///
 /// By convention, this class doesn't override any members of the superclass.
 /// Instead, it provides helpful functions that subclasses can call as

--- a/sky/packages/sky/lib/src/rendering/node.dart
+++ b/sky/packages/sky/lib/src/rendering/node.dart
@@ -68,31 +68,19 @@ class AbstractNode {
 
   /// Mark this node as attached.
   ///
-  /// Typically called only from overrides of [attachChildren] and to mark the
-  /// root of a tree attached.
+  /// Typically called only from the parent's attach(), and to mark the root of
+  /// a tree attached.
   void attach() {
     _attached = true;
-    attachChildren();
   }
-
-  /// Override this function in subclasses with child to call attach() for each
-  /// child. Do not call directly.
-  attachChildren() { }
 
   /// Mark this node as detached.
   ///
-  /// Typically called only from overrides for [detachChildren] and to mark the
-  /// root of a tree detached.
+  /// Typically called only from the parent's detach(), and to mark the root of
+  /// a tree detached.
   void detach() {
     _attached = false;
-    detachChildren();
   }
-
-  /// Override this function in subclasses with child to call detach() for each
-  /// child. Do not call directly.
-  detachChildren() { }
-
-  // TODO(ianh): remove attachChildren()/detachChildren() workaround once mixins can use super.
 
   AbstractNode _parent;
   /// The parent of this node in the tree.

--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -54,7 +54,8 @@ def main():
       subprocess.check_output([
           DARTANALYZER, "--package-warnings",
           "--package-root", os.path.join(WORKBENCH, "packages"),
-          "--fatal-warnings"
+          "--fatal-warnings",
+          "--supermixin",
       ] + app_paths, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:
       errors = [l for l in e.output.split('\n')

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -11,7 +11,7 @@ popd
 
 # Analyze the code.
 pushd sky/packages/sky
-../../../third_party/dart-sdk/dart-sdk/bin/dartanalyzer lib/widgets.dart
+../../../third_party/dart-sdk/dart-sdk/bin/dartanalyzer --supermixin lib/widgets.dart
 popd
 
 # Generate docs.


### PR DESCRIPTION
Dart supports this properly now.


Note: Looks like the analyzer doesn't yet? We might want to hold off on this until the analyzer does.