### PR TITLE
rev-flutter tool

### DIFF
--- a/sky/packages/updater/pubspec.yaml
+++ b/sky/packages/updater/pubspec.yaml
@@ -1,5 +1,4 @@
 name: updater
-version: 0.0.1
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: The autoupdater for flutter
 homepage: http://flutter.io

--- a/sky/packages/workbench/pubspec.yaml
+++ b/sky/packages/workbench/pubspec.yaml
@@ -5,7 +5,7 @@ description: A workspace to host pub packages
 homepage: https://github.com/flutter/engine/tree/master/sky/packages/workbench
 dependencies:
   flutter: ">=0.0.3 <0.1.0"
-  sky_tools: ">=0.0.26"
+  sky_tools: any
   cipher: any
   asn1lib: any
   flutter_rendering_examples: any

--- a/sky/tools/pubspec_maintenance/pubspec.yaml
+++ b/sky/tools/pubspec_maintenance/pubspec.yaml
@@ -1,0 +1,5 @@
+name: flutter-pubspec-maintenance
+dependencies:
+  den_api: ^0.1.0
+  path: ^1.3.6
+  pub_semver: ^1.2.2

--- a/sky/tools/pubspec_maintenance/rev_flutter.dart
+++ b/sky/tools/pubspec_maintenance/rev_flutter.dart
@@ -1,0 +1,110 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:den_api/den_api.dart';
+import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
+
+// set this to true when we decide to ship 0.1.0
+const bool haveWeEverReleasedAPointRelease = false;
+
+class FlutterPubspec {
+  static Future<FlutterPubspec> load(String path) async {
+    return new FlutterPubspec.fromPubspec(await Pubspec.load(path));
+  }
+
+  FlutterPubspec.fromPubspec(this._data) {
+    _openPubspecs.add(this);
+  }
+
+  final Pubspec _data;
+
+  String get name => _data.name;
+  Version get version => _data.version;
+
+  PackageDep get asDependency {
+    return new PackageDep(name, 'hosted', version, '');
+  }
+
+  void bumpVersion({ bool breakingChange }) {
+    _data.bump(haveWeEverReleasedAPointRelease && breakingChange ? ReleaseType.minor : ReleaseType.patch);
+    print('$name is now at $version');
+  }
+
+  void setDependency(FlutterPubspec dependency) {
+    _data.addDependency(dependency.asDependency);
+  }
+
+  void setDependencyIfNecessary(FlutterPubspec dependency) {
+    if (_data.dependencies.containsKey(dependency.name))
+      _data.addDependency(dependency.asDependency);
+  }
+
+  void _save() {
+    _data.save();
+  }
+
+  static List<FlutterPubspec> _openPubspecs = <FlutterPubspec>[];
+  static void saveAll() {
+    for (FlutterPubspec file in _openPubspecs)
+      file._save();
+  }
+}
+
+main() async {
+  bool breakingChange = true;
+
+
+  // The published packages
+
+  FlutterPubspec flutterEngine = await FlutterPubspec.load('sky/packages/sky_engine')
+  ..bumpVersion(breakingChange: breakingChange);
+
+  FlutterPubspec flutterServices = await FlutterPubspec.load('sky/packages/sky_services')
+  ..bumpVersion(breakingChange: breakingChange);
+
+  FlutterPubspec flutterFlx = await FlutterPubspec.load('sky/packages/flx')
+  ..bumpVersion(breakingChange: breakingChange)
+  ..setDependency(flutterServices);
+
+  FlutterPubspec flutter = await FlutterPubspec.load('sky/packages/sky')
+  ..bumpVersion(breakingChange: breakingChange)
+  ..setDependency(flutterEngine)
+  ..setDependency(flutterServices);
+
+  FlutterPubspec flutterSprites = await FlutterPubspec.load('skysprites')
+  ..bumpVersion(breakingChange: breakingChange)
+  ..setDependency(flutter);
+
+
+  // The internal packages
+
+  await FlutterPubspec.load('sky/packages/updater')
+  ..setDependency(flutter)
+  ..setDependency(flutterSprites);
+
+  await FlutterPubspec.load('sky/unit')
+  ..setDependency(flutter);
+
+  await FlutterPubspec.load('sky/packages/workbench')
+  ..setDependency(flutterServices)
+  ..setDependency(flutterFlx)
+  ..setDependency(flutter)
+  ..setDependency(flutterSprites);
+
+  Directory examples = new Directory('examples');
+  await for (FileSystemEntity entity in examples.list(recursive: true, followLinks: false)) {
+    if (entity is File && path.basename(entity.path) == Pubspec.basename) {
+      await FlutterPubspec.load(entity.path)
+      ..setDependency(flutter)
+      ..setDependencyIfNecessary(flutterSprites);
+    }
+  }
+
+  // we don't update these, since they're their own things and don't depend on
+  // the above packages:
+  //   sky/tools/pubspec_maintenance/pubspec.yaml
+  //   sky/packages/material_design_icons/pubspec.yaml
+
+  FlutterPubspec.saveAll();
+}


