### PR TITLE
Fix tapcancel on slop.

### DIFF
--- a/sky/packages/sky/lib/src/gestures/arena.dart
+++ b/sky/packages/sky/lib/src/gestures/arena.dart
@@ -146,8 +146,7 @@ class GestureArena {
     } else {
       assert(disposition == GestureDisposition.accepted);
       if (state.isOpen) {
-        if (state.eagerWinner == null)
-          state.eagerWinner = member;
+        state.eagerWinner ??= member;
       } else {
         _resolveInFavorOf(key, state, member);
       }

--- a/sky/packages/sky/lib/src/gestures/recognizer.dart
+++ b/sky/packages/sky/lib/src/gestures/recognizer.dart
@@ -112,7 +112,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
       // TODO(abarth): Maybe factor the slop handling out into a separate class?
       if (event.type == 'pointermove' && _getDistance(event) > kTouchSlop) {
         resolve(GestureDisposition.rejected);
-        stopTrackingPointer(event.pointer);
+        stopTrackingPointer(primaryPointer);
       } else {
         handlePrimaryPointer(event);
       }

--- a/sky/packages/sky/lib/src/gestures/tap.dart
+++ b/sky/packages/sky/lib/src/gestures/tap.dart
@@ -43,6 +43,15 @@ class TapGestureRecognizer extends PrimaryPointerGestureRecognizer {
     }
   }
 
+  void resolve(GestureDisposition disposition) {
+    if (_wonArena && disposition == GestureDisposition.rejected) {
+      if (onTapCancel != null)
+        onTapCancel();
+      _reset();
+    }      
+    super.resolve(disposition);
+  }
+
   void didExceedDeadline() {
     _checkDown();
   }


### PR DESCRIPTION
Make sure to send tapcancel when the primary pointer fails because of
slop, even if the gesture won by default.

Also, minor cleanup and clarification of an invariant.