### PR TITLE
Rename skyx to flx in the build process

### DIFF
--- a/sky/build/flx.gni
+++ b/sky/build/flx.gni
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-template("skyx") {
+template("flx") {
   bundle_prefix = target_name
-  bundle = "$target_gen_dir/${bundle_prefix}.skyx"
+  bundle = "$target_gen_dir/${bundle_prefix}.flx"
   snapshot = "$target_gen_dir/${bundle_prefix}_snapshot.bin"
 
   action("gen_${bundle_prefix}_bundle") {

--- a/sky/build/sky_app.gni
+++ b/sky/build/sky_app.gni
@@ -2,16 +2,16 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//sky/build/skyx.gni")
+import("//sky/build/flx.gni")
 
 template("sky_app") {
-  skyx_target_name = target_name
+  flx_target_name = target_name
 
   if (is_android || is_ios || is_mac) {
-    skyx_target_name = "app"
+    flx_target_name = "app"
   }
 
-  skyx(skyx_target_name) {
+  flx(flx_target_name) {
     main_dart = invoker.main_dart
 
     if (defined(invoker.manifest)) {
@@ -30,10 +30,10 @@ template("sky_app") {
 
     copy("gen_${bundle_prefix}_bundle") {
       sources = [
-        "$target_gen_dir/app.skyx",
+        "$target_gen_dir/app.flx",
       ]
       outputs = [
-        "$target_gen_dir/${bundle_prefix}.skyx",
+        "$target_gen_dir/${bundle_prefix}.flx",
       ]
 
       deps = [
@@ -47,13 +47,13 @@ template("sky_app") {
 
       sources = [
         "$root_build_dir/icudtl.dat",
-        "$target_gen_dir/app.skyx"
+        "$target_gen_dir/app.flx"
       ]
       if (defined(invoker.manifest)) {
         sources += [ invoker.manifest ]
       }
       deps = [
-        ":$skyx_target_name",
+        ":$flx_target_name",
         ":gen_${bundle_prefix}_bundle",
         "//third_party/icu:icudata",
       ]
@@ -63,7 +63,7 @@ template("sky_app") {
           bundle_gen_dir = get_label_info(bundle, "target_gen_dir")
           bundle_dir = get_label_info(bundle, "dir")
           bundle_name = get_label_info(bundle, "name")
-          sources += [ "$bundle_gen_dir/${bundle_name}.skyx" ]
+          sources += [ "$bundle_gen_dir/${bundle_name}.flx" ]
           deps += [
             "$bundle_dir:gen_${bundle_name}_bundle",
           ]
@@ -78,7 +78,7 @@ template("sky_app") {
       native_libs = [ "libsky_shell.so" ]
       asset_location = "$target_gen_dir/assets"
 
-      extensions_to_not_compress = ".skyx"
+      extensions_to_not_compress = ".flx"
 
       deps = [
         "//base:base_java",
@@ -113,7 +113,7 @@ template("sky_app") {
       resource_copy_ios(resources_gen_target_name) {
         resources = [
           "//third_party/icu/android/icudtl.dat",
-          "$target_gen_dir/app.skyx",
+          "$target_gen_dir/app.flx",
         ]
 
         if (defined(invoker.launcher_resources)) {
@@ -127,7 +127,7 @@ template("sky_app") {
       deps = [
         "//sky/shell:ios_scaffolding",
         ":$resources_gen_target_name",
-        ":$skyx_target_name",
+        ":$flx_target_name",
       ]
 
       if (defined(invoker.deps)) {
@@ -147,7 +147,7 @@ template("sky_app") {
       resource_copy_mac(resources_gen_target_name) {
         resources = [
           "//third_party/icu/android/icudtl.dat",
-          "$target_gen_dir/app.skyx",
+          "$target_gen_dir/app.flx",
         ]
 
         if (defined(invoker.launcher_resources)) {


### PR DESCRIPTION
APKs generated by the build currently aren't displayout output because
SkyApplication expects a resource named "app.flx" but the build is
producing "app.skyx".  This will bring the two into sync.