### PR TITLE
Fix crash when removing a card in card_collection

### DIFF
--- a/examples/widgets/card_collection.dart
+++ b/examples/widgets/card_collection.dart
@@ -301,7 +301,7 @@ class CardCollectionState extends State<CardCollection> {
             )
           : new DefaultTextStyle(
               style: DefaultTextStyle.of(context).merge(cardLabelStyle).merge(_textStyle).copyWith(
-                fontSize: _varyFontSizes ? 5.0 + _cardModels.length.toDouble() : null
+                fontSize: _varyFontSizes ? _cardModels.length.toDouble() : null
               ),
               child: new Column(<Widget>[
                   new Text(cardModel.label)

--- a/sky/packages/sky/lib/src/widgets/homogeneous_viewport.dart
+++ b/sky/packages/sky/lib/src/widgets/homogeneous_viewport.dart
@@ -140,7 +140,7 @@ class _HomogeneousViewportElement extends RenderObjectElement<HomogeneousViewpor
       renderObject.minExtent = getTotalExtent(null);
       renderObject.startOffset = offset;
       renderObject.overlayPainter = widget.overlayPainter;
-    });
+    }, building: true);
   }
 
   void _updateChildren() {

--- a/sky/unit/test/widget/scrollable_list_with_inherited_test.dart
+++ b/sky/unit/test/widget/scrollable_list_with_inherited_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+import 'widget_tester.dart';
+
+List<int> items = <int>[0, 1, 2, 3, 4, 5];
+
+Widget buildCard(BuildContext context, int index) {
+  if (index >= items.length)
+    return null;
+  return new Container(
+    key: new ValueKey<int>(items[index]),
+    height: 100.0,
+    child: new DefaultTextStyle(
+      style: new TextStyle(fontSize: 2.0 + items.length.toDouble()),
+      child: new Text('${items[index]}')
+    )
+  );
+}
+
+InvalidatorCallback invalidator;
+
+Widget buildFrame() {
+  return new ScrollableMixedWidgetList(
+    builder: buildCard,
+    token: items.length,
+    onInvalidatorAvailable: (InvalidatorCallback callback) { invalidator = callback; }
+  );
+}
+
+void main() {
+  test('MixedViewport is a build function (smoketest)', () {
+    testWidgets((WidgetTester tester) {
+      tester.pumpWidget(buildFrame());
+      expect(tester.findText('0'), isNotNull);
+      expect(tester.findText('1'), isNotNull);
+      expect(tester.findText('2'), isNotNull);
+      expect(tester.findText('3'), isNotNull);
+      items.removeAt(2);
+      tester.pumpWidget(buildFrame());
+      expect(tester.findText('0'), isNotNull);
+      expect(tester.findText('1'), isNotNull);
+      expect(tester.findText('2'), isNull);
+      expect(tester.findText('3'), isNotNull);
+    });
+  });
+}

--- a/sky/unit/test/widget/test_widgets.dart
+++ b/sky/unit/test/widget/test_widgets.dart
@@ -15,6 +15,16 @@ final BoxDecoration kBoxDecorationC = new BoxDecoration(
   backgroundColor: const Color(0xFF0000FF)
 );
 
+class TestBuildCounter extends StatelessComponent {
+  static int buildCount = 0;
+
+  Widget build(BuildContext context) {
+    ++buildCount;
+    return new DecoratedBox(decoration: kBoxDecorationA);
+  }
+}
+
+
 class FlipComponent extends StatefulComponent {
   FlipComponent({ Key key, this.left, this.right }) : super(key: key);
 
@@ -35,15 +45,6 @@ class FlipComponentState extends State<FlipComponent> {
 
   Widget build(BuildContext context) {
     return _showLeft ? config.left : config.right;
-  }
-}
-
-class TestBuildCounter extends StatelessComponent {
-  static int buildCount = 0;
-
-  Widget build(BuildContext context) {
-    ++buildCount;
-    return new DecoratedBox(decoration: kBoxDecorationA);
   }
 }
 


### PR DESCRIPTION
MixedViewport didn't use the building:true flag when locking itself, so
when it caused a rebuild of its children, we assumed that nobody was
allowed to mark things dirty below the list, and things crashed when
Inherited people did in fact rebuild.

Also:
 - default offset for MixedViewport
 - don't bother rebuilding if the underlying RenderObject is going to
   rebuild anyway for some reason
 - better docs for the "items must have keys" assert
 - keep the FlipComponent stuff together in test_widgets.dart