### PR TITLE
Don't warn on maybe-uninitialized in fnl

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -219,6 +219,11 @@ config("compiler") {
         "//buildtools/third_party/libc++abi/trunk/include",
       ]
     }
+
+    if (is_fnl) {
+      # TODO(kulakowski) remove when fnl no longer uses gcc
+      cflags += [ "-Wno-maybe-uninitialized" ]
+    }
   }
 
   if (is_clang && is_debug) {


### PR DESCRIPTION
Our GCC picks up on a bunch of these in release. Suppress this until we
switch to Clang.