### PR TITLE
Remove Canvas.getTotalMatrix

### DIFF
--- a/sky/engine/core/dart/painting.dart
+++ b/sky/engine/core/dart/painting.dart
@@ -524,10 +524,6 @@ class Canvas extends NativeFieldWrapperClass2 {
   }
   void _setMatrix(Float64List matrix4) native "Canvas_setMatrix";
 
-  /// Returns the current 4⨉4 transformation matrix as a list of 16 values in
-  /// column-major order.
-  Float64List getTotalMatrix() native "Canvas_getTotalMatrix";
-
   /// Reduces the clip region to the intersection of the current clip and the
   /// given rectangle.
   void clipRect(Rect rect) {

--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -37,7 +37,6 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
   V(Canvas, skew) \
   V(Canvas, transform) \
   V(Canvas, setMatrix) \
-  V(Canvas, getTotalMatrix) \
   V(Canvas, clipRect) \
   V(Canvas, clipRRect) \
   V(Canvas, clipPath) \
@@ -168,15 +167,6 @@ void Canvas::setMatrix(const Float64List& matrix4)
     if (!m_canvas)
         return;
     m_canvas->setMatrix(toSkMatrix(matrix4));
-}
-
-Float64List Canvas::getTotalMatrix()
-{
-    // Maybe we should throw an exception instead of returning an empty matrix?
-    SkMatrix sk_matrix;
-    if (m_canvas)
-        sk_matrix = m_canvas->getTotalMatrix();
-    return toMatrix4(sk_matrix);
 }
 
 void Canvas::clipRect(double left,

--- a/sky/engine/core/painting/Canvas.h
+++ b/sky/engine/core/painting/Canvas.h
@@ -57,8 +57,6 @@ public:
     void transform(const Float64List& matrix4);
     void setMatrix(const Float64List& matrix4);
 
-    Float64List getTotalMatrix();
-
     void clipRect(double left,
                   double top,
                   double right,


### PR DESCRIPTION
This is the only readback from the canvas API. Having a write-only interface
will unlock future optimizations. This function has no clients.

Fixes #4254