### PR TITLE
Add a bin/flutter.dart to the flutter package

### DIFF
--- a/sky/packages/sky/bin/flutter.dart
+++ b/sky/packages/sky/bin/flutter.dart
@@ -1,0 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:sky_tools/executable.dart' as executable;
+
+main(List<String> args) => executable.main(args);

--- a/sky/packages/sky/lib/sky_tool
+++ b/sky/packages/sky/lib/sky_tool
@@ -1255,15 +1255,15 @@ class SkyShellRunner(object):
 
         # Also make sure that args is consistent with machine state for local builds
         if args.local_build and args.sky_src_path is None:
-            real_sky_path = os.path.realpath(os.path.join(PACKAGES_DIR, 'sky'))
-            match = re.match(r'pub.dartlang.org/sky', real_sky_path)
+            real_flutter_path = os.path.realpath(os.path.join(PACKAGES_DIR, 'flutter'))
+            match = re.match(r'pub.dartlang.org/flutter', real_flutter_path)
             if match is not None:
                 args.local_build = False
             else:
                 sky_src_path = os.path.dirname(
                     os.path.dirname(
                         os.path.dirname(
-                            os.path.dirname(real_sky_path))))
+                            os.path.dirname(real_flutter_path))))
                 if sky_src_path == '/' or sky_src_path == '':
                     args.local_build = False
                 else:
@@ -1275,9 +1275,9 @@ class SkyShellRunner(object):
                                 'to your pubspec.yaml file and then run pub get again:\n'
                                 'dependency_overrides:\n'
                                 '  material_design_icons:\n'
-                                '    path: /path/to/sky_engine/src/sky/packages/material_design_icons\n'
-                                '  sky:\n'
-                                '    path: /path/to/sky_engine/src/sky/packages/sky\n')
+                                '    path: /path/to/flutter/engine/src/sky/packages/material_design_icons\n'
+                                '  flutter:\n'
+                                '    path: /path/to/flutter/engine/src/sky/packages/sky\n')
         if args.local_build:
             if not os.path.isdir(args.sky_src_path):
                 logging.warning('The selected sky-src-path (' + args.sky_src_path + ') does not exist.'

--- a/sky/packages/sky/pubspec.yaml
+++ b/sky/packages/sky/pubspec.yaml
@@ -16,3 +16,6 @@ dependencies:
   intl: '>=0.12.4+2 <0.13.0'
 environment:
   sdk: '>=1.12.0 <2.0.0'
+
+executables:
+  flutter:


### PR DESCRIPTION
This command will eventually become the main entrypoint for the Flutter tools.
Also, fixup a reference to the "sky" package in sky_tool.