### PR TITLE
Enable and test sky_shell --start-paused

### DIFF
--- a/sky/engine/bindings/dart_vm_entry_points.txt
+++ b/sky/engine/bindings/dart_vm_entry_points.txt
@@ -1,3 +1,4 @@
+dart:isolate,::,_startMainIsolate
 dart:mojo.internal,MojoHandleWatcher,mojoControlHandle
 dart:io,::,_setupHooks
 dart:ui,::,_beginFrame

--- a/sky/engine/core/script/dart_controller.h
+++ b/sky/engine/core/script/dart_controller.h
@@ -45,6 +45,7 @@ class DartController {
  private:
   void DidLoadMainLibrary(std::string url);
   void DidLoadSnapshot();
+  bool SendStartMessage(Dart_Handle root_library);
 
   std::unique_ptr<DOMDartState> dom_dart_state_;
   std::unique_ptr<DartSnapshotLoader> snapshot_loader_;

--- a/sky/engine/core/script/dart_debugger.cc
+++ b/sky/engine/core/script/dart_debugger.cc
@@ -13,6 +13,8 @@ namespace blink {
 
 void DartDebuggerIsolate::MessageLoop() {
   MonitorLocker ml(&monitor_);
+  Dart_MessageNotifyCallback saved_message_notify_callback =
+      Dart_GetMessageNotifyCallback();
   // Request notification on isolate messages.  This allows us to
   // respond to vm service messages while at breakpoint.
   Dart_SetMessageNotifyCallback(DartDebugger::NotifyIsolate);
@@ -30,7 +32,7 @@ void DartDebuggerIsolate::MessageLoop() {
     }
     ml.Wait();
   }
-  Dart_SetMessageNotifyCallback(nullptr);
+  Dart_SetMessageNotifyCallback(saved_message_notify_callback);
 }
 
 void DartDebugger::BptResolvedHandler(Dart_IsolateId isolate_id,

--- a/sky/engine/tonic/BUILD.gn
+++ b/sky/engine/tonic/BUILD.gn
@@ -33,6 +33,8 @@ source_set("tonic") {
     "dart_library_natives.h",
     "dart_library_provider.cc",
     "dart_library_provider.h",
+    "dart_message_handler.cc",
+    "dart_message_handler.h",
     "dart_microtask_queue.cc",
     "dart_microtask_queue.h",
     "dart_persistent_value.cc",

--- a/sky/engine/tonic/dart_message_handler.cc
+++ b/sky/engine/tonic/dart_message_handler.cc
@@ -1,0 +1,121 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/engine/tonic/dart_message_handler.h"
+
+#include "base/bind.h"
+#include "base/logging.h"
+#include "dart/runtime/include/dart_api.h"
+#include "dart/runtime/include/dart_native_api.h"
+#include "dart/runtime/include/dart_tools_api.h"
+#include "sky/engine/tonic/dart_error.h"
+#include "sky/engine/tonic/dart_state.h"
+
+namespace blink {
+
+DartMessageHandler::DartMessageHandler()
+    : handled_first_message_(false),
+      quit_message_loop_when_isolate_exits_(true),
+      isolate_exited_(false),
+      isolate_had_uncaught_exception_error_(false),
+      task_runner_(nullptr) {
+}
+
+DartMessageHandler::~DartMessageHandler() {
+  task_runner_ = nullptr;
+}
+
+void DartMessageHandler::Initialize(
+    const scoped_refptr<base::SingleThreadTaskRunner>& runner) {
+  // Only can be called once.
+  CHECK(!task_runner_);
+  task_runner_ = runner;
+  CHECK(task_runner_);
+  Dart_SetMessageNotifyCallback(MessageNotifyCallback);
+}
+
+void DartMessageHandler::OnMessage(DartState* dart_state) {
+  auto task_runner = dart_state->message_handler().task_runner();
+
+  // Schedule a task to run on the message loop thread.
+  task_runner->PostTask(FROM_HERE,
+                        base::Bind(&HandleMessage, dart_state->GetWeakPtr()));
+}
+
+void DartMessageHandler::OnHandleMessage(DartState* dart_state) {
+  DartIsolateScope scope(dart_state->isolate());
+  DartApiScope dart_api_scope;
+
+  bool error = false;
+
+  // On the first message, check if we should pause on isolate start.
+  if (!handled_first_message()) {
+    set_handled_first_message(true);
+    if (Dart_ShouldPauseOnStart()) {
+      // Mark that we are paused on isolate start.
+      Dart_SetPausedOnStart(true);
+    }
+  }
+
+  if (Dart_IsPausedOnStart()) {
+    // We are paused on isolate start. Only handle service messages until we are
+    // requested to resume.
+    if (Dart_HasServiceMessages()) {
+      bool resume = Dart_HandleServiceMessages();
+      if (!resume) {
+        return;
+      }
+      Dart_SetPausedOnStart(false);
+      // We've resumed, handle *all* normal messages that are in the queue.
+      error = LogIfError(Dart_HandleMessages());
+    }
+  } else if (Dart_IsPausedOnExit()) {
+    // We are paused on isolate exit. Only handle service messages until we are
+    // requested to resume.
+    if (Dart_HasServiceMessages()) {
+      bool resume = Dart_HandleServiceMessages();
+      if (!resume) {
+        return;
+      }
+      Dart_SetPausedOnExit(false);
+    }
+  } else {
+    // We are processing messages normally.
+    error = LogIfError(Dart_HandleMessage());
+  }
+
+  if (error) {
+    // Remember that we had an uncaught exception error.
+    isolate_had_uncaught_exception_error_ = true;
+  }
+
+  if (error || !Dart_HasLivePorts()) {
+    // The isolate has no live ports and would like to exit.
+    if (Dart_ShouldPauseOnExit()) {
+      // Mark that we are paused on exit.
+      Dart_SetPausedOnExit(true);
+    } else {
+      isolate_exited_ = true;
+      if (quit_message_loop_when_isolate_exits()) {
+        // Quit.
+        base::MessageLoop::current()->QuitWhenIdle();
+      }
+    }
+  }
+}
+
+void DartMessageHandler::MessageNotifyCallback(Dart_Isolate dest_isolate) {
+  auto dart_state = DartState::From(dest_isolate);
+  CHECK(dart_state);
+  dart_state->message_handler().OnMessage(dart_state);
+}
+
+void DartMessageHandler::HandleMessage(
+    base::WeakPtr<DartState> dart_state) {
+  if (!dart_state)
+    return;
+  dart_state->message_handler().OnHandleMessage(dart_state.get());
+}
+
+}  // namespace blink

--- a/sky/engine/tonic/dart_message_handler.h
+++ b/sky/engine/tonic/dart_message_handler.h
@@ -1,0 +1,75 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_ENGINE_TONIC_DART_MESSAGE_HANDLER_H_
+#define SKY_ENGINE_TONIC_DART_MESSAGE_HANDLER_H_
+
+#include "base/callback.h"
+#include "base/message_loop/message_loop.h"
+#include "dart/runtime/include/dart_api.h"
+
+namespace blink {
+class DartState;
+
+class DartMessageHandler {
+ public:
+  DartMessageHandler();
+  ~DartMessageHandler();
+
+  // Messages for the current isolate will be scheduled on |runner|.
+  void Initialize(const scoped_refptr<base::SingleThreadTaskRunner>& runner);
+
+  // Request the message loop to quit when isolate exits? Default is true.
+  void set_quit_message_loop_when_isolate_exits(
+      bool quit_message_loop_when_isolate_exits) {
+    quit_message_loop_when_isolate_exits_ =
+        quit_message_loop_when_isolate_exits;
+  }
+
+  bool quit_message_loop_when_isolate_exits() const {
+    return quit_message_loop_when_isolate_exits_;
+  }
+
+  // Did the isolate exit?
+  bool isolate_exited() const {
+    return isolate_exited_;
+  }
+
+  // Did the isolate have an uncaught exception error?
+  bool isolate_had_uncaught_exception_error() const {
+    return isolate_had_uncaught_exception_error_;
+  }
+
+ protected:
+  // Called from an unknown thread for each message.
+  void OnMessage(DartState* dart_state);
+  // By default, called on the task runner's thread for each message.
+  void OnHandleMessage(DartState* dart_state);
+
+  scoped_refptr<base::SingleThreadTaskRunner> task_runner() const {
+    return task_runner_;
+  }
+
+  bool handled_first_message() const {
+    return handled_first_message_;
+  }
+
+  void set_handled_first_message(bool handled_first_message) {
+    handled_first_message_ = handled_first_message;
+  }
+
+  bool handled_first_message_;
+  bool quit_message_loop_when_isolate_exits_;
+  bool isolate_exited_;
+  bool isolate_had_uncaught_exception_error_;
+  scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
+
+ private:
+  static void HandleMessage(base::WeakPtr<DartState> dart_state);
+  static void MessageNotifyCallback(Dart_Isolate dest_isolate);
+};
+
+}  // namespace blink
+
+#endif  // SKY_ENGINE_TONIC_DART_MESSAGE_HANDLER_H_

--- a/sky/engine/tonic/dart_state.cc
+++ b/sky/engine/tonic/dart_state.cc
@@ -8,6 +8,7 @@
 #include "sky/engine/tonic/dart_converter.h"
 #include "sky/engine/tonic/dart_exception_factory.h"
 #include "sky/engine/tonic/dart_library_loader.h"
+#include "sky/engine/tonic/dart_message_handler.h"
 #include "sky/engine/tonic/dart_timer_heap.h"
 
 namespace blink {
@@ -24,6 +25,8 @@ DartState::DartState()
       exception_factory_(new DartExceptionFactory(this)),
       library_loader_(new DartLibraryLoader(this)),
       timer_heap_(new DartTimerHeap()),
+      message_handler_(std::unique_ptr<DartMessageHandler>(
+          new DartMessageHandler())),
       weak_factory_(this) {
 }
 

--- a/sky/engine/tonic/dart_state.h
+++ b/sky/engine/tonic/dart_state.h
@@ -18,6 +18,7 @@ class DartClassLibrary;
 class DartExceptionFactory;
 class DartLibraryLoader;
 class DartTimerHeap;
+class DartMessageHandler;
 
 // DartState represents the state associated with a given Dart isolate. The
 // lifetime of this object is controlled by the DartVM. If you want to hold a
@@ -51,6 +52,7 @@ class DartState : public base::SupportsUserData {
   DartExceptionFactory& exception_factory() { return *exception_factory_; }
   DartLibraryLoader& library_loader() { return *library_loader_; }
   DartTimerHeap& timer_heap() { return *timer_heap_; }
+  DartMessageHandler& message_handler() { return *message_handler_; }
 
   Dart_Handle index_handle() { return index_handle_.value(); }
 
@@ -62,6 +64,8 @@ class DartState : public base::SupportsUserData {
   std::unique_ptr<DartExceptionFactory> exception_factory_;
   std::unique_ptr<DartLibraryLoader> library_loader_;
   std::unique_ptr<DartTimerHeap> timer_heap_;
+  std::unique_ptr<DartMessageHandler> message_handler_;
+
   DartPersistentValue index_handle_;
 
  protected:

--- a/sky/shell/testing/observatory/launcher.dart
+++ b/sky/shell/testing/observatory/launcher.dart
@@ -19,6 +19,7 @@ class ShellProcess {
                    .transform(new LineSplitter()).listen((line) {
       const String observatoryUriPrefix = 'Observatory listening on ';
       if (line.startsWith(observatoryUriPrefix)) {
+        print(line);
         Uri uri = Uri.parse(line.substring(observatoryUriPrefix.length));
         _observatoryUriCompleter.complete(uri);
       }
@@ -43,9 +44,11 @@ class ShellLauncher {
   ];
   final String shellExecutablePath;
   final String mainDartPath;
+  final bool startPaused;
 
   ShellLauncher(this.shellExecutablePath,
                 this.mainDartPath,
+                this.startPaused,
                 List<String> extraArgs) {
     if (extraArgs is List) {
       args.addAll(extraArgs);
@@ -55,7 +58,13 @@ class ShellLauncher {
 
   Future<ShellProcess> launch() async {
     try {
-      var process = await Process.start(shellExecutablePath, args);
+      List<String> shellArguments = [];
+      if (startPaused) {
+        shellArguments.add('--start-paused');
+      }
+      shellArguments.addAll(args);
+      print('Launching $shellExecutablePath $shellArguments');
+      var process = await Process.start(shellExecutablePath, shellArguments);
       return new ShellProcess(process);
     } catch (e) {
       print('Error launching shell: $e');


### PR DESCRIPTION
Re-apply a fixed #2377:
- Add tonic's DartMessageHandler which knows how to pause an isolate on start and exit.
- Use this message handler instead of the existing one in dart_controller.cc
- Remove the old message handler.

Plus:
- Respect --start-paused flag.
- Invoke main indirectly via a message.
- Add Observatory test that verifies --start-paused and resuming works.

Fixes https://github.com/flutter/flutter/issues/1457