### PR TITLE
Add a --use-glfw flag to //sky/tools/gn

### DIFF
--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -425,7 +425,10 @@ if (is_android) {
         "//sky/shell/platform/glfw/window_impl.h",
       ]
 
-      deps += [ "//third_party/glfw" ]
+      deps += [
+        "//third_party/glfw",
+        "//ui/gl",
+      ]
     } else {
       sources += [ "platform/linux/platform_view_linux.cc" ]
     }

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -97,6 +97,7 @@ def to_gn_args(args):
 
     gn_args['enable_firebase'] = args.enable_firebase
     gn_args['enable_gcm'] = args.enable_gcm
+    gn_args['use_glfw'] = args.use_glfw
 
     return gn_args
 
@@ -125,6 +126,7 @@ def parse_args(args):
 
   parser.add_argument('--enable-firebase', action='store_true', default=False)
   parser.add_argument('--enable-gcm', action='store_true', default=False)
+  parser.add_argument('--use-glfw', action='store_true', default=False)
 
   return parser.parse_args(args)
 

--- a/sky/tools/sky_snapshot/loader.cc
+++ b/sky/tools/sky_snapshot/loader.cc
@@ -4,6 +4,8 @@
 
 #include "sky/tools/sky_snapshot/loader.h"
 
+#include <memory>
+
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"


### PR DESCRIPTION
This flag makes it easier to enable the glfw configuration.

Also, fix an unrelated build error in loader.cc.