### PR TITLE
Add a Keyboard.ClearClient method that can be used to drop the KeyboardClient stub

### DIFF
--- a/services/editing/editing.mojom
+++ b/services/editing/editing.mojom
@@ -44,6 +44,7 @@ interface KeyboardClient {
 [ServiceName="editing::Keyboard"]
 interface Keyboard {
   SetClient(KeyboardClient client, KeyboardConfiguration configuration);
+  ClearClient();
   SetEditingState(EditingState state);
   Show();
   Hide();

--- a/services/editing/ios/keyboard_impl.h
+++ b/services/editing/ios/keyboard_impl.h
@@ -25,6 +25,7 @@ class KeyboardImpl : public ::editing::Keyboard {
   ~KeyboardImpl() override;
   void SetClient(mojo::InterfaceHandle<::editing::KeyboardClient> client,
                  ::editing::KeyboardConfigurationPtr configuration) override;
+  void ClearClient() override;
   void SetEditingState(::editing::EditingStatePtr state) override;
   void Show() override;
   void Hide() override;

--- a/services/editing/ios/keyboard_impl.mm
+++ b/services/editing/ios/keyboard_impl.mm
@@ -145,6 +145,10 @@ void KeyboardImpl::SetClient(mojo::InterfaceHandle<::editing::KeyboardClient> cl
   [client_ setClient: ::editing::KeyboardClientPtr::Create(client.Pass())];
 }
 
+void KeyboardImpl::ClearClient() {
+  // TODO: implement this
+}
+
 void KeyboardImpl::SetEditingState(::editing::EditingStatePtr state) {
   [client_ setEditingState:state.Pass()];
 }

--- a/services/editing/src/org/domokit/editing/KeyboardImpl.java
+++ b/services/editing/src/org/domokit/editing/KeyboardImpl.java
@@ -39,6 +39,11 @@ public class KeyboardImpl implements Keyboard {
     }
 
     @Override
+    public void clearClient() {
+        mViewState.close();
+    }
+
+    @Override
     public void setEditingState(EditingState state) {
         mViewState.setEditingState(state);
     }


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/6274