### PR TITLE
Fix reference to nib file in SkyShell.app

### DIFF
--- a/shell/platform/darwin/desktop/Info.plist
+++ b/shell/platform/darwin/desktop/Info.plist
@@ -27,7 +27,7 @@
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2015 The Flutter Authors. All rights reserved.</string>
 	<key>NSMainNibFile</key>
-	<string>sky_mac</string>
+	<string>flutter_mac</string>
 	<key>NSPrincipalClass</key>
 	<string>FlutterApplication</string>
 </dict>


### PR DESCRIPTION
Previously you would get an "Unable to load nib file: sky_mac, exiting" error when trying to launch the Mac SkyShell.app on the command line. Now, it works.

Fixes a regression introduced in 6794bc2ad7d0e518a3e34bcd7b042186b351c745