### PR TITLE
Specify the Android target_os in the gclient file used by Travis.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -47,9 +47,10 @@ def to_gn_args(args):
     gn_args = {}
 
     # Skia GN args.
-    gn_args['skia_use_dng_sdk'] = False # RAW image handling.
-    gn_args['skia_use_sfntly'] = False  # PDF handling.
-    gn_args['skia_use_libwebp'] = False # Needs third_party/libwebp.
+    gn_args['skia_use_dng_sdk'] = False    # RAW image handling.
+    gn_args['skia_use_sfntly'] = False     # PDF handling.
+    gn_args['skia_use_libwebp'] = False    # Needs third_party/libwebp.
+    gn_args['skia_use_fontconfig'] = False # Enabled on Linux.
 
     gn_args['is_debug'] = args.unoptimized
     gn_args['android_full_debug'] = args.target_os == 'android' and args.unoptimized

--- a/travis/gclient
+++ b/travis/gclient
@@ -5,3 +5,5 @@ solutions = [{
   "managed"     : False,
   "safesync_url": "",
 }]
+
+target_os = ["android"]


### PR DESCRIPTION
None of the Android DEPS were being picked up. They are now referenced
but not used by the new Skia BUILD.gn files.