### PR TITLE
iOS/Xcode: Run the snapshotter from the project directory

### DIFF
--- a/sky/build/SnapshotterInvoke
+++ b/sky/build/SnapshotterInvoke
@@ -74,6 +74,8 @@ SnapshotProject() {
 
   local project_path="$1"
 
+  RunCommand cd ${project_path}
+
   # Check if 'pub get' has been run
   RunCommand ls ${project_path}/packages
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
This fixes an issue where `readlink` would return relative paths instead of absolute now that `sky_engine` is in `bin/cache` in `$FLUTTER_ROOT`

cc @rmacnak-google 
