### PR TITLE
Support status bar taps in FlutterAppDelegate

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
@@ -9,10 +9,9 @@
 
 #include "FlutterMacros.h"
 
-// Empty implementation of UIApplicationDelegate, for simple apps
-// that don't need to customize the application delegate.
+// UIApplicationDelegate subclass, for simple Flutter apps that want default
+// behavior.
 FLUTTER_EXPORT
-__attribute__((deprecated("subclass UIResponder<UIApplicationDelegate>")))
 @interface FlutterAppDelegate : UIResponder<UIApplicationDelegate>
 
 @property(strong, nonatomic) UIWindow* window;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -3,7 +3,28 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
+#include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 
 @implementation FlutterAppDelegate
+
+// Returns the key window's rootViewController, if it's a FlutterViewController.
+// Otherwise, returns nil.
+- (FlutterViewController*)rootFlutterViewController {
+  UIViewController *viewController =
+      [UIApplication sharedApplication].keyWindow.rootViewController;
+  if ([viewController isKindOfClass:[FlutterViewController class]]) {
+    return (FlutterViewController*)viewController;
+  }
+  return nil;
+}
+
+- (void) touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event {
+  [super touchesBegan:touches withEvent:event];
+
+  // Pass status bar taps to key window Flutter rootViewController.
+  if (self.rootFlutterViewController != nil) {
+    [self.rootFlutterViewController handleStatusBarTouches:event];
+  }
+}
 
 @end


### PR DESCRIPTION
Provide a default status bar tap handler for FlutterAppDelegate.
By default, taps are passed to the key window's rootViewController if
it's a FlutterViewController. Apps with custom app delegates can
customize this behaviour to send the tap to the FlutterViewController(s)
they prefer by overriding touchesBegan:withEvent.