### PR TITLE
Performance Overlay fixes

### DIFF
--- a/flow/instrumentation.h
+++ b/flow/instrumentation.h
@@ -13,6 +13,8 @@
 namespace flow {
 namespace instrumentation {
 
+static const double kOneFrameMS = 1e3 / 60.0;
+
 class Stopwatch {
  public:
   class ScopedLap {
@@ -36,6 +38,8 @@ class Stopwatch {
 
   base::TimeDelta currentLap() const { return base::TimeTicks::Now() - _start; }
 
+  base::TimeDelta maxDelta() const;
+
   void visualize(SkCanvas& canvas, const SkRect& rect) const;
 
   void start();
@@ -48,8 +52,6 @@ class Stopwatch {
   base::TimeTicks _start;
   std::vector<base::TimeDelta> _laps;
   size_t _current_sample;
-
-  base::TimeDelta maxDelta() const;
 
   DISALLOW_COPY_AND_ASSIGN(Stopwatch);
 };

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -46,6 +46,7 @@ class Layer {
 
   void set_parent(ContainerLayer* parent) { parent_ = parent; }
 
+  // subclasses should assume this will be true by the time Paint() is called
   const bool has_paint_bounds() const { return has_paint_bounds_; }
 
   const SkRect& paint_bounds() const {

--- a/sky/engine/core/dart/compositing.dart
+++ b/sky/engine/core/dart/compositing.dart
@@ -104,10 +104,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// controls where the statistics are displayed.
   ///
   /// enabledOptions is a bit field with the following bits defined:
-  /// * 0x01: displayRasterizerStatistics - show GPU thread frame time
-  /// * 0x02: visualizeRasterizerStatistics - graph GPU thread frame times
-  /// * 0x04: displayEngineStatistics - show UI thread frame time
-  /// * 0x08: visualizeEngineStatistics - graph UI thread frame times
+  ///  - 0x01: displayRasterizerStatistics - show GPU thread frame time
+  ///  - 0x02: visualizeRasterizerStatistics - graph GPU thread frame times
+  ///  - 0x04: displayEngineStatistics - show UI thread frame time
+  ///  - 0x08: visualizeEngineStatistics - graph UI thread frame times
   /// Set enabledOptions to 0x0F to enable all the currently defined features.
   ///
   /// The "UI thread" is the thread that includes all the execution of


### PR DESCRIPTION
- fix dartdocs for addPerformanceOverlay
- make PerformanceOverlayLayer honour its x, y, and height.
- fix the y axis of PerformanceOverlayLayer to only show 3x16ms, since
  if it's more than 16ms it really doesn't matter what it is.
- make the label on the PerformanceOverlayLayer show the worst time on
  record not the instantaneous time.
- pin the fps to a maximum of 60Hz
