### PR TITLE
Move sky_snapshot to a more reasonable location

### DIFF
--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -15,7 +15,7 @@ group("sky") {
   ]
 
   if (dart_host_toolchain == host_toolchain) {
-    deps += [ "//flutter/sky/tools/sky_snapshot($dart_host_toolchain)" ]
+    deps += [ "//flutter/snapshotter($dart_host_toolchain)" ]
   }
 
   if (is_linux || is_android) {

--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -43,15 +43,6 @@ copy("sky_shell") {
     deps = []
   }
 
-  sky_snapshot_dir =
-      get_label_info("//flutter/sky/tools/sky_snapshot($host_toolchain)", "root_out_dir")
-
-  sources += [ "$sky_snapshot_dir/sky_snapshot" ]
-
-  deps += [
-    "//flutter/sky/tools/sky_snapshot($host_toolchain)",
-  ]
-
   outputs = [ "$root_dist_dir/shell/{{source_file_part}}" ]
 }
 

--- a/snapshotter/BUILD.gn
+++ b/snapshotter/BUILD.gn
@@ -2,7 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-executable("sky_snapshot") {
+executable("snapshotter") {
+  output_name = "sky_snapshot"
+
   sources = [
     "main.cc",
   ]

--- a/snapshotter/main.cc
+++ b/snapshotter/main.cc
@@ -26,7 +26,6 @@ extern const uint8_t kDartVmIsolateSnapshotBuffer[];
 extern const uint8_t kDartIsolateSnapshotBuffer[];
 }
 
-namespace sky_snapshot {
 namespace {
 
 using tonic::ToDart;
@@ -233,8 +232,7 @@ int CreateSnapshot(const ftl::CommandLine& command_line) {
 }
 
 }  // namespace
-}  // namespace sky_snapshot
 
 int main(int argc, const char* argv[]) {
-  return sky_snapshot::CreateSnapshot(ftl::CommandLineFromArgcArgv(argc, argv));
+  return CreateSnapshot(ftl::CommandLineFromArgcArgv(argc, argv));
 }


### PR DESCRIPTION
We should eventually rename it to something more sensible, but that's a more
disruptive change. This patch just moves the source code to somewhere easier to
find.