### PR TITLE
Dart/JNI: improve Java method lookup

### DIFF
--- a/sky/engine/bindings/jni/dart_jni.cc
+++ b/sky/engine/bindings/jni/dart_jni.cc
@@ -129,7 +129,6 @@ DART_NATIVE_CALLBACK_STATIC(JniString, Create);
   V(JniClass, CallStaticObjectMethod) \
   V(JniClass, CallStaticShortMethod) \
   V(JniClass, CallStaticVoidMethod) \
-  V(JniClass, NewObject) \
   V(JniClass, GetFieldId) \
   V(JniClass, GetMethodId) \
   V(JniClass, GetStaticBooleanField) \
@@ -143,6 +142,8 @@ DART_NATIVE_CALLBACK_STATIC(JniString, Create);
   V(JniClass, GetStaticMethodId) \
   V(JniClass, GetStaticObjectField) \
   V(JniClass, GetStaticShortField) \
+  V(JniClass, IsAssignable) \
+  V(JniClass, NewObject) \
   V(JniClass, SetStaticBooleanField) \
   V(JniClass, SetStaticByteField) \
   V(JniClass, SetStaticCharField) \
@@ -177,6 +178,7 @@ DART_NATIVE_CALLBACK_STATIC(JniString, Create);
   V(JniObject, GetFloatField) \
   V(JniObject, GetIntField) \
   V(JniObject, GetLongField) \
+  V(JniObject, GetObjectClass) \
   V(JniObject, GetObjectField) \
   V(JniObject, GetShortField) \
   V(JniObject, SetBooleanField) \

--- a/sky/engine/bindings/jni/jni_api.h
+++ b/sky/engine/bindings/jni/jni_api.h
@@ -5,6 +5,7 @@
 #ifndef SKY_ENGINE_BINDINGS_JNI_JNI_API_H_
 #define SKY_ENGINE_BINDINGS_JNI_JNI_API_H_
 
+#include "sky/engine/bindings/jni/jni_class.h"
 #include "sky/engine/bindings/jni/jni_object.h"
 
 namespace blink {

--- a/sky/engine/bindings/jni/jni_class.cc
+++ b/sky/engine/bindings/jni/jni_class.cc
@@ -142,6 +142,22 @@ fail:
   return nullptr;
 }
 
+bool JniClass::IsAssignable(const JniClass* clazz) {
+  Dart_Handle exception = nullptr;
+  {
+    ENTER_JNI();
+
+    jboolean result = env->IsAssignableFrom(java_class(), clazz->java_class());
+    if (CheckJniException(env, &exception)) goto fail;
+
+    return result == JNI_TRUE;
+  }
+fail:
+  Dart_ThrowException(exception);
+  ASSERT_NOT_REACHED();
+  return false;
+}
+
 PassRefPtr<JniObject> JniClass::GetStaticObjectField(jfieldID fieldId) {
   Dart_Handle exception = nullptr;
   {

--- a/sky/engine/bindings/jni/jni_class.h
+++ b/sky/engine/bindings/jni/jni_class.h
@@ -15,8 +15,6 @@
 
 namespace blink {
 
-class JniObject;
-
 // Wrapper that exposes a JNI jclass to Dart
 class JniClass : public JniObject {
   DEFINE_WRAPPERTYPEINFO();
@@ -37,6 +35,8 @@ class JniClass : public JniObject {
 
   PassRefPtr<JniObject> NewObject(jmethodID methodId,
                                   const std::vector<Dart_Handle>& args);
+
+  bool IsAssignable(const JniClass* clazz);
 
   PassRefPtr<JniObject> GetStaticObjectField(jfieldID fieldId);
   bool GetStaticBooleanField(jfieldID fieldId);

--- a/sky/engine/bindings/jni/jni_object.cc
+++ b/sky/engine/bindings/jni/jni_object.cc
@@ -7,6 +7,7 @@
 #include "base/strings/string_util.h"
 #include "sky/engine/bindings/jni/dart_jni.h"
 #include "sky/engine/bindings/jni/jni_array.h"
+#include "sky/engine/bindings/jni/jni_class.h"
 #include "sky/engine/bindings/jni/jni_string.h"
 
 namespace blink {
@@ -55,6 +56,22 @@ PassRefPtr<JniObject> JniObject::Create(JNIEnv* env, jobject object) {
   }
 
   return adoptRef(result);
+}
+
+PassRefPtr<JniClass> JniObject::GetObjectClass() {
+  Dart_Handle exception = nullptr;
+  {
+    ENTER_JNI();
+
+    jclass clazz = env->GetObjectClass(java_object());
+    if (CheckJniException(env, &exception)) goto fail;
+
+    return adoptRef(new JniClass(env, clazz));
+  }
+fail:
+  Dart_ThrowException(exception);
+  ASSERT_NOT_REACHED();
+  return nullptr;
 }
 
 PassRefPtr<JniObject> JniObject::GetObjectField(jfieldID fieldId) {

--- a/sky/engine/bindings/jni/jni_object.h
+++ b/sky/engine/bindings/jni/jni_object.h
@@ -14,6 +14,8 @@
 
 namespace blink {
 
+class JniClass;
+
 // Wrapper that exposes a JNI jobject to Dart
 class JniObject : public RefCounted<JniObject>, public DartWrappable {
   DEFINE_WRAPPERTYPEINFO();
@@ -24,6 +26,8 @@ class JniObject : public RefCounted<JniObject>, public DartWrappable {
   static PassRefPtr<JniObject> Create(JNIEnv* env, jobject object);
 
   jobject java_object() const { return object_.obj(); }
+
+  PassRefPtr<JniClass> GetObjectClass();
 
   PassRefPtr<JniObject> GetObjectField(jfieldID fieldId);
   bool GetBooleanField(jfieldID fieldId);

--- a/sky/engine/bindings/jni/jni_raw.dart
+++ b/sky/engine/bindings/jni/jni_raw.dart
@@ -19,6 +19,9 @@ class JniApi {
 
 /// Wrapper for a Java object accessed via JNI.
 class JniObject extends NativeFieldWrapperClass2 {
+  JniClass getObjectClass()
+      native 'JniObject_GetObjectClass';
+
   JniObject getObjectField(int fieldId)
       native 'JniObject_GetObjectField';
   bool getBooleanField(int fieldId)
@@ -97,6 +100,9 @@ class JniClass extends JniObject {
 
   JniObject newObject(int methodId, List args)
       native 'JniClass_NewObject';
+
+  bool isAssignable(JniClass clazz)
+      native 'JniClass_IsAssignable';
 
   JniObject getStaticObjectField(int fieldId)
       native 'JniClass_GetStaticObjectField';


### PR DESCRIPTION
Add more rules to determine which overloaded Java method should be invoked
for a given Dart call.  In particular, check whether the class of a
Dart-wrapped Java object matches the type declared for the corresponding
argument in the Java method.