### PR TITLE
Handle double-height status bar on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -343,15 +343,21 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
 
 - (void)viewDidLayoutSubviews {
   CGSize viewSize = self.view.bounds.size;
-  CGSize statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
-  CGFloat viewOffset = self.view.frame.origin.y;
+  CGFloat statusBarPadding = 0.0;
   CGFloat scale = [UIScreen mainScreen].scale;
+
+  if (self.parentViewController == nil) {
+    // If we're the root view controller, apply any padding necessary for the
+    // status bar. If we're not the root view controller, assume the root view
+    // controller has dealt with it.
+    CGSize sbSize = [UIApplication sharedApplication].statusBarFrame.size;
+    statusBarPadding = sbSize.height - self.view.frame.origin.y;
+  }
 
   _viewportMetrics.device_pixel_ratio = scale;
   _viewportMetrics.physical_width = viewSize.width * scale;
   _viewportMetrics.physical_height = viewSize.height * scale;
-  _viewportMetrics.physical_padding_top =
-      (statusBarSize.height - viewOffset) * scale;
+  _viewportMetrics.physical_padding_top = statusBarPadding * scale;
   [self updateViewportMetrics];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -342,14 +342,16 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
 }
 
 - (void)viewDidLayoutSubviews {
-  CGSize size = self.view.bounds.size;
+  CGSize viewSize = self.view.bounds.size;
+  CGSize statusBarSize = [UIApplication sharedApplication].statusBarFrame.size;
+  CGFloat viewOffset = self.view.frame.origin.y;
   CGFloat scale = [UIScreen mainScreen].scale;
 
   _viewportMetrics.device_pixel_ratio = scale;
-  _viewportMetrics.physical_width = size.width * scale;
-  _viewportMetrics.physical_height = size.height * scale;
+  _viewportMetrics.physical_width = viewSize.width * scale;
+  _viewportMetrics.physical_height = viewSize.height * scale;
   _viewportMetrics.physical_padding_top =
-      [UIApplication sharedApplication].statusBarFrame.size.height * scale;
+      (statusBarSize.height - viewOffset) * scale;
   [self updateViewportMetrics];
 }
 


### PR DESCRIPTION
In certain cases, iOS displays a double-height status bar (e.g., when an
application is using device location or while in a call). In such cases,
iOS offsets the app view origin by 20px, reduces view height by 20px,
then overlays a 40px opaque status bar: 20px covering the newly opened
20px gap at the top of the screen, 20px covering the top 20px of the
view, which had previously been under the standard-sized status bar.

Flutter previously set top padding to the height of the status bar,
which resulted in 40px padding with a double-sized status bar. However,
the padding should match the portion of the status bar overlapping the
view, which is 20px.

Note that the final case is the one in which no status bar is shown and
padding should be zero.