### PR TITLE
Allow PlatformMacMain to be called multiple times

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -7,8 +7,14 @@ group("default") {
   testonly = true
   deps = [
     "//sky",
-    "//sky/services/dynamic:sdk_lib",
   ]
+
+  if (is_ios) {
+    deps += [
+      "//sky/services/dynamic:sdk_lib",
+      "//sky/shell:flutter_framework",
+    ]
+  }
 }
 
 group("dist") {

--- a/sky/shell/platform/ios/flutter_view_controller.mm
+++ b/sky/shell/platform/ios/flutter_view_controller.mm
@@ -40,11 +40,6 @@
   if (self) {
     _dartBundle = [dartBundleOrNil retain];
 
-    NSBundle* bundle = [NSBundle bundleForClass:[self class]];
-    NSString* icuDataPath = [bundle pathForResource:@"icudtl" ofType:@"dat"];
-
-    sky::shell::PlatformMacMain(0, nullptr, icuDataPath.UTF8String, nullptr);
-
     [self performCommonViewControllerInitialization];
   }
 
@@ -74,6 +69,11 @@
   }
 
   _initialized = YES;
+
+  NSBundle* bundle = [NSBundle bundleForClass:[self class]];
+  NSString* icuDataPath = [bundle pathForResource:@"icudtl" ofType:@"dat"];
+
+  sky::shell::PlatformMacMain(0, nullptr, icuDataPath.UTF8String);
 
   _orientationPreferences = UIInterfaceOrientationMaskAll;
   _dynamicServiceLoader = [[FlutterDynamicServiceLoader alloc] init];

--- a/sky/shell/platform/ios/main_ios.mm
+++ b/sky/shell/platform/ios/main_ios.mm
@@ -8,8 +8,9 @@
 #include "sky/shell/platform/mac/platform_mac.h"
 
 int main(int argc, const char* argv[]) {
-  return sky::shell::PlatformMacMain(argc, argv, "", ^() {
-    return UIApplicationMain(argc, (char**)argv, nil,
-                             NSStringFromClass([FlutterAppDelegate class]));
-  });
+  // iOS does use the FlutterViewController that initializes the platform but
+  // we have the command line args here. So call it now.
+  sky::shell::PlatformMacMain(argc, argv, "");
+  return UIApplicationMain(argc, (char**)argv, nil,
+                           NSStringFromClass([FlutterAppDelegate class]));
 }

--- a/sky/shell/platform/mac/main_mac.mm
+++ b/sky/shell/platform/mac/main_mac.mm
@@ -32,21 +32,21 @@ void AttachMessageLoopToMainRunLoop(void) {
 int main(int argc, const char* argv[]) {
   [SkyApplication sharedApplication];
 
-  return sky::shell::PlatformMacMain(argc, argv, "", ^() {
-    base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
-    if (command_line.HasSwitch(sky::shell::switches::kHelp)) {
-      sky::shell::switches::PrintUsage("SkyShell");
-      return EXIT_SUCCESS;
-    }
+  sky::shell::PlatformMacMain(argc, argv, "");
 
-    if (command_line.HasSwitch(sky::shell::switches::kNonInteractive)) {
-      if (!sky::shell::InitForTesting())
-        return 1;
-      base::MessageLoop::current()->Run();
-      return EXIT_SUCCESS;
-    }
+  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
+  if (command_line.HasSwitch(sky::shell::switches::kHelp)) {
+    sky::shell::switches::PrintUsage("SkyShell");
+    return EXIT_SUCCESS;
+  }
 
-    sky::shell::AttachMessageLoopToMainRunLoop();
-    return NSApplicationMain(argc, argv);
-  });
+  if (command_line.HasSwitch(sky::shell::switches::kNonInteractive)) {
+    if (!sky::shell::InitForTesting())
+      return 1;
+    base::MessageLoop::current()->Run();
+    return EXIT_SUCCESS;
+  }
+
+  sky::shell::AttachMessageLoopToMainRunLoop();
+  return NSApplicationMain(argc, argv);
 }

--- a/sky/shell/platform/mac/platform_mac.h
+++ b/sky/shell/platform/mac/platform_mac.h
@@ -10,12 +10,7 @@
 namespace sky {
 namespace shell {
 
-typedef int (^PlatformMacMainCallback)(void);
-
-int PlatformMacMain(int argc,
-                    const char* argv[],
-                    std::string icu_data_path,
-                    PlatformMacMainCallback callback);
+void PlatformMacMain(int argc, const char* argv[], std::string icu_data_path);
 
 bool AttemptLaunchFromCommandLineSwitches(sky::SkyEnginePtr& engine);
 


### PR DESCRIPTION
It is called each time the embedder initializes a Flutter view controller. The Mac shell (which does not have a view controller), calls it before NSApplicationMain.

Common items like the base::AtExitManager and the platform message loop are stored in `EmbedderState`