### PR TITLE
Add static assert to check that all Dart wrappable instances are thread-safe reference-countable.

### DIFF
--- a/sky/engine/core/compositing/Scene.h
+++ b/sky/engine/core/compositing/Scene.h
@@ -11,13 +11,13 @@
 #include "flow/layers/layer_tree.h"
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkPicture.h"
 
 namespace blink {
 class DartLibraryNatives;
 
-class Scene : public RefCounted<Scene>, public DartWrappable {
+class Scene : public ThreadSafeRefCounted<Scene>, public DartWrappable {
   DEFINE_WRAPPERTYPEINFO();
 
  public:

--- a/sky/engine/core/compositing/SceneBuilder.h
+++ b/sky/engine/core/compositing/SceneBuilder.h
@@ -21,11 +21,11 @@
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/tonic/float64_list.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 
 namespace blink {
 
-class SceneBuilder : public RefCounted<SceneBuilder>, public DartWrappable {
+class SceneBuilder : public ThreadSafeRefCounted<SceneBuilder>, public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     static PassRefPtr<SceneBuilder> create() {

--- a/sky/engine/core/painting/Canvas.h
+++ b/sky/engine/core/painting/Canvas.h
@@ -18,7 +18,7 @@
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/tonic/float64_list.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 
 namespace blink {
@@ -29,7 +29,7 @@ class Paragraph;
 template <>
 struct DartConverter<SkCanvas::VertexMode> : public DartConverterInteger<SkCanvas::VertexMode> {};
 
-class Canvas : public RefCounted<Canvas>, public DartWrappable {
+class Canvas : public ThreadSafeRefCounted<Canvas>, public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     static PassRefPtr<Canvas> create(PictureRecorder* recorder, Rect& bounds);

--- a/sky/engine/core/painting/CanvasImage.h
+++ b/sky/engine/core/painting/CanvasImage.h
@@ -7,13 +7,13 @@
 
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkImage.h"
 
 namespace blink {
 class DartLibraryNatives;
 
-class CanvasImage final : public RefCounted<CanvasImage>,
+class CanvasImage final : public ThreadSafeRefCounted<CanvasImage>,
                           public DartWrappable {
   DEFINE_WRAPPERTYPEINFO();
  public:

--- a/sky/engine/core/painting/CanvasPath.h
+++ b/sky/engine/core/painting/CanvasPath.h
@@ -12,7 +12,7 @@
 #include "sky/engine/core/painting/RRect.h"
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkPath.h"
 
 // Note: There's a very similar class in ../../platform/graphics/Path.h
@@ -22,7 +22,7 @@
 namespace blink {
 class DartLibraryNatives;
 
-class CanvasPath : public RefCounted<CanvasPath>, public DartWrappable {
+class CanvasPath : public ThreadSafeRefCounted<CanvasPath>, public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~CanvasPath() override;

--- a/sky/engine/core/painting/ColorFilter.h
+++ b/sky/engine/core/painting/ColorFilter.h
@@ -9,13 +9,13 @@
 #include "sky/engine/core/painting/TransferMode.h"
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 
 namespace blink {
 class DartLibraryNatives;
 
-class ColorFilter : public RefCounted<ColorFilter>, public DartWrappable {
+class ColorFilter : public ThreadSafeRefCounted<ColorFilter>, public DartWrappable {
   DEFINE_WRAPPERTYPEINFO();
  public:
   ~ColorFilter() override;

--- a/sky/engine/core/painting/MaskFilter.h
+++ b/sky/engine/core/painting/MaskFilter.h
@@ -7,14 +7,14 @@
 
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 
 class SkMaskFilter;
 
 namespace blink {
 class DartLibraryNatives;
 
-class MaskFilter : public RefCounted<MaskFilter>, public DartWrappable {
+class MaskFilter : public ThreadSafeRefCounted<MaskFilter>, public DartWrappable {
   DEFINE_WRAPPERTYPEINFO();
  public:
   ~MaskFilter() override;

--- a/sky/engine/core/painting/Picture.h
+++ b/sky/engine/core/painting/Picture.h
@@ -7,14 +7,14 @@
 
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkPicture.h"
 
 namespace blink {
 class Canvas;
 class DartLibraryNatives;
 
-class Picture : public RefCounted<Picture>, public DartWrappable {
+class Picture : public ThreadSafeRefCounted<Picture>, public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     ~Picture() override;

--- a/sky/engine/core/painting/PictureRecorder.h
+++ b/sky/engine/core/painting/PictureRecorder.h
@@ -8,7 +8,7 @@
 #include "sky/engine/core/painting/Rect.h"
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 
 namespace blink {
@@ -16,7 +16,7 @@ class Canvas;
 class DartLibraryNatives;
 class Picture;
 
-class PictureRecorder : public RefCounted<PictureRecorder>,
+class PictureRecorder : public ThreadSafeRefCounted<PictureRecorder>,
                         public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:

--- a/sky/engine/core/painting/Shader.h
+++ b/sky/engine/core/painting/Shader.h
@@ -7,12 +7,12 @@
 
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "third_party/skia/include/core/SkShader.h"
 
 namespace blink {
 
-class Shader : public RefCounted<Shader>, public DartWrappable {
+class Shader : public ThreadSafeRefCounted<Shader>, public DartWrappable {
   DEFINE_WRAPPERTYPEINFO();
  public:
   ~Shader() override;

--- a/sky/engine/core/text/Paragraph.cpp
+++ b/sky/engine/core/text/Paragraph.cpp
@@ -4,12 +4,14 @@
 
 #include "sky/engine/core/text/ParagraphBuilder.h"
 
+#include "base/location.h"
 #include "sky/engine/core/painting/Rect.h"
 #include "sky/engine/core/rendering/PaintInfo.h"
 #include "sky/engine/core/rendering/RenderText.h"
 #include "sky/engine/core/rendering/style/RenderStyle.h"
 #include "sky/engine/platform/fonts/FontCache.h"
 #include "sky/engine/platform/graphics/GraphicsContext.h"
+#include "sky/engine/public/platform/Platform.h"
 #include "sky/engine/tonic/dart_args.h"
 #include "sky/engine/tonic/dart_binding_macros.h"
 #include "sky/engine/tonic/dart_converter.h"
@@ -47,6 +49,8 @@ Paragraph::Paragraph(PassOwnPtr<RenderView> renderView)
 
 Paragraph::~Paragraph()
 {
+    base::SingleThreadTaskRunner* runner = Platform::current()->GetUITaskRunner();
+    runner->DeleteSoon(FROM_HERE, m_renderView.leakPtr());
 }
 
 double Paragraph::width()

--- a/sky/engine/core/text/Paragraph.h
+++ b/sky/engine/core/text/Paragraph.h
@@ -7,7 +7,7 @@
 
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 #include "sky/engine/core/painting/Canvas.h"
 #include "sky/engine/core/painting/Offset.h"
 #include "sky/engine/core/rendering/RenderView.h"
@@ -16,7 +16,7 @@
 namespace blink {
 class DartLibraryNatives;
 
-class Paragraph : public RefCounted<Paragraph>, public DartWrappable {
+class Paragraph : public ThreadSafeRefCounted<Paragraph>, public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     static PassRefPtr<Paragraph> create(PassOwnPtr<RenderView> renderView) {

--- a/sky/engine/core/text/ParagraphBuilder.cpp
+++ b/sky/engine/core/text/ParagraphBuilder.cpp
@@ -4,12 +4,14 @@
 
 #include "sky/engine/core/text/ParagraphBuilder.h"
 
+#include "base/location.h"
 #include "sky/engine/core/rendering/RenderInline.h"
 #include "sky/engine/core/rendering/RenderParagraph.h"
 #include "sky/engine/core/rendering/RenderText.h"
 #include "sky/engine/core/rendering/style/RenderStyle.h"
 #include "sky/engine/core/script/ui_dart_state.h"
 #include "sky/engine/platform/text/LocaleToScriptMapping.h"
+#include "sky/engine/public/platform/Platform.h"
 #include "sky/engine/tonic/dart_args.h"
 #include "sky/engine/tonic/dart_binding_macros.h"
 #include "sky/engine/tonic/dart_converter.h"
@@ -135,6 +137,8 @@ ParagraphBuilder::ParagraphBuilder()
 
 ParagraphBuilder::~ParagraphBuilder()
 {
+    base::SingleThreadTaskRunner* runner = Platform::current()->GetUITaskRunner();
+    runner->DeleteSoon(FROM_HERE, m_renderView.leakPtr());
 }
 
 void ParagraphBuilder::pushStyle(Int32List& encoded, const std::string& fontFamily, double fontSize, double letterSpacing, double wordSpacing, double lineHeight)

--- a/sky/engine/core/text/ParagraphBuilder.h
+++ b/sky/engine/core/text/ParagraphBuilder.h
@@ -9,12 +9,12 @@
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/tonic/int32_list.h"
 #include "sky/engine/wtf/PassRefPtr.h"
-#include "sky/engine/wtf/RefCounted.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
 
 namespace blink {
 class DartLibraryNatives;
 
-class ParagraphBuilder : public RefCounted<ParagraphBuilder>, public DartWrappable {
+class ParagraphBuilder : public ThreadSafeRefCounted<ParagraphBuilder>, public DartWrappable {
     DEFINE_WRAPPERTYPEINFO();
 public:
     static PassRefPtr<ParagraphBuilder> create() {

--- a/sky/engine/tonic/dart_wrappable.h
+++ b/sky/engine/tonic/dart_wrappable.h
@@ -14,6 +14,9 @@
 #include "sky/engine/tonic/dart_wrapper_info.h"
 #include "sky/engine/wtf/PassRefPtr.h"
 #include "sky/engine/wtf/RefPtr.h"
+#include "sky/engine/wtf/ThreadSafeRefCounted.h"
+
+#include <type_traits>
 
 namespace blink {
 class DartGCVisitor;
@@ -82,7 +85,9 @@ static const DartWrapperInfo kDartWrapperInfo_##LibraryName_##ClassName = {    \
   &DerefObject_##LibraryName_##ClassName,                                      \
 };                                                                             \
 const DartWrapperInfo& ClassName::dart_wrapper_info_ =                         \
-    kDartWrapperInfo_##LibraryName_##ClassName;
+    kDartWrapperInfo_##LibraryName_##ClassName;                                \
+static_assert(std::is_base_of<WTF::ThreadSafeRefCountedBase, ClassName>::value,\
+    #ClassName " must be thread-safe reference-countable.");
 
 struct DartConverterWrappable {
   static DartWrappable* FromDart(Dart_Handle handle);


### PR DESCRIPTION
Now, if a Dart wrappable has the wrong ref/deref methods, a static assert trips and logs "_Foo_ must be thread-safe reference-countable".

@eseidel: I could not find cases where these instances could not be collected on a background thread either. Were you thinking of something specific? I can also add an assertion and force collections on a specific thread if you think that is better.

cc @abarth 

Fixes https://github.com/flutter/flutter/issues/2979