### PR TITLE
Add a counter to trace VSync events from the platform

### DIFF
--- a/sky/services/vsync/ios/vsync_provider_impl.mm
+++ b/sky/services/vsync/ios/vsync_provider_impl.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "sky/services/vsync/ios/vsync_provider_impl.h"
+#include "base/trace_event/trace_event.h"
 
 #include <Foundation/Foundation.h>
 #include <QuartzCore/CADisplayLink.h>
@@ -25,6 +26,7 @@ static inline uint64_t CurrentTimeMicrosSeconds() {
 @implementation VSyncClient {
   CADisplayLink* _displayLink;
   ::vsync::VSyncProvider::AwaitVSyncCallback _pendingCallback;
+  BOOL _traceLevel;
 }
 
 - (instancetype)init {
@@ -48,6 +50,7 @@ static inline uint64_t CurrentTimeMicrosSeconds() {
 }
 
 - (void)onDisplayLink:(CADisplayLink*)link {
+  TRACE_COUNTER1("vsync", "PlatformVSync", _traceLevel = !_traceLevel);
   _displayLink.paused = YES;
   _pendingCallback.Run(CurrentTimeMicrosSeconds());
 }


### PR DESCRIPTION
I was looking at the "Frame Request Pending" slice to check for updates tied to vsync. But since those are tied to work being done on the UI thread, I added this slice to the platform vsync provider.
![screen shot 2015-12-01 at 3 45 52 pm](https://cloud.githubusercontent.com/assets/44085/11518137/c597b610-9843-11e5-9e41-c47033174526.png)
