### PR TITLE
Track whether accessibility is enabled.

### DIFF
--- a/sky/shell/platform/android/org/domokit/sky/shell/FlutterSemanticsToAndroidAccessibilityBridge.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/FlutterSemanticsToAndroidAccessibilityBridge.java
@@ -29,6 +29,7 @@ public class FlutterSemanticsToAndroidAccessibilityBridge extends AccessibilityN
     private Map<Integer, PersistentAccessibilityNode> mTreeNodes;
     private PlatformViewAndroid mOwner;
     private SemanticsServer.Proxy mSemanticsServer;
+    private boolean mAccessilibilyEnabled;
     private PersistentAccessibilityNode mFocusedNode;
     private PersistentAccessibilityNode mHoveredNode;
 
@@ -39,6 +40,10 @@ public class FlutterSemanticsToAndroidAccessibilityBridge extends AccessibilityN
         mTreeNodes = new HashMap<Integer, PersistentAccessibilityNode>();
         mSemanticsServer = semanticsServer;
         mSemanticsServer.addSemanticsListener(this);
+    }
+
+    public void setAccessibilityEnabled(boolean accessibilityEnabled) {
+        mAccessilibilyEnabled = accessibilityEnabled;
     }
 
     @Override
@@ -213,6 +218,9 @@ public class FlutterSemanticsToAndroidAccessibilityBridge extends AccessibilityN
     }
 
     private void sendAccessibilityEvent(int virtualViewId, int eventType) {
+        if (!mAccessilibilyEnabled) {
+            return;
+        }
         if (virtualViewId == 0) {
             mOwner.sendAccessibilityEvent(eventType);
         } else {

--- a/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
@@ -342,13 +342,15 @@ public class PlatformViewAndroid extends SurfaceView
 
     // ACCESSIBILITY
 
+    private boolean mAccessibilityEnabled = false;
     private boolean mTouchExplorationEnabled = false;
 
     @Override
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
+        mAccessibilityEnabled = mAccessibilityManager.isEnabled();
         mTouchExplorationEnabled = mAccessibilityManager.isTouchExplorationEnabled();
-        if (mAccessibilityManager.isEnabled() || mTouchExplorationEnabled)
+        if (mAccessibilityEnabled || mTouchExplorationEnabled)
           ensureAccessibilityEnabled();
         mAccessibilityManager.addAccessibilityStateChangeListener(this);
         mAccessibilityManager.addTouchExplorationStateChangeListener(this);
@@ -356,8 +358,15 @@ public class PlatformViewAndroid extends SurfaceView
 
     @Override
     public void onAccessibilityStateChanged(boolean enabled) {
-        if (enabled)
+        if (enabled) {
+            mAccessibilityEnabled = true;
             ensureAccessibilityEnabled();
+        } else {
+            mAccessibilityEnabled = false;
+        }
+        if (mAccessibilityNodeProvider != null) {
+            mAccessibilityNodeProvider.setAccessibilityEnabled(mAccessibilityEnabled);
+        }
     }
 
     @Override


### PR DESCRIPTION
If we send accessibility events when accessibility is disabled, we crash.