### PR TITLE
Use the cull rect to select the rasterize size

### DIFF
--- a/sky/compositor/raster_cache.cc
+++ b/sky/compositor/raster_cache.cc
@@ -32,8 +32,15 @@ RasterCache::Entry::Entry() {
 RasterCache::Entry::~Entry() {
 }
 
-RefPtr<SkImage> RasterCache::GetImage(
-    SkPicture* picture, const SkISize& physical_size) {
+RefPtr<SkImage> RasterCache::GetImage(SkPicture* picture, const SkMatrix& ctm) {
+  SkScalar scaleX = ctm.getScaleX();
+  SkScalar scaleY = ctm.getScaleY();
+
+  SkRect rect = picture->cullRect();
+
+  SkISize physical_size = SkISize::Make(rect.width() * scaleX,
+                                        rect.height() * scaleY);
+
   if (physical_size.isEmpty())
     return nullptr;
 
@@ -57,8 +64,9 @@ RefPtr<SkImage> RasterCache::GetImage(
     entry.access_count = kRasterThreshold;
 
     if (!entry.image && isWorthRasterizing(picture)) {
+      SkMatrix matrix = SkMatrix::MakeScale(scaleX, scaleY);
       entry.image = adoptRef(SkImage::NewFromPicture(picture, physical_size,
-                                                     nullptr, nullptr));
+                                                     &matrix, nullptr));
     }
   }
 

--- a/sky/compositor/raster_cache.h
+++ b/sky/compositor/raster_cache.h
@@ -23,7 +23,7 @@ class RasterCache {
   RasterCache();
   ~RasterCache();
 
-  RefPtr<SkImage> GetImage(SkPicture* picture, const SkISize& physical_size);
+  RefPtr<SkImage> GetImage(SkPicture* picture, const SkMatrix& ctm);
   void SweepAfterFrame();
 
  private:


### PR DESCRIPTION
Using the picture's cull rect to select the size of the texture is more
accurate than using the paint bounds. The cull rect captures shadows and
other "out of bounds" drawing as well as shrinks down around empty space
in the recording.