### PR TITLE
Make Draggable use gestures

### DIFF
--- a/examples/widgets/drag_and_drop.dart
+++ b/examples/widgets/drag_and_drop.dart
@@ -6,29 +6,23 @@ import 'package:flutter/material.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/rendering.dart';
 
-class DragData {
-  DragData(this.text);
-
-  final String text;
-}
-
 class ExampleDragTarget extends StatefulComponent {
   ExampleDragTargetState createState() => new ExampleDragTargetState();
 }
 
 class ExampleDragTargetState extends State<ExampleDragTarget> {
-  String _text = 'Drag Target';
+  Color _color = Colors.grey[500];
 
-  void _handleAccept(DragData data) {
+  void _handleAccept(Color data) {
     setState(() {
-      _text = 'dropped: ${data.text}';
+      _color = data;
     });
   }
 
   Widget build(BuildContext context) {
-    return new DragTarget<DragData>(
+    return new DragTarget<Color>(
       onAccept: _handleAccept,
-      builder: (BuildContext context, List<DragData> data, _) {
+      builder: (BuildContext context, List<Color> data, _) {
         return new Container(
           height: 100.0,
           margin: new EdgeDims.all(10.0),
@@ -37,10 +31,7 @@ class ExampleDragTargetState extends State<ExampleDragTarget> {
               width: 3.0,
               color: data.isEmpty ? Colors.white : Colors.blue[500]
             ),
-            backgroundColor: data.isEmpty ? Colors.grey[500] : Colors.green[500]
-          ),
-          child: new Center(
-            child: new Text(_text)
+            backgroundColor: data.isEmpty ? _color : Colors.grey[200]
           )
         );
       }
@@ -49,42 +40,84 @@ class ExampleDragTargetState extends State<ExampleDragTarget> {
 }
 
 class Dot extends StatelessComponent {
-  Dot({ Key key, this.color, this.size }) : super(key: key);
+  Dot({ Key key, this.color, this.size, this.child }) : super(key: key);
   final Color color;
   final double size;
+  final Widget child;
   Widget build(BuildContext context) {
     return new Container(
       width: size,
       height: size,
       decoration: new BoxDecoration(
-        borderRadius: 10.0,
-        backgroundColor: color
-      )
+        backgroundColor: color,
+        shape: Shape.circle
+      ),
+      child: child
     );
   }
 }
 
 class ExampleDragSource extends StatelessComponent {
-  ExampleDragSource({ Key key, this.name, this.color }) : super(key: key);
-  final String name;
-  final Color color;
+  ExampleDragSource({
+    Key key,
+    this.color,
+    this.heavy: false,
+    this.under: true,
+    this.child
+  }) : super(key: key);
 
-  static const kDotSize = 50.0;
-  static const kFingerSize = 50.0;
+  final Color color;
+  final bool heavy;
+  final bool under;
+  final Widget child;
+
+  static const double kDotSize = 50.0;
+  static const double kHeavyMultiplier = 1.5;
+  static const double kFingerSize = 50.0;
 
   Widget build(BuildContext context) {
-    return new Draggable(
-      data: new DragData(name),
-      child: new Dot(color: color, size: kDotSize),
-      feedback: new Transform(
-        transform: new Matrix4.identity()..translate(-kDotSize / 2.0, -(kDotSize / 2.0 + kFingerSize)),
-        child: new Opacity(
-          opacity: 0.75,
-          child: new Dot(color: color, size: kDotSize)
-        )
-      ),
-      feedbackOffset: const Offset(0.0, -kFingerSize),
-      dragAnchor: DragAnchor.pointer
+    double size = kDotSize;
+    DraggableConstructor<Color> constructor = new Draggable<Color>#;
+    if (heavy) {
+      size *= kHeavyMultiplier;
+      constructor = new LongPressDraggable<Color>#;
+    }
+
+    Widget contents = new DefaultTextStyle(
+      style: Theme.of(context).text.body1.copyWith(textAlign: TextAlign.center),
+      child: new Dot(
+        color: color,
+        size: size,
+        child: new Center(child: child)
+      )
+    );
+
+    Widget feedback = new Opacity(
+      opacity: 0.75,
+      child: contents
+    );
+
+    Offset feedbackOffset;
+    DragAnchor anchor;
+    if (!under) {
+      feedback = new Transform(
+        transform: new Matrix4.identity()
+                     ..translate(-size / 2.0, -(size / 2.0 + kFingerSize)),
+        child: feedback
+      );
+      feedbackOffset = const Offset(0.0, -kFingerSize);
+      anchor = DragAnchor.pointer;
+    } else {
+      feedbackOffset = Offset.zero;
+      anchor = DragAnchor.child;
+    }
+
+    return constructor(
+      data: color,
+      child: contents,
+      feedback: feedback,
+      feedbackOffset: feedbackOffset,
+      dragAnchor: anchor
     );
   }
 }
@@ -95,25 +128,37 @@ class DragAndDropApp extends StatelessComponent {
       toolBar: new ToolBar(
         center: new Text('Drag and Drop Flutter Demo')
       ),
-      body: new DefaultTextStyle(
-        style: Theme.of(context).text.body1.copyWith(textAlign: TextAlign.center),
-        child: new Column(<Widget>[
-          new Flexible(child: new Row(<Widget>[
-              new ExampleDragSource(name: 'Orange', color: const Color(0xFFFF9000)),
-              new ExampleDragSource(name: 'Teal', color: const Color(0xFF00FFFF)),
-              new ExampleDragSource(name: 'Yellow', color: const Color(0xFFFFF000)),
-            ],
-            alignItems: FlexAlignItems.center,
-            justifyContent: FlexJustifyContent.spaceAround
-          )),
-          new Flexible(child: new Row(<Widget>[
-            new Flexible(child: new ExampleDragTarget()),
-            new Flexible(child: new ExampleDragTarget()),
-            new Flexible(child: new ExampleDragTarget()),
-            new Flexible(child: new ExampleDragTarget()),
-          ])),
-        ])
-      )
+      body: new Column(<Widget>[
+        new Flexible(child: new Row(<Widget>[
+            new ExampleDragSource(
+              color: const Color(0xFFFFF000),
+              under: true,
+              heavy: false,
+              child: new Text('under')
+            ),
+            new ExampleDragSource(
+              color: const Color(0xFF0FFF00),
+              under: false,
+              heavy: true,
+              child: new Text('long-press above')
+            ),
+            new ExampleDragSource(
+              color: const Color(0xFF00FFF0),
+              under: false,
+              heavy: false,
+              child: new Text('above')
+            ),
+          ],
+          alignItems: FlexAlignItems.center,
+          justifyContent: FlexJustifyContent.spaceAround
+        )),
+        new Flexible(child: new Row(<Widget>[
+          new Flexible(child: new ExampleDragTarget()),
+          new Flexible(child: new ExampleDragTarget()),
+          new Flexible(child: new ExampleDragTarget()),
+          new Flexible(child: new ExampleDragTarget()),
+        ])),
+      ])
     );
   }
 }

--- a/sky/packages/sky/lib/src/gestures/recognizer.dart
+++ b/sky/packages/sky/lib/src/gestures/recognizer.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui' as ui;
+import 'dart:ui' show Point, Offset;
 
 import 'arena.dart';
 import 'constants.dart';
@@ -84,10 +84,6 @@ enum GestureRecognizerState {
   defunct
 }
 
-ui.Point _getPoint(PointerInputEvent event) {
-  return new ui.Point(event.x, event.y);
-}
-
 abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecognizer {
   PrimaryPointerGestureRecognizer({ PointerRouter router, this.deadline })
     : super(router: router);
@@ -96,7 +92,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
 
   GestureRecognizerState state = GestureRecognizerState.ready;
   int primaryPointer;
-  ui.Point initialPosition;
+  Point initialPosition;
   Timer _timer;
 
   void addPointer(PointerInputEvent event) {
@@ -104,7 +100,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
     if (state == GestureRecognizerState.ready) {
       state = GestureRecognizerState.possible;
       primaryPointer = event.pointer;
-      initialPosition = _getPoint(event);
+      initialPosition = event.position;
       if (deadline != null)
         _timer = new Timer(deadline, didExceedDeadline);
     }
@@ -159,7 +155,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
   }
 
   double _getDistance(PointerInputEvent event) {
-    ui.Offset offset = _getPoint(event) - initialPosition;
+    Offset offset = event.position - initialPosition;
     return offset.distance;
   }
 

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -587,6 +587,7 @@ class Container extends StatelessComponent {
   }) : super(key: key) {
     assert(margin == null || margin.isNonNegative);
     assert(padding == null || padding.isNonNegative);
+    assert(decoration == null || decoration.shape != Shape.circle || decoration.borderRadius == null); // can't have a border radius if you're a circle
   }
 
   final Widget child;

--- a/sky/packages/sky/lib/src/widgets/gesture_detector.dart
+++ b/sky/packages/sky/lib/src/widgets/gesture_detector.dart
@@ -84,7 +84,7 @@ class GestureDetector extends StatefulComponent {
 }
 
 class _GestureDetectorState extends State<GestureDetector> {
-  final PointerRouter _router = FlutterBinding.instance.pointerRouter;
+  PointerRouter get _router => FlutterBinding.instance.pointerRouter;
 
   TapGestureRecognizer _tap;
   DoubleTapGestureRecognizer _doubleTap;

--- a/sky/tools/skyanalyzer
+++ b/sky/tools/skyanalyzer
@@ -40,6 +40,9 @@ _IGNORED_PATTERNS = [
   re.compile(r'^\[hint\] \(toText == toPlainText\) \? toStyledText : toPlainText has inferred type \(String, String\) → Widget \(.+styled_text.dart,.+\)'),
   re.compile(r'^\[hint\] .+ [?:] \([_, ]+\) .+ has inferred type .+'),
 
+  # analyzer doesn't support constructor tear-offs yet
+  re.compile(r'.+/examples/widgets/drag_and_drop.dart, line 8[03], col .+'),
+
   # Disable the lint checks that will be caught by code review
   re.compile(r'^\[lint\] Avoid defining a one-member abstract class when a simple function will do'),
   re.compile(r'^\[lint\] Prefer using lowerCamelCase for constant names\.'),


### PR DESCRIPTION
Draggable is now itself a gesture arena member. This means it won't
conflict with other gesture recognisers in the same path.

This also allows variants of Draggable that are triggered by other
gestures.

Also, some cleanup of DoubleTapGestureRecognizer, GestureDetector, and
PrimaryPointerGestureRecognizer.

Also, make MultiTapGestureRecognizer support a timeout for longpress.

Also, make Draggable data be typed.

Also, hide warnings about constructor warnings for now. Analyzer doesn't
support them yet. (Have to do this on a per-line basis)

Directions for future research:
 - animating the avatar (enter/exit transitions)
 - interaction with the navigator (canceling a drag on page navigation, etc)
 - double-tap draggable