### PR TITLE
Rasterize pictures along with side effects of filters and apply offset about picture origin.

### DIFF
--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -4,19 +4,30 @@
 
 #include "flutter/flow/layers/picture_layer.h"
 
+#include <utility>
+
 #include "flutter/flow/raster_cache.h"
 #include "lib/ftl/logging.h"
 
 namespace flow {
 
-PictureLayer::PictureLayer() {}
+PictureLayer::PictureLayer() : picture_bounds_(SkRect::MakeEmpty()) {}
 
 PictureLayer::~PictureLayer() {}
 
+void PictureLayer::set_picture(sk_sp<SkPicture> picture,
+                               SkRect picture_bounds) {
+  picture_ = std::move(picture);
+  picture_bounds_ = picture_bounds;
+}
+
 void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   if (auto cache = context->raster_cache) {
-    image_ = cache->GetPrerolledImage(context->gr_context, picture_.get(),
-                                      matrix, is_complex_, will_change_);
+    cached_image_ =
+        cache->GetPrerolledImage(context->gr_context,  // context
+                                 picture_.get(),       // picture to rasterize
+                                 picture_bounds_,      // bounds of the picture
+                                 matrix, is_complex_, will_change_);
   }
 
   context->child_paint_bounds =
@@ -27,14 +38,22 @@ void PictureLayer::Paint(PaintContext& context) {
   FTL_DCHECK(picture_);
 
   TRACE_EVENT1("flutter", "PictureLayer::Paint", "image",
-               image_ ? "prerolled" : "normal");
+               cached_image_ ? "prerolled" : "normal");
 
   SkAutoCanvasRestore save(&context.canvas, true);
   context.canvas.translate(offset_.x(), offset_.y());
 
-  if (image_) {
-    context.canvas.drawImageRect(image_.get(), picture_->cullRect(), nullptr,
-                                 SkCanvas::kFast_SrcRectConstraint);
+  if (cached_image_) {
+    SkImage* image = cached_image_->image().get();
+    const SkRect& image_bounds = cached_image_->bounds();
+    context.canvas.drawImageRect(
+        image,  // image to draw
+        SkRect::MakeWH(image_bounds.width(),
+                       image_bounds.height()),  // source rect
+        image_bounds,                           // dest rect
+        nullptr,                                // paint
+        SkCanvas::kFast_SrcRectConstraint       // constraint
+        );
   } else {
     context.canvas.drawPicture(picture_.get());
   }

--- a/flow/layers/picture_layer.h
+++ b/flow/layers/picture_layer.h
@@ -15,7 +15,7 @@ class PictureLayer : public Layer {
   ~PictureLayer() override;
 
   void set_offset(const SkPoint& offset) { offset_ = offset; }
-  void set_picture(sk_sp<SkPicture> picture) { picture_ = std::move(picture); }
+  void set_picture(sk_sp<SkPicture> picture, SkRect picture_bounds);
 
   void set_is_complex(bool value) { is_complex_ = value; }
   void set_will_change(bool value) { will_change_ = value; }
@@ -28,11 +28,10 @@ class PictureLayer : public Layer {
  private:
   SkPoint offset_;
   sk_sp<SkPicture> picture_;
+  SkRect picture_bounds_;
   bool is_complex_ = false;
   bool will_change_ = false;
-
-  // If we rasterized the picture separately, image_ holds the pixels.
-  sk_sp<SkImage> image_;
+  ftl::RefPtr<RasterCacheImage> cached_image_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(PictureLayer);
 };

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -192,7 +192,7 @@ void SceneBuilder::addPicture(double dx,
 
   std::unique_ptr<flow::PictureLayer> layer(new flow::PictureLayer());
   layer->set_offset(SkPoint::Make(dx, dy));
-  layer->set_picture(picture->picture());
+  layer->set_picture(picture->picture(), picture->picture_bounds());
   layer->set_is_complex(!!(hints & 1));
   layer->set_will_change(!!(hints & 2));
   m_currentLayer->Add(std::move(layer));

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -161,18 +161,23 @@ class Canvas : public ftl::RefCountedThreadSafe<Canvas>,
                  const tonic::Float32List& cull_rect);
 
   SkCanvas* canvas() const { return canvas_; }
+  const SkRect& picture_bounds() const { return picture_bounds_; }
+
   void Clear();
   bool IsRecording() const;
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  explicit Canvas(SkCanvas* canvas);
+  explicit Canvas(SkCanvas* canvas, SkRect initial_picture_bounds);
 
   // The SkCanvas is supplied by a call to SkPictureRecorder::beginRecording,
   // which does not transfer ownership.  For this reason, we hold a raw
   // pointer and manually set to null in Clear.
   SkCanvas* canvas_;
+  SkRect picture_bounds_;
+
+  void AccomodatePictureBounds(const SkRect& rect, const SkPaint* paint);
 };
 
 }  // namespace blink

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -6,9 +6,9 @@
 
 #include "flutter/common/threads.h"
 #include "flutter/lib/ui/painting/canvas.h"
+#include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/dart_args.h"
 #include "lib/tonic/dart_binding_macros.h"
-#include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/dart_library_natives.h"
 
 namespace blink {
@@ -19,11 +19,13 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Picture);
 
 DART_BIND_ALL(Picture, FOR_EACH_BINDING)
 
-ftl::RefPtr<Picture> Picture::Create(sk_sp<SkPicture> picture) {
-  return ftl::MakeRefCounted<Picture>(std::move(picture));
+ftl::RefPtr<Picture> Picture::Create(sk_sp<SkPicture> picture,
+                                     SkRect picture_bounds) {
+  return ftl::MakeRefCounted<Picture>(std::move(picture), picture_bounds);
 }
 
-Picture::Picture(sk_sp<SkPicture> picture) : picture_(std::move(picture)) {}
+Picture::Picture(sk_sp<SkPicture> picture, SkRect picture_bounds)
+    : picture_(std::move(picture)), picture_bounds_(picture_bounds) {}
 
 Picture::~Picture() {
   // Skia objects must be deleted on the IO thread so that any associated GL

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -13,7 +13,6 @@ class DartLibraryNatives;
 }  // namespace tonic
 
 namespace blink {
-class Canvas;
 
 class Picture : public ftl::RefCountedThreadSafe<Picture>,
                 public tonic::DartWrappable {
@@ -22,18 +21,21 @@ class Picture : public ftl::RefCountedThreadSafe<Picture>,
 
  public:
   ~Picture() override;
-  static ftl::RefPtr<Picture> Create(sk_sp<SkPicture> picture);
+  static ftl::RefPtr<Picture> Create(sk_sp<SkPicture> picture,
+                                     SkRect picture_bounds);
 
   const sk_sp<SkPicture>& picture() const { return picture_; }
+  const SkRect& picture_bounds() const { return picture_bounds_; }
 
   void dispose();
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  explicit Picture(sk_sp<SkPicture> picture);
+  explicit Picture(sk_sp<SkPicture> picture, SkRect picture_bounds);
 
   sk_sp<SkPicture> picture_;
+  SkRect picture_bounds_;
 };
 
 }  // namespace blink

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -6,9 +6,9 @@
 
 #include "flutter/lib/ui/painting/canvas.h"
 #include "flutter/lib/ui/painting/picture.h"
+#include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/dart_args.h"
 #include "lib/tonic/dart_binding_macros.h"
-#include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/dart_library_natives.h"
 
 namespace blink {
@@ -50,8 +50,8 @@ SkCanvas* PictureRecorder::BeginRecording(SkRect bounds) {
 ftl::RefPtr<Picture> PictureRecorder::endRecording() {
   if (!isRecording())
     return nullptr;
-  ftl::RefPtr<Picture> picture =
-      Picture::Create(picture_recorder_.finishRecordingAsPicture());
+  ftl::RefPtr<Picture> picture = Picture::Create(
+      picture_recorder_.finishRecordingAsPicture(), canvas_->picture_bounds());
   canvas_->Clear();
   canvas_->ClearDartWrapper();
   canvas_ = nullptr;


### PR DESCRIPTION
** Not for commit as-is. If this approach is accepted, will add `AccomodatePictureBounds` to all canvas entry points. **

As we build up the picture to be displayed in a picture layer, the effects of filters, strokes, paints before the origin, etc. are recorded in `picture_bounds`. If the raster cache decides that the picture is suitable for rasterization, rasterization takes place in a backing store large enough to accomodate the effects not included in the picture's cull rect. Any offsets about the origin are correctly recorded and take effect when the rasterized image replacement of the picture is draw onto the final onscreen surface.

Updated rasterization shown in https://www.youtube.com/watch?v=5rUGYrZmiWE

Fixes https://github.com/flutter/flutter/issues/5231