### PR TITLE
Only attempt to draw in the rasterizer if a valid layer tree is received.

### DIFF
--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -114,6 +114,10 @@ void RasterizerDirect::Draw(
 }
 
 void RasterizerDirect::DoDraw(std::unique_ptr<flow::LayerTree> layer_tree) {
+  if (layer_tree == nullptr) {
+    return;
+  }
+
   // There is no way for the compositor to know how long the layer tree
   // construction took. Fortunately, the layer tree does. Grab that time
   // for instrumentation.


### PR DESCRIPTION
If you are asking yourself how a null layer tree got there:

* RequstFrame -> Pipeline acquire producer right -> BeginFrame -> No Render -> Repeat.

This will be fixed with https://github.com/flutter/engine/pull/2957/files. The post to the rasterizer will only happen on render. This is a paranoid check that I think should be there anyway.