### PR TITLE
Workaround for surface size on Fuchsia/Magma

### DIFF
--- a/vulkan/vulkan_native_surface_magma.cc
+++ b/vulkan/vulkan_native_surface_magma.cc
@@ -8,6 +8,11 @@ namespace vulkan {
 
 VulkanNativeSurfaceMagma::VulkanNativeSurfaceMagma() = default;
 
+VulkanNativeSurfaceMagma::VulkanNativeSurfaceMagma(int32_t width,
+                                                   int32_t height) {
+  size_ = SkISize::Make(width, height);
+}
+
 VulkanNativeSurfaceMagma::~VulkanNativeSurfaceMagma() = default;
 
 const char* VulkanNativeSurfaceMagma::GetExtensionName() const {
@@ -50,7 +55,12 @@ bool VulkanNativeSurfaceMagma::IsValid() const {
 }
 
 SkISize VulkanNativeSurfaceMagma::GetSize() const {
-  return SkISize::Make(2160, 1440);
+  if (size_.width() != 0 && size_.height() != 0) {
+    return size_;
+  } else {
+    // TODO: Don't hardcode this after we get a proper Fuchsia Display API.
+    return SkISize::Make(2160, 1440);
+  }
 }
 
 }  // namespace vulkan

--- a/vulkan/vulkan_native_surface_magma.h
+++ b/vulkan/vulkan_native_surface_magma.h
@@ -14,6 +14,11 @@ class VulkanNativeSurfaceMagma : public vulkan::VulkanNativeSurface {
  public:
   VulkanNativeSurfaceMagma();
 
+  // Alternate constructor which allows the caller to specify the surface's
+  // width and height.
+  // TODO: Remove this once we have a Fuchsia Display API.
+  VulkanNativeSurfaceMagma(int32_t surface_width, int32_t surface_height);
+
   ~VulkanNativeSurfaceMagma();
 
   const char* GetExtensionName() const override;
@@ -29,6 +34,7 @@ class VulkanNativeSurfaceMagma : public vulkan::VulkanNativeSurface {
   SkISize GetSize() const override;
 
  private:
+  SkISize size_;
   FTL_DISALLOW_COPY_AND_ASSIGN(VulkanNativeSurfaceMagma);
 };
 


### PR DESCRIPTION
Allow surface size to be passed by caller
temporarily until we get a proper Display API