### PR TITLE
When looking for the host snapshotter, use the correct Dart toolchain.

### DIFF
--- a/sky/engine/bindings/BUILD.gn
+++ b/sky/engine/bindings/BUILD.gn
@@ -109,7 +109,7 @@ action("generate_snapshot_bin") {
   dart_jni_path = rebase_path("//sky/engine/bindings/jni/jni.dart")
 
   gen_snapshot_dir =
-      get_label_info("//dart/runtime/bin:gen_snapshot($host_toolchain)",
+      get_label_info("//dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
                      "root_out_dir")
   script = "//dart/runtime/tools/create_snapshot_bin.py"
 


### PR DESCRIPTION
This matters when building for armv7 where we need the 32-bit snapshotter on the host.

Fixes https://github.com/flutter/flutter/issues/2930