### PR TITLE
Relative paths in internal flutter libraries

### DIFF
--- a/sky/packages/sky/lib/rendering.dart
+++ b/sky/packages/sky/lib/rendering.dart
@@ -5,26 +5,26 @@
 /// The Flutter rendering tree.
 library rendering;
 
-export 'package:sky/src/rendering/auto_layout.dart';
-export 'package:sky/src/rendering/block.dart';
-export 'package:sky/src/rendering/box.dart';
-export 'package:sky/src/rendering/debug.dart';
-export 'package:sky/src/rendering/editable_paragraph.dart';
-export 'package:sky/src/rendering/error.dart';
-export 'package:sky/src/rendering/flex.dart';
-export 'package:sky/src/rendering/grid.dart';
-export 'package:sky/src/rendering/hit_test.dart';
-export 'package:sky/src/rendering/image.dart';
-export 'package:sky/src/rendering/layer.dart';
-export 'package:sky/src/rendering/node.dart';
-export 'package:sky/src/rendering/object.dart';
-export 'package:sky/src/rendering/paragraph.dart';
-export 'package:sky/src/rendering/proxy_box.dart';
-export 'package:sky/src/rendering/shifted_box.dart';
-export 'package:sky/src/rendering/binding.dart';
-export 'package:sky/src/rendering/stack.dart';
-export 'package:sky/src/rendering/toggleable.dart';
-export 'package:sky/src/rendering/view.dart';
-export 'package:sky/src/rendering/viewport.dart';
+export 'src/rendering/auto_layout.dart';
+export 'src/rendering/block.dart';
+export 'src/rendering/box.dart';
+export 'src/rendering/debug.dart';
+export 'src/rendering/editable_paragraph.dart';
+export 'src/rendering/error.dart';
+export 'src/rendering/flex.dart';
+export 'src/rendering/grid.dart';
+export 'src/rendering/hit_test.dart';
+export 'src/rendering/image.dart';
+export 'src/rendering/layer.dart';
+export 'src/rendering/node.dart';
+export 'src/rendering/object.dart';
+export 'src/rendering/paragraph.dart';
+export 'src/rendering/proxy_box.dart';
+export 'src/rendering/shifted_box.dart';
+export 'src/rendering/binding.dart';
+export 'src/rendering/stack.dart';
+export 'src/rendering/toggleable.dart';
+export 'src/rendering/view.dart';
+export 'src/rendering/viewport.dart';
 
 export 'package:vector_math/vector_math_64.dart' show Matrix4;

--- a/sky/packages/sky/lib/src/animation/animated_value.dart
+++ b/sky/packages/sky/lib/src/animation/animated_value.dart
@@ -4,7 +4,7 @@
 
 import 'dart:sky' show Color, Rect;
 
