### PR TITLE
Support dynamic registration of mojo services on Android

### DIFF
--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -1577,7 +1577,7 @@ template("android_apk") {
   }
 
   final_deps += [ ":$final_dex_target_name" ]
-  dex("$final_dex_target_name") {
+  dex("${final_dex_target_name}_jar") {
     deps = [
       ":$build_config_target",
       ":$java_target",
@@ -1588,9 +1588,19 @@ template("android_apk") {
     inputs = [
       _build_config,
     ]
-    output = final_dex_path
+    output = "${final_dex_path}.jar"
     dex_arg_key = "${_rebased_build_config}:final_dex:dependency_dex_files"
     args = [ "--inputs=@FileArg($dex_arg_key)" ]
+  }
+
+  dex("$final_dex_target_name") {
+    deps = [
+      ":${final_dex_target_name}_jar",
+    ]
+    sources = [
+      "${final_dex_path}.jar",
+    ]
+    output = final_dex_path
   }
 
   if (_native_libs != []) {

--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -28,9 +28,17 @@ group("sky") {
 
   if (is_android) {
     deps += [ "//sky/services/activity" ]
+
+    # TODO(mpcomplete): This is temporary until we move GCM out of the engine
+    # repo.
+    deps += [
+      "//sky/services/gcm:gcm_lib",
+      "//sky/services/gcm:interfaces_java",
+    ]
   }
 
   if (!is_android) {
     deps += [ "//third_party/mesa:osmesa" ]
   }
+
 }

--- a/sky/services/gcm/src/org/domokit/gcm/RegistrationIntentService.java
+++ b/sky/services/gcm/src/org/domokit/gcm/RegistrationIntentService.java
@@ -16,6 +16,8 @@ import com.google.android.gms.iid.InstanceID;
 import java.io.IOException;
 
 import org.chromium.base.ThreadUtils;
+import org.chromium.mojo.system.Core;
+import org.chromium.mojo.system.MessagePipeHandle;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.gcm.GcmListener;
 import org.chromium.mojom.gcm.GcmService;
@@ -35,6 +37,10 @@ public class RegistrationIntentService extends IntentService {
 
         public MojoService(Context context) {
             this.context = context;
+        }
+
+        public static void connectToService(Context context, Core core, MessagePipeHandle pipe) {
+            GcmService.MANAGER.bind(new MojoService(context), pipe);
         }
 
         @Override

--- a/sky/tools/release_engine.py
+++ b/sky/tools/release_engine.py
@@ -48,8 +48,10 @@ ZIP_ARTIFACTS = {
         'icudtl.dat',
         'dist/shell/SkyShell.apk',
         'dist/shell/flutter.mojo',
-        'gen/sky/shell/shell/classes.dex',
+        'gen/sky/shell/shell/classes.dex.jar',
         'gen/sky/shell/shell/shell/libs/armeabi-v7a/libsky_shell.so',
+        # TODO(mpcomplete): obsolete. Remove after updating the flutter tool.
+        'gen/sky/shell/shell/classes.dex',
     ],
     'linux-x64': [
         'dist/shell/icudtl.dat',


### PR DESCRIPTION
SkyApplication now reads service info from a services.json file bundled
with the apk. For each service, it registers a method that invokes
connectToService on a named class. This way, third party services can
register themselves.

There's a corresponding change to flutter_tools to generate this
services.json when building an apk that depends on services.