### PR TITLE
Filter for either "warning" or "error" for some dartanalyzer messages

### DIFF
--- a/travis/analyze.sh
+++ b/travis/analyze.sh
@@ -15,10 +15,10 @@ RESULTS=`dartanalyzer                                                          \
   | grep -v "\[error\] Target of URI does not exist: 'dart:mojo.internal'"     \
   | grep -v "\[error\] Native functions can only be declared in the SDK and code that is loaded through native extensions" \
   | grep -Ev "\[(hint|error)\] The function '.+' is not used"                  \
-  | grep -v "\[error\] Undefined name 'main'"                                  \
-  | grep -v "\[error\] Undefined name 'VMLibraryHooks"                         \
-  | grep -v "\[error\] Undefined name 'MojoHandleWatcher'"                     \
-  | grep -v "\[error\] Undefined name 'MojoCoreNatives'"                       \
+  | grep -Ev "\[(warning|error)\] Undefined name 'main'"                       \
+  | grep -Ev "\[(warning|error)\] Undefined name 'VMLibraryHooks"              \
+  | grep -Ev "\[(warning|error)\] Undefined name 'MojoHandleWatcher'"          \
+  | grep -Ev "\[(warning|error)\] Undefined name 'MojoCoreNatives'"            \
   | grep -v "\[error\] The library ''dart:_internal'' is internal"             \
   | grep -Ev "Unused import .+ui\.dart"                                        \
   | grep -v "\[info\] TODO"                                                    \


### PR DESCRIPTION
The buildbot and Travis are running inconsistent versions of the analyzer