### PR TITLE
Polish dart:ui API

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -13,7 +13,7 @@ void _updateWindowMetrics(double devicePixelRatio,
                           double left) {
   window
     .._devicePixelRatio = devicePixelRatio
-    .._size = new Size(width, height)
+    .._physicalSize = new Size(width, height)
     .._padding = new WindowPadding._(
       top: top, right: right, bottom: bottom, left: left);
   if (window.onMetricsChanged != null)

--- a/lib/ui/mojo_services.dart
+++ b/lib/ui/mojo_services.dart
@@ -19,10 +19,3 @@ class MojoServices {
   static int takeView() native "MojoServices_takeView";
   static int takeViewServices() native "MojoServices_takeViewServices";
 }
-
-// TODO(abarth): Remove these once clients have migrated to [MojoServices].
-int takeRootBundleHandle() => MojoServices.takeRootBundle();
-int takeServicesProvidedByEmbedder() => MojoServices.takeIncomingServices();
-int takeServicesProvidedToEmbedder() => MojoServices.takeOutgoingServices();
-int takeShellProxyHandle() => MojoServices.takeShell();
-int takeViewHandle() => MojoServices.takeView();

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -180,10 +180,10 @@ enum TextDecorationStyle {
 
 // This encoding must match the C++ version of ParagraphBuilder::pushStyle.
 //
-// The encoded array buffer has 7 elements.
+// The encoded array buffer has 8 elements.
 //
 //  - Element 0: A bit field where the ith bit indicates wheter the ith element
-//    has a non-null value. Bits 7 to 11 indicate whether |fontFamily|,
+//    has a non-null value. Bits 8 to 12 indicate whether |fontFamily|,
 //    |fontSize|, |letterSpacing|, |wordSpacing|, and |height| are non-null,
 //    respectively. Bit 0 is unused.
 //
@@ -201,18 +201,21 @@ enum TextDecorationStyle {
 //
 //  - Element 6: The enum index of the |fontStyle|.
 //
+//  - Element 7: The enum index of the |textBaseline|.
+//
 Int32List _encodeTextStyle(Color color,
                            TextDecoration decoration,
                            Color decorationColor,
                            TextDecorationStyle decorationStyle,
                            FontWeight fontWeight,
                            FontStyle fontStyle,
+                           TextBaseline textBaseline,
                            String fontFamily,
                            double fontSize,
                            double letterSpacing,
                            double wordSpacing,
                            double height) {
-  Int32List result = new Int32List(7);
+  Int32List result = new Int32List(8);
   if (color != null) {
     result[0] |= 1 << 1;
     result[1] = color.value;
@@ -237,24 +240,28 @@ Int32List _encodeTextStyle(Color color,
     result[0] |= 1 << 6;
     result[6] = fontStyle.index;
   }
-  if (fontFamily != null) {
+  if (textBaseline != null) {
     result[0] |= 1 << 7;
-    // Passed separately to native.
+    result[7] = textBaseline.index;
   }
-  if (fontSize != null) {
+  if (fontFamily != null) {
     result[0] |= 1 << 8;
     // Passed separately to native.
   }
-  if (letterSpacing != null) {
+  if (fontSize != null) {
     result[0] |= 1 << 9;
     // Passed separately to native.
   }
-  if (wordSpacing != null) {
+  if (letterSpacing != null) {
     result[0] |= 1 << 10;
     // Passed separately to native.
   }
-  if (height != null) {
+  if (wordSpacing != null) {
     result[0] |= 1 << 11;
+    // Passed separately to native.
+  }
+  if (height != null) {
+    result[0] |= 1 << 12;
     // Passed separately to native.
   }
   return result;
@@ -274,6 +281,7 @@ class TextStyle {
   /// * `fontSize`: The size of glyphs (in logical pixels) to use when painting the text.
   /// * `letterSpacing`: The amount of space (in logical pixels) to add between each letter.
   /// * `wordSpacing`: The amount of space (in logical pixels) to add at each sequence of white-space (i.e. between each word).
+  /// * `textBaseline`: The common baseline that should be aligned between this text span and its parent text span, or, for the root text spans, with the line box.
   /// * `height`: The height of this text span, as a multiple of the font size.
   TextStyle({
     Color color,
@@ -282,6 +290,7 @@ class TextStyle {
     TextDecorationStyle decorationStyle,
     FontWeight fontWeight,
     FontStyle fontStyle,
+    TextBaseline textBaseline,
     String fontFamily,
     double fontSize,
     double letterSpacing,
@@ -293,6 +302,7 @@ class TextStyle {
                                    decorationStyle,
                                    fontWeight,
                                    fontStyle,
+                                   textBaseline,
                                    fontFamily,
                                    fontSize,
                                    letterSpacing,
@@ -334,24 +344,25 @@ class TextStyle {
 
   String toString() {
     return 'TextStyle(${_encoded[0]}|'
-             'color: ${          _encoded[0] & 0x002 == 0x002 ? new Color(_encoded[1])                  : "unspecified"}, '
-             'decoration: ${     _encoded[0] & 0x004 == 0x003 ? new TextDecoration._(_encoded[2])       : "unspecified"}, '
-             'decorationColor: ${_encoded[0] & 0x008 == 0x008 ? new Color(_encoded[3])                  : "unspecified"}, '
-             'decorationStyle: ${_encoded[0] & 0x010 == 0x010 ? TextDecorationStyle.values[_encoded[4]] : "unspecified"}, '
-             'fontWeight: ${     _encoded[0] & 0x020 == 0x020 ? FontWeight.values[_encoded[5]]          : "unspecified"}, '
-             'fontStyle: ${      _encoded[0] & 0x040 == 0x040 ? FontStyle.values[_encoded[6]]           : "unspecified"}, '
-             'fontFamily: ${     _encoded[0] & 0x080 == 0x080 ? _fontFamily                             : "unspecified"}, '
-             'fontSize: ${       _encoded[0] & 0x100 == 0x100 ? _fontSize                               : "unspecified"}, '
-             'letterSpacing: ${  _encoded[0] & 0x200 == 0x200 ? "${_letterSpacing}x"                    : "unspecified"}, '
-             'wordSpacing: ${    _encoded[0] & 0x400 == 0x400 ? "${_wordSpacing}x"                      : "unspecified"}, '
-             'height: ${         _encoded[0] & 0x800 == 0x800 ? "${_height}x"                           : "unspecified"}'
+             'color: ${          _encoded[0] & 0x0002 == 0x0002 ? new Color(_encoded[1])                  : "unspecified"}, '
+             'decoration: ${     _encoded[0] & 0x0004 == 0x0004 ? new TextDecoration._(_encoded[2])       : "unspecified"}, '
+             'decorationColor: ${_encoded[0] & 0x0008 == 0x0008 ? new Color(_encoded[3])                  : "unspecified"}, '
+             'decorationStyle: ${_encoded[0] & 0x0010 == 0x0010 ? TextDecorationStyle.values[_encoded[4]] : "unspecified"}, '
+             'fontWeight: ${     _encoded[0] & 0x0020 == 0x0020 ? FontWeight.values[_encoded[5]]          : "unspecified"}, '
+             'fontStyle: ${      _encoded[0] & 0x0040 == 0x0040 ? FontStyle.values[_encoded[6]]           : "unspecified"}, '
+             'textBaseline: ${   _encoded[0] & 0x0080 == 0x0080 ? TextBaseline.values[_encoded[7]]        : "unspecified"}, '
+             'fontFamily: ${     _encoded[0] & 0x0100 == 0x0100 ? _fontFamily                             : "unspecified"}, '
+             'fontSize: ${       _encoded[0] & 0x0200 == 0x0200 ? _fontSize                               : "unspecified"}, '
+             'letterSpacing: ${  _encoded[0] & 0x0400 == 0x0400 ? "${_letterSpacing}x"                    : "unspecified"}, '
+             'wordSpacing: ${    _encoded[0] & 0x0800 == 0x0800 ? "${_wordSpacing}x"                      : "unspecified"}, '
+             'height: ${         _encoded[0] & 0x1000 == 0x1000 ? "${_height}x"                           : "unspecified"}'
            ')';
   }
 }
 
 // This encoding must match the C++ version ParagraphBuilder::build.
 //
-// The encoded array buffer has 3 elements.
+// The encoded array buffer has 4 elements.
 //
 //  - Element 0: A bit field where the ith bit indicates wheter the ith element
 //    has a non-null value. Bit 6 indicates whether |fontFamily| is non-null.
@@ -360,46 +371,39 @@ class TextStyle {
 //
 //  - Element 1: The enum index of the |textAlign|.
 //
-//  - Element 2: The enum index of the |textBaseline|.
+//  - Element 2: The index of the |fontWeight|.
 //
-//  - Element 3: The index of the |fontWeight|.
-//
-//  - Element 4: The enum index of the |fontStyle|.
+//  - Element 3: The enum index of the |fontStyle|.
 //
 Int32List _encodeParagraphStyle(TextAlign textAlign,
-                                TextBaseline textBaseline,
                                 FontWeight fontWeight,
                                 FontStyle fontStyle,
                                 String fontFamily,
                                 double fontSize,
                                 double lineHeight) {
-  Int32List result = new Int32List(5);
+  Int32List result = new Int32List(4);
   if (textAlign != null) {
     result[0] |= 1 << 1;
     result[1] = textAlign.index;
   }
-  if (textBaseline != null) {
-    result[0] |= 1 << 2;
-    result[2] = textBaseline.index;
-  }
   if (fontWeight != null) {
-    result[0] |= 1 << 3;
+    result[0] |= 1 << 2;
     result[3] = fontWeight.index;
   }
   if (fontStyle != null) {
-    result[0] |= 1 << 4;
+    result[0] |= 1 << 3;
     result[4] = fontStyle.index;
   }
   if (fontFamily != null) {
-    result[0] |= 1 << 5;
+    result[0] |= 1 << 4;
     // Passed separately to native.
   }
   if (fontSize != null) {
-    result[0] |= 1 << 6;
+    result[0] |= 1 << 5;
     // Passed separately to native.
   }
   if (lineHeight != null) {
-    result[0] |= 1 << 7;
+    result[0] |= 1 << 6;
     // Passed separately to native.
   }
   return result;
@@ -410,7 +414,6 @@ class ParagraphStyle {
   /// Creates a new ParagraphStyle object.
   ///
   /// * `textAlign`: The alignment of the text within the lines of the paragraph.
-  /// * `textBaseline`: The primary baseline along which different fonts should be aligned.
   /// * `fontWeight`: The typeface thickness to use when painting the text (e.g., bold).
   /// * `fontStyle`: The typeface variant to use when drawing the letters (e.g., italics).
   /// * `fontFamily`: The name of the font to use when painting the text (e.g., Roboto).
@@ -418,14 +421,12 @@ class ParagraphStyle {
   /// * `lineHeight`: The minimum height of the line boxes, as a multiple of the font size.
   ParagraphStyle({
     TextAlign textAlign,
-    TextBaseline textBaseline,
     FontWeight fontWeight,
     FontStyle fontStyle,
     String fontFamily,
     double fontSize,
     double lineHeight
   }) : _encoded = _encodeParagraphStyle(textAlign,
-                                        textBaseline,
                                         fontWeight,
                                         fontStyle,
                                         fontFamily,
@@ -461,13 +462,12 @@ class ParagraphStyle {
 
   String toString() {
     return 'ParagraphStyle('
-             'textAlign: ${   _encoded[0] & 0x002 == 0x002 ? TextAlign.values[_encoded[1]]    : "unspecified"}, '
-             'textBaseline: ${_encoded[0] & 0x004 == 0x004 ? TextBaseline.values[_encoded[2]] : "unspecified"}, '
-             'fontWeight: ${  _encoded[0] & 0x008 == 0x008 ? FontWeight.values[_encoded[3]]   : "unspecified"}, '
-             'fontStyle: ${   _encoded[0] & 0x010 == 0x010 ? FontStyle.values[_encoded[4]]    : "unspecified"}, '
-             'fontFamily: ${  _encoded[0] & 0x020 == 0x020 ? _fontFamily                      : "unspecified"}, '
-             'fontSize: ${    _encoded[0] & 0x040 == 0x040 ? _fontSize                        : "unspecified"}, '
-             'lineHeight: ${  _encoded[0] & 0x080 == 0x080 ? "${_lineHeight}x"                : "unspecified"}'
+             'textAlign: ${   _encoded[0] & 0x02 == 0x02 ? TextAlign.values[_encoded[1]]    : "unspecified"}, '
+             'fontWeight: ${  _encoded[0] & 0x04 == 0x04 ? FontWeight.values[_encoded[2]]   : "unspecified"}, '
+             'fontStyle: ${   _encoded[0] & 0x08 == 0x08 ? FontStyle.values[_encoded[3]]    : "unspecified"}, '
+             'fontFamily: ${  _encoded[0] & 0x10 == 0x10 ? _fontFamily                      : "unspecified"}, '
+             'fontSize: ${    _encoded[0] & 0x20 == 0x20 ? _fontSize                        : "unspecified"}, '
+             'lineHeight: ${  _encoded[0] & 0x40 == 0x40 ? "${_lineHeight}x"                : "unspecified"}'
            ')';
   }
 }

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -70,11 +70,12 @@ const int tsTextDecorationColorIndex = 3;
 const int tsTextDecorationStyleIndex = 4;
 const int tsFontWeightIndex = 5;
 const int tsFontStyleIndex = 6;
-const int tsFontFamilyIndex = 7;
-const int tsFontSizeIndex = 8;
-const int tsLetterSpacingIndex = 9;
-const int tsWordSpacingIndex = 10;
-const int tsHeightIndex = 11;
+const int tsTextBaselineIndex = 7;
+const int tsFontFamilyIndex = 8;
+const int tsFontSizeIndex = 9;
+const int tsLetterSpacingIndex = 10;
+const int tsWordSpacingIndex = 11;
+const int tsHeightIndex = 12;
 
 const int tsColorMask = 1 << tsColorIndex;
 const int tsTextDecorationMask = 1 << tsTextDecorationIndex;
@@ -82,6 +83,7 @@ const int tsTextDecorationColorMask = 1 << tsTextDecorationColorIndex;
 const int tsTextDecorationStyleMask = 1 << tsTextDecorationStyleIndex;
 const int tsFontWeightMask = 1 << tsFontWeightIndex;
 const int tsFontStyleMask = 1 << tsFontStyleIndex;
+const int tsTextBaselineMask = 1 << tsTextBaselineIndex;
 const int tsFontFamilyMask = 1 << tsFontFamilyIndex;
 const int tsFontSizeMask = 1 << tsFontSizeIndex;
 const int tsLetterSpacingMask = 1 << tsLetterSpacingIndex;
@@ -91,15 +93,13 @@ const int tsHeightMask = 1 << tsHeightIndex;
 // ParagraphStyle
 
 const int psTextAlignIndex = 1;
-const int psTextBaselineIndex = 2;
-const int psFontWeightIndex = 3;
-const int psFontStyleIndex = 4;
-const int psFontFamilyIndex = 5;
-const int psFontSizeIndex = 6;
-const int psLineHeightIndex = 7;
+const int psFontWeightIndex = 2;
+const int psFontStyleIndex = 3;
+const int psFontFamilyIndex = 4;
+const int psFontSizeIndex = 5;
+const int psLineHeightIndex = 6;
 
 const int psTextAlignMask = 1 << psTextAlignIndex;
-const int psTextBaselineMask = 1 << psTextBaselineIndex;
 const int psFontWeightMask = 1 << psFontWeightIndex;
 const int psFontStyleMask = 1 << psFontStyleIndex;
 const int psFontFamilyMask = 1 << psFontFamilyIndex;
@@ -169,6 +169,11 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
   if (mask & tsTextDecorationStyleMask)
     style->setTextDecorationStyle(
         static_cast<TextDecorationStyle>(encoded[tsTextDecorationStyleIndex]));
+
+  if (mask & tsTextBaselineMask) {
+    // TODO(abarth): Implement TextBaseline. The CSS version of this
+    // property wasn't wired up either.
+  }
 
   if (mask & (tsFontWeightMask | tsFontStyleMask | tsFontFamilyMask |
               tsFontSizeMask | tsLetterSpacingMask | tsWordSpacingMask)) {
@@ -244,11 +249,6 @@ ftl::RefPtr<Paragraph> ParagraphBuilder::build(tonic::Int32List& encoded,
 
     if (mask & psTextAlignMask)
       style->setTextAlign(static_cast<ETextAlign>(encoded[psTextAlignIndex]));
-
-    if (mask & psTextBaselineMask) {
-      // TODO(abarth): Implement TextBaseline. The CSS version of this
-      // property wasn't wired up either.
-    }
 
     if (mask & (psFontWeightMask | psFontStyleMask | psFontFamilyMask |
                 psFontSizeMask)) {

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -39,11 +39,19 @@ enum AppLifecycleState {
 class WindowPadding {
   const WindowPadding._({ this.left, this.top, this.right, this.bottom });
 
+  /// The distance from the left edge to the first unobscured pixel, in physical pixels.
   final double left;
+
+  /// The distance from the top edge to the first unobscured pixel, in physical pixels.
   final double top;
+
+  /// The distance from the right edge to the first unobscured pixel, in physical pixels.
   final double right;
+
+  /// The distance from the bottom edge to the first unobscured pixel, in physical pixels.
   final double bottom;
 
+  /// A window padding that has zeros for each edge.
   static const WindowPadding zero = const WindowPadding._(left: 0.0, top: 0.0, right: 0.0, bottom: 0.0);
 }
 
@@ -100,25 +108,20 @@ class Window {
   double _devicePixelRatio = 1.0;
 
   /// The dimensions of the rectangle into which the application will be drawn,
-  /// in logical pixels.
-  ///
-  /// Logical pixels are roughly the same visual size across devices. Physical
-  /// pixels are the size of the actual hardware pixels on the device. The
-  /// number of physical pixels per logical pixel is described by the
-  /// [devicePixelRatio].
-  Size get size => _size;
-  Size _size = Size.zero;
+  /// in physical pixels.
+  Size get physicalSize => _physicalSize;
+  Size _physicalSize = Size.zero;
 
-  /// The number of pixels on each side of the display rectangle into which the
-  /// application can render, but over which the operating system will likely
-  /// place system UI (such as the Android system notification area), or which
-  /// might be rendered outside of the physical display (e.g. overscan regions
-  /// on television screens).
+  /// The number of physical pixels on each side of the display rectangle into
+  /// which the application can render, but over which the operating system will
+  /// likely place system UI (such as the Android system notification area), or
+  /// which might be rendered outside of the physical display (e.g. overscan
+  /// regions on television screens).
   WindowPadding get padding => _padding;
   WindowPadding _padding = WindowPadding.zero;
 
-  /// A callback that is invoked whenever the [devicePixelRatio], [size], or
-  /// [padding] values change.
+  /// A callback that is invoked whenever the [devicePixelRatio],
+  /// [physicalSize], or [padding] values change.
   VoidCallback onMetricsChanged;
 
   /// The system-reported locale. This establishes the language and formatting
@@ -136,8 +139,8 @@ class Window {
 
   /// A callback that is invoked to notify the application that it is an
   /// appropriate time to provide a scene using the [SceneBuilder] API and the
-  /// [render()] method. When possible, this is driven by the hardware VSync
-  /// signal. This is only called if [scheduleFrame()] has been called since the
+  /// [render] method. When possible, this is driven by the hardware VSync
+  /// signal. This is only called if [scheduleFrame] has been called since the
   /// last time this callback was invoked.
   FrameCallback onBeginFrame;
 

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -50,17 +50,15 @@ void Window::UpdateWindowMetrics(const sky::ViewportMetricsPtr& metrics) {
   if (!dart_state)
     return;
   tonic::DartState::Scope scope(dart_state);
-  double device_pixel_ratio = metrics->device_pixel_ratio;
   DartInvokeField(
       library_.value(), "_updateWindowMetrics",
       {
-          ToDart(device_pixel_ratio),
-          ToDart(metrics->physical_width / device_pixel_ratio),
-          ToDart(metrics->physical_height / device_pixel_ratio),
-          ToDart(metrics->physical_padding_top / device_pixel_ratio),
-          ToDart(metrics->physical_padding_right / device_pixel_ratio),
-          ToDart(metrics->physical_padding_bottom / device_pixel_ratio),
-          ToDart(metrics->physical_padding_left / device_pixel_ratio),
+          ToDart(metrics->device_pixel_ratio), ToDart(metrics->physical_width),
+          ToDart(metrics->physical_height),
+          ToDart(metrics->physical_padding_top),
+          ToDart(metrics->physical_padding_right),
+          ToDart(metrics->physical_padding_bottom),
+          ToDart(metrics->physical_padding_left),
       });
 }
 

--- a/sky/shell/ui/engine.cc
+++ b/sky/shell/ui/engine.cc
@@ -156,13 +156,6 @@ void Engine::OnLocaleChanged(const mojo::String& language_code,
 
 void Engine::OnPointerPacket(pointer::PointerPacketPtr packet) {
   TRACE_EVENT0("flutter", "Engine::OnPointerPacket");
-
-  // Convert the pointers' x and y coordinates to logical pixels.
-  for (auto it = packet->pointers.begin(); it != packet->pointers.end(); ++it) {
-    (*it)->x /= viewport_metrics_->device_pixel_ratio;
-    (*it)->y /= viewport_metrics_->device_pixel_ratio;
-  }
-
   if (runtime_)
     runtime_->HandlePointerPacket(packet);
 }


### PR DESCRIPTION
This patch makes two API changes:

 * The dart:ui library now always communicates in physical pixels. The
   framework is responsible for converting to whatever logical coordinate
   system it wishes to use.
 * The textBaselien property is now on TextStyle rather than ParagraphStyle,
   which will let us choose which baseline to use on a per-span basis rather
   than on a per-paragraph basis.

Fixes https://github.com/flutter/flutter/issues/3779
Fixes https://github.com/flutter/flutter/issues/1360