### PR TITLE
Better asserts for MaterialApp and Navigator

### DIFF
--- a/sky/packages/sky/lib/src/material/material_app.dart
+++ b/sky/packages/sky/lib/src/material/material_app.dart
@@ -36,9 +36,12 @@ class MaterialApp extends StatefulComponent {
     Key key,
     this.title,
     this.theme,
-    this.routes,
+    this.routes: const <String, RouteBuilder>{},
     this.onGenerateRoute
-  }) : super(key: key);
+  }) : super(key: key) {
+    assert(routes != null);
+    assert(routes.containsKey(Navigator.defaultRouteName) || onGenerateRoute != null);
+  }
 
   final String title;
   final ThemeData theme;

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -23,7 +23,7 @@ abstract class Route {
 }
 
 class NamedRouteSettings {
-  const NamedRouteSettings({ this.name: '<anonymous>', this.mostValuableKeys });
+  const NamedRouteSettings({ this.name, this.mostValuableKeys });
 
   final String name;
   final Set<Key> mostValuableKeys;
@@ -92,6 +92,7 @@ class NavigatorState extends State<Navigator> {
   }
 
   void pushNamed(String name, { Set<Key> mostValuableKeys }) {
+    assert(name != null);
     NamedRouteSettings settings = new NamedRouteSettings(
       name: name,
       mostValuableKeys: mostValuableKeys


### PR DESCRIPTION
- runApp(new MaterialApp()) was crashing long after the constructor. Now
  it asserts in a more useful location.
- remove the default name for NamedRouteSettings. It was unused anyway.