### PR TITLE
Use VoidCallback in more places

### DIFF
--- a/sky/packages/sky/lib/src/animation/performance.dart
+++ b/sky/packages/sky/lib/src/animation/performance.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:ui' show VoidCallback;
 
 import 'animated_value.dart';
 import 'forces.dart';
@@ -23,7 +24,6 @@ enum PerformanceStatus {
   completed,
 }
 
-typedef void PerformanceListener();
 typedef void PerformanceStatusListener(PerformanceStatus status);
 
 /// An interface that is implemented by [Performance] that exposes a
@@ -36,9 +36,9 @@ abstract class PerformanceView {
   /// Update the given variable according to the current progress of the performance
   void updateVariable(Animatable variable);
   /// Calls the listener every time the progress of the performance changes
-  void addListener(PerformanceListener listener);
+  void addListener(VoidCallback listener);
   /// Stop calling the listener every time the progress of the performance changes
-  void removeListener(PerformanceListener listener);
+  void removeListener(VoidCallback listener);
   /// Calls listener every time the status of the performance changes
   void addStatusListener(PerformanceStatusListener listener);
   /// Stops calling the listener every time the status of the performance changes
@@ -76,8 +76,8 @@ class AlwaysCompletePerformance extends PerformanceView {
   }
 
   // this performance never changes state
-  void addListener(PerformanceListener listener) { }
-  void removeListener(PerformanceListener listener) { }
+  void addListener(VoidCallback listener) { }
+  void removeListener(VoidCallback listener) { }
   void addStatusListener(PerformanceStatusListener listener) { }
   void removeStatusListener(PerformanceStatusListener listener) { }
   PerformanceStatus get status => PerformanceStatus.completed;
@@ -98,10 +98,10 @@ class ReversePerformance extends PerformanceView {
     variable.setProgress(progress, curveDirection);
   }
 
-  void addListener(PerformanceListener listener) {
+  void addListener(VoidCallback listener) {
     masterPerformance.addListener(listener);
   }
-  void removeListener(PerformanceListener listener) {
+  void removeListener(VoidCallback listener) {
     masterPerformance.removeListener(listener);
   }
 
@@ -249,21 +249,21 @@ class Performance extends PerformanceView {
     return _timeline.animateWith(force.release(progress, velocity));
   }
 
-  final List<PerformanceListener> _listeners = new List<PerformanceListener>();
+  final List<VoidCallback> _listeners = new List<VoidCallback>();
 
   /// Calls the listener every time the progress of this performance changes
-  void addListener(PerformanceListener listener) {
+  void addListener(VoidCallback listener) {
     _listeners.add(listener);
   }
 
   /// Stop calling the listener every time the progress of this performance changes
-  void removeListener(PerformanceListener listener) {
+  void removeListener(VoidCallback listener) {
     _listeners.remove(listener);
   }
 
   void _notifyListeners() {
-    List<PerformanceListener> localListeners = new List<PerformanceListener>.from(_listeners);
-    for (PerformanceListener listener in localListeners)
+    List<VoidCallback> localListeners = new List<VoidCallback>.from(_listeners);
+    for (VoidCallback listener in localListeners)
       listener();
   }
 

--- a/sky/packages/sky/lib/src/material/raised_button.dart
+++ b/sky/packages/sky/lib/src/material/raised_button.dart
@@ -12,7 +12,7 @@ class RaisedButton extends MaterialButton {
   RaisedButton({
     Key key,
     Widget child,
-    GestureTapCallback onPressed
+    VoidCallback onPressed
   }) : super(key: key,
              child: child,
              onPressed: onPressed);

--- a/sky/packages/sky/lib/src/painting/basic_types.dart
+++ b/sky/packages/sky/lib/src/painting/basic_types.dart
@@ -17,4 +17,5 @@ export 'dart:ui' show
   TextAlign,
   TextBaseline,
   TextDecoration,
-  TextDecorationStyle;
+  TextDecorationStyle,
+  VoidCallback;

--- a/sky/packages/sky/lib/src/painting/box_painter.dart
+++ b/sky/packages/sky/lib/src/painting/box_painter.dart
@@ -640,8 +640,6 @@ void paintImage({
     canvas.drawImageNine(image, centerSlice, destinationRect, paint);
 }
 
-typedef void BackgroundImageChangeListener();
-
 /// A background image for a box.
 class BackgroundImage {
   BackgroundImage({
@@ -676,11 +674,11 @@ class BackgroundImage {
 
   final ImageResource _imageResource;
 
-  final List<BackgroundImageChangeListener> _listeners =
-    new List<BackgroundImageChangeListener>();
+  final List<VoidCallback> _listeners =
+    new List<VoidCallback>();
 
   /// Call listener when the background images changes (e.g., arrives from the network).
-  void addChangeListener(BackgroundImageChangeListener listener) {
+  void addChangeListener(VoidCallback listener) {
     // We add the listener to the _imageResource first so that the first change
     // listener doesn't get callback synchronously if the image resource is
     // already resolved.
@@ -690,7 +688,7 @@ class BackgroundImage {
   }
 
   /// No longer call listener when the background image changes.
-  void removeChangeListener(BackgroundImageChangeListener listener) {
+  void removeChangeListener(VoidCallback listener) {
     _listeners.remove(listener);
     // We need to remove ourselves as listeners from the _imageResource so that
     // we're not kept alive by the image_cache.
@@ -702,9 +700,9 @@ class BackgroundImage {
     if (resolvedImage == null)
       return;
     _image = resolvedImage;
-    final List<BackgroundImageChangeListener> localListeners =
-      new List<BackgroundImageChangeListener>.from(_listeners);
-    for (BackgroundImageChangeListener listener in localListeners)
+    final List<VoidCallback> localListeners =
+      new List<VoidCallback>.from(_listeners);
+    for (VoidCallback listener in localListeners)
       listener();
   }
 

--- a/sky/packages/sky/lib/src/widgets/dismissable.dart
+++ b/sky/packages/sky/lib/src/widgets/dismissable.dart
@@ -28,9 +28,6 @@ enum DismissDirection {
   down
 }
 
-typedef void ResizedCallback();
-typedef void DismissedCallback();
-
 class Dismissable extends StatefulComponent {
   Dismissable({
     Key key,
@@ -41,8 +38,8 @@ class Dismissable extends StatefulComponent {
   }) : super(key: key);
 
   final Widget child;
-  final ResizedCallback onResized;
-  final DismissedCallback onDismissed;
+  final VoidCallback onResized;
+  final VoidCallback onDismissed;
   final DismissDirection direction;
 
   _DismissableState createState() => new _DismissableState();

--- a/sky/packages/sky/lib/src/widgets/drag_target.dart
+++ b/sky/packages/sky/lib/src/widgets/drag_target.dart
@@ -14,7 +14,6 @@ import 'navigator.dart';
 typedef bool DragTargetWillAccept<T>(T data);
 typedef void DragTargetAccept<T>(T data);
 typedef Widget DragTargetBuilder<T>(BuildContext context, List<T> candidateData, List<dynamic> rejectedData);
-typedef void DragFinishedNotification();
 
 enum DragAnchor {
   /// Display the feedback anchored at the position of the original child. If
@@ -208,7 +207,7 @@ class DragRoute extends Route {
   final Point dragStartPoint;
   final Widget feedback;
   final Offset feedbackOffset;
-  final DragFinishedNotification onDragFinished;
+  final VoidCallback onDragFinished;
 
   DragTargetState _activeTarget;
   bool _activeTargetWillAcceptDrop = false;

--- a/sky/packages/sky/lib/src/widgets/editable_text.dart
+++ b/sky/packages/sky/lib/src/widgets/editable_text.dart
@@ -14,9 +14,6 @@ import 'framework.dart';
 
 const _kCursorBlinkHalfPeriod = 500; // milliseconds
 
-typedef void StringUpdated();
-typedef void StringSubmitted();
-
 class TextRange {
   const TextRange({ this.start, this.end });
   const TextRange.collapsed(int position)
@@ -45,8 +42,8 @@ class EditableString implements KeyboardClient {
   TextRange composing = const TextRange.empty();
   TextRange selection;
 
-  final StringUpdated onUpdated;
-  final StringSubmitted onSubmitted;
+  final VoidCallback onUpdated;
+  final VoidCallback onSubmitted;
 
   KeyboardClientStub stub;
 

--- a/sky/packages/sky/lib/src/widgets/heroes.dart
+++ b/sky/packages/sky/lib/src/widgets/heroes.dart
@@ -287,12 +287,10 @@ class _HeroMatch {
   final Object tag;
 }
 
-typedef void QuestFinishedHandler();
-
 class HeroParty {
   HeroParty({ this.onQuestFinished });
 
-  final QuestFinishedHandler onQuestFinished;
+  final VoidCallback onQuestFinished;
 
   List<_HeroQuestState> _heroes = <_HeroQuestState>[];
   bool get isEmpty => _heroes.isEmpty;


### PR DESCRIPTION
We still use special-purpose typedefs in the gesture code for symmetry with
other gesture callbacks.

Fixes #1827