### PR TITLE
Revert "Only suppress the sampling profiler on Mac/iOS when the engine is in …"

### DIFF
--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -83,7 +83,7 @@ static const char* kDartProfilingArgs[] = {
     // default profile period to 100Hz. This number is suitable for older
     // Raspberry Pi devices but quite low for current smartphones.
     "--profile_period=1000",
-#if ((WTF_OS_IOS || WTF_OS_MACOSX) && !defined(NDEBUG))
+#if (WTF_OS_IOS || WTF_OS_MACOSX)
     // On platforms where LLDB is the primary debugger, SIGPROF signals
     // overwhelm LLDB.
     "--no-profiler",
@@ -96,6 +96,10 @@ static const char *kDartMirrorsArgs[] = {
 
 static const char* kDartPrecompilationArgs[] = {
     "--precompilation",
+};
+
+static const char* kDartBackgroundCompilationArgs[] = {
+  "--background_compilation",
 };
 
 static const char* kDartCheckedModeArgs[] = {
@@ -510,6 +514,8 @@ void InitDartVM() {
 
   args.append(kDartProfilingArgs, arraysize(kDartProfilingArgs));
   args.append(kDartMirrorsArgs, arraysize(kDartMirrorsArgs));
+  args.append(kDartBackgroundCompilationArgs,
+              arraysize(kDartBackgroundCompilationArgs));
 
   if (IsRunningPrecompiledCode())
     args.append(kDartPrecompilationArgs, arraysize(kDartPrecompilationArgs));


### PR DESCRIPTION
Reverts flutter/engine#2804