### PR TITLE
Fix Mozart blends of child views

### DIFF
--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -19,6 +19,13 @@ void ChildSceneLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   transform_.preTranslate(offset_.x(), offset_.y());
   float inverse_device_pixel_ratio = 1.f / device_pixel_ratio_;
   transform_.preScale(inverse_device_pixel_ratio, inverse_device_pixel_ratio);
+
+  SkRect bounds = SkRect::MakeXYWH(
+    offset_.x(), offset_.y(),
+    physical_size_.width() * inverse_device_pixel_ratio,
+    physical_size_.height() * inverse_device_pixel_ratio);
+  set_paint_bounds(bounds);
+  context->child_paint_bounds = bounds;
 }
 
 void ChildSceneLayer::Paint(PaintContext& context) {

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -23,6 +23,7 @@ void OpacityLayer::UpdateScene(SceneUpdateContext& context,
   node->op = mozart::NodeOp::New();
   node->op->set_layer(mozart::LayerNodeOp::New());
   node->op->get_layer()->layer_rect = mozart::RectF::From(paint_bounds());
+  node->op->get_layer()->blend = mozart::Blend::New();
   node->op->get_layer()->blend->alpha = alpha_;
   UpdateSceneChildrenInsideNode(context, container, std::move(node));
 }


### PR DESCRIPTION
We need to compute the paint bounds of ChildViewLayers during Preroll.
Also, we need to allocate a BlendPtr before writing into it.