### PR TITLE
Pipelines vend single use continuations that callers can complete at any time to signal readiness of a pipeline resource.

### DIFF
--- a/sky/shell/ui/animator.h
+++ b/sky/shell/ui/animator.h
@@ -47,7 +47,7 @@ class Animator {
   vsync::VSyncProviderPtr fallback_vsync_provider_;
   ftl::RefPtr<LayerTreePipeline> layer_tree_pipeline_;
   flutter::Semaphore pending_frame_semaphore_;
-  std::unique_ptr<flow::LayerTree> renderable_tree_;
+  LayerTreePipeline::ProducerContinuation producer_continuation_;
   bool paused_;
 
   base::WeakPtrFactory<Animator> weak_factory_;

--- a/synchronization/pipeline.cc
+++ b/synchronization/pipeline.cc
@@ -3,9 +3,3 @@
 // found in the LICENSE file.
 
 #include "flutter/synchronization/pipeline.h"
-
-namespace flutter {
-
-//
-
-}  // namespace flutter

--- a/synchronization/pipeline.h
+++ b/synchronization/pipeline.h
@@ -34,7 +34,7 @@ class Pipeline : public ftl::RefCountedThreadSafe<Pipeline<R>> {
   /// preparing a completed pipeline resource.
   class ProducerContinuation {
    public:
-    ProducerContinuation() {}
+    ProducerContinuation() = default;
 
     ProducerContinuation(ProducerContinuation&& other)
         : continuation_(other.continuation_) {
@@ -74,7 +74,7 @@ class Pipeline : public ftl::RefCountedThreadSafe<Pipeline<R>> {
 
   explicit Pipeline(uint32_t depth) : empty_(depth), available_(0) {}
 
-  ~Pipeline() {}
+  ~Pipeline() = default;
 
   bool IsValid() const { return empty_.IsValid() && available_.IsValid(); }
 

--- a/synchronization/pipeline.h
+++ b/synchronization/pipeline.h
@@ -30,39 +30,60 @@ class Pipeline : public ftl::RefCountedThreadSafe<Pipeline<R>> {
   using Resource = R;
   using ResourcePtr = std::unique_ptr<Resource>;
 
+  /// Denotes a spot in the pipeline reserved for the producer to finish
+  /// preparing a completed pipeline resource.
+  class ProducerContinuation {
+   public:
+    ProducerContinuation() {}
+
+    ProducerContinuation(ProducerContinuation&& other)
+        : continuation_(other.continuation_) {
+      other.continuation_ = nullptr;
+    }
+
+    ProducerContinuation& operator=(ProducerContinuation&& other) {
+      std::swap(continuation_, other.continuation_);
+      return *this;
+    }
+
+    ~ProducerContinuation() {
+      if (continuation_) {
+        continuation_(nullptr);
+      }
+    }
+
+    void Complete(ResourcePtr resource) {
+      if (continuation_) {
+        continuation_(std::move(resource));
+        continuation_ = nullptr;
+      }
+    }
+
+    operator bool() const { return continuation_ != nullptr; }
+
+   private:
+    friend class Pipeline;
+
+    std::function<void(ResourcePtr)> continuation_;
+
+    ProducerContinuation(std::function<void(ResourcePtr)> continuation)
+        : continuation_(continuation) {}
+
+    FTL_DISALLOW_COPY_AND_ASSIGN(ProducerContinuation);
+  };
+
   explicit Pipeline(uint32_t depth) : empty_(depth), available_(0) {}
 
   ~Pipeline() {}
 
   bool IsValid() const { return empty_.IsValid() && available_.IsValid(); }
 
-  using Producer = std::function<ResourcePtr(void)>;
-
-  FTL_WARN_UNUSED_RESULT
-  bool Produce(Producer producer) {
-    if (producer == nullptr) {
-      return false;
-    }
-
+  ProducerContinuation Produce() {
     if (!empty_.TryWait()) {
-      return false;
+      return {};
     }
 
-    ResourcePtr resource;
-
-    {
-      TRACE_EVENT0("flutter", "PipelineProduce");
-      resource = producer();
-    }
-
-    {
-      ftl::MutexLocker lock(&queue_mutex_);
-      queue_.emplace(std::move(resource));
-    }
-
-    available_.Signal();
-
-    return true;
+    return {std::bind(&Pipeline::ProducerCommit, this, std::placeholders::_1)};
   }
 
   using Consumer = std::function<void(ResourcePtr)>;
@@ -103,6 +124,16 @@ class Pipeline : public ftl::RefCountedThreadSafe<Pipeline<R>> {
   Semaphore available_;
   ftl::Mutex queue_mutex_;
   std::queue<ResourcePtr> queue_;
+
+  void ProducerCommit(ResourcePtr resource) {
+    {
+      ftl::MutexLocker lock(&queue_mutex_);
+      queue_.emplace(std::move(resource));
+    }
+
+    // Ensure the queue mutex is not held as that would be a pessimization.
+    available_.Signal();
+  }
 
   FTL_DISALLOW_COPY_AND_ASSIGN(Pipeline);
 };


### PR DESCRIPTION
* Allows committing pipeline items before `BeginFrame` returns in the animator. Implements optimization discussed in https://github.com/flutter/engine/pull/2942#discussion_r75333272
* It is currently developer error to acquire producer continuations from a pipeline, delete the pipeline and attempt to complete the same. This is enough of an edge case that I have chosen not make pending continuations keep the pipeline alive.
* Measurement of the resource construction time is being added in an upcoming patch.

cc @abarth @tvolkert @jason-simmons 