### PR TITLE
Drop the last layer tree when tearing down the rasterizer

### DIFF
--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -75,6 +75,7 @@ void RasterizerDirect::Setup(PlatformView* platform_view,
 void RasterizerDirect::Teardown(
     base::WaitableEvent* teardown_completion_event) {
   platform_view_ = nullptr;
+  last_layer_tree_.reset();
   compositor_context_.OnGrContextDestroyed();
   teardown_completion_event->Signal();
 }


### PR DESCRIPTION
The LayerTree may be holding references to obsolete Skia/GPU resources,
notably the GrGLGpu.  The old GrGLGpu should be deleted before a new
GrGLGpu is created during the next rasterizer setup.

Fixes https://github.com/flutter/flutter/issues/5074