### PR TITLE
Fix order of matrix operations

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -84,8 +84,8 @@ skia::RefPtr<SkImage> RasterCache::GetPrerolledImage(GrContext* context,
       if (surface) {
         SkCanvas* canvas = surface->getCanvas();
         canvas->clear(SK_ColorTRANSPARENT);
-        canvas->translate(-rect.left(), -rect.top());
         canvas->scale(scaleX, scaleY);
+        canvas->translate(-rect.left(), -rect.top());
         canvas->drawPicture(picture);
         entry.image = skia::AdoptRef(surface->newImageSnapshot());
       }


### PR DESCRIPTION
When rasterzing with a non-zero left and top offset, we need to apply the scale
first so that we're translating in the correct coordinate system.

Fixes https://github.com/flutter/flutter/issues/1292