### PR TITLE
Added drawArc to Canvas.

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1302,9 +1302,11 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// radians around the oval, with zero radians being the point on
   /// the right hand side of the oval that crosses the horizontal line
   /// that intersects the center of the rectangle and with positive
-  /// angles going clockwise around the oval. If useCenter is true, the path is
-  /// closed back to the center, forming a wedge. Otherwise, the implied path
-  /// is not closed.
+  /// angles going clockwise around the oval. If useCenter is true, the arc is
+  /// closed back to the center, forming a circle sector. Otherwise, the arc is
+  /// not closed, forming a circle segment.
+  ///
+  /// This method is optimized for drawing arcs and should be faster than [Path.arcTo].
   void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {
     _drawArc(rect.left, rect.top, rect.right, rect.bottom, startAngle,
              sweepAngle, useCenter, paint._objects, paint._data);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1297,6 +1297,29 @@ class Canvas extends NativeFieldWrapperClass2 {
                    List<dynamic> paintObjects,
                    ByteData paintData) native "Canvas_drawCircle";
 
+  /// Draw an arc scaled to fit inside the given rectangle. It starts from
+  /// startAngle radians around the oval up to startAngle + sweepAngle
+  /// radians around the oval, with zero radians being the point on
+  /// the right hand side of the oval that crosses the horizontal line
+  /// that intersects the center of the rectangle and with positive
+  /// angles going clockwise around the oval. If useCenter is true, the oval
+  /// center is inserted into the implied path before the arc and the path is
+  /// closed back to the center, forming a wedge. Otherwise, the implied path
+  /// contains just the arc and is not closed.
+  void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {
+    _drawArc(rect.left, rect.top, rect.right, rect.bottom, startAngle,
+             sweepAngle, useCenter, paint._objects, paint._data);
+  }
+  void _drawArc(double left,
+                double top,
+                double right,
+                double bottom,
+                double startAngle,
+                double sweepAngle,
+                bool useCenter,
+                List<dynamic> paintObjects,
+                ByteData paintData) native "Canvas_drawArc";
+
   /// Draws the given [Path] with the given [Paint]. Whether this shape is
   /// filled or stroked (or both) is controlled by [Paint.style]. If the path is
   /// filled, then subpaths within it are implicitly closed (see [Path.close]).

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1302,10 +1302,9 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// radians around the oval, with zero radians being the point on
   /// the right hand side of the oval that crosses the horizontal line
   /// that intersects the center of the rectangle and with positive
-  /// angles going clockwise around the oval. If useCenter is true, the oval
-  /// center is inserted into the implied path before the arc and the path is
+  /// angles going clockwise around the oval. If useCenter is true, the path is
   /// closed back to the center, forming a wedge. Otherwise, the implied path
-  /// contains just the arc and is not closed.
+  /// is not closed.
   void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {
     _drawArc(rect.left, rect.top, rect.right, rect.bottom, startAngle,
              sweepAngle, useCenter, paint._objects, paint._data);

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -46,6 +46,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
   V(Canvas, drawDRRect)             \
   V(Canvas, drawOval)               \
   V(Canvas, drawCircle)             \
+  V(Canvas, drawArc)                \
   V(Canvas, drawPath)               \
   V(Canvas, drawImage)              \
   V(Canvas, drawImageRect)          \
@@ -240,6 +241,24 @@ void Canvas::drawCircle(double x,
   if (!canvas_)
     return;
   canvas_->drawCircle(x, y, radius, *paint.paint());
+}
+
+void Canvas::drawArc(double left,
+             double top,
+             double right,
+             double bottom,
+             double startAngle,
+             double sweepAngle,
+             bool useCenter,
+             const Paint& paint,
+             const PaintData& paint_data) {
+  if (!canvas_)
+    return;
+  canvas_->drawArc(SkRect::MakeLTRB(left, top, right, bottom),
+                   startAngle * 180.0 / M_PI,
+                   sweepAngle* 180.0 / M_PI,
+                   useCenter,
+                   *paint.paint());
 }
 
 void Canvas::drawPath(const CanvasPath* path,

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -100,6 +100,15 @@ class Canvas : public ftl::RefCountedThreadSafe<Canvas>,
                   double radius,
                   const Paint& paint,
                   const PaintData& paint_data);
+  void drawArc(double left,
+               double top,
+               double right,
+               double bottom,
+               double startAngle,
+               double sweepAngle,
+               bool useCenter,
+               const Paint& paint,
+               const PaintData& paint_data);
   void drawPath(const CanvasPath* path,
                 const Paint& paint,
                 const PaintData& paint_data);


### PR DESCRIPTION
Added a way to call SkCanvas::drawArc from Dart. This method is
optimized for the arc case and should be faster that drawing paths.