### PR TITLE
Enable threadsafe static initialization (aka 'magic statics')

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -145,8 +145,6 @@ config("compiler") {
     # --------------------------------
     cflags += [ "-fno-strict-aliasing" ]  # See http://crbug.com/32204
     common_flags = [
-      "-fno-threadsafe-statics",
-
       # Not exporting C++ inline functions can generally be applied anywhere
       # so we do so here. Normal function visibility is controlled by
       # //build/config/gcc:symbol_visibility_hidden.


### PR DESCRIPTION
C++11 guarantees that initialization of function statics will be
threadsafe. We disabled this by passing -fno-threadsafe-statics because
we used to support building using visual studio and older versions
(older than 2015) did not implement this functionality. Now we only use
modern toolchains which do support this and it's increasingly likely
that libraries we want to use and that other C++ developers will
expect rely on the standard behavior instead of our nonstandard init.
Using the toolchain's implementation of threadsafe initialization is
also very likely to be more efficient than our own handrolled
threadsafe initialization and less error prone.

With the specified behavior, many uses of base::Singleton for threadsafe
initialization can be replaced by function statics for a performance
boost. There's also a very slight risk that code that was depending on
racy initialization could break, but such code is at the very least
suspect if not outright broken already.

Equivalent change in Mojo is here: https://codereview.chromium.org/1683973002