### PR TITLE
Add missing dart:ui embedder entry points for the precompiler

### DIFF
--- a/sky/engine/bindings/dart_vm_entry_points.txt
+++ b/sky/engine/bindings/dart_vm_entry_points.txt
@@ -1,10 +1,13 @@
 dart:io,::,_setupHooks
 dart:mojo.internal,MojoHandleWatcher,_start
+dart:ui,::,_beginFrame
+dart:ui,::,_dispatchEvent
 dart:ui,::,_getCreateTimerClosure
 dart:ui,::,_getGetBaseURLClosure
 dart:ui,::,_getMainClosure
 dart:ui,::,_getPrintClosure
 dart:ui,::,_getScheduleMicrotaskClosure
+dart:ui,::,_updateWindowMetrics
 dart:ui,Canvas,Canvas.
 dart:ui,CharacterData,CharacterData.
 dart:ui,ClientRect,ClientRect.


### PR DESCRIPTION
This adds the entry points that need manual registration because of invocation from C++ only. Added https://github.com/flutter/engine/pull/1845