### PR TITLE
Attach a stencil buffer

### DIFF
--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -49,8 +49,9 @@ void RasterizerDirect::ConnectToRasterizer(
 }
 
 void RasterizerDirect::OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) {
-  surface_ =
-      gfx::GLSurface::CreateViewGLSurface(widget, gfx::SurfaceConfiguration());
+  gfx::SurfaceConfiguration config;
+  config.stencil_bits = 8;
+  surface_ = gfx::GLSurface::CreateViewGLSurface(widget, config);
   CHECK(surface_) << "GLSurface required.";
   // Eagerly create the GL context. For a while after the accelerated widget
   // is first available (after startup), the process is busy setting up dart

--- a/sky/shell/gpu/ganesh_canvas.cc
+++ b/sky/shell/gpu/ganesh_canvas.cc
@@ -52,12 +52,8 @@ SkCanvas* GaneshCanvas::GetCanvas(int32_t fbo, const SkISize& size) {
   desc.fWidth = size.width();
   desc.fHeight = size.height();
   desc.fConfig = kSkia8888_GrPixelConfig;
-#if defined(FNL_MUSL)
-  // TODO(kulakowski) This should be handled by MGL
-  desc.fOrigin = kTopLeft_GrSurfaceOrigin;
-#else
+  desc.fStencilBits = 8;
   desc.fOrigin = kBottomLeft_GrSurfaceOrigin;
-#endif
   desc.fRenderTargetHandle = fbo;
 
   skia::RefPtr<GrRenderTarget> target = skia::AdoptRef(


### PR DESCRIPTION
Skia can go faster (and crashes less) when we have a stencil buffer.

Fixes https://github.com/flutter/flutter/issues/1931