### PR TITLE
Detach the EGL surface from the GPU thread and then destroy it during the FlutterView surfaceDestroyed callback

### DIFF
--- a/shell/common/null_rasterizer.cc
+++ b/shell/common/null_rasterizer.cc
@@ -12,12 +12,17 @@ void NullRasterizer::Setup(
     std::unique_ptr<Surface> surface_or_null,
     ftl::Closure rasterizer_continuation,
     ftl::AutoResetWaitableEvent* setup_completion_event) {
+  surface_ = std::move(surface_or_null);
   rasterizer_continuation();
   setup_completion_event->Signal();
 }
 
 void NullRasterizer::Teardown(
     ftl::AutoResetWaitableEvent* teardown_completion_event) {
+  if (surface_) {
+    surface_->Teardown();
+    surface_.reset();
+  }
   teardown_completion_event->Signal();
 }
 

--- a/shell/common/null_rasterizer.h
+++ b/shell/common/null_rasterizer.h
@@ -32,6 +32,7 @@ class NullRasterizer : public Rasterizer {
 
  private:
   ftl::WeakPtrFactory<NullRasterizer> weak_factory_;
+  std::unique_ptr<Surface> surface_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(NullRasterizer);
 };

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -39,6 +39,8 @@ class Surface {
 
   virtual bool Setup() = 0;
 
+  virtual void Teardown() = 0;
+
   virtual bool IsValid() = 0;
 
   virtual std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) = 0;

--- a/shell/gpu/gpu_rasterizer.cc
+++ b/shell/gpu/gpu_rasterizer.cc
@@ -65,7 +65,10 @@ void GPURasterizer::Clear(SkColor color, const SkISize& size) {
 
 void GPURasterizer::Teardown(
     ftl::AutoResetWaitableEvent* teardown_completion_event) {
-  surface_.reset();
+  if (surface_) {
+    surface_->Teardown();
+    surface_.reset();
+  }
   last_layer_tree_.reset();
   compositor_context_.OnGrContextDestroyed();
   teardown_completion_event->Signal();

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -94,6 +94,10 @@ bool GPUSurfaceGL::Setup() {
   return true;
 }
 
+void GPUSurfaceGL::Teardown() {
+  delegate_->GLContextClearCurrent();
+}
+
 bool GPUSurfaceGL::IsValid() {
   return context_ != nullptr;
 }

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -31,6 +31,8 @@ class GPUSurfaceGL : public Surface {
 
   bool Setup() override;
 
+  void Teardown() override;
+
   bool IsValid() override;
 
   std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) override;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -79,6 +79,10 @@ bool AndroidSurfaceGL::SetNativeWindowForOnScreenContext(
   return true;
 }
 
+void AndroidSurfaceGL::TeardownOnScreenContext() {
+  onscreen_context_ = nullptr;
+}
+
 bool AndroidSurfaceGL::IsValid() const {
   if (!onscreen_context_ || !offscreen_context_) {
     return false;

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -24,6 +24,8 @@ class AndroidSurfaceGL : public GPUSurfaceGLDelegate {
       AndroidNativeWindow window,
       PlatformView::SurfaceConfig onscreen_config);
 
+  void TeardownOnScreenContext();
+
   bool IsValid() const;
 
   SkISize OnScreenSurfaceSize() const;

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -319,6 +319,7 @@ void PlatformViewAndroid::SetSemanticsEnabled(JNIEnv* env,
 
 void PlatformViewAndroid::ReleaseSurface() {
   NotifyDestroyed();
+  surface_gl_->TeardownOnScreenContext();
 }
 
 VsyncWaiter* PlatformViewAndroid::GetVsyncWaiter() {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/7147