### PR TITLE
Remove app.so and app.flx from the output paths of the `BuildFlutterApp` phase

### DIFF
--- a/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
+++ b/sky/build/sdk_xcode_harness/FlutterApplication.xcodeproj/project.pbxproj
@@ -210,8 +210,6 @@
 			inputPaths = (
 			);
 			outputPaths = (
-				"$(SOURCE_ROOT)/FlutterApplication/Generated/app.so",
-				"$(SOURCE_ROOT)/FlutterApplication/Generated/app.flx",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
The Dart sources the pubspec are missing from the list of output paths. These artifacts can easily become stale.