### PR TITLE
Make GN generate Xcode projects on Mac.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -161,8 +161,13 @@ def main(argv):
   command = [
     '%s/buildtools/%s/gn' % (SRC_ROOT, subdir),
     'gen',
-    '--check'
+    '--check',
   ]
+
+  if sys.platform == 'darwin':
+    # On the Mac, also generate Xcode projects for ease of editing.
+    command.append('--ide=xcode')
+
   gn_args = to_command_line(to_gn_args(args))
   out_dir = get_out_dir(args)
   print "gn gen --check in %s" % out_dir


### PR DESCRIPTION
Takes only about 80ms per GN run on my machine. So it is pretty fast. And having a fully indexed project makes development much easier. Ninja files are still generated. So there are no changes to the existing workflow.