### PR TITLE
Deprecate FlutterAppDelegate

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
@@ -12,6 +12,7 @@
 // Empty implementation of UIApplicationDelegate, for simple apps
 // that don't need to customize the application delegate.
 FLUTTER_EXPORT
+__attribute__((deprecated("subclass UIResponder<UIApplicationDelegate>")))
 @interface FlutterAppDelegate : UIResponder<UIApplicationDelegate>
 
 @property(strong, nonatomic) UIWindow* window;


### PR DESCRIPTION
All samples and the 'flutter create' command now use a project-specifc
app delegate.

Any projects that still rely on FlutterAppDelegate should create an
empty delegate that subclasses UIResponder<UIApplicationDelegate> and
defines:
  @property (strong, nonatomic) UIWindow *window;