### PR TITLE
Randomize the color of the checkerboard pattern per raster cache entry.

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -4,6 +4,8 @@
 
 #include "flutter/flow/raster_cache.h"
 
+#include <stdlib.h>
+
 #include <vector>
 
 #include "flutter/common/threads.h"
@@ -49,13 +51,17 @@ static void DrawCheckerboard(SkCanvas* canvas, const SkRect& rect) {
   // Draw a checkerboard
   canvas->save();
   canvas->clipRect(rect);
-  DrawCheckerboard(canvas, 0x4400FF00, 0x00000000, 12);
+
+  auto checkerboard_color =
+      SkColorSetARGBInline(64, rand() % 256, rand() % 256, rand() % 256);
+
+  DrawCheckerboard(canvas, checkerboard_color, 0x00000000, 12);
   canvas->restore();
 
   // Stroke the drawn area
   SkPaint debugPaint;
-  debugPaint.setStrokeWidth(3);
-  debugPaint.setColor(SK_ColorRED);
+  debugPaint.setStrokeWidth(8);
+  debugPaint.setColor(SkColorSetA(checkerboard_color, 255));
   debugPaint.setStyle(SkPaint::kStroke_Style);
   canvas->drawRect(rect, debugPaint);
 }


### PR DESCRIPTION
This way, we can better visualize different rasterized images in the hierarchy. Also, if a cached entry  is updated in place, we will be able to notice it immediately.
![screen shot 2016-11-10 at 5 19 20 pm](https://cloud.githubusercontent.com/assets/44085/20201022/d45ee35e-a769-11e6-8c72-f727a88de66b.png)
