### PR TITLE
Revert "Roll to mojo/public @ e8a607c6f017017faf9aac73bc881c419a71f90…

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -21,7 +21,7 @@ vars = {
   'chromium_git': 'https://chromium.googlesource.com',
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'github_git': 'https://github.com',
-  'mojo_sdk_revision': 'e8a607c6f017017faf9aac73bc881c419a71f902',
+  'mojo_sdk_revision': '6b5fb1227c742f5ecc077486ebc029f2711c61fa',
   'base_revision': '672b04e54b937ec899429a6bd5409c5a6300d151',
   'skia_revision': '5561e3ddbbf6c3e051075ada4a11ddc70760f03d',
 
@@ -45,7 +45,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '79ef956051698e3843e87c781112bfd9cc3695f0',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '2f656511ecc11565bd975b0f0ac7aa7383950132',
 
    # Fuchsia compatibility
    #

--- a/sky/engine/web/BUILD.gn
+++ b/sky/engine/web/BUILD.gn
@@ -10,7 +10,6 @@ source_set("web") {
   deps = [
     "//flutter/sky/engine/core",
     "//flutter/sky/engine/platform",
-    "//mojo/public/c",
   ]
 
   configs += [
@@ -26,7 +25,6 @@ source_set("web") {
   } else {
     deps += [
       "//mojo/message_pump",
-      "//mojo/public/c:gpu",
     ]
   }
 }

--- a/sky/engine/wtf/BUILD.gn
+++ b/sky/engine/wtf/BUILD.gn
@@ -262,7 +262,7 @@ executable("unittests") {
     # will be injected at runtime so the link succeeds.
     deps += [
       "//mojo/public/cpp/environment:standalone",
-      "//mojo/public/platform/native:system_thunks",
+      "//mojo/public/platform/native:system",
     ]
   }
 }


### PR DESCRIPTION
…2 (#3052)"

This reverts commit 92fdf25d391ff4518885bbbee768053f84563923.

This breaks the android x86 build:

gn gen --check in out/android_debug_x64
ERROR at //mojo/public/tools/BUILD.gn:59:9: Assertion failed.
        assert(current_cpu == "arm",
        ^-----
Only arm version prebuilt netowrk_service.mojo is available.
step returned non-zero exit code: 1