### PR TITLE
toString()ify more stuff

### DIFF
--- a/sky/engine/core/painting/Offset.dart
+++ b/sky/engine/core/painting/Offset.dart
@@ -61,5 +61,5 @@ class Offset extends OffsetBase {
   /// Compares two Offsets for equality.
   bool operator ==(dynamic other) => other is Offset && super == other;
 
-  String toString() => "Offset($dx, $dy)";
+  String toString() => "Offset(${dx.toStringAsFixed(1)}, ${dy.toStringAsFixed(1)})";
 }

--- a/sky/engine/core/painting/Point.dart
+++ b/sky/engine/core/painting/Point.dart
@@ -36,5 +36,5 @@ class Point {
     return result;
   }
 
-  String toString() => "Point($x, $y)";
+  String toString() => "Point(${x.toStringAsFixed(1)}, ${y.toStringAsFixed(1)})";
 }

--- a/sky/engine/core/painting/Rect.dart
+++ b/sky/engine/core/painting/Rect.dart
@@ -142,5 +142,5 @@ class Rect {
 
   int get hashCode => _value.fold(373, (value, item) => (37 * value + item.hashCode));
 
-  String toString() => "Rect.fromLTRB($left, $top, $right, $bottom)";
+  String toString() => "Rect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})";
 }

--- a/sky/engine/core/painting/Size.dart
+++ b/sky/engine/core/painting/Size.dart
@@ -61,5 +61,5 @@ class Size extends OffsetBase {
   /// Compares two Sizes for equality.
   bool operator ==(dynamic other) => other is Size && super == other;
 
-  String toString() => "Size($width, $height)";
+  String toString() => "Size(${width.toStringAsFixed(1)}, ${height.toStringAsFixed(1)})";
 }

--- a/sky/packages/sky/lib/src/material/icon.dart
+++ b/sky/packages/sky/lib/src/material/icon.dart
@@ -23,6 +23,8 @@ class IconThemeData {
   }
 
   int get hashCode => color.hashCode;
+
+  String toString() => '$color';
 }
 
 class IconTheme extends InheritedWidget {
@@ -45,6 +47,10 @@ class IconTheme extends InheritedWidget {
 
   bool updateShouldNotify(IconTheme old) => data != old.data;
 
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$data');
+  }
 }
 
 AssetBundle _initIconBundle() {
@@ -63,7 +69,10 @@ class Icon extends StatelessComponent {
     this.type: '',
     this.color,
     this.colorFilter
-  }) : super(key: key);
+  }) : super(key: key) {
+    assert(size != null);
+    assert(type != null);
+  }
 
   final int size;
   final String type;
@@ -107,5 +116,11 @@ class Icon extends StatelessComponent {
       height: size.toDouble(),
       colorFilter: colorFilter
     );
+  }
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$type');
+    description.add('size: $size');
   }
 }

--- a/sky/packages/sky/lib/src/material/icon_button.dart
+++ b/sky/packages/sky/lib/src/material/icon_button.dart
@@ -36,4 +36,9 @@ class IconButton extends StatelessComponent {
       )
     );
   }
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$icon');
+  }
 }

