### PR TITLE
Fix typo in image raster offset

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -84,7 +84,7 @@ skia::RefPtr<SkImage> RasterCache::GetPrerolledImage(GrContext* context,
       if (surface) {
         SkCanvas* canvas = surface->getCanvas();
         canvas->clear(SK_ColorTRANSPARENT);
-        canvas->translate(-rect.left(), -rect.right());
+        canvas->translate(-rect.left(), -rect.top());
         canvas->scale(scaleX, scaleY);
         canvas->drawPicture(picture);
         entry.image = skia::AdoptRef(surface->newImageSnapshot());


### PR DESCRIPTION
We shouldn't plumb the "right" value into the y coordinate.