### PR TITLE
Dont include any of the machinery to generate a precompilation snapshot on the embedder VM

### DIFF
--- a/sky/build/SnapshotterInvoke
+++ b/sky/build/SnapshotterInvoke
@@ -126,7 +126,7 @@ SnapshotProject() {
   # Note about "checked mode": Precompilation snapshots are never in checked
   # mode. The flag is also ignored by the standalone VM. So there is no sense
   # in generating the larger snapshot. For development purposes, a
-  # non-precompilation enabled VM is used.
+  # non-precompilation-enabled VM is used.
   RunCommand ${FLUTTER_ARCH_TOOLS_PATH}/Snapshotter                            \
       --vm_isolate_snapshot=${derived_dir}/kDartVmIsolateSnapshotBuffer        \
       --isolate_snapshot=${derived_dir}/kDartIsolateSnapshotBuffer             \

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -30,11 +30,16 @@ source_set("common") {
     "ui_delegate.h",
   ]
 
-  public_deps = [
+  if (is_ios && !use_ios_simulator) {
+    dart_deps = [ "//dart/runtime:libdart_precompiled_runtime" ]
+  } else {
+    dart_deps = [ "//dart/runtime:libdart" ]
+  }
+
+  public_deps = dart_deps + [
     "//base",
     "//base:i18n",
     "//build/config/sanitizers:deps",
-    "//dart/runtime:libdart",
     "//flow",
     "//mojo/common",
     "//mojo/data_pipe_utils",


### PR DESCRIPTION
On a fully stripped engine in release mode:
* With the precompiled code generation machinery: 12628k
* Without the precompiled code generation machinery: 10940k

Host snapshotter is of the same size as always.