### PR TITLE
Switch snapshotter and application runner based on Xcode target

### DIFF
--- a/sky/build/PackagerInvoke
+++ b/sky/build/PackagerInvoke
@@ -50,7 +50,7 @@ PackageProject() {
   # Remove old build artifacts
   RunCommand rm -f ${derived_dir}/app.flx
 
-  local src_dir=${SOURCE_ROOT}/FlutterResources
+  local src_dir=${SOURCE_ROOT}/Tools/common
   AssertExists $src_dir
 
   local precompilation_flag=""

--- a/sky/build/SnapshotterInvoke
+++ b/sky/build/SnapshotterInvoke
@@ -105,13 +105,14 @@ SnapshotProject() {
   local main_path="${project_path}/lib/main.dart"
   AssertExists $main_path
 
-  local src_dir=${SOURCE_ROOT}/FlutterResources
+  local src_dir=${SOURCE_ROOT}/Tools/common
   local derived_dir=${SOURCE_ROOT}/FlutterApplication/Generated
 
   RunCommand mkdir -p $derived_dir
 
   AssertExists $src_dir
   AssertExists $derived_dir
+  AssertExists ${FLUTTER_ARCH_TOOLS_PATH}
 
   # Remove old build artifacts
   RunCommand rm -f ${derived_dir}/kDartVmIsolateSnapshotBuffer.c
@@ -123,7 +124,7 @@ SnapshotProject() {
   # snapshot buffer and isolate snapshot buffer, we name the file to match
   # the name of the symbol the VM expects at runtime. On these binary files,
   # we invoke xxd.
-  RunCommand ${src_dir}/Snapshotter                                            \
+  RunCommand ${FLUTTER_ARCH_TOOLS_PATH}/Snapshotter                            \
       --vm_isolate_snapshot=${derived_dir}/kDartVmIsolateSnapshotBuffer        \
       --isolate_snapshot=${derived_dir}/kDartIsolateSnapshotBuffer             \
       --instructions_snapshot=${derived_dir}/InstructionsSnapshot.S            \

--- a/sky/build/sdk_xcode_harness/Flutter.xcconfig
+++ b/sky/build/sdk_xcode_harness/Flutter.xcconfig
@@ -1,0 +1,7 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "Local.xcconfig"
+
+FLUTTER_ARCH_TOOLS_PATH=${SOURCE_ROOT}/Tools/${PLATFORM_NAME}

--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		9E0FB06D1C1A3F5600DDAEFA /* InstructionsSnapshotSource.S in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */; };
 		9E0FB06E1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB06A1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c */; };
 		9E0FB06F1C1A3F5600DDAEFA /* kDartVmIsolateSnapshotBufferSource.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB06B1C1A3F5600DDAEFA /* kDartVmIsolateSnapshotBufferSource.c */; };
