### PR TITLE
Support ahead-of-time compilation on Android in the engine

### DIFF
--- a/sky/engine/bindings/bindings.gni
+++ b/sky/engine/bindings/bindings.gni
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//mojo/dart/packages/mojo/sdk_ext_sources.gni")
+import("//sky/engine/config.gni")
 
 bindings_output_dir = "$root_gen_dir/sky/bindings"
 
@@ -17,6 +18,11 @@ if (target_os == "ios" && !use_ios_simulator) {
     dart_host_toolchain = "//build/toolchain/mac:clang_x64"
   } else {
     assert(false, "Unknown active architecture on iOS")
+  }
+}
+if (target_os == "android" && flutter_aot) {
+  if (host_os == "linux" && target_cpu == "arm") {
+    dart_host_toolchain = "//build/toolchain/linux:clang_x86"
   }
 }
 

--- a/sky/engine/bindings/dart_vm_entry_points_android.txt
+++ b/sky/engine/bindings/dart_vm_entry_points_android.txt
@@ -1,0 +1,3 @@
+dart:jni,JniObject,JniObject.
+dart:jni,JniFloat,JniFloat.
+dart:jni,JniFloat,get:value

--- a/sky/engine/config.gni
+++ b/sky/engine/config.gni
@@ -28,6 +28,13 @@ declare_args() {
   } else {
     sky_dart_strict_mode = false
   }
+
+  # Enable ahead-of-time compilation on platforms where AOT is optional.
+  flutter_aot = false
+
+  # Set if the Dart runtime is being built in product mode, which excludes
+  # development features such as the debugger.
+  flutter_product_mode = false
 }
 
 # feature_defines_list ---------------------------------------------------------
