### PR TITLE
Remove unneeded symbol from main_ios.mm

### DIFF
--- a/sky/shell/platform/ios/main_ios.mm
+++ b/sky/shell/platform/ios/main_ios.mm
@@ -7,16 +7,6 @@
 
 #include "sky/shell/platform/mac/platform_mac.h"
 
-extern "C" {
-// TODO(csg): HACK! boringssl accesses this on Android using a weak symbol
-// instead of a global. Till the patch for that lands and propagates to Sky, we
-// specify the same here to get workable builds on iOS. This is a hack! Will
-// go away.
-unsigned long getauxval(unsigned long type) {
-  return 0;
-}
-}
-
 int main(int argc, const char * argv[]) {
   return PlatformMacMain(argc, argv, ^(){
     return UIApplicationMain(argc, (char **)argv, nil,


### PR DESCRIPTION
We don't appear to need this hack anymore.