### PR TITLE
Conditionally enable accessibility

### DIFF
--- a/sky/shell/platform/ios/framework/Source/FlutterView.h
+++ b/sky/shell/platform/ios/framework/Source/FlutterView.h
@@ -5,13 +5,9 @@
 #ifndef SKY_SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTER_VIEW_H_
 #define SKY_SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTER_VIEW_H_
 
-#include "mojo/public/interfaces/application/service_provider.mojom.h"
-
 #include <UIKit/UIKit.h>
 
 @interface FlutterView : UIView
-
-- (void)withAccessibility:(mojo::ServiceProvider*)serviceProvider;
 
 @end
 

--- a/sky/shell/platform/ios/framework/Source/FlutterView.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterView.mm
@@ -4,20 +4,11 @@
 
 #include "sky/shell/platform/ios/framework/Source/FlutterView.h"
 
-#include "base/memory/weak_ptr.h"
-#include "sky/shell/platform/ios/framework/Source/accessibility_bridge.h"
-
 @interface FlutterView ()<UIInputViewAudioFeedback>
 
 @end
 
-@implementation FlutterView {
-  std::unique_ptr<sky::shell::AccessibilityBridge> _accessibilityBridge;
-}
-
-- (void)withAccessibility:(mojo::ServiceProvider*)serviceProvider {
-  _accessibilityBridge.reset(new sky::shell::AccessibilityBridge(self, serviceProvider));
-}
+@implementation FlutterView
 
 - (void)layoutSubviews {
   CGFloat screenScale = [UIScreen mainScreen].scale;

--- a/sky/shell/platform/ios/framework/Source/accessibility_bridge.h
+++ b/sky/shell/platform/ios/framework/Source/accessibility_bridge.h
@@ -49,12 +49,12 @@ namespace shell {
 
 class AccessibilityBridge final : public semantics::SemanticsListener {
  public:
-  AccessibilityBridge(FlutterView*, mojo::ServiceProvider*);
+  AccessibilityBridge(UIView*, mojo::ServiceProvider*);
   ~AccessibilityBridge() override;
 
   void UpdateSemanticsTree(mojo::Array<semantics::SemanticsNodePtr>) override;
 
-  FlutterView* view() { return view_; }
+  UIView* view() { return view_; }
   semantics::SemanticsServer* server() { return semantics_server_.get(); }
 
  private:
@@ -65,7 +65,7 @@ class AccessibilityBridge final : public semantics::SemanticsListener {
   void RemoveSemanticObject(SemanticObject* node,
                             std::set<SemanticObject*>* updated_objects);
 
-  FlutterView* view_;
+  UIView* view_;
   semantics::SemanticsServerPtr semantics_server_;
   std::unordered_map<int, SemanticObject*> objects_;
 

--- a/sky/shell/platform/ios/framework/Source/accessibility_bridge.mm
+++ b/sky/shell/platform/ios/framework/Source/accessibility_bridge.mm
@@ -283,7 +283,7 @@ struct Geometry {
 namespace sky {
 namespace shell {
 
-AccessibilityBridge::AccessibilityBridge(FlutterView* view,
+AccessibilityBridge::AccessibilityBridge(UIView* view,
                                          mojo::ServiceProvider* serviceProvider)
     : view_(view), binding_(this) {
   mojo::ConnectToService(serviceProvider, mojo::GetProxy(&semantics_server_));
@@ -302,6 +302,7 @@ AccessibilityBridge::~AccessibilityBridge() {
 
 void AccessibilityBridge::UpdateSemanticsTree(
     mojo::Array<semantics::SemanticsNodePtr> nodes) {
+  LOG(INFO) << "UpdateSemanticsTree";
   std::set<SemanticObject*> updated_objects;
   std::set<SemanticObject*> removed_objects;
 


### PR DESCRIPTION
Previously we enabled accessibility unconditionally on iOS, which is more
expensive than necessary. We still enable it unconditionally on the simulator
because there's no API for determining whether accessibility is needed on the
simulator.