### PR TITLE
Add a dynamic services target with a variant for the embedder and dylib each

### DIFF
--- a/sky/services/dynamic/BUILD.gn
+++ b/sky/services/dynamic/BUILD.gn
@@ -1,0 +1,43 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("embedder") {
+  sources = [
+    "dynamic_service.c",
+    "dynamic_service.h",
+    "dynamic_service_definition.cc",
+    "dynamic_service_definition.h",
+    "dynamic_service_embedder.c",
+    "dynamic_service_embedder.h",
+    "dynamic_service_macros.h",
+  ]
+
+  deps = [
+    "//mojo/public/c/environment",
+    "//mojo/public/c/system",
+  ]
+
+  # In order for the embedder to access the routine that prepares the
+  # the thunk for dylib, It needs access to system_thunks.h. This is included
+  # in a target that includes mojo symbols already present on the embedder.
+  # This works around header checks just for these files.
+  check_includes = false
+}
+
+source_set("dylib") {
+  sources = [
+    "dynamic_service.c",
+    "dynamic_service.h",
+    "dynamic_service_dylib.cc",
+    "dynamic_service_dylib.h",
+    "dynamic_service_macros.h",
+  ]
+
+  deps = [
+    "//mojo/public/c/system",
+    "//mojo/public/cpp/bindings",
+    "//mojo/public/cpp/environment:standalone",
+    "//mojo/public/platform/native:system",
+  ]
+}

--- a/sky/services/dynamic/README.md
+++ b/sky/services/dynamic/README.md
@@ -1,0 +1,4 @@
+Flutter Dynamic Services Loader
+===============================
+
+Third party service implementations are packaged as dylibs. Each dylib implementation needs to import just one file (`dynamic_service_dylib.h`) and implement `FlutterServicePerform` to provide the service implementation. In order to build the dylib, the build step needs the `//sky/services/dynamic:dylib` GN rule.

--- a/sky/services/dynamic/dynamic_service.c
+++ b/sky/services/dynamic/dynamic_service.c
@@ -1,0 +1,32 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/services/dynamic/dynamic_service.h"
+
+const struct FlutterServiceVersion* FlutterServiceGetVersion() {
+  static const struct FlutterServiceVersion version = {
+      .major = 1,  // updated on breaking changes
+      .minor = 0,  // updated on augments
+      .patch = 0,  // informational, embedder does not care
+  };
+  return &version;
+}
+
+bool FlutterServiceVersionsCompatible(
+    const struct FlutterServiceVersion* embedder_version,
+    const struct FlutterServiceVersion* service_version) {
+  if (embedder_version == NULL || service_version == NULL) {
+    return false;
+  }
+
+  if (embedder_version->major != service_version->major) {
+    return false;
+  }
+
+  if (embedder_version->minor < service_version->minor) {
+    return false;
+  }
+
+  return true;
+}

