### PR TITLE
Apply window insets using an older API on pre-Lollipop systems

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -457,6 +457,21 @@ public class FlutterView extends SurfaceView
         return super.onApplyWindowInsets(insets);
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
+    protected boolean fitSystemWindows(Rect insets) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.KITKAT) {
+            mMetrics.physicalPaddingTop = insets.top;
+            mMetrics.physicalPaddingRight = insets.right;
+            mMetrics.physicalPaddingBottom = insets.bottom;
+            mMetrics.physicalPaddingLeft = insets.left;
+            updateViewportMetrics();
+            return true;
+        } else {
+            return super.fitSystemWindows(insets);
+        }
+    }
+
     private void attach() {
         mNativePlatformView = nativeAttach(this);
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/6586