### PR TITLE
Properly return VM service assets on Fuchsia.

### DIFF
--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -333,7 +333,7 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
 }
 
 Dart_Handle GetVMServiceAssetsArchiveCallback() {
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE || defined(OS_FUCHSIA)
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
   return nullptr;
 #else   // FLUTTER_RUNTIME_MODE
   return tonic::DartConverter<tonic::Uint8List>::ToDart(


### PR DESCRIPTION
In a previous change I re-included the observatory assets in the Fuchsia build, but didn't notice this bit here.

After this, if Settings::enable_observatory can be set to true somehow, the Observatory will come up in Flutter apps on Fuchsia. Unfortunately, I'm not sure how to do that.