### PR TITLE
Include internal Dart libraries in sky_engine.

### DIFF
--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -45,6 +45,11 @@ dart_sdk_lib_copy("developer") {
   destination = "$root_gen_dir/dart-pkg/sky_engine/dart_sdk"
 }
 
+dart_sdk_lib_copy("internal") {
+  sdk_lib_name = "internal"
+  destination = "$root_gen_dir/dart-pkg/sky_engine/dart_sdk"
+}
+
 dart_sdk_lib_copy("io") {
   sdk_lib_name = "io"
   destination = "$root_gen_dir/dart-pkg/sky_engine/dart_sdk"
@@ -88,6 +93,7 @@ group("copy_dart_sdk") {
     ":convert",
     ":core",
     ":developer",
+    ":internal",
     ":io",
     ":isolate",
     ":math",

--- a/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/sky/packages/sky_engine/lib/_embedder.yaml
@@ -10,7 +10,11 @@ embedded_libs:
   "dart:math": "../dart_sdk/math/math.dart"
   "dart:typed_data": "../dart_sdk/typed_data/typed_data.dart"
   "dart:ui": "../dart_ui/ui.dart"
-  "dart:_internal": "../dart_sdk/_empty.dart"
+  # The internal library is needed as some implementations bleed into the public
+  # API, e.g. List being Iterable by virtue of implementing
+  # EfficientLengthIterable.
+  # Not including this library yields analysis errors.
+  "dart:_internal": "../dart_sdk/internal/internal.dart"
   "dart:nativewrappers": "../dart_sdk/_empty.dart"
 
 analyzer:


### PR DESCRIPTION
This allows analysis to succeed. Otherwise we're seeing errors on List which does not appear as Iterable in core/list.dart unless one has knownledge of EfficientLengthIterable which is defined in internal/internal.dart.