### PR TITLE
Remove more //base dependencies from //sky/shell

### DIFF
--- a/sky/shell/dart/dart_library_provider_files.h
+++ b/sky/shell/dart/dart_library_provider_files.h
@@ -7,6 +7,7 @@
 
 #include "base/files/file_path.h"
 #include "flutter/tonic/dart_library_provider.h"
+#include "lib/ftl/macros.h"
 #include "lib/tonic/parsers/packages_map.h"
 
 namespace sky {
@@ -32,7 +33,7 @@ class DartLibraryProviderFiles : public blink::DartLibraryProvider {
   base::FilePath packages_;
   tonic::PackagesMap packages_map_;
 
-  DISALLOW_COPY_AND_ASSIGN(DartLibraryProviderFiles);
+  FTL_DISALLOW_COPY_AND_ASSIGN(DartLibraryProviderFiles);
 };
 
 }  // namespace shell

--- a/sky/shell/diagnostic/diagnostic_server.cc
+++ b/sky/shell/diagnostic/diagnostic_server.cc
@@ -103,7 +103,7 @@ void DiagnosticServer::HandleSkiaPictureRequest(Dart_Handle send_port) {
 }
 
 void DiagnosticServer::SkiaPictureTask(Dart_Port port_id) {
-  std::vector<base::WeakPtr<Rasterizer>> rasterizers;
+  std::vector<ftl::WeakPtr<Rasterizer>> rasterizers;
   Shell::Shared().GetRasterizers(&rasterizers);
   if (rasterizers.size() != 1) {
     SendNull(port_id);

--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -31,7 +31,7 @@ std::unique_ptr<Rasterizer> Rasterizer::Create() {
 }
 
 // sky::shell::Rasterizer override.
-base::WeakPtr<Rasterizer> RasterizerDirect::GetWeakRasterizerPtr() {
+ftl::WeakPtr<Rasterizer> RasterizerDirect::GetWeakRasterizerPtr() {
   return weak_factory_.GetWeakPtr();
 }
 
@@ -44,9 +44,10 @@ void RasterizerDirect::ConnectToRasterizer(
 }
 
 // sky::shell::Rasterizer override.
-void RasterizerDirect::Setup(PlatformView* platform_view,
-                             base::Closure continuation,
-                             base::WaitableEvent* setup_completion_event) {
+void RasterizerDirect::Setup(
+    PlatformView* platform_view,
+    ftl::Closure continuation,
+    ftl::AutoResetWaitableEvent* setup_completion_event) {
   CHECK(platform_view) << "Must be able to acquire the view.";
 
   // The context needs to be made current before the GrGL interface can be
@@ -66,14 +67,14 @@ void RasterizerDirect::Setup(PlatformView* platform_view,
     LOG(ERROR) << "WARNING: Flutter will be unable to render to the display";
   }
 
-  continuation.Run();
+  continuation();
 
   setup_completion_event->Signal();
 }
 
 // sky::shell::Rasterizer override.
 void RasterizerDirect::Teardown(
-    base::WaitableEvent* teardown_completion_event) {
+    ftl::AutoResetWaitableEvent* teardown_completion_event) {
   platform_view_ = nullptr;
   last_layer_tree_.reset();
   compositor_context_.OnGrContextDestroyed();

--- a/sky/shell/gpu/direct/rasterizer_direct.h
+++ b/sky/shell/gpu/direct/rasterizer_direct.h
@@ -5,9 +5,9 @@
 #ifndef SKY_SHELL_GPU_DIRECT_RASTERIZER_DIRECT_H_
 #define SKY_SHELL_GPU_DIRECT_RASTERIZER_DIRECT_H_
 
-#include "base/memory/weak_ptr.h"
-#include "base/synchronization/waitable_event.h"
 #include "flow/compositor_context.h"
+#include "lib/ftl/memory/weak_ptr.h"
+#include "lib/ftl/synchronization/waitable_event.h"
 #include "sky/shell/gpu/direct/ganesh_canvas.h"
 #include "sky/shell/rasterizer.h"
 
@@ -26,14 +26,15 @@ class RasterizerDirect : public Rasterizer {
 
   // sky::shell::Rasterizer override.
   void Setup(PlatformView* platform_view,
-             base::Closure continuation,
-             base::WaitableEvent* setup_completion_event) override;
+             ftl::Closure continuation,
+             ftl::AutoResetWaitableEvent* setup_completion_event) override;
 
   // sky::shell::Rasterizer override.
-  void Teardown(base::WaitableEvent* teardown_completion_event) override;
+  void Teardown(
+      ftl::AutoResetWaitableEvent* teardown_completion_event) override;
 
   // sky::shell::Rasterizer override.
-  base::WeakPtr<sky::shell::Rasterizer> GetWeakRasterizerPtr() override;
+  ftl::WeakPtr<sky::shell::Rasterizer> GetWeakRasterizerPtr() override;
 
   // sky::shell::Rasterizer override.
   flow::LayerTree* GetLastLayerTree() override;
@@ -44,12 +45,12 @@ class RasterizerDirect : public Rasterizer {
   mojo::Binding<rasterizer::Rasterizer> binding_;
   std::unique_ptr<flow::LayerTree> last_layer_tree_;
   PlatformView* platform_view_;
-  base::WeakPtrFactory<RasterizerDirect> weak_factory_;
+  ftl::WeakPtrFactory<RasterizerDirect> weak_factory_;
 
   // sky::services::rasterizer::Rasterizer (from rasterizer.mojom) override.
   void Draw(uint64_t layer_tree_ptr, const DrawCallback& callback) override;
 
-  DISALLOW_COPY_AND_ASSIGN(RasterizerDirect);
+  FTL_DISALLOW_COPY_AND_ASSIGN(RasterizerDirect);
 };
 
 }  // namespace shell

--- a/sky/shell/gpu/mojo/gl_texture_recycler.cc
+++ b/sky/shell/gpu/mojo/gl_texture_recycler.cc
@@ -82,7 +82,7 @@ mojo::gfx::composition::ResourcePtr GLTextureRecycler::BindTextureResource(
 }
 
 void GLTextureRecycler::ReleaseTexture(GLRecycledTextureInfo texture_info,
-                                bool recyclable) {
+                                       bool recyclable) {
   DCHECK(bound_textures_);
   bound_textures_--;
   if (recyclable && recycled_textures_.size() < max_recycled_textures_) {
@@ -93,7 +93,7 @@ void GLTextureRecycler::ReleaseTexture(GLRecycledTextureInfo texture_info,
 }
 
 GLTextureRecycler::GLTextureReleaser::GLTextureReleaser(
-    const base::WeakPtr<GLTextureRecycler>& provider,
+    const ftl::WeakPtr<GLTextureRecycler>& provider,
     GLRecycledTextureInfo info)
     : provider_(provider), texture_info_(std::move(info)), binding_(this) {}
 

--- a/sky/shell/gpu/mojo/gl_texture_recycler.h
+++ b/sky/shell/gpu/mojo/gl_texture_recycler.h
@@ -8,9 +8,10 @@
 #include <deque>
 #include <memory>
 
-#include "base/callback.h"
-#include "base/macros.h"
-#include "base/memory/weak_ptr.h"
+#include "base/memory/ref_counted.h"
+#include "lib/ftl/functional/closure.h"
+#include "lib/ftl/macros.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "mojo/services/gfx/composition/interfaces/resources.mojom.h"
 
@@ -29,7 +30,7 @@ namespace shell {
 class GLTextureRecycler {
  public:
   GLTextureRecycler(scoped_refptr<mojo::GLContext> gl_context,
-             uint32_t max_recycled_textures = 3u);
+                    uint32_t max_recycled_textures = 3u);
   ~GLTextureRecycler();
 
   // Obtains a texture of the specified size.
@@ -51,7 +52,7 @@ class GLTextureRecycler {
   // migrating to image pipes.
   class GLTextureReleaser : mojo::gfx::composition::MailboxTextureCallback {
    public:
-    GLTextureReleaser(const base::WeakPtr<GLTextureRecycler>& provider,
+    GLTextureReleaser(const ftl::WeakPtr<GLTextureRecycler>& provider,
                       GLRecycledTextureInfo info);
     ~GLTextureReleaser() override;
 
@@ -61,7 +62,7 @@ class GLTextureRecycler {
     void OnMailboxTextureReleased() override;
     void Release(bool recyclable);
 
-    base::WeakPtr<GLTextureRecycler> provider_;
+    ftl::WeakPtr<GLTextureRecycler> provider_;
     GLRecycledTextureInfo texture_info_;
     mojo::StrongBinding<mojo::gfx::composition::MailboxTextureCallback>
         binding_;
@@ -75,9 +76,9 @@ class GLTextureRecycler {
   std::deque<GLRecycledTextureInfo> recycled_textures_;
   uint32_t bound_textures_ = 0u;
 
-  base::WeakPtrFactory<GLTextureRecycler> weak_factory_;
+  ftl::WeakPtrFactory<GLTextureRecycler> weak_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(GLTextureRecycler);
+  FTL_DISALLOW_COPY_AND_ASSIGN(GLTextureRecycler);
 };
 
 }  // namespace shell

--- a/sky/shell/gpu/mojo/rasterizer_mojo.cc
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.cc
@@ -40,7 +40,7 @@ RasterizerMojo::~RasterizerMojo() {
   Shell::Shared().PurgeRasterizers();
 }
 
-base::WeakPtr<Rasterizer> RasterizerMojo::GetWeakRasterizerPtr() {
+ftl::WeakPtr<Rasterizer> RasterizerMojo::GetWeakRasterizerPtr() {
   return weak_factory_.GetWeakPtr();
 }
 
@@ -57,14 +57,16 @@ void RasterizerMojo::Init(mojo::ApplicationConnectorPtr connector,
   scene_ = scene.Pass();
 }
 
-void RasterizerMojo::Setup(PlatformView* platform_view,
-                           base::Closure rasterizer_continuation,
-                           base::WaitableEvent* setup_completion_event) {
+void RasterizerMojo::Setup(
+    PlatformView* platform_view,
+    ftl::Closure rasterizer_continuation,
+    ftl::AutoResetWaitableEvent* setup_completion_event) {
   setup_completion_event->Signal();
-  rasterizer_continuation.Run();
+  rasterizer_continuation();
 }
 
-void RasterizerMojo::Teardown(base::WaitableEvent* teardown_completion_event) {
+void RasterizerMojo::Teardown(
+    ftl::AutoResetWaitableEvent* teardown_completion_event) {
   teardown_completion_event->Signal();
 }
 

--- a/sky/shell/gpu/mojo/rasterizer_mojo.h
+++ b/sky/shell/gpu/mojo/rasterizer_mojo.h
@@ -5,8 +5,8 @@
 #ifndef SKY_SHELL_GPU_MOJO_RASTERIZER_MOJO_H_
 #define SKY_SHELL_GPU_MOJO_RASTERIZER_MOJO_H_
 
-#include "base/memory/weak_ptr.h"
 #include "flow/compositor_context.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "mojo/gpu/gl_context.h"
 #include "mojo/public/interfaces/application/application_connector.mojom.h"
 #include "mojo/services/gfx/composition/interfaces/scenes.mojom.h"
@@ -32,14 +32,15 @@ class RasterizerMojo : public Rasterizer {
 
   // sky::shell::rasterizer::Rasterizer override
   void Setup(PlatformView* platform_view,
-             base::Closure rasterizer_continuation,
-             base::WaitableEvent* setup_completion_event) override;
+             ftl::Closure rasterizer_continuation,
+             ftl::AutoResetWaitableEvent* setup_completion_event) override;
 
   // sky::shell::rasterizer::Rasterizer override
-  void Teardown(base::WaitableEvent* teardown_completion_event) override;
+  void Teardown(
+      ftl::AutoResetWaitableEvent* teardown_completion_event) override;
 
   // sky::shell::rasterizer::Rasterizer override
-  base::WeakPtr<Rasterizer> GetWeakRasterizerPtr() override;
+  ftl::WeakPtr<Rasterizer> GetWeakRasterizerPtr() override;
 
   // sky::shell::rasterizer::Rasterizer override
   flow::LayerTree* GetLastLayerTree() override;
@@ -60,11 +61,11 @@ class RasterizerMojo : public Rasterizer {
   std::unique_ptr<GLState> gl_state_;
   flow::CompositorContext compositor_context_;
   std::unique_ptr<flow::LayerTree> last_layer_tree_;
-  base::WeakPtrFactory<RasterizerMojo> weak_factory_;
+  ftl::WeakPtrFactory<RasterizerMojo> weak_factory_;
 
   void Draw(uint64_t layer_tree_ptr, const DrawCallback& callback) override;
 
-  DISALLOW_COPY_AND_ASSIGN(RasterizerMojo);
+  FTL_DISALLOW_COPY_AND_ASSIGN(RasterizerMojo);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/android/flutter_main.cc
+++ b/sky/shell/platform/android/flutter_main.cc
@@ -13,7 +13,7 @@
 #include "base/files/file_path.h"
 #include "base/lazy_instance.h"
 #include "base/logging.h"
-#include "base/macros.h"
+#include "lib/ftl/macros.h"
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"

--- a/sky/shell/platform/android/platform_view_android.cc
+++ b/sky/shell/platform/android/platform_view_android.cc
@@ -86,10 +86,9 @@ EGLResult<EGLSurface> CreatePBufferSurface(EGLDisplay display,
   return {surface != EGL_NO_SURFACE, surface};
 }
 
-EGLResult<EGLSurface> CreateContext(
-    EGLDisplay display,
-    EGLConfig config,
-    EGLContext share = EGL_NO_CONTEXT) {
+EGLResult<EGLSurface> CreateContext(EGLDisplay display,
+                                    EGLConfig config,
+                                    EGLContext share = EGL_NO_CONTEXT) {
   EGLint attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
 
   EGLContext context = eglCreateContext(display, config, share, attributes);
@@ -156,8 +155,7 @@ void InitGlobal() {
   std::tie(success, g_resource_surface) =
       CreatePBufferSurface(g_display, resource_egl_config);
   if (!success) {
-    DLOG(INFO)
-        << "Could not create the pbuffer surface for resource loading.";
+    DLOG(INFO) << "Could not create the pbuffer surface for resource loading.";
     LogLastEGLError();
     return;
   }
@@ -199,7 +197,7 @@ class AndroidNativeWindow {
  private:
   Handle window_;
 
-  DISALLOW_COPY_AND_ASSIGN(AndroidNativeWindow);
+  FTL_DISALLOW_COPY_AND_ASSIGN(AndroidNativeWindow);
 };
 
 class AndroidGLContext {
@@ -242,8 +240,8 @@ class AndroidGLContext {
 
     // Create a context for the configuration.
 
-    std::tie(success, context_) = CreateContext(g_display, config_,
-                                                g_resource_context);
+    std::tie(success, context_) =
+        CreateContext(g_display, config_, g_resource_context);
 
     if (!success) {
       DLOG(INFO) << "Could not create the main rendering context";
@@ -343,7 +341,7 @@ class AndroidGLContext {
     return {surface != EGL_NO_SURFACE, surface};
   }
 
-  DISALLOW_COPY_AND_ASSIGN(AndroidGLContext);
+  FTL_DISALLOW_COPY_AND_ASSIGN(AndroidGLContext);
 };
 
 static jlong Attach(JNIEnv* env, jclass clazz, jint skyEngineHandle) {
@@ -402,7 +400,7 @@ void PlatformViewAndroid::SurfaceDestroyed(JNIEnv* env, jobject obj) {
   context_ = nullptr;
 }
 
-base::WeakPtr<sky::shell::PlatformView> PlatformViewAndroid::GetWeakViewPtr() {
+ftl::WeakPtr<sky::shell::PlatformView> PlatformViewAndroid::GetWeakViewPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/sky/shell/platform/android/platform_view_android.h
+++ b/sky/shell/platform/android/platform_view_android.h
@@ -5,9 +5,8 @@
 #ifndef SKY_SHELL_PLATFORM_ANDROID_PLATFORM_VIEW_ANDROID_H_
 #define SKY_SHELL_PLATFORM_ANDROID_PLATFORM_VIEW_ANDROID_H_
 
-#include "base/macros.h"
 #include "base/android/jni_android.h"
-#include "base/synchronization/waitable_event.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "sky/shell/platform_view.h"
 
 namespace sky {
@@ -33,7 +32,7 @@ class PlatformViewAndroid : public PlatformView {
   void SurfaceDestroyed(JNIEnv* env, jobject obj);
 
   // sky::shell::PlatformView override
-  base::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
+  ftl::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
 
   // sky::shell::PlatformView override
   uint64_t DefaultFramebuffer() const override;
@@ -55,9 +54,9 @@ class PlatformViewAndroid : public PlatformView {
 
  private:
   std::unique_ptr<AndroidGLContext> context_;
-  base::WeakPtrFactory<PlatformViewAndroid> weak_factory_;
+  ftl::WeakPtrFactory<PlatformViewAndroid> weak_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(PlatformViewAndroid);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewAndroid);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/glfw/message_pump_glfw.h
+++ b/sky/shell/platform/glfw/message_pump_glfw.h
@@ -30,7 +30,7 @@ class MessagePumpGLFW : public base::MessagePump {
   bool should_quit_;
   base::TimeTicks delayed_work_time_;
 
-  DISALLOW_COPY_AND_ASSIGN(MessagePumpGLFW);
+  FTL_DISALLOW_COPY_AND_ASSIGN(MessagePumpGLFW);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/glfw/platform_view_glfw.h
+++ b/sky/shell/platform/glfw/platform_view_glfw.h
@@ -21,7 +21,7 @@ class PlatformViewGLFW : public PlatformView {
  private:
   gfx::AcceleratedWidget window_;
 
-  DISALLOW_COPY_AND_ASSIGN(PlatformViewGLFW);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewGLFW);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/glfw/window_impl.h
+++ b/sky/shell/platform/glfw/window_impl.h
@@ -52,7 +52,7 @@ class WindowImpl : public mojo::ServiceProvider,
   mojo::BindingSet<raw_keyboard::RawKeyboardService> raw_keyboard_bindings_;
   std::vector<raw_keyboard::RawKeyboardListenerPtr> raw_keyboard_listeners_;
 
-  DISALLOW_COPY_AND_ASSIGN(WindowImpl);
+  FTL_DISALLOW_COPY_AND_ASSIGN(WindowImpl);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
@@ -216,10 +216,14 @@ static void DynamicServiceResolve(void* baton,
   new sky::shell::PlatformServiceProvider(serviceProviderProxy.Pass(),
                                           serviceResolutionCallback);
 
+  ftl::WeakPtr<sky::shell::ApplicationMessagesImpl> appplication_messages_impl
+      = _appMessageReceiver.GetWeakPtr();
   mojo::ServiceProviderPtr viewServiceProvider;
-  new sky::shell::ViewServiceProvider(
-      base::Bind(&sky::shell::ApplicationMessagesImpl::AddBinding,
-                 _appMessageReceiver.GetWeakPtr()),
+  new sky::shell::ViewServiceProvider([appplication_messages_impl](
+      mojo::InterfaceRequest<flutter::platform::ApplicationMessages> request) {
+        if (appplication_messages_impl)
+          appplication_messages_impl->AddBinding(std::move(request));
+      },
       mojo::GetProxy(&viewServiceProvider));
 
   DCHECK(!_dartServices.is_bound());

--- a/sky/shell/platform/ios/framework/Source/accessibility_bridge.h
+++ b/sky/shell/platform/ios/framework/Source/accessibility_bridge.h
@@ -9,7 +9,7 @@
 #include <set>
 #include <unordered_map>
 
-#include "base/macros.h"
+#include "lib/ftl/macros.h"
 #include "mojo/public/cpp/bindings/array.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "mojo/public/interfaces/application/service_provider.mojom.h"
@@ -71,7 +71,7 @@ class AccessibilityBridge final : public semantics::SemanticsListener {
 
   mojo::Binding<semantics::SemanticsListener> binding_;
 
-  DISALLOW_COPY_AND_ASSIGN(AccessibilityBridge);
+  FTL_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridge);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/ios/framework/Source/application_messages_impl.h
+++ b/sky/shell/platform/ios/framework/Source/application_messages_impl.h
@@ -7,7 +7,7 @@
 
 #include <unordered_map>
 
-#include "base/memory/weak_ptr.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "mojo/public/cpp/bindings/binding_set.h"
 #include "sky/services/platform/app_messages.mojom.h"
 #include "sky/shell/platform/ios/framework/Headers/FlutterAsyncMessageListener.h"
@@ -21,16 +21,15 @@ class ApplicationMessagesImpl : public flutter::platform::ApplicationMessages {
   ApplicationMessagesImpl();
   ~ApplicationMessagesImpl() override;
 
-  base::WeakPtr<ApplicationMessagesImpl> GetWeakPtr();
-  void AddBinding(mojo::InterfaceRequest<flutter::platform::ApplicationMessages> request);
+  ftl::WeakPtr<ApplicationMessagesImpl> GetWeakPtr();
+  void AddBinding(
+      mojo::InterfaceRequest<flutter::platform::ApplicationMessages> request);
 
-  void SetMessageListener(
-      const std::string& message_name,
-      NSObject<FlutterMessageListener>* listener);
+  void SetMessageListener(const std::string& message_name,
+                          NSObject<FlutterMessageListener>* listener);
 
-  void SetAsyncMessageListener(
-      const std::string& message_name,
-      NSObject<FlutterAsyncMessageListener>* listener);
+  void SetAsyncMessageListener(const std::string& message_name,
+                               NSObject<FlutterAsyncMessageListener>* listener);
 
  private:
   void SendString(const mojo::String& message_name,
@@ -38,12 +37,11 @@ class ApplicationMessagesImpl : public flutter::platform::ApplicationMessages {
                   const SendStringCallback& callback) override;
 
   mojo::BindingSet<flutter::platform::ApplicationMessages> binding_;
-  std::unordered_map<
-      std::string, NSObject<FlutterMessageListener>*> listeners_;
-  std::unordered_map<
-      std::string, NSObject<FlutterAsyncMessageListener>*> async_listeners_;
+  std::unordered_map<std::string, NSObject<FlutterMessageListener>*> listeners_;
+  std::unordered_map<std::string, NSObject<FlutterAsyncMessageListener>*>
+      async_listeners_;
 
-  base::WeakPtrFactory<ApplicationMessagesImpl> weak_factory_;
+  ftl::WeakPtrFactory<ApplicationMessagesImpl> weak_factory_;
 };
 
 }  // namespace shell

--- a/sky/shell/platform/ios/framework/Source/application_messages_impl.mm
+++ b/sky/shell/platform/ios/framework/Source/application_messages_impl.mm
@@ -15,7 +15,7 @@ ApplicationMessagesImpl::ApplicationMessagesImpl() : weak_factory_(this) {
 ApplicationMessagesImpl::~ApplicationMessagesImpl() {
 }
 
-base::WeakPtr<ApplicationMessagesImpl> ApplicationMessagesImpl::GetWeakPtr() {
+ftl::WeakPtr<ApplicationMessagesImpl> ApplicationMessagesImpl::GetWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/sky/shell/platform/ios/framework/Source/flutter_touch_mapper.h
+++ b/sky/shell/platform/ios/framework/Source/flutter_touch_mapper.h
@@ -7,7 +7,7 @@
 
 #include <UIKit/UIKit.h>
 
-#include "base/macros.h"
+#include "lib/ftl/macros.h"
 
 #include <map>
 
@@ -33,7 +33,7 @@ class TouchMapper {
   BitSet free_spots_;
   std::map<UITouch*, int> touch_map_;
 
-  DISALLOW_COPY_AND_ASSIGN(TouchMapper);
+  FTL_DISALLOW_COPY_AND_ASSIGN(TouchMapper);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/ios/platform_view_ios.h
+++ b/sky/shell/platform/ios/platform_view_ios.h
@@ -7,9 +7,9 @@
 
 #include <memory>
 
-#include "base/macros.h"
 #include "base/mac/scoped_nsobject.h"
-#include "base/memory/weak_ptr.h"
+#include "lib/ftl/macros.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "sky/shell/platform_view.h"
 
 @class CAEAGLLayer;
@@ -25,7 +25,7 @@ class PlatformViewIOS : public PlatformView {
 
   ~PlatformViewIOS() override;
 
-  base::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
+  ftl::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
 
   uint64_t DefaultFramebuffer() const override;
 
@@ -37,9 +37,9 @@ class PlatformViewIOS : public PlatformView {
 
  private:
   std::unique_ptr<IOSGLContext> context_;
-  base::WeakPtrFactory<PlatformViewIOS> weak_factory_;
+  ftl::WeakPtrFactory<PlatformViewIOS> weak_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/ios/platform_view_ios.mm
+++ b/sky/shell/platform/ios/platform_view_ios.mm
@@ -266,7 +266,7 @@ class IOSGLContext {
     return true;
   }
 
-  DISALLOW_COPY_AND_ASSIGN(IOSGLContext);
+  FTL_DISALLOW_COPY_AND_ASSIGN(IOSGLContext);
 };
 
 PlatformViewIOS::PlatformViewIOS(CAEAGLLayer* layer)
@@ -275,7 +275,7 @@ PlatformViewIOS::PlatformViewIOS(CAEAGLLayer* layer)
 
 PlatformViewIOS::~PlatformViewIOS() = default;
 
-base::WeakPtr<sky::shell::PlatformView> PlatformViewIOS::GetWeakViewPtr() {
+ftl::WeakPtr<sky::shell::PlatformView> PlatformViewIOS::GetWeakViewPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/sky/shell/platform/linux/platform_view_linux.cc
+++ b/sky/shell/platform/linux/platform_view_linux.cc
@@ -13,7 +13,7 @@ PlatformViewLinux::PlatformViewLinux(const Config& config,
 
 PlatformViewLinux::~PlatformViewLinux() {}
 
-base::WeakPtr<sky::shell::PlatformView> PlatformViewLinux::GetWeakViewPtr() {
+ftl::WeakPtr<PlatformView> PlatformViewLinux::GetWeakViewPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/sky/shell/platform/linux/platform_view_linux.h
+++ b/sky/shell/platform/linux/platform_view_linux.h
@@ -12,12 +12,13 @@ namespace shell {
 
 class PlatformViewLinux : public PlatformView {
  public:
-  explicit PlatformViewLinux(const Config& config, SurfaceConfig surface_config);
+  explicit PlatformViewLinux(const Config& config,
+                             SurfaceConfig surface_config);
 
   ~PlatformViewLinux() override;
 
   // sky::shell::PlatformView override
-  base::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
+  ftl::WeakPtr<PlatformView> GetWeakViewPtr() override;
 
   // sky::shell::PlatformView override
   uint64_t DefaultFramebuffer() const override;
@@ -29,9 +30,9 @@ class PlatformViewLinux : public PlatformView {
   bool SwapBuffers() override;
 
  private:
-  base::WeakPtrFactory<PlatformViewLinux> weak_factory_;
+  ftl::WeakPtrFactory<PlatformViewLinux> weak_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(PlatformViewLinux);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewLinux);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mac/platform_mac.mm
+++ b/sky/shell/platform/mac/platform_mac.mm
@@ -107,7 +107,7 @@ class EmbedderState {
   base::AtExitManager exit_manager_;
   std::unique_ptr<base::MessageLoopForUI> embedder_message_loop_;
 
-  DISALLOW_COPY_AND_ASSIGN(EmbedderState);
+  FTL_DISALLOW_COPY_AND_ASSIGN(EmbedderState);
 };
 
 void PlatformMacMain(int argc, const char* argv[], std::string icu_data_path) {

--- a/sky/shell/platform/mac/platform_service_provider.h
+++ b/sky/shell/platform/mac/platform_service_provider.h
@@ -5,7 +5,7 @@
 #ifndef SKY_SHELL_PLATFORM_MAC_PLATFORM_SERVICE_PROVIDER_H_
 #define SKY_SHELL_PLATFORM_MAC_PLATFORM_SERVICE_PROVIDER_H_
 
-#include "base/macros.h"
+#include "lib/ftl/macros.h"
 #include "base/callback.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "mojo/public/interfaces/application/service_provider.mojom.h"
@@ -30,7 +30,7 @@ class PlatformServiceProvider : public mojo::ServiceProvider {
   DynamicServiceProviderCallback dynamic_service_provider_;
   mojo::StrongBinding<mojo::ServiceProvider> binding_;
 
-  DISALLOW_COPY_AND_ASSIGN(PlatformServiceProvider);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformServiceProvider);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mac/platform_view_mac.h
+++ b/sky/shell/platform/mac/platform_view_mac.h
@@ -5,9 +5,9 @@
 #ifndef SKY_SHELL_PLATFORM_MAC_PLATFORM_VIEW_MAC_H_
 #define SKY_SHELL_PLATFORM_MAC_PLATFORM_VIEW_MAC_H_
 
-#include "base/memory/weak_ptr.h"
-#include "sky/shell/platform_view.h"
 #include "base/mac/scoped_nsobject.h"
+#include "lib/ftl/memory/weak_ptr.h"
+#include "sky/shell/platform_view.h"
 
 @class NSOpenGLView;
 @class NSOpenGLContext;
@@ -21,7 +21,7 @@ class PlatformViewMac : public PlatformView {
 
   ~PlatformViewMac() override;
 
-  base::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
+  ftl::WeakPtr<PlatformView> GetWeakViewPtr() override;
 
   uint64_t DefaultFramebuffer() const override;
 
@@ -34,11 +34,11 @@ class PlatformViewMac : public PlatformView {
  private:
   base::scoped_nsobject<NSOpenGLView> opengl_view_;
   base::scoped_nsobject<NSOpenGLContext> resource_loading_context_;
-  base::WeakPtrFactory<PlatformViewMac> weak_factory_;
+  ftl::WeakPtrFactory<PlatformViewMac> weak_factory_;
 
   bool IsValid() const;
 
-  DISALLOW_COPY_AND_ASSIGN(PlatformViewMac);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewMac);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mac/platform_view_mac.mm
+++ b/sky/shell/platform/mac/platform_view_mac.mm
@@ -20,7 +20,7 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
 
 PlatformViewMac::~PlatformViewMac() = default;
 
-base::WeakPtr<sky::shell::PlatformView> PlatformViewMac::GetWeakViewPtr() {
+ftl::WeakPtr<sky::shell::PlatformView> PlatformViewMac::GetWeakViewPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/sky/shell/platform/mac/sky_window.mm
+++ b/sky/shell/platform/mac/sky_window.mm
@@ -16,6 +16,10 @@
 #include "sky/shell/switches.h"
 #include "sky/shell/ui_delegate.h"
 
+static void IgnoreRequest(
+    mojo::InterfaceRequest<flutter::platform::ApplicationMessages>) {
+}
+
 static void DynamicServiceResolve(const mojo::String& service_name,
                                   mojo::ScopedMessagePipeHandle handle) {}
 
@@ -83,7 +87,7 @@ static inline pointer::PointerType EventTypeFromNSEventPhase(
                                           base::Bind(DynamicServiceResolve));
 
   mojo::ServiceProviderPtr view_service_provider;
-  new sky::shell::ViewServiceProvider(sky::shell::AppMesssagesConnector(),
+  new sky::shell::ViewServiceProvider(IgnoreRequest,
                                       mojo::GetProxy(&view_service_provider));
 
   sky::ServicesDataPtr services = sky::ServicesData::New();

--- a/sky/shell/platform/mac/view_service_provider.cc
+++ b/sky/shell/platform/mac/view_service_provider.cc
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "base/logging.h"
 #include "sky/shell/platform/mac/view_service_provider.h"
+
+#include <utility>
 
 namespace sky {
 namespace shell {
@@ -11,27 +12,24 @@ namespace shell {
 ViewServiceProvider::ViewServiceProvider(
     AppMesssagesConnector connect_to_app_messages,
     mojo::InterfaceRequest<mojo::ServiceProvider> request)
-  : binding_(this, request.Pass()),
-    connect_to_app_messages_(connect_to_app_messages) {
-}
+    : binding_(this, request.Pass()),
+      connect_to_app_messages_(connect_to_app_messages) {}
 
-ViewServiceProvider::~ViewServiceProvider() {
-}
+ViewServiceProvider::~ViewServiceProvider() {}
 
 void ViewServiceProvider::ConnectToService(
     const mojo::String& service_name,
     mojo::ScopedMessagePipeHandle client_handle) {
-  if (service_name == ::flutter::platform::ApplicationMessages::Name_ &&
-      !connect_to_app_messages_.is_null()) {
-    connect_to_app_messages_.Run(
+  if (service_name == ::flutter::platform::ApplicationMessages::Name_) {
+    connect_to_app_messages_(
         mojo::InterfaceRequest<::flutter::platform::ApplicationMessages>(
-            client_handle.Pass()));
+            std::move(client_handle)));
     return;
   }
 #if TARGET_OS_IPHONE
   if (service_name == ::editing::Keyboard::Name_) {
     new sky::services::editing::KeyboardImpl(
-        mojo::InterfaceRequest<::editing::Keyboard>(client_handle.Pass()));
+        mojo::InterfaceRequest<::editing::Keyboard>(std::move(client_handle)));
     return;
   }
 #endif

--- a/sky/shell/platform/mac/view_service_provider.h
+++ b/sky/shell/platform/mac/view_service_provider.h
@@ -5,7 +5,9 @@
 #ifndef SKY_SHELL_PLATFORM_MAC_VIEW_SERVICE_PROVIDER_H_
 #define SKY_SHELL_PLATFORM_MAC_VIEW_SERVICE_PROVIDER_H_
 
-#include "base/bind.h"
+#include <functional>
+
+#include "lib/ftl/macros.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "mojo/public/interfaces/application/service_provider.mojom.h"
 #include "sky/engine/wtf/Assertions.h"
@@ -18,9 +20,9 @@
 namespace sky {
 namespace shell {
 
-typedef base::Callback<
-    void(mojo::InterfaceRequest<flutter::platform::ApplicationMessages>)
-  > AppMesssagesConnector;
+typedef std::function<void(
+    mojo::InterfaceRequest<flutter::platform::ApplicationMessages>)>
+    AppMesssagesConnector;
 
 class ViewServiceProvider : public mojo::ServiceProvider {
  public:
@@ -35,7 +37,7 @@ class ViewServiceProvider : public mojo::ServiceProvider {
   mojo::StrongBinding<mojo::ServiceProvider> binding_;
   AppMesssagesConnector connect_to_app_messages_;
 
-  DISALLOW_COPY_AND_ASSIGN(ViewServiceProvider);
+  FTL_DISALLOW_COPY_AND_ASSIGN(ViewServiceProvider);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mojo/content_handler_impl.h
+++ b/sky/shell/platform/mojo/content_handler_impl.h
@@ -5,7 +5,7 @@
 #ifndef SKY_SHELL_PLATFORM_MOJO_CONTENT_HANDLER_IMPL_H_
 #define SKY_SHELL_PLATFORM_MOJO_CONTENT_HANDLER_IMPL_H_
 
-#include "base/macros.h"
+#include "lib/ftl/macros.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "mojo/services/content_handler/interfaces/content_handler.mojom.h"
 
@@ -24,7 +24,7 @@ class ContentHandlerImpl : public mojo::ContentHandler {
                         mojo::URLResponsePtr response) override;
 
   mojo::StrongBinding<mojo::ContentHandler> binding_;
-  DISALLOW_COPY_AND_ASSIGN(ContentHandlerImpl);
+  FTL_DISALLOW_COPY_AND_ASSIGN(ContentHandlerImpl);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mojo/main_mojo.cc
+++ b/sky/shell/platform/mojo/main_mojo.cc
@@ -62,7 +62,7 @@ class MojoApp : public mojo::ApplicationImplBase {
 
   mojo::TracingImpl tracing_;
 
-  DISALLOW_COPY_AND_ASSIGN(MojoApp);
+  FTL_DISALLOW_COPY_AND_ASSIGN(MojoApp);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mojo/platform_view_mojo.cc
+++ b/sky/shell/platform/mojo/platform_view_mojo.cc
@@ -4,9 +4,7 @@
 
 #include "sky/shell/platform/mojo/platform_view_mojo.h"
 
-#include "base/bind.h"
-#include "base/location.h"
-#include "base/single_thread_task_runner.h"
+#include "glue/movable_wrapper.h"
 #include "sky/shell/gpu/mojo/rasterizer_mojo.h"
 
 namespace sky {
@@ -18,15 +16,17 @@ PlatformViewMojo::~PlatformViewMojo() = default;
 
 void PlatformViewMojo::InitRasterizer(mojo::ApplicationConnectorPtr connector,
                                       mojo::gfx::composition::ScenePtr scene) {
-  auto rasterizer_mojo = reinterpret_cast<RasterizerMojo*>(config_.rasterizer);
-  auto continuation =
-      base::Bind(&RasterizerMojo::Init,              // method
-                 base::Unretained(rasterizer_mojo),  // target
-                 base::Passed(&connector), base::Passed(&scene));
-  NotifyCreated(continuation);
+  auto rasterizer = reinterpret_cast<RasterizerMojo*>(config_.rasterizer);
+  auto wrapped_connector = glue::WrapMovable(std::move(connector));
+  auto wrapped_scene = glue::WrapMovable(std::move(scene));
+
+  NotifyCreated([rasterizer, wrapped_connector, wrapped_scene]() mutable {
+    if (rasterizer)
+      rasterizer->Init(wrapped_connector.Unwrap(), wrapped_scene.Unwrap());
+  });
 }
 
-base::WeakPtr<sky::shell::PlatformView> PlatformViewMojo::GetWeakViewPtr() {
+ftl::WeakPtr<sky::shell::PlatformView> PlatformViewMojo::GetWeakViewPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/sky/shell/platform/mojo/platform_view_mojo.h
+++ b/sky/shell/platform/mojo/platform_view_mojo.h
@@ -5,12 +5,13 @@
 #ifndef SKY_SHELL_PLATFORM_MOJO_PLATFORM_VIEW_MOJO_H_
 #define SKY_SHELL_PLATFORM_MOJO_PLATFORM_VIEW_MOJO_H_
 
-#include "base/macros.h"
+#include <utility>
+
+#include "lib/ftl/macros.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "mojo/public/interfaces/application/application_connector.mojom.h"
 #include "mojo/services/gfx/composition/interfaces/scenes.mojom.h"
 #include "sky/shell/platform_view.h"
-
-#include <utility>
 
 namespace sky {
 namespace shell {
@@ -25,7 +26,7 @@ class PlatformViewMojo : public PlatformView {
                       mojo::gfx::composition::ScenePtr scene);
 
   // sky::shell::PlatformView override
-  base::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
+  ftl::WeakPtr<PlatformView> GetWeakViewPtr() override;
 
   // sky::shell::PlatformView override
   uint64_t DefaultFramebuffer() const override;
@@ -40,9 +41,9 @@ class PlatformViewMojo : public PlatformView {
   bool SwapBuffers() override;
 
  private:
-  base::WeakPtrFactory<PlatformViewMojo> weak_factory_;
+  ftl::WeakPtrFactory<PlatformViewMojo> weak_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(PlatformViewMojo);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewMojo);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mojo/pointer_converter_mojo.h
+++ b/sky/shell/platform/mojo/pointer_converter_mojo.h
@@ -7,7 +7,7 @@
 
 #include <map>
 
-#include "base/macros.h"
+#include "lib/ftl/macros.h"
 #include "mojo/services/input_events/interfaces/input_events.mojom.h"
 #include "sky/services/pointer/pointer.mojom.h"
 
@@ -28,7 +28,7 @@ class PointerConverterMojo {
 
   std::map<int, std::pair<float, float>> pointer_positions_;
 
-  DISALLOW_COPY_AND_ASSIGN(PointerConverterMojo);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PointerConverterMojo);
 };
 
 }  // namespace shell

--- a/sky/shell/platform/mojo/view_impl.h
+++ b/sky/shell/platform/mojo/view_impl.h
@@ -7,7 +7,7 @@
 
 #include <vector>
 
-#include "base/macros.h"
+#include "lib/ftl/macros.h"
 #include "mojo/public/cpp/bindings/binding_set.h"
 #include "mojo/public/cpp/bindings/strong_binding.h"
 #include "mojo/public/interfaces/application/application_connector.mojom.h"
@@ -69,7 +69,7 @@ class ViewImpl : public mojo::ui::ViewListener,
 
   PointerConverterMojo pointer_converter_;
 
-  DISALLOW_COPY_AND_ASSIGN(ViewImpl);
+  FTL_DISALLOW_COPY_AND_ASSIGN(ViewImpl);
 };
 
 }  // namespace shell

--- a/sky/shell/platform_view.h
+++ b/sky/shell/platform_view.h
@@ -7,13 +7,12 @@
 
 #include <memory>
 
-#include "base/macros.h"
-#include "base/memory/weak_ptr.h"
-#include "base/synchronization/waitable_event.h"
-#include "base/threading/thread_local_storage.h"
+#include "lib/ftl/macros.h"
+#include "lib/ftl/memory/weak_ptr.h"
+#include "lib/ftl/synchronization/waitable_event.h"
 #include "sky/shell/shell.h"
-#include "sky/shell/ui/engine.h"
 #include "sky/shell/ui_delegate.h"
+#include "sky/shell/ui/engine.h"
 #include "third_party/skia/include/core/SkSize.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 
@@ -29,9 +28,9 @@ class PlatformView {
 
     ~Config();
 
-    base::WeakPtr<UIDelegate> ui_delegate;
+    ftl::WeakPtr<UIDelegate> ui_delegate;
     Rasterizer* rasterizer;
-    scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner;
+    ftl::RefPtr<ftl::TaskRunner> ui_task_runner;
   };
 
   struct SurfaceConfig {
@@ -51,11 +50,11 @@ class PlatformView {
 
   void NotifyCreated();
 
-  void NotifyCreated(base::Closure continuation);
+  void NotifyCreated(ftl::Closure continuation);
 
   void NotifyDestroyed();
 
-  virtual base::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() = 0;
+  virtual ftl::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() = 0;
 
   virtual uint64_t DefaultFramebuffer() const = 0;
 
@@ -82,10 +81,11 @@ class PlatformView {
 
   explicit PlatformView();
 
-  void SetupResourceContextOnIOThreadPerform(base::WaitableEvent* event);
+  void SetupResourceContextOnIOThreadPerform(
+      ftl::AutoResetWaitableEvent* event);
 
  private:
-  DISALLOW_COPY_AND_ASSIGN(PlatformView);
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformView);
 };
 
 }  // namespace shell

--- a/sky/shell/rasterizer.h
+++ b/sky/shell/rasterizer.h
@@ -7,10 +7,10 @@
 
 #include <memory>
 
-#include "base/callback.h"
-#include "base/memory/weak_ptr.h"
-#include "base/synchronization/waitable_event.h"
 #include "flow/layers/layer_tree.h"
+#include "lib/ftl/memory/weak_ptr.h"
+#include "lib/ftl/synchronization/waitable_event.h"
+#include "lib/ftl/functional/closure.h"
 #include "mojo/public/cpp/bindings/binding.h"
 #include "sky/services/rasterizer/rasterizer.mojom.h"
 
@@ -27,12 +27,13 @@ class Rasterizer : public rasterizer::Rasterizer {
       mojo::InterfaceRequest<rasterizer::Rasterizer> request) = 0;
 
   virtual void Setup(PlatformView* platform_view,
-                     base::Closure rasterizer_continuation,
-                     base::WaitableEvent* setup_completion_event) = 0;
+                     ftl::Closure rasterizer_continuation,
+                     ftl::AutoResetWaitableEvent* setup_completion_event) = 0;
 
-  virtual void Teardown(base::WaitableEvent* teardown_completion_event) = 0;
+  virtual void Teardown(
+      ftl::AutoResetWaitableEvent* teardown_completion_event) = 0;
 
-  virtual base::WeakPtr<sky::shell::Rasterizer> GetWeakRasterizerPtr() = 0;
+  virtual ftl::WeakPtr<Rasterizer> GetWeakRasterizerPtr() = 0;
 
   virtual flow::LayerTree* GetLastLayerTree() = 0;
 

--- a/sky/shell/shell.h
+++ b/sky/shell/shell.h
@@ -5,13 +5,11 @@
 #ifndef SKY_SHELL_SHELL_H_
 #define SKY_SHELL_SHELL_H_
 
-#include "base/macros.h"
-#include "base/memory/ref_counted.h"
-#include "base/memory/weak_ptr.h"
-#include "base/message_loop/message_loop.h"
-#include "base/synchronization/waitable_event.h"
 #include "base/threading/thread.h"
+#include "lib/ftl/macros.h"
 #include "lib/ftl/memory/ref_ptr.h"
+#include "lib/ftl/memory/weak_ptr.h"
+#include "lib/ftl/synchronization/waitable_event.h"
 #include "lib/ftl/tasks/task_runner.h"
 #include "sky/shell/tracing_controller.h"
 
@@ -33,18 +31,6 @@ class Shell {
 
   static Shell& Shared();
 
-  base::SingleThreadTaskRunner* gpu_task_runner() const {
-    return gpu_task_runner_.get();
-  }
-
-  base::SingleThreadTaskRunner* ui_task_runner() const {
-    return ui_task_runner_.get();
-  }
-
-  base::SingleThreadTaskRunner* io_task_runner() const {
-    return io_task_runner_.get();
-  }
-
   ftl::TaskRunner* gpu_ftl_task_runner() const {
     return gpu_ftl_task_runner_.get();
   }
@@ -61,17 +47,17 @@ class Shell {
 
   // Maintain a list of rasterizers.
   // These APIs must only be accessed on the GPU thread.
-  void AddRasterizer(const base::WeakPtr<Rasterizer>& rasterizer);
+  void AddRasterizer(const ftl::WeakPtr<Rasterizer>& rasterizer);
   void PurgeRasterizers();
-  void GetRasterizers(std::vector<base::WeakPtr<Rasterizer>>* rasterizer);
+  void GetRasterizers(std::vector<ftl::WeakPtr<Rasterizer>>* rasterizer);
 
   // List of PlatformViews.
 
   // These APIs must only be accessed on UI thread.
-  void AddPlatformView(const base::WeakPtr<PlatformView>& platform_view);
+  void AddPlatformView(const ftl::WeakPtr<PlatformView>& platform_view);
   void PurgePlatformViews();
   void GetPlatformViews(
-      std::vector<base::WeakPtr<PlatformView>>* platform_views);
+      std::vector<ftl::WeakPtr<PlatformView>>* platform_views);
 
   struct PlatformViewInfo {
     uintptr_t view_id;
@@ -99,7 +85,7 @@ class Shell {
 
   void WaitForPlatformViewsIdsUIThread(
       std::vector<PlatformViewInfo>* platform_views,
-      base::WaitableEvent* latch);
+      ftl::AutoResetWaitableEvent* latch);
 
   void RunInPlatformViewUIThread(uintptr_t view_id,
                                  const std::string& main,
@@ -107,15 +93,11 @@ class Shell {
                                  const std::string& assets_directory,
                                  bool* view_existed,
                                  int64_t* dart_isolate_id,
-                                 base::WaitableEvent* latch);
+                                 ftl::AutoResetWaitableEvent* latch);
 
   std::unique_ptr<base::Thread> gpu_thread_;
   std::unique_ptr<base::Thread> ui_thread_;
   std::unique_ptr<base::Thread> io_thread_;
-
-  scoped_refptr<base::SingleThreadTaskRunner> gpu_task_runner_;
-  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner_;
-  scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
 
   ftl::RefPtr<ftl::TaskRunner> gpu_ftl_task_runner_;
   ftl::RefPtr<ftl::TaskRunner> ui_ftl_task_runner_;
@@ -126,10 +108,10 @@ class Shell {
 
   TracingController tracing_controller_;
 
-  std::vector<base::WeakPtr<Rasterizer>> rasterizers_;
-  std::vector<base::WeakPtr<PlatformView>> platform_views_;
+  std::vector<ftl::WeakPtr<Rasterizer>> rasterizers_;
+  std::vector<ftl::WeakPtr<PlatformView>> platform_views_;
 
-  DISALLOW_COPY_AND_ASSIGN(Shell);
+  FTL_DISALLOW_COPY_AND_ASSIGN(Shell);
 };
 
 }  // namespace shell

--- a/sky/shell/testing/platform_view_test.cc
+++ b/sky/shell/testing/platform_view_test.cc
@@ -13,7 +13,7 @@ PlatformViewTest::PlatformViewTest() : weak_factory_(this) {}
 
 PlatformViewTest::~PlatformViewTest() = default;
 
-base::WeakPtr<sky::shell::PlatformView> PlatformViewTest::GetWeakViewPtr() {
+ftl::WeakPtr<PlatformView> PlatformViewTest::GetWeakViewPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/sky/shell/testing/platform_view_test.h
+++ b/sky/shell/testing/platform_view_test.h
@@ -6,6 +6,7 @@
 #define SKY_SHELL_TESTING_PLATFORM_VIEW_TEST_H_
 
 #include "lib/ftl/macros.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "sky/shell/platform_view.h"
 
 namespace sky {
@@ -19,7 +20,7 @@ class PlatformViewTest : public PlatformView {
 
   ~PlatformViewTest();
 
-  base::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
+  ftl::WeakPtr<sky::shell::PlatformView> GetWeakViewPtr() override;
 
   uint64_t DefaultFramebuffer() const override;
 
@@ -30,7 +31,7 @@ class PlatformViewTest : public PlatformView {
   bool SwapBuffers() override;
 
  private:
-  base::WeakPtrFactory<PlatformViewTest> weak_factory_;
+  ftl::WeakPtrFactory<PlatformViewTest> weak_factory_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewTest);
 };

--- a/sky/shell/testing/test_runner.h
+++ b/sky/shell/testing/test_runner.h
@@ -8,8 +8,8 @@
 #include <memory>
 #include <string>
 
-#include "base/macros.h"
-#include "base/memory/weak_ptr.h"
+#include "lib/ftl/macros.h"
+#include "lib/ftl/memory/weak_ptr.h"
 #include "mojo/public/cpp/bindings/binding_set.h"
 #include "sky/services/engine/sky_engine.mojom.h"
 
@@ -35,9 +35,9 @@ class TestRunner {
 
   std::unique_ptr<PlatformView> platform_view_;
   SkyEnginePtr sky_engine_;
-  base::WeakPtrFactory<TestRunner> weak_ptr_factory_;
+  ftl::WeakPtrFactory<TestRunner> weak_ptr_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(TestRunner);
+  FTL_DISALLOW_COPY_AND_ASSIGN(TestRunner);
 };
 
 }  // namespace shell

--- a/sky/shell/ui/animator.h
+++ b/sky/shell/ui/animator.h
@@ -59,7 +59,7 @@ class Animator {
 
   base::WeakPtrFactory<Animator> weak_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(Animator);
+  FTL_DISALLOW_COPY_AND_ASSIGN(Animator);
 };
 
 }  // namespace shell

--- a/sky/shell/ui/engine.h
+++ b/sky/shell/ui/engine.h
@@ -6,13 +6,13 @@
 #define SKY_SHELL_UI_ENGINE_H_
 
 #include "base/files/file_path.h"
-#include "base/macros.h"
-#include "base/memory/weak_ptr.h"
-#include "base/single_thread_task_runner.h"
 #include "flutter/assets/zip_asset_store.h"
+#include "lib/ftl/macros.h"
+#include "lib/ftl/memory/weak_ptr.h"
+#include "lib/ftl/tasks/task_runner.h"
 #include "mojo/public/cpp/application/service_provider_impl.h"
-#include "mojo/public/cpp/bindings/binding.h"
 #include "mojo/public/cpp/bindings/binding_set.h"
+#include "mojo/public/cpp/bindings/binding.h"
 #include "mojo/public/cpp/system/data_pipe.h"
 #include "mojo/public/cpp/system/handle.h"
 #include "mojo/public/interfaces/application/service_provider.mojom.h"
@@ -38,13 +38,13 @@ class Engine : public UIDelegate,
     Config();
     ~Config();
 
-    scoped_refptr<base::SingleThreadTaskRunner> gpu_task_runner;
+    ftl::RefPtr<ftl::TaskRunner> gpu_task_runner;
   };
 
   explicit Engine(const Config& config, rasterizer::RasterizerPtr rasterizer);
   ~Engine() override;
 
-  base::WeakPtr<Engine> GetWeakPtr();
+  ftl::WeakPtr<Engine> GetWeakPtr();
 
   static void Init();
 
@@ -59,8 +59,8 @@ class Engine : public UIDelegate,
  private:
   // UIDelegate implementation:
   void ConnectToEngine(mojo::InterfaceRequest<SkyEngine> request) override;
-  void OnOutputSurfaceCreated(const base::Closure& gpu_continuation) override;
-  void OnOutputSurfaceDestroyed(const base::Closure& gpu_continuation) override;
+  void OnOutputSurfaceCreated(const ftl::Closure& gpu_continuation) override;
+  void OnOutputSurfaceDestroyed(const ftl::Closure& gpu_continuation) override;
 
   // SkyEngine implementation:
   void SetServices(ServicesDataPtr services) override;
@@ -127,9 +127,9 @@ class Engine : public UIDelegate,
   bool activity_running_;
   bool have_surface_;
 
-  base::WeakPtrFactory<Engine> weak_factory_;
+  ftl::WeakPtrFactory<Engine> weak_factory_;
 
-  DISALLOW_COPY_AND_ASSIGN(Engine);
+  FTL_DISALLOW_COPY_AND_ASSIGN(Engine);
 };
 
 }  // namespace shell

--- a/sky/shell/ui_delegate.h
+++ b/sky/shell/ui_delegate.h
@@ -5,9 +5,9 @@
 #ifndef SKY_SHELL_UI_DELEGATE_H_
 #define SKY_SHELL_UI_DELEGATE_H_
 
+#include "lib/ftl/functional/closure.h"
 #include "mojo/public/cpp/bindings/interface_request.h"
 #include "sky/services/engine/sky_engine.mojom.h"
-#include "base/callback.h"
 
 namespace sky {
 namespace shell {
@@ -16,11 +16,10 @@ class UIDelegate {
  public:
   virtual void ConnectToEngine(mojo::InterfaceRequest<SkyEngine> request) = 0;
 
-  virtual void OnOutputSurfaceCreated(
-      const base::Closure& gpu_continuation) = 0;
+  virtual void OnOutputSurfaceCreated(const ftl::Closure& gpu_continuation) = 0;
 
   virtual void OnOutputSurfaceDestroyed(
-      const base::Closure& gpu_continuation) = 0;
+      const ftl::Closure& gpu_continuation) = 0;
 
  protected:
   virtual ~UIDelegate();


### PR DESCRIPTION
This patch hides the base::SingleThreadedTaskRunner, which pulls a big
switchover to ftl::WeakPtr and std::function.