### PR TITLE
Cleanup MojoServices in dart:ui

### DIFF
--- a/sky/engine/bindings/dart_vm_entry_points.txt
+++ b/sky/engine/bindings/dart_vm_entry_points.txt
@@ -14,10 +14,6 @@ dart:ui,::,_pushRoute
 dart:ui,::,_setupHooks
 dart:ui,::,_updateLocale
 dart:ui,::,_updateWindowMetrics
-dart:ui,::,takeRootBundleHandle
-dart:ui,::,takeServicesProvidedByEmbedder
-dart:ui,::,takeServicesProvidedToEmbedder
-dart:ui,::,takeShellProxyHandle
 dart:ui,Canvas,Canvas.
 dart:ui,Image,Image.
 dart:ui,ImageShader,ImageShader.

--- a/sky/engine/bindings/mojo_services.h
+++ b/sky/engine/bindings/mojo_services.h
@@ -24,34 +24,32 @@ class MojoServices {
 
   static void Create(Dart_Isolate isolate,
                      sky::ServicesDataPtr services,
-                     mojo::ServiceProviderPtr services_from_embedder,
+                     mojo::ServiceProviderPtr incoming_services,
                      mojo::asset_bundle::AssetBundlePtr root_bundle);
 
   static void RegisterNatives(DartLibraryNatives* natives);
 
-  mojo::Handle TakeShellProxy();
-  mojo::Handle TakeServicesProvidedByEmbedder();
-  mojo::Handle TakeServicesProvidedToEmbedder();
-  mojo::Handle TakeRootBundleHandle();
-  mojo::Handle TakeViewHandle();
+  int TakeRootBundle();
+  int TakeIncomingServices();
+  int TakeOutgoingServices();
+  int TakeShell();
+  int TakeView();
+  int TakeViewServices();
 
  private:
   explicit MojoServices(sky::ServicesDataPtr services,
-                        mojo::ServiceProviderPtr services_from_embedder,
+                        mojo::ServiceProviderPtr incoming_services,
                         mojo::asset_bundle::AssetBundlePtr root_bundle);
 
   sky::ServicesDataPtr services_;
-  mojo::ServiceProviderPtr services_from_embedder_;
+
   mojo::asset_bundle::AssetBundlePtr root_bundle_;
+  mojo::ServiceProviderPtr incoming_services_;
+  mojo::InterfaceRequest<mojo::ServiceProvider> outgoing_services_;
 
   // We need to hold this object to work around
   // https://github.com/domokit/mojo/issues/536
   mojo::ServiceProviderPtr services_from_dart_;
-
-  // A ServiceProvider supplied by the application that exposes services to
-  // the embedder.
-  mojo::InterfaceRequest<mojo::ServiceProvider>
-      services_provided_to_embedder_;
 
   MOJO_DISALLOW_COPY_AND_ASSIGN(MojoServices);
 };

--- a/sky/engine/core/dart/mojo_services.dart
+++ b/sky/engine/core/dart/mojo_services.dart
@@ -4,8 +4,25 @@
 
 part of dart_ui;
 
-int takeRootBundleHandle() native "takeRootBundleHandle";
-int takeServicesProvidedByEmbedder() native "takeServicesProvidedByEmbedder";
-int takeServicesProvidedToEmbedder() native "takeServicesProvidedToEmbedder";
-int takeShellProxyHandle() native "takeShellProxyHandle";
-int takeViewHandle() native "takeViewHandle";
+/// Mojo handles provided to the application at startup.
+///
+/// The application can take ownership of these handles by calling the static
+/// "take" functions on this object. Once taken, the application is responsible
+/// for managing the handles.
+class MojoServices {
+  MojoServices._();
+
+  static int takeRootBundle() native "MojoServices_takeRootBundle";
+  static int takeIncomingServices() native "MojoServices_takeIncomingServices";
+  static int takeOutgoingServices() native "MojoServices_takeOutgoingServices";
+  static int takeShell() native "MojoServices_takeShell";
+  static int takeView() native "MojoServices_takeView";
+  static int takeViewServices() native "MojoServices_takeViewServices";
+}
+
+// TODO(abarth): Remove these once clients have migrated to [MojoServices].
+int takeRootBundleHandle() => MojoServices.takeRootBundle();
+int takeServicesProvidedByEmbedder() => MojoServices.takeIncomingServices();
+int takeServicesProvidedToEmbedder() => MojoServices.takeOutgoingServices();
+int takeShellProxyHandle() => MojoServices.takeShell();
+int takeViewHandle() => MojoServices.takeView();

