### PR TITLE
Don't destroy the engine when detaching from the window

### DIFF
--- a/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
@@ -131,8 +131,7 @@ public class PlatformViewAndroid extends SurfaceView {
         return mSkyEngine;
     }
 
-    @Override
-    protected void onDetachedFromWindow() {
+    void destroy() {
         getHolder().removeCallback(mSurfaceCallback);
         nativeDetach(mNativePlatformView);
         mNativePlatformView = 0;

--- a/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -86,6 +86,9 @@ public class SkyActivity extends Activity {
      */
     @Override
     protected void onDestroy() {
+        if (mView != null) {
+            mView.destroy();
+        }
         // Do we need to shut down Sky too?
         mTracingController.stop();
         super.onDestroy();


### PR DESCRIPTION
Reading the Android docs, it sounds like an android.view.View can re-attach to
the window after detaching. Previously, we destroyed the engine when we
detached from the window. Now we wait for the activity to be destroyed.

Hopefully fixes https://github.com/flutter/flutter/issues/997