### PR TITLE
Implement a protocol for discovering active Flutter instances on Android

### DIFF
--- a/sky/engine/core/script/dart_service_isolate.cc
+++ b/sky/engine/core/script/dart_service_isolate.cc
@@ -7,6 +7,7 @@
 #include "base/logging.h"
 #include "dart/runtime/include/dart_api.h"
 #include "sky/engine/core/script/embedder_resources.h"
+#include "sky/engine/tonic/dart_converter.h"
 #include "sky/engine/tonic/dart_error.h"
 #include "sky/engine/tonic/dart_library_natives.h"
 
@@ -38,6 +39,7 @@ namespace {
 static Dart_LibraryTagHandler g_embedder_tag_handler;
 static DartLibraryNatives* g_natives;
 static EmbedderResources* g_resources;
+static int observatory_port_;
 
 Dart_NativeFunction GetNativeFunction(Dart_Handle name,
                                       int argument_count,
@@ -61,7 +63,15 @@ void DartServiceIsolate::TriggerResourceLoad(Dart_NativeArguments args) {
 }
 
 void DartServiceIsolate::NotifyServerState(Dart_NativeArguments args) {
-  // NO-OP.
+  Dart_Handle exception = nullptr;
+  int port = DartConverter<int>::FromArguments(args, 1, exception);
+  if (!exception) {
+    observatory_port_ = port;
+  }
+}
+
+int DartServiceIsolate::GetObservatoryPort() {
+  return observatory_port_;
 }
 
 void DartServiceIsolate::Shutdown(Dart_NativeArguments args) {

--- a/sky/engine/core/script/dart_service_isolate.h
+++ b/sky/engine/core/script/dart_service_isolate.h
@@ -21,6 +21,8 @@ class DartServiceIsolate {
                       bool running_precompiled,
                       char** error);
 
+  static int GetObservatoryPort();
+
  private:
   // Native entries.
   static void TriggerResourceLoad(Dart_NativeArguments args);

--- a/sky/shell/platform/android/platform_view_android.cc
+++ b/sky/shell/platform/android/platform_view_android.cc
@@ -11,6 +11,7 @@
 #include "base/bind.h"
 #include "base/location.h"
 #include "jni/FlutterView_jni.h"
+#include "sky/engine/core/script/dart_service_isolate.h"
 #include "sky/shell/gpu/direct/surface_notifications_direct.h"
 #include "sky/shell/shell.h"
 #include "sky/shell/shell_view.h"
@@ -26,6 +27,10 @@ static jlong Attach(JNIEnv* env, jclass clazz, jint skyEngineHandle) {
       mojo::InterfaceRequest<SkyEngine>(mojo::ScopedMessagePipeHandle(
           mojo::MessagePipeHandle(skyEngineHandle))));
   return reinterpret_cast<jlong>(shell_view->view());
+}
+
+jint GetObservatoryPort(JNIEnv* env, jclass clazz) {
+  return blink::DartServiceIsolate::GetObservatoryPort();
 }
 
 // static


### PR DESCRIPTION
Tools can send a broadcast intent that will cause Flutter processes to write their names and observatory ports to the log in JSON format.