### PR TITLE
Roll Dart SDK to ed00447138f95ea4ba612509a244ca8205735372

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -27,7 +27,7 @@ vars = {
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated
-  'dart_revision': 'b46af1e75f9d124ce0e5f8226d570e93ac87d3a9',
+  'dart_revision': 'ed00447138f95ea4ba612509a244ca8205735372',
   'dart_boringssl_gen_revision': '1a810313a0290e1caace9da73fa3ab89995ad2c7',
   'dart_boringssl_revision': 'd519bf6be0b447fb80fbc539d4bff4479b5482a2',
   'dart_observatory_packages_revision': '26aad88f1c1915d39bbcbff3cad589e2402fdcf1',

--- a/lib/snapshot/snapshot.c.tmpl
+++ b/lib/snapshot/snapshot.c.tmpl
@@ -10,20 +10,16 @@
 // generated snapshot binary file for the vm isolate.
 // This string forms the content of the dart vm isolate snapshot which
 // is loaded into the vm isolate.
-static const uint8_t kDartVmSnapshotData_[]
-    __attribute__((aligned(8))) = { %s };
-const uint8_t* kDartVmSnapshotData
-    __attribute__((visibility("default"), used)) = kDartVmSnapshotData_;
-const uint8_t* kDartVmSnapshotInstructions
-    __attribute__((visibility("default"), used)) = NULL;
+const uint8_t kDartVmSnapshotData[]
+    __attribute__((visibility("default"), aligned(8), used)) = { %s };
+const uint8_t kDartVmSnapshotInstructions[]
+    __attribute__((visibility("default"), aligned(8), used)) = {};
 
 // The string on the next line will be filled in with the contents of the
 // generated snapshot binary file for a regular dart isolate.
 // This string forms the content of a regular dart isolate snapshot which
 // is loaded into an isolate when it is created.
-static const uint8_t kDartIsolateSnapshotData_[]
-    __attribute__((aligned(8))) = { %s };
-const uint8_t* kDartIsolateSnapshotData
-    __attribute__((visibility("default"), used)) = kDartIsolateSnapshotData_;
-const uint8_t* kDartIsolateSnapshotInstructions
-    __attribute__((visibility("default"), used)) = NULL;
+const uint8_t kDartIsolateSnapshotData[]
+    __attribute__((visibility("default"), aligned(8), used)) = { %s };
+const uint8_t kDartIsolateSnapshotInstructions[]
+    __attribute__((visibility("default"), aligned(8), used)) = {};

--- a/runtime/dart_init.h
+++ b/runtime/dart_init.h
@@ -36,7 +36,7 @@ extern void* kDartIsolateSnapshotData;
 extern void* kDartIsolateSnapshotInstructions;
 }
 
-#define DART_SYMBOL(symbol) (symbol)
+#define DART_SYMBOL(symbol) (&symbol)
 
 #endif  // DART_ALLOW_DYNAMIC_RESOLUTION
 

--- a/snapshotter/main.cc
+++ b/snapshotter/main.cc
@@ -24,10 +24,10 @@
 #include "lib/tonic/file_loader/file_loader.h"
 
 extern "C" {
-extern const uint8_t* kDartVmSnapshotData;
-extern const uint8_t* kDartVmSnapshotInstructions;
-extern const uint8_t* kDartIsolateSnapshotData;
-extern const uint8_t* kDartIsolateSnapshotInstructions;
+extern const uint8_t kDartVmSnapshotData[];
+extern const uint8_t kDartVmSnapshotInstructions[];
+extern const uint8_t kDartIsolateSnapshotData[];
+extern const uint8_t kDartIsolateSnapshotInstructions[];
 }
 
 namespace {


### PR DESCRIPTION
... and revert 275ffdcef80ffb85f4be62b9e8d1b17b5c0fdacf

Broke iOS simulator builds; should no longer be necessary after rolling
the Dart SDK to ed00447138f95ea4ba612509a244ca8205735372.

On iOS simulator builds, we were seeing DartLookupSymbolInLibrary return
a pointer to a address of the snapshot data rather than the address of
the snapshot buffer itself. On simulator builds we don't build the
snapshot data into a buffer in app.dylib (kDartVmSnapshotData) but link
it statically into the engine itself.