### PR TITLE
Do not delete the DrainJob within the DrainJob::Start callback

### DIFF
--- a/sky/engine/platform/mojo/data_pipe.cc
+++ b/sky/engine/platform/mojo/data_pipe.cc
@@ -35,7 +35,7 @@ class DrainJob : public mojo::common::DataPipeDrainer::Client {
   void OnDataComplete() override {
     Platform::current()->GetUITaskRunner()->PostTask(FROM_HERE,
       base::Bind(callback_, buffer_.release()));
-    delete this;
+    base::MessageLoop::current()->DeleteSoon(FROM_HERE, this);
   }
 
   base::Callback<void(PassRefPtr<SharedBuffer>)> callback_;


### PR DESCRIPTION
DrainDataPipeInBackground posts a callback to DrainJob::Start, which
constructs a DataPipeDrainer.  The DataPipeDrainer's constructor may
call OnDataComplete.  If this happens, it is unsafe to delete the
DrainJob while the callback is still running.