### PR TITLE
StatisticsLayer was shifting subsequent paints.

### DIFF
--- a/sky/compositor/statistics_layer.cc
+++ b/sky/compositor/statistics_layer.cc
@@ -66,7 +66,7 @@ void StatisticsLayer::Paint(PaintContext::ScopedFrame& frame) {
   using Opt = CompositorOptions::Option;
 
   SkScalar width = has_paint_bounds() ? paint_bounds().width() : 0;
-  SkAutoCanvasRestore save(&frame.canvas(), false);
+  SkAutoCanvasRestore save(&frame.canvas(), true);
 
   VisualizeStopWatch(frame.canvas(), frame.context().frame_time(), width,
                      options_.isEnabled(Opt::VisualizeRasterizerStatistics),


### PR DESCRIPTION
Turns out we weren't actually saving and restoring the matrix, so our
combined 180.0 pixel downshift was also affecting all subsequent
paints in the frame.