### PR TITLE
Fix system ui overlays on Android.

### DIFF
--- a/sky/services/platform/src/org/domokit/platform/SystemChromeImpl.java
+++ b/sky/services/platform/src/org/domokit/platform/SystemChromeImpl.java
@@ -60,10 +60,10 @@ public class SystemChromeImpl implements SystemChrome {
         int flags = View.SYSTEM_UI_FLAG_LAYOUT_STABLE |
                     View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN;
 
-        if ((overlays & SystemUiOverlay.TOP) != 0) {
+        if ((overlays & SystemUiOverlay.TOP) == 0) {
             flags |= View.SYSTEM_UI_FLAG_FULLSCREEN;
         }
-        if ((overlays & SystemUiOverlay.BOTTOM) != 0) {
+        if ((overlays & SystemUiOverlay.BOTTOM) == 0) {
             flags |= View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION |
                      View.SYSTEM_UI_FLAG_HIDE_NAVIGATION;
         }


### PR DESCRIPTION
The logic was reversed -- we should only go into fullscreen if the
user didn't specify a TOP overlay, and we should only hide the
system ui navigation if the user didn't specify a BOTTOM overlay.