### PR TITLE
Preroll rasterization

### DIFF
--- a/sky/compositor/container_layer.cc
+++ b/sky/compositor/container_layer.cc
@@ -18,6 +18,17 @@ void ContainerLayer::Add(std::unique_ptr<Layer> layer) {
   layers_.push_back(std::move(layer));
 }
 
+void ContainerLayer::Preroll(PaintContext::ScopedFrame& frame,
+                             const SkMatrix& matrix) {
+  PrerollChildren(frame, matrix);
+}
+
+void ContainerLayer::PrerollChildren(PaintContext::ScopedFrame& frame,
+                                     const SkMatrix& matrix) {
+  for (auto& layer : layers_)
+    layer->Preroll(frame, matrix);
+}
+
 void ContainerLayer::PaintChildren(PaintContext::ScopedFrame& frame) const {
   for (auto& layer : layers_)
     layer->Paint(frame);

--- a/sky/compositor/container_layer.h
+++ b/sky/compositor/container_layer.h
@@ -18,6 +18,10 @@ class ContainerLayer : public Layer {
 
   void Add(std::unique_ptr<Layer> layer);
 
+  void Preroll(PaintContext::ScopedFrame& frame,
+               const SkMatrix& matrix) override;
+
+  void PrerollChildren(PaintContext::ScopedFrame& frame, const SkMatrix& matrix);
   void PaintChildren(PaintContext::ScopedFrame& frame) const;
 
   const std::vector<std::unique_ptr<Layer>>& layers() const { return layers_; }

--- a/sky/compositor/layer.cc
+++ b/sky/compositor/layer.cc
@@ -18,5 +18,8 @@ Layer::Layer()
 Layer::~Layer() {
 }
 
+void Layer::Preroll(PaintContext::ScopedFrame& frame, const SkMatrix& matrix) {
+}
+
 }  // namespace compositor
 }  // namespace sky

--- a/sky/compositor/layer.h
+++ b/sky/compositor/layer.h
@@ -31,6 +31,8 @@ class Layer {
   Layer();
   virtual ~Layer();
 
+  virtual void Preroll(PaintContext::ScopedFrame& frame,
+                       const SkMatrix& matrix);
   virtual void Paint(PaintContext::ScopedFrame& frame) = 0;
 
   ContainerLayer* parent() const { return parent_; }

--- a/sky/compositor/layer_tree.cc
+++ b/sky/compositor/layer_tree.cc
@@ -15,5 +15,10 @@ LayerTree::LayerTree() : rasterizer_tracing_threashold_(0) {
 LayerTree::~LayerTree() {
 }
 
+void LayerTree::Raster(PaintContext::ScopedFrame& frame) {
+  root_layer_->Preroll(frame, SkMatrix());
+  root_layer_->Paint(frame);
+}
+
 }  // namespace compositor
 }  // namespace sky

