### PR TITLE
Eliminate use of ASL on iOS, --no-redirect-to-syslog flag

### DIFF
--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -62,11 +62,6 @@ DEF_SWITCH(NonInteractive,
            "non-interactive",
            "Make the shell non-interactive. By default, the shell attempts "
            "to setup a window and create an OpenGL context.")
-DEF_SWITCH(NoRedirectToSyslog,
-           "no-redirect-to-syslog",
-           "On iOS: Don't redirect stdout and stderr to syslog by default. "
-           "This is used by the tools to read device logs. However, this can "
-           "cause logs to not show up when launched from Xcode.")
 DEF_SWITCH(Packages, "packages", "Specify the path to the packages.")
 DEF_SWITCH(StartPaused,
            "start-paused",

--- a/shell/platform/darwin/common/platform_mac.mm
+++ b/shell/platform/darwin/common/platform_mac.mm
@@ -36,20 +36,6 @@ static void InitializeLogging() {
                        false);  // Tick count
 }
 
-static void RedirectIOConnectionsToSyslog() {
-#if TARGET_OS_IPHONE
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          FlagForSwitch(Switch::NoRedirectToSyslog))) {
-    return;
-  }
-
-  asl_log_descriptor(NULL, NULL, ASL_LEVEL_INFO, STDOUT_FILENO,
-                     ASL_LOG_DESCRIPTOR_WRITE);
-  asl_log_descriptor(NULL, NULL, ASL_LEVEL_NOTICE, STDERR_FILENO,
-                     ASL_LOG_DESCRIPTOR_WRITE);
-#endif
-}
-
 static void InitializeCommandLine() {
   base::mac::ScopedNSAutoreleasePool pool;
   base::CommandLine::StringVector vector;
@@ -76,8 +62,6 @@ class EmbedderState {
         << "Embedder initialization must occur on the main platform thread";
 
     InitializeCommandLine();
-
-    RedirectIOConnectionsToSyslog();
 
     InitializeLogging();
 


### PR DESCRIPTION
ASL is deprecated and replaced by os_log() on iOS. As of iOS 10.3,
calling this function breaks our logging altogether. os_log isn't
available pre-iOS 10.0. Rather than implement version checks and
conditional logic, this change eliminates the existing redirection
altogether. All engine code should be logging via the syslog redirection
implemented in Logger_PrintString in dart_runtime_hooks.cc.

Since stdio redirection is eliminated, we eliminate the flag that
controls whether such redirection is enabled.