### PR TITLE
Reset the animator before assigning a new vsync provider

### DIFF
--- a/sky/shell/ui/animator.cc
+++ b/sky/shell/ui/animator.cc
@@ -126,5 +126,19 @@ bool Animator::AwaitVSync() {
   return false;
 }
 
+void Animator::Reset() {
+  weak_factory_.InvalidateWeakPtrs();
+
+  outstanding_requests_ = 0;
+  did_defer_frame_request_ = false;
+  engine_requested_frame_ = false;
+  paused_ = false;
+}
+
+void Animator::set_vsync_provider(vsync::VSyncProviderPtr vsync_provider) {
+  DCHECK(!engine_requested_frame_);
+  vsync_provider_ = vsync_provider.Pass();
+}
+
 }  // namespace shell
 }  // namespace sky

--- a/sky/shell/ui/animator.h
+++ b/sky/shell/ui/animator.h
@@ -24,15 +24,15 @@ class Animator {
 
   void Start();
   void Stop();
+  void Reset();
+
+  void set_vsync_provider(vsync::VSyncProviderPtr vsync_provider);
 
   void set_scene_scheduler(
       mojo::gfx::composition::SceneSchedulerPtr scene_scheduler) {
     scene_scheduler_ = scene_scheduler.Pass();
   }
 
-  void set_vsync_provider(vsync::VSyncProviderPtr vsync_provider) {
-    vsync_provider_ = vsync_provider.Pass();
-  }
 
  private:
   void Animate(mojo::gfx::composition::FrameInfoPtr frame_info);

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -119,6 +119,7 @@ void Engine::SetServices(ServicesDataPtr services) {
   services_ = services.Pass();
 
   if (services_->scene_scheduler) {
+    animator_->Reset();
     animator_->set_scene_scheduler(services_->scene_scheduler.Pass());
   } else {
 #if defined(OS_ANDROID) || defined(OS_IOS)
@@ -130,6 +131,7 @@ void Engine::SetServices(ServicesDataPtr services) {
       mojo::ConnectToService(services_->services_provided_by_embedder.get(),
                              &vsync_provider);
     }
+    animator_->Reset();
     animator_->set_vsync_provider(vsync_provider.Pass());
 #endif
   }


### PR DESCRIPTION
When the engine starts a new version of the Dart application, the animator may
have pending callbacks and other state related to the previous run of the app.
This state must be cleared before the new vsync provider is assigned.