### PR TITLE
Make the creation of VulkanWindow platform agnostic by refactoring out Android specific surface creation logic.

### DIFF
--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -11,6 +11,10 @@ source_set("vulkan") {
     "vulkan_interface.h",
     "vulkan_proc_table.cc",
     "vulkan_proc_table.h",
+    "vulkan_surface.cc",
+    "vulkan_surface.h",
+    "vulkan_surface_android.cc",
+    "vulkan_surface_android.h",
     "vulkan_window.cc",
     "vulkan_window.h",
   ]

--- a/vulkan/vulkan_interface.h
+++ b/vulkan/vulkan_interface.h
@@ -7,23 +7,12 @@
 
 #define VK_NO_PROTOTYPES 1
 
+#include "lib/ftl/build_config.h"
+
+#if OS_ANDROID
+#define VK_USE_PLATFORM_ANDROID_KHR 1
+#endif  // OS_ANDROID
+
 #include "third_party/vulkan/src/vulkan/vulkan.h"
-
-#define VK_KHR_ANDROID_SURFACE_EXTENSION_NAME "VK_KHR_android_surface"
-
-typedef VkFlags VkAndroidSurfaceCreateFlagsKHR;
-
-typedef struct VkAndroidSurfaceCreateInfoKHR {
-  VkStructureType sType;
-  const void* pNext;
-  VkAndroidSurfaceCreateFlagsKHR flags;
-  void* window;
-} VkAndroidSurfaceCreateInfoKHR;
-
-typedef VkResult(VKAPI_PTR* PFN_vkCreateAndroidSurfaceKHR)(
-    VkInstance instance,
-    const VkAndroidSurfaceCreateInfoKHR* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkSurfaceKHR* pSurface);
 
 #endif  // FLUTTER_VULKAN_VULKAN_INTERFACE_H_

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -70,7 +70,6 @@ bool VulkanProcTable::AcquireProcs() {
   ACQUIRE_PROC(enumeratePhysicalDevices, "vkEnumeratePhysicalDevices");
   ACQUIRE_PROC(createDevice, "vkCreateDevice");
   ACQUIRE_PROC(destroyDevice, "vkDestroyDevice");
-  ACQUIRE_PROC(createAndroidSurfaceKHR, "vkCreateAndroidSurfaceKHR");
   ACQUIRE_PROC(getDeviceQueue, "vkGetDeviceQueue");
   ACQUIRE_PROC(getPhysicalDeviceSurfaceCapabilitiesKHR,
                "vkGetPhysicalDeviceSurfaceCapabilitiesKHR");
@@ -81,8 +80,8 @@ bool VulkanProcTable::AcquireProcs() {
   ACQUIRE_PROC(getPhysicalDeviceSurfacePresentModesKHR,
                "vkGetPhysicalDeviceSurfacePresentModesKHR");
   ACQUIRE_PROC(destroySurfaceKHR, "vkDestroySurfaceKHR");
-  ACQUIRE_PROC(createCommandPool, "createCommandPool");
-  ACQUIRE_PROC(destroyCommandPool, "destroyCommandPool");
+  ACQUIRE_PROC(createCommandPool, "vkCreateCommandPool");
+  ACQUIRE_PROC(destroyCommandPool, "vkDestroyCommandPool");
   ACQUIRE_PROC(createSemaphore, "vkCreateSemaphore");
   ACQUIRE_PROC(destroySemaphore, "vkDestroySemaphore");
   ACQUIRE_PROC(allocateCommandBuffers, "vkAllocateCommandBuffers");
@@ -90,6 +89,10 @@ bool VulkanProcTable::AcquireProcs() {
   ACQUIRE_PROC(createFence, "vkCreateFence");
   ACQUIRE_PROC(destroyFence, "vkDestroyFence");
   ACQUIRE_PROC(waitForFences, "vkWaitForFences");
+
+#if OS_ANDROID
+  ACQUIRE_PROC(createAndroidSurfaceKHR, "vkCreateAndroidSurfaceKHR");
+#endif  // OS_ANDROID
 
 #undef ACQUIRE_PROC
 

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -45,7 +45,6 @@ class VulkanProcTable {
   Proc<PFN_vkEnumeratePhysicalDevices> enumeratePhysicalDevices;
   Proc<PFN_vkCreateDevice> createDevice;
   Proc<PFN_vkDestroyDevice> destroyDevice;
-  Proc<PFN_vkCreateAndroidSurfaceKHR> createAndroidSurfaceKHR;
   Proc<PFN_vkGetDeviceQueue> getDeviceQueue;
   Proc<PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR>
       getPhysicalDeviceSurfaceCapabilitiesKHR;
@@ -66,6 +65,10 @@ class VulkanProcTable {
   Proc<PFN_vkCreateFence> createFence;
   Proc<PFN_vkDestroyFence> destroyFence;
   Proc<PFN_vkWaitForFences> waitForFences;
+
+#if OS_ANDROID
+  Proc<PFN_vkCreateAndroidSurfaceKHR> createAndroidSurfaceKHR;
+#endif  // OS_ANDROID
 
  private:
   bool valid_;

--- a/vulkan/vulkan_surface.cc
+++ b/vulkan/vulkan_surface.cc
@@ -1,0 +1,13 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vulkan_surface.h"
+
+namespace vulkan {
+
+VulkanSurface::VulkanSurface() = default;
+
+VulkanSurface::~VulkanSurface() = default;
+
+}  // namespace vulkan

--- a/vulkan/vulkan_surface.h
+++ b/vulkan/vulkan_surface.h
@@ -1,0 +1,34 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_VULKAN_VULKAN_SURFACE_H_
+#define FLUTTER_VULKAN_VULKAN_SURFACE_H_
+
+#include "lib/ftl/macros.h"
+#include "vulkan_handle.h"
+#include "vulkan_proc_table.h"
+
+namespace vulkan {
+
+class VulkanSurface {
+ public:
+  VulkanSurface();
+
+  virtual ~VulkanSurface();
+
+  virtual const char* ExtensionName() = 0;
+
+  virtual VkSurfaceKHR CreateSurfaceHandle(
+      VulkanProcTable& vk,
+      VulkanHandle<VkInstance>& instance) = 0;
+
+  virtual bool IsValid() const = 0;
+
+ private:
+  FTL_DISALLOW_COPY_AND_ASSIGN(VulkanSurface);
+};
+
+}  // namespace vulkan
+
+#endif  // FLUTTER_VULKAN_VULKAN_SURFACE_H_

--- a/vulkan/vulkan_surface_android.cc
+++ b/vulkan/vulkan_surface_android.cc
@@ -1,0 +1,56 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "vulkan_surface_android.h"
+
+namespace vulkan {
+
+VulkanSurfaceAndroid::VulkanSurfaceAndroid(ANativeWindow* native_window)
+    : native_window_(native_window) {
+  if (native_window_ == nullptr) {
+    return;
+  }
+  ANativeWindow_acquire(native_window_);
+}
+
+VulkanSurfaceAndroid::~VulkanSurfaceAndroid() {
+  if (native_window_ == nullptr) {
+    return;
+  }
+  ANativeWindow_release(native_window_);
+}
+
+const char* VulkanSurfaceAndroid::ExtensionName() {
+  return VK_KHR_ANDROID_SURFACE_EXTENSION_NAME;
+}
+
+VkSurfaceKHR VulkanSurfaceAndroid::CreateSurfaceHandle(
+    VulkanProcTable& vk,
+    VulkanHandle<VkInstance>& instance) {
+  if (!vk.IsValid() || !instance) {
+    return VK_NULL_HANDLE;
+  }
+
+  const VkAndroidSurfaceCreateInfoKHR create_info = {
+      .sType = VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR,
+      .pNext = nullptr,
+      .flags = 0,
+      .window = native_window_,
+  };
+
+  VkSurfaceKHR surface = VK_NULL_HANDLE;
+
+  if (vk.createAndroidSurfaceKHR(instance, &create_info, nullptr, &surface) !=
+      VK_SUCCESS) {
+    return VK_NULL_HANDLE;
+  }
+
+  return surface;
+}
+
+bool VulkanSurfaceAndroid::IsValid() const {
+  return native_window_ != nullptr;
+}
+
+}  // namespace vulkan

--- a/vulkan/vulkan_surface_android.h
+++ b/vulkan/vulkan_surface_android.h
@@ -1,0 +1,37 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_VULKAN_VULKAN_SURFACE_ANDROID_H_
+#define FLUTTER_VULKAN_VULKAN_SURFACE_ANDROID_H_
+
+#include "lib/ftl/macros.h"
+#include "vulkan_surface.h"
+
+struct ANativeWindow;
+typedef struct ANativeWindow ANativeWindow;
+
+namespace vulkan {
+
+class VulkanSurfaceAndroid : public VulkanSurface {
+ public:
+  VulkanSurfaceAndroid(ANativeWindow* native_window);
+
+  ~VulkanSurfaceAndroid() override;
+
+  const char* ExtensionName() override;
+
+  VkSurfaceKHR CreateSurfaceHandle(VulkanProcTable& vk,
+                                   VulkanHandle<VkInstance>& instance) override;
+
+  bool IsValid() const override;
+
+ private:
+  ANativeWindow* native_window_;
+
+  FTL_DISALLOW_COPY_AND_ASSIGN(VulkanSurfaceAndroid);
+};
+
+}  // namespace vulkan
+
+#endif  // FLUTTER_VULKAN_VULKAN_SURFACE_ANDROID_H_

--- a/vulkan/vulkan_window.h
+++ b/vulkan/vulkan_window.h
@@ -13,12 +13,13 @@
 #include "vulkan_handle.h"
 #include "vulkan_proc_table.h"
 #include "vulkan_backbuffer.h"
+#include "vulkan_surface.h"
 
 namespace vulkan {
 
 class VulkanWindow {
  public:
-  VulkanWindow(void* native_window);
+  VulkanWindow(std::unique_ptr<VulkanSurface> platform_surface);
 
   ~VulkanWindow();
 
@@ -28,6 +29,7 @@ class VulkanWindow {
   bool valid_;
   VulkanProcTable vk;
   VulkanHandle<VkInstance> instance_;
+  std::unique_ptr<VulkanSurface> platform_surface_;
   VulkanHandle<VkSurfaceKHR> surface_;
   VulkanHandle<VkPhysicalDevice> physical_device_;
   VulkanHandle<VkDevice> device_;
@@ -38,7 +40,7 @@ class VulkanWindow {
 
   bool CreateInstance();
 
-  bool CreateSurface(void* native_window);
+  bool CreateSurface();
 
   bool SelectPhysicalDevice();
 


### PR DESCRIPTION
cc @abarth @jason-simmons 