### PR TITLE
Pass the dart io entry points to gen_snapshot so that we don't tree shake away the code

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -25,7 +25,7 @@ vars = {
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
-  'dart_revision': '4653729898189cc6563a15632a531997b81376f0',
+  'dart_revision': '78c82d5a0cf46480f99441f207b5e417184c8c8e',
   'dart_boringssl_revision': 'daeafc22c66ad48f6b32fc8d3362eb9ba31b774e',
   'dart_observatory_packages_revision': 'cf90eb9077177d3d6b3fd5e8289477c2385c026a',
   'dart_root_certificates_revision': 'aed07942ce98507d2be28cbd29e879525410c7fc',

--- a/sky/engine/bindings/bindings.gni
+++ b/sky/engine/bindings/bindings.gni
@@ -52,11 +52,14 @@ template("dart_precompile") {
       "//dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
       "//sky/engine/bindings:generate_dart_ui"
     ]
+    dart_io_entry_points_manifest =
+        "//dart/runtime/bin/dart_io_entries.txt"
     embedder_entry_points_manifest =
         "//sky/engine/bindings/dart_vm_entry_points.txt"
     inputs = [
       "//dart/runtime/tools/create_snapshot_bin.py",
       "//sky/engine/bindings/internals.dart",
+      dart_io_entry_points_manifest,
       embedder_entry_points_manifest,
     ] + rebase_path(dart_mojo_internal_sdk_sources,
                     "",
@@ -94,6 +97,8 @@ template("dart_precompile") {
       rebase_path(assembly_path, root_build_dir),
       "--embedder_entry_points_manifest",
       rebase_path(embedder_entry_points_manifest, root_build_dir),
+      "--embedder_entry_points_manifest",
+      rebase_path(dart_io_entry_points_manifest, root_build_dir),
       "--target_os",
       target_os,
       "--url_mapping=dart:mojo.internal,$dart_mojo_internal_path",


### PR DESCRIPTION
- [x] Roll the runtime forward
- [x] Wire up the Dart IO entry points to gen_snapshot.

Fixes https://github.com/flutter/flutter/issues/4131

@jason-simmons @rmacnak-google 

