### PR TITLE
Copy Flutter.podspec to engine out directory.

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -177,6 +177,16 @@ copy("framework_icu") {
   ]
 }
 
+copy("framework_podspec") {
+  visibility = [ ":*" ]
+  sources = [
+    "framework/Flutter.podspec",
+  ]
+  outputs = [
+    "$root_out_dir/Flutter.podspec",
+  ]
+}
+
 group("flutter_framework") {
   public_deps = [
     ":framework_dylib",
@@ -185,5 +195,6 @@ group("flutter_framework") {
     ":framework_info_plist",
     ":framework_install_name",
     ":framework_module_map",
+    ":framework_podspec",
   ]
 }


### PR DESCRIPTION
So `flutter run --local-engine=...` will work out of the box.

Fixes flutter/flutter#9154.