### PR TITLE
Don't crash when RasterizerMojo::Draw happens without a context

### DIFF
--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -46,6 +46,10 @@ void RasterizerMojo::ConnectToRasterizer (
 void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
                           const DrawCallback& callback) {
   TRACE_EVENT0("flutter", "RasterizerMojo::Draw");
+  if (!context_) {
+    callback.Run();
+    return;
+  }
 
   scoped_ptr<compositor::LayerTree> layer_tree(
       reinterpret_cast<compositor::LayerTree*>(layer_tree_ptr));


### PR DESCRIPTION
If we don't have a context, we can't draw, so bail out early.