### PR TITLE
Flutter embedded in Flutter via Mozart is double scaled

### DIFF
--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -11,7 +11,7 @@ namespace flow {
 // TODO(abarth): We need to figure out how to allocate these ids sensibly.
 static uint32_t next_id = 10;
 
-ChildSceneLayer::ChildSceneLayer() {
+ChildSceneLayer::ChildSceneLayer() : device_pixel_ratio_(1.0f) {
 }
 
 ChildSceneLayer::~ChildSceneLayer() {
@@ -39,8 +39,8 @@ void ChildSceneLayer::UpdateScene(mojo::gfx::composition::SceneUpdate* update,
   child_node->op->set_scene(mojo::gfx::composition::SceneNodeOp::New());
   child_node->op->get_scene()->scene_resource_id = id;
   child_node->content_clip = mojo::RectF::New();
-  child_node->content_clip->width = physical_size_.width();
-  child_node->content_clip->height = physical_size_.height();
+  child_node->content_clip->width = physical_size_.width() / device_pixel_ratio_;
+  child_node->content_clip->height = physical_size_.height() / device_pixel_ratio_;
   child_node->content_transform = mojo::Transform::From(transform_);
   update->nodes.insert(id, child_node.Pass());
   container->child_node_ids.push_back(id);

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -17,6 +17,10 @@ class ChildSceneLayer : public Layer {
 
   void set_offset(const SkPoint& offset) { offset_ = offset; }
 
+  void set_device_pixel_ratio(float device_pixel_ratio) {
+    device_pixel_ratio_ = device_pixel_ratio;
+  }
+
   void set_physical_size(const SkISize& physical_size) {
     physical_size_ = physical_size;
   }
@@ -32,6 +36,7 @@ class ChildSceneLayer : public Layer {
 
  private:
   SkPoint offset_;
+  float device_pixel_ratio_;
   SkISize physical_size_;
   mojo::gfx::composition::SceneTokenPtr scene_token_;
   SkMatrix transform_;

--- a/sky/engine/core/compositing/SceneBuilder.cpp
+++ b/sky/engine/core/compositing/SceneBuilder.cpp
@@ -165,6 +165,7 @@ void SceneBuilder::addPicture(const Offset& offset, Picture* picture)
 }
 
 void SceneBuilder::addChildScene(const Offset& offset,
+                                 double device_pixel_ratio,
                                  int physical_width,
                                  int physical_height,
                                  uint32_t scene_token) {
@@ -172,6 +173,7 @@ void SceneBuilder::addChildScene(const Offset& offset,
         return;
     std::unique_ptr<flow::ChildSceneLayer> layer(new flow::ChildSceneLayer());
     layer->set_offset(SkPoint::Make(offset.sk_size.width(), offset.sk_size.height()));
+    layer->set_device_pixel_ratio(device_pixel_ratio);
     layer->set_physical_size(SkISize::Make(physical_width, physical_height));
     mojo::gfx::composition::SceneTokenPtr token = mojo::gfx::composition::SceneToken::New();
     token->value = scene_token;

--- a/sky/engine/core/compositing/SceneBuilder.h
+++ b/sky/engine/core/compositing/SceneBuilder.h
@@ -46,6 +46,7 @@ public:
     void addPerformanceOverlay(uint64_t enabledOptions, const Rect& bounds);
     void addPicture(const Offset& offset, Picture* picture);
     void addChildScene(const Offset& offset,
+                       double device_pixel_ratio,
                        int physical_width,
                        int physical_height,
                        uint32_t scene_token);

--- a/sky/engine/core/dart/compositing.dart
+++ b/sky/engine/core/dart/compositing.dart
@@ -116,6 +116,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// the Mojo view manager, but this function is agnostic as to the source of
   /// scene token.
   void addChildScene(Offset offset,
+                     double devicePixelRatio,
                      int physicalWidth,
                      int physicalHeight,
                      int sceneToken) native "SceneBuilder_addChildScene";


### PR DESCRIPTION
We weren't correctly dividing by the device pixel ratio when asking Mozart to
present our child scene.