### PR TITLE
Instead of depending on a potentially missing Interpreter.xcconfig, add the variable to Flutter.xcconfig.

### DIFF
--- a/sky/build/sdk_xcode_harness/Flutter.xcconfig.tmpl
+++ b/sky/build/sdk_xcode_harness/Flutter.xcconfig.tmpl
@@ -4,8 +4,5 @@
 
 #include "Local.xcconfig"
 
-// This file only exists in case the embedder VM supports the interpreter on the
-// device. If this file is not present, it is not an error.
-#include "Interpreter.xcconfig"
-
 FLUTTER_ARCH_TOOLS_PATH=${SOURCE_ROOT}/Tools/${PLATFORM_NAME}
+DART_EXPERIMENTAL_INTERPRETER={{ interpreter }}

--- a/sky/build/sdk_xcode_harness/Interpreter.xcconfig
+++ b/sky/build/sdk_xcode_harness/Interpreter.xcconfig
@@ -1,5 +1,0 @@
-// Copyright 2016 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-DART_EXPERIMENTAL_INTERPRETER=1

--- a/sky/build/sky_precompilation_sdk.gni
+++ b/sky/build/sky_precompilation_sdk.gni
@@ -4,6 +4,7 @@
 
 import("//build/config/templates/templates.gni")
 import("//sky/engine/bindings/bindings.gni")
+import("//sky/build/template.gni")
 
 template("sky_precompilation_sdk") {
   assert(is_ios, "The precompilation SDK is only supported for iOS targets")
@@ -68,20 +69,29 @@ template("sky_precompilation_sdk") {
 
   copy("copy_sdk_xcode_harness") {
     sources = [
-      "//sky/build/sdk_xcode_harness/Flutter.xcconfig",
       "//sky/build/sdk_xcode_harness/FlutterApplication",
       "//sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj",
       "//sky/build/sdk_xcode_harness/Local.xcconfig",
       "//sky/build/sdk_xcode_harness/Runner",
     ]
 
-    if (dart_experimental_interpreter) {
-      sources += [
-        "//sky/build/sdk_xcode_harness/Interpreter.xcconfig",
-      ]
-    }
-
     outputs = [  "$sdk_dir/{{source_file_part}}"  ]
+  }
+
+  render_template("flutter_xcconfig") {
+    template = "//sky/build/sdk_xcode_harness/Flutter.xcconfig.tmpl"
+    output = "$sdk_dir/Flutter.xcconfig"
+    stamp_file = "$root_build_dir/expand_flutter_xcconfig.stamp"
+
+    variables = [
+      "interpreter"
+    ]
+
+    if (dart_experimental_interpreter) {
+      variables += [ "1" ]
+    } else {
+      variables += [ "0" ]
+    }
   }
 
   # All user editable files are copied to the out directory so that developers
@@ -97,12 +107,13 @@ template("sky_precompilation_sdk") {
 
   group(target_name) {
     deps = [
-      ":copy_snapshotter",
       ":copy_flutter_framework",
-      ":embedder_entry_points",
-      ":precompilation_xcode_scripts",
       ":copy_sdk_xcode_harness",
+      ":copy_snapshotter",
       ":copy_user_editable_files",
+      ":embedder_entry_points",
+      ":flutter_xcconfig",
+      ":precompilation_xcode_scripts",
     ]
   }
 }

--- a/sky/build/template.gni
+++ b/sky/build/template.gni
@@ -1,0 +1,38 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# A GN template used to process a Jinj2 template file.
+template("render_template") {
+  set_sources_assignment_filter([])
+
+  assert(defined(invoker.template), "The template file to render.")
+  assert(defined(invoker.output), "The output of template expansion.")
+  assert(defined(invoker.variables), "The list of template variables.")
+  assert(defined(invoker.stamp_file), "The stamp file.")
+
+  action(target_name) {
+    if(defined(invoker.visibility)) {
+      visibility = invoker.visibility
+    }
+
+    script = "//sky/build/template.py"
+
+    sources = [ invoker.template ]
+    outputs = [
+      invoker.output,
+      invoker.stamp_file,
+    ]
+
+    args = [
+      "--template",
+      rebase_path(invoker.template, root_build_dir),
+      "--output",
+      rebase_path(invoker.output, root_build_dir),
+      "--stamp",
+      rebase_path(invoker.stamp_file, root_build_dir),
+    ]
+
+    args += invoker.variables
+  }
+}

--- a/sky/build/template.py
+++ b/sky/build/template.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+#
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+'''Renders a single template file using the Jinga templating engine.'''
+
+import argparse
+import sys
+import os
+import itertools
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '../../../third_party'))
+import jinja2
+from jinja2 import Environment, FileSystemLoader
+
+
+def make_stamp_file(stamp_path):
+  dir_name = os.path.dirname(stamp_path)
+
+  with open(stamp_path, 'a'):
+    os.utime(stamp_path, None)
+
+
+def main():
+  parser = argparse.ArgumentParser(description=__doc__)
+  
+  parser.add_argument('--template', help='The template file to render')
+  parser.add_argument('--stamp', help='The template stamp file')
+  parser.add_argument('--output',
+                      help='The output file to render the template to')
+  parser.add_argument('vars', metavar='V', nargs='+',
+                      help='A list of key value pairs used as template args')
+
+  args = parser.parse_args()
+
+  template_file = os.path.abspath(args.template)
+
+  if not os.path.isfile(template_file):
+    print 'Cannot find file at path: ', template_file
+    return 1
+
+  env = jinja2.Environment(loader=FileSystemLoader('/'),
+                           undefined=jinja2.StrictUndefined)
+
+  template = env.get_template(template_file)
+
+  variables = dict(itertools.izip_longest(*[iter(args.vars)] * 2, fillvalue=''))
+
+  output = template.render(variables)
+
+  with open(os.path.abspath(args.output), 'wb') as file:
+    file.write(output)
+
+  make_stamp_file(args.stamp)
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
I thought I was being clever by depending on a Interpreter.xcconfig that would be missing in AOTC modes. However, Xcode was caching this variable and would use the wrong settings while I was iterating on the engine. This makes the change explicit and also adds a stamp file.

I could not use the jinja2 template expansion because it was in the android directory and included a lot of more advanced options that were not necessary for a simple template expansion.