--- a/sky/services/engine/sky_engine.mojom
+++ b/sky/services/engine/sky_engine.mojom
@@ -29,9 +29,10 @@ struct ViewportMetrics {
 
 struct ServicesData {
   mojo.Shell? shell;
-  mojo.ServiceProvider? services_provided_by_embedder;
-  mojo.ServiceProvider&? services_provided_to_embedder;
+  mojo.ServiceProvider? incoming_services;
+  mojo.ServiceProvider&? outgoing_services;
   mojo.ui.View? view;
+  mojo.ServiceProvider? view_services;
   mojo.gfx.composition.SceneScheduler? scene_scheduler;
 };
 

--- a/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
+++ b/sky/shell/platform/android/org/domokit/sky/shell/PlatformViewAndroid.java
@@ -360,8 +360,8 @@ public class PlatformViewAndroid extends SurfaceView
         mDartServiceProvider = dartServiceProvider.first;
 
         ServicesData services = new ServicesData();
-        services.servicesProvidedByEmbedder = serviceProvider.first;
-        services.servicesProvidedToEmbedder = dartServiceProvider.second;
+        services.incomingServices = serviceProvider.first;
+        services.outgoingServices = dartServiceProvider.second;
         mSkyEngine.setServices(services);
 
         resetAccessibilityTree();

--- a/sky/shell/platform/ios/FlutterViewController.mm
+++ b/sky/shell/platform/ios/FlutterViewController.mm
@@ -179,7 +179,7 @@ static void DynamicServiceResolve(void* baton,
                                           serviceResolutionCallback);
 
   sky::ServicesDataPtr services = sky::ServicesData::New();
-  services->services_provided_by_embedder = serviceProvider.Pass();
+  services->incoming_services = serviceProvider.Pass();
   _engine->SetServices(services.Pass());
 }
 

--- a/sky/shell/platform/mac/sky_window.mm
+++ b/sky/shell/platform/mac/sky_window.mm
@@ -82,7 +82,7 @@ static inline pointer::PointerType EventTypeFromNSEventPhase(
   new sky::shell::PlatformServiceProvider(mojo::GetProxy(&service_provider),
                                           base::Bind(DynamicServiceResolve));
   sky::ServicesDataPtr services = sky::ServicesData::New();
-  services->services_provided_by_embedder = service_provider.Pass();
+  services->incoming_services = service_provider.Pass();
   _sky_engine->SetServices(services.Pass());
 
   if (sky::shell::AttemptLaunchFromCommandLineSwitches(_sky_engine)) {

--- a/sky/shell/platform/mojo/application_impl.cc
+++ b/sky/shell/platform/mojo/application_impl.cc
@@ -78,8 +78,8 @@ void ApplicationImpl::CreateView(
 
   ServicesDataPtr services = ServicesData::New();
   services->shell = shell.Pass();
-  services->services_provided_by_embedder = incoming_services.Pass();
-  services->services_provided_to_embedder = outgoing_services.Pass();
+  services->incoming_services = incoming_services.Pass();
+  services->outgoing_services = outgoing_services.Pass();
 
   ViewImpl* view = new ViewImpl(view_owner.Pass(), services.Pass(), url_);
   view->Run(bundle_path_);

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -102,11 +102,11 @@ void Engine::OnOutputSurfaceDestroyed(const base::Closure& gpu_continuation) {
 void Engine::SetServices(ServicesDataPtr services) {
   services_ = services.Pass();
 
-  if (services_->services_provided_by_embedder) {
-    services_provided_by_embedder_ = mojo::ServiceProviderPtr::Create(
-        services_->services_provided_by_embedder.Pass());
+  if (services_->incoming_services) {
+    incoming_services_ = mojo::ServiceProviderPtr::Create(
+        services_->incoming_services.Pass());
     service_provider_impl_.set_fallback_service_provider(
-        services_provided_by_embedder_.get());
+        incoming_services_.get());
   }
 
   if (services_->scene_scheduler) {
@@ -122,7 +122,7 @@ void Engine::SetServices(ServicesDataPtr services) {
       mojo::ConnectToService(shell.get(), "mojo:vsync", &vsync_provider);
       services_->shell = shell.Pass();
     } else {
-      mojo::ConnectToService(services_provided_by_embedder_.get(), &vsync_provider);
+      mojo::ConnectToService(incoming_services_.get(), &vsync_provider);
     }
     animator_->Reset();
     animator_->set_vsync_provider(vsync_provider.Pass());

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -109,7 +109,7 @@ class Engine : public UIDelegate,
 
   ServicesDataPtr services_;
   mojo::ServiceProviderImpl service_provider_impl_;
-  mojo::ServiceProviderPtr services_provided_by_embedder_;
+  mojo::ServiceProviderPtr incoming_services_;
   mojo::BindingSet<mojo::ServiceProvider> service_provider_bindings_;
 
   mojo::asset_bundle::AssetBundlePtr root_bundle_;


### PR DESCRIPTION
This patch cleans up the way we expose Mojo services into Dart. It also adds a
service provider for "view services," which will evetually contain the raw
keyboard service.