### PR TITLE
Correct TabNavigatorWidth, tabs.dart example

### DIFF
--- a/examples/widgets/tabs.dart
+++ b/examples/widgets/tabs.dart
@@ -136,5 +136,10 @@ class TabbedNavigatorAppState extends State<TabbedNavigatorApp> {
 }
 
 void main() {
-  runApp(new TabbedNavigatorApp());
+  runApp(new MaterialApp(
+    title: 'Tabs',
+    routes: <String, RouteBuilder>{
+      '/': (RouteArguments args) => new TabbedNavigatorApp(),
+    }
+  ));
 }

--- a/sky/packages/sky/lib/src/material/tabs.dart
+++ b/sky/packages/sky/lib/src/material/tabs.dart
@@ -601,6 +601,8 @@ class TabNavigator extends StatelessComponent {
         isScrollable: isScrollable
       ),
       new Flexible(child: views[selectedIndex].builder(context))
-    ]);
+    ],
+      alignItems: FlexAlignItems.stretch
+    );
   }
 }


### PR DESCRIPTION
The tab bar should be as wide as possible.
