### PR TITLE
window.render should render immediately

### DIFF
--- a/sky/engine/core/dart/window.dart
+++ b/sky/engine/core/dart/window.dart
@@ -156,8 +156,10 @@ class Window {
   void scheduleFrame() native "Window_scheduleFrame";
 
   /// Updates the application's rendering on the GPU with the newly provided
-  /// [Scene]. For optimal performance, this should only be called in response
-  /// to the [onBeginFrame] callback being invoked.
+  /// [Scene]. This function must be called within the scope of the
+  /// [onBeginFrame] callback being invoked. If this function is called multiple
+  /// times during a single [onBeginFrame] callback or called outside the scope
+  /// of an [onBeginFrame], the call will be ignored.
   ///
   /// To record graphical operations, first create a
   /// [PictureRecorder], then construct a [Canvas], passing that

--- a/sky/engine/public/sky/sky_view.cc
+++ b/sky/engine/public/sky/sky_view.cc
@@ -85,10 +85,8 @@ void SkyView::RunFromSnapshot(mojo::ScopedDataPipeConsumerHandle snapshot) {
   dart_controller_->RunFromSnapshot(snapshot.Pass());
 }
 
-std::unique_ptr<flow::LayerTree> SkyView::BeginFrame(
-    base::TimeTicks frame_time) {
+void SkyView::BeginFrame(base::TimeTicks frame_time) {
   GetWindow()->BeginFrame(frame_time);
-  return std::move(layer_tree_);
 }
 
 void SkyView::HandlePointerPacket(const pointer::PointerPacketPtr& packet) {
@@ -109,7 +107,7 @@ void SkyView::FlushRealTimeEvents() {
 }
 
 void SkyView::Render(Scene* scene) {
-  layer_tree_ = scene->takeLayerTree();
+  client_->Render(scene->takeLayerTree());
 }
 
 void SkyView::DidCreateSecondaryIsolate(Dart_Isolate isolate) {

--- a/sky/engine/public/sky/sky_view.h
+++ b/sky/engine/public/sky/sky_view.h
@@ -43,8 +43,7 @@ class SkyView : public WindowClient, public IsolateClient {
   void PushRoute(const std::string& route);
   void PopRoute();
 
-  std::unique_ptr<flow::LayerTree> BeginFrame(
-      base::TimeTicks frame_time);
+  void BeginFrame(base::TimeTicks frame_time);
 
   void CreateView(const std::string& script_uri);
 
@@ -73,7 +72,6 @@ class SkyView : public WindowClient, public IsolateClient {
   std::string language_code_;
   std::string country_code_;
   std::unique_ptr<DartController> dart_controller_;
-  std::unique_ptr<flow::LayerTree> layer_tree_;
 
   base::WeakPtrFactory<SkyView> weak_factory_;
 

--- a/sky/shell/ui/animator.h
+++ b/sky/shell/ui/animator.h
@@ -6,6 +6,7 @@
 #define SKY_SHELL_UI_ANIMATOR_H_
 
 #include "base/memory/weak_ptr.h"
+#include "base/time/time.h"
 #include "mojo/services/gfx/composition/interfaces/scheduling.mojom.h"
 #include "mojo/services/vsync/interfaces/vsync.mojom.h"
 #include "sky/shell/ui/engine.h"
@@ -21,6 +22,8 @@ class Animator {
 
   void RequestFrame();
   void FlushRealTimeEvents();
+
+  void Render(std::unique_ptr<flow::LayerTree> layer_tree);
 
   void Start();
   void Stop();
@@ -49,6 +52,8 @@ class Animator {
   bool did_defer_frame_request_;
   bool engine_requested_frame_;
   bool paused_;
+  bool is_ready_to_draw_;
+  base::TimeTicks begin_time_;
 
   base::WeakPtrFactory<Animator> weak_factory_;
 

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -55,7 +55,7 @@ class Engine : public UIDelegate,
 
   static void Init();
 
-  std::unique_ptr<flow::LayerTree> BeginFrame(base::TimeTicks frame_time);
+  void BeginFrame(base::TimeTicks frame_time);
 
  private:
   // UIDelegate implementation:


### PR DESCRIPTION
Previously we would hold the layer tree until the we returned from Dart. Now we
send the layer tree to the rasterizer thread immediately.