### PR TITLE
Enable simulator builds when using precompilation for iOS

### DIFF
--- a/sky/engine/bindings/bindings.gni
+++ b/sky/engine/bindings/bindings.gni
@@ -56,7 +56,7 @@ template("dart_precompile") {
          "The dart script must be specified")
 
   dart_host_toolchain = host_toolchain
-  if (target_os == "ios") {
+  if (target_os == "ios" && !use_ios_simulator) {
     # During precompilation, a 64 bit Dart VM cannot generate code for a 32 bit
     # architecture (and vice-versa). The snapshotter that is running on the host
     # needs to know about the target architecture and built accordingly.

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -50,10 +50,12 @@ def to_gn_args(args):
     elif args.target_os == 'ios':
         gn_args['target_os'] = 'ios'
         gn_args['ios_deployment_target'] = '7.0'
+        gn_args['use_ios_simulator'] = args.simulator
         if args.simulator:
             gn_args['use_libjpeg_turbo'] = False
-        gn_args['use_ios_simulator'] = args.simulator
-        gn_args['dart_target_arch'] = ios_target_cpu
+        else:
+          # The iOS simulator snapshot is host targetted
+          gn_args['dart_target_arch'] = ios_target_cpu
     else:
         gn_args['use_aura'] = False
         gn_args['use_glib'] = False


### PR DESCRIPTION
Sister patch in dartlang/sdk: https://codereview.chromium.org/1432603002
