### PR TITLE
Add Tonic macros for dispatching to static methods

### DIFF
--- a/sky/engine/tonic/dart_args.h
+++ b/sky/engine/tonic/dart_args.h
@@ -16,8 +16,8 @@ namespace blink {
 
 class DartArgIterator {
  public:
-  explicit DartArgIterator(Dart_NativeArguments args)
-      : args_(args), index_(1), had_exception_(false) { }
+  DartArgIterator(Dart_NativeArguments args, int start_index = 1)
+      : args_(args), index_(start_index), had_exception_(false) { }
 
   template<typename T>
   T GetNext() {
@@ -163,6 +163,16 @@ void DartCall(Sig func, Dart_NativeArguments args) {
   if (it.had_exception())
     return;
   decoder.Dispatch(func);
+}
+
+template<typename Sig>
+void DartCallStatic(Sig func, Dart_NativeArguments args) {
+  DartArgIterator it(args, 0);
+  using Indices = typename IndicesForSignature<Sig>::type;
+  DartDispatcher<Indices, Sig> decoder(&it);
+  if (it.had_exception())
+    return;
+  DartReturn(decoder.Dispatch(func), args);
 }
 
 template<typename Sig>

--- a/sky/engine/tonic/dart_binding_macros.h
+++ b/sky/engine/tonic/dart_binding_macros.h
@@ -12,9 +12,18 @@
     DartCall(&CLASS::METHOD, args); \
   }
 
+#define DART_NATIVE_CALLBACK_STATIC(CLASS, METHOD) \
+  static void CLASS_##METHOD(Dart_NativeArguments args) { \
+    DartCallStatic(&CLASS::METHOD, args); \
+  }
+
 #define DART_REGISTER_NATIVE(CLASS, METHOD) \
   { #CLASS "_" #METHOD, CLASS_##METHOD, \
     IndicesForSignature<decltype(&CLASS::METHOD)>::count + 1, true },
+
+#define DART_REGISTER_NATIVE_STATIC(CLASS, METHOD) \
+  { #CLASS "_" #METHOD, CLASS_##METHOD, \
+    IndicesForSignature<decltype(&CLASS::METHOD)>::count, true },
 
 #define DART_BIND_ALL(CLASS, FOR_EACH) \
 FOR_EACH(DART_NATIVE_CALLBACK) \


### PR DESCRIPTION
DartArgIterator was starting at argument index 1 because it assumed that the
arguments include a pointer to the "this" object for an instance method.
DART_REGISTER_NATIVE makes the same assumption in the argument count.

This change adds versions of the macros that are suitable for static methods
with no implicit arguments.