### PR TITLE
The build failed without Firebase

### DIFF
--- a/sky/services/firebase/BUILD.gn
+++ b/sky/services/firebase/BUILD.gn
@@ -7,12 +7,16 @@
 
 import("//mojo/public/tools/bindings/mojom.gni")
 
+declare_args() {                                                                
+  enable_firebase = false                                                 
+}
+
 group("firebase") {
   deps = [
     ":interfaces",
   ]
 
-  if (is_ios || is_android) {
+  if (enable_firebase && (is_ios || is_android)) {
     deps += [ ":firebase_lib" ]
   }
 }
@@ -22,6 +26,8 @@ mojom("interfaces") {
     "firebase.mojom",
   ]
 }
+
+if (enable_firebase) {
 
 if (is_android) {
   import("//build/config/android/config.gni")
@@ -80,4 +86,6 @@ if (is_ios) {
       "-ObjC",
     ]
   }
+}
+
 }


### PR DESCRIPTION
Firebase shouldn't be needed to build Flutter.