### PR TITLE
Fix bug with text input where the cursor would render before a single

### DIFF
--- a/sky/engine/core/rendering/RenderText.cpp
+++ b/sky/engine/core/rendering/RenderText.cpp
@@ -224,7 +224,7 @@ void RenderText::appendAbsoluteTextBoxesForRange(std::vector<TextBox>& boxes, un
             boxes.emplace_back(localToAbsoluteQuad(r).enclosingBoundingBox(), box->direction());
         } else {
             FloatRect rect = localQuadForTextBox(box, start, end, /* useSelectionHeight */ false);
-            if (!rect.isZero())
+            if (!rect.isEmpty())
                 boxes.emplace_back(localToAbsoluteQuad(rect).enclosingBoundingBox(), box->direction());
         }
     }


### PR DESCRIPTION
trailing space rather than after.

We were including an empty rectangle in the list of TextBoxes for that
range.

BUG=https://github.com/flutter/flutter/issues/4911