### PR TITLE
Remove `ios_active_arch` and directly specify `arm64` vs `armv7` preference via `target_cpu`

### DIFF
--- a/build/config/arm.gni
+++ b/build/config/arm.gni
@@ -2,11 +2,17 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-if (current_cpu == "arm") {
+if (current_cpu == "arm" || current_cpu == "arm64") {
   declare_args() {
     # Version of the ARM processor when compiling on ARM. Ignored on non-ARM
     # platforms.
-    arm_version = 7
+    if (current_cpu == "arm") {
+      arm_version = 7
+    } else if(current_cpu == "arm64") {
+      arm_version = 8
+    } else {
+      assert(false, "Unconfigured arm version")
+    }
 
     # The ARM floating point mode. This is either the string "hard", "soft", or
     # "softfp". An empty string means to use the default one for the

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -60,14 +60,6 @@ declare_args() {
     # The patch is preapplied to the internal toolchain and hence all bots.
     msvs_xtree_patched = false
   }
-
-  # By default, iOS executables are fat binaries that contain armv7 and arm64
-  # build artifacts. This is suitable for release builds and for testing on
-  # older devices. However, generating fat binaries takes a very long time, and,
-  # depending on the application type, may be unnecessary. If the type of
-  # architecture is known beforehand, setting that as the active arch will
-  # greatly reduce build times and reduce binary sizes.
-  ios_active_arch = "arm64"
 }
 
 # default_include_dirs ---------------------------------------------------------
@@ -271,19 +263,15 @@ config("compiler") {
         "i386",
       ]
     } else if (current_cpu == "arm") {
-      if (ios_active_arch != "") {
-        common_mac_flags += [
-          "-arch",
-          ios_active_arch,
-        ]
-      } else {
-        common_mac_flags += [
-          "-arch",
-          "arm64",
-          "-arch",
-          "armv7",
-        ]
-      }
+      common_mac_flags += [
+        "-arch",
+        "armv7",
+      ]
+    } else if (current_cpu == "arm64") {
+      common_mac_flags += [
+        "-arch",
+        "arm64",
+      ]
     }
 
     cflags += common_mac_flags

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -5,7 +5,7 @@
 import("//build/config/features.gni")
 import("//build/config/ui.gni")
 import("//testing/test.gni")
-if (current_cpu == "arm") {
+if (current_cpu == "arm" || current_cpu == "arm64") {
   import("//build/config/arm.gni")
 }
 if (current_cpu == "mipsel" || current_cpu == "mips64el") {
@@ -583,6 +583,9 @@ source_set("skia_opts") {
     } else {
       sources = gypi_skia_opts.none_sources
     }
+  } else if (current_cpu == "arm64") {
+    # TODO(1841): NEON sources are not currently used on arm64.
+    sources = gypi_skia_opts.none_sources
   } else if (current_cpu == "mipsel") {
     cflags += [ "-fomit-frame-pointer" ]
 

--- a/sky/engine/bindings/bindings.gni
+++ b/sky/engine/bindings/bindings.gni
@@ -55,6 +55,20 @@ template("dart_precompile") {
   assert(defined(invoker.dart_script),
          "The dart script must be specified")
 
+  dart_host_toolchain = host_toolchain
+  if (target_os == "ios") {
+    # During precompilation, a 64 bit Dart VM cannot generate code for a 32 bit
+    # architecture (and vice-versa). The snapshotter that is running on the host
+    # needs to know about the target architecture and built accordingly.
+    if (target_cpu == "arm") {
+      dart_host_toolchain = "//build/toolchain/mac:clang_i386"
+    } else if (target_cpu == "arm64") {
+      dart_host_toolchain = "//build/toolchain/mac:clang_x64"
+    } else {
+      assert(false, "Unknown active architecture on iOS")
+    }
+  }
+
   vm_isolate_snapshot_name = target_name + "_vm_isolate.bin"
   vm_isolate_snapshot = "$target_gen_dir/$vm_isolate_snapshot_name"
   isolate_snapshot_name = target_name + "_isolate.bin"
@@ -65,7 +79,7 @@ template("dart_precompile") {
   instructions_gen_target_name = target_name + "_instructions"
   action(instructions_gen_target_name) {
     deps = [
-      "//dart/runtime/bin:gen_snapshot($host_toolchain)",
+      "//dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
     ]
     embedder_entry_points_manifest =
         "//sky/engine/bindings/dart_vm_entry_points.txt"
@@ -92,7 +106,7 @@ template("dart_precompile") {
         rebase_path("$root_build_dir/clang_x64/gen/sky/bindings/dart_ui.dart")
 
     gen_snapshot_dir =
-        get_label_info("//dart/runtime/bin:gen_snapshot($host_toolchain)",
+        get_label_info("//dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
                        "root_out_dir")
     script = "//dart/runtime/tools/create_snapshot_bin.py"
 

--- a/sky/engine/config.gni
+++ b/sky/engine/config.gni
@@ -8,7 +8,7 @@ if (is_android) {
   import("//build/config/android/config.gni")
 }
 
-if (target_cpu == "arm") {
+if (target_cpu == "arm" || target_cpu == "arm64") {
   import("//build/config/arm.gni")
 } else {
   # TODO(brettw) remove this once && early-out is checked in.

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -40,6 +40,11 @@ def to_gn_args(args):
     gn_args['is_debug'] = args.debug
     gn_args['is_clang'] = args.clang and args.target_os not in ['android']
 
+    ios_target_cpu = 'arm64'
+    if args.ios_force_armv7:
+      ios_target_cpu = 'arm'
+      pass
+
     if args.target_os == 'android':
         gn_args['target_os'] = 'android'
     elif args.target_os == 'ios':
@@ -48,13 +53,19 @@ def to_gn_args(args):
         if args.simulator:
             gn_args['use_libjpeg_turbo'] = False
         gn_args['use_ios_simulator'] = args.simulator
-        gn_args['dart_target_arch'] = "arm64"
+        gn_args['dart_target_arch'] = ios_target_cpu
     else:
         gn_args['use_aura'] = False
         gn_args['use_glib'] = False
         gn_args['use_system_harfbuzz'] = False
 
     if args.target_os in ['android', 'ios'] and not args.simulator:
+      if args.target_os == 'ios':
+        # iOS defaults to arm64 builds unless forced to build armv7. This
+        # flag will go away once universal builds are supported
+        gn_args['target_cpu'] = ios_target_cpu
+      else:
+        # There are currently no arm64 Android builds
         gn_args['target_cpu'] = 'arm'
     else:
         gn_args['target_cpu'] = 'x64'
@@ -83,6 +94,7 @@ def parse_args(args):
   parser.add_argument('--target-os', type=str, choices=['android', 'ios'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')
   parser.add_argument('--ios', dest='target_os', action='store_const', const='ios')
+  parser.add_argument('--ios-force-armv7', dest='ios_force_armv7', action='store_true', default=False)
   parser.add_argument('--simulator', action='store_true', default=False)
 
   parser.add_argument('--goma', default=True, action='store_true')


### PR DESCRIPTION
Earlier, I was using the `ios_active_arch` to set the `arm` subtype preference (and keeping the current_cpu constantly set to "arm"). This appears to be incorrect after inspecting the `mips` targets. I have adopted the same approach for `arm`.

cc @abarth @jamesr 