### PR TITLE
Respect the —enable-checked-mode flag when not running precompiled code instead of defaulting it on.

### DIFF
--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -523,17 +523,10 @@ void SetRegisterNativeServiceProtocolExtensionHook(
 }
 
 static bool ShouldEnableCheckedMode() {
-  if (IsRunningPrecompiledCode()) {
-    // Checked mode is never enabled during precompilation. Even snapshot
-    // generation disables checked mode arguments.
-    return false;
-  }
-
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  return true;
-#else
-  return Settings::Get().enable_dart_checked_mode;
-#endif
+  // Checked mode is never enabled during precompilation. Even snapshot
+  // generation disables checked mode arguments.
+  return IsRunningPrecompiledCode() ? false
+                                    : Settings::Get().enable_dart_checked_mode;
 }
 
 void PushBackAll(std::vector<const char*>* args,


### PR DESCRIPTION
The `--enable-checked-mode` flag was essentially broken on all platforms because we run precompiled code in profile and release on mobile platforms (in which case the first condition hit) and always ignored the flag in debug. The desktop shells were also always in debug product mode. This fixes the --enable-checked-mode flag allowing configurations like DBC without checked mode or desktop JIT without checked mode.

cc @jason-simmons @HansMuller 