### PR TITLE
Jank insted of flicker in Mozart

### DIFF
--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -99,7 +99,7 @@ void RasterizerMojo::Draw(uint64_t layer_tree_ptr,
   root_node->op->get_image()->content_rect->height = size.height;
   root_node->op->get_image()->image_resource_id = kContentImageResourceId;
   root_node->hit_test_behavior = mojo::gfx::composition::HitTestBehavior::New();
-  root_node->combinator = mojo::gfx::composition::Node::Combinator::PRUNE;
+  root_node->combinator = mojo::gfx::composition::Node::Combinator::MERGE;
   layer_tree->UpdateScene(update.get(), root_node.get());
 
   update->nodes.insert(kRootNodeId, root_node.Pass());


### PR DESCRIPTION
Currently there's no good way of synchronizing layout changes with children in
Mozart. Previously we flickered when we were out of sync with our child. Now we
jank instead because that's a more acceptable artifact while we work on
improving Mozart.

Fixes https://github.com/flutter/flutter/issues/3024