### PR TITLE
Add isRootNode to SemanticFlags

### DIFF
--- a/sky/services/semantics/semantics.mojom
+++ b/sky/services/semantics/semantics.mojom
@@ -18,6 +18,7 @@ struct SemanticsNode {
 struct SemanticFlags {
   // This is intended to just be booleans, so that it can be extended
   // over time yet still be packed tightly.
+  bool isRootNode = false;
   bool canBeTapped = false;
   bool canBeLongPressed = false;
   bool canBeScrolledHorizontally = false;


### PR DESCRIPTION
Right now, the root node always has an ID of zero, but codifying
that in the SemanticsListener seems too much like magic, so this
adds an explicit flag to signal which node is the root node.