### PR TITLE
Fix bindings for drawAtlas

### DIFF
--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -307,7 +307,7 @@ void Canvas::drawPicture(Picture* picture)
 void Canvas::drawVertices(SkCanvas::VertexMode vertexMode,
         const Vector<Point>& vertices,
         const Vector<Point>& textureCoordinates,
-        const Vector<SkColor>& colors,
+        const Vector<CanvasColor>& colors,
         TransferMode transferMode,
         const Vector<int>& indices,
         const Paint& paint)
@@ -325,6 +325,11 @@ void Canvas::drawVertices(SkCanvas::VertexMode vertexMode,
   for (const Point& point : textureCoordinates)
     skTextureCoordinates.append(point.sk_point);
 
+  Vector<SkColor> skColors;
+  skColors.reserveInitialCapacity(colors.size());
+  for (const CanvasColor& color : colors)
+    skColors.append(color);
+
   Vector<uint16_t> skIndices;
   skIndices.reserveInitialCapacity(indices.size());
   for (uint16_t i : indices)
@@ -337,7 +342,7 @@ void Canvas::drawVertices(SkCanvas::VertexMode vertexMode,
     skVertices.size(),
     skVertices.data(),
     skTextureCoordinates.isEmpty() ? nullptr : skTextureCoordinates.data(),
-    colors.isEmpty() ? nullptr : colors.data(),
+    skColors.isEmpty() ? nullptr : skColors.data(),
     transferModePtr.get(),
     skIndices.isEmpty() ? nullptr : skIndices.data(),
     skIndices.size(),
@@ -347,7 +352,7 @@ void Canvas::drawVertices(SkCanvas::VertexMode vertexMode,
 
 void Canvas::drawAtlas(CanvasImage* atlas,
     const Vector<RSTransform>& transforms, const Vector<Rect>& rects,
-    const Vector<SkColor>& colors, TransferMode mode,
+    const Vector<CanvasColor>& colors, TransferMode mode,
     const Rect& cullRect, const Paint& paint)
 {
   if (!m_canvas)
@@ -365,11 +370,16 @@ void Canvas::drawAtlas(CanvasImage* atlas,
   for (const Rect& rect : rects)
     skRects.append(rect.sk_rect);
 
+  Vector<SkColor> skColors;
+  skColors.reserveInitialCapacity(colors.size());
+  for (const CanvasColor& color : colors)
+    skColors.append(color);
+
   m_canvas->drawAtlas(
       skImage.get(),
       skXForms.data(),
       skRects.data(),
-      colors.isEmpty() ? nullptr : colors.data(),
+      skColors.isEmpty() ? nullptr : skColors.data(),
       skXForms.size(),
       mode,
       cullRect.is_null ? nullptr : &cullRect.sk_rect,

--- a/sky/engine/core/painting/Canvas.h
+++ b/sky/engine/core/painting/Canvas.h
@@ -74,14 +74,14 @@ public:
     void drawVertices(SkCanvas::VertexMode vertexMode,
         const Vector<Point>& vertices,
         const Vector<Point>& textureCoordinates,
-        const Vector<SkColor>& colors,
+        const Vector<CanvasColor>& colors,
         TransferMode transferMode,
         const Vector<int>& indices,
         const Paint& paint);
 
     void drawAtlas(CanvasImage* atlas,
         const Vector<RSTransform>& transforms, const Vector<Rect>& rects,
-        const Vector<SkColor>& colors, TransferMode mode,
+        const Vector<CanvasColor>& colors, TransferMode mode,
         const Rect& cullRect, const Paint& paint);
 
     SkCanvas* skCanvas() { return m_canvas; }

--- a/sky/engine/core/painting/CanvasColor.cpp
+++ b/sky/engine/core/painting/CanvasColor.cpp
@@ -10,19 +10,19 @@
 
 namespace blink {
 
-SkColor DartConverter<CanvasColor>::FromDart(Dart_Handle dart_color) {
+CanvasColor DartConverter<CanvasColor>::FromDart(Dart_Handle dart_color) {
   Dart_Handle value =
       Dart_GetField(dart_color, DOMDartState::Current()->value_handle());
 
-  uint64_t color = 0;
-  Dart_Handle rv = Dart_IntegerToUint64(value, &color);
+  uint64_t sk_color = 0;
+  Dart_Handle rv = Dart_IntegerToUint64(value, &sk_color);
   DCHECK(!LogIfError(rv));
-  DCHECK(color <= 0xffffffff);
+  DCHECK(sk_color <= 0xffffffff);
 
-  return static_cast<SkColor>(color);
+  return static_cast<SkColor>(sk_color);
 }
 
-SkColor DartConverter<CanvasColor>::FromArguments(
+CanvasColor DartConverter<CanvasColor>::FromArguments(
     Dart_NativeArguments args,
     int index,
     Dart_Handle& exception) {
@@ -32,9 +32,9 @@ SkColor DartConverter<CanvasColor>::FromArguments(
 }
 
 void DartConverter<CanvasColor>::SetReturnValue(Dart_NativeArguments args,
-                                                SkColor val) {
+                                                CanvasColor val) {
   Dart_Handle color_class = DOMDartState::Current()->color_class();
-  Dart_Handle constructor_args[] = { ToDart(val) };
+  Dart_Handle constructor_args[] = { ToDart(val.sk_color) };
   Dart_SetReturnValue(args,
                       Dart_New(color_class, Dart_Null(), 1, constructor_args));
 }

--- a/sky/engine/core/painting/CanvasColor.h
+++ b/sky/engine/core/painting/CanvasColor.h
@@ -14,31 +14,25 @@
 namespace blink {
 
 struct CanvasColor {
-  SkColor color;
+  SkColor sk_color;
 
-  CanvasColor(SkColor color) : color(color) { }
-  CanvasColor() : color() { }
-  operator SkColor() const { return color; }
-};
-
-template <>
-struct DartConverterTypes<CanvasColor> {
-  using ConverterType = CanvasColor;
-  using ValueType = SkColor;
+  CanvasColor(SkColor color) : sk_color(color) { }
+  CanvasColor() : sk_color() { }
+  operator SkColor() const { return sk_color; }
 };
 
 template <>
 struct DartConverter<CanvasColor> {
-  static SkColor FromDart(Dart_Handle handle);
-  static SkColor FromArguments(Dart_NativeArguments args,
-                               int index,
-                               Dart_Handle& exception);
-  static SkColor FromArgumentsWithNullCheck(Dart_NativeArguments args,
+  static CanvasColor FromDart(Dart_Handle handle);
+  static CanvasColor FromArguments(Dart_NativeArguments args,
+                                   int index,
+                                   Dart_Handle& exception);
+  static CanvasColor FromArgumentsWithNullCheck(Dart_NativeArguments args,
                                             int index,
                                             Dart_Handle& exception) {
     return FromArguments(args, index, exception);
   }
-  static void SetReturnValue(Dart_NativeArguments args, SkColor val);
+  static void SetReturnValue(Dart_NativeArguments args, CanvasColor val);
 };
 
 } // namespace blink

--- a/sky/engine/core/painting/CanvasGradient.cpp
+++ b/sky/engine/core/painting/CanvasGradient.cpp
@@ -37,7 +37,7 @@ PassRefPtr<CanvasGradient> CanvasGradient::create() {
 }
 
 void CanvasGradient::initLinear(const Vector<Point>& end_points,
-                                const Vector<SkColor>& colors,
+                                const Vector<CanvasColor>& colors,
                                 const Vector<float>& color_stops,
                                 SkShader::TileMode tile_mode) {
   ASSERT(end_points.size() == 2);
@@ -46,22 +46,32 @@ void CanvasGradient::initLinear(const Vector<Point>& end_points,
   for (int i = 0; i < 2; ++i)
     sk_end_points[i] = end_points[i].sk_point;
 
+  Vector<SkColor> sk_colors;
+  sk_colors.reserveInitialCapacity(colors.size());
+  for (const CanvasColor& color : colors)
+    sk_colors.append(color);
+
   SkShader* shader = SkGradientShader::CreateLinear(
-      sk_end_points, colors.data(), color_stops.data(), colors.size(),
+      sk_end_points, sk_colors.data(), color_stops.data(), sk_colors.size(),
       tile_mode);
   set_shader(adoptRef(shader));
 }
 
 void CanvasGradient::initRadial(const Point& center,
                                 double radius,
-                                const Vector<SkColor>& colors,
+                                const Vector<CanvasColor>& colors,
                                 const Vector<float>& color_stops,
                                 SkShader::TileMode tile_mode) {
   ASSERT(colors.size() == color_stops.size() || color_stops.data() == nullptr);
 
+  Vector<SkColor> sk_colors;
+  sk_colors.reserveInitialCapacity(colors.size());
+  for (const CanvasColor& color : colors)
+    sk_colors.append(color);
+
   SkShader* shader = SkGradientShader::CreateRadial(
-      center.sk_point, radius, colors.data(), color_stops.data(), colors.size(),
-      tile_mode);
+      center.sk_point, radius, sk_colors.data(), color_stops.data(),
+      sk_colors.size(), tile_mode);
   set_shader(adoptRef(shader));
 }
 

--- a/sky/engine/core/painting/CanvasGradient.h
+++ b/sky/engine/core/painting/CanvasGradient.h
@@ -26,13 +26,13 @@ class CanvasGradient : public Shader {
   static PassRefPtr<CanvasGradient> create();
 
   void initLinear(const Vector<Point>& end_points,
-                  const Vector<SkColor>& colors,
+                  const Vector<CanvasColor>& colors,
                   const Vector<float>& color_stops,
                   SkShader::TileMode tile_mode);
 
   void initRadial(const Point& center,
                   double radius,
-                  const Vector<SkColor>& colors,
+                  const Vector<CanvasColor>& colors,
                   const Vector<float>& color_stops,
                   SkShader::TileMode tile_mode);
 


### PR DESCRIPTION
In changing the binding systems, I broke the colors parameter to drawAtlas. It
was looking for an array of ints rather than an array of Colors. Now we use
CanvasImage, which has the proper converter.

Fixes #1137