### PR TITLE
Fix the use of depfile in flutter_app GN template

### DIFF
--- a/build/flutter_app.gni
+++ b/build/flutter_app.gni
@@ -63,7 +63,9 @@ template("flutter_app") {
 
   main_dart = invoker.main_dart
 
-  action(target_name) {
+  flutter_snapshot_name = target_name + "_snapshot"
+
+  action(flutter_snapshot_name) {
     depfile = depfile_path
 
     inputs = [
@@ -71,13 +73,51 @@ template("flutter_app") {
     ]
 
     outputs = [
-      bundle_path,
       snapshot_path,
     ]
 
     if (defined(invoker.sources)) {
       sources = invoker.sources
     }
+
+    script = "//flutter/build/snapshot.py"
+
+    args = [
+      "--snapshotter-path",
+      rebase_path(flutter_snapshot),
+      "--app-dir",
+      rebase_path("."),
+      "--main-dart",
+      rebase_path(main_dart),
+      "--packages",
+      rebase_path(dot_packages),
+      "--snapshot",
+      rebase_path(snapshot_path),
+      "--depfile",
+      rebase_path(depfile_path),
+      "--build-output",
+      rebase_path(snapshot_path, root_build_dir),
+
+    ]
+
+    deps = [
+      ":$dart_package_name",
+      flutter_snapshot_label,
+    ]
+
+    if (defined(invoker.deps)) {
+      deps += invoker.deps
+    }
+  }
+
+  action(target_name) {
+    inputs = [
+      snapshot_path,
+    ]
+
+    outputs = [
+      bundle_path,
+    ]
 
     script = "//flutter/build/package.py"
 
@@ -92,33 +132,22 @@ template("flutter_app") {
       rebase_path(flutter_tools_packages),
       "--flutter-tools-main",
       rebase_path(flutter_tools_main),
-      "--snapshotter-path",
-      rebase_path(flutter_snapshot),
       "--working-dir",
       rebase_path("$target_gen_dir/build"),
       "--app-dir",
       rebase_path("."),
-      "--main-dart",
-      rebase_path(main_dart),
       "--packages",
       rebase_path(dot_packages),
       "--output-file",
       rebase_path(bundle_path),
       "--snapshot",
       rebase_path(snapshot_path),
-      "--depfile",
-      rebase_path(depfile_path),
     ]
 
     deps = [
-      ":$dart_package_name",
+      ":$flutter_snapshot_name",
       dart_binary_label,
-      flutter_snapshot_label,
       flutter_tools_label,
     ]
-
-    if (defined(invoker.deps)) {
-      deps += invoker.deps
-    }
   }
 }

--- a/build/package.py
+++ b/build/package.py
@@ -22,20 +22,14 @@ def main():
                       help='The package map for the Flutter tool')
   parser.add_argument('--flutter-tools-main', type=str, required=True,
                       help='The main.dart file for the Flutter tool')
-  parser.add_argument('--snapshotter-path', type=str, required=True,
-                      help='The Flutter snapshotter')
   parser.add_argument('--working-dir', type=str, required=True,
                       help='The directory where to put intermediate files')
   parser.add_argument('--app-dir', type=str, required=True,
                       help='The root of the app')
-  parser.add_argument('--main-dart', type=str, required=True,
-                      help='The main.dart file to use')
   parser.add_argument('--packages', type=str, required=True,
                       help='The package map to use')
   parser.add_argument('--snapshot', type=str, required=True,
                       help='Path to application snapshot')
-  parser.add_argument('--depfile', type=str, required=True,
-                      help='Where to output dependency information')
   parser.add_argument('--output-file', type=str, required=True,
                       help='Where to output application bundle')
 
@@ -49,12 +43,9 @@ def main():
     args.dart,
     '--packages=%s' % args.flutter_tools_packages,
     args.flutter_tools_main,
-    '--snapshotter-path=%s' % args.snapshotter_path,
     '--working-dir=%s' % args.working_dir,
-    '--target=%s' % args.main_dart,
     '--packages=%s' % args.packages,
     '--snapshot=%s' % args.snapshot,
-    '--depfile=%s' % args.depfile,
     '--output-file=%s' % args.output_file,
     '--header=#!mojo mojo:flutter_content_handler',
   ], env=env, cwd=args.app_dir)

--- a/build/snapshot.py
+++ b/build/snapshot.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import subprocess
+import os
+import sys
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Snapshot a Flutter application')
+
+  parser.add_argument('--snapshotter-path', type=str, required=True,
+                      help='The Flutter snapshotter')
+  parser.add_argument('--app-dir', type=str, required=True,
+                      help='The root of the app')
+  parser.add_argument('--main-dart', type=str, required=True,
+                      help='The main.dart file to use')
+  parser.add_argument('--packages', type=str, required=True,
+                      help='The package map to use')
+  parser.add_argument('--snapshot', type=str, required=True,
+                      help='Path to application snapshot')
+  parser.add_argument('--depfile', type=str, required=True,
+                      help='Where to output dependency information')
+  parser.add_argument('--build-output', type=str, required=True,
+                      help='Target name used in the depfile')
+
+  args = parser.parse_args()
+
+  result = subprocess.call([
+    args.snapshotter_path,
+    '--packages=%s' % args.packages,
+    '--snapshot=%s' % args.snapshot,
+    '--depfile=%s' % args.depfile,
+    '--build-output=%s' % args.build_output,
+    args.main_dart,
+  ], cwd=args.app_dir)
+
+  return result
+
+
+if __name__ == '__main__':
+  sys.exit(main())


### PR DESCRIPTION
This fixes two issues, both related to the use of depfile in the
flutter_app GN template: bundle_path shouldn't be listed in outputs
since it's not specified in the depfile generated by Dart, and the
snapshot file path has to be relative to the build directory to
ensure that the path in the generated depfile is relative.
