### PR TITLE
Make FlutterAppDelegate an empty AppDelegate

### DIFF
--- a/sky/shell/platform/ios/framework/Headers/FlutterAppDelegate.h
+++ b/sky/shell/platform/ios/framework/Headers/FlutterAppDelegate.h
@@ -9,9 +9,8 @@
 
 #include "FlutterMacros.h"
 
-// A simple app delegate that creates a single full-screen Flutter application.
-// Using FlutterAppDelegate is optional. The framework provides this interface
-// to make it easy to get started with simple Flutter apps.
+// Empty implementation of UIApplicationDelegate, for simple apps
+// that don't need to customize the application delegate.
 FLUTTER_EXPORT
 @interface FlutterAppDelegate : UIResponder<UIApplicationDelegate>
 

--- a/sky/shell/platform/ios/framework/Source/FlutterAppDelegate.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterAppDelegate.mm
@@ -3,56 +3,7 @@
 // found in the LICENSE file.
 
 #include "sky/shell/platform/ios/framework/Headers/FlutterAppDelegate.h"
-#include "sky/shell/platform/ios/framework/Headers/FlutterViewController.h"
 
 @implementation FlutterAppDelegate
-
-- (BOOL)application:(UIApplication*)application
-    didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-  FlutterDartProject* project =
-      [[FlutterDartProject alloc] initFromDefaultSourceForConfiguration];
-
-  CGRect frame = [UIScreen mainScreen].bounds;
-  UIWindow* window = [[UIWindow alloc] initWithFrame:frame];
-  FlutterViewController* viewController =
-      [[FlutterViewController alloc] initWithProject:project
-                                             nibName:nil
-                                              bundle:nil];
-  [project release];
-  window.rootViewController = viewController;
-  [viewController release];
-  self.window = window;
-  [window release];
-  [self.window makeKeyAndVisible];
-
-  return YES;
-}
-
-// Use the NSNotificationCenter to notify services when we're opened with URLs.
-// TODO(jackson): Revisit this API once we have more services using URLs to make
-// it more typed and less brittle
-- (BOOL)application:(UIApplication*)app
-            openURL:(NSURL*)url
-  sourceApplication:(NSString*)sourceApplication
-         annotation:(id)annotation {
-
-  NSDictionary* dict = [@{
-    @"handled" : [NSMutableDictionary dictionary],
-    @"url" : url,
-    @"sourceApplication" : sourceApplication,
-  } mutableCopy];
-
-  if (annotation != nil)
-    [dict setValue:annotation forKey:@"annotation"];
-
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"openURL"
-                                                      object:self
-                                                    userInfo:dict];
-
-  BOOL handled = ((NSNumber*)dict[@"handled"][@"value"]).boolValue;
-  [dict release];
-
-  return handled;
-}
 
 @end

--- a/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
@@ -65,7 +65,10 @@ void FlutterInit(int argc, const char* argv[]) {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
 
   if (self) {
-    _dartProject.reset([project retain]);
+    if (project == nil)
+      _dartProject.reset([[FlutterDartProject alloc] initFromDefaultSourceForConfiguration]);
+    else
+      _dartProject.reset([project retain]);
 
     [self performCommonViewControllerInitialization];
   }


### PR DESCRIPTION
The code from FlutterAppDelegate is moving into the iOS template project. See flutter/flutter#4895 (which should be merged before this one)