### PR TITLE
Remove defunct references to third_party/iccjpeg and third_party/qcms.

### DIFF
--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -39,9 +39,7 @@ static_library("core") {
     "//flutter/sky/engine/wtf",
     "//lib/ftl",
     "//lib/tonic",
-    "//third_party/iccjpeg",
     "//third_party/libpng",
-    "//third_party/qcms",
     "//third_party/skia",
     "//third_party/zlib",
   ]


### PR DESCRIPTION
The same will be removed from buildroot as well.