### PR TITLE
RawKeyboardService leaks

### DIFF
--- a/sky/services/raw_keyboard/raw_keyboard.mojom
+++ b/sky/services/raw_keyboard/raw_keyboard.mojom
@@ -15,5 +15,4 @@ interface RawKeyboardListener {
 [ServiceName="raw_keyboard::RawKeyboardService"]
 interface RawKeyboardService {
   AddListener(RawKeyboardListener listener);
-  RemoveListener(RawKeyboardListener listener);
 };

--- a/sky/services/raw_keyboard/src/org/domokit/raw_keyboard/RawKeyboardServiceImpl.java
+++ b/sky/services/raw_keyboard/src/org/domokit/raw_keyboard/RawKeyboardServiceImpl.java
@@ -20,12 +20,7 @@ public class RawKeyboardServiceImpl implements RawKeyboardService {
 
     @Override
     public void addListener(RawKeyboardListener listener) {
-        mViewState.addListener(listener);
-    }
-
-    @Override
-    public void removeListener(RawKeyboardListener listener) {
-        mViewState.removeListener(listener);
+        mViewState.addListener((RawKeyboardListener.Proxy) listener);
     }
 
     @Override

--- a/sky/services/raw_keyboard/src/org/domokit/raw_keyboard/RawKeyboardServiceState.java
+++ b/sky/services/raw_keyboard/src/org/domokit/raw_keyboard/RawKeyboardServiceState.java
@@ -10,6 +10,7 @@ import android.view.View;
 
 import java.util.ArrayList;
 
+import org.chromium.mojo.bindings.ConnectionErrorHandler;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.raw_keyboard.RawKeyboardListener;
 import org.chromium.mojom.raw_keyboard.RawKeyboardService;
@@ -23,18 +24,19 @@ import org.chromium.mojom.sky.KeyData;
 public class RawKeyboardServiceState implements View.OnKeyListener {
     private static final String TAG = "RawKeyboardServiceState";
 
-    private ArrayList<RawKeyboardListener> mListeners = new ArrayList<RawKeyboardListener>();
+    private ArrayList<RawKeyboardListener.Proxy> mListeners = new ArrayList<RawKeyboardListener.Proxy>();
 
     public RawKeyboardServiceState() {
     }
 
-    public void addListener(RawKeyboardListener listener) {
+    public void addListener(final RawKeyboardListener.Proxy listener) {
         mListeners.add(listener);
-    }
-
-    public void removeListener(RawKeyboardListener listener) {
-        mListeners.remove(listener);
-        listener.close();
+        listener.getProxyHandler().setErrorHandler(new ConnectionErrorHandler() {
+            @Override
+            public void onConnectionError(MojoException e) {
+                mListeners.remove(listener);
+            }
+        });
     }
 
     public void close() {


### PR DESCRIPTION
The removeListener function didn't actually remove anything from the
list because Mojo objects don't maintain their identity when you
transfer them through a message pipe. Now we just watch for errors on
the listener's pipe, which means the way you stop listening is just to
close your end of the pipe.