### PR TITLE
Better debugging support for flutter on mojo.

### DIFF
--- a/sky/shell/platform/mojo/main_mojo.cc
+++ b/sky/shell/platform/mojo/main_mojo.cc
@@ -23,6 +23,7 @@ namespace shell {
 namespace {
 
 const char kEnableCheckedMode[] = "--enable-checked-mode";
+const char kPauseIsolatesOnStart[] = "--pause-isolates-on-start";
 
 }  // namespace
 
@@ -43,6 +44,7 @@ class MojoApp : public mojo::ApplicationImplBase {
     blink::SkySettings settings;
     settings.enable_observatory = true;
     settings.enable_dart_checked_mode = HasArg(kEnableCheckedMode);
+    settings.start_paused = HasArg(kPauseIsolatesOnStart);
     blink::SkySettings::Set(settings);
 
     Shell::Init();


### PR DESCRIPTION
Add a --pause-isolates-on-start flag to the flutter mojo content
handler to match the one that's supported by the dart mojo content
handler.

Fixes: https://github.com/flutter/flutter/issues/4802