### PR TITLE
Disable profiling by default. Allow enabling via --enable-dart-profiling.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -20,6 +20,7 @@ struct Settings {
   bool start_paused = false;
   bool trace_startup = false;
   bool endless_trace_buffer = false;
+  bool enable_dart_profiling = false;
   std::string aot_snapshot_path;
   std::string aot_isolate_snapshot_file_name;
   std::string aot_vm_isolate_snapshot_file_name;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -144,6 +144,8 @@ void Shell::InitStandalone(std::string icu_data_path) {
     }
   }
   settings.start_paused = command_line.HasSwitch(switches::kStartPaused);
+  settings.enable_dart_profiling =
+      command_line.HasSwitch(switches::kEnableDartProfiling);
   settings.endless_trace_buffer =
       command_line.HasSwitch(switches::kEndlessTraceBuffer);
   settings.trace_startup = command_line.HasSwitch(switches::kTraceStartup);

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -18,6 +18,7 @@ const char kCacheDirPath[] = "cache-dir-path";
 const char kDartFlags[] = "dart-flags";
 const char kDeviceObservatoryPort[] = "observatory-port";
 const char kDisableObservatory[] = "disable-observatory";
+const char kEnableDartProfiling[] = "enable-dart-profiling";
 const char kEndlessTraceBuffer[] = "endless-trace-buffer";
 const char kFLX[] = "flx";
 const char kHelp[] = "help";

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -19,6 +19,7 @@ extern const char kCacheDirPath[];
 extern const char kDartFlags[];
 extern const char kDeviceObservatoryPort[];
 extern const char kDisableObservatory[];
+extern const char kEnableDartProfiling[];
 extern const char kEndlessTraceBuffer[];
 extern const char kFLX[];
 extern const char kHelp[];


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/6904