### PR TITLE
Add Paragraph#getPositionForOffset

### DIFF
--- a/sky/engine/core/core.gni
+++ b/sky/engine/core/core.gni
@@ -14,6 +14,8 @@ sky_core_files = [
   "editing/CompositionUnderline.h",
   "editing/CompositionUnderlineRangeFilter.cpp",
   "editing/CompositionUnderlineRangeFilter.h",
+  "editing/PositionWithAffinity.cpp",
+  "editing/PositionWithAffinity.h",
   "painting/Canvas.cpp",
   "painting/Canvas.h",
   "painting/CanvasColor.cpp",

--- a/sky/engine/core/editing/PositionWithAffinity.cpp
+++ b/sky/engine/core/editing/PositionWithAffinity.cpp
@@ -1,0 +1,20 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/engine/core/editing/PositionWithAffinity.h"
+
+namespace blink {
+
+PositionWithAffinity::PositionWithAffinity(RenderObject* renderer, int offset, EAffinity affinity)
+    : m_renderer(renderer)
+    , m_offset(offset)
+    , m_affinity(affinity)
+{
+}
+
+PositionWithAffinity::~PositionWithAffinity()
+{
+}
+
+} // namespace blink

--- a/sky/engine/core/editing/PositionWithAffinity.h
+++ b/sky/engine/core/editing/PositionWithAffinity.h
@@ -1,0 +1,44 @@
+// Copyright 2014 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_ENGINE_CORE_EDITING_POSITIONWITHAFFINITY_H_
+#define SKY_ENGINE_CORE_EDITING_POSITIONWITHAFFINITY_H_
+
+namespace blink {
+
+class RenderObject;
+
+enum EAffinity { UPSTREAM, DOWNSTREAM };
+
+// VisiblePosition default affinity is downstream because
+// the callers do not really care (they just want the
+// deep position without regard to line position), and this
+// is cheaper than UPSTREAM
+#define VP_DEFAULT_AFFINITY DOWNSTREAM
+
+// Callers who do not know where on the line the position is,
+// but would like UPSTREAM if at a line break or DOWNSTREAM
+// otherwise, need a clear way to specify that.  The
+// constructors auto-correct UPSTREAM to DOWNSTREAM if the
+// position is not at a line break.
+#define VP_UPSTREAM_IF_POSSIBLE UPSTREAM
+
+class PositionWithAffinity {
+public:
+    PositionWithAffinity(RenderObject* renderer, int offset, EAffinity = DOWNSTREAM);
+    ~PositionWithAffinity();
+
+    RenderObject* renderer() const { return m_renderer; }
+    int offset() const { return m_offset; }
+    EAffinity affinity() const { return m_affinity; }
+
+private:
+    RenderObject* m_renderer;
+    int m_offset;
+    EAffinity m_affinity;
+};
+
+} // namespace blink
+
+#endif  // SKY_ENGINE_CORE_EDITING_POSITIONWITHAFFINITY_H_

--- a/sky/engine/core/rendering/RenderBlock.h
+++ b/sky/engine/core/rendering/RenderBlock.h
@@ -132,6 +132,8 @@ public:
 
     LayoutUnit textIndentOffset() const;
 
+    virtual PositionWithAffinity positionForPoint(const LayoutPoint&) override;
+
     // Block flows subclass availableWidth to handle multi column layout (shrinking the width available to children when laying out.)
     virtual LayoutUnit availableLogicalWidth() const override final;
 
@@ -274,6 +276,8 @@ private:
     virtual void absoluteQuads(Vector<FloatQuad>&) const override;
 
     virtual LayoutRect localCaretRect(InlineBox*, int caretOffset, LayoutUnit* extraWidthToEndOfLine = 0) override final;
+
+    PositionWithAffinity positionForPointWithInlineChildren(const LayoutPoint&);
 
     void removeFromGlobalMaps();
     bool widthAvailableToChildrenHasChanged();

--- a/sky/engine/core/rendering/RenderBox.h
+++ b/sky/engine/core/rendering/RenderBox.h
@@ -435,6 +435,8 @@ public:
         return true;
     }
 
