### PR TITLE
Remove dependency from //sky/services/platform to //sky/services/activity

### DIFF
--- a/sky/services/platform/BUILD.gn
+++ b/sky/services/platform/BUILD.gn
@@ -30,8 +30,6 @@ if (is_android) {
       "//base:base_java",
       "//mojo/public/java:bindings",
       "//mojo/public/java:system",
-      "//sky/services/activity:activity_lib",
-      "//sky/services/activity:interfaces_java",
       ":interfaces_java",
     ]
   }

--- a/sky/services/platform/src/org/domokit/platform/HapticFeedbackImpl.java
+++ b/sky/services/platform/src/org/domokit/platform/HapticFeedbackImpl.java
@@ -10,12 +10,17 @@ import android.view.View;
 
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.flutter.platform.HapticFeedback;
-import org.domokit.activity.ActivityImpl;
 
 /**
  * Android implementation of HapticFeedback.
  */
 public class HapticFeedbackImpl implements HapticFeedback {
+    private final Activity mActivity;
+
+    public HapticFeedbackImpl(Activity activity) {
+        mActivity = activity;
+    }
+
     @Override
     public void close() {}
 
@@ -24,13 +29,7 @@ public class HapticFeedbackImpl implements HapticFeedback {
 
     @Override
     public void vibrate(VibrateResponse callback) {
-        Activity activity = ActivityImpl.getCurrentActivity();
-        if (activity == null) {
-            callback.call(false);
-            return;
-        }
-
-        View view = activity.getWindow().getDecorView();
+        View view = mActivity.getWindow().getDecorView();
         view.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS);
         callback.call(true);
     }

--- a/sky/services/platform/src/org/domokit/platform/SystemChromeImpl.java
+++ b/sky/services/platform/src/org/domokit/platform/SystemChromeImpl.java
@@ -11,14 +11,18 @@ import android.view.View;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.flutter.platform.DeviceOrientation;
 import org.chromium.mojom.flutter.platform.SystemChrome;
-import org.chromium.mojom.flutter.platform.SystemUiOverlay
-;
-import org.domokit.activity.ActivityImpl;
+import org.chromium.mojom.flutter.platform.SystemUiOverlay;
 
 /**
  * Android implementation of SystemChrome.
  */
 public class SystemChromeImpl implements SystemChrome {
+    private final Activity mActivity;
+
+    public SystemChromeImpl(Activity activity) {
+        mActivity = activity;
+    }
+
     @Override
     public void close() {}
 
@@ -28,12 +32,6 @@ public class SystemChromeImpl implements SystemChrome {
     @Override
     public void setPreferredOrientations(int deviceOrientationMask,
                                          SetPreferredOrientationsResponse callback) {
-        Activity activity = ActivityImpl.getCurrentActivity();
-        if (activity == null) {
-            callback.call(false);
-            return;
-        }
-
         // Currently the Android implementation only supports masks with zero or one
         // selected device orientations.
         int androidOrientation;
@@ -52,19 +50,13 @@ public class SystemChromeImpl implements SystemChrome {
             return;
         }
 
-        activity.setRequestedOrientation(androidOrientation);
+        mActivity.setRequestedOrientation(androidOrientation);
         callback.call(true);
     }
 
     @Override
     public void setEnabledSystemUiOverlays(int overlays,
                                            SetEnabledSystemUiOverlaysResponse callback) {
-        Activity activity = ActivityImpl.getCurrentActivity();
-        if (activity == null) {
-            callback.call(false);
-            return;
-        }
-
         int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                     View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
 
@@ -76,7 +68,7 @@ public class SystemChromeImpl implements SystemChrome {
                      View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
         }
 
-        activity.getWindow().getDecorView().setSystemUiVisibility(flags);
+        mActivity.getWindow().getDecorView().setSystemUiVisibility(flags);
         callback.call(true);
     }
 }

--- a/sky/services/platform/src/org/domokit/platform/SystemSoundImpl.java
+++ b/sky/services/platform/src/org/domokit/platform/SystemSoundImpl.java
@@ -11,12 +11,17 @@ import android.view.View;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.mojom.flutter.platform.SystemSound;
 import org.chromium.mojom.flutter.platform.SystemSoundType;
-import org.domokit.activity.ActivityImpl;
 
 /**
  * Android implementation of SystemSound.
  */
 public class SystemSoundImpl implements SystemSound {
+    private final Activity mActivity;
+
+    public SystemSoundImpl(Activity activity) {
+        mActivity = activity;
+    }
+
     @Override
     public void close() {}
 
@@ -30,13 +35,7 @@ public class SystemSoundImpl implements SystemSound {
             return;
         }
 
-        Activity activity = ActivityImpl.getCurrentActivity();
-        if (activity == null) {
-            callback.call(false);
-            return;
-        }
-
-        View view = activity.getWindow().getDecorView();
+        View view = mActivity.getWindow().getDecorView();
         view.playSoundEffect(SoundEffectConstants.CLICK);
         callback.call(true);
     }

--- a/sky/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/sky/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -176,7 +176,7 @@ public class FlutterMain {
         registry.register(HapticFeedback.MANAGER.getName(), new ServiceFactory() {
             @Override
             public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                HapticFeedback.MANAGER.bind(new HapticFeedbackImpl(), pipe);
+                HapticFeedback.MANAGER.bind(new HapticFeedbackImpl((android.app.Activity) context), pipe);
             }
         });
 
@@ -190,14 +190,14 @@ public class FlutterMain {
         registry.register(SystemChrome.MANAGER.getName(), new ServiceFactory() {
             @Override
             public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                SystemChrome.MANAGER.bind(new SystemChromeImpl(), pipe);
+                SystemChrome.MANAGER.bind(new SystemChromeImpl((android.app.Activity) context), pipe);
             }
         });
 
         registry.register(SystemSound.MANAGER.getName(), new ServiceFactory() {
             @Override
             public void connectToService(Context context, Core core, MessagePipeHandle pipe) {
-                SystemSound.MANAGER.bind(new SystemSoundImpl(), pipe);
+                SystemSound.MANAGER.bind(new SystemSoundImpl((android.app.Activity) context), pipe);
             }
         });
     }


### PR DESCRIPTION
Instead of using a static Activity, we can use the one we get when we construct
the service.