### PR TITLE
Allow detach of an Android PlatformView that still holds a window

### DIFF
--- a/sky/shell/platform/android/platform_view_android.cc
+++ b/sky/shell/platform/android/platform_view_android.cc
@@ -47,7 +47,6 @@ PlatformViewAndroid::~PlatformViewAndroid() {
 }
 
 void PlatformViewAndroid::Detach(JNIEnv* env, jobject obj) {
-  DCHECK(!window_);
   shell_view_.reset();
   // Note: |this| has been destroyed at this point.
 }


### PR DESCRIPTION
The PlatformView may not receive the surfaceDestroy notification before its
activity is destroyed (this was happening on the Android emulator).

If this happens, allow the PlatformView to be detached and have it release
its window during destruction.