### PR TITLE
Remove //third_party/BUILD.gn

### DIFF
--- a/third_party/BUILD.gn
+++ b/third_party/BUILD.gn
@@ -1,9 +1,0 @@
-# Copyright 2014 The Chromium Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
-
-group("jpeg") {
-  deps = [
-    "//third_party/libjpeg:libjpeg",
-  ]
-}

--- a/third_party/iccjpeg/BUILD.gn
+++ b/third_party/iccjpeg/BUILD.gn
@@ -14,6 +14,6 @@ source_set("iccjpeg") {
 
   public_configs = [ ":iccjpeg_config" ]
   deps = [
-    "//third_party:jpeg",
+    "//third_party/libjpeg",
   ]
 }

--- a/ui/gfx/BUILD.gn
+++ b/ui/gfx/BUILD.gn
@@ -95,9 +95,9 @@ component("gfx") {
     "//base:i18n",
     "//skia",
     "//third_party/harfbuzz-ng",
+    "//third_party/libjpeg",
     "//third_party/libpng",
     "//third_party/zlib",
-    "//third_party:jpeg",
     "//ui/gfx/geometry",
   ]
   public_deps = [


### PR DESCRIPTION
We no longer need this hack to mux between libjpeg and libjpeg_turbo.