### PR TITLE
Make bundle path optional for the RUN intent on Android

### DIFF
--- a/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
+++ b/shell/platform/android/org/domokit/sky/shell/SkyActivity.java
@@ -134,7 +134,14 @@ public class SkyActivity extends Activity {
         String action = intent.getAction();
         if (Intent.ACTION_RUN.equals(action)) {
             String route = intent.getStringExtra("route");
-            mView.runFromBundle(intent.getDataString(),
+            String appBundlePath = intent.getDataString();
+            if (appBundlePath == null) {
+              // Fall back to the installation path if no bundle path
+              // was specified.
+              appBundlePath =
+                  FlutterMain.findAppBundlePath(getApplicationContext());
+            }
+            mView.runFromBundle(appBundlePath,
                                 intent.getStringExtra("snapshot"));
             if (route != null)
                 mView.pushRoute(route);


### PR DESCRIPTION
- [x] Make bundle path optional for the RUN intent on Android

The above is necessary to support running with a prebuilt apk.

@tvolkert @jason-simmons 