### PR TITLE
Rewire platform messages to work like semantics

### DIFF
--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -147,6 +147,11 @@ void RuntimeHolder::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
 
 void RuntimeHolder::UpdateSemantics(std::vector<blink::SemanticsNode> update) {}
 
+void RuntimeHolder::HandlePlatformMessage(
+    ftl::RefPtr<blink::PlatformMessage> message) {
+  message->InvokeCallbackWithError();
+}
+
 void RuntimeHolder::DidCreateMainIsolate(Dart_Isolate isolate) {
   blink::MojoServices::Create(isolate, nullptr, nullptr,
                               std::move(root_bundle_));

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -40,6 +40,8 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   void ScheduleFrame() override;
   void Render(std::unique_ptr<flow::LayerTree> layer_tree) override;
   void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
+  void HandlePlatformMessage(
+      ftl::RefPtr<blink::PlatformMessage> message) override;
   void DidCreateMainIsolate(Dart_Isolate isolate) override;
 
   // |mozart::InputListener| implementation:

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "dart/runtime/include/dart_api.h"
-#include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/sky/engine/wtf/RefPtr.h"
 #include "lib/ftl/build_config.h"
 #include "lib/tonic/dart_persistent_value.h"
@@ -49,14 +48,6 @@ class UIDartState : public tonic::DartState {
   DartJniIsolateData* jni_data();
 #endif
 
-  void set_platform_message_sink(PlatformMessage::Sink sink) {
-    platform_message_sink_ = std::move(sink);
-  }
-
-  const PlatformMessage::Sink& platform_message_sink() const {
-    return platform_message_sink_;
-  }
-
   void set_font_selector(PassRefPtr<FontSelector> selector);
   PassRefPtr<FontSelector> font_selector();
 
@@ -68,7 +59,6 @@ class UIDartState : public tonic::DartState {
   std::string debug_name_;
   std::unique_ptr<MojoServices> mojo_services_;
   std::unique_ptr<Window> window_;
-  PlatformMessage::Sink platform_message_sink_;
   RefPtr<FontSelector> font_selector_;
 
 #if defined(OS_ANDROID)

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -55,11 +55,9 @@ void SendPlatformMessage(Dart_Handle window,
   auto message = ftl::MakeRefCounted<blink::PlatformMessage>(
       name, std::vector<char>(buffer, buffer + data.length_in_bytes()),
       tonic::DartPersistentValue(dart_state, callback));
-  if (const auto& sink = dart_state->platform_message_sink()) {
-    sink(std::move(message));
-  } else {
-    message->InvokeCallbackWithError();
-  }
+
+  UIDartState::Current()->window()->client()->HandlePlatformMessage(
+      std::move(message));
 }
 
 void _SendPlatformMessage(Dart_NativeArguments args) {

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -6,6 +6,7 @@
 #define FLUTTER_LIB_UI_WINDOW_WINDOW_H_
 
 #include "flutter/lib/ui/semantics/semantics_update.h"
+#include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/services/engine/sky_engine.mojom.h"
 #include "lib/ftl/time/time_point.h"
@@ -23,6 +24,7 @@ class WindowClient {
   virtual void ScheduleFrame() = 0;
   virtual void Render(Scene* scene) = 0;
   virtual void UpdateSemantics(SemanticsUpdate* update) = 0;
+  virtual void HandlePlatformMessage(ftl::RefPtr<PlatformMessage> message) = 0;
 
  protected:
   virtual ~WindowClient();

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -117,6 +117,11 @@ void RuntimeController::UpdateSemantics(SemanticsUpdate* update) {
     client_->UpdateSemantics(update->takeNodes());
 }
 
+void RuntimeController::HandlePlatformMessage(
+    ftl::RefPtr<PlatformMessage> message) {
+  client_->HandlePlatformMessage(std::move(message));
+}
+
 void RuntimeController::DidCreateSecondaryIsolate(Dart_Isolate isolate) {
   client_->DidCreateSecondaryIsolate(isolate);
 }

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -56,6 +56,7 @@ class RuntimeController : public WindowClient, public IsolateClient {
   void ScheduleFrame() override;
   void Render(Scene* scene) override;
   void UpdateSemantics(SemanticsUpdate* update) override;
+  void HandlePlatformMessage(ftl::RefPtr<PlatformMessage> message) override;
 
   void DidCreateSecondaryIsolate(Dart_Isolate isolate) override;
 

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -11,6 +11,7 @@
 #include "dart/runtime/include/dart_api.h"
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
+#include "flutter/lib/ui/window/platform_message.h"
 
 namespace blink {
 
@@ -19,6 +20,7 @@ class RuntimeDelegate {
   virtual void ScheduleFrame() = 0;
   virtual void Render(std::unique_ptr<flow::LayerTree> layer_tree) = 0;
   virtual void UpdateSemantics(std::vector<SemanticsNode> update) = 0;
+  virtual void HandlePlatformMessage(ftl::RefPtr<PlatformMessage> message) = 0;
 
   virtual void DidCreateMainIsolate(Dart_Isolate isolate);
   virtual void DidCreateSecondaryIsolate(Dart_Isolate isolate);

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -360,4 +360,14 @@ void Engine::UpdateSemantics(std::vector<blink::SemanticsNode> update) {
       }));
 }
 
+void Engine::HandlePlatformMessage(
+    ftl::RefPtr<blink::PlatformMessage> message) {
+  blink::Threads::Platform()->PostTask([
+    platform_view = platform_view_, message = std::move(message)
+  ]() mutable {
+    if (platform_view)
+      platform_view->HandlePlatformMessage(std::move(message));
+  });
+}
+
 }  // namespace shell

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -79,6 +79,8 @@ class Engine : public sky::SkyEngine, public blink::RuntimeDelegate {
   void ScheduleFrame() override;
   void Render(std::unique_ptr<flow::LayerTree> layer_tree) override;
   void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
+  void HandlePlatformMessage(
+      ftl::RefPtr<blink::PlatformMessage> message) override;
   void DidCreateMainIsolate(Dart_Isolate isolate) override;
   void DidCreateSecondaryIsolate(Dart_Isolate isolate) override;
 

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -116,6 +116,11 @@ ftl::WeakPtr<PlatformView> PlatformView::GetWeakPtr() {
 
 void PlatformView::UpdateSemantics(std::vector<blink::SemanticsNode> update) {}
 
+void PlatformView::HandlePlatformMessage(
+    ftl::RefPtr<blink::PlatformMessage> message) {
+  message->InvokeCallbackWithError();
+}
+
 void PlatformView::SetupResourceContextOnIOThread() {
   ftl::AutoResetWaitableEvent latch;
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -53,6 +53,8 @@ class PlatformView {
   virtual bool ResourceContextMakeCurrent() = 0;
 
   virtual void UpdateSemantics(std::vector<blink::SemanticsNode> update);
+  virtual void HandlePlatformMessage(
+      ftl::RefPtr<blink::PlatformMessage> message);
 
   Rasterizer& rasterizer() { return *rasterizer_; }
   Engine& engine() { return *engine_; }

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -28,7 +28,10 @@ class PlatformViewAndroid : public PlatformView {
 
   void Detach(JNIEnv* env, jobject obj);
 
-  void SurfaceCreated(JNIEnv* env, jobject obj, jobject jsurface, jint backgroundColor);
+  void SurfaceCreated(JNIEnv* env,
+                      jobject obj,
+                      jobject jsurface,
+                      jint backgroundColor);
 
   void SurfaceChanged(JNIEnv* env, jobject obj, jint width, jint height);
 
@@ -55,6 +58,9 @@ class PlatformViewAndroid : public PlatformView {
 
   void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
 
+  void HandlePlatformMessage(
+      ftl::RefPtr<blink::PlatformMessage> message) override;
+
   void RunFromSource(const std::string& main,
                      const std::string& packages,
                      const std::string& assets_directory) override;
@@ -79,8 +85,6 @@ class PlatformViewAndroid : public PlatformView {
   void GetBitmapGpuTask(ftl::AutoResetWaitableEvent* latch,
                         jobject* pixels_out,
                         SkISize* size_out);
-
-  void HandlePlatformMessage(ftl::RefPtr<blink::PlatformMessage> message);
 
   FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewAndroid);
 };


### PR DESCRIPTION
After this patch, platform messages now take the same path through the system
that semantics data does (on Android). Support on iOS will be in another patch.