### PR TITLE
Adds //vfx

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -8,6 +8,7 @@ group("default") {
   deps = [
     "//sky",
     "//sky/services/dynamic:sdk_lib",
+    "//vfx",
   ]
 }
 

--- a/vfx/BUILD.gn
+++ b/vfx/BUILD.gn
@@ -1,0 +1,10 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+group("vfx") {
+  deps = [
+    "//vfx/geometry",
+    "//vfx/gl",
+  ]
+}

--- a/vfx/geometry/BUILD.gn
+++ b/vfx/geometry/BUILD.gn
@@ -1,0 +1,25 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("geometry") {
+  sources = [
+    "color.h",
+    "cuboid.h",
+    "matrix.cc",
+    "matrix.h",
+    "offset.cc",
+    "offset.h",
+    "plane.cc",
+    "plane.h",
+    "point.cc",
+    "point.h",
+    "quad.cc",
+    "quad.h",
+    "sphere.h",
+    "triangle.cc",
+    "triangle.h",
+    "wedge.cc",
+    "wedge.h",
+  ]
+}

--- a/vfx/geometry/color.h
+++ b/vfx/geometry/color.h
@@ -1,0 +1,44 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_COLOR_H_
+#define VFX_GEOMETRY_COLOR_H_
+
+#include <memory>
+
+#include "vfx/geometry/offset.h"
+
+namespace vfx {
+
+// An RGBA color.
+class Color {
+ public:
+  Color() { memset(data_, 0, sizeof(data_)); }
+  explicit Color(float data[4]) { memcpy(data_, data, sizeof(data_)); }
+  Color(float r, float g, float b, float a) {
+    data_[0] = r;
+    data_[1] = g;
+    data_[2] = b;
+    data_[3] = a;
+  }
+
+  float r() const { return data_[0]; }
+  float g() const { return data_[1]; }
+  float b() const { return data_[2]; }
+  float a() const { return data_[3]; }
+
+  const float* data() const { return data_; }
+
+  void set_r(float r) { data_[0] = r; }
+  void set_g(float g) { data_[1] = g; }
+  void set_b(float b) { data_[2] = b; }
+  void set_a(float a) { data_[3] = a; }
+
+ private:
+  float data_[4];
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_COLOR_H_

--- a/vfx/geometry/cuboid.h
+++ b/vfx/geometry/cuboid.h
@@ -1,0 +1,58 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_CUBOID_H_
+#define VFX_GEOMETRY_CUBOID_H_
+
+#include <vector>
+
+#include "vfx/geometry/point.h"
+#include "vfx/geometry/quad.h"
+
+namespace vfx {
+
+// A solid bounded by six planes.
+class Cuboid {
+ public:
+  Cuboid() { }
+  Cuboid(const Quad& a, const Quad& b) {
+    a_ = a;
+    b_ = b;
+  }
+
+  const Quad& a() const { return a_; }
+  const Quad& b() const { return b_; }
+
+  void set_a(const Quad& a) { a_ = a; }
+  void set_b(const Quad& b) { b_ = b; }
+
+  template<typename Vertex>
+  std::vector<Vertex> Tessellate(Vertex make_vertex(const Point& point)) const {
+    std::vector<Vertex> vertices;
+    vertices.reserve(14);
+    vertices.push_back(make_vertex(a_[0]));
+    vertices.push_back(make_vertex(a_[1]));
+    vertices.push_back(make_vertex(a_[3]));
+    vertices.push_back(make_vertex(a_[2]));
+    vertices.push_back(make_vertex(b_[2]));
+    vertices.push_back(make_vertex(a_[1]));
+    vertices.push_back(make_vertex(b_[1]));
+    vertices.push_back(make_vertex(a_[0]));
+    vertices.push_back(make_vertex(b_[0]));
+    vertices.push_back(make_vertex(a_[3]));
+    vertices.push_back(make_vertex(b_[3]));
+    vertices.push_back(make_vertex(b_[2]));
+    vertices.push_back(make_vertex(b_[0]));
+    vertices.push_back(make_vertex(b_[1]));
+    return vertices;
+  }
+
+ private:
+  Quad a_;
+  Quad b_;
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_CUBOID_H_

--- a/vfx/geometry/matrix.cc
+++ b/vfx/geometry/matrix.cc
@@ -1,0 +1,111 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/geometry/matrix.h"
+
+#include <math.h>
+
+namespace vfx {
+
+static_assert(sizeof(Matrix) == sizeof(float) * 16,
+              "Matrix should contain only floats");
+
+void Matrix::SetZero() {
+  memset(data_, 0, sizeof(data_));
+}
+
+void Matrix::SetIdentity() {
+  memset(data_, 0, sizeof(data_));
+  data_[0][0] = 1.0f;
+  data_[1][1] = 1.0f;
+  data_[2][2] = 1.0f;
+  data_[3][3] = 1.0f;
+}
+
+void Matrix::SetFrustum(float left,
+                        float right,
+                        float bottom,
+                        float top,
+                        float near_z,
+                        float far_z) {
+  float dx = right - left;
+  float dy = top - bottom;
+  float dz = far_z - near_z;
+
+  if ((near_z <= 0.0f) ||
+      (far_z <= 0.0f) ||
+      (dx <= 0.0f) ||
+      (dy <= 0.0f) ||
+      (dz <= 0.0f)) {
+    SetIdentity();
+  } else {
+    data_[0][0] = 2.0f * near_z / dx;
+    data_[1][0] = 0.0f;
+    data_[2][0] = 0.0f;
+    data_[3][0] = 0.0f;
+
+    data_[0][1] = 0.0f;
+    data_[1][1] = 2.0f * near_z / dy;
+    data_[2][1] = 0.0f;
+    data_[3][1] = 0.0f;
+
+    data_[0][2] = (right + left) / dx;
+    data_[1][2] = (top + bottom) / dy;
+    data_[2][2] = -(near_z + far_z) / dz;
+    data_[3][2] = -1.0f;
+
+    data_[0][3] = 0.0f;
+    data_[1][3] = 0.0f;
+    data_[2][3] = -2.0f * near_z * far_z / dz;
+    data_[3][3] = 0.0f;
+  }
+}
+
+void Matrix::SetPerspective(float fov_y,
+                            float aspect,
+                            float near_z,
+                            float far_z) {
+  float dy = tanf(fov_y / 360.0f * M_PI) * near_z;
+  float dx = dy * aspect;
+  SetFrustum(-dx, dx, -dy, dy, near_z, far_z);
+}
+
+void Matrix::PreTranslate(const Offset& offset) {
+  float dx = offset.dx();
+  float dy = offset.dy();
+  float dz = offset.dz();
+
+  data_[3][0] += dx * data_[0][0] + dy * data_[1][0] + dz * data_[2][0];
+  data_[3][1] += dx * data_[0][1] + dy * data_[1][1] + dz * data_[2][1];
+  data_[3][2] += dx * data_[0][2] + dy * data_[1][2] + dz * data_[2][2];
+  data_[3][3] += dx * data_[0][3] + dy * data_[1][3] + dz * data_[2][3];
+}
+
+void Matrix::PostTranslate(const Offset& offset) {
+  float dx = offset.dx();
+  if (dx != 0) {
+    data_[0][0] += data_[0][3] * dx;
+    data_[1][0] += data_[1][3] * dx;
+    data_[2][0] += data_[2][3] * dx;
+    data_[3][0] += data_[3][3] * dx;
+  }
+
+  float dy = offset.dy();
+  if (dy != 0) {
+    data_[0][1] += data_[0][3] * dy;
+    data_[1][1] += data_[1][3] * dy;
+    data_[2][1] += data_[2][3] * dy;
+    data_[3][1] += data_[3][3] * dy;
+  }
+
+  float dz = offset.dz();
+  if (dz != 0) {
+    data_[0][2] += data_[0][3] * dz;
+    data_[1][2] += data_[1][3] * dz;
+    data_[2][2] += data_[2][3] * dz;
+    data_[3][2] += data_[3][3] * dz;
+  }
+}
+
+}  // namespace vfx

--- a/vfx/geometry/matrix.h
+++ b/vfx/geometry/matrix.h
@@ -1,0 +1,50 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_MATRIX_H_
+#define VFX_GEOMETRY_MATRIX_H_
+
+#include <memory>
+
+#include "vfx/geometry/offset.h"
+
+namespace vfx {
+
+// A 4x4 projective matrix.
+class Matrix {
+ public:
+  Matrix() { SetIdentity(); }
+  explicit Matrix(float data[4][4]) { memcpy(data_, data, sizeof(data_)); }
+
+  const float* data() const { return &data_[0][0]; }
+
+  float get(size_t col, size_t row) const { return data_[col][row]; }
+
+  void set(size_t col, size_t row, float value) {
+    data_[col][row] = value;
+  }
+
+  void SetZero();
+  void SetIdentity();
+  void SetFrustum(float left,
+                  float right,
+                  float bottom,
+                  float top,
+                  float near_z,
+                  float far_z);
+  void SetPerspective(float fov_y,
+                      float aspect,
+                      float near_z,
+                      float far_z);
+
+  void PreTranslate(const Offset& offset);
+  void PostTranslate(const Offset& offset);
+
+ private:
+  float data_[4][4];
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_MATRIX_H_

--- a/vfx/geometry/offset.cc
+++ b/vfx/geometry/offset.cc
@@ -1,0 +1,29 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/geometry/point.h"
+
+#include <math.h>
+
+namespace vfx {
+
+float Offset::NormSquared() const {
+  return data_[0] * data_[0] + data_[1] * data_[1] + data_[2] * data_[2];
+}
+
+Offset& Offset::Normalize() {
+  float norm = sqrt(NormSquared());
+  data_[0] /= norm;
+  data_[1] /= norm;
+  data_[2] /= norm;
+  return *this;
+}
+
+Offset Offset::Cross(const Offset& v) {
+  return Offset(dy() * v.dz() - dz() * v.dy(),
+                dz() * v.dx() - dx() * v.dz(),
+                dx() * v.dy() - dy() * v.dx());
+}
+
+}  // namespace vfx

--- a/vfx/geometry/offset.h
+++ b/vfx/geometry/offset.h
@@ -1,0 +1,63 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_OFFSET_H_
+#define VFX_GEOMETRY_OFFSET_H_
+
+#include <memory>
+
+namespace vfx {
+
+// A vector in three dimensions.
+class Offset {
+ public:
+  Offset() { memset(data_, 0, sizeof(data_)); }
+  explicit Offset(float data[3]) { memcpy(data_, data, sizeof(data_)); }
+  Offset(float dx, float dy, float dz) {
+    data_[0] = dx;
+    data_[1] = dy;
+    data_[2] = dz;
+  }
+
+  float dx() const { return data_[0]; }
+  float dy() const { return data_[1]; }
+  float dz() const { return data_[2]; }
+
+  const float* data() const { return data_; }
+
+  void set_dx(float dx) { data_[0] = dx; }
+  void set_dy(float dy) { data_[1] = dy; }
+  void set_dz(float dz) { data_[2] = dz; }
+
+  Offset& Scale(float factor) {
+    data_[0] *= factor;
+    data_[1] *= factor;
+    data_[2] *= factor;
+    return *this;
+  }
+
+  Offset& Normalize();
+
+  float NormSquared() const;
+  Offset Cross(const Offset& v);
+
+ private:
+  float data_[3];
+};
+
+inline Offset operator*(double a, const Offset& v) {
+  return Offset(a * v.dx(), a * v.dy(), a * v.dz());
+}
+
+inline Offset operator*(const Offset& v, double a) {
+  return a * v;
+}
+
+inline Offset operator+(const Offset& v, const Offset& w) {
+  return Offset(v.dx() + w.dx(), v.dy() + w.dy(), v.dz() + w.dz());
+}
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_OFFSET_H_

--- a/vfx/geometry/plane.cc
+++ b/vfx/geometry/plane.cc
@@ -1,0 +1,31 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/geometry/plane.h"
+
+#include <math.h>
+
+#include "vfx/geometry/offset.h"
+
+namespace vfx {
+
+Plane::Plane(const Point& p1, const Point& p2, const Point& p3) {
+  Offset v = p2 - p1;
+  Offset w = p3 - p1;
+  Offset normal = v.Cross(w);
+  data_[0] = normal.dx();
+  data_[1] = normal.dy();
+  data_[2] = normal.dz();
+  data_[3] = a() * p1.x() + b() * p1.y() + c() * p1.y();
+}
+
+Plane& Plane::FlipNormal() {
+  data_[0] = -data_[0];
+  data_[1] = -data_[1];
+  data_[2] = -data_[2];
+  data_[3] = -data_[3];
+  return *this;
+}
+
+}  // namespace vfx

--- a/vfx/geometry/plane.h
+++ b/vfx/geometry/plane.h
@@ -1,0 +1,47 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_PLANE_H_
+#define VFX_GEOMETRY_PLANE_H_
+
+#include <memory>
+
+#include "vfx/geometry/point.h"
+
+namespace vfx {
+
+// A plane in three dimensions defined by ax + by + cz = d.
+class Plane {
+ public:
+  Plane() { memset(data_, 0, sizeof(data_)); }
+  explicit Plane(float data[4]) { memcpy(data_, data, sizeof(data_)); }
+  Plane(float a, float b, float c, float d) {
+    data_[0] = a;
+    data_[1] = b;
+    data_[2] = c;
+    data_[3] = d;
+  }
+  Plane(const Point& p1, const Point& p2, const Point& p3);
+
+  float a() const { return data_[0]; }
+  float b() const { return data_[1]; }
+  float c() const { return data_[2]; }
+  float d() const { return data_[3]; }
+
+  const float* data() const { return data_; }
+
+  void set_a(float a) { data_[0] = a; }
+  void set_b(float b) { data_[1] = b; }
+  void set_c(float c) { data_[2] = c; }
+  void set_d(float d) { data_[3] = d; }
+
+  Plane& FlipNormal();
+
+ private:
+  float data_[4];
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_PLANE_H_

--- a/vfx/geometry/point.cc
+++ b/vfx/geometry/point.cc
@@ -1,0 +1,19 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/geometry/point.h"
+
+#include <math.h>
+
+#include "vfx/geometry/offset.h"
+
+namespace vfx {
+
+void Point::Move(const Offset& offset) {
+  data_[0] += offset.dx();
+  data_[1] += offset.dy();
+  data_[2] += offset.dz();
+}
+
+}  // namespace vfx

--- a/vfx/geometry/point.h
+++ b/vfx/geometry/point.h
@@ -1,0 +1,59 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_POINT_H_
+#define VFX_GEOMETRY_POINT_H_
+
+#include <memory>
+
+#include "vfx/geometry/offset.h"
+
+namespace vfx {
+
+// A point in three dimensions.
+class Point {
+ public:
+  Point() { memset(data_, 0, sizeof(data_)); }
+  explicit Point(float data[3]) { memcpy(data_, data, sizeof(data_)); }
+  Point(float x, float y, float z) {
+    data_[0] = x;
+    data_[1] = y;
+    data_[2] = z;
+  }
+
+  float x() const { return data_[0]; }
+  float y() const { return data_[1]; }
+  float z() const { return data_[2]; }
+
+  const float* data() const { return data_; }
+
+  void set_x(float x) { data_[0] = x; }
+  void set_y(float y) { data_[1] = y; }
+  void set_z(float z) { data_[2] = z; }
+
+  void Move(const Offset& offset);
+
+ private:
+  float data_[3];
+};
+
+inline Offset operator-(const Point& a, const Point& b) {
+  return Offset(a.x() - b.x(), a.y() - b.y(), a.z() - b.z());
+}
+
+inline Point operator-(const Point& base, const Offset& offset) {
+  return Point(base.x() - offset.dx(),
+               base.y() - offset.dy(),
+               base.z() - offset.dz());
+}
+
+inline Point operator+(const Point& base, const Offset& offset) {
+  return Point(base.x() + offset.dx(),
+               base.y() + offset.dy(),
+               base.z() + offset.dz());
+}
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_POINT_H_

--- a/vfx/geometry/quad.cc
+++ b/vfx/geometry/quad.cc
@@ -1,0 +1,59 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/geometry/quad.h"
+
+#include "vfx/geometry/offset.h"
+
+namespace vfx {
+
+void Quad::Move(const Offset& offset) {
+  data_[0].Move(offset);
+  data_[1].Move(offset);
+  data_[2].Move(offset);
+  data_[3].Move(offset);
+}
+
+Quad Quad::ProjectDistanceFromSource(const Point& source,
+                                     double distance) const {
+  Offset ray[4] = {
+    p1() - source,
+    p2() - source,
+    p3() - source,
+    p4() - source,
+  };
+
+  ray[0].Normalize();
+  ray[1].Normalize();
+  ray[2].Normalize();
+  ray[3].Normalize();
+
+  ray[0].Scale(distance);
+  ray[1].Scale(distance);
+  ray[2].Scale(distance);
+  ray[3].Scale(distance);
+
+  return Quad(source + ray[0],
+              source + ray[1],
+              source + ray[2],
+              source + ray[3]);
+}
+
+Offset Quad::GetNormal() const {
+  Offset v = p2() - p1();
+  Offset w = p3() - p1();
+  return v.Cross(w);
+}
+
+Offset Quad::GetUnitNormal() const {
+  Offset normal = GetNormal();
+  normal.Normalize();
+  return normal;
+}
+
+Plane Quad::GetPlane() const {
+  return Plane(p1(), p2(), p3());
+}
+
+}  // namespace vfx

--- a/vfx/geometry/quad.h
+++ b/vfx/geometry/quad.h
@@ -1,0 +1,60 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_QUAD_H_
+#define VFX_GEOMETRY_QUAD_H_
+
+#include <memory>
+
+#include "vfx/geometry/point.h"
+#include "vfx/geometry/plane.h"
+
+namespace vfx {
+class Offset;
+
+// A region bounded by four lines in a plane.
+class Quad {
+ public:
+  Quad() { memset(data_, 0, sizeof(data_)); }
+  explicit Quad(Point data[4]) { memcpy(data_, data, sizeof(data_)); }
+  Quad(const Point& p1, const Point& p2, const Point& p3, const Point& p4) {
+    data_[0] = p1;
+    data_[1] = p2;
+    data_[2] = p3;
+    data_[3] = p4;
+  }
+
+  const Point& p1() const { return data_[0]; }
+  const Point& p2() const { return data_[1]; }
+  const Point& p3() const { return data_[2]; }
+  const Point& p4() const { return data_[3]; }
+
+  const Point* data() const { return data_; }
+  const Point& operator[](size_t i) const { return data_[i]; }
+
+  void set_p1(const Point& p1) { data_[0] = p1; }
+  void set_p2(const Point& p2) { data_[1] = p2; }
+  void set_p3(const Point& p3) { data_[2] = p3; }
+  void set_p4(const Point& p4) { data_[3] = p4; }
+
+  void Move(const Offset& offset);
+  Quad ProjectDistanceFromSource(const Point& source, double distance) const;
+
+  Offset GetNormal() const;
+  Offset GetUnitNormal() const;
+
+  // Returns the plane that contains this quad.
+  //
+  // Because quads use floating point, it's unlikely that a quad actually lies
+  // in a mathematical plane. This function actually returns the plane that
+  // contains p1, p2, and p3.
+  Plane GetPlane() const;
+
+ private:
+  Point data_[4];
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_QUAD_H_

--- a/vfx/geometry/sphere.h
+++ b/vfx/geometry/sphere.h
@@ -1,0 +1,31 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_SPHERE_H_
+#define VFX_GEOMETRY_SPHERE_H_
+
+#include "vfx/geometry/point.h"
+
+namespace vfx {
+
+class Sphere {
+ public:
+  Sphere() : radius_(0.0f) { }
+  Sphere(const Point& center, double radius)
+    : center_(center), radius_(radius) { }
+
+  const Point& center() const { return center_; }
+  double radius() const { return radius_; }
+
+  void set_center(const Point& center) { center_ = center; }
+  void set_radius(double radius) { radius_ = radius; }
+
+ private:
+  Point center_;
+  double radius_;
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_SPHERE_H_

--- a/vfx/geometry/triangle.cc
+++ b/vfx/geometry/triangle.cc
@@ -1,0 +1,20 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/geometry/triangle.h"
+
+#include <utility>
+
+namespace vfx {
+
+Plane Triangle::GetPlane() const {
+  return Plane(p1(), p2(), p3());
+}
+
+Triangle& Triangle::FlipNormal() {
+  std::swap(data_[1], data_[2]);
+  return *this;
+}
+
+}  // namespace vfx

--- a/vfx/geometry/triangle.h
+++ b/vfx/geometry/triangle.h
@@ -1,0 +1,48 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_TRIANGLE_H_
+#define VFX_GEOMETRY_TRIANGLE_H_
+
+#include <memory>
+
+#include "vfx/geometry/point.h"
+#include "vfx/geometry/plane.h"
+
+namespace vfx {
+
+// A region bounded by three lines in a plane.
+class Triangle {
+ public:
+  Triangle() { memset(data_, 0, sizeof(data_)); }
+  explicit Triangle(Point data[3]) { memcpy(data_, data, sizeof(data_)); }
+  Triangle(const Point& p1, const Point& p2, const Point& p3) {
+    data_[0] = p1;
+    data_[1] = p2;
+    data_[2] = p3;
+  }
+
+  const Point& p1() const { return data_[0]; }
+  const Point& p2() const { return data_[1]; }
+  const Point& p3() const { return data_[2]; }
+
+  const Point* data() const { return data_; }
+  const Point& operator[](size_t i) const { return data_[i]; }
+
+  void set_p1(const Point& p1) { data_[0] = p1; }
+  void set_p2(const Point& p2) { data_[1] = p2; }
+  void set_p3(const Point& p3) { data_[2] = p3; }
+
+  Triangle& FlipNormal();
+
+  // Returns the plane that contains this triangle.
+  Plane GetPlane() const;
+
+ private:
+  Point data_[3];
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_TRIANGLE_H_

--- a/vfx/geometry/wedge.cc
+++ b/vfx/geometry/wedge.cc
@@ -1,0 +1,25 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/geometry/wedge.h"
+
+namespace vfx {
+
+Plane Wedge::GetPlane(size_t index) const {
+  switch (index) {
+  case 0:
+    return a_.GetPlane();;
+  case 1:
+    return b_.GetPlane();;
+  case 2:
+    return Plane(a_[0], a_[2], b_[2]);
+  case 3:
+    return Plane(a_[1], a_[0], b_[0]);
+  case 4:
+    return Plane(a_[2], a_[1], b_[1]);
+  }
+  return Plane();
+}
+
+}  // namespace vfx

--- a/vfx/geometry/wedge.h
+++ b/vfx/geometry/wedge.h
@@ -1,0 +1,57 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_WEDGE_H_
+#define VFX_GEOMETRY_WEDGE_H_
+
+#include <vector>
+
+#include "vfx/geometry/plane.h"
+#include "vfx/geometry/point.h"
+#include "vfx/geometry/triangle.h"
+
+namespace vfx {
+
+// A solid bounded by five planes.
+class Wedge {
+ public:
+  Wedge() { }
+  Wedge(const Triangle& a, const Triangle& b) {
+    a_ = a;
+    b_ = b;
+  }
+
+  const Triangle& a() const { return a_; }
+  const Triangle& b() const { return b_; }
+
+  void set_a(const Triangle& a) { a_ = a; }
+  void set_b(const Triangle& b) { b_ = b; }
+
+  template<typename Vertex>
+  std::vector<Vertex> Tessellate(Vertex make_vertex(const Point& point)) const {
+    std::vector<Vertex> vertices;
+    vertices.reserve(14);
+    vertices.push_back(make_vertex(a_[0]));
+    vertices.push_back(make_vertex(a_[1]));
+    vertices.push_back(make_vertex(a_[2]));
+    vertices.push_back(make_vertex(b_[2]));
+    vertices.push_back(make_vertex(a_[0]));
+    vertices.push_back(make_vertex(b_[0]));
+    vertices.push_back(make_vertex(a_[1]));
+    vertices.push_back(make_vertex(b_[1]));
+    vertices.push_back(make_vertex(b_[2]));
+    vertices.push_back(make_vertex(b_[0]));
+    return vertices;
+  }
+
+  Plane GetPlane(size_t index) const;
+
+ private:
+  Triangle a_;
+  Triangle b_;
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_WEDGE_H_

--- a/vfx/gl/BUILD.gn
+++ b/vfx/gl/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("gl") {
+  sources = [
+    "array_buffer.h",
+    "color_program.cc",
+    "color_program.h",
+    "element_array_buffer.h",
+    "frame_buffer.cc",
+    "frame_buffer.h",
+    "program.cc",
+    "program.h",
+    "shader.cc",
+    "shader.h",
+    "texture.cc",
+    "texture.h",
+    "texture_program.cc",
+    "texture_program.h",
+  ]
+
+  deps = [
+    "//base",
+  ]
+
+  public_deps = [
+    "//ui/gl",
+    "//ui/gfx/geometry",
+  ]
+}

--- a/vfx/gl/array_buffer.h
+++ b/vfx/gl/array_buffer.h
@@ -1,0 +1,80 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GEOMETRY_TRIANGLE_STRIP_H_
+#define VFX_GEOMETRY_TRIANGLE_STRIP_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/macros.h"
+#include "ui/gl/gl_bindings.h"
+#include "vfx/geometry/point.h"
+
+namespace vfx {
+
+template<typename Vertex>
+class ArrayBuffer {
+ public:
+  ArrayBuffer() : mode_(GL_TRIANGLE_STRIP), vertex_buffer_(0) { }
+  ~ArrayBuffer() {
+    if (vertex_buffer_)
+      glDeleteBuffersARB(1, &vertex_buffer_);
+  }
+
+  ArrayBuffer(GLenum mode, std::vector<Vertex> data)
+    : mode_(mode),
+      vertices_(std::move(data)),
+      vertex_buffer_(0) { }
+
+  ArrayBuffer(ArrayBuffer&& other)
+    : mode_(other.mode_),
+      vertices_(std::move(other.vertices_)),
+      vertex_buffer_(other.vertex_buffer_) {
+    other.vertex_buffer_ = 0;
+  }
+
+  ArrayBuffer& operator=(ArrayBuffer&& other) {
+    if (this == &other)
+      return *this;
+    mode_ = other.mode_;
+    vertices_ = std::move(other.vertices_);
+    vertex_buffer_ = other.vertex_buffer_;
+    other.vertex_buffer_ = 0;
+    return *this;
+  }
+
+  const Vertex* data() const { return vertices_.data(); }
+  size_t count() const { return vertices_.size(); }
+
+  void BufferData(GLenum usage) {
+    if (!vertex_buffer_)
+      glGenBuffersARB(1, &vertex_buffer_);
+    GLsizeiptr size = vertices_.size() * sizeof(Vertex);
+    glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);
+    glBufferData(GL_ARRAY_BUFFER, size, vertices_.data(), usage);
+  }
+
+  bool is_buffered() const { return vertex_buffer_; }
+
+  void Bind() const {
+    glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);
+  }
+
+  void Draw() const {
+    DCHECK(is_buffered());
+    glDrawArrays(mode_, 0, vertices_.size());
+  }
+
+ private:
+  GLenum mode_;
+  std::vector<Vertex> vertices_;
+  GLuint vertex_buffer_;
+
+  DISALLOW_COPY_AND_ASSIGN(ArrayBuffer);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GEOMETRY_TRIANGLE_STRIP_H_

--- a/vfx/gl/color_program.cc
+++ b/vfx/gl/color_program.cc
@@ -1,0 +1,52 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/gl/color_program.h"
+
+#include <memory>
+
+#include "base/logging.h"
+#include "ui/gl/gl_bindings.h"
+
+namespace vfx {
+namespace {
+
+const char kVertexShaderSource[] = R"GLSL(
+uniform mat4 u_transform;
+attribute vec3 a_position;
+attribute vec4 a_color;
+varying vec4 v_color;
+
+void main() {
+  gl_Position = u_transform * vec4(a_position, 1.0);
+  v_color = a_color;
+}
+)GLSL";
+
+
+const char kFragmentShaderSource[] = R"GLSL(
+varying lowp vec4 v_color;
+
+void main() {
+  gl_FragColor = v_color;
+}
+)GLSL";
+
+}  // namespace
+
+ColorProgram::ColorProgram()
+  : vertex_shader_(GL_VERTEX_SHADER, kVertexShaderSource),
+    fragment_shader_(GL_FRAGMENT_SHADER, kFragmentShaderSource),
+    program_(&vertex_shader_, &fragment_shader_),
+    u_transform_(glGetUniformLocation(program_.id(), "u_transform")),
+    a_position_(glGetAttribLocation(program_.id(), "a_position")),
+    a_color_(glGetAttribLocation(program_.id(), "a_color")) {
+  glEnableVertexAttribArray(a_position_);
+  glEnableVertexAttribArray(a_color_);
+}
+
+ColorProgram::~ColorProgram() {
+}
+
+}  // namespace vfx

--- a/vfx/gl/color_program.h
+++ b/vfx/gl/color_program.h
@@ -1,0 +1,59 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GL_COLOR_PROGRAM_H_
+#define VFX_GL_COLOR_PROGRAM_H_
+
+#include "base/macros.h"
+#include "ui/gl/gl_bindings.h"
+#include "vfx/geometry/color.h"
+#include "vfx/geometry/matrix.h"
+#include "vfx/geometry/point.h"
+#include "vfx/gl/program.h"
+#include "vfx/gl/shader.h"
+
+namespace vfx {
+
+class ColorProgram {
+ public:
+  ColorProgram();
+  ~ColorProgram();
+
+  struct Vertex {
+    Point point;
+    Color color;
+  };
+
+  GLuint id() const { return program_.id(); }
+
+  template<typename Buffer>
+  void Draw(const Matrix& transform, const Buffer& geometry) {
+    const GLvoid* kPositionOffset = nullptr;
+    const GLvoid* kColorOffset = reinterpret_cast<GLvoid*>(sizeof(GLfloat) * 3);
+
+    glUseProgram(program_.id());
+    glUniformMatrix4fv(u_transform_, 1, GL_FALSE, transform.data());
+    geometry.Bind();
+    glVertexAttribPointer(a_position_, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          kPositionOffset);
+    glVertexAttribPointer(a_color_, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          kColorOffset);
+    geometry.Draw();
+  }
+
+ private:
+  Shader vertex_shader_;
+  Shader fragment_shader_;
+  Program program_;
+
+  GLint u_transform_;
+  GLint a_position_;
+  GLint a_color_;
+
+  DISALLOW_COPY_AND_ASSIGN(ColorProgram);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GL_COLOR_PROGRAM_H_

--- a/vfx/gl/element_array_buffer.h
+++ b/vfx/gl/element_array_buffer.h
@@ -1,0 +1,158 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GL_ELEMENT_ARRAY_H_
+#define VFX_GL_ELEMENT_ARRAY_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/macros.h"
+#include "base/logging.h"
+#include "ui/gl/gl_bindings.h"
+
+namespace vfx {
+
+template<typename Vertex>
+class ElementArrayBuffer {
+ public:
+  ElementArrayBuffer() : vertex_buffer_(0), index_buffer_(0) { }
+
+  ~ElementArrayBuffer() {
+    DeleteBuffers();
+  }
+
+  ElementArrayBuffer(ElementArrayBuffer&& other)
+    : vertices_(std::move(other.vertices_)),
+      indices_(std::move(other.indices_)),
+      vertex_buffer_(other.vertex_buffer_),
+      index_buffer_(other.index_buffer_) {
+    other.vertex_buffer_ = 0;
+    other.index_buffer_ = 0;
+  }
+
+  ElementArrayBuffer& operator=(ElementArrayBuffer&& other) {
+    if (this == &other)
+      return *this;
+    DeleteBuffers();
+    vertices_ = std::move(other.vertices_);
+    indices_ = std::move(other.indices_);
+    vertex_buffer_ = other.vertex_buffer_;
+    index_buffer_ = other.index_buffer_;
+
+    other.vertex_buffer_ = 0;
+    other.index_buffer_ = 0;
+    return *this;
+  }
+
+  typedef uint8_t Index;
+
+  void AddVertex(Vertex vertex) {
+    vertices_.push_back(std::move(vertex));
+  }
+
+  void AddTriangleIndices(Index a, Index b, Index c) {
+    indices_.push_back(a);
+    indices_.push_back(b);
+    indices_.push_back(c);
+  }
+
+  void AddQuadIndices(Index a, Index b, Index c, Index d) {
+    indices_.push_back(a);
+    indices_.push_back(b);
+    indices_.push_back(c);
+
+    indices_.push_back(c);
+    indices_.push_back(d);
+    indices_.push_back(a);
+  }
+
+  void AddTriangle(Vertex p1, Vertex p2, Vertex p3) {
+    uint16_t base = vertices_.size();
+
+    vertices_.push_back(std::move(p1));
+    vertices_.push_back(std::move(p2));
+    vertices_.push_back(std::move(p3));
+
+    indices_.push_back(base + 0);
+    indices_.push_back(base + 1);
+    indices_.push_back(base + 2);
+  }
+
+  void AddQuad(Vertex p1, Vertex p2, Vertex p3, Vertex p4) {
+    uint16_t base = vertices_.size();
+
+    vertices_.push_back(std::move(p1));
+    vertices_.push_back(std::move(p2));
+    vertices_.push_back(std::move(p3));
+    vertices_.push_back(std::move(p4));
+
+    indices_.push_back(base + 0);
+    indices_.push_back(base + 1);
+    indices_.push_back(base + 2);
+
+    indices_.push_back(base + 2);
+    indices_.push_back(base + 3);
+    indices_.push_back(base + 0);
+  }
+
+  const Vertex* vertex_data() const { return vertices_.data(); }
+  size_t vertex_count() const { return vertices_.size(); }
+
+  const Index* index_data() const { return indices_.data(); }
+  size_t index_count() const { return indices_.size(); }
+
+  void BufferData(GLenum usage) {
+    if (!vertex_buffer_)
+      glGenBuffersARB(1, &vertex_buffer_);
+    if (!index_buffer_)
+      glGenBuffersARB(1, &index_buffer_);
+
+    GLsizeiptr vertex_size = vertex_count() * sizeof(Vertex);
+    GLsizeiptr index_size = index_count() * sizeof(Index);
+
+    glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);
+    glBufferData(GL_ARRAY_BUFFER, vertex_size, vertices_.data(), usage);
+    
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer_);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, index_size, indices_.data(), usage);
+  }
+
+  bool is_buffered() const { return vertex_buffer_ && index_buffer_; }
+
+  void Bind() const {
+    glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer_);
+  }
+
+  void Draw() const {
+    DCHECK(is_buffered());
+    glDrawElements(GL_TRIANGLES, index_count(), GL_UNSIGNED_BYTE, 0);
+  }
+
+ private:
+  std::vector<Vertex> vertices_;
+  std::vector<Index> indices_;
+
+  GLuint vertex_buffer_;
+  GLuint index_buffer_;
+
+  void DeleteBuffers() {
+    if (vertex_buffer_) {
+      glDeleteBuffersARB(1, &vertex_buffer_);
+      vertex_buffer_ = 0;
+    }
+
+    if (index_buffer_) {
+      glDeleteBuffersARB(1, &index_buffer_);
+      index_buffer_ = 0;
+    }
+  }
+
+  DISALLOW_COPY_AND_ASSIGN(ElementArrayBuffer);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GL_ELEMENT_ARRAY_H_

--- a/vfx/gl/frame_buffer.cc
+++ b/vfx/gl/frame_buffer.cc
@@ -1,0 +1,73 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/gl/frame_buffer.h"
+
+#include "ui/gl/gl_bindings.h"
+
+namespace vfx {
+
+FrameBuffer::FrameBuffer() : id_(0) {
+}
+
+FrameBuffer::FrameBuffer(gfx::Size size)
+  : id_(0), size_(std::move(size)) {
+  color_ = Texture::CreateRGBA(size_);
+  depth_ = Texture::CreateDepth(size_);
+
+  glGenFramebuffersEXT(1, &id_);
+  glBindFramebufferEXT(GL_FRAMEBUFFER, id_);
+  glFramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, color_.id(), 0);
+  glFramebufferTexture2DEXT(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth_.id(), 0);
+
+  GLenum status = glCheckFramebufferStatusEXT(GL_FRAMEBUFFER);
+  if (status != GL_FRAMEBUFFER_COMPLETE)
+    LOG(FATAL) << "Failed to create frame buffer: " << status;
+}
+
+FrameBuffer::~FrameBuffer() {
+  DeleteFrameBuffer();
+}
+
+FrameBuffer::FrameBuffer(FrameBuffer&& other)
+  : id_(other.id_),
+    size_(std::move(other.size_)),
+    color_(std::move(other.color_)),
+    depth_(std::move(other.depth_)) {
+  other.id_ = 0;
+}
+
+FrameBuffer& FrameBuffer::operator=(FrameBuffer&& other) {
+  if (this == &other)
+    return *this;
+  DeleteFrameBuffer();
+  id_ = other.id_;
+  size_ = std::move(other.size_);
+  color_ = std::move(other.color_);
+  depth_ = std::move(other.depth_);
+
+  other.id_ = 0;
+  return *this;
+}
+
+void FrameBuffer::Bind() const {
+  glBindFramebufferEXT(GL_FRAMEBUFFER, id_);
+}
+
+Texture FrameBuffer::TakeColor() {
+  return std::move(color_);
+}
+
+Texture FrameBuffer::TakeDepth() {
+  return std::move(depth_);
+}
+
+void FrameBuffer::DeleteFrameBuffer() {
+  if (id_) {
+    glDeleteFramebuffersEXT(1, &id_);
+    id_ = 0;
+  }
+}
+
+}  // namespace vfx

--- a/vfx/gl/frame_buffer.h
+++ b/vfx/gl/frame_buffer.h
@@ -1,0 +1,48 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GL_FRAME_BUFFER_H_
+#define VFX_GL_FRAME_BUFFER_H_
+
+#include <GL/gl.h>
+
+#include "base/macros.h"
+#include "ui/gfx/geometry/size.h"
+#include "vfx/gl/texture.h"
+
+namespace vfx {
+
+class FrameBuffer {
+ public:
+  FrameBuffer();
+  explicit FrameBuffer(gfx::Size size);
+  ~FrameBuffer();
+
+  FrameBuffer(FrameBuffer&& other);
+  FrameBuffer& operator=(FrameBuffer&& other);
+
+  void Bind() const;
+  Texture TakeColor();
+  Texture TakeDepth();
+
+  bool is_null() const { return id_ == 0; }
+  GLuint id() const { return id_; }
+
+  const Texture& color() const { return color_; }
+  const Texture& depth() const { return depth_; }
+
+ private:
+  GLuint id_;
+  gfx::Size size_;
+  Texture color_;
+  Texture depth_;
+
+  void DeleteFrameBuffer();
+
+  DISALLOW_COPY_AND_ASSIGN(FrameBuffer);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GL_FRAME_BUFFER_H_

--- a/vfx/gl/program.cc
+++ b/vfx/gl/program.cc
@@ -1,0 +1,44 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/gl/program.h"
+
+#include "base/logging.h"
+#include "ui/gl/gl_bindings.h"
+#include "vfx/gl/shader.h"
+
+namespace vfx {
+
+Program::Program(Shader* vertex_shader, Shader* fragment_shader)
+  : id_(glCreateProgram()) {
+  DCHECK(vertex_shader->type() == GL_VERTEX_SHADER);
+  DCHECK(fragment_shader->type() == GL_FRAGMENT_SHADER);
+
+  glAttachShader(id_, vertex_shader->id());
+  glAttachShader(id_, fragment_shader->id());
+  glLinkProgram(id_);
+
+  GLint status = 0;
+  glGetProgramiv(id_, GL_LINK_STATUS, &status);
+  if (!status) {
+    GLsizei expected_length = 0;
+    glGetProgramiv(id_, GL_INFO_LOG_LENGTH, &expected_length);
+    std::string error;
+    error.resize(expected_length);
+    GLsizei actual_length = 0;
+    glGetProgramInfoLog(id_, expected_length, &actual_length, &error[0]);
+    error.resize(actual_length);
+    LOG(FATAL) << "Linking program failed: " << error;
+    glDeleteProgram(id_);
+    id_ = 0;
+  }
+}
+
+Program::~Program() {
+  if (id_)
+    glDeleteProgram(id_);
+  id_ = 0;
+}
+
+}  // namespace vfx

--- a/vfx/gl/program.h
+++ b/vfx/gl/program.h
@@ -1,0 +1,30 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GL_PROGRAM_H_
+#define VFX_GL_PROGRAM_H_
+
+#include <GL/gl.h>
+
+#include "base/macros.h"
+
+namespace vfx {
+class Shader;
+
+class Program {
+ public:
+  Program(Shader* vertex_shader, Shader* fragment_shader);
+  ~Program();
+
+  GLuint id() const { return id_; }
+
+ private:
+  GLuint id_;
+
+  DISALLOW_COPY_AND_ASSIGN(Program);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GL_PROGRAM_H_

--- a/vfx/gl/shader.cc
+++ b/vfx/gl/shader.cc
@@ -1,0 +1,43 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/gl/shader.h"
+
+#include <memory>
+
+#include "base/logging.h"
+#include "ui/gl/gl_bindings.h"
+
+namespace vfx {
+
+Shader::Shader(GLenum type, const std::string& source)
+  : type_(type), id_(glCreateShader(type)) {
+  const char* cstring = source.c_str();
+  glShaderSource(id_, 1, &cstring, NULL);
+  glCompileShader(id_);
+
+  GLint status = 0;
+  glGetShaderiv(id_, GL_COMPILE_STATUS, &status);
+
+  if (!status) {
+    GLsizei expected_length = 0;
+    glGetShaderiv(id_, GL_INFO_LOG_LENGTH, &expected_length);
+    std::string error;
+    error.resize(expected_length);
+    GLsizei actual_length = 0;
+    glGetShaderInfoLog(id_, expected_length, &actual_length, &error[0]);
+    error.resize(actual_length);
+    LOG(FATAL) << "Compilation of shader failed: " << error;
+    glDeleteShader(id_);
+    id_ = 0;
+  }
+}
+
+Shader::~Shader() {
+  if (id_)
+    glDeleteShader(id_);
+  id_ = 0;
+}
+
+}  // namespace vfx

--- a/vfx/gl/shader.h
+++ b/vfx/gl/shader.h
@@ -1,0 +1,32 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GL_SHADER_H_
+#define VFX_GL_SHADER_H_
+
+#include <GL/gl.h>
+#include <string>
+
+#include "base/macros.h"
+
+namespace vfx {
+
+class Shader {
+ public:
+  Shader(GLenum type, const std::string& source);
+  ~Shader();
+
+  GLenum type() const { return type_; }
+  GLuint id() const { return id_; }
+
+ private:
+  GLenum type_;
+  GLuint id_;
+
+  DISALLOW_COPY_AND_ASSIGN(Shader);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GL_SHADER_H_

--- a/vfx/gl/texture.cc
+++ b/vfx/gl/texture.cc
@@ -1,0 +1,81 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/gl/texture.h"
+
+#include "ui/gl/gl_bindings.h"
+
+namespace vfx {
+
+Texture::Desc::Desc()
+  : internal_format(GL_RGBA),
+    format(GL_RGBA),
+    type(GL_UNSIGNED_BYTE) { 
+}
+
+Texture::Texture() : id_(0) {
+}
+
+Texture::Texture(const Desc& desc) : id_(0), size_(desc.size) {
+  glGenTextures(1, &id_);
+  glBindTexture(GL_TEXTURE_2D, id_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexImage2D(GL_TEXTURE_2D, 0, desc.internal_format, desc.size.width(),
+               desc.size.height(), 0, desc.format, desc.type, nullptr);
+}
+
+Texture::~Texture() {
+  DeleteTexture();
+}
+
+Texture Texture::CreateRGBA(gfx::Size size) {
+  Desc desc;
+  desc.size = std::move(size);
+  desc.internal_format = GL_RGBA;
+  desc.format = GL_RGBA;
+  desc.type = GL_UNSIGNED_BYTE;
+  return Texture(desc);
+}
+
+Texture Texture::CreateDepth(gfx::Size size) {
+  Desc desc;
+  desc.size = std::move(size);
+  desc.internal_format = GL_DEPTH_COMPONENT;
+  desc.format = GL_DEPTH_COMPONENT;
+  desc.type = GL_UNSIGNED_INT;
+  return Texture(desc);
+}
+
+Texture::Texture(Texture&& other)
+  : id_(other.id_),
+    size_(std::move(other.size_)) {
+  other.id_ = 0;
+}
+
+Texture& Texture::operator=(Texture&& other) {
+  if (this == &other)
+    return *this;
+  DeleteTexture();
+  id_ = other.id_;
+  size_ = std::move(other.size_);
+
+  other.id_ = 0;
+  return *this;
+}
+
+void Texture::Bind() const {
+  glBindTexture(GL_TEXTURE_2D, id_);
+}
+
+void Texture::DeleteTexture() {
+  if (id_) {
+    glDeleteTextures(1, &id_);
+    id_ = 0;
+  }
+}
+
+}  // namespace vfx

--- a/vfx/gl/texture.h
+++ b/vfx/gl/texture.h
@@ -1,0 +1,52 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GL_TEXTURE_H_
+#define VFX_GL_TEXTURE_H_
+
+#include <GL/gl.h>
+
+#include "base/macros.h"
+#include "ui/gfx/geometry/size.h"
+
+namespace vfx {
+
+class Texture {
+ public:
+  struct Desc {
+    Desc();
+
+    gfx::Size size;
+    GLint internal_format;
+    GLenum format;
+    GLenum type;
+  };
+
+  Texture();
+  explicit Texture(const Desc& desc);
+  ~Texture();
+
+  static Texture CreateRGBA(gfx::Size size);
+  static Texture CreateDepth(gfx::Size size);
+
+  Texture(Texture&& other);
+  Texture& operator=(Texture&& other);
+
+  bool is_null() const { return id_ == 0; }
+  GLuint id() const { return id_; }
+
+  void Bind() const;
+
+ private:
+  GLuint id_;
+  gfx::Size size_;
+
+  void DeleteTexture();
+
+  DISALLOW_COPY_AND_ASSIGN(Texture);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GL_TEXTURE_H_

--- a/vfx/gl/texture_program.cc
+++ b/vfx/gl/texture_program.cc
@@ -1,0 +1,60 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vfx/gl/texture_program.h"
+
+#include <memory>
+
+#include "ui/gl/gl_bindings.h"
+
+namespace vfx {
+namespace {
+
+const char kVertexShaderSource[] = R"GLSL(
+uniform mat4 u_transform;
+attribute vec3 a_position;
+attribute vec4 a_color;
+attribute vec2 a_tex_coord;
+
+varying vec2 v_tex_coord;
+varying vec4 v_color;
+
+void main() {
+  gl_Position = u_transform * vec4(a_position, 1.0);
+  v_color = a_color;
+  v_tex_coord = a_tex_coord;
+}
+)GLSL";
+
+
+const char kFragmentShaderSource[] = R"GLSL(
+varying lowp vec4 v_color;
+varying lowp vec2 v_tex_coord;
+uniform sampler2D u_texture;
+
+void main(void) {
+  gl_FragColor = v_color * texture2D(u_texture, v_tex_coord);
+}
+)GLSL";
+
+}  // namespace
+
+TextureProgram::TextureProgram()
+  : vertex_shader_(GL_VERTEX_SHADER, kVertexShaderSource),
+    fragment_shader_(GL_FRAGMENT_SHADER, kFragmentShaderSource),
+    program_(&vertex_shader_, &fragment_shader_),
+    u_transform_(glGetUniformLocation(program_.id(), "u_transform")),
+    u_texture_(glGetUniformLocation(program_.id(), "u_texture")),
+    a_position_(glGetAttribLocation(program_.id(), "a_position")),
+    a_color_(glGetAttribLocation(program_.id(), "a_color")),
+    a_tex_coord_(glGetAttribLocation(program_.id(), "a_tex_coord")) {
+  glEnableVertexAttribArray(a_position_);
+  glEnableVertexAttribArray(a_color_);
+  glEnableVertexAttribArray(a_tex_coord_);
+}
+
+TextureProgram::~TextureProgram() {
+}
+
+}  // namespace vfx

--- a/vfx/gl/texture_program.h
+++ b/vfx/gl/texture_program.h
@@ -1,0 +1,73 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef VFX_GL_TEXTURE_PROGRAM_H_
+#define VFX_GL_TEXTURE_PROGRAM_H_
+
+#include "base/macros.h"
+#include "ui/gfx/geometry/point_f.h"
+#include "ui/gl/gl_bindings.h"
+#include "vfx/geometry/color.h"
+#include "vfx/geometry/matrix.h"
+#include "vfx/geometry/point.h"
+#include "vfx/gl/program.h"
+#include "vfx/gl/shader.h"
+
+namespace vfx {
+
+class TextureProgram {
+ public:
+  TextureProgram();
+  ~TextureProgram();
+
+  struct Vertex {
+    Point point;
+    Color color;
+    gfx::PointF tex_coord;
+  };
+
+  GLuint id() const { return program_.id(); }
+
+  template<typename Buffer>
+  void Draw(const Matrix& transform,
+            GLuint texture_id,
+            const Buffer& geometry) {
+    const GLvoid* kPositionOffset = nullptr;
+    const GLvoid* kColorOffset = reinterpret_cast<GLvoid*>(sizeof(GLfloat) * 3);
+    const GLvoid* kTexCoordOffset =
+        reinterpret_cast<GLvoid*>(sizeof(GLfloat) * 7);
+
+    glActiveTexture(GL_TEXTURE0);
+    glBindTexture(GL_TEXTURE_2D, texture_id);
+
+    glUseProgram(program_.id());
+    glUniformMatrix4fv(u_transform_, 1, GL_FALSE, transform.data());
+    glUniform1i(u_texture_, 0);
+    geometry.Bind();
+    glVertexAttribPointer(a_position_, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          kPositionOffset);
+    glVertexAttribPointer(a_color_, 4, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          kColorOffset);
+    glVertexAttribPointer(a_tex_coord_, 2, GL_FLOAT, GL_FALSE, sizeof(Vertex),
+                          kTexCoordOffset);
+    geometry.Draw();
+  }
+
+ private:
+  Shader vertex_shader_;
+  Shader fragment_shader_;
+  Program program_;
+
+  GLint u_transform_;
+  GLint u_texture_;
+  GLint a_position_;
+  GLint a_color_;
+  GLint a_tex_coord_;
+
+  DISALLOW_COPY_AND_ASSIGN(TextureProgram);
+};
+
+}  // namespace vfx
+
+#endif  // VFX_GL_TEXTURE_PROGRAM_H_


### PR DESCRIPTION
This patch adds some basic 3D geometry classes and helper code for
working with OpenGL. The vfx geometry classes differ from the gfx
geometry classes because vfx is focued on 3D geometry whereas gfx is
focused on 2D geometry. Eventually I'd like to merge the two libraries
and share the code with mojo.git, but this patch is just a start.

The OpenGL helpers are some basic scaffolding for interacting with
OpenGL ES. They offer a moderate level of opinion that's been useful in
my experimenting with shadowing techniques because they offer less
abstraction than their Skia counterparts.