--- a/sky/packages/sky/lib/src/material/material_button.dart
+++ b/sky/packages/sky/lib/src/material/material_button.dart
@@ -47,6 +47,12 @@ abstract class MaterialButton extends StatefulComponent {
   final bool enabled;
   final ButtonColor textColor;
   final GestureTapCallback onPressed;
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    if (!enabled)
+      description.add('disabled');
+  }
 }
 
 abstract class MaterialButtonState<T extends MaterialButton> extends State<T> {

--- a/sky/packages/sky/lib/src/material/progress_indicator.dart
+++ b/sky/packages/sky/lib/src/material/progress_indicator.dart
@@ -14,15 +14,15 @@ const double _kLinearProgressIndicatorHeight = 6.0;
 const double _kMinCircularProgressIndicatorSize = 15.0;
 const double _kCircularProgressIndicatorStrokeWidth = 3.0;
 
+// TODO(hansmuller) implement the support for buffer indicator
+
 abstract class ProgressIndicator extends StatefulComponent {
   ProgressIndicator({
     Key key,
-    this.value,
-    this.bufferValue
+    this.value
   }) : super(key: key);
 
   final double value; // Null for non-determinate progress indicator.
-  final double bufferValue; // TODO(hansmuller) implement the support for this.
 
   Color _getBackgroundColor(BuildContext context) => Theme.of(context).primarySwatch[200];
   Color _getValueColor(BuildContext context) => Theme.of(context).primaryColor;
@@ -31,6 +31,11 @@ abstract class ProgressIndicator extends StatefulComponent {
   Widget _buildIndicator(BuildContext context, double performanceValue);
 
   _ProgressIndicatorState createState() => new _ProgressIndicatorState();
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('${(value.clamp(0.0, 1.0) * 100.0).toStringAsFixed(1)}%');
+  }
 }
 
 class _ProgressIndicatorState extends State<ProgressIndicator> {
@@ -72,9 +77,8 @@ class _ProgressIndicatorState extends State<ProgressIndicator> {
 class LinearProgressIndicator extends ProgressIndicator {
   LinearProgressIndicator({
     Key key,
-    double value,
-    double bufferValue
-  }) : super(key: key, value: value, bufferValue: bufferValue);
+    double value
+  }) : super(key: key, value: value);
 
   void _paint(BuildContext context, double performanceValue, Canvas canvas, Size size) {
     Paint paint = new Paint()
@@ -120,9 +124,8 @@ class CircularProgressIndicator extends ProgressIndicator {
 
   CircularProgressIndicator({
     Key key,
-    double value,
-    double bufferValue
-  }) : super(key: key, value: value, bufferValue: bufferValue);
+    double value
+  }) : super(key: key, value: value);
 
   void _paint(BuildContext context, double performanceValue, Canvas canvas, Size size) {
     Paint paint = new Paint()

--- a/sky/packages/sky/lib/src/material/tabs.dart
+++ b/sky/packages/sky/lib/src/material/tabs.dart
@@ -281,6 +281,16 @@ class TabLabel {
 
   final String text;
   final String icon;
+
+  String toString() {
+    if (text != null && icon != null)
+      return '"$text" ($icon)';
+    if (text != null)
+      return '"$text"';
+    if (icon != null)
+      return '$icon';
+    return 'EMPTY TAB LABEL';
+  }
 }
 
 class Tab extends StatelessComponent {
@@ -344,6 +354,11 @@ class Tab extends StatelessComponent {
       onTap: onSelected,
       child: centeredLabel
     );
+  }
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$label');
   }
 }
 

--- a/sky/packages/sky/lib/src/material/theme.dart
+++ b/sky/packages/sky/lib/src/material/theme.dart
@@ -28,4 +28,9 @@ class Theme extends InheritedWidget {
   }
 
   bool updateShouldNotify(Theme old) => data != old.data;
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('$data');
+  }
 }

--- a/sky/packages/sky/lib/src/material/theme_data.dart
+++ b/sky/packages/sky/lib/src/material/theme_data.dart
@@ -124,4 +124,6 @@ class ThemeData {
     value = 37 * value + accentColorBrightness.hashCode;
     return value;
   }
+
+  String toString() => '$primaryColor $brightness etc...';
 }

--- a/sky/packages/sky/lib/src/material/title.dart
+++ b/sky/packages/sky/lib/src/material/title.dart
@@ -17,4 +17,9 @@ class Title extends StatelessComponent {
     updateTaskDescription(title, Theme.of(context).primaryColor);
     return child;
   }
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('"$title"');
+  }
 }

--- a/sky/packages/sky/lib/src/rendering/box.dart
+++ b/sky/packages/sky/lib/src/rendering/box.dart
@@ -254,7 +254,21 @@ class BoxConstraints extends Constraints {
     return value;
   }
 
-  String toString() => "BoxConstraints($minWidth<=w<=$maxWidth, $minHeight<=h<=$maxHeight)";
+  String toString() {
+    if (minWidth == double.INFINITY && minHeight == double.INFINITY)
+      return 'BoxConstraints(biggest)';
+    if (minWidth == 0 && maxWidth == double.INFINITY &&
+        minHeight == 0 && maxHeight == double.INFINITY)
+      return 'BoxConstraints(unconstrained)';
+    String describe(double min, double max, String dim) {
+      if (min == max)
+        return '$dim=${min.toStringAsFixed(1)}';
+      return '${min.toStringAsFixed(1)}<=$dim<=${max.toStringAsFixed(1)}';
+    }
+    final String width = describe(minWidth, maxWidth, 'w');
+    final String height = describe(minHeight, maxHeight, 'h');
+    return 'BoxConstraints($width, $height)';
+  }
 }
 
 /// A hit test entry used by [RenderBox]

--- a/sky/packages/sky/lib/src/rendering/stack.dart
+++ b/sky/packages/sky/lib/src/rendering/stack.dart
@@ -132,7 +132,7 @@ class RelativeRect {
     return value;
   }
 
-  String toString() => "RelativeRect.fromLTRB($left, $top, $right, $bottom)";
+  String toString() => "RelativeRect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})";
 }
 
 /// Parent data for use with [RenderStack]

--- a/sky/packages/sky/lib/src/rendering/view.dart
+++ b/sky/packages/sky/lib/src/rendering/view.dart
@@ -23,6 +23,8 @@ class ViewConstraints {
 
   /// The orientation of the output surface (aspirational)
   final int orientation;
+
+  String toString() => '$size';
 }
 
 /// The root of the render tree
