### PR TITLE
Remove callback from ApplicationController.Kill fidl interface.

### DIFF
--- a/content_handler/application_controller_impl.cc
+++ b/content_handler/application_controller_impl.cc
@@ -51,7 +51,7 @@ ApplicationControllerImpl::ApplicationControllerImpl(
 
 ApplicationControllerImpl::~ApplicationControllerImpl() = default;
 
-void ApplicationControllerImpl::Kill(const KillCallback& callback) {
+void ApplicationControllerImpl::Kill() {
   runtime_holder_.reset();
   app_->Destroy(this);
   // |this| has been deleted at this point.

--- a/content_handler/application_controller_impl.h
+++ b/content_handler/application_controller_impl.h
@@ -33,7 +33,7 @@ class ApplicationControllerImpl : public app::ApplicationController,
 
   // |app::ApplicationController| implementation
 
-  void Kill(const KillCallback& callback) override;
+  void Kill() override;
   void Detach() override;
 
   // |app::ServiceProvider| implementation


### PR DESCRIPTION
This needs to be submitted in conjuction with:

https://fuchsia-review.googlesource.com/c/21242
https://fuchsia-review.googlesource.com/c/21378

As context, the overall change is to remove the repsonse callback from the ApplicationController.Kill altogether. From now on, if you want to detect that the application closed after a Kill, observe when the ApplicationController connection closes.