### PR TITLE
Android should use PointerDataPackets

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -53,6 +53,10 @@ void _onAppLifecycleStateChanged(int state) {
     window.onAppLifecycleStateChanged(AppLifecycleState.values[state]);
 }
 
+// If this value changes, update the encoding code in the following files:
+//
+//  * pointer_data.cc
+//  * FlutterView.java
 const int _kPointerDataFieldCount = 19;
 
 PointerDataPacket _unpackPointerDataPacket(ByteData packet) {

--- a/lib/ui/window/pointer_data_packet.cc
+++ b/lib/ui/window/pointer_data_packet.cc
@@ -11,6 +11,9 @@ namespace blink {
 PointerDataPacket::PointerDataPacket(size_t count)
     : data_(count * sizeof(PointerData)) {}
 
+PointerDataPacket::PointerDataPacket(char* data, size_t num_bytes)
+    : data_(data, data + num_bytes) {}
+
 PointerDataPacket::~PointerDataPacket() = default;
 
 void PointerDataPacket::SetPointerData(size_t i, const PointerData& data) {

--- a/lib/ui/window/pointer_data_packet.h
+++ b/lib/ui/window/pointer_data_packet.h
@@ -17,6 +17,7 @@ namespace blink {
 class PointerDataPacket {
  public:
   explicit PointerDataPacket(size_t count);
+  PointerDataPacket(char* data, size_t num_bytes);
   ~PointerDataPacket();
 
   void SetPointerData(size_t i, const PointerData& data);

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -185,13 +185,19 @@ void Engine::OnLocaleChanged(const mojo::String& language_code,
     runtime_->SetLocale(language_code_, country_code_);
 }
 
-// TODO(abarth): Remove pointer::PointerPacketPtr and route
-// blink::PointerDataPacket here.
+void Engine::HandlePointerDataPacket(const PointerDataPacket& packet) {
+  TRACE_EVENT0("flutter", "Engine::HandlePointerDataPacket");
+  if (runtime_)
+    runtime_->HandlePointerDataPacket(packet);
+}
+
+// TODO(abarth): Remove pointer::PointerPacketPtr and route PointerDataPacket
+// here.
 void Engine::OnPointerPacket(pointer::PointerPacketPtr packetPtr) {
   TRACE_EVENT0("flutter", "Engine::OnPointerPacket");
   if (runtime_) {
     const size_t length = packetPtr->pointers.size();
-    blink::PointerDataPacket packet(length);
+    PointerDataPacket packet(length);
     for (size_t i = 0; i < length; ++i) {
       const pointer::PointerPtr& pointer = packetPtr->pointers[i];
       blink::PointerData pointer_data;

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -25,6 +25,7 @@
 
 namespace shell {
 class Animator;
+using PointerDataPacket = blink::PointerDataPacket;
 
 class Engine : public UIDelegate,
                public sky::SkyEngine,
@@ -47,6 +48,8 @@ class Engine : public UIDelegate,
   Dart_Port GetUIIsolateMainPort();
 
   std::string GetUIIsolateName();
+
+  void HandlePointerDataPacket(const PointerDataPacket& packet);
 
  private:
   // UIDelegate implementation:

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -79,7 +79,6 @@ android_library("java") {
     "//flutter/services/media:media_lib",
     "//flutter/services/platform:interfaces_java",
     "//flutter/services/platform:platform_lib",
-    "//flutter/services/pointer:interfaces_java",
     "//flutter/services/raw_keyboard:interfaces_java",
     "//flutter/services/raw_keyboard:raw_keyboard_lib",
     "//flutter/services/semantics:interfaces_java",

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -33,6 +33,9 @@ class PlatformViewAndroid : public PlatformView {
 
   void SurfaceDestroyed(JNIEnv* env, jobject obj);
 
+  void DispatchPointerDataPacket(JNIEnv* env, jobject obj, jobject buffer,
+                                 jint position);
+
   base::android::ScopedJavaLocalRef<jobject> GetBitmap(JNIEnv* env,
                                                        jobject obj);
 


### PR DESCRIPTION
We now use JNI rather than Mojo to transport pointer data from Java to Dart.
Also, fill in a few more of the pointer data fields from information in Java.