### PR TITLE
Improve the crash fix in rasterizer_mojo

### DIFF
--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -46,7 +46,7 @@ void RasterizerMojo::ConnectToRasterizer (
 void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
                           const DrawCallback& callback) {
   TRACE_EVENT0("flutter", "RasterizerMojo::Draw");
-  if (!context_) {
+  if (!MGLGetCurrentContext()) {
     callback.Run();
     return;
   }


### PR DESCRIPTION
The previous version can still crash if we try to draw between the time when we
initialize context_ and when we actually make the MGL context current.