### PR TITLE
Extract jinja template rule from Android specific rules

### DIFF
--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -417,59 +417,6 @@ template("java_cpp_enum") {
   }
 }
 
-# Declare a target for processing a Jinja template.
-#
-# Variables
-#   input: The template file to be processed.
-#   output: Where to save the result.
-#   variables: (Optional) A list of variables to make available to the template
-#     processing environment, e.g. ["name=foo", "color=red"].
-#
-# Example
-#   jinja_template("chrome_shell_manifest") {
-#     input = "shell/java/AndroidManifest.xml"
-#     output = "$target_gen_dir/AndroidManifest.xml"
-#   }
-template("jinja_template") {
-  set_sources_assignment_filter([])
-  if (defined(invoker.testonly)) {
-    testonly = invoker.testonly
-  }
-
-  assert(defined(invoker.input))
-  assert(defined(invoker.output))
-
-  action(target_name) {
-    if (defined(invoker.visibility)) {
-      visibility = invoker.visibility
-    }
-
-    sources = [
-      invoker.input,
-    ]
-    script = "//build/android/gyp/jinja_template.py"
-    depfile = "$target_gen_dir/$target_name.d"
-
-    outputs = [
-      depfile,
-      invoker.output,
-    ]
-
-    args = [
-      "--inputs",
-      rebase_path(invoker.input, root_build_dir),
-      "--output",
-      rebase_path(invoker.output, root_build_dir),
-      "--depfile",
-      rebase_path(depfile, root_build_dir),
-    ]
-    if (defined(invoker.variables)) {
-      variables = invoker.variables
-      args += [ "--variables=${variables}" ]
-    }
-  }
-}
-
 # Declare a target for processing Android resources as Jinja templates.
 #
 # This takes an Android resource directory where each resource is a Jinja

--- a/build/config/templates/templates.gni
+++ b/build/config/templates/templates.gni
@@ -1,0 +1,56 @@
+# Copyright 2015 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Declare a target for processing a template.
+#
+# Variables
+#   input: The template file to be processed.
+#   output: Where to save the result.
+#   variables: A list of variables to make available to the template
+#     processing environment, e.g. ["name=foo", "color=red"].
+#
+# Example
+#   file_template("chrome_shell_manifest") {
+#     input = "shell/java/AndroidManifest.xml"
+#     output = "$target_gen_dir/AndroidManifest.xml"
+#     variables = "app_name=chrome_shell app_version=1"
+#   }
+template("file_template") {
+  set_sources_assignment_filter([])
+
+  if (defined(invoker.testonly)) {
+    testonly = invoker.testonly
+  }
+
+  assert(defined(invoker.input),
+      "The input file must be specified")
+  assert(defined(invoker.output),
+      "The output file must be specified")
+  assert(defined(invoker.variables),
+      "The variable used for substitution in templates must be specified")
+
+  variables = invoker.variables
+
+  action(target_name) {
+    if(defined(invoker.visibility)) {
+      visibility = invoker.visibility
+    }
+
+    script = "//build/android/gyp/jinja_template.py"
+    depfile = "$target_gen_dir/$target_name.d"
+
+    sources = [ invoker.input ]
+    outputs = [ invoker.output, depfile ]
+
+    args = [
+      "--inputs",
+      rebase_path(invoker.input, root_build_dir),
+      "--output",
+      rebase_path(invoker.output, root_build_dir),
+      "--depfile",
+      rebase_path(depfile, root_build_dir),
+      "--variables=${variables}"
+    ]
+  }
+}


### PR DESCRIPTION
Previously, non Android targets could not import any of the Jinja templating GN rules because of assertions that verified that the Android tools were correctly installed. This just moves the rule into a gni that can be imported by non Android targets