### PR TITLE
Be explicit about the sysroot in the toolchain definition instead of inferring the same from active arguments.

### DIFF
--- a/build/config/ios/ios_sdk.gni
+++ b/build/config/ios/ios_sdk.gni
@@ -18,18 +18,31 @@ declare_args() {
 
   # The iOS Code signing identity to use
   ios_code_signing_identity = ""
+
+  # The path to the iOS device SDK.
+  ios_device_sdk_path = ""
+
+  # The path to the iOS simulator SDK.
+  ios_simulator_sdk_path = ""
 }
 
-if (ios_sdk_path == "") {
-  # Compute default target.
-  if (use_ios_simulator) {
-    _ios_sdk_to_query = "iphonesimulator"
-  } else {
-    _ios_sdk_to_query = "iphoneos"
-  }
-  _ios_sdk_result =
-      exec_script("ios_sdk.py", [ _ios_sdk_to_query ], "list lines")
-  ios_sdk_path = _ios_sdk_result[0]
+if (ios_device_sdk_path == "") {
+  _ios_device_sdk_result =
+      exec_script("ios_sdk.py", [ "iphoneos" ], "list lines")
+  ios_device_sdk_path = _ios_device_sdk_result[0]
+}
+
+if (ios_simulator_sdk_path == "") {
+  _ios_sim_sdk_result =
+      exec_script("ios_sdk.py", [ "iphonesimulator" ], "list lines")
+  ios_simulator_sdk_path = _ios_sim_sdk_result[0]
+}
+
+# Compute default target.
+if (use_ios_simulator) {
+  ios_sdk_path = ios_simulator_sdk_path
+} else {
+  ios_sdk_path = ios_device_sdk_path
 }
 
 if (use_ios_simulator) {

--- a/build/config/mac/BUILD.gn
+++ b/build/config/mac/BUILD.gn
@@ -6,9 +6,6 @@ import("//build/config/sysroot.gni")
 
 config("sdk") {
   common_flags = [
-    "-isysroot",
-    sysroot,
-    "-mmacosx-version-min=$mac_sdk_min",
     "-stdlib=libc++",
   ]
 

--- a/build/toolchain/mac/BUILD.gn
+++ b/build/toolchain/mac/BUILD.gn
@@ -8,6 +8,7 @@
 
 import("../goma.gni")
 import("//build/config/ios/ios_sdk.gni")
+import("//build/config/mac/mac_sdk.gni")
 
 assert(host_os == "mac")
 
@@ -217,7 +218,7 @@ mac_toolchain("ios_clang_arm") {
   cxx = "${goma_prefix}$prefix/clang++"
   ld = cxx
   is_clang = true
-  sysroot_flags = "-isysroot $sysroot -miphoneos-version-min=$ios_deployment_target"
+  sysroot_flags = "-isysroot $ios_device_sdk_path -miphoneos-version-min=$ios_deployment_target"
 }
 
 # Toolchain used for iOS simulator targets.
@@ -230,7 +231,7 @@ mac_toolchain("ios_clang_x64") {
   cxx = "${goma_prefix}$prefix/clang++"
   ld = cxx
   is_clang = true
-  sysroot_flags = "-isysroot $sysroot -mios-simulator-version-min=$ios_deployment_target"
+  sysroot_flags = "-isysroot $ios_simulator_sdk_path -mios-simulator-version-min=$ios_deployment_target"
 }
 
 # Toolchain used for Mac host targets.
@@ -243,6 +244,7 @@ mac_toolchain("clang_x64") {
   cxx = "${goma_prefix}$prefix/clang++"
   ld = cxx
   is_clang = true
+  sysroot_flags = "-isysroot $mac_sdk_path -mmacosx-version-min=$mac_sdk_min"
 }
 
 # Toolchain used for Mac host (i386) targets.
@@ -255,4 +257,5 @@ mac_toolchain("clang_i386") {
   cxx = "${goma_prefix}$prefix/clang++"
   ld = cxx
   is_clang = true
+  sysroot_flags = "-isysroot $mac_sdk_path -mmacosx-version-min=$mac_sdk_min"
 }


### PR DESCRIPTION
Earlier, it was possible to for the build system to use the simulator sysroot for device builds and vice versa if an explicit toolchain was specified. Now, the sysroot information is part of the toolchain.