### PR TITLE
Add basic --deploy mode

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -25,7 +25,7 @@ vars = {
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
-  'dart_revision': '7060b6a07b74da52492be4469da5cd150a2ef940',
+  'dart_revision': '01c543cb0abadba28bec2fda8c72e2b8b431314d',
   'dart_observatory_packages_revision': 'cf90eb9077177d3d6b3fd5e8289477c2385c026a',
   'dart_root_certificates_revision': 'aed07942ce98507d2be28cbd29e879525410c7fc',
 

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -27,6 +27,10 @@ def get_out_dir(args):
     else:
         target_dir += 'Release'
 
+    # Currently --develop does not change the out-dir.
+    if not args.develop:
+        target_dir += '_Deploy'
+
     if args.ios_force_armv7:
         target_dir += '_armv7'
 
@@ -102,6 +106,7 @@ def to_gn_args(args):
     gn_args['enable_gcm'] = args.enable_gcm
     gn_args['enable_google_sign_in'] = args.enable_google_sign_in
     gn_args['use_glfw'] = args.use_glfw
+    gn_args['dart_product'] = not args.develop
 
     return gn_args
 
@@ -111,6 +116,11 @@ def parse_args(args):
 
   parser.add_argument('--debug', default=True, action='store_true')
   parser.add_argument('--release', default=False, dest='debug', action='store_false')
+
+  # Deploy is a placeholder for https://github.com/flutter/flutter/issues/3263
+  # Adding it now unblocks bot/tool work.
+  parser.add_argument('--develop', default=True, action='store_true')
+  parser.add_argument('--deploy', default=False, dest='develop', action='store_false')
 
   parser.add_argument('--target-os', type=str, choices=['android', 'ios'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')


### PR DESCRIPTION
Not clear what configs are needed.  Release is probably the wrong name now.  Probably want --develop and --deploy instead?  Not sure.

As written the bots will need to pass --release --deploy, which seems a bit silly.

@jason-simmons @devoncarew @abarth @johnmccutchan 