### PR TITLE
We throw an exception if you tap the screen during load

### DIFF
--- a/sky/packages/sky/lib/src/rendering/binding.dart
+++ b/sky/packages/sky/lib/src/rendering/binding.dart
@@ -144,7 +144,7 @@ class FlutterBinding extends HitTestTarget {
       _renderView = renderViewOverride;
     }
     assert(_renderView != null);
-    scheduler.addPersistentFrameCallback(beginFrame);
+    scheduler.addPersistentFrameCallback(_handlePersistentFrameCallback);
 
     assert(_instance == this);
   }
@@ -172,8 +172,12 @@ class FlutterBinding extends HitTestTarget {
       listener(size);
   }
 
+  void _handlePersistentFrameCallback(Duration timeStamp) {
+    beginFrame();
+  }
+
   /// Pump the rendering pipeline to generate a frame for the given time stamp
-  void beginFrame(Duration timeStamp) {
+  void beginFrame() {
     RenderObject.flushLayout();
     _renderView.updateCompositingBits();
     RenderObject.flushPaint();

--- a/sky/packages/sky/lib/src/rendering/box.dart
+++ b/sky/packages/sky/lib/src/rendering/box.dart
@@ -543,6 +543,7 @@ abstract class RenderBox extends RenderObject {
   /// coordinate space of the callee.  The callee is responsible for checking
   /// whether the given position is within its bounds.
   bool hitTest(HitTestResult result, { Point position }) {
+    assert(!needsLayout);
     if (position.x >= 0.0 && position.x < _size.width &&
         position.y >= 0.0 && position.y < _size.height) {
       if (hitTestChildren(result, position: position) || hitTestSelf(position)) {

--- a/sky/packages/sky/lib/src/widgets/binding.dart
+++ b/sky/packages/sky/lib/src/widgets/binding.dart
@@ -22,9 +22,9 @@ class WidgetFlutterBinding extends FlutterBinding {
 
   static WidgetFlutterBinding get instance => FlutterBinding.instance;
 
-  void beginFrame(Duration timeStamp) {
+  void beginFrame() {
     buildDirtyElements();
-    super.beginFrame(timeStamp);
+    super.beginFrame();
     Element.finalizeTree();
   }
 
@@ -74,6 +74,7 @@ class WidgetFlutterBinding extends FlutterBinding {
       container: renderView,
       child: app
     ).attachToRenderTree(_renderViewElement);
+    beginFrame();
   }
 }
 


### PR DESCRIPTION
Inside runApp, we were building the render tree for the app, but we weren't
calling layout, which meant we were running a hit test on a dirty tree. Now
hitTest specifically asserts that the tree is clean and we synchronously call
layout for your app during runApp.

Fixes #1960