### PR TITLE
Enable background compilation by default

### DIFF
--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -72,17 +72,12 @@ static const char* kDartArgs[] = {
     // default profile period to 100Hz. This number is suitable for older
     // Raspberry Pi devices but quite low for current smartphones.
     "--profile_period=1000",
+    "--background_compilation",
 #if (WTF_OS_IOS || WTF_OS_MACOSX)
     // On platforms where LLDB is the primary debugger, SIGPROF signals
     // overwhelm LLDB.
     "--no-profiler",
 #endif
-};
-
-// Background compilation isn't quite ready, but this flag turns it on if we
-// want to experiment with it.
-static const char* kDartBackgroundCompilationArgs[]{
-    "--background_compilation",
 };
 
 static const char* kDartPrecompilationArgs[]{
@@ -311,9 +306,6 @@ void InitDartVM() {
 
   if (enable_checked_mode)
     args.append(kDartCheckedModeArgs, arraysize(kDartCheckedModeArgs));
-
-  if (SkySettings::Get().enable_background_compilation)
-    args.append(kDartBackgroundCompilationArgs, arraysize(kDartBackgroundCompilationArgs));
 
   if (SkySettings::Get().start_paused)
     args.append(kDartStartPausedArgs, arraysize(kDartStartPausedArgs));

--- a/sky/engine/public/platform/sky_settings.h
+++ b/sky/engine/public/platform/sky_settings.h
@@ -14,7 +14,6 @@ struct SkySettings {
   uint32_t observatory_port = 8181;
   bool start_paused = false;
   bool enable_dart_checked_mode = false;
-  bool enable_background_compilation = false;
 
   static const SkySettings& Get();
   static void Set(const SkySettings& settings);

--- a/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -42,9 +42,6 @@ public class SkyActivity extends Activity {
         if (intent.getBooleanExtra("enable-checked-mode", false)) {
             args.add("--enable-checked-mode");
         }
-        if (intent.getBooleanExtra("enable-background-compilation", false)) {
-            args.add("--enable-background-compilation");
-        }
         if (intent.getBooleanExtra("trace-startup", false)) {
             args.add("--trace-startup");
         }

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -101,8 +101,6 @@ void Shell::InitStandalone() {
   settings.start_paused = command_line.HasSwitch(switches::kStartPaused);
   settings.enable_dart_checked_mode =
       command_line.HasSwitch(switches::kEnableCheckedMode);
-  settings.enable_background_compilation =
-      command_line.HasSwitch(switches::kEnableBackgroundCompilation);
   blink::SkySettings::Set(settings);
 
   Init();

--- a/sky/shell/switches.cc
+++ b/sky/shell/switches.cc
@@ -11,7 +11,6 @@ namespace shell {
 namespace switches {
 
 const char kEnableCheckedMode[] = "enable-checked-mode";
-const char kEnableBackgroundCompilation[] = "enable-background-compilation";
 const char kFLX[] = "flx";
 const char kHelp[] = "help";
 const char kNonInteractive[] = "non-interactive";

--- a/sky/shell/switches.h
+++ b/sky/shell/switches.h
@@ -12,7 +12,6 @@ namespace shell {
 namespace switches {
 
 extern const char kEnableCheckedMode[];
-extern const char kEnableBackgroundCompilation[];
 extern const char kFLX[];
 extern const char kHelp[];
 extern const char kNonInteractive[];


### PR DESCRIPTION
We've been enabling it in the flutter tool for a while. This patch enables by
default in general.