### PR TITLE
Don't anti-alias RRect and Path clips

### DIFF
--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -122,14 +122,14 @@ void Canvas::clipRRect(const RRect& rrect)
 {
     if (!m_canvas)
         return;
-    m_canvas->clipRRect(rrect.sk_rrect, SkRegion::kIntersect_Op, true);
+    m_canvas->clipRRect(rrect.sk_rrect, SkRegion::kIntersect_Op);
 }
 
 void Canvas::clipPath(const CanvasPath* path)
 {
     if (!m_canvas)
         return;
-    m_canvas->clipPath(path->path(), SkRegion::kIntersect_Op, true);
+    m_canvas->clipPath(path->path(), SkRegion::kIntersect_Op);
 }
 
 void Canvas::drawColor(SkColor color, SkXfermode::Mode transferMode)


### PR DESCRIPTION
We should probably expose this dial to clients eventually, but this patch just
makes our default match Skia's default of not anti-aliasing RRect and Path
clips.