### PR TITLE
Move ganesh_canvas to sky/shell/gpu/direct/

### DIFF
--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -4,8 +4,6 @@
 
 source_set("common") {
   sources = [
-    "gpu/ganesh_canvas.cc",
-    "gpu/ganesh_canvas.h",
     "gpu/picture_serializer.cc",
     "gpu/picture_serializer.h",
     "rasterizer.cc",
@@ -68,6 +66,8 @@ source_set("gpu_direct") {
     "gpu/direct/surface_notifications_direct.h",
     "gpu/direct/rasterizer_direct.cc",
     "gpu/direct/rasterizer_direct.h",
+    "gpu/direct/ganesh_canvas.cc",
+    "gpu/direct/ganesh_canvas.h",
   ]
 
   deps = [

--- a/sky/shell/gpu/direct/ganesh_canvas.cc
+++ b/sky/shell/gpu/direct/ganesh_canvas.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "sky/shell/gpu/ganesh_canvas.h"
+#include "sky/shell/gpu/direct/ganesh_canvas.h"
 
 #include "base/logging.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"

--- a/sky/shell/gpu/direct/ganesh_canvas.h
+++ b/sky/shell/gpu/direct/ganesh_canvas.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef SKY_SHELL_GPU_GANESH_CANVAS_H_
-#define SKY_SHELL_GPU_GANESH_CANVAS_H_
+#ifndef SKY_SHELL_GPU_DIRECT_GANESH_CANVAS_H_
+#define SKY_SHELL_GPU_DIRECT_GANESH_CANVAS_H_
 
 #include "base/basictypes.h"
 #include "skia/ext/refptr.h"
@@ -38,4 +38,4 @@ class GaneshCanvas {
 }  // namespace shell
 }  // namespace sky
 
-#endif  // SKY_SHELL_GPU_GANESH_CANVAS_H_
+#endif  // SKY_SHELL_GPU_DIRECT_GANESH_CANVAS_H_

--- a/sky/shell/gpu/direct/rasterizer_direct.h
+++ b/sky/shell/gpu/direct/rasterizer_direct.h
@@ -8,7 +8,7 @@
 #include "base/memory/weak_ptr.h"
 #include "flow/paint_context.h"
 #include "skia/ext/refptr.h"
-#include "sky/shell/gpu/ganesh_canvas.h"
+#include "sky/shell/gpu/direct/ganesh_canvas.h"
 #include "sky/shell/rasterizer.h"
 #include "ui/gfx/native_widget_types.h"
 


### PR DESCRIPTION
We only use the ganesh canvas in the direct configuration. This patch moves the
class into the directory to make that clear.