### PR TITLE
Do not modify the set of active streams within the embedder tracing c…

### DIFF
--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -102,6 +102,10 @@ static const char* kDartStartPausedArgs[]{
     "--pause_isolates_on_start",
 };
 
+static const char* kDartTraceStartupArgs[]{
+    "--timeline_streams=Compiler,Dart,Embedder,GC",
+};
+
 const char kFileUriPrefix[] = "file://";
 
 const char kDartFlags[] = "dart-flags";
@@ -409,6 +413,9 @@ void InitDartVM() {
 
   if (SkySettings::Get().start_paused)
     args.append(kDartStartPausedArgs, arraysize(kDartStartPausedArgs));
+
+  if (SkySettings::Get().trace_startup)
+    args.append(kDartTraceStartupArgs, arraysize(kDartTraceStartupArgs));
 
   Vector<std::string> dart_flags;
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(kDartFlags)) {

--- a/sky/engine/public/platform/sky_settings.h
+++ b/sky/engine/public/platform/sky_settings.h
@@ -16,6 +16,7 @@ struct SkySettings {
   uint32_t observatory_port = 0;
   bool start_paused = false;
   bool enable_dart_checked_mode = false;
+  bool trace_startup = false;
 
   static const SkySettings& Get();
   static void Set(const SkySettings& settings);

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -135,12 +135,10 @@ void Shell::InitStandalone(std::string icu_data_path) {
   settings.start_paused = command_line.HasSwitch(switches::kStartPaused);
   settings.enable_dart_checked_mode =
       command_line.HasSwitch(switches::kEnableCheckedMode);
+  settings.trace_startup = command_line.HasSwitch(switches::kTraceStartup);
   blink::SkySettings::Set(settings);
 
   Init();
-
-  if (command_line.HasSwitch(switches::kTraceStartup))
-    Shared().tracing_controller().StartTracing();
 }
 
 void Shell::Init() {

--- a/sky/shell/tracing_controller.cc
+++ b/sky/shell/tracing_controller.cc
@@ -171,14 +171,9 @@ void TracingController::StartTracing() {
 
   tracing_active_ = true;
 
-  StartDartTracing();
   StartBaseTracing();
 
   AddTraceMetadata();
-}
-
-void TracingController::StartDartTracing() {
-  Dart_GlobalTimelineSetRecordedStreams(DART_TIMELINE_STREAM_ALL);
 }
 
 void TracingController::StartBaseTracing() {
@@ -199,7 +194,6 @@ void TracingController::StopTracing() {
   tracing_active_ = false;
 
   StopBaseTracing();
-  StopDartTracing();
 }
 
 void TracingController::StopBaseTracing() {
@@ -207,10 +201,6 @@ void TracingController::StopBaseTracing() {
 
   log->SetDisabled();
   log->SetEventCallbackDisabled();
-}
-
-void TracingController::StopDartTracing() {
-  Dart_GlobalTimelineSetRecordedStreams(DART_TIMELINE_STREAM_DISABLE);
 }
 
 base::FilePath TracingController::TracePathWithExtension(

--- a/sky/shell/tracing_controller.h
+++ b/sky/shell/tracing_controller.h
@@ -49,9 +49,6 @@ class TracingController {
 
   void StopBaseTracing();
 
-  void StartDartTracing();
-  void StopDartTracing();
-
   base::FilePath TracePathWithExtension(base::FilePath dir,
                                         std::string extension) const;
 


### PR DESCRIPTION
…allbacks

Dart invokes Start/StopTracing callbacks within the _setVMTimelineFlags service
method whenever the embedder timeline stream toggles on or off.  Flutter's
implementation of these callbacks was modifying the set of enabled streams,
which could override the intended behavior of _setVMTimelineFlags.

Start/StopTracing will now only control Flutter's embedder-specific log.

Also needed to change the Flutter engine's --trace-startup flag to set the
corresponding timeline stream flag on the Dart VM.