### PR TITLE
Do not show an assertion failure if Dart_FinalizeLoading returns an e…

### DIFF
--- a/sky/tools/sky_snapshot/main.cc
+++ b/sky/tools/sky_snapshot/main.cc
@@ -89,7 +89,8 @@ int main(int argc, const char* argv[]) {
   CHECK(args.size() == 1);
   LoadScript(args[0]);
 
-  CHECK(!LogIfError(Dart_FinalizeLoading(true)));
+  if (LogIfError(Dart_FinalizeLoading(true)))
+    return 1;
 
   CHECK(command_line.HasSwitch(switches::kSnapshot));
   WriteSnapshot(command_line.GetSwitchValuePath(switches::kSnapshot));


### PR DESCRIPTION
…rror while building a snapshot

This might happen due to errors expected during development (e.g. a mistyped
Dart class name)