### PR TITLE
Reduce latency of low-volume debugPrint output

### DIFF
--- a/sky/packages/sky/lib/src/rendering/debug.dart
+++ b/sky/packages/sky/lib/src/rendering/debug.dart
@@ -47,11 +47,18 @@ void debugPrint(String message) {
     _debugPrintTask();
 }
 int _debugPrintedCharacters = 0;
-int _kDebugPrintCapacity = 32 * 1024;
+int _kDebugPrintCapacity = 16 * 1024;
+Duration _kDebugPrintPauseTime = const Duration(seconds: 1);
 Queue<String> _debugPrintBuffer = new Queue<String>();
+Stopwatch _debugPrintStopwatch = new Stopwatch();
 bool _debugPrintScheduled = false;
 void _debugPrintTask() {
   _debugPrintScheduled = false;
+  if (_debugPrintStopwatch.elapsed > _kDebugPrintPauseTime) {
+    _debugPrintStopwatch.stop();
+    _debugPrintStopwatch.reset();
+    _debugPrintedCharacters = 0;
+  }
   while (_debugPrintedCharacters < _kDebugPrintCapacity && _debugPrintBuffer.length > 0) {
     String line = _debugPrintBuffer.removeFirst();
     _debugPrintedCharacters += line.length; // TODO(ianh): Use the UTF-8 byte length instead
@@ -60,6 +67,8 @@ void _debugPrintTask() {
   if (_debugPrintBuffer.length > 0) {
     _debugPrintScheduled = true;
     _debugPrintedCharacters = 0;
-    new Timer(new Duration(seconds: 1), _debugPrintTask);
+    new Timer(_kDebugPrintPauseTime, _debugPrintTask);
+  } else {
+    _debugPrintStopwatch.start();
   }
 }


### PR DESCRIPTION
If we haven't printed anything for a second, then reset the count of how
much we've printed.

I also reduced the amount of data to ~16kb until we	pause because I saw
some corruption even pausing 1 second every ~32kb. (Numbers are
approximate because we're counting UTF-16 characters and some of the
characters in the output are multiple bytes in UTF-8.)
