### PR TITLE
KeyboardServiceState#setSelection shouldn't crash

### DIFF
--- a/services/keyboard/src/org/chromium/mojo/keyboard/KeyboardServiceState.java
+++ b/services/keyboard/src/org/chromium/mojo/keyboard/KeyboardServiceState.java
@@ -59,6 +59,9 @@ public class KeyboardServiceState {
     }
 
     public void setSelection(int start, int end) {
+        int length = mActiveEditable.length();
+        start = Math.max(Math.min(start, length), 0);
+        end = Math.max(Math.min(end, length), 0);
         Selection.setSelection(mActiveEditable, start, end);
     }
 }


### PR DESCRIPTION
Now we sanity check our inputs instead of crashing.

Fixes https://github.com/flutter/flutter/issues/1033