### PR TITLE
Make FlutterActivity extend from FragmentActivity

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -67,8 +67,13 @@ shared_library("flutter_shell_native") {
   ]
 }
 
+java_prebuilt("android_support_v4") {
+  jar_path = "//third_party/android_tools/sdk/extras/android/support/v4/android-support-v4.jar"
+}
+
 java_library("flutter_shell_java") {
   supports_android = true
+  bypass_platform_checks = true
 
   java_files = [
     "io/flutter/app/FlutterActivity.java",
@@ -100,7 +105,10 @@ java_library("flutter_shell_java") {
   ]
 
   jar_path = "$root_out_dir/flutter_java.jar"
+
+  deps = [":android_support_v4"]
 }
+
 
 copy("flutter_shell_assets") {
   visibility = [ ":*" ]

--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -4,10 +4,10 @@
 
 package io.flutter.app;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
 import android.view.Window;
 import android.view.WindowManager;
 import io.flutter.plugin.platform.PlatformPlugin;
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 /**
  * Base class for activities that use Flutter.
  */
-public class FlutterActivity extends Activity {
+public class FlutterActivity extends FragmentActivity {
     private FlutterView flutterView;
 
     private String[] getArgsFromIntent(Intent intent) {


### PR DESCRIPTION
FragmentActivity is required for plugins that use auto managed Google APIs, such as Google Sign-In. Requires flutter/flutter#9036 to land so that gradle builds include FragmentActivity.

This change is required for flutter/flutter#8581