### PR TITLE
Fix OpenGL symbol resolution on iOS

### DIFF
--- a/ui/gl/gl_implementation_ios.cc
+++ b/ui/gl/gl_implementation_ios.cc
@@ -15,7 +15,7 @@
 namespace gfx {
 
 static const char* OpenGLESFrameworkPath =
-    "/System/Library/Framework/OpenGLES.framework/OpenGLES";
+    "/System/Library/Frameworks/OpenGLES.framework/OpenGLES";
 
 static void* OpenGLESLibraryHandle(void) {
   static void* library_handle = NULL;


### PR DESCRIPTION
This fixes crashes when the debugger is not connected on the iPhone. The name mapping in dlopen would fail with the dlerror "no cache image with name". I have replaced the path the "install-name" specified in the SDK. As to why this works on iPads, iPod Touches, and older iPhones (irrespective of whether the debugger is connected), http://stackoverflow.com/questions/10830488 may be offer an explanation. I don't know :/