### PR TITLE
Fix PipelineProducer traces. Also add back the OnDisplayLink trace on iOS.

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -53,6 +53,7 @@ shared_library("flutter_framework_dylib") {
   deps = [
     "//base:base",
     "//dart/runtime:libdart",
+    "//flutter/glue",
     "//flutter/lib/ui",
     "//flutter/shell/common",
     "//flutter/shell/gpu",

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -11,6 +11,7 @@
 #include <mach/mach_time.h>
 
 #include "flutter/common/threads.h"
+#include "flutter/glue/trace_event.h"
 #include "lib/ftl/logging.h"
 
 @interface VSyncClient : NSObject
@@ -20,6 +21,7 @@
 @implementation VSyncClient {
   CADisplayLink* _displayLink;
   shell::VsyncWaiter::Callback _pendingCallback;
+  bool _traceCounter;
 }
 
 - (instancetype)init {
@@ -44,6 +46,8 @@
 }
 
 - (void)onDisplayLink:(CADisplayLink*)link {
+  _traceCounter = !_traceCounter;
+  TRACE_COUNTER1("flutter", "OnDisplayLink", _traceCounter);
   ftl::TimePoint frame_time = ftl::TimePoint::Now();
   _displayLink.paused = YES;
   auto callback = std::move(_pendingCallback);

--- a/synchronization/pipeline.h
+++ b/synchronization/pipeline.h
@@ -5,13 +5,13 @@
 #ifndef SYNCHRONIZATION_PIPELINE_H_
 #define SYNCHRONIZATION_PIPELINE_H_
 
+#include "flutter/glue/trace_event.h"
+#include "flutter/synchronization/pipeline.h"
+#include "flutter/synchronization/semaphore.h"
+#include "lib/ftl/functional/closure.h"
 #include "lib/ftl/macros.h"
 #include "lib/ftl/memory/ref_counted.h"
 #include "lib/ftl/synchronization/mutex.h"
-#include "lib/ftl/functional/closure.h"
-#include "flutter/synchronization/semaphore.h"
-#include "flutter/synchronization/pipeline.h"
-#include "flutter/glue/trace_event.h"
 
 #include <memory>
 #include <queue>
@@ -74,7 +74,6 @@ class Pipeline : public ftl::RefCountedThreadSafe<Pipeline<R>> {
 
     ProducerContinuation(Continuation continuation, size_t trace_id)
         : continuation_(continuation), trace_id_(trace_id) {
-      TRACE_EVENT_ASYNC_BEGIN0("flutter", "PipelineItem", trace_id_);
       TRACE_EVENT_ASYNC_BEGIN0("flutter", "PipelineProduce", trace_id_);
     }
 
@@ -128,8 +127,6 @@ class Pipeline : public ftl::RefCountedThreadSafe<Pipeline<R>> {
     }
 
     empty_.Signal();
-
-    TRACE_EVENT_ASYNC_END0("flutter", "PipelineItem", trace_id);
 
     return items_count > 0 ? PipelineConsumeResult::MoreAvailable
                            : PipelineConsumeResult::Done;


### PR DESCRIPTION
I removed the unused PipelineItemTrace.

@yjbanov: You should be able to now depend on PipelineProducer for ui_thread profiling and PipelineConsumer for gpu_thread profiling.