### PR TITLE
Fix bustage by adding a DartConverter<unsigned long>.

### DIFF
--- a/sky/engine/tonic/dart_converter.h
+++ b/sky/engine/tonic/dart_converter.h
@@ -99,11 +99,19 @@ template <>
 struct DartConverter<long long> : public DartConverterInteger<long long> {};
 
 template <>
+struct DartConverter<unsigned long> : public DartConverterInteger<unsigned long> {};
+
+template <>
 struct DartConverter<unsigned long long> {
+
+  // TODO(abarth): The Dart VM API doesn't yet have an entry-point for
+  // an unsigned 64-bit type. We will need to add a Dart API for
+  // constructing an integer from uint64_t.
+  //
+  // (In the meantime, we have asserts below to check that we're never
+  // converting values that have the 64th bit set.)
+
   static Dart_Handle ToDart(unsigned long long val) {
-    // FIXME: WebIDL unsigned long long is guaranteed to fit into 64-bit
-    // unsigned,
-    // so we need a dart API for constructing an integer from uint64_t.
     DCHECK(val <= 0x7fffffffffffffffLL);
     return Dart_NewInteger(static_cast<int64_t>(val));
   }


### PR DESCRIPTION
Also, update a comment to better explain why unsigned long long is special.