### PR TITLE
some work towards a --start-paused flag

### DIFF
--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -93,6 +93,10 @@ static const char* kDartCheckedModeArgs[] = {
     "--error_on_bad_override",
 };
 
+static const char* kDartStartPausedArgs[]{
+    "--pause_isolates_on_start",
+};
+
 void IsolateShutdownCallback(void* callback_data) {
   // TODO(dart)
 }
@@ -294,6 +298,9 @@ void InitDartVM() {
 
   if (enable_checked_mode)
     args.append(kDartCheckedModeArgs, arraysize(kDartCheckedModeArgs));
+
+  if (SkySettings::Get().start_paused)
+    args.append(kDartStartPausedArgs, arraysize(kDartStartPausedArgs));
 
   CHECK(Dart_SetVMFlags(args.size(), args.data()));
 

--- a/sky/engine/public/platform/sky_settings.h
+++ b/sky/engine/public/platform/sky_settings.h
@@ -9,6 +9,7 @@ namespace blink {
 
 struct SkySettings {
   bool enable_observatory = false;
+  bool start_paused = false;
   bool enable_dart_checked_mode = false;
 
   static const SkySettings& Get();

--- a/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -45,6 +45,9 @@ public class SkyActivity extends Activity {
         if (intent.getBooleanExtra("trace-startup", false)) {
             args.add("--trace-startup");
         }
+        if (intent.getBooleanExtra("start-paused", false)) {
+            args.add("--start-paused");
+        }
         if (!args.isEmpty()) {
             String[] argsArray = new String[args.size()];
             return args.toArray(argsArray);

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -83,6 +83,7 @@ void Shell::InitStandalone() {
   blink::SkySettings settings;
   settings.enable_observatory =
       !command_line.HasSwitch(switches::kNonInteractive);
+  settings.start_paused = command_line.HasSwitch(switches::kStartPaused);
   settings.enable_dart_checked_mode =
       command_line.HasSwitch(switches::kEnableCheckedMode);
   blink::SkySettings::Set(settings);

--- a/sky/shell/switches.cc
+++ b/sky/shell/switches.cc
@@ -15,12 +15,14 @@ const char kFLX[] = "flx";
 const char kHelp[] = "help";
 const char kNonInteractive[] = "non-interactive";
 const char kPackageRoot[] = "package-root";
+const char kStartPaused[] = "start-paused";
 const char kTraceStartup[] = "trace-startup";
 
 void PrintUsage(const std::string& executable_name) {
   std::cerr << "Usage: " << executable_name
             << " --" << kEnableCheckedMode
             << " --" << kNonInteractive
+            << " --" << kStartPaused
             << " --" << kTraceStartup
             << " --" << kFLX << "=FLX"
             << " --" << kPackageRoot << "=PACKAGE_ROOT"

--- a/sky/shell/switches.h
+++ b/sky/shell/switches.h
@@ -16,6 +16,7 @@ extern const char kFLX[];
 extern const char kHelp[];
 extern const char kNonInteractive[];
 extern const char kPackageRoot[];
+extern const char kStartPaused[];
 extern const char kTraceStartup[];
 
 void PrintUsage(const std::string& executable_name);

--- a/sky/shell/tracing_controller.cc
+++ b/sky/shell/tracing_controller.cc
@@ -32,7 +32,7 @@ static const char* ObservatoryInvoke(const char* method,
                                      intptr_t num_params,
                                      void* user_data) {
   if (user_data == nullptr) {
-    // During the desctruction on the tracing controller, the user data is
+    // During the destruction of the tracing controller, the user data is
     // cleared. Make sure that observatory requests to service calls are not
     // attempted after tracing controller destruction.
     return strdup(kObservatoryResultFail);
@@ -54,8 +54,7 @@ static const char* ObservatoryInvoke(const char* method,
       // Flushing the trace log requires an active message loop. However,
       // observatory callbacks are made on a dart worker thread. We setup a
       // message loop manually and tell the flush completion handler to
-      // terminate
-      // the loop when done
+      // terminate the loop when done
       base::MessageLoop worker_thread_loop;
 
       base::FilePath temp_dir;


### PR DESCRIPTION
Related to https://github.com/flutter/flutter/pull/1526. This looks for a `--start-paused` flag and passes it into the VM as `--pause_isolates_on_start`. From talking to @johnmccutchan, the current isolate start paused mechanism will not work for Flutter. We can land this PR if it gets us closer to a solution, or close it if not.

@abarth @johnmccutchan 