### PR TITLE
Finish removing //base dependency from //flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 /third_party/dejavu-fonts-ttf-2.34/ttf/*.ttf
 /third_party/freetype-android/src
 /third_party/go/tool/
+/third_party/gtest/
 /third_party/icu/
 /third_party/jsr-305/src/
 /third_party/libc++/trunk/

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -46,7 +46,7 @@ source_set("flow") {
   ]
 
   deps = [
-    "//base",
+    "//glue",
     "//lib/ftl",
     "//mojo/services/gfx/composition/interfaces",
     "//mojo/skia",

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -8,9 +8,9 @@
 #include <memory>
 #include <vector>
 
-#include "base/trace_event/trace_event.h"
 #include "flow/instrumentation.h"
 #include "flow/raster_cache.h"
+#include "glue/trace_event.h"
 #include "lib/ftl/logging.h"
 #include "lib/ftl/macros.h"
 #include "skia/ext/refptr.h"

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -4,7 +4,7 @@
 
 #include "flow/layers/layer_tree.h"
 
-#include "base/trace_event/trace_event.h"
+#include "glue/trace_event.h"
 #include "flow/layers/layer.h"
 
 namespace flow {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -4,7 +4,7 @@
 
 #include "flow/raster_cache.h"
 
-#include "base/trace_event/trace_event.h"
+#include "glue/trace_event.h"
 #include "lib/ftl/logging.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkImage.h"

--- a/glue/BUILD.gn
+++ b/glue/BUILD.gn
@@ -1,0 +1,13 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("glue") {
+  sources = [
+    "trace_event.h"
+  ]
+
+  deps = [
+    "//base",
+  ]
+}

--- a/glue/README.md
+++ b/glue/README.md
@@ -1,0 +1,5 @@
+# Glue
+
+This library provides glue between Flutter and //base, which lets us isolate our
+dependency on //base. Eventually, we'll drive the contents of this library to
+zero and remove our dependency on //base.

--- a/glue/trace_event.h
+++ b/glue/trace_event.h
@@ -1,0 +1,11 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#if defined(__Fuchsia__)
+#define TRACE_EVENT0(a, b)
+#define TRACE_EVENT1(a, b, c, d)
+#define TRACE_EVENT2(a, b, c, d, e, f)
+#else
+#include "base/trace_event/trace_event.h"
+#endif  // defined(__Fuchsia__)


### PR DESCRIPTION
This patch introduces a //glue library that isolates our dependency on //base.
This will let us clean up our //base dependencies ahead of actually being able
to fully remove them.