### PR TITLE
Make Offset, Point, and Size more resilient

### DIFF
--- a/sky/engine/core/painting/Offset.dart
+++ b/sky/engine/core/painting/Offset.dart
@@ -64,5 +64,5 @@ class Offset extends OffsetBase {
   /// Compares two Offsets for equality.
   bool operator ==(dynamic other) => other is Offset && super == other;
 
-  String toString() => "Offset(${dx.toStringAsFixed(1)}, ${dy.toStringAsFixed(1)})";
+  String toString() => "Offset(${dx?.toStringAsFixed(1)}, ${dy?.toStringAsFixed(1)})";
 }

--- a/sky/engine/core/painting/Point.dart
+++ b/sky/engine/core/painting/Point.dart
@@ -49,5 +49,5 @@ class Point {
 
   int get hashCode => hashValues(x, y);
 
-  String toString() => "Point(${x.toStringAsFixed(1)}, ${y.toStringAsFixed(1)})";
+  String toString() => "Point(${x?.toStringAsFixed(1)}, ${y?.toStringAsFixed(1)})";
 }

--- a/sky/engine/core/painting/Size.dart
+++ b/sky/engine/core/painting/Size.dart
@@ -66,5 +66,5 @@ class Size extends OffsetBase {
   /// Compares two Sizes for equality.
   bool operator ==(dynamic other) => other is Size && super == other;
 
-  String toString() => "Size(${width.toStringAsFixed(1)}, ${height.toStringAsFixed(1)})";
+  String toString() => "Size(${width?.toStringAsFixed(1)}, ${height?.toStringAsFixed(1)})";
 }


### PR DESCRIPTION
Turns out you can create these with null values, so toString() shouldn't
assume the values aren't null.