### PR TITLE
[iOS] Make FlutterInit redundant and deprecate the same.

### DIFF
--- a/shell/platform/darwin/common/platform_mac.h
+++ b/shell/platform/darwin/common/platform_mac.h
@@ -9,9 +9,7 @@
 
 namespace shell {
 
-void PlatformMacMain(int argc,
-                     const char* argv[],
-                     std::string icu_data_path,
+void PlatformMacMain(std::string icu_data_path,
                      std::string application_library_path);
 
 bool AttemptLaunchFromCommandLineSwitches(Engine* engine);

--- a/shell/platform/darwin/desktop/main_mac.mm
+++ b/shell/platform/darwin/desktop/main_mac.mm
@@ -32,7 +32,7 @@ void AttachMessageLoopToMainRunLoop(void) {
 int main(int argc, const char* argv[]) {
   [FlutterApplication sharedApplication];
 
-  shell::PlatformMacMain(argc, argv, "", "");
+  shell::PlatformMacMain("", "");
 
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
   if (command_line.HasSwitch(shell::FlagForSwitch(shell::Switch::Help))) {

--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_FLUTTERVIEWCONTROLLER_H_
 #define FLUTTER_FLUTTERVIEWCONTROLLER_H_
 
-#include <sys/cdefs.h>
 #import <UIKit/UIKit.h>
+#include <sys/cdefs.h>
 
 #include "FlutterAsyncMessageListener.h"
 #include "FlutterDartProject.h"
@@ -24,23 +24,27 @@ FLUTTER_EXPORT
 - (void)sendString:(NSString*)message withMessageName:(NSString*)messageName;
 
 - (void)sendString:(NSString*)message
-   withMessageName:(NSString*)messageName
-          callback:(void (^)(NSString*))callback;
+    withMessageName:(NSString*)messageName
+           callback:(void (^)(NSString*))callback;
 
 - (void)addMessageListener:(NSObject<FlutterMessageListener>*)listener;
 
 - (void)removeMessageListener:(NSObject<FlutterMessageListener>*)listener;
 
-- (void)addAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener;
+- (void)addAsyncMessageListener:
+    (NSObject<FlutterAsyncMessageListener>*)listener;
 
-- (void)removeAsyncMessageListener:(NSObject<FlutterAsyncMessageListener>*)listener;
+- (void)removeAsyncMessageListener:
+    (NSObject<FlutterAsyncMessageListener>*)listener;
 
 @end
 
 __BEGIN_DECLS
 
 // Initializes Flutter for this process. Need only be called once per process.
-FLUTTER_EXPORT void FlutterInit(int argc, const char* argv[]);
+FLUTTER_EXPORT void FlutterInit(int argc, const char* argv[])
+    __attribute__((deprecated("This call is no longer necessary and will be "
+                              "removed in an upcoming release.")));
 
 __END_DECLS
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -56,11 +56,15 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
 @end
 
 void FlutterInit(int argc, const char* argv[]) {
+  // Deprecated. To be removed.
+}
+
+static void FlutterInitShell() {
   NSBundle* bundle = [NSBundle bundleForClass:[FlutterViewController class]];
   NSString* icuDataPath = [bundle pathForResource:@"icudtl" ofType:@"dat"];
   NSString* libraryName =
       [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTLibraryPath"];
-  shell::PlatformMacMain(argc, argv, icuDataPath.UTF8String,
+  shell::PlatformMacMain(icuDataPath.UTF8String,
                          libraryName != nil ? libraryName.UTF8String : "");
 }
 
@@ -82,6 +86,8 @@ void FlutterInit(int argc, const char* argv[]) {
 - (instancetype)initWithProject:(FlutterDartProject*)project
                         nibName:(NSString*)nibNameOrNil
                          bundle:(NSBundle*)nibBundleOrNil {
+  FlutterInitShell();
+
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
 
   if (self) {
@@ -111,6 +117,7 @@ void FlutterInit(int argc, const char* argv[]) {
 - (void)performCommonViewControllerInitialization {
   if (_initialized)
     return;
+
   _initialized = YES;
 
   _orientationPreferences = UIInterfaceOrientationMaskAll;
@@ -342,7 +349,7 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
 }
 
 - (bool)isWindowFullscreen {
-  UIWindow *window = self.view.window;
+  UIWindow* window = self.view.window;
   return CGRectEqualToRect(window.frame, window.screen.bounds);
 }
 
@@ -357,11 +364,12 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
     return 0.0;
   }
 
-  UIScreen *screen = self.view.window.screen;
+  UIScreen* screen = self.view.window.screen;
   CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
   CGRect viewFrame = [self.view convertRect:self.view.bounds
                           toCoordinateSpace:screen.coordinateSpace];
-  CGFloat padding = statusFrame.origin.y + statusFrame.size.height - viewFrame.origin.y;
+  CGFloat padding =
+      statusFrame.origin.y + statusFrame.size.height - viewFrame.origin.y;
   return MAX(padding, 0.0);
 }
 


### PR DESCRIPTION
Swift embedders don't have access to main and hence would have to do extra work to convert process info arguments into FlutterInit arguments. Now we do the same on the behalf of the embedder. This makes FlutterInit redundant. This has been deprecated and will be removed soon.