+		9E40464E1C1B67AB00A4B87C /* app.flx in Resources */ = {isa = PBXBuildFile; fileRef = 9E40464D1C1B67A300A4B87C /* app.flx */; };
+		9E40465D1C1B6E9200A4B87C /* icudtl.dat in Resources */ = {isa = PBXBuildFile; fileRef = 9E4046541C1B6A3600A4B87C /* icudtl.dat */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,16 +43,6 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9E07CFBD1BE82E5900BCD8DE /* Copy Flutter Runner Executable And Resources */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 7;
-			files = (
-			);
-			name = "Copy Flutter Runner Executable And Resources";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -66,20 +58,18 @@
 		9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = InstructionsSnapshotSource.S; sourceTree = "<group>"; };
 		9E0FB06A1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kDartIsolateSnapshotBufferSource.c; sourceTree = "<group>"; };
 		9E0FB06B1C1A3F5600DDAEFA /* kDartVmIsolateSnapshotBufferSource.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kDartVmIsolateSnapshotBufferSource.c; sourceTree = "<group>"; };
-		9E40462E1C1B617500A4B87C /* EmbedderEntryPoints */ = {isa = PBXFileReference; lastKnownFileType = text; path = EmbedderEntryPoints; sourceTree = "<group>"; };
-		9E40462F1C1B617500A4B87C /* PackagerInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = PackagerInvoke; sourceTree = "<group>"; };
-		9E4046301C1B617500A4B87C /* Runner.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Runner.xcconfig; sourceTree = "<group>"; };
-		9E4046311C1B617500A4B87C /* ScriptSnapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = ScriptSnapshotter; sourceTree = "<group>"; };
-		9E4046321C1B617500A4B87C /* SnapshotterInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = SnapshotterInvoke; sourceTree = "<group>"; };
-		9E4046331C1B617500A4B87C /* icudtl.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = icudtl.dat; sourceTree = "<group>"; };
-		9E4046361C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
-		9E4046371C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
-		9E4046391C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
-		9E40463A1C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
-		9E40463D1C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
-		9E40463E1C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
-		9E4046401C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
-		9E4046411C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
+		9E40464B1C1B64B500A4B87C /* Flutter.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Flutter.xcconfig; sourceTree = "<group>"; };
+		9E40464D1C1B67A300A4B87C /* app.flx */ = {isa = PBXFileReference; lastKnownFileType = file; path = app.flx; sourceTree = "<group>"; };
+		9E4046501C1B6A3600A4B87C /* EmbedderEntryPoints */ = {isa = PBXFileReference; lastKnownFileType = text; path = EmbedderEntryPoints; sourceTree = "<group>"; };
+		9E4046511C1B6A3600A4B87C /* PackagerInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = PackagerInvoke; sourceTree = "<group>"; };
+		9E4046521C1B6A3600A4B87C /* ScriptSnapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = ScriptSnapshotter; sourceTree = "<group>"; };
+		9E4046531C1B6A3600A4B87C /* SnapshotterInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = SnapshotterInvoke; sourceTree = "<group>"; };
+		9E4046541C1B6A3600A4B87C /* icudtl.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = icudtl.dat; sourceTree = "<group>"; };
+		9E4046561C1B6A3600A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
+		9E4046571C1B6A3600A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
+		9E4046591C1B6A3600A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
+		9E40465A1C1B6A3600A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
+		9E40465E1C1B6F7900A4B87C /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,6 +94,8 @@
 		9E07CF7C1BE7F4D200BCD8DE = {
 			isa = PBXGroup;
 			children = (
+				9E40465E1C1B6F7900A4B87C /* Local.xcconfig */,
+				9E40464B1C1B64B500A4B87C /* Flutter.xcconfig */,
 				9E07CF881BE7F4D200BCD8DE /* FlutterApplication */,
 				9E07CF9B1BE8280A00BCD8DE /* Runner */,
 				9E40462C1C1B617500A4B87C /* Tools */,
