### PR TITLE
Update buildroot (target triple) and boringssl (Clang IAS) fixes for non-ARM platforms.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -28,7 +28,7 @@ vars = {
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
   'dart_revision': 'cfbf1a511e6e64d35789e34e161a7b10a88a439c',
-  'dart_boringssl_gen_revision': '922830c0aad900dd3d143eef1ba06faa83fe263b',
+  'dart_boringssl_gen_revision': 'de218d3e1b6d210e1d132ecc748e0125d1020ac9',
   'dart_boringssl_revision': '8d343b44bbab829d1a28fdef650ca95f7db4412e',
   'dart_observatory_packages_revision': '26aad88f1c1915d39bbcbff3cad589e2402fdcf1',
   'dart_root_certificates_revision': 'aed07942ce98507d2be28cbd29e879525410c7fc',
@@ -45,7 +45,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a938377f3f705a75c9054ed851677e33750eb0ee',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '8e04368ac4c14efc5d6421ef5f3c3876ba0170f7',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
This fixes x86 and x64 Android builds.