### PR TITLE
Fix ASSERT in weather demo

### DIFF
--- a/sky/engine/core/dart/painting.dart
+++ b/sky/engine/core/dart/painting.dart
@@ -813,9 +813,9 @@ class Canvas extends NativeFieldWrapperClass2 {
 
   /// Draws a sequence of points according to the given [PointMode].
   void drawPoints(PointMode pointMode, List<Point> points, Paint paint) {
-    _drawPoints(pointMode.index, _encodePointList(points), paint);
+    _drawPoints(paint, pointMode.index, _encodePointList(points));
   }
-  void _drawPoints(int pointMode, Float32List points, Paint paint) native "Canvas_drawPoints";
+  void _drawPoints(Paint paint, int pointMode, Float32List points) native "Canvas_drawPoints";
 
   void drawVertices(VertexMode vertexMode,
                     List<Point> vertices,
@@ -837,17 +837,17 @@ class Canvas extends NativeFieldWrapperClass2 {
     final Int32List indexBuffer = new Int32List.fromList(indicies);
 
     _drawVertices(
-      vertexMode.index, vertexBuffer, textureCoordinateBuffer, colorBuffer,
-      transferMode.index, indexBuffer, paint
+      paint, vertexMode.index, vertexBuffer, textureCoordinateBuffer,
+      colorBuffer, transferMode.index, indexBuffer
     );
   }
-  void _drawVertices(int vertexMode,
+  void _drawVertices(Paint paint,
+                     int vertexMode,
                      Float32List vertices,
                      Float32List textureCoordinates,
                      Int32List colors,
                      int transferMode,
-                     Int32List indicies,
-                     Paint paint) native "Canvas_drawVertices";
+                     Int32List indicies) native "Canvas_drawVertices";
 
   // TODO(eseidel): Paint should be optional, but optional doesn't work.
   void drawAtlas(Image atlas,
@@ -864,8 +864,8 @@ class Canvas extends NativeFieldWrapperClass2 {
     if (colors.isNotEmpty && colors.length != rectCount)
       throw new ArgumentError("if supplied, [colors] length must match that of [transforms] and [rects]");
 
-    final Float32List rstTransformBuffer = new Float32List(rectCount);
-    final Float32List rectBuffer = new Float32List(rectCount);
+    final Float32List rstTransformBuffer = new Float32List(rectCount * 4);
+    final Float32List rectBuffer = new Float32List(rectCount * 4);
 
     for (int i = 0; i < rectCount; ++i) {
       final int index0 = i * 4;
@@ -887,15 +887,15 @@ class Canvas extends NativeFieldWrapperClass2 {
     final Int32List colorBuffer = colors.isEmpty ? null : _encodeColorList(colors);
     final Float32List cullRectBuffer = cullRect?._value;
 
-    _drawAtlas(atlas, rstTransformBuffer, rectBuffer, colorBuffer, transferMode.index, cullRectBuffer, paint);
+    _drawAtlas(paint, atlas, rstTransformBuffer, rectBuffer, colorBuffer, transferMode.index, cullRectBuffer);
   }
-  void _drawAtlas(Image atlas,
+  void _drawAtlas(Paint paint,
+                  Image atlas,
                   Float32List rstTransforms,
                   Float32List rects,
                   Int32List colors,
                   int transferMode,
-                  Float32List cullRect,
-                  Paint paint) native "Canvas_drawAtlas";
+                  Float32List cullRect) native "Canvas_drawAtlas";
 }
 
 /// An object representing a sequence of recorded graphical operations.

--- a/sky/engine/core/painting/Canvas.cpp
+++ b/sky/engine/core/painting/Canvas.cpp
@@ -330,9 +330,9 @@ void Canvas::drawParagraph(Paragraph* paragraph, double x, double y) {
     paragraph->paint(this, x, y);
 }
 
-void Canvas::drawPoints(SkCanvas::PointMode pointMode,
-                        const Float32List& points,
-                        const Paint& paint) {
+void Canvas::drawPoints(const Paint& paint,
+                        SkCanvas::PointMode pointMode,
+                        const Float32List& points) {
   if (!m_canvas)
     return;
 
@@ -382,13 +382,13 @@ void Canvas::drawVertices(
 }
 
 void Canvas::drawAtlas(
+    const Paint& paint,
     CanvasImage* atlas,
     const Float32List& transforms,
     const Float32List& rects,
     const Int32List& colors,
     int transferMode,
-    const Float32List& cullRect,
-    const Paint& paint) {
+    const Float32List& cullRect) {
   if (!m_canvas)
     return;
 

--- a/sky/engine/core/painting/Canvas.h
+++ b/sky/engine/core/painting/Canvas.h
@@ -104,25 +104,33 @@ public:
     void drawPicture(Picture* picture);
     void drawParagraph(Paragraph* paragraph, double x, double y);
 
-    void drawPoints(SkCanvas::PointMode pointMode,
-                    const Float32List& points,
-                    const Paint& paint);
+    // The paint argument is first for the following functions because Paint
+    // still uses Dart_GetField to extract data from the DartVM. Once we create
+    // a view unto a Float32List, we cannot re-enter the VM to call
+    // Dart_GetField. That means we either need to process the paint argument
+    // first or remove the Dart_GetField from marshalling the paint argument.
+    //
+    // TODO(abarth): Remove the Dart_GetField from marshalling the paint argument.
 
-    void drawVertices(SkCanvas::VertexMode vertexMode,
+    void drawPoints(const Paint& paint,
+                    SkCanvas::PointMode pointMode,
+                    const Float32List& points);
+
+    void drawVertices(const Paint& paint,
+                      SkCanvas::VertexMode vertexMode,
                       const Float32List& vertices,
                       const Float32List& textureCoordinates,
                       const Int32List& colors,
                       int transferMode,
-                      const Int32List& indices,
-                      const Paint& paint);
+                      const Int32List& indices);
 
-    void drawAtlas(CanvasImage* atlas,
+    void drawAtlas(const Paint& paint,
+                   CanvasImage* atlas,
                    const Float32List& transforms,
                    const Float32List& rects,
                    const Int32List& colors,
                    int transferMode,
-                   const Float32List& cullRect,
-                   const Paint& paint);
+                   const Float32List& cullRect);
 
     SkCanvas* skCanvas() { return m_canvas; }
     void clearSkCanvas() { m_canvas = nullptr; }

--- a/sky/engine/core/painting/CanvasGradient.cpp
+++ b/sky/engine/core/painting/CanvasGradient.cpp
@@ -41,7 +41,7 @@ void CanvasGradient::initLinear(const Float32List& end_points,
                                 const Float32List& color_stops,
                                 SkShader::TileMode tile_mode) {
   DCHECK(end_points.num_elements() == 4);
-  DCHECK(colors.num_elements() * 2 == color_stops.num_elements() || color_stops.data() == nullptr);
+  DCHECK(colors.num_elements() == color_stops.num_elements() || color_stops.data() == nullptr);
 
   static_assert(sizeof(SkPoint) == sizeof(float) * 2, "SkPoint doesn't use floats.");
   static_assert(sizeof(SkColor) == sizeof(int32_t), "SkColor doesn't use int32_t.");


### PR DESCRIPTION
Because we're not using array buffers to marshall the vertex data for
drawVertices and drawAtlas, we need to process the paint argument first so that
we don't call Dart_GetField after creating a view into an array buffer.