### PR TITLE
Remove almost all uses of base::scoped_ptr

### DIFF
--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -27,8 +27,8 @@ namespace shell {
 
 static const double kOneFrameDuration = 1e3 / 60.0;
 
-scoped_ptr<Rasterizer> Rasterizer::Create() {
-  return make_scoped_ptr(new RasterizerDirect());
+std::unique_ptr<Rasterizer> Rasterizer::Create() {
+  return std::unique_ptr<Rasterizer>(new RasterizerDirect());
 }
 
 RasterizerDirect::RasterizerDirect()
@@ -67,13 +67,13 @@ void RasterizerDirect::Draw(uint64_t layer_tree_ptr,
                             const DrawCallback& callback) {
   TRACE_EVENT0("flutter", "RasterizerDirect::Draw");
 
+  std::unique_ptr<flow::LayerTree> layer_tree(
+      reinterpret_cast<flow::LayerTree*>(layer_tree_ptr));
+
   if (!surface_) {
     callback.Run();
     return;
   }
-
-  scoped_ptr<flow::LayerTree> layer_tree(
-      reinterpret_cast<flow::LayerTree*>(layer_tree_ptr));
 
   gfx::Size size(layer_tree->frame_size().width(),
                  layer_tree->frame_size().height());

--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -20,8 +20,8 @@ void ContextLostThunk(void* closure) {
 
 }  // namespace
 
-scoped_ptr<Rasterizer> Rasterizer::Create() {
-  return make_scoped_ptr(new RasterizerMojo());
+std::unique_ptr<Rasterizer> Rasterizer::Create() {
+  return std::unique_ptr<Rasterizer>(new RasterizerMojo());
 }
 
 RasterizerMojo::RasterizerMojo() : binding_(this), weak_factory_(this) {
@@ -46,13 +46,14 @@ void RasterizerMojo::ConnectToRasterizer (
 void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
                           const DrawCallback& callback) {
   TRACE_EVENT0("flutter", "RasterizerMojo::Draw");
+
+  std::unique_ptr<flow::LayerTree> layer_tree(
+      reinterpret_cast<flow::LayerTree*>(layer_tree_ptr));
+
   if (!MGLGetCurrentContext()) {
     callback.Run();
     return;
   }
-
-  scoped_ptr<flow::LayerTree> layer_tree(
-      reinterpret_cast<flow::LayerTree*>(layer_tree_ptr));
 
   if (layer_tree->frame_size().isEmpty()) {
     callback.Run();

--- a/sky/shell/platform/android/platform_view_android.cc
+++ b/sky/shell/platform/android/platform_view_android.cc
@@ -21,7 +21,7 @@ namespace shell {
 static jlong Attach(JNIEnv* env, jclass clazz, jint skyEngineHandle) {
   ShellView* shell_view = new ShellView(Shell::Shared());
   auto view = static_cast<PlatformViewAndroid*>(shell_view->view());
-  view->SetShellView(make_scoped_ptr(shell_view));
+  view->SetShellView(std::unique_ptr<ShellView>(shell_view));
   view->ConnectToEngine(
       mojo::MakeRequest<SkyEngine>(mojo::ScopedMessagePipeHandle(
           mojo::MessagePipeHandle(skyEngineHandle))));
@@ -70,9 +70,9 @@ void PlatformViewAndroid::SurfaceDestroyed(JNIEnv* env, jobject obj) {
   ReleaseWindow();
 }
 
-void PlatformViewAndroid::SetShellView(scoped_ptr<ShellView> shell_view) {
+void PlatformViewAndroid::SetShellView(std::unique_ptr<ShellView> shell_view) {
   DCHECK(!shell_view_);
-  shell_view_ = shell_view.Pass();
+  shell_view_ = std::move(shell_view);
 }
 
 void PlatformViewAndroid::ReleaseWindow() {

--- a/sky/shell/platform/android/platform_view_android.h
+++ b/sky/shell/platform/android/platform_view_android.h
@@ -25,7 +25,7 @@ class PlatformViewAndroid : public PlatformView {
   void SurfaceCreated(JNIEnv* env, jobject obj, jobject jsurface);
   void SurfaceDestroyed(JNIEnv* env, jobject obj);
 
-  void SetShellView(scoped_ptr<ShellView> shell_view);
+  void SetShellView(std::unique_ptr<ShellView> shell_view);
 
  private:
   void ReleaseWindow();
@@ -34,7 +34,7 @@ class PlatformViewAndroid : public PlatformView {
   // lifetime is controlled by the Android view hierarchy, we flip around the
   // ownership and have the shell_view owned by Java. We reset this pointer in
   // |Detach|, which will eventually cause |~PlatformViewAndroid|.
-  scoped_ptr<ShellView> shell_view_;
+  std::unique_ptr<ShellView> shell_view_;
   gfx::AcceleratedWidget window_;
 
   DISALLOW_COPY_AND_ASSIGN(PlatformViewAndroid);

--- a/sky/shell/platform/android/sky_main.cc
+++ b/sky/shell/platform/android/sky_main.cc
@@ -31,7 +31,7 @@ namespace shell {
 
 namespace {
 
-LazyInstance<scoped_ptr<base::MessageLoop>> g_java_message_loop =
+LazyInstance<std::unique_ptr<base::MessageLoop>> g_java_message_loop =
     LAZY_INSTANCE_INITIALIZER;
 
 void InitializeLogging() {

--- a/sky/shell/platform/android/update_service_android.cc
+++ b/sky/shell/platform/android/update_service_android.cc
@@ -15,7 +15,7 @@ namespace sky {
 namespace shell {
 
 static jlong CheckForUpdates(JNIEnv* env, jobject jcaller) {
-  scoped_ptr<UpdateTaskAndroid> task(new UpdateTaskAndroid(env, jcaller));
+  std::unique_ptr<UpdateTaskAndroid> task(new UpdateTaskAndroid(env, jcaller));
   task->Start();
   return reinterpret_cast<jlong>(task.release());
 }

--- a/sky/shell/platform/android/update_service_android.h
+++ b/sky/shell/platform/android/update_service_android.h
@@ -6,9 +6,9 @@
 #define SKY_SHELL_ANDROID_UPDATE_SERVICE_ANDROID_H_
 
 #include <jni.h>
+#include <memory>
 
 #include "base/android/scoped_java_ref.h"
-#include "base/memory/scoped_ptr.h"
 #include "sky/engine/public/sky/sky_headless.h"
 
 namespace sky {
@@ -31,7 +31,7 @@ class UpdateTaskAndroid : public blink::SkyHeadless::Client {
   // SkyHeadless::Client:
   void DidCreateIsolate(Dart_Isolate isolate) override;
 
-  scoped_ptr<blink::SkyHeadless> headless_;
+  std::unique_ptr<blink::SkyHeadless> headless_;
   base::android::ScopedJavaGlobalRef<jobject> update_service_;
 };
 

--- a/sky/shell/platform/ios/sky_surface.mm
+++ b/sky/shell/platform/ios/sky_surface.mm
@@ -91,7 +91,7 @@ class TouchMapper {
   CGPoint _lastScrollTranslation;
 
   sky::SkyEnginePtr _sky_engine;
-  scoped_ptr<sky::shell::ShellView> _shell_view;
+  std::unique_ptr<sky::shell::ShellView> _shell_view;
   TouchMapper _touch_mapper;
 }
 

--- a/sky/shell/platform/mac/platform_mac.mm
+++ b/sky/shell/platform/mac/platform_mac.mm
@@ -72,7 +72,7 @@ int PlatformMacMain(int argc,
   // marker that can be used as a reference for startup.
   TRACE_EVENT_INSTANT0("flutter", "main", TRACE_EVENT_SCOPE_PROCESS);
 
-  scoped_ptr<base::MessageLoopForUI> message_loop(new base::MessageLoopForUI());
+  std::unique_ptr<base::MessageLoopForUI> message_loop(new base::MessageLoopForUI());
 
 #if TARGET_OS_IPHONE
   // One cannot start the message loop on the platform main thread. Instead,

--- a/sky/shell/platform/mac/sky_window.mm
+++ b/sky/shell/platform/mac/sky_window.mm
@@ -45,7 +45,7 @@ static inline pointer::PointerType EventTypeFromNSEventPhase(NSEventPhase phase)
 
 @implementation SkyWindow {
   sky::SkyEnginePtr _sky_engine;
-  scoped_ptr<sky::shell::ShellView> _shell_view;
+  std::unique_ptr<sky::shell::ShellView> _shell_view;
 }
 
 @synthesize renderSurface = _renderSurface;

--- a/sky/shell/platform/mojo/sky_application_impl.h
+++ b/sky/shell/platform/mojo/sky_application_impl.h
@@ -45,7 +45,7 @@ class SkyApplicationImpl : public mojo::Application {
   mojo::URLResponsePtr initial_response_;
   mojo::ShellPtr shell_;
   mojo::asset_bundle::AssetBundlePtr bundle_;
-  scoped_ptr<ShellView> shell_view_;
+  std::unique_ptr<ShellView> shell_view_;
 };
 
 }  // namespace shell

--- a/sky/shell/rasterizer.h
+++ b/sky/shell/rasterizer.h
@@ -8,7 +8,6 @@
 #include <memory>
 
 #include "base/callback.h"
-#include "base/memory/scoped_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "mojo/public/cpp/bindings/binding.h"
 #include "flow/layer_tree.h"
@@ -25,7 +24,7 @@ class Rasterizer : public rasterizer::Rasterizer {
   virtual base::WeakPtr<::sky::shell::Rasterizer> GetWeakRasterizerPtr() = 0;
 
   // Implemented by each GPU backend.
-  static scoped_ptr<Rasterizer> Create();
+  static std::unique_ptr<Rasterizer> Create();
 };
 
 }  // namespace shell

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -37,7 +37,7 @@ class NonDiscardableMemory : public base::DiscardableMemory {
   void* data() const override { return data_.get(); }
 
  private:
-  scoped_ptr<uint8_t[]> data_;
+  std::unique_ptr<uint8_t[]> data_;
 };
 
 class NonDiscardableMemoryAllocator : public base::DiscardableMemoryAllocator {

--- a/sky/shell/shell.h
+++ b/sky/shell/shell.h
@@ -7,7 +7,6 @@
 
 #include "base/macros.h"
 #include "base/memory/ref_counted.h"
-#include "base/memory/scoped_ptr.h"
 #include "base/message_loop/message_loop.h"
 #include "base/threading/thread.h"
 #include "sky/shell/tracing_controller.h"
@@ -46,9 +45,9 @@ class Shell {
   void InitGPU(const base::Thread::Options& options);
   void InitUI(const base::Thread::Options& options);
 
-  scoped_ptr<base::Thread> gpu_thread_;
-  scoped_ptr<base::Thread> ui_thread_;
-  scoped_ptr<base::Thread> io_thread_;
+  std::unique_ptr<base::Thread> gpu_thread_;
+  std::unique_ptr<base::Thread> ui_thread_;
+  std::unique_ptr<base::Thread> io_thread_;
 
   scoped_refptr<base::SingleThreadTaskRunner> gpu_task_runner_;
   scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner_;

--- a/sky/shell/shell_view.cc
+++ b/sky/shell/shell_view.cc
@@ -14,12 +14,6 @@
 
 namespace sky {
 namespace shell {
-namespace {
-
-template<typename T>
-void Drop(scoped_ptr<T> ptr) { }
-
-}  // namespace
 
 ShellView::ShellView(Shell& shell)
     : shell_(shell) {
@@ -30,10 +24,8 @@ ShellView::ShellView(Shell& shell)
 
 ShellView::~ShellView() {
   view_ = nullptr;
-  shell_.gpu_task_runner()->PostTask(FROM_HERE,
-      base::Bind(&Drop<Rasterizer>, base::Passed(&rasterizer_)));
-  shell_.ui_task_runner()->PostTask(FROM_HERE,
-      base::Bind(&Drop<Engine>, base::Passed(&engine_)));
+  shell_.gpu_task_runner()->DeleteSoon(FROM_HERE, rasterizer_.release());
+  shell_.ui_task_runner()->DeleteSoon(FROM_HERE, engine_.release());
 }
 
 void ShellView::CreateEngine() {

--- a/sky/shell/shell_view.h
+++ b/sky/shell/shell_view.h
@@ -5,9 +5,10 @@
 #ifndef SKY_SHELL_SHELL_VIEW_H_
 #define SKY_SHELL_SHELL_VIEW_H_
 
+#include <memory>
+
 #include "base/files/file_path.h"
 #include "base/macros.h"
-#include "base/memory/scoped_ptr.h"
 #include "mojo/public/cpp/system/data_pipe.h"
 
 namespace sky {
@@ -29,9 +30,9 @@ class ShellView {
   void CreatePlatformView();
 
   Shell& shell_;
-  scoped_ptr<PlatformView> view_;
-  scoped_ptr<Rasterizer> rasterizer_;
-  scoped_ptr<Engine> engine_;
+  std::unique_ptr<PlatformView> view_;
+  std::unique_ptr<Rasterizer> rasterizer_;
+  std::unique_ptr<Engine> engine_;
 
   DISALLOW_COPY_AND_ASSIGN(ShellView);
 };

--- a/sky/shell/testing/test_runner.h
+++ b/sky/shell/testing/test_runner.h
@@ -5,6 +5,7 @@
 #ifndef SKY_SHELL_TESTING_TEST_RUNNER_H_
 #define SKY_SHELL_TESTING_TEST_RUNNER_H_
 
+#include <memory>
 #include <string>
 
 #include "base/macros.h"
@@ -32,7 +33,7 @@ class TestRunner {
   TestRunner();
   ~TestRunner();
 
-  scoped_ptr<ShellView> shell_view_;
+  std::unique_ptr<ShellView> shell_view_;
   SkyEnginePtr sky_engine_;
 
   base::WeakPtrFactory<TestRunner> weak_ptr_factory_;

--- a/sky/shell/ui/animator.cc
+++ b/sky/shell/ui/animator.cc
@@ -83,14 +83,14 @@ void Animator::BeginFrame(int64_t time_stamp) {
   base::TimeTicks frame_time = time_stamp ?
       base::TimeTicks::FromInternalValue(time_stamp) : base::TimeTicks::Now();
 
-  scoped_ptr<flow::LayerTree> layer_tree =
-      make_scoped_ptr(engine_->BeginFrame(frame_time).release());
+  std::unique_ptr<flow::LayerTree> layer_tree = engine_->BeginFrame(frame_time);
 
   if (!layer_tree) {
     OnFrameComplete();
     return;
   }
 
+  // TODO(abarth): Doesn't this leak if OnFrameComplete never runs?
   rasterizer_->Draw(reinterpret_cast<uint64_t>(layer_tree.release()),
       base::Bind(&Animator::OnFrameComplete, weak_factory_.GetWeakPtr()));
 }

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -7,7 +7,6 @@
 
 #include "base/files/file_path.h"
 #include "base/macros.h"
-#include "base/memory/scoped_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/single_thread_task_runner.h"
 #include "mojo/public/cpp/bindings/binding.h"
@@ -87,11 +86,11 @@ class Engine : public UIDelegate,
   void StartAnimatorIfPossible();
 
   Config config_;
-  scoped_ptr<Animator> animator_;
+  std::unique_ptr<Animator> animator_;
 
   ServicesDataPtr services_;
   mojo::asset_bundle::AssetBundlePtr root_bundle_;
-  scoped_ptr<blink::DartLibraryProvider> dart_library_provider_;
+  std::unique_ptr<blink::DartLibraryProvider> dart_library_provider_;
   std::unique_ptr<blink::SkyView> sky_view_;
 
   gfx::Size physical_size_;


### PR DESCRIPTION
We now use std::unique_ptr more consistently.