### PR TITLE
Apply iOS status bar padding only to fullscreen views

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -341,23 +341,33 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
   });
 }
 
+- (bool)isWindowFullscreen {
+  UIWindow *window = self.view.window;
+  return CGRectEqualToRect(window.frame, window.screen.bounds);
+}
+
+- (CGFloat)statusBarPadding {
+  // If not fullscreen, assume we don't want padding.
+  if (![self isWindowFullscreen]) {
+    return 0.0;
+  }
+
+  UIScreen *screen = self.view.window.screen;
+  CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
+  CGRect viewFrame = [self.view convertRect:self.view.bounds
+                          toCoordinateSpace:screen.coordinateSpace];
+  CGFloat padding = statusFrame.origin.y + statusFrame.size.height - viewFrame.origin.y;
+  return MAX(padding, 0.0);
+}
+
 - (void)viewDidLayoutSubviews {
   CGSize viewSize = self.view.bounds.size;
-  CGFloat statusBarPadding = 0.0;
   CGFloat scale = [UIScreen mainScreen].scale;
-
-  if (self.parentViewController == nil) {
-    // If we're the root view controller, apply any padding necessary for the
-    // status bar. If we're not the root view controller, assume the root view
-    // controller has dealt with it.
-    CGSize sbSize = [UIApplication sharedApplication].statusBarFrame.size;
-    statusBarPadding = sbSize.height - self.view.frame.origin.y;
-  }
 
   _viewportMetrics.device_pixel_ratio = scale;
   _viewportMetrics.physical_width = viewSize.width * scale;
   _viewportMetrics.physical_height = viewSize.height * scale;
-  _viewportMetrics.physical_padding_top = statusBarPadding * scale;
+  _viewportMetrics.physical_padding_top = [self statusBarPadding] * scale;
   [self updateViewportMetrics];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -347,6 +347,11 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
 }
 
 - (CGFloat)statusBarPadding {
+  // If we're a child of a containing view, let the container apply padding.
+  if (self.parentViewController != nil) {
+    return 0.0;
+  }
+
   // If not fullscreen, assume we don't want padding.
   if (![self isWindowFullscreen]) {
     return 0.0;


### PR DESCRIPTION
Previously padding was applied to account for the status bar, whether in
standard or expanded 'in-call' geometry only if the current view was not
a subview of a containing view. This didn't cover the case of root views
embedded in other windows (e.g. dialogs).

We also ensure that the window is fullscreen to account for cases like
small dialogs centred on the screen.