--- a/sky/services/dynamic/dynamic_service.h
+++ b/sky/services/dynamic/dynamic_service.h
@@ -1,0 +1,66 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_H_
+#define SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_H_
+
+#include <stdbool.h>
+
+#include "mojo/public/c/environment/async_waiter.h"
+#include "mojo/public/c/environment/logger.h"
+#include "mojo/public/c/system/types.h"
+#include "sky/services/dynamic/dynamic_service_macros.h"
+
+FLUTTER_C_API_START
+
+/// ============================================================================
+/// The definitions in the file (and this file alone) form the stable Flutter
+/// dynamic services ABI.
+/// ============================================================================
+
+#pragma pack(push, 8)
+/// The dynamic Flutter service version is responsible for deciding if services
+/// built with older or newer versions of Flutter will work with the current
+/// embedder. This struct is stable and will never change. The version check
+/// is the first thing performed by the embedder, and, in case of breaking
+/// changes (as decribed below), no other service calls are made.
+struct FlutterServiceVersion {
+  /// If major versions of the embedder and the service differ, it indicates
+  /// a completely breaking change. The embedder will refuse to load a service
+  /// with any mismatch.
+  uint32_t major;
+  /// If minor versions of the embedder and the service differ, it indicates
+  /// that parts of the ABI were augmented but the exisiting components have
+  /// remained stable. The embedder will only attempt to load the service if
+  /// its minor version is greater than or equal to that of the service.
+  uint32_t minor;
+  /// The patch version is used to indicate trivial non-ABI breaking updates.
+  /// The embedder does not use this to accept or reject services being loaded.
+  /// This field may be used to check if certain bug fixes are present in either
+  /// the embedder or service runtimes.
+  uint32_t patch;
+};
+#pragma pack(pop)
+
+/// Gets the version of the Flutter dynamic services. This is basically the
+/// only method guaranteed to be stable across major, minor and patch revisions.
+FLUTTER_EXPORT const struct FlutterServiceVersion* FlutterServiceGetVersion(
+    void);
+
+bool FlutterServiceVersionsCompatible(
+    const struct FlutterServiceVersion* embedder_version,
+    const struct FlutterServiceVersion* service_version);
+
+FLUTTER_EXPORT
+void FlutterServiceOnLoad(const struct MojoAsyncWaiter* waiter,
+                          const struct MojoLogger* logger);
+
+FLUTTER_EXPORT void FlutterServiceInvoke(MojoHandle client_handle,
+                                         const char* service_name);
+
+FLUTTER_EXPORT void FlutterServiceOnUnload(void);
+
+FLUTTER_C_API_END
+
+#endif  // SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_H_

