### PR TITLE
Fix a leak of RenderObjects in Paragraph/ParagraphBuilder

### DIFF
--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -42,9 +42,11 @@ Paragraph::Paragraph(PassOwnPtr<RenderView> renderView)
     : m_renderView(renderView) {}
 
 Paragraph::~Paragraph() {
-  PassOwnPtr<RenderView> renderView = m_renderView.release();
-  Threads::UI()->PostTask(
-      [renderView]() { /* renderView's destructor runs. */ });
+  if (m_renderView) {
+    RenderView* renderView = m_renderView.leakPtr();
+    Threads::UI()->PostTask(
+        [renderView]() { renderView->destroy(); });
+  }
 }
 
 double Paragraph::width() {

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -208,9 +208,11 @@ ParagraphBuilder::ParagraphBuilder(tonic::Int32List& encoded,
 }
 
 ParagraphBuilder::~ParagraphBuilder() {
-  PassOwnPtr<RenderView> renderView = m_renderView.release();
-  Threads::UI()->PostTask(
-      [renderView]() { /* renderView's destructor runs. */ });
+  if (m_renderView) {
+    RenderView* renderView = m_renderView.leakPtr();
+    Threads::UI()->PostTask(
+        [renderView]() { renderView->destroy(); });
+  }
 }
 
 void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,

--- a/runtime/asset_font_selector.cc
+++ b/runtime/asset_font_selector.cc
@@ -186,7 +186,7 @@ PassRefPtr<FontData> AssetFontSelector::getFontData(
                                    font_description.orientation(),
                                    font_description.useSubpixelPositioning());
 
-    font_data = SimpleFontData::create(platform_data);
+    font_data = SimpleFontData::create(platform_data, CustomFontData::create());
     font_platform_data_cache_.set(key, font_data);
   }
 


### PR DESCRIPTION
The RenderView destructor does not delete its descendants.
RenderObject::destroy must be called to delete the object tree along with
other cleanup tasks.

Also associate a CustomFontData with dynamically loaded fonts in order to get
the desired FontDataCache behavior at RenderObject::destroy time.