### PR TITLE
Allow PlatformMacMain to be called mutliple times by third party flutter embedders

### DIFF
--- a/sky/shell/platform/ios/flutter_view_controller.mm
+++ b/sky/shell/platform/ios/flutter_view_controller.mm
@@ -35,6 +35,8 @@
 - (instancetype)initWithDartBundle:(NSBundle*)dartBundleOrNil
                            nibName:(NSString*)nibNameOrNil
                             bundle:(NSBundle*)bundleOrNil {
+  sky::shell::PlatformMacMain(0, nullptr, nullptr);
+
   self = [super initWithNibName:nibNameOrNil bundle:bundleOrNil];
 
   if (self) {


### PR DESCRIPTION
If we control the embedder, we call it just once and have it wrap UIApplicationMain.