### PR TITLE
Clear the GPU thread's EGL context only after the GPUSurfaceGL has been destroyed

### DIFF
--- a/shell/common/null_rasterizer.cc
+++ b/shell/common/null_rasterizer.cc
@@ -20,7 +20,6 @@ void NullRasterizer::Setup(
 void NullRasterizer::Teardown(
     ftl::AutoResetWaitableEvent* teardown_completion_event) {
   if (surface_) {
-    surface_->Teardown();
     surface_.reset();
   }
   teardown_completion_event->Signal();

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -39,8 +39,6 @@ class Surface {
 
   virtual bool Setup() = 0;
 
-  virtual void Teardown() = 0;
-
   virtual bool IsValid() = 0;
 
   virtual std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) = 0;

--- a/shell/gpu/gpu_rasterizer.cc
+++ b/shell/gpu/gpu_rasterizer.cc
@@ -67,7 +67,6 @@ void GPURasterizer::Clear(SkColor color, const SkISize& size) {
 void GPURasterizer::Teardown(
     ftl::AutoResetWaitableEvent* teardown_completion_event) {
   if (surface_) {
-    surface_->Teardown();
     surface_.reset();
   }
   last_layer_tree_.reset();

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -94,10 +94,6 @@ bool GPUSurfaceGL::Setup() {
   return true;
 }
 
-void GPUSurfaceGL::Teardown() {
-  delegate_->GLContextClearCurrent();
-}
-
 bool GPUSurfaceGL::IsValid() {
   return context_ != nullptr;
 }

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -31,8 +31,6 @@ class GPUSurfaceGL : public Surface {
 
   bool Setup() override;
 
-  void Teardown() override;
-
   bool IsValid() override;
 
   std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) override;

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -319,6 +319,15 @@ void PlatformViewAndroid::SetSemanticsEnabled(JNIEnv* env,
 
 void PlatformViewAndroid::ReleaseSurface() {
   NotifyDestroyed();
+
+  ftl::AutoResetWaitableEvent latch;
+  blink::Threads::Gpu()->PostTask([this, &latch]() {
+    if (surface_gl_->IsValid())
+      surface_gl_->GLContextClearCurrent();
+    latch.Signal();
+  });
+  latch.Wait();
+
   surface_gl_->TeardownOnScreenContext();
 }
 


### PR DESCRIPTION
The GPUSurfaceGL holds references to Skia objects that may own GL objects.
If the GL objects are destructed on the GPU thread after the EGL context has been
dropped, then the GL delete calls will not take effect.