### PR TITLE
Move SkPicture destruction to the IO thread to fix a GL memory leak

### DIFF
--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -30,6 +30,8 @@ void CanvasImage::RegisterNatives(tonic::DartLibraryNatives* natives) {
 CanvasImage::CanvasImage() {}
 
 CanvasImage::~CanvasImage() {
+  // Skia objects must be deleted on the IO thread so that any associated GL
+  // objects will be cleaned up through the IO thread's GL context.
   SkImage* image = image_.release();
   Threads::IO()->PostTask([image]() { image->unref(); });
 }

--- a/lib/ui/painting/mask_filter.cc
+++ b/lib/ui/painting/mask_filter.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/lib/ui/painting/mask_filter.h"
 
+#include "flutter/common/threads.h"
 #include "lib/tonic/dart_args.h"
 #include "lib/tonic/dart_binding_macros.h"
 #include "lib/tonic/converter/dart_converter.h"
@@ -34,6 +35,11 @@ ftl::RefPtr<MaskFilter> MaskFilter::Create(unsigned style,
 MaskFilter::MaskFilter(sk_sp<SkMaskFilter> filter)
     : filter_(std::move(filter)) {}
 
-MaskFilter::~MaskFilter() {}
+MaskFilter::~MaskFilter() {
+  // Skia objects must be deleted on the IO thread so that any associated GL
+  // objects will be cleaned up through the IO thread's GL context.
+  SkMaskFilter* filter = filter_.release();
+  Threads::IO()->PostTask([filter]() { filter->unref(); });
+}
 
 }  // namespace blink

--- a/lib/ui/painting/shader.cc
+++ b/lib/ui/painting/shader.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/lib/ui/painting/shader.h"
 
+#include "flutter/common/threads.h"
+
 namespace blink {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Shader);
@@ -12,6 +14,10 @@ Shader::Shader(sk_sp<SkShader> shader) : shader_(shader) {
 }
 
 Shader::~Shader() {
+  // Skia objects must be deleted on the IO thread so that any associated GL
+  // objects will be cleaned up through the IO thread's GL context.
+  SkShader* shader = shader_.release();
+  Threads::IO()->PostTask([shader]() { shader->unref(); });
 }
 
 } // namespace blink


### PR DESCRIPTION
An SkPicture may hold a reference to an SkImage backed by a GL texture.
The GL texture is associated with the resource context bound to the IO
thread and must be deleted through that context.