### PR TITLE
Add hsw_sources from Skia opts to fix missing symbol issue.

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -524,6 +524,8 @@ source_set("skia_opts") {
     assert(false, "Need to port cpu specific stuff from skia_library_opts.gyp")
   }
 
+  sources += gypi_skia_opts.hsw_sources
+
   if (is_android && !is_debug) {
     configs -= [ "//build/config/compiler:optimize" ]
     configs += [ "//build/config/compiler:optimize_max" ]


### PR DESCRIPTION
This fixes host builds as well. The previous fix addressed device builds but I failed to test the host.