### PR TITLE
Mozart embedding can see crazy width/height

### DIFF
--- a/sky/engine/public/platform/sky_display_metrics.h
+++ b/sky/engine/public/platform/sky_display_metrics.h
@@ -11,8 +11,8 @@ namespace blink {
 
 struct SkyDisplayMetrics {
   float device_pixel_ratio = 1.0;
-  int physical_width;
-  int physical_height;
+  int physical_width = 0;
+  int physical_height = 0;
   int physical_padding_top = 0;
   int physical_padding_right = 0;
   int physical_padding_bottom = 0;


### PR DESCRIPTION
We should initialize the width and height of the display to something
reasonable.