### PR TITLE
Ensure licence diff works on both Linux and macOS

### DIFF
--- a/travis/licenses.sh
+++ b/travis/licenses.sh
@@ -14,6 +14,6 @@ else
     echo "For more information, see the script in:"
     echo "  https://github.com/flutter/engine/tree/master/tools/licenses"
     echo ""
-    diff -u6 flutter/travis/licenses.golden out/license-script-output
+    diff -U 6 flutter/travis/licenses.golden out/license-script-output
     exit 1
 fi


### PR DESCRIPTION
On macOS diff -u6 results in:
  diff: `-6' option is obsolete; use `-U 6'
the latter syntax is supported on both Linux and macOS.