### PR TITLE
Removed custom service definition logging.

### DIFF
--- a/sky/shell/platform/ios/framework/Source/FlutterDynamicServiceLoader.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterDynamicServiceLoader.mm
@@ -103,8 +103,6 @@
     _services = [[NSMutableDictionary alloc] init];
 
     [self populateServiceDefinitions];
-
-    LOG(INFO) << _services.count << " custom service definitions registered";
   }
 
   return self;
@@ -126,8 +124,6 @@
                                       ofType:@"json"];
 
   if (definitionsPath.length == 0) {
-    LOG(INFO) << "Could not find the service definitions manifest. No custom "
-                 "services will be available.";
     return;
   }
 


### PR DESCRIPTION
Since this functionality will be removed soon, this patch removes
the logging in order not to hinder the iOS development experience.