### PR TITLE
Apply iOS status bar padding to flutter views

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -347,29 +347,13 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(
   });
 }
 
-- (bool)isWindowFullscreen {
-  UIWindow* window = self.view.window;
-  return CGRectEqualToRect(window.frame, window.screen.bounds);
-}
-
 - (CGFloat)statusBarPadding {
-  // If we're a child of a containing view, let the container apply padding.
-  if (self.parentViewController != nil) {
-    return 0.0;
-  }
-
-  // If not fullscreen, assume we don't want padding.
-  if (![self isWindowFullscreen]) {
-    return 0.0;
-  }
-
   UIScreen* screen = self.view.window.screen;
   CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
   CGRect viewFrame = [self.view convertRect:self.view.bounds
                           toCoordinateSpace:screen.coordinateSpace];
-  CGFloat padding =
-      statusFrame.origin.y + statusFrame.size.height - viewFrame.origin.y;
-  return MAX(padding, 0.0);
+  CGRect intersection = CGRectIntersection(statusFrame, viewFrame);
+  return CGRectIsNull(intersection) ? 0.0 : intersection.size.height;
 }
 
 - (void)viewDidLayoutSubviews {


### PR DESCRIPTION
This change eliminates two previous assumptions:
1. If a Flutter view is embedded in a parent view, that the parent view
   controller would apply any status bar padding necessary.
2. That we should not apply padding unless the flutter view is
   fullscreen.

A simple case where the first assumption fails to hold is a Flutter view
embedded in a UINavigationController with a hidden toolbar. A simple
case where the second assumption fails to hold is a view in a window
whose top overlaps the status bar but isn't fullscreen.