### PR TITLE
Make OpacityLayer hit SkRecordNoopSaveLayerDrawRestores

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -19,8 +19,7 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
 void OpacityLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkPaint paint;
-  paint.setColor(SkColorSetARGB(alpha_, 0, 0, 0));
-  paint.setXfermodeMode(SkXfermode::kSrcOver_Mode);
+  paint.setAlpha(alpha_);
 
   SkCanvas& canvas = frame.canvas();
   SkAutoCanvasRestore save(&canvas, false);


### PR DESCRIPTION
Previously we were applying opacity in a different way than Skia
expects. Now we use the exact pattern that Skia expects so that we hit
more optimizations inside SkRecordOptimize.

After this patch, we don't actually get the optimization because we
don't yet run SkRecordOptimize over the composited tree. A later patch
will actually cause us to run SkRecordOptimize.