### PR TITLE
Remove FNL build configuration

### DIFF
--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -24,10 +24,6 @@ group("sky") {
     deps += [ "//sky/tools/sky_snapshot($dart_host_toolchain)" ]
   }
 
-  if (is_fnl) {
-    deps -= [ "//sky/shell" ]
-  }
-
   if (is_linux || is_android) {
     deps += [ "//sky/shell/platform/mojo" ]
   }

--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -24,14 +24,6 @@ copy("sky_shell") {
     deps = [
       "//sky/shell:shell_struct",
     ]
-  } else if (is_fnl) {
-    sources = [
-      "$root_build_dir/flutter.mojo",
-    ]
-
-    deps = [
-      "//sky/shell/platform/mojo",
-    ]
   } else if (!is_ios) {
     sources = [
       "$root_build_dir/flutter.mojo",

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -410,7 +410,7 @@ if (is_android) {
   sky_precompilation_sdk("shell") {
     sdk_name = "Flutter"
   }
-} else if (is_linux && !is_fnl) {
+} else if (is_linux) {
   executable("shell") {
     output_name = "sky_shell"
 
@@ -500,8 +500,6 @@ if (is_android) {
       ":sky_resources",
     ]
   }
-} else if (is_fnl) {
-  # Nothing fnl specific.
 } else {
   assert(false, "Unsupported platform")
 }

--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -16,8 +16,6 @@ def get_out_dir(args):
         target_dir += 'android_'
     elif args.target_os == 'ios':
         target_dir += 'ios_'
-    elif args.target_os == 'fnl':
-        target_dir += 'fnl_'
 
     if args.simulator:
         target_dir += 'sim_'
@@ -47,7 +45,7 @@ def to_gn_args(args):
     gn_args = {}
 
     gn_args['is_debug'] = args.debug
-    gn_args['is_clang'] = args.clang and args.target_os not in ['android', 'fnl']
+    gn_args['is_clang'] = args.clang and args.target_os not in ['android']
 
 
     ios_target_cpu = 'arm64'
@@ -68,11 +66,6 @@ def to_gn_args(args):
         else:
           # The iOS simulator snapshot is host targetted
           aot = True
-    elif args.target_os == 'fnl':
-      gn_args['target_os'] = 'fnl'
-      gn_args['use_aura'] = False
-      gn_args['use_ozone'] = True
-      aot = False
     else:
       gn_args['use_aura'] = False
       gn_args['use_system_harfbuzz'] = False
@@ -140,7 +133,6 @@ def parse_args(args):
 
   parser.add_argument('--target-os', type=str, choices=['android', 'ios'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')
-  parser.add_argument('--fnl', dest='target_os', action='store_const', const='fnl')
   parser.add_argument('--ios', dest='target_os', action='store_const', const='ios')
   parser.add_argument('--ios-force-armv7', dest='ios_force_armv7', action='store_true', default=False)
   parser.add_argument('--simulator', action='store_true', default=False)


### PR DESCRIPTION
These build definitions no longer work with the current version of FNL. Once
FNL is ready, we'll add new build definitions that work for it again.