### PR TITLE
Remove ScriptSnapshotter from precompilation SDK

### DIFF
--- a/sky/build/PackagerInvoke
+++ b/sky/build/PackagerInvoke
@@ -63,7 +63,6 @@ PackageProject() {
       --target ${dart_main}                                                    \
       --output-file ${derived_dir}/app.flx                                     \
       --packages ${packages}                                                   \
-      --compiler ${src_dir}/ScriptSnapshotter                                  \
       ${precompilation_flag}                                                   \
 
   if [[ $? -ne 0 ]]; then

--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -60,7 +60,6 @@
 		9E40464B1C1B64B500A4B87C /* Flutter.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Flutter.xcconfig; sourceTree = "<group>"; };
 		9E4046501C1B6A3600A4B87C /* EmbedderEntryPoints */ = {isa = PBXFileReference; lastKnownFileType = text; path = EmbedderEntryPoints; sourceTree = "<group>"; };
 		9E4046511C1B6A3600A4B87C /* PackagerInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = PackagerInvoke; sourceTree = "<group>"; };
-		9E4046521C1B6A3600A4B87C /* ScriptSnapshotter */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = ScriptSnapshotter; sourceTree = "<group>"; };
 		9E4046531C1B6A3600A4B87C /* SnapshotterInvoke */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = SnapshotterInvoke; sourceTree = "<group>"; };
 		9E4046541C1B6A3600A4B87C /* icudtl.dat */ = {isa = PBXFileReference; lastKnownFileType = file; path = icudtl.dat; sourceTree = "<group>"; };
 		9E4046561C1B6A3600A4B87C /* FlutterRunner */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.executable"; path = FlutterRunner; sourceTree = "<group>"; };
@@ -160,7 +159,6 @@
 			children = (
 				9E4046501C1B6A3600A4B87C /* EmbedderEntryPoints */,
 				9E4046511C1B6A3600A4B87C /* PackagerInvoke */,
-				9E4046521C1B6A3600A4B87C /* ScriptSnapshotter */,
 				9E4046531C1B6A3600A4B87C /* SnapshotterInvoke */,
 				9E4046541C1B6A3600A4B87C /* icudtl.dat */,
 			);

--- a/sky/build/sky_precompilation_sdk.gni
+++ b/sky/build/sky_precompilation_sdk.gni
@@ -34,20 +34,6 @@ template("sky_precompilation_sdk") {
     deps = [  snapshotter_target  ]
   }
 
-  script_snapshotter_copy_gen_target_name =
-      target_name + "_copy_script_snapshotter"
-  copy(script_snapshotter_copy_gen_target_name) {
-    script_snapshotter_target = "//sky/tools/sky_snapshot($dart_host_toolchain)"
-    script_snapshotter_directory =
-        get_label_info(script_snapshotter_target, "root_out_dir")
-    script_snapshotter_name = get_label_info(script_snapshotter_target, "name")
-
-    sources = [  "$script_snapshotter_directory/$script_snapshotter_name"  ]
-    outputs = [  "$sdk_dir/$tools_dir/ScriptSnapshotter"  ]
-
-    deps = [  script_snapshotter_target  ]
-  }
-
   copy("embedder_entry_points") {
     sources = [ "//sky/engine/bindings/dart_vm_entry_points.txt" ]
     outputs = [  "$sdk_dir/$tools_dir/EmbedderEntryPoints"  ]
@@ -114,7 +100,6 @@ template("sky_precompilation_sdk") {
   group(target_name) {
     deps = [
       ":$snapshotter_copy_gen_target_name",
-      ":$script_snapshotter_copy_gen_target_name",
       ":embedder_entry_points",
       ":$copy_runner_gen_target_name",
       ":$copy_data_gen_target_name",


### PR DESCRIPTION
We don't need to use an explict version of the script snapshotter that is
packaged with the iOS SDK. Instead, we can rely on the flutter command having a
working snapshotter.