### PR TITLE
Restored BottomSheet dismiss tap

### DIFF
--- a/sky/packages/sky/lib/src/material/bottom_sheet.dart
+++ b/sky/packages/sky/lib/src/material/bottom_sheet.dart
@@ -68,23 +68,26 @@ class _BottomSheetState extends State<_BottomSheet> {
   }
 
   Widget build(BuildContext context) {
-    return new BuilderTransition(
-      performance: config.route._performance,
-      variables: <AnimatedValue<double>>[_layout.childTop],
-      builder: (BuildContext context) {
-        return new ClipRect(
-          child: new CustomOneChildLayout(
-            delegate: _layout,
-            token: _layout.childTop.value,
-            child: new GestureDetector(
-              onVerticalDragStart: _handleDragStart,
-              onVerticalDragUpdate: _handleDragUpdate,
-              onVerticalDragEnd: _handleDragEnd,
-              child: new Material(child: config.route.child)
+    return new GestureDetector(
+      onTap: () { Navigator.of(context).pop(); },
+      child: new BuilderTransition(
+        performance: config.route._performance,
+        variables: <AnimatedValue<double>>[_layout.childTop],
+        builder: (BuildContext context) {
+          return new ClipRect(
+            child: new CustomOneChildLayout(
+              delegate: _layout,
+              token: _layout.childTop.value,
+              child: new GestureDetector(
+                onVerticalDragStart: _handleDragStart,
+                onVerticalDragUpdate: _handleDragUpdate,
+                onVerticalDragEnd: _handleDragEnd,
+                child: new Material(child: config.route.child)
+              )
             )
-          )
-        );
-      }
+          );
+        }
+      )
     );
   }
 }

--- a/sky/unit/test/widget/bottom_sheet_test.dart
+++ b/sky/unit/test/widget/bottom_sheet_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:test/test.dart';
+
+import 'widget_tester.dart';
+
+void main() {
+  test('Verify that a tap dismisses the BottomSheet', () {
+    testWidgets((WidgetTester tester) {
+      BuildContext context;
+      tester.pumpWidget(new MaterialApp(
+          routes: <String, RouteBuilder>{
+            '/': (RouteArguments args) {
+              context = args.context;
+              return new Container();
+            }
+          }
+      ));
+
+      tester.pump();
+      expect(tester.findText('BottomSheet'), isNull);
+
+      showModalBottomSheet(context: context, child: new Text('BottomSheet'));
+      tester.pump(); // bottom sheet show animation starts
+      tester.pump(new Duration(seconds: 1)); // animation done
+      expect(tester.findText('BottomSheet'), isNotNull);
+
+      // Tap on the the bottom sheet itself to dismiss it
+      tester.tap(tester.findText('BottomSheet'));
+      tester.pump(); // bottom sheet dismiss animation starts
+      tester.pump(new Duration(seconds: 1)); // animation done
+      expect(tester.findText('BottomSheet'), isNull);
+
+      showModalBottomSheet(context: context, child: new Text('BottomSheet'));
+      tester.pump(); // bottom sheet show animation starts
+      tester.pump(new Duration(seconds: 1)); // animation done
+      expect(tester.findText('BottomSheet'), isNotNull);
+
+      // Tap above the the bottom sheet to dismiss it
+      tester.tapAt(new Point(20.0, 20.0));
+      tester.pump(); // bottom sheet dismiss animation starts
+      tester.pump(new Duration(seconds: 1)); // animation done
+      expect(tester.findText('BottomSheet'), isNull);
+    });
+  });
+
+}


### PR DESCRIPTION
It was inadvertantly left out of the cutover to ModalRoute https://github.com/flutter/engine/pull/1898.