### PR TITLE
Clear the Flow raster cache when a GrContext is destroyed

### DIFF
--- a/flow/paint_context.cc
+++ b/flow/paint_context.cc
@@ -49,4 +49,8 @@ PaintContext::ScopedFrame::~ScopedFrame() {
 PaintContext::~PaintContext() {
 }
 
+void PaintContext::OnGrContextDestroyed() {
+  raster_cache_.Clear();
+}
+
 }  // namespace flow

--- a/flow/paint_context.h
+++ b/flow/paint_context.h
@@ -51,6 +51,8 @@ class PaintContext {
                            SkCanvas& canvas,
                            bool instrumentation_enabled = true);
 
+  void OnGrContextDestroyed();
+
   RasterCache& raster_cache() { return raster_cache_; }
   const instrumentation::Counter& frame_count() const { return frame_count_; }
   const instrumentation::Stopwatch& frame_time() const { return frame_time_; }

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -112,4 +112,8 @@ void RasterCache::SweepAfterFrame() {
     cache_.erase(it);
 }
 
+void RasterCache::Clear() {
+  cache_.clear();
+}
+
 }  // namespace flow

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -25,6 +25,8 @@ class RasterCache {
       GrContext* context, SkPicture* picture, const SkMatrix& ctm);
   void SweepAfterFrame();
 
+  void Clear();
+
  private:
   struct Entry {
     Entry();

--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -130,6 +130,7 @@ void RasterizerDirect::Draw(uint64_t layer_tree_ptr,
 void RasterizerDirect::OnOutputSurfaceDestroyed() {
   if (context_) {
     CHECK(context_->MakeCurrent(surface_.get()));
+    paint_context_.OnGrContextDestroyed();
     ganesh_canvas_.SetGrGLInterface(nullptr);
     context_ = nullptr;
   }


### PR DESCRIPTION
After an application is suspended and the GrContext associated with the
Flutter view is destroyed, the raster cache still contains images tied
to the defunct context.  The SkyShell process will crash if these images
are used after the application resumes.