### PR TITLE
Fix a race in PlatformView construction

### DIFF
--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -18,10 +18,7 @@ namespace shell {
 PlatformView::PlatformView(std::unique_ptr<Rasterizer> rasterizer)
     : rasterizer_(std::move(rasterizer)),
       size_(SkISize::Make(0, 0)),
-      weak_factory_(this) {
-  blink::Threads::UI()->PostTask(
-      [self = GetWeakPtr()] { Shell::Shared().AddPlatformView(self); });
-}
+      weak_factory_(this) {}
 
 PlatformView::~PlatformView() {
   blink::Threads::UI()->PostTask([] { Shell::Shared().PurgePlatformViews(); });
@@ -35,6 +32,13 @@ PlatformView::~PlatformView() {
 
 void PlatformView::CreateEngine() {
   engine_.reset(new Engine(this));
+}
+
+// Add this to the shell's list of PlatformVIews.
+// Subclasses should call this after the object is fully constructed.
+void PlatformView::PostAddToShellTask() {
+  blink::Threads::UI()->PostTask(
+      [self = GetWeakPtr()] { Shell::Shared().AddPlatformView(self); });
 }
 
 void PlatformView::DispatchPlatformMessage(

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -70,6 +70,7 @@ class PlatformView {
   explicit PlatformView(std::unique_ptr<Rasterizer> rasterizer);
 
   void CreateEngine();
+  void PostAddToShellTask();
 
   void SetupResourceContextOnIOThreadPerform(
       ftl::AutoResetWaitableEvent* event);

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -104,6 +104,8 @@ PlatformViewAndroid::PlatformViewAndroid()
   SetupResourceContextOnIOThread();
 
   UpdateThreadPriorities();
+
+  PostAddToShellTask();
 }
 
 PlatformViewAndroid::~PlatformViewAndroid() = default;

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -34,6 +34,8 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
     shell::Shell::Shared().tracing_controller().set_traces_base_path(
         [[paths objectAtIndex:0] UTF8String]);
   }
+
+  PostAddToShellTask();
 }
 
 PlatformViewMac::~PlatformViewMac() = default;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -282,6 +282,8 @@ PlatformViewIOS::PlatformViewIOS(CAEAGLLayer* layer)
                                                        NSUserDomainMask, YES);
   shell::Shell::Shared().tracing_controller().set_traces_base_path(
       [paths.firstObject UTF8String]);
+
+  PostAddToShellTask();
 }
 
 PlatformViewIOS::~PlatformViewIOS() = default;

--- a/shell/platform/linux/platform_view_glfw.cc
+++ b/shell/platform/linux/platform_view_glfw.cc
@@ -49,6 +49,8 @@ PlatformViewGLFW::PlatformViewGLFW()
   });
 
   valid_ = true;
+
+  PostAddToShellTask();
 }
 
 PlatformViewGLFW::~PlatformViewGLFW() {

--- a/shell/testing/platform_view_test.cc
+++ b/shell/testing/platform_view_test.cc
@@ -12,6 +12,7 @@ namespace shell {
 PlatformViewTest::PlatformViewTest()
     : PlatformView(std::unique_ptr<Rasterizer>(new NullRasterizer())) {
   CreateEngine();
+  PostAddToShellTask();
 }
 
 PlatformViewTest::~PlatformViewTest() = default;


### PR DESCRIPTION
The PlatformView superclass constructor was posting a task to the UI thread
that adds the view to the shell's global list.  This could result in UI thread
operations seeing PlatformView instances that are not fully constructed and do
not yet have an engine.

This was happening in https://github.com/flutter/flutter/issues/7735