### PR TITLE
Improve paint bounds computation in flow

### DIFF
--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -12,11 +12,6 @@ BackdropFilterLayer::BackdropFilterLayer() {
 BackdropFilterLayer::~BackdropFilterLayer() {
 }
 
-void BackdropFilterLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  ContainerLayer::Preroll(context, matrix);
-  set_paint_bounds(context->child_paint_bounds);
-}
-
 void BackdropFilterLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkCanvas& canvas = frame.canvas();
   SkAutoCanvasRestore save(&canvas, false);

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -17,7 +17,6 @@ class BackdropFilterLayer : public ContainerLayer {
   void set_filter(SkImageFilter* filter) { filter_ = skia::SharePtr(filter); }
 
  protected:
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -12,10 +12,17 @@ ClipPathLayer::ClipPathLayer() {
 ClipPathLayer::~ClipPathLayer() {
 }
 
+void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  PrerollChildren(context, matrix);
+  if (!context->child_paint_bounds.intersect(clip_path_.getBounds()))
+    context->child_paint_bounds.setEmpty();
+  set_paint_bounds(context->child_paint_bounds);
+}
+
 void ClipPathLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkCanvas& canvas = frame.canvas();
   SkAutoCanvasRestore save(&canvas, false);
-  canvas.saveLayer(&clip_path_.getBounds(), nullptr);
+  canvas.saveLayer(&paint_bounds(), nullptr);
   canvas.clipPath(clip_path_);
   PaintChildren(frame);
 }

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -17,6 +17,7 @@ class ClipPathLayer : public ContainerLayer {
   void set_clip_path(const SkPath& clip_path) { clip_path_ = clip_path; }
 
  protected:
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -12,10 +12,17 @@ ClipRectLayer::ClipRectLayer() {
 ClipRectLayer::~ClipRectLayer() {
 }
 
+void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  PrerollChildren(context, matrix);
+  if (!context->child_paint_bounds.intersect(clip_rect_))
+    context->child_paint_bounds.setEmpty();
+  set_paint_bounds(context->child_paint_bounds);
+}
+
 void ClipRectLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkCanvas& canvas = frame.canvas();
   SkAutoCanvasRestore save(&canvas, true);
-  canvas.clipRect(clip_rect_);
+  canvas.clipRect(paint_bounds());
   PaintChildren(frame);
 }
 

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -17,6 +17,7 @@ class ClipRectLayer : public ContainerLayer {
   void set_clip_rect(const SkRect& clip_rect) { clip_rect_ = clip_rect; }
 
  protected:
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -12,10 +12,17 @@ ClipRRectLayer::ClipRRectLayer() {
 ClipRRectLayer::~ClipRRectLayer() {
 }
 
+void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  PrerollChildren(context, matrix);
+  if (!context->child_paint_bounds.intersect(clip_rrect_.getBounds()))
+    context->child_paint_bounds.setEmpty();
+  set_paint_bounds(context->child_paint_bounds);
+}
+
 void ClipRRectLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkCanvas& canvas = frame.canvas();
   SkAutoCanvasRestore save(&canvas, false);
-  canvas.saveLayer(&clip_rrect_.getBounds(), nullptr);
+  canvas.saveLayer(&paint_bounds(), nullptr);
   canvas.clipRRect(clip_rrect_);
   PaintChildren(frame);
 }

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -16,6 +16,8 @@ class ClipRRectLayer : public ContainerLayer {
 
   void set_clip_rrect(const SkRRect& clip_rrect) { clip_rrect_ = clip_rrect; }
 
+ protected:
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -12,11 +12,6 @@ ColorFilterLayer::ColorFilterLayer() {
 ColorFilterLayer::~ColorFilterLayer() {
 }
 
-void ColorFilterLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  ContainerLayer::Preroll(context, matrix);
-  set_paint_bounds(context->child_paint_bounds);
-}
-
 void ColorFilterLayer::Paint(PaintContext::ScopedFrame& frame) {
   skia::RefPtr<SkColorFilter> color_filter =
       skia::AdoptRef(SkColorFilter::CreateModeFilter(color_, transfer_mode_));

--- a/flow/layers/color_filter_layer.h
+++ b/flow/layers/color_filter_layer.h
@@ -21,7 +21,6 @@ class ColorFilterLayer : public ContainerLayer {
   }
 
  protected:
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -19,6 +19,7 @@ void ContainerLayer::Add(std::unique_ptr<Layer> layer) {
 
 void ContainerLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   PrerollChildren(context, matrix);
+  set_paint_bounds(context->child_paint_bounds);
 }
 
 void ContainerLayer::PrerollChildren(PrerollContext* context,

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -12,11 +12,6 @@ OpacityLayer::OpacityLayer() {
 OpacityLayer::~OpacityLayer() {
 }
 
-void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  ContainerLayer::Preroll(context, matrix);
-  set_paint_bounds(context->child_paint_bounds);
-}
-
 void OpacityLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkPaint paint;
   paint.setAlpha(alpha_);

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -17,7 +17,6 @@ class OpacityLayer : public ContainerLayer {
   void set_alpha(int alpha) { alpha_ = alpha; }
 
  protected:
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -9,15 +9,12 @@
 #include "flow/layers/performance_overlay_layer.h"
 
 namespace flow {
+namespace {
 
-PerformanceOverlayLayer::PerformanceOverlayLayer(uint64_t enabledOptions)
-    : options_(enabledOptions) {
-}
-
-static void DrawStatisticsText(SkCanvas& canvas,
-                               const std::string& string,
-                               int x,
-                               int y) {
+void DrawStatisticsText(SkCanvas& canvas,
+                        const std::string& string,
+                        int x,
+                        int y) {
   SkPaint paint;
   paint.setTextSize(14);
   paint.setLinearText(false);
@@ -25,15 +22,15 @@ static void DrawStatisticsText(SkCanvas& canvas,
   canvas.drawText(string.c_str(), string.size(), x, y, paint);
 }
 
-static void VisualizeStopWatch(SkCanvas& canvas,
-                               const instrumentation::Stopwatch& stopwatch,
-                               SkScalar x,
-                               SkScalar y,
-                               SkScalar width,
-                               SkScalar height,
-                               bool show_graph,
-                               bool show_labels,
-                               std::string label_prefix) {
+void VisualizeStopWatch(SkCanvas& canvas,
+                        const instrumentation::Stopwatch& stopwatch,
+                        SkScalar x,
+                        SkScalar y,
+                        SkScalar width,
+                        SkScalar height,
+                        bool show_graph,
+                        bool show_labels,
+                        const std::string& label_prefix) {
   const int labelX = 8; // distance from x
   const int labelY = -10; // distance from y+height
 
@@ -60,10 +57,16 @@ static void VisualizeStopWatch(SkCanvas& canvas,
   }
 }
 
+}  // namespace
+
+PerformanceOverlayLayer::PerformanceOverlayLayer(uint64_t enabledOptions)
+    : options_(enabledOptions) {
+}
+
+
 void PerformanceOverlayLayer::Paint(PaintContext::ScopedFrame& frame) {
-  if (!options_) {
+  if (!options_)
     return;
-  }
 
   SkScalar x = paint_bounds().x();
   SkScalar y = paint_bounds().y();

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -12,11 +12,6 @@ ShaderMaskLayer::ShaderMaskLayer() {
 ShaderMaskLayer::~ShaderMaskLayer() {
 }
 
-void ShaderMaskLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  ContainerLayer::Preroll(context, matrix);
-  set_paint_bounds(context->child_paint_bounds);
-}
-
 void ShaderMaskLayer::Paint(PaintContext::ScopedFrame& frame) {
   SkCanvas& canvas = frame.canvas();
   SkAutoCanvasRestore save(&canvas, false);

--- a/flow/layers/shader_mask_layer.h
+++ b/flow/layers/shader_mask_layer.h
@@ -27,7 +27,6 @@ class ShaderMaskLayer : public ContainerLayer {
   }
 
  protected:
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext::ScopedFrame& frame) override;
 
  private:


### PR DESCRIPTION
We now compute the bounds for all container layers, including clips, and
use those bounds to tighten down our clips and save layers.