### PR TITLE
RawKeyboardListener is not a service. Dont assign it a service name.

### DIFF
--- a/sky/services/raw_keyboard/raw_keyboard.mojom
+++ b/sky/services/raw_keyboard/raw_keyboard.mojom
@@ -7,7 +7,6 @@ module raw_keyboard;
 
 import "sky/services/engine/input_event.mojom";
 
-[ServiceName="raw_keyboard::RawKeyboardListener"]
 interface RawKeyboardListener {
   OnKey(sky.InputEvent event);
 };


### PR DESCRIPTION
cc @abarth Was just reviewing what had to be done. Minor fix.