### PR TITLE
Add a switch that disables redirecting standard streams to syslog.

### DIFF
--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/xcshareddata/xcschemes/Application.xcscheme
@@ -63,6 +63,10 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
+            argument = "--no-redirect-to-syslog"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--observatory-port=8181"
             isEnabled = "YES">
          </CommandLineArgument>

--- a/sky/shell/platform/mac/platform_mac.mm
+++ b/sky/shell/platform/mac/platform_mac.mm
@@ -39,6 +39,11 @@ static void InitializeLogging() {
 
 static void RedirectIOConnectionsToSyslog() {
 #if TARGET_OS_IPHONE
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          sky::shell::switches::kNoRedirectToSyslog)) {
+    return;
+  }
+
   asl_log_descriptor(NULL, NULL, ASL_LEVEL_INFO, STDOUT_FILENO,
                      ASL_LOG_DESCRIPTOR_WRITE);
   asl_log_descriptor(NULL, NULL, ASL_LEVEL_NOTICE, STDERR_FILENO,
@@ -52,9 +57,9 @@ class EmbedderState {
     CHECK([NSThread isMainThread])
         << "Embedder initialization must occur on the main platform thread";
 
-    RedirectIOConnectionsToSyslog();
-
     base::CommandLine::Init(argc, argv);
+
+    RedirectIOConnectionsToSyslog();
 
     InitializeLogging();
 

--- a/sky/shell/switches.cc
+++ b/sky/shell/switches.cc
@@ -20,6 +20,7 @@ const char kStartPaused[] = "start-paused";
 const char kTraceStartup[] = "trace-startup";
 const char kDeviceObservatoryPort[] = "observatory-port";
 const char kAotSnapshotPath[] = "aot-snapshot-path";
+const char kNoRedirectToSyslog[] = "no-redirect-to-syslog";
 
 void PrintUsage(const std::string& executable_name) {
   std::cerr << "Usage: " << executable_name

--- a/sky/shell/switches.h
+++ b/sky/shell/switches.h
@@ -21,6 +21,7 @@ extern const char kStartPaused[];
 extern const char kTraceStartup[];
 extern const char kDeviceObservatoryPort[];
 extern const char kAotSnapshotPath[];
+extern const char kNoRedirectToSyslog[];
 
 void PrintUsage(const std::string& executable_name);
 


### PR DESCRIPTION
When developing the engine from Xcode, it is useful to see log output in Xcode's UI. We were redirecting streams away so that the tools could pick read these logs. With the change to the scheme, when running from Xcode, the logs will show up in Xcode's UI. When, running from the tools, that flag will not be present and the tools will work as they always have.