### PR TITLE
Use the presence of handler to determine 'enabled'

### DIFF
--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -91,7 +91,6 @@ class StockHomeState extends State<StockHome> {
                 actions: <Widget>[
                   new FlatButton(
                     child: new Text('USE IT'),
-                    enabled: false,
                     onPressed: () {
                       config.navigator.pop(false);
                     }

--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -42,6 +42,7 @@ class CardCollectionState extends State<CardCollection> {
   bool _snapToCenter = false;
   bool _fixedSizeCards = false;
   bool _sunshine = false;
+  bool _varyFontSizes = false;
   InvalidatorCallback _invalidator;
   Size _cardCollectionSize = new Size(200.0, 200.0);
 
@@ -127,6 +128,7 @@ class CardCollectionState extends State<CardCollection> {
           buildDrawerCheckbox("Snap fling scrolls to center", _snapToCenter, _toggleSnapToCenter),
           buildDrawerCheckbox("Fixed size cards", _fixedSizeCards, _toggleFixedSizeCards),
           buildDrawerCheckbox("Let the sun shine", _sunshine, _toggleSunshine),
+          buildDrawerCheckbox("Vary font sizes", _varyFontSizes, _toggleVaryFontSizes, enabled: !_editable),
           new DrawerDivider(),
           buildDrawerColorRadioItem("Deep Purple", Colors.deepPurple, _primaryColor, _selectColor),
           buildDrawerColorRadioItem("Green", Colors.green, _primaryColor, _selectColor),
@@ -181,6 +183,12 @@ class CardCollectionState extends State<CardCollection> {
     });
   }
 
+  void _toggleVaryFontSizes() {
+    setState(() {
+      _varyFontSizes = !_varyFontSizes;
+    });
+  }
+
   void _selectColor(Map<int, Color> selection) {
     setState(() {
       _primaryColor = selection;
@@ -199,12 +207,15 @@ class CardCollectionState extends State<CardCollection> {
     });
   }
 
-  Widget buildDrawerCheckbox(String label, bool value, void callback()) {
+  Widget buildDrawerCheckbox(String label, bool value, void callback(), { bool enabled: true }) {
     return new DrawerItem(
-      onPressed: callback,
+      onPressed: enabled ? callback : null,
       child: new Row(<Widget>[
         new Flexible(child: new Text(label)),
-        new Checkbox(value: value, onChanged: (_) { callback(); })
+        new Checkbox(
+          value: value,
+          onChanged: enabled ? (_) { callback(); } : null
+        )
       ])
     );
   }
@@ -218,8 +229,7 @@ class CardCollectionState extends State<CardCollection> {
         new Radio<Map<int, Color>>(
           value: itemValue,
           groupValue: currentValue,
-          enabled: enabled,
-          onChanged: onChanged
+          onChanged: enabled ? onChanged : null
         )
       ])
     );
@@ -234,8 +244,7 @@ class CardCollectionState extends State<CardCollection> {
         new Radio<DismissDirection>(
           value: itemValue,
           groupValue: currentValue,
-          enabled: enabled,
-          onChanged: onChanged
+          onChanged: enabled ? onChanged : null
         )
       ])
     );
@@ -250,8 +259,7 @@ class CardCollectionState extends State<CardCollection> {
         new Radio<TextStyle>(
           value: itemValue,
           groupValue: currentValue,
-          enabled: enabled,
-          onChanged: onChanged
+          onChanged: enabled ? onChanged : null
         )
       ])
     );
@@ -292,7 +300,9 @@ class CardCollectionState extends State<CardCollection> {
               )
             )
           : new DefaultTextStyle(
-              style: DefaultTextStyle.of(context).merge(cardLabelStyle).merge(_textStyle),
+              style: DefaultTextStyle.of(context).merge(cardLabelStyle).merge(_textStyle).copyWith(
+                fontSize: _varyFontSizes ? 5.0 + _cardModels.length.toDouble() : null
+              ),
               child: new Column(<Widget>[
                   new Text(cardModel.label)
                 ],

--- a/examples/widgets/container.dart
+++ b/examples/widgets/container.dart
@@ -26,9 +26,7 @@ class ContainerApp extends StatelessComponent {
               onPressed: () => print("Hello World")
             ),
             new RaisedButton(
-              child: new Text('DISABLED'),
-              onPressed: () => print("Hello World"),
-              enabled: false
+              child: new Text('DISABLED')
             )
           ])
         ),

