### PR TITLE
Serve the asset bundle directly out of an FLX zip file

### DIFF
--- a/services/asset_bundle/BUILD.gn
+++ b/services/asset_bundle/BUILD.gn
@@ -12,6 +12,8 @@ source_set("lib") {
     "asset_unpacker_impl.h",
     "asset_unpacker_job.cc",
     "asset_unpacker_job.h",
+    "zip_asset_bundle.cc",
+    "zip_asset_bundle.h",
   ]
 
   deps = [

--- a/services/asset_bundle/zip_asset_bundle.cc
+++ b/services/asset_bundle/zip_asset_bundle.cc
@@ -1,0 +1,152 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/asset_bundle/zip_asset_bundle.h"
+
+#include "base/bind.h"
+#include "base/location.h"
+#include "base/message_loop/message_loop.h"
+#include "base/task_runner.h"
+#include "third_party/zlib/contrib/minizip/unzip.h"
+
+namespace mojo {
+namespace asset_bundle {
+
+void ZipAssetBundle::Create(
+    InterfaceRequest<AssetBundle> request,
+    const base::FilePath& zip_path,
+    scoped_refptr<base::TaskRunner> worker_runner) {
+  new ZipAssetBundle(request.Pass(), zip_path, worker_runner.Pass());
+}
+
+ZipAssetBundle::ZipAssetBundle(
+    InterfaceRequest<AssetBundle> request,
+    const base::FilePath& zip_path,
+    scoped_refptr<base::TaskRunner> worker_runner)
+    : binding_(this, request.Pass()),
+      zip_path_(zip_path),
+      worker_runner_(worker_runner.Pass()) {
+}
+
+ZipAssetBundle::~ZipAssetBundle() {
+}
+
+void ZipAssetBundle::GetAsStream(
+    const String& asset_name,
+    const Callback<void(ScopedDataPipeConsumerHandle)>& callback) {
+  DataPipe pipe;
+  callback.Run(pipe.consumer_handle.Pass());
+
+  ZipAssetHandler* handler = new ZipAssetHandler(
+      zip_path_,
+      asset_name.To<std::string>(),
+      pipe.producer_handle.Pass(),
+      worker_runner_);
+
+  worker_runner_->PostTask(
+      FROM_HERE,
+      base::Bind(&ZipAssetHandler::Start, base::Unretained(handler)));
+}
+
+ZipAssetHandler::ZipAssetHandler(
+    const base::FilePath& zip_path,
+    const std::string& asset_name,
+    ScopedDataPipeProducerHandle producer,
+    scoped_refptr<base::TaskRunner> worker_runner)
+  : zip_path_(zip_path),
+    asset_name_(asset_name),
+    producer_(producer.Pass()),
+    main_runner_(base::MessageLoop::current()->task_runner()),
+    worker_runner_(worker_runner.Pass()),
+    zip_file_(nullptr),
+    buffer_(nullptr),
+    buffer_size_(0) {
+}
+
+ZipAssetHandler::~ZipAssetHandler() {
+  if (zip_file_) {
+    unzClose(zip_file_);
+  }
+}
+
+void ZipAssetHandler::Start() {
+  zip_file_ = unzOpen2(zip_path_.AsUTF8Unsafe().c_str(), NULL);
+  if (!zip_file_) {
+    LOG(ERROR) << "Unable to open ZIP file: " << zip_path_.value();
+    delete this;
+    return;
+  }
+
+  int result = unzLocateFile(zip_file_, asset_name_.c_str(), 0);
+  if (result != UNZ_OK) {
+    LOG(WARNING) << "Requested asset '" << asset_name_ << "' does not exist.";
+    delete this;
+    return;
+  }
+
+  result = unzOpenCurrentFile(zip_file_);
+  if (result != UNZ_OK) {
+    LOG(WARNING) << "unzOpenCurrentFile failed, error=" << result;
+    delete this;
+    return;
+  }
+
+  CopyData();
+}
+
+void ZipAssetHandler::CopyData() {
+  while (true) {
+    MojoResult mojo_result = BeginWriteDataRaw(producer_.get(),
+                                               &buffer_, &buffer_size_,
+                                               MOJO_WRITE_DATA_FLAG_NONE);
+    if (mojo_result == MOJO_RESULT_SHOULD_WAIT) {
+      main_runner_->PostTask(FROM_HERE,
+                             base::Bind(&ZipAssetHandler::WaitForWritable,
+                                        base::Unretained(this)));
+      return;
+    } else if (mojo_result != MOJO_RESULT_OK) {
+      LOG(WARNING) << "Mojo BeginWrite failed, error=" << mojo_result;
+      delete this;
+      return;
+    }
+
+    int bytes_read = unzReadCurrentFile(zip_file_, buffer_, buffer_size_);
+    mojo_result = EndWriteDataRaw(producer_.get(), std::max(0, bytes_read));
+
+    if (bytes_read == 0) {
+      // Unzip is complete.
+      delete this;
+      return;
+    }
+    if (bytes_read < 0) {
+      LOG(WARNING) << "Asset unzip failed, error=" << bytes_read;
+      delete this;
+      return;
+    }
+    if (mojo_result != MOJO_RESULT_OK) {
+      LOG(WARNING) << "Mojo EndWrite failed, error=" << mojo_result;
+      delete this;
+      return;
+    }
+  }
+}
+
+void ZipAssetHandler::WaitForWritable() {
+  waiter_.reset(new AsyncWaiter(
+      producer_.get(), MOJO_HANDLE_SIGNAL_WRITABLE,
+      base::Bind(&ZipAssetHandler::OnWritable, base::Unretained(this))));
+}
+
+void ZipAssetHandler::OnWritable(MojoResult mojo_result) {
+  if (mojo_result == MOJO_RESULT_OK) {
+    worker_runner_->PostTask(FROM_HERE,
+                             base::Bind(&ZipAssetHandler::CopyData,
+                                        base::Unretained(this)));
+  } else {
+    delete this;
+  }
+}
+
+}  // namespace asset_bundle
+}  // namespace mojo

--- a/services/asset_bundle/zip_asset_bundle.h
+++ b/services/asset_bundle/zip_asset_bundle.h
@@ -1,0 +1,79 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/task_runner.h"
+#include "base/files/file_path.h"
+#include "base/memory/weak_ptr.h"
+#include "mojo/public/cpp/bindings/interface_request.h"
+#include "mojo/public/cpp/bindings/strong_binding.h"
+#include "mojo/public/cpp/environment/async_waiter.h"
+#include "mojo/services/asset_bundle/interfaces/asset_bundle.mojom.h"
+#include "third_party/zlib/contrib/minizip/unzip.h"
+
+namespace mojo {
+namespace asset_bundle {
+
+// An implementation of AssetBundle that serves assets directly out of a
+// ZIP archive.
+class ZipAssetBundle : public AssetBundle {
+ public:
+  static void Create(InterfaceRequest<AssetBundle> request,
+                     const base::FilePath& zip_path,
+                     scoped_refptr<base::TaskRunner> worker_runner);
+  ~ZipAssetBundle() override;
+
+  // AssetBundle implementation
+  void GetAsStream(
+      const String& asset_name,
+      const Callback<void(ScopedDataPipeConsumerHandle)>& callback) override;
+
+ private:
+  ZipAssetBundle(InterfaceRequest<AssetBundle> request,
+                 const base::FilePath& zip_path,
+                 scoped_refptr<base::TaskRunner> worker_runner);
+
+  StrongBinding<AssetBundle> binding_;
+  const base::FilePath zip_path_;
+  scoped_refptr<base::TaskRunner> worker_runner_;
+
+  DISALLOW_COPY_AND_ASSIGN(ZipAssetBundle);
+};
+
+// Reads an asset from a ZIP archive and writes it to a Mojo pipe.
+class ZipAssetHandler {
+  friend class ZipAssetBundle;
+
+ public:
+  ZipAssetHandler(const base::FilePath& zip_path,
+                    const std::string& asset_name,
+                    ScopedDataPipeProducerHandle producer,
+                    scoped_refptr<base::TaskRunner> worker_runner);
+  ~ZipAssetHandler();
+
+  void Start();
+
+ private:
+  void CopyData();
+  void OnWritable(MojoResult result);
+  void WaitForWritable();
+
+  const base::FilePath zip_path_;
+  const std::string asset_name_;
+  ScopedDataPipeProducerHandle producer_;
+
+  scoped_refptr<base::SingleThreadTaskRunner> main_runner_;
+  scoped_refptr<base::TaskRunner> worker_runner_;
+
+  unzFile zip_file_;
+
+  void* buffer_;
+  uint32_t buffer_size_;
+
+  scoped_ptr<AsyncWaiter> waiter_;
+
+  DISALLOW_COPY_AND_ASSIGN(ZipAssetHandler);
+};
+
+}  // namespace asset_bundle
+}  // namespace mojo

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -12,6 +12,7 @@
 #include "mojo/data_pipe_utils/data_pipe_utils.h"
 #include "mojo/public/cpp/application/connect.h"
 #include "services/asset_bundle/asset_unpacker_job.h"
+#include "services/asset_bundle/zip_asset_bundle.h"
 #include "sky/engine/public/platform/sky_display_metrics.h"
 #include "sky/engine/public/platform/WebInputEvent.h"
 #include "sky/engine/public/web/Sky.h"
@@ -47,6 +48,7 @@ PlatformImpl* g_platform_impl = nullptr;
 }  // namespace
 
 using mojo::asset_bundle::AssetUnpackerJob;
