### PR TITLE
Add an association between FlutterViews and Dart Isolates to the PlatformView service protocol support

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -26,7 +26,7 @@ vars = {
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
-  'dart_revision': 'a83edeee956c31d50c99be03668802aa548b7661',
+  'dart_revision': '5a2193ecc4f5672a61169cba93197dc3aa46e1d1',
   'dart_boringssl_revision': '8d343b44bbab829d1a28fdef650ca95f7db4412e',
   'dart_observatory_packages_revision': 'a01235b5b71df27b602dae4676d0bf771cbe7fa2',
   'dart_root_certificates_revision': 'aed07942ce98507d2be28cbd29e879525410c7fc',

--- a/sky/engine/bindings/flutter_dart_state.cc
+++ b/sky/engine/bindings/flutter_dart_state.cc
@@ -19,13 +19,14 @@ IsolateClient::~IsolateClient() {}
 
 FlutterDartState::FlutterDartState(IsolateClient* isolate_client,
                                    const std::string& url)
-    : isolate_client_(isolate_client), url_(url) {
+    : isolate_client_(isolate_client), url_(url), main_port_(ILLEGAL_PORT) {
 #ifdef OS_ANDROID
   jni_data_.reset(new DartJniIsolateData());
 #endif
 }
 
 FlutterDartState::~FlutterDartState() {
+  main_port_ = ILLEGAL_PORT;
   // We've already destroyed the isolate. Revoke any weak ptrs held by
   // DartPersistentValues so they don't try to enter the destroyed isolate to
   // clean themselves up.
@@ -40,7 +41,9 @@ FlutterDartState* FlutterDartState::Current() {
   return static_cast<FlutterDartState*>(DartState::Current());
 }
 
-void FlutterDartState::DidSetIsolate() {}
+void FlutterDartState::DidSetIsolate() {
+  main_port_ = Dart_GetMainPortId();
+}
 
 void FlutterDartState::set_mojo_services(
     std::unique_ptr<MojoServices> mojo_services) {

--- a/sky/engine/bindings/flutter_dart_state.h
+++ b/sky/engine/bindings/flutter_dart_state.h
@@ -37,6 +37,10 @@ class FlutterDartState : public DartState {
 
   static FlutterDartState* Current();
 
+  Dart_Port main_port() const {
+    return main_port_;
+  }
+
   void set_mojo_services(std::unique_ptr<MojoServices> mojo_services);
   MojoServices* mojo_services();
 
@@ -50,6 +54,8 @@ class FlutterDartState : public DartState {
  private:
   IsolateClient* isolate_client_;
   std::string url_;
+
+  Dart_Port main_port_;
 
   std::unique_ptr<MojoServices> mojo_services_;
 

--- a/sky/engine/core/script/dart_controller.cc
+++ b/sky/engine/core/script/dart_controller.cc
@@ -170,6 +170,7 @@ void DartController::CreateIsolateFor(std::unique_ptr<UIDartState> state) {
       ftl::RefPtr<ftl::TaskRunner>(Platform::current()->GetUITaskRunner()));
 
   Dart_SetShouldPauseOnStart(SkySettings::Get().start_paused);
+
   ui_dart_state_->SetIsolate(isolate);
   FTL_CHECK(!LogIfError(Dart_SetLibraryTagHandler(DartLibraryTagHandler)));
 

--- a/sky/engine/public/sky/sky_view.cc
+++ b/sky/engine/public/sky/sky_view.cc
@@ -113,4 +113,15 @@ void SkyView::OnAppLifecycleStateChanged(sky::AppLifecycleState state) {
   GetWindow()->OnAppLifecycleStateChanged(state);
 }
 
+Dart_Port SkyView::GetMainPort() {
+  if (!dart_controller_) {
+    return ILLEGAL_PORT;
+  }
+  if (!dart_controller_->dart_state()) {
+    return ILLEGAL_PORT;
+  }
+  return dart_controller_->dart_state()->main_port();
+}
+
+
 }  // namespace blink

--- a/sky/engine/public/sky/sky_view.h
+++ b/sky/engine/public/sky/sky_view.h
@@ -53,6 +53,8 @@ class SkyView : public WindowClient, public IsolateClient {
 
   void OnAppLifecycleStateChanged(sky::AppLifecycleState state);
 
+  Dart_Port GetMainPort();
+
  private:
   explicit SkyView(SkyViewClient* client);
 

--- a/sky/shell/shell.h
+++ b/sky/shell/shell.h
@@ -73,16 +73,23 @@ class Shell {
   void GetPlatformViews(
       std::vector<base::WeakPtr<PlatformView>>* platform_views);
 
+  struct PlatformViewInfo {
+    uintptr_t view_id;
+    int64_t isolate_id;
+  };
+
   // These APIs can be called from any thread.
   // Return the list of platform view ids at the time of this call.
-  void WaitForPlatformViewIds(std::vector<uintptr_t>* platform_view_ids);
+  void WaitForPlatformViewIds(std::vector<PlatformViewInfo>* platform_view_ids);
+
   // Attempt to run a script inside a flutter view indicated by |view_id|.
   // Will set |view_existed| to true if the view was found and false otherwise.
   void RunInPlatformView(uintptr_t view_id,
                          const char* main_script,
                          const char* packages_file,
                          const char* asset_directory,
-                         bool* view_existed);
+                         bool* view_existed,
+                         int64_t* dart_isolate_id);
 
  private:
   Shell();
@@ -90,14 +97,16 @@ class Shell {
   void InitGpuThread();
   void InitUIThread();
 
-  void WaitForPlatformViewsIdsUIThread(std::vector<uintptr_t>* platform_views,
-                                       base::WaitableEvent* latch);
+  void WaitForPlatformViewsIdsUIThread(
+      std::vector<PlatformViewInfo>* platform_views,
+      base::WaitableEvent* latch);
 
   void RunInPlatformViewUIThread(uintptr_t view_id,
                                  const std::string& main,
                                  const std::string& packages,
                                  const std::string& assets_directory,
                                  bool* view_existed,
+                                 int64_t* dart_isolate_id,
                                  base::WaitableEvent* latch);
 
   std::unique_ptr<base::Thread> gpu_thread_;

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -90,6 +90,13 @@ void Engine::RunFromSource(const std::string& main,
   RunFromLibrary(main);
 }
 
+Dart_Port Engine::GetUIIsolateMainPort() {
+  if (!sky_view_) {
+    return ILLEGAL_PORT;
+  }
+  return sky_view_->GetMainPort();
+}
+
 void Engine::ConnectToEngine(mojo::InterfaceRequest<SkyEngine> request) {
   binding_.Bind(request.Pass());
 }

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -54,6 +54,8 @@ class Engine : public UIDelegate,
                      const std::string& packages,
                      const std::string& assets_directory);
 
+  Dart_Port GetUIIsolateMainPort();
+
  private:
   // UIDelegate implementation:
   void ConnectToEngine(mojo::InterfaceRequest<SkyEngine> request) override;


### PR DESCRIPTION
- Roll Dart forward to enable faster DevFS writing (33% speedup)
- Add an association between FlutterView and the UI isolate. This will be used in Flutter Tools to provide better diagnostic logging.