### PR TITLE
Restore previous tap behaviors: no timeout, one pointer

### DIFF
--- a/sky/packages/sky/lib/src/gestures/constants.dart
+++ b/sky/packages/sky/lib/src/gestures/constants.dart
@@ -6,7 +6,7 @@
 // https://github.com/android/platform_frameworks_base/blob/master/core/java/android/view/ViewConfiguration.java
 
 const Duration kLongPressTimeout = const Duration(milliseconds: 500);
-const Duration kTapTimeout = const Duration(milliseconds: 100);
+const Duration kPressTimeout = const Duration(milliseconds: 100);
 const Duration kJumpTapTimeout = const Duration(milliseconds: 500);
 const Duration kDoubleTapTimeout = const Duration(milliseconds: 300);
 const Duration kDoubleTapMinTime = const Duration(milliseconds: 40);

--- a/sky/packages/sky/lib/src/gestures/double_tap.dart
+++ b/sky/packages/sky/lib/src/gestures/double_tap.dart
@@ -52,7 +52,6 @@ class DoubleTapGestureRecognizer extends DisposableArenaMember {
       entry: GestureArena.instance.add(event.pointer, this)
     );
     _trackers[event.pointer] = tracker;
-    tracker.startTimer(() => _reject(tracker));
     tracker.startTrackingPointer(router, handleEvent);
   }
 
@@ -145,7 +144,6 @@ class DoubleTapGestureRecognizer extends DisposableArenaMember {
   }
 
   void _freezeTracker(TapTracker tracker) {
-    tracker.stopTimer();
     tracker.stopTrackingPointer(router, handleEvent);
   }
 

--- a/sky/packages/sky/lib/src/gestures/long_press.dart
+++ b/sky/packages/sky/lib/src/gestures/long_press.dart
@@ -12,7 +12,7 @@ typedef void GestureLongPressCallback();
 
 class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   LongPressGestureRecognizer({ PointerRouter router, this.onLongPress })
-    : super(router: router, deadline: kTapTimeout + kLongPressTimeout);
+    : super(router: router, deadline: kLongPressTimeout);
 
   GestureLongPressCallback onLongPress;
 

--- a/sky/packages/sky/lib/src/gestures/show_press.dart
+++ b/sky/packages/sky/lib/src/gestures/show_press.dart
@@ -11,7 +11,7 @@ typedef void GestureShowPressCallback();
 
 class ShowPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   ShowPressGestureRecognizer({ PointerRouter router, this.onShowPress })
-    : super(router: router, deadline: kTapTimeout);
+    : super(router: router, deadline: kPressTimeout);
 
   GestureShowPressCallback onShowPress;
 

--- a/sky/packages/sky/lib/src/material/ink_well.dart
+++ b/sky/packages/sky/lib/src/material/ink_well.dart
@@ -35,8 +35,8 @@ class _InkSplash {
       duration: new Duration(milliseconds: (_targetRadius / _kSplashUnconfirmedVelocity).floor())
     )..addListener(_handleRadiusChange);
 
-    // Wait kTapTimeout to avoid creating tiny splashes during scrolls.
-    _startTimer = new Timer(kTapTimeout, _play);
+    // Wait kPressTimeout to avoid creating tiny splashes during scrolls.
+    _startTimer = new Timer(kPressTimeout, _play);
   }
 
   final Point position;

--- a/sky/unit/test/gestures/double_tap_test.dart
+++ b/sky/unit/test/gestures/double_tap_test.dart
@@ -223,7 +223,7 @@ void main() {
     tap.dispose();
   });
 
-  test('Intra-tap delay cancels double tap', () {
+  test('Intra-tap delay does not cancel double tap', () {
     PointerRouter router = new PointerRouter();
     DoubleTapGestureRecognizer tap = new DoubleTapGestureRecognizer(router: router);
 
@@ -252,9 +252,9 @@ void main() {
       expect(doubleTapRecognized, isFalse);
 
       router.route(up2);
-      expect(doubleTapRecognized, isFalse);
+      expect(doubleTapRecognized, isTrue);
       GestureArena.instance.sweep(2);
-      expect(doubleTapRecognized, isFalse);
+      expect(doubleTapRecognized, isTrue);
     });
 
     tap.dispose();

--- a/sky/unit/test/gestures/tap_test.dart
+++ b/sky/unit/test/gestures/tap_test.dart
@@ -84,7 +84,7 @@ void main() {
     tap.dispose();
   });
 
-  test('Should recognize two overlapping taps', () {
+  test('Should not recognize two overlapping taps', () {
     PointerRouter router = new PointerRouter();
     TapGestureRecognizer tap = new TapGestureRecognizer(router: router);
 
@@ -112,9 +112,9 @@ void main() {
     expect(tapsRecognized, 1);
 
     router.route(up2);
-    expect(tapsRecognized, 2);
+    expect(tapsRecognized, 1);
     GestureArena.instance.sweep(2);
-    expect(tapsRecognized, 2);
+    expect(tapsRecognized, 1);
 
     tap.dispose();
   });
@@ -144,7 +144,7 @@ void main() {
     tap.dispose();
   });
 
-  test('Timeout cancels tap', () {
+  test('Timeout does not cancel tap', () {
     PointerRouter router = new PointerRouter();
     TapGestureRecognizer tap = new TapGestureRecognizer(router: router);
 
@@ -163,9 +163,9 @@ void main() {
       async.elapse(new Duration(milliseconds: 500));
       expect(tapRecognized, isFalse);
       router.route(up1);
-      expect(tapRecognized, isFalse);
+      expect(tapRecognized, isTrue);
       GestureArena.instance.sweep(1);
-      expect(tapRecognized, isFalse);
+      expect(tapRecognized, isTrue);
     });
 
     tap.dispose();


### PR DESCRIPTION
Don't use a timeout to cancel tap tracking. Track only one primary pointer
and ignore non-primary pointers. Update tests to reflect desired behaviors.

Fixes #1779, #1780, #1781.