### PR TITLE
Mark SkyShell as debuggable

### DIFF
--- a/build/android/lint/suppressions.xml
+++ b/build/android/lint/suppressions.xml
@@ -41,6 +41,9 @@ Still reading?
   <issue id="HandlerLeak">
     <ignore path="remoting/android/java/src/org/chromium/chromoting/TapGestureDetector.java"/>
   </issue>
+  <issue id="HardcodedDebugMode" severity="Fatal">
+    <ignore path="AndroidManifest.xml"/>
+  </issue>
   <issue id="IconDensities">
     <!-- crbug.com/457918 is tracking missing assets -->
     <ignore path="components/web_contents_delegate_android/android/java/res/drawable-xxhdpi"/>

--- a/sky/shell/android/AndroidManifest.xml
+++ b/sky/shell/android/AndroidManifest.xml
@@ -10,7 +10,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true" />
 
-    <application android:label="Sky Shell" android:name="SkyApplication">
+    <application android:label="Sky Shell" android:name="SkyApplication" android:debuggable="true">
         <activity android:configChanges="orientation|keyboardHidden|keyboard|screenSize"
                   android:hardwareAccelerated="true"
                   android:launchMode="standard"


### PR DESCRIPTION
This patch makes it easier to work with SkyShell on non-rooted devices.