### PR TITLE
Don’t depend on tonic/debugger in release since the Dart debugger is unavailable in product mode.

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -70,9 +70,14 @@ source_set("runtime") {
     "//flutter/skia",
     "//lib/ftl",
     "//lib/tonic",
-    "//lib/tonic/debugger",
     "//mojo/public/platform/dart:mojo_internal_impl",
   ]
+
+  if (flutter_runtime_mode != "release") {
+    deps += [
+      "//lib/tonic/debugger",
+    ]
+  }
 
   if (is_android) {
     deps += [

--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -16,7 +16,6 @@ source_set("libraries") {
     "//flutter/sky/engine/wtf",
     "//lib/ftl",
     "//lib/tonic",
-    "//lib/tonic/debugger",
     "//mojo/application",
     "//mojo/data_pipe_utils",
     "//mojo/public/c/system",
@@ -30,6 +29,12 @@ source_set("libraries") {
     "//third_party/qcms",
     "//third_party/zlib",
   ]
+
+  if (flutter_runtime_mode != "release") {
+    public_deps += [
+      "//lib/tonic/debugger",
+    ]
+  }
 
   if (is_android) {
     public_deps += [


### PR DESCRIPTION
Earlier, we were not enabling the debugger but still depending on the tonic/debugger which relied on bits in the dart/runtime which were guarded away in product mode.

cc @tvolkert 