### PR TITLE
Remove ColorFilter widget

### DIFF
--- a/sky/packages/sky/lib/src/rendering/layer.dart
+++ b/sky/packages/sky/lib/src/rendering/layer.dart
@@ -307,29 +307,3 @@ class OpacityLayer extends ContainerLayer {
     builder.pop();
   }
 }
-
-/// A composited layer that applies a color filter to its children
-class ColorFilterLayer extends ContainerLayer {
-  ColorFilterLayer({
-    Offset offset: Offset.zero,
-    this.bounds,
-    this.color,
-    this.transferMode
-  }) : super(offset: offset);
-
-  /// Unused
-  Rect bounds;
-  // TODO(abarth): Remove.
-
-  /// The color to use as input to the color filter
-  Color color;
-
-  /// The transfer mode to use to combine [color] with the children's painting
-  TransferMode transferMode;
-
-  void addToScene(ui.SceneBuilder builder, Offset layerOffset) {
-    builder.pushColorFilter(color, transferMode, bounds.shift(offset));
-    addChildrenToScene(builder, offset + layerOffset);
-    builder.pop();
-  }
-}

--- a/sky/packages/sky/lib/src/rendering/object.dart
+++ b/sky/packages/sky/lib/src/rendering/object.dart
@@ -276,43 +276,6 @@ class PaintingContext {
     }
   }
 
-  static Paint _getPaintForColorFilter(Color color, TransferMode transferMode) {
-    return new Paint()
-      ..colorFilter = new ui.ColorFilter.mode(color, transferMode)
-      ..isAntiAlias = false;
-  }
-
-  /// Paint a child with a color filter
-  ///
-  /// The color filter is constructed by combining the given color and the given
-  /// transfer mode, as if they were passed to the [ColorFilter.mode] constructor.
-  ///
-  /// If the child needs compositing, the blending operation will be applied by
-  /// a compositing layer. Otherwise, the blending operation will be applied by
-  /// the canvas.
-  void paintChildWithColorFilter(RenderObject child,
-                                 Point childPosition,
-                                 Rect bounds,
-                                 Color color,
-                                 TransferMode transferMode) {
-    assert(debugCanPaintChild(child));
-    final Offset childOffset = childPosition.toOffset();
-    if (!child.needsCompositing) {
-      canvas.saveLayer(bounds, _getPaintForColorFilter(color, transferMode));
-      canvas.translate(childOffset.dx, childOffset.dy);
-      insertChild(child, Offset.zero);
-      canvas.restore();
-    } else {
-      ColorFilterLayer paintLayer = new ColorFilterLayer(
-          offset: childOffset,
-          bounds: bounds,
-          color: color,
-          transferMode: transferMode);
-      _containerLayer.append(paintLayer);
-      compositeChild(child, parentLayer: paintLayer);
-    }
-  }
-
   static Paint _getPaintForShaderMask(Rect bounds,
                                       ShaderCallback shaderCallback,
                                       TransferMode transferMode) {

--- a/sky/packages/sky/lib/src/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/src/rendering/proxy_box.dart
@@ -621,45 +621,6 @@ class RenderOpacity extends RenderProxyBox {
   }
 }
 
-/// Applies a color filter when painting its child
-///
-/// This class paints its child into an intermediate buffer and then blends the
-/// child back into the scene using a color filter.
-///
-/// Note: This class is relatively expensive because it requires painting the
-/// child into an intermediate buffer.
-class RenderColorFilter extends RenderProxyBox {
-  RenderColorFilter({ RenderBox child, Color color, TransferMode transferMode })
-    : _color = color, _transferMode = transferMode, super(child);
-
-  /// The color to use as input to the color filter
-  Color get color => _color;
-  Color _color;
-  void set color (Color newColor) {
-    assert(newColor != null);
-    if (_color == newColor)
-      return;
-    _color = newColor;
-    markNeedsPaint();
-  }
-
-  /// The transfer mode to use when combining the child's painting and the [color]
-  TransferMode get transferMode => _transferMode;
-  TransferMode _transferMode;
-  void set transferMode (TransferMode newTransferMode) {
-    assert(newTransferMode != null);
-    if (_transferMode == newTransferMode)
-      return;
-    _transferMode = newTransferMode;
-    markNeedsPaint();
-  }
-
-  void paint(PaintingContext context, Offset offset) {
-    if (child != null)
-      context.paintChildWithColorFilter(child, offset.toPoint(), offset & size, _color, _transferMode);
-  }
-}
-
 class RenderShaderMask extends RenderProxyBox {
   RenderShaderMask({ RenderBox child, ShaderCallback shaderCallback, TransferMode transferMode })
     : _shaderCallback = shaderCallback, _transferMode = transferMode, super(child);

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -83,24 +83,6 @@ class Opacity extends OneChildRenderObjectWidget {
   }
 }
 
-class ColorFilter extends OneChildRenderObjectWidget {
-  ColorFilter({ Key key, this.color, this.transferMode, Widget child })
-    : super(key: key, child: child) {
-    assert(color != null);
-    assert(transferMode != null);
-  }
-
-  final Color color;
-  final TransferMode transferMode;
-
-  RenderColorFilter createRenderObject() => new RenderColorFilter(color: color, transferMode: transferMode);
-
-  void updateRenderObject(RenderColorFilter renderObject, ColorFilter oldWidget) {
-    renderObject.color = color;
-    renderObject.transferMode = transferMode;
-  }
-}
-
 class ShaderMask extends OneChildRenderObjectWidget {
   ShaderMask({
     Key key,


### PR DESCRIPTION
This widget is slow and not commonly used. The original reason we added it was
to colorize images, but now that feature is built into the image and background
image widgets.

Fixes #1646