### PR TITLE
[iOS] Ensure FlutterMain is called before interacting with the engine in any way.

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -39,6 +39,8 @@ shared_library("flutter_framework_dylib") {
     "framework/Source/FlutterViewController.mm",
     "framework/Source/accessibility_bridge.h",
     "framework/Source/accessibility_bridge.mm",
+    "framework/Source/flutter_main_ios.h",
+    "framework/Source/flutter_main_ios.mm",
     "framework/Source/flutter_touch_mapper.h",
     "framework/Source/flutter_touch_mapper.mm",
     "framework/Source/platform_message_router.h",

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -9,6 +9,7 @@
 #include "flutter/common/threads.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartSource.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h"
 
 static NSURL* URLForSwitch(const char* name) {
   auto cmd = *base::CommandLine::ForCurrentProcess();
@@ -29,6 +30,12 @@ static NSURL* URLForSwitch(const char* name) {
   FlutterDartSource* _dartSource;
 
   VMType _vmTypeRequirement;
+}
+
++ (void)initialize {
+  if (self == [FlutterDartProject class]) {
+    shell::FlutterMain();
+  }
 }
 
 #pragma mark - Override base class designated initializers

--- a/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h
@@ -1,0 +1,18 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTER_MAIN_IOS_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTER_MAIN_IOS_H_
+
+#include "lib/ftl/macros.h"
+
+namespace shell {
+
+/// Initializes the Flutter shell. This must be called before interacting with
+/// the engine in any way. It is safe to call this method multiple times.
+void FlutterMain();
+
+}  // namespace shell
+
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTER_MAIN_IOS_H_

--- a/shell/platform/darwin/ios/framework/Source/flutter_main_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_main_ios.mm
@@ -1,0 +1,20 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h"
+#include "flutter/shell/platform/darwin/common/platform_mac.h"
+#include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+
+namespace shell {
+
+void FlutterMain() {
+  NSBundle* bundle = [NSBundle bundleForClass:[FlutterViewController class]];
+  NSString* icuDataPath = [bundle pathForResource:@"icudtl" ofType:@"dat"];
+  NSString* libraryName =
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTLibraryPath"];
+  shell::PlatformMacMain(icuDataPath.UTF8String,
+                         libraryName != nil ? libraryName.UTF8String : "");
+}
+
+}  // namespace shell


### PR DESCRIPTION
`FlutterViewController` and `FlutterDartProject` are the only two classes exposed to Flutter clients that can possibly interact with the engine. Fixes Hello Services.