### PR TITLE
Setup SKP tracing base path for the Mac desktop platform.

### DIFF
--- a/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
+++ b/sky/shell/platform/ios/framework/Source/FlutterViewController.mm
@@ -77,18 +77,9 @@ void FlutterInit(int argc, const char* argv[]) {
       reinterpret_cast<CAEAGLLayer*>(self.view.layer));
   _platformView->SetupResourceContextOnIOThread();
 
-  [self setupTracing];
-
   [self setupNotificationCenterObservers];
 
   [self connectToEngineAndLoad];
-}
-
-- (void)setupTracing {
-  NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
-                                                       NSUserDomainMask, YES);
-  sky::shell::Shell::Shared().tracing_controller().set_traces_base_path(
-      [paths.firstObject UTF8String]);
 }
 
 - (void)setupNotificationCenterObservers {

--- a/sky/shell/platform/ios/platform_view_ios.mm
+++ b/sky/shell/platform/ios/platform_view_ios.mm
@@ -275,7 +275,12 @@ class IOSGLContext {
 PlatformViewIOS::PlatformViewIOS(CAEAGLLayer* layer)
     : context_(WTF::MakeUnique<IOSGLContext>(surface_config_, layer)),
       dynamic_service_loader_([[FlutterDynamicServiceLoader alloc] init]),
-      weak_factory_(this) {}
+      weak_factory_(this) {
+  NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
+                                                       NSUserDomainMask, YES);
+  sky::shell::Shell::Shared().tracing_controller().set_traces_base_path(
+      [paths.firstObject UTF8String]);
+}
 
 PlatformViewIOS::~PlatformViewIOS() = default;
 

--- a/sky/shell/platform/mac/platform_view_mac.mm
+++ b/sky/shell/platform/mac/platform_view_mac.mm
@@ -28,7 +28,12 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
       resource_loading_context_([[NSOpenGLContext alloc]
           initWithFormat:gl_view.pixelFormat
             shareContext:gl_view.openGLContext]),
-      weak_factory_(this) {}
+      weak_factory_(this) {
+  NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
+                                                       NSUserDomainMask, YES);
+  sky::shell::Shell::Shared().tracing_controller().set_traces_base_path(
+      [paths.firstObject UTF8String]);
+}
 
 PlatformViewMac::~PlatformViewMac() = default;
 


### PR DESCRIPTION
Replicates iOS behavior of placing trace files in the documents directory.