### PR TITLE
Include the FTL build config macros in some files that rely on them

### DIFF
--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -11,6 +11,7 @@
 #include "dart/runtime/bin/embedded_dart_io.h"
 #include "dart/runtime/include/dart_api.h"
 #include "dart/runtime/include/dart_tools_api.h"
+#include "lib/ftl/build_config.h"
 #include "lib/ftl/logging.h"
 #include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/dart_library_natives.h"

--- a/services/icu/icu.cc
+++ b/services/icu/icu.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/services/icu/icu.h"
 
+#include "lib/ftl/build_config.h"
 #include "mojo/public/cpp/application/connect.h"
 #include "mojo/services/icu_data/interfaces/icu_data.mojom.h"
 #include "flutter/services/icu/constants.h"


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/5424