### PR TITLE
Disable Dart profiling on iOS and MacOS

### DIFF
--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -80,10 +80,9 @@ static const char* kDartArgs[] = {
     // default profile period to 100Hz. This number is suitable for older
     // Raspberry Pi devices but quite low for current smartphones.
     "--profile_period=1000",
-#if (WTF_OS_IOS || WTF_OS_MACOSX) && !defined(NDEBUG)
+#if (WTF_OS_IOS || WTF_OS_MACOSX)
     // On platforms where LLDB is the primary debugger, SIGPROF signals
-    // overwhelm LLDB. Since in debug builds, CPU profiling information is
-    // less useful anyway, vm profiling is disabled to enable a usable debugger.
+    // overwhelm LLDB.
     "--no-profile",
 #endif
 };


### PR DESCRIPTION
There still seem to be some issues with profiling with precompilation. This results in crashes early in the lifecycle. Since this only happens in release builds, it is hard to debug. So I am gating this till I can get a build of LLDB that is able to debug what is going on.