### PR TITLE
Remove deprecated Dart methods

### DIFF
--- a/sky/engine/core/dart/compositing.dart
+++ b/sky/engine/core/dart/compositing.dart
@@ -14,34 +14,17 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
 
   void pushTransform(Float64List matrix4) native "SceneBuilder_pushTransform";
   void pushClipRect(Rect rect) native "SceneBuilder_pushClipRect";
-  void _pushClipRRect(RRect rrect) native "SceneBuilder_pushClipRRect";
-  void _pushClipPath(Path path) native "SceneBuilder_pushClipPath";
-  void _pushOpacity(int alpha) native "SceneBuilder_pushOpacity";
-  void _pushColorFilter(Color color, TransferMode transferMode) native "SceneBuilder_pushColorFilter";
+  void pushClipRRect(RRect rrect) native "SceneBuilder_pushClipRRect";
+  void pushClipPath(Path path) native "SceneBuilder_pushClipPath";
+  void pushOpacity(int alpha) native "SceneBuilder_pushOpacity";
+  void pushColorFilter(Color color, TransferMode transferMode) native "SceneBuilder_pushColorFilter";
   void pushShaderMask(Shader shader, Rect maskRect, TransferMode transferMode) native "SceneBuilder_pushShaderMask";
 
   void pop() native "SceneBuilder_pop";
 
   void addPerformanceOverlay(int enabledOptions, Rect bounds) native "SceneBuilder_addPerformanceOverlay";
-  void _addPicture(Offset offset, Picture picture) native "SceneBuilder_addPicture";
+  void addPicture(Offset offset, Picture picture) native "SceneBuilder_addPicture";
   void setRasterizerTracingThreshold(int frameInterval) native "SceneBuilder_setRasterizerTracingThreshold";
 
   Scene build() native "SceneBuilder_build";
-
-  // TODO(abarth): Remove these once clients stop passing bounds.
-  void pushClipRRect(RRect rrect, [ Rect bounds ]) {
-    _pushClipRRect(rrect);
-  }
-  void pushClipPath(Path path, [ Rect bounds ]) {
-    _pushClipPath(path);
-  }
-  void pushOpacity(int alpha, [ Rect bounds ]) {
-    _pushOpacity(alpha);
-  }
-  void pushColorFilter(Color color, TransferMode transferMode, [ Rect bounds ]) {
-    _pushColorFilter(color, transferMode);
-  }
-  void addPicture(Offset offset, Picture picture, [ Rect bounds ]) {
-    _addPicture(offset, picture);
-  }
 }

--- a/sky/engine/core/dart/painting.dart
+++ b/sky/engine/core/dart/painting.dart
@@ -216,7 +216,6 @@ class Canvas extends NativeFieldWrapperClass2 {
   void scale(double sx, double sy) native "Canvas_scale";
   void rotate(double radians) native "Canvas_rotate";
   void skew(double sx, double sy) native "Canvas_skew";
-  void concat(Float64List matrix4) native "Canvas_concat";
 
   void _transform(Float64List matrix4) native "Canvas_transform";
   void transform(Float64List matrix4) {

--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -22,17 +22,6 @@ static void Canvas_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&Canvas::create, args);
 }
 
-static void Canvas_concat(Dart_NativeArguments args) {
-  DartArgIterator it(args);
-  Float64List matrix4 = it.GetNext<Float64List>();
-  if (it.had_exception())
-    return;
-  ExceptionState es;
-  GetReceiver<Canvas>(args)->concat(matrix4, es);
-  if (es.had_exception())
-    Dart_ThrowException(es.GetDartException(args, true));
-}
-
 IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
 
 #define FOR_EACH_BINDING(V) \
@@ -66,15 +55,11 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
   V(Canvas, drawVertices) \
   V(Canvas, drawAtlas)
 
-  // These are custom because of ExceptionState:
-  // V(Canvas, concat)
-
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
 
 void Canvas::RegisterNatives(DartLibraryNatives* natives) {
   natives->Register({
     { "Canvas_constructor", Canvas_constructor, 3, true },
-    { "Canvas_concat", Canvas_concat, 2, true },
 FOR_EACH_BINDING(DART_REGISTER_NATIVE)
   });
 }
@@ -166,17 +151,6 @@ void Canvas::setMatrix(const Float64List& matrix4)
     if (!m_canvas)
         return;
     m_canvas->setMatrix(toSkMatrix(matrix4));
-}
-
-void Canvas::concat(const Float64List& matrix4, ExceptionState& es)
-{
-    if (!m_canvas)
-        return es.ThrowTypeError("No canvas");
-
-    SkMatrix sk_matrix = toSkMatrix(matrix4, es);
-    if (es.had_exception())
-        return;
-    m_canvas->concat(sk_matrix);
 }
 
 Float64List Canvas::getTotalMatrix()

--- a/sky/engine/core/painting/Canvas.h
+++ b/sky/engine/core/painting/Canvas.h
@@ -48,9 +48,6 @@ public:
     void transform(const Float64List& matrix4);
     void setMatrix(const Float64List& matrix4);
 
-    // TODO(abarth): Remove concat.
-    void concat(const Float64List& matrix4, ExceptionState&);
-
     Float64List getTotalMatrix();
 
     void clipRect(const Rect& rect);


### PR DESCRIPTION
All the clients have migrated to the new methods.

Fixes https://github.com/flutter/flutter/issues/1080