### PR TITLE
Roll Dart runtime forward to 6aab1cecb25f8e04087320f2082336073628afb4

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -25,8 +25,8 @@ vars = {
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
-  'dart_revision': '80dec9493fa8caa2d26c230a23ae7e8eb7cb3bb6',
-  'dart_observatory_packages_revision': 'a731d3b1caf27b45aecdce9378b87a510240264d',
+  'dart_revision': '6aab1cecb25f8e04087320f2082336073628afb4',
+  'dart_observatory_packages_revision': '5c199c5954146747f75ed127871207718dc87786',
   'dart_root_certificates_revision': 'c3a41df63afacec62fcb8135196177e35fe72f71',
 
   'buildtools_revision': '565d04e8741429fb1b4f26d102f2c6c3b849edeb',

--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -104,11 +104,12 @@ bool IsServiceIsolateURL(const char* url_name) {
 // watcher isolate and the service isolate. Presumably, we'll want application
 // isolates to spawn their own isolates.
 Dart_Isolate IsolateCreateCallback(const char* script_uri,
-                                          const char* main,
-                                          const char* package_root,
-                                          Dart_IsolateFlags* flags,
-                                          void* callback_data,
-                                          char** error) {
+                                   const char* main,
+                                   const char* package_root,
+                                   const char** package_map,
+                                   Dart_IsolateFlags* flags,
+                                   void* callback_data,
+                                   char** error) {
   if (IsServiceIsolateURL(script_uri)) {
     CHECK(kDartIsolateSnapshotBuffer);
     DartState* dart_state = new DartState();


### PR DESCRIPTION
Roll Dart runtime forward to:

6aab1cecb25f8e04087320f2082336073628afb4

Roll Observatory pub packages to:

5c199c5954146747f75ed127871207718dc87786

---

Update to new isolate create callback signature.