### PR TITLE
Make the platform view house the SkyEnginePtr.

### DIFF
--- a/sky/shell/platform_view.h
+++ b/sky/shell/platform_view.h
@@ -6,6 +6,7 @@
 #define SKY_SHELL_PLATFORM_VIEW_H_
 
 #include <memory>
+#include <type_traits>
 
 #include "base/macros.h"
 #include "base/memory/weak_ptr.h"
@@ -14,6 +15,7 @@
 #include "sky/shell/shell.h"
 #include "sky/shell/ui/engine.h"
 #include "sky/shell/ui_delegate.h"
+#include "sky/services/engine/sky_engine.mojom.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 
@@ -43,13 +45,11 @@ class PlatformView {
     uint8_t stencil_bits = 8;
   };
 
-  void SetupResourceContextOnIOThread();
-
   static base::ThreadLocalStorage::StaticSlot ResourceContext;
 
   virtual ~PlatformView();
 
-  void ConnectToEngine(mojo::InterfaceRequest<SkyEngine> request);
+  SkyEnginePtr& GetEnginePtr();
 
   void NotifyCreated();
 
@@ -77,10 +77,13 @@ class PlatformView {
 
   std::unique_ptr<Rasterizer> rasterizer_;
   std::unique_ptr<Engine> engine_;
+  SkyEnginePtr engine_ptr_;
 
   SkISize size_;
 
   explicit PlatformView();
+
+  void SetupResourceContextOnIOThread();
 
   void SetupResourceContextOnIOThreadPerform(base::WaitableEvent* event);
 

--- a/sky/shell/testing/test_runner.cc
+++ b/sky/shell/testing/test_runner.cc
@@ -18,14 +18,12 @@ namespace shell {
 
 TestRunner::TestRunner()
     : platform_view_(new PlatformViewTest()), weak_ptr_factory_(this) {
-  platform_view_->ConnectToEngine(GetProxy(&sky_engine_));
-
   ViewportMetricsPtr metrics = ViewportMetrics::New();
 
   metrics->physical_width = 800;
   metrics->physical_height = 600;
 
-  sky_engine_->OnViewportMetricsChanged(metrics.Pass());
+  platform_view_->GetEnginePtr()->OnViewportMetricsChanged(metrics.Pass());
 }
 
 TestRunner::~TestRunner() = default;
@@ -38,7 +36,7 @@ TestRunner& TestRunner::Shared() {
 }
 
 void TestRunner::Run(const TestDescriptor& test) {
-  sky_engine_->RunFromFile(test.path, test.packages, "");
+  platform_view_->GetEnginePtr()->RunFromFile(test.path, test.packages, "");
 }
 
 }  // namespace shell


### PR DESCRIPTION
cc @abarth @johnmccutchan This is so that its easier for anyone with access to the platform view to make calls into the engine.

Only contains the Mac backend implementation. If this interface looks OK, will patch the other platforms.