### PR TITLE
use 'build --target' in the xcode project instead of --main

### DIFF
--- a/sky/build/PackagerInvoke
+++ b/sky/build/PackagerInvoke
@@ -64,7 +64,7 @@ PackageProject() {
 
   RunCommand ${FLUTTER_ROOT}/bin/flutter build                                 \
       --asset-base ${icons_path}                                               \
-      --main ${dart_main}                                                      \
+      --target ${dart_main}                                                    \
       --output-file ${derived_dir}/app.flx                                     \
       --package-root ${package_root}                                           \
       --compiler ${src_dir}/ScriptSnapshotter                                  \


### PR DESCRIPTION
Update the xcode project to call `build --target` instead of `build --main`.

@chinmaygarde 