### PR TITLE
Ensure that the license script does not mix state among components

### DIFF
--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -400,6 +400,10 @@ abstract class License implements Comparable<License> {
 
 final Map<String, License> _registry = <String, License>{};
 
+void clearLicenseRegistry() {
+  _registry.clear();
+}
+
 final License missingLicense = new UniqueLicense._('<missing>', LicenseType.unknown);
 
 String _reformat(String body) {

--- a/travis/licenses_golden/licenses_lib
+++ b/travis/licenses_golden/licenses_lib
@@ -8,7 +8,7 @@ USED LICENSES:
 
 ====================================================================================================
 LIBRARY: icu
-ORIGIN: ../../../base/third_party/icu/LICENSE
+ORIGIN: ../../../lib/ftl/third_party/icu/LICENSE
 TYPE: LicenseType.unknown
 FILE: ../../../lib/ftl/third_party/icu/icu_utf.cc
 FILE: ../../../lib/ftl/third_party/icu/icu_utf.h


### PR DESCRIPTION
The script keeps state in the objects representing the repository files,
and it also maintains a cache of licenses.  This state should be freshly
recreated for each component so data from previous components does not
leak through.