### PR TITLE
Create a new pipe to the ServiceProvider when PlatformViewAndroid sta…

### DIFF
--- a/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
@@ -271,14 +271,20 @@ public class PlatformViewAndroid extends SurfaceView {
         ServiceRegistry localRegistry = new ServiceRegistry();
         configureLocalServices(localRegistry);
 
+        mServiceProvider = new PlatformServiceProvider(core, getContext(), localRegistry);
+    }
+
+    void runFromBundle(String path) {
+        Core core = CoreImpl.getInstance();
         Pair<ServiceProvider.Proxy, InterfaceRequest<ServiceProvider>> serviceProvider =
                 ServiceProvider.MANAGER.getInterfaceRequest(core);
-        mServiceProvider = new PlatformServiceProvider(core, getContext(), localRegistry);
         ServiceProvider.MANAGER.bind(mServiceProvider, serviceProvider.second);
 
         ServicesData services = new ServicesData();
         services.servicesProvidedByEmbedder = serviceProvider.first;
         mSkyEngine.setServices(services);
+
+        mSkyEngine.runFromBundle(path);
     }
 
     private static native long nativeAttach(int inputObserverHandle);

--- a/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -138,7 +138,7 @@ public class SkyActivity extends Activity {
         File dataDir = new File(PathUtils.getDataDirectory(this));
         File appBundle = new File(dataDir, SkyApplication.APP_BUNDLE);
         if (appBundle.exists()) {
-            mView.getEngine().runFromBundle(appBundle.getPath());
+            mView.runFromBundle(appBundle.getPath());
             return;
         }
     }
@@ -151,7 +151,7 @@ public class SkyActivity extends Activity {
         String action = intent.getAction();
 
         if (Intent.ACTION_RUN.equals(action)) {
-            mView.getEngine().runFromBundle(intent.getDataString());
+            mView.runFromBundle(intent.getDataString());
             String route = intent.getStringExtra("route");
             if (route != null)
                 mView.getEngine().pushRoute(route);
@@ -167,7 +167,7 @@ public class SkyActivity extends Activity {
         if (!bundle.exists()) {
             return false;
         }
-        mView.getEngine().runFromBundle(bundle.getPath());
+        mView.runFromBundle(bundle.getPath());
         return true;
     }
 


### PR DESCRIPTION
…rts a Dart isolate

Previously PlatformViewAndroid would create a pipe and hand it off to the
SkyEngine, which would give it to the isolate's DartState.  If a second
isolate is created, the SkyEngine would no longer hold a valid proxy to a
ServicesProvider, and the new isolate's Dart code can not obtain the
servicesProvidedByEmbedder.