### PR TITLE
When rasterizing to a recorder backed canvas for SKP tracing, don’t attempt to update the raster cache.

### DIFF
--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -41,7 +41,7 @@ class Layer {
   virtual ~Layer();
 
   struct PrerollContext {
-    RasterCache& raster_cache;
+    RasterCache* raster_cache;
     GrContext* gr_context;
     SkRect child_paint_bounds;
   };

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -13,20 +13,20 @@ LayerTree::LayerTree() : scene_version_(0), rasterizer_tracing_threshold_(0) {}
 
 LayerTree::~LayerTree() {}
 
-void LayerTree::Raster(CompositorContext::ScopedFrame& frame) {
+void LayerTree::Raster(CompositorContext::ScopedFrame& frame,
+                       bool ignore_raster_cache) {
   {
     TRACE_EVENT0("flutter", "LayerTree::Preroll");
     Layer::PrerollContext context = {
-        frame.context().raster_cache(), frame.gr_context(), SkRect::MakeEmpty(),
+        ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
+        frame.gr_context(), SkRect::MakeEmpty(),
     };
     root_layer_->Preroll(&context, SkMatrix());
   }
 
   {
-    Layer::PaintContext context = {
-        frame.canvas(), frame.context().frame_time(),
-        frame.context().engine_time(),
-    };
+    Layer::PaintContext context = {frame.canvas(), frame.context().frame_time(),
+                                   frame.context().engine_time()};
     TRACE_EVENT0("flutter", "LayerTree::Paint");
     root_layer_->Paint(context);
   }

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -23,7 +23,8 @@ class LayerTree {
 
   ~LayerTree();
 
-  void Raster(CompositorContext::ScopedFrame& frame);
+  void Raster(CompositorContext::ScopedFrame& frame,
+              bool ignore_raster_cache = false);
 
   // TODO(abarth): Integrate scene updates with the rasterization pass so that
   // we can draw on top of child scenes (and so that we can apply clips and

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -14,8 +14,11 @@ PictureLayer::PictureLayer() {}
 PictureLayer::~PictureLayer() {}
 
 void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  image_ = context->raster_cache.GetPrerolledImage(
-      context->gr_context, picture_.get(), matrix, is_complex_, will_change_);
+  if (auto cache = context->raster_cache) {
+    image_ = cache->GetPrerolledImage(context->gr_context, picture_.get(),
+                                      matrix, is_complex_, will_change_);
+  }
+
   context->child_paint_bounds =
       picture_->cullRect().makeOffset(offset_.x(), offset_.y());
 }

--- a/sky/shell/gpu/direct/rasterizer_direct.cc
+++ b/sky/shell/gpu/direct/rasterizer_direct.cc
@@ -166,16 +166,16 @@ void RasterizerDirect::DoDraw(std::unique_ptr<flow::LayerTree> layer_tree) {
     std::string path = tracingController.PictureTracingPathForCurrentTime();
     LOG(INFO) << "Frame threshold exceeded. Capturing SKP to " << path;
 
-    SkPictureRecorder recoder;
-    recoder.beginRecording(SkRect::MakeWH(size.width(), size.height()));
+    SkPictureRecorder recorder;
+    recorder.beginRecording(SkRect::MakeWH(size.width(), size.height()));
 
     {
       auto frame = compositor_context_.AcquireFrame(
-          nullptr, *recoder.getRecordingCanvas(), false);
-      layer_tree->Raster(frame);
+          nullptr, *recorder.getRecordingCanvas(), false);
+      layer_tree->Raster(frame, true);
     }
 
-    sk_sp<SkPicture> picture = recoder.finishRecordingAsPicture();
+    sk_sp<SkPicture> picture = recorder.finishRecordingAsPicture();
     SerializePicture(path, picture.get());
   }
 


### PR DESCRIPTION
We could get into a situation where the second time we rasterize a picture for an SKP, the raster cache detects that the same picture is being repeated in subsequent onscreen frames and then proceeds to rasterize the contents to an offscreen texture. This not only causes an unnecessary cache entry, but also shows the cached image in the final SKP trace (which is not what was originally displayed on screen).