### PR TITLE
Add OpenSSL as supported licence type

### DIFF
--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -13,7 +13,7 @@ const int kMaxSize = 5 * 1024; // only look for copyrights and licenses at the t
 
 class FetchedContentsOf extends Key { FetchedContentsOf(dynamic value) : super(value); }
 
-enum LicenseType { unknown, bsd, gpl, lgpl, mpl, afl, mit, freetype, apache, apacheNotice, eclipse, ijg, zlib, icu, apsl, libpng }
+enum LicenseType { unknown, bsd, gpl, lgpl, mpl, afl, mit, freetype, apache, apacheNotice, eclipse, ijg, zlib, icu, apsl, libpng, openssl }
 
 LicenseType convertLicenseNameToType(String name) {
   switch (name) {
@@ -36,6 +36,8 @@ LicenseType convertLicenseNameToType(String name) {
       return LicenseType.icu;
     case 'Apple Public Source License':
       return LicenseType.apsl;
+    case 'OpenSSL':
+      return LicenseType.openssl;
     // common file names that don't say what the type is
     case 'COPYING':
     case 'COPYING.txt':
@@ -166,6 +168,7 @@ abstract class License implements Comparable<License> {
         case LicenseType.eclipse:
         case LicenseType.ijg:
         case LicenseType.apsl:
+        case LicenseType.openssl:
           return new MessageLicense._(body, type, origin: origin);
         case LicenseType.libpng:
           return new BlankLicense._(body, type, origin: origin);
@@ -278,6 +281,7 @@ abstract class License implements Comparable<License> {
           case LicenseType.eclipse:
           case LicenseType.ijg:
           case LicenseType.apsl:
+          case LicenseType.openssl:
             assert(this is MessageLicense);
             break;
           case LicenseType.libpng:

--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -756,13 +756,17 @@ Iterable<_LicenseMatch> _tryReferenceByFilename(String body, LicenseFileReferenc
   }
 }
 
-Iterable<_LicenseMatch> _tryReferenceByType(String body, RegExp pattern, LicenseSource parentDirectory, { String origin }) sync* {
-  for (_PartialLicenseMatch match in _findLicenseBlocks(body, pattern, 1, 2)) {
+Iterable<_LicenseMatch> _tryReferenceByType(String body, RegExp pattern, LicenseSource parentDirectory, { String origin, bool needsCopyright: true }) sync* {
+  for (_PartialLicenseMatch match in _findLicenseBlocks(body, pattern, 1, 2, needsCopyright: needsCopyright)) {
     final LicenseType type = convertLicenseNameToType(match.group(3));
     final License template = parentDirectory.nearestLicenseOfType(type);
     if (template == null)
       throw 'failed to find accompanying $type license in $parentDirectory';
-    assert(_reformat(match.getCopyrights()) != '');
+    assert(() {
+      String copyrights = _reformat(match.getCopyrights());
+      assert(needsCopyright && copyrights.isNotEmpty || !needsCopyright && copyrights.isEmpty);
+      return true;
+    });
     yield* _expand(template, match.getCopyrights(), match.start, match.end, debug: '_tryReferenceByType', origin: origin);
   }
 }
@@ -821,6 +825,7 @@ List<License> determineLicensesFor(String fileContents, String filename, License
   results.addAll(csAttribution.expand((RegExp pattern) => _tryAttribution(fileContents, pattern, origin: origin)));
   results.addAll(csReferencesByFilename.expand((LicenseFileReferencePattern pattern) => _tryReferenceByFilename(fileContents, pattern, parentDirectory, origin: origin)));
   results.addAll(csReferencesByType.expand((RegExp pattern) => _tryReferenceByType(fileContents, pattern, parentDirectory, origin: origin)));
+  results.addAll(csReferencesByTypeNoCopyright.expand((RegExp pattern) => _tryReferenceByType(fileContents, pattern, parentDirectory, origin: origin, needsCopyright: false)));
   results.addAll(csReferencesByUrl.expand((MultipleVersionedLicenseReferencePattern pattern) => _tryReferenceByUrl(fileContents, pattern, parentDirectory, origin: origin)));
   results.addAll(csLicenses.expand((RegExp pattern) => _tryInline(fileContents, pattern, needsCopyright: true, origin: origin)));
   results.addAll(csNotices.expand((RegExp pattern) => _tryInline(fileContents, pattern, needsCopyright: false, origin: origin)));

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1993,10 +1993,37 @@ class RepositoryBoringSSLSourceDirectory extends RepositoryDirectory {
   }
 
   @override
+  RepositoryFile createFile(fs.IoNode entry) {
+    if (entry.name == 'LICENSE')
+      return new RepositoryOpenSSLLicenseFile(this, entry);
+    return super.createFile(entry);
+  }
+
+  @override
   RepositoryDirectory createSubdirectory(fs.Directory entry) {
     if (entry.name == 'third_party')
       return new RepositoryBoringSSLThirdPartyDirectory(this, entry);
     return super.createSubdirectory(entry);
+  }
+}
+
+class RepositoryOpenSSLLicenseFile extends RepositorySingleLicenseFile {
+  RepositoryOpenSSLLicenseFile(RepositoryDirectory parent, fs.TextFile io)
+    : super(parent, io, new License.message(io.readString(), LicenseType.openssl, origin: io.fullName)) {
+    _verifyLicense(io);
+  }
+
+  static void _verifyLicense(fs.TextFile io) {
+    final String contents = io.readString();
+    if (!contents.contains('BoringSSL is a fork of OpenSSL. As such, large parts of it fall under OpenSSL'))
+      throw 'unexpected OpenSSL license file contents:\n----8<----\n$contents\n----<8----';
+  }
+
+  @override
+  License licenseOfType(LicenseType type) {
+    if (type == LicenseType.openssl)
+      return license;
+    return null;
   }
 }
 

--- a/tools/licenses/lib/patterns.dart
+++ b/tools/licenses/lib/patterns.dart
@@ -550,6 +550,24 @@ final List<RegExp> csReferencesByType = <RegExp>[
 
 ];
 
+final List<RegExp> csReferencesByTypeNoCopyright = <RegExp>[
+
+  // used with _tryReferenceByType
+  // groups 1 and 2 are the prefix, group 3 is the license type
+
+  new RegExp(
+    kIndent +
+    r'Written by Andy Polyakov <appro@openssl\.org> for the OpenSSL '
+    r'project\. The module is, however, dual licensed under (OpenSSL) and '
+    r'CRYPTOGAMS licenses depending on where you obtain it\. For further '
+    r'details see http://www\.openssl\.org/~appro/cryptogams/\. '
+    r'Permission to use under GPL terms is granted\.'.replaceAll(' ', _linebreak),
+    multiLine: true,
+    caseSensitive: false
+  ),
+
+];
+
 class MultipleVersionedLicenseReferencePattern {
   MultipleVersionedLicenseReferencePattern({ this.firstPrefixIndex, this.indentPrefixIndex, this.licenseIndices, this.versionIndicies, this.checkLocalFirst: true, this.pattern });
   final int firstPrefixIndex;


### PR DESCRIPTION
Adds special handling for the OpenSSL licensed files under BoringSSL.
Specifically, some of the ARM assembly files in the latest Dart SDK are
dual-licensed with OpenSSL.

Those files (e.g., sha256-armv4.S) include a block that specifies the
code is dual-licenced under OpenSSL, but doesn't include a copyright
date of its own.