### PR DESCRIPTION
A tool to update all the pubspec.yaml versions when we're revving flutter.

Sample output if you run it right now:

```diff
diff --git a/examples/address_book/pubspec.yaml b/examples/address_book/pubspec.yaml
index 30a73e7..22ac048 100644
--- a/examples/address_book/pubspec.yaml
+++ b/examples/address_book/pubspec.yaml
@@ -1,6 +1,7 @@
 name: address_book
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
 dependency_overrides:
   material_design_icons:
diff --git a/examples/fitness/pubspec.yaml b/examples/fitness/pubspec.yaml
index c018dd7..93ac318 100644
--- a/examples/fitness/pubspec.yaml
+++ b/examples/fitness/pubspec.yaml
@@ -1,6 +1,7 @@
 name: fitness
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   playfair: ^0.0.10
   path: ^1.3.6
   sky_tools: any
diff --git a/examples/game/pubspec.yaml b/examples/game/pubspec.yaml
index 1787c99..eace10d 100644
--- a/examples/game/pubspec.yaml
+++ b/examples/game/pubspec.yaml
@@ -1,8 +1,10 @@
 name: asteroids
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
-  flutter_sprites: any
+  flutter_sprites: 
+    '0.0.11'
   box2d: any
 dependency_overrides:
   material_design_icons:
diff --git a/examples/hello_world/pubspec.yaml b/examples/hello_world/pubspec.yaml
index 7cdd0bc..b93e699 100644
--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,6 +1,7 @@
 name: hello_world
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
 dependency_overrides:
   material_design_icons:
diff --git a/examples/mine_digger/pubspec.yaml b/examples/mine_digger/pubspec.yaml
index b07705c..2b35c30 100644
--- a/examples/mine_digger/pubspec.yaml
+++ b/examples/mine_digger/pubspec.yaml
@@ -1,6 +1,7 @@
 name: mine_digger
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
 dependency_overrides:
   material_design_icons:
diff --git a/examples/raw/pubspec.yaml b/examples/raw/pubspec.yaml
index 0443125..5210f83 100644
--- a/examples/raw/pubspec.yaml
+++ b/examples/raw/pubspec.yaml
@@ -1,6 +1,7 @@
 name: sky_raw_examples
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
 dependency_overrides:
   material_design_icons:
diff --git a/examples/rendering/pubspec.yaml b/examples/rendering/pubspec.yaml
index 5158fb4..1beaa6f 100644
--- a/examples/rendering/pubspec.yaml
+++ b/examples/rendering/pubspec.yaml
@@ -1,6 +1,7 @@
 name: flutter_rendering_examples
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
 dependency_overrides:
   material_design_icons:
diff --git a/examples/stocks/pubspec.yaml b/examples/stocks/pubspec.yaml
index 2d1c054..e363d47 100644
--- a/examples/stocks/pubspec.yaml
+++ b/examples/stocks/pubspec.yaml
@@ -1,6 +1,7 @@
 name: stocks
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
 dependency_overrides:
   material_design_icons:
diff --git a/examples/widgets/pubspec.yaml b/examples/widgets/pubspec.yaml
index 8cc7e8c..0bb1e33 100644
--- a/examples/widgets/pubspec.yaml
+++ b/examples/widgets/pubspec.yaml
@@ -1,6 +1,7 @@
 name: sky_widgets_examples
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
   flutter_rendering_examples: any
 dependency_overrides:
diff --git a/sky/packages/flx/pubspec.yaml b/sky/packages/flx/pubspec.yaml
index acaae9e..1fd13d6 100644
--- a/sky/packages/flx/pubspec.yaml
+++ b/sky/packages/flx/pubspec.yaml
@@ -1,10 +1,11 @@
 name: flx
-version: 0.0.2
+version: 0.0.3
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Library for dealing with Flutter bundle (.flx) files
 homepage: http://flutter.io
 dependencies:
-  sky_services: ^0.0.40
+  sky_services: 
+    '0.0.44'
   yaml: ^2.1.3
   asn1lib: ^0.4.1
   cipher: ^0.7.1
diff --git a/sky/packages/sky/pubspec.yaml b/sky/packages/sky/pubspec.yaml
index 3b172b7..596f22e 100644
--- a/sky/packages/sky/pubspec.yaml
+++ b/sky/packages/sky/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter
-version: 0.0.13
+version: 0.0.14
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A framework for writing Flutter applications
 homepage: http://flutter.io
@@ -9,8 +9,10 @@ dependencies:
   material_design_icons: '>=0.0.3 <0.1.0'
   mojo_sdk: 0.1.0
   newton: '>=0.1.4 <0.2.0'
-  sky_engine: 0.0.43
-  sky_services: 0.0.43
+  sky_engine: 
+    '0.0.44'
+  sky_services: 
+    '0.0.44'
   sky_tools: '>=0.0.25 <0.1.0'
   vector_math: '>=1.4.3 <2.0.0'
 environment:
diff --git a/sky/packages/sky_engine/pubspec.yaml b/sky/packages/sky_engine/pubspec.yaml
index 2b8ea1c..f773e9f 100644
--- a/sky/packages/sky_engine/pubspec.yaml
+++ b/sky/packages/sky_engine/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sky_engine
-version: 0.0.43
+version: 0.0.44
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Dart SDK extensions for dart:ui
 homepage: http://flutter.io
diff --git a/sky/packages/sky_services/pubspec.yaml b/sky/packages/sky_services/pubspec.yaml
index 7fafb72..b7c2cac 100644
--- a/sky/packages/sky_services/pubspec.yaml
+++ b/sky/packages/sky_services/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sky_services
-version: 0.0.43
+version: 0.0.44
 author: Flutter Authors <flutter-dev@googlegroups.com>
 description: Mojom interfaces associated with Flutter
 homepage: http://flutter.io
diff --git a/sky/packages/updater/pubspec.yaml b/sky/packages/updater/pubspec.yaml
index 1048fb8..4ac6370 100644
--- a/sky/packages/updater/pubspec.yaml
+++ b/sky/packages/updater/pubspec.yaml
@@ -4,11 +4,14 @@ description: The autoupdater for flutter
 homepage: http://flutter.io
 dependencies:
   mojo: 0.3.0
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_services: ^0.0.40
   yaml: ^2.1.3
   path: ^1.3.0
   flx: 0.0.1
+  flutter_sprites:
+    '0.0.11'
 dependency_overrides:
   flutter:
     path: ../sky
diff --git a/sky/packages/workbench/pubspec.yaml b/sky/packages/workbench/pubspec.yaml
index 1a5795f..0971ac9 100644
--- a/sky/packages/workbench/pubspec.yaml
+++ b/sky/packages/workbench/pubspec.yaml
@@ -4,14 +4,19 @@ author: Flutter Authors <flutter-dev@googlegroups.com>
 description: A workspace to host pub packages
 homepage: https://github.com/flutter/engine/tree/master/sky/packages/workbench
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
   cipher: any
   asn1lib: any
   flutter_rendering_examples: any
-  flutter_sprites: any
+  flutter_sprites: 
+    '0.0.11'
   playfair: any
-  flx: any
+  flx: 
+    '0.0.3'
+  sky_services:
+    '0.0.44'
 dependency_overrides:
   material_design_icons:
     path: ../material_design_icons
diff --git a/sky/unit/pubspec.yaml b/sky/unit/pubspec.yaml
index 62c6b7e..4558d87 100644
--- a/sky/unit/pubspec.yaml
+++ b/sky/unit/pubspec.yaml
@@ -1,6 +1,7 @@
 name: sky_unit_tests
 dependencies:
-  flutter: ">=0.0.3 <0.1.0"
+  flutter: 
+    '0.0.14'
   sky_tools: any
   test: any
   quiver: any
diff --git a/skysprites/pubspec.yaml b/skysprites/pubspec.yaml
index 7b3be98..4f859eb 100644
--- a/skysprites/pubspec.yaml
+++ b/skysprites/pubspec.yaml
@@ -1,8 +1,9 @@
 name: flutter_sprites
 description: A sprite toolkit built on top of Flutter
-version: 0.0.10
+version: 0.0.11
 author: Flutter Authors <flutter-dev@googlegroups.com>
 homepage: http://flutter.io
 dependencies:
-  flutter: ">=0.0.13 <0.1.0"
+  flutter: 
+    '0.0.14'
   box2d: ">=0.2.0 <0.3.0"
```