### PR TITLE
Give the CustomPaint and SizeObserver callbacks better names

### DIFF
--- a/examples/game/lib/main.dart
+++ b/examples/game/lib/main.dart
@@ -159,7 +159,7 @@ class TextureButtonState extends State<TextureButton> {
         width: config.width,
         height: config.height,
         child: new CustomPaint(
-          callback: paintCallback,
+          onPaint: paintCallback,
           token: new _TextureButtonToken(
             _highlight,
             config.texture,

--- a/examples/rendering/baseline.dart
+++ b/examples/rendering/baseline.dart
@@ -37,7 +37,7 @@ RenderBox getBox(double lh) {
           padding: new EdgeDims.all(10.0),
           child: new RenderCustomPaint(
             child: paragraph,
-            callback: (canvas, size) {
+            onPaint: (canvas, size) {
               double baseline = paragraph.getDistanceToBaseline(TextBaseline.alphabetic);
               double w = paragraph.getMaxIntrinsicWidth(new BoxConstraints.loose(size));
               double h = paragraph.getMaxIntrinsicHeight(new BoxConstraints.loose(size));

--- a/examples/stocks/lib/stock_arrow.dart
+++ b/examples/stocks/lib/stock_arrow.dart
@@ -25,7 +25,7 @@ class StockArrow extends StatelessComponent {
     // TODO(jackson): This should change colors with the theme
     Color color = _colorForPercentChange(percentChange);
     const double kSize = 40.0;
-    var arrow = new CustomPaint(callback: (ui.Canvas canvas, Size size) {
+    var arrow = new CustomPaint(onPaint: (ui.Canvas canvas, Size size) {
       Paint paint = new Paint()..color = color;
       paint.strokeWidth = 1.0;
       const double padding = 2.0;

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -337,7 +337,7 @@ class CardCollectionState extends State<CardCollection> {
       ]);
 
     Widget body = new SizeObserver(
-      callback: _updateCardCollectionSize,
+      onSizeChanged: _updateCardCollectionSize,
       child: new Container(
         padding: const EdgeDims.symmetric(vertical: 12.0, horizontal: 8.0),
         decoration: new BoxDecoration(backgroundColor: Theme.of(context).primarySwatch[50]),

--- a/examples/widgets/overlay_geometry.dart
+++ b/examples/widgets/overlay_geometry.dart
@@ -58,7 +58,7 @@ class Marker extends StatelessComponent {
         child: new Container(
           width: size,
           height: size,
-          child: new CustomPaint(callback: paintMarker)
+          child: new CustomPaint(onPaint: paintMarker)
         )
       )
     );

--- a/examples/widgets/pageable_list.dart
+++ b/examples/widgets/pageable_list.dart
@@ -136,7 +136,7 @@ class PageableListAppState extends State<PageableListApp> {
           : pageSize.width
     );
     return new SizeObserver(
-      callback: updatePageSize,
+      onSizeChanged: updatePageSize,
       child: list
     );
   }

--- a/examples/widgets/scale.dart
+++ b/examples/widgets/scale.dart
@@ -63,7 +63,7 @@ class ScaleAppState extends State<ScaleApp> {
         body: new GestureDetector(
           onScaleStart: _handleScaleStart,
           onScaleUpdate: _handleScaleUpdate,
-          child: new CustomPaint(callback: paint, token: "$_zoom $_offset")
+          child: new CustomPaint(onPaint: paint, token: "$_zoom $_offset")
         )
       )
     );

--- a/sky/packages/sky/lib/src/material/input.dart
+++ b/sky/packages/sky/lib/src/material/input.dart
@@ -116,7 +116,7 @@ class _InputState extends ScrollableState<Input> {
 
     return new Listener(
       child: new SizeObserver(
-        callback: _handleContainerSizeChanged,
+        onSizeChanged: _handleContainerSizeChanged,
         child: new Container(
           child: new Stack(textChildren),
           padding: _kTextfieldPadding,

--- a/sky/packages/sky/lib/src/material/popup_menu.dart
+++ b/sky/packages/sky/lib/src/material/popup_menu.dart
@@ -75,7 +75,7 @@ class PopupMenu extends StatelessComponent {
         variables: <AnimatedValue<double>>[width, height],
         builder: (BuildContext context) {
           return new CustomPaint(
-            callback: (ui.Canvas canvas, Size size) {
+            onPaint: (ui.Canvas canvas, Size size) {
               double widthValue = width.value * size.width;
               double heightValue = height.value * size.height;
               painter.paint(canvas, new Rect.fromLTWH(size.width - widthValue, 0.0, widthValue, heightValue));

--- a/sky/packages/sky/lib/src/material/progress_indicator.dart
+++ b/sky/packages/sky/lib/src/material/progress_indicator.dart
@@ -107,7 +107,7 @@ class LinearProgressIndicator extends ProgressIndicator {
       ),
       child: new CustomPaint(
         token: _getCustomPaintToken(performanceValue),
-        callback: (Canvas canvas, Size size) {
+        onPaint: (Canvas canvas, Size size) {
           _paint(context, performanceValue, canvas, size);
         }
       )
@@ -157,7 +157,7 @@ class CircularProgressIndicator extends ProgressIndicator {
       ),
       child: new CustomPaint(
         token: _getCustomPaintToken(performanceValue),
-        callback: (Canvas canvas, Size size) {
+        onPaint: (Canvas canvas, Size size) {
           _paint(context, performanceValue, canvas, size);
         }
       )

--- a/sky/packages/sky/lib/src/material/radio.dart
+++ b/sky/packages/sky/lib/src/material/radio.dart
@@ -45,7 +45,7 @@ class Radio extends StatelessComponent {
         width: kDiameter,
         height: kDiameter,
         child: new CustomPaint(
-          callback: (Canvas canvas, Size size) {
+          onPaint: (Canvas canvas, Size size) {
 
             // Draw the outer circle
             Paint paint = new Paint()

--- a/sky/packages/sky/lib/src/material/tabs.dart
+++ b/sky/packages/sky/lib/src/material/tabs.dart
@@ -545,7 +545,7 @@ class _TabBarState extends ScrollableState<TabBar> {
 
     if (config.isScrollable) {
       content = new SizeObserver(
-        callback: _handleViewportSizeChanged,
+        onSizeChanged: _handleViewportSizeChanged,
         child: new Viewport(
           scrollDirection: ScrollDirection.horizontal,
           scrollOffset: new Offset(scrollOffset, 0.0),

--- a/sky/packages/sky/lib/src/rendering/proxy_box.dart
+++ b/sky/packages/sky/lib/src/rendering/proxy_box.dart
@@ -962,33 +962,33 @@ class RenderTransform extends RenderProxyBox {
 /// Called when a size changes
 typedef void SizeChangedCallback(Size newSize);
 
-/// Calls [callback] whenever the child's layout size changes
+/// Calls [onSizeChanged] whenever the child's layout size changes
 ///
 /// Note: Size observer calls its callback during layout, which means you cannot
 /// dirty layout information during the callback.
 class RenderSizeObserver extends RenderProxyBox {
   RenderSizeObserver({
-    this.callback,
+    this.onSizeChanged,
     RenderBox child
   }) : super(child) {
-    assert(callback != null);
+    assert(onSizeChanged != null);
   }
 
   /// The callback to call whenever the child's layout size changes
-  SizeChangedCallback callback;
+  SizeChangedCallback onSizeChanged;
 
   void performLayout() {
     Size oldSize = hasSize ? size : null;
     super.performLayout();
     if (oldSize != size)
-      callback(size);
+      onSizeChanged(size);
   }
 }
 
 /// Called when its time to paint into the given canvas
 typedef void CustomPaintCallback(PaintingCanvas canvas, Size size);
 
-/// Delegates its painting to [callback]
+/// Delegates its painting to [onPaint]
 ///
 /// When asked to paint, custom paint first calls its callback with the current
 /// canvas and then paints its children. The coodinate system of the canvas
@@ -1003,36 +1003,36 @@ typedef void CustomPaintCallback(PaintingCanvas canvas, Size size);
 class RenderCustomPaint extends RenderProxyBox {
 
   RenderCustomPaint({
-    CustomPaintCallback callback,
+    CustomPaintCallback onPaint,
     RenderBox child
   }) : super(child) {
-    assert(callback != null);
-    _callback = callback;
+    assert(onPaint != null);
+    _onPaint = onPaint;
   }
 
   /// The callback to which this render object delegates its painting
   ///
   /// The callback must be non-null whenever the render object is attached to
   /// the render tree.
-  CustomPaintCallback get callback => _callback;
-  CustomPaintCallback _callback;
-  void set callback (CustomPaintCallback newCallback) {
+  CustomPaintCallback get onPaint => _onPaint;
+  CustomPaintCallback _onPaint;
+  void set onPaint (CustomPaintCallback newCallback) {
     assert(newCallback != null || !attached);
-    if (_callback == newCallback)
+    if (_onPaint == newCallback)
       return;
-    _callback = newCallback;
+    _onPaint = newCallback;
     markNeedsPaint();
   }
 
   void attach() {
-    assert(_callback != null);
+    assert(_onPaint != null);
     super.attach();
   }
 
   void paint(PaintingContext context, Offset offset) {
-    assert(_callback != null);
+    assert(_onPaint != null);
     context.canvas.translate(offset.dx, offset.dy);
-    _callback(context.canvas, size);
+    _onPaint(context.canvas, size);
     // TODO(abarth): We should translate back before calling super because in
     // the future, super.paint might switch our compositing layer.
     super.paint(context, Offset.zero);

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -134,24 +134,24 @@ class DecoratedBox extends OneChildRenderObjectWidget {
 }
 
 class CustomPaint extends OneChildRenderObjectWidget {
-  CustomPaint({ Key key, this.callback, this.token, Widget child })
+  CustomPaint({ Key key, this.onPaint, this.token, Widget child })
     : super(key: key, child: child) {
-    assert(callback != null);
+    assert(onPaint != null);
   }
 
-  final CustomPaintCallback callback;
+  final CustomPaintCallback onPaint;
   final Object token; // set this to be repainted automatically when the token changes
 
-  RenderCustomPaint createRenderObject() => new RenderCustomPaint(callback: callback);
+  RenderCustomPaint createRenderObject() => new RenderCustomPaint(onPaint: onPaint);
 
   void updateRenderObject(RenderCustomPaint renderObject, CustomPaint oldWidget) {
     if (oldWidget != null && oldWidget.token != token)
       renderObject.markNeedsPaint();
-    renderObject.callback = callback;
+    renderObject.onPaint = onPaint;
   }
 
   void didUnmountRenderObject(RenderCustomPaint renderObject) {
-    renderObject.callback = null;
+    renderObject.onPaint = null;
   }
 }
 
@@ -428,21 +428,21 @@ class Viewport extends OneChildRenderObjectWidget {
 }
 
 class SizeObserver extends OneChildRenderObjectWidget {
-  SizeObserver({ Key key, this.callback, Widget child })
+  SizeObserver({ Key key, this.onSizeChanged, Widget child })
     : super(key: key, child: child) {
-    assert(callback != null);
+    assert(onSizeChanged != null);
   }
 
-  final SizeChangedCallback callback;
+  final SizeChangedCallback onSizeChanged;
 
-  RenderSizeObserver createRenderObject() => new RenderSizeObserver(callback: callback);
+  RenderSizeObserver createRenderObject() => new RenderSizeObserver(onSizeChanged: onSizeChanged);
 
   void updateRenderObject(RenderSizeObserver renderObject, SizeObserver oldWidget) {
-    renderObject.callback = callback;
+    renderObject.onSizeChanged = onSizeChanged;
   }
 
   void didUnmountRenderObject(RenderSizeObserver renderObject) {
-    renderObject.callback = null;
+    renderObject.onSizeChanged = null;
   }
 }
 

--- a/sky/packages/sky/lib/src/widgets/dismissable.dart
+++ b/sky/packages/sky/lib/src/widgets/dismissable.dart
@@ -251,7 +251,7 @@ class _DismissableState extends State<Dismissable> {
       onVerticalDragUpdate: _directionIsYAxis ? _handleDragUpdate : null,
       onVerticalDragEnd: _directionIsYAxis ? _handleDragEnd : null,
       child: new SizeObserver(
-        callback: _handleSizeChanged,
+        onSizeChanged: _handleSizeChanged,
         child: new FadeTransition(
           performance: _fadePerformance.view,
           opacity: new AnimatedValue<double>(1.0, end: 0.0),

--- a/sky/packages/sky/lib/src/widgets/mimic.dart
+++ b/sky/packages/sky/lib/src/widgets/mimic.dart
@@ -81,7 +81,7 @@ class MimicableState extends State<Mimicable> {
       );
     }
     return new SizeObserver(
-      callback: _handleSizeChanged,
+      onSizeChanged: _handleSizeChanged,
       child: config.child
     );
   }

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -54,11 +54,11 @@ class NavigatorState extends State<Navigator> {
     _insertRoute(route);
   }
 
-  void pushState(State owner, Function callback) {
+  void pushState(State owner, StateRouteCallback onPop) {
     push(new StateRoute(
       route: currentRoute,
       owner: owner,
-      callback: callback
+      onPop: onPop
     ));
   }
 
@@ -318,11 +318,11 @@ class PageRoute extends PerformanceRoute {
 }
 
 class StateRoute extends Route {
-  StateRoute({ this.route, this.owner, this.callback });
+  StateRoute({ this.route, this.owner, this.onPop });
 
   Route route;
   State owner;
-  StateRouteCallback callback;
+  StateRouteCallback onPop;
 
   bool get hasContent => false;
   bool get modal => false;
@@ -330,8 +330,8 @@ class StateRoute extends Route {
 
   void didPop([dynamic result]) {
     assert(result == null);
-    if (callback != null)
-      callback(this);
+    if (onPop != null)
+      onPop(this);
     super.didPop(result);
   }
 

--- a/sky/packages/sky/lib/src/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/src/widgets/scrollable.dart
@@ -362,12 +362,12 @@ class ScrollableViewportState extends ScrollableState<ScrollableViewport> {
 
   Widget buildContent(BuildContext context) {
     return new SizeObserver(
-      callback: _handleViewportSizeChanged,
+      onSizeChanged: _handleViewportSizeChanged,
       child: new Viewport(
         scrollOffset: scrollOffsetVector,
         scrollDirection: config.scrollDirection,
         child: new SizeObserver(
-          callback: _handleChildSizeChanged,
+          onSizeChanged: _handleChildSizeChanged,
           child: config.child
         )
       )
@@ -596,7 +596,7 @@ abstract class ScrollableWidgetListState<T extends ScrollableWidgetList> extends
     }
 
     return new SizeObserver(
-      callback: _handleSizeChanged,
+      onSizeChanged: _handleSizeChanged,
       child: new Container(
         padding: _crossAxisPadding,
         child: new HomogeneousViewport(
@@ -820,7 +820,7 @@ class ScrollableMixedWidgetListState extends ScrollableState<ScrollableMixedWidg
 
   Widget buildContent(BuildContext context) {
     return new SizeObserver(
-      callback: _handleSizeChanged,
+      onSizeChanged: _handleSizeChanged,
       child: new MixedViewport(
         startOffset: scrollOffset,
         builder: config.builder,

--- a/sky/specs/style-guide.md
+++ b/sky/specs/style-guide.md
@@ -45,10 +45,9 @@ variables, constants, enum values, etc) is lowerCamelCase. Constant
 doubles and strings are prefixed with k. Prefer using a local const
 or a static const in a relevant class than using a global constant.
 
-When naming callbacks, use `FooCallback` for the typedef, `onFoo` (or,
-if there's only one and the whole purpose of the class is this
-callback, `callback`) for the callback argument or property, and
-`handleFoo` for the method that is called.
+When naming callbacks, use `FooCallback` for the typedef, `onFoo` for
+the callback argument or property, and `handleFoo` for the method
+that is called.
 
 If you have a callback with arguments but you want to ignore the
 arguments, name them `_`, `__`, `___`, etc. If you name any of them,

--- a/sky/unit/test/widget/fractionally_sized_box_test.dart
+++ b/sky/unit/test/widget/fractionally_sized_box_test.dart
@@ -19,7 +19,7 @@ void main() {
             width: 0.5,
             height: 0.25,
             child: new SizeObserver(
-              callback: (Size size) {
+              onSizeChanged: (Size size) {
                 detectedSize = size;
               },
               child: new Container(

--- a/sky/unit/test/widget/size_observer_test.dart
+++ b/sky/unit/test/widget/size_observer_test.dart
@@ -11,7 +11,7 @@ void main() {
       List<Size> results = <Size>[];
       tester.pumpWidget(new Center(
         child: new SizeObserver(
-          callback: (Size size) { results.add(size); },
+          onSizeChanged: (Size size) { results.add(size); },
           child: new Container(width:0.0, height:0.0)
         )
       ));
@@ -20,7 +20,7 @@ void main() {
       expect(results, equals([Size.zero]));
       tester.pumpWidget(new Center(
         child: new SizeObserver(
-          callback: (Size size) { results.add(size); },
+          onSizeChanged: (Size size) { results.add(size); },
           child: new Container(width:100.0, height:0.0)
         )
       ));
@@ -29,7 +29,7 @@ void main() {
       expect(results, equals([Size.zero, const Size(100.0, 0.0)]));
       tester.pumpWidget(new Center(
         child: new SizeObserver(
-          callback: (Size size) { results.add(size); },
+          onSizeChanged: (Size size) { results.add(size); },
           child: new Container(width:0.0, height:0.0)
         )
       ));
@@ -38,7 +38,7 @@ void main() {
       expect(results, equals([Size.zero, const Size(100.0, 0.0), Size.zero]));
       tester.pumpWidget(new Center(
         child: new SizeObserver(
-          callback: (Size size) { results.add(size); },
+          onSizeChanged: (Size size) { results.add(size); },
           child: new Container(width:0.0, height:0.0)
         )
       ));

--- a/sky/unit/test/widget/stack_test.dart
+++ b/sky/unit/test/widget/stack_test.dart
@@ -139,7 +139,7 @@ void main() {
       Widget buildFrame(int index) {
         itemsPainted = <int>[];
         List<Widget> items = new List<Widget>.generate(itemCount, (i) {
-          return new CustomPaint(child: new Text('$i'), callback: (_, __) { itemsPainted.add(i); });
+          return new CustomPaint(child: new Text('$i'), onPaint: (_, __) { itemsPainted.add(i); });
         });
         return new Center(child: new IndexedStack(items, index: index));
       }


### PR DESCRIPTION
The style we use for callbacks in widgets is "onFoo". These classes were using
an order naming convention and just called their callbacks "callback".