### PR TITLE
Don't call Dart_TimelineGetMicros during startup on Mac

### DIFF
--- a/sky/shell/platform/mac/platform_mac.mm
+++ b/sky/shell/platform/mac/platform_mac.mm
@@ -56,7 +56,11 @@ static void RedirectIOConnectionsToSyslog() {
 class EmbedderState {
  public:
   EmbedderState(int argc, const char* argv[], std::string icu_data_path) {
+#if TARGET_OS_IPHONE
+    // This calls crashes on MacOS because we haven't run Dart_Initialize yet.
+    // See https://github.com/flutter/flutter/issues/4006
     blink::engine_main_enter_ts = Dart_TimelineGetMicros();
+#endif
     CHECK([NSThread isMainThread])
         << "Embedder initialization must occur on the main platform thread";
 


### PR DESCRIPTION
It crashes. We either need to make it safe to call before
Dart_Initialize on Mac or we need to use some other way of measuring
startup time.

Fixes #4006