### PR TITLE
Disable the fullscreen text entry mode on Android

### DIFF
--- a/services/editing/src/org/domokit/editing/KeyboardViewState.java
+++ b/services/editing/src/org/domokit/editing/KeyboardViewState.java
@@ -67,7 +67,7 @@ public class KeyboardViewState {
             return null;
         outAttrs.inputType = inputTypeFromKeyboardType(mConfiguration.type);
         outAttrs.actionLabel = mConfiguration.actionLabel;
-        outAttrs.imeOptions = EditorInfo.IME_ACTION_DONE;
+        outAttrs.imeOptions = EditorInfo.IME_ACTION_DONE | EditorInfo.IME_FLAG_NO_FULLSCREEN;
         InputConnectionAdaptor connection = new InputConnectionAdaptor(mView, mClient);
         if (mIncomingState != null) {
             outAttrs.initialSelStart = mIncomingState.selectionBase;


### PR DESCRIPTION
This mode requires that our editor implementation provide ExtractedText,
which we currently do not support

See https://github.com/flutter/flutter/issues/4899