### PR TITLE
Support RGB_x888 on Fuchsia

### DIFF
--- a/content_handler/framebuffer_skia.cc
+++ b/content_handler/framebuffer_skia.cc
@@ -65,6 +65,7 @@ void FramebufferSkia::Bind(mojo::InterfaceHandle<mojo::Framebuffer> framebuffer,
       sk_alpha_type = kOpaque_SkAlphaType;
       break;
     case mojo::FramebufferFormat::ARGB_8888:
+    case mojo::FramebufferFormat::RGB_x888:
       sk_color_type = kRGBA_8888_SkColorType;
       sk_alpha_type = kPremul_SkAlphaType;
       break;
@@ -89,7 +90,8 @@ void FramebufferSkia::Bind(mojo::InterfaceHandle<mojo::Framebuffer> framebuffer,
 }
 
 void FramebufferSkia::ConvertToCorrectPixelFormatIfNeeded() {
-  if (info_->format == mojo::FramebufferFormat::ARGB_8888) {
+  if (info_->format == mojo::FramebufferFormat::ARGB_8888 ||
+      info_->format == mojo::FramebufferFormat::RGB_x888) {
     // we need to convert from RGBA to ARGB
     SkPixmap bufferPixmap;
 
@@ -101,6 +103,11 @@ void FramebufferSkia::ConvertToCorrectPixelFormatIfNeeded() {
         std::swap(buffer[i + 0], buffer[i + 2]);
     }
   }
+}
+
+void FramebufferSkia::Finish() {
+  framebuffer_->Flush([] {});
+  framebuffer_.WaitForIncomingResponse();
 }
 
 }  // namespace flutter_content_handler

--- a/content_handler/framebuffer_skia.h
+++ b/content_handler/framebuffer_skia.h
@@ -23,7 +23,7 @@ class FramebufferSkia {
   // Needed because Skia does not support drawing to ARGB directly.
   void ConvertToCorrectPixelFormatIfNeeded();
 
-  mojo::Framebuffer* get() const { return framebuffer_.get(); }
+  void Finish();
   const sk_sp<SkSurface>& surface() { return surface_; }
 
  private:

--- a/content_handler/rasterizer.cc
+++ b/content_handler/rasterizer.cc
@@ -36,8 +36,8 @@ void Rasterizer::Draw(std::unique_ptr<flow::LayerTree> layer_tree,
   canvas->flush();
 
   framebuffer_.ConvertToCorrectPixelFormatIfNeeded();
-
-  framebuffer_.get()->Flush(ftl::MakeRunnable(std::move(callback)));
+  framebuffer_.Finish();
+  callback();
 }
 
 }  // namespace flutter_content_handler


### PR DESCRIPTION
The new boot sequence on Fuchsia now gives us the more accurate RGB_x888 pixel
format, which we should support. Also finish pushing pixels to the screen
before drawing new pixels.