### PR TITLE
change sky to flutter in the adb logs

### DIFF
--- a/sky/engine/bindings/dart_runtime_hooks.cc
+++ b/sky/engine/bindings/dart_runtime_hooks.cc
@@ -147,7 +147,7 @@ void Logger_PrintString(Dart_NativeArguments args) {
 #if defined(OS_ANDROID)
     // In addition to writing to the stdout, write to the logcat so that the
     // message is discoverable when running on an unrooted device.
-    __android_log_print(ANDROID_LOG_INFO, "sky", "%.*s", length, chars);
+    __android_log_print(ANDROID_LOG_INFO, "flutter", "%.*s", length, chars);
 #elif __APPLE__
     syslog(1 /* LOG_ALERT */, "%.*s", (int)length, chars);
 #endif


### PR DESCRIPTION
Change 'sky' to 'flutter' in the adb logs.

`android: I/sky     : foo` ==> `android: I/flutter     : foo`