### PR TITLE
Right-aligned text paints offscreen sometimes

### DIFF
--- a/sky/packages/sky/lib/src/painting/text_painter.dart
+++ b/sky/packages/sky/lib/src/painting/text_painter.dart
@@ -166,21 +166,22 @@ class TextPainter {
   }
 
   /// The width at which decreasing the width of the text would prevent it from painting itself completely within its bounds
-  double get minContentWidth {
+  double get minIntrinsicWidth {
     assert(!_needsLayout);
     return _applyFloatingPointHack(_paragraph.minIntrinsicWidth);
   }
 
   /// The width at which increasing the width of the text no longer decreases the height
-  double get maxContentWidth {
+  double get maxIntrinsicWidth {
     assert(!_needsLayout);
     return _applyFloatingPointHack(_paragraph.maxIntrinsicWidth);
   }
 
-  /// The height required to paint the text completely within its bounds
-  double get height {
+  Size get size {
     assert(!_needsLayout);
-    return _applyFloatingPointHack(_paragraph.height);
+    double height = _applyFloatingPointHack(_paragraph.height);
+    double width = _applyFloatingPointHack(_paragraph.width);
+    return new Size(width, height);
   }
 
   /// The distance from the top of the text to the first baseline of the given type

--- a/sky/packages/sky/lib/src/rendering/editable_paragraph.dart
+++ b/sky/packages/sky/lib/src/rendering/editable_paragraph.dart
@@ -68,7 +68,7 @@ class RenderEditableParagraph extends RenderParagraph {
     // because we only support single-line text.
     layoutText(constraints);
     return constraints.constrainWidth(
-      textPainter.maxContentWidth + _kCursorGap + _kCursorWidth
+      textPainter.size.width + _kCursorGap + _kCursorWidth
     );
   }
 
@@ -83,10 +83,8 @@ class RenderEditableParagraph extends RenderParagraph {
   void performLayout() {
     layoutText(constraints);
 
-    Size newContentSize = new Size(
-      textPainter.maxContentWidth + _kCursorGap + _kCursorWidth,
-      textPainter.height
-    );
+    Offset cursorPadding = const Offset(_kCursorGap + _kCursorWidth, 0.0);
+    Size newContentSize = textPainter.size + cursorPadding;
     size = constraints.constrain(newContentSize);
 
     if (_contentSize == null || _contentSize != newContentSize) {
@@ -109,7 +107,7 @@ class RenderEditableParagraph extends RenderParagraph {
 
     if (_showCursor) {
       Rect cursorRect =  new Rect.fromLTWH(
-        textPainter.maxContentWidth + _kCursorGap,
+        textPainter.size.width + _kCursorGap,
         _kCursorHeightOffset,
         _kCursorWidth,
         size.height - 2.0 * _kCursorHeightOffset

--- a/sky/packages/sky/lib/src/rendering/paragraph.dart
+++ b/sky/packages/sky/lib/src/rendering/paragraph.dart
@@ -59,22 +59,27 @@ class RenderParagraph extends RenderBox {
     textPainter.minHeight = constraints.minHeight;
     textPainter.maxHeight = constraints.maxHeight;
     textPainter.layout();
+    // By default, we shrinkwrap to the intrinsic width.
+    double width = constraints.constrainWidth(textPainter.maxIntrinsicWidth);
+    textPainter.minWidth = width;
+    textPainter.maxWidth = width;
+    textPainter.layout();
     _constraintsForCurrentLayout = constraints;
   }
 
   double getMinIntrinsicWidth(BoxConstraints constraints) {
     layoutText(constraints);
-    return constraints.constrainWidth(textPainter.minContentWidth);
+    return constraints.constrainWidth(textPainter.minIntrinsicWidth);
   }
 
   double getMaxIntrinsicWidth(BoxConstraints constraints) {
     layoutText(constraints);
-    return constraints.constrainWidth(textPainter.maxContentWidth);
+    return constraints.constrainWidth(textPainter.maxIntrinsicWidth);
   }
 
   double _getIntrinsicHeight(BoxConstraints constraints) {
     layoutText(constraints);
-    return constraints.constrainHeight(textPainter.height);
+    return constraints.constrainHeight(textPainter.size.height);
   }
 
   double getMinIntrinsicHeight(BoxConstraints constraints) {
@@ -93,12 +98,7 @@ class RenderParagraph extends RenderBox {
 
   void performLayout() {
     layoutText(constraints);
-
-    // We use textPainter.maxContentWidth here, rather that textPainter.width,
-    // because the latter is the width that it used to wrap the text, whereas
-    // the former is the actual width of the text.
-    size = constraints.constrain(new Size(textPainter.maxContentWidth,
-                                          textPainter.height));
+    size = constraints.constrain(textPainter.size);
   }
 
   void paint(PaintingContext context, Offset offset) {

--- a/skysprites/lib/src/label.dart
+++ b/skysprites/lib/src/label.dart
@@ -43,7 +43,7 @@ class Label extends Node {
       _painter.minWidth = 0.0;
       _painter.layout();
 
-      _width = _painter.maxContentWidth.ceil().toDouble();
+      _width = _painter.maxIntrinsicWidth.ceil().toDouble();
 
       _painter.maxWidth = _width;
       _painter.minWidth = _width;


### PR DESCRIPTION
We were assuming that the text extended from 0.0 to its max content width.
That's not correct for right-aligned text. Instead, we need to layout the text
again at the width we want it to occupy.