### PR TITLE
Add a —disable-observatory flag to explicitly disable observatory even in non-product modes.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -13,6 +13,7 @@
 namespace blink {
 
 struct Settings {
+  bool enable_observatory = false;
   // Port on target will be auto selected by the OS. A message will be printed
   // on the target with the port after it has been selected.
   uint32_t observatory_port = 0;

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -203,14 +203,15 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
     DartMojoInternal::InitForIsolate();
     DartRuntimeHooks::Install(DartRuntimeHooks::SecondaryIsolate, script_uri);
     const Settings& settings = Settings::Get();
-
-    std::string ip = "127.0.0.1";
-    const intptr_t port = settings.observatory_port;
-    const bool disable_websocket_origin_check = false;
-    const bool service_isolate_booted = DartServiceIsolate::Startup(
-        ip, port, tonic::DartState::HandleLibraryTag,
-        IsRunningPrecompiledCode(), disable_websocket_origin_check, error);
-    FTL_CHECK(service_isolate_booted) << error;
+    if (settings.enable_observatory) {
+      std::string ip = "127.0.0.1";
+      const intptr_t port = settings.observatory_port;
+      const bool disable_websocket_origin_check = false;
+      const bool service_isolate_booted = DartServiceIsolate::Startup(
+          ip, port, tonic::DartState::HandleLibraryTag,
+          IsRunningPrecompiledCode(), disable_websocket_origin_check, error);
+      FTL_CHECK(service_isolate_booted) << error;
+    }
 
     if (g_service_isolate_hook)
       g_service_isolate_hook(IsRunningPrecompiledCode());

--- a/sky/shell/shell.cc
+++ b/sky/shell/shell.cc
@@ -71,7 +71,9 @@ base::LazyInstance<NonDiscardableMemoryAllocator> g_discardable;
 
 void ServiceIsolateHook(bool running_precompiled) {
   if (!running_precompiled) {
-    DiagnosticServer::Start();
+    const blink::Settings& settings = blink::Settings::Get();
+    if (settings.enable_observatory)
+      DiagnosticServer::Start();
   }
 }
 
@@ -129,7 +131,9 @@ void Shell::InitStandalone(std::string icu_data_path) {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
 
   blink::Settings settings;
-
+  // Enable Observatory
+  settings.enable_observatory =
+      !command_line.HasSwitch(switches::kDisableObservatory);
   // Set Observatory Port
   if (command_line.HasSwitch(switches::kDeviceObservatoryPort)) {
     auto port_string =

--- a/sky/shell/switches.cc
+++ b/sky/shell/switches.cc
@@ -18,6 +18,7 @@ const char kAotVmIsolateSnapshot[] = "vm-isolate-snapshot";
 const char kCacheDirPath[] = "cache-dir-path";
 const char kDartFlags[] = "dart-flags";
 const char kDeviceObservatoryPort[] = "observatory-port";
+const char kDisableObservatory[] = "disable-observatory";
 const char kEndlessTraceBuffer[] = "endless-trace-buffer";
 const char kFLX[] = "flx";
 const char kHelp[] = "help";

--- a/sky/shell/switches.h
+++ b/sky/shell/switches.h
@@ -19,6 +19,7 @@ extern const char kAotVmIsolateSnapshot[];
 extern const char kCacheDirPath[];
 extern const char kDartFlags[];
 extern const char kDeviceObservatoryPort[];
+extern const char kDisableObservatory[];
 extern const char kEndlessTraceBuffer[];
 extern const char kFLX[];
 extern const char kHelp[];


### PR DESCRIPTION
cc @jason-simmons @Hixie 