### PR TITLE
Revert ShadowMaskFilter use and roll Skia to 246a3c269d8dc91a47ff27f7b71508bf9e74edf5.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'github_git': 'https://github.com',
   'base_revision': 'b2412302ed4e45bfb47d7b5c0c3418077009e1ce',
-  'skia_revision': '77a7a1b57c16c97f056c1e50c03bdc954947778c',
+  'skia_revision': '246a3c269d8dc91a47ff27f7b71508bf9e74edf5',
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated

--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'github_git': 'https://github.com',
   'base_revision': 'b2412302ed4e45bfb47d7b5c0c3418077009e1ce',
-  'skia_revision': '130a118cc68f8f9973e9572356011de378463fea',
+  'skia_revision': '77a7a1b57c16c97f056c1e50c03bdc954947778c',
 
   # Note: When updating the Dart revision, ensure that all entries that are
   # dependencies of dart are also updated

--- a/flow/bitmap_image.cc
+++ b/flow/bitmap_image.cc
@@ -7,10 +7,7 @@
 namespace flow {
 
 sk_sp<SkImage> BitmapImageCreate(SkImageGenerator& generator) {
-  SkBitmap bitmap;
-  if (generator.tryGenerateBitmap(&bitmap))
-    return SkImage::MakeFromBitmap(bitmap);
-  return nullptr;
+  return SkImage::MakeFromGenerator(&generator);
 }
 
 }  // namespace flow

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -23,7 +23,6 @@
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkRect.h"
-#include "third_party/skia/include/core/SkXfermode.h"
 
 namespace flow {
 class ContainerLayer;

--- a/flow/texture_image_gles2.cc
+++ b/flow/texture_image_gles2.cc
@@ -221,7 +221,7 @@ sk_sp<SkImage> TextureImageCreate(GrContext* context,
   {
     TRACE_EVENT0("flutter", "DecodeRecommended");
     // Try the guessed config.
-    if (generator.tryGenerateBitmap(&bitmap)) {
+    if (generator.tryGenerateBitmap(&bitmap, generator.getInfo(), nullptr)) {
       return TextureImageCreate(context, bitmap);
     }
   }

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -861,49 +861,9 @@ class MaskFilter extends NativeFieldWrapperClass2 {
   ///
   /// A blur is an expensive operation and should therefore be used sparingly.
   MaskFilter.blur(BlurStyle style, double sigma) {
-    _constructorBlur(style.index, sigma);
+    _constructor(style.index, sigma);
   }
-  void _constructorBlur(int style, double sigma) native "MaskFilter_constructorBlur";
-
-  /// Creates a mask filter that implements a pair of shadows for an occluding
-  /// object - one representing ambient occlusion, and one representing a
-  /// displaced shadow from a point light.
-  ///
-  /// `occluderHeight`: Height of occluding object off of ground plane.
-  ///
-  /// `lightPos`: Position of the light applied to this object.
-  ///
-  /// `lightRadius`: Radius of the light (light is assumed to be spherical).
-  ///
-  /// `ambientAlpha`: Base opacity of the ambient occlusion shadow.
-  ///
-  /// `spotAlpha`: Base opacity of the displaced spot shadow.
-  MaskFilter.shadow({
-    double occluderHeight: 0.0,
-    double lightPosX: 0.0,
-    double lightPosY: 0.0,
-    double lightPosZ: 0.0,
-    double lightRadius: 0.0,
-    double ambientAlpha: 0.0,
-    double spotAlpha: 0.0,
-  }) {
-    if (!(occluderHeight > 0.0 &&
-          lightPosZ > occluderHeight &&
-          lightRadius > 0.0 &&
-          ambientAlpha >= 0.0 &&
-          spotAlpha >= 0.0))
-      throw new ArgumentError("Invalid shadow mask filter parameters");
-
-    _constructorShadow(occluderHeight, lightPosX, lightPosY, lightPosZ,
-                       lightRadius, ambientAlpha, spotAlpha);
-  }
-  void _constructorShadow(double occluderHeight,
-                          double lightPosX,
-                          double lightPosY,
-                          double lightPosZ,
-                          double lightRadius,
-                          double ambientAlpha,
-                          double spotAlpha) native "MaskFilter_constructorShadow";
+  void _constructor(int style, double sigma) native "MaskFilter_constructor";
 }
 
 /// A description of a color filter to apply when drawing a shape or compositing

--- a/lib/ui/painting/mask_filter.cc
+++ b/lib/ui/painting/mask_filter.cc
@@ -11,45 +11,24 @@
 #include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/dart_library_natives.h"
 #include "third_party/skia/include/effects/SkBlurMaskFilter.h"
-#include "third_party/skia/include/effects/SkShadowMaskFilter.h"
 
 namespace blink {
 
-static void MaskFilter_constructorBlur(Dart_NativeArguments args) {
-  DartCallConstructor(&MaskFilter::CreateBlur, args);
-}
-
-static void MaskFilter_constructorShadow(Dart_NativeArguments args) {
-  DartCallConstructor(&MaskFilter::CreateShadow, args);
+static void MaskFilter_constructor(Dart_NativeArguments args) {
+  DartCallConstructor(&MaskFilter::Create, args);
 }
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, MaskFilter);
 
 void MaskFilter::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({
-      {"MaskFilter_constructorBlur", MaskFilter_constructorBlur, 3, true},
-      {"MaskFilter_constructorShadow", MaskFilter_constructorShadow, 8, true},
+      {"MaskFilter_constructor", MaskFilter_constructor, 3, true},
   });
 }
 
-ftl::RefPtr<MaskFilter> MaskFilter::CreateBlur(unsigned style, double sigma) {
+ftl::RefPtr<MaskFilter> MaskFilter::Create(unsigned style, double sigma) {
   return ftl::MakeRefCounted<MaskFilter>(
       SkBlurMaskFilter::Make(static_cast<SkBlurStyle>(style), sigma));
-}
-
-ftl::RefPtr<MaskFilter> MaskFilter::CreateShadow(double occluderHeight,
-                                                 double lightPosX,
-                                                 double lightPosY,
-                                                 double lightPosZ,
-                                                 double lightRadius,
-                                                 double ambientAlpha,
-                                                 double spotAlpha) {
-  return ftl::MakeRefCounted<MaskFilter>(
-      SkShadowMaskFilter::Make(occluderHeight,
-                               SkPoint3::Make(lightPosX, lightPosY, lightPosZ),
-                               lightRadius,
-                               ambientAlpha,
-                               spotAlpha));
 }
 
 MaskFilter::MaskFilter(sk_sp<SkMaskFilter> filter)

--- a/lib/ui/painting/mask_filter.h
+++ b/lib/ui/painting/mask_filter.h
@@ -23,15 +23,7 @@ class MaskFilter : public ftl::RefCountedThreadSafe<MaskFilter>,
 
  public:
   ~MaskFilter() override;
-  static ftl::RefPtr<MaskFilter> CreateBlur(unsigned style, double sigma);
-
-  static ftl::RefPtr<MaskFilter> CreateShadow(double occluderHeight,
-                                              double lightPosX,
-                                              double lightPosY,
-                                              double lightPosZ,
-                                              double lightRadius,
-                                              double ambientAlpha,
-                                              double spotAlpha);
+  static ftl::RefPtr<MaskFilter> Create(unsigned style, double sigma);
 
   const sk_sp<SkMaskFilter>& filter() { return filter_; }
 

--- a/shell/common/diagnostic/diagnostic_server.cc
+++ b/shell/common/diagnostic/diagnostic_server.cc
@@ -136,7 +136,7 @@ void DiagnosticServer::SkiaPictureTask(Dart_Port port_id) {
   SkDynamicMemoryWStream stream;
   PngPixelSerializer serializer;
   picture->serialize(&stream, &serializer);
-  sk_sp<SkData> picture_data(stream.snapshotAsData());
+  sk_sp<SkData> picture_data(stream.detachAsData());
 
   Dart_CObject c_object;
   c_object.type = Dart_CObject_kTypedData;

--- a/sky/engine/platform/BUILD.gn
+++ b/sky/engine/platform/BUILD.gn
@@ -249,6 +249,7 @@ source_set("platform") {
     "//flutter/common",
     "//flutter/sky/engine/wtf",
     "//third_party/skia",
+    "//third_party/skia:effects",
     "//third_party/skia:gpu",
   ]
 

--- a/sky/engine/platform/graphics/DrawLooperBuilder.cpp
+++ b/sky/engine/platform/graphics/DrawLooperBuilder.cpp
@@ -38,7 +38,6 @@
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/skia/include/core/SkDrawLooper.h"
 #include "third_party/skia/include/core/SkPaint.h"
-#include "third_party/skia/include/core/SkXfermode.h"
 #include "third_party/skia/include/effects/SkBlurMaskFilter.h"
 
 namespace blink {

--- a/sky/engine/platform/graphics/GraphicsContext.cpp
+++ b/sky/engine/platform/graphics/GraphicsContext.cpp
@@ -38,7 +38,6 @@
 #include "third_party/skia/include/core/SkClipStack.h"
 #include "third_party/skia/include/core/SkColorFilter.h"
 #include "third_party/skia/include/core/SkData.h"
-#include "third_party/skia/include/core/SkDevice.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
@@ -268,7 +267,7 @@ bool GraphicsContext::getTransformedClipBounds(FloatRect* bounds) const
     if (contextDisabled())
         return false;
     SkIRect skIBounds;
-    if (!m_canvas->getClipDeviceBounds(&skIBounds))
+    if (!m_canvas->getDeviceClipBounds(&skIBounds))
         return false;
     SkRect skBounds = SkRect::Make(skIBounds);
     *bounds = FloatRect(skBounds);
@@ -1142,7 +1141,7 @@ void GraphicsContext::clipOutRoundedRect(const RoundedRect& rect)
     if (contextDisabled())
         return;
 
-    clipRoundedRect(rect, kDifference_SkClipOp);
+    clipRoundedRect(rect, SkClipOp::kDifference);
 }
 
 void GraphicsContext::canvasClip(const Path& pathToClip, WindRule clipRule)

--- a/sky/engine/platform/graphics/GraphicsContext.h
+++ b/sky/engine/platform/graphics/GraphicsContext.h
@@ -283,12 +283,12 @@ public:
 
     void clip(const IntRect& rect) { clipRect(rect); }
     void clip(const FloatRect& rect) { clipRect(rect); }
-    void clipRoundedRect(const RoundedRect&, SkClipOp = kIntersect_SkClipOp);
-    void clipOut(const IntRect& rect) { clipRect(rect, NotAntiAliased, kDifference_SkClipOp); }
+    void clipRoundedRect(const RoundedRect&, SkClipOp = SkClipOp::kIntersect);
+    void clipOut(const IntRect& rect) { clipRect(rect, NotAntiAliased, SkClipOp::kDifference); }
     void clipOutRoundedRect(const RoundedRect&);
     void clipPath(const Path&, WindRule = RULE_EVENODD);
     void clipConvexPolygon(size_t numPoints, const FloatPoint*, bool antialias = true);
-    void clipRect(const SkRect&, AntiAliasingMode = NotAntiAliased, SkClipOp = kIntersect_SkClipOp);
+    void clipRect(const SkRect&, AntiAliasingMode = NotAntiAliased, SkClipOp = SkClipOp::kIntersect);
 
     void drawText(const Font&, const TextRunPaintInfo&, const FloatPoint&);
     void drawEmphasisMarks(const Font&, const TextRunPaintInfo&, const AtomicString& mark, const FloatPoint&);
@@ -395,8 +395,8 @@ private:
 
 
     // SkCanvas wrappers.
-    void clipPath(const SkPath&, AntiAliasingMode = NotAntiAliased, SkClipOp = kIntersect_SkClipOp);
-    void clipRRect(const SkRRect&, AntiAliasingMode = NotAntiAliased, SkClipOp = kIntersect_SkClipOp);
+    void clipPath(const SkPath&, AntiAliasingMode = NotAntiAliased, SkClipOp = SkClipOp::kIntersect);
+    void clipRRect(const SkRRect&, AntiAliasingMode = NotAntiAliased, SkClipOp = SkClipOp::kIntersect);
     void concat(const SkMatrix&);
     void drawRRect(const SkRRect&, const SkPaint&);
 

--- a/sky/engine/platform/graphics/Image.h
+++ b/sky/engine/platform/graphics/Image.h
@@ -37,7 +37,6 @@
 #include "flutter/sky/engine/wtf/RefCounted.h"
 #include "flutter/sky/engine/wtf/RefPtr.h"
 #include "flutter/sky/engine/wtf/text/WTFString.h"
-#include "third_party/skia/include/core/SkXfermode.h"
 
 namespace blink {
 

--- a/sky/engine/platform/graphics/RegionTracker.cpp
+++ b/sky/engine/platform/graphics/RegionTracker.cpp
@@ -158,7 +158,7 @@ static inline bool getDeviceClipAsRect(const GraphicsContext* context, SkRect& d
     }
 
     SkIRect deviceClipIRect;
-    if (context->canvas()->getClipDeviceBounds(&deviceClipIRect))
+    if (context->canvas()->getDeviceClipBounds(&deviceClipIRect))
         deviceClipRect.set(deviceClipIRect);
     else
         deviceClipRect.setEmpty();

--- a/sky/engine/platform/graphics/skia/SkiaUtils.h
+++ b/sky/engine/platform/graphics/skia/SkiaUtils.h
@@ -43,7 +43,6 @@
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
-#include "third_party/skia/include/core/SkXfermode.h"
 
 namespace blink {
 

--- a/sky/packages/sky_engine/LICENSE
+++ b/sky/packages/sky_engine/LICENSE
@@ -16457,26 +16457,6 @@ Copyright (C) 2016, D. R. Commander
 Modifications are under the same license as the original code (see above)
 --------------------------------------------------------------------------------
 libsdl
-
-Copyright (C) 1997-2015 Sam Lantinga <slouken@libsdl.org>
-
-This software is provided 'as-is', without any express or implied
-warranty.  In no event will the authors be held liable for any damages
-arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose,
-including commercial applications, and to alter it and redistribute it
-freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not
-   claim that you wrote the original software. If you use this software
-   in a product, an acknowledgment in the product documentation would be
-   appreciated but is not required.
-2. Altered source versions must be plainly marked as such, and must not be
-   misrepresented as being the original software.
-3. This notice may not be removed or altered from any source distribution.
---------------------------------------------------------------------------------
-libsdl
 skia
 
 Copyright 2016 Google Inc.
@@ -21182,6 +21162,36 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 skia
 
+Copyright 2009 Motorola
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+skia
+
 Copyright 2009 The Android Open Source Project
 
 Redistribution and use in source and binary forms, with or without
@@ -21603,6 +21613,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 skia
 
+Copyright 2014 Google Inc.
+Copyright 2017 ARM Ltd.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+skia
+
 Copyright 2014 Google, Inc
 
 Redistribution and use in source and binary forms, with or without
@@ -21754,6 +21795,66 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 skia
 
 Copyright 2016 The Android Open Source Project
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+skia
+
+Copyright 2017 ARM Ltd.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+skia
+
+Copyright 2017 Google Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
The ShadowMaskFilter usage in lib/ui was using APIs in Skia that have been modified. On @jason-simmons ' suggestion, I have reverted the same before applying the roll. This does not contain the removal of our TextureImage as I have yet to work around issues with `SkImage::makeTextureImage`.