### PR TITLE
Add an android-cpu engine build flag that can select ARM, x86 (32-bit…

### DIFF
--- a/sky/tools/gn
+++ b/sky/tools/gn
@@ -29,6 +29,9 @@ def get_out_dir(args):
     if not args.develop:
         target_dir += '_Deploy'
 
+    if args.android_cpu != 'arm':
+        target_dir += '_' + args.android_cpu
+
     if args.ios_force_armv7:
         target_dir += '_armv7'
 
@@ -46,12 +49,6 @@ def to_gn_args(args):
 
     gn_args['is_debug'] = args.debug
     gn_args['is_clang'] = args.clang and args.target_os not in ['android']
-
-
-    ios_target_cpu = 'arm64'
-    if args.ios_force_armv7:
-      ios_target_cpu = 'arm'
-      pass
 
     if args.target_os == 'android':
         gn_args['target_os'] = 'android'
@@ -71,16 +68,15 @@ def to_gn_args(args):
       gn_args['use_system_harfbuzz'] = False
       aot = False
 
-    if args.target_os in ['android', 'ios'] and not args.simulator:
-      if args.target_os == 'ios':
-        # iOS defaults to arm64 builds unless forced to build armv7. This
-        # flag will go away once universal builds are supported
-        gn_args['target_cpu'] = ios_target_cpu
-      else:
-        # There are currently no arm64 Android builds
-        gn_args['target_cpu'] = 'arm'
-    else:
-        gn_args['target_cpu'] = 'x64'
+    if args.target_os == 'android':
+        gn_args['target_cpu'] = args.android_cpu
+    elif args.target_os == 'ios':
+        if args.simulator:
+            gn_args['target_cpu'] = 'x64'
+        elif args.ios_force_armv7:
+            gn_args['target_cpu'] = 'arm'
+        else:
+            gn_args['target_cpu'] = 'arm64'
 
     gn_args['flutter_aot'] = aot
     if aot:
@@ -133,6 +129,7 @@ def parse_args(args):
 
   parser.add_argument('--target-os', type=str, choices=['android', 'ios'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')
+  parser.add_argument('--android-cpu', type=str, choices=['arm', 'x64', 'x86'], default='arm')
   parser.add_argument('--ios', dest='target_os', action='store_const', const='ios')
   parser.add_argument('--ios-force-armv7', dest='ios_force_armv7', action='store_true', default=False)
   parser.add_argument('--simulator', action='store_true', default=False)


### PR DESCRIPTION
…), and x64 targets

Remove the use of --simulator to indicate x64 on Android