### PR TITLE
Remove the extra lints from _embedder.yaml

### DIFF
--- a/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/sky/packages/sky_engine/lib/_embedder.yaml
@@ -15,45 +15,4 @@ embedded_libs:
 
 analyzer:
   language:
-    enableStrictCallChecks: true
     enableSuperMixins: true
-  strong-mode: true
-  errors:
-    # We allow overriding fields (if they use super, ideally...).
-    strong_mode_invalid_field_override: ignore
-    # We allow type narrowing.
-    strong_mode_invalid_method_override: ignore
-    strong_mode_static_type_error: ignore
-    strong_mode_down_cast_composite: ignore
-    todo: ignore
-linter:
-  rules:
-    - avoid_empty_else
-    - always_declare_return_types
-    - always_specify_types
-    - annotate_overrides
-    # - avoid_as # https://github.com/dart-lang/linter/issues/195
-    - avoid_init_to_null
-    # - avoid_return_types_on_setters # https://github.com/dart-lang/linter/issues/202
-    - camel_case_types
-    # - constant_identifier_names # https://github.com/dart-lang/linter/issues/204 (and 203)
-    - empty_constructor_bodies
-    - hash_and_equals
-    # - implementation_imports # https://github.com/dart-lang/linter/issues/203
-    - library_names
-    - library_prefixes
-    - non_constant_identifier_names
-    # - one_member_abstracts # https://github.com/dart-lang/linter/issues/203
-    - package_api_docs
-    - package_names
-    - package_prefixed_library_names
-    - prefer_is_not_empty
-    # - public_member_api_docs # still a lot of work to do before enabling this one
-    - slash_for_doc_comments
-    - sort_constructors_first
-    - sort_unnamed_constructors_first
-    - super_goes_last
-    - type_annotate_public_apis # subset of always_specify_types
-    - type_init_formals
-    - unnecessary_brace_in_string_interp
-    - unnecessary_getters_setters


### PR DESCRIPTION
These were forcing our customers to obey these lints, but not all of our
customers like them. We might enable some of these in the future if they have
concrete benefits (e.g., faster generated code when compiling ahead-of-time).