@@ -123,6 +115,7 @@
 		9E07CF881BE7F4D200BCD8DE /* FlutterApplication */ = {
 			isa = PBXGroup;
 			children = (
+				9E40464C1C1B67A300A4B87C /* Generated */,
 				9E07CF891BE7F4D200BCD8DE /* FlutterApplication.h */,
 				9E0FB0681C1A3F5600DDAEFA /* FlutterApplication.c */,
 				9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */,
@@ -155,78 +148,49 @@
 		9E40462C1C1B617500A4B87C /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				9E40462D1C1B617500A4B87C /* Common */,
-				9E4046341C1B617500A4B87C /* Device */,
-				9E40463B1C1B617500A4B87C /* Simulator */,
+				9E40464F1C1B6A3600A4B87C /* common */,
+				9E4046551C1B6A3600A4B87C /* iphoneos */,
+				9E4046581C1B6A3600A4B87C /* iphonesimulator */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
 		};
-		9E40462D1C1B617500A4B87C /* Common */ = {
+		9E40464C1C1B67A300A4B87C /* Generated */ = {
 			isa = PBXGroup;
 			children = (
-				9E40462E1C1B617500A4B87C /* EmbedderEntryPoints */,
-				9E40462F1C1B617500A4B87C /* PackagerInvoke */,
-				9E4046301C1B617500A4B87C /* Runner.xcconfig */,
-				9E4046311C1B617500A4B87C /* ScriptSnapshotter */,
-				9E4046321C1B617500A4B87C /* SnapshotterInvoke */,
-				9E4046331C1B617500A4B87C /* icudtl.dat */,
+				9E40464D1C1B67A300A4B87C /* app.flx */,
 			);
-			path = Common;
+			path = Generated;
 			sourceTree = "<group>";
 		};
-		9E4046341C1B617500A4B87C /* Device */ = {
+		9E40464F1C1B6A3600A4B87C /* common */ = {
 			isa = PBXGroup;
 			children = (
-				9E4046351C1B617500A4B87C /* Debug */,
-				9E4046381C1B617500A4B87C /* Release */,
+				9E4046501C1B6A3600A4B87C /* EmbedderEntryPoints */,
+				9E4046511C1B6A3600A4B87C /* PackagerInvoke */,
+				9E4046521C1B6A3600A4B87C /* ScriptSnapshotter */,
+				9E4046531C1B6A3600A4B87C /* SnapshotterInvoke */,
+				9E4046541C1B6A3600A4B87C /* icudtl.dat */,
 			);
-			path = Device;
+			path = common;
 			sourceTree = "<group>";
 		};
-		9E4046351C1B617500A4B87C /* Debug */ = {
+		9E4046551C1B6A3600A4B87C /* iphoneos */ = {
 			isa = PBXGroup;
 			children = (
-				9E4046361C1B617500A4B87C /* FlutterRunner */,
-				9E4046371C1B617500A4B87C /* Snapshotter */,
+				9E4046561C1B6A3600A4B87C /* FlutterRunner */,
+				9E4046571C1B6A3600A4B87C /* Snapshotter */,
 			);
-			path = Debug;
+			path = iphoneos;
 			sourceTree = "<group>";
 		};
-		9E4046381C1B617500A4B87C /* Release */ = {
+		9E4046581C1B6A3600A4B87C /* iphonesimulator */ = {
 			isa = PBXGroup;
 			children = (
-				9E4046391C1B617500A4B87C /* FlutterRunner */,
-				9E40463A1C1B617500A4B87C /* Snapshotter */,
+				9E4046591C1B6A3600A4B87C /* FlutterRunner */,
+				9E40465A1C1B6A3600A4B87C /* Snapshotter */,
 			);
-			path = Release;
-			sourceTree = "<group>";
-		};
-		9E40463B1C1B617500A4B87C /* Simulator */ = {
-			isa = PBXGroup;
-			children = (
-				9E40463C1C1B617500A4B87C /* Debug */,
-				9E40463F1C1B617500A4B87C /* Release */,
-			);
-			path = Simulator;
-			sourceTree = "<group>";
-		};
-		9E40463C1C1B617500A4B87C /* Debug */ = {
-			isa = PBXGroup;
-			children = (
-				9E40463D1C1B617500A4B87C /* FlutterRunner */,
-				9E40463E1C1B617500A4B87C /* Snapshotter */,
-			);
-			path = Debug;
-			sourceTree = "<group>";
-		};
-		9E40463F1C1B617500A4B87C /* Release */ = {
-			isa = PBXGroup;
-			children = (
-				9E4046401C1B617500A4B87C /* FlutterRunner */,
-				9E4046411C1B617500A4B87C /* Snapshotter */,
-			);
-			path = Release;
+			path = iphonesimulator;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -272,7 +236,7 @@
 				9E07CF971BE8280A00BCD8DE /* Frameworks */,
 				9E07CF981BE8280A00BCD8DE /* Resources */,
 				9E07CFB91BE82D2600BCD8DE /* Embed Frameworks */,
-				9E07CFBD1BE82E5900BCD8DE /* Copy Flutter Runner Executable And Resources */,
+				9E40465C1C1B6DEC00A4B87C /* Copy Flutter Runner Executable And Resources */,
 			);
 			buildRules = (
 			);
@@ -325,6 +289,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E40464E1C1B67AB00A4B87C /* app.flx in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -332,6 +297,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9E40465D1C1B6E9200A4B87C /* icudtl.dat in Resources */,
 				9E07CFAC1BE8280A00BCD8DE /* LaunchScreen.storyboard in Resources */,
 				9E07CFA91BE8280A00BCD8DE /* Assets.xcassets in Resources */,
 			);
@@ -357,7 +323,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SOURCE_ROOT}/FlutterResources/SnapshotterInvoke ${FLUTTER_APPLICATION_PATH}";
+			shellScript = "${SOURCE_ROOT}/Tools/common/SnapshotterInvoke ${FLUTTER_APPLICATION_PATH}";
 			showEnvVarsInLog = 0;
 		};
 		9E07CFF21BEAB2E800BCD8DE /* Run FLX Packager + Optional Script Snapshotter */ = {
@@ -375,7 +341,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SOURCE_ROOT}/FlutterResources/PackagerInvoke ${FLUTTER_APPLICATION_PATH}";
+			shellScript = "${SOURCE_ROOT}/Tools/common/PackagerInvoke ${FLUTTER_APPLICATION_PATH}";
+			showEnvVarsInLog = 0;
+		};
+		9E40465C1C1B6DEC00A4B87C /* Copy Flutter Runner Executable And Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Flutter Runner Executable And Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cp ${FLUTTER_ARCH_TOOLS_PATH}/FlutterRunner ${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/FlutterRunner";
 			showEnvVarsInLog = 0;
 		};
 		9EBB2F351BF675C200177634 /* Ensure `pub get` */ = {
@@ -391,7 +372,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e\npushd ${FLUTTER_APPLICATION_PATH}\n${DART_SDK_PATH}/bin/pub get\npopd\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -439,9 +419,9 @@
 /* Begin XCBuildConfiguration section */
 		9E07CF8C1BE7F4D200BCD8DE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9E40464B1C1B64B500A4B87C /* Flutter.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(FLUTTER_TARGET_ARCH)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -480,7 +460,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALID_ARCHS = "$(FLUTTER_TARGET_ARCH)";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -488,9 +467,9 @@
 		};
 		9E07CF8D1BE7F4D200BCD8DE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9E40464B1C1B64B500A4B87C /* Flutter.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(FLUTTER_TARGET_ARCH)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -524,7 +503,6 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
-				VALID_ARCHS = "$(FLUTTER_TARGET_ARCH)";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -533,13 +511,10 @@
 		9E07CF8F1BE7F4D200BCD8DE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DART_SDK_PATH = dart/sdk/path;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FLUTTER_APPLICATION_PATH = path/to/application;
-				FLUTTER_ROOT = path/to/flutter/repo;
 				INFOPLIST_FILE = FlutterApplication/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -553,13 +528,10 @@
 		9E07CF901BE7F4D200BCD8DE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DART_SDK_PATH = dart/sdk/path;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FLUTTER_APPLICATION_PATH = path/to/application;
-				FLUTTER_ROOT = path/to/flutter/repo;
 				INFOPLIST_FILE = FlutterApplication/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;

--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		9E07CFB51BE82D2600BCD8DE /* FlutterApplication.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E07CF861BE7F4D200BCD8DE /* FlutterApplication.framework */; };
 		9E07CFB61BE82D2600BCD8DE /* FlutterApplication.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9E07CF861BE7F4D200BCD8DE /* FlutterApplication.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9E07CFBA1BE82DFF00BCD8DE /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 9E07CF9D1BE8280A00BCD8DE /* main.m */; };
