### PR TITLE
Do not convert the package map to an absolute path

### DIFF
--- a/sky/tools/sky_snapshot/loader.cc
+++ b/sky/tools/sky_snapshot/loader.cc
@@ -88,7 +88,7 @@ Loader::Loader() {
 }
 
 void Loader::LoadPackagesMap(const base::FilePath& packages) {
-  packages_ = base::MakeAbsoluteFilePath(packages);
+  packages_ = packages;
   dependencies_.insert(packages_.AsUTF8Unsafe());
   std::string packages_source;
   if (!base::ReadFileToString(packages_, &packages_source)) {


### PR DESCRIPTION
Package map entries can contain relative paths, and these paths will be based
on the package map path as originally specified