+    virtual PositionWithAffinity positionForPoint(const LayoutPoint&) override;
+
     void removeFloatingOrPositionedChildFromBlockLists();
 
     RenderLayer* enclosingFloatPaintingLayer() const;

--- a/sky/engine/core/rendering/RenderInline.cpp
+++ b/sky/engine/core/rendering/RenderInline.cpp
@@ -370,6 +370,23 @@ bool RenderInline::hitTestCulledInline(const HitTestRequest& request, HitTestRes
     return false;
 }
 
+PositionWithAffinity RenderInline::positionForPoint(const LayoutPoint& point)
+{
+    // FIXME(sky): Now that we don't have continuations, can this whole function just be the following?
+    // return containingBlock()->positionForPoint(point);
+
+    // FIXME: Does not deal with relative positioned inlines (should it?)
+    RenderBlock* cb = containingBlock();
+    if (firstLineBox()) {
+        // This inline actually has a line box.  We must have clicked in the border/padding of one of these boxes.  We
+        // should try to find a result by asking our containing block.
+        return cb->positionForPoint(point);
+    }
+
+    // Translate the coords from the pre-anonymous block to the post-anonymous block.
+    return RenderBoxModelObject::positionForPoint(point);
+}
+
 namespace {
 
 class LinesBoundingBoxGeneratorContext {

--- a/sky/engine/core/rendering/RenderInline.h
+++ b/sky/engine/core/rendering/RenderInline.h
@@ -116,6 +116,8 @@ private:
 
     virtual void mapLocalToContainer(const RenderBox* paintInvalidationContainer, TransformState&, MapCoordinatesFlags = ApplyContainerFlip) const override;
 
+    virtual PositionWithAffinity positionForPoint(const LayoutPoint&) override final;
+
     virtual IntRect borderBoundingBox() const override final
     {
         IntRect boundingBox = linesBoundingBox();

--- a/sky/engine/core/rendering/RenderObject.cpp
+++ b/sky/engine/core/rendering/RenderObject.cpp
@@ -1402,6 +1402,11 @@ void RenderObject::postDestroy()
     delete this;
 }
 
+PositionWithAffinity RenderObject::positionForPoint(const LayoutPoint&)
+{
+    return createPositionWithAffinity(caretMinOffset(), DOWNSTREAM);
+}
+
 // FIXME(sky): Change the callers to use nodeAtPoint direclty and remove this function.
 // Or, rename nodeAtPoint to hitTest?
 bool RenderObject::hitTest(const HitTestRequest& request, HitTestResult& result, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset)
@@ -1525,6 +1530,11 @@ bool RenderObject::supportsTouchAction() const
     if (isInline() && !isReplaced())
         return false;
     return true;
+}
+
+PositionWithAffinity RenderObject::createPositionWithAffinity(int offset, EAffinity affinity)
+{
+    return PositionWithAffinity(this, offset, affinity);
 }
 
 bool RenderObject::canUpdateSelectionOnRootLineBoxes()

--- a/sky/engine/core/rendering/RenderObject.h
+++ b/sky/engine/core/rendering/RenderObject.h
@@ -26,6 +26,7 @@
 #ifndef SKY_ENGINE_CORE_RENDERING_RENDEROBJECT_H_
 #define SKY_ENGINE_CORE_RENDERING_RENDEROBJECT_H_
 
+#include "sky/engine/core/editing/PositionWithAffinity.h"
 #include "sky/engine/core/rendering/HitTestRequest.h"
 #include "sky/engine/core/rendering/RenderObjectChildList.h"
 #include "sky/engine/core/rendering/SubtreeLayoutScope.h"
@@ -389,6 +390,10 @@ public:
     bool hitTest(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset);
     virtual void updateHitTestResult(HitTestResult&, const LayoutPoint&);
     virtual bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset);
+
+    virtual PositionWithAffinity positionForPoint(const LayoutPoint&);
+    PositionWithAffinity createPositionWithAffinity(int offset, EAffinity);
+    PositionWithAffinity createPositionWithAffinity(const Position&);
 
     virtual void dirtyLinesFromChangedChild(RenderObject*);
 

