### PR TITLE
Polish Mojo platform implementation

### DIFF
--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -98,6 +98,7 @@ void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
   update->nodes.insert(kBackgroundNodeId, background_node.Pass());
 
   auto root_node = mojo::gfx::composition::Node::New();
+  root_node->combinator = mojo::gfx::composition::Node::Combinator::PRUNE;
   root_node->child_node_ids.push_back(kBackgroundNodeId);
   layer_tree->UpdateScene(update.get(), root_node.get());
 

--- a/sky/shell/platform/mojo/application_impl.h
+++ b/sky/shell/platform/mojo/application_impl.h
@@ -53,6 +53,7 @@ class ApplicationImpl : public mojo::Application,
 
   mojo::StrongBinding<mojo::Application> binding_;
   mojo::URLResponsePtr initial_response_;
+  mojo::ServiceRegistryPtr initial_service_registry_;
   mojo::BindingSet<mojo::ServiceProvider> service_provider_bindings_;
   mojo::BindingSet<mojo::ui::ViewProvider> view_provider_bindings_;
   std::string url_;


### PR DESCRIPTION
* Use Node::Combinator::PRUNE, which stops the Mozart launcher from showing red
  when we're loading child views. Instead of blocking the whole app, we'll now
  just prune away the children that aren't ready. Eventually we'll want
  to let authors control these operations.

* Grab the service registry in AcceptConnection rather than CreateView. The
  CreateView comes from the Mozart launcher, which isn't where we want to get
  the service registry. Now we get the service registry from the first app to
  connect, which isn't right either but at least works while we sort out what
  we really want.