### PR TITLE
Partially port FML to Windows.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -90,6 +90,13 @@ source_set("fml") {
       "platform/linux/timerfd.h",
     ]
   }
+
+  if (is_win) {
+    sources += [
+      "platform/win/message_loop_win.cc",
+      "platform/win/message_loop_win.h",
+    ]
+  }
 }
 
 executable("fml_unittests") {

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -25,6 +25,11 @@ using PlatformMessageLoopImpl = fml::MessageLoopAndroid;
 #include "flutter/fml/platform/linux/message_loop_linux.h"
 using PlatformMessageLoopImpl = fml::MessageLoopLinux;
 
+#elif OS_WIN
+
+#include "flutter/fml/platform/win/message_loop_win.h"
+using PlatformMessageLoopImpl = fml::MessageLoopWin;
+
 #else
 
 #error This platform does not have a message loop implementation.

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -8,6 +8,8 @@
 #include "gtest/gtest.h"
 #include "lib/ftl/synchronization/waitable_event.h"
 
+#include <iostream>
+
 #define TIME_SENSITIVE(x) TimeSensitiveTest_##x
 
 TEST(MessageLoop, GetCurrent) {
@@ -193,7 +195,7 @@ TEST(MessageLoop, TIME_SENSITIVE(MultipleDelayedTasksWithIncreasingDeltas)) {
     for (int target_ms = 0 + 2; target_ms < count + 2; target_ms++) {
       auto begin = ftl::TimePoint::Now();
       loop.GetTaskRunner()->PostDelayedTask(
-          [begin, target_ms, &checked]() {
+          [begin, target_ms, &checked, count]() {
             auto delta = ftl::TimePoint::Now() - begin;
             auto ms = delta.ToMillisecondsF();
             ASSERT_GE(ms, target_ms - 2);
@@ -217,10 +219,10 @@ TEST(MessageLoop, TIME_SENSITIVE(MultipleDelayedTasksWithDecreasingDeltas)) {
   std::thread thread([&checked, count]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     auto& loop = fml::MessageLoop::GetCurrent();
-    for (int target_ms = count + 2; target_ms >= 0 + 2; target_ms--) {
+    for (int target_ms = count + 2; target_ms > 0 + 2; target_ms--) {
       auto begin = ftl::TimePoint::Now();
       loop.GetTaskRunner()->PostDelayedTask(
-          [begin, target_ms, &checked]() {
+          [begin, target_ms, &checked, count]() {
             auto delta = ftl::TimePoint::Now() - begin;
             auto ms = delta.ToMillisecondsF();
             ASSERT_GE(ms, target_ms - 2);

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -8,8 +8,6 @@
 #include "gtest/gtest.h"
 #include "lib/ftl/synchronization/waitable_event.h"
 
-#include <iostream>
-
 #define TIME_SENSITIVE(x) TimeSensitiveTest_##x
 
 TEST(MessageLoop, GetCurrent) {

--- a/fml/platform/win/message_loop_win.cc
+++ b/fml/platform/win/message_loop_win.cc
@@ -6,20 +6,18 @@
 
 namespace fml {
 
-MessageLoopWin::MessageLoopWin() {
-  timer_ = CreateWaitableTimer(NULL, FALSE, NULL);
-  FTL_CHECK(timer_);
+MessageLoopWin::MessageLoopWin()
+    : timer_(CreateWaitableTimer(NULL, FALSE, NULL)) {
+  FTL_CHECK(timer_.is_valid());
 }
 
-MessageLoopWin::~MessageLoopWin() {
-  FTL_CHECK(CloseHandle(timer_));
-}
+MessageLoopWin::~MessageLoopWin() = default;
 
 void MessageLoopWin::Run() {
   running_ = true;
 
   while (running_) {
-    FTL_CHECK(WaitForSingleObject(timer_, INFINITE) == 0);
+    FTL_CHECK(WaitForSingleObject(timer_.get(), INFINITE) == 0);
     RunExpiredTasksNow();
   }
 }
@@ -35,7 +33,7 @@ void MessageLoopWin::WakeUp(ftl::TimePoint time_point) {
   if (time_point > now) {
     due_time.QuadPart = (time_point - now).ToNanoseconds() / -100;
   }
-  FTL_CHECK(SetWaitableTimer(timer_, &due_time, 0, NULL, NULL, FALSE));
+  FTL_CHECK(SetWaitableTimer(timer_.get(), &due_time, 0, NULL, NULL, FALSE));
 }
 
 }  // namespace fml

--- a/fml/platform/win/message_loop_win.cc
+++ b/fml/platform/win/message_loop_win.cc
@@ -1,0 +1,41 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/platform/win/message_loop_win.h"
+
+namespace fml {
+
+MessageLoopWin::MessageLoopWin() {
+  timer_ = CreateWaitableTimer(NULL, FALSE, NULL);
+  FTL_CHECK(timer_);
+}
+
+MessageLoopWin::~MessageLoopWin() {
+  FTL_CHECK(CloseHandle(timer_));
+}
+
+void MessageLoopWin::Run() {
+  running_ = true;
+
+  while (running_) {
+    FTL_CHECK(WaitForSingleObject(timer_, INFINITE) == 0);
+    RunExpiredTasksNow();
+  }
+}
+
+void MessageLoopWin::Terminate() {
+  running_ = false;
+  WakeUp(ftl::TimePoint::Now());
+}
+
+void MessageLoopWin::WakeUp(ftl::TimePoint time_point) {
+  LARGE_INTEGER due_time = {0};
+  ftl::TimePoint now = ftl::TimePoint::Now();
+  if (time_point > now) {
+    due_time.QuadPart = (time_point - now).ToNanoseconds() / -100;
+  }
+  FTL_CHECK(SetWaitableTimer(timer_, &due_time, 0, NULL, NULL, FALSE));
+}
+
+}  // namespace fml

--- a/fml/platform/win/message_loop_win.h
+++ b/fml/platform/win/message_loop_win.h
@@ -11,13 +11,20 @@
 
 #include "flutter/fml/message_loop_impl.h"
 #include "lib/ftl/macros.h"
+#include "lib/ftl/memory/unique_object.h"
 
 namespace fml {
 
 class MessageLoopWin : public MessageLoopImpl {
  private:
+  struct UniqueHandleTraits {
+    static HANDLE InvalidValue() { return NULL; }
+    static bool IsValid(HANDLE value) { return value != NULL; }
+    static void Free(HANDLE value) { CloseHandle(value); }
+  };
+
   bool running_;
-  HANDLE timer_;
+  ftl::UniqueObject<HANDLE, UniqueHandleTraits> timer_;
 
   MessageLoopWin();
 

--- a/fml/platform/win/message_loop_win.h
+++ b/fml/platform/win/message_loop_win.h
@@ -1,0 +1,39 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_PLATFORM_WIN_MESSAGE_LOOP_WIN_H_
+#define FLUTTER_FML_PLATFORM_WIN_MESSAGE_LOOP_WIN_H_
+
+#include <atomic>
+
+#include <windows.h>
+
+#include "flutter/fml/message_loop_impl.h"
+#include "lib/ftl/macros.h"
+
+namespace fml {
+
+class MessageLoopWin : public MessageLoopImpl {
+ private:
+  bool running_;
+  HANDLE timer_;
+
+  MessageLoopWin();
+
+  ~MessageLoopWin() override;
+
+  void Run() override;
+
+  void Terminate() override;
+
+  void WakeUp(ftl::TimePoint time_point) override;
+
+  FRIEND_MAKE_REF_COUNTED(MessageLoopWin);
+  FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopWin);
+  FTL_DISALLOW_COPY_AND_ASSIGN(MessageLoopWin);
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_PLATFORM_GENERIC_MESSAGE_LOOP_GENERIC_H_

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1399,6 +1399,8 @@ FILE: ../../../flutter/fml/platform/linux/message_loop_linux.h
 FILE: ../../../flutter/fml/platform/linux/paths_linux.cc
 FILE: ../../../flutter/fml/platform/linux/timerfd.cc
 FILE: ../../../flutter/fml/platform/linux/timerfd.h
+FILE: ../../../flutter/fml/platform/win/message_loop_win.cc
+FILE: ../../../flutter/fml/platform/win/message_loop_win.h
 FILE: ../../../flutter/fml/task_observer.h
 FILE: ../../../flutter/fml/task_runner.cc
 FILE: ../../../flutter/fml/task_runner.h


### PR DESCRIPTION
* Adds a message loop impl for Windows
* Ports `thread.cc` to Windows

All FML unittests are now passing on Windows.

FML as a whole does not compile on windows yet because `mapping.cc` imports `sys/mman.h`, which is not available on Windows and the replacement API for memory-mapped files is very different on Windows, see https://msdn.microsoft.com/en-us/library/windows/desktop/aa366556%28v=vs.85%29.aspx.