-		9E07CFF41BEAB58200BCD8DE /* app.flx in Resources */ = {isa = PBXBuildFile; fileRef = 9E07CFF31BEAB58200BCD8DE /* app.flx */; };
 		9E0FB06C1C1A3F5600DDAEFA /* FlutterApplication.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB0681C1A3F5600DDAEFA /* FlutterApplication.c */; };
 		9E0FB06D1C1A3F5600DDAEFA /* InstructionsSnapshotSource.S in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */; };
 		9E0FB06E1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB06A1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c */; };
@@ -63,10 +62,6 @@
 		9E07CFA81BE8280A00BCD8DE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9E07CFAB1BE8280A00BCD8DE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		9E07CFAD1BE8280A00BCD8DE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		9E07CFE51BEAA35200BCD8DE /* InstructionsSnapshot.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; name = InstructionsSnapshot.S; path = Generated/InstructionsSnapshot.S; sourceTree = "<group>"; };
-		9E07CFE61BEAA35200BCD8DE /* kDartIsolateSnapshotBuffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = kDartIsolateSnapshotBuffer.c; path = Generated/kDartIsolateSnapshotBuffer.c; sourceTree = "<group>"; };
-		9E07CFE71BEAA35200BCD8DE /* kDartVmIsolateSnapshotBuffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = kDartVmIsolateSnapshotBuffer.c; path = Generated/kDartVmIsolateSnapshotBuffer.c; sourceTree = "<group>"; };
-		9E07CFF31BEAB58200BCD8DE /* app.flx */ = {isa = PBXFileReference; lastKnownFileType = file; name = app.flx; path = Generated/app.flx; sourceTree = "<group>"; };
 		9E0FB0681C1A3F5600DDAEFA /* FlutterApplication.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = FlutterApplication.c; sourceTree = "<group>"; };
 		9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = InstructionsSnapshotSource.S; sourceTree = "<group>"; };
 		9E0FB06A1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kDartIsolateSnapshotBufferSource.c; sourceTree = "<group>"; };
@@ -128,7 +123,6 @@
 		9E07CF881BE7F4D200BCD8DE /* FlutterApplication */ = {
 			isa = PBXGroup;
 			children = (
-				9E07CFD61BE997D800BCD8DE /* Generated */,
 				9E07CF891BE7F4D200BCD8DE /* FlutterApplication.h */,
 				9E0FB0681C1A3F5600DDAEFA /* FlutterApplication.c */,
 				9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */,
@@ -156,17 +150,6 @@
 				9E07CF9D1BE8280A00BCD8DE /* main.m */,
 			);
 			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		9E07CFD61BE997D800BCD8DE /* Generated */ = {
-			isa = PBXGroup;
-			children = (
-				9E07CFF31BEAB58200BCD8DE /* app.flx */,
-				9E07CFE51BEAA35200BCD8DE /* InstructionsSnapshot.S */,
-				9E07CFE61BEAA35200BCD8DE /* kDartIsolateSnapshotBuffer.c */,
-				9E07CFE71BEAA35200BCD8DE /* kDartVmIsolateSnapshotBuffer.c */,
-			);
-			name = Generated;
 			sourceTree = "<group>";
 		};
 		9E40462C1C1B617500A4B87C /* Tools */ = {
@@ -342,7 +325,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9E07CFF41BEAB58200BCD8DE /* app.flx in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 		9E0FB06D1C1A3F5600DDAEFA /* InstructionsSnapshotSource.S in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */; };
 		9E0FB06E1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB06A1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c */; };
 		9E0FB06F1C1A3F5600DDAEFA /* kDartVmIsolateSnapshotBufferSource.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E0FB06B1C1A3F5600DDAEFA /* kDartVmIsolateSnapshotBufferSource.c */; };
