### PR TITLE
Allow running in debug product mode with checked mode off.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -24,6 +24,7 @@ struct Settings {
   bool endless_trace_buffer = false;
   bool enable_dart_profiling = false;
   bool use_test_fonts = false;
+  bool dart_non_checked_mode = false;
   std::string aot_snapshot_path;
   std::string aot_vm_snapshot_data_filename;
   std::string aot_vm_snapshot_instr_filename;

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -199,9 +199,9 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
   Dart_Isolate isolate = Dart_CreateIsolate(
       script_uri, "main",
       reinterpret_cast<const uint8_t*>(DART_SYMBOL(kDartIsolateSnapshotData)),
-      reinterpret_cast<const uint8_t*>(DART_SYMBOL(kDartIsolateSnapshotInstructions)),
-      nullptr,
-      dart_state, error);
+      reinterpret_cast<const uint8_t*>(
+          DART_SYMBOL(kDartIsolateSnapshotInstructions)),
+      nullptr, dart_state, error);
   FTL_CHECK(isolate) << error;
   dart_state->SetIsolate(isolate);
   FTL_CHECK(Dart_IsServiceIsolate(isolate));
@@ -280,8 +280,7 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
       script_uri, main,
       reinterpret_cast<uint8_t*>(DART_SYMBOL(kDartIsolateSnapshotData)),
       reinterpret_cast<uint8_t*>(DART_SYMBOL(kDartIsolateSnapshotInstructions)),
-      nullptr,
-      dart_state, error);
+      nullptr, dart_state, error);
   FTL_CHECK(isolate) << error;
   dart_state->SetIsolate(isolate);
   FTL_CHECK(!LogIfError(
@@ -378,9 +377,11 @@ DartJniIsolateData* GetDartJniDataForCurrentIsolate() {
 #if DART_ALLOW_DYNAMIC_RESOLUTION
 
 constexpr char kDartVmSnapshotDataName[] = "kDartVmSnapshotData";
-constexpr char kDartVmSnapshotInstructionsName[] = "kDartVmSnapshotInstructions";
+constexpr char kDartVmSnapshotInstructionsName[] =
+    "kDartVmSnapshotInstructions";
 constexpr char kDartIsolateSnapshotDataName[] = "kDartIsolateSnapshotData";
-constexpr char kDartIsolateSnapshotInstructionsName[] = "kDartIsolateSnapshotInstructions";
+constexpr char kDartIsolateSnapshotInstructionsName[] =
+    "kDartIsolateSnapshotInstructions";
 
 #if OS(IOS)
 
@@ -623,7 +624,8 @@ void InitDartVM() {
 #else
   // Enable checked mode if we are not running precompiled code. We run non-
   // precompiled code only in the debug product mode.
-  const bool use_checked_mode = !IsRunningPrecompiledCode();
+  const bool use_checked_mode =
+      !IsRunningPrecompiledCode() && !settings.dart_non_checked_mode;
 #endif
 
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -42,8 +42,10 @@ bool IsViewInvalid(const ftl::WeakPtr<PlatformView>& platform_view) {
   return !platform_view;
 }
 
-template <typename T> bool GetSwitchValue(const base::CommandLine& command_line,
-                                          Switch sw, T* result) {
+template <typename T>
+bool GetSwitchValue(const base::CommandLine& command_line,
+                    Switch sw,
+                    T* result) {
   auto port_string = command_line.GetSwitchValueASCII(FlagForSwitch(sw));
   std::stringstream stream(port_string);
   T value = 0;
@@ -155,6 +157,10 @@ void Shell::InitStandalone(std::string icu_data_path,
     }
   }
 
+  // Checked mode overrides.
+  settings.dart_non_checked_mode =
+      command_line.HasSwitch(FlagForSwitch(Switch::DartNonCheckedMode));
+
   settings.enable_diagnostic =
       !command_line.HasSwitch(FlagForSwitch(Switch::DisableDiagnostic));
 
@@ -185,10 +191,12 @@ void Shell::InitStandalone(std::string icu_data_path,
       FlagForSwitch(Switch::AotVmSnapshotData));
   settings.aot_vm_snapshot_instr_filename = command_line.GetSwitchValueASCII(
       FlagForSwitch(Switch::AotVmSnapshotInstructions));
-  settings.aot_isolate_snapshot_data_filename = command_line.GetSwitchValueASCII(
-      FlagForSwitch(Switch::AotIsolateSnapshotData));
-  settings.aot_isolate_snapshot_instr_filename = command_line.GetSwitchValueASCII(
-      FlagForSwitch(Switch::AotIsolateSnapshotInstructions));
+  settings.aot_isolate_snapshot_data_filename =
+      command_line.GetSwitchValueASCII(
+          FlagForSwitch(Switch::AotIsolateSnapshotData));
+  settings.aot_isolate_snapshot_instr_filename =
+      command_line.GetSwitchValueASCII(
+          FlagForSwitch(Switch::AotIsolateSnapshotInstructions));
 
   settings.temp_directory_path =
       command_line.GetSwitchValueASCII(FlagForSwitch(Switch::CacheDirPath));
@@ -205,8 +213,8 @@ void Shell::InitStandalone(std::string icu_data_path,
   }
 
   if (command_line.HasSwitch(FlagForSwitch(Switch::LogTag))) {
-    settings.log_tag = command_line.GetSwitchValueASCII(
-        FlagForSwitch(Switch::LogTag));
+    settings.log_tag =
+        command_line.GetSwitchValueASCII(FlagForSwitch(Switch::LogTag));
   }
 
   blink::Settings::Set(settings);

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -86,6 +86,13 @@ DEF_SWITCH(RunForever,
            "run-forever",
            "In non-interactive mode, keep the shell running after the Dart "
            "script has completed.")
+DEF_SWITCH(DartNonCheckedMode,
+           "dart-non-checked-mode",
+           "Dart code runs in checked mode when the runtime mode is debug. In "
+           "profile and release product modes, the application code is "
+           "precompiled and checked mode is unsupported. However, this flag "
+           "may be specified if the user wishes to run in the debug product "
+           "mode (i.e. with JIT or DBC) with checked mode off.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);


### PR DESCRIPTION
Dart code runs in checked mode when the runtime mode is debug. In profile and release product modes, the application code is precompiled and checked mode is unsupported. However, this flag may be specified if the user wishes to run in the debug product mode (i.e. with JIT or DBC) with checked mode off.

I remember we had this flag earlier. Not sure when we removed the same.