### PR TITLE
Remove Dart entry point for ServiceRegistry

### DIFF
--- a/sky/engine/bindings/dart_vm_entry_points.txt
+++ b/sky/engine/bindings/dart_vm_entry_points.txt
@@ -14,7 +14,6 @@ dart:ui,::,_pushRoute
 dart:ui,::,_updateLocale
 dart:ui,::,_updateWindowMetrics
 dart:ui,::,takeRootBundleHandle
-dart:ui,::,takeServiceRegistry
 dart:ui,::,takeServicesProvidedByEmbedder
 dart:ui,::,takeServicesProvidedToEmbedder
 dart:ui,::,takeShellProxyHandle

--- a/sky/engine/bindings/mojo_services.cc
+++ b/sky/engine/bindings/mojo_services.cc
@@ -33,11 +33,6 @@ void DartTakeShellProxyHandle(Dart_NativeArguments args) {
       args, GetMojoServices()->TakeShellProxy().value());
 }
 
-void DartTakeServiceRegistry(Dart_NativeArguments args) {
-  Dart_SetIntegerReturnValue(
-      args, GetMojoServices()->TakeServiceRegistry().value());
-}
-
 void DartTakeServicesProvidedByEmbedder(Dart_NativeArguments args) {
   Dart_SetIntegerReturnValue(
       args, GetMojoServices()->TakeServicesProvidedByEmbedder().value());
@@ -58,7 +53,6 @@ void DartTakeViewHostHandle(Dart_NativeArguments args) {
 void MojoServices::RegisterNatives(DartLibraryNatives* natives) {
   natives->Register({
     {"takeRootBundleHandle", DartTakeRootBundleHandle, 0, true},
-    {"takeServiceRegistry", DartTakeServiceRegistry, 0, true},
     {"takeServicesProvidedByEmbedder", DartTakeServicesProvidedByEmbedder, 0, true},
     {"takeServicesProvidedToEmbedder", DartTakeServicesProvidedToEmbedder, 0, true},
     {"takeShellProxyHandle", DartTakeShellProxyHandle, 0, true},
@@ -103,10 +97,6 @@ void MojoServices::Create(
 
 mojo::Handle MojoServices::TakeShellProxy() {
   return services_ ? services_->shell.PassInterface().PassHandle().release() : mojo::Handle();
-}
-
-mojo::Handle MojoServices::TakeServiceRegistry() {
-  return mojo::Handle();
 }
 
 mojo::Handle MojoServices::TakeServicesProvidedByEmbedder() {

--- a/sky/engine/bindings/mojo_services.h
+++ b/sky/engine/bindings/mojo_services.h
@@ -33,7 +33,6 @@ class MojoServices
   static void RegisterNatives(DartLibraryNatives* natives);
 
   mojo::Handle TakeShellProxy();
-  mojo::Handle TakeServiceRegistry();
   mojo::Handle TakeServicesProvidedByEmbedder();
   mojo::Handle TakeServicesProvidedToEmbedder();
   mojo::Handle TakeRootBundleHandle();

--- a/sky/engine/core/dart/mojo_services.dart
+++ b/sky/engine/core/dart/mojo_services.dart
@@ -5,7 +5,6 @@
 part of dart_ui;
 
 int takeRootBundleHandle() native "takeRootBundleHandle";
-int takeServiceRegistry() native "takeServiceRegistry";
 int takeServicesProvidedByEmbedder() native "takeServicesProvidedByEmbedder";
 int takeServicesProvidedToEmbedder() native "takeServicesProvidedToEmbedder";
 int takeShellProxyHandle() native "takeShellProxyHandle";


### PR DESCRIPTION
We don't use this entry point anymore.