### PR TITLE
Rework switches in the shell so that they display help text for all flags.

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -126,13 +126,15 @@ void Shell::InitStandalone(std::string icu_data_path) {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
 
   blink::Settings settings;
+
   // Enable Observatory
   settings.enable_observatory =
-      !command_line.HasSwitch(switches::kDisableObservatory);
+      !command_line.HasSwitch(FlagForSwitch(Switch::DisableObservatory));
+
   // Set Observatory Port
-  if (command_line.HasSwitch(switches::kDeviceObservatoryPort)) {
-    auto port_string =
-        command_line.GetSwitchValueASCII(switches::kDeviceObservatoryPort);
+  if (command_line.HasSwitch(FlagForSwitch(Switch::DeviceObservatoryPort))) {
+    auto port_string = command_line.GetSwitchValueASCII(
+        FlagForSwitch(Switch::DeviceObservatoryPort));
     std::stringstream stream(port_string);
     uint32_t port = 0;
     if (stream >> port) {
@@ -143,28 +145,40 @@ void Shell::InitStandalone(std::string icu_data_path) {
           << settings.observatory_port;
     }
   }
-  settings.start_paused = command_line.HasSwitch(switches::kStartPaused);
-  settings.enable_dart_profiling =
-      command_line.HasSwitch(switches::kEnableDartProfiling);
-  settings.endless_trace_buffer =
-      command_line.HasSwitch(switches::kEndlessTraceBuffer);
-  settings.trace_startup = command_line.HasSwitch(switches::kTraceStartup);
-  settings.aot_snapshot_path =
-      command_line.GetSwitchValueASCII(switches::kAotSnapshotPath);
-  settings.aot_isolate_snapshot_file_name =
-      command_line.GetSwitchValueASCII(switches::kAotIsolateSnapshot);
-  settings.aot_vm_isolate_snapshot_file_name =
-      command_line.GetSwitchValueASCII(switches::kAotVmIsolateSnapshot);
-  settings.aot_instructions_blob_file_name =
-      command_line.GetSwitchValueASCII(switches::kAotInstructionsBlob);
-  settings.aot_rodata_blob_file_name =
-      command_line.GetSwitchValueASCII(switches::kAotRodataBlob);
-  settings.temp_directory_path =
-      command_line.GetSwitchValueASCII(switches::kCacheDirPath);
 
-  if (command_line.HasSwitch(switches::kDartFlags)) {
+  settings.start_paused =
+      command_line.HasSwitch(FlagForSwitch(Switch::StartPaused));
+
+  settings.enable_dart_profiling =
+      command_line.HasSwitch(FlagForSwitch(Switch::EnableDartProfiling));
+
+  settings.endless_trace_buffer =
+      command_line.HasSwitch(FlagForSwitch(Switch::EndlessTraceBuffer));
+
+  settings.trace_startup =
+      command_line.HasSwitch(FlagForSwitch(Switch::TraceStartup));
+
+  settings.aot_snapshot_path =
+      command_line.GetSwitchValueASCII(FlagForSwitch(Switch::AotSnapshotPath));
+
+  settings.aot_isolate_snapshot_file_name = command_line.GetSwitchValueASCII(
+      FlagForSwitch(Switch::AotIsolateSnapshot));
+
+  settings.aot_vm_isolate_snapshot_file_name = command_line.GetSwitchValueASCII(
+      FlagForSwitch(Switch::AotVmIsolateSnapshot));
+
+  settings.aot_instructions_blob_file_name = command_line.GetSwitchValueASCII(
+      FlagForSwitch(Switch::AotInstructionsBlob));
+
+  settings.aot_rodata_blob_file_name =
+      command_line.GetSwitchValueASCII(FlagForSwitch(Switch::AotRodataBlob));
+
+  settings.temp_directory_path =
+      command_line.GetSwitchValueASCII(FlagForSwitch(Switch::CacheDirPath));
+
+  if (command_line.HasSwitch(FlagForSwitch(Switch::DartFlags))) {
     std::stringstream stream(
-        command_line.GetSwitchValueNative(switches::kDartFlags));
+        command_line.GetSwitchValueNative(FlagForSwitch(Switch::DartFlags)));
     std::istream_iterator<std::string> end;
     for (std::istream_iterator<std::string> it(stream); it != end; ++it)
       settings.dart_flags.push_back(*it);

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -2,45 +2,89 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+// Include once for the default enum definition.
 #include "flutter/shell/common/switches.h"
 
-#include <iostream>
+#undef SHELL_COMMON_SWITCHES_H_
+
+struct SwitchDesc {
+  shell::Switch sw;
+  const char* flag;
+  const char* help;
+};
+
+#undef DEF_SWITCHES_START
+#undef DEF_SWITCH
+#undef DEF_SWITCHES_END
+
+// clang-format off
+#define DEF_SWITCHES_START static const struct SwitchDesc gSwitchDescs[] = {
+#define DEF_SWITCH(p_swtch, p_flag, p_help) \
+  { .sw = shell::Switch:: p_swtch, .flag = p_flag, .help = p_help },
+#define DEF_SWITCHES_END };
+// clang-format on
+
+// Include again for struct definition.
+#include "flutter/shell/common/switches.h"
 
 namespace shell {
-namespace switches {
-
-const char kAotInstructionsBlob[] = "instructions-blob";
-const char kAotIsolateSnapshot[] = "isolate-snapshot";
-const char kAotRodataBlob[] = "rodata-blob";
-const char kAotSnapshotPath[] = "aot-snapshot-path";
-const char kAotVmIsolateSnapshot[] = "vm-isolate-snapshot";
-const char kCacheDirPath[] = "cache-dir-path";
-const char kDartFlags[] = "dart-flags";
-const char kDeviceObservatoryPort[] = "observatory-port";
-const char kDisableObservatory[] = "disable-observatory";
-const char kEnableDartProfiling[] = "enable-dart-profiling";
-const char kEndlessTraceBuffer[] = "endless-trace-buffer";
-const char kFLX[] = "flx";
-const char kHelp[] = "help";
-const char kMainDartFile[] = "dart-main";
-const char kNonInteractive[] = "non-interactive";
-const char kNoRedirectToSyslog[] = "no-redirect-to-syslog";
-const char kPackages[] = "packages";
-const char kStartPaused[] = "start-paused";
-const char kTraceStartup[] = "trace-startup";
 
 void PrintUsage(const std::string& executable_name) {
-  // clang-format off
-  std::cerr << "Usage: " << executable_name
-            << " --" << kNonInteractive
-            << " --" << kStartPaused
-            << " --" << kTraceStartup
-            << " --" << kFLX << "=FLX"
-            << " --" << kPackages << "=PACKAGES"
-            << " --" << kDeviceObservatoryPort << "=8181"
-            << " [ MAIN_DART ]" << std::endl;
-  // clang-format on
+  std::cerr << std::endl << "  " << executable_name << std::endl << std::endl;
+
+  std::cerr << "Available Flags:" << std::endl;
+
+  const uint32_t column_width = 80;
+
+  const uint32_t flags_count = static_cast<uint32_t>(Switch::Sentinel);
+
+  uint32_t max_width = 2;
+  for (uint32_t i = 0; i < flags_count; i++) {
+    auto desc = gSwitchDescs[i];
+    max_width = std::max<uint32_t>(strlen(desc.flag) + 2, max_width);
+  }
+
+  const uint32_t help_width = column_width - max_width - 3;
+
+  std::cerr << std::string(column_width, '-') << std::endl;
+  for (uint32_t i = 0; i < flags_count; i++) {
+    auto desc = gSwitchDescs[i];
+
+    std::cerr << std::setw(max_width)
+              << std::string("--") + std::string(desc.flag) << " : ";
+
+    std::istringstream stream(desc.help);
+    int32_t remaining = help_width;
+
+    std::string word;
+    while (stream >> word && remaining > 0) {
+      remaining -= (word.size() + 1);
+      if (remaining <= 0) {
+        std::cerr << std::endl
+                  << std::string(max_width, ' ') << "   " << word << " ";
+        remaining = help_width;
+      } else {
+        std::cerr << word << " ";
+      }
+    }
+
+    std::cerr << std::endl;
+  }
+  std::cerr << std::string(column_width, '-') << std::endl;
 }
 
-}  // namespace switches
+const char* FlagForSwitch(Switch swtch) {
+  for (uint32_t i = 0; i < static_cast<uint32_t>(Switch::Sentinel); i++) {
+    if (gSwitchDescs[i].sw == swtch) {
+      return gSwitchDescs[i].flag;
+    }
+  }
+  return nullptr;
+}
+
 }  // namespace shell

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -5,34 +5,80 @@
 #ifndef SHELL_COMMON_SWITCHES_H_
 #define SHELL_COMMON_SWITCHES_H_
 
-#include <string>
-
 namespace shell {
-namespace switches {
 
-extern const char kAotInstructionsBlob[];
-extern const char kAotIsolateSnapshot[];
-extern const char kAotRodataBlob[];
-extern const char kAotSnapshotPath[];
-extern const char kAotVmIsolateSnapshot[];
-extern const char kCacheDirPath[];
-extern const char kDartFlags[];
-extern const char kDeviceObservatoryPort[];
-extern const char kDisableObservatory[];
-extern const char kEnableDartProfiling[];
-extern const char kEndlessTraceBuffer[];
-extern const char kFLX[];
-extern const char kHelp[];
-extern const char kMainDartFile[];
-extern const char kNonInteractive[];
-extern const char kNoRedirectToSyslog[];
-extern const char kPackages[];
-extern const char kStartPaused[];
-extern const char kTraceStartup[];
+// clang-format off
+#ifndef DEF_SWITCHES_START
+#define DEF_SWITCHES_START enum class Switch {
+#endif
+#ifndef DEF_SWITCH
+#define DEF_SWITCH(swtch, flag, help) swtch,
+#endif
+#ifndef DEF_SWITCHES_END
+#define DEF_SWITCHES_END Sentinel, } ;
+#endif
+// clang-format on
+
+DEF_SWITCHES_START
+DEF_SWITCH(AotInstructionsBlob,
+           "instructions-blob",
+           "Path to the instructions snapshot blob.")
+DEF_SWITCH(AotIsolateSnapshot,
+           "isolate-snapshot",
+           "Path to the isolate snapshot blob.")
+DEF_SWITCH(AotRodataBlob, "rodata-blob", "Path to the rodata blob.")
+DEF_SWITCH(AotSnapshotPath, "aot-snapshot-path", "Path to the AOT snapshot.")
+DEF_SWITCH(AotVmIsolateSnapshot,
+           "vm-isolate-snapshot",
+           "Path to the VM isolate snapshot.")
+DEF_SWITCH(CacheDirPath, "cache-dir-path", "Path to the cache directory.")
+DEF_SWITCH(DartFlags,
+           "dart-flags",
+           "Flags passed directly to the Dart VM without being interpreted "
+           "by the Flutter shell.")
+DEF_SWITCH(DeviceObservatoryPort,
+           "observatory-port",
+           "A custom Dart Observatory port. The default is 8181.")
+DEF_SWITCH(DisableObservatory,
+           "disable-observatory",
+           "Disable the Dart Observatory. The observatory is never available "
+           "in release mode.")
+DEF_SWITCH(EnableDartProfiling,
+           "enable-dart-profiling",
+           "Enable Dart profiling. Profiling information can be viewed from "
+           "the observatory.")
+DEF_SWITCH(EndlessTraceBuffer,
+           "endless-trace-buffer",
+           "Enable an endless trace buffer. The default is a ring buffer. "
+           "This is useful when very old events need to viewed. For example, "
+           "during application launch. Memory usage will continue to grow "
+           "indefinitely however.")
+DEF_SWITCH(FLX, "flx", "Specify the the FLX path.")
+DEF_SWITCH(Help, "help", "Display this help text.")
+DEF_SWITCH(MainDartFile, "dart-main", "The path to the main Dart file.")
+DEF_SWITCH(NonInteractive,
+           "non-interactive",
+           "Make the shell non-interactive. By default, the shell attempts "
+           "to setup a window and create an OpenGL context.")
+DEF_SWITCH(NoRedirectToSyslog,
+           "no-redirect-to-syslog",
+           "On iOS: Don't redirect stdout and stderr to syslog by default. "
+           "This is used by the tools to read device logs. However, this can "
+           "cause logs to not show up when launched from Xcode.")
+DEF_SWITCH(Packages, "packages", "Specify the path to the packages.")
+DEF_SWITCH(StartPaused,
+           "start-paused",
+           "Start the application paused in the Dart debugger.")
+DEF_SWITCH(TraceStartup,
+           "trace-startup",
+           "Trace early application lifecycle. Automatically switches to an "
+           "endless trace buffer.")
+DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);
 
-}  // namespace switches
+const char* FlagForSwitch(Switch sw);
+
 }  // namespace shell
 
 #endif  // SHELL_COMMON_SWITCHES_H_

--- a/shell/platform/darwin/common/platform_mac.mm
+++ b/shell/platform/darwin/common/platform_mac.mm
@@ -17,8 +17,8 @@
 #include "base/message_loop/message_loop.h"
 #include "base/trace_event/trace_event.h"
 #include "dart/runtime/include/dart_tools_api.h"
-#include "flutter/runtime/start_up.h"
 #include "flutter/common/threads.h"
+#include "flutter/runtime/start_up.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/common/tracing_controller.h"
@@ -39,7 +39,7 @@ static void InitializeLogging() {
 static void RedirectIOConnectionsToSyslog() {
 #if TARGET_OS_IPHONE
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          shell::switches::kNoRedirectToSyslog)) {
+          FlagForSwitch(Switch::NoRedirectToSyslog))) {
     return;
   }
 
@@ -68,7 +68,7 @@ class EmbedderState {
     InitializeLogging();
 
     base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
-    if (command_line.HasSwitch(shell::switches::kTraceStartup)) {
+    if (command_line.HasSwitch(FlagForSwitch(Switch::TraceStartup))) {
       // Usually, all tracing within flutter is managed via the tracing
       // controller
       // The tracing controller is accessed via the shell instance. This means
@@ -167,23 +167,26 @@ bool AttemptLaunchFromCommandLineSwitches(Engine* engine) {
 
   auto command_line = *base::CommandLine::ForCurrentProcess();
 
-  if (command_line.HasSwitch(switches::kFLX) ||
-      command_line.HasSwitch(switches::kMainDartFile) ||
-      command_line.HasSwitch(switches::kPackages)) {
+  if (command_line.HasSwitch(FlagForSwitch(Switch::FLX)) ||
+      command_line.HasSwitch(FlagForSwitch(Switch::MainDartFile)) ||
+      command_line.HasSwitch(FlagForSwitch(Switch::Packages))) {
     // The main dart file, flx bundle and the package root must be specified in
     // one go. We dont want to end up in a situation where we take one value
     // from the command line and the others from user defaults. In case, any
     // new flags are specified, forget about all the old ones.
-    [defaults removeObjectForKey:@(switches::kFLX)];
-    [defaults removeObjectForKey:@(switches::kMainDartFile)];
-    [defaults removeObjectForKey:@(switches::kPackages)];
+    [defaults removeObjectForKey:@(FlagForSwitch(Switch::FLX))];
+    [defaults removeObjectForKey:@(FlagForSwitch(Switch::MainDartFile))];
+    [defaults removeObjectForKey:@(FlagForSwitch(Switch::Packages))];
 
     [defaults synchronize];
   }
 
-  std::string bundle_path = ResolveCommandLineLaunchFlag(switches::kFLX);
-  std::string main = ResolveCommandLineLaunchFlag(switches::kMainDartFile);
-  std::string packages = ResolveCommandLineLaunchFlag(switches::kPackages);
+  std::string bundle_path =
+      ResolveCommandLineLaunchFlag(FlagForSwitch(Switch::FLX));
+  std::string main =
+      ResolveCommandLineLaunchFlag(FlagForSwitch(Switch::MainDartFile));
+  std::string packages =
+      ResolveCommandLineLaunchFlag(FlagForSwitch(Switch::Packages));
 
   if (!FlagsValidForCommandLineLaunch(bundle_path, main, packages)) {
     return false;
@@ -192,9 +195,12 @@ bool AttemptLaunchFromCommandLineSwitches(Engine* engine) {
   // Save the newly resolved dart main file and the package root to user
   // defaults so that the next time the user launches the application in the
   // simulator without the tooling, the application boots up.
-  [defaults setObject:@(bundle_path.c_str()) forKey:@(switches::kFLX)];
-  [defaults setObject:@(main.c_str()) forKey:@(switches::kMainDartFile)];
-  [defaults setObject:@(packages.c_str()) forKey:@(switches::kPackages)];
+  [defaults setObject:@(bundle_path.c_str())
+               forKey:@(FlagForSwitch(Switch::FLX))];
+  [defaults setObject:@(main.c_str())
+               forKey:@(FlagForSwitch(Switch::MainDartFile))];
+  [defaults setObject:@(packages.c_str())
+               forKey:@(FlagForSwitch(Switch::Packages))];
 
   [defaults synchronize];
 

--- a/shell/platform/darwin/desktop/main_mac.mm
+++ b/shell/platform/darwin/desktop/main_mac.mm
@@ -35,12 +35,13 @@ int main(int argc, const char* argv[]) {
   shell::PlatformMacMain(argc, argv, "");
 
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
-  if (command_line.HasSwitch(shell::switches::kHelp)) {
-    shell::switches::PrintUsage("SkyShell");
+  if (command_line.HasSwitch(shell::FlagForSwitch(shell::Switch::Help))) {
+    shell::PrintUsage([NSProcessInfo processInfo].processName.UTF8String);
     return EXIT_SUCCESS;
   }
 
-  if (command_line.HasSwitch(shell::switches::kNonInteractive)) {
+  if (command_line.HasSwitch(
+          shell::FlagForSwitch(shell::Switch::NonInteractive))) {
     if (!shell::InitForTesting())
       return 1;
     base::MessageLoop::current()->Run();

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -45,7 +45,8 @@ void PlatformViewMac::SetupAndLoadDart() {
 
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
 
-  std::string bundle_path = command_line.GetSwitchValueASCII(switches::kFLX);
+  std::string bundle_path =
+      command_line.GetSwitchValueASCII(FlagForSwitch(Switch::FLX));
   if (!bundle_path.empty()) {
     blink::Threads::UI()->PostTask(
         [ engine = engine().GetWeakPtr(), bundle_path ] {
@@ -59,7 +60,7 @@ void PlatformViewMac::SetupAndLoadDart() {
   if (args.size() > 0) {
     std::string main = args[0];
     std::string packages =
-        command_line.GetSwitchValueASCII(switches::kPackages);
+        command_line.GetSwitchValueASCII(FlagForSwitch(Switch::Packages));
     blink::Threads::UI()->PostTask(
         [ engine = engine().GetWeakPtr(), main, packages ] {
           if (engine)

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -92,7 +92,7 @@ static NSURL* URLForSwitch(const char* name) {
     // Load directly from sources if the appropriate command line flags are
     // specified. If not, try loading from a script snapshot in the framework
     // bundle.
-    NSURL* flxURL = URLForSwitch(shell::switches::kFLX);
+    NSURL* flxURL = URLForSwitch(shell::FlagForSwitch(shell::Switch::FLX));
 
     if (flxURL == nil) {
       // If the URL was not specified on the command line, look inside the
@@ -102,8 +102,10 @@ static NSURL* URLForSwitch(const char* name) {
                      isDirectory:NO];
     }
 
-    NSURL* dartMainURL = URLForSwitch(shell::switches::kMainDartFile);
-    NSURL* dartPackagesURL = URLForSwitch(shell::switches::kPackages);
+    NSURL* dartMainURL =
+        URLForSwitch(shell::FlagForSwitch(shell::Switch::MainDartFile));
+    NSURL* dartPackagesURL =
+        URLForSwitch(shell::FlagForSwitch(shell::Switch::Packages));
 
     return [self initWithFLXArchive:flxURL
                            dartMain:dartMainURL

--- a/shell/platform/linux/main_linux.cc
+++ b/shell/platform/linux/main_linux.cc
@@ -24,7 +24,7 @@ int RunNonInteractive() {
   shell::Shell::InitStandalone();
 
   if (!shell::InitForTesting()) {
-    shell::switches::PrintUsage("sky_shell");
+    shell::PrintUsage("sky_shell");
     return 1;
   }
 
@@ -44,7 +44,8 @@ int RunInteractive() {
 
   shell::Shell::InitStandalone();
 
-  std::string target = command_line.GetSwitchValueASCII(shell::switches::kFLX);
+  std::string target = command_line.GetSwitchValueASCII(
+      shell::FlagForSwitch(shell::Switch::FLX));
 
   if (target.empty()) {
     // Alternatively, use the first positional argument.
@@ -90,12 +91,13 @@ int main(int argc, const char* argv[]) {
 
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
 
-  if (command_line.HasSwitch(shell::switches::kHelp)) {
-    shell::switches::PrintUsage("sky_shell");
+  if (command_line.HasSwitch(shell::FlagForSwitch(shell::Switch::Help))) {
+    shell::PrintUsage("sky_shell");
     return 0;
   }
 
-  if (command_line.HasSwitch(shell::switches::kNonInteractive)) {
+  if (command_line.HasSwitch(
+          shell::FlagForSwitch(shell::Switch::NonInteractive))) {
     return RunNonInteractive();
   }
 

--- a/shell/testing/testing.cc
+++ b/shell/testing/testing.cc
@@ -14,7 +14,8 @@ bool InitForTesting() {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
 
   TestRunner::TestDescriptor test;
-  test.packages = command_line.GetSwitchValueASCII(switches::kPackages);
+  test.packages =
+      command_line.GetSwitchValueASCII(FlagForSwitch(Switch::Packages));
   auto args = command_line.GetArgs();
   if (args.empty())
     return false;


### PR DESCRIPTION
* Now only one file (switches.h) needs to be modified for adding, removing and updating shell flags.
* Help text needs to be specified for every flag (I have added stubs for the flags I don’t fully understand).
![screen shot 2016-11-22 at 3 42 38 pm](https://cloud.githubusercontent.com/assets/44085/20546636/6dbc56c0-b0cb-11e6-8687-d299f2a24013.png)
