### PR TITLE
Annotate flutter_wtf_unittests as testonly

### DIFF
--- a/sky/engine/wtf/BUILD.gn
+++ b/sky/engine/wtf/BUILD.gn
@@ -213,6 +213,8 @@ source_set("wtf") {
 executable("unittests") {
   output_name = "flutter_wtf_unittests"
 
+  testonly = true
+
   sources = [
     "CheckedArithmeticTest.cpp",
     "DequeTest.cpp",


### PR DESCRIPTION
This allows setting testonly=true for gtest in the Fuchsia build.