### PR TITLE
Further tighten flutter's dependency on mojo following 77622e

### DIFF
--- a/sky/packages/sky/pubspec.yaml
+++ b/sky/packages/sky/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: http://flutter.io
 dependencies:
   cassowary: '>=0.1.7 <0.2.0'
   material_design_icons: '>=0.0.3 <0.1.0'
-  mojo_services: '>=0.3.0 <0.4.0'
+  mojo_services: 0.3.0
   mojo: 0.2.0
   newton: '>=0.1.4 <0.2.0'
   sky_engine: 0.0.39


### PR DESCRIPTION
This change is required for examples/widgets/piano.dart to work.