### PR TITLE
Initial take at a native unit test harness.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -15,6 +15,12 @@ group("default") {
       "//sky/shell:flutter_framework",
     ]
   }
+
+  if (is_mac) {
+    deps += [
+      "//sky/shell:shell_test",
+    ]
+  }
 }
 
 group("dist") {

--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -50,3 +50,23 @@ group("sky") {
     deps += [ "//third_party/google_sign_in" ]
   }
 }
+
+source_set("sky_test") {
+  testonly = true
+
+  sources = [
+    "test/run_all_tests.cc",
+    "test/test_suite.cc",
+    "test/test_suite.h",
+  ]
+
+  deps = [
+    "//base/test:test_support",
+  ]
+
+  if (is_mac) {
+    deps += [
+      "//sky/shell:mac_scaffolding",
+    ]
+  }
+}

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("//build/config/ui.gni")
 import("//mojo/dart/embedder/embedder.gni")
+import("//testing/test.gni")
 
 dart_embedder_resources("generate_sky_embedder_diagnostic_server_resources_cc") {
   inputs = [
@@ -434,7 +435,6 @@ if (is_android) {
 
   source_set("mac_scaffolding") {
     sources = [
-      "platform/mac/main_mac.mm",
       "platform/mac/platform_mac.h",
       "platform/mac/platform_mac.mm",
       "platform/mac/platform_service_provider.cc",
@@ -463,6 +463,18 @@ if (is_android) {
     ]
   }
 
+  source_set("mac_entry") {
+    sources = [
+      "platform/mac/main_mac.mm",
+    ]
+
+    deps = [
+      ":common",
+      ":mac_scaffolding",
+      ":testing",
+    ]
+  }
+
   mac_app("shell") {
     app_name = "SkyShell"
     info_plist = "platform/mac/Info.plist"
@@ -477,10 +489,21 @@ if (is_android) {
     }
 
     deps = [
+      ":mac_entry",
       ":mac_scaffolding",
       ":sky_resources",
     ]
   }
 } else {
   assert(false, "Unsupported platform")
+}
+
+test("shell_test") {
+  sources = [
+    "shell_test.cc",
+  ]
+
+  deps = [
+    "//sky:sky_test",
+  ]
 }

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -143,6 +143,10 @@ void Shell::InitStandalone(std::string icu_data_path) {
   Init();
 }
 
+bool Shell::IsInitialized() {
+  return g_shell != nullptr;
+}
+
 void Shell::Init() {
   base::DiscardableMemoryAllocator::SetInstance(&g_discardable.Get());
   DCHECK(!g_shell);

--- a/sky/shell/shell.h
+++ b/sky/shell/shell.h
@@ -27,6 +27,8 @@ class Shell {
   // Init the shell to run inside MojoShell.
   static void Init();
 
+  static bool IsInitialized();
+
   static Shell& Shared();
 
   base::SingleThreadTaskRunner* gpu_task_runner() const {

--- a/sky/shell/shell_test.cc
+++ b/sky/shell/shell_test.cc
@@ -1,0 +1,11 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "shell.h"
+#include "gtest/gtest.h"
+
+TEST(ShellTest, SimpleInitialization) {
+  // The embedder must initialize the shell for us.
+  ASSERT_TRUE(sky::shell::Shell::IsInitialized());
+}

--- a/sky/test/run_all_tests.cc
+++ b/sky/test/run_all_tests.cc
@@ -1,0 +1,16 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/test/launcher/unit_test_launcher.h"
+
+#include "test_suite.h"
+
+int RunFlutterTestSuite(int argc, char** argv) {
+  return flutter::test::TestSuite(argc, argv).Run();
+}
+
+int main(int argc, char** argv) {
+  return base::LaunchUnitTestsSerially(
+      argc, argv, base::Bind(&RunFlutterTestSuite, argc, argv));
+}

--- a/sky/test/test_suite.cc
+++ b/sky/test/test_suite.cc
@@ -1,0 +1,28 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "build/build_config.h"
+#include "sky/test/test_suite.h"
+
+#if defined(OS_MACOSX) && !defined(OS_IOS)
+#include "sky/shell/platform/mac/platform_mac.h"
+#endif
+
+namespace flutter {
+namespace test {
+
+TestSuite::TestSuite(int argc, char** argv) : base::TestSuite(argc, argv) {}
+
+TestSuite::~TestSuite() {}
+
+void TestSuite::Initialize() {
+#if defined(OS_MACOSX) && !defined(OS_IOS)
+  sky::shell::PlatformMacMain(0, NULL, "");
+#endif
+}
+
+void TestSuite::Shutdown() {}
+
+}  // namespace test
+}  // namespace flutter

--- a/sky/test/test_suite.h
+++ b/sky/test/test_suite.h
@@ -1,0 +1,31 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SRC_SKY_TEST_FLUTTER_TEST_SUITE_H_
+#define SRC_SKY_TEST_FLUTTER_TEST_SUITE_H_
+
+#include "base/macros.h"
+#include "base/test/test_suite.h"
+
+namespace flutter {
+namespace test {
+
+class TestSuite : public base::TestSuite {
+ public:
+  TestSuite(int argc, char** argv);
+
+  ~TestSuite() override;
+
+ private:
+  void Initialize() override;
+
+  void Shutdown() override;
+
+  DISALLOW_COPY_AND_ASSIGN(TestSuite);
+};
+
+}  // namespace test
+}  // namespace flutter
+
+#endif  // SRC_SKY_TEST_FLUTTER_TEST_SUITE_H_


### PR DESCRIPTION
Steps to add a unit test target:

* Create a target using the "test" template in "testing/test.gni"
* Add your test files as sources to this target.
* Add the "//sky:sky_test" target as a dep.
* Depend on the new target from somewhere (usually root BUILD.gn)

cc @jason-simmons, @abarth 