### PR TITLE
Stocks FAB "+" sometimes teleports to near the top left

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -84,8 +84,9 @@ skia::RefPtr<SkImage> RasterCache::GetPrerolledImage(GrContext* context,
       if (surface) {
         SkCanvas* canvas = surface->getCanvas();
         canvas->clear(SK_ColorTRANSPARENT);
-        SkMatrix matrix = SkMatrix::MakeScale(scaleX, scaleY);
-        canvas->drawPicture(picture, &matrix, nullptr);
+        canvas->translate(-rect.left(), -rect.right());
+        canvas->scale(scaleX, scaleY);
+        canvas->drawPicture(picture);
         entry.image = skia::AdoptRef(surface->newImageSnapshot());
       }
     }


### PR DESCRIPTION
The matrix argument to drawPicture doesn't seem to do what we want exactly.
Instead, use the normal matrix in the canvas. Also, handle cull rects with
non-zero left and top coordinates.

Fixes #1229