### PR TITLE
Load deferred import libraries when building the snapshot

### DIFF
--- a/sky/tools/sky_snapshot/vm.cc
+++ b/sky/tools/sky_snapshot/vm.cc
@@ -15,6 +15,7 @@ extern void* kDartIsolateSnapshotBuffer;
 
 static const char* kDartArgs[] = {
     "--enable_mirrors=false",
+    "--load_deferred_eagerly=true",
 };
 
 void InitDartVM() {


### PR DESCRIPTION
Without this, Dart will attempt to resolve deferred imports at runtime,
which is not feasible in Flutter