### PR TITLE
Decorate kDartWriteProtectCodeArgs with FTL_ALLOW_UNUSED_TYPE since it may not be used in all configurations.

### DIFF
--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -90,7 +90,7 @@ static const char* kDartBackgroundCompilationArgs[] = {
     "--background_compilation",
 };
 
-static const char* kDartWriteProtectCodeArgs[] = {
+static const char* kDartWriteProtectCodeArgs[] FTL_ALLOW_UNUSED_TYPE = {
     "--no_write_protect_code",
 };
 
@@ -641,8 +641,7 @@ void InitDartVM() {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // Debug mode uses the JIT, disable code page write protection to avoid
   // memory page protection changes before and after every compilation.
-  PushBackAll(&args,
-              kDartWriteProtectCodeArgs,
+  PushBackAll(&args, kDartWriteProtectCodeArgs,
               arraysize(kDartWriteProtectCodeArgs));
 #endif
 


### PR DESCRIPTION
I didn't want to add the `#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG` guard on the declaration because the author would have to remember to change the guard in two places if it ever did.