### PR TITLE
record startup time in Android; pass it to Dart timeline

### DIFF
--- a/sky/engine/core/core.gni
+++ b/sky/engine/core/core.gni
@@ -7,6 +7,8 @@ sky_core_output_dir = "$root_gen_dir/sky/core"
 sky_core_files = [
   "Init.cpp",
   "Init.h",
+  "start_up.h",
+  "start_up.cc",
   "compositing/Scene.cpp",
   "compositing/Scene.h",
   "compositing/SceneBuilder.cpp",

--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -36,6 +36,7 @@
 #include "sky/engine/tonic/dart_wrappable.h"
 #include "sky/engine/tonic/uint8_list.h"
 #include "sky/engine/wtf/MakeUnique.h"
+#include "sky/engine/core/start_up.h"
 
 #ifdef OS_ANDROID
 #include "sky/engine/bindings/jni/dart_jni.h"
@@ -104,6 +105,7 @@ static const char* kDartStartPausedArgs[]{
 
 static const char* kDartTraceStartupArgs[]{
     "--timeline_streams=Compiler,Dart,Embedder,GC",
+    "--timeline_recorder=endless",
 };
 
 const char kFileUriPrefix[] = "file://";
@@ -472,6 +474,20 @@ void InitDartVM() {
                           nullptr,
                           // VM service assets archive
                           GetVMServiceAssetsArchiveCallback) == nullptr);
+
+    // Send the earliest available timestamp in the application lifecycle to
+    // timeline. The difference between this timestamp and the time we render the
+    // very first frame gives us a good idea about Flutter's startup time.
+    if (blink::engine_main_enter_ts != 0) {
+      Dart_TimelineEvent("FlutterEngineMainEnter",    // label
+                         blink::engine_main_enter_ts, // timestamp0
+                         0,                           // timestamp1_or_async_id
+                         Dart_Timeline_Event_Instant, // event type
+                         0,                           // argument_count
+                         nullptr,                     // argument_names
+                         nullptr                      // argument_values
+                         );
+    }
   }
 
   // Allow streaming of stdout and stderr by the Dart vm.

--- a/sky/engine/core/start_up.cc
+++ b/sky/engine/core/start_up.cc
@@ -1,0 +1,11 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/engine/core/start_up.h"
+
+namespace blink {
+
+int64_t engine_main_enter_ts = 0;
+
+}  // namespace blink

--- a/sky/engine/core/start_up.h
+++ b/sky/engine/core/start_up.h
@@ -1,0 +1,24 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_ENGINE_CORE_START_UP_H_
+#define SKY_ENGINE_CORE_START_UP_H_
+
+#include <stdint.h>
+
+namespace blink {
+
+// The earliest available timestamp in the application's lifecycle. The
+// difference between this timestamp and the time we render the very first
+// frame gives us a good idea about Flutter's startup time.
+//
+// This timestamp only covers Flutter's own startup. In an upside-down model
+// it is possible that the first Flutter view is not initialized until some
+// time later. In this case the timestamp may not cover the time spent in the
+// user code prior to initializing Flutter.
+extern int64_t engine_main_enter_ts;
+
+}  // namespace blink
+
+#endif  // SKY_ENGINE_CORE_START_UP_H_

--- a/sky/shell/platform/android/flutter_main.cc
+++ b/sky/shell/platform/android/flutter_main.cc
@@ -22,7 +22,9 @@
 #include "mojo/edk/embedder/embedder.h"
 #include "mojo/edk/embedder/simple_platform_support.h"
 #include "sky/shell/shell.h"
+#include "sky/engine/core/start_up.h"
 #include "ui/gl/gl_surface.h"
+#include "dart/runtime/include/dart_tools_api.h"
 
 using base::LazyInstance;
 
@@ -82,6 +84,12 @@ static void Init(JNIEnv* env,
   Shell::InitStandalone();
 
   InitializeTracing();
+}
+
+static void RecordStartTimestamp(JNIEnv* env, jclass jcaller,
+    jlong initTimeMillis) {
+  int64_t initTimeMicros = static_cast<int64_t>(initTimeMillis) * static_cast<int64_t>(1000);
+  blink::engine_main_enter_ts = Dart_TimelineGetMicros() - initTimeMicros;
 }
 
 bool RegisterFlutterMain(JNIEnv* env) {


### PR DESCRIPTION
iOS implementation coming next in a follow-up PR.