### PR TITLE
Hold services_provided_to_embedder open

### DIFF
--- a/sky/shell/ui/internals.cc
+++ b/sky/shell/ui/internals.cc
@@ -102,10 +102,7 @@ Internals::Internals(ServicesDataPtr services,
   }
   service_provider_impl_.AddService<mojo::asset_bundle::AssetUnpacker>(this);
 
-  // Currently we don't consume any services provided by the application.
-  // So there's no need to hold the proxy to the application's ServiceProvider.
-  mojo::ServiceProviderPtr application_service_provider;
-  services_provided_to_embedder_ = GetProxy(&application_service_provider);
+  services_provided_to_embedder_ = GetProxy(&services_provided_to_embedder);
 }
 
 Internals::~Internals() {

--- a/sky/shell/ui/internals.h
+++ b/sky/shell/ui/internals.h
@@ -50,6 +50,10 @@ class Internals
   mojo::ServiceProviderPtr service_provider_;
   mojo::ServiceProviderImpl service_provider_impl_;
 
+  // We need to hold this object to work around
+  // https://github.com/domokit/mojo/issues/536
+  mojo::ServiceProviderPtr services_provided_to_embedder;
+
   // A ServiceProvider supplied by the application that exposes services to
   // the embedder.
   mojo::InterfaceRequest<mojo::ServiceProvider>


### PR DESCRIPTION
If we let services_provided_to_embedder close, we'll trigger a bug in Dart's
ApplicationConnection framework code. I've filed
https://github.com/domokit/mojo/issues/536 and will fix that separately. This
patch works around the issue for now.