### PR TITLE
Make gen_snapshot compile on Windows

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -33,7 +33,7 @@ vars = {
   'dart_observatory_packages_revision': '26aad88f1c1915d39bbcbff3cad589e2402fdcf1',
   'dart_root_certificates_revision': '0068d8911140e591ebb750af296e81940a9906f5',
 
-  'buildtools_revision': '1f4c1c3bd3bd4c991e6565a0dc509c8d8a3f90b4',
+  'buildtools_revision': '5655267acc2b1c672aec43bfbd28c645908fcd74',
 }
 
 # Only these hosts are allowed for dependencies in this DEPS file.
@@ -46,7 +46,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '8bdd40871339d8297b2681bbe218543d80ceda1b',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '62de2ab9a1e6ffdaec93b74f6e0b4adf57c3f571',
 
    # Fuchsia compatibility
    #
@@ -118,6 +118,9 @@ deps = {
   'src/third_party/libjpeg-turbo':
    Var('skia_git') + '/third_party/libjpeg-turbo.git' + '@' + 'debddedc75850bcdeb8a57258572f48b802a4bb3',
 
+  'src/third_party/gyp':
+   Var('chromium_git') + '/external/gyp.git' + '@' + '6ee91ad8659871916f9aa840d42e1513befdf638',
+
    # Headers for Vulkan 1.0
    'src/third_party/vulkan':
    Var('github_git') + '/KhronosGroup/Vulkan-Docs.git' + '@' + 'e29c2489e238509c41aeb8c7bce9d669a496344b',
@@ -163,6 +166,12 @@ hooks = [
     ],
   },
   {
+    # Update the Windows toolchain if necessary.
+    'name': 'win_toolchain',
+    'pattern': '.',
+    'action': ['python', 'src/build/vs_toolchain.py', 'update'],
+  },
+  {
     'name': 'download_android_tools',
     'pattern': '.',
     'action': [
@@ -171,9 +180,9 @@ hooks = [
     ],
   },
   {
-    'name': 'clang',
+    'name': 'buildtools',
     'pattern': '.',
-    'action': ['/bin/bash', 'src/buildtools/update.sh', '--toolchain', '--ninja', '--gn'],
+    'action': ['python', 'src/tools/buildtools/update.py'],
   },
   {
     # Pull dart sdk if needed

--- a/shell/platform/BUILD.gn
+++ b/shell/platform/BUILD.gn
@@ -15,6 +15,8 @@ group("platform") {
     deps = [
       "linux",
     ]
+  } else if (is_win) {
+    print("Shell currently not supported on Windows.")
   } else {
     assert(false, "Unknown/Unsupported platform.")
   }

--- a/tools/gn
+++ b/tools/gn
@@ -57,7 +57,7 @@ def to_gn_args(args):
 
     gn_args['is_debug'] = args.unoptimized
     gn_args['android_full_debug'] = args.target_os == 'android' and args.unoptimized
-    gn_args['is_clang'] = True
+    gn_args['is_clang'] = not sys.platform.startswith(('cygwin', 'win'))
 
     ios_target_cpu = 'arm64'
 
@@ -189,7 +189,7 @@ def main(argv):
   if gn_call_result == 0:
     # Generate/Replace the compile commands database in out.
     compile_cmd_gen_cmd = [
-      '%s/buildtools/%s/ninja' % (SRC_ROOT, subdir),
+      'ninja',
       '-C',
       out_dir,
       '-t',

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1887,6 +1887,7 @@ class RepositoryRootThirdPartyDirectory extends RepositoryGenericThirdPartyDirec
     return entry.name != 'appurify-python' // only used by tests
         && entry.name != 'dart-sdk' // redundant with //engine/dart; https://github.com/flutter/flutter/issues/2618
         && entry.name != 'firebase' // only used by bots; https://github.com/flutter/flutter/issues/3722
+        && entry.name != 'gyp' // build-time only
         && entry.name != 'jinja2' // build-time code generation
         && entry.name != 'junit' // only mentioned in build files, not used
         && entry.name != 'libxml' // dependency of the testing system that we don't actually use


### PR DESCRIPTION
On a windows host:
* setup `.gclient` just like on linux/mac
* `gclient sync`
* `cd src/`
* `python ./flutter/tools/gn --unoptimized`
* `ninja -C out\host_debug_unopt gen_snapshot`


Required for https://github.com/flutter/flutter/issues/138