### PR TITLE
Improve handling of window insets on Android

### DIFF
--- a/sky/engine/core/window/window.cc
+++ b/sky/engine/core/window/window.cc
@@ -54,19 +54,15 @@ void Window::UpdateWindowMetrics(const SkyDisplayMetrics& metrics) {
   if (!dart_state)
     return;
   DartState::Scope scope(dart_state);
-
   double device_pixel_ratio = metrics.device_pixel_ratio;
-  double width = metrics.physical_size.width / device_pixel_ratio;
-  double height = metrics.physical_size.height / device_pixel_ratio;
-
   DartInvokeField(library_.value(), "_updateWindowMetrics", {
     ToDart(device_pixel_ratio),
-    ToDart(width),
-    ToDart(height),
-    ToDart(metrics.padding_top),
-    ToDart(metrics.padding_right),
-    ToDart(metrics.padding_bottom),
-    ToDart(metrics.padding_left),
+    ToDart(metrics.physical_size.width / device_pixel_ratio),
+    ToDart(metrics.physical_size.height / device_pixel_ratio),
+    ToDart(metrics.physical_padding_top / device_pixel_ratio),
+    ToDart(metrics.physical_padding_right / device_pixel_ratio),
+    ToDart(metrics.physical_padding_bottom / device_pixel_ratio),
+    ToDart(metrics.physical_padding_left / device_pixel_ratio),
   });
 }
 

--- a/sky/engine/public/platform/sky_display_metrics.h
+++ b/sky/engine/public/platform/sky_display_metrics.h
@@ -10,12 +10,12 @@
 namespace blink {
 
 struct SkyDisplayMetrics {
-  WebSize physical_size;
   float device_pixel_ratio = 1.0;
-  double padding_top = 0.0;
-  double padding_right = 0.0;
-  double padding_bottom = 0.0;
-  double padding_left = 0.0;
+  WebSize physical_size;
+  int physical_padding_top = 0;
+  int physical_padding_right = 0;
+  int physical_padding_bottom = 0;
+  int physical_padding_left = 0;
 };
 
 } // namespace blink

--- a/sky/services/engine/sky_engine.mojom
+++ b/sky/services/engine/sky_engine.mojom
@@ -17,13 +17,13 @@ enum AppLifecycleState {
 };
 
 struct ViewportMetrics {
+  float device_pixel_ratio = 1.0;
   int32 physical_width;
   int32 physical_height;
-  float device_pixel_ratio = 1.0;
-  double padding_top;
-  double padding_right;
-  double padding_bottom;
-  double padding_left;
+  int32 physical_padding_top;
+  int32 physical_padding_right;
+  int32 physical_padding_bottom;
+  int32 physical_padding_left;
 };
 
 struct ServicesData {

--- a/sky/shell/platform/android/AndroidManifest.xml
+++ b/sky/shell/platform/android/AndroidManifest.xml
@@ -15,7 +15,8 @@
                   android:hardwareAccelerated="true"
                   android:launchMode="standard"
                   android:name="SkyActivity"
-                  android:theme="@android:style/Theme.Black.NoTitleBar">
+                  android:theme="@android:style/Theme.Black.NoTitleBar"
+                  android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -9,7 +9,9 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
+import android.view.Window;
 import android.view.WindowManager;
 
 import org.chromium.base.PathUtils;
@@ -57,23 +59,18 @@ public class SkyActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        PlatformViewAndroid.EdgeDims edgeDims = new PlatformViewAndroid.EdgeDims();
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            getWindow().addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
-            getWindow().setStatusBarColor(0x40000000);
+            Window window = getWindow();
+            window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS);
+            window.setStatusBarColor(0x40000000);
+            window.getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
         }
-        // TODO(abarth): We should get this value from the Android framework somehow.
-        edgeDims.top = 25.0;
-        // TODO(abarth): Unclear if we want to use fullscreen if we don't have
-        // a transparent system bar.
-        getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
 
         String[] args = getArgsFromIntent(getIntent());
         SkyMain.ensureInitialized(getApplicationContext(), args);
-        mView = new PlatformViewAndroid(this, edgeDims);
+        mView = new PlatformViewAndroid(this);
         ActivityImpl.setCurrentActivity(this);
         setContentView(mView);
         mTracingController = new TracingController(this);
@@ -175,7 +172,7 @@ public class SkyActivity extends Activity {
     }
 
     public void onConfigurationChanged(Configuration newConfig) {
-	super.onConfigurationChanged(newConfig);
+    	super.onConfigurationChanged(newConfig);
 
         Locale locale = getResources().getConfiguration().locale;
         mView.getEngine().onLocaleChanged(locale.getLanguage(),

--- a/sky/shell/platform/ios/sky_surface.mm
+++ b/sky/shell/platform/ios/sky_surface.mm
@@ -132,11 +132,11 @@ static std::string TracesBasePath() {
   CGFloat scale = [UIScreen mainScreen].scale;
 
   sky::ViewportMetricsPtr metrics = sky::ViewportMetrics::New();
+  metrics->device_pixel_ratio = scale;
   metrics->physical_width = size.width * scale;
   metrics->physical_height = size.height * scale;
-  metrics->device_pixel_ratio = scale;
-  metrics->padding_top =
-      [UIApplication sharedApplication].statusBarFrame.size.height;
+  metrics->physical_padding_top =
+      [UIApplication sharedApplication].statusBarFrame.size.height * scale;
 
   _sky_engine->OnViewportMetricsChanged(metrics.Pass());
 }

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -134,12 +134,12 @@ void Engine::SetServices(ServicesDataPtr services) {
 void Engine::OnViewportMetricsChanged(ViewportMetricsPtr metrics) {
   physical_size_.SetSize(metrics->physical_width, metrics->physical_height);
 
-  display_metrics_.physical_size = physical_size_;
   display_metrics_.device_pixel_ratio = metrics->device_pixel_ratio;
-  display_metrics_.padding_top = metrics->padding_top;
-  display_metrics_.padding_right = metrics->padding_right;
-  display_metrics_.padding_bottom = metrics->padding_bottom;
-  display_metrics_.padding_left = metrics->padding_left;
+  display_metrics_.physical_size = physical_size_;
+  display_metrics_.physical_padding_top = metrics->physical_padding_top;
+  display_metrics_.physical_padding_right = metrics->physical_padding_right;
+  display_metrics_.physical_padding_bottom = metrics->physical_padding_bottom;
+  display_metrics_.physical_padding_left = metrics->physical_padding_left;
 
   if (sky_view_)
     sky_view_->SetDisplayMetrics(display_metrics_);


### PR DESCRIPTION
Now that we understand window insets, we don't need to hard-code the size of
the status bar. Also, convert the viewport metrics to be consistently in
physical pixels.