### PR TITLE
Add support for verifying .flx signatures when updating

### DIFF
--- a/examples/fitness/sky.yaml
+++ b/examples/fitness/sky.yaml
@@ -1,6 +1,6 @@
 name: fitness
 version: 0.0.1
-update_url: http://localhost:9888/examples/fitness/
+update-url: http://localhost:9888/examples/fitness/
 material-design-icons:
   - name: action/assessment
   - name: action/help

--- a/examples/stocks/sky.yaml
+++ b/examples/stocks/sky.yaml
@@ -1,3 +1,6 @@
+name: stocks
+version: 0.0.2
+update-url: http://localhost:9888/examples/stocks/
 material-design-icons:
   - name: action/account_balance
   - name: action/assessment

--- a/sky/packages/sky/pubspec.yaml
+++ b/sky/packages/sky/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   newton: '>=0.1.4 <0.2.0'
   sky_engine: 0.0.38
   sky_services: 0.0.38
-  sky_tools: '>=0.0.20 <0.1.0'
+  sky_tools: '>=0.0.25 <0.1.0'
   vector_math: '>=1.4.3 <2.0.0'
   intl: '>=0.12.4+2 <0.13.0'
 environment:

--- a/sky/packages/updater/lib/bundle.dart
+++ b/sky/packages/updater/lib/bundle.dart
@@ -1,0 +1,75 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+const String kBundleMagic = '#!mojo ';
+
+Future<List<int>> _readBytesWithLength(RandomAccessFile file) async {
+  ByteData buffer = new ByteData(4);
+  await file.readInto(buffer.buffer.asUint8List());
+  int length = buffer.getUint32(0, Endianness.LITTLE_ENDIAN);
+  return await file.read(length);
+}
+
+const int kMaxLineLen = 10*1024;
+const int kNewline = 0x0A;
+Future<String> _readLine(RandomAccessFile file) async {
+  String line = '';
+  while (line.length < kMaxLineLen) {
+    int byte = await file.readByte();
+    if (byte == -1 || byte == kNewline)
+      break;
+    line += new String.fromCharCode(byte);
+  }
+  return line;
+}
+
+// Represents a parsed .flx Bundle. Contains information from the bundle's
+// header, as well as an open File handle positioned where the zip content
+// begins.
+// The bundle format is:
+// #!mojo <any string>\n
+// <32-bit length><signature of the manifest data>
+// <32-bit length><manifest data>
+// <zip content>
+//
+// The manifest is a JSON string containing the following keys:
+// (optional) name: the name of the package.
+// version: the package version.
+// update-url: the base URL to download a new manifest and bundle.
+// key: a BASE-64 encoded DER-encoded ASN.1 representation of the Q point of the
+//   ECDSA public key that was used to sign this manifest.
+// content-hash: an integer SHA-256 hash value of the <zip content>.
+class Bundle {
+  Bundle(this.path);
+
+  final String path;
+  List<int> signatureBytes;
+  List<int> manifestBytes;
+  Map<String, dynamic> manifest;
+  RandomAccessFile content;
+
+  Future<bool> _readHeader() async {
+    content = await new File(path).open();
+    String magic = await _readLine(content);
+    if (!magic.startsWith(kBundleMagic))
+      return false;
+    signatureBytes = await _readBytesWithLength(content);
+    manifestBytes = await _readBytesWithLength(content);
+    String manifestString = UTF8.decode(manifestBytes);
+    manifest = JSON.decode(manifestString);
+    return true;
+  }
+
+  static Future<Bundle> readHeader(String path) async {
+    Bundle bundle = new Bundle(path);
+    if (!await bundle._readHeader())
+      return null;
+    return bundle;
+  }
+}

--- a/sky/packages/updater/lib/pipe_to_file.dart
+++ b/sky/packages/updater/lib/pipe_to_file.dart
@@ -30,13 +30,13 @@ class PipeToFile {
     return _consumer.endRead(thisRead.lengthInBytes);
   }
 
-  Future<MojoResult> drain() async {
-    var completer = new Completer();
+  Future drain() async {
+    Completer completer = new Completer();
     // TODO(mpcomplete): Is it legit to pass an async callback to listen?
     _eventStream.listen((List<int> event) async {
-      var mojoSignals = new MojoHandleSignals(event[1]);
+      MojoHandleSignals mojoSignals = new MojoHandleSignals(event[1]);
       if (mojoSignals.isReadable) {
-        var result = await _doRead();
+        MojoResult result = await _doRead();
         if (!result.isOk) {
           _eventStream.close();
           _eventStream = null;
@@ -58,7 +58,7 @@ class PipeToFile {
   }
 
   static Future<MojoResult> copyToFile(MojoDataPipeConsumer consumer, String outputPath) {
-    var drainer = new PipeToFile(consumer, outputPath);
+    PipeToFile drainer = new PipeToFile(consumer, outputPath);
     return drainer.drain();
   }
 }

--- a/sky/packages/updater/lib/version.dart
+++ b/sky/packages/updater/lib/version.dart
@@ -9,7 +9,7 @@ import 'dart:math';
 // Usage: assert(new Version('1.1.0') < new Version('1.2.1'));
 class Version {
   Version(String versionStr) :
-    _parts = versionStr.split('.').map((val) => int.parse(val)).toList();
+    _parts = versionStr.split('.').map((String val) => int.parse(val)).toList();
 
   List<int> _parts;
 
@@ -28,5 +28,5 @@ class Version {
     return _parts.length - other._parts.length;  // results in 1.0 < 1.0.0
   }
 
-  int get hashCode => _parts.fold(373, (acc, part) => 37*acc + part);
+  int get hashCode => _parts.fold(373, (int acc, int part) => 37*acc + part);
 }

--- a/sky/packages/updater/pubspec.yaml
+++ b/sky/packages/updater/pubspec.yaml
@@ -9,6 +9,8 @@ dependencies:
   sky_services: any
   path: any
   yaml: any
+  cipher: any
+  asn1lib: any
 dependency_overrides:
   flutter:
     path: ../sky

--- a/sky/packages/workbench/pubspec.yaml
+++ b/sky/packages/workbench/pubspec.yaml
@@ -6,6 +6,8 @@ homepage: https://github.com/flutter/engine/tree/master/sky/packages/workbench
 dependencies:
   flutter: ">=0.0.3 <0.1.0"
   sky_tools: any
+  cipher: any
+  asn1lib: any
 dependency_overrides:
   material_design_icons:
     path: ../material_design_icons

--- a/sky/tools/sky_build.py
+++ b/sky/tools/sky_build.py
@@ -33,6 +33,7 @@ def main():
         '--output-file', os.path.abspath(args.output_file),
         '--package-root', os.path.abspath(args.package_root),
         '--snapshot', os.path.abspath(args.snapshot),
+        '--private-key', os.path.abspath(os.path.join(args.package_root, '..', 'privatekey.der')),
     ]
 
     if args.manifest:


### PR DESCRIPTION
Adds a step to the updater to verify that the new .flx package is signed and untampered.

Each .flx contains a signed manifest file. The manifest contains a SHA-256 hash of the .flx contents. See bundle.dart for a description of the new .flx format.