### PR TITLE
Work around an Apple Clang issue where the compiler defines __ARM_FEATURE_CRC32 even though the crc32 instruction is unavailable.

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -220,6 +220,9 @@ config("skia_library_config") {
     cflags = [
       # Skia uses routines deprecated in iOS 7 and above
       "-Wno-deprecated-declarations",
+      # Clang incorrectly defines this even though the crc32 instruction is
+      # unavailable https://github.com/lionheart/openradar-mirror/issues/7653
+      "-U__ARM_FEATURE_CRC32",
     ]
 
     libs = [ "ImageIO.framework" ]


### PR DESCRIPTION
cc @jason-simmons @abarth 