### PR TITLE
Do not pass a PlatformView weak pointer to the IO thread

### DIFF
--- a/sky/shell/platform_view.cc
+++ b/sky/shell/platform_view.cc
@@ -127,7 +127,7 @@ void PlatformView::SetupResourceContextOnIOThread() {
   Shell::Shared().io_task_runner()->PostTask(
       FROM_HERE,
       base::Bind(&PlatformView::SetupResourceContextOnIOThreadPerform,
-                 GetWeakViewPtr(), base::Unretained(&latch)));
+                 base::Unretained(this), base::Unretained(&latch)));
   latch.Wait();
 }
 


### PR DESCRIPTION
PlatformViews are owned by the UI thread