### PR TITLE
Allow registering multiple task observers per message loop.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -13,6 +13,7 @@ source_set("fml") {
     "message_loop_impl.cc",
     "message_loop_impl.h",
     "paths.h",
+    "task_observer.h",
     "task_runner.cc",
     "task_runner.h",
     "thread.cc",

--- a/fml/message_loop.cc
+++ b/fml/message_loop.cc
@@ -63,8 +63,12 @@ ftl::RefPtr<MessageLoopImpl> MessageLoop::GetLoopImpl() const {
   return loop_;
 }
 
-void MessageLoop::SetTaskObserver(TaskObserver observer) {
-  loop_->SetTaskObserver(std::move(observer));
+void MessageLoop::AddTaskObserver(TaskObserver* observer) {
+  loop_->AddTaskObserver(observer);
+}
+
+void MessageLoop::RemoveTaskObserver(TaskObserver* observer) {
+  loop_->RemoveTaskObserver(observer);
 }
 
 }  // namespace fml

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_FML_MESSAGE_LOOP_H_
 #define FLUTTER_FML_MESSAGE_LOOP_H_
 
+#include "flutter/fml/task_observer.h"
 #include "lib/ftl/macros.h"
 #include "lib/ftl/tasks/task_runner.h"
 
@@ -23,9 +24,9 @@ class MessageLoop {
 
   void Terminate();
 
-  using TaskObserver = std::function<void(void)>;
+  void AddTaskObserver(TaskObserver* observer);
 
-  void SetTaskObserver(TaskObserver observer);
+  void RemoveTaskObserver(TaskObserver* observer);
 
   ftl::RefPtr<ftl::TaskRunner> GetTaskRunner() const;
 

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <deque>
 #include <queue>
+#include <set>
 #include <utility>
 
 #include "flutter/fml/message_loop.h"
@@ -34,7 +35,9 @@ class MessageLoopImpl : public ftl::RefCountedThreadSafe<MessageLoopImpl> {
 
   void PostTask(ftl::Closure task, ftl::TimePoint target_time);
 
-  void SetTaskObserver(MessageLoop::TaskObserver observer);
+  void AddTaskObserver(TaskObserver* observer);
+
+  void RemoveTaskObserver(TaskObserver* observer);
 
   void DoRun();
 
@@ -67,7 +70,7 @@ class MessageLoopImpl : public ftl::RefCountedThreadSafe<MessageLoopImpl> {
   using DelayedTaskQueue = std::
       priority_queue<DelayedTask, std::deque<DelayedTask>, DelayedTaskCompare>;
 
-  MessageLoop::TaskObserver task_observer_;
+  std::set<TaskObserver*> task_observers_;
   ftl::Mutex delayed_tasks_mutex_;
   DelayedTaskQueue delayed_tasks_ FTL_GUARDED_BY(delayed_tasks_mutex_);
   size_t order_ FTL_GUARDED_BY(delayed_tasks_mutex_);

--- a/fml/task_observer.h
+++ b/fml/task_observer.h
@@ -1,0 +1,21 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_TASK_OBSERVER_H_
+#define FLUTTER_FML_TASK_OBSERVER_H_
+
+#include "lib/ftl/macros.h"
+
+namespace fml {
+
+class TaskObserver {
+ public:
+  virtual ~TaskObserver() = default;
+
+  virtual void DidProcessTask() = 0;
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_TASK_OBSERVER_H_

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1940,6 +1940,7 @@ FILE: ../../../flutter/fml/platform/linux/message_loop_linux.h
 FILE: ../../../flutter/fml/platform/linux/paths_linux.cc
 FILE: ../../../flutter/fml/platform/linux/timerfd.cc
 FILE: ../../../flutter/fml/platform/linux/timerfd.h
+FILE: ../../../flutter/fml/task_observer.h
 FILE: ../../../flutter/fml/task_runner.cc
 FILE: ../../../flutter/fml/task_runner.h
 FILE: ../../../flutter/fml/thread.cc


### PR DESCRIPTION
This is required because the Linux test shell registers another task observer and attempts shutdown of the shell on each task invocation (by checking if it has live ports).