### PR TITLE
Fix hot reloading

### DIFF
--- a/glue/task_runner_adaptor.cc
+++ b/glue/task_runner_adaptor.cc
@@ -20,7 +20,9 @@ void RunClosure(ftl::Closure task) {
 }  // namespace
 
 TaskRunnerAdaptor::TaskRunnerAdaptor(scoped_refptr<base::TaskRunner> runner)
-    : runner_(std::move(runner)) {}
+    : runner_(std::move(runner)) {
+  FTL_DCHECK(runner_);
+}
 
 TaskRunnerAdaptor::~TaskRunnerAdaptor() {}
 

--- a/glue/thread.cc
+++ b/glue/thread.cc
@@ -16,14 +16,14 @@ class Thread::ThreadImpl : public base::Thread {
   ThreadImpl(std::string name) : base::Thread(std::move(name)) {}
 };
 
-Thread::Thread(std::string name) : impl_(new ThreadImpl(name)) {
-  task_runner_ = ftl::MakeRefCounted<TaskRunnerAdaptor>(impl_->task_runner());
-}
+Thread::Thread(std::string name) : impl_(new ThreadImpl(name)) {}
 
 Thread::~Thread() {}
 
 bool Thread::Start() {
-  return impl_->Start();
+  bool result = impl_->Start();
+  task_runner_ = ftl::MakeRefCounted<TaskRunnerAdaptor>(impl_->task_runner());
+  return result;
 }
 
 }  // namespace glue


### PR DESCRIPTION
We were creating the task runner adaptor before the underlying base::Thread had
a TaskRunner to adapt. Now we wait until after we start the thread.