### PR TITLE
Specify a clip rect for ChildSceneLayers.

### DIFF
--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -38,6 +38,9 @@ void ChildSceneLayer::UpdateScene(mojo::gfx::composition::SceneUpdate* update,
   child_node->op = mojo::gfx::composition::NodeOp::New();
   child_node->op->set_scene(mojo::gfx::composition::SceneNodeOp::New());
   child_node->op->get_scene()->scene_resource_id = id;
+  child_node->content_clip = mojo::RectF::New();
+  child_node->content_clip->width = physical_size_.width();
+  child_node->content_clip->height = physical_size_.height();
   child_node->content_transform = mojo::Transform::From(transform_);
   update->nodes.insert(id, child_node.Pass());
   container->child_node_ids.push_back(id);


### PR DESCRIPTION
When linking in a scene, it's a good idea to specify its clip rectangle
to ensure that its content does not draw or capture input from its
surrounding space.

A future version of the Mozart view manager may automatically wrap a
view's scene with a clip rectangle to avoid composition gotchas like this
but it currently doesn't.  So the net effect is that if you embed a view
without specifying a clip, it can draw or capture input from anywhere
within its container.