### PR TITLE
Lots of trivial warning fixes

### DIFF
--- a/examples/stocks/lib/stock_data.dart
+++ b/examples/stocks/lib/stock_data.dart
@@ -57,8 +57,8 @@ const _kChunkCount = 30;
 
 String _urlToFetch(int chunk) {
   if (rootBundle == null)
-    return '../data/stock_data_${chunk}.json';
-  return 'https://domokit.github.io/examples/stocks/data/stock_data_${chunk}.json';
+    return '../data/stock_data_$chunk.json';
+  return 'https://domokit.github.io/examples/stocks/data/stock_data_$chunk.json';
 }
 
 class StockDataFetcher {
@@ -81,9 +81,7 @@ class StockDataFetcher {
         return;
       }
       JsonDecoder decoder = new JsonDecoder();
-
       callback(new StockData(decoder.convert(json)));
-
       if (_nextChunk < _kChunkCount)
         _fetchNextChunk();
     });

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -37,8 +37,10 @@ class StockHomeState extends State<StockHome> {
   }
 
   void _handleSearchEnd() {
-    assert(config.navigator.currentRoute is StateRoute);
-    assert((config.navigator.currentRoute as StateRoute).owner == this); // TODO(ianh): remove cast once analyzer is cleverer
+    assert(() {
+      final StateRoute currentRoute = config.navigator.currentRoute;
+      assert(currentRoute.owner == this);
+    });
     config.navigator.pop();
     setState(() {
       _isSearching = false;
@@ -74,7 +76,7 @@ class StockHomeState extends State<StockHome> {
   void _showDrawer() {
     showDrawer(
       navigator: config.navigator,
-      child: new Block([
+      child: new Block(<Widget>[
         new DrawerHeader(child: new Text('Stocks')),
         new DrawerItem(
           icon: 'action/assessment',
@@ -88,7 +90,7 @@ class StockHomeState extends State<StockHome> {
               return new Dialog(
                 title: new Text('Not Implemented'),
                 content: new Text('This feature has not yet been implemented.'),
-                actions: [
+                actions: <Widget>[
                   new FlatButton(
                     child: new Text('USE IT'),
                     enabled: false,
@@ -117,7 +119,7 @@ class StockHomeState extends State<StockHome> {
         new DrawerItem(
           icon: 'action/thumb_up',
           onPressed: () => _handleStockModeChange(StockMode.optimistic),
-          child: new Row([
+          child: new Row(<Widget>[
             new Flexible(child: new Text('Optimistic')),
             new Radio(value: StockMode.optimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
           ])
@@ -125,7 +127,7 @@ class StockHomeState extends State<StockHome> {
         new DrawerItem(
           icon: 'action/thumb_down',
           onPressed: () => _handleStockModeChange(StockMode.pessimistic),
-          child: new Row([
+          child: new Row(<Widget>[
             new Flexible(child: new Text('Pessimistic')),
             new Radio(value: StockMode.pessimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
           ])
@@ -155,7 +157,7 @@ class StockHomeState extends State<StockHome> {
         onPressed: _showDrawer
       ),
       center: new Text('Stocks'),
-      right: [
+      right: <Widget>[
         new IconButton(
           icon: "action/search",
           onPressed: _handleSearchBegin
@@ -171,14 +173,14 @@ class StockHomeState extends State<StockHome> {
   int selectedTabIndex = 0;
 
   Iterable<Stock> _getStockList(Iterable<String> symbols) {
-    return symbols.map((symbol) => config.stocks[symbol]);
+    return symbols.map((String symbol) => config.stocks[symbol]);
   }
 
   Iterable<Stock> _filterBySearchQuery(Iterable<Stock> stocks) {
     if (_searchQuery == null)
       return stocks;
     RegExp regexp = new RegExp(_searchQuery, caseSensitive: false);
-    return stocks.where((stock) => stock.symbol.contains(regexp));
+    return stocks.where((Stock stock) => stock.symbol.contains(regexp));
   }
 
   Widget buildStockList(BuildContext context, Iterable<Stock> stocks) {
@@ -211,7 +213,7 @@ class StockHomeState extends State<StockHome> {
         )
       ],
       selectedIndex: selectedTabIndex,
-      onChanged: (tabIndex) {
+      onChanged: (int tabIndex) {
         setState(() { selectedTabIndex = tabIndex; } );
       }
     );
@@ -245,7 +247,7 @@ class StockHomeState extends State<StockHome> {
       navigator: config.navigator,
       placeholderKey: _snackBarPlaceholderKey,
       content: new Text("Stock purchased!"),
-      actions: [
+      actions: <SnackBarAction>[
         new SnackBarAction(label: "UNDO", onPressed: _handleUndo)
       ]
     );

--- a/examples/stocks/lib/stock_menu.dart
+++ b/examples/stocks/lib/stock_menu.dart
@@ -19,7 +19,7 @@ Future showStockMenu(NavigatorState navigator, { bool autorefresh, ValueChanged 
       return <PopupMenuItem>[
         new PopupMenuItem(
           value: _MenuItems.autorefresh,
-          child: new Row([
+          child: new Row(<Widget>[
               new Flexible(child: new Text('Autorefresh')),
               new Checkbox(
                 value: autorefresh,
@@ -59,9 +59,9 @@ Future showStockMenu(NavigatorState navigator, { bool autorefresh, ValueChanged 
         return new Dialog(
           title: new Text('Not Implemented'),
           content: new Text('This feature has not yet been implemented.'),
-          actions: [
+          actions: <Widget>[
             new FlatButton(
-              child: new Row([
+              child: new Row(<Widget>[
                 new Icon(
                   type: 'device/dvr',
                   size: 18

--- a/examples/stocks/lib/stock_row.dart
+++ b/examples/stocks/lib/stock_row.dart
@@ -10,9 +10,15 @@ class StockRowPartGlobalKey extends GlobalKey {
   const StockRowPartGlobalKey(this.stock, this.part) : super.constructor();
   final Stock stock;
   final StockRowPartKind part;
-  String toString() => '[StockRowPartGlobalKey ${stock.symbol}:${part.toString().split(".")[1]})]';
-  bool operator==(other) => other is StockRowPartGlobalKey && identical(other.stock, stock) && identical(other.part, part);
+  bool operator ==(dynamic other) {
+    if (other is! StockRowPartGlobalKey)
+      return false;
+    final StockRowPartGlobalKey typedOther = other;
+    return stock == typedOther.stock &&
+           part == typedOther.part;
+  }
   int get hashCode => 37 * (37 * (373) + identityHashCode(stock)) + identityHashCode(part);
+  String toString() => '[StockRowPartGlobalKey ${stock.symbol}:${part.toString().split(".")[1]})]';
 }
 
 typedef void StockRowActionCallback(Stock stock, GlobalKey row, GlobalKey arrowKey, GlobalKey symbolKey, GlobalKey priceKey);
@@ -65,14 +71,14 @@ class StockRow extends StatelessComponent {
             bottom: new BorderSide(color: Theme.of(context).dividerColor)
           )
         ),
-        child: new Row([
+        child: new Row(<Widget>[
           new Container(
             key: arrowKey,
             child: new StockArrow(percentChange: stock.percentChange),
             margin: const EdgeDims.only(right: 5.0)
           ),
           new Flexible(
-            child: new Row([
+            child: new Row(<Widget>[
                 new Flexible(
                   flex: 2,
                   child: new Text(

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -42,7 +42,7 @@ class StockSettingsState extends State<StockSettings> {
             onDismiss: () {
               navigator.pop(false);
             },
-            actions: [
+            actions: <Widget>[
               new FlatButton(
                 child: new Text('NO THANKS'),
                 onPressed: () {
@@ -87,22 +87,22 @@ class StockSettingsState extends State<StockSettings> {
       child: new ScrollableViewport(
         child: new Container(
           padding: const EdgeDims.symmetric(vertical: 20.0),
-          child: new BlockBody([
+          child: new BlockBody(<Widget>[
             new DrawerItem(
               icon: 'action/thumb_up',
               onPressed: () => _confirmOptimismChange(),
-              child: new Row([
+              child: new Row(<Widget>[
                 new Flexible(child: new Text('Everything is awesome')),
                 new Checkbox(
                   value: config.optimism == StockMode.optimistic,
-                  onChanged: (_) => _confirmOptimismChange()
+                  onChanged: (bool value) => _confirmOptimismChange()
                 ),
               ])
             ),
             new DrawerItem(
               icon: 'action/backup',
               onPressed: () { _handleBackupChanged(!(config.backup == BackupMode.enabled)); },
-              child: new Row([
+              child: new Row(<Widget>[
                 new Flexible(child: new Text('Back up stock list to the cloud')),
                 new Switch(
                   value: config.backup == BackupMode.enabled,

--- a/examples/stocks/lib/stock_symbol_viewer.dart
+++ b/examples/stocks/lib/stock_symbol_viewer.dart
@@ -33,12 +33,12 @@ class StockSymbolViewerState extends State<StockSymbolViewer> {
         center: new Text('${config.stock.name} (${config.stock.symbol})')
       ),
       body: new Material(
-        child: new Block([
+        child: new Block(<Widget>[
           new Container(
             padding: new EdgeDims.all(20.0),
-            child: new Column([
+            child: new Column(<Widget>[
                 new Text('Last Sale', style: headings),
-                new Text('${lastSale} (${changeInPrice})'),
+                new Text('$lastSale ($changeInPrice)'),
                 new Container(
                   height: 8.0
                 ),

--- a/sky/engine/core/painting/Color.dart
+++ b/sky/engine/core/painting/Color.dart
@@ -46,8 +46,6 @@ class Color {
   /// The blue channel of this color in an 8 bit value
   int get blue => (0x000000ff & _value) >> 0;
 
-  bool operator ==(other) => other is Color && _value == other._value;
-
   /// Returns a new color that matches this color with the alpha channel replaced with a.
   Color withAlpha(int a) {
     return new Color.fromARGB(a, red, green, blue);
@@ -87,6 +85,14 @@ class Color {
     );
   }
 
+  bool operator ==(dynamic other) {
+    if (other is! Color)
+      return false;
+    final Color typedOther = other;
+    return value == typedOther.value;
+  }
+
   int get hashCode => _value.hashCode;
+
   String toString() => "Color(0x${_value.toRadixString(16).padLeft(8, '0')})";
 }

--- a/sky/engine/core/painting/Offset.dart
+++ b/sky/engine/core/painting/Offset.dart
@@ -45,9 +45,6 @@ class Offset extends OffsetBase {
   /// Returns the point at (0, 0) plus this offset.
   Point toPoint() => new Point(this.dx, this.dy);
 
-  /// Compares two Offsets for equality.
-  bool operator ==(other) => other is Offset && super == other;
-
   /// Linearly interpolate between two offsets
   ///
   /// If either offset is null, this function interpolates from [Offset.zero].
@@ -60,6 +57,9 @@ class Offset extends OffsetBase {
       return a * (1.0 - t);
     return new Offset(lerpDouble(a.dx, b.dx, t), lerpDouble(a.dy, b.dy, t));
   }
+
+  /// Compares two Offsets for equality.
+  bool operator ==(dynamic other) => other is Offset && super == other;
 
   String toString() => "Offset($dx, $dy)";
 }

--- a/sky/engine/core/painting/OffsetBase.dart
+++ b/sky/engine/core/painting/OffsetBase.dart
@@ -17,10 +17,12 @@ abstract class OffsetBase {
   bool operator >(OffsetBase other) => _dx > other._dx && _dy > other._dy;
   bool operator >=(OffsetBase other) => _dx > other._dx && _dy >= other._dy;
 
-  bool operator ==(other) {
-    return other is OffsetBase &&
-           other._dx == _dx &&
-           other._dy == _dy;
+  bool operator ==(dynamic other) {
+    if (other is! OffsetBase)
+      return false;
+    final OffsetBase typedOther = other;
+    return _dx == typedOther._dx &&
+           _dy == typedOther._dy;
   }
 
   int get hashCode {

--- a/sky/engine/core/painting/Point.dart
+++ b/sky/engine/core/painting/Point.dart
@@ -13,7 +13,6 @@ class Point {
 
   static const Point origin = const Point(0.0, 0.0);
 
-  bool operator ==(other) => other is Point && x == other.x && y == other.y;
   Point operator -() => new Point(-x, -y);
   Offset operator -(Point other) => new Offset(x - other.x, y - other.y);
   Point operator +(Offset other) => new Point(x + other.dx, y + other.dy);
@@ -22,11 +21,20 @@ class Point {
   // does the equivalent of "return this - Point.origin"
   Offset toOffset() => new Offset(x, y);
 
+  bool operator ==(dynamic other) {
+    if (other is! Point)
+      return false;
+    final Point typedOther = other;
+    return x == typedOther.x &&
+           y == typedOther.y;
+  }
+
   int get hashCode {
     int result = 373;
     result = 37 * result + x.hashCode;
     result = 37 * result + y.hashCode;
     return result;
   }
+
   String toString() => "Point($x, $y)";
 }

--- a/sky/engine/core/painting/Rect.dart
+++ b/sky/engine/core/painting/Rect.dart
@@ -128,15 +128,20 @@ class Rect {
     );
   }
 
-  bool operator ==(other) {
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
     if (other is! Rect)
       return false;
+    final Rect typedOther = other;
     for (var i = 0; i < 4; ++i) {
-      if (_value[i] != other._value[i])
+      if (_value[i] != typedOther._value[i])
         return false;
     }
     return true;
   }
+
   int get hashCode =>_value.fold(373, (value, item) => (37 * value + item.hashCode));
+
   String toString() => "Rect.fromLTRB($left, $top, $right, $bottom)";
 }

--- a/sky/engine/core/painting/Size.dart
+++ b/sky/engine/core/painting/Size.dart
@@ -45,9 +45,6 @@ class Size extends OffsetBase {
   Point bottomLeft(Point origin) => new Point(origin.x, origin.y + height);
   Point bottomRight(Point origin) => new Point(origin.x + width, origin.y + height);
 
-  /// Compares two Sizes for equality.
-  bool operator ==(other) => other is Size && super == other;
-
   /// Linearly interpolate between two sizes
   ///
   /// If either size is null, this function interpolates from [Offset.zero].
@@ -60,6 +57,9 @@ class Size extends OffsetBase {
       return a * (1.0 - t);
     return new Size(lerpDouble(a.width, b.width, t), lerpDouble(a.height, b.height, t));
   }
+
+  /// Compares two Sizes for equality.
+  bool operator ==(dynamic other) => other is Size && super == other;
 
   String toString() => "Size($width, $height)";
 }

--- a/sky/packages/sky/lib/src/animation/scheduler.dart
+++ b/sky/packages/sky/lib/src/animation/scheduler.dart
@@ -45,7 +45,7 @@ class Scheduler {
     Map<int, SchedulerCallback> callbacks = _transientCallbacks;
     _transientCallbacks = new Map<int, SchedulerCallback>();
 
-    callbacks.forEach((id, callback) {
+    callbacks.forEach((int id, SchedulerCallback callback) {
       if (!_removedIds.contains(id))
         callback(timeStamp);
     });

--- a/sky/packages/sky/lib/src/gestures/recognizer.dart
+++ b/sky/packages/sky/lib/src/gestures/recognizer.dart
@@ -30,7 +30,7 @@ abstract class GestureRecognizer extends GestureArenaMember {
   void didStopTrackingLastPointer(int pointer);
 
   void resolve(GestureDisposition disposition) {
-    List<GestureArenaEntry> localEntries = new List.from(_entries);
+    List<GestureArenaEntry> localEntries = new List<GestureArenaEntry>.from(_entries);
     _entries.clear();
     for (GestureArenaEntry entry in localEntries)
       entry.resolve(disposition);

--- a/sky/packages/sky/lib/src/material/checkbox.dart
+++ b/sky/packages/sky/lib/src/material/checkbox.dart
@@ -151,7 +151,7 @@ class _RenderCheckbox extends RenderToggleable {
       paint.setStyle(ui.PaintingStyle.fill);
       paint.setShader(new ui.Gradient.radial(
           new Point(_kEdgeSize / 2.0, _kEdgeSize / 2.0),
-          _kEdgeSize * (_kMidpoint - position) * 8.0, [
+          _kEdgeSize * (_kMidpoint - position) * 8.0, <Color>[
         const ui.Color(0x00000000),
         uncheckedColor
       ]));

--- a/sky/packages/sky/lib/src/material/colors.dart
+++ b/sky/packages/sky/lib/src/material/colors.dart
@@ -21,7 +21,7 @@ class Colors {
   static const white30 = const Color(0x4DFFFFFF); // text of disabled flat button in dark theme
   static const white12 = const Color(0x1FFFFFFF); // background of disabled raised buttons in dark theme
 
-  static const Map<int, Color> red = const {
+  static const Map<int, Color> red = const <int, Color>{
      50: const Color(0xFFFFEBEE),
     100: const Color(0xFFFFCDD2),
     200: const Color(0xFFEF9A9A),
@@ -34,14 +34,14 @@ class Colors {
     900: const Color(0xFFB71C1C),
   };
 
-  static const Map<int, Color> redAccent = const {
+  static const Map<int, Color> redAccent = const <int, Color>{
     100: const Color(0xFFFF8A80),
     200: const Color(0xFFFF5252),
     400: const Color(0xFFFF1744),
     700: const Color(0xFFD50000),
   };
 
-  static const Map<int, Color> pink = const {
+  static const Map<int, Color> pink = const <int, Color>{
      50: const Color(0xFFFCE4EC),
     100: const Color(0xFFF8BBD0),
     200: const Color(0xFFF48FB1),
@@ -54,14 +54,14 @@ class Colors {
     900: const Color(0xFF880E4F),
   };
 
-  static const Map<int, Color> pinkAccent = const {
+  static const Map<int, Color> pinkAccent = const <int, Color>{
     100: const Color(0xFFFF80AB),
     200: const Color(0xFFFF4081),
     400: const Color(0xFFF50057),
     700: const Color(0xFFC51162),
   };
 
-  static const Map<int, Color> purple = const {
+  static const Map<int, Color> purple = const <int, Color>{
      50: const Color(0xFFF3E5F5),
     100: const Color(0xFFE1BEE7),
     200: const Color(0xFFCE93D8),
@@ -74,14 +74,14 @@ class Colors {
     900: const Color(0xFF4A148C),
   };
 
-  static const Map<int, Color> purpleAccent = const {
+  static const Map<int, Color> purpleAccent = const <int, Color>{
     100: const Color(0xFFEA80FC),
     200: const Color(0xFFE040FB),
     400: const Color(0xFFD500F9),
     700: const Color(0xFFAA00FF),
   };
 
-  static const Map<int, Color> deepPurple = const {
+  static const Map<int, Color> deepPurple = const <int, Color>{
      50: const Color(0xFFEDE7F6),
     100: const Color(0xFFD1C4E9),
     200: const Color(0xFFB39DDB),
@@ -94,14 +94,14 @@ class Colors {
     900: const Color(0xFF311B92),
   };
 
-  static const Map<int, Color> deepPurpleAccent = const {
+  static const Map<int, Color> deepPurpleAccent = const <int, Color>{
     100: const Color(0xFFB388FF),
     200: const Color(0xFF7C4DFF),
     400: const Color(0xFF651FFF),
     700: const Color(0xFF6200EA),
   };
 
-  static const Map<int, Color> indigo = const {
+  static const Map<int, Color> indigo = const <int, Color>{
      50: const Color(0xFFE8EAF6),
     100: const Color(0xFFC5CAE9),
     200: const Color(0xFF9FA8DA),
@@ -114,14 +114,14 @@ class Colors {
     900: const Color(0xFF1A237E),
   };
 
-  static const Map<int, Color> indigoAccent = const {
+  static const Map<int, Color> indigoAccent = const <int, Color>{
     100: const Color(0xFF8C9EFF),
     200: const Color(0xFF536DFE),
     400: const Color(0xFF3D5AFE),
     700: const Color(0xFF304FFE),
   };
 
-  static const Map<int, Color> blue = const {
+  static const Map<int, Color> blue = const <int, Color>{
      50: const Color(0xFFE3F2FD),
     100: const Color(0xFFBBDEFB),
     200: const Color(0xFF90CAF9),
@@ -134,14 +134,14 @@ class Colors {
     900: const Color(0xFF0D47A1),
   };
 
-  static const Map<int, Color> blueAccent = const {
+  static const Map<int, Color> blueAccent = const <int, Color>{
     100: const Color(0xFF82B1FF),
     200: const Color(0xFF448AFF),
     400: const Color(0xFF2979FF),
     700: const Color(0xFF2962FF),
   };
 
-  static const Map<int, Color> lightBlue = const {
+  static const Map<int, Color> lightBlue = const <int, Color>{
      50: const Color(0xFFE1F5FE),
     100: const Color(0xFFB3E5FC),
     200: const Color(0xFF81D4FA),
@@ -154,14 +154,14 @@ class Colors {
     900: const Color(0xFF01579B),
   };
 
-  static const Map<int, Color> lightBlueAccent = const {
+  static const Map<int, Color> lightBlueAccent = const <int, Color>{
     100: const Color(0xFF80D8FF),
     200: const Color(0xFF40C4FF),
     400: const Color(0xFF00B0FF),
     700: const Color(0xFF0091EA),
   };
 
-  static const Map<int, Color> cyan = const {
+  static const Map<int, Color> cyan = const <int, Color>{
      50: const Color(0xFFE0F7FA),
     100: const Color(0xFFB2EBF2),
     200: const Color(0xFF80DEEA),
@@ -174,14 +174,14 @@ class Colors {
     900: const Color(0xFF006064),
   };
 
-  static const Map<int, Color> cyanAccent = const {
+  static const Map<int, Color> cyanAccent = const <int, Color>{
     100: const Color(0xFF84FFFF),
     200: const Color(0xFF18FFFF),
     400: const Color(0xFF00E5FF),
     700: const Color(0xFF00B8D4),
   };
 
-  static const Map<int, Color> teal = const {
+  static const Map<int, Color> teal = const <int, Color>{
      50: const Color(0xFFE0F2F1),
     100: const Color(0xFFB2DFDB),
     200: const Color(0xFF80CBC4),
@@ -194,14 +194,14 @@ class Colors {
     900: const Color(0xFF004D40),
   };
 
-  static const Map<int, Color> tealAccent = const {
+  static const Map<int, Color> tealAccent = const <int, Color>{
     100: const Color(0xFFA7FFEB),
     200: const Color(0xFF64FFDA),
     400: const Color(0xFF1DE9B6),
     700: const Color(0xFF00BFA5),
   };
 
-  static const Map<int, Color> green = const {
+  static const Map<int, Color> green = const <int, Color>{
      50: const Color(0xFFE8F5E9),
     100: const Color(0xFFC8E6C9),
     200: const Color(0xFFA5D6A7),
@@ -214,14 +214,14 @@ class Colors {
     900: const Color(0xFF1B5E20),
   };
 
-  static const Map<int, Color> greenAccent = const {
+  static const Map<int, Color> greenAccent = const <int, Color>{
     100: const Color(0xFFB9F6CA),
     200: const Color(0xFF69F0AE),
     400: const Color(0xFF00E676),
     700: const Color(0xFF00C853),
   };
 
-  static const Map<int, Color> lightGreen = const {
+  static const Map<int, Color> lightGreen = const <int, Color>{
      50: const Color(0xFFF1F8E9),
     100: const Color(0xFFDCEDC8),
     200: const Color(0xFFC5E1A5),
@@ -234,14 +234,14 @@ class Colors {
     900: const Color(0xFF33691E),
   };
 
-  static const Map<int, Color> lightGreenAccent = const {
+  static const Map<int, Color> lightGreenAccent = const <int, Color>{
     100: const Color(0xFFCCFF90),
     200: const Color(0xFFB2FF59),
     400: const Color(0xFF76FF03),
     700: const Color(0xFF64DD17),
   };
 
-  static const Map<int, Color> lime = const {
+  static const Map<int, Color> lime = const <int, Color>{
      50: const Color(0xFFF9FBE7),
     100: const Color(0xFFF0F4C3),
     200: const Color(0xFFE6EE9C),
@@ -254,14 +254,14 @@ class Colors {
     900: const Color(0xFF827717),
   };
 
-  static const Map<int, Color> limeAccent = const {
+  static const Map<int, Color> limeAccent = const <int, Color>{
     100: const Color(0xFFF4FF81),
     200: const Color(0xFFEEFF41),
     400: const Color(0xFFC6FF00),
     700: const Color(0xFFAEEA00),
   };
 
-  static const Map<int, Color> yellow = const {
+  static const Map<int, Color> yellow = const <int, Color>{
      50: const Color(0xFFFFFDE7),
     100: const Color(0xFFFFF9C4),
     200: const Color(0xFFFFF59D),
@@ -274,14 +274,14 @@ class Colors {
     900: const Color(0xFFF57F17),
   };
 
-  static const Map<int, Color> yellowAccent = const {
+  static const Map<int, Color> yellowAccent = const <int, Color>{
     100: const Color(0xFFFFFF8D),
     200: const Color(0xFFFFFF00),
     400: const Color(0xFFFFEA00),
     700: const Color(0xFFFFD600),
   };
 
-  static const Map<int, Color> amber = const {
+  static const Map<int, Color> amber = const <int, Color>{
      50: const Color(0xFFFFF8E1),
     100: const Color(0xFFFFECB3),
     200: const Color(0xFFFFE082),
@@ -294,14 +294,14 @@ class Colors {
     900: const Color(0xFFFF6F00),
   };
 
-  static const Map<int, Color> amberAccent = const {
+  static const Map<int, Color> amberAccent = const <int, Color>{
     100: const Color(0xFFFFE57F),
     200: const Color(0xFFFFD740),
     400: const Color(0xFFFFC400),
     700: const Color(0xFFFFAB00),
   };
 
-  static const Map<int, Color> orange = const {
+  static const Map<int, Color> orange = const <int, Color>{
      50: const Color(0xFFFFF3E0),
     100: const Color(0xFFFFE0B2),
     200: const Color(0xFFFFCC80),
@@ -314,14 +314,14 @@ class Colors {
     900: const Color(0xFFE65100),
   };
 
-  static const Map<int, Color> orangeAccent = const {
+  static const Map<int, Color> orangeAccent = const <int, Color>{
     100: const Color(0xFFFFD180),
     200: const Color(0xFFFFAB40),
     400: const Color(0xFFFF9100),
     700: const Color(0xFFFF6D00),
   };
 
-  static const Map<int, Color> deepOrange = const {
+  static const Map<int, Color> deepOrange = const <int, Color>{
      50: const Color(0xFFFBE9E7),
     100: const Color(0xFFFFCCBC),
     200: const Color(0xFFFFAB91),
@@ -334,14 +334,14 @@ class Colors {
     900: const Color(0xFFBF360C),
   };
 
-  static const Map<int, Color> deepOrangeAccent = const {
+  static const Map<int, Color> deepOrangeAccent = const <int, Color>{
     100: const Color(0xFFFF9E80),
     200: const Color(0xFFFF6E40),
     400: const Color(0xFFFF3D00),
     700: const Color(0xFFDD2C00),
   };
 
-  static const Map<int, Color> brown = const {
+  static const Map<int, Color> brown = const <int, Color>{
      50: const Color(0xFFEFEBE9),
     100: const Color(0xFFD7CCC8),
     200: const Color(0xFFBCAAA4),
@@ -354,7 +354,7 @@ class Colors {
     900: const Color(0xFF3E2723),
   };
 
-  static const Map<int, Color> grey = const {
+  static const Map<int, Color> grey = const <int, Color>{
      50: const Color(0xFFFAFAFA),
     100: const Color(0xFFF5F5F5),
     200: const Color(0xFFEEEEEE),
@@ -369,7 +369,7 @@ class Colors {
     900: const Color(0xFF212121),
   };
 
-  static const Map<int, Color> blueGrey = const {
+  static const Map<int, Color> blueGrey = const <int, Color>{
      50: const Color(0xFFECEFF1),
     100: const Color(0xFFCFD8DC),
     200: const Color(0xFFB0BEC5),

--- a/sky/packages/sky/lib/src/material/date_picker.dart
+++ b/sky/packages/sky/lib/src/material/date_picker.dart
@@ -94,7 +94,7 @@ class _DatePickerState extends State<DatePicker> {
         );
         break;
     }
-    return new Column([
+    return new Column(<Widget>[
       header,
       new Container(
         height: _calendarHeight,
@@ -145,7 +145,7 @@ class _DatePickerHeader extends StatelessComponent {
     return new Container(
       padding: new EdgeDims.all(10.0),
       decoration: new BoxDecoration(backgroundColor: theme.primaryColor),
-      child: new Column([
+      child: new Column(<Widget>[
         new GestureDetector(
           onTap: () => _handleChangeMode(DatePickerMode.day),
           child: new Text(new DateFormat("MMM").format(selectedDate).toUpperCase(), style: monthStyle)
@@ -190,11 +190,11 @@ class DayPicker extends StatelessComponent {
     DateFormat dateFormat = new DateFormat();
     DateSymbols symbols = dateFormat.dateSymbols;
 
-    List<Text> headers = [];
+    List<Text> headers = <Text>[];
     for (String weekDay in symbols.NARROWWEEKDAYS) {
       headers.add(new Text(weekDay, style: headerStyle));
     }
-    List<Widget> rows = [
+    List<Widget> rows = <Widget>[
       new Text(new DateFormat("MMMM y").format(displayedMonth), style: monthStyle),
       new Flex(
         headers,
@@ -208,7 +208,7 @@ class DayPicker extends StatelessComponent {
     int daysInMonth = new DateTime(year, month + 1).difference(new DateTime(year, month)).inDays;
     int firstDay =  new DateTime(year, month).day;
     int weeksShown = 6;
-    List<int> days = [
+    List<int> days = <int>[
       DateTime.SUNDAY,
       DateTime.MONDAY,
       DateTime.TUESDAY,
@@ -218,7 +218,7 @@ class DayPicker extends StatelessComponent {
       DateTime.SATURDAY
     ];
     int daySlots = weeksShown * days.length;
-    List<Widget> labels = [];
+    List<Widget> labels = <Widget>[];
     for (int i = 0; i < daySlots; i++) {
       // This assumes a start day of SUNDAY, but could be changed.
       int day = i - firstDay + 1;

--- a/sky/packages/sky/lib/src/material/dialog.dart
+++ b/sky/packages/sky/lib/src/material/dialog.dart
@@ -101,7 +101,7 @@ class Dialog extends StatelessComponent {
       ));
     }
 
-    return new Stack([
+    return new Stack(<Widget>[
       new GestureDetector(
         onTap: onDismiss,
         child: new Container(

--- a/sky/packages/sky/lib/src/material/drawer.dart
+++ b/sky/packages/sky/lib/src/material/drawer.dart
@@ -61,7 +61,7 @@ class _Drawer extends StatelessComponent {
         if (interactive)
           route._settle(velocity);
       },
-      child: new Stack([
+      child: new Stack(<Widget>[
         // mask
         new GestureDetector(
           onTap: () {

--- a/sky/packages/sky/lib/src/material/drawer_header.dart
+++ b/sky/packages/sky/lib/src/material/drawer_header.dart
@@ -29,7 +29,7 @@ class DrawerHeader extends StatelessComponent {
       ),
       padding: const EdgeDims.only(bottom: 7.0),
       margin: const EdgeDims.only(bottom: 8.0),
-      child: new Column([
+      child: new Column(<Widget>[
         new Flexible(child: new Container()),
         new Container(
           padding: const EdgeDims.symmetric(horizontal: 16.0),

--- a/sky/packages/sky/lib/src/material/edges.dart
+++ b/sky/packages/sky/lib/src/material/edges.dart
@@ -5,7 +5,7 @@
 enum MaterialEdge { canvas, card, circle }
 
 // This map gives the border radii for each type of material.
-const Map<MaterialEdge, double> edges = const {
+const Map<MaterialEdge, double> edges = const <MaterialEdge, double>{
   MaterialEdge.canvas: null,
   MaterialEdge.card: 2.0,
   MaterialEdge.circle: null,

--- a/sky/packages/sky/lib/src/material/icon.dart
+++ b/sky/packages/sky/lib/src/material/icon.dart
@@ -15,7 +15,13 @@ class IconThemeData {
   const IconThemeData({ this.color });
   final IconThemeColor color;
 
-  bool operator==(other) => other.runtimeType == runtimeType && other.color == color;
+  bool operator ==(dynamic other) {
+    if (other is! IconThemeData)
+      return false;
+    final IconThemeData typedOther = other;
+    return color == typedOther;
+  }
+
   int get hashCode => color.hashCode;
 }
 
@@ -96,7 +102,7 @@ class Icon extends StatelessComponent {
     String colorSuffix = _getColorSuffix(context);
     return new AssetImage(
       bundle: _iconBundle,
-      name: '${category}/${density}/ic_${subtype}_${colorSuffix}_${size}dp.png',
+      name: '$category/$density/ic_${subtype}_${colorSuffix}_${size}dp.png',
       width: size.toDouble(),
       height: size.toDouble(),
       colorFilter: colorFilter

--- a/sky/packages/sky/lib/src/material/input.dart
+++ b/sky/packages/sky/lib/src/material/input.dart
@@ -119,6 +119,7 @@ class _InputState extends ScrollableState<Input> {
         )
       ),
       onPointerDown: (_) {
+        // TODO(ianh): https://github.com/flutter/engine/issues/1530
         if (Focus.at(context, config)) {
           assert(_keyboardHandle.attached);
           _keyboardHandle.showByRequest();

--- a/sky/packages/sky/lib/src/material/popup_menu.dart
+++ b/sky/packages/sky/lib/src/material/popup_menu.dart
@@ -49,7 +49,7 @@ class PopupMenu extends StatelessComponent {
     ));
 
     double unit = 1.0 / (items.length + 1.5); // 1.0 for the width and 0.5 for the last item's fade.
-    List<Widget> children = [];
+    List<Widget> children = <Widget>[];
 
     for (int i = 0; i < items.length; ++i) {
       double start = (i + 1) * unit;
@@ -64,15 +64,15 @@ class PopupMenu extends StatelessComponent {
       );
     }
 
-    final width = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, unit));
-    final height = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, unit * items.length));
+    final AnimatedValue<double> width = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, unit));
+    final AnimatedValue<double> height = new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, unit * items.length));
 
     return new FadeTransition(
       performance: performance,
       opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: new Interval(0.0, 1.0 / 3.0)),
       child: new BuilderTransition(
         performance: performance,
-        variables: [width, height],
+        variables: <AnimatedValue<double>>[width, height],
         builder: (BuildContext context) {
           return new CustomPaint(
             callback: (ui.Canvas canvas, Size size) {

--- a/sky/packages/sky/lib/src/material/progress_indicator.dart
+++ b/sky/packages/sky/lib/src/material/progress_indicator.dart
@@ -60,7 +60,7 @@ class _ProgressIndicatorState extends State<ProgressIndicator> {
       return config._buildIndicator(context, _performance.value);
 
     return new BuilderTransition(
-      variables: [_performance.variable],
+      variables: <AnimatedValue<double>>[_performance.variable],
       performance: _performance.view,
       builder: (BuildContext context) {
         return config._buildIndicator(context, _performance.value);

--- a/sky/packages/sky/lib/src/material/radial_reaction.dart
+++ b/sky/packages/sky/lib/src/material/radial_reaction.dart
@@ -37,7 +37,7 @@ class RadialReaction {
         _showPerformance.updateVariable(_innerRadius);
       });
     _fade = new ValuePerformance<double>(
-      variable: new AnimatedValue(1.0, end: 0.0, curve: easeIn),
+      variable: new AnimatedValue<double>(1.0, end: 0.0, curve: easeIn),
       duration: _kHideDuration
     );
   }

--- a/sky/packages/sky/lib/src/material/shadows.dart
+++ b/sky/packages/sky/lib/src/material/shadows.dart
@@ -6,8 +6,8 @@ import 'dart:ui' show Color, Offset;
 
 import 'package:flutter/painting.dart';
 
-const Map<int, List<BoxShadow>> shadows = const {
-  1: const [
+const Map<int, List<BoxShadow>> shadows = const <int, List<BoxShadow>>{
+  1: const <BoxShadow>[
     const BoxShadow(
       color: const Color(0x1F000000),
       offset: const Offset(0.0, 1.0),
@@ -17,7 +17,7 @@ const Map<int, List<BoxShadow>> shadows = const {
       offset: const Offset(0.0, 1.0),
       blur: 2.0),
     ],
-  2: const [
+  2: const <BoxShadow>[
     const BoxShadow(
       color: const Color(0x29000000),
       offset: const Offset(0.0, 3.0),
@@ -27,7 +27,7 @@ const Map<int, List<BoxShadow>> shadows = const {
       offset: const Offset(0.0, 3.0),
       blur: 6.0),
   ],
-  3: const [
+  3: const <BoxShadow>[
     const BoxShadow(
       color: const Color(0x30000000),
       offset: const Offset(0.0, 10.0),
@@ -37,7 +37,7 @@ const Map<int, List<BoxShadow>> shadows = const {
       offset: const Offset(0.0, 6.0),
       blur: 6.0),
   ],
-  4: const [
+  4: const <BoxShadow>[
     const BoxShadow(
       color: const Color(0x40000000),
       offset: const Offset(0.0, 14.0),
@@ -47,7 +47,7 @@ const Map<int, List<BoxShadow>> shadows = const {
       offset: const Offset(0.0, 10.0),
       blur: 10.0),
   ],
-  5: const [
+  5: const <BoxShadow>[
     const BoxShadow(
       color: const Color(0x4E000000),
       offset: const Offset(0.0, 19.0),

--- a/sky/packages/sky/lib/src/material/snack_bar.dart
+++ b/sky/packages/sky/lib/src/material/snack_bar.dart
@@ -24,7 +24,7 @@ class SnackBarAction extends StatelessComponent {
   final String label;
   final GestureTapCallback onPressed;
 
-  Widget build(BuildContext) {
+  Widget build(BuildContext context) {
     return new GestureDetector(
       onTap: onPressed,
       child: new Container(
@@ -51,7 +51,7 @@ class SnackBar extends StatelessComponent {
   final PerformanceView performance;
 
   Widget build(BuildContext context) {
-    List<Widget> children = [
+    List<Widget> children = <Widget>[
       new Flexible(
         child: new Container(
           margin: const EdgeDims.symmetric(vertical: _kVerticalPadding),

--- a/sky/packages/sky/lib/src/material/switch.dart
+++ b/sky/packages/sky/lib/src/material/switch.dart
@@ -70,7 +70,7 @@ class _RenderSwitch extends RenderToggleable {
     Color thumbColor: _kThumbOffColor,
     ValueChanged onChanged
   }) : _thumbColor = thumbColor,
-        super(value: value, onChanged: onChanged, size: _kSwitchSize) {}
+        super(value: value, onChanged: onChanged, size: _kSwitchSize);
 
   Color _thumbColor;
   Color get thumbColor => _thumbColor;

--- a/sky/packages/sky/lib/src/material/tabs.dart
+++ b/sky/packages/sky/lib/src/material/tabs.dart
@@ -33,8 +33,7 @@ const int _kTabIconSize = 24;
 const double _kTabBarScrollDrag = 0.025;
 const Duration _kTabBarScroll = const Duration(milliseconds: 200);
 
-class _TabBarParentData extends BoxParentData with
-    ContainerParentDataMixin<RenderBox> { }
+class _TabBarParentData extends ContainerBoxParentDataMixin<RenderBox> { }
 
 class _RenderTabBar extends RenderBox with
     ContainerRenderObjectMixin<RenderBox, _TabBarParentData>,
@@ -100,8 +99,8 @@ class _RenderTabBar extends RenderBox with
     RenderBox child = firstChild;
     while (child != null) {
       maxWidth = math.max(maxWidth, child.getMinIntrinsicWidth(widthConstraints));
-      assert(child.parentData is _TabBarParentData);
-      child = child.parentData.nextSibling;
+      final _TabBarParentData childParentData = child.parentData;
+      child = childParentData.nextSibling;
     }
     double width = isScrollable ? maxWidth : maxWidth * childCount;
     return constraints.constrainWidth(width);
@@ -115,8 +114,8 @@ class _RenderTabBar extends RenderBox with
     RenderBox child = firstChild;
     while (child != null) {
       maxWidth = math.max(maxWidth, child.getMaxIntrinsicWidth(widthConstraints));
-      assert(child.parentData is _TabBarParentData);
-      child = child.parentData.nextSibling;
+      final _TabBarParentData childParentData = child.parentData;
+      child = childParentData.nextSibling;
     }
     double width = isScrollable ? maxWidth : maxWidth * childCount;
     return constraints.constrainWidth(width);
@@ -139,10 +138,10 @@ class _RenderTabBar extends RenderBox with
     RenderBox child = firstChild;
     while (child != null) {
       child.layout(tabConstraints);
-      assert(child.parentData is _TabBarParentData);
-      child.parentData.position = new Point(x, 0.0);
+      final _TabBarParentData childParentData = child.parentData;
+      childParentData.position = new Point(x, 0.0);
       x += tabWidth;
-      child = child.parentData.nextSibling;
+      child = childParentData.nextSibling;
     }
   }
 
@@ -157,10 +156,10 @@ class _RenderTabBar extends RenderBox with
     RenderBox child = firstChild;
     while (child != null) {
       child.layout(tabConstraints, parentUsesSize: true);
-      assert(child.parentData is _TabBarParentData);
-      child.parentData.position = new Point(x, 0.0);
+      final _TabBarParentData childParentData = child.parentData;
+      childParentData.position = new Point(x, 0.0);
       x += child.size.width;
-      child = child.parentData.nextSibling;
+      child = childParentData.nextSibling;
     }
     return x;
   }
@@ -180,7 +179,8 @@ class _RenderTabBar extends RenderBox with
       int childIndex = 0;
       while (child != null) {
         widths[childIndex++] = child.size.width;
-        child = child.parentData.nextSibling;
+        final _TabBarParentData childParentData = child.parentData;
+        child = childParentData.nextSibling;
       }
       assert(childIndex == widths.length);
     }
@@ -221,24 +221,24 @@ class _RenderTabBar extends RenderBox with
       return;
     }
 
-    var size = new Size(selectedTab.size.width, _kTabIndicatorHeight);
-    var point = new Point(
-      selectedTab.parentData.position.x,
+    final Size size = new Size(selectedTab.size.width, _kTabIndicatorHeight);
+    final _TabBarParentData selectedTabParentData = selectedTab.parentData;
+    final Point point = new Point(
+      selectedTabParentData.position.x,
       _tabBarHeight - _kTabIndicatorHeight
     );
-    Rect rect = (point + offset) & size;
-    canvas.drawRect(rect, new Paint()..color = indicatorColor);
+    canvas.drawRect((point + offset) & size, new Paint()..color = indicatorColor);
   }
 
   void paint(PaintingContext context, Offset offset) {
     int index = 0;
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is _TabBarParentData);
-      context.paintChild(child, child.parentData.position + offset);
+      final _TabBarParentData childParentData = child.parentData;
+      context.paintChild(child, childParentData.position + offset);
       if (index++ == selectedIndex)
         _paintIndicator(context.canvas, child, offset);
-      child = child.parentData.nextSibling;
+      child = childParentData.nextSibling;
     }
   }
 }
@@ -426,7 +426,7 @@ class _TabBarState extends ScrollableState<TabBar> {
     assert(tabIndex >= 0 && tabIndex < _tabWidths.length);
     double tabLeft = 0.0;
     if (tabIndex > 0)
-      tabLeft = _tabWidths.take(tabIndex).reduce((sum, width) => sum + width);
+      tabLeft = _tabWidths.take(tabIndex).reduce((double sum, double width) => sum + width);
     double tabTop = 0.0;
     double tabBottom = _tabBarSize.height - _kTabIndicatorHeight;
     double tabRight = tabLeft + _tabWidths[tabIndex];
@@ -469,7 +469,7 @@ class _TabBarState extends ScrollableState<TabBar> {
   void _updateScrollBehavior() {
     scrollBehavior.updateExtents(
       containerExtent: config.scrollDirection == ScrollDirection.vertical ? _viewportSize.height : _viewportSize.width,
-      contentExtent: _tabWidths.reduce((sum, width) => sum + width)
+      contentExtent: _tabWidths.reduce((double sum, double width) => sum + width)
     );
   }
 
@@ -523,7 +523,7 @@ class _TabBarState extends ScrollableState<TabBar> {
       child: new DefaultTextStyle(
         style: textStyle,
         child: new BuilderTransition(
-          variables: [_indicatorRect],
+          variables: <AnimatedValue<Rect>>[_indicatorRect],
           performance: _indicatorAnimation.view,
           builder: (BuildContext context) {
             return new _TabBarWrapper(
@@ -591,9 +591,9 @@ class TabNavigator extends StatelessComponent {
   Widget build(BuildContext context) {
     assert(views != null && views.isNotEmpty);
     assert(selectedIndex >= 0 && selectedIndex < views.length);
-    return new Column([
+    return new Column(<Widget>[
       new TabBar(
-        labels: views.map((view) => view.label),
+        labels: views.map((TabNavigatorView view) => view.label),
         onChanged: onChanged,
         selectedIndex: selectedIndex,
         isScrollable: isScrollable

--- a/sky/packages/sky/lib/src/material/tool_bar.dart
+++ b/sky/packages/sky/lib/src/material/tool_bar.dart
@@ -70,7 +70,7 @@ class ToolBar extends StatelessComponent {
       ),
       child: new DefaultTextStyle(
         style: sideStyle,
-        child: new Column([
+        child: new Column(<Widget>[
             new Container(
               child: new Row(children),
               height: kToolBarHeight

--- a/sky/packages/sky/lib/src/painting/box_painter.dart
+++ b/sky/packages/sky/lib/src/painting/box_painter.dart
@@ -101,15 +101,6 @@ class EdgeDims {
     );
   }
 
-  bool operator ==(other) {
-    return identical(this, other) ||
-      (other is EdgeDims &&
-       top == other.top &&
-       right == other.right &&
-       bottom == other.bottom &&
-       left == other.left);
-  }
-
   /// Linearly interpolate between two EdgeDims
   ///
   /// If either is null, this function interpolates from [EdgeDims.zero].
@@ -131,6 +122,18 @@ class EdgeDims {
   /// An EdgeDims with zero offsets in each direction
   static const EdgeDims zero = const EdgeDims.TRBL(0.0, 0.0, 0.0, 0.0);
 
+  bool operator ==(dynamic other) {
+    if (identical(this, other))
+      return true;
+    if (other is! EdgeDims)
+      return false;
+    final EdgeDims typedOther = other;
+    return top == typedOther.top &&
+           right == typedOther.right &&
+           bottom == typedOther.bottom &&
+           left == typedOther.left;
+  }
+
   int get hashCode {
     int value = 373;
     value = 37 * value + top.hashCode;
@@ -139,6 +142,7 @@ class EdgeDims {
     value = 37 * value + right.hashCode;
     return value;
   }
+
   String toString() => "EdgeDims($top, $right, $bottom, $left)";
 }
 
@@ -322,8 +326,7 @@ class LinearGradient extends Gradient {
   final ui.TileMode tileMode;
 
   ui.Shader createShader() {
-    return new ui.Gradient.linear([begin, end], this.colors,
-                                   this.stops, this.tileMode);
+    return new ui.Gradient.linear(<Point>[begin, end], this.colors, this.stops, this.tileMode);
   }
 
   String toString() {
@@ -612,7 +615,7 @@ class BoxDecoration {
   }
 
   String toString([String prefix = '']) {
-    List<String> result = [];
+    List<String> result = <String>[];
     if (backgroundColor != null)
       result.add('${prefix}backgroundColor: $backgroundColor');
     if (backgroundImage != null)
@@ -622,13 +625,13 @@ class BoxDecoration {
     if (borderRadius != null)
       result.add('${prefix}borderRadius: $borderRadius');
     if (boxShadow != null)
-      result.add('${prefix}boxShadow: ${boxShadow.map((shadow) => shadow.toString())}');
+      result.add('${prefix}boxShadow: ${boxShadow.map((BoxShadow shadow) => shadow.toString())}');
     if (gradient != null)
       result.add('${prefix}gradient: $gradient');
     if (shape != Shape.rectangle)
       result.add('${prefix}shape: $shape');
     if (result.isEmpty)
-      return '${prefix}<no decorations specified>';
+      return '$prefix<no decorations specified>';
     return result.join('\n');
   }
 }

--- a/sky/packages/sky/lib/src/painting/shadows.dart
+++ b/sky/packages/sky/lib/src/painting/shadows.dart
@@ -6,23 +6,24 @@ import 'dart:ui' as ui;
 
 /// A helper class to build a [ui.DrawLooper] for drawing shadows
 class ShadowDrawLooperBuilder {
-  var builder_ = new ui.LayerDrawLooperBuilder();
+  ui.LayerDrawLooperBuilder _builder = new ui.LayerDrawLooperBuilder();
 
   /// Add a shadow with the given parameters
   void addShadow(ui.Offset offset, ui.Color color, double blur) {
-    builder_.addLayerOnTop(
-          new ui.DrawLooperLayerInfo()
-            ..setPaintBits(ui.PaintBits.all)
-            ..setOffset(offset)
-            ..setColorMode(ui.TransferMode.src),
-          new ui.Paint()
-            ..color = color
-            ..maskFilter = new ui.MaskFilter.blur(ui.BlurStyle.normal, blur));
+    _builder.addLayerOnTop(
+      new ui.DrawLooperLayerInfo()
+        ..setPaintBits(ui.PaintBits.all)
+        ..setOffset(offset)
+        ..setColorMode(ui.TransferMode.src),
+      new ui.Paint()
+        ..color = color
+        ..maskFilter = new ui.MaskFilter.blur(ui.BlurStyle.normal, blur)
+    );
   }
 
   /// Returns the draw looper built for the added shadows
   ui.DrawLooper build() {
-    builder_.addLayerOnTop(new ui.DrawLooperLayerInfo(), new ui.Paint());
-    return builder_.build();
+    _builder.addLayerOnTop(new ui.DrawLooperLayerInfo(), new ui.Paint());
+    return _builder.build();
   }
 }

--- a/sky/packages/sky/lib/src/painting/text_style.dart
+++ b/sky/packages/sky/lib/src/painting/text_style.dart
@@ -137,7 +137,7 @@ class TextStyle {
       TextDecoration.overline: 'overline',
       TextDecoration.lineThrough: 'lineThrough'
     };
-    return decoration.map((d) => toCSS[d]).join(' ');
+    return decoration.map((TextDecoration d) => toCSS[d]).join(' ');
   }
 
   static String _decorationStyleToCSSString(TextDecorationStyle decorationStyle) {
@@ -210,24 +210,26 @@ class TextStyle {
       }[textAlign];
     }
     if (height != null) {
-      cssStyle['line-height'] = '${height}';
+      cssStyle['line-height'] = '$height';
     }
   }
 
-  bool operator ==(other) {
+  bool operator ==(dynamic other) {
     if (identical(this, other))
       return true;
-    return other is TextStyle &&
-      color == other.color &&
-      fontFamily == other.fontFamily &&
-      fontSize == other.fontSize &&
-      fontWeight == other.fontWeight &&
-      fontStyle == other.fontStyle &&
-      textAlign == other.textAlign &&
-      textBaseline == other.textBaseline &&
-      decoration == other.decoration &&
-      decorationColor == other.decorationColor &&
-      decorationStyle == other.decorationStyle;
+    if (other is! TextStyle)
+      return false;
+    final TextStyle typedOther = other;
+    return color == typedOther.color &&
+           fontFamily == typedOther.fontFamily &&
+           fontSize == typedOther.fontSize &&
+           fontWeight == typedOther.fontWeight &&
+           fontStyle == typedOther.fontStyle &&
+           textAlign == typedOther.textAlign &&
+           textBaseline == typedOther.textBaseline &&
+           decoration == typedOther.decoration &&
+           decorationColor == typedOther.decorationColor &&
+           decorationStyle == typedOther.decorationStyle;
   }
 
   int get hashCode {
@@ -247,12 +249,12 @@ class TextStyle {
   }
 
   String toString([String prefix = '']) {
-    List<String> result = [];
+    List<String> result = <String>[];
     if (color != null)
       result.add('${prefix}color: $color');
     // TODO(hansmuller): escape the fontFamily string.
     if (fontFamily != null)
-      result.add('${prefix}fontFamily: "${fontFamily}"');
+      result.add('${prefix}fontFamily: "$fontFamily"');
     if (fontSize != null)
       result.add('${prefix}fontSize: $fontSize');
     if (fontWeight != null)
@@ -270,7 +272,7 @@ class TextStyle {
     if (decorationStyle != null)
       result.add('${prefix}decorationStyle: $decorationStyle');
     if (result.isEmpty)
-      return '${prefix}<no style specified>';
+      return '$prefix<no style specified>';
     return result.join('\n');
   }
 }

--- a/sky/packages/sky/lib/src/rendering/flex.dart
+++ b/sky/packages/sky/lib/src/rendering/flex.dart
@@ -8,7 +8,7 @@ import 'box.dart';
 import 'object.dart';
 
 /// Parent data for use with [RenderFlex]
-class FlexParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> {
+class FlexParentData extends ContainerBoxParentDataMixin<RenderBox> {
   /// The flex factor to use for this child
   ///
   /// If null, the child is inflexible and determines its own size. If non-null,
@@ -174,8 +174,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         } else {
           inflexibleSpace += childSize(child, childConstraints);
         }
-        assert(child.parentData is FlexParentData);
-        child = child.parentData.nextSibling;
+        final FlexParentData childParentData = child.parentData;
+        child = childParentData.nextSibling;
       }
       double mainSize = maxFlexFractionSoFar * totalFlex + inflexibleSpace;
 
@@ -237,8 +237,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           inflexibleSpace += mainSize;
           maxCrossSize = math.max(maxCrossSize, crossSize);
         }
-        assert(child.parentData is FlexParentData);
-        child = child.parentData.nextSibling;
+        final FlexParentData childParentData = child.parentData;
+        child = childParentData.nextSibling;
       }
 
       // Determine the spacePerFlex by allocating the remaining available space
@@ -265,8 +265,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           }
           maxCrossSize = math.max(maxCrossSize, crossSize);
         }
-        assert(child.parentData is FlexParentData);
-        child = child.parentData.nextSibling;
+        final FlexParentData childParentData = child.parentData;
+        child = childParentData.nextSibling;
       }
 
       // Ensure that we don't violate the given constraints with our result
@@ -283,7 +283,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     return _getIntrinsicSize(
       constraints: constraints,
       sizingDirection: FlexDirection.horizontal,
-      childSize: (c, innerConstraints) => c.getMinIntrinsicWidth(innerConstraints)
+      childSize: (RenderBox child, BoxConstraints innerConstraints) => child.getMinIntrinsicWidth(innerConstraints)
     );
   }
 
@@ -291,7 +291,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     return _getIntrinsicSize(
       constraints: constraints,
       sizingDirection: FlexDirection.horizontal,
-      childSize: (c, innerConstraints) => c.getMaxIntrinsicWidth(innerConstraints)
+      childSize: (RenderBox child, BoxConstraints innerConstraints) => child.getMaxIntrinsicWidth(innerConstraints)
     );
   }
 
@@ -299,7 +299,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     return _getIntrinsicSize(
       constraints: constraints,
       sizingDirection: FlexDirection.vertical,
-      childSize: (c, innerConstraints) => c.getMinIntrinsicHeight(innerConstraints)
+      childSize: (RenderBox child, BoxConstraints innerConstraints) => child.getMinIntrinsicHeight(innerConstraints)
     );
   }
 
@@ -307,7 +307,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     return _getIntrinsicSize(
       constraints: constraints,
       sizingDirection: FlexDirection.vertical,
-      childSize: (c, innerConstraints) => c.getMaxIntrinsicHeight(innerConstraints));
+      childSize: (RenderBox child, BoxConstraints innerConstraints) => child.getMaxIntrinsicHeight(innerConstraints));
   }
 
   double computeDistanceToActualBaseline(TextBaseline baseline) {
@@ -317,8 +317,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
   }
 
   int _getFlex(RenderBox child) {
-    assert(child.parentData is FlexParentData);
-    return child.parentData.flex != null ? child.parentData.flex : 0;
+    final FlexParentData childParentData = child.parentData;
+    return childParentData.flex != null ? childParentData.flex : 0;
   }
 
   double _getCrossSize(RenderBox child) {
@@ -342,7 +342,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     double freeSpace = canFlex ? mainSize : 0.0;
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is FlexParentData);
+      final FlexParentData childParentData = child.parentData;
       totalChildren++;
       int flex = _getFlex(child);
       if (flex > 0) {
@@ -350,7 +350,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         // When the container is infinite, for example if you are in a scrollable viewport, then
         // it wouldn't make any sense to have a flexible child.
         assert(canFlex && 'See https://flutter.github.io/layout/#flex' is String);
-        totalFlex += child.parentData.flex;
+        totalFlex += childParentData.flex;
       } else {
         BoxConstraints innerConstraints;
         if (alignItems == FlexAlignItems.stretch) {
@@ -378,7 +378,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
         freeSpace -= _getMainSize(child);
         crossSize = math.max(crossSize, _getCrossSize(child));
       }
-      child = child.parentData.nextSibling;
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
     }
     _overflow = math.max(0.0, -freeSpace);
     freeSpace = math.max(0.0, freeSpace);
@@ -433,8 +434,8 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
           if (distance != null)
             maxBaselineDistance = math.max(maxBaselineDistance, distance);
         }
-        assert(child.parentData is FlexParentData);
-        child = child.parentData.nextSibling;
+        final FlexParentData childParentData = child.parentData;
+        child = childParentData.nextSibling;
       }
     }
 
@@ -502,7 +503,7 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     double childMainPosition = leadingSpace;
     child = firstChild;
     while (child != null) {
-      assert(child.parentData is FlexParentData);
+      final FlexParentData childParentData = child.parentData;
       double childCrossPosition;
       switch (_alignItems) {
         case FlexAlignItems.stretch:
@@ -527,14 +528,14 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
       }
       switch (_direction) {
         case FlexDirection.horizontal:
-          child.parentData.position = new Point(childMainPosition, childCrossPosition);
+          childParentData.position = new Point(childMainPosition, childCrossPosition);
           break;
         case FlexDirection.vertical:
-          child.parentData.position = new Point(childCrossPosition, childMainPosition);
+          childParentData.position = new Point(childCrossPosition, childMainPosition);
           break;
       }
       childMainPosition += _getMainSize(child) + betweenSpace;
-      child = child.parentData.nextSibling;
+      child = childParentData.nextSibling;
     }
   }
 
@@ -593,6 +594,6 @@ class RenderFlex extends RenderBox with ContainerRenderObjectMixin<RenderBox, Fl
     return header;
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}direction: ${_direction}\n${prefix}justifyContent: ${_justifyContent}\n${prefix}alignItems: ${_alignItems}\n${prefix}textBaseline: ${_textBaseline}\n';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}direction: $_direction\n${prefix}justifyContent: $_justifyContent\n${prefix}alignItems: $_alignItems\n${prefix}textBaseline: $_textBaseline\n';
 
 }

--- a/sky/packages/sky/lib/src/rendering/grid.dart
+++ b/sky/packages/sky/lib/src/rendering/grid.dart
@@ -42,7 +42,7 @@ class _GridMetrics {
 }
 
 /// Parent data for use with [RenderGrid]
-class GridParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> {}
+class GridParentData extends ContainerBoxParentDataMixin<RenderBox> {}
 
 /// Implements the grid layout algorithm
 ///
@@ -120,14 +120,17 @@ class RenderGrid extends RenderBox with ContainerRenderObjectMixin<RenderBox, Gr
 
       double x = (column + 1) * metrics.childPadding + (column * metrics.childSize.width);
       double y = (row + 1) * metrics.childPadding + (row * metrics.childSize.height);
-      child.parentData.position = new Point(x, y);
+      final GridParentData childParentData = child.parentData;
+      childParentData.position = new Point(x, y);
 
       column += 1;
       if (column >= metrics.childrenPerRow) {
         row += 1;
         column = 0;
       }
-      child = child.parentData.nextSibling;
+
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
     }
   }
 

--- a/sky/packages/sky/lib/src/rendering/image.dart
+++ b/sky/packages/sky/lib/src/rendering/image.dart
@@ -174,5 +174,5 @@ class RenderImage extends RenderBox {
     );
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}width: ${width}\n${prefix}height: ${height}\n';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}width: $width\n${prefix}height: $height\n';
 }

--- a/sky/packages/sky/lib/src/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/src/rendering/proxy_box.dart
@@ -142,7 +142,7 @@ class RenderConstrainedBox extends RenderProxyBox {
     }
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}additionalConstraints: ${additionalConstraints}\n';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}additionalConstraints: $additionalConstraints\n';
 }
 
 /// A render object that, for both width and height, imposes a tight constraint
@@ -376,7 +376,7 @@ class RenderAspectRatio extends RenderProxyBox {
   RenderAspectRatio({
     RenderBox child,
     double aspectRatio
-  }) : super(child), _aspectRatio = aspectRatio {
+  }) : _aspectRatio = aspectRatio, super(child) {
     assert(_aspectRatio != null);
   }
 
@@ -419,7 +419,7 @@ class RenderAspectRatio extends RenderProxyBox {
       child.layout(new BoxConstraints.tight(size));
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}aspectRatio: ${aspectRatio}\n';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}aspectRatio: $aspectRatio\n';
 }
 
 /// Sizes its child to the child's intrinsic width
@@ -514,7 +514,7 @@ class RenderIntrinsicWidth extends RenderProxyBox {
     }
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}stepWidth: ${stepWidth}\n${prefix}stepHeight: ${stepHeight}\n';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}stepWidth: $stepWidth\n${prefix}stepHeight: $stepHeight\n';
 
 }
 
@@ -628,8 +628,7 @@ class RenderOpacity extends RenderProxyBox {
 /// child into an intermediate buffer.
 class RenderColorFilter extends RenderProxyBox {
   RenderColorFilter({ RenderBox child, Color color, ui.TransferMode transferMode })
-    : _color = color, _transferMode = transferMode, super(child) {
-  }
+    : _color = color, _transferMode = transferMode, super(child);
 
   /// The color to use as input to the color filter
   Color get color => _color;
@@ -661,8 +660,7 @@ class RenderColorFilter extends RenderProxyBox {
 
 class RenderShaderMask extends RenderProxyBox {
   RenderShaderMask({ RenderBox child, ShaderCallback shaderCallback, ui.TransferMode transferMode })
-    : _shaderCallback = shaderCallback, _transferMode = transferMode, super(child) {
-  }
+    : _shaderCallback = shaderCallback, _transferMode = transferMode, super(child);
 
   ShaderCallback get shaderCallback => _shaderCallback;
   ShaderCallback _shaderCallback;
@@ -969,9 +967,9 @@ class RenderTransform extends RenderProxyBox {
   }
 
   String debugDescribeSettings(String prefix) {
-    List<String> result = _transform.toString().split('\n').map((s) => '$prefix  $s\n').toList();
+    List<String> result = _transform.toString().split('\n').map((String s) => '$prefix  $s\n').toList();
     result.removeLast();
-    return '${super.debugDescribeSettings(prefix)}${prefix}transform matrix:\n${result.join()}\n${prefix}origin: ${origin}\n';
+    return '${super.debugDescribeSettings(prefix)}${prefix}transform matrix:\n${result.join()}\n${prefix}origin: $origin\n';
   }
 }
 

--- a/sky/packages/sky/lib/src/rendering/shifted_box.dart
+++ b/sky/packages/sky/lib/src/rendering/shifted_box.dart
@@ -44,9 +44,9 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
     if (child != null) {
       assert(!needsLayout);
       result = child.getDistanceToActualBaseline(baseline);
-      assert(child.parentData is BoxParentData);
+      final BoxParentData childParentData = child.parentData;
       if (result != null)
-        result += child.parentData.position.y;
+        result += childParentData.position.y;
     } else {
       result = super.computeDistanceToActualBaseline(baseline);
     }
@@ -54,15 +54,17 @@ abstract class RenderShiftedBox extends RenderBox with RenderObjectWithChildMixi
   }
 
   void paint(PaintingContext context, Offset offset) {
-    if (child != null)
-      context.paintChild(child, child.parentData.position + offset);
+    if (child != null) {
+      final BoxParentData childParentData = child.parentData;
+      context.paintChild(child, childParentData.position + offset);
+    }
   }
 
   void hitTestChildren(HitTestResult result, { Point position }) {
     if (child != null) {
-      assert(child.parentData is BoxParentData);
-      child.hitTest(result, position: new Point(position.x - child.parentData.position.x,
-                                                position.y - child.parentData.position.y));
+      final BoxParentData childParentData = child.parentData;
+      child.hitTest(result, position: new Point(position.x - childParentData.position.x,
+                                                position.y - childParentData.position.y));
     }
   }
 
@@ -125,15 +127,15 @@ class RenderPadding extends RenderShiftedBox {
     }
     BoxConstraints innerConstraints = constraints.deflate(padding);
     child.layout(innerConstraints, parentUsesSize: true);
-    assert(child.parentData is BoxParentData);
-    child.parentData.position = new Point(padding.left, padding.top);
+    final BoxParentData childParentData = child.parentData;
+    childParentData.position = new Point(padding.left, padding.top);
     size = constraints.constrain(new Size(
       padding.left + child.size.width + padding.right,
       padding.top + child.size.height + padding.bottom
     ));
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}padding: ${padding}\n';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}padding: $padding\n';
 }
 
 enum ShrinkWrap {
@@ -204,16 +206,16 @@ class RenderPositionedBox extends RenderShiftedBox {
       child.layout(constraints.loosen(), parentUsesSize: true);
       size = constraints.constrain(new Size(_shinkWrapWidth ? child.size.width : double.INFINITY,
                                             _shinkWrapHeight ? child.size.height : double.INFINITY));
-      assert(child.parentData is BoxParentData);
       Offset delta = size - child.size;
-      child.parentData.position = (delta.scale(horizontal, vertical)).toPoint();
+      final BoxParentData childParentData = child.parentData;
+      childParentData.position = (delta.scale(horizontal, vertical)).toPoint();
     } else {
       size = constraints.constrain(new Size(_shinkWrapWidth ? 0.0 : double.INFINITY,
                                             _shinkWrapHeight ? 0.0 : double.INFINITY));
     }
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}horizontal: ${horizontal}\n${prefix}vertical: ${vertical}\n';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}horizontal: $horizontal\n${prefix}vertical: $vertical\n';
 }
 
 class RenderBaseline extends RenderShiftedBox {
@@ -253,13 +255,13 @@ class RenderBaseline extends RenderShiftedBox {
     if (child != null) {
       child.layout(constraints.loosen(), parentUsesSize: true);
       size = constraints.constrain(child.size);
-      assert(child.parentData is BoxParentData);
       double delta = baseline - child.getDistanceToBaseline(baselineType);
-      child.parentData.position = new Point(0.0, delta);
+      final BoxParentData childParentData = child.parentData;
+      childParentData.position = new Point(0.0, delta);
     } else {
       performResize();
     }
   }
 
-  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}baseline: ${baseline}\nbaselineType: ${baselineType}';
+  String debugDescribeSettings(String prefix) => '${super.debugDescribeSettings(prefix)}${prefix}baseline: $baseline\nbaselineType: $baselineType';
 }

--- a/sky/packages/sky/lib/src/rendering/stack.dart
+++ b/sky/packages/sky/lib/src/rendering/stack.dart
@@ -8,7 +8,7 @@ import 'box.dart';
 import 'object.dart';
 
 /// Parent data for use with [RenderStack]
-class StackParentData extends BoxParentData with ContainerParentDataMixin<RenderBox> {
+class StackParentData extends ContainerBoxParentDataMixin<RenderBox> {
   /// The offset of the child's top edge from the top of the stack
   double top;
 
@@ -84,10 +84,11 @@ abstract class RenderStackBase extends RenderBox
     double width = constraints.minWidth;
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is StackParentData);
-      if (!child.parentData.isPositioned)
+      final StackParentData childParentData = child.parentData;
+      if (!childParentData.isPositioned)
         width = math.max(width, child.getMinIntrinsicWidth(constraints));
-      child = child.parentData.nextSibling;
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
     }
     assert(width == constraints.constrainWidth(width));
     return width;
@@ -98,12 +99,13 @@ abstract class RenderStackBase extends RenderBox
     double width = constraints.minWidth;
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is StackParentData);
-      if (!child.parentData.isPositioned) {
+      final StackParentData childParentData = child.parentData;
+      if (!childParentData.isPositioned) {
         hasNonPositionedChildren = true;
         width = math.max(width, child.getMaxIntrinsicWidth(constraints));
       }
-      child = child.parentData.nextSibling;
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
     }
     if (!hasNonPositionedChildren)
       return constraints.constrainWidth();
@@ -115,10 +117,11 @@ abstract class RenderStackBase extends RenderBox
     double height = constraints.minHeight;
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is StackParentData);
-      if (!child.parentData.isPositioned)
+      final StackParentData childParentData = child.parentData;
+      if (!childParentData.isPositioned)
         height = math.max(height, child.getMinIntrinsicHeight(constraints));
-      child = child.parentData.nextSibling;
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
     }
     assert(height == constraints.constrainHeight(height));
     return height;
@@ -129,12 +132,13 @@ abstract class RenderStackBase extends RenderBox
     double height = constraints.minHeight;
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is StackParentData);
-      if (!child.parentData.isPositioned) {
+      final StackParentData childParentData = child.parentData;
+      if (!childParentData.isPositioned) {
         hasNonPositionedChildren = true;
         height = math.max(height, child.getMaxIntrinsicHeight(constraints));
       }
-      child = child.parentData.nextSibling;
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
     }
     if (!hasNonPositionedChildren)
       return constraints.constrainHeight();
@@ -155,21 +159,20 @@ abstract class RenderStackBase extends RenderBox
 
     RenderBox child = firstChild;
     while (child != null) {
-      assert(child.parentData is StackParentData);
-      final StackParentData parentData = child.parentData;
+      final StackParentData childParentData = child.parentData;
 
-      if (!parentData.isPositioned) {
+      if (!childParentData.isPositioned) {
         hasNonPositionedChildren = true;
 
         child.layout(constraints, parentUsesSize: true);
-        parentData.position = Point.origin;
+        childParentData.position = Point.origin;
 
         final Size childSize = child.size;
         width = math.max(width, childSize.width);
         height = math.max(height, childSize.height);
       }
 
-      child = parentData.nextSibling;
+      child = childParentData.nextSibling;
     }
 
     if (hasNonPositionedChildren) {
@@ -184,46 +187,46 @@ abstract class RenderStackBase extends RenderBox
 
     child = firstChild;
     while (child != null) {
-      assert(child.parentData is StackParentData);
-      final StackParentData childData = child.parentData;
+      final StackParentData childParentData = child.parentData;
 
-      if (!childData.isPositioned) {
+      if (!childParentData.isPositioned) {
         double x = (size.width - child.size.width) * horizontalAlignment;
         double y = (size.height - child.size.height) * verticalAlignment;
-        childData.position = new Point(x, y);
+        childParentData.position = new Point(x, y);
       } else {
         BoxConstraints childConstraints = const BoxConstraints();
 
-        if (childData.left != null && childData.right != null)
-          childConstraints = childConstraints.tightenWidth(size.width - childData.right - childData.left);
+        if (childParentData.left != null && childParentData.right != null)
+          childConstraints = childConstraints.tightenWidth(size.width - childParentData.right - childParentData.left);
 
-        if (childData.top != null && childData.bottom != null)
-          childConstraints = childConstraints.tightenHeight(size.height - childData.bottom - childData.top);
+        if (childParentData.top != null && childParentData.bottom != null)
+          childConstraints = childConstraints.tightenHeight(size.height - childParentData.bottom - childParentData.top);
 
         child.layout(childConstraints, parentUsesSize: true);
 
         double x = 0.0;
-        if (childData.left != null)
-          x = childData.left;
-        else if (childData.right != null)
-          x = size.width - childData.right - child.size.width;
+        if (childParentData.left != null)
+          x = childParentData.left;
+        else if (childParentData.right != null)
+          x = size.width - childParentData.right - child.size.width;
 
         if (x < 0.0 || x + child.size.width > size.width)
           _hasVisualOverflow = true;
 
         double y = 0.0;
-        if (childData.top != null)
-          y = childData.top;
-        else if (childData.bottom != null)
-          y = size.height - childData.bottom - child.size.height;
+        if (childParentData.top != null)
+          y = childParentData.top;
+        else if (childParentData.bottom != null)
+          y = size.height - childParentData.bottom - child.size.height;
 
         if (y < 0.0 || y + child.size.height > size.height)
           _hasVisualOverflow = true;
 
-        childData.position = new Point(x, y);
+        childParentData.position = new Point(x, y);
       }
 
-      child = childData.nextSibling;
+      assert(child.parentData == childParentData);
+      child = childParentData.nextSibling;
     }
   }
 
@@ -320,8 +323,8 @@ class RenderIndexedStack extends RenderStackBase {
     RenderBox child = firstChild;
     int i = 0;
     while (child != null && i < index) {
-      assert(child.parentData is StackParentData);
-      child = child.parentData.nextSibling;
+      final StackParentData childParentData = child.parentData;
+      child = childParentData.nextSibling;
       i += 1;
     }
     assert(i == index);
@@ -334,8 +337,9 @@ class RenderIndexedStack extends RenderStackBase {
       return;
     assert(position != null);
     RenderBox child = _childAtIndex();
-    Point transformed = new Point(position.x - child.parentData.position.x,
-                                  position.y - child.parentData.position.y);
+    final StackParentData childParentData = child.parentData;
+    Point transformed = new Point(position.x - childParentData.position.x,
+                                  position.y - childParentData.position.y);
     child.hitTest(result, position: transformed);
   }
 
@@ -343,6 +347,7 @@ class RenderIndexedStack extends RenderStackBase {
     if (firstChild == null)
       return;
     RenderBox child = _childAtIndex();
-    context.paintChild(child, child.parentData.position + offset);
+    final StackParentData childParentData = child.parentData;
+    context.paintChild(child, childParentData.position + offset);
   }
 }

--- a/sky/packages/sky/lib/src/rendering/viewport.dart
+++ b/sky/packages/sky/lib/src/rendering/viewport.dart
@@ -128,8 +128,8 @@ class RenderViewport extends RenderBox with RenderObjectWithChildMixin<RenderBox
     if (child != null) {
       child.layout(_getInnerConstraints(constraints), parentUsesSize: true);
       size = constraints.constrain(child.size);
-      assert(child.parentData is BoxParentData);
-      child.parentData.position = Point.origin;
+      final BoxParentData childParentData = child.parentData;
+      childParentData.position = Point.origin;
     } else {
       performResize();
     }

--- a/sky/packages/sky/lib/src/services/asset_bundle.dart
+++ b/sky/packages/sky/lib/src/services/asset_bundle.dart
@@ -50,7 +50,7 @@ Future _fetchAndUnpackBundle(String relativeUrl, AssetBundleProxy bundle) async 
 }
 
 class MojoAssetBundle extends AssetBundle {
-  MojoAssetBundle(AssetBundleProxy this._bundle);
+  MojoAssetBundle(this._bundle);
 
   factory MojoAssetBundle.fromNetwork(String relativeUrl) {
     AssetBundleProxy bundle = new AssetBundleProxy.unbound();

--- a/sky/packages/sky/lib/src/services/fetch.dart
+++ b/sky/packages/sky/lib/src/services/fetch.dart
@@ -53,7 +53,7 @@ Future<UrlResponse> fetchUrl(String relativeUrl) async {
   UrlRequest request = new UrlRequest()
     ..url = url
     ..autoFollowRedirects = true;
-  return fetch(request);
+  return await fetch(request);
 }
 
 Future<Response> fetchBody(String relativeUrl) async {

--- a/sky/packages/sky/lib/src/services/image_cache.dart
+++ b/sky/packages/sky/lib/src/services/image_cache.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection';
 import 'dart:ui' as ui;
 
 import 'package:mojo/mojo/url_response.mojom.dart';
@@ -15,7 +14,7 @@ import 'image_resource.dart';
 Future<ui.Image> _fetchImage(String url) async {
   UrlResponse response = await fetchUrl(url);
   if (response.statusCode >= 400) {
-    print("Failed (${response.statusCode}) to load image ${url}");
+    print("Failed (${response.statusCode}) to load image $url");
     return null;
   }
   return await decodeImageFromDataPipe(response.body);
@@ -24,7 +23,7 @@ Future<ui.Image> _fetchImage(String url) async {
 class _ImageCache {
   _ImageCache._();
 
-  final HashMap<String, ImageResource> _cache = new Map<String, ImageResource>();
+  final Map<String, ImageResource> _cache = new Map<String, ImageResource>();
 
   ImageResource load(String url) {
     return _cache.putIfAbsent(url, () {

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -770,7 +770,7 @@ class DefaultTextStyle extends InheritedWidget {
 }
 
 class Text extends StatelessComponent {
-  Text(this.data, { Key key, TextStyle this.style }) : super(key: key) {
+  Text(this.data, { Key key, this.style }) : super(key: key) {
     assert(data != null);
   }
 
@@ -790,7 +790,7 @@ class Text extends StatelessComponent {
       combinedStyle = style;
     }
     if (combinedStyle != null)
-      text = new StyledTextSpan(combinedStyle, [text]);
+      text = new StyledTextSpan(combinedStyle, <TextSpan>[text]);
     return new Paragraph(text: text);
   }
 

--- a/sky/packages/sky/lib/src/widgets/mixed_viewport.dart
+++ b/sky/packages/sky/lib/src/widgets/mixed_viewport.dart
@@ -56,7 +56,13 @@ class _ChildKey {
   factory _ChildKey.fromWidget(Widget widget) => new _ChildKey(widget.runtimeType, widget.key);
   final Type type;
   final Key key;
-  bool operator ==(other) => other is _ChildKey && other.type == type && other.key == key;
+  bool operator ==(dynamic other) {
+    if (other is! _ChildKey)
+      return false;
+    final _ChildKey typedOther = other;
+    return type == typedOther.type &&
+           key == typedOther.key;
+  }
   int get hashCode => 373 * 37 * type.hashCode + key.hashCode;
   String toString() => "_ChildKey(type: $type, key: $key)";
 }
@@ -327,7 +333,7 @@ class _MixedViewportElement extends RenderObjectElement<MixedViewport> {
     double newExtent = _getElementExtent(element, innerConstraints);
     bool result = _childExtents[index] == newExtent;
     if (!result)
-      print("Element $element at index $index was size ${_childExtents[index]} but is now size ${newExtent} yet no invalidate() was received to that effect");
+      print("Element $element at index $index was size ${_childExtents[index]} but is now size $newExtent yet no invalidate() was received to that effect");
     return result;
   }
 

--- a/sky/packages/sky/lib/src/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/src/widgets/scrollable.dart
@@ -511,7 +511,7 @@ abstract class ScrollableWidgetListState<T extends ScrollableWidgetList> extends
 
   List<Widget> _buildItems(BuildContext context, int start, int count) {
     List<Widget> result = buildItems(context, start, count);
-    assert(result.every((item) => item.key != null));
+    assert(result.every((Widget item) => item.key != null));
     return result;
   }
 
@@ -603,7 +603,7 @@ class PageableList<T> extends ScrollableList<T> {
   final Curve curve;
   final PageChangedCallback onPageChanged;
 
-  PageableListState<T> createState() => new PageableListState();
+  PageableListState<T> createState() => new PageableListState<T>();
 }
 
 class PageableListState<T> extends ScrollableListState<T, PageableList<T>> {

--- a/sky/packages/sky/lib/src/widgets/statistics_overlay.dart
+++ b/sky/packages/sky/lib/src/widgets/statistics_overlay.dart
@@ -44,12 +44,14 @@ class StatisticsOverlay extends LeafRenderObjectWidget {
   StatisticsOverlay({ this.optionsMask, this.rasterizerThreshold: 0, Key key }) : super(key: key);
 
   /// Create a statistics overaly that displays all available statistics
-  StatisticsOverlay.allEnabled({ Key key, this.rasterizerThreshold: 0 }) : super(key: key), optionsMask = (
-    1 << StatisticsOption.displayRasterizerStatistics.index |
-    1 << StatisticsOption.visualizeRasterizerStatistics.index |
-    1 << StatisticsOption.displayEngineStatistics.index |
-    1 << StatisticsOption.visualizeEngineStatistics.index
-  );
+  StatisticsOverlay.allEnabled({ Key key, this.rasterizerThreshold: 0 })
+    : optionsMask = (
+        1 << StatisticsOption.displayRasterizerStatistics.index |
+        1 << StatisticsOption.visualizeRasterizerStatistics.index |
+        1 << StatisticsOption.displayEngineStatistics.index |
+        1 << StatisticsOption.visualizeEngineStatistics.index
+      ),
+      super(key: key);
 
   final int optionsMask;
 

--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 # Copyright 2014 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
@@ -23,9 +24,18 @@ _IGNORED_PATTERNS = [
   re.compile(r'^$'),
   re.compile(r'^Analyzing \['),
   re.compile(r'^No issues found'),
-
-  # Ignore analyzer status output.
   re.compile(r'^[0-9]+ (error|warning|hint).*found[.]'),
+
+  # Disable the Strong checks that we don't care about.
+  re.compile(r'^\[error\] Invalid override\. The type of [^ ]+ \(.+\) is not a subtype of [^ ]+ \(.+\)\.'), # we allow type narrowing
+  re.compile(r'^\[(warning|hint)\] .+ will need runtime check to cast to type .+'), # https://github.com/dart-lang/sdk/issues/24542
+  re.compile(r'^\[hint\] .+ requires dynamic invoke'), # too many false positives, e.g. https://github.com/dart-lang/sdk/issues/24564
+  re.compile(r'^\[hint\] Runtime check on non-ground type .+ may throw StrongModeError'), # https://github.com/dart-lang/sdk/issues/24565
+  re.compile(r'^\[hint] \([_, ]+\) .+ has inferred type '), # ignore underscore-only arguments
+
+  # Disable the lint checks that will be caught by code review
+  re.compile(r'^\[lint\] Avoid defining a one-member abstract class when a simple function will do'),
+  re.compile(r'^\[lint\] Prefer using lowerCamelCase for constant names.'),
 
   # TODO: Fix all the warnings in the mojo packages
   re.compile(r'.*pub-cache.*\.mojom\.dart'),
@@ -54,7 +64,14 @@ def main():
       subprocess.check_output([
           DARTANALYZER, "--package-warnings",
           "--package-root", os.path.join(WORKBENCH, "packages"),
+          "--ignore-unrecognized-flags",
+          "--fatal-hints",
           "--fatal-warnings",
+          "--lints",
+          "--strong",
+          "--strong-hints",
+          "--enable-strict-call-checks",
+          "--enable_type_checks",
           "--supermixin",
       ] + app_paths, stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as e:

--- a/sky/unit/test/widget/input_test.dart
+++ b/sky/unit/test/widget/input_test.dart
@@ -77,11 +77,17 @@ void main() {
 
       // Check that the cursor visibility toggles after each blink interval.
       void checkCursorToggle() {
-        bool initialShowCursor = editableText.test_showCursor;
-        tester.async.elapse(editableText.test_cursorBlinkPeriod);
-        expect(editableText.test_showCursor, equals(!initialShowCursor));
-        tester.async.elapse(editableText.test_cursorBlinkPeriod);
-        expect(editableText.test_showCursor, equals(initialShowCursor));
+        bool initialShowCursor = editableText.cursorCurrentlyVisible;
+        tester.async.elapse(editableText.cursorBlinkInterval);
+        expect(editableText.cursorCurrentlyVisible, equals(!initialShowCursor));
+        tester.async.elapse(editableText.cursorBlinkInterval);
+        expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
+        tester.async.elapse(editableText.cursorBlinkInterval ~/ 10);
+        expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
+        tester.async.elapse(editableText.cursorBlinkInterval);
+        expect(editableText.cursorCurrentlyVisible, equals(!initialShowCursor));
+        tester.async.elapse(editableText.cursorBlinkInterval);
+        expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
       }
 
       checkCursorToggle();

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -10,8 +10,11 @@ SKY_SHELL=../../out/sky_shell ../../third_party/dart-sdk/dart-sdk/bin/pub run sk
 popd
 
 # Analyze the code.
+pushd sky/packages/workbench
+../../../third_party/dart-sdk/dart-sdk/bin/pub get
+popd
 pushd sky/packages/sky
-../../../third_party/dart-sdk/dart-sdk/bin/dartanalyzer --supermixin lib/widgets.dart
+../../tools/skyanalyzer --congratulate lib/widgets.dart
 popd
 
 # Generate docs.


### PR DESCRIPTION
Add type annotations in many places.
Fix some identifiers to have more lint-satisfying names.
Make all operator==s consistent in style.
Reorder some functions for consistency.
Make ParentData no longer dynamic, and fix all the code around that.