### PR TITLE
Heroes don't reverse any more

### DIFF
--- a/sky/packages/sky/lib/src/widgets/heroes.dart
+++ b/sky/packages/sky/lib/src/widgets/heroes.dart
@@ -366,14 +366,17 @@ class HeroParty {
 
   PerformanceView _currentPerformance;
 
+  void _clearCurrentPerformance() {
+    _currentPerformance?.removeStatusListener(_handleUpdate);
+    _currentPerformance = null;
+  }
+
   Iterable<Widget> getWidgets(BuildContext context, PerformanceView performance) sync* {
     assert(performance != null || _heroes.length == 0);
     if (performance != _currentPerformance) {
-      if (_currentPerformance != null)
-        _currentPerformance.removeStatusListener(_handleUpdate);
+      _clearCurrentPerformance();
       _currentPerformance = performance;
-      if (_currentPerformance != null)
-        _currentPerformance.addStatusListener(_handleUpdate);
+      _currentPerformance?.addStatusListener(_handleUpdate);
     }
     for (_HeroQuestState hero in _heroes)
       yield hero.build(context, performance);
@@ -389,7 +392,7 @@ class HeroParty {
           source._resetChild();
       }
       _heroes.clear();
-      _currentPerformance = null;
+      _clearCurrentPerformance();
       if (onQuestFinished != null)
         onQuestFinished();
     }

--- a/sky/packages/sky/lib/src/widgets/navigator.dart
+++ b/sky/packages/sky/lib/src/widgets/navigator.dart
@@ -9,7 +9,6 @@ abstract class Route {
   List<OverlayEntry> get overlayEntries;
 
   void didPush(OverlayState overlay, OverlayEntry insertionPoint);
-  void didMakeCurrent();
   void didPop(dynamic result);
 }
 
@@ -95,13 +94,11 @@ class NavigatorState extends State<Navigator> {
     _popAllEphemeralRoutes();
     route.didPush(overlay, _currentOverlay);
     _modal.add(route);
-    route.didMakeCurrent();
   }
 
   void pushEphemeral(Route route) {
     route.didPush(overlay, _currentOverlay);
     _ephemeral.add(route);
-    route.didMakeCurrent();
   }
 
   void _popAllEphemeralRoutes() {
@@ -114,7 +111,6 @@ class NavigatorState extends State<Navigator> {
 
   void pop([dynamic result]) {
     _removeCurrentRoute().didPop(result);
-    currentRoute.didMakeCurrent();
   }
 
   Widget build(BuildContext context) {

--- a/sky/packages/sky/lib/src/widgets/routes.dart
+++ b/sky/packages/sky/lib/src/widgets/routes.dart
@@ -17,7 +17,6 @@ class StateRoute extends Route {
   List<OverlayEntry> get overlayEntries => const <OverlayEntry>[];
 
   void didPush(OverlayState overlay, OverlayEntry insertionPoint) { }
-  void didMakeCurrent() { }
   void didPop(dynamic result) {
     if (onPop != null)
       onPop();
@@ -37,8 +36,6 @@ class OverlayRoute extends Route {
       insertionPoint = _overlayEntries.last;
     }
   }
-
-  void didMakeCurrent() { }
 
   void didPop(dynamic result) {
     for (OverlayEntry entry in _overlayEntries)


### PR DESCRIPTION
We need to use the performance for the "from" route when going backwards. Also,
fix a bug in the HeroParty where it would call the quest finished callback
multiple times.

Fixes #1958