### PR TITLE
Routes shouldn't be interactive when animating out

### DIFF
--- a/examples/fitness/lib/feed.dart
+++ b/examples/fitness/lib/feed.dart
@@ -248,9 +248,6 @@ class AddItemDialogState extends State<AddItemDialog> {
     return new Dialog(
       title: new Text("What are you doing?"),
       content: new Block(menuItems),
-      onDismiss: () {
-        Navigator.of(context).pop();
-      },
       actions: <Widget>[
         new FlatButton(
           child: new Text('CANCEL'),

--- a/examples/fitness/lib/settings.dart
+++ b/examples/fitness/lib/settings.dart
@@ -70,9 +70,6 @@ class SettingsFragmentState extends State<SettingsFragment> {
           keyboardType: KeyboardType.NUMBER,
           onChanged: _handleGoalWeightChanged
         ),
-        onDismiss: () {
-          Navigator.of(context).pop();
-        },
         actions: <Widget>[
           new FlatButton(
             child: new Text('CANCEL'),

--- a/examples/stocks/lib/stock_menu.dart
+++ b/examples/stocks/lib/stock_menu.dart
@@ -11,7 +11,7 @@ const double _kMenuMargin = 16.0; // 24.0 on tablet
 Future showStockMenu({BuildContext context, bool autorefresh, ValueChanged<bool> onAutorefreshChanged }) async {
   switch (await showMenu(
     context: context,
-    position: new MenuPosition(
+    position: new ModalPosition(
       right: ui.window.padding.right + _kMenuMargin,
       top: ui.window.padding.top + _kMenuMargin
     ),

--- a/examples/stocks/lib/stock_settings.dart
+++ b/examples/stocks/lib/stock_settings.dart
@@ -21,6 +21,7 @@ class StockSettings extends StatefulComponent {
 
 class StockSettingsState extends State<StockSettings> {
   void _handleOptimismChanged(bool value) {
+    value ??= false;
     sendUpdates(value ? StockMode.optimistic : StockMode.pessimistic, config.backup);
   }
 
@@ -39,9 +40,6 @@ class StockSettingsState extends State<StockSettings> {
           child: new Dialog(
             title: new Text("Change mode?"),
             content: new Text("Optimistic mode means everything is awesome. Are you sure you can handle that?"),
-            onDismiss: () {
-              Navigator.of(context).pop(false);
-            },
             actions: <Widget>[
               new FlatButton(
                 child: new Text('NO THANKS'),

--- a/sky/packages/sky/lib/src/material/bottom_sheet.dart
+++ b/sky/packages/sky/lib/src/material/bottom_sheet.dart
@@ -68,43 +68,28 @@ class _BottomSheetState extends State<_BottomSheet> {
   }
 
   Widget build(BuildContext context) {
-    return new Focus(
-      key: new GlobalObjectKey(config.route),
-      autofocus: true,
-      child: new GestureDetector(
-        onTap: () { Navigator.of(context).pop(); },
-        child: new Stack(<Widget>[
-          // mask
-          new ColorTransition(
-            performance: config.route._performance,
-            color: new AnimatedColorValue(Colors.transparent, end: Colors.black54),
-            child: new Container()
-          ),
-          new BuilderTransition(
-            performance: config.route._performance,
-            variables: <AnimatedValue<double>>[_layout.childTop],
-            builder: (BuildContext context) {
-              return new ClipRect(
-                child: new CustomOneChildLayout(
-                  delegate: _layout,
-                  token: _layout.childTop.value,
-                  child: new GestureDetector(
-                    onVerticalDragStart: _handleDragStart,
-                    onVerticalDragUpdate: _handleDragUpdate,
-                    onVerticalDragEnd: _handleDragEnd,
-                    child: new Material(child: config.route.child)
-                  )
-                )
-              );
-            }
+    return new BuilderTransition(
+      performance: config.route._performance,
+      variables: <AnimatedValue<double>>[_layout.childTop],
+      builder: (BuildContext context) {
+        return new ClipRect(
+          child: new CustomOneChildLayout(
+            delegate: _layout,
+            token: _layout.childTop.value,
+            child: new GestureDetector(
+              onVerticalDragStart: _handleDragStart,
+              onVerticalDragUpdate: _handleDragUpdate,
+              onVerticalDragEnd: _handleDragEnd,
+              child: new Material(child: config.route.child)
+            )
           )
-        ])
-      )
+        );
+      }
     );
   }
 }
 
-class _ModalBottomSheetRoute extends TransitionRoute {
+class _ModalBottomSheetRoute extends ModalRoute {
   _ModalBottomSheetRoute({ this.completer, this.child }) {
     _performance = new Performance(duration: transitionDuration, debugLabel: 'ModalBottomSheet');
   }
@@ -122,7 +107,8 @@ class _ModalBottomSheetRoute extends TransitionRoute {
     return _performance;
   }
 
-  List<Widget> createWidgets() => [ new _BottomSheet(route: this) ];
+  Color get barrierColor => Colors.black54;
+  Widget createModalWidget() => new _BottomSheet(route: this);
 
   void didPop([dynamic result]) {
     completer.complete(result);

--- a/sky/packages/sky/lib/src/material/dialog.dart
+++ b/sky/packages/sky/lib/src/material/dialog.dart
@@ -24,8 +24,7 @@ class Dialog extends StatelessComponent {
     this.titlePadding,
     this.content,
     this.contentPadding,
-    this.actions,
-    this.onDismiss
+    this.actions
   }) : super(key: key);
 
   /// The (optional) title of the dialog is displayed in a large font at the top
@@ -46,9 +45,6 @@ class Dialog extends StatelessComponent {
   /// The (optional) set of actions that are displayed at the bottom of the
   /// dialog.
   final List<Widget> actions;
-
-  /// An (optional) callback that is called when the dialog is dismissed.
-  final VoidCallback onDismiss;
 
   Color _getColor(BuildContext context) {
     switch (Theme.of(context).brightness) {
@@ -100,38 +96,26 @@ class Dialog extends StatelessComponent {
       ));
     }
 
-    // TODO(abarth): We should return the backdrop as a separate entry from createWidgets.
-    return new Stack(<Widget>[
-      new GestureDetector(
-        onTap: onDismiss,
-        child: new Container(
-          decoration: const BoxDecoration(
-            backgroundColor: const Color(0x7F000000)
-          )
-        )
-      ),
-      new Center(
-        child: new Container(
-          margin: new EdgeDims.symmetric(horizontal: 40.0, vertical: 24.0),
-          child: new ConstrainedBox(
-            constraints: new BoxConstraints(minWidth: 280.0),
-            child: new Material(
-              level: 4,
-              color: _getColor(context),
-              type: MaterialType.card,
-              child: new IntrinsicWidth(
-                child: new Block(dialogBody)
-              )
+    return new Center(
+      child: new Container(
+        margin: new EdgeDims.symmetric(horizontal: 40.0, vertical: 24.0),
+        child: new ConstrainedBox(
+          constraints: new BoxConstraints(minWidth: 280.0),
+          child: new Material(
+            level: 4,
+            color: _getColor(context),
+            type: MaterialType.card,
+            child: new IntrinsicWidth(
+              child: new Block(dialogBody)
             )
           )
         )
       )
-    ]);
-
+    );
   }
 }
 
-class _DialogRoute extends TransitionRoute {
+class _DialogRoute extends ModalRoute {
   _DialogRoute({ this.completer, this.child });
 
   final Completer completer;
@@ -139,19 +123,14 @@ class _DialogRoute extends TransitionRoute {
 
   bool get opaque => false;
   Duration get transitionDuration => const Duration(milliseconds: 150);
+  Color get barrierColor => Colors.black54;
 
-  List<Widget> createWidgets() {
-    return [
-      new Focus(
-        key: new GlobalObjectKey(this),
-        autofocus: true,
-        child:  new FadeTransition(
-          performance: performance,
-          opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.easeOut),
-          child: child
-        )
-      )
-    ];
+  Widget createModalWidget() {
+    return new FadeTransition(
+      performance: performance,
+      opacity: new AnimatedValue<double>(0.0, end: 1.0, curve: Curves.easeOut),
+      child: child
+    );
   }
 
   void didPop([dynamic result]) {

--- a/sky/packages/sky/lib/src/material/dropdown.dart
+++ b/sky/packages/sky/lib/src/material/dropdown.dart
@@ -21,8 +21,11 @@ const double _kMenuHorizontalPadding = 36.0;
 const double _kBaselineOffsetFromBottom = 20.0;
 const Border _kDropdownUnderline = const Border(bottom: const BorderSide(color: const Color(0xFFBDBDBD), width: 2.0));
 
-class _DropdownMenu extends StatelessComponent {
-  _DropdownMenu({ Key key, this.route }) : super(key: key);
+class _DropdownMenu extends StatusTransitionComponent {
+  _DropdownMenu({
+    Key key,
+    _MenuRoute route
+  }) : route = route, super(key: key, performance: route.performance);
 
   final _MenuRoute route;
 
@@ -92,7 +95,6 @@ class _DropdownMenu extends StatelessComponent {
       left: menuRect.left - _kMenuHorizontalPadding,
       child: new Focus(
         key: new GlobalObjectKey(route),
-        autofocus: true,
         child: new FadeTransition(
           performance: route.performance,
           opacity: menuOpacity,
@@ -117,6 +119,7 @@ class _DropdownMenu extends StatelessComponent {
   }
 }
 
+// TODO(abarth): This should use ModalRoute.
 class _MenuRoute extends TransitionRoute {
   _MenuRoute({
     this.completer,

--- a/sky/packages/sky/lib/src/widgets/modal_barrier.dart
+++ b/sky/packages/sky/lib/src/widgets/modal_barrier.dart
@@ -2,19 +2,124 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/animation.dart';
+
 import 'basic.dart';
+import 'focus.dart';
 import 'framework.dart';
 import 'navigator.dart';
+import 'routes.dart';
+import 'status_transitions.dart';
+import 'transitions.dart';
+
+const Color _kTransparent = const Color(0x00000000);
 
 class ModalBarrier extends StatelessComponent {
-  ModalBarrier({ Key key }) : super(key: key);
+  ModalBarrier({
+    Key key,
+    this.color
+  }) : super(key: key);
+
+  final Color color;
 
   Widget build(BuildContext context) {
+    Widget child;
+
+    if (color != null) {
+      child = new DecoratedBox(
+        decoration: new BoxDecoration(
+          backgroundColor: color
+        )
+      );
+    }
+
     return new Listener(
       onPointerDown: (_) {
         Navigator.of(context).pop();
       },
-      child: new Container()
+      child: new ConstrainedBox(
+        constraints: const BoxConstraints.expand(),
+        child: child
+      )
     );
+  }
+}
+
+class _AnimatedModalBarrier extends StatelessComponent {
+  _AnimatedModalBarrier({
+    Key key,
+    this.color,
+    this.performance
+  }) : super(key: key);
+
+  final AnimatedColorValue color;
+  final PerformanceView performance;
+
+  Widget build(BuildContext context) {
+    return new BuilderTransition(
+      performance: performance,
+      variables: <AnimatedColorValue>[color],
+      builder: (BuildContext context) {
+        return new IgnorePointer(
+          ignoring: performance.status == PerformanceStatus.reverse,
+          child: new ModalBarrier(color: color.value)
+        );
+      }
+    );
+  }
+}
+
+class _ModalScope extends StatusTransitionComponent {
+  _ModalScope({
+    Key key,
+    ModalRoute route,
+    this.child
+  }) : route = route, super(key: key, performance: route.performance);
+
+  final ModalRoute route;
+  final Widget child;
+
+  Widget build(BuildContext context) {
+    Widget focus = new Focus(
+      key: new GlobalObjectKey(route),
+      child: new IgnorePointer(
+        ignoring: route.performance.status == PerformanceStatus.reverse,
+        child: child
+      )
+    );
+    ModalPosition position = route.position;
+    if (position == null)
+      return focus;
+    return new Positioned(
+      top: position.top,
+      right: position.right,
+      bottom: position.bottom,
+      left: position.left,
+      child: focus
+    );
+  }
+}
+
+class ModalPosition {
+  const ModalPosition({ this.top, this.right, this.bottom, this.left });
+  final double top;
+  final double right;
+  final double bottom;
+  final double left;
+}
+
+abstract class ModalRoute extends TransitionRoute {
+  ModalPosition get position => null;
+  Color get barrierColor => _kTransparent;
+  Widget createModalWidget();
+
+  List<Widget> createWidgets() {
+    return [
+      new _AnimatedModalBarrier(
+        color: new AnimatedColorValue(_kTransparent, end: barrierColor, curve: Curves.ease),
+        performance: performance
+      ),
+      new _ModalScope(route: this, child: createModalWidget()),
+    ];
   }
 }

--- a/sky/packages/sky/lib/src/widgets/status_transitions.dart
+++ b/sky/packages/sky/lib/src/widgets/status_transitions.dart
@@ -1,0 +1,51 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/animation.dart';
+
+import 'framework.dart';
+
+abstract class StatusTransitionComponent extends StatefulComponent {
+  StatusTransitionComponent({
+    Key key,
+    this.performance
+  }) : super(key: key) {
+    assert(performance != null);
+  }
+
+  final PerformanceView performance;
+
+  Widget build(BuildContext context);
+
+  _StatusTransitionState createState() => new _StatusTransitionState();
+}
+
+class _StatusTransitionState extends State<StatusTransitionComponent> {
+  void initState() {
+    super.initState();
+    config.performance.addStatusListener(_performanceStatusChanged);
+  }
+
+  void didUpdateConfig(StatusTransitionComponent oldConfig) {
+    if (config.performance != oldConfig.performance) {
+      oldConfig.performance.removeStatusListener(_performanceStatusChanged);
+      config.performance.addStatusListener(_performanceStatusChanged);
+    }
+  }
+
+  void dispose() {
+    config.performance.removeStatusListener(_performanceStatusChanged);
+    super.dispose();
+  }
+
+  void _performanceStatusChanged(PerformanceStatus status) {
+    setState(() {
+      // The performance's state is our build state, and it changed already.
+    });
+  }
+
+  Widget build(BuildContext context) {
+    return config.build(context);
+  }
+}

--- a/sky/packages/sky/lib/widgets.dart
+++ b/sky/packages/sky/lib/widgets.dart
@@ -30,6 +30,7 @@ export 'src/widgets/placeholder.dart';
 export 'src/widgets/routes.dart';
 export 'src/widgets/scrollable.dart';
 export 'src/widgets/statistics_overlay.dart';
+export 'src/widgets/status_transitions.dart';
 export 'src/widgets/transitions.dart';
 export 'src/widgets/unique_component.dart';
 


### PR DESCRIPTION
This patch introduces the notion of a ModalRoute that puts up a modal barrier
and makes the route invisible to hit testing when its animating out. This patch
also uses this mechanism in a number of places (including PageRoute). There are
still a few more cases to convert, but that's work for a future patch.

Fixes #1684