### PR TITLE
Use a custom Skia font manager that delegates to FontCacheLinux on Linux.

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -22,6 +22,9 @@ executable("linux") {
     "//lib/ftl",
     "//third_party/glfw",
     "//third_party/skia",
+    # Required by FontCacheLinux. Not Skia. Skia uses a custom font manager
+    # that delegates to us.
+    "//third_party:fontconfig",
   ]
 
   ldflags = [

--- a/tools/gn
+++ b/tools/gn
@@ -47,9 +47,10 @@ def to_gn_args(args):
     gn_args = {}
 
     # Skia GN args.
-    gn_args['skia_use_dng_sdk'] = False # RAW image handling.
-    gn_args['skia_use_sfntly'] = False  # PDF handling.
-    gn_args['skia_use_libwebp'] = False # Needs third_party/libwebp.
+    gn_args['skia_use_dng_sdk'] = False    # RAW image handling.
+    gn_args['skia_use_sfntly'] = False     # PDF handling.
+    gn_args['skia_use_libwebp'] = False    # Needs third_party/libwebp.
+    gn_args['skia_use_fontconfig'] = False # Use the custom font manager instead.
 
     gn_args['is_debug'] = args.unoptimized
     gn_args['android_full_debug'] = args.target_os == 'android' and args.unoptimized


### PR DESCRIPTION
This should fix Linux host shell issues reported in https://github.com/flutter/flutter/pull/6927