### PR TITLE
Use LayoutUnit to normalize infinity properly

### DIFF
--- a/sky/engine/core/text/Paragraph.cpp
+++ b/sky/engine/core/text/Paragraph.cpp
@@ -87,7 +87,7 @@ void Paragraph::layout(double width)
 {
     FontCachePurgePreventer fontCachePurgePreventer;
 
-    int maxWidth = width;
+    int maxWidth = LayoutUnit(width); // Handles infinity properly.
     int maxHeight = intMaxForLayoutUnit;
     if (m_legacyWidthUsed) {
       maxWidth = std::max(m_minWidth, m_maxWidth);


### PR DESCRIPTION
In the new ParagraphConstraints code path, we weren't converting through
LayoutUnit, so we weren't getting the right overflow behavior for extremely
large double values. This resulted in test/rendering/block_test.dart failing.