### PR TITLE
Use VoidCallback for onPressed and friends

### DIFF
--- a/examples/game/lib/main.dart
+++ b/examples/game/lib/main.dart
@@ -141,7 +141,7 @@ class TextureButton extends StatefulComponent {
     this.height: 128.0
   }) : super(key: key);
 
-  final GestureTapCallback onPressed;
+  final VoidCallback onPressed;
   final Texture texture;
   final Texture textureDown;
   final double width;

--- a/sky/packages/sky/lib/src/material/dialog.dart
+++ b/sky/packages/sky/lib/src/material/dialog.dart
@@ -48,7 +48,7 @@ class Dialog extends StatelessComponent {
   final List<Widget> actions;
 
   /// An (optional) callback that is called when the dialog is dismissed.
-  final GestureTapCallback onDismiss;
+  final VoidCallback onDismiss;
 
   Color _getColor(BuildContext context) {
     switch (Theme.of(context).brightness) {

--- a/sky/packages/sky/lib/src/material/drawer_item.dart
+++ b/sky/packages/sky/lib/src/material/drawer_item.dart
@@ -15,7 +15,7 @@ class DrawerItem extends StatelessComponent {
 
   final String icon;
   final Widget child;
-  final GestureTapCallback onPressed;
+  final VoidCallback onPressed;
   final bool selected;
 
   TextStyle _getTextStyle(ThemeData themeData) {

--- a/sky/packages/sky/lib/src/material/flat_button.dart
+++ b/sky/packages/sky/lib/src/material/flat_button.dart
@@ -12,7 +12,7 @@ class FlatButton extends MaterialButton {
   FlatButton({
     Key key,
     Widget child,
-    GestureTapCallback onPressed
+    VoidCallback onPressed
   }) : super(key: key,
              child: child,
              onPressed: onPressed);

--- a/sky/packages/sky/lib/src/material/floating_action_button.dart
+++ b/sky/packages/sky/lib/src/material/floating_action_button.dart
@@ -24,7 +24,7 @@ class FloatingActionButton extends StatefulComponent {
 
   final Widget child;
   final Color backgroundColor;
-  final GestureTapCallback onPressed;
+  final VoidCallback onPressed;
 
   _FloatingActionButtonState createState() => new _FloatingActionButtonState();
 }

--- a/sky/packages/sky/lib/src/material/icon_button.dart
+++ b/sky/packages/sky/lib/src/material/icon_button.dart
@@ -19,7 +19,7 @@ class IconButton extends StatelessComponent {
   final String icon;
   final IconThemeColor color;
   final ColorFilter colorFilter;
-  final GestureTapCallback onPressed;
+  final VoidCallback onPressed;
 
   Widget build(BuildContext context) {
     return new GestureDetector(

--- a/sky/packages/sky/lib/src/material/material_button.dart
+++ b/sky/packages/sky/lib/src/material/material_button.dart
@@ -42,7 +42,7 @@ abstract class MaterialButton extends StatefulComponent {
 
   final Widget child;
   final ButtonColor textColor;
-  final GestureTapCallback onPressed;
+  final VoidCallback onPressed;
 
   bool get enabled => onPressed != null;
 

--- a/sky/packages/sky/lib/src/material/snack_bar.dart
+++ b/sky/packages/sky/lib/src/material/snack_bar.dart
@@ -20,7 +20,7 @@ class SnackBarAction extends StatelessComponent {
   }
 
   final String label;
-  final GestureTapCallback onPressed;
+  final VoidCallback onPressed;
 
   Widget build(BuildContext context) {
     return new GestureDetector(

--- a/sky/packages/sky/lib/src/material/tabs.dart
+++ b/sky/packages/sky/lib/src/material/tabs.dart
@@ -305,7 +305,7 @@ class Tab extends StatelessComponent {
     assert(label.text != null || label.icon != null);
   }
 
-  final GestureTapCallback onSelected;
+  final VoidCallback onSelected;
   final TabLabel label;
   final Color color;
   final bool selected;

--- a/sky/packages/sky/lib/src/rendering/basic_types.dart
+++ b/sky/packages/sky/lib/src/rendering/basic_types.dart
@@ -12,4 +12,5 @@ export 'dart:ui' show
   Point,
   Rect,
   Size,
-  TransferMode;
+  TransferMode,
+  VoidCallback;

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -55,8 +55,9 @@ export 'package:flutter/rendering.dart' show
     TextStyle,
     TransferMode,
     ValueChanged,
-    normal,
+    VoidCallback,
     bold,
+    normal,
     underline,
     overline,
     lineThrough;


### PR DESCRIPTION
Previous these callbacks were leaking the implementation detail that they were
triggered by taps. In a later patch, we're going to add a parameter to
GestureTapCallback that these callbacks won't have.

Related to #1807