### PR TITLE
Text snaps to pixel grid, images don't

### DIFF
--- a/sky/engine/core/text/Paragraph.cpp
+++ b/sky/engine/core/text/Paragraph.cpp
@@ -66,18 +66,19 @@ void Paragraph::paint(Canvas* canvas, const Offset& offset)
 
     // Very simplified painting to allow painting an arbitrary (layer-less) subtree.
     RenderBox* box = firstChildBox();
-    GraphicsContext context(canvas->skCanvas());
+    SkCanvas* skCanvas = canvas->skCanvas();
+    skCanvas->translate(offset.sk_size.width(), offset.sk_size.height());
 
+    GraphicsContext context(skCanvas);
     Vector<RenderBox*> layers;
-    LayoutPoint paintOffset(offset.sk_size.width(), offset.sk_size.height());
     LayoutRect bounds = box->absoluteBoundingBoxRect();
     DCHECK(bounds.x() == 0 && bounds.y() == 0);
-    bounds.setLocation(paintOffset);
     PaintInfo paintInfo(&context, enclosingIntRect(bounds), box);
-    box->paint(paintInfo, paintOffset, layers);
-
+    box->paint(paintInfo, LayoutPoint(), layers);
     // Note we're ignoring any layers encountered.
     // TODO(abarth): Remove the concept of RenderLayers.
+
+    skCanvas->translate(-offset.sk_size.width(), -offset.sk_size.height());
 }
 
 } // namespace blink


### PR DESCRIPTION
Previously, we tried to use the render tree's paint offset to move the text to
the proper position, but that appears to snap to integer logical pixels,
introducing jitter. Now we use the SkCanvas's matrix to position the text,
removing the jitter.

Fixes https://github.com/flutter/flutter/issues/234