### PR TITLE
Improve performance of marshaling simple Paint objects to native code

### DIFF
--- a/sky/engine/core/painting/Paint.cpp
+++ b/sky/engine/core/painting/Paint.cpp
@@ -51,6 +51,16 @@ Paint DartConverter<Paint>::FromDart(Dart_Handle dart_paint) {
   Dart_Handle value_handle = DOMDartState::Current()->value_handle();
   Dart_Handle data = Dart_GetField(dart_paint, value_handle);
 
+  if (Dart_IsInteger(data)) {
+    // This is a simple Paint object that just contains a color with
+    // anti-aliasing enabled. The data is the color, represented as an
+    // int in the same format as SkColor.
+    result.sk_paint.setColor(DartConverter<SkColor>::FromDart(data));
+    result.sk_paint.setAntiAlias(true);
+    result.is_null = false;
+    return result;
+  }
+
   DCHECK(Dart_IsList(data));
 
   intptr_t length;

--- a/sky/engine/core/painting/Paint.dart
+++ b/sky/engine/core/painting/Paint.dart
@@ -29,7 +29,23 @@ class Paint {
   StrokeCap strokeCap;
 
   // Must match PaintFields enum in Paint.cpp.
-  List<dynamic> get _value {
+  dynamic get _value {
+    // The most common usage is a Paint with no options besides a color and
+    // anti-aliasing.  In this case, save time by just returning the color
+    // as an int.
+    if (strokeWidth == null &&
+        isAntiAlias &&
+        colorFilter == null &&
+        drawLooper == null &&
+        filterQuality == null &&
+        maskFilter == null &&
+        shader == null &&
+        style == null &&
+        transferMode == null &&
+        strokeCap == null) {
+      return color.value;
+    }
+
     return [
       strokeWidth,
       isAntiAlias,


### PR DESCRIPTION
Paint is an argument on most methods of Canvas, and in many uses the Paint
contains only a color.  In this case, return the Paint's value to native code
as an int instead of constructing a list of attributes.

This improved run time on a drawRect benchmark by 35%.