### PR TITLE
Do not upgrade the version of google_play_services in third_party/and…

### DIFF
--- a/build/android_sdk_extras.json
+++ b/build/android_sdk_extras.json
@@ -1,9 +1,2 @@
 [
-  {
-    "dir_name": "google",
-    "version": "21.0.0",
-    "zip": "google_google_play_services_21.0.0.zip",
-    "package": "google_play_services",
-    "package_id": "extra-google-google_play_services"
-  }
 ]


### PR DESCRIPTION
…roid_tools

The setup instructions for engine development ask users to run build/install-build-deps-android.sh,
which updates the Android SDK packages listed in android_sdk_extras.json

This process was upgrading the Play Services package to a version that is incompatible
with our build scripts.