--- a/sky/services/dynamic/dynamic_service_definition.cc
+++ b/sky/services/dynamic/dynamic_service_definition.cc
@@ -1,0 +1,206 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/services/dynamic/dynamic_service_definition.h"
+
+#include <dlfcn.h>
+
+namespace sky {
+namespace services {
+
+std::unique_ptr<DynamicServiceDefinition> DynamicServiceDefinition::Initialize(
+    const mojo::String& dylib_path) {
+  auto definition = std::unique_ptr<DynamicServiceDefinition>(
+      new DynamicServiceDefinition(dylib_path));
+
+  if (definition->IsReady()) {
+    return definition;
+  }
+
+  return nullptr;
+}
+
+DynamicServiceDefinition::DynamicServiceDefinition(
+    const mojo::String& dylib_path)
+    : service_procs_(), is_ready_(false) {
+  Setup(dylib_path);
+}
+
+DynamicServiceDefinition::~DynamicServiceDefinition() {
+  Teardown();
+}
+
+void DynamicServiceDefinition::Setup(const mojo::String& dylib_path) {
+  std::lock_guard<std::mutex> lock(lifecycle_mtx_);
+
+  if (!OpenDylib(dylib_path)) {
+    return;
+  }
+
+  // Remember, the service version proc is the only absolutely stable part
+  // of the runtime. All other proc acquisition and setup tasks must be
+  // performed *after* the version check is complete.
+
+  if (!AcquireServiceVersionProc()) {
+    return;
+  }
+
+  if (!CheckServiceVersion()) {
+    return;
+  }
+
+  if (!AcquireServiceProcs()) {
+    return;
+  }
+
+  if (!InstallSystemThunks()) {
+    return;
+  }
+
+  if (!InvokeLibraryOnLoad()) {
+    return;
+  }
+
+  is_ready_ = true;
+}
+
+void DynamicServiceDefinition::Teardown() {
+  std::lock_guard<std::mutex> lock(lifecycle_mtx_);
+
+  is_ready_ = false;
+
+  InvokeLibraryOnUnload();
+
+  CloseDylib();
+}
+
+bool DynamicServiceDefinition::IsReady() const {
+  return is_ready_;
+}
+
+bool DynamicServiceDefinition::OpenDylib(const mojo::String& dylib_path) {
+  dlerror();
+  dylib_handle_ = dlopen(dylib_path.data(), RTLD_NOW);
+
+  if (dylib_handle_ == nullptr || dlerror() != nullptr) {
+    dylib_handle_ = nullptr;
+    return false;
+  }
+
+  return true;
+}
+
+bool DynamicServiceDefinition::CloseDylib() {
+  if (dylib_handle_ == nullptr) {
+    return true;
+  }
+
+  dlerror();
+  dlclose(dylib_handle_);
+  return dlerror() == nullptr;
+}
+
+static bool AcquireProc(void* handle, const char* name, void** dest) {
+  dlerror();
+  void* sym = dlsym(handle, name);
+  if (sym != nullptr && dlerror() == nullptr) {
+    *dest = sym;
+    return true;
+  }
+  return false;
+}
+
+bool DynamicServiceDefinition::AcquireServiceVersionProc() {
+  return AcquireProc(dylib_handle_, kFlutterServiceGetVersionProcName,
+                     reinterpret_cast<void**>(&service_procs_.version));
+}
+
+bool DynamicServiceDefinition::AcquireServiceProcs() {
+  if (!AcquireProc(dylib_handle_, kFlutterServiceOnLoadProcName,
+                   reinterpret_cast<void**>(&service_procs_.load))) {
+    return false;
+  }
+
+  if (!AcquireProc(dylib_handle_, kFlutterServiceInvokeProcName,
+                   reinterpret_cast<void**>(&service_procs_.invoke))) {
+    return false;
+  }
+
+  if (!AcquireProc(dylib_handle_, kFlutterServiceOnUnloadProcName,
+                   reinterpret_cast<void**>(&service_procs_.unload))) {
+    return false;
+  }
+
+  if (!AcquireProc(dylib_handle_, "MojoSetSystemThunks",
+                   reinterpret_cast<void**>(&service_procs_.set_thunks))) {
+    return false;
+  }
+
+  return true;
+}
+
+bool DynamicServiceDefinition::CheckServiceVersion() {
+  if (service_procs_.version == nullptr) {
+    return false;
+  }
+
+  const FlutterServiceVersion* embedder_version = FlutterServiceGetVersion();
+  const FlutterServiceVersion* service_version = service_procs_.version();
+
+  return FlutterServiceVersionsCompatible(embedder_version, service_version);
+}
+
+bool DynamicServiceDefinition::InstallSystemThunks() {
+  if (service_procs_.set_thunks == nullptr) {
+    return false;
+  }
+
+  MojoSystemThunks embedder_thunks = MojoMakeSystemThunks();
+
+  size_t result = service_procs_.set_thunks(&embedder_thunks);
+
+  if (result > sizeof(MojoSystemThunks)) {
+    // The dylib expects to use a system thunks table that is larger than what
+    // is currently supported by the embedder. This indicates that the embedder
+    // is older than the dylib.
+    return false;
+  }
+
+  return true;
+}
+
+bool DynamicServiceDefinition::InvokeLibraryOnLoad() {
+  if (service_procs_.load == nullptr) {
+    return false;
+  }
+
+  service_procs_.load(mojo::Environment::GetDefaultAsyncWaiter(),
+                      mojo::Environment::GetDefaultLogger());
+  return true;
+}
+
+bool DynamicServiceDefinition::InvokeLibraryOnUnload() {
+  if (service_procs_.unload == nullptr) {
+    return false;
+  }
+
+  service_procs_.unload();
+  return true;
+}
+
+void DynamicServiceDefinition::InvokeServiceHandler(
+    mojo::ScopedMessagePipeHandle handle,
+    const mojo::String& service_name) const {
+  if (!is_ready_ || service_procs_.invoke == nullptr) {
+    // Handle goes out of scope and is collected
+    return;
+  }
+
+  mojo::MessagePipeHandle rawMessageHandle = handle.release();
+  // The service assumes ownership of the handle
+  service_procs_.invoke(rawMessageHandle.value(), service_name.data());
+}
+
+}  // namespace services
+}  // namespace sky

