### PR TITLE
Enable ThreadTime support on iOS

### DIFF
--- a/base/time/time.h
+++ b/base/time/time.h
@@ -733,7 +733,7 @@ class BASE_EXPORT ThreadTicks : public time_internal::TimeBase<ThreadTicks> {
   // Returns true if ThreadTicks::Now() is supported on this system.
   static bool IsSupported() {
 #if (defined(_POSIX_THREAD_CPUTIME) && (_POSIX_THREAD_CPUTIME >= 0)) || \
-    (defined(OS_MACOSX) && !defined(OS_IOS)) || defined(OS_ANDROID)
+    defined(OS_MACOSX) || defined(OS_ANDROID)
     return true;
 #else
     return false;

--- a/base/time/time_mac.cc
+++ b/base/time/time_mac.cc
@@ -69,10 +69,6 @@ int64_t ComputeCurrentTicks() {
 }
 
 int64_t ComputeThreadTicks() {
-#if defined(OS_IOS)
-  NOTREACHED();
-  return 0;
-#else
   base::mac::ScopedMachSendRight thread(mach_thread_self());
   mach_msg_type_number_t thread_info_count = THREAD_BASIC_INFO_COUNT;
   thread_basic_info_data_t thread_info_data;
@@ -94,7 +90,6 @@ int64_t ComputeThreadTicks() {
   absolute_micros *= base::Time::kMicrosecondsPerSecond;
   absolute_micros += thread_info_data.user_time.microseconds;
   return absolute_micros.ValueOrDie();
-#endif  // defined(OS_IOS)
 }
 
 }  // namespace


### PR DESCRIPTION
I am able to get richer traces. However, I am unsure why this was intentionally disabled on iOS. @jamesr, @abarth any ideas?

![screen shot 2015-12-03 at 5 57 03 pm](https://cloud.githubusercontent.com/assets/44085/11579948/51b01fa8-99e7-11e5-9960-01eefd54c945.png)