### PR TITLE
Teach Fuchsia build about FLUTTER_ROOT

### DIFF
--- a/build/flutter_app.gni
+++ b/build/flutter_app.gni
@@ -49,7 +49,8 @@ template("flutter_app") {
   dart_binary_dir = get_label_info(dart_binary_label, "root_out_dir")
   dart_binary = "$dart_binary_dir/dart_no_observatory"
 
-  flutter_tools_label = "//lib/flutter/packages/flutter_tools"
+  flutter_root = "//lib/flutter"
+  flutter_tools_label = "$flutter_root/packages/flutter_tools"
   flutter_tools_gen_dir = get_label_info(flutter_tools_label, "target_gen_dir")
   flutter_tools_name = get_label_info(flutter_tools_label, "name")
   flutter_tools_packages = "$flutter_tools_gen_dir/$flutter_tools_name.packages"
@@ -83,6 +84,8 @@ template("flutter_app") {
     args = [
       "--root",
       rebase_path(dart_binary_dir),
+      "--flutter-root",
+      rebase_path(flutter_root),
       "--dart",
       rebase_path(dart_binary),
       "--flutter-tools-packages",

--- a/build/package.py
+++ b/build/package.py
@@ -14,6 +14,8 @@ def main():
 
   parser.add_argument('--root', type=str, required=True,
                       help='The root of the output directory')
+  parser.add_argument('--flutter-root', type=str, required=True,
+                      help='The root of the Flutter SDK')
   parser.add_argument('--dart', type=str, required=True,
                       help='The Dart binary to use')
   parser.add_argument('--flutter-tools-packages', type=str, required=True,
@@ -41,6 +43,7 @@ def main():
 
   env = os.environ.copy()
   env['LD_LIBRARY_PATH'] = args.root
+  env['FLUTTER_ROOT'] = args.flutter_root
 
   result = subprocess.call([
     args.dart,


### PR DESCRIPTION
We need to pass the FLUTTER_ROOT to the flutter_tools so that it can find
resources such as the schema for flutter.yaml.