--- a/sky/services/dynamic/dynamic_service_definition.h
+++ b/sky/services/dynamic/dynamic_service_definition.h
@@ -1,0 +1,65 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_DEFINITION_H_
+#define SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_DEFINITION_H_
+
+#include "mojo/public/cpp/system/macros.h"
+#include "mojo/public/cpp/bindings/string.h"
+#include "mojo/public/platform/native/system_thunks.h"
+#include "sky/services/dynamic/dynamic_service_embedder.h"
+
+#include <mutex>
+
+namespace sky {
+namespace services {
+
+class DynamicServiceDefinition {
+ public:
+  static std::unique_ptr<DynamicServiceDefinition> Initialize(
+      const mojo::String& dylib_path);
+
+  void InvokeServiceHandler(mojo::ScopedMessagePipeHandle handle,
+                            const mojo::String& service_name) const;
+
+  ~DynamicServiceDefinition();
+
+ private:
+  struct ServiceProcs {
+    FlutterServiceGetVersionProc version;
+    FlutterServiceOnLoadProc load;
+    FlutterServiceInvokeProc invoke;
+    FlutterServiceOnUnloadProc unload;
+    MojoSetSystemThunksFn set_thunks;
+  };
+
+  explicit DynamicServiceDefinition(const mojo::String& dylib_path);
+
+  bool IsReady() const;
+
+  std::mutex lifecycle_mtx_;
+
+  void* dylib_handle_;
+  ServiceProcs service_procs_;
+  bool is_ready_;
+
+  void Setup(const mojo::String& dylib_path);
+  void Teardown();
+
+  bool OpenDylib(const mojo::String& dylib_path);
+  bool CloseDylib();
+  bool AcquireServiceVersionProc();
+  bool AcquireServiceProcs();
+  bool CheckServiceVersion();
+  bool InstallSystemThunks();
+  bool InvokeLibraryOnLoad();
+  bool InvokeLibraryOnUnload();
+
+  MOJO_DISALLOW_COPY_AND_ASSIGN(DynamicServiceDefinition);
+};
+
+}  // namespace services
+}  // namespace sky
+
+#endif  // SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_DEFINITION_H_

--- a/sky/services/dynamic/dynamic_service_dylib.cc
+++ b/sky/services/dynamic/dynamic_service_dylib.cc
@@ -1,0 +1,41 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/services/dynamic/dynamic_service.h"
+
+#include <assert.h>
+
+#include "sky/services/dynamic/dynamic_service_dylib.h"
+#include "mojo/public/cpp/environment/environment.h"
+
+static mojo::Environment* g_dylib_environment;
+
+void FlutterServiceOnLoad(const MojoAsyncWaiter* waiter,
+                          const MojoLogger* logger) {
+  // Assert that the dylib environment is not already initialized somehow.
+  assert(g_dylib_environment == nullptr);
+  g_dylib_environment = new mojo::Environment(waiter, logger);
+}
+
+void FlutterServiceInvoke(MojoHandle client_handle, const char* service_name) {
+  assert(g_dylib_environment != nullptr);
+
+  // The service is always responsible for releasing the client handle. Create
+  // a scoped handle immediately.
+  mojo::MessagePipeHandle message_pipe_handle(client_handle);
+  mojo::ScopedMessagePipeHandle scoped_handle(message_pipe_handle);
+
+  mojo::String name(service_name);
+
+  // Call the user callback
+  FlutterServicePerform(scoped_handle.Pass(), name);
+}
+
+void FlutterServiceOnUnload() {
+  // Make sure the library is not being unloaded without the OnLoad callback
+  // being called already.
+  assert(g_dylib_environment != nullptr);
+  delete g_dylib_environment;
+  g_dylib_environment = nullptr;
+}

--- a/sky/services/dynamic/dynamic_service_dylib.h
+++ b/sky/services/dynamic/dynamic_service_dylib.h
@@ -1,0 +1,15 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_DYLIB_H_
+#define SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_DYLIB_H_
+
+#include "sky/services/dynamic/dynamic_service_macros.h"
+#include "mojo/public/cpp/system/message_pipe.h"
+#include "mojo/public/cpp/bindings/string.h"
+
+void FlutterServicePerform(mojo::ScopedMessagePipeHandle client_handle,
+                           const mojo::String& service_name);
+
+#endif  // SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_DYLIB_H_

--- a/sky/services/dynamic/dynamic_service_embedder.c
+++ b/sky/services/dynamic/dynamic_service_embedder.c
@@ -1,0 +1,11 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/services/dynamic/dynamic_service_embedder.h"
+
+const char* const kFlutterServiceGetVersionProcName =
+    "FlutterServiceGetVersion";
+const char* const kFlutterServiceOnLoadProcName = "FlutterServiceOnLoad";
+const char* const kFlutterServiceInvokeProcName = "FlutterServiceInvoke";
+const char* const kFlutterServiceOnUnloadProcName = "FlutterServiceOnUnload";