--- a/sky/engine/core/rendering/RenderReplaced.cpp
+++ b/sky/engine/core/rendering/RenderReplaced.cpp
@@ -374,6 +374,26 @@ void RenderReplaced::computePreferredLogicalWidths()
     clearPreferredLogicalWidthsDirty();
 }
 
+PositionWithAffinity RenderReplaced::positionForPoint(const LayoutPoint& point)
+{
+    // FIXME: This code is buggy if the replaced element is relative positioned.
+    InlineBox* box = inlineBoxWrapper();
+    RootInlineBox* rootBox = box ? &box->root() : 0;
+
+    LayoutUnit top = rootBox ? rootBox->selectionTop() : logicalTop();
+    LayoutUnit bottom = rootBox ? rootBox->selectionBottom() : logicalBottom();
+
+    LayoutUnit blockDirectionPosition = point.y() + y();
+
+    if (blockDirectionPosition < top)
+        return createPositionWithAffinity(caretMinOffset(), DOWNSTREAM); // coordinates are above
+
+    if (blockDirectionPosition >= bottom)
+        return createPositionWithAffinity(caretMaxOffset(), DOWNSTREAM); // coordinates are below
+
+    return RenderBox::positionForPoint(point);
+}
+
 LayoutRect RenderReplaced::localSelectionRect(bool checkWhetherSelected) const
 {
     if (checkWhetherSelected && !isSelected())

--- a/sky/engine/core/rendering/RenderReplaced.h
+++ b/sky/engine/core/rendering/RenderReplaced.h
@@ -78,6 +78,8 @@ private:
     virtual void computePreferredLogicalWidths() override final;
     virtual void paintReplaced(PaintInfo&, const LayoutPoint&) { }
 
+    virtual PositionWithAffinity positionForPoint(const LayoutPoint&) override final;
+
     virtual bool canBeSelectionLeaf() const override { return true; }
 
     void computeAspectRatioInformationForRenderBox(FloatSize& constrainedSize, double& intrinsicRatio) const;

--- a/sky/engine/core/rendering/RenderText.h
+++ b/sky/engine/core/rendering/RenderText.h
@@ -65,6 +65,8 @@ public:
     enum ClippingOption { NoClipping, ClipToEllipsis };
     void absoluteQuads(Vector<FloatQuad>&, ClippingOption = NoClipping) const;
 
+    virtual PositionWithAffinity positionForPoint(const LayoutPoint&) override;
+
     bool is8Bit() const { return m_text.is8Bit(); }
     const LChar* characters8() const { return m_text.impl()->characters8(); }
     const UChar* characters16() const { return m_text.impl()->characters16(); }

--- a/sky/engine/core/text/Paragraph.h
+++ b/sky/engine/core/text/Paragraph.h
@@ -48,6 +48,7 @@ public:
     void paint(Canvas* canvas, const Offset& offset);
 
     std::vector<TextBox> getRectsForRange(unsigned start, unsigned end);
+    Dart_Handle getPositionForOffset(const Offset& offset);
 
     RenderView* renderView() const { return m_renderView.get(); }
 
@@ -55,6 +56,8 @@ public:
 
 private:
     RenderBox* firstChildBox() const { return m_renderView->firstChildBox(); }
+
+    int absoluteOffsetForPosition(const PositionWithAffinity& position);
 
     LayoutUnit m_minWidth;
     LayoutUnit m_maxWidth;


### PR DESCRIPTION
We'll use this function to position the caret when the user taps a text
input control.

Very little of the code in this patch is actually new. Most of it is
restoring code that we previously removed from the engine. I've made
some small changes to the restored code to handle the lack of a DOM. The
only major change is to RenderObject::createPositionWithAffinity, which
now just returns the values it captures instead of trying to compute a
DOM position.

TextAffinity and TextPosition are lifted from package:flutter. Once this
patch rolls into package:flutter, I'll remove the declarations there.