### PR TITLE
Keep the selection within bounds in deleteSurroundingText

### DIFF
--- a/sky/packages/sky/lib/src/material/input.dart
+++ b/sky/packages/sky/lib/src/material/input.dart
@@ -37,16 +37,18 @@ class Input extends Scrollable {
   final StringValueChanged onChanged;
   final StringValueSubmitted onSubmitted;
 
-  _InputState createState() => new _InputState();
+  InputState createState() => new InputState();
 }
 
-class _InputState extends ScrollableState<Input> {
+class InputState extends ScrollableState<Input> {
   String _value;
   EditableString _editableValue;
   KeyboardHandle _keyboardHandle = KeyboardHandle.unattached;
 
   double _contentWidth = 0.0;
   double _containerWidth = 0.0;
+
+  EditableString get editableValue => _editableValue;
 
   void initState() {
     super.initState();

--- a/sky/packages/sky/lib/src/widgets/editable_text.dart
+++ b/sky/packages/sky/lib/src/widgets/editable_text.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:mojo_services/keyboard/keyboard.mojom.dart';
 import 'package:flutter/painting.dart';
@@ -112,8 +113,9 @@ class EditableString implements KeyboardClient {
     _delete(afterRange);
     _delete(beforeRange);
     selection = new TextRange(
-        start: selection.start - beforeLength,
-        end: selection.end - beforeLength);
+      start: math.max(selection.start - beforeLength, 0),
+      end: math.max(selection.end - beforeLength, 0)
+    );
     onUpdated();
   }
 

--- a/sky/unit/test/widget/input_test.dart
+++ b/sky/unit/test/widget/input_test.dart
@@ -101,4 +101,38 @@ void main() {
       checkCursorToggle();
     });
   });
+
+  test('Selection remains valid', () {
+    testWidgets((WidgetTester tester) {
+      GlobalKey inputKey = new GlobalKey();
+      String inputValue;
+
+      Widget builder() {
+        return new Center(
+          child: new Input(
+            key: inputKey,
+            placeholder: 'Placeholder'
+          )
+        );
+      }
+
+      tester.pumpWidget(builder());
+
+      const String testValue = 'ABC';
+      mockKeyboard.client.commitText(testValue, testValue.length);
+      InputState input = tester.findStateOfType(InputState);
+
+      // Delete characters and verify that the selection follows the length
+      // of the text.
+      for (int i = 0; i < testValue.length; i++) {
+        mockKeyboard.client.deleteSurroundingText(1, 0);
+        expect(input.editableValue.selection.start, equals(testValue.length - i - 1));
+      }
+
+      // Delete a characters when the text is empty.  The selection should
+      // remain at zero.
+      mockKeyboard.client.deleteSurroundingText(1, 0);
+      expect(input.editableValue.selection.start, equals(0));
+    });
+  });
 }


### PR DESCRIPTION
If the text is empty, the IME may call deleteSurroundingText(1, 0) if the user
hits the delete key.  The selection should remain at position 0 if this
happens.