### PR TITLE
Use BGRA color type now that it is supported by Skia on Fuchsia.

### DIFF
--- a/content_handler/framebuffer_skia.h
+++ b/content_handler/framebuffer_skia.h
@@ -19,10 +19,6 @@ class FramebufferSkia {
   void Bind(mojo::InterfaceHandle<mojo::Framebuffer> framebuffer,
             mojo::FramebufferInfoPtr info);
 
-  // Converts pixels from internal format of BGRA to ARGB.
-  // Needed because Skia does not support drawing to ARGB directly.
-  void ConvertToCorrectPixelFormatIfNeeded();
-
   void Finish();
   const sk_sp<SkSurface>& surface() { return surface_; }
 

--- a/content_handler/rasterizer.cc
+++ b/content_handler/rasterizer.cc
@@ -35,7 +35,6 @@ void Rasterizer::Draw(std::unique_ptr<flow::LayerTree> layer_tree,
   layer_tree->Raster(frame);
   canvas->flush();
 
-  framebuffer_.ConvertToCorrectPixelFormatIfNeeded();
   framebuffer_.Finish();
   callback();
 }


### PR DESCRIPTION
I'm pretty sure using RGBA on Fuchsia will crash right now.  Skia only seems to want to support one of these formats at a time.