### PR TITLE
Add 'ext.ui.window.scheduleFrame' service protocol extension

### DIFF
--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -13,10 +13,28 @@ class _Logger {
   static void _printString(String s) native "Logger_PrintString";
 }
 
+// A service protocol extension to schedule a frame to be rendered into the
+// window.
+Future<developer.ServiceExtensionResponse> _scheduleFrame(
+    String method,
+    Map<String, String> parameters
+    ) async {
+  // Schedule the frame.
+  window.scheduleFrame();
+  // Always succeed.
+  return new developer.ServiceExtensionResponse.result(JSON.encode({
+    'type': 'Success',
+  }));
+}
+
 void _setupHooks() {
   // Wire up timer implementation that is driven by MojoHandleWatcher.
   VMLibraryHooks.eventHandlerSendData = MojoHandleWatcher.timer;
   VMLibraryHooks.timerMillisecondClock = MojoCoreNatives.timerMillisecondClock;
+  assert(() {
+    // In debug mode, register the schedule frame extension.
+    developer.registerExtension('ext.ui.window.scheduleFrame', _scheduleFrame);
+  });
 }
 
 void _scheduleMicrotask(void callback()) native "ScheduleMicrotask";

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -14,6 +14,9 @@
 library dart_ui;
 
 import 'dart:_internal';
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer' as developer;
 import 'dart:math' as math;
 import 'dart:mojo.internal';
 import 'dart:nativewrappers';


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/5863

@abarth @Hixie 

- [x] Add 'ext.ui.window.scheduleFrame' service protocol extension so that we can support hot reloading in applications that don't use the framework.