### PR TITLE
Perform all iOS logging through ASL

### DIFF
--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -154,7 +154,7 @@ void Logger_PrintString(Dart_NativeArguments args) {
     __android_log_print(ANDROID_LOG_INFO, tag, "%.*s", (int)length,
                         chars);
 #elif __APPLE__
-    asl_log(NULL, NULL, ASL_LEVEL_NOTICE, "%.*s", (int)length, chars);
+    asl_log_message(ASL_LEVEL_NOTICE, "%.*s", (int)length, chars);
 #endif
   }
   if (dart::bin::ShouldCaptureStdout()) {

--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -28,10 +28,7 @@
 #endif
 
 #if __APPLE__
-extern "C" {
-// Cannot import the syslog.h header directly because of macro collision
-extern void syslog(int, const char*, ...);
-}
+#include <asl.h>
 #endif
 
 using tonic::LogIfError;
@@ -157,7 +154,7 @@ void Logger_PrintString(Dart_NativeArguments args) {
     __android_log_print(ANDROID_LOG_INFO, tag, "%.*s", (int)length,
                         chars);
 #elif __APPLE__
-    syslog(1 /* LOG_ALERT */, "%.*s", (int)length, chars);
+    asl_log(NULL, NULL, ASL_LEVEL_NOTICE, "%.*s", (int)length, chars);
 #endif
   }
   if (dart::bin::ShouldCaptureStdout()) {

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -62,6 +62,11 @@ DEF_SWITCH(NonInteractive,
            "non-interactive",
            "Make the shell non-interactive. By default, the shell attempts "
            "to setup a window and create an OpenGL context.")
+DEF_SWITCH(NoRedirectToSyslog,
+           "no-redirect-to-syslog",
+           "On iOS: Don't redirect stdout and stderr to syslog by default. "
+           "This is used by the tools to read device logs. However, this can "
+           "cause logs to not show up when launched from Xcode.")
 DEF_SWITCH(Packages, "packages", "Specify the path to the packages.")
 DEF_SWITCH(StartPaused,
            "start-paused",

--- a/shell/platform/darwin/common/platform_mac.mm
+++ b/shell/platform/darwin/common/platform_mac.mm
@@ -36,6 +36,20 @@ static void InitializeLogging() {
                        false);  // Tick count
 }
 
+static void RedirectIOConnectionsToSyslog() {
+#if TARGET_OS_IPHONE
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          FlagForSwitch(Switch::NoRedirectToSyslog))) {
+    return;
+  }
+
+  asl_log_descriptor(NULL, NULL, ASL_LEVEL_NOTICE, STDOUT_FILENO,
+                     ASL_LOG_DESCRIPTOR_WRITE);
+  asl_log_descriptor(NULL, NULL, ASL_LEVEL_WARNING, STDERR_FILENO,
+                     ASL_LOG_DESCRIPTOR_WRITE);
+#endif
+}
+
 static void InitializeCommandLine() {
   base::mac::ScopedNSAutoreleasePool pool;
   base::CommandLine::StringVector vector;
@@ -62,6 +76,8 @@ class EmbedderState {
         << "Embedder initialization must occur on the main platform thread";
 
     InitializeCommandLine();
+
+    RedirectIOConnectionsToSyslog();
 
     InitializeLogging();
 


### PR DESCRIPTION
As of iOS 10, ASL is deprecated and replaced with os_log. ASL calls
continue to result in logging but as of iOS 10.3, only ASL_LOG_NOTICE
level and above are logged by default.

This change partially reverts 2937f06a15cecf5e9398334617ca156316dae52b,
adding back stdout and stderr redirection, which resulted in loss of
some direct writes to stdout that were necessary for debugging.

This change replaces the direct use of syslog with ASL on iOS, which
Apple has stated will continue to log on iOS >= 10. This eliminates the
need for the previous fwd-declaration of syslog.