### PR TITLE
Remove the enable_observatory instance variable from blink::Settings.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -13,7 +13,6 @@
 namespace blink {
 
 struct Settings {
-  bool enable_observatory = false;
   // Port on target will be auto selected by the OS. A message will be printed
   // on the target with the port after it has been selected.
   uint32_t observatory_port = 0;

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -203,15 +203,14 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
     DartMojoInternal::InitForIsolate();
     DartRuntimeHooks::Install(DartRuntimeHooks::SecondaryIsolate, script_uri);
     const Settings& settings = Settings::Get();
-    if (settings.enable_observatory) {
-      std::string ip = "127.0.0.1";
-      const intptr_t port = settings.observatory_port;
-      const bool disable_websocket_origin_check = false;
-      const bool service_isolate_booted = DartServiceIsolate::Startup(
-          ip, port, tonic::DartState::HandleLibraryTag,
-          IsRunningPrecompiledCode(), disable_websocket_origin_check, error);
-      FTL_CHECK(service_isolate_booted) << error;
-    }
+
+    std::string ip = "127.0.0.1";
+    const intptr_t port = settings.observatory_port;
+    const bool disable_websocket_origin_check = false;
+    const bool service_isolate_booted = DartServiceIsolate::Startup(
+        ip, port, tonic::DartState::HandleLibraryTag,
+        IsRunningPrecompiledCode(), disable_websocket_origin_check, error);
+    FTL_CHECK(service_isolate_booted) << error;
 
     if (g_service_isolate_hook)
       g_service_isolate_hook(IsRunningPrecompiledCode());

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -71,9 +71,7 @@ base::LazyInstance<NonDiscardableMemoryAllocator> g_discardable;
 
 void ServiceIsolateHook(bool running_precompiled) {
   if (!running_precompiled) {
-    const blink::Settings& settings = blink::Settings::Get();
-    if (settings.enable_observatory)
-      DiagnosticServer::Start();
+    DiagnosticServer::Start();
   }
 }
 
@@ -131,9 +129,7 @@ void Shell::InitStandalone(std::string icu_data_path) {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
 
   blink::Settings settings;
-  // Enable Observatory
-  settings.enable_observatory =
-      !command_line.HasSwitch(switches::kNonInteractive);
+
   // Set Observatory Port
   if (command_line.HasSwitch(switches::kDeviceObservatoryPort)) {
     auto port_string =


### PR DESCRIPTION
We used to be able to toggle observatory via a command line flag. But now, we enable or disable observatory based on the Flutter product mode.

This also allows us to fix an issue where the —non-interactive flags was being hijacked by the Dart initialization logic to enable or disable observatory. However this flag was orignally meant for the standalone runner to launch either to run tests or to run a full graphics enabled window on the desktop.