### PR TITLE
Move embedded resources to //flutter/runtime

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -2,6 +2,28 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//mojo/dart/embedder/embedder.gni")
+
+vmservice_sources_gypi =
+  exec_script("//build/gypi_to_gn.py",
+      [ rebase_path("//dart/runtime/bin/vmservice/vmservice_sources.gypi") ],
+      "scope",
+      [ rebase_path("//dart/runtime/bin/vmservice/vmservice_sources.gypi") ])
+
+dart_embedder_resources("gen_embedded_resources_cc") {
+  inputs = rebase_path(vmservice_sources_gypi.sources,
+                       "",
+                       "//dart/runtime/bin/vmservice")
+  root_prefix = "//dart/runtime/bin/"
+  output = "$target_gen_dir/embedded_resources.cc"
+  table_name = "flutter_embedded_service_isolate"
+}
+
+source_set("embedded_resources_cc") {
+  sources = [ "$target_gen_dir/embedded_resources.cc" ]
+  deps = [ ":gen_embedded_resources_cc" ]
+}
+
 source_set("runtime") {
   sources = [
     "dart_controller.cc",
@@ -21,6 +43,7 @@ source_set("runtime") {
   ]
 
   deps = [
+    ":embedded_resources_cc",
     "//dart/runtime:libdart",
     "//dart/runtime/bin:embedded_dart_io",
     "//flutter/assets",

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -31,7 +31,7 @@ static const char* kServiceIsolateScript = "vmservice_io.dart";
 
 namespace mojo {
 namespace dart {
-extern ResourcesEntry __sky_embedder_service_isolate_resources_[];
+extern ResourcesEntry __flutter_embedded_service_isolate_resources_[];
 }
 }
 
@@ -104,7 +104,7 @@ bool DartServiceIsolate::Startup(std::string server_ip,
 
   if (!g_resources) {
     g_resources = new EmbedderResources(
-        &mojo::dart::__sky_embedder_service_isolate_resources_[0]);
+        &mojo::dart::__flutter_embedded_service_isolate_resources_[0]);
   }
 
   Dart_Handle result;

--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//flutter/sky/engine/core/core.gni")
-import("//mojo/dart/embedder/embedder.gni")
 
 visibility = [ "//flutter/sky/engine/*", "//flutter/sky/shell/*" ]
 
@@ -54,26 +53,10 @@ source_set("prerequisites") {
   ]
 }
 
-vmservice_sources_gypi =
-  exec_script("//build/gypi_to_gn.py",
-      [ rebase_path("//dart/runtime/bin/vmservice/vmservice_sources.gypi") ],
-      "scope",
-      [ rebase_path("//dart/runtime/bin/vmservice/vmservice_sources.gypi") ])
-
-dart_embedder_resources("generate_sky_embedder_service_isolate_resources_cc") {
-  inputs = rebase_path(vmservice_sources_gypi.sources,
-                       "",
-                       "//dart/runtime/bin/vmservice")
-  root_prefix = "//dart/runtime/bin/"
-  output = "$target_gen_dir/sky_embedder_service_isolate_resources.cc"
-  table_name = "sky_embedder_service_isolate"
-}
-
 static_library("core") {
   output_name = "sky_core"
 
   deps = [
-    ":generate_sky_embedder_service_isolate_resources_cc",
     ":libraries",
     ":prerequisites",
     "//dart/runtime:libdart",
@@ -94,13 +77,6 @@ static_library("core") {
   }
 
   sources = sky_core_files
-
-  sources += [ "$target_gen_dir/sky_embedder_service_isolate_resources.cc" ]
-
-  include_dirs = [
-    # Needed for dart_mirrors_api.h in dart_controller.cc
-    rebase_path("//dart/runtime"),
-  ]
 
   forward_dependent_configs_from = [ ":libraries" ]
 }


### PR DESCRIPTION
This data is actually used in //flutter/runtime, so it makes more sense to
generate it and include it in the build from there.