### PR TITLE
Scrollable widgets don't fling in MojoShell

### DIFF
--- a/sky/shell/platform/mojo/BUILD.gn
+++ b/sky/shell/platform/mojo/BUILD.gn
@@ -6,7 +6,7 @@ import("//mojo/public/mojo_application.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 
 mojo_native_application("mojo") {
-  output_name = "sky_shell"
+  output_name = "flutter"
 
   sources = [
     "content_handler_impl.cc",

--- a/sky/shell/platform/mojo/platform_view_mojo.cc
+++ b/sky/shell/platform/mojo/platform_view_mojo.cc
@@ -122,7 +122,9 @@ void PlatformViewMojo::OnEvent(mojo::EventPtr event,
       if (!data)
         break;
       pointer::PointerPtr pointer = pointer::Pointer::New();
-      pointer->time_stamp = event->time_stamp;
+      // TODO(abarth): Sort out the units for time_stamp.
+      // See https://github.com/domokit/mojo/issues/541
+      pointer->time_stamp = event->time_stamp / 1000;
       pointer->pointer = data->pointer_id;
       pointer->type = GetTypeFromAction(event->action);
       pointer->kind = GetKindFromKind(data->kind);


### PR DESCRIPTION
There's some confusion over the units for time_stamp. This patch works around
the issue. I've filed a bug (https://github.com/domokit/mojo/issues/541) to
figure out the right fix.

Also, rename the final target to flutter.mojo, which is a more descriptive
name.