### PR TITLE
Move font selector into //flutter/runtime

### DIFF
--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -10,6 +10,7 @@
 #include "flutter/common/threads.h"
 #include "flutter/content_handler/rasterizer.h"
 #include "flutter/lib/ui/mojo_services.h"
+#include "flutter/runtime/asset_font_selector.h"
 #include "flutter/runtime/dart_controller.h"
 #include "flutter/services/engine/sky_engine.mojom.h"
 #include "lib/ftl/functional/make_copyable.h"
@@ -104,6 +105,9 @@ void RuntimeHolder::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
 void RuntimeHolder::DidCreateMainIsolate(Dart_Isolate isolate) {
   blink::MojoServices::Create(isolate, nullptr, nullptr,
                               std::move(root_bundle_));
+
+  if (asset_store_)
+    blink::AssetFontSelector::Install(asset_store_);
 }
 
 void RuntimeHolder::InitRootBundle(std::vector<char> bundle) {

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -40,6 +40,8 @@ source_set("embedded_resources_cc") {
 
 source_set("runtime") {
   sources = [
+    "asset_font_selector.cc",
+    "asset_font_selector.h",
     "dart_controller.cc",
     "dart_controller.h",
     "dart_init.cc",
@@ -74,9 +76,11 @@ source_set("runtime") {
     "//flutter/services/engine:interfaces",
     "//flutter/services/pointer:interfaces",
     "//flutter/skia",
+    "//flutter/sky/engine/platform",
     "//lib/ftl",
     "//lib/tonic",
     "//mojo/public/platform/dart:mojo_internal_impl",
+    "//third_party/rapidjson",
   ]
 
   if (flutter_runtime_mode != "release") {

--- a/runtime/asset_font_selector.h
+++ b/runtime/asset_font_selector.h
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef SKY_SHELL_UI_FLUTTER_FONT_SELECTOR_H_
-#define SKY_SHELL_UI_FLUTTER_FONT_SELECTOR_H_
+#ifndef FLUTTER_RUNTIME_ASSET_FONT_SELECTOR_H_
+#define FLUTTER_RUNTIME_ASSET_FONT_SELECTOR_H_
 
 #include <unordered_map>
 #include <vector>
@@ -13,24 +13,22 @@
 #include "flutter/sky/engine/platform/fonts/FontSelector.h"
 #include "flutter/sky/engine/platform/fonts/SimpleFontData.h"
 
-namespace sky {
-namespace shell {
+namespace blink {
 
 // A FontSelector implementation that resolves custon font names to assets
 // loaded from the FLX.
-class FlutterFontSelector : public blink::FontSelector {
+class AssetFontSelector : public FontSelector {
  public:
   struct FlutterFontAttributes;
 
-  ~FlutterFontSelector() override;
+  ~AssetFontSelector() override;
 
-  static void Install(ftl::RefPtr<blink::ZipAssetStore> asset_store);
+  static void Install(ftl::RefPtr<ZipAssetStore> asset_store);
 
-  PassRefPtr<blink::FontData> getFontData(
-      const blink::FontDescription& font_description,
-      const AtomicString& family_name) override;
+  PassRefPtr<FontData> getFontData(const FontDescription& font_description,
+                                   const AtomicString& family_name) override;
 
-  void willUseFontData(const blink::FontDescription& font_description,
+  void willUseFontData(const FontDescription& font_description,
                        const AtomicString& family,
                        UChar32 character) override;
 
@@ -41,31 +39,29 @@ class FlutterFontSelector : public blink::FontSelector {
  private:
   struct TypefaceAsset;
 
-  FlutterFontSelector(ftl::RefPtr<blink::ZipAssetStore> asset_store);
+  explicit AssetFontSelector(ftl::RefPtr<ZipAssetStore> asset_store);
 
   void parseFontManifest();
 
-  sk_sp<SkTypeface> getTypefaceAsset(
-      const blink::FontDescription& font_description,
-      const AtomicString& family_name);
+  sk_sp<SkTypeface> getTypefaceAsset(const FontDescription& font_description,
+                                     const AtomicString& family_name);
 
-  ftl::RefPtr<blink::ZipAssetStore> asset_store_;
+  ftl::RefPtr<ZipAssetStore> asset_store_;
 
   HashMap<AtomicString, std::vector<FlutterFontAttributes>> font_family_map_;
 
   std::unordered_map<std::string, std::unique_ptr<TypefaceAsset>>
       typeface_cache_;
 
-  typedef HashMap<blink::FontCacheKey,
-                  RefPtr<blink::SimpleFontData>,
-                  blink::FontCacheKeyHash,
-                  blink::FontCacheKeyTraits>
+  typedef HashMap<FontCacheKey,
+                  RefPtr<SimpleFontData>,
+                  FontCacheKeyHash,
+                  FontCacheKeyTraits>
       FontPlatformDataCache;
 
   FontPlatformDataCache font_platform_data_cache_;
 };
 
-}  // namespace shell
-}  // namespace sky
+}  // namespace blink
 
-#endif  // SKY_SHELL_UI_FLUTTER_FONT_SELECTOR_H_
+#endif  // FLUTTER_RUNTIME_ASSET_FONT_SELECTOR_H_

--- a/sky/shell/BUILD.gn
+++ b/sky/shell/BUILD.gn
@@ -38,8 +38,6 @@ source_set("common") {
     "ui/animator.h",
     "ui/engine.cc",
     "ui/engine.h",
-    "ui/flutter_font_selector.cc",
-    "ui/flutter_font_selector.h",
     "ui_delegate.cc",
     "ui_delegate.h",
   ]

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -15,12 +15,12 @@
 #include "flutter/glue/movable_wrapper.h"
 #include "flutter/glue/trace_event.h"
 #include "flutter/lib/ui/mojo_services.h"
+#include "flutter/runtime/asset_font_selector.h"
 #include "flutter/runtime/dart_controller.h"
 #include "flutter/runtime/dart_init.h"
 #include "flutter/runtime/runtime_init.h"
 #include "flutter/sky/engine/public/web/Sky.h"
 #include "flutter/sky/shell/ui/animator.h"
-#include "flutter/sky/shell/ui/flutter_font_selector.h"
 #include "lib/ftl/files/path.h"
 #include "mojo/public/cpp/application/connect.h"
 #include "third_party/skia/include/core/SkCanvas.h"
@@ -291,7 +291,7 @@ void Engine::DidCreateMainIsolate(Dart_Isolate isolate) {
                               std::move(root_bundle_));
 
   if (asset_store_)
-    FlutterFontSelector::Install(asset_store_);
+    blink::AssetFontSelector::Install(asset_store_);
 }
 
 void Engine::DidCreateSecondaryIsolate(Dart_Isolate isolate) {
@@ -331,8 +331,8 @@ void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   if (!viewport_metrics_)
     return;
 
-  SkISize frame_size = SkISize::Make(
-      viewport_metrics_->physical_width, viewport_metrics_->physical_height);
+  SkISize frame_size = SkISize::Make(viewport_metrics_->physical_width,
+                                     viewport_metrics_->physical_height);
   if (frame_size.isEmpty())
     return;
 


### PR DESCRIPTION
This patch makes it easier to share the code with
//flutter/content_handler on Fuchsia.