### PR TITLE
Make RequestFrame less janky in the no vsync case

### DIFF
--- a/sky/shell/ui/animator.cc
+++ b/sky/shell/ui/animator.cc
@@ -43,9 +43,10 @@ void Animator::RequestFrame() {
   }
 
   if (!AwaitVSync()) {
-    base::MessageLoop::current()->PostTask(
+    base::MessageLoop::current()->PostDelayedTask(
         FROM_HERE,
-        base::Bind(&Animator::BeginFrame, weak_factory_.GetWeakPtr(), 0));
+        base::Bind(&Animator::BeginFrame, weak_factory_.GetWeakPtr(), 0),
+        base::TimeDelta::FromMilliseconds(16));
   }
 }
 


### PR DESCRIPTION
Instead of spamming the MessageLoop, guess that 16ms is a good amount of
time to wait