### PR TITLE
Remove GetField calls from compositing upload

### DIFF
--- a/sky/engine/core/compositing/SceneBuilder.h
+++ b/sky/engine/core/compositing/SceneBuilder.h
@@ -36,22 +36,32 @@ public:
     ~SceneBuilder() override;
 
     void pushTransform(const Float64List& matrix4, ExceptionState&);
-    void pushClipRect(const Rect& rect);
+    void pushClipRect(double left, double right, double top, double bottom);
     void pushClipRRect(const RRect& rrect);
     void pushClipPath(const CanvasPath* path);
     void pushOpacity(int alpha);
-    void pushColorFilter(CanvasColor color, TransferMode transferMode);
+    void pushColorFilter(int color, int transferMode);
     void pushBackdropFilter(ImageFilter* filter);
-    void pushShaderMask(Shader* shader, const Rect& maskRect, TransferMode transferMode);
+    void pushShaderMask(Shader* shader,
+                        double maskRectLeft,
+                        double maskRectRight,
+                        double maskRectTop,
+                        double maskRectBottom,
+                        int transferMode);
     void pop();
 
-    void addPerformanceOverlay(uint64_t enabledOptions, const Rect& bounds);
-    void addPicture(const Offset& offset, Picture* picture);
-    void addChildScene(const Offset& offset,
-                       double device_pixel_ratio,
-                       int physical_width,
-                       int physical_height,
-                       uint32_t scene_token);
+    void addPerformanceOverlay(uint64_t enabledOptions,
+                               double left,
+                               double right,
+                               double top,
+                               double bottom);
+    void addPicture(double dx, double dy, Picture* picture);
+    void addChildScene(double dx,
+                       double dy,
+                       double devicePixelRatio,
+                       int physicalWidth,
+                       int physicalHeight,
+                       uint32_t sceneToken);
 
     void setRasterizerTracingThreshold(uint32_t frameInterval);
 

--- a/sky/engine/core/dart/compositing.dart
+++ b/sky/engine/core/dart/compositing.dart
@@ -47,7 +47,13 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// Rasterization outside the given rectangle is discarded.
   ///
   /// See [pop] for details about the operation stack.
-  void pushClipRect(Rect rect) native "SceneBuilder_pushClipRect";
+  void pushClipRect(Rect rect) {
+    _pushClipRect(rect.left, rect.right, rect.top, rect.bottom);
+  }
+  void _pushClipRect(double left,
+                     double right,
+                     double top,
+                     double bottom) native "SceneBuilder_pushClipRect";
 
   /// Pushes a rounded-rectangular clip operation onto the operation stack.
   ///
@@ -79,7 +85,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// transfer mode.
   ///
   /// See [pop] for details about the operation stack.
-  void pushColorFilter(Color color, TransferMode transferMode) native "SceneBuilder_pushColorFilter";
+  void pushColorFilter(Color color, TransferMode transferMode) {
+    _pushColorFilter(color.value, transferMode.index);
+  }
+  void _pushColorFilter(int color, int transferMode) native "SceneBuilder_pushColorFilter";
 
   /// Pushes a backdrop filter operation onto the operation stack.
   ///
@@ -95,7 +104,20 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// rectangle using the given transfer mode.
   ///
   /// See [pop] for details about the operation stack.
-  void pushShaderMask(Shader shader, Rect maskRect, TransferMode transferMode) native "SceneBuilder_pushShaderMask";
+  void pushShaderMask(Shader shader, Rect maskRect, TransferMode transferMode) {
+    _pushShaderMask(shader,
+                    maskRect.left,
+                    maskRect.right,
+                    maskRect.top,
+                    maskRect.bottom,
+                    transferMode.index);
+  }
+  void _pushShaderMask(Shader shader,
+                       double maskRectLeft,
+                       double maskRectRight,
+                       double maskRectTop,
+                       double maskRectBottom,
+                       int transferMode) native "SceneBuilder_pushShaderMask";
 
   /// Ends the effect of the most recently pushed operation.
   ///
@@ -129,12 +151,26 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// See also the [PerformanceOverlayOption] enum in the rendering library.
   /// for more details.
   // Values above must match constants in //engine/src/sky/compositor/performance_overlay_layer.h
-  void addPerformanceOverlay(int enabledOptions, Rect bounds) native "SceneBuilder_addPerformanceOverlay";
+  void addPerformanceOverlay(int enabledOptions, Rect bounds) {
+    _addPerformanceOverlay(enabledOptions,
+                           bounds.left,
+                           bounds.right,
+                           bounds.top,
+                           bounds.bottom);
+  }
+  void _addPerformanceOverlay(int enabledOptions,
+                              double left,
+                              double right,
+                              double top,
+                              double bottom) native "SceneBuilder_addPerformanceOverlay";
 
   /// Adds a [Picture] to the scene.
   ///
   /// The picture is rasterized at the given offset.
-  void addPicture(Offset offset, Picture picture) native "SceneBuilder_addPicture";
+  void addPicture(Offset offset, Picture picture) {
+    _addPicture(offset.dx, offset.dy, picture);
+  }
+  void _addPicture(double dx, double dy, Picture picture) native "SceneBuilder_addPicture";
 
   /// (mojo-only) Adds a scene rendered by another application to the scene for
   /// this application.
@@ -146,7 +182,20 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
                      double devicePixelRatio,
                      int physicalWidth,
                      int physicalHeight,
-                     int sceneToken) native "SceneBuilder_addChildScene";
+                     int sceneToken) {
+    _addChildScene(offset.dx,
+                   offset.dy,
+                   devicePixelRatio,
+                   physicalWidth,
+                   physicalHeight,
+                   sceneToken);
+  }
+  void _addChildScene(double dx,
+                      double dy,
+                      double devicePixelRatio,
+                      int physicalWidth,
+                      int physicalHeight,
+                      int sceneToken) native "SceneBuilder_addChildScene";
 
   /// Sets a threshold after which additional debugging information should be recorded.
   ///


### PR DESCRIPTION
Now we grab the underlying primative values before exiting the VM.