### PR TITLE
Remove scaffolding for Navigator1 to Navigator2 transition

### DIFF
--- a/sky/packages/sky/lib/src/material/material_app.dart
+++ b/sky/packages/sky/lib/src/material/material_app.dart
@@ -31,6 +31,13 @@ AssetBundle _initDefaultBundle() {
 
 final AssetBundle _defaultBundle = _initDefaultBundle();
 
+class RouteArguments {
+  const RouteArguments({ this.context });
+  final BuildContext context;
+}
+typedef Widget RouteBuilder(RouteArguments args);
+typedef RouteBuilder RouteGenerator(String name);
+
 class MaterialApp extends StatefulComponent {
   MaterialApp({
     Key key,

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -5,15 +5,6 @@
 import 'framework.dart';
 import 'overlay.dart';
 
-// ---------------- Begin scaffolding for Navigator1 to Navigator2 transition
-class RouteArguments {
-  const RouteArguments({ this.context });
-  final BuildContext context;
-}
-typedef Widget RouteBuilder(RouteArguments args);
-typedef RouteBuilder RouteGenerator(String name);
-// ---------------- End scaffolding for Navigator1 to Navigator2 transition
-
 abstract class Route {
   List<OverlayEntry> get overlayEntries;
 


### PR DESCRIPTION
These types belong at the MaterialApp level.

Fixes #1969