### PR TITLE
Add flutter_services package to uniformly expose services to Flutter …

### DIFF
--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -3,6 +3,26 @@
 # found in the LICENSE file.
 
 if (is_android) {
+  action("flutter_services") {
+    script = "//flutter/sky/tools/dist_dart_pkg.py"
+
+    source = "//flutter/sky/packages/flutter_services"
+    dest = "$root_build_dir/dist/packages/flutter_services"
+
+    inputs = [ source ]
+    outputs = [ dest ]
+
+    args = [
+      "--source",
+      rebase_path(source),
+      "--dest",
+      rebase_path(dest),
+    ]
+
+    deps = [
+      "//flutter/sky/packages/flutter_services",
+    ]
+  }
   action("sky_engine") {
     script = "//flutter/sky/tools/dist_dart_pkg.py"
 
@@ -49,6 +69,7 @@ if (is_android) {
 group("dist") {
   if (is_android) {
     deps = [
+      ":flutter_services",
       ":sky_engine",
       ":sky_services",
     ]

--- a/sky/packages/BUILD.gn
+++ b/sky/packages/BUILD.gn
@@ -8,5 +8,6 @@ group("packages") {
   deps = [
     "//flutter/sky/packages/sky_engine",
     "//flutter/sky/packages/sky_services",
+    "//flutter/sky/packages/flutter_services",
   ]
 }

--- a/sky/packages/flutter_services/BUILD.gn
+++ b/sky/packages/flutter_services/BUILD.gn
@@ -1,0 +1,7 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+group("flutter_services") {
+  deps = [ "//flutter/sky/packages/sky_services" ]
+}

--- a/sky/packages/flutter_services/lib/activity.dart
+++ b/sky/packages/flutter_services/lib/activity.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/activity/activity.mojom.dart';
+export 'package:sky_services/activity/activity.mojom.dart';

--- a/sky/packages/flutter_services/lib/editing.dart
+++ b/sky/packages/flutter_services/lib/editing.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/editing/editing.mojom.dart';
+export 'package:sky_services/editing/editing.mojom.dart';

--- a/sky/packages/flutter_services/lib/input_event.dart
+++ b/sky/packages/flutter_services/lib/input_event.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/sky/input_event.mojom.dart';
+export 'package:sky_services/sky/input_event.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/asset_bundle/asset_bundle.dart
+++ b/sky/packages/flutter_services/lib/mojo/asset_bundle/asset_bundle.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/asset_bundle/asset_bundle.mojom.dart';
+export 'package:mojo_services/mojo/asset_bundle/asset_bundle.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/geometry.dart
+++ b/sky/packages/flutter_services/lib/mojo/geometry.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/geometry.mojom.dart';
+export 'package:mojo_services/mojo/geometry.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/gfx/composition/scene_token.dart
+++ b/sky/packages/flutter_services/lib/mojo/gfx/composition/scene_token.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/gfx/composition/scene_token.mojom.dart';
+export 'package:mojo_services/mojo/gfx/composition/scene_token.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/network_service.dart
+++ b/sky/packages/flutter_services/lib/mojo/network_service.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/network_service.mojom.dart';
+export 'package:mojo_services/mojo/network_service.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/ui/view_containers.dart
+++ b/sky/packages/flutter_services/lib/mojo/ui/view_containers.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/ui/view_containers.mojom.dart';
+export 'package:mojo_services/mojo/ui/view_containers.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/ui/view_properties.dart
+++ b/sky/packages/flutter_services/lib/mojo/ui/view_properties.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/ui/view_properties.mojom.dart';
+export 'package:mojo_services/mojo/ui/view_properties.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/ui/view_provider.dart
+++ b/sky/packages/flutter_services/lib/mojo/ui/view_provider.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/ui/view_provider.mojom.dart';
+export 'package:mojo_services/mojo/ui/view_provider.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/ui/view_token.dart
+++ b/sky/packages/flutter_services/lib/mojo/ui/view_token.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/ui/view_token.mojom.dart';
+export 'package:mojo_services/mojo/ui/view_token.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/ui/views.dart
+++ b/sky/packages/flutter_services/lib/mojo/ui/views.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/ui/views.mojom.dart';
+export 'package:mojo_services/mojo/ui/views.mojom.dart';

--- a/sky/packages/flutter_services/lib/mojo/url_loader.dart
+++ b/sky/packages/flutter_services/lib/mojo/url_loader.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:mojo_services/mojo/url_loader.mojom.dart';
+export 'package:mojo_services/mojo/url_loader.mojom.dart';

--- a/sky/packages/flutter_services/lib/platform/app_messages.dart
+++ b/sky/packages/flutter_services/lib/platform/app_messages.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/flutter/platform/app_messages.mojom.dart';
+export 'package:sky_services/flutter/platform/app_messages.mojom.dart';

--- a/sky/packages/flutter_services/lib/platform/haptic_feedback.dart
+++ b/sky/packages/flutter_services/lib/platform/haptic_feedback.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/flutter/platform/haptic_feedback.mojom.dart';
+export 'package:sky_services/flutter/platform/haptic_feedback.mojom.dart';

--- a/sky/packages/flutter_services/lib/platform/path_provider.dart
+++ b/sky/packages/flutter_services/lib/platform/path_provider.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/flutter/platform/path_provider.mojom.dart';
+export 'package:sky_services/flutter/platform/path_provider.mojom.dart';

--- a/sky/packages/flutter_services/lib/platform/system_chrome.dart
+++ b/sky/packages/flutter_services/lib/platform/system_chrome.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/flutter/platform/system_chrome.mojom.dart';
+export 'package:sky_services/flutter/platform/system_chrome.mojom.dart';

--- a/sky/packages/flutter_services/lib/platform/system_sound.dart
+++ b/sky/packages/flutter_services/lib/platform/system_sound.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/flutter/platform/system_sound.mojom.dart';
+export 'package:sky_services/flutter/platform/system_sound.mojom.dart';

--- a/sky/packages/flutter_services/lib/platform/url_launcher.dart
+++ b/sky/packages/flutter_services/lib/platform/url_launcher.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/flutter/platform/url_launcher.mojom.dart';
+export 'package:sky_services/flutter/platform/url_launcher.mojom.dart';

--- a/sky/packages/flutter_services/lib/pointer.dart
+++ b/sky/packages/flutter_services/lib/pointer.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/pointer/pointer.mojom.dart';
+export 'package:sky_services/pointer/pointer.mojom.dart';

--- a/sky/packages/flutter_services/lib/raw_keyboard.dart
+++ b/sky/packages/flutter_services/lib/raw_keyboard.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/raw_keyboard/raw_keyboard.mojom.dart';
+export 'package:sky_services/raw_keyboard/raw_keyboard.mojom.dart';

--- a/sky/packages/flutter_services/lib/semantics.dart
+++ b/sky/packages/flutter_services/lib/semantics.dart
@@ -1,0 +1,6 @@
+/// Copyright 2014 The Chromium Authors. All rights reserved.
+/// Use of this source code is governed by a BSD-style license that can be
+/// found in the LICENSE file.
+
+import 'package:sky_services/semantics/semantics.mojom.dart';
+export 'package:sky_services/semantics/semantics.mojom.dart';

--- a/sky/packages/flutter_services/pubspec.yaml
+++ b/sky/packages/flutter_services/pubspec.yaml
@@ -1,0 +1,11 @@
+name: flutter_services
+version: 0.0.1
+author: Flutter Authors <flutter-dev@googlegroups.com>
+description: Services exported from the Flutter engine
+homepage: http://flutter.io
+dependencies:
+  sky_services:
+    path:
+      ../sky_services
+environment:
+  sdk: '>=1.8.0 <2.0.0'


### PR DESCRIPTION
…library

This adds a flutter_services package responsible for exposing the Dart
interfaces exported by the engine in a uniform fashion, regardless of
how and where the generated code for the interfaces are organized.