### PR TITLE
Add ParagraphConstraints

### DIFF
--- a/sky/engine/core/dart/text.dart
+++ b/sky/engine/core/dart/text.dart
@@ -583,6 +583,38 @@ class TextPosition {
   }
 }
 
+/// Layout constraints for [Paragraph] objects.
+///
+/// Instances of this class are typically used with [Paragraph.layout].
+class ParagraphConstraints {
+  /// Creates constraints for laying out a pargraph.
+  ///
+  /// The [width] argument must not be null.
+  ParagraphConstraints({ this.width }) {
+    assert(width != null);
+  }
+
+  /// The width the paragraph should use whey computing the positions of glyphs.
+  ///
+  /// If possible, the paragraph will select a soft line break prior to reaching
+  /// this width. If no soft line break is available, the paragraph will select
+  /// a hard line break prior to reaching this width.
+  ///
+  /// This width will also be used for positioning glyphs with [TextAlign].
+  final double width;
+
+  bool operator ==(dynamic other) {
+    if (other is! ParagraphConstraints)
+      return false;
+    final ParagraphConstraints typedOther = other;
+    return typedOther.width == width;
+  }
+
+  int get hashCode => width.hashCode;
+
+  String toString() => 'ParagraphConstraints(width: $width)';
+}
+
 /// A paragraph of text.
 ///
 /// A paragraph retains the size and position of each glyph in the text and can
@@ -650,7 +682,8 @@ abstract class Paragraph extends NativeFieldWrapperClass2 {
   /// Setting the [minWidth], [maxWidth], [minHeight], or [maxHeight]
   /// invalidates the layout of this paragraph, requiring a call to this
   /// function before painting or reading geometry from this paragraph.
-  void layout() native "Paragraph_layout";
+  void layout([ParagraphConstraints constraints]) => _layout(constraints?.width);
+  void _layout(double width) native "Paragraph_layout";
 
   /// Returns a list of text boxes that enclose the given text range.
   List<TextBox> getBoxesForRange(int start, int end) native "Paragraph_getRectsForRange";

--- a/sky/engine/core/text/Paragraph.cpp
+++ b/sky/engine/core/text/Paragraph.cpp
@@ -43,7 +43,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Paragraph);
 DART_BIND_ALL(Paragraph, FOR_EACH_BINDING)
 
 Paragraph::Paragraph(PassOwnPtr<RenderView> renderView)
-    : m_renderView(renderView)
+    : m_legacyWidthUsed(false), m_renderView(renderView)
 {
 }
 
@@ -83,12 +83,16 @@ double Paragraph::ideographicBaseline()
     return firstChildBox()->firstLineBoxBaseline(FontBaselineOrAuto(IdeographicBaseline));
 }
 
-void Paragraph::layout()
+void Paragraph::layout(double width)
 {
     FontCachePurgePreventer fontCachePurgePreventer;
 
-    LayoutUnit maxWidth = std::max(m_minWidth, m_maxWidth);
-    LayoutUnit maxHeight = std::max(m_minHeight, m_maxHeight);
+    int maxWidth = width;
+    int maxHeight = intMaxForLayoutUnit;
+    if (m_legacyWidthUsed) {
+      maxWidth = std::max(m_minWidth, m_maxWidth);
+      maxHeight = std::max(m_minHeight, m_maxHeight);
+    }
     m_renderView->setFrameViewSize(IntSize(maxWidth, maxHeight));
     m_renderView->layout();
 }

--- a/sky/engine/core/text/Paragraph.h
+++ b/sky/engine/core/text/Paragraph.h
@@ -26,10 +26,10 @@ public:
     ~Paragraph() override;
 
     double minWidth() { return m_minWidth; }
-    void setMinWidth(double width) { m_minWidth = width; }
+    void setMinWidth(double width) { m_minWidth = width; m_legacyWidthUsed = true; }
 
     double maxWidth() { return m_maxWidth; }
-    void setMaxWidth(double width) { m_maxWidth = width; }
+    void setMaxWidth(double width) { m_maxWidth = width; m_legacyWidthUsed = true; }
 
     double minHeight() { return m_minHeight; }
     void setMinHeight(double height) { m_minHeight = height; }
@@ -44,7 +44,7 @@ public:
     double alphabeticBaseline();
     double ideographicBaseline();
 
-    void layout();
+    void layout(double width);
     void paint(Canvas* canvas, const Offset& offset);
 
     std::vector<TextBox> getRectsForRange(unsigned start, unsigned end);
@@ -59,6 +59,7 @@ private:
 
     int absoluteOffsetForPosition(const PositionWithAffinity& position);
 
+    bool m_legacyWidthUsed;
     LayoutUnit m_minWidth;
     LayoutUnit m_maxWidth;
     LayoutUnit m_minHeight;


### PR DESCRIPTION
This patch begins to update the Paragraph interface to something sensible. It
introduces a ParagraphConstraints object that is passed to layout() to control
the layout of the paragraph. Once clients are migrated over, the argument will
become required.