### PR TITLE
Enable service isolate under precompilation

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -25,7 +25,7 @@ vars = {
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
-  'dart_revision': '2bf488f9e753ecd5418799c5f0508856670b46aa',
+  'dart_revision': '37dd876bf1a6e6854abc85ebdd9c513e03743580',
   'dart_observatory_packages_revision': '5c199c5954146747f75ed127871207718dc87786',
   'dart_root_certificates_revision': 'c3a41df63afacec62fcb8135196177e35fe72f71',
 

--- a/sky/engine/bindings/bindings.gni
+++ b/sky/engine/bindings/bindings.gni
@@ -105,6 +105,8 @@ template("dart_precompile") {
         rebase_path("//sky/engine/bindings/internals.dart")
     dart_ui_path =
         rebase_path("$root_build_dir/gen/sky/bindings/dart_ui.dart")
+    service_path =
+        rebase_path("//sky/engine/core/script/dart_service_isolate/main.dart")
 
     gen_snapshot_dir =
         get_label_info("//dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
@@ -131,6 +133,7 @@ template("dart_precompile") {
       "--url_mapping=dart:mojo.internal,$dart_mojo_internal_path",
       "--url_mapping=dart:ui,$dart_ui_path",
       "--url_mapping=dart:ui_internals,$dart_ui_internals_path",
+      "--url_mapping=dart:vmservice_sky,$service_path",
     ]
   }
 

--- a/sky/engine/bindings/dart_vm_entry_points.txt
+++ b/sky/engine/bindings/dart_vm_entry_points.txt
@@ -40,3 +40,6 @@ dart:ui_internals,::,takeServiceRegistry
 dart:ui_internals,::,takeServicesProvidedByEmbedder
 dart:ui_internals,::,takeServicesProvidedToEmbedder
 dart:ui_internals,::,takeShellProxyHandle
+dart:vmservice_sky,::,_addResource
+dart:vmservice_sky,::,boot
+dart:vmservice_sky,::,main

--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -155,12 +155,12 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
       // Start the handle watcher from the service isolate so it isn't available
       // for debugging or general Observatory interaction.
       EnsureHandleWatcherStarted();
-      if (!IsRunningPrecompiledCode() &&
-          RuntimeEnabledFeatures::observatoryEnabled()) {
+      if (RuntimeEnabledFeatures::observatoryEnabled()) {
         std::string ip = "127.0.0.1";
         const intptr_t port = 8181;
         const bool service_isolate_booted =
-            DartServiceIsolate::Startup(ip, port, DartLibraryTagHandler, error);
+            DartServiceIsolate::Startup(ip, port, DartLibraryTagHandler,
+                                        IsRunningPrecompiledCode(), error);
         CHECK(service_isolate_booted) << error;
       }
     }

--- a/sky/engine/core/script/dart_service_isolate.h
+++ b/sky/engine/core/script/dart_service_isolate.h
@@ -18,6 +18,7 @@ class DartServiceIsolate {
   static bool Startup(std::string server_ip,
                       intptr_t server_port,
                       Dart_LibraryTagHandler embedder_tag_handler,
+                      bool running_precompiled,
                       char** error);
 
  private:


### PR DESCRIPTION
Sister patch in dart-lang/sdk: https://codereview.chromium.org/1418833004/. Will update the DEPS when that lands and rebase.

Original CL in Rietveld: https://codereview.chromium.org/1417483009/
cc @rmacnak-google