### PR TITLE
In the stock list, filter out any symbols that have not yet been fetched

### DIFF
--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -175,7 +175,8 @@ class StockHomeState extends State<StockHome> {
   int selectedTabIndex = 0;
 
   Iterable<Stock> _getStockList(Iterable<String> symbols) {
-    return symbols.map((String symbol) => config.stocks[symbol]);
+    return symbols.map((String symbol) => config.stocks[symbol])
+        .where((Stock stock) => stock != null);
   }
 
   Iterable<Stock> _filterBySearchQuery(Iterable<Stock> stocks) {


### PR DESCRIPTION
If you load the example and immediately switch to the Portfolio tab, you may
see exceptions due to symbols that are in the portfolio list but whose
data is not yet present in the stocks map