### PR TITLE
Delete DartState during isolate shutdown

### DIFF
--- a/sky/engine/core/script/dart_controller.h
+++ b/sky/engine/core/script/dart_controller.h
@@ -40,14 +40,17 @@ class DartController {
   void CreateIsolateFor(std::unique_ptr<UIDartState> ui_dart_state);
   void Shutdown();
 
-  UIDartState* dart_state() const { return ui_dart_state_.get(); }
+  UIDartState* dart_state() const { return ui_dart_state_; }
 
  private:
   void DidLoadMainLibrary(std::string url);
   void DidLoadSnapshot();
   bool SendStartMessage(Dart_Handle root_library);
 
-  std::unique_ptr<UIDartState> ui_dart_state_;
+  // The DartState associated with the main isolate.  This will be deleted
+  // during isolate shutdown.
+  UIDartState* ui_dart_state_;
+
   std::unique_ptr<DartSnapshotLoader> snapshot_loader_;
 
   base::WeakPtrFactory<DartController> weak_factory_;

--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -102,7 +102,8 @@ const char kFileUriPrefix[] = "file://";
 const char kDartFlags[] = "dart-flags";
 
 void IsolateShutdownCallback(void* callback_data) {
-  // TODO(dart)
+  DartState* dart_state = static_cast<DartState*>(callback_data);
+  delete dart_state;
 }
 
 bool IsServiceIsolateURL(const char* url_name) {


### PR DESCRIPTION
This solves two problems:
* UIDartState was being deleted during destruction of DartController after the
  isolate had been shut down.  The UIDartState held persistent handles to Dart
  objects, and deleting them when the isolate no longer exists caused an
  assertion failure.
* DartStates created for secondary isolates were never being deleted

Fixes https://github.com/flutter/flutter/issues/2549