### PR TITLE
Add glue::PrintStackTrace()

### DIFF
--- a/glue/BUILD.gn
+++ b/glue/BUILD.gn
@@ -5,6 +5,8 @@
 source_set("glue") {
   sources = [
     "movable_wrapper.h",
+    "stack_trace.cc",
+    "stack_trace.h",
     "task_runner_adaptor.cc",
     "task_runner_adaptor.h",
     "trace_event.h",

--- a/glue/stack_trace.cc
+++ b/glue/stack_trace.cc
@@ -1,0 +1,15 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "glue/stack_trace.h"
+
+#include "base/debug/stack_trace.h"
+
+namespace glue {
+
+void PrintStackTrace() {
+  base::debug::StackTrace().Print();
+}
+
+}  // namespace glue

--- a/glue/stack_trace.h
+++ b/glue/stack_trace.h
@@ -1,0 +1,14 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef GLUE_STACK_TRACE_H_
+#define GLUE_STACK_TRACE_H_
+
+namespace glue {
+
+void PrintStackTrace();
+
+}  // namespace glue
+
+#endif  // GLUE_STACK_TRACE_H_

--- a/sky/engine/wtf/Assertions.cpp
+++ b/sky/engine/wtf/Assertions.cpp
@@ -33,6 +33,7 @@
 
 #include "sky/engine/wtf/Assertions.h"
 
+#include "glue/stack_trace.h"
 #include "sky/engine/wtf/Compiler.h"
 #include "sky/engine/wtf/OwnPtr.h"
 #include "sky/engine/wtf/PassOwnPtr.h"
@@ -55,8 +56,6 @@
 #if OS(ANDROID)
 #include <android/log.h>
 #endif
-
-#include "base/debug/stack_trace.h"
 
 extern "C" {
 
@@ -151,7 +150,7 @@ void WTFReportArgumentAssertionFailure(const char* file, int line, const char* f
 
 void WTFReportBacktrace()
 {
-    base::debug::StackTrace().Print();
+    glue::PrintStackTrace();
 }
 
 void WTFReportFatalError(const char* file, int line, const char* function, const char* format, ...)

--- a/sky/engine/wtf/BUILD.gn
+++ b/sky/engine/wtf/BUILD.gn
@@ -193,6 +193,7 @@ component("wtf") {
 
   deps = [
     "//base",
+    "//glue",
     "//third_party/icu",
   ]
 


### PR DESCRIPTION
We don't have a way to print stack traces on Fuchsia yet. This patch
isolates this base dependency in //glue.