### PR TITLE
Copy platform message buffers into byte arrays passed via JNI

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -596,11 +596,11 @@ public class FlutterView extends SurfaceView
     }
 
     // Called by native to send us a platform message.
-    private void handlePlatformMessage(String channel, ByteBuffer message, final int responseId) {
+    private void handlePlatformMessage(String channel, byte[] message, final int responseId) {
         OnBinaryMessageListenerAsync listener = mMessageListeners.get(channel);
         if (listener != null) {
             try {
-                listener.onMessage(this, message,
+                listener.onMessage(this, ByteBuffer.wrap(message),
                     new BinaryMessageResponse() {
                         @Override
                         public void send(ByteBuffer response) {
@@ -622,11 +622,11 @@ public class FlutterView extends SurfaceView
     private final Map<Integer, BinaryMessageReplyCallback> mPendingResponses = new HashMap<>();
 
     // Called by native to respond to a platform message that we sent.
-    private void handlePlatformMessageResponse(int responseId, ByteBuffer response) {
+    private void handlePlatformMessageResponse(int responseId, byte[] response) {
         BinaryMessageReplyCallback callback = mPendingResponses.remove(responseId);
         if (callback != null) {
             try {
-                callback.onReply(response);
+                callback.onReply(ByteBuffer.wrap(response));
             } catch (Exception ex) {
                 Log.e(TAG, "Uncaught exception in binary message listener reply", ex);
             }

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -279,15 +279,14 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
 
   g_handle_platform_message_method =
       env->GetMethodID(g_flutter_view_class->obj(), "handlePlatformMessage",
-                       "(Ljava/lang/String;Ljava/nio/ByteBuffer;I)V");
+                       "(Ljava/lang/String;[BI)V");
 
   if (g_handle_platform_message_method == nullptr) {
     return false;
   }
 
   g_handle_platform_message_response_method = env->GetMethodID(
-      g_flutter_view_class->obj(), "handlePlatformMessageResponse",
-      "(ILjava/nio/ByteBuffer;)V");
+      g_flutter_view_class->obj(), "handlePlatformMessageResponse", "(I[B)V");
 
   if (g_handle_platform_message_response_method == nullptr) {
     return false;


### PR DESCRIPTION
The Java message object may be held by user-provided message handlers beyond
the lifetime of the raw blink::PlatformMessage and its data buffer