### PR TITLE
Add ObjC, ObjCXX and ASM files to the compilation database.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -173,9 +173,11 @@ def main(argv):
       out_dir,
       '-t',
       'compdb',
-      'cxx',
       'cc',
-      'mm',
+      'cxx',
+      'objc',
+      'objcxx',
+      'asm',
     ]
 
     contents = subprocess.check_output(compile_cmd_gen_cmd, cwd=SRC_ROOT)


### PR DESCRIPTION
These map to Ninja rules specified in toolchain.gni.