### PR TITLE
Disable dead code stripping in the Dart framework dylib

### DIFF
--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -512,6 +512,7 @@
 		9E07CF8F1BE7F4D200BCD8DE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = NO;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -530,6 +531,7 @@
 		9E07CF901BE7F4D200BCD8DE /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				DEAD_CODE_STRIPPING = NO;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;


### PR DESCRIPTION
cc @rmacnak-google @abarth 

This fixes an issue where the precompiler generates code that crashes lld. This only seemed to happen for sufficiently large applications. For example, hello_world and gallery were fine but the game was not. To be clear, this does not disable dead code stripping in the engine. That runner is already prepared ahead of time using a separate step. Not having this flag should make no difference to binary size.