### PR TITLE
Fix crash when running widget example

### DIFF
--- a/sky/engine/core/script/dart_controller.cc
+++ b/sky/engine/core/script/dart_controller.cc
@@ -59,7 +59,7 @@ bool DartController::SendStartMessage(Dart_Handle root_library) {
     Dart_Isolate isolate = dart_state()->isolate();
     DCHECK(Dart_CurrentIsolate() == isolate);
     Dart_ExitIsolate();
-    CHECK(Dart_IsolateMakeRunnable(isolate));
+    Dart_IsolateMakeRunnable(isolate);
     Dart_EnterIsolate(isolate);
   }
 


### PR DESCRIPTION
Dart_IsolateMakeRunnable was returning false, which can indicate that the
isolate was already running. This patch seems harmless, but I'll follow up to
understand more about what's happening here.

Fixes #2383