### PR TITLE
Switch whitespace mode back to pre-wrap

### DIFF
--- a/sky/engine/core/rendering/style/RenderStyle.h
+++ b/sky/engine/core/rendering/style/RenderStyle.h
@@ -966,7 +966,7 @@ public:
     static EPosition initialPosition() { return StaticPosition; }
     static EUnicodeBidi initialUnicodeBidi() { return UBNormal; }
     static EVisibility initialVisibility() { return VISIBLE; }
-    static EWhiteSpace initialWhiteSpace() { return PRE_LINE; }
+    static EWhiteSpace initialWhiteSpace() { return PRE_WRAP; }
     static short initialHorizontalBorderSpacing() { return 0; }
     static short initialVerticalBorderSpacing() { return 0; }
     static Color initialColor() { return Color::white; }


### PR DESCRIPTION
When we removed position: sticky, we introduced a subtle line breaking
bug to pre-wrap that would cause whitespace to accumulate at the
beginning of lines that follow unclean breaks. This patch adds back the
deleted code (cleansed of the position sticky bits).