### PR TITLE
FlutterViewController should not retain listeners

### DIFF
--- a/sky/shell/platform/ios/framework/Headers/FlutterAsyncMessageListener.h
+++ b/sky/shell/platform/ios/framework/Headers/FlutterAsyncMessageListener.h
@@ -15,6 +15,8 @@ FLUTTER_EXPORT
 - (void)didReceiveString:(NSString*)message
                 callback:(void(^)(NSString*))sendResponse;
 
+@property(readonly, strong, nonatomic) NSString* messageName;
+
 @end
 
 #endif  // FLUTTER_FLUTTERASYNCMESSAGELISTENER_H_

--- a/sky/shell/platform/ios/framework/Headers/FlutterMessageListener.h
+++ b/sky/shell/platform/ios/framework/Headers/FlutterMessageListener.h
@@ -14,6 +14,8 @@ FLUTTER_EXPORT
 
 - (NSString*)didReceiveString:(NSString*)message;
 
+@property(readonly, strong, nonatomic) NSString* messageName;
+
 @end
 
 #endif  // FLUTTER_FLUTTERMESSAGELISTENER_H_

--- a/sky/shell/platform/ios/framework/Headers/FlutterViewController.h
+++ b/sky/shell/platform/ios/framework/Headers/FlutterViewController.h
@@ -28,11 +28,13 @@ FLUTTER_EXPORT
    withMessageName:(NSString*)messageName
           callback:(void(^)(NSString*))callback;
 
-- (void)setMessageListener:(NSObject<FlutterMessageListener>*)listener
-       forMessagesWithName:(NSString*)messageName;
+- (void)addMessageListener:(NSObject<FlutterMessageListener>*)listener;
 
-- (void)setAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener
-            forMessagesWithName:(NSString*)messageName;
+- (void)removeMessageListener:(NSObject<FlutterMessageListener>*)listener;
+
+- (void)addAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener;
+
+- (void)removeAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener;
 
 @end
 

--- a/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
@@ -483,20 +483,32 @@ static inline PointerTypeMapperPhase PointerTypePhaseFromUITouchPhase(
   });
 }
 
-- (void)setMessageListener:(NSObject<FlutterMessageListener>*)listener
-       forMessagesWithName:(NSString*)messageName {
+- (void)addMessageListener:(NSObject<FlutterMessageListener>*)listener {
   NSAssert(listener, @"The listener must not be null");
+  NSString* messageName = listener.messageName;
   NSAssert(messageName, @"The messageName must not be null");
-  _appMessageReceiver.SetMessageListener(messageName.UTF8String,
-      base::scoped_nsprotocol<NSObject<FlutterMessageListener>*>(listener));
+  _appMessageReceiver.SetMessageListener(messageName.UTF8String, listener);
 }
 
-- (void)setAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener
-            forMessagesWithName:(NSString*)messageName {
+- (void)removeMessageListener:(NSObject<FlutterMessageListener>*)listener {
   NSAssert(listener, @"The listener must not be null");
+  NSString* messageName = listener.messageName;
   NSAssert(messageName, @"The messageName must not be null");
-  _appMessageReceiver.SetAsyncMessageListener(messageName.UTF8String,
-      base::scoped_nsprotocol<NSObject<FlutterAsyncMessageListener>*>(listener));
+  _appMessageReceiver.SetMessageListener(messageName.UTF8String, nil);
+}
+
+- (void)addAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener {
+  NSAssert(listener, @"The listener must not be null");
+  NSString* messageName = listener.messageName;
+  NSAssert(messageName, @"The messageName must not be null");
+  _appMessageReceiver.SetAsyncMessageListener(messageName.UTF8String, listener);
+}
+
+- (void)removeAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener {
+  NSAssert(listener, @"The listener must not be null");
+  NSString* messageName = listener.messageName;
+  NSAssert(messageName, @"The messageName must not be null");
+  _appMessageReceiver.SetAsyncMessageListener(messageName.UTF8String, nil);
 }
 
 @end

--- a/sky/shell/platform/ios/framework/Source/application_messages_impl.h
+++ b/sky/shell/platform/ios/framework/Source/application_messages_impl.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 
 #include "base/memory/weak_ptr.h"
-#include "base/mac/scoped_nsobject.h"
 #include "mojo/common/binding_set.h"
 #include "sky/services/platform/app_messages.mojom.h"
 #include "sky/shell/platform/ios/framework/Headers/FlutterAsyncMessageListener.h"
@@ -27,11 +26,11 @@ class ApplicationMessagesImpl : public flutter::platform::ApplicationMessages {
 
   void SetMessageListener(
       const std::string& message_name,
-      base::scoped_nsprotocol<NSObject<FlutterMessageListener>*> listener);
+      NSObject<FlutterMessageListener>* listener);
 
   void SetAsyncMessageListener(
       const std::string& message_name,
-      base::scoped_nsprotocol<NSObject<FlutterAsyncMessageListener>*> listener);
+      NSObject<FlutterAsyncMessageListener>* listener);
 
  private:
   void SendString(const mojo::String& message_name,
@@ -40,11 +39,9 @@ class ApplicationMessagesImpl : public flutter::platform::ApplicationMessages {
 
   mojo::BindingSet<flutter::platform::ApplicationMessages> binding_;
   std::unordered_map<
-      std::string,
-      base::scoped_nsprotocol<NSObject<FlutterMessageListener>*>> listeners_;
+      std::string, NSObject<FlutterMessageListener>*> listeners_;
   std::unordered_map<
-      std::string,
-      base::scoped_nsprotocol<NSObject<FlutterAsyncMessageListener>*>> async_listeners_;
+      std::string, NSObject<FlutterAsyncMessageListener>*> async_listeners_;
 
   base::WeakPtrFactory<ApplicationMessagesImpl> weak_factory_;
 };

--- a/sky/shell/platform/ios/framework/Source/application_messages_impl.mm
+++ b/sky/shell/platform/ios/framework/Source/application_messages_impl.mm
@@ -26,14 +26,20 @@ void ApplicationMessagesImpl::AddBinding(
 
 void ApplicationMessagesImpl::SetMessageListener(
     const std::string& message_name,
-    base::scoped_nsprotocol<NSObject<FlutterMessageListener>*> listener) {
-  listeners_[message_name] = listener;
+    NSObject<FlutterMessageListener>* listener) {
+  if (listener)
+    listeners_[message_name] = listener;
+  else
+    listeners_.erase(message_name);
 }
 
 void ApplicationMessagesImpl::SetAsyncMessageListener(
     const std::string& message_name,
-    base::scoped_nsprotocol<NSObject<FlutterAsyncMessageListener>*> listener) {
-  async_listeners_[message_name] = listener;
+    NSObject<FlutterAsyncMessageListener>* listener) {
+  if (listener)
+    async_listeners_[message_name] = listener;
+  else
+    async_listeners_.erase(message_name);
 }
 
 void ApplicationMessagesImpl::SendString(


### PR DESCRIPTION
This patch makes the FlutterViewController interface more idiomatic by not
retaining listeners. It's the callers responsibility to make sure the lifetimes
work out.
