### PR TITLE
Fix permissions for BuildFlutterApp

### DIFF
--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "${SOURCE_ROOT}/Tools/common/BuildFlutterApp ${FLUTTER_APPLICATION_PATH}";
+			shellScript = "/bin/sh ${SOURCE_ROOT}/Tools/common/BuildFlutterApp ${FLUTTER_APPLICATION_PATH}";
 		};
 		9E046CD71C9CA1AC00A1E391 /* Copy Extra Assets */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
Instead of trying to execute the script directly, use /bin/sh to execute the
script.