### PR TITLE
If the vsync provider is being replaced, make sure the animator expects no more signals from the old registration.

### DIFF
--- a/sky/shell/ui/animator.cc
+++ b/sky/shell/ui/animator.cc
@@ -106,6 +106,10 @@ void Animator::RequestFrame() {
 
 void Animator::set_vsync_provider(vsync::VSyncProviderPtr vsync_provider) {
   vsync_provider_ = vsync_provider.Pass();
+
+  // We may be waiting on a VSync signal from the old VSync provider.
+  pending_frame_semaphore_.Signal();
+
   RequestFrame();
 }
 


### PR DESCRIPTION
This happens when we tear down and replace services in case of hot reloading.

cc @johnmccutchan @abarth 