--- a/sky/compositor/layer_tree.h
+++ b/sky/compositor/layer_tree.h
@@ -21,6 +21,8 @@ class LayerTree {
   LayerTree();
   ~LayerTree();
 
+  void Raster(PaintContext::ScopedFrame& frame);
+
   Layer* root_layer() const { return root_layer_.get(); }
 
   void set_root_layer(std::unique_ptr<Layer> root_layer) {

--- a/sky/compositor/paint_context.cc
+++ b/sky/compositor/paint_context.cc
@@ -28,8 +28,9 @@ void PaintContext::endFrame(ScopedFrame& frame, bool enableInstrumentation) {
   }
 }
 
-PaintContext::ScopedFrame PaintContext::AcquireFrame(SkCanvas& canvas) {
-  return ScopedFrame(*this, canvas);
+PaintContext::ScopedFrame PaintContext::AcquireFrame(GrContext* gr_context,
+                                                     SkCanvas& canvas) {
+  return ScopedFrame(*this, gr_context, canvas);
 }
 
 PaintContext::ScopedFrame PaintContext::AcquireFrame(
@@ -38,8 +39,11 @@ PaintContext::ScopedFrame PaintContext::AcquireFrame(
   return ScopedFrame(*this, trace_file_name, frame_size);
 }
 
-PaintContext::ScopedFrame::ScopedFrame(PaintContext& context, SkCanvas& canvas)
-    : context_(context), canvas_(&canvas), instrumentation_enabled_(true) {
+PaintContext::ScopedFrame::ScopedFrame(PaintContext& context,
+                                       GrContext* gr_context,
+                                       SkCanvas& canvas)
+    : context_(context), gr_context_(gr_context), canvas_(&canvas),
+      instrumentation_enabled_(true) {
   context_.beginFrame(*this, instrumentation_enabled_);
 }
 

--- a/sky/compositor/paint_context.h
+++ b/sky/compositor/paint_context.h
@@ -26,6 +26,7 @@ class PaintContext {
     SkCanvas& canvas() { return *canvas_; }
 
     PaintContext& context() const { return context_; }
+    GrContext* gr_context() const { return gr_context_; }
 
     ScopedFrame(ScopedFrame&& frame);
 
@@ -33,12 +34,13 @@ class PaintContext {
 
    private:
     PaintContext& context_;
+    GrContext* gr_context_;
     SkCanvas* canvas_;
     std::string trace_file_name_;
     std::unique_ptr<SkPictureRecorder> trace_recorder_;
     const bool instrumentation_enabled_;
 
-    ScopedFrame(PaintContext& context, SkCanvas& canvas);
+    ScopedFrame(PaintContext& context, GrContext* gr_context, SkCanvas& canvas);
 
     ScopedFrame(PaintContext& context,
                 const std::string& trace_file_name,
@@ -52,7 +54,7 @@ class PaintContext {
   PaintContext();
   ~PaintContext();
 
-  ScopedFrame AcquireFrame(SkCanvas& canvas);
+  ScopedFrame AcquireFrame(GrContext* gr_context, SkCanvas& canvas);
 
   ScopedFrame AcquireFrame(const std::string& trace_file_name,
                            gfx::Size frame_size);

--- a/sky/compositor/picture_layer.h
+++ b/sky/compositor/picture_layer.h
@@ -21,11 +21,16 @@ class PictureLayer : public Layer {
 
   SkPicture* picture() const { return picture_.get(); }
 
+  void Preroll(PaintContext::ScopedFrame& frame,
+               const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:
   SkPoint offset_;
   RefPtr<SkPicture> picture_;
+
+  // If we rasterized the picture separately, image_ holds the pixels.
+  RefPtr<SkImage> image_;
 
   DISALLOW_COPY_AND_ASSIGN(PictureLayer);
 };

--- a/sky/compositor/transform_layer.cc
+++ b/sky/compositor/transform_layer.cc
@@ -13,6 +13,13 @@ TransformLayer::TransformLayer() {
 TransformLayer::~TransformLayer() {
 }
 
+void TransformLayer::Preroll(PaintContext::ScopedFrame& frame,
+                             const SkMatrix& matrix) {
+  SkMatrix childMatrix;
+  childMatrix.setConcat(matrix, transform_);
+  PrerollChildren(frame, childMatrix);
+}
+
 void TransformLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkCanvas& canvas = frame.canvas();
   canvas.save();

--- a/sky/compositor/transform_layer.h
+++ b/sky/compositor/transform_layer.h
@@ -17,6 +17,8 @@ class TransformLayer : public ContainerLayer {
 
   void set_transform(const SkMatrix& transform) { transform_ = transform; }
 
+  void Preroll(PaintContext::ScopedFrame& frame,
+               const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:

--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -89,9 +89,9 @@ void RasterizerDirect::Draw(uint64_t layer_tree_ptr,
     SkCanvas* canvas = ganesh_canvas_.GetCanvas(
       surface_->GetBackingFrameBufferObject(), layer_tree->frame_size());
     sky::compositor::PaintContext::ScopedFrame frame =
-        paint_context_.AcquireFrame(*canvas);
+        paint_context_.AcquireFrame(ganesh_canvas_.gr_context(), *canvas);
     canvas->clear(SK_ColorBLACK);
-    layer_tree->root_layer()->Paint(frame);
+    layer_tree->Raster(frame);
     canvas->flush();
     surface_->SwapBuffers();
   }

--- a/sky/shell/gpu/ganesh_canvas.h
+++ b/sky/shell/gpu/ganesh_canvas.h
@@ -26,6 +26,8 @@ class GaneshCanvas {
 
   bool IsValid();
 
+  GrContext* gr_context() { return gr_context_.get(); }
+
  private:
   skia::RefPtr<GrContext> gr_context_;
   skia::RefPtr<SkSurface> sk_surface_;

--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -63,9 +63,9 @@ void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
                    layer_tree->frame_size().height());
   SkCanvas* canvas = ganesh_canvas_.GetCanvas(0, layer_tree->frame_size());
   sky::compositor::PaintContext::ScopedFrame frame =
-      paint_context_.AcquireFrame(*canvas);
+      paint_context_.AcquireFrame(ganesh_canvas_.gr_context(), *canvas);
   canvas->clear(SK_ColorBLACK);
-  layer_tree->root_layer()->Paint(frame);
+  layer_tree->Raster(frame);
   canvas->flush();
   MGLSwapBuffers();
   callback.Run();


### PR DESCRIPTION
Prerolling the rasterization tasks reduces the number of render target
switches because we don't interrupt the main render target.