### PR TITLE
Exit the non-interactive sky_shell on Linux when the Dart script has completed

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -137,4 +137,16 @@ std::string RuntimeController::GetIsolateName() {
   return dart_controller_->dart_state()->debug_name();
 }
 
+bool RuntimeController::HasLivePorts() {
+  if (!dart_controller_) {
+    return false;
+  }
+  UIDartState* dart_state = dart_controller_->dart_state();
+  if (!dart_state) {
+    return false;
+  }
+  DartState::Scope scope(dart_state);
+  return Dart_HasLivePorts();
+}
+
 }  // namespace blink

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -44,6 +44,8 @@ class RuntimeController : public WindowClient, public IsolateClient {
 
   std::string GetIsolateName();
 
+  bool HasLivePorts();
+
  private:
   explicit RuntimeController(RuntimeDelegate* client);
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -155,6 +155,12 @@ std::string Engine::GetUIIsolateName() {
   return runtime_->GetIsolateName();
 }
 
+bool Engine::UIIsolateHasLivePorts() {
+  if (!runtime_)
+    return false;
+  return runtime_->HasLivePorts();
+}
+
 void Engine::OnOutputSurfaceCreated(const ftl::Closure& gpu_continuation) {
   blink::Threads::Gpu()->PostTask(gpu_continuation);
   have_surface_ = true;

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -59,6 +59,8 @@ class Engine : public blink::RuntimeDelegate {
 
   std::string GetUIIsolateName();
 
+  bool UIIsolateHasLivePorts();
+
   void OnOutputSurfaceCreated(const ftl::Closure& gpu_continuation);
   void OnOutputSurfaceDestroyed(const ftl::Closure& gpu_continuation);
   void SetViewportMetrics(const blink::ViewportMetrics& metrics);

--- a/shell/testing/test_runner.h
+++ b/shell/testing/test_runner.h
@@ -26,6 +26,8 @@ class TestRunner {
 
   void Run(const TestDescriptor& test);
 
+  PlatformView& platform_view() { return *platform_view_; }
+
  private:
   TestRunner();
   ~TestRunner();


### PR DESCRIPTION
The script will be finished when the microtask queue has been drained and
Dart_HasLivePorts is returning false for the main isolate