### PR TITLE
iOS: Dont strip release binaries

### DIFF
--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -66,8 +66,6 @@ template("mac_toolchain") {
       sysroot_flags = "-isysroot $sysroot $version_flags"
     }
 
-    strip = !is_debug && !use_ios_simulator
-
     toolchain_flags = ""
     if (invoker.toolchain_cpu == "i386") {
       toolchain_flags = "-m32"
@@ -186,14 +184,7 @@ template("mac_toolchain") {
       outfile = "{{root_out_dir}}/{{target_output_name}}{{output_extension}}"
       rspfile = "$outfile.rsp"
 
-      intermediate_outfile = outfile
-      strip_command =  ""
-      if (strip) {
-        intermediate_outfile = "$outfile.unstripped"
-        strip_command = "strip $intermediate_outfile -o $outfile"
-      }
-
-      command = "$ld $sysroot_flags $toolchain_flags {{ldflags}} -Xlinker -rpath -Xlinker @executable_path/Frameworks -o $intermediate_outfile -Wl,-filelist,$rspfile {{solibs}} {{libs}}; $strip_command"
+      command = "$ld $sysroot_flags $toolchain_flags {{ldflags}} -Xlinker -rpath -Xlinker @executable_path/Frameworks -o $outfile -Wl,-filelist,$rspfile {{solibs}} {{libs}}"
       description = "LINK $outfile"
       rspfile_content = "{{inputs_newline}}"
       outputs = [


### PR DESCRIPTION
* We make Xcode strip the binary on archival for release.
* Better stack traces when the engine hits release assertions and crashes.