### PR TITLE
Handle 0x0 sizes in Mozart

### DIFF
--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -60,7 +60,10 @@ void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
   size.width = layer_tree->frame_size().width();
   size.height = layer_tree->frame_size().height();
 
-  // TODO(abarth): Handle size == 0x0.
+  if (size.width <= 0 || size.height <= 0.0) {
+    callback.Run();
+    return;
+  }
 
   std::unique_ptr<mojo::GLTexture> texture =
       gl_state_->gl_texture_recycler.GetTexture(size);


### PR DESCRIPTION
When we're created off-screen, Mozart gives us a 0x0 view to populate. Rather
than trying to draw a 0x0 texture, we just acknolwedge the frame request
immediately. This matches what we do in the non-Mozart rasterizer.