### PR TITLE
Update flutter_app template to new .packages filename scheme

### DIFF
--- a/build/flutter_app.gni
+++ b/build/flutter_app.gni
@@ -75,7 +75,7 @@ template("flutter_app") {
       "--main-dart",
       rebase_path(main_dart),
       "--packages",
-      rebase_path("$target_gen_dir/.packages"),
+      rebase_path("$target_gen_dir/$dart_package_name.packages"),
       "--bundle",
       rebase_path(bundle_path),
       "--bundle-header",
@@ -89,6 +89,7 @@ template("flutter_app") {
     ]
 
     deps = [
+      ":$dart_package_name",
       flutter_snapshot_label,
     ]
 


### PR DESCRIPTION
The name of the generated packages file now includes the target name.

This changed in https://fuchsia.googlesource.com/build/+/16ecfe0216a68663ca400253bbc58943c80516e7