### PR TITLE
Add MultiLicense license class

### DIFF
--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2013,7 +2013,7 @@ class RepositoryBoringSSLSourceDirectory extends RepositoryDirectory {
 /// part of the copyright notices and can be skipped.
 class RepositoryOpenSSLLicenseFile extends RepositorySingleLicenseFile {
   RepositoryOpenSSLLicenseFile(RepositoryDirectory parent, fs.TextFile io)
-    : super(parent, io, new License.message(LineSplitter.split(io.readString()).skip(23).join('\n'), LicenseType.openssl, origin: io.fullName)) {
+    : super(parent, io, new License.fromBodyAndType(LineSplitter.split(io.readString()).skip(23).join('\n'), LicenseType.openssl, origin: io.fullName)) {
     _verifyLicense(io);
   }
 


### PR DESCRIPTION
In cases where a reference-by-filename license block contains its own
copyright notice, emit that block as a duplicate license in addition to
the license extracted from the referenced license file.