### PR TITLE
Avoid linking to GL from the Linux test shell.

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -23,6 +23,4 @@ executable("linux") {
     "//third_party:fontconfig",
     "//third_party/skia",
   ]
-
-  ldflags = [ "-lGL" ]
 }


### PR DESCRIPTION
Missed this linker line when I removed glfw. However `ldd` still shows we are linking with GL. That is being sourced from the Skia BUILD.gn file. I will need to patch Skia and do a roll before we stop linking with GL at all.

```
$ ldd out/host_debug_unopt/sky_shell 
	linux-vdso.so.1 =>  (0x00007ffeeedb9000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fba6354e000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fba63330000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fba63128000)
	libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007fba62efe000)
	libGL.so.1 => /usr/lib/x86_64-linux-gnu/mesa/libGL.so.1 (0x00007fba62c98000)
	libGLU.so.1 => /usr/lib/x86_64-linux-gnu/libGLU.so.1 (0x00007fba62a2a000)
	libfontconfig.so.1 => /usr/lib/x86_64-linux-gnu/libfontconfig.so.1 (0x00007fba627ee000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fba624e8000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fba622d2000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fba61f0d000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fba63752000)
	libglapi.so.0 => /usr/lib/x86_64-linux-gnu/libglapi.so.0 (0x00007fba61ce6000)
	libXext.so.6 => /usr/lib/x86_64-linux-gnu/libXext.so.6 (0x00007fba61ad4000)
	libXdamage.so.1 => /usr/lib/x86_64-linux-gnu/libXdamage.so.1 (0x00007fba618d1000)
	libXfixes.so.3 => /usr/lib/x86_64-linux-gnu/libXfixes.so.3 (0x00007fba616cb000)
	libX11-xcb.so.1 => /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1 (0x00007fba614c9000)
	libX11.so.6 => /usr/lib/x86_64-linux-gnu/libX11.so.6 (0x00007fba61194000)
	libxcb-glx.so.0 => /usr/lib/x86_64-linux-gnu/libxcb-glx.so.0 (0x00007fba60f7d000)
	libxcb-dri2.so.0 => /usr/lib/x86_64-linux-gnu/libxcb-dri2.so.0 (0x00007fba60d78000)
	libxcb-dri3.so.0 => /usr/lib/x86_64-linux-gnu/libxcb-dri3.so.0 (0x00007fba60b75000)
	libxcb-present.so.0 => /usr/lib/x86_64-linux-gnu/libxcb-present.so.0 (0x00007fba60972000)
	libxcb-sync.so.1 => /usr/lib/x86_64-linux-gnu/libxcb-sync.so.1 (0x00007fba6076c000)
	libxcb.so.1 => /usr/lib/x86_64-linux-gnu/libxcb.so.1 (0x00007fba6054d000)
	libxshmfence.so.1 => /usr/lib/x86_64-linux-gnu/libxshmfence.so.1 (0x00007fba6034b000)
	libXxf86vm.so.1 => /usr/lib/x86_64-linux-gnu/libXxf86vm.so.1 (0x00007fba60145000)
	libdrm.so.2 => /usr/lib/x86_64-linux-gnu/libdrm.so.2 (0x00007fba5ff37000)
	libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fba5fc33000)
	libfreetype.so.6 => /usr/lib/x86_64-linux-gnu/libfreetype.so.6 (0x00007fba5f990000)
	libXau.so.6 => /usr/lib/x86_64-linux-gnu/libXau.so.6 (0x00007fba5f78c000)
	libXdmcp.so.6 => /usr/lib/x86_64-linux-gnu/libXdmcp.so.6 (0x00007fba5f586000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007fba5f36d000)
	libpng12.so.0 => /lib/x86_64-linux-gnu/libpng12.so.0 (0x00007fba5f147000)

```