### PR TITLE
Stop dropping top level languageerrors on the floor during reload

### DIFF
--- a/flutter/tonic/dart_library_loader.cc
+++ b/flutter/tonic/dart_library_loader.cc
@@ -223,8 +223,7 @@ Dart_Handle DartLibraryLoader::HandleLibraryTag(Dart_LibraryTag tag,
     return DartState::Current()->library_loader().Source(library, url);
   }
   if (tag == Dart_kScriptTag) {
-    DartIsolateReloader::HandleLibraryTag(tag, library, url);
-    return Dart_Null();
+    return DartIsolateReloader::HandleLibraryTag(tag, library, url);
   }
   DCHECK(false);
   return Dart_NewApiError("Unknown library tag.");


### PR DESCRIPTION
Return the error from the tag handler instead of always returning Dart_Null.