### PR TITLE
Avoid importing the internal lib into the builtin since its disallowed after Dart_Precompile.

### DIFF
--- a/sky/engine/bindings/dart_runtime_hooks.cc
+++ b/sky/engine/bindings/dart_runtime_hooks.cc
@@ -76,10 +76,6 @@ static void InitDartInternal(Dart_Handle builtin_library,
       internal_library, ToDart("_printClosure"), print));
 
   if (isolate_type == DartRuntimeHooks::MainIsolate) {
-    // Import internal_library into builtin_library.
-    DART_CHECK_VALID(Dart_LibraryImportLibrary(builtin_library,
-                                               internal_library,
-                                               Dart_Null()));
     // Call |_setupHooks| to configure |VMLibraryHooks|.
     Dart_Handle method_name =
         Dart_NewStringFromCString("_setupHooks");

--- a/sky/engine/bindings/dart_ui.dart
+++ b/sky/engine/bindings/dart_ui.dart
@@ -11,6 +11,7 @@
 /// pointer input system, and functions for image decoding.
 library dart_ui;
 
+import 'dart:_internal';
 import 'dart:math' as math;
 import 'dart:mojo.internal';
 import 'dart:nativewrappers';

--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -82,6 +82,10 @@ static const char *kDartMirrorsArgs[] = {
   "--enable_mirrors=false",
 };
 
+static const char* kDartPrecompilationArgs[] = {
+    "--precompilation",
+};
+
 static const char* kDartBackgroundCompilationArgs[] = {
   "--background_compilation",
 };
@@ -333,6 +337,8 @@ void InitDartVM() {
     args.append(kDartMirrorsArgs, arraysize(kDartMirrorsArgs));
     args.append(kDartBackgroundCompilationArgs,
                 arraysize(kDartBackgroundCompilationArgs));
+  } else {
+    args.append(kDartPrecompilationArgs, arraysize(kDartPrecompilationArgs));
   }
 
   if (enable_checked_mode)

--- a/travis/analyze.sh
+++ b/travis/analyze.sh
@@ -1,4 +1,31 @@
 echo "Analyzing dart:ui library..."
-RESULTS=`dartanalyzer --ignore-unrecognized-flags --supermixin --enable-strict-call-checks --enable_type_checks --strong --package-warnings --fatal-warnings --strong-hints --fatal-hints --lints out/Debug/gen/sky/bindings/dart_ui.dart 2>&1 |grep -v "\[error\] Target of URI does not exist: 'dart:mojo.internal'" | grep -v "\[error\] Native functions can only be declared in the SDK and code that is loaded through native extensions" | grep -Ev "\[(hint|error)\] The function '.+' is not used" | grep -v "\[warning\] Undefined name 'main'" |grep -v "\[warning\] Undefined name 'VMLibraryHooks" | grep -v "\[warning\] Undefined name 'MojoHandleWatcher'" | grep -v "\[warning\] Undefined name 'MojoCoreNatives'" | grep -v "\[info\] TODO" | grep -Ev "[0-9]+ errors.*found." | grep -v "Analyzing \[out/Debug/gen/sky/bindings/dart_ui.dart\]\.\.\."`
+RESULTS=`dartanalyzer                                                          \
+  --ignore-unrecognized-flags                                                  \
+  --supermixin                                                                 \
+  --enable-strict-call-checks                                                  \
+  --enable_type_checks                                                         \
+  --strong                                                                     \
+  --package-warnings                                                           \
+  --fatal-warnings                                                             \
+  --strong-hints                                                               \
+  --fatal-hints                                                                \
+  --lints                                                                      \
+  out/Debug/gen/sky/bindings/dart_ui.dart                                      \
+  2>&1                                                                         \
+  | grep -v "\[error\] Target of URI does not exist: 'dart:mojo.internal'"     \
+  | grep -v "\[error\] Native functions can only be declared in the SDK and code that is loaded through native extensions" \
+  | grep -Ev "\[(hint|error)\] The function '.+' is not used"                  \
+  | grep -v "\[warning\] Undefined name 'main'"                                \
+  | grep -v "\[warning\] Undefined name 'VMLibraryHooks"                       \
+  | grep -v "\[warning\] Undefined name 'MojoHandleWatcher'"                   \
+  | grep -v "\[warning\] Undefined name 'MojoCoreNatives'"                     \
+  | grep -v "\[error\] The library ''dart:_internal'' is internal"             \
+  | grep -Ev "Unused import .+dart_ui\.dart"                                   \
+  | grep -v "\[info\] TODO"                                                    \
+  | grep -Ev "[0-9]+ errors.*found."                                           \
+  | grep -v "Analyzing \[out/Debug/gen/sky/bindings/dart_ui.dart\]\.\.\."`
+
 echo "$RESULTS"
-if [ -n "$RESULTS" ]; then exit 1; fi
+if [ -n "$RESULTS" ];
+  then exit 1;
+fi


### PR DESCRIPTION
Import the library directly in dart_ui.dart.

Fixes https://github.com/flutter/flutter/issues/2586

cc @johnmccutchan, @rmacnak-google, @abarth 
