### PR TITLE
Snapshots: Don't use an empty array where a NULL array is expected.

### DIFF
--- a/lib/snapshot/snapshot.c.tmpl
+++ b/lib/snapshot/snapshot.c.tmpl
@@ -10,16 +10,20 @@
 // generated snapshot binary file for the vm isolate.
 // This string forms the content of the dart vm isolate snapshot which
 // is loaded into the vm isolate.
-const uint8_t kDartVmSnapshotData[]
-    __attribute__((visibility("default"), aligned(8), used)) = { %s };
-const uint8_t kDartVmSnapshotInstructions[]
-    __attribute__((visibility("default"), aligned(8), used)) = {};
+static const uint8_t kDartVmSnapshotData_[]
+    __attribute__((aligned(8))) = { %s };
+const uint8_t* kDartVmSnapshotData
+    __attribute__((visibility("default"), used)) = kDartVmSnapshotData_;
+const uint8_t* kDartVmSnapshotInstructions
+    __attribute__((visibility("default"), used)) = NULL;
 
 // The string on the next line will be filled in with the contents of the
 // generated snapshot binary file for a regular dart isolate.
 // This string forms the content of a regular dart isolate snapshot which
 // is loaded into an isolate when it is created.
-const uint8_t kDartIsolateSnapshotData[]
-    __attribute__((visibility("default"), aligned(8), used)) = { %s };
-const uint8_t kDartIsolateSnapshotInstructions[]
-    __attribute__((visibility("default"), aligned(8), used)) = {};
+static const uint8_t kDartIsolateSnapshotData_[]
+    __attribute__((aligned(8))) = { %s };
+const uint8_t* kDartIsolateSnapshotData
+    __attribute__((visibility("default"), used)) = kDartIsolateSnapshotData_;
+const uint8_t* kDartIsolateSnapshotInstructions
+    __attribute__((visibility("default"), used)) = NULL;

--- a/runtime/dart_init.h
+++ b/runtime/dart_init.h
@@ -36,7 +36,7 @@ extern void* kDartIsolateSnapshotData;
 extern void* kDartIsolateSnapshotInstructions;
 }
 
-#define DART_SYMBOL(symbol) (&symbol)
+#define DART_SYMBOL(symbol) (symbol)
 
 #endif  // DART_ALLOW_DYNAMIC_RESOLUTION
 

--- a/snapshotter/main.cc
+++ b/snapshotter/main.cc
@@ -24,10 +24,10 @@
 #include "lib/tonic/file_loader/file_loader.h"
 
 extern "C" {
-extern const uint8_t kDartVmSnapshotData[];
-extern const uint8_t kDartVmSnapshotInstructions[];
-extern const uint8_t kDartIsolateSnapshotData[];
-extern const uint8_t kDartIsolateSnapshotInstructions[];
+extern const uint8_t* kDartVmSnapshotData;
+extern const uint8_t* kDartVmSnapshotInstructions;
+extern const uint8_t* kDartIsolateSnapshotData;
+extern const uint8_t* kDartIsolateSnapshotInstructions;
 }
 
 namespace {


### PR DESCRIPTION
Fixes dart-lang/sdk#28504