### PR TITLE
Pass the Mozart ViewHost into Dart

### DIFF
--- a/sky/engine/bindings/internals.dart
+++ b/sky/engine/bindings/internals.dart
@@ -11,3 +11,4 @@ int takeServiceRegistry() native "takeServiceRegistry";
 int takeServicesProvidedByEmbedder() native "takeServicesProvidedByEmbedder";
 int takeServicesProvidedToEmbedder() native "takeServicesProvidedToEmbedder";
 int takeShellProxyHandle() native "takeShellProxyHandle";
+int takeViewHostHandle() native "takeViewHostHandle";

--- a/sky/services/engine/BUILD.gn
+++ b/sky/services/engine/BUILD.gn
@@ -15,6 +15,7 @@ mojom("interfaces") {
     "//mojo/services/asset_bundle/interfaces",
     "//mojo/services/gfx/composition/interfaces",
     "//mojo/services/service_registry/interfaces",
+    "//mojo/services/ui/views/interfaces",
     "//sky/services/pointer:interfaces",
   ]
 }

--- a/sky/services/engine/sky_engine.mojom
+++ b/sky/services/engine/sky_engine.mojom
@@ -9,6 +9,7 @@ import "mojo/public/interfaces/application/shell.mojom";
 import "mojo/services/asset_bundle/interfaces/asset_bundle.mojom";
 import "mojo/services/gfx/composition/interfaces/scheduling.mojom";
 import "mojo/services/service_registry/interfaces/service_registry.mojom";
+import "mojo/services/ui/views/interfaces/views.mojom";
 import "sky/services/engine/input_event.mojom";
 import "sky/services/pointer/pointer.mojom";
 
@@ -32,6 +33,7 @@ struct ServicesData {
   mojo.ServiceRegistry? service_registry;
   mojo.ServiceProvider? services_provided_by_embedder;
   mojo.ServiceProvider&? services_provided_to_embedder;
+  mojo.ui.ViewHost? view_host;
   mojo.gfx.composition.SceneScheduler? scene_scheduler;
 };
 

--- a/sky/shell/platform/mojo/view_impl.h
+++ b/sky/shell/platform/mojo/view_impl.h
@@ -49,7 +49,6 @@ class ViewImpl : public mojo::ui::View,
   mojo::StrongBinding<mojo::ui::View> binding_;
   std::string url_;
   mojo::ui::ViewManagerPtr view_manager_;
-  mojo::ui::ViewHostPtr view_host_;
   mojo::ServiceProviderPtr view_service_provider_;
   mojo::ui::InputConnectionPtr input_connection_;
   mojo::Binding<mojo::ui::InputListener> listener_binding_;

--- a/sky/shell/ui/internals.cc
+++ b/sky/shell/ui/internals.cc
@@ -51,6 +51,11 @@ void TakeServicesProvidedToEmbedder(Dart_NativeArguments args) {
       args, GetInternals()->TakeServicesProvidedToEmbedder().value());
 }
 
+void TakeViewHostHandle(Dart_NativeArguments args) {
+  Dart_SetIntegerReturnValue(
+      args, GetInternals()->TakeViewHostHandle().value());
+}
+
 static DartLibraryNatives* g_natives;
 
 void EnsureNatives() {
@@ -63,6 +68,7 @@ void EnsureNatives() {
     {"takeServicesProvidedByEmbedder", TakeServicesProvidedByEmbedder, 0, true},
     {"takeServicesProvidedToEmbedder", TakeServicesProvidedToEmbedder, 0, true},
     {"takeShellProxyHandle", TakeShellProxyHandle, 0, true},
+    {"takeViewHostHandle", TakeViewHostHandle, 0, true},
   });
 }
 
@@ -134,6 +140,10 @@ mojo::Handle Internals::TakeRootBundleHandle() {
 
 mojo::Handle Internals::TakeServicesProvidedToEmbedder() {
   return services_provided_to_embedder_.PassMessagePipe().release();
+}
+
+mojo::Handle Internals::TakeViewHostHandle() {
+  return services_ ? services_->view_host.PassInterface().PassHandle().release() : mojo::Handle();
 }
 
 }  // namespace shell

--- a/sky/shell/ui/internals.h
+++ b/sky/shell/ui/internals.h
@@ -35,6 +35,7 @@ class Internals
   mojo::Handle TakeServicesProvidedByEmbedder();
   mojo::Handle TakeServicesProvidedToEmbedder();
   mojo::Handle TakeRootBundleHandle();
+  mojo::Handle TakeViewHostHandle();
 
  private:
   explicit Internals(ServicesDataPtr services,


### PR DESCRIPTION
Dart needs access to the ViewHost in order to create child views.