+using mojo::asset_bundle::ZipAssetBundle;
 
 Engine::Config::Config() {
 }
@@ -222,10 +224,11 @@ void Engine::RunFromFile(const mojo::String& main,
 
 void Engine::RunFromBundle(const mojo::String& path) {
   TRACE_EVENT0("flutter", "Engine::RunFromBundle");
-  AssetUnpackerJob* unpacker = new AssetUnpackerJob(
-      mojo::GetProxy(&root_bundle_), base::WorkerPool::GetTaskRunner(true));
   std::string path_str = path;
-  unpacker->Unpack(Fetch(base::FilePath(path_str)));
+  ZipAssetBundle::Create(mojo::GetProxy(&root_bundle_),
+                         base::FilePath(path_str),
+                         base::WorkerPool::GetTaskRunner(true));
+
   root_bundle_->GetAsStream(kSnapshotKey,
                             base::Bind(&Engine::RunFromSnapshotStream,
                                        weak_factory_.GetWeakPtr(), path_str));


### PR DESCRIPTION
Currently, during application startup we:
  * copy the FLX file to a Mojo pipe
  * write the Mojo pipe contents back to a temporary file on disk
  * unzip the FLX contents into cache storage
This contributes to startup latency and requires that we later clean up the
cache.

With this change, the assets will be extracted from the FLX archive
on demand with no writes to storage. Runtime cost should be minimal
given that most assets (except for the snapshot) are not compressed
in the archive.