### PR TITLE
Fix iOS build

### DIFF
--- a/sky/engine/bindings/dart_vm_entry_points.txt
+++ b/sky/engine/bindings/dart_vm_entry_points.txt
@@ -4,7 +4,6 @@ dart:isolate,::,_startMainIsolate
 dart:mojo.internal,MojoHandleWatcher,mojoControlHandle
 dart:ui,::,_beginFrame
 dart:ui,::,_dispatchPointerPacket
-dart:ui,::,_getCreateTimerClosure
 dart:ui,::,_getGetBaseURLClosure
 dart:ui,::,_getMainClosure
 dart:ui,::,_getPrintClosure

--- a/sky/engine/core/dart/natives.dart
+++ b/sky/engine/core/dart/natives.dart
@@ -13,7 +13,7 @@ class _Logger {
   static void _printString(String s) native "Logger_PrintString";
 }
 
-_setupHooks() {
+void _setupHooks() {
   // Wire up timer implementation that is driven by MojoHandleWatcher.
   VMLibraryHooks.eventHandlerSendData = MojoHandleWatcher.timer;
   VMLibraryHooks.timerMillisecondClock = MojoCoreNatives.timerMillisecondClock;


### PR DESCRIPTION
We don't have _getCreateTimerClosure, which means we need to remove it from the
dart_vm_entry_points.txt list.

Fixes https://github.com/flutter/flutter/issues/2569