### PR TITLE
Directly load the bundle at a known path instead of doing a search by identifier.

### DIFF
--- a/sky/shell/platform/ios/FlutterAppDelegate.mm
+++ b/sky/shell/platform/ios/FlutterAppDelegate.mm
@@ -34,10 +34,13 @@ NSURL* URLForSwitch(const char* name) {
                 dartMain:URLForSwitch(sky::shell::switches::kMainDartFile)
              packageRoot:URLForSwitch(sky::shell::switches::kPackageRoot)];
 #else
-  FlutterDartProject* project = [[FlutterDartProject alloc]
-      initWithPrecompiledDartBundle:
-          [NSBundle bundleWithIdentifier:
-                        @"io.flutter.application.FlutterApplication"]];
+  NSString* bundlePath =
+      [[NSBundle mainBundle] pathForResource:@"FlutterApplication"
+                                      ofType:@"framework"
+                                 inDirectory:@"Frameworks"];
+  NSBundle* bundle = [NSBundle bundleWithPath:bundlePath];
+  FlutterDartProject* project =
+      [[FlutterDartProject alloc] initWithPrecompiledDartBundle:bundle];
 #endif
 
   CGRect frame = [UIScreen mainScreen].bounds;

--- a/sky/shell/platform/ios/FlutterDartProject.mm
+++ b/sky/shell/platform/ios/FlutterDartProject.mm
@@ -24,7 +24,7 @@
   self = [super init];
 
   if (self) {
-    _precompiledDartBundle = [bundle copy];
+    _precompiledDartBundle = [bundle retain];
 
     [self checkReadiness];
   }
@@ -108,7 +108,7 @@ static NSString* NSStringFromVMType(VMType type) {
       return;
     case VMTypePrecompilation:
       [self runFromPrecompiledSourceInEngine:engine result:result];
-      break;
+      return;
     case VMTypeInvalid:
       break;
   }


### PR DESCRIPTION
Also fixes an issue where a error would get logged even though loading from the precompiled application bundle was successful.