### PR TITLE
Switch to manually encoded pointer data

### DIFF
--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -52,6 +52,10 @@ source_set("ui") {
     "text/text_box.h",
     "ui_dart_state.cc",
     "ui_dart_state.h",
+    "window/pointer_data_packet.cc",
+    "window/pointer_data_packet.h",
+    "window/pointer_data.cc",
+    "window/pointer_data.h",
     "window/window.cc",
     "window/window.h",
   ]

--- a/lib/ui/dart_ui.gni
+++ b/lib/ui/dart_ui.gni
@@ -11,6 +11,7 @@ dart_ui_files = [
   "//flutter/lib/ui/mojo_services.dart",
   "//flutter/lib/ui/natives.dart",
   "//flutter/lib/ui/painting.dart",
+  "//flutter/lib/ui/pointer.dart",
   "//flutter/lib/ui/text.dart",
   "//flutter/lib/ui/ui.dart",
   "//flutter/lib/ui/window.dart",

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -1,0 +1,221 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of dart_ui;
+
+/// How the pointer has changed since the last report.
+enum PointerChange {
+  /// The device has started tracking the pointer.
+  ///
+  /// For example, the pointer might be hovering above the device, having not yet
+  /// made contact with the surface of the device.
+  add,
+
+  /// The device is no longer tracking the pointer.
+  ///
+  /// For example, the pointer might have drifted out of the device's hover
+  /// detection range or might have been disconnected from the system entirely.
+  remove,
+
+  /// The pointer has made contact with the device.
+  down,
+
+  /// The pointer has moved with respect to the device.
+  move,
+
+  /// The pointer has stopped making contact with the device.
+  up,
+
+  /// The input from the pointer is no longer directed towards this receiver.
+  cancel,
+}
+
+/// The kind of pointer device.
+enum PointerDeviceKind {
+  /// A touch-based pointer device.
+  touch,
+
+  /// A mouse-based pointer device.
+  mouse,
+
+  /// A pointer device with a stylus.
+  stylus,
+
+  /// A pointer device with a stylus that has been inverted.
+  invertedStylus,
+}
+
+/// Information about the state of a pointer.
+class PointerData {
+  /// Creates an object that represents the state of a pointer.
+  const PointerData({
+    this.timeStamp: Duration.ZERO,
+    this.pointer: 0,
+    this.change: PointerChange.cancel,
+    this.kind: PointerDeviceKind.touch,
+    this.physicalX: 0.0,
+    this.physicalY: 0.0,
+    this.buttons: 0,
+    this.obscured: false,
+    this.pressure: 0.0,
+    this.pressureMin: 0.0,
+    this.pressureMax: 0.0,
+    this.distance: 0.0,
+    this.distanceMax: 0.0,
+    this.radiusMajor: 0.0,
+    this.radiusMinor: 0.0,
+    this.radiusMin: 0.0,
+    this.radiusMax: 0.0,
+    this.orientation: 0.0,
+    this.tilt: 0.0,
+  });
+
+  /// Time of event dispatch, relative to an arbitrary timeline.
+  final Duration timeStamp;
+
+  /// Unique identifier for the pointer, potentially reused.
+  final int pointer;
+
+  final PointerChange change;
+
+  /// The kind of input device for which the event was generated.
+  final PointerDeviceKind kind;
+
+  /// X coordinate of the position of the pointer, in physical pixels in the
+  /// global coordinate space.
+  final double physicalX;
+
+  /// Y coordinate of the position of the pointer, in physical pixels in the
+  /// global coordinate space.
+  final double physicalY;
+
+  /// Bit field using the *Button constants (primaryMouseButton,
+  /// secondaryStylusButton, etc). For example, if this has the value 6 and the
+  /// [kind] is [PointerDeviceKind.invertedStylus], then this indicates an
+  /// upside-down stylus with both its primary and secondary buttons pressed.
+  final int buttons;
+
+  /// Set if an application from a different security domain is in any way
+  /// obscuring this application's window. (Aspirational; not currently
+  /// implemented.)
+  final bool obscured;
+
+  /// The pressure of the touch as a number ranging from 0.0, indicating a touch
+  /// with no discernible pressure, to 1.0, indicating a touch with "normal"
+  /// pressure, and possibly beyond, indicating a stronger touch. For devices
+  /// that do not detect pressure (e.g. mice), returns 1.0.
+  final double pressure;
+
+  /// The minimum value that [pressure] can return for this pointer. For devices
+  /// that do not detect pressure (e.g. mice), returns 1.0. This will always be
+  /// a number less than or equal to 1.0.
+  final double pressureMin;
+
+  /// The maximum value that [pressure] can return for this pointer. For devices
+  /// that do not detect pressure (e.g. mice), returns 1.0. This will always be
+  /// a greater than or equal to 1.0.
+  final double pressureMax;
+
+  /// The distance of the detected object from the input surface (e.g. the
+  /// distance of a stylus or finger from a touch screen), in arbitrary units on
+  /// an arbitrary (not necessarily linear) scale. If the pointer is down, this
+  /// is 0.0 by definition.
+  final double distance;
+
+  /// The maximum value that a distance can return for this pointer. If this
+  /// input device cannot detect "hover touch" input events, then this will be
+  /// 0.0.
+  final double distanceMax;
+
+  /// The radius of the contact ellipse along the major axis, in logical pixels.
+  final double radiusMajor;
+
+  /// The radius of the contact ellipse along the minor axis, in logical pixels.
+  final double radiusMinor;
+
+  /// The minimum value that could be reported for radiusMajor and radiusMinor
+  /// for this pointer, in logical pixels.
+  final double radiusMin;
+
+  /// The minimum value that could be reported for radiusMajor and radiusMinor
+  /// for this pointer, in logical pixels.
+  final double radiusMax;
+
+  /// For PointerDeviceKind.touch events:
+  ///
+  /// The angle of the contact ellipse, in radius in the range:
+  ///
+  ///    -pi/2 < orientation <= pi/2
+  ///
+  /// ...giving the angle of the major axis of the ellipse with the y-axis
+  /// (negative angles indicating an orientation along the top-left /
+  /// bottom-right diagonal, positive angles indicating an orientation along the
+  /// top-right / bottom-left diagonal, and zero indicating an orientation
+  /// parallel with the y-axis).
+  ///
+  /// For PointerDeviceKind.stylus and PointerDeviceKind.invertedStylus events:
+  ///
+  /// The angle of the stylus, in radians in the range:
+  ///
+  ///    -pi < orientation <= pi
+  ///
+  /// ...giving the angle of the axis of the stylus projected onto the input
+  /// surface, relative to the positive y-axis of that surface (thus 0.0
+  /// indicates the stylus, if projected onto that surface, would go from the
+  /// contact point vertically up in the positive y-axis direction, pi would
+  /// indicate that the stylus would go down in the negative y-axis direction;
+  /// pi/4 would indicate that the stylus goes up and to the right, -pi/2 would
+  /// indicate that the stylus goes to the left, etc).
+  final double orientation;
+
+  /// For PointerDeviceKind.stylus and PointerDeviceKind.invertedStylus events:
+  ///
+  /// The angle of the stylus, in radians in the range:
+  ///
+  ///    0 <= tilt <= pi/2
+  ///
+  /// ...giving the angle of the axis of the stylus, relative to the axis
+  /// perpendicular to the input surface (thus 0.0 indicates the stylus is
+  /// orthogonal to the plane of the input surface, while pi/2 indicates that
+  /// the stylus is flat on that surface).
+  final double tilt;
+
+  @override
+  String toString() => '$runtimeType(x: $physicalX, y: $physicalY)';
+
+  /// Returns a complete textual description of the information in this object.
+  String toStringFull() {
+    return '$runtimeType('
+             'timeStamp: $timeStamp, '
+             'pointer: $pointer, '
+             'change:: $change, '
+             'kind: $kind, '
+             'physicalX: $physicalX, '
+             'physicalY: $physicalY, '
+             'buttons: $buttons, '
+             'pressure: $pressure, '
+             'pressureMin: $pressureMin, '
+             'pressureMax: $pressureMax, '
+             'distance: $distance, '
+             'distanceMax: $distanceMax, '
+             'radiusMajor: $radiusMajor, '
+             'radiusMinor: $radiusMinor, '
+             'radiusMin: $radiusMin, '
+             'radiusMax: $radiusMax, '
+             'orientation: $orientation, '
+             'tilt: $tilt'
+           ')';
+  }
+}
+
+/// A sequence of reports about the state of pointers.
+class PointerDataPacket {
+  /// Creates a packet of pointer data reports.
+  const PointerDataPacket({ this.pointers: const <PointerData>[] });
+
+  /// Data about the individual pointers in this packet.
+  ///
+  /// This list might contain multiple pieces of data about the same pointer.
+  final List<PointerData> pointers;
+}

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -30,5 +30,6 @@ part 'lerp.dart';
 part 'mojo_services.dart';
 part 'natives.dart';
 part 'painting.dart';
+part 'pointer.dart';
 part 'text.dart';
 part 'window.dart';

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -13,6 +13,9 @@ typedef void FrameCallback(Duration duration);
 /// Signature for [Window.onPointerPacket].
 typedef void PointerPacketCallback(ByteData serializedPacket);
 
+/// Signature for [Window.onPointerDataPacket].
+typedef void PointerDataPacketCallback(PointerDataPacket packet);
+
 /// Signature for [Window.onAppLifecycleStateChanged].
 typedef void AppLifecycleStateCallback(AppLifecycleState state);
 
@@ -148,6 +151,9 @@ class Window {
   /// provided in the form of a raw byte stream containing an encoded mojo
   /// PointerPacket.
   PointerPacketCallback onPointerPacket;
+
+  /// A callback that is invoked when pointer data is available.
+  PointerDataPacketCallback onPointerDataPacket;
 
   /// The route or path that the operating system requested when the application
   /// was launched.

--- a/lib/ui/window/pointer_data.cc
+++ b/lib/ui/window/pointer_data.cc
@@ -1,0 +1,15 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/window/pointer_data.h"
+
+namespace blink {
+
+// If this value changes, update the pointer data unpacking code in hooks.dart.
+static constexpr int kPointerDataFieldCount = 19;
+
+static_assert(sizeof(PointerData) == sizeof(int64_t) * kPointerDataFieldCount,
+              "PointerData has the wrong size");
+
+}  // namespace blink

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -1,0 +1,55 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_WINDOW_POINTER_DATA_H_
+#define FLUTTER_LIB_UI_WINDOW_POINTER_DATA_H_
+
+#include <stdint.h>
+
+namespace blink {
+
+// This structure is unpacked by hooks.dart.
+struct alignas(8) PointerData {
+  // Must match the PointerChange enum in pointer.dart.
+  enum class Change : int64_t {
+    kAdd,
+    kRemove,
+    kDown,
+    kMove,
+    kUp,
+    kCancel,
+  };
+
+  // Must match the PointerDeviceKind enum in pointer.dart.
+  enum class DeviceKind : int64_t {
+    kTouch,
+    kMouse,
+    kStylus,
+    kInvertedStylus,
+  };
+
+  int64_t time_stamp;
+  int64_t pointer;
+  Change change;
+  DeviceKind kind;
+  double physical_x;
+  double physical_y;
+  int64_t buttons;
+  int64_t obscured;
+  double pressure;
+  double pressure_min;
+  double pressure_max;
+  double distance;
+  double distance_max;
+  double radius_major;
+  double radius_minor;
+  double radius_min;
+  double radius_max;
+  double orientation;
+  double tilt;
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_WINDOW_POINTER_DATA_H_

--- a/lib/ui/window/pointer_data_packet.cc
+++ b/lib/ui/window/pointer_data_packet.cc
@@ -1,0 +1,20 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/window/pointer_data_packet.h"
+
+#include <string.h>
+
+namespace blink {
+
+PointerDataPacket::PointerDataPacket(size_t count)
+    : data_(count * sizeof(PointerData)) {}
+
+PointerDataPacket::~PointerDataPacket() = default;
+
+void PointerDataPacket::SetPointerData(size_t i, const PointerData& data) {
+  memcpy(&data_[i * sizeof(PointerData)], &data, sizeof(PointerData));
+}
+
+}  // namespace blink

--- a/lib/ui/window/pointer_data_packet.h
+++ b/lib/ui/window/pointer_data_packet.h
@@ -1,0 +1,33 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_H_
+#define FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_H_
+
+#include <string.h>
+
+#include <vector>
+
+#include "flutter/lib/ui/window/pointer_data.h"
+#include "lib/ftl/macros.h"
+
+namespace blink {
+
+class PointerDataPacket {
+ public:
+  explicit PointerDataPacket(size_t count);
+  ~PointerDataPacket();
+
+  void SetPointerData(size_t i, const PointerData& data);
+  const std::vector<char>& data() const { return data_; }
+
+ private:
+  std::vector<char> data_;
+
+  FTL_DISALLOW_COPY_AND_ASSIGN(PointerDataPacket);
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_H_

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -5,10 +5,11 @@
 #ifndef FLUTTER_LIB_UI_WINDOW_WINDOW_H_
 #define FLUTTER_LIB_UI_WINDOW_WINDOW_H_
 
-#include "lib/ftl/time/time_point.h"
-#include "lib/tonic/dart_persistent_value.h"
+#include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/services/engine/sky_engine.mojom.h"
 #include "flutter/services/pointer/pointer.mojom.h"
+#include "lib/ftl/time/time_point.h"
+#include "lib/tonic/dart_persistent_value.h"
 
 namespace tonic {
 class DartLibraryNatives;
@@ -38,6 +39,7 @@ class Window {
   void UpdateLocale(const std::string& language_code,
                     const std::string& country_code);
   void DispatchPointerPacket(const pointer::PointerPacketPtr& packet);
+  void DispatchPointerDataPacket(const PointerDataPacket& packet);
   void BeginFrame(ftl::TimePoint frameTime);
 
   void PushRoute(const std::string& route);

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -82,6 +82,12 @@ void RuntimeController::HandlePointerPacket(
   GetWindow()->DispatchPointerPacket(packet);
 }
 
+void RuntimeController::HandlePointerDataPacket(
+    const PointerDataPacket& packet) {
+  TRACE_EVENT0("input", "RuntimeController::HandlePointerDataPacket");
+  GetWindow()->DispatchPointerDataPacket(packet);
+}
+
 Window* RuntimeController::GetWindow() {
   return dart_controller_->dart_state()->window();
 }
@@ -122,6 +128,5 @@ std::string RuntimeController::GetIsolateName() {
   }
   return dart_controller_->dart_state()->debug_name();
 }
-
 
 }  // namespace blink

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -9,6 +9,7 @@
 
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/lib/ui/ui_dart_state.h"
+#include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/window.h"
 #include "flutter/services/engine/sky_engine.mojom.h"
 #include "flutter/services/pointer/pointer.mojom.h"
@@ -39,6 +40,7 @@ class RuntimeController : public WindowClient, public IsolateClient {
   void BeginFrame(ftl::TimePoint frame_time);
 
   void HandlePointerPacket(const pointer::PointerPacketPtr& packet);
+  void HandlePointerDataPacket(const PointerDataPacket& packet);
 
   void OnAppLifecycleStateChanged(sky::AppLifecycleState state);
 


### PR DESCRIPTION
Rather than using mojom to encode pointer data, we now encode and decode it
manually. A future patch will remove the mojom codepath once the framework is
updated.