### PR TITLE
Explicitly load and unload the precompiled code bundle.

### DIFF
--- a/sky/shell/platform/ios/FlutterDartProject.mm
+++ b/sky/shell/platform/ios/FlutterDartProject.mm
@@ -120,6 +120,15 @@ static NSString* NSStringFromVMType(VMType type) {
 
 - (void)runFromPrecompiledSourceInEngine:(sky::SkyEnginePtr&)engine
                                   result:(LaunchResult)result {
+  if (![_precompiledDartBundle load]) {
+    NSString* message = [NSString
+        stringWithFormat:
+            @"Could not load the framework ('%@') containing precompiled code.",
+            _precompiledDartBundle.bundleIdentifier];
+    result(NO, message);
+    return;
+  }
+
   NSString* path =
       [_precompiledDartBundle pathForResource:@"app" ofType:@"flx"];
 
@@ -160,6 +169,7 @@ static NSString* NSStringFromVMType(VMType type) {
 #pragma mark - Misc.
 
 - (void)dealloc {
+  [_precompiledDartBundle unload];
   [_precompiledDartBundle release];
   [_dartSource release];
 


### PR DESCRIPTION
If called via `bundleWithIdentifier:` the bundle may not have been loaded. This makes it explicit.