### PR TITLE
Leak the embedder message loop on Mac.

### DIFF
--- a/sky/shell/platform/mac/platform_mac.mm
+++ b/sky/shell/platform/mac/platform_mac.mm
@@ -89,10 +89,7 @@ class EmbedderState {
   }
 
   ~EmbedderState() {
-    CHECK([NSThread isMainThread])
-        << "Embedder destruction must occur on the main platform thread";
 #if !TARGET_OS_IPHONE
-    embedder_message_loop_->QuitNow();
     embedder_message_loop_.release();
 #endif
   }


### PR DESCRIPTION
Dart has the tendency to call `exit()` on arbitrary threads. This causes
the assertion to trip. Since this should only happen when Dart is
running the shell in non-interactive mode, we leak the message loop
without proper shutdown.

We should never hit this path on iOS.