### PR TITLE
Jank regression: Don't destruct Paragraphs on the UI thread.

### DIFF
--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -41,11 +41,7 @@ DART_BIND_ALL(Paragraph, FOR_EACH_BINDING)
 Paragraph::Paragraph(PassOwnPtr<RenderView> renderView)
     : m_renderView(renderView) {}
 
-Paragraph::~Paragraph() {
-  PassOwnPtr<RenderView> renderView = m_renderView.release();
-  Threads::UI()->PostTask(
-      [renderView]() { /* renderView's destructor runs. */ });
-}
+Paragraph::~Paragraph() { }
 
 double Paragraph::width() {
   return firstChildBox()->width();

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -135,11 +135,7 @@ ParagraphBuilder::ParagraphBuilder() {
   m_renderView->addChild(m_currentRenderObject);
 }
 
-ParagraphBuilder::~ParagraphBuilder() {
-  PassOwnPtr<RenderView> renderView = m_renderView.release();
-  Threads::UI()->PostTask(
-      [renderView]() { /* renderView's destructor runs. */ });
-}
+ParagraphBuilder::~ParagraphBuilder() { }
 
 void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
                                  const std::string& fontFamily,


### PR DESCRIPTION
Let destruction run on the background finalizer's thread.

Removes 250-900 ms pauses (complex_layout, Nexus 4) on the frame after the frame that runs a scavenge, where 600-2800 PostTasks were handled on the UI thread.