### PR TITLE
Dont override the explicitly set paint bounds in Layer::Preroll.

### DIFF
--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -17,7 +17,9 @@ Layer::Layer()
 Layer::~Layer() = default;
 
 void Layer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  set_paint_bounds(SkRect::MakeEmpty());
+  if (!has_paint_bounds()) {
+    set_paint_bounds(SkRect::MakeEmpty());
+  }
 }
 
 #if defined(OS_FUCHSIA)


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/7257
Regressed in updated for child views rendering in Fuchsia https://github.com/flutter/engine/commit/21f6aa52

Now that I read this again, I don't really like the `has_paint_bounds`/`set_paint_bounds` scheme. I think a simple `join_paint_bounds` on the base layer ought to be enough to handle this bounds management. Will tackle that in a later patch. This patch fixes the performance overlay (which has an explicit paint bounds assignment).