### PR TITLE
Add buildtools to recursedeps entry in DEPS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -125,6 +125,10 @@ deps = {
    Var('github_git') + '/KhronosGroup/Vulkan-Docs.git' + '@' + 'e29c2489e238509c41aeb8c7bce9d669a496344b',
 }
 
+recursedeps = [
+  'src/buildtools',
+]
+
 deps_os = {
   'android': {
     'src/third_party/colorama/src':


### PR DESCRIPTION
gclient now uses this to decide whether to look at a dependent
repo's DEPS file, which is needed for buildtools.

See https://groups.google.com/a/chromium.org/forum/#!topic/chromium-dev/NsGSfdLaDMI
for more detail.