### PR TITLE
Inability to find a codesigning identity is not a fatal error

### DIFF
--- a/build/config/ios/ios_sdk.gni
+++ b/build/config/ios/ios_sdk.gni
@@ -42,11 +42,4 @@ if (use_ios_simulator) {
                                   [], "list lines")
     ios_code_signing_identity = _ios_identities[0]
   }
-
-  if (ios_code_signing_identity == "") {
-    print("Tried to prepare a device build without specifying a code signing")
-    print("identity and could not detect one automatically either.")
-    print("TIP: Simulator builds dont require code signing...")
-    assert(false)
-  }
 }


### PR DESCRIPTION
We no longer build fully codesigned applications using GN. Instead Xcode is used for final code signing and packaging. GN can still codesign application if the user sets the identity via `gn args` (this should not be too common)