-		9E29675A1C03C1D200546454 /* FlutterRunner in Resources */ = {isa = PBXBuildFile; fileRef = 9E2967581C03C18700546454 /* FlutterRunner */; };
-		9E29675B1C03C1D200546454 /* icudtl.dat in Resources */ = {isa = PBXBuildFile; fileRef = 9E2967591C03C18700546454 /* icudtl.dat */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -73,13 +71,20 @@
 		9E0FB0691C1A3F5600DDAEFA /* InstructionsSnapshotSource.S */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.asm; path = InstructionsSnapshotSource.S; sourceTree = "<group>"; };
 		9E0FB06A1C1A3F5600DDAEFA /* kDartIsolateSnapshotBufferSource.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kDartIsolateSnapshotBufferSource.c; sourceTree = "<group>"; };
 		9E0FB06B1C1A3F5600DDAEFA /* kDartVmIsolateSnapshotBufferSource.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = kDartVmIsolateSnapshotBufferSource.c; sourceTree = "<group>"; };
-		9E2967531C03C17300546454 /* EmbedderEntryPoints */ = {isa = PBXFileReference; lastKnownFileType = text; name = EmbedderEntryPoints; path = FlutterResources/EmbedderEntryPoints; sourceTree = SOURCE_ROOT; };
-		9E2967541C03C17300546454 /* PackagerInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = PackagerInvoke; path = FlutterResources/PackagerInvoke; sourceTree = SOURCE_ROOT; };
-		9E2967551C03C17300546454 /* Runner.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Runner.xcconfig; path = FlutterResources/Runner.xcconfig; sourceTree = SOURCE_ROOT; };
-		9E2967561C03C17300546454 /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = Snapshotter; path = FlutterResources/Snapshotter; sourceTree = SOURCE_ROOT; };
-		9E2967571C03C17300546454 /* SnapshotterInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; name = SnapshotterInvoke; path = FlutterResources/SnapshotterInvoke; sourceTree = SOURCE_ROOT; };
-		9E2967581C03C18700546454 /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; name = FlutterRunner; path = FlutterResources/FlutterRunner; sourceTree = SOURCE_ROOT; };
-		9E2967591C03C18700546454 /* icudtl.dat */ = {isa = PBXFileReference; lastKnownFileType = file; name = icudtl.dat; path = FlutterResources/icudtl.dat; sourceTree = SOURCE_ROOT; };
+		9E40462E1C1B617500A4B87C /* EmbedderEntryPoints */ = {isa = PBXFileReference; lastKnownFileType = text; path = EmbedderEntryPoints; sourceTree = "<group>"; };
+		9E40462F1C1B617500A4B87C /* PackagerInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = PackagerInvoke; sourceTree = "<group>"; };
+		9E4046301C1B617500A4B87C /* Runner.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Runner.xcconfig; sourceTree = "<group>"; };
+		9E4046311C1B617500A4B87C /* ScriptSnapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = ScriptSnapshotter; sourceTree = "<group>"; };
+		9E4046321C1B617500A4B87C /* SnapshotterInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = SnapshotterInvoke; sourceTree = "<group>"; };
+		9E4046331C1B617500A4B87C /* icudtl.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = icudtl.dat; sourceTree = "<group>"; };
+		9E4046361C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
+		9E4046371C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
+		9E4046391C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
+		9E40463A1C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
+		9E40463D1C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
+		9E40463E1C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
+		9E4046401C1B617500A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
+		9E4046411C1B617500A4B87C /* Snapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = Snapshotter; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -106,7 +111,7 @@
 			children = (
 				9E07CF881BE7F4D200BCD8DE /* FlutterApplication */,
 				9E07CF9B1BE8280A00BCD8DE /* Runner */,
