### PR TITLE
Pool route opinions in one place.

### DIFF
--- a/sky/packages/sky/lib/src/widgets/modal_barrier.dart
+++ b/sky/packages/sky/lib/src/widgets/modal_barrier.dart
@@ -39,8 +39,8 @@ class ModalBarrier extends StatelessComponent {
   }
 }
 
-class _AnimatedModalBarrier extends StatelessComponent {
-  _AnimatedModalBarrier({
+class AnimatedModalBarrier extends StatelessComponent {
+  AnimatedModalBarrier({
     Key key,
     this.color,
     this.performance
@@ -103,20 +103,20 @@ class ModalPosition {
 }
 
 abstract class ModalRoute extends TransitionRoute {
+
   ModalPosition get position => null;
   Color get barrierColor => _kTransparent;
-  Widget buildModalWidget(BuildContext context);
 
-  Widget _buildModalBarrier(BuildContext context) {
-    return new _AnimatedModalBarrier(
-      color: new AnimatedColorValue(_kTransparent, end: barrierColor, curve: Curves.ease),
-      performance: performance
-    );
+  Widget buildModalBarrier(BuildContext context) {
+    return new ModalBarrier(color: barrierColor);
   }
 
-  Widget _buildModalScope(BuildContext context) {
+  Widget buildModalScope(BuildContext context) {
     return new _ModalScope(route: this, child: buildModalWidget(context));
   }
 
-  List<WidgetBuilder> get builders => <WidgetBuilder>[ _buildModalBarrier, _buildModalScope ];
+  Widget buildModalWidget(BuildContext context);
+
+  List<WidgetBuilder> get builders => <WidgetBuilder>[ buildModalBarrier, buildModalScope ];
+
 }

--- a/sky/packages/sky/lib/src/widgets/page.dart
+++ b/sky/packages/sky/lib/src/widgets/page.dart
@@ -11,6 +11,8 @@ import 'navigator.dart';
 import 'page_storage.dart';
 import 'transitions.dart';
 
+const Color _kTransparent = const Color(0x00000000);
+
 class _PageTransition extends TransitionWithChild {
   _PageTransition({
     Key key,
@@ -105,6 +107,14 @@ class PageRoute extends ModalRoute {
 
   String get name => settings.name;
   Duration get transitionDuration => const Duration(milliseconds: 150);
+
+  Widget buildModalBarrier(BuildContext context) {
+    return new AnimatedModalBarrier(
+      color: new AnimatedColorValue(_kTransparent, end: barrierColor, curve: Curves.ease),
+      performance: performance
+    );
+  }
+
   Widget buildModalWidget(BuildContext context) => new _Page(key: pageKey, route: this);
 
   final PageStorageBucket _storageBucket = new PageStorageBucket();


### PR DESCRIPTION
Extract the animation opinions around routes all into
page.dart (specifically, the modal barrier animation). This will make it
easier to move these all into the material layer together later.