### PR TITLE
Improve error handling in sky_snapshoter

### DIFF
--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -10,6 +10,7 @@ group("sky") {
     "//sky/engine/wtf:unittests($host_toolchain)",
     "//sky/packages",
     "//sky/shell",
+    "//sky/tools/sky_snapshot",
   ]
 
   if (is_android) {

--- a/sky/tools/sky_snapshot/loader.cc
+++ b/sky/tools/sky_snapshot/loader.cc
@@ -18,7 +18,10 @@ namespace {
 std::string Fetch(const std::string& url) {
   base::FilePath path(url);
   std::string source;
-  CHECK(base::ReadFileToString(path, &source)) << url;
+  if (!base::ReadFileToString(path, &source)) {
+    fprintf(stderr, "error: Unable to find Dart library '%s'.\n", url.c_str());
+    exit(1);
+  }
   return source;
 }
 

--- a/sky/tools/sky_snapshot/main.cc
+++ b/sky/tools/sky_snapshot/main.cc
@@ -19,9 +19,9 @@
 #include "sky/tools/sky_snapshot/vm.h"
 
 void Usage() {
-  std::cerr << "Usage: sky_packager"
+  std::cerr << "Usage: sky_snapshot"
             << " --" << switches::kPackageRoot << " --" << switches::kSnapshot
-            << " <sky-app>" << std::endl;
+            << " <lib/main.dart>" << std::endl;
 }
 
 void WriteSnapshot(base::FilePath path) {


### PR DESCRIPTION
Now we print a more sensible error message and exit with an error instead of
appearing to crash.

Fixes https://github.com/flutter/flutter/issues/53