### PR TITLE
Create compile_commands.json on each GN invocation and add a YCM conf.

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -1,0 +1,60 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import os
+import ycm_core
+
+compile_commands_dir = os.path.normpath(os.path.dirname(os.path.abspath(__file__)) + '/../out')
+
+if os.path.exists(compile_commands_dir):
+  compilation_db = ycm_core.CompilationDatabase(compile_commands_dir)
+else:
+  compilation_db = None
+
+path_flags = [
+  '--sysroot=',
+  '-I',
+  '-iquote',
+  '-isystem',
+]
+
+def MakeFlagAbsolute(working_dir, flag):
+  # Check if its a flag that contains a path. (an ite, in the path_flags)
+  for path_flag in path_flags:
+    if flag.startswith(path_flag):
+      path_component = flag[len(path_flag):]
+      return path_flag + os.path.join(working_dir, path_component)
+
+  # Check if its a regular flag that does not contain a path. (defines, warnings, etc..)
+  if flag.startswith('-'):
+    return flag
+
+  # The file path is directly specified. (compiler, input, output, etc..)
+  return os.path.join(working_dir, flag)
+
+
+def MakeFlagsAbsolute(working_dir, flags):
+  if not working_dir:
+    return list(flags)
+
+  updated_flags = []
+
+  for flag in flags:
+    updated_flags.append(MakeFlagAbsolute(working_dir, flag))
+
+  return updated_flags
+
+empty_flags = { 'flags' : '' }
+
+def FlagsForFile(filename, **kwargs):
+  if not compilation_db:
+    return empty_flags
+
+  info = compilation_db.GetCompilationInfoForFile(filename)
+
+  if not info:
+    return empty_flags
+
+  return { 'flags' : MakeFlagsAbsolute(info.compiler_working_dir_,
+                                       info.compiler_flags_) }

--- a/tools/gn
+++ b/tools/gn
@@ -163,8 +163,27 @@ def main(argv):
   print "gn gen --check in %s" % out_dir
   command.append(out_dir)
   command.append('--args=%s' % ' '.join(gn_args))
-  return subprocess.call(command, cwd=SRC_ROOT)
+  gn_call_result = subprocess.call(command, cwd=SRC_ROOT)
 
+  if gn_call_result == 0:
+    # Generate/Replace the compile commands database in out.
+    compile_cmd_gen_cmd = [
+      '%s/buildtools/%s/ninja' % (SRC_ROOT, subdir),
+      '-C',
+      out_dir,
+      '-t',
+      'compdb',
+      'cxx',
+      'cc',
+      'mm',
+    ]
+
+    contents = subprocess.check_output(compile_cmd_gen_cmd, cwd=SRC_ROOT)
+    compile_commands = open('%s/out/compile_commands.json' % SRC_ROOT, 'w+')
+    compile_commands.write(contents)
+    compile_commands.close()
+
+  return gn_call_result
 
 if __name__ == '__main__':
     sys.exit(main(sys.argv))


### PR DESCRIPTION
With this patch, if you have setup the [YouCompleteMe daemon](https://github.com/Valloric/ycmd)  and have a plugin installed for your editor (Sublime, Vim, Emacs, Atom, etc..), you should get IDE like behavior (completions, errors displayed inline as you type, "Go To Definition", etc.).

If you re-run GN with a different target, the compile commands will update automatically and your editor should adapt accordingly.

I have been patching this into my workflow. But this is editor/platform agnostic and should not affect anything if your have not setup YCMD. So I propose we add it to the repo.

![screen shot 2016-10-26 at 12 42 19 pm](https://cloud.githubusercontent.com/assets/44085/19742538/57bcdcac-9b7a-11e6-9023-538b6e0ef085.png)
