### PR TITLE
Initialize AndroidSurfaceGL and its associated resource context before ANativeWindow acquisition.

### DIFF
--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <utility>
 #include "flutter/shell/platform/android/android_surface_gl.h"
+#include <utility>
 #include "lib/ftl/logging.h"
 #include "lib/ftl/memory/ref_ptr.h"
 
@@ -40,15 +40,28 @@ static ftl::RefPtr<AndroidContextGL> GlobalResourceLoadingContext(
   return global_context;
 }
 
-AndroidSurfaceGL::AndroidSurfaceGL(AndroidNativeWindow window,
-                                   PlatformView::SurfaceConfig onscreen_config,
-                                   PlatformView::SurfaceConfig offscreen_config)
-    : valid_(false) {
+AndroidSurfaceGL::AndroidSurfaceGL(
+    PlatformView::SurfaceConfig offscreen_config) {
   // Acquire the offscreen context.
   offscreen_context_ = GlobalResourceLoadingContext(offscreen_config);
 
   if (!offscreen_context_ || !offscreen_context_->IsValid()) {
-    return;
+    offscreen_context_ = nullptr;
+  }
+}
+
+AndroidSurfaceGL::~AndroidSurfaceGL() = default;
+
+bool AndroidSurfaceGL::SetNativeWindowForOnScreenContext(
+    AndroidNativeWindow window,
+    PlatformView::SurfaceConfig onscreen_config) {
+  // In any case, we want to get rid of our current onscreen context.
+  onscreen_context_ = nullptr;
+
+  // If the offscreen context has not been setup, we dont have the sharegroup.
+  // So bail.
+  if (!offscreen_context_ || !offscreen_context_->IsValid()) {
+    return false;
   }
 
   // Create the onscreen context.
@@ -57,51 +70,53 @@ AndroidSurfaceGL::AndroidSurfaceGL(AndroidNativeWindow window,
       offscreen_context_.get() /* sharegroup */);
 
   if (!onscreen_context_->IsValid()) {
-    return;
+    onscreen_context_ = nullptr;
+    return false;
   }
 
-  // All done.
-  valid_ = true;
+  return true;
 }
 
-AndroidSurfaceGL::~AndroidSurfaceGL() = default;
-
 bool AndroidSurfaceGL::IsValid() const {
-  return valid_;
+  if (!onscreen_context_ || !offscreen_context_) {
+    return false;
+  }
+
+  return onscreen_context_->IsValid() && offscreen_context_->IsValid();
 }
 
 SkISize AndroidSurfaceGL::OnScreenSurfaceSize() const {
-  FTL_DCHECK(valid_);
+  FTL_DCHECK(onscreen_context_ && onscreen_context_->IsValid());
   return onscreen_context_->GetSize();
 }
 
 bool AndroidSurfaceGL::OnScreenSurfaceResize(const SkISize& size) const {
-  FTL_DCHECK(valid_);
+  FTL_DCHECK(onscreen_context_ && onscreen_context_->IsValid());
   return onscreen_context_->Resize(size);
 }
 
 bool AndroidSurfaceGL::GLOffscreenContextMakeCurrent() {
-  FTL_DCHECK(valid_);
+  FTL_DCHECK(offscreen_context_ && offscreen_context_->IsValid());
   return offscreen_context_->MakeCurrent();
 }
 
 bool AndroidSurfaceGL::GLContextMakeCurrent() {
-  FTL_DCHECK(valid_);
+  FTL_DCHECK(onscreen_context_ && onscreen_context_->IsValid());
   return onscreen_context_->MakeCurrent();
 }
 
 bool AndroidSurfaceGL::GLContextClearCurrent() {
-  FTL_DCHECK(valid_);
+  FTL_DCHECK(onscreen_context_ && onscreen_context_->IsValid());
   return onscreen_context_->ClearCurrent();
 }
 
 bool AndroidSurfaceGL::GLContextPresent() {
-  FTL_DCHECK(valid_);
+  FTL_DCHECK(onscreen_context_ && onscreen_context_->IsValid());
   return onscreen_context_->SwapBuffers();
 }
 
 intptr_t AndroidSurfaceGL::GLContextFBO() const {
-  FTL_DCHECK(valid_);
+  FTL_DCHECK(onscreen_context_ && onscreen_context_->IsValid());
   // The default window bound framebuffer on Android.
   return 0;
 }

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -16,11 +16,13 @@ namespace shell {
 
 class AndroidSurfaceGL : public GPUSurfaceGLDelegate {
  public:
-  AndroidSurfaceGL(AndroidNativeWindow window,
-                   PlatformView::SurfaceConfig onscreen_config,
-                   PlatformView::SurfaceConfig offscreen_config);
+  explicit AndroidSurfaceGL(PlatformView::SurfaceConfig offscreen_config);
 
   ~AndroidSurfaceGL();
+
+  bool SetNativeWindowForOnScreenContext(
+      AndroidNativeWindow window,
+      PlatformView::SurfaceConfig onscreen_config);
 
   bool IsValid() const;
 
@@ -41,7 +43,6 @@ class AndroidSurfaceGL : public GPUSurfaceGLDelegate {
  private:
   ftl::RefPtr<AndroidContextGL> onscreen_context_;
   ftl::RefPtr<AndroidContextGL> offscreen_context_;
-  bool valid_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceGL);
 };

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -316,10 +316,7 @@ void PlatformViewAndroid::SetSemanticsEnabled(JNIEnv* env,
 }
 
 void PlatformViewAndroid::ReleaseSurface() {
-  if (surface_gl_) {
-    NotifyDestroyed();
-    surface_gl_ = nullptr;
-  }
+  NotifyDestroyed();
 }
 
 VsyncWaiter* PlatformViewAndroid::GetVsyncWaiter() {

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -9,10 +9,9 @@
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <sys/types.h>
-
+#include <unistd.h>
 #include <memory>
 #include <utility>
-
 #include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
@@ -65,6 +64,13 @@ class PlatformMessageResponseAndroid : public blink::PlatformMessageResponse {
 PlatformViewAndroid::PlatformViewAndroid()
     : PlatformView(std::make_unique<GPURasterizer>()) {
   CreateEngine();
+
+  // Create the GL surface so that we can setup the resource context.
+  PlatformView::SurfaceConfig offscreen_config;
+  offscreen_config.stencil_bits = 0;
+  surface_gl_ = std::make_unique<AndroidSurfaceGL>(offscreen_config);
+
+  SetupResourceContextOnIOThread();
 }
 
 PlatformViewAndroid::~PlatformViewAndroid() = default;
@@ -87,29 +93,25 @@ void PlatformViewAndroid::SurfaceCreated(JNIEnv* env,
   // Use the default onscreen configuration.
   PlatformView::SurfaceConfig onscreen_config;
 
-  // The offscreen config is the same as the default except we know we don't
-  // need the stencil buffer.
-  PlatformView::SurfaceConfig offscreen_config;
-  offscreen_config.stencil_bits = 0;
-
-  auto surface = std::make_unique<AndroidSurfaceGL>(window, onscreen_config,
-                                                    offscreen_config);
-
-  if (surface->IsValid()) {
-    surface_gl_ = std::move(surface);
-  } else {
+  if (!surface_gl_->SetNativeWindowForOnScreenContext(window,
+                                                      onscreen_config)) {
     LOG(INFO) << "Could not create the OpenGL Android Surface.";
   }
 
   ANativeWindow_release(window);
 
-  auto gl_surface = std::make_unique<GPUSurfaceGL>(surface_gl_.get());
-  NotifyCreated(std::move(gl_surface), [this, backgroundColor] {
-    if (surface_gl_)
-      rasterizer().Clear(backgroundColor, surface_gl_->OnScreenSurfaceSize());
-  });
+  if (!surface_gl_->IsValid()) {
+    return;
+  }
 
-  SetupResourceContextOnIOThread();
+  NotifyCreated(
+      std::make_unique<GPUSurfaceGL>(surface_gl_.get()),  // GPU surface
+      [this, backgroundColor] {
+        if (surface_gl_)
+          rasterizer().Clear(backgroundColor,
+                             surface_gl_->OnScreenSurfaceSize());
+      });
+
   UpdateThreadPriorities();
 }
 


### PR DESCRIPTION
This allows us to create the IO thread context way earlier and service load requests on the same. Before this patch, early lifecycle loads would use the default Skia texture loader instead of the Async texture loader we provide.

Fixes https://github.com/flutter/flutter/issues/6581