### PR TITLE
Allow specification of the FLX bundle (containing no Dart snapshot) outside the iOS/Mac application bundle.

### DIFF
--- a/sky/services/engine/sky_engine.mojom
+++ b/sky/services/engine/sky_engine.mojom
@@ -48,7 +48,7 @@ interface SkyEngine {
   PushRoute(string route);
   PopRoute();
 
-  RunFromFile(string main, string package_root);
+  RunFromFile(string main, string package_root, string bundle);
   RunFromPrecompiledSnapshot(string path);
   RunFromBundle(string path);
 

--- a/sky/shell/platform/ios/main_ios.mm
+++ b/sky/shell/platform/ios/main_ios.mm
@@ -3,13 +3,13 @@
 // found in the LICENSE file.
 
 #import <UIKit/UIKit.h>
-#import "sky/shell/platform/ios/sky_app_delegate.h"
 
+#include "sky/shell/platform/ios/sky_app_delegate.h"
 #include "sky/shell/platform/mac/platform_mac.h"
 
-int main(int argc, const char * argv[]) {
-  return PlatformMacMain(argc, argv, ^(){
-    return UIApplicationMain(argc, (char **)argv, nil,
+int main(int argc, const char* argv[]) {
+  return sky::shell::PlatformMacMain(argc, argv, ^() {
+    return UIApplicationMain(argc, (char**)argv, nil,
                              NSStringFromClass([SkyAppDelegate class]));
   });
 }

--- a/sky/shell/platform/mac/main_mac.mm
+++ b/sky/shell/platform/mac/main_mac.mm
@@ -32,7 +32,7 @@ void AttachMessageLoopToMainRunLoop(void) {
 int main(int argc, const char* argv[]) {
   [SkyApplication sharedApplication];
 
-  return PlatformMacMain(argc, argv, ^() {
+  return sky::shell::PlatformMacMain(argc, argv, ^() {
     base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
     if (command_line.HasSwitch(sky::shell::switches::kHelp)) {
       sky::shell::switches::PrintUsage("SkyShell");

--- a/sky/shell/platform/mac/platform_mac.h
+++ b/sky/shell/platform/mac/platform_mac.h
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef SKY_SHELL_MAC_PLATFORM_MAC_H_
-#define SKY_SHELL_MAC_PLATFORM_MAC_H_
+#ifndef SKY_SHELL_PLATFORM_MAC_PLATFORM_MAC_H_
+#define SKY_SHELL_PLATFORM_MAC_PLATFORM_MAC_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include "sky/services/engine/sky_engine.mojom.h"
+
+namespace sky {
+namespace shell {
 
 typedef int (^PlatformMacMainCallback)(void);
 
@@ -15,8 +16,9 @@ int PlatformMacMain(int argc,
                     const char* argv[],
                     PlatformMacMainCallback callback);
 
-#ifdef __cplusplus
-}
-#endif
+bool AttemptLaunchFromCommandLineSwitches(sky::SkyEnginePtr& engine);
 
-#endif  // SKY_SHELL_MAC_PLATFORM_MAC_H_
+}  // namespace shell
+}  // namespace sky
+
+#endif  // SKY_SHELL_PLATFORM_MAC_PLATFORM_MAC_H_

--- a/sky/shell/platform/mac/platform_mac.mm
+++ b/sky/shell/platform/mac/platform_mac.mm
@@ -4,6 +4,8 @@
 
 #include "sky/shell/platform/mac/platform_mac.h"
 
+#include <Foundation/Foundation.h>
+
 #include <asl.h>
 #include "base/at_exit.h"
 #include "base/command_line.h"
@@ -20,6 +22,9 @@
 #include "sky/shell/ui_delegate.h"
 #include "ui/gl/gl_surface.h"
 #include "base/trace_event/trace_event.h"
+
+namespace sky {
+namespace shell {
 
 static void InitializeLogging() {
   logging::LoggingSettings settings;
@@ -72,7 +77,8 @@ int PlatformMacMain(int argc,
   // marker that can be used as a reference for startup.
   TRACE_EVENT_INSTANT0("flutter", "main", TRACE_EVENT_SCOPE_PROCESS);
 
-  std::unique_ptr<base::MessageLoopForUI> message_loop(new base::MessageLoopForUI());
+  std::unique_ptr<base::MessageLoopForUI> message_loop(
+      new base::MessageLoopForUI());
 
 #if TARGET_OS_IPHONE
   // One cannot start the message loop on the platform main thread. Instead,
@@ -96,3 +102,95 @@ int PlatformMacMain(int argc,
 
   return result;
 }
+
+static bool FlagsValidForCommandLineLaunch(const std::string& dart_main,
+                                           const std::string& package_root,
+                                           const std::string& bundle) {
+  if (dart_main.size() == 0 || package_root.size() == 0 || bundle.size() == 0) {
+    return false;
+  }
+
+  // Ensure that the paths exists. This catches cases where the user has
+  // successfully launched the application from the tooling but has since moved
+  // the source files on disk and is launching again directly.
+
+  NSFileManager* manager = [NSFileManager defaultManager];
+
+  if (![manager fileExistsAtPath:@(dart_main.c_str())]) {
+    return false;
+  }
+
+  if (![manager fileExistsAtPath:@(package_root.c_str())]) {
+    return false;
+  }
+
+  if (![manager fileExistsAtPath:@(bundle.c_str())]) {
+    return false;
+  }
+
+  return true;
+}
+
+static std::string ResolveCommandLineLaunchFlag(const char* name) {
+  auto command_line = *base::CommandLine::ForCurrentProcess();
+
+  if (command_line.HasSwitch(name)) {
+    return command_line.GetSwitchValueASCII(name);
+  }
+
+  const char* saved_default =
+      [[NSUserDefaults standardUserDefaults] stringForKey:@(name)].UTF8String;
+
+  if (saved_default != NULL) {
+    return saved_default;
+  }
+
+  return "";
+}
+
+bool AttemptLaunchFromCommandLineSwitches(sky::SkyEnginePtr& engine) {
+  base::mac::ScopedNSAutoreleasePool pool;
+
+  using namespace sky::shell::switches;
+
+  NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+
+  auto command_line = *base::CommandLine::ForCurrentProcess();
+
+  if (command_line.HasSwitch(kMainDartFile) ||
+      command_line.HasSwitch(kPackageRoot) || command_line.HasSwitch(kFLX)) {
+    // The main dart file, flx bundle and the package root must be specified in
+    // one go. We dont want to end up in a situation where we take one value
+    // from the command line and the others from user defaults. In case, any
+    // new flags are specified, forget about all the old ones.
+    [defaults removeObjectForKey:@(kMainDartFile)];
+    [defaults removeObjectForKey:@(kPackageRoot)];
+    [defaults removeObjectForKey:@(kFLX)];
+
+    [defaults synchronize];
+  }
+
+  std::string dart_main = ResolveCommandLineLaunchFlag(kMainDartFile);
+  std::string package_root = ResolveCommandLineLaunchFlag(kPackageRoot);
+  std::string bundle = ResolveCommandLineLaunchFlag(kFLX);
+
+  if (!FlagsValidForCommandLineLaunch(dart_main, package_root, bundle)) {
+    return false;
+  }
+
+  // Save the newly resolved dart main file and the package root to user
+  // defaults so that the next time the user launches the application in the
+  // simulator without the tooling, the application boots up.
+  [defaults setObject:@(dart_main.c_str()) forKey:@(kMainDartFile)];
+  [defaults setObject:@(package_root.c_str()) forKey:@(kPackageRoot)];
+  [defaults setObject:@(bundle.c_str()) forKey:@(kFLX)];
+
+  [defaults synchronize];
+
+  // Finally launch with the newly resolved arguments.
+  engine->RunFromFile(dart_main, package_root, bundle);
+  return true;
+}
+
+}  // namespace shell
+}  // namespace sky

--- a/sky/shell/switches.cc
+++ b/sky/shell/switches.cc
@@ -14,6 +14,7 @@ const char kEnableCheckedMode[] = "enable-checked-mode";
 const char kFLX[] = "flx";
 const char kHelp[] = "help";
 const char kNonInteractive[] = "non-interactive";
+const char kMainDartFile[] = "dart-main";
 const char kPackageRoot[] = "package-root";
 const char kStartPaused[] = "start-paused";
 const char kTraceStartup[] = "trace-startup";

--- a/sky/shell/switches.h
+++ b/sky/shell/switches.h
@@ -15,6 +15,7 @@ extern const char kEnableCheckedMode[];
 extern const char kFLX[];
 extern const char kHelp[];
 extern const char kNonInteractive[];
+extern const char kMainDartFile[];
 extern const char kPackageRoot[];
 extern const char kStartPaused[];
 extern const char kTraceStartup[];

--- a/sky/shell/testing/test_runner.cc
+++ b/sky/shell/testing/test_runner.cc
@@ -22,8 +22,7 @@ static TestRunner* g_test_runner = nullptr;
 }  // namespace
 
 TestRunner::TestRunner()
-  : shell_view_(new ShellView(Shell::Shared())),
-    weak_ptr_factory_(this) {
+    : shell_view_(new ShellView(Shell::Shared())), weak_ptr_factory_(this) {
   CHECK(!g_test_runner) << "Only create one TestRunner.";
 
   shell_view_->view()->ConnectToEngine(GetProxy(&sky_engine_));
@@ -33,8 +32,7 @@ TestRunner::TestRunner()
   sky_engine_->OnViewportMetricsChanged(metrics.Pass());
 }
 
-TestRunner::~TestRunner() {
-}
+TestRunner::~TestRunner() {}
 
 TestRunner& TestRunner::Shared() {
   if (!g_test_runner)
@@ -43,7 +41,7 @@ TestRunner& TestRunner::Shared() {
 }
 
 void TestRunner::Run(const TestDescriptor& test) {
-  sky_engine_->RunFromFile(test.path, test.package_root);
+  sky_engine_->RunFromFile(test.path, test.package_root, "");
 }
 
 }  // namespace shell

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -64,11 +64,12 @@ class Engine : public UIDelegate,
   void SetServices(ServicesDataPtr services) override;
   void OnViewportMetricsChanged(ViewportMetricsPtr metrics) override;
   void OnLocaleChanged(const mojo::String& language_code,
-		       const mojo::String& country_code) override;
+                       const mojo::String& country_code) override;
   void OnPointerPacket(pointer::PointerPacketPtr packet) override;
 
   void RunFromFile(const mojo::String& main,
-                   const mojo::String& package_root) override;
+                   const mojo::String& package_root,
+                   const mojo::String& bundle) override;
   void RunFromPrecompiledSnapshot(const mojo::String& bundle_path) override;
   void RunFromBundle(const mojo::String& path) override;
   void RunFromBundleAndSnapshot(const mojo::String& bundle_path,
@@ -91,6 +92,8 @@ class Engine : public UIDelegate,
 
   void StopAnimator();
   void StartAnimatorIfPossible();
+
+  void ConfigureZipAssetBundle(const mojo::String& path);
 
   Config config_;
   std::unique_ptr<Animator> animator_;


### PR DESCRIPTION
Allows launching of apps without having any Xcodebuild step in the simulator. Relaunch the application in either the iOS simulator or the Mac shell to see the latest changes.