### PR TITLE
Gesture class hierarchy tune-up

### DIFF
--- a/sky/packages/sky/lib/src/gestures/arena.dart
+++ b/sky/packages/sky/lib/src/gestures/arena.dart
@@ -21,11 +21,6 @@ abstract class GestureArenaMember {
 
   /// Called when this member loses the arena for the given key.
   void rejectGesture(Object key);
-
-  /// Release any resources used by the object. Called when the object is no
-  /// longer needed (e.g. a gesture recogniser is being unregistered from a
-  /// [GestureDetector]).
-  void dispose() { }
 }
 
 /// An interface to information to an arena

--- a/sky/packages/sky/lib/src/gestures/drag.dart
+++ b/sky/packages/sky/lib/src/gestures/drag.dart
@@ -33,7 +33,7 @@ bool _isFlingGesture(GestureVelocity velocity) {
     velocitySquared < kMaxFlingVelocity * kMaxFlingVelocity;
 }
 
-abstract class _DragGestureRecognizer<T extends dynamic> extends GestureRecognizer {
+abstract class _DragGestureRecognizer<T extends dynamic> extends OneSequenceGestureRecognizer {
   _DragGestureRecognizer({ PointerRouter router, this.onStart, this.onUpdate, this.onEnd })
     : super(router: router);
 

--- a/sky/packages/sky/lib/src/gestures/multitap.dart
+++ b/sky/packages/sky/lib/src/gestures/multitap.dart
@@ -50,7 +50,7 @@ class _TapTracker {
 }
 
 
-class DoubleTapGestureRecognizer extends GestureArenaMember {
+class DoubleTapGestureRecognizer extends GestureRecognizer {
 
   DoubleTapGestureRecognizer({ this.router, this.onDoubleTap });
 
@@ -111,7 +111,7 @@ class DoubleTapGestureRecognizer extends GestureArenaMember {
     }
   }
 
-  void acceptGesture(int pointer) {}
+  void acceptGesture(int pointer) { }
 
   void rejectGesture(int pointer) {
     _TapTracker tracker = _trackers[pointer];
@@ -267,7 +267,7 @@ class _TapGesture extends _TapTracker {
 /// independently. That is, each pointer sequence that could resolve to a tap
 /// does so independently of others: down-1, down-2, up-1, up-2 produces two
 /// taps, on up-1 and up-2.
-class MultiTapGestureRecognizer extends GestureArenaMember {
+class MultiTapGestureRecognizer extends GestureRecognizer {
   MultiTapGestureRecognizer({
     this.router,
     this.onTapDown,

--- a/sky/packages/sky/lib/src/gestures/recognizer.dart
+++ b/sky/packages/sky/lib/src/gestures/recognizer.dart
@@ -13,7 +13,22 @@ import 'pointer_router.dart';
 export 'pointer_router.dart' show PointerRouter;
 
 abstract class GestureRecognizer extends GestureArenaMember {
-  GestureRecognizer({ PointerRouter router }) : _router = router {
+
+  /// Call this with the pointerdown event of each pointer that should be
+  /// considered for this gesture. (It's the GestureRecognizer's responsibility
+  /// to then add itself to the global pointer router to receive subsequent
+  /// events for this pointer.)
+  void addPointer(PointerInputEvent event);
+
+  /// Release any resources used by the object. Called when the object is no
+  /// longer needed (e.g. a gesture recogniser is being unregistered from a
+  /// [GestureDetector]).
+  void dispose() { }
+
+}
+
+abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
+  OneSequenceGestureRecognizer({ PointerRouter router }) : _router = router {
     assert(_router != null);
   }
 
@@ -21,9 +36,6 @@ abstract class GestureRecognizer extends GestureArenaMember {
 
   final List<GestureArenaEntry> _entries = new List<GestureArenaEntry>();
   final Set<int> _trackedPointers = new Set<int>();
-
-  /// The primary entry point for users of this class.
-  void addPointer(PointerInputEvent event);
 
   void handleEvent(PointerInputEvent event);
   void acceptGesture(int pointer) { }
@@ -76,7 +88,7 @@ ui.Point _getPoint(PointerInputEvent event) {
   return new ui.Point(event.x, event.y);
 }
 
-abstract class PrimaryPointerGestureRecognizer extends GestureRecognizer {
+abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecognizer {
   PrimaryPointerGestureRecognizer({ PointerRouter router, this.deadline })
     : super(router: router);
 

--- a/sky/packages/sky/lib/src/gestures/scale.dart
+++ b/sky/packages/sky/lib/src/gestures/scale.dart
@@ -20,7 +20,7 @@ typedef void GestureScaleStartCallback(ui.Point focalPoint);
 typedef void GestureScaleUpdateCallback(double scale, ui.Point focalPoint);
 typedef void GestureScaleEndCallback();
 
-class ScaleGestureRecognizer extends GestureRecognizer {
+class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   ScaleGestureRecognizer({ PointerRouter router, this.onStart, this.onUpdate, this.onEnd })
     : super(router: router);
 

--- a/sky/packages/sky/lib/src/widgets/gesture_detector.dart
+++ b/sky/packages/sky/lib/src/widgets/gesture_detector.dart
@@ -202,7 +202,7 @@ class _GestureDetectorState extends State<GestureDetector> {
     }
   }
 
-  GestureArenaMember _ensureDisposed(GestureArenaMember recognizer) {
+  GestureRecognizer _ensureDisposed(GestureRecognizer recognizer) {
     recognizer?.dispose();
     return null;
   }


### PR DESCRIPTION
Make all the *GestureRecognizer classes inherit from a class called
GestureRecognizer. Give the old GestureRecognizer a name that is more
precise about its purpose. Remove the members of GestureArenaMember that
aren't used by GestureArenas.