### PR TITLE
Stop processing multiline text after maxLines.

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -693,8 +693,12 @@ abstract class Paragraph extends NativeFieldWrapperClass2 {
   double get alphabeticBaseline native "Paragraph_alphabeticBaseline";
 
   /// The distance from the top of the paragraph to the ideographic
-   /// baseline of the first line, in logical pixels.
+  /// baseline of the first line, in logical pixels.
   double get ideographicBaseline native "Paragraph_ideographicBaseline";
+
+  /// True if there is more vertical content, but the text was truncated
+  /// because we reached [ParagraphStyle.maxLines] lines of text.
+  bool get didExceedMaxLines native "Paragraph_didExceedMaxLines";
 
   /// Computes the size and position of each glyph in the paragraph.
   void layout(ParagraphConstraints constraints) => _layout(constraints.width);

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -7,6 +7,7 @@
 #include "flutter/common/threads.h"
 #include "flutter/sky/engine/core/rendering/PaintInfo.h"
 #include "flutter/sky/engine/core/rendering/RenderText.h"
+#include "flutter/sky/engine/core/rendering/RenderParagraph.h"
 #include "flutter/sky/engine/core/rendering/style/RenderStyle.h"
 #include "flutter/sky/engine/platform/fonts/FontCache.h"
 #include "flutter/sky/engine/platform/graphics/GraphicsContext.h"
@@ -30,6 +31,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Paragraph);
   V(Paragraph, maxIntrinsicWidth)   \
   V(Paragraph, alphabeticBaseline)  \
   V(Paragraph, ideographicBaseline) \
+  V(Paragraph, didExceedMaxLines) \
   V(Paragraph, layout)              \
   V(Paragraph, paint)               \
   V(Paragraph, getWordBoundary)     \
@@ -73,6 +75,13 @@ double Paragraph::alphabeticBaseline() {
 double Paragraph::ideographicBaseline() {
   return firstChildBox()->firstLineBoxBaseline(
       FontBaselineOrAuto(IdeographicBaseline));
+}
+
+bool Paragraph::didExceedMaxLines() {
+  RenderBox* box = firstChildBox();
+  ASSERT(box->isRenderParagraph());
+  RenderParagraph* paragraph = static_cast<RenderParagraph*>(box);
+  return paragraph->didExceedMaxLines();
 }
 
 void Paragraph::layout(double width) {

--- a/lib/ui/text/paragraph.h
+++ b/lib/ui/text/paragraph.h
@@ -34,6 +34,7 @@ class Paragraph : public ftl::RefCountedThreadSafe<Paragraph>,
   double maxIntrinsicWidth();
   double alphabeticBaseline();
   double ideographicBaseline();
+  bool didExceedMaxLines();
 
   void layout(double width);
   void paint(Canvas* canvas, double x, double y);

--- a/sky/engine/core/rendering/RenderParagraph.cpp
+++ b/sky/engine/core/rendering/RenderParagraph.cpp
@@ -856,8 +856,9 @@ void RenderParagraph::layoutRunsAndFloatsInRange(LineLayoutState& layoutState,
     bool checkForEndLineMatch = layoutState.endLine();
     RenderTextInfo renderTextInfo;
     VerticalPositionCache verticalPositionCache;
-
     LineBreaker lineBreaker(this);
+
+    m_didExceedMaxLines = false;
 
     while (!endOfLine.atEnd()) {
         // FIXME: Is this check necessary before the first iteration or can it be moved to the end?

--- a/sky/engine/core/rendering/RenderParagraph.cpp
+++ b/sky/engine/core/rendering/RenderParagraph.cpp
@@ -28,6 +28,7 @@ namespace blink {
 using namespace WTF::Unicode;
 
 RenderParagraph::RenderParagraph()
+    : m_didExceedMaxLines(false)
 {
 }
 
@@ -880,7 +881,8 @@ void RenderParagraph::layoutRunsAndFloatsInRange(LineLayoutState& layoutState,
         endOfLine = lineBreaker.nextLineBreak(resolver, layoutState.lineInfo(), renderTextInfo,
             lastFloatFromPreviousLine, wordMeasurements);
         renderTextInfo.m_lineBreakIterator.resetPriorContext();
-        if (resolver.position().atEnd()) {
+        m_didExceedMaxLines = layoutState.lineInfo().lineIndex() > styleToUse->maxLines() && !layoutState.lineInfo().isEmpty();
+        if (resolver.position().atEnd() || m_didExceedMaxLines) {
             // FIXME: We shouldn't be creating any runs in nextLineBreak to begin with!
             // Once BidiRunList is separated from BidiResolver this will not be needed.
             resolver.runs().deleteRuns();
@@ -934,6 +936,7 @@ void RenderParagraph::layoutRunsAndFloatsInRange(LineLayoutState& layoutState,
 
         // Limit ellipsized text to a single line.
         if (lineBreaker.lineWasEllipsized()) {
+            m_didExceedMaxLines = true;
             resolver.setPosition(InlineIterator(resolver.position().root(), 0, 0), 0);
             break;
         }

--- a/sky/engine/core/rendering/RenderParagraph.h
+++ b/sky/engine/core/rendering/RenderParagraph.h
@@ -54,6 +54,8 @@ public:
         return obj->isOutOfFlowPositioned() && !obj->style()->isOriginalDisplayInlineType() && !obj->container()->isRenderInline();
     }
 
+    bool didExceedMaxLines() const { return m_didExceedMaxLines; }
+
     // TODO(ojan): Remove the need for these.
     using RenderBlock::lineBoxes;
     using RenderBlock::firstLineBox;
@@ -103,6 +105,8 @@ private:
     void determineEndPosition(LineLayoutState&, RootInlineBox* startBox, InlineIterator& cleanLineStart, BidiStatus& cleanLineBidiStatus);
     bool checkPaginationAndFloatsAtEndLine(LineLayoutState&);
     bool matchedEndLine(LineLayoutState&, const InlineBidiResolver&, const InlineIterator& endLineStart, const BidiStatus& endLineStatus);
+
+    bool m_didExceedMaxLines;
 };
 
 DEFINE_RENDER_OBJECT_TYPE_CASTS(RenderParagraph, isRenderParagraph());


### PR DESCRIPTION
Added a Paragraph.didExceedMaxLines property to query when this occurs.

Needed for https://github.com/flutter/flutter/issues/7271