### PR TITLE
Don't include Observatory in production Flutter apps

### DIFF
--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -73,10 +73,15 @@ static_library("core") {
     "//sky/services/pointer:interfaces",
     "//dart/runtime/bin:embedded_dart_io",
     "//dart/runtime:libdart",
-    "//dart/runtime/observatory:embedded_observatory_archive",
     "//dart/runtime/vm:libdart_platform",
     "//mojo/services/navigation/interfaces",
   ]
+
+  if (flutter_develop_mode) {
+    deps += [
+      "//dart/runtime/observatory:embedded_observatory_archive",
+    ]
+  }
 
   sources = sky_core_files
 


### PR DESCRIPTION
Observatory is needed only in development mode.

Fixes #890