@@ -55,4 +62,12 @@ if (sky_dart_strict_mode) {
 
 if (sky_use_dart) {
   feature_defines_list += [ "WTF_USE_DART=1" ]
+}
+
+if (flutter_aot) {
+  feature_defines_list += [ "FLUTTER_AOT=1" ]
+}
+
+if (flutter_product_mode) {
+  feature_defines_list += [ "FLUTTER_PRODUCT_MODE=1" ]
 }

--- a/sky/engine/core/core.gni
+++ b/sky/engine/core/core.gni
@@ -201,8 +201,6 @@ sky_core_files = [
   "rendering/style/StyleVisualData.h",
   "script/dart_controller.cc",
   "script/dart_controller.h",
-  "script/dart_debugger.cc",
-  "script/dart_debugger.h",
   "script/dart_init.cc",
   "script/dart_init.h",
   "script/dart_service_isolate.cc",
@@ -221,6 +219,13 @@ sky_core_files = [
   "window/window.cc",
   "window/window.h",
 ]
+
+if (!flutter_product_mode) {
+  sky_core_files += [
+    "script/dart_debugger.cc",
+    "script/dart_debugger.h",
+  ]
+}
 
 core_dart_files = get_path_info([
                                   "dart/compositing.dart",

--- a/sky/engine/core/script/dart_init.h
+++ b/sky/engine/core/script/dart_init.h
@@ -13,13 +13,11 @@
 
 namespace blink {
 
-#define DART_ALLOW_DYNAMIC_RESOLUTION OS(IOS)
+#define DART_ALLOW_DYNAMIC_RESOLUTION (OS(IOS) || FLUTTER_AOT)
 
 #if DART_ALLOW_DYNAMIC_RESOLUTION
 
-extern const char* kDartVmIsolateSnapshotBufferName;
 extern const char* kDartIsolateSnapshotBufferName;
-extern const char* kInstructionsSnapshotName;
 
 void* _DartSymbolLookup(const char* symbol_name);
 

--- a/sky/engine/platform/exported/sky_settings.cc
+++ b/sky/engine/platform/exported/sky_settings.cc
@@ -4,20 +4,24 @@
 
 #include "sky/engine/public/platform/sky_settings.h"
 
+#include <memory>
+
+#include "base/lazy_instance.h"
 #include "base/logging.h"
 
 namespace blink {
 
-static SkySettings s_settings;
+static base::LazyInstance<SkySettings> s_settings = LAZY_INSTANCE_INITIALIZER;
+
 static bool s_have_settings = false;
 
 const SkySettings& SkySettings::Get() {
-  return s_settings;
+  return s_settings.Get();
 }
 
 void SkySettings::Set(const SkySettings& settings) {
   CHECK(!s_have_settings);
-  s_settings = settings;
+  s_settings.Get() = settings;
   s_have_settings = true;
 }
 

--- a/sky/engine/public/platform/sky_settings.h
+++ b/sky/engine/public/platform/sky_settings.h
@@ -7,6 +7,8 @@
 
 #include <stdint.h>
 
+#include <string>
+
 namespace blink {
 
 struct SkySettings {
@@ -17,6 +19,7 @@ struct SkySettings {
   bool start_paused = false;
   bool enable_dart_checked_mode = false;
   bool trace_startup = false;
+  std::string aot_snapshot_path;
 
   static const SkySettings& Get();
   static void Set(const SkySettings& settings);

--- a/sky/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/sky/shell/platform/android/io/flutter/view/FlutterView.java
@@ -385,11 +385,15 @@ public class FlutterView extends SurfaceView
 
         resetAccessibilityTree();
 
-        String scriptUri = "file://" + bundlePath;
-        if (snapshotPath != null) {
-            mSkyEngine.runFromBundleAndSnapshot(scriptUri, bundlePath, snapshotPath);
+        if (FlutterMain.isRunningPrecompiledCode()) {
+            mSkyEngine.runFromPrecompiledSnapshot(bundlePath);
         } else {
-            mSkyEngine.runFromBundle(scriptUri, bundlePath);
+            String scriptUri = "file://" + bundlePath;
+            if (snapshotPath != null) {
+                mSkyEngine.runFromBundleAndSnapshot(scriptUri, bundlePath, snapshotPath);
+            } else {
+                mSkyEngine.runFromBundle(scriptUri, bundlePath);
+            }
         }
 
         // Connect to the ApplicationMessages service exported by the Flutter framework

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -136,6 +136,8 @@ void Shell::InitStandalone(std::string icu_data_path) {
   settings.enable_dart_checked_mode =
       command_line.HasSwitch(switches::kEnableCheckedMode);
   settings.trace_startup = command_line.HasSwitch(switches::kTraceStartup);
+  settings.aot_snapshot_path = command_line.GetSwitchValueASCII(
+      switches::kAotSnapshotPath);
   blink::SkySettings::Set(settings);
 
   Init();

--- a/sky/shell/switches.cc
+++ b/sky/shell/switches.cc
@@ -19,6 +19,7 @@ const char kPackages[] = "packages";
 const char kStartPaused[] = "start-paused";
 const char kTraceStartup[] = "trace-startup";
 const char kDeviceObservatoryPort[] = "observatory-port";
+const char kAotSnapshotPath[] = "aot-snapshot-path";
 
 void PrintUsage(const std::string& executable_name) {
   std::cerr << "Usage: " << executable_name

--- a/sky/shell/switches.h
+++ b/sky/shell/switches.h
@@ -20,6 +20,7 @@ extern const char kPackages[];
 extern const char kStartPaused[];
 extern const char kTraceStartup[];
 extern const char kDeviceObservatoryPort[];
+extern const char kAotSnapshotPath[];
 
 void PrintUsage(const std::string& executable_name);
 

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -67,7 +67,6 @@ def to_gn_args(args):
           aot = False
         else:
           # The iOS simulator snapshot is host targetted
-          gn_args['dart_target_arch'] = ios_target_cpu
           aot = True
     elif args.target_os == 'fnl':
       gn_args['target_os'] = 'fnl'
@@ -91,12 +90,16 @@ def to_gn_args(args):
         gn_args['target_cpu'] = 'x64'
 
     if aot:
+        gn_args['flutter_aot'] = True
+        gn_args['dart_target_arch'] = gn_args['target_cpu']
         if args.debug:
             gn_args['dart_runtime_mode'] = 'profile'
         else:
             gn_args['dart_runtime_mode'] = 'release'
     else:
         gn_args['dart_runtime_mode'] = 'develop'
+
+    gn_args['flutter_product_mode'] = (gn_args['dart_runtime_mode'] == 'release')
 
     if args.target_sysroot:
       gn_args['target_sysroot'] = args.target_sysroot


### PR DESCRIPTION
This include build system changes for selecting Dart's precompiler mode
plus a way to locate and load the precompiled snapshot library from an
Android application