### PR TITLE
Add system-level routing

### DIFF
--- a/sky/engine/bindings/dart_vm_entry_points.txt
+++ b/sky/engine/bindings/dart_vm_entry_points.txt
@@ -1,13 +1,14 @@
 dart:io,::,_setupHooks
 dart:mojo.internal,MojoHandleWatcher,_start
 dart:ui,::,_beginFrame
-dart:ui,::,_dispatchEvent
 dart:ui,::,_dispatchPointerPacket
 dart:ui,::,_getCreateTimerClosure
 dart:ui,::,_getGetBaseURLClosure
 dart:ui,::,_getMainClosure
 dart:ui,::,_getPrintClosure
 dart:ui,::,_getScheduleMicrotaskClosure
+dart:ui,::,_popRoute
+dart:ui,::,_pushRoute
 dart:ui,::,_updateWindowMetrics
 dart:ui,Canvas,Canvas.
 dart:ui,Drawable,Drawable.

--- a/sky/engine/core/dart/hooks.dart
+++ b/sky/engine/core/dart/hooks.dart
@@ -20,9 +20,19 @@ void _updateWindowMetrics(double devicePixelRatio,
     window.onMetricsChanged();
 }
 
-void _dispatchEvent(String eventType, double timeStamp) {
+void _pushRoute(String route) {
+  assert(window.defaultRouteName == null);
+  window.defaultRouteName = route;
+  // TODO(abarth): If we ever start calling _pushRoute other than before main,
+  // we should add a change notification callback.
+}
+
+void _popRoute() {
+  if (window.onPopRoute != null)
+    window.onPopRoute();
+  // TODO(abarth): Remove after engine roll.
   if (window.onEvent != null)
-    window.onEvent(eventType, timeStamp);
+    window.onEvent('back', 0.0);
 }
 
 void _dispatchPointerPacket(ByteData serializedPacket) {

--- a/sky/engine/core/dart/window.dart
+++ b/sky/engine/core/dart/window.dart
@@ -31,9 +31,12 @@ class Window {
   WindowPadding _padding;
 
   _FrameCallback onBeginFrame;
-  _EventCallback onEvent;
+  _EventCallback onEvent; // TODO(abarth): Remove.
   _PointerPacketCallback onPointerPacket;
   VoidCallback onMetricsChanged;
+
+  String defaultRouteName;
+  VoidCallback onPopRoute;
 
   void scheduleFrame() native "Window_scheduleFrame";
   void render(Scene scene) native "Window_render";

--- a/sky/engine/core/window/window.cc
+++ b/sky/engine/core/window/window.cc
@@ -66,16 +66,24 @@ void Window::UpdateWindowMetrics(const SkyDisplayMetrics& metrics) {
   });
 }
 
-void Window::DispatchEvent(const String& event_type, double time_stamp) {
+void Window::PushRoute(const std::string& route) {
   DartState* dart_state = library_.dart_state().get();
   if (!dart_state)
     return;
   DartState::Scope scope(dart_state);
 
-  DartInvokeField(library_.value(), "_dispatchEvent", {
-    DartConverter<String>::ToDart(dart_state, event_type),
-    ToDart(time_stamp)
+  DartInvokeField(library_.value(), "_pushRoute", {
+    StdStringToDart(route),
   });
+}
+
+void Window::PopRoute() {
+  DartState* dart_state = library_.dart_state().get();
+  if (!dart_state)
+    return;
+  DartState::Scope scope(dart_state);
+
+  DartInvokeField(library_.value(), "_popRoute", {});
 }
 
 void Window::DispatchPointerPacket(const pointer::PointerPacketPtr& packet) {

--- a/sky/engine/core/window/window.h
+++ b/sky/engine/core/window/window.h
@@ -33,9 +33,11 @@ class Window {
 
   void DidCreateIsolate();
   void UpdateWindowMetrics(const SkyDisplayMetrics& metrics);
-  void DispatchEvent(const String& event_type, double time_stamp);
   void DispatchPointerPacket(const pointer::PointerPacketPtr& packet);
   void BeginFrame(base::TimeTicks frameTime);
+
+  void PushRoute(const std::string& route);
+  void PopRoute();
 
   static void RegisterNatives(DartLibraryNatives* natives);
 

--- a/sky/engine/public/sky/sky_view.cc
+++ b/sky/engine/public/sky/sky_view.cc
@@ -33,6 +33,14 @@ void SkyView::SetDisplayMetrics(const SkyDisplayMetrics& metrics) {
   GetWindow()->UpdateWindowMetrics(display_metrics_);
 }
 
+void SkyView::PushRoute(const std::string& route) {
+  GetWindow()->PushRoute(route);
+}
+
+void SkyView::PopRoute() {
+  GetWindow()->PopRoute();
+}
+
 void SkyView::CreateView(const String& name) {
   DCHECK(!dart_controller_);
 
@@ -66,14 +74,6 @@ std::unique_ptr<sky::compositor::LayerTree> SkyView::BeginFrame(
     base::TimeTicks frame_time) {
   GetWindow()->BeginFrame(frame_time);
   return std::move(layer_tree_);
-}
-
-void SkyView::HandleInputEvent(const WebInputEvent& inputEvent) {
-  TRACE_EVENT0("input", "SkyView::HandleInputEvent");
-
-  if (inputEvent.type == WebInputEvent::Back) {
-    GetWindow()->DispatchEvent("back", inputEvent.timeStampMS);
-  }
 }
 
 void SkyView::HandlePointerPacket(const pointer::PointerPacketPtr& packet) {

--- a/sky/engine/public/sky/sky_view.h
+++ b/sky/engine/public/sky/sky_view.h
@@ -38,6 +38,8 @@ class SkyView : public WindowClient {
 
   const SkyDisplayMetrics& display_metrics() const { return display_metrics_; }
   void SetDisplayMetrics(const SkyDisplayMetrics& metrics);
+  void PushRoute(const std::string& route);
+  void PopRoute();
 
   std::unique_ptr<sky::compositor::LayerTree> BeginFrame(
       base::TimeTicks frame_time);
@@ -50,7 +52,6 @@ class SkyView : public WindowClient {
   void RunFromSnapshot(const WebString& name,
                        mojo::ScopedDataPipeConsumerHandle snapshot);
 
-  void HandleInputEvent(const WebInputEvent& event);
   void HandlePointerPacket(const pointer::PointerPacketPtr& packet);
 
   void StartDartTracing();

--- a/sky/services/engine/sky_engine.mojom
+++ b/sky/services/engine/sky_engine.mojom
@@ -36,8 +36,10 @@ interface SkyEngine {
   OnActivityResumed();
 
   OnViewportMetricsChanged(ViewportMetrics metrics);
-  OnInputEvent(InputEvent event);
   OnPointerPacket(pointer.PointerPacket packet);
+
+  PushRoute(string route);
+  PopRoute();
 
   RunFromFile(string main, string package_root);
   RunFromPrecompiledSnapshot(string path);

--- a/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -81,9 +81,7 @@ public class SkyActivity extends Activity {
     @Override
     public void onBackPressed() {
         if (mView != null) {
-            InputEvent event = new InputEvent();
-            event.type = EventType.BACK;
-            mView.getEngine().onInputEvent(event);
+            mView.getEngine().popRoute();
             return;
         }
         super.onBackPressed();
@@ -140,6 +138,9 @@ public class SkyActivity extends Activity {
 
         if (Intent.ACTION_RUN.equals(action)) {
             mView.getEngine().runFromBundle(intent.getDataString());
+            String route = intent.getStringExtra("route");
+            if (route != null)
+                mView.getEngine().pushRoute(route);
             return true;
         }
 

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -61,7 +61,6 @@ class Engine : public UIDelegate,
   // SkyEngine implementation:
   void SetServices(ServicesDataPtr services) override;
   void OnViewportMetricsChanged(ViewportMetricsPtr metrics) override;
-  void OnInputEvent(InputEventPtr event) override;
   void OnPointerPacket(pointer::PointerPacketPtr packet) override;
 
   void RunFromFile(const mojo::String& main,
@@ -71,7 +70,8 @@ class Engine : public UIDelegate,
   void RunFromBundle(const mojo::String& path) override;
   void RunFromAssetBundle(const mojo::String& url,
                           mojo::asset_bundle::AssetBundlePtr bundle) override;
-
+  void PushRoute(const mojo::String& route) override;
+  void PopRoute() override;
   void OnActivityPaused() override;
   void OnActivityResumed() override;
 
@@ -96,6 +96,7 @@ class Engine : public UIDelegate,
   std::unique_ptr<blink::SkyView> sky_view_;
 
   gfx::Size physical_size_;
+  std::string initial_route_;
   blink::SkyDisplayMetrics display_metrics_;
   mojo::Binding<SkyEngine> binding_;
 


### PR DESCRIPTION
We now respect the "route" field in Intents to load a route other than '/'.
Also, use popRoute rather than events to indicate that the framework has asked
us to go back.