### PR TITLE
Bump up limits on the GrResourceCache used for the main GrContext.

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -14,13 +14,12 @@
 
 namespace shell {
 
-// The limit of the number of GPU resources we hold in the GrContext's
-// GPU cache.
-static const int kMaxGaneshResourceCacheCount = 2048;
+// Default maximum number of budgeted resources in the cache.
+static const int kGrCacheMaxCount = 8192;
 
-// The limit of the bytes allocated toward GPU resources in the GrContext's
-// GPU cache.
-static const size_t kMaxGaneshResourceCacheBytes = 96 * 1024 * 1024;
+// Default maximum number of bytes of GPU memory of budgeted resources in the
+// cache.
+static const size_t kGrCacheMaxByteSize = 512 * (1 << 20);
 
 GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
     : delegate_(delegate), weak_factory_(this) {}
@@ -57,8 +56,7 @@ bool GPUSurfaceGL::Setup() {
     return false;
   }
 
-  context_->setResourceCacheLimits(kMaxGaneshResourceCacheCount,
-                                   kMaxGaneshResourceCacheBytes);
+  context_->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
 
   delegate_->GLContextClearCurrent();
 


### PR DESCRIPTION
I took the numbers from [GrResourceContext](https://github.com/google/skia/blob/a950a86d225b7912e9878ecaa47da71acc88a66d/src/gpu/GrResourceCache.h#L50) as a baseline and bumped up the cache byte size to 512. If [Android One](https://en.wikipedia.org/wiki/Android_One) devices have 1 GB of memory, 512 seemed like something reasonable. But, these numbers are arbitrary still. I tried to find a way to query the platform for these numbers but couldn't find anything reliable.

Based on advice from @brianosman and @mattsarett.