### PR TITLE
Keep precision in iOS event timestamp

### DIFF
--- a/shell/platform/darwin/desktop/sky_window.mm
+++ b/shell/platform/darwin/desktop/sky_window.mm
@@ -104,8 +104,9 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(
 
   blink::PointerData pointer_data;
   pointer_data.Clear();
-  pointer_data.time_stamp =
-      ftl::TimeDelta::FromSeconds(event.timestamp).ToMicroseconds();
+
+  constexpr int kMicrosecondsPerSecond = 1000 * 1000;
+  pointer_data.time_stamp = event.timestamp * kMicrosecondsPerSecond;
   pointer_data.change = PointerChangeFromNSEventPhase(phase);
   pointer_data.kind = blink::PointerData::DeviceKind::kMouse;
   pointer_data.physical_x = location.x;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -254,13 +254,11 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
     DCHECK(touch_identifier != 0);
     CGPoint windowCoordinates = [touch locationInView:nil];
 
-    auto pointer_time =
-        ftl::TimeDelta::FromSeconds(touch.timestamp).ToMicroseconds();
-
     blink::PointerData pointer_data;
     pointer_data.Clear();
 
-    pointer_data.time_stamp = pointer_time;
+    constexpr int kMicrosecondsPerSecond = 1000 * 1000;
+    pointer_data.time_stamp = touch.timestamp * kMicrosecondsPerSecond;
     pointer_data.change = eventTypePhase.first;
     pointer_data.kind = blink::PointerData::DeviceKind::kTouch;
     pointer_data.pointer = touch_identifier;


### PR DESCRIPTION
Previously we were rounding event time stamps to the nearest second
because ftl::TimeDelta::FromSeconds takes an integer number of seconds.
Now we just convert directly from floating point seconds to
microseconds to avoid losing precision.

Fixes https://github.com/flutter/flutter/issues/6313