### PR TITLE
Ensure GL context as soon as the accelerated widget is available

### DIFF
--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -53,6 +53,11 @@ void RasterizerDirect::OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widge
   surface_ =
       gfx::GLSurface::CreateViewGLSurface(widget, gfx::SurfaceConfiguration());
   CHECK(surface_) << "GLSurface required.";
+  // Eagerly create the GL context. For a while after the accelerated widget
+  // is first available (after startup), the process is busy setting up dart
+  // isolates. During this time, we are free to create the context. Thus
+  // avoiding a delay when the first frame is painted.
+  EnsureGLContext();
 }
 
 void RasterizerDirect::Draw(uint64_t layer_tree_ptr,


### PR DESCRIPTION
Doing this eagerly saves ~50ms on startup
![screen shot 2015-12-03 at 2 01 34 pm](https://cloud.githubusercontent.com/assets/44085/11575599/bf9110c0-99c6-11e5-925e-c61b4635fc63.png)
