### PR TITLE
Fully detach the IDL compiler from the build

### DIFF
--- a/sky/engine/bindings/BUILD.gn
+++ b/sky/engine/bindings/BUILD.gn
@@ -141,36 +141,13 @@ source_set("snapshot_cc") {
   ]
 }
 
-copy("copy_core_dart_files") {
-  sources = core_dart_files
-  outputs = [
-    "$bindings_output_dir/Custom{{source_file_part}}",
+copy("generate_dart_ui") {
+  sources = [
+    "dart_ui.dart",
   ]
-}
-
-action("generate_dart_ui") {
-  sources = core_dart_files
-  script = "$bindings_scripts_dir/compiler.py"
-
-  file_list = "$target_gen_dir/${target_name}_file_list.txt"
-  write_file(file_list, rebase_path(sources, root_build_dir))
-
-  inputs = sources + [ "scripts/templates/dart_blink.template" ]
+  sources += core_dart_files
 
   outputs = [
-    file_list,
-    "$bindings_output_dir/dart_ui.dart",
-  ]
-
-  args = [
-    "--output-directory",
-    rebase_path(bindings_output_dir, root_build_dir),
-    "--generate-dart-blink",
-    rebase_path(bindings_output_dir, root_build_dir),
-    rebase_path(file_list, root_build_dir),
-  ]
-
-  deps = [
-    ":copy_core_dart_files",
+    "$bindings_output_dir/{{source_file_part}}",
   ]
 }

--- a/sky/engine/bindings/dart_ui.dart
+++ b/sky/engine/bindings/dart_ui.dart
@@ -1,0 +1,31 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+library dart_ui;
+
+import 'dart:async';
+import 'dart:nativewrappers';
+import 'dart:typed_data';
+import 'dart:math' as math;
+
+part 'Color.dart';
+part 'FilterQuality.dart';
+part 'Offset.dart';
+part 'OffsetBase.dart';
+part 'Paint.dart';
+part 'PaintingStyle.dart';
+part 'Point.dart';
+part 'RRect.dart';
+part 'RSTransform.dart';
+part 'Rect.dart';
+part 'Size.dart';
+part 'TransferMode.dart';
+part 'compositing.dart';
+part 'hash_codes.dart';
+part 'hooks.dart';
+part 'lerp.dart';
+part 'natives.dart';
+part 'painting.dart';
+part 'text.dart';
+part 'window.dart';


### PR DESCRIPTION
Prior to this patch, we were still using it to generate dart_ui.dart.
We'll eventually want to reorganize the dart files in the engine. See
https://github.com/flutter/flutter/issues/1040 for some discussion.