### PR TITLE
Start sketching out the Dart/Objective-C bridge

### DIFF
--- a/sky/engine/bindings/BUILD.gn
+++ b/sky/engine/bindings/BUILD.gn
@@ -37,6 +37,10 @@ source_set("bindings") {
     "//sky/engine/wtf",
   ]
 
+  if (is_mac) {
+    deps += [ "//sky/engine/bindings/objc" ]
+  }
+
   # On iOS (device), precompiled snapshots contain the instruction buffer.
   # Generation of the same requires all application specific script code to be
   # specified up front. In such cases, there can be no updater or generic

--- a/sky/engine/bindings/objc/BUILD.gn
+++ b/sky/engine/bindings/objc/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("objc") {
+  sources = [
+    "dart_objc.cc",
+    "dart_objc.h",
+  ]
+
+  deps = [
+    "//base",
+    "//dart/runtime:libdart",
+    "//sky/engine/tonic",
+    "//sky/engine/wtf",
+  ]
+}

--- a/sky/engine/bindings/objc/dart_objc.cc
+++ b/sky/engine/bindings/objc/dart_objc.cc
@@ -1,0 +1,82 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/engine/bindings/objc/dart_objc.h"
+
+#include <objc/message.h>
+#include <objc/runtime.h>
+
+#include "sky/engine/tonic/dart_args.h"
+#include "sky/engine/tonic/dart_binding_macros.h"
+#include "sky/engine/tonic/dart_converter.h"
+#include "sky/engine/tonic/dart_direct_wrappable.h"
+#include "sky/engine/tonic/dart_error.h"
+#include "sky/engine/tonic/dart_library_natives.h"
+#include "sky/engine/tonic/dart_wrappable.h"
+
+namespace blink {
+
+IMPLEMENT_DIRECT_WRAPPABLE(Selector, SEL)
+IMPLEMENT_DIRECT_WRAPPABLE(Ivar, Ivar)
+IMPLEMENT_DIRECT_WRAPPABLE(Property, objc_property_t)
+IMPLEMENT_DIRECT_WRAPPABLE(Method, Method)
+
+namespace {
+
+static DartLibraryNatives* g_natives;
+
+Dart_NativeFunction GetNativeFunction(Dart_Handle name,
+                                         int argument_count,
+                                         bool* auto_setup_scope) {
+  return g_natives->GetNativeFunction(name, argument_count, auto_setup_scope);
+}
+
+const uint8_t* GetSymbol(Dart_NativeFunction native_function) {
+  return g_natives->GetSymbol(native_function);
+}
+
+#define DART_OBJC_CALLBACK(CLASS, METHOD) \
+  static void Dart_##CLASS##_##METHOD(Dart_NativeArguments args) { \
+    DartCall(&CLASS##_##METHOD, args); \
+  }
+
+#define DART_REGISTER_OBJC(CLASS, METHOD) \
+  { #CLASS "_" #METHOD, Dart_##CLASS##_##METHOD, \
+    IndicesForSignature<decltype(&Dart_##CLASS##_##METHOD)>::count + 1, true },
+
+#define FOR_EACH_BINDING(V) \
+  V(ivar, getName) \
+  V(ivar, getOffset) \
+  V(ivar, getTypeEncoding) \
+  V(method, getName) \
+  V(method, getNumberOfArguments) \
+  V(method, getTypeEncoding) \
+  V(property, getAttributes) \
+  V(property, getName) \
+  V(sel, getName) \
+  V(sel, getUid) \
+  V(sel, isEqual) \
+  V(sel, isMapped) \
+  V(sel, registerName)
+
+FOR_EACH_BINDING(DART_OBJC_CALLBACK)
+
+}  // namespace
+
+void DartObjC::InitForGlobal() {
+  if (!g_natives) {
+    g_natives = new DartLibraryNatives();
+    g_natives->Register({
+FOR_EACH_BINDING(DART_REGISTER_OBJC)
+    });
+  }
+}
+
+void DartObjC::InitForIsolate() {
+  DCHECK(g_natives);
+  DART_CHECK_VALID(Dart_SetNativeResolver(
+      Dart_LookupLibrary(ToDart("dart:objc")), GetNativeFunction, GetSymbol));
+}
+
+}  // namespace blink

--- a/sky/engine/bindings/objc/dart_objc.dart
+++ b/sky/engine/bindings/objc/dart_objc.dart
@@ -1,0 +1,132 @@
+// Copyright 2016 Google, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+library dart_objc;
+
+import 'dart:nativewrappers';
+
+Object nil = null;
+bool YES = true;
+bool NO = false;
+
+class Selector extends NativeWrapper2 {
+  String get name native 'sel_getName';
+  bool get isMapped native 'sel_isMapped';
+  bool isEqual(Selector other) native 'sel_isEqual';
+
+  static Selector registerName(String name) native 'sel_registerName';
+  static Selector getUid(String name) native 'sel_getUid';
+}
+
+class AssociationPolicy {
+  AssociationPolicy._();
+
+  const int assign = 0;
+  const int retainNonatomic = 1;
+  const int copyNonatomic = 3;
+  const int retain = 01401;
+  const int copy = 01403;
+}
+
+class id extends NativeWrapper2 {
+  id copy(int size) native 'object_copy';
+  id dispose() native 'object_dispose';
+  Class get cls native 'object_getClass';
+  void set cls(Class cls) native 'object_setClass';
+  bool get isClass native 'object_isClass';
+  String get className native 'object_getClassName';
+  id getIvar(Ivar ivar) native 'object_getIvar';
+  void setIvar(Ivar ivar) native 'object_setIvar';
+  void setInstanceVariable(String name, int value) native 'object_setInstanceVariable';
+  int getInstanceVariable(String name) native 'object_getInstanceVariable';
+  void setAssociatedObject(int key, id value, int policy) native 'objc_setAssociatedObject';
+  id getAssociatedObject(int key) native 'objc_getAssociatedObject';
+  void removeAssociatedObjects() native 'objc_removeAssociatedObjects';
+
+  id msgSend(Selector selector, List args) native 'objc_msgSend';
+  id msgSendSuper(Selector selector, List args) native 'objc_msgSendSuper';
+}
+
+class Class extends NativeWrapper2 {
+  String get className native 'class_getName';
+  bool get isMetaClass native 'class_isMetaClass';
+  Class get superclass native 'class_getSuperclass';
+  void set superclass(Class cls) native 'class_setSuperclass';
+  int get version native 'class_getVersion'
+  void set version(int version) native 'class_setVersion';
+  int get instanceSize native 'class_getInstanceSize';
+  Ivar getInstanceVariable(String name) native 'class_getInstanceVariable';
+  Ivar getClassVariable(String name) native 'class_getClassVariable';
+  List<Ivar> copyIvarList() native 'class_copyIvarList';
+  Method getInstanceMethod(Selector selector) native 'class_getInstanceMethod';
+  Method getClassMethod(Selector selector) native 'class_getInstanceMethod';
+  bool respondsToSelector(Selector selector) native 'class_respondsToSelector';
+  List<Method> copyMethodList() native 'class_copyMethodList';
+  bool conformsToProtocol(Protocol protocol) native 'class_conformsToProtocol';
+  List<Protocol> copyProtocolList() native 'class_copyProtocolList';
+  Property getProperty(String name) native 'class_getProperty';
+  List<Property> copyPropertyList() native 'class_copyPropertyList';
+  String getIvarLayout() native 'class_getIvarLayout';
+  String getWeakIvarLayout() native 'class_getWeakIvarLayout';
+  bool addProtocol(Protocol protocol) native 'class_addProtocol';
+}
+
+class Protocol extends NativeWrapper2 {
+  bool conformsToProtocol(Protocol protocol) native 'protocol_conformsToProtocol';
+  bool isEqual(Protocol other) native 'protocol_isEqual';
+  String get name native 'protocol_getName';
+  MethodDescription getMethodDescription(Selector selector, bool isRequiredMethod, bool isInstanceMethod) native 'protocol_getMethodDescription';
+  List<MethodDescription> copyMethodDescriptionList(bool isRequiredMethod, bool isInstanceMethod) native 'protocol_copyMethodDescriptionList';
+  Property getProperty(String name, bool isRequiredProperty, bool isInstanceProperty) native 'protocol_getProperty';
+  List<Property> copyPropertyList() native 'protocol_copyPropertyList';
+  List<Protocol> copyProtocolList() native 'protocol_copyProtocolList';
+  void addMethodDescription(Selector selector, String types, bool isRequiredMethod, bool isInstanceMethod) native 'protocol_addMethodDescription';
+  void addProtocol(Protocol additional) native 'protocol_addProtocol';
+  void addProperty(String name, List<PropertyAttribute> attributes, bool isRequiredProperty, bool isInstanceProperty) native 'protocol_addProperty';
+}
+
+class Method extends NativeWrapper2 {
+  Selector get name native 'method_getName';
+  String get typeEncoding native 'method_getTypeEncoding';
+  String get numberOfArguments native 'method_getNumberOfArguments';
+  String get returnType native 'method_copyReturnType';
+  String getArgumentType(int index) native 'method_copyArgumentType';
+}
+
+class Ivar extends NativeWrapper2 {
+  String get name native 'ivar_getName';
+  String get typeEncoding native 'ivar_getTypeEncoding';
+  int get offset native 'ivar_getOffset';
+}
+
+class Property extends NativeWrapper2 {
+  String get name native 'property_getName';
+  String get value native 'property_copyAttributeValue';
+  String get attributes native 'property_getAttributes';
+  List<PropertyAttribute> copyAttributeList() native 'property_copyAttributeList';
+}
+
+class MethodDescription {
+  Selector name;
+  String types;
+}
+
+class PropertyAttribute {
+  String name;
+  String value;
+}
+
+Class getClass(String name) native 'objc_getClass';
+Class getMetaClass(String name) native 'objc_getMetaClass';
+Class lookUpClass(String name) native 'objc_lookUpClass';
+Class getRequiredClass(String name) native 'objc_getRequiredClass';
+List<Class> getClassList() native 'objc_getClassList';
+Class getFutureClass(String name) native 'objc_getFutureClass';
+Class allocateClassPair(Class superclass, String name, int extraBytes) native 'objc_allocateClassPair';
+void registerClassPair(Class cls) native 'objc_registerClassPair';
+void disposeClassPair(Class cls) native 'objc_disposeClassPair';
+Protocol getProtocol(String name) native 'objc_getProtocol';
+List<Protocol> copyProtocolList() native 'objc_copyProtocolList';
+Protocol allocateProtocol(String name) native 'objc_allocateProtocol';
+void registerProtocol(Protocol protocol) native 'objc_registerProtocol';

--- a/sky/engine/bindings/objc/dart_objc.h
+++ b/sky/engine/bindings/objc/dart_objc.h
@@ -1,0 +1,23 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_ENGINE_BINDINGS_OBJC_DART_OBJC_H_
+#define SKY_ENGINE_BINDINGS_OBJC_DART_OBJC_H_
+
+#include "base/macros.h"
+
+namespace blink {
+
+class DartObjC {
+ public:
+  static void InitForGlobal();
+  static void InitForIsolate();
+
+ private:
+  DISALLOW_IMPLICIT_CONSTRUCTORS(DartObjC);
+};
+
+}  // namespace blink
+
+#endif  // SKY_ENGINE_BINDINGS_OBJC_DART_OBJC_H_

--- a/sky/engine/tonic/BUILD.gn
+++ b/sky/engine/tonic/BUILD.gn
@@ -15,6 +15,8 @@ source_set("tonic") {
     "dart_converter.h",
     "dart_dependency_catcher.cc",
     "dart_dependency_catcher.h",
+    "dart_direct_wrappable.cc",
+    "dart_direct_wrappable.h",
     "dart_error.cc",
     "dart_error.h",
     "dart_exception_factory.cc",

--- a/sky/engine/tonic/dart_converter.h
+++ b/sky/engine/tonic/dart_converter.h
@@ -267,6 +267,29 @@ struct DartConverter<AtomicString> {
   }
 };
 
+template <>
+struct DartConverter<const char*> {
+  static Dart_Handle ToDart(const char* val) {
+    return Dart_NewStringFromCString(val);
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args, const char* val) {
+    Dart_SetReturnValue(args, ToDart(val));
+  }
+
+  static const char* FromDart(Dart_Handle handle) {
+    const char* result = nullptr;
+    Dart_StringToCString(handle, &result);
+    return result;
+  }
+
+  static const char* FromArguments(Dart_NativeArguments args,
+                                   int index,
+                                   Dart_Handle& exception) {
+    return FromDart(Dart_GetNativeArgument(args, index));
+  }
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 // Collections
 
@@ -342,8 +365,32 @@ struct DartConverter<DartValue*> {
   static PassRefPtr<DartValue> FromArguments(Dart_NativeArguments args,
                                              int index,
                                              Dart_Handle& exception) {
-    // TODO(abarth): What should we do with auto_scope?
     return FromDart(Dart_GetNativeArgument(args, index));
+  }
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Dart_Handle
+
+template <>
+struct DartConverter<Dart_Handle> {
+  static Dart_Handle ToDart(DartState* state, Dart_Handle val) {
+    return val;
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args, Dart_Handle val) {
+    Dart_SetReturnValue(args, val);
+  }
+
+  static Dart_Handle FromDart(Dart_Handle handle) {
+    return handle;
+  }
+
+  static Dart_Handle FromArguments(Dart_NativeArguments args,
+                                   int index,
+                                   Dart_Handle& exception) {
+    return Dart_GetNativeArgument(args, index);
   }
 };
 

--- a/sky/engine/tonic/dart_direct_wrappable.cc
+++ b/sky/engine/tonic/dart_direct_wrappable.cc
@@ -1,0 +1,53 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/engine/tonic/dart_direct_wrappable.h"
+
+#include "sky/engine/tonic/dart_class_library.h"
+#include "sky/engine/tonic/dart_error.h"
+#include "sky/engine/tonic/dart_state.h"
+#include "sky/engine/tonic/dart_wrappable.h"
+#include "sky/engine/tonic/dart_wrapper_info.h"
+
+namespace blink {
+
+Dart_Handle DartDirectWrappable<void*>::Wrap(
+    DartState* dart_state,
+    void* val,
+    const DartWrapperInfo& info) {
+  Dart_PersistentHandle type = dart_state->class_library().GetClass(info);
+  DCHECK(!LogIfError(type));
+
+  intptr_t native_fields[DartWrappable::kNumberOfNativeFields];
+  native_fields[DartWrappable::kPeerIndex] = reinterpret_cast<intptr_t>(val);
+  native_fields[DartWrappable::kWrapperInfoIndex] = reinterpret_cast<intptr_t>(&info);
+  Dart_Handle wrapper =
+      Dart_AllocateWithNativeFields(type, DartWrappable::kNumberOfNativeFields, native_fields);
+  DCHECK(!LogIfError(wrapper));
+  return wrapper;
+}
+
+void* DartDirectWrappable<void*>::FromDart(Dart_Handle handle) {
+  intptr_t peer = 0;
+  Dart_Handle result =
+      Dart_GetNativeInstanceField(handle, DartWrappable::kPeerIndex, &peer);
+  if (Dart_IsError(result))
+    return nullptr;
+  return reinterpret_cast<void*>(peer);
+}
+
+void* DartDirectWrappable<void*>::FromArguments(Dart_NativeArguments args,
+                                                int index,
+                                                Dart_Handle& exception) {
+  intptr_t native_fields[DartWrappable::kNumberOfNativeFields];
+  Dart_Handle result = Dart_GetNativeFieldsOfArgument(
+      args, index, DartWrappable::kNumberOfNativeFields, native_fields);
+  if (Dart_IsError(result)) {
+    exception = Dart_NewStringFromCString(DartError::kInvalidArgument);
+    return nullptr;
+  }
+  return reinterpret_cast<void*>(native_fields[DartWrappable::kPeerIndex]);
+}
+
+}  // namespace blink

--- a/sky/engine/tonic/dart_direct_wrappable.h
+++ b/sky/engine/tonic/dart_direct_wrappable.h
@@ -1,0 +1,84 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_ENGINE_TONIC_DART_DIRECT_WRAPPABLE_H_
+#define SKY_ENGINE_TONIC_DART_DIRECT_WRAPPABLE_H_
+
+#include "dart/runtime/include/dart_api.h"
+#include "sky/engine/tonic/dart_converter.h"
+
+namespace blink {
+class DartState;
+struct DartWrapperInfo;
+
+template<typename T>
+struct DartDirectWrappable;
+
+template<>
+struct DartDirectWrappable<void*> {
+  static Dart_Handle Wrap(DartState* dart_state, void* val,
+                          const DartWrapperInfo& info);
+  static void* FromDart(Dart_Handle handle);
+  static void* FromArguments(Dart_NativeArguments args,
+                             int index,
+                             Dart_Handle& exception);
+};
+
+template<typename T>
+struct DartDirectWrappable {
+  static Dart_Handle Wrap(DartState* dart_state, T val,
+                          const DartWrapperInfo& info) {
+    return DartDirectWrappable<void*>::Wrap(dart_state, static_cast<void*>(val),
+                                            info);
+  }
+
+  static T FromDart(Dart_Handle handle) {
+    return static_cast<T>(DartDirectWrappable<void*>::FromDart(handle));
+  }
+
+  static T FromArguments(Dart_NativeArguments args, int index,
+                         Dart_Handle& exception) {
+    return static_cast<T>(DartDirectWrappable<void*>::FromArguments(
+        args, index, exception));
+  }
+};
+
+template<typename T, const DartWrapperInfo& (*GetWrapperInfo)()>
+struct DartConverterDirectWrappable {
+  static Dart_Handle ToDart(T val) {
+    if (!val)
+      return Dart_Null();
+    return DartDirectWrappable<T>::Wrap(
+        DartState::Current(), val, GetWrapperInfo());
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args, T val) {
+    Dart_SetReturnValue(args, ToDart(val));
+  }
+
+  static T FromDart(Dart_Handle handle) {
+    return DartDirectWrappable<T>::FromDart(handle);
+  }
+
+  static T FromArguments(Dart_NativeArguments args,
+                         int index,
+                         Dart_Handle& exception) {
+    return DartDirectWrappable<T>::FromArguments(args, index, exception);
+  }
+};
+
+#define IMPLEMENT_DIRECT_WRAPPABLE(DartName, ImplType)                         \
+static const DartWrapperInfo kDartWrapperInfo_##DartName = {                   \
+  #DartName, 0, 0, 0,                                                          \
+};                                                                             \
+static const DartWrapperInfo& GetWrapperTypeInfo##DartName() {                 \
+  return kDartWrapperInfo_##DartName;                                          \
+}                                                                              \
+template <>                                                                    \
+struct DartConverter<ImplType> : public DartConverterDirectWrappable<          \
+    ImplType, GetWrapperTypeInfo##DartName> {};
+
+}  // namespace blink
+
+#endif  // SKY_ENGINE_TONIC_DART_DIRECT_WRAPPABLE_H_


### PR DESCRIPTION
This patch includes the start of a Dart/Objective-C bridge by exposing
(some of) the Objective-C ABI through a dart:objc built-in library.