### PR TITLE
Support the JNI bridge in secondary isolates

### DIFF
--- a/sky/engine/bindings/jni/dart_jni.cc
+++ b/sky/engine/bindings/jni/dart_jni.cc
@@ -266,6 +266,10 @@ bool DartJni::InitJni() {
   return true;
 }
 
+void DartJni::OnThreadExit() {
+  base::android::DetachFromVM();
+}
+
 ScopedJavaLocalRef<jclass> DartJni::GetClass(JNIEnv* env, const char* name) {
   jobject clazz = env->CallObjectMethod(
       g_jvm_data->class_loader.obj(),

--- a/sky/engine/bindings/jni/dart_jni.h
+++ b/sky/engine/bindings/jni/dart_jni.h
@@ -28,6 +28,7 @@ class DartJni {
   static void InitForGlobal();
   static void InitForIsolate();
   static bool InitJni();
+  static void OnThreadExit();
 
   static base::android::ScopedJavaLocalRef<jclass> GetClass(
       JNIEnv* env, const char* name);


### PR DESCRIPTION
This requires detaching from the JVM at thread shutdown using a callback
that was recently added to the Dart VM.