### PR TITLE
When launching directly from Xcode, use 8181 as the observatory port.

### DIFF
--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
@@ -74,6 +74,10 @@
             argument = "--packages=$(FLUTTER_APPLICATION_PATH)/.packages"
             isEnabled = "YES">
          </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--observatory-port=8181"
+            isEnabled = "YES">
+         </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>


### PR DESCRIPTION
While iterating on the engine, the application is usually launched directly by Xcode. Opening observatory is usually involves looking for the log statement that includes the port (the tools usually parse this when they launch the application). This patch default the port to 8181.