@@ -53,7 +55,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   ViewConstraints get rootConstraints => _rootConstraints;
   ViewConstraints _rootConstraints;
   void set rootConstraints(ViewConstraints value) {
-    if (_rootConstraints == value)
+    if (rootConstraints == value)
       return;
     _rootConstraints = value;
     markNeedsLayout();
@@ -80,12 +82,12 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   }
 
   void performLayout() {
-    if (_rootConstraints.orientation != _orientation) {
+    if (rootConstraints.orientation != _orientation) {
       if (_orientation != null && child != null)
-        child.rotate(oldAngle: _orientation, newAngle: _rootConstraints.orientation, time: timeForRotation);
-      _orientation = _rootConstraints.orientation;
+        child.rotate(oldAngle: _orientation, newAngle: rootConstraints.orientation, time: timeForRotation);
+      _orientation = rootConstraints.orientation;
     }
-    _size = _rootConstraints.size;
+    _size = rootConstraints.size;
     assert(!_size.isInfinite);
 
     if (child != null)
@@ -127,4 +129,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   }
 
   Rect get paintBounds => Point.origin & size;
+
+  String debugDescribeSettings(String prefix) => '${prefix}view width: ${ui.view.width} (in device pixels)\n${prefix}view height: ${ui.view.height} (in device pixels)\n${prefix}device pixel ratio: ${ui.view.devicePixelRatio} (device pixels per logical pixel)\n${prefix}root constraints: $rootConstraints (in logical pixels)\n';
+  // call to ${super.debugDescribeSettings(prefix)} is omitted because the root superclasses don't include any interesting information for this class
 }

--- a/sky/packages/sky/lib/src/widgets/animated_container.dart
+++ b/sky/packages/sky/lib/src/widgets/animated_container.dart
@@ -124,7 +124,6 @@ class _AnimatedContainerState extends State<AnimatedContainer> {
   void _updateAllVariables() {
     setState(() {
       _updateVariable(_constraints);
-      _updateVariable(_constraints);
       _updateVariable(_decoration);
       _updateVariable(_foregroundDecoration);
       _updateVariable(_margin);
@@ -223,5 +222,25 @@ class _AnimatedContainerState extends State<AnimatedContainer> {
       width: _width?.value,
       height: _height?.value
     );
+  }
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    if (_constraints != null)
+      description.add('has constraints');
+    if (_decoration != null)
+      description.add('has background');
+    if (_foregroundDecoration != null)
+      description.add('has foreground');
+    if (_margin != null)
+      description.add('has margin');
+    if (_padding != null)
+      description.add('has padding');
+    if (_transform != null)
+      description.add('has transform');
+    if (_width != null)
+      description.add('has width');
+    if (_height != null)
+      description.add('has height');
   }
 }

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -314,7 +314,7 @@ class ConstrainedBox extends OneChildRenderObjectWidget {
 
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);
-    description.add('constraints: $constraints');
+    description.add('$constraints');
   }
 }
 
@@ -547,6 +547,26 @@ class Container extends StatelessComponent {
       current = new Transform(transform: transform, child: current);
 
     return current;
+  }
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    if (constraints != null)
+      description.add('$constraints');
+    if (decoration != null)
+      description.add('has background');
+    if (foregroundDecoration != null)
+      description.add('has foreground');
+    if (margin != null)
+      description.add('margin: $margin');
+    if (padding != null)
+      description.add('padding: $padding');
+    if (transform != null)
+      description.add('has transform');
+    if (width != null)
+      description.add('width: $width');
+    if (height != null)
+      description.add('height: $height');
   }
 
 }

--- a/sky/packages/sky/lib/src/widgets/focus.dart
+++ b/sky/packages/sky/lib/src/widgets/focus.dart
@@ -22,8 +22,8 @@ class _FocusScope extends InheritedWidget {
     Widget child
   }) : super(key: key, child: child);
 
-  final bool scopeFocused;
   final FocusState focusState;
+  final bool scopeFocused;
 
   // These are mutable because we implicitly change them when they're null in
   // certain cases, basically pretending retroactively that we were constructed
@@ -61,6 +61,15 @@ class _FocusScope extends InheritedWidget {
     return false;
   }
 
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    if (scopeFocused)
+      description.add('this scope has focus');
+    if (focusedScope != null)
+      description.add('focused subscope: $focusedScope');
+    if (focusedWidget != null)
+      description.add('focused widget: $focusedWidget');
+  }
 }
 
 class Focus extends StatefulComponent {


### PR DESCRIPTION
- truncate pixel values to 1dp since there's really no point being told
  the Size is 302.98732587287 by 648.28498579187.

- describe more Widgets so that debugDumpApp() is more useful.

- remove bufferValue from ProgressIndicator (cc @hansmuller) since it's
  not yet implemented.

- half-hearted toString() for ThemeData. There's no point making a
  complete one, since it would cause line-wrap even on big monitors in
  debugDumpApp dumps, and you can easily get the actual values from a
  debugging if that's the issue.

- flesh out BoxConstraints.toString() so that fully unconstrained and
  fully infinite constraints are called out explicitly. I experimented
  with adding even more special cases, e.g. calling out unconstrained
  widths with fixed heights, etc, but it made the output less readable.

- remove a redundant _updateVariable() in AnimatedContainer (cc
  @abarth).

- add more information to RenderView.toString().