### PR TITLE
Update selection base when deleting surrogates

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -112,18 +112,16 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
 - (void)deleteBackward {
   int start = std::max(0, std::min(_selectionBase, _selectionExtent));
   int end = std::max(0, std::max(_selectionBase, _selectionExtent));
-  int len = end - start;
-  if (len > 0) {
-    NSRange selRange = [self.text
-        rangeOfComposedCharacterSequencesForRange:NSMakeRange(start, len)];
-    [self.text deleteCharactersInRange:selRange];
-  } else if (start > 0) {
-    start -= 1;
-    NSRange charRange = [self.text rangeOfComposedCharacterSequenceAtIndex:start];
-    [self.text deleteCharactersInRange:charRange];
+  NSRange delRange = NSMakeRange(start, end - start);
+  if (delRange.length > 0) {
+    delRange = [self.text rangeOfComposedCharacterSequencesForRange:delRange];
+    [self.text deleteCharactersInRange:delRange];
+  } else if (delRange.location > 0) {
+    delRange = [self.text rangeOfComposedCharacterSequenceAtIndex:delRange.location - 1];
+    [self.text deleteCharactersInRange:delRange];
   }
-  _selectionBase = start;
-  _selectionExtent = start;
+  _selectionBase = delRange.location;
+  _selectionExtent = delRange.location;
   _selectionAffinity = _kTextAffinityDownstream;
   [self updateEditingState];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -112,16 +112,16 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
 - (void)deleteBackward {
   int start = std::max(0, std::min(_selectionBase, _selectionExtent));
   int end = std::max(0, std::max(_selectionBase, _selectionExtent));
-  NSRange delRange = NSMakeRange(start, end - start);
-  if (delRange.length > 0) {
-    delRange = [self.text rangeOfComposedCharacterSequencesForRange:delRange];
-    [self.text deleteCharactersInRange:delRange];
-  } else if (delRange.location > 0) {
-    delRange = [self.text rangeOfComposedCharacterSequenceAtIndex:delRange.location - 1];
-    [self.text deleteCharactersInRange:delRange];
+  NSRange deleteRange = NSMakeRange(start, end - start);
+  if (deleteRange.length > 0) {
+    deleteRange = [self.text rangeOfComposedCharacterSequencesForRange:deleteRange];
+    [self.text deleteCharactersInRange:deleteRange];
+  } else if (deleteRange.location > 0) {
+    deleteRange = [self.text rangeOfComposedCharacterSequenceAtIndex:deleteRange.location - 1];
+    [self.text deleteCharactersInRange:deleteRange];
   }
-  _selectionBase = delRange.location;
-  _selectionExtent = delRange.location;
+  _selectionBase = deleteRange.location;
+  _selectionExtent = deleteRange.location;
   _selectionAffinity = _kTextAffinityDownstream;
   [self updateEditingState];
 }


### PR DESCRIPTION
Ensure selection base is updated when deleting surrogates

This fixes a bug in which the selection base was not updated when
deleting at index of the trailing char of a Unicode surrogate,
introduced in 38664ac32223228476166b9050ab400c102fda05.

Minor refactor to consolidate logic around NSRange.
