### PR TITLE
Remove the startup flash on Android

### DIFF
--- a/sky/shell/gpu/direct/rasterizer_direct.h
+++ b/sky/shell/gpu/direct/rasterizer_direct.h
@@ -20,22 +20,19 @@ class RasterizerDirect : public Rasterizer {
 
   ~RasterizerDirect() override;
 
-  // sky::shell::Rasterizer override.
   void Setup(PlatformView* platform_view,
              ftl::Closure continuation,
              ftl::AutoResetWaitableEvent* setup_completion_event) override;
 
-  // sky::shell::Rasterizer override.
+  void Clear(SkColor color) override;
+
   void Teardown(
       ftl::AutoResetWaitableEvent* teardown_completion_event) override;
 
-  // sky::shell::Rasterizer override.
   ftl::WeakPtr<sky::shell::Rasterizer> GetWeakRasterizerPtr() override;
 
-  // sky::shell::Rasterizer override.
   flow::LayerTree* GetLastLayerTree() override;
 
-  // sky::shell::Rasterizer override.
   void Draw(ftl::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) override;
 
  private:

--- a/sky/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/sky/shell/platform/android/io/flutter/view/FlutterView.java
@@ -16,6 +16,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.Surface;
@@ -114,15 +115,25 @@ public class FlutterView extends SurfaceView
         attach();
         assert mNativePlatformView != 0;
 
-        mSurfaceCallback = new SurfaceHolder.Callback() {
-            @Override
-            public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-            }
+        int color = 0xFF000000;
+        TypedValue typedValue = new TypedValue();
+        context.getTheme().resolveAttribute(android.R.attr.colorBackground, typedValue, true);
+        if (typedValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && typedValue.type <= TypedValue.TYPE_LAST_COLOR_INT)
+          color = typedValue.data;
+        // TODO(abarth): Consider letting the developer override this color.
+        final int backgroundColor = color;
 
+        mSurfaceCallback = new SurfaceHolder.Callback() {
             @Override
             public void surfaceCreated(SurfaceHolder holder) {
                 assert mNativePlatformView != 0;
                 nativeSurfaceCreated(mNativePlatformView, holder.getSurface());
+            }
+
+            @Override
+            public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
+                assert mNativePlatformView != 0;
+                nativeSurfaceChanged(mNativePlatformView, backgroundColor);
             }
 
             @Override
@@ -507,6 +518,7 @@ public class FlutterView extends SurfaceView
     private static native void nativeDetach(long nativePlatformViewAndroid);
     private static native void nativeSurfaceCreated(long nativePlatformViewAndroid,
                                                     Surface surface);
+    private static native void nativeSurfaceChanged(long nativePlatformViewAndroid, int backgroundColor);
     private static native void nativeSurfaceDestroyed(long nativePlatformViewAndroid);
 
 

--- a/sky/shell/platform/android/platform_view_android.cc
+++ b/sky/shell/platform/android/platform_view_android.cc
@@ -398,11 +398,14 @@ void PlatformViewAndroid::SurfaceCreated(JNIEnv* env,
     }
     ANativeWindow_release(window);
   }
+}
 
-  NotifyCreated();
-
+void PlatformViewAndroid::SurfaceChanged(JNIEnv* env,
+                                         jobject obj,
+                                         jint backgroundColor) {
+  NotifyCreated(
+      [this, backgroundColor] { config_.rasterizer->Clear(backgroundColor); });
   SetupResourceContextOnIOThread();
-
   UpdateThreadPriorities();
 }
 

--- a/sky/shell/platform/android/platform_view_android.h
+++ b/sky/shell/platform/android/platform_view_android.h
@@ -30,6 +30,9 @@ class PlatformViewAndroid : public PlatformView {
   void SurfaceCreated(JNIEnv* env, jobject obj, jobject jsurface);
 
   // Called from Java
+  void SurfaceChanged(JNIEnv* env, jobject obj, jint backgroundColor);
+
+  // Called from Java
   void SurfaceDestroyed(JNIEnv* env, jobject obj);
 
   // sky::shell::PlatformView override

--- a/sky/shell/rasterizer.h
+++ b/sky/shell/rasterizer.h
@@ -27,6 +27,8 @@ class Rasterizer {
                      ftl::Closure rasterizer_continuation,
                      ftl::AutoResetWaitableEvent* setup_completion_event) = 0;
 
+  virtual void Clear(SkColor color) = 0;
+
   virtual void Teardown(
       ftl::AutoResetWaitableEvent* teardown_completion_event) = 0;
 


### PR DESCRIPTION
We need to block in the surfaceChanged callback until we can swap the GL
surface with some content in order to avoid flashing transparent and then
black.

Fixes https://github.com/flutter/flutter/issues/5373