### PR TITLE
Include child scenes when uploading to Mozart

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -42,7 +42,8 @@ source_set("flow") {
 
   deps = [
     "//base",
-    "//skia",
     "//mojo/services/gfx/composition/interfaces",
+    "//mojo/skia",
+    "//skia",
   ]
 }

--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -4,7 +4,12 @@
 
 #include "flow/layers/child_scene_layer.h"
 
+#include "mojo/skia/type_converters.h"
+
 namespace flow {
+
+// TODO(abarth): We need to figure out how to allocate these ids sensibly.
+static uint32_t next_id = 10;
 
 ChildSceneLayer::ChildSceneLayer() {
 }
@@ -12,7 +17,29 @@ ChildSceneLayer::ChildSceneLayer() {
 ChildSceneLayer::~ChildSceneLayer() {
 }
 
+void ChildSceneLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  transform_ = matrix;
+}
+
 void ChildSceneLayer::Paint(PaintContext::ScopedFrame& frame) {
+}
+
+void ChildSceneLayer::UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                                  mojo::gfx::composition::Node* container) {
+  uint32_t id = next_id++;
+
+  auto child_resource = mojo::gfx::composition::Resource::New();
+  child_resource->set_scene(mojo::gfx::composition::SceneResource::New());
+  child_resource->get_scene()->scene_token = scene_token_.Clone();
+  update->resources.insert(id, child_resource.Pass());
+
+  auto child_node = mojo::gfx::composition::Node::New();
+  child_node->op = mojo::gfx::composition::NodeOp::New();
+  child_node->op->set_scene(mojo::gfx::composition::SceneNodeOp::New());
+  child_node->op->get_scene()->scene_resource_id = id;
+  child_node->content_transform = mojo::Transform::From(transform_);
+  update->nodes.insert(id, child_node.Pass());
+  container->child_node_ids.push_back(id);
 }
 
 }  // namespace flow

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -25,12 +25,16 @@ class ChildSceneLayer : public Layer {
     scene_token_ = scene_token.Pass();
   }
 
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
+  void UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                   mojo::gfx::composition::Node* container) override;
 
  private:
   SkPoint offset_;
   SkISize physical_size_;
   mojo::gfx::composition::SceneTokenPtr scene_token_;
+  SkMatrix transform_;
 
   DISALLOW_COPY_AND_ASSIGN(ChildSceneLayer);
 };

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -37,4 +37,10 @@ void ContainerLayer::PaintChildren(PaintContext::ScopedFrame& frame) const {
     layer->Paint(frame);
 }
 
+void ContainerLayer::UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                                 mojo::gfx::composition::Node* container) {
+  for (auto& layer : layers_)
+    layer->UpdateScene(update, container);
+}
+
 }  // namespace flow

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -22,6 +22,9 @@ class ContainerLayer : public Layer {
 
   void PaintChildren(PaintContext::ScopedFrame& frame) const;
 
+  void UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                   mojo::gfx::composition::Node* container) override;
+
   const std::vector<std::unique_ptr<Layer>>& layers() const { return layers_; }
 
  private:

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -20,4 +20,8 @@ Layer::~Layer() {
 void Layer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 }
 
+void Layer::UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                        mojo::gfx::composition::Node* container) {
+}
+
 }  // namespace flow

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -10,8 +10,9 @@
 
 #include "base/logging.h"
 #include "base/macros.h"
-#include "skia/ext/refptr.h"
 #include "flow/paint_context.h"
+#include "mojo/services/gfx/composition/interfaces/scenes.mojom.h"
+#include "skia/ext/refptr.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkColor.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
@@ -37,6 +38,9 @@ class Layer {
 
   virtual void Preroll(PrerollContext* context, const SkMatrix& matrix);
   virtual void Paint(PaintContext::ScopedFrame& frame) = 0;
+
+  virtual void UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                           mojo::gfx::composition::Node* container);
 
   ContainerLayer* parent() const { return parent_; }
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -17,15 +17,21 @@ LayerTree::~LayerTree() {
 
 void LayerTree::Raster(PaintContext::ScopedFrame& frame) {
   {
-    TRACE_EVENT0("flutter", "LayerTree::Preroll")
+    TRACE_EVENT0("flutter", "LayerTree::Preroll");
     Layer::PrerollContext context = { frame, SkRect::MakeEmpty() };
     root_layer_->Preroll(&context, SkMatrix());
   }
 
   {
-    TRACE_EVENT0("flutter", "LayerTree::Paint")
+    TRACE_EVENT0("flutter", "LayerTree::Paint");
     root_layer_->Paint(frame);
   }
+}
+
+void LayerTree::UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                            mojo::gfx::composition::Node* container) {
+  TRACE_EVENT0("flutter", "LayerTree::UpdateScene");
+  root_layer_->UpdateScene(update, container);
 }
 
 }  // namespace flow

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -22,6 +22,12 @@ class LayerTree {
 
   void Raster(PaintContext::ScopedFrame& frame);
 
+  // TODO(abarth): Integrate scene updates with the rasterization pass so that
+  // we can draw on top of child scenes (and so that we can apply clips and
+  // blending operations to child scene).
+  void UpdateScene(mojo::gfx::composition::SceneUpdate* update,
+                   mojo::gfx::composition::Node* container);
+
   Layer* root_layer() const { return root_layer_.get(); }
 
   void set_root_layer(std::unique_ptr<Layer> root_layer) {

--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -84,6 +84,8 @@ void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
   DCHECK(resource);
 
   auto update = mojo::gfx::composition::SceneUpdate::New();
+  update->clear_resources = true;
+  update->clear_nodes = true;
   update->resources.insert(kContentImageResourceId, resource.Pass());
   auto root_node = mojo::gfx::composition::Node::New();
   root_node->op = mojo::gfx::composition::NodeOp::New();
@@ -93,6 +95,8 @@ void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
   root_node->op->get_image()->content_rect->height = size.height;
   root_node->op->get_image()->image_resource_id = kContentImageResourceId;
   update->nodes.insert(kRootNodeId, root_node.Pass());
+
+  layer_tree->UpdateScene(update.get(), root_node.get());
 
   scene_->Update(update.Pass());
   scene_->Publish(nullptr);


### PR DESCRIPTION
Previously we just dropped child scenes on the floor. Now we upload them
to Mozart. However, we just draw them on top of all the other content
and don't apply any clips or blends.