### PR TITLE
Check the image decoder's failed flag after obtaining the frame buffer

### DIFF
--- a/sky/engine/core/painting/painting.cc
+++ b/sky/engine/core/painting/painting.cc
@@ -43,9 +43,13 @@ void DecodeImage(scoped_ptr<DartPersistentValue> callback,
     DartInvokeAppClosure(callback->value(), {Dart_Null()});
     return;
   }
+  ImageFrame* imageFrame = decoder->frameBufferAtIndex(0);
+  if (decoder->failed()) {
+    DartInvokeAppClosure(callback->value(), {Dart_Null()});
+    return;
+  }
 
   RefPtr<CanvasImage> resultImage = CanvasImage::create();
-  ImageFrame* imageFrame = decoder->frameBufferAtIndex(0);
   RefPtr<SkImage> skImage = adoptRef(
       SkImage::NewFromBitmap(imageFrame->getSkBitmap()));
   resultImage->setImage(skImage.release());


### PR DESCRIPTION
Some decoders (e.g. JPEG) do not execute the decode until the call to
frmaeBufferAtIndex.  If the decode fails, we should not try to return a
bitmap.