### PR TITLE
Replace Center and Align shrinkWrap parameter with widthFactor and heightFactor

### DIFF
--- a/examples/widgets/scrollbar.dart
+++ b/examples/widgets/scrollbar.dart
@@ -33,7 +33,8 @@ class ScrollbarAppState extends State<ScrollbarApp> {
     Widget scrollable = new Container(
       margin: new EdgeDims.symmetric(horizontal: 6.0), // TODO(hansmuller) 6.0 should be based on _kScrollbarThumbWidth
       child: new Center(
-        shrinkWrap: ShrinkWrap.both,
+        widthFactor: 1.0,
+        heightFactor: 1.0,
         child: new Container(
           width: 80.0,
           height: _itemExtent * 5.0,

--- a/sky/packages/sky/lib/src/material/material_button.dart
+++ b/sky/packages/sky/lib/src/material/material_button.dart
@@ -92,7 +92,7 @@ abstract class MaterialButtonState<T extends MaterialButton> extends State<T> {
     Widget contents = new Container(
       padding: new EdgeDims.symmetric(horizontal: 8.0),
       child: new Center(
-        shrinkWrap: ShrinkWrap.width,
+        widthFactor: 1.0,
         child: config.child
       )
     );

--- a/sky/packages/sky/lib/src/material/tabs.dart
+++ b/sky/packages/sky/lib/src/material/tabs.dart
@@ -344,7 +344,7 @@ class Tab extends StatelessComponent {
     }
 
     Container centeredLabel = new Container(
-      child: new Center(child: labelContent, shrinkWrap: ShrinkWrap.both),
+      child: new Center(child: labelContent, widthFactor: 1.0, heightFactor: 1.0),
       constraints: new BoxConstraints(minWidth: _kMinTabWidth),
       padding: _kTabLabelPadding
     );

--- a/sky/packages/sky/lib/src/widgets/basic.dart
+++ b/sky/packages/sky/lib/src/widgets/basic.dart
@@ -48,7 +48,6 @@ export 'package:flutter/rendering.dart' show
     Rect,
     ScrollDirection,
     Shape,
-    ShrinkWrap,
     Size,
     StyledTextSpan,
     TextAlign,
@@ -238,26 +237,27 @@ class Align extends OneChildRenderObjectWidget {
   Align({
     Key key,
     this.alignment: const FractionalOffset(0.5, 0.5),
-    this.shrinkWrap: ShrinkWrap.none,
+    this.widthFactor,
+    this.heightFactor,
     Widget child
-  }) : super(key: key, child: child) {
-    assert(shrinkWrap != null);
-  }
+  }) : super(key: key, child: child);
 
   final FractionalOffset alignment;
-  final ShrinkWrap shrinkWrap;
+  final double widthFactor;
+  final double heightFactor;
 
-  RenderPositionedBox createRenderObject() => new RenderPositionedBox(alignment: alignment, shrinkWrap: shrinkWrap);
+  RenderPositionedBox createRenderObject() => new RenderPositionedBox(alignment: alignment, widthFactor: widthFactor, heightFactor: heightFactor);
 
   void updateRenderObject(RenderPositionedBox renderObject, Align oldWidget) {
     renderObject.alignment = alignment;
-    renderObject.shrinkWrap = shrinkWrap;
+    renderObject.widthFactor = widthFactor;
+    renderObject.heightFactor = heightFactor;
   }
 }
 
 class Center extends Align {
-  Center({ Key key, ShrinkWrap shrinkWrap: ShrinkWrap.none, Widget child })
-    : super(key: key, shrinkWrap: shrinkWrap, child: child);
+  Center({ Key key, widthFactor, heightFactor, Widget child })
+    : super(key: key, widthFactor: widthFactor, heightFactor: heightFactor, child: child);
 }
 
 class CustomOneChildLayout extends OneChildRenderObjectWidget {

--- a/sky/unit/test/rendering/positioned_box_test.dart
+++ b/sky/unit/test/rendering/positioned_box_test.dart
@@ -21,22 +21,49 @@ void main() {
       additionalConstraints: new BoxConstraints.tight(new Size(100.0, 100.0)),
       child: new RenderDecoratedBox(decoration: new BoxDecoration())
     );
-    RenderPositionedBox positioner = new RenderPositionedBox(child: sizer, shrinkWrap: ShrinkWrap.width);
+    RenderPositionedBox positioner = new RenderPositionedBox(child: sizer, widthFactor: 1.0);
     layout(positioner, constraints: new BoxConstraints.loose(new Size(200.0, 200.0)));
 
     expect(positioner.size.width, equals(100.0), reason: "positioner width");
     expect(positioner.size.height, equals(200.0), reason: "positioner height");
 
-    positioner.shrinkWrap = ShrinkWrap.height;
+    positioner.widthFactor = null;
+    positioner.heightFactor = 1.0;
     pumpFrame();
 
     expect(positioner.size.width, equals(200.0), reason: "positioner width");
     expect(positioner.size.height, equals(100.0), reason: "positioner height");
 
-    positioner.shrinkWrap = ShrinkWrap.both;
+    positioner.widthFactor = 1.0;
     pumpFrame();
 
     expect(positioner.size.width, equals(100.0), reason: "positioner width");
     expect(positioner.size.height, equals(100.0), reason: "positioner height");
+  });
+
+  test('RenderPositionedBox width and height factors', () {
+    RenderConstrainedBox sizer = new RenderConstrainedBox(
+      additionalConstraints: new BoxConstraints.tight(new Size(100.0, 100.0)),
+      child: new RenderDecoratedBox(decoration: new BoxDecoration())
+    );
+    RenderPositionedBox positioner = new RenderPositionedBox(child: sizer, widthFactor: 1.0, heightFactor: 0.0);
+    layout(positioner, constraints: new BoxConstraints.loose(new Size(200.0, 200.0)));
+
+    expect(positioner.size.width, equals(100.0));
+    expect(positioner.size.height, equals(0.0));
+
+    positioner.widthFactor = 0.5;
+    positioner.heightFactor = 0.5;
+    pumpFrame();
+
+    expect(positioner.size.width, equals(50.0));
+    expect(positioner.size.height, equals(50.0));
+
+    positioner.widthFactor = null;
+    positioner.heightFactor = null;
+    pumpFrame();
+
+    expect(positioner.size.width, equals(200.0));
+    expect(positioner.size.height, equals(200.0));
   });
 }


### PR DESCRIPTION
Specifying widthFactor and/or heightFactor causes the Align's size to match the child's size scaled by the width and height factors.

The existing functionality is still available. For example `shrinkWrap: ShrinkWrap.width` is now `widthFactor: 1.0`.
