### PR TITLE
RenderOverflowBox baseline logic

### DIFF
--- a/examples/rendering/baseline.dart
+++ b/examples/rendering/baseline.dart
@@ -37,7 +37,7 @@ RenderBox getBox(double lh) {
           padding: new EdgeDims.all(10.0),
           child: new RenderCustomPaint(
             child: paragraph,
-            onPaint: (canvas, size) {
+            onPaint: (PaintingCanvas canvas, Size size) {
               double baseline = paragraph.getDistanceToBaseline(TextBaseline.alphabetic);
               double w = paragraph.getMaxIntrinsicWidth(new BoxConstraints.loose(size));
               double h = paragraph.getMaxIntrinsicHeight(new BoxConstraints.loose(size));

--- a/sky/packages/sky/lib/src/rendering/overflow.dart
+++ b/sky/packages/sky/lib/src/rendering/overflow.dart
@@ -108,6 +108,12 @@ class RenderOverflowBox extends RenderBox with RenderObjectWithChildMixin<Render
     return constraints.constrainHeight();
   }
 
+  double computeDistanceToActualBaseline(TextBaseline baseline) {
+    if (child != null)
+      return child.getDistanceToActualBaseline(baseline);
+    return super.computeDistanceToActualBaseline(baseline);
+  }
+
   bool get sizedByParent => true;
 
   void performResize() {

--- a/sky/unit/test/rendering/overflow_test.dart
+++ b/sky/unit/test/rendering/overflow_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:test/test.dart';
+
+import 'rendering_tester.dart';
+
+void main() {
+  test("overflow should not affect baseline", () {
+    RenderBox root, child, text;
+    double baseline1, baseline2, height1, height2;
+
+    root = new RenderPositionedBox(
+      child: new RenderCustomPaint(
+        child: child = text = new RenderParagraph(new PlainTextSpan('Hello World')),
+        onPaint: (PaintingCanvas canvas, Size size) {
+          baseline1 = child.getDistanceToBaseline(TextBaseline.alphabetic);
+          height1 = text.size.height;
+        }
+      )
+    );
+    layout(root, phase: EnginePhase.paint);
+
+    root = new RenderPositionedBox(
+      child: new RenderCustomPaint(
+        child: child = new RenderOverflowBox(
+          child: text = new RenderParagraph(new PlainTextSpan('Hello World')),
+          maxHeight: height1 / 2.0
+        ),
+        onPaint: (PaintingCanvas canvas, Size size) {
+          baseline2 = child.getDistanceToBaseline(TextBaseline.alphabetic);
+          height2 = text.size.height;
+        }
+      )
+    );
+    layout(root, phase: EnginePhase.paint);
+
+    expect(baseline1, lessThan(height1));
+    expect(height2, equals(height1 / 2.0));
+    expect(baseline2, equals(baseline1));
+    expect(baseline2, greaterThan(height2));
+  });
+}


### PR DESCRIPTION
I accidentally lost this when extracting RenderOverflowBox from
RenderProxyBox.

Also, add a test for RenderOverflowBox.