### PR TITLE
Use a slightly faster path for drawImage

### DIFF
--- a/sky/engine/core/dart/painting.dart
+++ b/sky/engine/core/dart/painting.dart
@@ -246,7 +246,13 @@ class Canvas extends NativeFieldWrapperClass2 {
   void drawCircle(Point c, double radius, Paint paint) native "Canvas_drawCircle";
   void drawPath(Path path, Paint paint) native "Canvas_drawPath";
   void drawImage(Image image, Point p, Paint paint) native "Canvas_drawImage";
+
+  /// Drawss the src rect from the image into the canvas as dst rect.
+  ///
+  /// Might sample from outside the src rect by half the width of an applied
+  /// filter.
   void drawImageRect(Image image, Rect src, Rect dst, Paint paint) native "Canvas_drawImageRect";
+
   void drawImageNine(Image image, Rect center, Rect dst, Paint paint) native "Canvas_drawImageNine";
   void drawPicture(Picture picture) native "Canvas_drawPicture";
 

--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -284,7 +284,7 @@ void Canvas::drawImageRect(const CanvasImage* image, Rect& src, Rect& dst, const
     if (!m_canvas)
         return;
     ASSERT(image);
-    m_canvas->drawImageRect(image->image(), src.sk_rect, dst.sk_rect, paint.paint());
+    m_canvas->drawImageRect(image->image(), src.sk_rect, dst.sk_rect, paint.paint(), SkCanvas::kFast_SrcRectConstraint);
 }
 
 void Canvas::drawImageNine(const CanvasImage* image, Rect& center, Rect& dst, const Paint& paint) {


### PR DESCRIPTION
We don't need the strict mode for legacy compatibility because we don't have
any legacy yet. At some point, we might want to expose the strict mode for
people who want to pack their sprite sheets very tightly, but the sprites
library uses drawAtlas instead already.