### PR TITLE
Make Route.build() arguments match RouteBuilder()

### DIFF
--- a/sky/packages/sky/lib/src/material/dialog.dart
+++ b/sky/packages/sky/lib/src/material/dialog.dart
@@ -139,11 +139,11 @@ class _DialogRoute extends PerformanceRoute {
   bool get opaque => false;
   Duration get transitionDuration => const Duration(milliseconds: 150);
 
-  Widget build(NavigatorState navigator, PerformanceView nextRoutePerformance) {
+  Widget build(RouteArguments args) {
     return new FadeTransition(
-      performance: performance,
+      performance: args.previousPerformance,
       opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.easeOut),
-      child: builder(new RouteArguments(navigator: navigator, previousPerformance: this.performance, nextPerformance: nextRoutePerformance))
+      child: builder(args)
     );
   }
 

--- a/sky/packages/sky/lib/src/material/drawer.dart
+++ b/sky/packages/sky/lib/src/material/drawer.dart
@@ -112,7 +112,7 @@ class _DrawerRoute extends Route {
 
   bool _interactive = true;
 
-  Widget build(NavigatorState navigator, PerformanceView nextRoutePerformance) {
+  Widget build(RouteArguments args) {
     return new Focus(
       key: new GlobalObjectKey(this),
       autofocus: true,

--- a/sky/packages/sky/lib/src/material/material_app.dart
+++ b/sky/packages/sky/lib/src/material/material_app.dart
@@ -26,9 +26,7 @@ class MaterialApp extends StatefulComponent {
     this.theme,
     this.routes,
     this.onGenerateRoute
-  }) : super(key: key) {
-    assert(routes != null);
-  }
+  }) : super(key: key);
 
   final String title;
   final ThemeData theme;

--- a/sky/packages/sky/lib/src/material/popup_menu.dart
+++ b/sky/packages/sky/lib/src/material/popup_menu.dart
@@ -134,7 +134,7 @@ class _MenuRoute extends PerformanceRoute {
   bool get opaque => false;
   Duration get transitionDuration => _kMenuDuration;
 
-  Widget build(NavigatorState navigator, PerformanceView nextRoutePerformance) {
+  Widget build(RouteArguments args) {
     return new Positioned(
       top: position?.top,
       right: position?.right,

--- a/sky/packages/sky/lib/src/material/snack_bar.dart
+++ b/sky/packages/sky/lib/src/material/snack_bar.dart
@@ -102,7 +102,7 @@ class _SnackBarRoute extends PerformanceRoute {
   bool get modal => false;
   Duration get transitionDuration => const Duration(milliseconds: 200);
 
-  Widget build(NavigatorState navigator, PerformanceView nextRoutePerformance) => null;
+  Widget build(RouteArguments args) => null;
 }
 
 void showSnackBar({ NavigatorState navigator, GlobalKey<PlaceholderState> placeholderKey, Widget content, List<SnackBarAction> actions }) {

--- a/sky/packages/sky/lib/src/widgets/drag_target.dart
+++ b/sky/packages/sky/lib/src/widgets/drag_target.dart
@@ -4,7 +4,6 @@
 
 import 'dart:collection';
 
-import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
@@ -257,7 +256,7 @@ class DragRoute extends Route {
   bool get modal => false;
   bool get opaque => false;
 
-  Widget build(NavigatorState navigator, PerformanceView nextRoutePerformance) {
+  Widget build(RouteArguments args) {
     return new Positioned(
       left: _lastOffset.dx,
       top: _lastOffset.dy,


### PR DESCRIPTION
(These are changes that are unrelated to Heroes but that were part of
the Heroes patch.)

Also, assert at creation time that all the named Route builders passed
to Navigator create non-null widget trees (so that the right place in
the author's code will be on the stack). (Turns out we had a buggy test
that this caught. I fixed that a few days ago.)

Also very minor new code comments and code reorg to help make the heroes
patch easier to review.