### PR TITLE
Add convenience accessors to MethodCall

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/MethodCall.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodCall.java
@@ -20,8 +20,8 @@ public final class MethodCall {
      * Arguments for the call.
      *
      * Consider using {@link #arguments()} for cases where a particular run-time type is expected.
-     * Consider using {@link #argument(String)} when that run-time type is a {@link java.util.Map}
-     * or a {@link org.json.JSONObject}.
+     * Consider using {@link #argument(String)} when that run-time type is a {@link Map}
+     * or a {@link JSONObject}.
      */
     public final Object arguments;
 
@@ -50,14 +50,15 @@ public final class MethodCall {
 
     /**
      * Returns a String-keyed argument of this method call, assuming {@link #arguments} is a
-     * {@link java.util.Map} or a {@link org.json.JSONObject}. The static type of the returned
-     * result is determined by the call-site.
+     * {@link Map} or a {@link JSONObject}. The static type of the returned result is determined
+     * by the call-site.
      *
      * @param <T> the intended type of the argument.
      * @param key the String key.
      * @return the argument value at the specified key, with static type T, or {@code null}, if
      * such an entry is not present.
-     * @throws ClassCastException if {@link #arguments} is neither a Map nor a JSONObject.
+     * @throws ClassCastException if {@link #arguments} can be cast to neither {@link Map} nor
+     * {@link JSONObject}.
      */
     @SuppressWarnings("unchecked")
     public <T> T argument(String key) {

--- a/shell/platform/android/io/flutter/plugin/common/MethodCall.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodCall.java
@@ -20,7 +20,8 @@ public final class MethodCall {
      * Arguments for the call.
      *
      * Consider using {@link #arguments()} for cases where a particular run-time type is expected.
-     * Consider using {@link #argument(String)} when that run-time type is a Map with String keys.
+     * Consider using {@link #argument(String)} when that run-time type is a {@link java.util.Map}
+     * or a {@link org.json.JSONObject}.
      */
     public final Object arguments;
 

--- a/shell/platform/android/io/flutter/plugin/common/MethodCall.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodCall.java
@@ -4,6 +4,9 @@
 
 package io.flutter.plugin.common;
 
+import java.util.Map;
+import org.json.JSONObject;
+
 /**
  * Command object representing a method call on a {@link FlutterMethodChannel}.
  */
@@ -15,6 +18,9 @@ public final class MethodCall {
 
     /**
      * Arguments for the call.
+     *
+     * Consider using {@link #arguments()} for cases where a particular run-time type is expected.
+     * Consider using {@link #argument(String)} when that run-time type is a Map with String keys.
      */
     public final Object arguments;
 
@@ -28,5 +34,40 @@ public final class MethodCall {
         assert method != null;
         this.method = method;
         this.arguments = arguments;
+    }
+
+    /**
+     * Returns the arguments of this method call with a static type determined by the call-site.
+     *
+     * @param <T> the intended type of the arguments.
+     * @return the arguments with static type T
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T arguments() {
+        return (T) arguments;
+    }
+
+    /**
+     * Returns a String-keyed argument of this method call, assuming {@link #arguments} is a
+     * {@link java.util.Map} or a {@link org.json.JSONObject}. The static type of the returned
+     * result is determined by the call-site.
+     *
+     * @param <T> the intended type of the argument.
+     * @param key the String key.
+     * @return the argument value at the specified key, with static type T, or {@code null}, if
+     * such an entry is not present.
+     * @throws ClassCastException if {@link #arguments} is neither a Map nor a JSONObject.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T argument(String key) {
+        if (arguments == null) {
+            return null;
+        } else if (arguments instanceof Map) {
+            return (T) ((Map<?, ?>) arguments).get(key);
+        } else if (arguments instanceof JSONObject) {
+            return (T) ((JSONObject) arguments).opt(key);
+        } else {
+            throw new ClassCastException();
+        }
     }
 }


### PR DESCRIPTION
Exploits Java type inference to allow replacing

    @SuppressWarnings("unchecked")
    public void onMethodCall(MethodCall call, Response response) {
        ...
        response(doStuff((List<String>) call.arguments));
        ...
    }
    private int doStuff(List<String> strings) {...}

with

    public void onMethodCall(MethodCall call, Response response) {
        ...
        response(doStuff(call.arguments()));
        ...
    }
    private int doStuff(List<String> strings) {...}

Also makes it easier to use maps as arguments, replacing

    public void onMethodCall(MethodCall call, Response response) {
        ...
        Integer value = (Integer) ((Map<?, ?>) call.arguments).get("key");
        ...
    }

with

    public void onMethodCall(MethodCall call, Response response) {
        ...
        Integer value = call.argument("key");
        ...
    }
