### PR TITLE
Fix Linux builds by correctly initializing the GPURasterizer.

### DIFF
--- a/shell/platform/linux/platform_view_glfw.cc
+++ b/shell/platform/linux/platform_view_glfw.cc
@@ -16,7 +16,7 @@ inline PlatformViewGLFW* ToPlatformView(GLFWwindow* window) {
 }
 
 PlatformViewGLFW::PlatformViewGLFW()
-    : PlatformView(std::make_unique<GPURasterizer>()),
+    : PlatformView(std::make_unique<GPURasterizer>(nullptr)),
       valid_(false),
       glfw_window_(nullptr),
       buttons_(0) {


### PR DESCRIPTION
The API was updated recently so platforms can report memory usage for the
rasterizer to display as an overlay.