### PR TITLE
Change services to create temporary files that will be deleted by the…

### DIFF
--- a/sky/services/common/BUILD.gn
+++ b/sky/services/common/BUILD.gn
@@ -1,0 +1,10 @@
+if (is_android) {
+  import("//build/config/android/config.gni")
+  import("//build/config/android/rules.gni")
+
+  android_library("common_lib") {
+    java_files = [
+      "src/org/domokit/common/ResourcePaths.java",
+    ]
+  }
+}

--- a/sky/services/common/src/org/domokit/common/ResourcePaths.java
+++ b/sky/services/common/src/org/domokit/common/ResourcePaths.java
@@ -1,0 +1,21 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.domokit.common;
+
+import android.content.Context;
+
+import java.io.File;
+import java.io.IOException;
+
+public class ResourcePaths {
+    // The filename prefix used by Chromium temporary file APIs.
+    public static final String TEMPORARY_RESOURCE_PREFIX = ".org.chromium.Chromium.";
+
+    // Return a temporary file that will be cleaned up by the ResourceCleaner.
+    public static File createTempFile(Context context, String suffix) throws IOException {
+        return File.createTempFile(TEMPORARY_RESOURCE_PREFIX, "_" + suffix,
+                                   context.getCacheDir());
+    }
+}

--- a/sky/services/media/BUILD.gn
+++ b/sky/services/media/BUILD.gn
@@ -36,6 +36,7 @@ if (is_android) {
       "//mojo/java",
       "//mojo/public/java:bindings",
       "//mojo/public/java:system",
+      "//sky/services/common:common_lib",
       ":interfaces_java",
     ]
   }

--- a/sky/services/media/src/org/domokit/media/MediaPlayerImpl.java
+++ b/sky/services/media/src/org/domokit/media/MediaPlayerImpl.java
@@ -12,6 +12,7 @@ import org.chromium.mojo.system.Core;
 import org.chromium.mojo.system.DataPipe;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.media.MediaPlayer;
+import org.domokit.common.ResourcePaths;
 
 import java.io.File;
 import java.io.IOException;
@@ -78,7 +79,7 @@ public class MediaPlayerImpl implements MediaPlayer, android.media.MediaPlayer.O
         File outputDir = mContext.getCacheDir();
         mPrepareResponse = callback;
         try {
-            mTempFile = File.createTempFile("sky_media_player", "temp", outputDir);
+            mTempFile = ResourcePaths.createTempFile(mContext, "mediaPlayer");
         } catch (IOException e) {
             Log.e(TAG, "Failed to create temporary file", e);
             callback.call(false);

--- a/sky/services/media/src/org/domokit/media/SoundPoolImpl.java
+++ b/sky/services/media/src/org/domokit/media/SoundPoolImpl.java
@@ -13,6 +13,7 @@ import org.chromium.mojo.system.Core;
 import org.chromium.mojo.system.DataPipe;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.media.SoundPool;
+import org.domokit.common.ResourcePaths;
 
 import java.io.File;
 import java.io.IOException;
@@ -67,7 +68,7 @@ public class SoundPoolImpl implements SoundPool, android.media.SoundPool.OnLoadC
     public void load(DataPipe.ConsumerHandle consumerHandle, final LoadResponse callback) {
         File file;
         try {
-            file = File.createTempFile("sky_sound_pool", "temp", mContext.getCacheDir());
+            file = ResourcePaths.createTempFile(mContext, "soundPool");
         } catch (IOException e) {
             Log.e(TAG, "Failed to create temporary file", e);
             callback.call(false, 0);

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -179,6 +179,7 @@ if (is_android) {
       "//services/sensors:sensors_lib",
       "//sky/services/activity:activity_lib",
       "//sky/services/activity:interfaces_java",
+      "//sky/services/common:common_lib",
       "//sky/services/editing:editing_lib",
       "//sky/services/editing:interfaces_java",
       "//sky/services/engine:interfaces_java",

--- a/sky/shell/platform/android/org/domokit/sky/shell/ResourceCleaner.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/ResourceCleaner.java
@@ -11,13 +11,15 @@ import android.util.Log;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.io.IOException;
+
+import org.domokit.common.ResourcePaths;
 
 /**
  * A class to clean up orphaned resource directories after unclean shutdowns.
  **/
 public class ResourceCleaner {
     private static final String TAG = "ResourceCleaner";
-    private static final String TEMPORARY_RESOURCE_PREFIX = ".org.chromium.Chromium.";
     private static final long DELAY_MS = 5000;
 
     private class CleanTask extends AsyncTask<Void, Void, Void> {
@@ -67,7 +69,7 @@ public class ResourceCleaner {
         final CleanTask task = new CleanTask(cacheDir.listFiles(new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
-                boolean result = name.startsWith(TEMPORARY_RESOURCE_PREFIX);
+                boolean result = name.startsWith(ResourcePaths.TEMPORARY_RESOURCE_PREFIX);
                 return result;
             }
         }));


### PR DESCRIPTION
… ResourceCleaner

If the Sky shell process does not have an orderly shutdown, then temporary
files created by services may never be cleaned up.

The ResourceCleaner task will run at the next startup and clean up any files
that match the prefix used by Chromium's temporary file API.  Services will
now use the same prefix for their files.