### PR TITLE
Cleanup timeline markers.

### DIFF
--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <vector>
 
+#include "flutter/fml/trace_event.h"
 #include "lib/ftl/build_config.h"
 
 #if OS_MACOSX
@@ -111,6 +112,7 @@ ftl::TimePoint MessageLoopImpl::RegisterTaskAndGetNextWake(
 }
 
 ftl::TimePoint MessageLoopImpl::RunExpiredTasksAndGetNextWake() {
+  TRACE_EVENT0("fml", "MessageLoop::RunExpiredTasks");
   std::vector<ftl::Closure> invocations;
 
   {

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -47,6 +47,7 @@ class Animator {
   ftl::RefPtr<LayerTreePipeline> layer_tree_pipeline_;
   flutter::Semaphore pending_frame_semaphore_;
   LayerTreePipeline::ProducerContinuation producer_continuation_;
+  int64_t frame_number_;
   bool paused_;
 
   ftl::WeakPtrFactory<Animator> weak_factory_;

--- a/shell/common/tracing_controller.cc
+++ b/shell/common/tracing_controller.cc
@@ -30,6 +30,8 @@ static void AddTraceMetadata() {
   blink::Threads::Gpu()->PostTask([]() { Dart_SetThreadName("gpu_thread"); });
   blink::Threads::UI()->PostTask([]() { Dart_SetThreadName("ui_thread"); });
   blink::Threads::IO()->PostTask([]() { Dart_SetThreadName("io_thread"); });
+  blink::Threads::Platform()->PostTask(
+      []() { Dart_SetThreadName("platform_thread"); });
 }
 
 void TracingController::StartTracing() {


### PR DESCRIPTION
* Name the platform thread in the timeline. This does not affect (nor is it affected by) the pthread name set by the embedder.
* Make it easier in the timeline to see not only when the frame was request, but also when that frame request was fulfilled.
* Trace message loop wakes.