--- a/examples/widgets/sector.dart
+++ b/examples/widgets/sector.dart
@@ -73,7 +73,6 @@ class SectorAppState extends State<SectorApp> {
           padding: new EdgeDims.symmetric(horizontal: 8.0, vertical: 25.0),
           child: new Row(<Widget>[
               new RaisedButton(
-                enabled: _enabledAdd,
                 child: new IntrinsicWidth(
                   child: new Row(<Widget>[
                     new Container(
@@ -84,10 +83,9 @@ class SectorAppState extends State<SectorApp> {
                     new Text('ADD SECTOR'),
                   ])
                 ),
-                onPressed: addSector
+                onPressed: _enabledAdd ? addSector : null
               ),
               new RaisedButton(
-                enabled: _enabledRemove,
                 child: new IntrinsicWidth(
                   child: new Row(<Widget>[
                     new Container(
@@ -98,7 +96,7 @@ class SectorAppState extends State<SectorApp> {
                     new Text('REMOVE SECTOR'),
                   ])
                 ),
-                onPressed: removeSector
+                onPressed: _enabledRemove ? removeSector : null
               )
             ],
             justifyContent: FlexJustifyContent.spaceAround

--- a/sky/packages/sky/lib/src/material/checkbox.dart
+++ b/sky/packages/sky/lib/src/material/checkbox.dart
@@ -7,11 +7,10 @@ import 'dart:ui' as ui;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
 import 'theme.dart';
 
 const double _kMidpoint = 0.5;
-const Color _kLightUncheckedColor = const Color(0x8A000000);
-const Color _kDarkUncheckedColor = const Color(0xB2FFFFFF);
 const double _kEdgeSize = 18.0;
 const double _kEdgeRadius = 1.0;
 const double _kStrokeWidth = 2.0;
@@ -30,21 +29,37 @@ class Checkbox extends StatelessComponent {
   ///
   /// * `value` determines whether the checkbox is checked.
   /// * `onChanged` is called whenever the state of the checkbox should change.
-  const Checkbox({Key key, this.value, this.onChanged}) : super(key: key);
+  const Checkbox({
+    Key key,
+    this.value,
+    this.onChanged
+  }) : super(key: key);
 
   final bool value;
   final ValueChanged<bool> onChanged;
 
+  bool get enabled => onChanged != null;
+
   Widget build(BuildContext context) {
     ThemeData themeData = Theme.of(context);
-    Color uncheckedColor = themeData.brightness == ThemeBrightness.light
-        ? _kLightUncheckedColor
-        : _kDarkUncheckedColor;
+    if (enabled) {
+      Color uncheckedColor = themeData.brightness == ThemeBrightness.light
+          ? Colors.black54
+          : Colors.white70;
+      return new _CheckboxWrapper(
+        value: value,
+        onChanged: onChanged,
+        uncheckedColor: uncheckedColor,
+        accentColor: themeData.accentColor
+      );
+    }
+    Color disabledColor = themeData.brightness == ThemeBrightness.light
+        ? Colors.black26
+        : Colors.white30;
     return new _CheckboxWrapper(
       value: value,
-      onChanged: onChanged,
-      uncheckedColor: uncheckedColor,
-      accentColor: themeData.accentColor
+      uncheckedColor: disabledColor,
+      accentColor: disabledColor
     );
   }
 }

--- a/sky/packages/sky/lib/src/material/flat_button.dart
+++ b/sky/packages/sky/lib/src/material/flat_button.dart
@@ -12,11 +12,9 @@ class FlatButton extends MaterialButton {
   FlatButton({
     Key key,
     Widget child,
-    bool enabled: true,
     GestureTapCallback onPressed
   }) : super(key: key,
              child: child,
-             enabled: enabled,
              onPressed: onPressed);
 
   _FlatButtonState createState() => new _FlatButtonState();

--- a/sky/packages/sky/lib/src/material/material_button.dart
+++ b/sky/packages/sky/lib/src/material/material_button.dart
@@ -36,17 +36,15 @@ abstract class MaterialButton extends StatefulComponent {
   MaterialButton({
     Key key,
     this.child,
-    this.enabled: true,
     this.textColor,
     this.onPressed
-  }) : super(key: key) {
-    assert(enabled != null);
-  }
+  }) : super(key: key);
 
   final Widget child;
-  final bool enabled;
   final ButtonColor textColor;
   final GestureTapCallback onPressed;
+
+  bool get enabled => onPressed != null;
 
   void debugFillDescription(List<String> description) {
     super.debugFillDescription(description);

--- a/sky/packages/sky/lib/src/material/radio.dart
+++ b/sky/packages/sky/lib/src/material/radio.dart
@@ -12,18 +12,16 @@ import 'theme.dart';
 class Radio<T> extends StatelessComponent {
   Radio({
     Key key,
-    this.enabled,
     this.value,
     this.groupValue,
     this.onChanged
-  }) : super(key: key) {
-    assert(onChanged != null);
-  }
+  }) : super(key: key);
 
-  final bool enabled;
   final T value;
   final T groupValue;
   final ValueChanged<T> onChanged;
+
+  bool get enabled => onChanged != null;
 
   Color _getColor(BuildContext context) {
     ThemeData themeData = Theme.of(context);

--- a/sky/packages/sky/lib/src/material/raised_button.dart
+++ b/sky/packages/sky/lib/src/material/raised_button.dart
@@ -12,14 +12,10 @@ class RaisedButton extends MaterialButton {
   RaisedButton({
     Key key,
     Widget child,
-    bool enabled: true,
     GestureTapCallback onPressed
   }) : super(key: key,
              child: child,
-             enabled: enabled,
-             onPressed: onPressed) {
-    assert(enabled != null);
-  }
+             onPressed: onPressed);
 
   _RaisedButtonState createState() => new _RaisedButtonState();
 }

--- a/sky/packages/sky/lib/src/rendering/toggleable.dart
+++ b/sky/packages/sky/lib/src/rendering/toggleable.dart
@@ -19,10 +19,12 @@ const Duration _kToggleDuration = const Duration(milliseconds: 200);
 // ValueChanged on a tap gesture and driving a changed animation. Subclasses are
 // responsible for painting.
 abstract class RenderToggleable extends RenderConstrainedBox {
-  RenderToggleable({bool value, Size size, ValueChanged<bool> onChanged})
-      : _value = value,
-        _onChanged = onChanged,
-        super(additionalConstraints: new BoxConstraints.tight(size)) {
+  RenderToggleable({
+    bool value,
+    Size size,
+    this.onChanged
+  }) : _value = value,
+       super(additionalConstraints: new BoxConstraints.tight(size)) {
     _performance = new ValuePerformance<double>(
       variable: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.easeIn, reverseCurve: Curves.easeOut),
       duration: _kToggleDuration,
@@ -30,15 +32,21 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     )..addListener(markNeedsPaint);
   }
 
+  bool get value => _value;
+  bool _value;
+  void set value(bool value) {
+    if (value == _value)
+      return;
+    _value = value;
+    performance.play(value ? AnimationDirection.forward : AnimationDirection.reverse);
+  }
+
+  ValueChanged<bool> onChanged;
+
   ValuePerformance<double> get performance => _performance;
   ValuePerformance<double> _performance;
 
   double get position => _performance.value;
-
-  void handleEvent(InputEvent event, BoxHitTestEntry entry) {
-    if (event.type == 'pointerdown')
-      _tap.addPointer(event);
-  }
 
   TapGestureRecognizer _tap;
 
@@ -56,23 +64,13 @@ abstract class RenderToggleable extends RenderConstrainedBox {
     super.detach();
   }
 
+  void handleEvent(InputEvent event, BoxHitTestEntry entry) {
+    if (event.type == 'pointerdown' && onChanged != null)
+      _tap.addPointer(event);
+  }
+
   void _handleTap() {
-    if (_onChanged != null)
-      _onChanged(!_value);
-  }
-
-  bool get value => _value;
-  bool _value;
-  void set value(bool value) {
-    if (value == _value)
-      return;
-    _value = value;
-    performance.play(value ? AnimationDirection.forward : AnimationDirection.reverse);
-  }
-
-  ValueChanged<bool> get onChanged => _onChanged;
-  ValueChanged<bool> _onChanged;
-  void set onChanged(ValueChanged<bool> onChanged) {
-    _onChanged = onChanged;
+    if (onChanged != null)
+      onChanged(!_value);
   }
 }

--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -41,8 +41,9 @@ _IGNORED_PATTERNS = [
   re.compile(r'^\[hint\] Runtime check on non-ground type .+ may throw StrongModeError'), # https://github.com/dart-lang/sdk/issues/24565
   re.compile(r'^\[hint] \([_, ]+\) .+ has inferred type '), # ignore underscore-only arguments
 
-  # Bogus hint
-  re.compile(r'^\[hint\] \(toText == toPlainText\) \? toStyledText : toPlainText has inferred type \(String, String\) → Widget \(.+styled_text.dart,.+\)'), # https://github.com/dart-lang/sdk/issues/24710
+  # Bogus hint - https://github.com/dart-lang/sdk/issues/24710
+  re.compile(r'^\[hint\] \(toText == toPlainText\) \? toStyledText : toPlainText has inferred type \(String, String\) → Widget \(.+styled_text.dart,.+\)'),
+  re.compile(r'^\[hint\] .+ \? \([_, ]+\) {.+} : null has inferred type .+'), # 
 
   # Disable the lint checks that will be caught by code review
   re.compile(r'^\[lint\] Avoid defining a one-member abstract class when a simple function will do'),


### PR DESCRIPTION
Instread of an explicit 'enabled' bool, this uses the presence of the
event handler to determine if a widget is enabled or not. This means
that if you've not passed a handler, your widget will be disabled, which
makes sense, since it wouldn't work anyway.

Adds this feature to checkbox, and ports raised button, flat button, and
radio buttons to this new model.

Adds a checkbox to card_collection that can be disabled.

Hide a (basically bogus) hint from the (soon to be disabled) strong hint
mode in the analyzer that this reveals.