### PR TITLE
Merge DisposableArenaMember and GestureArenaMember

### DIFF
--- a/sky/packages/sky/lib/src/gestures/arena.dart
+++ b/sky/packages/sky/lib/src/gestures/arena.dart
@@ -21,6 +21,11 @@ abstract class GestureArenaMember {
 
   /// Called when this member loses the arena for the given key.
   void rejectGesture(Object key);
+
+  /// Release any resources used by the object. Called when the object is no
+  /// longer needed (e.g. a gesture recogniser is being unregistered from a
+  /// [GestureDetector]).
+  void dispose() { }
 }
 
 /// An interface to information to an arena

--- a/sky/packages/sky/lib/src/gestures/recognizer.dart
+++ b/sky/packages/sky/lib/src/gestures/recognizer.dart
@@ -12,11 +12,7 @@ import 'pointer_router.dart';
 
 export 'pointer_router.dart' show PointerRouter;
 
-abstract class DisposableArenaMember extends GestureArenaMember {
-    void dispose();
-}
-
-abstract class GestureRecognizer extends DisposableArenaMember {
+abstract class GestureRecognizer extends GestureArenaMember {
   GestureRecognizer({ PointerRouter router }) : _router = router {
     assert(_router != null);
   }

--- a/sky/packages/sky/lib/src/gestures/tap.dart
+++ b/sky/packages/sky/lib/src/gestures/tap.dart
@@ -182,7 +182,7 @@ class _TapGesture extends _TapTracker {
 /// independently. That is, each pointer sequence that could resolve to a tap
 /// does so independently of others: down-1, down-2, up-1, up-2 produces two
 /// taps, on up-1 and up-2.
-class MultiTapGestureRecognizer extends DisposableArenaMember {
+class MultiTapGestureRecognizer extends GestureArenaMember {
   MultiTapGestureRecognizer({
     this.router,
     this.onTapDown,
@@ -243,7 +243,7 @@ class MultiTapGestureRecognizer extends DisposableArenaMember {
 
 }
 
-class DoubleTapGestureRecognizer extends DisposableArenaMember {
+class DoubleTapGestureRecognizer extends GestureArenaMember {
 
   DoubleTapGestureRecognizer({ this.router, this.onDoubleTap });
 

--- a/sky/packages/sky/lib/src/widgets/gesture_detector.dart
+++ b/sky/packages/sky/lib/src/widgets/gesture_detector.dart
@@ -217,7 +217,7 @@ class _GestureDetectorState extends State<GestureDetector> {
     }
   }
 
-  DisposableArenaMember _ensureDisposed(DisposableArenaMember recognizer) {
+  GestureArenaMember _ensureDisposed(GestureArenaMember recognizer) {
     recognizer?.dispose();
     return null;
   }


### PR DESCRIPTION
Turns out there were no uses of GestureArenaMember other than those that
use DisposableArenaMember.