### PR TITLE
Avoid leaking service runtime symbols from the Flutter embedder.

### DIFF
--- a/sky/services/dynamic/BUILD.gn
+++ b/sky/services/dynamic/BUILD.gn
@@ -23,31 +23,28 @@ source_set("embedder") {
   # in a target that includes mojo symbols already present on the embedder.
   # This works around header checks just for these files.
   check_includes = false
-}
 
-service_sources = [
-  "dynamic_service.c",
-  "dynamic_service.h",
-  "dynamic_service_dylib.cc",
-  "dynamic_service_dylib.h",
-  "dynamic_service_macros.h",
-]
-
-service_deps = [
-  "//mojo/public/c/system",
-  "//mojo/public/cpp/bindings",
-  "//mojo/public/cpp/environment:standalone",
-  "//mojo/public/platform/native:system",
-]
-
-source_set("dylib") {
-  sources = service_sources
-  deps = service_deps
+  defines = [
+    "DYNAMIC_SERVICE_EMBEDDER",
+  ]
 }
 
 static_library("sdk_lib") {
   output_name = "FlutterServices"
   complete_static_lib = true
-  sources = service_sources
-  deps = service_deps
+
+  sources = [
+    "dynamic_service.c",
+    "dynamic_service.h",
+    "dynamic_service_dylib.cc",
+    "dynamic_service_dylib.h",
+    "dynamic_service_macros.h",
+  ]
+
+  deps = [
+    "//mojo/public/c/system",
+    "//mojo/public/cpp/bindings",
+    "//mojo/public/cpp/environment:standalone",
+    "//mojo/public/platform/native:system",
+  ]
 }

--- a/sky/services/dynamic/dynamic_service_macros.h
+++ b/sky/services/dynamic/dynamic_service_macros.h
@@ -5,7 +5,16 @@
 #ifndef SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_MACROS_H_
 #define SKY_SERVICES_DYNAMIC_DYNAMIC_SERVICE_MACROS_H_
 
+#if defined(DYNAMIC_SERVICE_EMBEDDER)
+
+// Embedder does not export any symbols
+#define FLUTTER_EXPORT
+
+#else  // defined(DYNAMIC_SERVICE_EMBEDDER)
+
 #define FLUTTER_EXPORT __attribute__((visibility("default")))
+
+#endif  // defined(DYNAMIC_SERVICE_EMBEDDER)
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
Also gets rid of an defunct target in `dynamic/BUILD.gn`