### PR TITLE
Radio<T> and ValueChanged<T>

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -243,7 +243,7 @@ class AddItemDialogState extends State<AddItemDialog> {
     for (String routeName in _labels.keys) {
       menuItems.add(new DialogMenuItem(<Widget>[
         new Flexible(child: new Text(_labels[routeName])),
-        new Radio(value: routeName, groupValue: _addItemRoute, onChanged: _handleAddItemRouteChanged),
+        new Radio<String>(value: routeName, groupValue: _addItemRoute, onChanged: _handleAddItemRouteChanged),
       ], onPressed: () => _handleAddItemRouteChanged(routeName)));
     }
     return new Dialog(

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -123,7 +123,7 @@ class StockHomeState extends State<StockHome> {
           onPressed: () => _handleStockModeChange(StockMode.optimistic),
           child: new Row(<Widget>[
             new Flexible(child: new Text('Optimistic')),
-            new Radio(value: StockMode.optimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
+            new Radio<StockMode>(value: StockMode.optimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
           ])
         ),
         new DrawerItem(
@@ -131,7 +131,7 @@ class StockHomeState extends State<StockHome> {
           onPressed: () => _handleStockModeChange(StockMode.pessimistic),
           child: new Row(<Widget>[
             new Flexible(child: new Text('Pessimistic')),
-            new Radio(value: StockMode.pessimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
+            new Radio<StockMode>(value: StockMode.pessimistic, groupValue: config.stockMode, onChanged: _handleStockModeChange)
           ])
         ),
         new DrawerDivider(),

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -124,14 +124,14 @@ class CardCollectionState extends State<CardCollection> {
           buildDrawerCheckbox("Fixed size cards", _fixedSizeCards, _toggleFixedSizeCards),
           buildDrawerCheckbox("Let the sun shine", _sunshine, _toggleSunshine),
           new DrawerDivider(),
-          buildDrawerRadioItem("Deep Purple", Colors.deepPurple, _primaryColor, _selectColor),
-          buildDrawerRadioItem("Green", Colors.green, _primaryColor, _selectColor),
-          buildDrawerRadioItem("Amber", Colors.amber, _primaryColor, _selectColor),
-          buildDrawerRadioItem("Teal", Colors.teal, _primaryColor, _selectColor),
+          buildDrawerColorRadioItem("Deep Purple", Colors.deepPurple, _primaryColor, _selectColor),
+          buildDrawerColorRadioItem("Green", Colors.green, _primaryColor, _selectColor),
+          buildDrawerColorRadioItem("Amber", Colors.amber, _primaryColor, _selectColor),
+          buildDrawerColorRadioItem("Teal", Colors.teal, _primaryColor, _selectColor),
           new DrawerDivider(),
-          buildDrawerRadioItem("Dismiss horizontally", DismissDirection.horizontal, _dismissDirection, _changeDismissDirection, icon: 'action/code'),
-          buildDrawerRadioItem("Dismiss left", DismissDirection.left, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_back'),
-          buildDrawerRadioItem("Dismiss right", DismissDirection.right, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_forward'),
+          buildDrawerDirectionRadioItem("Dismiss horizontally", DismissDirection.horizontal, _dismissDirection, _changeDismissDirection, icon: 'action/code'),
+          buildDrawerDirectionRadioItem("Dismiss left", DismissDirection.left, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_back'),
+          buildDrawerDirectionRadioItem("Dismiss right", DismissDirection.right, _dismissDirection, _changeDismissDirection, icon: 'navigation/arrow_forward'),
         ])
       )
     );
@@ -161,7 +161,7 @@ class CardCollectionState extends State<CardCollection> {
     });
   }
 
-  void _selectColor(selection) {
+  void _selectColor(Map<int, Color> selection) {
     setState(() {
       _primaryColor = selection;
     });
@@ -184,13 +184,28 @@ class CardCollectionState extends State<CardCollection> {
     );
   }
 
-  Widget buildDrawerRadioItem(String label, itemValue, currentValue, RadioValueChanged onChanged, { String icon }) {
+  Widget buildDrawerColorRadioItem(String label, Map<int, Color> itemValue, Map<int, Color> currentValue, ValueChanged<Map<int, Color>> onChanged, { String icon }) {
     return new DrawerItem(
       icon: icon,
       onPressed: () { onChanged(itemValue); },
       child: new Row(<Widget>[
         new Flexible(child: new Text(label)),
-        new Radio(
+        new Radio<Map<int, Color>>(
+          value: itemValue,
+          groupValue: currentValue,
+          onChanged: onChanged
+        )
+      ])
+    );
+  }
+
+  Widget buildDrawerDirectionRadioItem(String label, DismissDirection itemValue, DismissDirection currentValue, ValueChanged<DismissDirection> onChanged, { String icon }) {
+    return new DrawerItem(
+      icon: icon,
+      onPressed: () { onChanged(itemValue); },
+      child: new Row(<Widget>[
+        new Flexible(child: new Text(label)),
+        new Radio<DismissDirection>(
           value: itemValue,
           groupValue: currentValue,
           onChanged: onChanged

--- a/sky/packages/sky/lib/src/material/checkbox.dart
+++ b/sky/packages/sky/lib/src/material/checkbox.dart
@@ -9,8 +9,6 @@ import 'package:flutter/widgets.dart';
 
 import 'theme.dart';
 
-export 'package:flutter/rendering.dart' show ValueChanged;
-
 const double _kMidpoint = 0.5;
 const Color _kLightUncheckedColor = const Color(0x8A000000);
 const Color _kDarkUncheckedColor = const Color(0xB2FFFFFF);

--- a/sky/packages/sky/lib/src/material/date_picker.dart
+++ b/sky/packages/sky/lib/src/material/date_picker.dart
@@ -4,17 +4,15 @@
 
 import 'dart:async';
 
-import 'package:intl/date_symbols.dart';
-import 'package:intl/intl.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:intl/date_symbols.dart';
+import 'package:intl/intl.dart';
 
 import 'colors.dart';
 import 'ink_well.dart';
 import 'theme.dart';
 import 'typography.dart';
-
-typedef void DatePickerValueChanged(DateTime dateTime);
 
 enum DatePickerMode { day, year }
 
@@ -33,7 +31,7 @@ class DatePicker extends StatefulComponent {
   }
 
   final DateTime selectedDate;
-  final DatePickerValueChanged onChanged;
+  final ValueChanged<DateTime> onChanged;
   final DateTime firstDate;
   final DateTime lastDate;
 
@@ -176,7 +174,7 @@ class DayPicker extends StatelessComponent {
 
   final DateTime selectedDate;
   final DateTime currentDate;
-  final DatePickerValueChanged onChanged;
+  final ValueChanged<DateTime> onChanged;
   final DateTime displayedMonth;
 
   Widget build(BuildContext context) {
@@ -282,7 +280,7 @@ class MonthPicker extends ScrollableWidgetList {
   }
 
   final DateTime selectedDate;
-  final DatePickerValueChanged onChanged;
+  final ValueChanged<DateTime> onChanged;
   final DateTime firstDate;
   final DateTime lastDate;
 
@@ -355,7 +353,7 @@ class YearPicker extends ScrollableWidgetList {
   }
 
   final DateTime selectedDate;
-  final DatePickerValueChanged onChanged;
+  final ValueChanged<DateTime> onChanged;
   final DateTime firstDate;
   final DateTime lastDate;
 

--- a/sky/packages/sky/lib/src/material/input.dart
+++ b/sky/packages/sky/lib/src/material/input.dart
@@ -3,15 +3,14 @@
 // found in the LICENSE file.
 
 import 'package:flutter/animation.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'theme.dart';
 
+export 'package:flutter/rendering.dart' show ValueChanged;
 export 'package:flutter/services.dart' show KeyboardType;
-
-typedef void StringValueChanged(String value);
-typedef void StringValueSubmitted(String value);
 
 // TODO(eseidel): This isn't right, it's 16px on the bottom:
 // http://www.google.com/design/spec/components/text-fields.html#text-fields-single-line-text-field
@@ -34,8 +33,8 @@ class Input extends Scrollable {
   final String initialValue;
   final KeyboardType keyboardType;
   final String placeholder;
-  final StringValueChanged onChanged;
-  final StringValueSubmitted onSubmitted;
+  final ValueChanged<String> onChanged;
+  final ValueChanged<String> onSubmitted;
 
   InputState createState() => new InputState();
 }

--- a/sky/packages/sky/lib/src/material/radio.dart
+++ b/sky/packages/sky/lib/src/material/radio.dart
@@ -11,9 +11,7 @@ import 'theme.dart';
 const Color _kLightOffColor = const Color(0x8A000000);
 const Color _kDarkOffColor = const Color(0xB2FFFFFF);
 
-typedef void RadioValueChanged(Object value);
-
-class Radio extends StatelessComponent {
+class Radio<T> extends StatelessComponent {
   Radio({
     Key key,
     this.value,
@@ -23,9 +21,9 @@ class Radio extends StatelessComponent {
     assert(onChanged != null);
   }
 
-  final Object value;
-  final Object groupValue;
-  final RadioValueChanged onChanged;
+  final T value;
+  final T groupValue;
+  final ValueChanged<T> onChanged;
 
   Color _getColor(BuildContext context) {
     ThemeData themeData = Theme.of(context);
@@ -59,6 +57,7 @@ class Radio extends StatelessComponent {
               paint.style = ui.PaintingStyle.fill;
               canvas.drawCircle(const Point(kOuterRadius, kOuterRadius), kInnerRadius, paint);
             }
+
           }
         )
       )

--- a/sky/packages/sky/lib/src/material/switch.dart
+++ b/sky/packages/sky/lib/src/material/switch.dart
@@ -13,8 +13,6 @@ import 'radial_reaction.dart';
 import 'shadows.dart';
 import 'theme.dart';
 
-export 'package:flutter/rendering.dart' show ValueChanged;
-
 const Color _kThumbOffColor = const Color(0xFFFAFAFA);
 const Color _kTrackOffColor = const Color(0x42000000);
 const double _kSwitchWidth = 35.0;


### PR DESCRIPTION
Make Radio widgets take a type that describes the type of their value,
so that you can catch when you use the wrong value.

Standardise on `ValueChanged<Foo>` instead of having a `FooValueChanged`
for every value of `Foo`.