### PR TITLE
Remove references to unused GN files and flags.

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -13,8 +13,8 @@ group("skia") {
 } else {
 
 import("//build/config/features.gni")
-import("//build/config/ui.gni")
 import("//testing/test.gni")
+
 if (current_cpu == "arm" || current_cpu == "arm64") {
   import("//build/config/arm.gni")
 }

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -465,9 +465,6 @@ component("skia") {
       "//build/config/linux:fontconfig",
       "//build/config/linux:freetype2",
     ]
-    if (use_pango) {
-      configs += [ "//build/config/linux:pangocairo" ]
-    }
     deps += [ "//third_party/icu:icuuc" ]
   }
 

--- a/sky/engine/public/BUILD.gn
+++ b/sky/engine/public/BUILD.gn
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//tools/grit/grit_rule.gni")
-
 group("test_support") {
   deps = [
     "//flutter/sky/engine/web:test_support",

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/config/ui.gni")
 import("//mojo/dart/embedder/embedder.gni")
 
 dart_embedder_resources("generate_sky_embedder_diagnostic_server_resources_cc") {

--- a/tools/gn
+++ b/tools/gn
@@ -64,7 +64,6 @@ def to_gn_args(args):
           # Always use AOT on iOS devices until the interpreter stabilizes
           aot = True
     else:
-      gn_args['use_aura'] = False
       gn_args['use_system_harfbuzz'] = False
       aot = False
 


### PR DESCRIPTION
Counterpart to the patch in buildroot that removed unused flags and files: https://github.com/flutter/buildroot/pull/5