### PR TITLE
Don't spin hot in MessagePumpGLFW

### DIFF
--- a/sky/shell/platform/glfw/message_pump_glfw.cc
+++ b/sky/shell/platform/glfw/message_pump_glfw.cc
@@ -48,7 +48,7 @@ void MessagePumpGLFW::Run(Delegate* delegate) {
       continue;
 
     if (delayed_work_time_.is_null()) {
-      glfwPollEvents();
+      glfwWaitEvents();
     } else {
       base::TimeDelta delay = delayed_work_time_ - base::TimeTicks::Now();
       if (delay > base::TimeDelta()) {


### PR DESCRIPTION
When there are no pending timers, we should sit in glfwWaitEvents instead of
continuously calling glfwPollEvents. This reduces CPU utilization
significantly.