### PR TITLE
Bump up the mac_sdk_min GN arg to 10.8 and fix deprecated declaration.

### DIFF
--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -6,7 +6,7 @@ import("//build/config/chrome_build.gni")
 
 declare_args() {
   # Minimum supported version of the Mac SDK.
-  mac_sdk_min = "10.6"
+  mac_sdk_min = "10.8"
 
   # Path to a specific version of the Mac SDKJ, not including a backslash at
   # the end. If empty, the path to the lowest version greater than or equal to

--- a/ui/gl/gl_context_cgl.cc
+++ b/ui/gl/gl_context_cgl.cc
@@ -278,10 +278,10 @@ bool GLContextCGL::GetTotalGpuMemory(size_t* bytes) {
     GLint video_memory = 0;
     if (CGLDescribeRenderer(renderer_info,
                             renderer_index,
-                            kCGLRPVideoMemory,
+                            kCGLRPVideoMemoryMegabytes,
                             &video_memory) != kCGLNoError)
         continue;
-    *bytes = video_memory;
+    *bytes = (video_memory * 1000000);
     return true;
   }
 


### PR DESCRIPTION
Required by the Dart dependency.