### PR TITLE
Add podspec to Flutter iOS framework.

### DIFF
--- a/shell/platform/darwin/ios/framework/Flutter.podspec
+++ b/shell/platform/darwin/ios/framework/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# NOTE: This podspec is NOT to be published. It is only used as a local source!
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter Engine'
+  s.version          = '1.0.0'
+  s.summary          = 'High-performance, high-fidelity mobile apps.'
+  s.description      = <<-DESC
+Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
+                       DESC
+  s.homepage         = 'https://flutter.io'
+  s.license          = { :type => 'MIT', :file => '../../../../../LICENSE' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '7.0'
+  s.vendored_frameworks = 'Flutter.framework'
+end

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1075,6 +1075,7 @@ FILE: ../../../flutter/shell/common/skia_event_tracer_impl.cc
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
 FILE: ../../../flutter/shell/platform/darwin/desktop/Info.plist
 FILE: ../../../flutter/shell/platform/darwin/desktop/flutter_mac.xib
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Flutter.podspec
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Info.plist
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/module.modulemap
 FILE: ../../../flutter/sky/engine/core/editing/CompositionUnderlineRangeFilter.cpp


### PR DESCRIPTION
Flutter iOS apps are already pod-enabled, so we might as well turn the
engine framework into a pod, so we don't have to manually copy the
current Flutter.framework into the app directory on every build, but
rather let Cocoapods wire things up for us.

For that to happen, we need a pod spec for Flutter.framework. This spec
will not be published, but rather downloaded as part of the engine
artifacts, and the app's Podfile will have a local path dependency on
it.