### PR TITLE
Explicitly tell the platform view to update its backing store.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -14,11 +14,11 @@
 #include "flutter/shell/gpu/gpu_surface_gl.h"
 #include "flutter/shell/platform/darwin/common/platform_mac.h"
 #include "flutter/shell/platform/darwin/common/string_conversions.h"
-#include "flutter/shell/platform/darwin/ios/framework/Source/flutter_touch_mapper.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/flutter_touch_mapper.h"
 #include "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 #include "lib/ftl/functional/make_copyable.h"
 #include "lib/ftl/time/time_delta.h"
@@ -330,10 +330,13 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
 
 - (void)updateViewportMetrics {
   blink::Threads::UI()->PostTask([
-    engine = _platformView->engine().GetWeakPtr(), metrics = _viewportMetrics
+    weak_platform_view = _platformView->GetWeakPtr(), metrics = _viewportMetrics
   ] {
-    if (engine.get())
-      engine->SetViewportMetrics(metrics);
+    if (!weak_platform_view) {
+      return;
+    }
+    weak_platform_view->UpdateSurfaceSize();
+    weak_platform_view->engine().SetViewportMetrics(metrics);
   });
 }
 

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -38,6 +38,10 @@ class PlatformViewIOS : public PlatformView, public GPUSurfaceGLDelegate {
     return platform_message_router_;
   }
 
+  ftl::WeakPtr<PlatformViewIOS> GetWeakPtr();
+
+  void UpdateSurfaceSize();
+
   VsyncWaiter* GetVsyncWaiter() override;
 
   bool ResourceContextMakeCurrent() override;
@@ -64,6 +68,7 @@ class PlatformViewIOS : public PlatformView, public GPUSurfaceGLDelegate {
   sky::SkyEnginePtr engine_;
   PlatformMessageRouter platform_message_router_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
+  ftl::WeakPtrFactory<PlatformViewIOS> weak_factory_;
 
   void SetupAndLoadFromSource(const std::string& main,
                               const std::string& packages,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/6374
Regressed in https://github.com/flutter/engine/commit/d9d23336863bca886479c417d2a37f2c223251ec

This linked issue was introduced because we didn't want to make the context current per frame. iOS (and other platforms) would update their backing stores on that call. Since the call was removed, so was the correct resizing of the surface's backing store.