### PR TITLE
[gn] Explicitly include common.gni in build files that use vars from it

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
+
 vmservice_sources_gypi =
   exec_script("//build/gypi_to_gn.py",
       [ rebase_path("//dart/runtime/bin/vmservice/vmservice_sources.gypi") ],

--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
 import("//flutter/sky/engine/core/core.gni")
 
 visibility = [ "//flutter/sky/engine/*", "//flutter/sky/shell/*" ]


### PR DESCRIPTION
runtime/BUILD.gn and ..core/BUILD.gn use flutter_runtime_mode which
is defined in common.gni. If the build comes through common/BUILD.gn
this is imported (implicity) but builds that depend on specific
files, like the Fuchsia build, won't have this imported.  This
imports the gni from the build files that use it instead of relying
on it already being there.