### PR TITLE
Disable gn check for glue/trace_event.h non-Fuchsia path

### DIFF
--- a/glue/trace_event.h
+++ b/glue/trace_event.h
@@ -19,7 +19,7 @@
 
 #else  // defined(__Fuchsia__)
 
-#include "flutter/fml/trace_event.h"
+#include "flutter/fml/trace_event.h"  // nogncheck
 
 #endif  // defined(__Fuchsia__)
 


### PR DESCRIPTION
gn check does not run a C preprocessor, so it cannot understand that a
particular include does not apply to a particular build configuration.