### PR TITLE
Pass -lgcc_s to sky_snapshot build.

### DIFF
--- a/sky/tools/sky_snapshot/BUILD.gn
+++ b/sky/tools/sky_snapshot/BUILD.gn
@@ -23,4 +23,12 @@ executable("sky_snapshot") {
     "//sky/engine/bindings:snapshot_cc",
     "//third_party/zlib",
   ]
+
+  ldflags = [
+    # libgcc_s is not a DT_NEEDED library; it normally gets loaded implicitly.
+    # This flag ensures that rpath is referenced when searching for
+    # the so, which in turn gets the resulting sky_snapshot binary
+    # closer to being able to run in Google's production environment. 
+    "-lgcc_s",
+  ]
 }


### PR DESCRIPTION
libgcc_s is not a DT_NEEDED library; it gets loaded implicitly.
This change ensures that rpath is referenced when searching for
the so. This in turn gets the resulting sky_snapshot binary
closer to being able to run in Google's production environment.