### PR TITLE
Simplify image uploading

### DIFF
--- a/lib/ui/painting/image_decoding.cc
+++ b/lib/ui/painting/image_decoding.cc
@@ -30,7 +30,7 @@ sk_sp<SkImage> DecodeImage(std::vector<uint8_t> buffer) {
   if (buffer.empty())
     return nullptr;
 
-  sk_sp<SkData> sk_data = SkData::MakeWithoutCopy(buffer.data(), buffer.size());
+  sk_sp<SkData> sk_data = SkData::MakeWithCopy(buffer.data(), buffer.size());
 
   if (sk_data == nullptr)
     return nullptr;

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -11,6 +11,7 @@
 #include "flutter/shell/common/rasterizer.h"
 #include "flutter/shell/common/vsync_waiter_fallback.h"
 #include "lib/ftl/functional/make_copyable.h"
+#include "third_party/skia/include/gpu/GrContextOptions.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
 namespace shell {
@@ -164,9 +165,12 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
     return;
   }
 
+  GrContextOptions options;
+  options.fDisableGpuYUVConversion = true;
   blink::ResourceContext::Set(GrContext::Create(
       GrBackend::kOpenGL_GrBackend,
-      reinterpret_cast<GrBackendContext>(GrGLCreateNativeInterface())));
+      reinterpret_cast<GrBackendContext>(GrGLCreateNativeInterface()),
+      options));
   latch->Signal();
 }
 

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -166,6 +166,10 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
   }
 
   GrContextOptions options;
+  // There is currently a bug with doing GPU YUV to RGB conversions on the IO thread.
+  // The necessary work isn't being flushed or synchronized with the other threads
+  // correctly, so the textures end up blank.  For now, suppress that feature, which
+  // will cause texture uploads to do CPU YUV conversion.
   options.fDisableGpuYUVConversion = true;
   blink::ResourceContext::Set(GrContext::Create(
       GrBackend::kOpenGL_GrBackend,


### PR DESCRIPTION
Relies on not-yet-landed Skia change:
  https://skia-review.googlesource.com/c/8443/

This allows for the deletion of texture_image_gles2.cc and
bitmap_image.cc.