### PR TITLE
Add a temporary engine systrace logger till the Dart timeline learns how to log to systrace.

### DIFF
--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -31,6 +31,8 @@ source_set("common") {
     "shell.h",
     "switches.cc",
     "switches.h",
+    "systrace_logger.cc",
+    "systrace_logger.h",
     "tracing_controller.cc",
     "tracing_controller.h",
     "ui/animator.cc",

--- a/sky/shell/systrace_logger.cc
+++ b/sky/shell/systrace_logger.cc
@@ -1,0 +1,56 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/sky/shell/systrace_logger.h"
+#include "lib/ftl/files/eintr_wrapper.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <string.h>
+
+namespace sky {
+namespace shell {
+
+static const size_t kBufferSize = 256;
+
+SystraceLogger::SystraceLogger()
+    : trace_fd_(HANDLE_EINTR(
+          ::open("/sys/kernel/debug/tracing/trace_marker", O_WRONLY))),
+      pid_(getpid()) {}
+
+SystraceLogger::~SystraceLogger() {
+  IGNORE_EINTR(::close(trace_fd_));
+}
+
+void SystraceLogger::TraceBegin(const char* label) const {
+  char buffer[kBufferSize];
+  int buffer_written = snprintf(buffer, sizeof(buffer), "B|%d|%s", pid_, label);
+
+  if (buffer_written <= 0 || buffer_written > kBufferSize) {
+    return;
+  }
+
+  HANDLE_EINTR(::write(trace_fd_, buffer, buffer_written));
+}
+
+void SystraceLogger::TraceEnd() const {
+  HANDLE_EINTR(::write(trace_fd_, "E", 1));
+}
+
+void SystraceLogger::TraceCount(const char* label, int count) const {
+  char buffer[kBufferSize];
+
+  int buffer_written =
+      snprintf(buffer, sizeof(buffer), "C|%d|%s|%d", pid_, label, count);
+
+  if (buffer_written <= 0 || buffer_written > kBufferSize) {
+    return;
+  }
+
+  HANDLE_EINTR(::write(trace_fd_, buffer, buffer_written));
+}
+
+}  // namespace shell
+}  // namespace sky

--- a/sky/shell/systrace_logger.h
+++ b/sky/shell/systrace_logger.h
@@ -1,0 +1,37 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SKY_SHELL_SYSTRACE_LOGGER_H_
+#define FLUTTER_SKY_SHELL_SYSTRACE_LOGGER_H_
+
+#include "lib/ftl/macros.h"
+
+#include <sys/types.h>
+
+namespace sky {
+namespace shell {
+
+class SystraceLogger {
+ public:
+  SystraceLogger();
+
+  ~SystraceLogger();
+
+  void TraceBegin(const char* label) const;
+
+  void TraceEnd() const;
+
+  void TraceCount(const char* label, int count) const;
+
+ private:
+  int trace_fd_;
+  int pid_;
+
+  FTL_DISALLOW_COPY_AND_ASSIGN(SystraceLogger);
+};
+
+}  // namespace shell
+}  // namespace sky
+
+#endif  // FLUTTER_SKY_SHELL_SYSTRACE_LOGGER_H_


### PR DESCRIPTION
This is useful in tracing performance issues caused by buffer queue stalls. @johnmccutchan mentioned that Dart will eventually be able to trace this. So for now, I have just added it to shell and am wiring it in when I need the extra information from `systrace`. Will remove it once the Dart patches have landed.

![screen shot 2016-08-29 at 4 47 49 pm](https://cloud.githubusercontent.com/assets/44085/18071198/a66f93f2-6e08-11e6-8ed8-887ca14144d7.png)
