### PR TITLE
Fix the Input crash.

### DIFF
--- a/services/keyboard/src/org/chromium/mojo/keyboard/KeyboardServiceImpl.java
+++ b/services/keyboard/src/org/chromium/mojo/keyboard/KeyboardServiceImpl.java
@@ -69,6 +69,7 @@ public class KeyboardServiceImpl implements KeyboardService {
         InputMethodManager imm =
                 (InputMethodManager) mContext.getSystemService(Context.INPUT_METHOD_SERVICE);
         imm.restartInput(mViewState.getView());
+        mViewState.setText(text);
     }
 
     @Override


### PR DESCRIPTION
KeyboardServiceImpl's setText method was dropping the new text on
the floor instead of passing it on to the KeyboardServiceState.
Then it was passing the selection indices through, so they were
out of range, which the Android runtime doesn't like.

Fixes https://github.com/flutter/flutter/issues/964