### PR TITLE
Set the CSS overflow-wrap property to enable line breaks within a word

### DIFF
--- a/sky/engine/core/rendering/style/RenderStyle.h
+++ b/sky/engine/core/rendering/style/RenderStyle.h
@@ -1024,7 +1024,7 @@ public:
     static EUserSelect initialUserSelect() { return SELECT_TEXT; }
     static TextOverflow initialTextOverflow() { return TextOverflowClip; }
     static EWordBreak initialWordBreak() { return NormalWordBreak; }
-    static EOverflowWrap initialOverflowWrap() { return NormalOverflowWrap; }
+    static EOverflowWrap initialOverflowWrap() { return BreakOverflowWrap; }
     static LineBreak initialLineBreak() { return LineBreakAuto; }
     static const AtomicString& initialHighlight() { return nullAtom; }
     static const AtomicString& initialHyphenationString() { return nullAtom; }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/162