### PR TITLE
Fix pod name in Flutter.podspec.

### DIFF
--- a/shell/platform/darwin/ios/framework/Flutter.podspec
+++ b/shell/platform/darwin/ios/framework/Flutter.podspec
@@ -3,7 +3,7 @@
 #
 
 Pod::Spec.new do |s|
-  s.name             = 'Flutter Engine'
+  s.name             = 'Flutter'
   s.version          = '1.0.0'
   s.summary          = 'High-performance, high-fidelity mobile apps.'
   s.description      = <<-DESC


### PR DESCRIPTION
Names matter, and I apparently forgot to test after adding ' Engine' to
the name. Names can't contain spaces, and must match the filename.