### PR TITLE
Teach //flutter/lib/ui to build on Fuchsia

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -8,10 +8,12 @@ group("flutter") {
   if (is_fuchsia) {
     # TODO(abarth) Remove this specific list once Fuchsia can build everything.
     deps = [
-      "//flutter/snapshotter",
       "//flutter/assets",
       "//flutter/flow",
       "//flutter/glue",
+      "//flutter/lib/ui",
+      "//flutter/snapshotter",
+      "//flutter/tonic",
     ]
   } else {
     deps = [

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -41,15 +41,10 @@ source_set("ui") {
   ]
 
   deps = [
-    "//base",
     "//flutter/flow",
-    "//flutter/tonic",
     "//flutter/glue",
-    "//lib/tonic",
     "//flutter/skia",
-
-    # For image_decoding:
-    "//flutter/sky/engine/platform",
-    "//flutter/sky/engine/wtf",
+    "//flutter/tonic",
+    "//lib/tonic",
   ]
 }

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -145,13 +145,14 @@ void SceneBuilder::pushShaderMask(Shader* shader,
   addLayer(std::move(layer), m_cullRects.top());
 }
 
-void SceneBuilder::addLayer(std::unique_ptr<flow::ContainerLayer> layer, const SkRect& cullRect) {
-  DCHECK(layer);
+void SceneBuilder::addLayer(std::unique_ptr<flow::ContainerLayer> layer,
+                            const SkRect& cullRect) {
+  FTL_DCHECK(layer);
 
   m_cullRects.push(cullRect);
 
   if (!m_rootLayer) {
-    DCHECK(!m_currentLayer);
+    FTL_DCHECK(!m_currentLayer);
     m_rootLayer = std::move(layer);
     m_currentLayer = m_rootLayer.get();
     return;

--- a/sky/engine/core/script/ui_dart_state.cc
+++ b/sky/engine/core/script/ui_dart_state.cc
@@ -5,18 +5,21 @@
 #include "flutter/sky/engine/core/script/ui_dart_state.h"
 
 #include "flutter/sky/engine/core/window/window.h"
+#include "flutter/sky/engine/public/platform/Platform.h"
 
 namespace blink {
 
 UIDartState::UIDartState(IsolateClient* isolate_client,
                          const std::string& url,
                          std::unique_ptr<Window> window)
-    : FlutterDartState(isolate_client, url),
-      window_(std::move(window)) {
+    : FlutterDartState(isolate_client, url), window_(std::move(window)) {
+  ui_task_runner_ =
+      ftl::RefPtr<ftl::TaskRunner>(Platform::current()->GetUITaskRunner());
+  io_task_runner_ =
+      ftl::RefPtr<ftl::TaskRunner>(Platform::current()->GetIOTaskRunner());
 }
 
-UIDartState::~UIDartState() {
-}
+UIDartState::~UIDartState() {}
 
 UIDartState* UIDartState::Current() {
   return static_cast<UIDartState*>(DartState::Current());

--- a/tonic/dart_state.h
+++ b/tonic/dart_state.h
@@ -5,7 +5,10 @@
 #ifndef FLUTTER_TONIC_DART_STATE_H_
 #define FLUTTER_TONIC_DART_STATE_H_
 
+#include <utility>
+
 #include "dart/runtime/include/dart_api.h"
+#include "lib/ftl/tasks/task_runner.h"
 #include "lib/tonic/dart_persistent_value.h"
 #include "lib/tonic/dart_state.h"
 #include "lib/tonic/scopes/dart_api_scope.h"
@@ -21,7 +24,17 @@ class DartState : public tonic::DartState {
   static DartState* From(Dart_Isolate isolate);
   static DartState* Current();
 
+  const ftl::RefPtr<ftl::TaskRunner>& ui_task_runner() {
+    return ui_task_runner_;
+  }
+  const ftl::RefPtr<ftl::TaskRunner>& io_task_runner() {
+    return io_task_runner_;
+  }
+
  protected:
+  ftl::RefPtr<ftl::TaskRunner> ui_task_runner_;
+  ftl::RefPtr<ftl::TaskRunner> io_task_runner_;
+
   FTL_DISALLOW_COPY_AND_ASSIGN(DartState);
 };
 


### PR DESCRIPTION
This patch removes the //flutter/sky/engine dependency from //flutter/lib/ui,
which lets us build the bulk of the dart:ui library without needing to build
//flutter/sky/engine.