### PR TITLE
Added LayoutId widget, MultiChildLayoutDelegate.isChild()

### DIFF
--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -288,6 +288,39 @@ class CustomOneChildLayout extends OneChildRenderObjectWidget {
   }
 }
 
+class LayoutId extends ParentDataWidget {
+  LayoutId({
+    Key key,
+    Widget child,
+    this.id
+  }) : super(key: key, child: child);
+
+  final Object id;
+
+  void debugValidateAncestor(Widget ancestor) {
+    assert(() {
+      'LayoutId must placed inside a CustomMultiChildLayout';
+      return ancestor is CustomMultiChildLayout;
+    });
+  }
+
+  void applyParentData(RenderObject renderObject) {
+    assert(renderObject.parentData is MultiChildLayoutParentData);
+    final MultiChildLayoutParentData parentData = renderObject.parentData;
+    if (parentData.id != id) {
+      parentData.id = id;
+      AbstractNode targetParent = renderObject.parent;
+      if (targetParent is RenderObject)
+        targetParent.markNeedsLayout();
+    }
+  }
+
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('id: $id');
+  }
+}
+
 class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
   CustomMultiChildLayout(List<Widget> children, {
     Key key,

--- a/sky/unit/test/widget/custom_multi_child_layout_test.dart
+++ b/sky/unit/test/widget/custom_multi_child_layout_test.dart
@@ -14,16 +14,16 @@ class TestMultiChildLayoutDelegate extends MultiChildLayoutDelegate {
 
   Size performLayoutSize;
   BoxConstraints performLayoutConstraints;
-  int performLayoutChildCount;
   Size performLayoutSize0;
   Size performLayoutSize1;
+  bool performLayoutIsChild;
 
-  void performLayout(Size size, BoxConstraints constraints, int childCount) {
+  void performLayout(Size size, BoxConstraints constraints) {
     performLayoutSize = size;
     performLayoutConstraints = constraints;
-    performLayoutChildCount = childCount;
     performLayoutSize0 = layoutChild(0, constraints);
     performLayoutSize1 = layoutChild(1, constraints);
+    performLayoutIsChild = isChild('fred');
   }
 }
 
@@ -33,8 +33,8 @@ void main() {
       TestMultiChildLayoutDelegate delegate = new TestMultiChildLayoutDelegate();
       tester.pumpWidget(new Center(
         child: new CustomMultiChildLayout([
-          new Container(width: 150.0, height: 100.0),
-          new Container(width: 100.0, height: 200.0)
+          new LayoutId(id: 0, child: new Container(width: 150.0, height: 100.0)),
+          new LayoutId(id: 1, child: new Container(width: 100.0, height: 200.0))
         ],
           delegate: delegate
         )
@@ -51,11 +51,11 @@ void main() {
       expect(delegate.performLayoutConstraints.maxWidth, 800.0);
       expect(delegate.performLayoutConstraints.minHeight, 0.0);
       expect(delegate.performLayoutConstraints.maxHeight, 600.0);
-      expect(delegate.performLayoutChildCount, 2);
       expect(delegate.performLayoutSize0.width, 150.0);
       expect(delegate.performLayoutSize0.height, 100.0);
       expect(delegate.performLayoutSize1.width, 100.0);
       expect(delegate.performLayoutSize1.height, 200.0);
+      expect(delegate.performLayoutIsChild, false);
     });
   });
 }


### PR DESCRIPTION
The MultiChildLayoutDelegate methods now identify children with an Object valued id, instead of the child's index.

Each CustomMultiChildLayout child that's to be managed by the delegate must be given a unique identifier with LayoutId. Like: `new LayoutId(id: 'fred', child: fredWidget)`.

MultiChildLayoutDelegate classes can determine which children were provided with isChild(id).

Updated _ScaffoldLayout.
