### PR TITLE
Handle non-null terminated strings properly

### DIFF
--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -1106,7 +1106,7 @@ class RRect {
 
   // Returns the minimum between min and scale to which radius1 and radius2
   // should be scaled with in order not to exceed the limit.
-  double _getMin(double min, double radius1, double radius2, limit) {
+  double _getMin(double min, double radius1, double radius2, double limit) {
     double sum = radius1 + radius2;
     if (sum > limit && sum != 0.0)
       return math.min(min, limit / sum);

--- a/shell/platform/darwin/ios/framework/Source/application_messages_impl.mm
+++ b/shell/platform/darwin/ios/framework/Source/application_messages_impl.mm
@@ -35,9 +35,13 @@ void ApplicationMessagesImpl::AddBinding(
 
 void ApplicationMessagesImpl::HandlePlatformMessage(
     ftl::RefPtr<blink::PlatformMessage> message) {
-  NSString* string = [NSString stringWithUTF8String:message->data().data()];
-  ftl::RefPtr<blink::PlatformMessageResponse> completer = message->response();
+  const auto& buffer = message->data();
+  NSString* string = [[NSString alloc] initWithBytes:buffer.data()
+                                              length:buffer.size()
+                                            encoding:NSUTF8StringEncoding];
+  [string autorelease];
 
+  ftl::RefPtr<blink::PlatformMessageResponse> completer = message->response();
   {
     auto it = listeners_.find(message->name());
     if (it != listeners_.end()) {


### PR DESCRIPTION
The function we were using to initialize this NSString assumed that our
UTF-8 data was null-terminated, which wasn't a valid assumption.

Fixes https://github.com/flutter/flutter/issues/6359