### PR TITLE
On host targets, add dependencies on host unit test executables.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -17,6 +17,15 @@ group("flutter") {
       "//flutter/snapshotter($host_toolchain)",
     ]
   }
+
+  # If on the host, compile all unittests targets.
+  if (current_toolchain == host_toolchain) {
+    deps += [
+      "//flutter/sky/engine/wtf:wtf_unittests",
+      "//flutter/synchronization:synchronization_unittests",
+      "//lib/ftl:ftl_unittests",
+    ]
+  }
 }
 
 if (!is_fuchsia) {

--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -8,7 +8,6 @@ group("sky") {
   testonly = true
 
   deps = [
-    "//flutter/sky/engine/wtf:unittests($host_toolchain)",
     "//flutter/sky/packages",
   ]
 

--- a/sky/engine/wtf/BUILD.gn
+++ b/sky/engine/wtf/BUILD.gn
@@ -210,9 +210,7 @@ source_set("wtf") {
   }
 }
 
-executable("unittests") {
-  output_name = "flutter_wtf_unittests"
-
+executable("wtf_unittests") {
   testonly = true
 
   sources = [
@@ -252,6 +250,8 @@ executable("unittests") {
 
   deps = [
     ":wtf",
+    # Does not use //flutter/testing because it needs and provides its own main
+    # function in RunAllTests.cpp.
     "//third_party/gtest",
   ]
 }

--- a/synchronization/BUILD.gn
+++ b/synchronization/BUILD.gn
@@ -16,3 +16,14 @@ source_set("synchronization") {
     "//lib/ftl",
   ]
 }
+
+executable("synchronization_unittests") {
+  sources = [
+    "semaphore_unittest.cc",
+  ]
+
+  deps = [
+    ":synchronization",
+    "//flutter/testing",
+  ]
+}

--- a/synchronization/semaphore_unittest.cc
+++ b/synchronization/semaphore_unittest.cc
@@ -1,0 +1,27 @@
+// Copyright 2016 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <thread>
+
+#include "flutter/synchronization/semaphore.h"
+#include "gtest/gtest.h"
+
+TEST(SemaphoreTest, SimpleValidity) {
+  flutter::Semaphore sem(100);
+  ASSERT_TRUE(sem.IsValid());
+}
+
+TEST(SemaphoreTest, WaitOnZero) {
+  flutter::Semaphore sem(0);
+  ASSERT_FALSE(sem.TryWait());
+}
+
+TEST(SemaphoreTest, WaitOnZeroSignalThenWait) {
+  flutter::Semaphore sem(0);
+  ASSERT_FALSE(sem.TryWait());
+  std::thread thread([&sem]() { sem.Signal(); });
+  thread.join();
+  ASSERT_TRUE(sem.TryWait());
+  ASSERT_FALSE(sem.TryWait());
+}

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -1,0 +1,13 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("testing") {
+  sources = [
+    "//flutter/testing/run_all_unittests.cc",
+  ]
+
+  public_deps = [
+    "//third_party/gtest",
+  ]
+}

--- a/testing/run_all_unittests.cc
+++ b/testing/run_all_unittests.cc
@@ -1,0 +1,10 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Towards adding a script that will run on a bot that tests all the executables. I have added FTL and WTF unit test targets. Also, added a test target for flutter/synchronization with basic tests. Will add more such targets as I go through existing code.

WTF unit tests are failing right now however. Trying to figure out these breaks.

A small start towards testing engine components (if only on the host for now).