### PR TITLE
Ignore VERSION_MACOSX_[SN]DK in licence aggregator

### DIFF
--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1505,6 +1505,8 @@ class RepositoryAndroidToolsDirectory extends RepositoryDirectory {
   bool shouldRecurse(fs.IoNode entry) {
     return entry.name != 'VERSION_LINUX_SDK'
         && entry.name != 'VERSION_LINUX_NDK'
+        && entry.name != 'VERSION_MACOSX_SDK'
+        && entry.name != 'VERSION_MACOSX_NDK'
         && super.shouldRecurse(entry);
   }
 


### PR DESCRIPTION
Not shipped to clients.