### PR TITLE
Track scroll position

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -44,9 +44,8 @@ class DialogMenuItem extends StatelessComponent {
 }
 
 class FeedFragment extends StatefulComponent {
-  FeedFragment({ this.navigator, this.userData, this.onItemCreated, this.onItemDeleted });
+  FeedFragment({ this.userData, this.onItemCreated, this.onItemDeleted });
 
-  final NavigatorState navigator;
   final UserData userData;
   final FitnessItemHandler onItemCreated;
   final FitnessItemHandler onItemDeleted;
@@ -62,7 +61,7 @@ class FeedFragmentState extends State<FeedFragment> {
     setState(() {
       _fitnessMode = value;
     });
-    config.navigator.pop();
+    Navigator.of(context).pop();
   }
 
   void _showDrawer() {
@@ -93,8 +92,8 @@ class FeedFragmentState extends State<FeedFragment> {
   }
 
   void _handleShowSettings() {
-    config.navigator.pop();
-    config.navigator.pushNamed('/settings');
+    Navigator.of(context).pop();
+    Navigator.of(context).pushNamed('/settings');
   }
 
   // TODO(jackson): We should be localizing
@@ -122,7 +121,7 @@ class FeedFragmentState extends State<FeedFragment> {
       content: new Text("Item deleted."),
       actions: <SnackBarAction>[new SnackBarAction(label: "UNDO", onPressed: () {
         config.onItemCreated(item);
-        config.navigator.pop();
+        Navigator.of(context).pop();
       })]
     );
   }
@@ -193,7 +192,7 @@ class FeedFragmentState extends State<FeedFragment> {
   void _handleActionButtonPressed() {
     showDialog(context: context, child: new AddItemDialog()).then((routeName) {
       if (routeName != null)
-        config.navigator.pushNamed(routeName);
+        Navigator.of(context).pushNamed(routeName);
     });
   }
 

--- a/examples/fitness/lib/main.dart
+++ b/examples/fitness/lib/main.dart
@@ -135,7 +135,6 @@ class FitnessAppState extends State<FitnessApp> {
       routes: <String, RouteBuilder>{
         '/': (RouteArguments args) {
           return new FeedFragment(
-            navigator: args.navigator,
             userData: _userData,
             onItemCreated: _handleItemCreated,
             onItemDeleted: _handleItemDeleted
@@ -143,19 +142,16 @@ class FitnessAppState extends State<FitnessApp> {
         },
         '/meals/new': (RouteArguments args) {
           return new MealFragment(
-            navigator: args.navigator,
             onCreated: _handleItemCreated
           );
         },
         '/measurements/new': (RouteArguments args) {
           return new MeasurementFragment(
-            navigator: args.navigator,
             onCreated: _handleItemCreated
           );
         },
         '/settings': (RouteArguments args) {
           return new SettingsFragment(
-            navigator: args.navigator,
             userData: _userData,
             updater: settingsUpdater
           );

--- a/examples/fitness/lib/meal.dart
+++ b/examples/fitness/lib/meal.dart
@@ -43,9 +43,8 @@ class MealRow extends FitnessItemRow {
 }
 
 class MealFragment extends StatefulComponent {
-  MealFragment({ this.navigator, this.onCreated });
+  MealFragment({ this.onCreated });
 
-  NavigatorState navigator;
   FitnessItemHandler onCreated;
 
   MealFragmentState createState() => new MealFragmentState();
@@ -56,14 +55,14 @@ class MealFragmentState extends State<MealFragment> {
 
   void _handleSave() {
     config.onCreated(new Meal(when: new DateTime.now(), description: _description));
-    config.navigator.pop();
+    Navigator.of(context).pop();
   }
 
   Widget buildToolBar() {
     return new ToolBar(
       left: new IconButton(
         icon: "navigation/close",
-        onPressed: config.navigator.pop),
+        onPressed: Navigator.of(context).pop),
       center: new Text('New Meal'),
       right: <Widget>[
         // TODO(abarth): Should this be a FlatButton?

--- a/examples/fitness/lib/measurement.dart
+++ b/examples/fitness/lib/measurement.dart
@@ -104,9 +104,8 @@ class MeasurementDateDialogState extends State<MeasurementDateDialog> {
 }
 
 class MeasurementFragment extends StatefulComponent {
-  MeasurementFragment({ this.navigator, this.onCreated });
+  MeasurementFragment({ this.onCreated });
 
-  final NavigatorState navigator;
   final FitnessItemHandler onCreated;
 
   MeasurementFragmentState createState() => new MeasurementFragmentState();
@@ -131,14 +130,14 @@ class MeasurementFragmentState extends State<MeasurementFragment> {
       );
     }
     config.onCreated(new Measurement(when: _when, weight: parsedWeight));
-    config.navigator.pop();
+    Navigator.of(context).pop();
   }
 
   Widget buildToolBar() {
     return new ToolBar(
       left: new IconButton(
         icon: "navigation/close",
-        onPressed: config.navigator.pop),
+        onPressed: Navigator.of(context).pop),
       center: new Text('New Measurement'),
       right: <Widget>[
         // TODO(abarth): Should this be a FlatButton?

--- a/examples/fitness/lib/settings.dart
+++ b/examples/fitness/lib/settings.dart
@@ -10,9 +10,8 @@ typedef void SettingsUpdater({
 });
 
 class SettingsFragment extends StatefulComponent {
-  SettingsFragment({ this.navigator, this.userData, this.updater });
+  SettingsFragment({ this.userData, this.updater });
 
-  final NavigatorState navigator;
   final UserData userData;
   final SettingsUpdater updater;
 
@@ -29,7 +28,7 @@ class SettingsFragmentState extends State<SettingsFragment> {
     return new ToolBar(
       left: new IconButton(
         icon: "navigation/arrow_back",
-        onPressed: config.navigator.pop
+        onPressed: Navigator.of(context).pop
       ),
       center: new Text('Settings')
     );
@@ -48,7 +47,7 @@ class SettingsFragmentState extends State<SettingsFragment> {
   void _handleGoalWeightChanged(String goalWeight) {
     // TODO(jackson): Looking for null characters to detect enter key is a hack
     if (goalWeight.endsWith("\u{0}")) {
-      config.navigator.pop(double.parse(goalWeight.replaceAll("\u{0}", "")));
+      Navigator.of(context).pop(double.parse(goalWeight.replaceAll("\u{0}", "")));
     } else {
       setState(() {
         try {

--- a/examples/game/lib/main.dart
+++ b/examples/game/lib/main.dart
@@ -108,10 +108,10 @@ class GameDemoState extends State<GameDemo> {
                 _sounds,
                 (int lastScore) {
                   setState(() { _lastScore = lastScore; });
-                  args.navigator.pop();
+                  Navigator.of(args.context).pop();
                 }
               );
-              args.navigator.pushNamed('/game');
+              Navigator.of(args.context).pushNamed('/game');
             },
             texture: _spriteSheetUI['btn_play_up.png'],
             textureDown: _spriteSheetUI['btn_play_down.png'],

--- a/examples/stocks/lib/main.dart
+++ b/examples/stocks/lib/main.dart
@@ -92,8 +92,8 @@ class StocksAppState extends State<StocksApp> {
       title: 'Stocks',
       theme: theme,
       routes: <String, RouteBuilder>{
-         '/':         (RouteArguments args) => new StockHome(args.navigator, _stocks, _symbols, _optimismSetting, modeUpdater),
-         '/settings': (RouteArguments args) => new StockSettings(args.navigator, _optimismSetting, _backupSetting, settingsUpdater)
+         '/':         (RouteArguments args) => new StockHome(_stocks, _symbols, _optimismSetting, modeUpdater),
+         '/settings': (RouteArguments args) => new StockSettings(_optimismSetting, _backupSetting, settingsUpdater)
       },
       onGenerateRoute: _getRoute
     );

--- a/examples/stocks/lib/stock_home.dart
+++ b/examples/stocks/lib/stock_home.dart
@@ -7,9 +7,8 @@ part of stocks;
 typedef void ModeUpdater(StockMode mode);
 
 class StockHome extends StatefulComponent {
-  StockHome(this.navigator, this.stocks, this.symbols, this.stockMode, this.modeUpdater);
+  StockHome(this.stocks, this.symbols, this.stockMode, this.modeUpdater);
 
-  final NavigatorState navigator;
   final Map<String, Stock> stocks;
   final List<String> symbols;
   final StockMode stockMode;
@@ -25,7 +24,7 @@ class StockHomeState extends State<StockHome> {
   String _searchQuery;
 
   void _handleSearchBegin() {
-    config.navigator.pushState(this, (_) {
+    Navigator.of(context).pushState(this, (_) {
       setState(() {
         _isSearching = false;
         _searchQuery = null;
@@ -38,10 +37,10 @@ class StockHomeState extends State<StockHome> {
 
   void _handleSearchEnd() {
     assert(() {
-      final StateRoute currentRoute = config.navigator.currentRoute;
+      final StateRoute currentRoute = Navigator.of(context).currentRoute;
       return currentRoute.owner == this;
     });
-    config.navigator.pop();
+    Navigator.of(context).pop();
   }
 
   void _handleSearchQueryChanged(String query) {
@@ -93,13 +92,13 @@ class StockHomeState extends State<StockHome> {
                     child: new Text('USE IT'),
                     enabled: false,
                     onPressed: () {
-                      config.navigator.pop(false);
+                      Navigator.of(context).pop(false);
                     }
                   ),
                   new FlatButton(
                     child: new Text('OH WELL'),
                     onPressed: () {
-                      config.navigator.pop(false);
+                      Navigator.of(context).pop(false);
                     }
                   ),
                 ]
@@ -143,8 +142,8 @@ class StockHomeState extends State<StockHome> {
   }
 
   void _handleShowSettings() {
-    config.navigator.pop();
-    config.navigator.pushNamed('/settings');
+    Navigator.of(context).pop();
+    Navigator.of(context).pushNamed('/settings');
   }
 
   Widget buildToolBar() {
@@ -194,7 +193,7 @@ class StockHomeState extends State<StockHome> {
       onOpen: (Stock stock, Key arrowKey) {
         Set<Key> mostValuableKeys = new Set<Key>();
         mostValuableKeys.add(arrowKey);
-        config.navigator.pushNamed('/stock/${stock.symbol}', mostValuableKeys: mostValuableKeys);
+        Navigator.of(context).pushNamed('/stock/${stock.symbol}', mostValuableKeys: mostValuableKeys);
       }
     );
   }
@@ -240,7 +239,7 @@ class StockHomeState extends State<StockHome> {
   }
 
   void _handleUndo() {
-    config.navigator.pop();
+    Navigator.of(context).pop();
   }
 
   void _handleStockPurchased() {

--- a/examples/stocks/lib/stock_list.dart
+++ b/examples/stocks/lib/stock_list.dart
@@ -13,6 +13,7 @@ class StockList extends StatelessComponent {
 
   Widget build(BuildContext context) {
     return new ScrollableList<Stock>(
+      key: new Key('stock_list'),
       items: stocks,
       itemExtent: StockRow.kHeight,
       itemBuilder: (BuildContext context, Stock stock) {

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -10,9 +10,8 @@ typedef void SettingsUpdater({
 });
 
 class StockSettings extends StatefulComponent {
-  const StockSettings(this.navigator, this.optimism, this.backup, this.updater);
+  const StockSettings(this.optimism, this.backup, this.updater);
 
-  final NavigatorState navigator;
   final StockMode optimism;
   final BackupMode backup;
   final SettingsUpdater updater;
@@ -41,19 +40,19 @@ class StockSettingsState extends State<StockSettings> {
             title: new Text("Change mode?"),
             content: new Text("Optimistic mode means everything is awesome. Are you sure you can handle that?"),
             onDismiss: () {
-              config.navigator.pop(false);
+              Navigator.of(context).pop(false);
             },
             actions: <Widget>[
               new FlatButton(
                 child: new Text('NO THANKS'),
                 onPressed: () {
-                  config.navigator.pop(false);
+                  Navigator.of(context).pop(false);
                 }
               ),
               new FlatButton(
                 child: new Text('AGREE'),
                 onPressed: () {
-                  config.navigator.pop(true);
+                  Navigator.of(context).pop(true);
                 }
               ),
             ]
@@ -75,7 +74,7 @@ class StockSettingsState extends State<StockSettings> {
     return new ToolBar(
       left: new IconButton(
         icon: 'navigation/arrow_back',
-        onPressed: config.navigator.pop
+        onPressed: Navigator.of(context).pop
       ),
       center: new Text('Settings')
     );

--- a/examples/widgets/drag_and_drop.dart
+++ b/examples/widgets/drag_and_drop.dart
@@ -65,8 +65,7 @@ class Dot extends StatelessComponent {
 }
 
 class ExampleDragSource extends StatelessComponent {
-  ExampleDragSource({ Key key, this.navigator, this.name, this.color }) : super(key: key);
-  final NavigatorState navigator;
+  ExampleDragSource({ Key key, this.name, this.color }) : super(key: key);
   final String name;
   final Color color;
 
@@ -75,7 +74,6 @@ class ExampleDragSource extends StatelessComponent {
 
   Widget build(BuildContext context) {
     return new Draggable(
-      navigator: navigator,
       data: new DragData(name),
       child: new Dot(color: color, size: kDotSize),
       feedback: new Transform(
@@ -91,13 +89,7 @@ class ExampleDragSource extends StatelessComponent {
   }
 }
 
-class DragAndDropApp extends StatefulComponent {
-  DragAndDropApp({ this.navigator });
-  final NavigatorState navigator;
-  DragAndDropAppState createState() => new DragAndDropAppState();
-}
-
-class DragAndDropAppState extends State<DragAndDropApp> {
+class DragAndDropApp extends StatelessComponent {
   Widget build(BuildContext context) {
     return new Scaffold(
       toolBar: new ToolBar(
@@ -107,9 +99,9 @@ class DragAndDropAppState extends State<DragAndDropApp> {
         style: Theme.of(context).text.body1.copyWith(textAlign: TextAlign.center),
         child: new Column(<Widget>[
           new Flexible(child: new Row(<Widget>[
-              new ExampleDragSource(navigator: config.navigator, name: 'Orange', color: const Color(0xFFFF9000)),
-              new ExampleDragSource(navigator: config.navigator, name: 'Teal', color: const Color(0xFF00FFFF)),
-              new ExampleDragSource(navigator: config.navigator, name: 'Yellow', color: const Color(0xFFFFF000)),
+              new ExampleDragSource(name: 'Orange', color: const Color(0xFFFF9000)),
+              new ExampleDragSource(name: 'Teal', color: const Color(0xFF00FFFF)),
+              new ExampleDragSource(name: 'Yellow', color: const Color(0xFFFFF000)),
             ],
             alignItems: FlexAlignItems.center,
             justifyContent: FlexJustifyContent.spaceAround
@@ -130,7 +122,7 @@ void main() {
   runApp(new MaterialApp(
     title: 'Drag and Drop Flutter Demo',
     routes: <String, RouteBuilder>{
-     '/': (RouteArguments args) => new DragAndDropApp(navigator: args.navigator)
+     '/': (RouteArguments args) => new DragAndDropApp()
     }
   ));
 }

--- a/examples/widgets/navigation.dart
+++ b/examples/widgets/navigation.dart
@@ -12,11 +12,11 @@ final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
       new Text("You are at home"),
       new RaisedButton(
         child: new Text('GO SHOPPING'),
-        onPressed: () => args.navigator.pushNamed('/shopping')
+        onPressed: () => Navigator.of(args.context).pushNamed('/shopping')
       ),
       new RaisedButton(
         child: new Text('START ADVENTURE'),
-        onPressed: () => args.navigator.pushNamed('/adventure')
+        onPressed: () => Navigator.of(args.context).pushNamed('/adventure')
       )],
       justifyContent: FlexJustifyContent.center
     )
@@ -28,11 +28,11 @@ final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
       new Text("Village Shop"),
       new RaisedButton(
         child: new Text('RETURN HOME'),
-        onPressed: () => args.navigator.pop()
+        onPressed: () => Navigator.of(args.context).pop()
       ),
       new RaisedButton(
         child: new Text('GO TO DUNGEON'),
-        onPressed: () => args.navigator.pushNamed('/adventure')
+        onPressed: () => Navigator.of(args.context).pushNamed('/adventure')
       )],
       justifyContent: FlexJustifyContent.center
     )
@@ -44,7 +44,7 @@ final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
       new Text("Monster's Lair"),
       new RaisedButton(
         child: new Text('RUN!!!'),
-        onPressed: () => args.navigator.pop()
+        onPressed: () => Navigator.of(args.context).pop()
       )],
       justifyContent: FlexJustifyContent.center
     )

--- a/sky/packages/sky/lib/src/material/radio.dart
+++ b/sky/packages/sky/lib/src/material/radio.dart
@@ -12,7 +12,7 @@ import 'theme.dart';
 class Radio<T> extends StatelessComponent {
   Radio({
     Key key,
-    this.enabled,
+    this.enabled: true,
     this.value,
     this.groupValue,
     this.onChanged

--- a/sky/packages/sky/lib/src/widgets/drag_target.dart
+++ b/sky/packages/sky/lib/src/widgets/drag_target.dart
@@ -38,19 +38,16 @@ enum DragAnchor {
 class Draggable extends StatefulComponent {
   Draggable({
     Key key,
-    this.navigator,
     this.data,
     this.child,
     this.feedback,
     this.feedbackOffset: Offset.zero,
     this.dragAnchor: DragAnchor.child
   }) : super(key: key) {
-    assert(navigator != null);
     assert(child != null);
     assert(feedback != null);
   }
 
-  final NavigatorState navigator;
   final dynamic data;
   final Widget child;
   final Widget feedback;
@@ -92,12 +89,12 @@ class _DraggableState extends State<Draggable> {
       }
     );
     _route.update(point);
-    config.navigator.push(_route);
+    Navigator.of(context).push(_route);
   }
 
   void _updateDrag(PointerInputEvent event) {
     if (_route != null) {
-      config.navigator.setState(() {
+      Navigator.of(context).setState(() {
         _route.update(new Point(event.x, event.y));
       });
     }
@@ -105,7 +102,7 @@ class _DraggableState extends State<Draggable> {
 
   void _cancelDrag(PointerInputEvent event) {
     if (_route != null) {
-      config.navigator.popRoute(_route, DragEndKind.canceled);
+      Navigator.of(context).popRoute(_route, DragEndKind.canceled);
       assert(_route == null);
     }
   }
@@ -113,7 +110,7 @@ class _DraggableState extends State<Draggable> {
   void _drop(PointerInputEvent event) {
     if (_route != null) {
       _route.update(new Point(event.x, event.y));
-      config.navigator.popRoute(_route, DragEndKind.dropped);
+      Navigator.of(context).popRoute(_route, DragEndKind.dropped);
       assert(_route == null);
     }
   }

--- a/sky/packages/sky/lib/src/widgets/focus.dart
+++ b/sky/packages/sky/lib/src/widgets/focus.dart
@@ -111,8 +111,9 @@ class Focus extends StatefulComponent {
     return true;
   }
 
-  // Don't call moveTo() from your build() function, it's intended to be called
-  // from event listeners, e.g. in response to a finger tap or tab key.
+  // Don't call moveTo() and moveScopeTo() from your build()
+  // functions, it's intended to be called from event listeners, e.g.
+  // in response to a finger tap or tab key.
 
   static void moveTo(BuildContext context, Widget widget) {
     assert(widget != null);
@@ -122,7 +123,7 @@ class Focus extends StatefulComponent {
       focusScope.focusState._setFocusedWidget(widget.key);
   }
 
-  static void _moveScopeTo(BuildContext context, Focus component) {
+  static void moveScopeTo(BuildContext context, Focus component) {
     assert(component != null);
     assert(component.key != null);
     _FocusScope focusScope = context.inheritedWidgetOfType(_FocusScope);
@@ -209,8 +210,6 @@ class FocusState extends State<Focus> {
 
   void initState() {
     super.initState();
-    if (config.autofocus)
-      Focus._moveScopeTo(context, config);
     _updateWidgetRemovalListener(_focusedWidget);
     _updateScopeRemovalListener(_focusedScope);
   }

--- a/sky/packages/sky/lib/src/widgets/framework.dart
+++ b/sky/packages/sky/lib/src/widgets/framework.dart
@@ -1023,8 +1023,12 @@ abstract class ComponentElement<T extends Widget> extends BuildableElement<T> {
     super.mount(parent, newSlot);
     assert(_child == null);
     assert(_active);
-    rebuild();
+    firstBuild();
     assert(_child != null);
+  }
+
+  void firstBuild() {
+    rebuild();
   }
 
   /// Reinvokes the build() method of the StatelessComponent object (for
@@ -1098,6 +1102,13 @@ class StatefulComponentElement<T extends StatefulComponent, U extends State<T>> 
     assert(_state._config == null);
     _state._config = widget;
     assert(_state._debugLifecycleState == _StateLifecycle.created);
+  }
+
+  U get state => _state;
+  U _state;
+
+  void firstBuild() {
+    assert(_state._debugLifecycleState == _StateLifecycle.created);
     try {
       _debugSetAllowIgnoredCallsToMarkNeedsBuild(true);
       _state.initState();
@@ -1111,10 +1122,8 @@ class StatefulComponentElement<T extends StatefulComponent, U extends State<T>> 
       return false;
     });
     assert(() { _state._debugLifecycleState = _StateLifecycle.ready; return true; });
+    super.firstBuild();
   }
-
-  U get state => _state;
-  U _state;
 
   void update(T newWidget) {
     super.update(newWidget);

--- a/sky/packages/sky/lib/src/widgets/scrollable.dart
+++ b/sky/packages/sky/lib/src/widgets/scrollable.dart
@@ -16,6 +16,7 @@ import 'framework.dart';
 import 'gesture_detector.dart';
 import 'homogeneous_viewport.dart';
 import 'mixed_viewport.dart';
+import 'navigator.dart';
 
 // The gesture velocity properties are pixels/second, config min,max limits are pixels/ms
 const double _kMillisecondsPerSecond = 1000.0;
@@ -54,15 +55,25 @@ abstract class Scrollable extends StatefulComponent {
 abstract class ScrollableState<T extends Scrollable> extends State<T> {
   void initState() {
     super.initState();
-    if (config.initialScrollOffset is double)
-      _scrollOffset = config.initialScrollOffset;
     _animation = new SimulationStepper(_setScrollOffset);
+    if (config.key != null) {
+      _route = Route.of(context);
+      if (_route != null) {
+        double lastOffset = _route.readState(config.key);
+        if (lastOffset != null)
+          _scrollOffset = lastOffset;
+      }
+    }
+    if (_scrollOffset == null && config.initialScrollOffset != null)
+      _scrollOffset = config.initialScrollOffset;
   }
+
+  Route _route;
 
   SimulationStepper _animation;
 
-  double _scrollOffset = 0.0;
   double get scrollOffset => _scrollOffset;
+  double _scrollOffset = 0.0;
 
   Offset get scrollOffsetVector {
     if (config.scrollDirection == ScrollDirection.horizontal)
@@ -178,6 +189,8 @@ abstract class ScrollableState<T extends Scrollable> extends State<T> {
     setState(() {
       _scrollOffset = newScrollOffset;
     });
+    if (_route != null)
+      _route.writeState(config.key, _scrollOffset);
     dispatchOnScroll();
   }
 

--- a/sky/unit/test/widget/draggable_test.dart
+++ b/sky/unit/test/widget/draggable_test.dart
@@ -15,7 +15,6 @@ void main() {
         routes: <String, RouteBuilder>{
           '/': (RouteArguments args) { return new Column(<Widget>[
               new Draggable(
-                navigator: args.navigator,
                 data: 1,
                 child: new Text('Source'),
                 feedback: new Text('Dragging')

--- a/sky/unit/test/widget/drawer_test.dart
+++ b/sky/unit/test/widget/drawer_test.dart
@@ -13,7 +13,7 @@ void main() {
         new MaterialApp(
           routes: <String, RouteBuilder>{
             '/': (RouteArguments args) {
-              navigator = args.navigator;
+              navigator = Navigator.of(args.context);
               return new Container();
             }
           }
@@ -42,7 +42,7 @@ void main() {
         new MaterialApp(
           routes: <String, RouteBuilder>{
             '/': (RouteArguments args) {
-              navigator = args.navigator;
+              navigator = Navigator.of(args.context);
               return new Container();
             }
           }

--- a/sky/unit/test/widget/navigator_test.dart
+++ b/sky/unit/test/widget/navigator_test.dart
@@ -4,14 +4,10 @@ import 'package:test/test.dart';
 import 'widget_tester.dart';
 
 class FirstComponent extends StatelessComponent {
-  FirstComponent(this.navigator);
-
-  final NavigatorState navigator;
-
   Widget build(BuildContext context) {
     return new GestureDetector(
       onTap: () {
-        navigator.pushNamed('/second');
+        Navigator.of(context).pushNamed('/second');
       },
       child: new Container(
         decoration: new BoxDecoration(
@@ -24,17 +20,13 @@ class FirstComponent extends StatelessComponent {
 }
 
 class SecondComponent extends StatefulComponent {
-  SecondComponent(this.navigator);
-
-  final NavigatorState navigator;
-
   SecondComponentState createState() => new SecondComponentState();
 }
 
 class SecondComponentState extends State<SecondComponent> {
   Widget build(BuildContext context) {
     return new GestureDetector(
-      onTap: config.navigator.pop,
+      onTap: Navigator.of(context).pop,
       child: new Container(
         decoration: new BoxDecoration(
           backgroundColor: new Color(0xFFFF00FF)
@@ -49,8 +41,8 @@ void main() {
   test('Can navigator navigate to and from a stateful component', () {
     testWidgets((WidgetTester tester) {
       final Map<String, RouteBuilder> routes = <String, RouteBuilder>{
-        '/': (RouteArguments args) => new FirstComponent(args.navigator),
-        '/second': (RouteArguments args) => new SecondComponent(args.navigator),
+        '/': (RouteArguments args) => new FirstComponent(),
+        '/second': (RouteArguments args) => new SecondComponent(),
       };
 
       tester.pumpWidget(new Navigator(routes: routes));

--- a/sky/unit/test/widget/snack_bar_test.dart
+++ b/sky/unit/test/widget/snack_bar_test.dart
@@ -16,7 +16,7 @@ void main() {
             return new GestureDetector(
               onTap: () {
                 showSnackBar(
-                  context: args.navigator.context,
+                  context: args.context,
                   placeholderKey: placeholderKey,
                   content: new Text(helloSnackBar)
                 );


### PR DESCRIPTION
- Change RouteArguments to pass the route's BuildContext rather than
  the Navigator. This caused the bulk of the examples/ and .../test/
  changes (those are mostly mechanical changes).

- Give a key to the StockList. This is what makes it store its scroll
  state between navigations.

- Make initState() actually get called when the State's Element is in
  the tree, so you can use Foo.of() functions there.

- Provide a RouteWidget so that routes have a position in the Widget
  tree. The bulk of the route logic is still in a longer-lived Route
  object for now.

- Make Route.setState() only rebuild the actual route, not the whole
  navigator.

- Provided a Route.of().

- Provided a dumb Route.writeState / Route.readState API.

- Made scrollables hook into this API to track state.