### PR TITLE
Fix ImageShader crash, and add dartdocs

### DIFF
--- a/sky/engine/core/dart/compositing.dart
+++ b/sky/engine/core/dart/compositing.dart
@@ -5,7 +5,18 @@
 part of dart_ui;
 
 /// An opaque object representing a composited scene.
-abstract class Scene extends NativeFieldWrapperClass2 {
+///
+/// To create a Scene object, use a [SceneBuilder].
+///
+/// Scene objects can be displayed on the screen using the
+/// [Window.render] method.
+class Scene extends NativeFieldWrapperClass2 {
+  /// Creates an uninitialized Scene object.
+  ///
+  /// Calling the Scene constructor directly will not create a useable
+  /// object. To create a Scene object, use a [SceneBuilder].
+  Scene(); // (this constructor is here just so we can document it)
+
   /// Releases the resources used by this scene.
   ///
   /// After calling this function, the scene is cannot be used further.
@@ -13,9 +24,15 @@ abstract class Scene extends NativeFieldWrapperClass2 {
 }
 
 /// Builds a [Scene] containing the given visuals.
+///
+/// A [Scene] can then be rendered using [Window.render].
+///
+/// To draw graphical operations onto a [Scene], first create a
+/// [Picture] using a [PictureRecorder] and a [Canvas], and then add
+/// it to the scene using [addPicture].
 class SceneBuilder extends NativeFieldWrapperClass2 {
-  // TODO(abarth): Remove this ignored "bounds" argument.
-  SceneBuilder([Rect bounds]) { _constructor(); }
+  /// Creates an empty [SceneBuilder] object.
+  SceneBuilder() { _constructor(); }
   void _constructor() native "SceneBuilder_constructor";
 
   /// Pushes a transform operation onto the operation stack.
@@ -87,7 +104,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// controls where the statistics are displayed.
   void addPerformanceOverlay(int enabledOptions, Rect bounds) native "SceneBuilder_addPerformanceOverlay";
 
-  /// Adds a picture to the scene.
+  /// Adds a [Picture] to the scene.
   ///
   /// The picture is rasterized at the given offset.
   void addPicture(Offset offset, Picture picture) native "SceneBuilder_addPicture";
@@ -113,8 +130,9 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
 
   /// Finishes building the scene.
   ///
-  /// Returns a [Scene] containing the objects that have been added to this
-  /// scene builder.
+  /// Returns a [Scene] containing the objects that have been added to
+  /// this scene builder. The [Scene] can then be displayed on the
+  /// screen with [Window.render].
   ///
   /// After calling this function, the scene builder object is invalid and
   /// cannot be used further.

--- a/sky/engine/core/dart/text.dart
+++ b/sky/engine/core/dart/text.dart
@@ -106,7 +106,7 @@ enum TextBaseline {
 class TextDecoration {
   const TextDecoration._(this._mask);
 
-  /// Constructs a decoration that paints the union of all the given decorations.
+  /// Creates a decoration that paints the union of all the given decorations.
   factory TextDecoration.combine(List<TextDecoration> decorations) {
     int mask = 0;
     for (TextDecoration decoration in decorations)
@@ -262,7 +262,7 @@ Int32List _encodeTextStyle(Color color,
 
 /// An opaque object that determines the size, position, and rendering of text.
 class TextStyle {
-  /// Constructs a new TextStyle object.
+  /// Creates a new TextStyle object.
   ///
   /// * [color] The color to use when painting the text.
   /// * [decoration] The decorations to paint near the text (e.g., an underline).
@@ -382,7 +382,7 @@ Int32List _encodeParagraphStyle(TextAlign textAlign,
 
 /// An opaque object that determines the position of lines within a paragraph of text.
 class ParagraphStyle {
-  /// Constructs a new ParagraphStyle object.
+  /// Creates a new ParagraphStyle object.
   ///
   /// * [textAlign] .
   /// * [textBaseline] .

--- a/sky/engine/core/dart/window.dart
+++ b/sky/engine/core/dart/window.dart
@@ -44,6 +44,13 @@ class WindowPadding {
 /// consisting of a language and a country. This is a subset of locale
 /// identifiers as defined by BCP 47.
 class Locale {
+  /// Creates a new Locale object. The first argument is the
+  /// primary language subtag, the second is the region subtag.
+  ///
+  /// For example:
+  ///
+  ///     const Locale swissFrench = const Locale('fr', 'CH');
+  ///     const Locale canadianFrench = const Locale('fr', 'CA');
   const Locale(this.languageCode, this.countryCode);
 
   /// The primary language subtag for the locale.
@@ -73,6 +80,9 @@ class Locale {
 }
 
 /// The most basic interface to the host operating system's user interface.
+///
+/// There is a single Window instance in the system, which you can
+/// obtain from the [window] property.
 class Window {
   Window._();
 
@@ -141,6 +151,18 @@ class Window {
   /// Updates the application's rendering on the GPU with the newly provided
   /// [Scene]. For optimal performance, this should only be called in response
   /// to the [onBeginFrame] callback being invoked.
+  ///
+  /// To record graphical operations, first create a
+  /// [PictureRecorder], then construct a [Canvas], passing that
+  /// [PictureRecorder] to its constructor. After issuing all the
+  /// graphical operations, call the [endRecording] function on the
+  /// [PictureRecorder] to obtain the final [Picture] that represents
+  /// the issued graphical operations.
+  /// 
+  /// Next, create a [SceneBuilder], and add the [Picture] to it using
+  /// [SceneBuilder.addPicture]. With the [SceneBuilder.build] method
+  /// you can then obtain a [Scene] object, which you can display to
+  /// the user via this [render] function.
   void render(Scene scene) native "Window_render";
 
   /// Flushes pending real-time events, executing their callbacks.


### PR DESCRIPTION
Adds or augments the documentation of various objects in dart:ui.

Make it possible to construct a (useless) Scene, so that it doesn't appear as "abstract" in the documentation (it's not abstract, it's just that it has private state only the SceneBuilder knows how to set).

Removes the ignored argument to SceneBuilder. (See https://github.com/flutter/flutter/pull/2504)

Document the useless default constructor on Gradient.

Add a call to the ImageShader constructor so that ImageShader doesn't crash.

Reorder some members so that private versions come after public versions
so that docs will come before both.

Change some dart:ui dartdocs that use the word "Constructs" to use "Creates" for more consistency with the prevailing style over in dart land.