### PR TITLE
Look inside the main bundle for the service definitions manifest.

### DIFF
--- a/sky/shell/platform/ios/framework/Source/FlutterDynamicServiceLoader.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterDynamicServiceLoader.mm
@@ -121,9 +121,9 @@
 }
 
 - (void)populateServiceDefinitions {
-  NSString* definitionsPath = [[NSBundle bundleForClass:[self class]]
-      pathForResource:@"ServiceDefinitions"
-               ofType:@"json"];
+  NSString* definitionsPath =
+      [[NSBundle mainBundle] pathForResource:@"ServiceDefinitions"
+                                      ofType:@"json"];
 
   if (definitionsPath.length == 0) {
     LOG(INFO) << "Could not find the service definitions manifest. No custom "


### PR DESCRIPTION
Earlier, the dynamic service loader was part of the main application
bundle. But now, we package it into Flutter.framework and let the user
control "main". The old path was looking for the manifest in the wrong
spot.