### PR TITLE
Fix on stack hot reloading in the Flutter embedder

### DIFF
--- a/flutter/tonic/BUILD.gn
+++ b/flutter/tonic/BUILD.gn
@@ -27,6 +27,8 @@ source_set("tonic") {
     "dart_invoke.h",
     "dart_io.cc",
     "dart_io.h",
+    "dart_isolate_reloader.cc",
+    "dart_isolate_reloader.h",
     "dart_isolate_scope.cc",
     "dart_isolate_scope.h",
     "dart_library_loader.cc",

--- a/flutter/tonic/dart_isolate_reloader.cc
+++ b/flutter/tonic/dart_isolate_reloader.cc
@@ -1,0 +1,330 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/tonic/dart_isolate_reloader.h"
+
+#include "base/bind.h"
+#include "base/callback.h"
+#include "base/threading/thread.h"
+#include "flutter/tonic/dart_api_scope.h"
+#include "flutter/tonic/dart_converter.h"
+#include "flutter/tonic/dart_dependency_catcher.h"
+#include "flutter/tonic/dart_error.h"
+#include "flutter/tonic/dart_isolate_scope.h"
+#include "flutter/tonic/dart_library_provider.h"
+#include "flutter/tonic/dart_library_loader.h"
+#include "flutter/tonic/dart_state.h"
+#include "flutter/tonic/monitor.h"
+#include "mojo/data_pipe_utils/data_pipe_drainer.h"
+
+using mojo::common::DataPipeDrainer;
+
+namespace blink {
+
+// As each source file is loaded, a LoadResult is queued to be processed on the
+// isolate's thread. A LoadResult contains the payload or an error message.
+class DartIsolateReloader::LoadResult {
+ public:
+  // Successful load result.
+  LoadResult(intptr_t tag,
+             const std::string& url,
+             const std::string& library_url,
+             std::vector<uint8_t> payload)
+      : success_(true),
+        tag_(tag),
+        url_(url),
+        library_url_(library_url),
+        payload_(std::move(payload)) {
+    DCHECK(success());
+  }
+
+  // Error load result.
+  LoadResult(intptr_t tag,
+             const std::string& url,
+             const std::string& library_url,
+             const std::string& error)
+      : success_(false),
+        tag_(tag),
+        url_(url),
+        library_url_(library_url),
+        error_(error) {
+  }
+
+  bool success() const { return success_; }
+
+  Dart_Handle Finish() {
+    if (!success()) {
+      return StdStringToDart(error_);
+    }
+    Dart_Handle uri = StdStringToDart(url_);
+    Dart_Handle library = Dart_Null();
+    if (!library_url_.empty()) {
+      library = Dart_LookupLibrary(StdStringToDart(library_url_));
+    }
+    Dart_Handle source =
+        Dart_NewStringFromUTF8(payload_.data(), payload_.size());
+    Dart_Handle result = Dart_Null();
+    switch (tag_) {
+      case Dart_kImportTag:
+        result = Dart_LoadLibrary(uri, source, 0, 0);
+        break;
+      case Dart_kSourceTag:
+        result = Dart_LoadSource(library, uri, source, 0, 0);
+        break;
+      case Dart_kScriptTag:
+        result = Dart_LoadScript(uri, source, 0, 0);
+        break;
+    }
+
+    if (Dart_IsError(result)) {
+      return result;
+    }
+    return Dart_Null();
+  }
+
+ private:
+  bool success_;
+  intptr_t tag_;
+  std::string url_;
+  std::string library_url_;
+  std::string error_;
+  std::vector<uint8_t> payload_;
+};
+
+DartIsolateReloader::DartIsolateReloader(DartLibraryProvider* library_provider)
+    : thread_(new base::Thread("DartIsolateReloader")),
+      library_provider_(library_provider),
+      load_error_(Dart_Null()),
+      pending_requests_(0) {
+  CHECK(thread_->Start());
+}
+
+DartIsolateReloader::~DartIsolateReloader() {
+}
+
+void DartIsolateReloader::SendRequest(Dart_LibraryTag tag,
+                                      Dart_Handle url,
+                                      Dart_Handle library_url) {
+  scoped_refptr<base::TaskRunner> runner =
+      thread_->message_loop()->task_runner();
+
+  MonitorLocker ml(&monitor_);
+
+  // Post a task to the worker thread. This task will request the I/O and
+  // post a LoadResult to be processed once complete.
+  if (runner->PostTask(
+        FROM_HERE,
+        base::Bind(&DartIsolateReloader::RequestTask,
+                   library_provider_,
+                   this,
+                   static_cast<intptr_t>(tag),
+                   StdStringFromDart(url),
+                   StdStringFromDart(library_url)))) {
+    pending_requests_++;
+  }
+}
+
+void DartIsolateReloader::PostResult(std::unique_ptr<LoadResult> load_result) {
+  MonitorLocker ml(&monitor_);
+  pending_requests_--;
+  load_results_.push(std::move(load_result));
+  ml.Notify();
+}
+
+// As each source file is requested, a LoadRequest is queued to be processed on
+// worker thread.
+class DartIsolateReloader::LoadRequest : public DataPipeDrainer::Client {
+ public:
+  LoadRequest(DartLibraryProvider* library_provider,
+              DartIsolateReloader* isolate_reloader,
+              intptr_t tag,
+              const std::string& url,
+              const std::string& library_url)
+      : isolate_reloader_(isolate_reloader),
+        tag_(tag),
+        url_(url),
+        library_url_(library_url),
+        weak_factory_(this) {
+    library_provider->GetLibraryAsStream(
+        url_,
+        base::Bind(&LoadRequest::OnStreamAvailable,
+                   weak_factory_.GetWeakPtr()));
+  }
+
+ protected:
+  void OnStreamAvailable(mojo::ScopedDataPipeConsumerHandle pipe) {
+    if (!pipe.is_valid()) {
+      std::unique_ptr<DartIsolateReloader::LoadResult> result(
+          new DartIsolateReloader::LoadResult(
+              tag_,
+              url_,
+              library_url_,
+              "File " + url_ + " could not be read."));
+      LOG(ERROR) << "Load failed for " << url_;
+      isolate_reloader_->PostResult(std::move(result));
+      // We are finished with this request.
+      delete this;
+      return;
+    }
+    drainer_.reset(new DataPipeDrainer(this, pipe.Pass()));
+  }
+
+  // DataPipeDrainer::Client
+  void OnDataAvailable(const void* data, size_t num_bytes) override {
+    const uint8_t* bytes = static_cast<const uint8_t*>(data);
+    buffer_.insert(buffer_.end(), bytes, bytes + num_bytes);
+  }
+
+  // DataPipeDrainer::Client
+  void OnDataComplete() override {
+    std::unique_ptr<DartIsolateReloader::LoadResult> result(
+        new DartIsolateReloader::LoadResult(tag_,
+                                            url_,
+                                            library_url_,
+                                            std::move(buffer_)));
+    isolate_reloader_->PostResult(std::move(result));
+    // We are finished with this request.
+    delete this;
+  }
+
+ private:
+  DartIsolateReloader* isolate_reloader_;
+  intptr_t tag_;
+  std::string url_;
+  std::string library_url_;
+  std::vector<uint8_t> buffer_;
+  std::unique_ptr<DataPipeDrainer> drainer_;
+
+  base::WeakPtrFactory<LoadRequest> weak_factory_;
+};
+
+void DartIsolateReloader::RequestTask(DartLibraryProvider* library_provider,
+                                      DartIsolateReloader* isolate_reloader,
+                                      intptr_t tag,
+                                      const std::string& url,
+                                      const std::string& library_url) {
+  DCHECK(isolate_reloader);
+  DCHECK(library_provider);
+  DCHECK(tag > 0);
+  // Construct a new LoadRequest. The pointer is dropped here because
+  // the request deletes itself on success and failure.
+  new LoadRequest(library_provider,
+                  isolate_reloader,
+                  tag,
+                  url,
+                  library_url);
+}
+
+void DartIsolateReloader::HandleLoadResultLocked(LoadResult* load_result) {
+  if (load_error_ != Dart_Null()) {
+    // Already have a sticky error. Just drop this result.
+    return;
+  }
+
+  // Drop the lock temporarily around the call to Finish because it may
+  // trigger a recursive call into the tag handler.
+  monitor_.Exit();
+  Dart_Handle error_or_null = load_result->Finish();
+  monitor_.Enter();
+
+  if (!Dart_IsNull(error_or_null)) {
+    // Set sticky error.
+    load_error_ = error_or_null;
+  }
+}
+
+void DartIsolateReloader::ProcessResultQueueLocked() {
+  while (load_results_.size() > 0) {
+    // Grab the first load result.
+    std::unique_ptr<LoadResult> result = std::move(load_results_.front());
+    load_results_.pop();
+    HandleLoadResultLocked(result.get());
+  }
+}
+
+bool DartIsolateReloader::IsCompleteLocked() {
+  return (pending_requests_ == 0) && load_results_.empty();
+}
+
+bool DartIsolateReloader::BlockUntilComplete() {
+  MonitorLocker ml(&monitor_);
+
+  while (true) {
+    ProcessResultQueueLocked();
+
+    if (IsCompleteLocked()) {
+      break;
+    }
+
+    // Wait to be notified about new I/O results.
+    ml.Wait();
+  }
+  return !Dart_IsNull(load_error_);
+}
+
+Dart_Handle DartIsolateReloader::HandleLibraryTag(Dart_LibraryTag tag,
+                                                  Dart_Handle library,
+                                                  Dart_Handle url) {
+  if (tag == Dart_kCanonicalizeUrl) {
+    // Pass through to actual tag handler.
+    return DartLibraryLoader::HandleLibraryTag(tag, library, url);
+  }
+  DartState* dart_state = DartState::Current();
+  DCHECK(dart_state);
+  DartIsolateReloader* isolate_reloader = dart_state->isolate_reloader();
+  // The first call into the tag handler ends up blocking the calling thread
+  // until the entire reload has completed. All other calls into the
+  // tag handler schedule requests and return immediately.
+  const bool blocking_call = (tag == Dart_kScriptTag);
+  if (!isolate_reloader) {
+    // The first call into this tag handler must be for the script.
+    DCHECK(tag == Dart_kScriptTag);
+    // Associate the reloader with the isolate. The reloader is owned
+    // by the dart_state.
+    dart_state->set_isolate_reloader(
+        std::unique_ptr<DartIsolateReloader>(
+            new DartIsolateReloader(
+                dart_state->library_loader().library_provider())));
+    // Get a pointer to the reloader.
+    isolate_reloader = dart_state->isolate_reloader();
+    // Switch the tag handler.
+    Dart_SetLibraryTagHandler(DartIsolateReloader::HandleLibraryTag);
+  } else {
+    // We should not see another request for the script.
+    DCHECK(tag != Dart_kScriptTag);
+  }
+
+  // Issue I/O request.
+  isolate_reloader->SendRequest(tag,
+                                url,
+                                (library != Dart_Null()) ?
+                                Dart_LibraryUrl(library) : Dart_Null());
+
+  if (blocking_call) {
+    // Block and process LoadResults until the load is complete.
+    const bool load_error = isolate_reloader->BlockUntilComplete();
+    // Grab the (possibly null) load error from the reloader before its gone.
+    Dart_Handle result = isolate_reloader->load_error_;
+    // The reloader will be deleted once we call set_isolate_reloader below.
+    isolate_reloader = nullptr;
+    // Disassociate reloader from the isolate, this causes it to be deleted.
+    dart_state->set_isolate_reloader(nullptr);
+    Dart_SetLibraryTagHandler(DartLibraryLoader::HandleLibraryTag);
+    if (load_error) {
+      // If we hit an error, return the load error.
+      return result;
+    } else {
+      // Finalize loading.
+      result = Dart_FinalizeLoading(true);
+      if (Dart_IsError(result)) {
+        // If we hit an error, return the load error.
+        return result;
+      }
+    }
+  }
+
+  return Dart_Null();
+}
+
+}  // namespace blink

--- a/flutter/tonic/dart_isolate_reloader.h
+++ b/flutter/tonic/dart_isolate_reloader.h
@@ -1,0 +1,72 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TONIC_DART_ISOLATE_RELOADER_H_
+#define FLUTTER_TONIC_DART_ISOLATE_RELOADER_H_
+
+#include <string>
+#include <vector>
+#include <queue>
+
+#include "base/callback_forward.h"
+#include "base/macros.h"
+#include "base/memory/weak_ptr.h"
+#include "base/threading/thread.h"
+#include "dart/runtime/include/dart_api.h"
+#include "flutter/tonic/monitor.h"
+
+namespace blink {
+class DartLibraryProvider;
+class Monitor;
+
+// Reloading an isolate must be an atomic operation, meaning, no other tasks
+// can run while reloading. A nested run loop is not sufficient because other
+// tasks that invoke Dart code can be run. When |HandleLibraryTag| is invoked
+// the calling thread will be blocked until the load has fully completed. To
+// avoid relying on the message loop we use our own queue and notification
+// mechanism.
+class DartIsolateReloader {
+ public:
+  // The |DartLibraryProvider| used to load the library sources.
+  DartIsolateReloader(DartLibraryProvider* library_provider);
+  ~DartIsolateReloader();
+
+  static Dart_Handle HandleLibraryTag(Dart_LibraryTag tag,
+                                      Dart_Handle library,
+                                      Dart_Handle url);
+
+ private:
+  class LoadRequest;
+  class LoadResult;
+
+  void SendRequest(Dart_LibraryTag tag,
+                   Dart_Handle url,
+                   Dart_Handle library_url);
+
+  void PostResult(std::unique_ptr<LoadResult> load_result);
+
+  static void RequestTask(DartLibraryProvider* library_provider,
+                          DartIsolateReloader* isolate_reloader,
+                          intptr_t tag,
+                          const std::string& url,
+                          const std::string& library_url);
+
+  void HandleLoadResultLocked(LoadResult* load_result);
+  void ProcessResultQueueLocked();
+  bool IsCompleteLocked();
+  bool BlockUntilComplete();
+
+  std::unique_ptr<base::Thread> thread_;
+  DartLibraryProvider* library_provider_;
+
+  Monitor monitor_;
+  // The monitor is used to protect the following fields:
+  Dart_Handle load_error_;
+  std::queue<std::unique_ptr<LoadResult>> load_results_;
+  intptr_t pending_requests_;
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_TONIC_DART_ISOLATE_RELOADER_H_

--- a/flutter/tonic/dart_message_handler.cc
+++ b/flutter/tonic/dart_message_handler.cc
@@ -39,8 +39,9 @@ void DartMessageHandler::OnMessage(DartState* dart_state) {
   auto task_runner = dart_state->message_handler().task_runner();
 
   // Schedule a task to run on the message loop thread.
-  task_runner->PostTask(FROM_HERE,
-                        base::Bind(&HandleMessage, dart_state->GetWeakPtr()));
+  task_runner->PostTask(
+      FROM_HERE,
+      base::Bind(&HandleMessage, dart_state->GetWeakPtr()));
 }
 
 void DartMessageHandler::OnHandleMessage(DartState* dart_state) {

--- a/flutter/tonic/dart_state.cc
+++ b/flutter/tonic/dart_state.cc
@@ -19,12 +19,13 @@ DartState::Scope::~Scope() {
 }
 
 DartState::DartState()
-    : isolate_(NULL),
+    : isolate_(nullptr),
       class_library_(std::unique_ptr<DartClassLibrary>(new DartClassLibrary)),
       exception_factory_(new DartExceptionFactory(this)),
       library_loader_(new DartLibraryLoader(this)),
       message_handler_(std::unique_ptr<DartMessageHandler>(
           new DartMessageHandler())),
+      isolate_reloader_(nullptr),
       weak_factory_(this) {
 }
 

--- a/flutter/tonic/dart_state.h
+++ b/flutter/tonic/dart_state.h
@@ -11,6 +11,7 @@
 #include "flutter/tonic/dart_api_scope.h"
 #include "flutter/tonic/dart_isolate_scope.h"
 #include "flutter/tonic/dart_persistent_value.h"
+#include "flutter/tonic/dart_isolate_reloader.h"
 
 namespace blink {
 class DartClassLibrary;
@@ -52,6 +53,13 @@ class DartState {
   DartLibraryLoader& library_loader() { return *library_loader_; }
   DartMessageHandler& message_handler() { return *message_handler_; }
 
+  // Takes ownership of |isolate_reloader|.
+  void set_isolate_reloader(
+        std::unique_ptr<DartIsolateReloader> isolate_reloader) {
+    isolate_reloader_ = std::move(isolate_reloader);
+  }
+  DartIsolateReloader* isolate_reloader() { return isolate_reloader_.get(); }
+
   Dart_Handle index_handle() { return index_handle_.value(); }
 
   virtual void DidSetIsolate() {}
@@ -62,6 +70,7 @@ class DartState {
   std::unique_ptr<DartExceptionFactory> exception_factory_;
   std::unique_ptr<DartLibraryLoader> library_loader_;
   std::unique_ptr<DartMessageHandler> message_handler_;
+  std::unique_ptr<DartIsolateReloader> isolate_reloader_;
 
   DartPersistentValue index_handle_;
 

--- a/flutter/tonic/monitor.h
+++ b/flutter/tonic/monitor.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef SKY_ENGINE_CORE_SCRIPT_MONITOR_H_
-#define SKY_ENGINE_CORE_SCRIPT_MONITOR_H_
+#ifndef FLUTTER_TONIC_DART_MONITOR_H_
+#define FLUTTER_TONIC_DART_MONITOR_H_
 
 #include "base/synchronization/condition_variable.h"
 #include "base/synchronization/lock.h"
@@ -72,4 +72,4 @@ class MonitorLocker {
 }  // namespace blink
 
 
-#endif  // SKY_ENGINE_CORE_SCRIPT_MONITOR_H_
+#endif  // FLUTTER_TONIC_DART_MONITOR_H_

--- a/sky/engine/core/core.gni
+++ b/sky/engine/core/core.gni
@@ -158,7 +158,6 @@ sky_core_files = [
   "script/dart_service_isolate.h",
   "script/embedder_resources.cc",
   "script/embedder_resources.h",
-  "script/monitor.h",
   "script/ui_dart_state.cc",
   "script/ui_dart_state.h",
   "text/Paragraph.cpp",

--- a/sky/engine/core/script/dart_debugger.h
+++ b/sky/engine/core/script/dart_debugger.h
@@ -11,7 +11,7 @@
 #include "dart/runtime/include/dart_api.h"
 #include "dart/runtime/include/dart_native_api.h"
 #include "dart/runtime/include/dart_tools_api.h"
-#include "sky/engine/core/script/monitor.h"
+#include "flutter/tonic/monitor.h"
 
 namespace base {
   class Lock;


### PR DESCRIPTION
- [x] Remove old non-atomic inner message loop loading code.
- [x] Add `DartIsolateReloader` which takes a `DartLibraryProvider` and does an atomic reload without using the message loop.

Fixes https://github.com/flutter/flutter/issues/4732