--- a/sky/services/dynamic/dynamic_service_embedder.h
+++ b/sky/services/dynamic/dynamic_service_embedder.h
@@ -1,0 +1,26 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_EMBEDDER_H_
+#define SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_EMBEDDER_H_
+
+#include "sky/services/dynamic/dynamic_service.h"
+
+typedef const struct FlutterServiceVersion* (*FlutterServiceGetVersionProc)(
+    void);
+typedef void (*FlutterServiceOnLoadProc)(const struct MojoAsyncWaiter*,
+                                         const struct MojoLogger*);
+typedef void (*FlutterServiceInvokeProc)(MojoHandle, const char*);
+typedef void (*FlutterServiceOnUnloadProc)();
+
+FLUTTER_C_API_START
+
+extern const char* const kFlutterServiceGetVersionProcName;
+extern const char* const kFlutterServiceOnLoadProcName;
+extern const char* const kFlutterServiceInvokeProcName;
+extern const char* const kFlutterServiceOnUnloadProcName;
+
+FLUTTER_C_API_END
+
+#endif  // SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_EMBEDDER_H_

--- a/sky/services/dynamic/dynamic_service_macros.h
+++ b/sky/services/dynamic/dynamic_service_macros.h
@@ -1,0 +1,22 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_MACROS_H_
+#define SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_MACROS_H_
+
+#define FLUTTER_EXPORT __attribute__((visibility("default")))
+
+#ifdef __cplusplus
+
+#define FLUTTER_C_API_START extern "C" {
+#define FLUTTER_C_API_END }
+
+#else  // __cplusplus
+
+#define FLUTTER_C_API_START
+#define FLUTTER_C_API_END
+
+#endif  // __cplusplus
+
+#endif  // SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_MACROS_H_

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -231,28 +231,13 @@ if (is_android) {
   import("//build/config/ios/ios_sdk.gni")
   import("//sky/build/sky_precompilation_sdk.gni")
 
-  source_set("dynamic_service_loader") {
-    sources = [
-      "platform/ios/sky_dynamic_service_loader.h",
-      "platform/ios/sky_dynamic_service_loader.mm",
-    ]
-
-    deps = [
-      ":common",
-    ]
-
-    # In order for the embedder to access the routine that prepares the
-    # the thunk for dylib, It needs access to system_thunks.h. This is included
-    # in a target that includes mojo symbols already present on the embedder.
-    # This works around header checks just for these files.
-    check_includes = false
-  }
-
   source_set("ios_scaffolding") {
     sources = [
       "platform/ios/main_ios.mm",
       "platform/ios/sky_app_delegate.h",
       "platform/ios/sky_app_delegate.mm",
+      "platform/ios/sky_dynamic_service_loader.h",
+      "platform/ios/sky_dynamic_service_loader.mm",
       "platform/ios/sky_surface.h",
       "platform/ios/sky_surface.mm",
       "platform/ios/sky_view_controller.h",
@@ -274,13 +259,13 @@ if (is_android) {
       "//mojo/edk/base_edk",
       "//mojo/edk/system",
       "//sky/services/activity",
+      "//sky/services/dynamic:embedder",
       "//sky/services/editing",
       "//sky/services/media",
       "//sky/services/ns_net",
       "//sky/services/vsync",
       "//ui/gl",
       ":common",
-      ":dynamic_service_loader",
       ":gpu_direct",
     ]
   }


### PR DESCRIPTION
* The embedder depends on dynamic:embedder
* The dylib depends on dynamic:dylib
* The embedder calls OnLoad and OnUnload callbacks that setup and teardown the dylib environment
* The dylib contains a thin library that services OnLoad, OnUnload and OnInvoke so that vendors dont have to do it themselves (and potentially mess it up)
* The vendor only has to implement the `FlutterServicePerform` method that takes a fully scoped handle
* This patch is a WIP till we get a stable Flutter ABI. The stuff in mojo/public is *NOT* stable