### PR TITLE
Use `dart_host_toolchain` when building host binaries that depend on Dart

### DIFF
--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//sky/engine/bindings/bindings.gni")
+
 group("sky") {
   testonly = true
 
@@ -10,8 +12,11 @@ group("sky") {
     "//sky/engine/wtf:unittests($host_toolchain)",
     "//sky/packages",
     "//sky/shell",
-    "//sky/tools/sky_snapshot($host_toolchain)",
   ]
+
+  if (dart_host_toolchain == host_toolchain) {
+    deps += [ "//sky/tools/sky_snapshot($dart_host_toolchain)" ]
+  }
 
   if (is_linux || is_android) {
     deps += [ "//sky/shell/platform/mojo" ]

--- a/sky/build/flx.gni
+++ b/sky/build/flx.gni
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//sky/engine/bindings/bindings.gni")
+
 template("flx") {
   bundle_prefix = target_name
   bundle = "$target_gen_dir/${bundle_prefix}.flx"
@@ -48,13 +50,7 @@ template("flx") {
       ]
     }
 
-    deps = []
-
-    if (!is_ios) {
-      # sky_snapshot is used to create a script snapshot. iOS builds use
-      # a precompiled snapshot. So this dependency is redundant.
-      deps += [ "//sky/tools/sky_snapshot($host_toolchain)" ]
-    }
+    deps = [ "//sky/tools/sky_snapshot($dart_host_toolchain)" ]
 
     if (defined(invoker.deps)) {
       deps += invoker.deps

--- a/sky/engine/bindings/BUILD.gn
+++ b/sky/engine/bindings/BUILD.gn
@@ -60,7 +60,7 @@ source_set("bindings") {
 
 action("generate_snapshot_bin") {
   deps = [
-    "//dart/runtime/bin:gen_snapshot($host_toolchain)",
+    "//dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
     ":generate_dart_ui",
   ]
   inputs = [


### PR DESCRIPTION
* Fixed armv7 precompilation builds
* dart/runtime can only be built once per ninja invocation due to the "dart_target_arch" arg. Building the snapshotter with the host_toolchain will cause a conflict when the same target need to be rebuilt to target armv7.