### PR TITLE
Do not double delete the test font data stream

### DIFF
--- a/runtime/test_font_selector.cc
+++ b/runtime/test_font_selector.cc
@@ -26,7 +26,7 @@ PassRefPtr<FontData> TestFontSelector::getFontData(
     return test_font_data_;
   }
 
-  auto typeface = SkTypeface::MakeFromStream(GetTestFontData().get());
+  auto typeface = SkTypeface::MakeFromStream(GetTestFontData().release());
 
   FontPlatformData platform_data(typeface, "Ahem", 14.0, false, false,
                                  FontOrientation::Horizontal, false);


### PR DESCRIPTION
SkTypeface::MakeFromStream takes ownership of the passed SkStreamAsset*

Fixes https://github.com/flutter/flutter/issues/7657