### PR TITLE
Do legacy image decoding for now

### DIFF
--- a/lib/ui/painting/image_decoding.cc
+++ b/lib/ui/painting/image_decoding.cc
@@ -40,9 +40,9 @@ sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer) {
   }
 
   if (auto context = ResourceContext::Get()) {
-    auto colorspace = SkColorSpace::MakeSRGB();
+    // TODO: Supply actual destination color space once available
     if (auto texture_image =
-            raster_image->makeTextureImage(context, colorspace.get())) {
+            raster_image->makeTextureImage(context, nullptr)) {
 #ifdef OS_ANDROID
       glFlush();
 #endif


### PR DESCRIPTION
Fixes iOS color problems, and cuts image memory usage in half. Because iOS doesn't have the sRGB decode extension, Skia is suppressing sRGB support. To get a color-correct image decode, we were therefore decoding to linear half-float. This brings us back to 8888 and avoids the linearization step, so colors are correct.