### PR TITLE
Clear invalid resources from the raster cache when the surface is destroyed.

### DIFF
--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -75,6 +75,7 @@ void RasterizerDirect::Setup(PlatformView* platform_view,
 void RasterizerDirect::Teardown(
     base::WaitableEvent* teardown_completion_event) {
   platform_view_ = nullptr;
+  compositor_context_.OnGrContextDestroyed();
   teardown_completion_event->Signal();
 }
 


### PR DESCRIPTION
…troyed