### PR TITLE
Additional instrumentation for tracing engine performance

### DIFF
--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -15,6 +15,7 @@ BackdropFilterLayer::~BackdropFilterLayer() {
 }
 
 void BackdropFilterLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "BackdropFilterLayer::Paint");
   SkAutoCanvasRestore save(&context.canvas, false);
   context.canvas.saveLayer(SkCanvas::SaveLayerRec{
       &paint_bounds(), nullptr, filter_.get(), 0});

--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -25,6 +25,7 @@ void ChildSceneLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 }
 
 void ChildSceneLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "ChildSceneLayer::Paint");
 }
 
 void ChildSceneLayer::UpdateScene(mojo::gfx::composition::SceneUpdate* update,

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -20,6 +20,7 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 }
 
 void ClipPathLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "ClipPathLayer::Paint");
   SkAutoCanvasRestore save(&context.canvas, false);
   context.canvas.saveLayer(&paint_bounds(), nullptr);
   context.canvas.clipPath(clip_path_);

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -20,6 +20,7 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 }
 
 void ClipRectLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "ClipRectLayer::Paint");
   SkAutoCanvasRestore save(&context.canvas, true);
   context.canvas.clipRect(paint_bounds());
   PaintChildren(context);

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -20,6 +20,7 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 }
 
 void ClipRRectLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "ClipRRectLayer::Paint");
   SkAutoCanvasRestore save(&context.canvas, false);
   context.canvas.saveLayer(&paint_bounds(), nullptr);
   context.canvas.clipRRect(clip_rrect_);

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -13,6 +13,7 @@ ColorFilterLayer::~ColorFilterLayer() {
 }
 
 void ColorFilterLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "ColorFilterLayer::Paint");
   sk_sp<SkColorFilter> color_filter =
       SkColorFilter::MakeModeFilter(color_, transfer_mode_);
   SkPaint paint;

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -18,6 +18,7 @@ void ContainerLayer::Add(std::unique_ptr<Layer> layer) {
 }
 
 void ContainerLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  TRACE_EVENT0("flutter", "ContainerLayer::Preroll");
   PrerollChildren(context, matrix);
   set_paint_bounds(context->child_paint_bounds);
 }
@@ -34,6 +35,7 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
 }
 
 void ContainerLayer::PaintChildren(PaintContext& context) const {
+  TRACE_EVENT0("flutter", "ContainerLayer::PaintChildren");
   for (auto& layer : layers_)
     layer->Paint(context);
 }

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -10,6 +10,7 @@
 
 #include "base/logging.h"
 #include "base/macros.h"
+#include "base/trace_event/trace_event.h"
 #include "flow/instrumentation.h"
 #include "flow/raster_cache.h"
 #include "skia/ext/refptr.h"

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -13,6 +13,7 @@ OpacityLayer::~OpacityLayer() {
 }
 
 void OpacityLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "OpacityLayer::Paint");
   SkPaint paint;
   paint.setAlpha(alpha_);
 

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -68,6 +68,7 @@ void PerformanceOverlayLayer::Paint(PaintContext& context) {
   if (!options_)
     return;
 
+  TRACE_EVENT0("flutter", "PerformanceOverlayLayer::Paint");
   SkScalar x = paint_bounds().x();
   SkScalar y = paint_bounds().y();
   SkScalar width = paint_bounds().width();

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -29,6 +29,7 @@ void PictureLayer::Preroll(PrerollContext* context,
 
 void PictureLayer::Paint(PaintContext& context) {
   DCHECK(picture_);
+  TRACE_EVENT0("flutter", "PictureLayer::Paint");
 
   if (image_) {
     SkRect rect = picture_->cullRect().makeOffset(offset_.x(), offset_.y());

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -29,15 +29,16 @@ void PictureLayer::Preroll(PrerollContext* context,
 
 void PictureLayer::Paint(PaintContext& context) {
   DCHECK(picture_);
-  TRACE_EVENT0("flutter", "PictureLayer::Paint");
 
   if (image_) {
+    TRACE_EVENT1("flutter", "PictureLayer::Paint", "image", "prerolled");
     SkRect rect = picture_->cullRect().makeOffset(offset_.x(), offset_.y());
     context.canvas.drawImageRect(image_.get(), rect, nullptr,
                                  SkCanvas::kFast_SrcRectConstraint);
     if (kDebugCheckerboardRasterizedLayers)
       DrawCheckerboard(&context.canvas, rect);
   } else {
+    TRACE_EVENT1("flutter", "PictureLayer::Paint", "image", "normal");
     SkAutoCanvasRestore save(&context.canvas, true);
     context.canvas.translate(offset_.x(), offset_.y());
     context.canvas.drawPicture(picture_.get());

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -13,6 +13,7 @@ ShaderMaskLayer::~ShaderMaskLayer() {
 }
 
 void ShaderMaskLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "ShaderMaskLayer::Paint");
   SkAutoCanvasRestore save(&context.canvas, false);
   context.canvas.saveLayer(&paint_bounds(), nullptr);
   PaintChildren(context);

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -20,6 +20,7 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 }
 
 void TransformLayer::Paint(PaintContext& context) {
+  TRACE_EVENT0("flutter", "TransformLayer::Paint");
   SkAutoCanvasRestore save(&context.canvas, true);
   context.canvas.concat(transform_);
   PaintChildren(context);


### PR DESCRIPTION
Added reporting for Paint() calls to event tracing in all layer types.  This gives better visibility into what's happening within RasterizerDirect::Draw().