### PR TITLE
Enable Observatory in the content handler

### DIFF
--- a/content_handler/app.cc
+++ b/content_handler/app.cc
@@ -46,7 +46,9 @@ App::App() {
                                      ui_task_runner,   // UI
                                      io_task_runner    // IO
                                      ));
-  blink::Settings::Set(blink::Settings());
+  blink::Settings settings;
+  settings.enable_observatory = true;
+  blink::Settings::Set(settings);
   blink::InitRuntime();
 
   blink::SetFontProvider(


### PR DESCRIPTION
I'm not sure that this is the right way to do this, but this change causes the Observatory to come up correctly in the content handler.