### PR TITLE
Add stubs for text handling on Fuchsia

### DIFF
--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -66,7 +66,14 @@ source_set("ui") {
     "//mojo/services/asset_bundle/interfaces",
   ]
 
-  if (!is_fuchsia) {
+  if (is_fuchsia) {
+    sources += [
+      "text/paragraph_builder_stub.cc",
+      "text/paragraph_builder_stub.h",
+      "text/paragraph_stub.cc",
+      "text/paragraph_stub.h",
+    ]
+  } else {
     sources += [
       "text/paragraph_builder.cc",
       "text/paragraph_builder.h",

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -23,7 +23,10 @@
 #include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/logging/dart_error.h"
 
-#if !defined(OS_FUCHSIA)
+#if defined(OS_FUCHSIA)
+#include "flutter/lib/ui/text/paragraph_builder_stub.h"
+#include "flutter/lib/ui/text/paragraph_stub.h"
+#else
 #include "flutter/lib/ui/text/paragraph_builder.h"
 #include "flutter/lib/ui/text/paragraph.h"
 #endif
@@ -60,10 +63,8 @@ void DartUI::InitForGlobal() {
     ImageShader::RegisterNatives(g_natives);
     MaskFilter::RegisterNatives(g_natives);
     MojoServices::RegisterNatives(g_natives);
-#if !defined(OS_FUCHSIA)
     Paragraph::RegisterNatives(g_natives);
     ParagraphBuilder::RegisterNatives(g_natives);
-#endif
     Picture::RegisterNatives(g_natives);
     PictureRecorder::RegisterNatives(g_natives);
     Scene::RegisterNatives(g_natives);

--- a/lib/ui/mojo_services.cc
+++ b/lib/ui/mojo_services.cc
@@ -22,27 +22,45 @@ MojoServices* GetMojoServices() {
 }
 
 void DartTakeRootBundle(Dart_NativeArguments args) {
-  Dart_SetIntegerReturnValue(args, GetMojoServices()->TakeRootBundle());
+  int handle = MOJO_HANDLE_INVALID;
+  if (MojoServices* services = GetMojoServices())
+    handle = services->TakeRootBundle();
+  Dart_SetIntegerReturnValue(args, handle);
 }
 
 void DartTakeIncomingServices(Dart_NativeArguments args) {
-  Dart_SetIntegerReturnValue(args, GetMojoServices()->TakeIncomingServices());
+  int handle = MOJO_HANDLE_INVALID;
+  if (MojoServices* services = GetMojoServices())
+    handle = services->TakeIncomingServices();
+  Dart_SetIntegerReturnValue(args, handle);
 }
 
 void DartTakeOutgoingServices(Dart_NativeArguments args) {
-  Dart_SetIntegerReturnValue(args, GetMojoServices()->TakeOutgoingServices());
+  int handle = MOJO_HANDLE_INVALID;
+  if (MojoServices* services = GetMojoServices())
+    handle = services->TakeOutgoingServices();
+  Dart_SetIntegerReturnValue(args, handle);
 }
 
 void DartTakeShell(Dart_NativeArguments args) {
-  Dart_SetIntegerReturnValue(args, GetMojoServices()->TakeShell());
+  int handle = MOJO_HANDLE_INVALID;
+  if (MojoServices* services = GetMojoServices())
+    handle = services->TakeShell();
+  Dart_SetIntegerReturnValue(args, handle);
 }
 
 void DartTakeView(Dart_NativeArguments args) {
-  Dart_SetIntegerReturnValue(args, GetMojoServices()->TakeView());
+  int handle = MOJO_HANDLE_INVALID;
+  if (MojoServices* services = GetMojoServices())
+    handle = services->TakeView();
+  Dart_SetIntegerReturnValue(args, handle);
 }
 
 void DartTakeViewServices(Dart_NativeArguments args) {
-  Dart_SetIntegerReturnValue(args, GetMojoServices()->TakeViewServices());
+  int handle = MOJO_HANDLE_INVALID;
+  if (MojoServices* services = GetMojoServices())
+    handle = services->TakeViewServices();
+  Dart_SetIntegerReturnValue(args, handle);
 }
 
 }  // namespace

--- a/lib/ui/text/paragraph_builder_stub.cc
+++ b/lib/ui/text/paragraph_builder_stub.cc
@@ -1,0 +1,59 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/text/paragraph_builder_stub.h"
+
+#include "lib/tonic/converter/dart_converter.h"
+#include "lib/tonic/dart_args.h"
+#include "lib/tonic/dart_binding_macros.h"
+#include "lib/tonic/dart_library_natives.h"
+
+namespace blink {
+
+static void ParagraphBuilder_constructor(Dart_NativeArguments args) {
+  DartCallConstructor(&ParagraphBuilder::create, args);
+}
+
+IMPLEMENT_WRAPPERTYPEINFO(ui, ParagraphBuilder);
+
+#define FOR_EACH_BINDING(V)      \
+  V(ParagraphBuilder, pushStyle) \
+  V(ParagraphBuilder, pop)       \
+  V(ParagraphBuilder, addText)   \
+  V(ParagraphBuilder, build)
+
+FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
+
+void ParagraphBuilder::RegisterNatives(tonic::DartLibraryNatives* natives) {
+  natives->Register(
+      {{"ParagraphBuilder_constructor", ParagraphBuilder_constructor, 1, true},
+       FOR_EACH_BINDING(DART_REGISTER_NATIVE)});
+}
+
+ParagraphBuilder::ParagraphBuilder() {}
+
+ParagraphBuilder::~ParagraphBuilder() {}
+
+void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
+                                 const std::string& fontFamily,
+                                 double fontSize,
+                                 double letterSpacing,
+                                 double wordSpacing,
+                                 double height) {
+  encoded.Release();
+}
+
+void ParagraphBuilder::pop() {}
+
+void ParagraphBuilder::addText(const std::string& text) {}
+
+ftl::RefPtr<Paragraph> ParagraphBuilder::build(tonic::Int32List& encoded,
+                                               const std::string& fontFamily,
+                                               double fontSize,
+                                               double lineHeight) {
+  encoded.Release();
+  return Paragraph::create();
+}
+
+}  // namespace blink

--- a/lib/ui/text/paragraph_builder_stub.h
+++ b/lib/ui/text/paragraph_builder_stub.h
@@ -1,0 +1,53 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_TEXT_PARAGRAPH_BUILDER_STUB_H_
+#define FLUTTER_LIB_UI_TEXT_PARAGRAPH_BUILDER_STUB_H_
+
+#include "flutter/lib/ui/text/paragraph_stub.h"
+#include "lib/tonic/dart_wrappable.h"
+#include "lib/tonic/typed_data/int32_list.h"
+
+namespace tonic {
+class DartLibraryNatives;
+}  // namespace tonic
+
+namespace blink {
+
+class ParagraphBuilder : public ftl::RefCountedThreadSafe<ParagraphBuilder>,
+                         public tonic::DartWrappable {
+  DEFINE_WRAPPERTYPEINFO();
+  FRIEND_MAKE_REF_COUNTED(ParagraphBuilder);
+
+ public:
+  static ftl::RefPtr<ParagraphBuilder> create() {
+    return ftl::MakeRefCounted<ParagraphBuilder>();
+  }
+
+  ~ParagraphBuilder() override;
+
+  void pushStyle(tonic::Int32List& encoded,
+                 const std::string& fontFamily,
+                 double fontSize,
+                 double letterSpacing,
+                 double wordSpacing,
+                 double height);
+  void pop();
+
+  void addText(const std::string& text);
+
+  ftl::RefPtr<Paragraph> build(tonic::Int32List& encoded,
+                               const std::string& fontFamily,
+                               double fontSize,
+                               double lineHeight);
+
+  static void RegisterNatives(tonic::DartLibraryNatives* natives);
+
+ private:
+  ParagraphBuilder();
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_TEXT_PARAGRAPH_BUILDER_STUB_H_

--- a/lib/ui/text/paragraph_stub.cc
+++ b/lib/ui/text/paragraph_stub.cc
@@ -1,0 +1,81 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/text/paragraph_stub.h"
+
+#include "lib/tonic/converter/dart_converter.h"
+#include "lib/tonic/dart_args.h"
+#include "lib/tonic/dart_binding_macros.h"
+#include "lib/tonic/dart_library_natives.h"
+
+using tonic::ToDart;
+
+namespace blink {
+
+IMPLEMENT_WRAPPERTYPEINFO(ui, Paragraph);
+
+#define FOR_EACH_BINDING(V)         \
+  V(Paragraph, width)               \
+  V(Paragraph, height)              \
+  V(Paragraph, minIntrinsicWidth)   \
+  V(Paragraph, maxIntrinsicWidth)   \
+  V(Paragraph, alphabeticBaseline)  \
+  V(Paragraph, ideographicBaseline) \
+  V(Paragraph, layout)              \
+  V(Paragraph, paint)               \
+  V(Paragraph, getWordBoundary)     \
+  V(Paragraph, getRectsForRange)    \
+  V(Paragraph, getPositionForOffset)
+
+DART_BIND_ALL(Paragraph, FOR_EACH_BINDING)
+
+Paragraph::Paragraph() {}
+
+Paragraph::~Paragraph() {}
+
+double Paragraph::width() {
+  return 0.0;
+}
+
+double Paragraph::height() {
+  return 0.0;
+}
+
+double Paragraph::minIntrinsicWidth() {
+  return 0.0;
+}
+
+double Paragraph::maxIntrinsicWidth() {
+  return 0.0;
+}
+
+double Paragraph::alphabeticBaseline() {
+  return 0.0;
+}
+
+double Paragraph::ideographicBaseline() {
+  return 0.0;
+}
+
+void Paragraph::layout(double width) {}
+
+void Paragraph::paint(Canvas* canvas, double x, double y) {}
+
+void Paragraph::getRectsForRange(unsigned start, unsigned end) {}
+
+Dart_Handle Paragraph::getPositionForOffset(double dx, double dy) {
+  Dart_Handle result = Dart_NewList(2);
+  Dart_ListSetAt(result, 0, ToDart(0));
+  Dart_ListSetAt(result, 1, ToDart(0));
+  return result;
+}
+
+Dart_Handle Paragraph::getWordBoundary(unsigned offset) {
+  Dart_Handle result = Dart_NewList(2);
+  Dart_ListSetAt(result, 0, ToDart(0));
+  Dart_ListSetAt(result, 1, ToDart(0));
+  return result;
+}
+
+}  // namespace blink

--- a/lib/ui/text/paragraph_stub.h
+++ b/lib/ui/text/paragraph_stub.h
@@ -1,0 +1,51 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_TEXT_PARAGRAPH_STUB_H_
+#define FLUTTER_LIB_UI_TEXT_PARAGRAPH_STUB_H_
+
+#include "flutter/lib/ui/painting/canvas.h"
+#include "lib/tonic/dart_wrappable.h"
+
+namespace tonic {
+class DartLibraryNatives;
+}  // namespace tonic
+
+namespace blink {
+
+class Paragraph : public ftl::RefCountedThreadSafe<Paragraph>,
+                  public tonic::DartWrappable {
+  DEFINE_WRAPPERTYPEINFO();
+  FRIEND_MAKE_REF_COUNTED(Paragraph);
+
+ public:
+  static ftl::RefPtr<Paragraph> create() {
+    return ftl::MakeRefCounted<Paragraph>();
+  }
+
+  ~Paragraph() override;
+
+  double width();
+  double height();
+  double minIntrinsicWidth();
+  double maxIntrinsicWidth();
+  double alphabeticBaseline();
+  double ideographicBaseline();
+
+  void layout(double width);
+  void paint(Canvas* canvas, double x, double y);
+
+  void getRectsForRange(unsigned start, unsigned end);
+  Dart_Handle getPositionForOffset(double dx, double dy);
+  Dart_Handle getWordBoundary(unsigned offset);
+
+  static void RegisterNatives(tonic::DartLibraryNatives* natives);
+
+ private:
+  Paragraph();
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_TEXT_PARAGRAPH_STUB_H_


### PR DESCRIPTION
We don't yet have support for text on Fuchsia. This patch add stub
implementations of Paragraph and ParagraphBuilder so that Flutter apps
that use text don't error out. Instead, the text is 0x0 and invisible.

Also, teach MojoServices not to crash if it hasn't been created by the
time Dart tries to use it.