### PR TITLE
Avoid using [NSArray firstObject] on the Mac platform view.

### DIFF
--- a/sky/shell/platform/mac/platform_view_mac.mm
+++ b/sky/shell/platform/mac/platform_view_mac.mm
@@ -4,6 +4,7 @@
 
 #include "flutter/sky/shell/platform/mac/platform_view_mac.h"
 
+#include <Foundation/Foundation.h>
 #include <AppKit/AppKit.h>
 
 #include "base/command_line.h"

--- a/sky/shell/platform/mac/platform_view_mac.mm
+++ b/sky/shell/platform/mac/platform_view_mac.mm
@@ -31,8 +31,10 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
       weak_factory_(this) {
   NSArray* paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
                                                        NSUserDomainMask, YES);
-  sky::shell::Shell::Shared().tracing_controller().set_traces_base_path(
-      [paths.firstObject UTF8String]);
+  if (paths.count > 0) {
+    sky::shell::Shell::Shared().tracing_controller().set_traces_base_path(
+        [[paths objectAtIndex:0] UTF8String]);
+  }
 }
 
 PlatformViewMac::~PlatformViewMac() = default;


### PR DESCRIPTION
This was causing problems on the buildbot. But I am still not sure why since `-mmacosx-version-min=10.8` is specified and the `firstObject` was added in 10.6. I could not reproduce this problem locally either.
