### PR TITLE
Add support on Android for --trace-startup

### DIFF
--- a/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -19,6 +19,7 @@ import org.chromium.mojom.sky.InputEvent;
 import org.domokit.activity.ActivityImpl;
 
 import java.io.File;
+import java.util.ArrayList;
 
 /**
  * Base class for activities that use Sky.
@@ -31,9 +32,16 @@ public class SkyActivity extends Activity {
         // Before adding more entries to this list, consider that arbitrary
         // Android applications can generate intents with extra data and that
         // there are many security-sensitive args in the binary.
+        ArrayList<String> args = new ArrayList<String>();
         if (intent.getBooleanExtra("enable-checked-mode", false)) {
-            String[] args = { "--enable-checked-mode"};
-            return args;
+            args.add("--enable-checked-mode");
+        }
+        if (intent.getBooleanExtra("trace-startup", false)) {
+            args.add("--trace-startup");
+        }
+        if (!args.isEmpty()) {
+            String[] argsArray = new String[args.size()];
+            return args.toArray(argsArray);
         }
         return null;
     }

--- a/sky/shell/switches.cc
+++ b/sky/shell/switches.cc
@@ -21,6 +21,7 @@ void PrintUsage(const std::string& executable_name) {
   std::cerr << "Usage: " << executable_name
             << " --" << kEnableCheckedMode
             << " --" << kNonInteractive
+            << " --" << kTraceStartup
             << " --" << kFLX << "=FLX"
             << " --" << kPackageRoot << "=PACKAGE_ROOT"
             << " [ MAIN_DART ]" << std::endl;


### PR DESCRIPTION
Now 'flutter start --trace-startup' can trigger this tracing
on Android

@chinmaygarde