### PR TITLE
Always reset parentData when dropping children

### DIFF
--- a/sky/packages/sky/lib/src/rendering/object.dart
+++ b/sky/packages/sky/lib/src/rendering/object.dart
@@ -464,6 +464,7 @@ abstract class RenderObject extends AbstractNode implements HitTestTarget {
     assert(child.parentData != null);
     child._cleanRelayoutSubtreeRoot();
     child.parentData.detach();
+    child.parentData = null;
     super.dropChild(child);
     markNeedsLayout();
     _markNeedsCompositingBitsUpdate();

--- a/sky/unit/test/rendering/box_test.dart
+++ b/sky/unit/test/rendering/box_test.dart
@@ -73,4 +73,25 @@ void main() {
     expect(coloredBox.size.width, equals(780.0));
     expect(coloredBox.size.height, equals(580.0));
   });
+
+  test("reparenting should clear position", () {
+    RenderDecoratedBox coloredBox = new RenderDecoratedBox(
+      decoration: new BoxDecoration());
+    RenderPadding paddedBox = new RenderPadding(
+      child: coloredBox, padding: const EdgeDims.all(10.0));
+
+    layout(paddedBox);
+
+    BoxParentData parentData = coloredBox.parentData;
+    expect(parentData.position.x, isNot(equals(0.0)));
+
+    paddedBox.child = null;
+    RenderConstrainedBox constraintedBox = new RenderConstrainedBox(
+      child: coloredBox, additionalConstraints: const BoxConstraints());
+
+    layout(constraintedBox);
+
+    parentData = coloredBox.parentData;
+    expect(parentData.position.x, equals(0.0));
+  });
 }


### PR DESCRIPTION
Previously, we'd leave the old values in the parent data if the types matches,
but not all render objects would reset these values during layout. For example,
RenderProxyBox doesn't set the position field because it doesn't read the
position field. However, leaving the old data there violates the invariants of
the box protocol and can cause trouble (e.g., localToGlobal giving the wrong
result).

Fixes #1939