-				9E07CFEB1BEAA44D00BCD8DE /* FlutterResources */,
+				9E40462C1C1B617500A4B87C /* Tools */,
 				9E07CF871BE7F4D200BCD8DE /* Products */,
 			);
 			sourceTree = "<group>";
@@ -164,19 +169,81 @@
 			name = Generated;
 			sourceTree = "<group>";
 		};
-		9E07CFEB1BEAA44D00BCD8DE /* FlutterResources */ = {
+		9E40462C1C1B617500A4B87C /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				9E2967531C03C17300546454 /* EmbedderEntryPoints */,
-				9E2967541C03C17300546454 /* PackagerInvoke */,
-				9E2967551C03C17300546454 /* Runner.xcconfig */,
-				9E2967561C03C17300546454 /* Snapshotter */,
-				9E2967571C03C17300546454 /* SnapshotterInvoke */,
-				9E2967581C03C18700546454 /* FlutterRunner */,
-				9E2967591C03C18700546454 /* icudtl.dat */,
+				9E40462D1C1B617500A4B87C /* Common */,
+				9E4046341C1B617500A4B87C /* Device */,
+				9E40463B1C1B617500A4B87C /* Simulator */,
 			);
-			name = FlutterResources;
-			path = RunnerResources;
+			path = Tools;
+			sourceTree = "<group>";
+		};
+		9E40462D1C1B617500A4B87C /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				9E40462E1C1B617500A4B87C /* EmbedderEntryPoints */,
+				9E40462F1C1B617500A4B87C /* PackagerInvoke */,
+				9E4046301C1B617500A4B87C /* Runner.xcconfig */,
+				9E4046311C1B617500A4B87C /* ScriptSnapshotter */,
+				9E4046321C1B617500A4B87C /* SnapshotterInvoke */,
+				9E4046331C1B617500A4B87C /* icudtl.dat */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		9E4046341C1B617500A4B87C /* Device */ = {
+			isa = PBXGroup;
+			children = (
+				9E4046351C1B617500A4B87C /* Debug */,
+				9E4046381C1B617500A4B87C /* Release */,
+			);
+			path = Device;
+			sourceTree = "<group>";
+		};
+		9E4046351C1B617500A4B87C /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				9E4046361C1B617500A4B87C /* FlutterRunner */,
+				9E4046371C1B617500A4B87C /* Snapshotter */,
+			);
+			path = Debug;
+			sourceTree = "<group>";
+		};
+		9E4046381C1B617500A4B87C /* Release */ = {
+			isa = PBXGroup;
+			children = (
+				9E4046391C1B617500A4B87C /* FlutterRunner */,
+				9E40463A1C1B617500A4B87C /* Snapshotter */,
+			);
+			path = Release;
+			sourceTree = "<group>";
+		};
+		9E40463B1C1B617500A4B87C /* Simulator */ = {
+			isa = PBXGroup;
+			children = (
+				9E40463C1C1B617500A4B87C /* Debug */,
+				9E40463F1C1B617500A4B87C /* Release */,
+			);
+			path = Simulator;
+			sourceTree = "<group>";
+		};
+		9E40463C1C1B617500A4B87C /* Debug */ = {
+			isa = PBXGroup;
+			children = (
+				9E40463D1C1B617500A4B87C /* FlutterRunner */,
+				9E40463E1C1B617500A4B87C /* Snapshotter */,
+			);
+			path = Debug;
+			sourceTree = "<group>";
+		};
+		9E40463F1C1B617500A4B87C /* Release */ = {
+			isa = PBXGroup;
+			children = (
+				9E4046401C1B617500A4B87C /* FlutterRunner */,
+				9E4046411C1B617500A4B87C /* Snapshotter */,
+			);
+			path = Release;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -285,8 +352,6 @@
 			files = (
 				9E07CFAC1BE8280A00BCD8DE /* LaunchScreen.storyboard in Resources */,
 				9E07CFA91BE8280A00BCD8DE /* Assets.xcassets in Resources */,
-				9E29675B1C03C1D200546454 /* icudtl.dat in Resources */,
-				9E29675A1C03C1D200546454 /* FlutterRunner in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -392,7 +457,6 @@
 /* Begin XCBuildConfiguration section */
 		9E07CF8C1BE7F4D200BCD8DE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E2967551C03C17300546454 /* Runner.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(FLUTTER_TARGET_ARCH)";
@@ -442,7 +506,6 @@
 		};
 		9E07CF8D1BE7F4D200BCD8DE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9E2967551C03C17300546454 /* Runner.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(FLUTTER_TARGET_ARCH)";

--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9E07CF991BE8280A00BCD8DE"
+               BuildableName = "Runner.app"
+               BlueprintName = "Runner"
+               ReferencedContainer = "container:FlutterApplication.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9E07CF991BE8280A00BCD8DE"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:FlutterApplication.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9E07CF991BE8280A00BCD8DE"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:FlutterApplication.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9E07CF991BE8280A00BCD8DE"
+            BuildableName = "Runner.app"
+            BlueprintName = "Runner"
+            ReferencedContainer = "container:FlutterApplication.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Framework.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0720"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9E07CF851BE7F4D200BCD8DE"
+               BuildableName = "FlutterApplication.framework"
+               BlueprintName = "FlutterApplication"
+               ReferencedContainer = "container:FlutterApplication.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9E07CF851BE7F4D200BCD8DE"
+            BuildableName = "FlutterApplication.framework"
+            BlueprintName = "FlutterApplication"
+            ReferencedContainer = "container:FlutterApplication.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9E07CF851BE7F4D200BCD8DE"
+            BuildableName = "FlutterApplication.framework"
+            BlueprintName = "FlutterApplication"
+            ReferencedContainer = "container:FlutterApplication.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/sky/build/sdk_xcode_harness/Local.xcconfig
+++ b/sky/build/sdk_xcode_harness/Local.xcconfig
@@ -1,0 +1,11 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//
+// This file generated. Do not modify or check into version control.
+//
+
+DART_SDK_PATH=/path/to/dart/sdk
+FLUTTER_APPLICATION_PATH=path/to/flutter/application
+FLUTTER_ROOT=/path/to/flutter/root

--- a/sky/build/sdk_xcode_harness/Runner/Info.plist
+++ b/sky/build/sdk_xcode_harness/Runner/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>Flutter</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/sky/build/sky_precompilation_sdk.gni
+++ b/sky/build/sky_precompilation_sdk.gni
@@ -13,16 +13,13 @@ template("sky_precompilation_sdk") {
   sdk_name = invoker.sdk_name
   sdk_dir = "$root_out_dir/$sdk_name"
   tools_dir_name = "Tools"
-  tools_dir = "$tools_dir_name/Common"
+  tools_dir = "$tools_dir_name/common"
 
-  arch_tools_dir = "$tools_dir_name/Device"
+  # The architecture specific suffixes are chosen to match the ${PLATFORM_NAME}
+  # used by the .xcconfig files
+  arch_tools_dir = "$tools_dir_name/iphoneos"
   if (use_ios_simulator) {
-    arch_tools_dir = "$tools_dir_name/Simulator"
-  }
-
-  arch_tools_dir = "$arch_tools_dir/Release"
-  if (is_debug) {
-    arch_tools_dir = "$arch_tools_dir/Debug"
+    arch_tools_dir = "$tools_dir_name/iphonesimulator"
   }
 
   snapshotter_copy_gen_target_name = target_name + "_copy_snapshotter"
@@ -66,8 +63,10 @@ template("sky_precompilation_sdk") {
 
   copy("copy_sdk_xcode_harness") {
     sources = [
+      "//sky/build/sdk_xcode_harness/Flutter.xcconfig",
       "//sky/build/sdk_xcode_harness/FlutterApplication",
       "//sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj",
+      "//sky/build/sdk_xcode_harness/Local.xcconfig",
       "//sky/build/sdk_xcode_harness/Runner",
     ]
     outputs = [  "$sdk_dir/{{source_file_part}}"  ]
@@ -100,13 +99,6 @@ template("sky_precompilation_sdk") {
     set_sources_assignment_filter(sources_assignment_filter)
   }
 
-  copy_config_gen_target_name = target_name + "_sdk_config"
-  file_template(copy_config_gen_target_name) {
-    input = "//sky/build/Runner.xcconfig.template"
-    output = "$sdk_dir/$tools_dir/Runner.xcconfig"
-    variables = "target_arch=$target_cpu"
-  }
-
   group(target_name) {
     deps = [
       ":$snapshotter_copy_gen_target_name",
@@ -116,7 +108,6 @@ template("sky_precompilation_sdk") {
       ":$copy_data_gen_target_name",
       ":precompilation_xcode_scripts",
       ":copy_sdk_xcode_harness",
-      ":$copy_config_gen_target_name",
     ]
   }
 }

--- a/sky/build/sky_precompilation_sdk.gni
+++ b/sky/build/sky_precompilation_sdk.gni
@@ -12,7 +12,18 @@ template("sky_precompilation_sdk") {
 
   sdk_name = invoker.sdk_name
   sdk_dir = "$root_out_dir/$sdk_name"
-  resources_dir = "FlutterResources"
+  tools_dir_name = "Tools"
+  tools_dir = "$tools_dir_name/Common"
+
+  arch_tools_dir = "$tools_dir_name/Device"
+  if (use_ios_simulator) {
+    arch_tools_dir = "$tools_dir_name/Simulator"
+  }
+
+  arch_tools_dir = "$arch_tools_dir/Release"
+  if (is_debug) {
+    arch_tools_dir = "$arch_tools_dir/Debug"
+  }
 
   snapshotter_copy_gen_target_name = target_name + "_copy_snapshotter"
   copy(snapshotter_copy_gen_target_name) {
@@ -21,7 +32,7 @@ template("sky_precompilation_sdk") {
     snapshotter_name = get_label_info(snapshotter_target, "name")
 
     sources = [  "$snapshotter_directory/$snapshotter_name"  ]
-    outputs = [  "$sdk_dir/$resources_dir/Snapshotter"  ]
+    outputs = [  "$sdk_dir/$arch_tools_dir/Snapshotter"  ]
 
     deps = [  snapshotter_target  ]
   }
@@ -35,14 +46,14 @@ template("sky_precompilation_sdk") {
     script_snapshotter_name = get_label_info(script_snapshotter_target, "name")
 
     sources = [  "$script_snapshotter_directory/$script_snapshotter_name"  ]
-    outputs = [  "$sdk_dir/$resources_dir/ScriptSnapshotter"  ]
+    outputs = [  "$sdk_dir/$tools_dir/ScriptSnapshotter"  ]
 
     deps = [  script_snapshotter_target  ]
   }
 
   copy("embedder_entry_points") {
     sources = [ "//sky/engine/bindings/dart_vm_entry_points.txt" ]
-    outputs = [  "$sdk_dir/$resources_dir/EmbedderEntryPoints"  ]
+    outputs = [  "$sdk_dir/$tools_dir/EmbedderEntryPoints"  ]
   }
 
   copy("precompilation_xcode_scripts") {
@@ -50,7 +61,7 @@ template("sky_precompilation_sdk") {
       "//sky/build/SnapshotterInvoke",
       "//sky/build/PackagerInvoke",
     ]
-    outputs = [  "$sdk_dir/$resources_dir/{{source_file_part}}"  ]
+    outputs = [  "$sdk_dir/$tools_dir/{{source_file_part}}"  ]
   }
 
   copy("copy_sdk_xcode_harness") {
@@ -76,7 +87,7 @@ template("sky_precompilation_sdk") {
   copy_runner_gen_target_name = target_name + "_copy_runner"
   copy(copy_runner_gen_target_name) {
     sources = [  "$root_out_dir/$executable_gen_target_name"  ]
-    outputs = [  "$sdk_dir/$resources_dir/FlutterRunner"  ]
+    outputs = [  "$sdk_dir/$arch_tools_dir/FlutterRunner"  ]
 
     deps = [  ":$executable_gen_target_name"  ]
   }
@@ -85,14 +96,14 @@ template("sky_precompilation_sdk") {
   copy(copy_data_gen_target_name) {
     set_sources_assignment_filter([])
     sources = [  "//third_party/icu/android/icudtl.dat"  ]
-    outputs = [  "$sdk_dir/$resources_dir/{{source_file_part}}"  ]
+    outputs = [  "$sdk_dir/$tools_dir/{{source_file_part}}"  ]
     set_sources_assignment_filter(sources_assignment_filter)
   }
 
   copy_config_gen_target_name = target_name + "_sdk_config"
   file_template(copy_config_gen_target_name) {
     input = "//sky/build/Runner.xcconfig.template"
-    output = "$sdk_dir/$resources_dir/Runner.xcconfig"
+    output = "$sdk_dir/$tools_dir/Runner.xcconfig"
     variables = "target_arch=$target_cpu"
   }
 


### PR DESCRIPTION
Selecting the target to run on (device or simulator) will cause the build machinery to select the right snapshotter, decide if precompilation is necessary and package the flx accordingly. This can now be done from within the same Xcode project instead of having different engine builds for each variant.