### PR TITLE
Add collection of PlatformViews to the Shell and allow them to be queried over the service protocol

### DIFF
--- a/sky/engine/core/script/dart_init.cc
+++ b/sky/engine/core/script/dart_init.cc
@@ -124,6 +124,8 @@ const char kDartFlags[] = "dart-flags";
 
 bool g_service_isolate_initialized = false;
 ServiceIsolateHook g_service_isolate_hook = nullptr;
+RegisterNativeServiceProtocolExtensionHook
+    g_register_native_service_protocol_extensions_hook = nullptr;
 
 void IsolateShutdownCallback(void* callback_data) {
   DartState* dart_state = static_cast<DartState*>(callback_data);
@@ -209,6 +211,11 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
   Dart_ExitIsolate();
 
   g_service_isolate_initialized = true;
+  // Register any native service protocol extensions.
+  if (g_register_native_service_protocol_extensions_hook) {
+    g_register_native_service_protocol_extensions_hook(
+        IsRunningPrecompiledCode());
+  }
   return isolate;
 }
 
@@ -495,6 +502,12 @@ static void EmbedderTimelineStopRecording() {
 void SetServiceIsolateHook(ServiceIsolateHook hook) {
   CHECK(!g_service_isolate_initialized);
   g_service_isolate_hook = hook;
+}
+
+void SetRegisterNativeServiceProtocolExtensionHook(
+    RegisterNativeServiceProtocolExtensionHook hook) {
+  CHECK(!g_service_isolate_initialized);
+  g_register_native_service_protocol_extensions_hook = hook;
 }
 
 static bool ShouldEnableCheckedMode() {

--- a/sky/engine/core/script/dart_init.h
+++ b/sky/engine/core/script/dart_init.h
@@ -42,6 +42,7 @@ bool IsRunningPrecompiledCode();
 using EmbedderTracingCallback = base::Callback<void(void)>;
 
 typedef void (*ServiceIsolateHook)(bool);
+typedef void (*RegisterNativeServiceProtocolExtensionHook)(bool);
 
 struct EmbedderTracingCallbacks {
   EmbedderTracingCallback start_tracing_callback;
@@ -59,6 +60,11 @@ void SetEmbedderTracingCallbacks(
 // Provide a function that will be called during initialization of the
 // service isolate.
 void SetServiceIsolateHook(ServiceIsolateHook hook);
+
+// Provide a function that will be called to register native service protocol
+// extensions.
+void SetRegisterNativeServiceProtocolExtensionHook(
+    RegisterNativeServiceProtocolExtensionHook hook);
 
 Dart_Handle DartLibraryTagHandler(Dart_LibraryTag tag,
                                   Dart_Handle library,

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -23,6 +23,8 @@ source_set("common") {
     "gpu/picture_serializer.h",
     "platform_view.cc",
     "platform_view.h",
+    "platform_view_service_protocol.cc",
+    "platform_view_service_protocol.h",
     "rasterizer.cc",
     "rasterizer.h",
     "shell.cc",

--- a/sky/shell/platform_view.cc
+++ b/sky/shell/platform_view.cc
@@ -50,6 +50,10 @@ PlatformView::PlatformView()
 
 PlatformView::~PlatformView() {
   Shell& shell = Shell::Shared();
+  // Purge dead PlatformViews.
+  shell.ui_task_runner()->PostTask(
+      FROM_HERE,
+      base::Bind(&Shell::PurgePlatformViews, base::Unretained(&shell)));
   shell.gpu_task_runner()->DeleteSoon(FROM_HERE, rasterizer_.release());
   shell.ui_task_runner()->DeleteSoon(FROM_HERE, engine_.release());
 }
@@ -58,6 +62,12 @@ void PlatformView::ConnectToEngine(mojo::InterfaceRequest<SkyEngine> request) {
   config_.ui_task_runner->PostTask(
       FROM_HERE, base::Bind(&UIDelegate::ConnectToEngine, config_.ui_delegate,
                             base::Passed(&request)));
+  Shell& shell = Shell::Shared();
+  shell.ui_task_runner()->PostTask(
+      FROM_HERE,
+      base::Bind(&Shell::AddPlatformView,
+                 base::Unretained(&shell),
+                 GetWeakViewPtr()));
 }
 
 void PlatformView::NotifyCreated() {

--- a/sky/shell/platform_view_service_protocol.cc
+++ b/sky/shell/platform_view_service_protocol.cc
@@ -1,0 +1,79 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "sky/shell/platform_view_service_protocol.h"
+
+#include "sky/shell/shell.h"
+
+namespace sky {
+namespace shell {
+
+void PlatformViewServiceProtocol::RegisterHook(bool running_precompiled_code) {
+  if (running_precompiled_code) {
+    return;
+  }
+  Dart_RegisterRootServiceRequestCallback(kRunInViewExtensionName,
+                                          &RunInView,
+                                          nullptr);
+  Dart_RegisterRootServiceRequestCallback(kListViewsExtensionName,
+                                          &ListViews,
+                                          nullptr);
+}
+
+const char* PlatformViewServiceProtocol::kRunInViewExtensionName =
+    "_flutter.runInView";
+
+bool PlatformViewServiceProtocol::RunInView(const char* method,
+                                            const char** param_keys,
+                                            const char** param_values,
+                                            intptr_t num_params,
+                                            void* user_data,
+                                            const char** json_object) {
+  // TODO(johnmccutchan): Implement this.
+  *json_object = strdup("{\"type\": \"Success\"}");
+  return true;
+}
+
+const char* PlatformViewServiceProtocol::kListViewsExtensionName =
+    "_flutter.listViews";
+
+bool PlatformViewServiceProtocol::ListViews(const char* method,
+                                            const char** param_keys,
+                                            const char** param_values,
+                                            intptr_t num_params,
+                                            void* user_data,
+                                            const char** json_object) {
+  // Ask the Shell for the list of platform views. This will run a task on
+  // the UI thread before returning.
+  Shell& shell = Shell::Shared();
+  std::vector<base::WeakPtr<PlatformView>> platform_views;
+  shell.WaitForPlatformViews(&platform_views);
+
+  std::stringstream response;
+
+  response << "{\"type\":\"FlutterViewList\",\"views\":[";
+  bool prefix_comma = false;
+  for (auto it = platform_views.begin(); it != platform_views.end(); it++) {
+    PlatformView* view = it->get();
+    if (!view) {
+      // Skip any platform views which have been deleted.
+      continue;
+    }
+    if (prefix_comma) {
+      response << ',';
+    } else {
+      prefix_comma = true;
+    }
+    response << "{\"type\":\"FlutterView\", \"id\": \"_flutterView/";
+    response << "0x" << std::hex << reinterpret_cast<uintptr_t>(view);
+    response << "\"}";
+  }
+  response << "]}";
+  // Copy the response.
+  *json_object = strdup(response.str().c_str());
+  return true;
+}
+
+}  // namespace shell
+}  // namespace sky

--- a/sky/shell/platform_view_service_protocol.h
+++ b/sky/shell/platform_view_service_protocol.h
@@ -1,0 +1,41 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SKY_SHELL_PLATFORM_VIEW_SERVICE_PROTOCOL_H_
+#define SKY_SHELL_PLATFORM_VIEW_SERVICE_PROTOCOL_H_
+
+#include <memory>
+
+#include "sky/shell/platform_view.h"
+#include "dart/runtime/include/dart_tools_api.h"
+
+namespace sky {
+namespace shell {
+
+class PlatformViewServiceProtocol {
+ public:
+  static void RegisterHook(bool running_precompiled_code);
+
+ private:
+  static const char* kRunInViewExtensionName;
+  static bool RunInView(const char* method,
+                        const char** param_keys,
+                        const char** param_values,
+                        intptr_t num_params,
+                        void* user_data,
+                        const char** json_object);
+
+  static const char* kListViewsExtensionName;
+  static bool ListViews(const char* method,
+                        const char** param_keys,
+                        const char** param_values,
+                        intptr_t num_params,
+                        void* user_data,
+                        const char** json_object);
+};
+
+}  // namespace shell
+}  // namespace sky
+
+#endif  // SKY_SHELL_PLATFORM_VIEW_SERVICE_PROTOCOL_H_


### PR DESCRIPTION
- [x] Persist a list of PlatformViews in the Shell.
- [x] Implement a service protocol extension "_flutter.listViews" which returns the list of views.

Sending this out now to make sure I haven't gone down a totally wrong path.

From this I plan to implement the "_flutter.runInView" service protocol extension which will let me launch a Flutter application in a specific view.