### PR TITLE
make default XCode project work out of the box

### DIFF
--- a/sky/build/PackagerInvoke
+++ b/sky/build/PackagerInvoke
@@ -22,6 +22,9 @@ AssertExists() {
 }
 
 PackageProject() {
+
+  local PATH=${DART_SDK}/bin:${PATH}
+
   # Check that the project path was specified
   if [[ -z "$1" ]]; then
     EchoError "Project path not specified"

--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\npushd ${FLUTTER_APPLICATION_PATH}\npub get\npopd\n";
+			shellScript = "set -e\npushd ${FLUTTER_APPLICATION_PATH}\n${DART_SDK}/bin/pub get\npopd\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -476,12 +476,13 @@
 		9E07CF8F1BE7F4D200BCD8DE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DART_SDK = "${SRCROOT}/../../../third_party/dart-sdk/dart-sdk";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FLUTTER_APPLICATION_PATH = path/to/application;
-				FLUTTER_ROOT = path/to/flutter/repo;
+				FLUTTER_APPLICATION_PATH = "${SRCROOT}/../../../../../flutter/examples/hello_world/";
+				FLUTTER_ROOT = "${SRCROOT}/../../../../../flutter";
 				INFOPLIST_FILE = FlutterApplication/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -495,12 +496,13 @@
 		9E07CF901BE7F4D200BCD8DE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DART_SDK = "${SRCROOT}/../../../third_party/dart-sdk/dart-sdk";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FLUTTER_APPLICATION_PATH = path/to/application;
-				FLUTTER_ROOT = path/to/flutter/repo;
+				FLUTTER_APPLICATION_PATH = "${SRCROOT}/../../../../../flutter/examples/hello_world/";
+				FLUTTER_ROOT = "${SRCROOT}/../../../../../flutter";
 				INFOPLIST_FILE = FlutterApplication/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;


### PR DESCRIPTION
If user follows the current docs for checking out and building `flutter/engine`/`flutter/flutter` then the updated XCode project settings in this pull request will make the build JustWork(TM).

I've added a Build Setting for Dart SDK which points to `third_party/dart-sdk/dart-sdk`. This solves several issues: 1) user may not have dart/pub on the path 2) there is a known issue with XCode where it's practically impossible to set the PATH variable.

Also, I set the initial flutter app to point to `flutter/examples/hello_world`.

After `ninja` finishes compiling all the user would have to do is `open out/ios_sim_Release/Flutter/` (or whatever their out dir is), double click on the xcode project and hit play, then switch to the Runner and hit play again and they should have `Hello, world!` open in iOS Simulator.