### PR TITLE
TabView children don't render correctly

### DIFF
--- a/sky/compositor/picture_layer.cc
+++ b/sky/compositor/picture_layer.cc
@@ -37,8 +37,9 @@ void PictureLayer::Paint(PaintContext::ScopedFrame& frame) {
     if (kDebugCheckerboardRasterizedLayers)
       DrawCheckerboard(&canvas, rect);
   } else {
-    SkMatrix matrix = SkMatrix::MakeTrans(offset_.x(), offset_.y());
-    canvas.drawPicture(picture_.get(), &matrix, nullptr);
+    SkAutoCanvasRestore save(&canvas, true);
+    canvas.translate(offset_.x(), offset_.y());
+    canvas.drawPicture(picture_.get());
   }
 }
 


### PR DESCRIPTION
The matrix parameter to drawPicture doesn't quite work the way we expected.
This patch moves us back to using the translate function on SkCanvas.

Fixes https://github.com/flutter/flutter/issues/1205