### PR TITLE
Guard against sysmacros.h pulling in defines for `major` and `minor` on some platforms.

### DIFF
--- a/flow/gl_connection.h
+++ b/flow/gl_connection.h
@@ -11,6 +11,14 @@
 #include <string>
 #include <set>
 
+#ifdef major
+#undef major
+#endif
+
+#ifdef minor
+#undef minor
+#endif
+
 namespace flow {
 
 class GLConnection {


### PR DESCRIPTION
Fixes Linux builds. cc @abarth 