### PR TITLE
Revert "--print-deps now returns resolved paths (#3449)"

### DIFF
--- a/snapshotter/main.cc
+++ b/snapshotter/main.cc
@@ -277,7 +277,7 @@ int CreateSnapshot(const ftl::CommandLine& command_line) {
       return 1;
     }
     // The script has been loaded, print out the minimal dependencies to run.
-    for (const auto& dep : loader.dependencies()) {
+    for (const auto& dep : loader.url_dependencies()) {
       std::string file = dep;
       FTL_DCHECK(!file.empty());
       std::cout << file << "\n";


### PR DESCRIPTION
This reverts commit 0a7b177c330367904597a6129b3eb653d29dfca0.

Reason: broke hot reload when using "package:" style imports for
sources within the same project.

/tbr @abarth 