### PR TITLE
Fix breaking builds because of Skia roll.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -57,7 +57,7 @@ deps = {
    Var('fuchsia_git') + '/ftl' + '@' + '5e9935c7205c119ce05098dc1d9c8eaac0595ba4',
 
   'src/lib/tonic':
-   Var('fuchsia_git') + '/tonic' + '@' + '5ca4053563027007ef2e7b2892efe63c26d30259',
+   Var('fuchsia_git') + '/tonic' + '@' + 'ba6d0c08d694ba0c4cdc400b763be21f9bd1d8d2',
 
   'src/lib/zip':
    Var('fuchsia_git') + '/zip' + '@' + '92dc87ca645fe8e9f5151ef6dac86d8311a7222f',

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -115,6 +115,8 @@ config("skia_library_config") {
     "//third_party/skia/src/gpu",
   ]
 
+  include_dirs += gypi_skia_sources.sksl_include_dirs
+
   if (is_mac || is_ios) {
     include_dirs += [ "//third_party/skia/include/utils/mac" ]
   }
@@ -230,6 +232,7 @@ component("skia") {
   sources += gypi_skia_core.sources
   sources += gypi_skia_effects.sources
   sources += gypi_skia_sources.utils_sources
+  sources += gypi_skia_sources.sksl_sources
 
   sources += [
     "//third_party/skia/src/codec/SkAndroidCodec.cpp",


### PR DESCRIPTION
* Update skia/BUILD to pull in missing header include paths and files.
* Update the tonic dep to pull in partial template specialization for enums.