### PR TITLE
Use crypto package for BASE64 encoding.

### DIFF
--- a/sky/packages/flx/lib/signing.dart
+++ b/sky/packages/flx/lib/signing.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
+import 'dart:convert' hide BASE64;
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -11,6 +11,7 @@ import 'package:asn1lib/asn1lib.dart';
 import 'package:bignum/bignum.dart';
 import 'package:cipher/cipher.dart';
 import 'package:cipher/impl/client.dart';
+import 'package:crypto/crypto.dart';
 
 export 'package:cipher/cipher.dart' show AsymmetricKeyPair;
 

--- a/sky/packages/flx/pubspec.yaml
+++ b/sky/packages/flx/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   yaml: ^2.1.3
   asn1lib: ^0.4.1
   cipher: ^0.7.1
+  crypto: ^0.9.1
   path: ^1.3.0
 environment:
   sdk: '>=1.12.0 <2.0.0'

--- a/sky/unit/test/flx/bundle_test.dart
+++ b/sky/unit/test/flx/bundle_test.dart
@@ -1,7 +1,8 @@
-import 'dart:convert';
+import 'dart:convert' hide BASE64;
 import 'dart:typed_data';
 import 'dart:io';
 
+import 'package:crypto/crypto.dart';
 import 'package:flx/signing.dart';
 import 'package:flx/bundle.dart';
 import 'package:path/path.dart' as path;

--- a/sky/unit/test/flx/signing_test.dart
+++ b/sky/unit/test/flx/signing_test.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
-import 'dart:convert';
+import 'dart:convert' hide BASE64;
 import 'dart:typed_data';
 
 import 'package:bignum/bignum.dart';
+import 'package:cipher/cipher.dart' hide CipherParameters;
+import 'package:crypto/crypto.dart';
 import 'package:flx/signing.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:test/test.dart';
-import 'package:cipher/cipher.dart' hide CipherParameters;
 
 main() async {
   // The following constant was generated via the openssl shell commands:


### PR DESCRIPTION
This means we no longer depend on the dart 1.13 beta SDK.