### PR TITLE
Debug grid over the navigator stack

### DIFF
--- a/sky/packages/sky/lib/src/widgets/gridpaper.dart
+++ b/sky/packages/sky/lib/src/widgets/gridpaper.dart
@@ -1,0 +1,36 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+
+class GridPaper extends StatelessComponent {
+  GridPaper({
+    Key key,
+    this.color: const Color(0xFF000000),
+    this.interval: 100.0
+  }) : super(key: key);
+
+  final Color color;
+  final double interval;
+
+  Widget build(BuildContext context) {
+    return new IgnorePointer(child: new CustomPaint(
+      onPaint: (PaintingCanvas canvas, Size size) {
+        Paint linePaint = new Paint()
+          ..color = color;
+        for (double x = 0.0; x <= size.width; x += interval / 10.0) {
+          linePaint.strokeWidth = (x % interval == 0.0) ? 1.0 : (x % (interval / 2.0) == 0.0) ? 0.5: 0.25;
+          canvas.drawLine(new Point(x, 0.0), new Point(x, size.height), linePaint);
+        }
+        for (double y = 0.0; y <= size.height; y += interval / 10.0) {
+          linePaint.strokeWidth = (y % interval == 0.0) ? 1.0 : (y % (interval / 2.0) == 0.0) ? 0.5: 0.25;
+          canvas.drawLine(new Point(0.0, y), new Point(size.width, y), linePaint);
+        }
+      })
+    );
+  }
+}

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -3,11 +3,19 @@
 // found in the LICENSE file.
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/rendering.dart';
 
 import 'basic.dart';
 import 'focus.dart';
 import 'framework.dart';
 import 'transitions.dart';
+import 'gridpaper.dart';
+
+/// Set this to true to overlay a pixel grid on the screen, with every 100
+/// pixels marked with a thick maroon line and every 10 pixels marked with a
+/// thin maroon line. This can help with verifying widget positions.
+bool debugShowGrid = false;
+Color debugGridColor = const Color(0x7F7F2020);
 
 const String kDefaultRouteName = '/';
 
@@ -149,8 +157,15 @@ class NavigatorState extends State<Navigator> {
     });
   }
 
-  Widget build(BuildContext context) {
-    List<Widget> visibleRoutes = new List<Widget>();
+   Widget build(BuildContext context) {
+    List<Widget> visibleRoutes = <Widget>[];
+
+    assert(() {
+      if (debugShowGrid)
+        visibleRoutes.add(new GridPaper(color: debugGridColor));
+      return true;
+    });
+
     bool alreadyInsertedModalBarrier = false;
     Route nextContentRoute;
     for (int i = _history.length-1; i >= 0; i -= 1) {


### PR DESCRIPTION
This grid makes it significantly easier to track down errors when you're
looking at coordinates in a render tree dump and want to see if they're
what you expect or if they're wildly away from the right location.