### PR TITLE
Move the JNI bridge out of dart:ui and into a separate dart:jni library

### DIFF
--- a/sky/engine/bindings/BUILD.gn
+++ b/sky/engine/bindings/BUILD.gn
@@ -37,10 +37,6 @@ source_set("bindings") {
     "//sky/engine/wtf",
   ]
 
-  if (is_android) {
-    deps += [ "//sky/engine/bindings/jni" ]
-  }
-
   # On iOS (device), precompiled snapshots contain the instruction buffer.
   # Generation of the same requires all application specific script code to be
   # specified up front. In such cases, there can be no updater or generic
@@ -82,6 +78,7 @@ action("generate_snapshot_bin") {
   dart_ui_internals_path =
       rebase_path("//sky/engine/bindings/internals.dart")
   dart_ui_path = rebase_path("$bindings_output_dir/dart_ui.dart")
+  dart_jni_path = rebase_path("//sky/engine/bindings/jni/jni.dart")
 
   gen_snapshot_dir =
       get_label_info("//dart/runtime/bin:gen_snapshot($host_toolchain)",
@@ -104,6 +101,7 @@ action("generate_snapshot_bin") {
     "--url_mapping=dart:mojo.internal,$dart_mojo_internal_path",
     "--url_mapping=dart:ui,$dart_ui_path",
     "--url_mapping=dart:ui_internals,$dart_ui_internals_path",
+    "--url_mapping=dart:jni,$dart_jni_path",
   ]
 }
 
@@ -148,7 +146,6 @@ source_set("snapshot_cc") {
 copy("generate_dart_ui") {
   sources = [
     "dart_ui.dart",
-    "jni/jni.dart",
   ]
   sources += core_dart_files
 

--- a/sky/engine/bindings/dart_ui.cc
+++ b/sky/engine/bindings/dart_ui.cc
@@ -25,10 +25,6 @@
 #include "sky/engine/tonic/dart_converter.h"
 #include "sky/engine/tonic/dart_error.h"
 
-#ifdef OS_ANDROID
-#include "sky/engine/bindings/jni/dart_jni.h"
-#endif
-
 namespace blink {
 namespace {
 
@@ -67,11 +63,6 @@ void DartUI::InitForGlobal() {
     Scene::RegisterNatives(g_natives);
     SceneBuilder::RegisterNatives(g_natives);
     Window::RegisterNatives(g_natives);
-
-#ifdef OS_ANDROID
-    // TODO(jsimmons): move this into a dart:jni library
-    DartJni::RegisterNatives(g_natives);
-#endif
   }
 }
 

--- a/sky/engine/bindings/dart_ui.dart
+++ b/sky/engine/bindings/dart_ui.dart
@@ -24,7 +24,6 @@ part 'TransferMode.dart';
 part 'compositing.dart';
 part 'hash_codes.dart';
 part 'hooks.dart';
-part 'jni.dart';
 part 'lerp.dart';
 part 'natives.dart';
 part 'painting.dart';

--- a/sky/engine/bindings/jni/dart_jni.h
+++ b/sky/engine/bindings/jni/dart_jni.h
@@ -16,7 +16,8 @@ namespace blink {
 
 class DartJni {
  public:
-  static void RegisterNatives(DartLibraryNatives* natives);
+  static void InitForGlobal();
+  static void InitForIsolate();
   static bool InitJni();
 
   static base::android::ScopedJavaLocalRef<jclass> GetClass(

--- a/sky/engine/bindings/jni/jni.dart
+++ b/sky/engine/bindings/jni/jni.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+library dart_jni;
+
+import 'dart:nativewrappers';
 
 /// Wrapper for a Java class accessed via JNI.
 class JniClass extends NativeFieldWrapperClass2 {

--- a/sky/engine/bindings/snapshot.dart
+++ b/sky/engine/bindings/snapshot.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'dart:core';
 import 'dart:io';
 import 'dart:isolate';
+import 'dart:jni';
 import 'dart:math';
 import 'dart:mojo.internal';
 import 'dart:ui';

--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -73,6 +73,10 @@ static_library("core") {
     "//mojo/services/navigation/interfaces",
   ]
 
+  if (is_android) {
+    deps += [ "//sky/engine/bindings/jni" ]
+  }
+
   sources = sky_core_files
 
   sources += [ "$target_gen_dir/sky_embedder_service_isolate_resources.cc" ]

--- a/sky/engine/core/compositing/Scene.cpp
+++ b/sky/engine/core/compositing/Scene.cpp
@@ -13,7 +13,7 @@
 
 namespace blink {
 
-IMPLEMENT_WRAPPERTYPEINFO(Scene);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Scene);
 
 #define FOR_EACH_BINDING(V) \
   V(Scene, dispose)

--- a/sky/engine/core/compositing/SceneBuilder.cpp
+++ b/sky/engine/core/compositing/SceneBuilder.cpp
@@ -37,7 +37,7 @@ static void SceneBuilder_pushTransform(Dart_NativeArguments args) {
     Dart_ThrowException(es.GetDartException(args, true));
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(SceneBuilder);
+IMPLEMENT_WRAPPERTYPEINFO(ui, SceneBuilder);
 
 #define FOR_EACH_BINDING(V) \
   V(SceneBuilder, pushClipRect) \

--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -33,7 +33,7 @@ static void Canvas_concat(Dart_NativeArguments args) {
     Dart_ThrowException(es.GetDartException(args, true));
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(Canvas);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
 
 #define FOR_EACH_BINDING(V) \
   V(Canvas, save) \

--- a/sky/engine/core/painting/CanvasGradient.cpp
+++ b/sky/engine/core/painting/CanvasGradient.cpp
@@ -17,7 +17,7 @@ static void Gradient_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&CanvasGradient::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(Gradient);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Gradient);
 
 #define FOR_EACH_BINDING(V) \
   V(Gradient, initLinear) \

--- a/sky/engine/core/painting/CanvasImage.cpp
+++ b/sky/engine/core/painting/CanvasImage.cpp
@@ -13,7 +13,7 @@ namespace blink {
 
 typedef CanvasImage Image;
 
-IMPLEMENT_WRAPPERTYPEINFO(Image);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Image);
 
 #define FOR_EACH_BINDING(V) \
   V(Image, width) \

--- a/sky/engine/core/painting/CanvasPath.cpp
+++ b/sky/engine/core/painting/CanvasPath.cpp
@@ -17,7 +17,7 @@ static void Path_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&CanvasPath::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(Path);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Path);
 
 #define FOR_EACH_BINDING(V) \
   V(Path, moveTo) \

--- a/sky/engine/core/painting/ColorFilter.cpp
+++ b/sky/engine/core/painting/ColorFilter.cpp
@@ -15,7 +15,7 @@ static void ColorFilter_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&ColorFilter::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(ColorFilter);
+IMPLEMENT_WRAPPERTYPEINFO(ui, ColorFilter);
 
 void ColorFilter::RegisterNatives(DartLibraryNatives* natives) {
   natives->Register({

--- a/sky/engine/core/painting/DrawLooper.cpp
+++ b/sky/engine/core/painting/DrawLooper.cpp
@@ -6,7 +6,7 @@
 
 namespace blink {
 
-IMPLEMENT_WRAPPERTYPEINFO(DrawLooper);
+IMPLEMENT_WRAPPERTYPEINFO(ui, DrawLooper);
 
 DrawLooper::DrawLooper(PassRefPtr<SkDrawLooper> looper)
     : looper_(looper) {

--- a/sky/engine/core/painting/DrawLooperLayerInfo.cpp
+++ b/sky/engine/core/painting/DrawLooperLayerInfo.cpp
@@ -15,7 +15,7 @@ static void DrawLooperLayerInfo_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&DrawLooperLayerInfo::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(DrawLooperLayerInfo);
+IMPLEMENT_WRAPPERTYPEINFO(ui, DrawLooperLayerInfo);
 
 #define FOR_EACH_BINDING(V) \
   V(DrawLooperLayerInfo, setPaintBits) \

--- a/sky/engine/core/painting/ImageShader.cpp
+++ b/sky/engine/core/painting/ImageShader.cpp
@@ -29,7 +29,7 @@ static void ImageShader_initWithImage(Dart_NativeArguments args) {
     Dart_ThrowException(es.GetDartException(args, true));
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(ImageShader);
+IMPLEMENT_WRAPPERTYPEINFO(ui, ImageShader);
 
 void ImageShader::RegisterNatives(DartLibraryNatives* natives) {
   natives->Register({

--- a/sky/engine/core/painting/LayerDrawLooperBuilder.cpp
+++ b/sky/engine/core/painting/LayerDrawLooperBuilder.cpp
@@ -19,7 +19,7 @@ static void LayerDrawLooperBuilder_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&LayerDrawLooperBuilder::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(LayerDrawLooperBuilder);
+IMPLEMENT_WRAPPERTYPEINFO(ui, LayerDrawLooperBuilder);
 
 #define FOR_EACH_BINDING(V) \
   V(LayerDrawLooperBuilder, build) \

--- a/sky/engine/core/painting/MaskFilter.cpp
+++ b/sky/engine/core/painting/MaskFilter.cpp
@@ -16,7 +16,7 @@ static void MaskFilter_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&MaskFilter::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(MaskFilter);
+IMPLEMENT_WRAPPERTYPEINFO(ui, MaskFilter);
 
 void MaskFilter::RegisterNatives(DartLibraryNatives* natives) {
   natives->Register({

--- a/sky/engine/core/painting/Picture.cpp
+++ b/sky/engine/core/painting/Picture.cpp
@@ -12,7 +12,7 @@
 
 namespace blink {
 
-IMPLEMENT_WRAPPERTYPEINFO(Picture);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Picture);
 
 #define FOR_EACH_BINDING(V) \
   V(Picture, playback) \

--- a/sky/engine/core/painting/PictureRecorder.cpp
+++ b/sky/engine/core/painting/PictureRecorder.cpp
@@ -17,7 +17,7 @@ static void PictureRecorder_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&PictureRecorder::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(PictureRecorder);
+IMPLEMENT_WRAPPERTYPEINFO(ui, PictureRecorder);
 
 #define FOR_EACH_BINDING(V) \
   V(PictureRecorder, isRecording) \

--- a/sky/engine/core/painting/Shader.cpp
+++ b/sky/engine/core/painting/Shader.cpp
@@ -6,7 +6,7 @@
 
 namespace blink {
 
-IMPLEMENT_WRAPPERTYPEINFO(Shader);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Shader);
 
 Shader::Shader(PassRefPtr<SkShader> shader)
     : shader_(shader) {

--- a/sky/engine/core/script/dart_controller.cc
+++ b/sky/engine/core/script/dart_controller.cc
@@ -32,6 +32,10 @@
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/MakeUnique.h"
 
+#ifdef OS_ANDROID
+#include "sky/engine/bindings/jni/dart_jni.h"
+#endif
+
 namespace blink {
 namespace {
 
@@ -157,8 +161,16 @@ void DartController::CreateIsolateFor(std::unique_ptr<DOMDartState> state) {
     DartMojoInternal::InitForIsolate();
     DartRuntimeHooks::Install(DartRuntimeHooks::MainIsolate);
 
-    dart_state()->class_library().set_provider(
+    dart_state()->class_library().add_provider(
+      "ui",
       WTF::MakeUnique<DartClassProvider>(dart_state(), "dart:ui"));
+
+#ifdef OS_ANDROID
+    DartJni::InitForIsolate();
+    dart_state()->class_library().add_provider(
+      "jni",
+      WTF::MakeUnique<DartClassProvider>(dart_state(), "dart:jni"));
+#endif
   }
   Dart_ExitIsolate();
 }

--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -33,6 +33,10 @@
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/tonic/uint8_list.h"
 
+#ifdef OS_ANDROID
+#include "sky/engine/bindings/jni/dart_jni.h"
+#endif
+
 namespace dart {
 namespace observatory {
 
@@ -121,6 +125,9 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
       DartIO::InitForIsolate();
       DartUI::InitForIsolate();
       DartMojoInternal::InitForIsolate();
+#ifdef OS_ANDROID
+      DartJni::InitForIsolate();
+#endif
       DartRuntimeHooks::Install(DartRuntimeHooks::DartIOIsolate);
       if (SkySettings::Get().enable_observatory) {
         std::string ip = "127.0.0.1";
@@ -151,6 +158,9 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
     DartIO::InitForIsolate();
     DartUI::InitForIsolate();
     DartMojoInternal::InitForIsolate();
+#ifdef OS_ANDROID
+    DartJni::InitForIsolate();
+#endif
 
     if (!script_uri)
       CreateEmptyRootLibraryIfNeeded();
@@ -291,6 +301,9 @@ void InitDartVM() {
   }
 
   DartUI::InitForGlobal();
+#ifdef OS_ANDROID
+  DartJni::InitForGlobal();
+#endif
 
   {
     TRACE_EVENT0("flutter", "Dart_Initialize");

--- a/sky/engine/core/text/Paragraph.cpp
+++ b/sky/engine/core/text/Paragraph.cpp
@@ -15,7 +15,7 @@
 
 namespace blink {
 
-IMPLEMENT_WRAPPERTYPEINFO(Paragraph);
+IMPLEMENT_WRAPPERTYPEINFO(ui, Paragraph);
 
 #define FOR_EACH_BINDING(V) \
   V(Paragraph, minWidth) \

--- a/sky/engine/core/text/ParagraphBuilder.cpp
+++ b/sky/engine/core/text/ParagraphBuilder.cpp
@@ -107,7 +107,7 @@ static void ParagraphBuilder_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&ParagraphBuilder::create, args);
 }
 
-IMPLEMENT_WRAPPERTYPEINFO(ParagraphBuilder);
+IMPLEMENT_WRAPPERTYPEINFO(ui, ParagraphBuilder);
 
 #define FOR_EACH_BINDING(V) \
   V(ParagraphBuilder, pushStyle) \

--- a/sky/engine/tonic/dart_class_library.cc
+++ b/sky/engine/tonic/dart_class_library.cc
@@ -19,14 +19,16 @@ DartClassLibrary::~DartClassLibrary() {
 }
 
 Dart_PersistentHandle DartClassLibrary::GetClass(const DartWrapperInfo& info) {
-  DCHECK(provider_);
-
   const auto& result = cache_.insert(std::make_pair(&info, nullptr));
   if (!result.second) {
     // Already present, return value.
     return result.first->second;
   }
-  Dart_Handle class_handle = provider_->GetClassByName(info.interface_name);
+
+  auto it = providers_.find(info.library_name);
+  DCHECK(it != providers_.end());
+
+  Dart_Handle class_handle = it->second->GetClassByName(info.interface_name);
   result.first->second = Dart_NewPersistentHandle(class_handle);
   return result.first->second;
 }

--- a/sky/engine/tonic/dart_class_library.h
+++ b/sky/engine/tonic/dart_class_library.h
@@ -20,14 +20,16 @@ class DartClassLibrary {
   explicit DartClassLibrary();
   ~DartClassLibrary();
 
-  void set_provider(std::unique_ptr<DartClassProvider> provider) {
-    provider_ = std::move(provider);
+  void add_provider(const std::string& library_name,
+                    std::unique_ptr<DartClassProvider> provider) {
+    providers_.insert(std::make_pair(library_name, std::move(provider)));
   }
 
   Dart_PersistentHandle GetClass(const DartWrapperInfo& info);
 
  private:
-  std::unique_ptr<DartClassProvider> provider_;
+  std::unordered_map<std::string, std::unique_ptr<DartClassProvider>>
+      providers_;
   std::unordered_map<const DartWrapperInfo*, Dart_PersistentHandle> cache_;
 
   DISALLOW_COPY_AND_ASSIGN(DartClassLibrary);

--- a/sky/engine/tonic/dart_direct_wrappable.h
+++ b/sky/engine/tonic/dart_direct_wrappable.h
@@ -68,16 +68,16 @@ struct DartConverterDirectWrappable {
   }
 };
 
-#define IMPLEMENT_DIRECT_WRAPPABLE(DartName, ImplType)                         \
-static const DartWrapperInfo kDartWrapperInfo_##DartName = {                   \
-  #DartName, 0, 0, 0,                                                          \
+#define IMPLEMENT_DIRECT_WRAPPABLE(LibraryName, DartName, ImplType)            \
+static const DartWrapperInfo kDartWrapperInfo_##LibraryName_##DartName = {     \
+  #LibraryName, #DartName, 0, 0, 0,                                            \
 };                                                                             \
-static const DartWrapperInfo& GetWrapperTypeInfo##DartName() {                 \
-  return kDartWrapperInfo_##DartName;                                          \
+static const DartWrapperInfo& GetWrapperTypeInfo_##LibraryName_##DartName() {  \
+  return kDartWrapperInfo_##LibraryName_##DartName;                            \
 }                                                                              \
 template <>                                                                    \
 struct DartConverter<ImplType> : public DartConverterDirectWrappable<          \
-    ImplType, GetWrapperTypeInfo##DartName> {};
+    ImplType, GetWrapperTypeInfo_##LibraryName_##DartName> {};
 
 }  // namespace blink
 

--- a/sky/engine/tonic/dart_wrappable.h
+++ b/sky/engine/tonic/dart_wrappable.h
@@ -65,20 +65,22 @@ class DartWrappable {
  private:                                                                      \
   static const DartWrapperInfo& dart_wrapper_info_
 
-#define IMPLEMENT_WRAPPERTYPEINFO(ClassName)                                   \
-static void RefObject_##ClassName(DartWrappable* impl) {                       \
+#define IMPLEMENT_WRAPPERTYPEINFO(LibraryName, ClassName)                      \
+static void RefObject_##LibraryName_##ClassName(DartWrappable* impl) {         \
   static_cast<ClassName*>(impl)->ref();                                        \
 }                                                                              \
-static void DerefObject_##ClassName(DartWrappable* impl) {                     \
+static void DerefObject_##LibraryName_##ClassName(DartWrappable* impl) {       \
   static_cast<ClassName*>(impl)->deref();                                      \
 }                                                                              \
-static const DartWrapperInfo kDartWrapperInfo_##ClassName = {                  \
+static const DartWrapperInfo kDartWrapperInfo_##LibraryName_##ClassName = {    \
+  #LibraryName,                                                                \
   #ClassName,                                                                  \
   sizeof(ClassName),                                                           \
-  &RefObject_##ClassName,                                                      \
-  &DerefObject_##ClassName,                                                    \
+  &RefObject_##LibraryName_##ClassName,                                        \
+  &DerefObject_##LibraryName_##ClassName,                                      \
 };                                                                             \
-const DartWrapperInfo& ClassName::dart_wrapper_info_ = kDartWrapperInfo_##ClassName;
+const DartWrapperInfo& ClassName::dart_wrapper_info_ =                         \
+    kDartWrapperInfo_##LibraryName_##ClassName;
 
 struct DartConverterWrappable {
   static DartWrappable* FromDart(Dart_Handle handle);

--- a/sky/engine/tonic/dart_wrapper_info.h
+++ b/sky/engine/tonic/dart_wrapper_info.h
@@ -13,6 +13,7 @@ class DartWrappable;
 typedef void (*DartWrappableAccepter)(DartWrappable*);
 
 struct DartWrapperInfo {
+  const char* library_name;
   const char* interface_name;
   const size_t size_in_bytes;
   const DartWrappableAccepter ref_object;


### PR DESCRIPTION
This also extends DartClassLibrary to support multiple DartClassProviders
for different libraries