### PR TITLE
Remove ContainerLayer::paintChildren trace per @abarth

### DIFF
--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -35,7 +35,8 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
 }
 
 void ContainerLayer::PaintChildren(PaintContext& context) const {
-  TRACE_EVENT0("flutter", "ContainerLayer::PaintChildren");
+  // Intentionally not tracing here as there should be no self-time
+  // and the trace event on this common function has a small overhead.
   for (auto& layer : layers_)
     layer->Paint(context);
 }


### PR DESCRIPTION
Turns out this path is very common and even the small overhead from tracing isn't worth spending on this function.