-import 'package:sky/src/animation/curves.dart';
+import 'curves.dart';
 
 /// The direction in which an animation is running
 enum AnimationDirection {

--- a/sky/packages/sky/lib/src/animation/performance.dart
+++ b/sky/packages/sky/lib/src/animation/performance.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 
-import 'package:sky/src/animation/animated_value.dart';
-import 'package:sky/src/animation/forces.dart';
-import 'package:sky/src/animation/simulation_stepper.dart';
+import 'animated_value.dart';
+import 'forces.dart';
+import 'simulation_stepper.dart';
 
 /// The status of an animation
 enum PerformanceStatus {

--- a/sky/packages/sky/lib/src/animation/simulation_stepper.dart
+++ b/sky/packages/sky/lib/src/animation/simulation_stepper.dart
@@ -5,9 +5,9 @@
 import 'dart:async';
 
 import 'package:newton/newton.dart';
-import 'package:sky/src/animation/animated_value.dart';
-import 'package:sky/src/animation/curves.dart';
-import 'package:sky/src/animation/ticker.dart';
+import 'animated_value.dart';
+import 'curves.dart';
+import 'ticker.dart';
 
 /// A simulation that varies from [begin] to [end] over [duration] using [curve]
 ///

--- a/sky/packages/sky/lib/src/animation/ticker.dart
+++ b/sky/packages/sky/lib/src/animation/ticker.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:sky/src/animation/scheduler.dart';
+import 'scheduler.dart';
 
 typedef TickerCallback(Duration elapsed);
 

--- a/sky/packages/sky/lib/src/gestures/drag.dart
+++ b/sky/packages/sky/lib/src/gestures/drag.dart
@@ -4,9 +4,9 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/gestures/arena.dart';
-import 'package:sky/src/gestures/recognizer.dart';
-import 'package:sky/src/gestures/constants.dart';
+import 'arena.dart';
+import 'recognizer.dart';
+import 'constants.dart';
 
 enum DragState {
   ready,

--- a/sky/packages/sky/lib/src/gestures/long_press.dart
+++ b/sky/packages/sky/lib/src/gestures/long_press.dart
@@ -4,10 +4,10 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/gestures/arena.dart';
-import 'package:sky/src/gestures/constants.dart';
-import 'package:sky/src/gestures/pointer_router.dart';
-import 'package:sky/src/gestures/recognizer.dart';
+import 'arena.dart';
+import 'constants.dart';
+import 'pointer_router.dart';
+import 'recognizer.dart';
 
 typedef void GestureLongPressCallback();
 

--- a/sky/packages/sky/lib/src/gestures/recognizer.dart
+++ b/sky/packages/sky/lib/src/gestures/recognizer.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 import 'dart:sky' as sky;
 
-import 'package:sky/src/gestures/arena.dart';
-import 'package:sky/src/gestures/constants.dart';
-import 'package:sky/src/gestures/pointer_router.dart';
+import 'arena.dart';
+import 'constants.dart';
+import 'pointer_router.dart';
 
-export 'package:sky/src/gestures/pointer_router.dart' show PointerRouter;
+export 'pointer_router.dart' show PointerRouter;
 
 abstract class GestureRecognizer extends GestureArenaMember {
   GestureRecognizer({ PointerRouter router }) : _router = router {

--- a/sky/packages/sky/lib/src/gestures/scale.dart
+++ b/sky/packages/sky/lib/src/gestures/scale.dart
@@ -4,9 +4,9 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/gestures/arena.dart';
-import 'package:sky/src/gestures/recognizer.dart';
-import 'package:sky/src/gestures/constants.dart';
+import 'arena.dart';
+import 'recognizer.dart';
+import 'constants.dart';
 
 enum ScaleState {
   ready,

--- a/sky/packages/sky/lib/src/gestures/show_press.dart
+++ b/sky/packages/sky/lib/src/gestures/show_press.dart
@@ -4,9 +4,9 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/gestures/arena.dart';
-import 'package:sky/src/gestures/constants.dart';
-import 'package:sky/src/gestures/recognizer.dart';
+import 'arena.dart';
+import 'constants.dart';
+import 'recognizer.dart';
 
 typedef void GestureShowPressCallback();
 

--- a/sky/packages/sky/lib/src/gestures/tap.dart
+++ b/sky/packages/sky/lib/src/gestures/tap.dart
@@ -4,8 +4,8 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/gestures/arena.dart';
-import 'package:sky/src/gestures/recognizer.dart';
+import 'arena.dart';
+import 'recognizer.dart';
 
 typedef void GestureTapCallback();
 

--- a/sky/packages/sky/lib/src/painting/box_painter.dart
+++ b/sky/packages/sky/lib/src/painting/box_painter.dart
@@ -7,7 +7,8 @@ import 'dart:sky' as sky;
 import 'dart:sky' show Point, Offset, Size, Rect, Color, Paint, Path;
 
 import 'package:sky/services.dart';
-import 'package:sky/src/painting/shadows.dart';
+
+import 'shadows.dart';
 
 /// An immutable set of offsets in each of the four cardinal directions
 ///

--- a/sky/packages/sky/lib/src/painting/text_painter.dart
+++ b/sky/packages/sky/lib/src/painting/text_painter.dart
@@ -4,9 +4,9 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/painting/text_style.dart';
+import 'text_style.dart';
 
-export 'package:sky/src/painting/text_style.dart';
+export 'text_style.dart';
 
 /// An immutable span of text
 abstract class TextSpan {

--- a/sky/packages/sky/lib/src/rendering/auto_layout.dart
+++ b/sky/packages/sky/lib/src/rendering/auto_layout.dart
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:cassowary/cassowary.dart' as al;
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
+
+import 'box.dart';
+import 'object.dart';
 
 /// Hosts the edge parameters and vends useful methods to construct expressions
 /// for constraints. Also sets up and manages implicit constraints and edit

--- a/sky/packages/sky/lib/src/rendering/binding.dart
+++ b/sky/packages/sky/lib/src/rendering/binding.dart
@@ -6,10 +6,11 @@ import 'dart:sky' as sky;
 
 import 'package:sky/animation.dart';
 import 'package:sky/gestures.dart';
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/hit_test.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/view.dart';
+
+import 'box.dart';
+import 'hit_test.dart';
+import 'object.dart';
+import 'view.dart';
 
 int _hammingWeight(int value) {
   if (value == 0)

--- a/sky/packages/sky/lib/src/rendering/block.dart
+++ b/sky/packages/sky/lib/src/rendering/block.dart
@@ -4,9 +4,10 @@
 
 import 'dart:math' as math;
 
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
 import 'package:vector_math/vector_math_64.dart';
+
+import 'box.dart';
+import 'object.dart';
 
 /// Parent data for use with [RenderBlockBase]
 class BlockParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> { }

--- a/sky/packages/sky/lib/src/rendering/box.dart
+++ b/sky/packages/sky/lib/src/rendering/box.dart
@@ -6,9 +6,10 @@ import 'dart:math' as math;
 import 'dart:sky' as sky;
 
 import 'package:sky/painting.dart';
-import 'package:sky/src/rendering/debug.dart';
-import 'package:sky/src/rendering/object.dart';
 import 'package:vector_math/vector_math_64.dart';
+
+import 'debug.dart';
+import 'object.dart';
 
 export 'package:sky/painting.dart' show TextBaseline;
 

--- a/sky/packages/sky/lib/src/rendering/editable_paragraph.dart
+++ b/sky/packages/sky/lib/src/rendering/editable_paragraph.dart
@@ -3,10 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:sky/painting.dart';
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/paragraph.dart';
-import 'package:sky/src/rendering/proxy_box.dart' show SizeChangedCallback;
+
+import 'box.dart';
+import 'object.dart';
+import 'paragraph.dart';
+import 'proxy_box.dart' show SizeChangedCallback;
 
 const _kCursorGap = 1.0; // pixels
 const _kCursorHeightOffset = 2.0; // pixels

--- a/sky/packages/sky/lib/src/rendering/error.dart
+++ b/sky/packages/sky/lib/src/rendering/error.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/debug.dart';
-import 'package:sky/src/rendering/object.dart';
+import 'box.dart';
+import 'debug.dart';
+import 'object.dart';
 
 const double _kMaxWidth = 100000.0;
 const double _kMaxHeight = 100000.0;

--- a/sky/packages/sky/lib/src/rendering/flex.dart
+++ b/sky/packages/sky/lib/src/rendering/flex.dart
@@ -4,8 +4,8 @@
 
 import 'dart:math' as math;
 
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
+import 'box.dart';
+import 'object.dart';
 
 /// Parent data for use with [RenderFlex]
 class FlexParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> {

--- a/sky/packages/sky/lib/src/rendering/grid.dart
+++ b/sky/packages/sky/lib/src/rendering/grid.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
+import 'box.dart';
+import 'object.dart';
 
 class _GridMetrics {
   // Grid is width-in, height-out.  We fill the max width and adjust height

--- a/sky/packages/sky/lib/src/rendering/image.dart
+++ b/sky/packages/sky/lib/src/rendering/image.dart
@@ -5,8 +5,9 @@
 import 'dart:sky' as sky;
 
 import 'package:sky/painting.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/box.dart';
+
+import 'box.dart';
+import 'object.dart';
 
 /// An image in the render tree
 ///

--- a/sky/packages/sky/lib/src/rendering/object.dart
+++ b/sky/packages/sky/lib/src/rendering/object.dart
@@ -7,14 +7,15 @@ import 'dart:sky' as sky;
 import 'dart:sky' show Point, Offset, Size, Rect, Color, Paint, Path;
 
 import 'package:sky/animation.dart';
-import 'package:sky/src/rendering/debug.dart';
-import 'package:sky/src/rendering/hit_test.dart';
-import 'package:sky/src/rendering/layer.dart';
-import 'package:sky/src/rendering/node.dart';
 import 'package:vector_math/vector_math_64.dart';
 
+import 'debug.dart';
+import 'hit_test.dart';
+import 'layer.dart';
+import 'node.dart';
+
 export 'dart:sky' show Point, Offset, Size, Rect, Color, Paint, Path;
-export 'package:sky/src/rendering/hit_test.dart' show HitTestTarget, HitTestEntry, HitTestResult;
+export 'hit_test.dart' show HitTestTarget, HitTestEntry, HitTestResult;
 
 typedef sky.Shader ShaderCallback(Rect bounds);
 

--- a/sky/packages/sky/lib/src/rendering/paragraph.dart
+++ b/sky/packages/sky/lib/src/rendering/paragraph.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/src/painting/text_painter.dart';
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
+import 'package:sky/painting.dart';
+
+import 'box.dart';
+import 'object.dart';
 
 export 'package:sky/src/painting/text_painter.dart';
 

--- a/sky/packages/sky/lib/src/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/src/rendering/proxy_box.dart
@@ -4,11 +4,11 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/painting/box_painter.dart';
-import 'package:sky/src/painting/text_style.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/box.dart';
+import 'package:sky/painting.dart';
 import 'package:vector_math/vector_math_64.dart';
+
+import 'box.dart';
+import 'object.dart';
 
 export 'package:sky/src/painting/box_painter.dart';
 

--- a/sky/packages/sky/lib/src/rendering/shifted_box.dart
+++ b/sky/packages/sky/lib/src/rendering/shifted_box.dart
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:sky/painting.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/box.dart';
+
+import 'box.dart';
+import 'object.dart';
 
 abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixin<RenderBox> {
 

--- a/sky/packages/sky/lib/src/rendering/stack.dart
+++ b/sky/packages/sky/lib/src/rendering/stack.dart
@@ -4,8 +4,8 @@
 
 import 'dart:math' as math;
 
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
+import 'box.dart';
+import 'object.dart';
 
 /// Parent data for use with [RenderStack]
 class StackParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> {

--- a/sky/packages/sky/lib/src/rendering/statistics_box.dart
+++ b/sky/packages/sky/lib/src/rendering/statistics_box.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
+import 'box.dart';
+import 'object.dart';
 
 class StatisticsBox extends RenderBox {
 

--- a/sky/packages/sky/lib/src/rendering/toggleable.dart
+++ b/sky/packages/sky/lib/src/rendering/toggleable.dart
@@ -6,10 +6,11 @@ import 'dart:sky' as sky;
 
 import 'package:sky/animation.dart';
 import 'package:sky/gestures.dart';
-import 'package:sky/src/rendering/binding.dart';
-import 'package:sky/src/rendering/box.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/proxy_box.dart';
+
+import 'binding.dart';
+import 'box.dart';
+import 'object.dart';
+import 'proxy_box.dart';
 
 typedef void ValueChanged(bool value);
 

--- a/sky/packages/sky/lib/src/rendering/view.dart
+++ b/sky/packages/sky/lib/src/rendering/view.dart
@@ -5,10 +5,11 @@
 import 'dart:sky' as sky;
 
 import 'package:sky/animation.dart';
-import 'package:sky/src/rendering/layer.dart';
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/box.dart';
 import 'package:vector_math/vector_math_64.dart';
+
+import 'box.dart';
+import 'layer.dart';
+import 'object.dart';
 
 /// The layout constraints for the root render object
 class ViewConstraints {

--- a/sky/packages/sky/lib/src/rendering/viewport.dart
+++ b/sky/packages/sky/lib/src/rendering/viewport.dart
@@ -4,9 +4,10 @@
 
 import 'dart:sky' as sky;
 
-import 'package:sky/src/rendering/object.dart';
-import 'package:sky/src/rendering/box.dart';
 import 'package:vector_math/vector_math_64.dart';
+
+import 'box.dart';
+import 'object.dart';
 
 /// The direction in which to scroll
 enum ScrollDirection {

--- a/sky/packages/sky/lib/src/services/activity.dart
+++ b/sky/packages/sky/lib/src/services/activity.dart
@@ -5,8 +5,9 @@
 import 'dart:sky';
 import 'dart:async';
 
-import 'package:sky/src/services/shell.dart';
 import 'package:sky_services/activity/activity.mojom.dart';
+
+import 'shell.dart';
 
 export 'package:sky_services/activity/activity.mojom.dart';
 

--- a/sky/packages/sky/lib/src/services/asset_bundle.dart
+++ b/sky/packages/sky/lib/src/services/asset_bundle.dart
@@ -9,11 +9,12 @@ import 'dart:typed_data';
 
 import 'package:mojo/core.dart' as core;
 import 'package:mojo_services/mojo/asset_bundle/asset_bundle.mojom.dart';
-import 'package:sky/src/services/fetch.dart';
-import 'package:sky/src/services/image_cache.dart';
-import 'package:sky/src/services/image_decoder.dart';
-import 'package:sky/src/services/image_resource.dart';
-import 'package:sky/src/services/shell.dart';
+
+import 'fetch.dart';
+import 'image_cache.dart';
+import 'image_decoder.dart';
+import 'image_resource.dart';
+import 'shell.dart';
 
 abstract class AssetBundle {
   void close();

--- a/sky/packages/sky/lib/src/services/fetch.dart
+++ b/sky/packages/sky/lib/src/services/fetch.dart
@@ -10,7 +10,8 @@ import 'package:mojo/mojo/url_request.mojom.dart';
 import 'package:mojo/mojo/url_response.mojom.dart';
 import 'package:mojo_services/mojo/network_service.mojom.dart';
 import 'package:mojo_services/mojo/url_loader.mojom.dart';
-import 'package:sky/src/services/shell.dart';
+
+import 'shell.dart';
 
 export 'package:mojo/mojo/url_response.mojom.dart' show UrlResponse;
 

--- a/sky/packages/sky/lib/src/services/image_cache.dart
+++ b/sky/packages/sky/lib/src/services/image_cache.dart
@@ -7,9 +7,10 @@ import 'dart:collection';
 import 'dart:sky' as sky;
 
 import 'package:mojo/mojo/url_response.mojom.dart';
-import 'package:sky/src/services/fetch.dart';
-import 'package:sky/src/services/image_decoder.dart';
-import 'package:sky/src/services/image_resource.dart';
+
+import 'fetch.dart';
+import 'image_decoder.dart';
+import 'image_resource.dart';
 
 Future<sky.Image> _fetchImage(String url) async {
   UrlResponse response = await fetchUrl(url);

--- a/sky/packages/sky/lib/src/services/keyboard.dart
+++ b/sky/packages/sky/lib/src/services/keyboard.dart
@@ -3,7 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:mojo_services/keyboard/keyboard.mojom.dart';
-import 'package:sky/src/services/shell.dart';
+
+import 'shell.dart';
 
 export 'package:mojo_services/keyboard/keyboard.mojom.dart';
 

--- a/sky/packages/sky/lib/src/services/shell.dart
+++ b/sky/packages/sky/lib/src/services/shell.dart
@@ -7,7 +7,8 @@ import 'dart:sky.internals' as internals;
 import 'package:mojo/application.dart';
 import 'package:mojo/core.dart' as core;
 import 'package:mojo/mojo/service_provider.mojom.dart';
-import 'package:sky/src/services/embedder.dart';
+
+import 'embedder.dart';
 
 ApplicationConnection _initConnection() {
   int rawHandle = internals.takeServicesProvidedByEmbedder();


### PR DESCRIPTION
Now that you import a top-level file for each layer of the Flutter
framework, within the framework we can use relative paths without being
worried about the copy/pasta problem we used to have.