### PR TITLE
Re-introduce //flutter/lib/snapshot:generate_snapshot_bin target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -7,6 +7,7 @@ group("flutter") {
 
   deps = [
     "//flutter/sky",
+    "//flutter/lib/snapshot:generate_snapshot_bin",
   ]
 
   if (is_fuchsia) {


### PR DESCRIPTION
This target accidentally fell out of scope with #3471, but it is needed to compile the engine on Windows.