### PR TITLE
Update style guide to recommend `flutter analyze`.

### DIFF
--- a/sky/specs/style-guide.md
+++ b/sky/specs/style-guide.md
@@ -35,7 +35,7 @@ rules, so avoid using that for now.)
 
 Always use the Dart Analyzer. Avoid checking in code that increases
 the output of the analyzer unless you've filed a bug with the Dart
-team. (Use "skyanalyzer" to run the analyzer on Flutter code.)
+team. (Use `flutter analyze` to run the analyzer on Flutter code.)
 
 Use assert()s liberally to describe the contracts that you expect your
 code to follow.


### PR DESCRIPTION
Removes reference to "skyanalyzer" (I think now gone?) in favor of `flutter analyze`.

@Hixie.