### PR TITLE
debugPaintPointersEnabled mode

### DIFF
--- a/sky/packages/sky/lib/src/rendering/debug.dart
+++ b/sky/packages/sky/lib/src/rendering/debug.dart
@@ -30,6 +30,12 @@ ui.Color debugPaintLayerBordersColor = const ui.Color(0xFFFF9800);
 /// Causes RenderObjects to paint warnings when painting outside their bounds.
 bool debugPaintBoundsEnabled = false;
 
+/// Causes RenderBox objects to flash while they are being tapped
+bool debugPaintPointersEnabled = false;
+
+/// The color to use when reporting pointers.
+int debugPaintPointersColorValue = 0x00BBBB;
+
 /// The color to use when painting RenderError boxes in checked mode.
 ui.Color debugErrorBoxColor = const ui.Color(0xFFFF0000);
 

--- a/sky/packages/sky/lib/src/rendering/object.dart
+++ b/sky/packages/sky/lib/src/rendering/object.dart
@@ -1014,7 +1014,6 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       _debugDoingThisPaint = true;
       debugLastActivePaint = _debugActivePaint;
       _debugActivePaint = this;
-      debugPaint(context, offset);
       if (debugPaintBoundsEnabled) {
         context.canvas.save();
         context.canvas.clipRect(paintBounds.shift(offset));
@@ -1031,6 +1030,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
       _debugReportException('paint', e, stack);
     }
     assert(() {
+      debugPaint(context, offset);
       if (debugPaintBoundsEnabled)
         context.canvas.restore();
       _debugActivePaint = debugLastActivePaint;
@@ -1082,8 +1082,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
   // EVENTS
 
   /// Override this function to handle events that hit this render object
-  void handleEvent(InputEvent event, HitTestEntry entry) {
-  }
+  void handleEvent(InputEvent event, HitTestEntry entry) { }
 
 
   // HIT TESTING


### PR DESCRIPTION
Implements a mode that highlights RenderBoxes while events are being
routed through them.

Also, moves the size painting to after paint, so that opaque boxes
don't obscure the debugging lines.