### PR TITLE
Do not convert the package map to an absolute path

### DIFF
--- a/sky/shell/dart/dart_library_provider_files.cc
+++ b/sky/shell/dart/dart_library_provider_files.cc
@@ -68,7 +68,7 @@ DartLibraryProviderFiles::~DartLibraryProviderFiles() {
 }
 
 void DartLibraryProviderFiles::LoadPackagesMap(const base::FilePath& packages) {
-  packages_ = base::MakeAbsoluteFilePath(packages);
+  packages_ = packages;
   std::string packages_source;
   if (!base::ReadFileToString(packages_, &packages_source)) {
     LOG(ERROR) << "error: Unable to load .packages file '"


### PR DESCRIPTION
Package map entries can contain relative paths.
See related commit: d7d99c6