### PR TITLE
Support Android x86.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -25,7 +25,7 @@ vars = {
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
-  'dart_revision': 'e091d17fd9e94e3f9a0cebab713b27bb8908240f',
+  'dart_revision': '7c2c02d6a6e299124946672eeaf52b71fbd74d3e',
   'dart_observatory_packages_revision': 'cf90eb9077177d3d6b3fd5e8289477c2385c026a',
   'dart_root_certificates_revision': 'c3a41df63afacec62fcb8135196177e35fe72f71',
 

--- a/sky/engine/bindings/dart_runtime_hooks.cc
+++ b/sky/engine/bindings/dart_runtime_hooks.cc
@@ -161,7 +161,7 @@ void Logger_PrintString(Dart_NativeArguments args) {
 #if defined(OS_ANDROID)
     // In addition to writing to the stdout, write to the logcat so that the
     // message is discoverable when running on an unrooted device.
-    __android_log_print(ANDROID_LOG_INFO, "flutter", "%.*s", length, chars);
+    __android_log_print(ANDROID_LOG_INFO, "flutter", "%.*s", (int)length, chars);
 #elif __APPLE__
     syslog(1 /* LOG_ALERT */, "%.*s", (int)length, chars);
 #endif

--- a/sky/engine/bindings/jni/jni_array.cc
+++ b/sky/engine/bindings/jni/jni_array.cc
@@ -425,7 +425,7 @@ int64_t JniLongArray::GetArrayElement(jsize index) {
     env->GetLongArrayRegion(java_array<jlongArray>(), index, 1, &result);
     if (CheckJniException(env, &exception)) goto fail;
 
-    return result;
+    return static_cast<int64_t>(result);
   }
 fail:
   Dart_ThrowException(exception);
@@ -438,8 +438,9 @@ void JniLongArray::SetArrayElement(jsize index, int64_t value) {
   {
     ENTER_JNI();
 
+    jlong jni_value = static_cast<jlong>(value);
     env->SetLongArrayRegion(java_array<jlongArray>(), index, 1,
-                            &value);
+                            &jni_value);
     if (CheckJniException(env, &exception)) goto fail;
 
     return;

--- a/sky/engine/tonic/dart_converter.h
+++ b/sky/engine/tonic/dart_converter.h
@@ -89,6 +89,9 @@ template <>
 struct DartConverter<int> : public DartConverterInteger<int> {};
 
 template <>
+struct DartConverter<long int> : public DartConverterInteger<long int> {};
+
+template <>
 struct DartConverter<unsigned> : public DartConverterInteger<unsigned> {};
 
 template <>


### PR DESCRIPTION
Also rolls Dart to include their Android x86 fixes.
https://github.com/dart-lang/sdk/commit/7c2c02d6a6e299124946672eeaf52b71fbd74d3e

I'm not sure if this is the right way to roll Dart, I didn't see a wiki on it.

This is another part of the fix for https://github.com/flutter/flutter/issues/490

@jason-simmons @chinmaygarde @abarth