### PR TITLE
Update Skia revision

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -21,7 +21,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'mojo_sdk_revision': 'c29387104b5fbcbf681e2da2559a3db5860f153f',
   'mojo_devtools_revision': '49879d78ce4486e10c2214a101d9b2e82794b2f4',
-  'skia_revision': '87ed6be0e4ea8b0a88915045f697d0fd734ed6f5',
+  'skia_revision': '52e2581700b719aad317605160a2cef45d3db68b',
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -464,6 +464,7 @@ component("skia") {
     sources -= [
       "//third_party/skia/src/fonts/SkFontMgr_fontconfig.cpp",
       "//third_party/skia/src/ports/SkFontConfigInterface_direct.cpp",
+      "//third_party/skia/src/ports/SkFontConfigInterface_direct_factory.cpp",
       "//third_party/skia/src/ports/SkFontHost_fontconfig.cpp",
     ]
   }
@@ -554,7 +555,7 @@ source_set("skia_opts") {
 
   if (current_cpu == "x86" || current_cpu == "x64") {
     sources = gypi_skia_opts.sse2_sources + gypi_skia_opts.ssse3_sources +
-              gypi_skia_opts.sse41_sources +
+              gypi_skia_opts.sse41_sources + gypi_skia_opts.avx_sources +
               [
                 # Chrome-specific.
                 "ext/convolver_SSE2.cc",

--- a/skia/config/SkUserConfig.h
+++ b/skia/config/SkUserConfig.h
@@ -192,13 +192,6 @@ SK_API void SkDebugf_FileLine(const char* file, int line, bool fatal,
     "%s:%d: failed assertion \"%s\"\n", \
     __FILE__, __LINE__, #cond); } } while (false)
 
-#if !defined(ANDROID)   // On Android, we use the skia default settings.
-#define SK_A32_SHIFT    24
-#define SK_R32_SHIFT    16
-#define SK_G32_SHIFT    8
-#define SK_B32_SHIFT    0
-#endif
-
 #if defined(SK_BUILD_FOR_WIN32)
 
 #define SK_BUILD_FOR_WIN

--- a/skia/ext/bitmap_platform_device_mac.cc
+++ b/skia/ext/bitmap_platform_device_mac.cc
@@ -23,13 +23,6 @@ namespace skia {
 namespace {
 
 static CGContextRef CGContextForData(void* data, int width, int height) {
-#define HAS_ARGB_SHIFTS(a, r, g, b) \
-            (SK_A32_SHIFT == (a) && SK_R32_SHIFT == (r) \
-             && SK_G32_SHIFT == (g) && SK_B32_SHIFT == (b))
-#if defined(SK_CPU_LENDIAN) && HAS_ARGB_SHIFTS(24, 16, 8, 0)
-  // Allocate a bitmap context with 4 components per pixel (BGRA).  Apple
-  // recommends these flags for improved CG performance.
-
   // CGBitmapContextCreate returns NULL if width/height are 0. However, our
   // callers expect to get a canvas back (which they later resize/reallocate)
   // so we pin the dimensions here.
@@ -38,13 +31,8 @@ static CGContextRef CGContextForData(void* data, int width, int height) {
   CGContextRef context =
       CGBitmapContextCreate(data, width, height, 8, width * 4,
                             base::mac::GetSystemColorSpace(),
-                            kCGImageAlphaPremultipliedFirst |
+                            kCGImageAlphaPremultipliedLast |
                                 kCGBitmapByteOrder32Host);
-#else
-#error We require that Skia's and CoreGraphics's recommended \
-       image memory layout match.
-#endif
-#undef HAS_ARGB_SHIFTS
 
   if (!context)
     return NULL;

--- a/skia/ext/bitmap_platform_device_mac.cc
+++ b/skia/ext/bitmap_platform_device_mac.cc
@@ -32,7 +32,7 @@ static CGContextRef CGContextForData(void* data, int width, int height) {
       CGBitmapContextCreate(data, width, height, 8, width * 4,
                             base::mac::GetSystemColorSpace(),
                             kCGImageAlphaPremultipliedLast |
-                                kCGBitmapByteOrder32Host);
+                                kCGBitmapByteOrder32Little);
 
   if (!context)
     return NULL;

--- a/skia/ext/skia_utils_ios.mm
+++ b/skia/ext/skia_utils_ios.mm
@@ -39,12 +39,6 @@ SkBitmap CGImageToSkBitmap(CGImageRef image, CGSize size, bool is_opaque) {
 
   void* data = bitmap.getPixels();
 
-  // Allocate a bitmap context with 4 components per pixel (BGRA). Apple
-  // recommends these flags for improved CG performance.
-#define HAS_ARGB_SHIFTS(a, r, g, b) \
-            (SK_A32_SHIFT == (a) && SK_R32_SHIFT == (r) \
-             && SK_G32_SHIFT == (g) && SK_B32_SHIFT == (b))
-#if defined(SK_CPU_LENDIAN) && HAS_ARGB_SHIFTS(24, 16, 8, 0)
   base::ScopedCFTypeRef<CGColorSpaceRef> color_space(
       CGColorSpaceCreateDeviceRGB());
   base::ScopedCFTypeRef<CGContextRef> context(CGBitmapContextCreate(
@@ -54,12 +48,7 @@ SkBitmap CGImageToSkBitmap(CGImageRef image, CGSize size, bool is_opaque) {
       8,
       size.width * 4,
       color_space,
-      kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host));
-#else
-#error We require that Skia's and CoreGraphics's recommended \
-       image memory layout match.
-#endif
-#undef HAS_ARGB_SHIFTS
+      kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Host));
 
   DCHECK(context);
   if (!context)

--- a/skia/ext/skia_utils_ios.mm
+++ b/skia/ext/skia_utils_ios.mm
@@ -48,7 +48,7 @@ SkBitmap CGImageToSkBitmap(CGImageRef image, CGSize size, bool is_opaque) {
       8,
       size.width * 4,
       color_space,
-      kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Host));
+      kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Little));
 
   DCHECK(context);
   if (!context)

--- a/skia/ext/skia_utils_mac.mm
+++ b/skia/ext/skia_utils_mac.mm
@@ -33,12 +33,6 @@ SkBitmap NSImageOrNSImageRepToSkBitmapWithColorSpace(
 
   void* data = bitmap.getPixels();
 
-  // Allocate a bitmap context with 4 components per pixel (BGRA). Apple
-  // recommends these flags for improved CG performance.
-#define HAS_ARGB_SHIFTS(a, r, g, b) \
-            (SK_A32_SHIFT == (a) && SK_R32_SHIFT == (r) \
-             && SK_G32_SHIFT == (g) && SK_B32_SHIFT == (b))
-#if defined(SK_CPU_LENDIAN) && HAS_ARGB_SHIFTS(24, 16, 8, 0)
   base::ScopedCFTypeRef<CGContextRef> context(CGBitmapContextCreate(
       data,
       size.width,
@@ -46,12 +40,7 @@ SkBitmap NSImageOrNSImageRepToSkBitmapWithColorSpace(
       8,
       size.width * 4,
       color_space,
-      kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host));
-#else
-#error We require that Skia's and CoreGraphics's recommended \
-       image memory layout match.
-#endif
-#undef HAS_ARGB_SHIFTS
+      kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Host));
 
   // Something went really wrong. Best guess is that the bitmap data is invalid.
   DCHECK(context);

--- a/skia/ext/skia_utils_mac.mm
+++ b/skia/ext/skia_utils_mac.mm
@@ -40,7 +40,7 @@ SkBitmap NSImageOrNSImageRepToSkBitmapWithColorSpace(
       8,
       size.width * 4,
       color_space,
-      kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Host));
+      kCGImageAlphaPremultipliedLast | kCGBitmapByteOrder32Little));
 
   // Something went really wrong. Best guess is that the bitmap data is invalid.
   DCHECK(context);
@@ -430,7 +430,7 @@ CGContextRef SkiaBitLocker::cgContext() {
       CGColorSpaceCreateDeviceRGB());
   cgContext_ = CGBitmapContextCreate(bitmap_.getPixels(), bitmap_.width(),
     bitmap_.height(), 8, bitmap_.rowBytes(), colorSpace, 
-    kCGBitmapByteOrder32Host | kCGImageAlphaPremultipliedFirst);
+    kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedLast);
   DCHECK(cgContext_);
 
   SkMatrix matrix = canvas_->getTotalMatrix();

--- a/skia/skia_gn_files.gypi
+++ b/skia/skia_gn_files.gypi
@@ -14,6 +14,7 @@
     '<(skia_src_path)/images/SkScaledBitmapSampler.cpp',
     '<(skia_src_path)/images/SkScaledBitmapSampler.h',
     '<(skia_src_path)/ports/SkFontConfigInterface_direct.cpp',
+    '<(skia_src_path)/ports/SkFontConfigInterface_direct_factory.cpp',
     '<(skia_src_path)/ports/SkFontHost_fontconfig.cpp',
     '<(skia_src_path)/ports/SkFontHost_FreeType_common.cpp',
     '<(skia_src_path)/ports/SkFontHost_FreeType_common.h',

--- a/skia/skia_library.gypi
+++ b/skia/skia_library.gypi
@@ -30,6 +30,7 @@
     '../third_party/skia/src/images/SkScaledBitmapSampler.h',
 
     '../third_party/skia/src/ports/SkFontConfigInterface_direct.cpp',
+    '../third_party/skia/src/ports/SkFontConfigInterface_direct_factory.cpp',
 
     '../third_party/skia/src/fonts/SkFontMgr_fontconfig.cpp',
     '../third_party/skia/src/ports/SkFontHost_fontconfig.cpp',
@@ -231,6 +232,7 @@
     [ 'OS=="win" or OS=="mac" or OS=="ios" or OS=="android"', {
       'sources!': [
         '../third_party/skia/src/ports/SkFontConfigInterface_direct.cpp',
+        '../third_party/skia/src/ports/SkFontConfigInterface_direct_factory.cpp',
         '../third_party/skia/src/ports/SkFontHost_fontconfig.cpp',
         '../third_party/skia/src/fonts/SkFontMgr_fontconfig.cpp',
       ],

--- a/sky/compositor/picture_serializer.cc
+++ b/sky/compositor/picture_serializer.cc
@@ -14,12 +14,12 @@ namespace sky {
 class PngPixelSerializer : public SkPixelSerializer {
  public:
   bool onUseEncodedData(const void*, size_t) override { return true; }
-  SkData* onEncodePixels(const SkImageInfo& info, const void* pixels,
-      size_t row_bytes) override {
+
+  SkData* onEncode(const SkPixmap& pixmap) override {
     std::vector<unsigned char> data;
 
     SkBitmap bm;
-    if (!bm.installPixels(info, const_cast<void*>(pixels), row_bytes))
+    if (!bm.installPixels(pixmap))
       return nullptr;
     if (!gfx::PNGCodec::EncodeBGRASkBitmap(bm, false, &data))
       return nullptr;

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -3,7 +3,6 @@ set -ex
 
 PATH="$HOME/depot_tools:$PATH"
 
-(cd ..; gclient sync)
 sky/tools/gn --debug
 ninja -C out/Debug generate_dart_ui
 travis/analyze.sh

--- a/travis/gclient
+++ b/travis/gclient
@@ -1,5 +1,5 @@
 solutions = [{
-  "name"        : "..",
+  "name"        : "src",
   "url"         : "https://github.com/flutter/engine.git",
   "deps_file"   : "DEPS",
   "managed"     : False,

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -3,6 +3,8 @@ set -ex
 
 (cd; git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git)
 
+PATH="$HOME/depot_tools:$PATH"
+
 cd ..
 mv engine src
 mkdir engine
@@ -10,3 +12,4 @@ mv src engine
 cd engine/src
 
 mv travis/gclient ../.gclient
+gclient sync


### PR DESCRIPTION
* Let Skia pick the default color component shifts (SkUserConfig.h)
* Switch to using 32bpp, 8bpc, premultiplied last color format when transferring bitmap context data buffer between Skia and CoreGraphics. Should be supported acrroding to [`table 2-1`](https://developer.apple.com/library/ios/documentation/GraphicsImaging/Conceptual/drawingwithquartz2d/dq_context/dq_context.html)