### PR TITLE
Implement UITextinput protocol

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -19,31 +19,131 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   return UIKeyboardTypeDefault;
 }
 
-@interface FlutterTextInputView : UIView<UIKeyInput>
+#pragma mark - FlutterTextPosition
 
+/** An indexed position in the buffer of a Flutter text editing widget. */
+@interface FlutterTextPosition : UITextPosition
+
+@property(nonatomic, readonly) NSUInteger index;
+
++ (instancetype)positionWithIndex:(NSUInteger)index;
+- (instancetype)initWithIndex:(NSUInteger)index;
+
+@end
+
+@implementation FlutterTextPosition
+
++ (instancetype)positionWithIndex:(NSUInteger)index {
+  return [[[FlutterTextPosition alloc] initWithIndex:index] autorelease];
+}
+
+- (instancetype)initWithIndex:(NSUInteger)index {
+  self = [super init];
+  if (self) {
+    _index = index;
+  }
+  return self;
+}
+
+@end
+
+#pragma mark - FlutterTextRange
+
+/** A range of text in the buffer of a Flutter text editing widget. */
+@interface FlutterTextRange : UITextRange<NSCopying>
+
+@property(nonatomic, readonly) NSRange range;
+
++ (instancetype)rangeWithNSRange:(NSRange)range;
+
+@end
+
+@implementation FlutterTextRange
+
++ (instancetype)rangeWithNSRange:(NSRange)range {
+  return [[[FlutterTextRange alloc] initWithNSRange:range] autorelease];
+}
+
+- (instancetype)initWithNSRange:(NSRange)range {
+  self = [super init];
+  if (self) {
+    _range = range;
+  }
+  return self;
+}
+
+- (UITextPosition*)start {
+  return [FlutterTextPosition positionWithIndex:self.range.location];
+}
+
+- (UITextPosition*)end {
+  return [FlutterTextPosition positionWithIndex:self.range.location + self.range.length];
+}
+
+- (BOOL)isEmpty {
+  return self.range.length == 0;
+}
+
+- (id)copyWithZone:(NSZone*)zone {
+  return [[FlutterTextRange allocWithZone:zone] initWithNSRange:self.range];
+}
+
+@end
+
+@interface FlutterTextInputView : UIView<UITextInput>
+
+// UITextInput
 @property(nonatomic, readonly) NSMutableString* text;
+@property(nonatomic, readonly) NSMutableString* markedText;
+@property(readwrite, copy) UITextRange* selectedTextRange;
+@property(nonatomic, strong) UITextRange* markedTextRange;
+@property(nonatomic, copy) NSDictionary* markedTextStyle;
+@property(nonatomic, assign) id<UITextInputDelegate> inputDelegate;
+
+// UITextInputTraits
+@property(nonatomic) UITextAutocapitalizationType autocapitalizationType;
+@property(nonatomic) UITextAutocorrectionType autocorrectionType;
+@property(nonatomic) UITextSpellCheckingType spellCheckingType;
+@property(nonatomic) BOOL enablesReturnKeyAutomatically;
+@property(nonatomic) UIKeyboardAppearance keyboardAppearance;
+@property(nonatomic) UIKeyboardType keyboardType;
+@property(nonatomic) UIReturnKeyType returnKeyType;
+@property(nonatomic, getter=isSecureTextEntry) BOOL secureTextEntry;
+@property(nonatomic, copy) UITextContentType textContentType;
+
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
 
 @end
 
 @implementation FlutterTextInputView {
   int _textInputClient;
-  int _selectionBase;
-  int _selectionExtent;
   const char* _selectionAffinity;
+  FlutterTextRange* _selectedTextRange;
 }
 
-@synthesize keyboardType = _keyboardType;
-
-@synthesize textInputDelegate = _textInputDelegate;
+@synthesize tokenizer = _tokenizer;
 
 - (instancetype)init {
   self = [super init];
 
   if (self) {
-    _selectionBase = -1;
-    _selectionExtent = -1;
+    _textInputClient = 0;
+    _selectionAffinity = _kTextAffinityUpstream;
+
+    // UITextInput
     _text = [[NSMutableString alloc] init];
+    _markedText = [[NSMutableString alloc] init];
+    _selectedTextRange = [[FlutterTextRange alloc] initWithNSRange:NSMakeRange(0, 0)];
+
+    // UITextInputTraits
+    _autocapitalizationType = UITextAutocapitalizationTypeSentences;
+    _autocorrectionType = UITextAutocorrectionTypeDefault;
+    _spellCheckingType = UITextSpellCheckingTypeDefault;
+    _enablesReturnKeyAutomatically = NO;
+    _keyboardAppearance = UIKeyboardAppearanceDefault;
+    _keyboardType = UIKeyboardTypeDefault;
+    _returnKeyType = UIReturnKeyDefault;
+    _secureTextEntry = NO;
   }
 
   return self;
@@ -51,6 +151,10 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
 
 - (void)dealloc {
   [_text release];
+  [_markedText release];
+  [_markedTextRange release];
+  [_selectedTextRange release];
+  [_tokenizer release];
   [super dealloc];
 }
 
@@ -59,16 +163,23 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
 }
 
 - (void)setTextInputState:(NSDictionary*)state {
-  _selectionBase = [state[@"selectionBase"] intValue];
-  _selectionExtent = [state[@"selectionExtent"] intValue];
+  NSInteger selectionBase = [state[@"selectionBase"] intValue];
+  NSInteger selectionExtent = [state[@"selectionExtent"] intValue];
+
+  [self.inputDelegate textWillChange:self];
+  [self.text setString:state[@"text"]];
+  [self.inputDelegate textDidChange:self];
+
+  [self.inputDelegate selectionWillChange:self];
+  NSUInteger start = MAX(0, MIN(selectionBase, selectionExtent));
+  NSUInteger end = MAX(0, MAX(selectionBase, selectionExtent));
+  NSRange selectedRange = NSMakeRange(start, end - start);
+  [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
+          updateEditingState:NO];
   _selectionAffinity = _kTextAffinityDownstream;
   if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
     _selectionAffinity = _kTextAffinityUpstream;
-  [self.text setString:state[@"text"]];
-}
-
-- (UITextAutocorrectionType)autocorrectionType {
-  return UITextAutocorrectionTypeNo;
+  [self.inputDelegate selectionDidChange:self];
 }
 
 #pragma mark - UIResponder Overrides
@@ -77,52 +188,290 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   return YES;
 }
 
+#pragma mark - UITextInput Overrides
+
+- (id<UITextInputTokenizer>)tokenizer {
+  if (_tokenizer == nil) {
+    _tokenizer = [[UITextInputStringTokenizer alloc] initWithTextInput:self];
+  }
+  return _tokenizer;
+}
+
+- (UITextRange*)selectedTextRange {
+  return [[_selectedTextRange copy] autorelease];
+}
+
+- (void)setSelectedTextRange:(UITextRange*)selectedTextRange {
+  [self setSelectedTextRange:selectedTextRange updateEditingState:YES];
+}
+
+- (void)setSelectedTextRange:(UITextRange*)selectedTextRange updateEditingState:(BOOL)update {
+  if (_selectedTextRange != selectedTextRange) {
+    UITextRange* oldSelectedRange = _selectedTextRange;
+    _selectedTextRange = [selectedTextRange copy];
+    [oldSelectedRange release];
+
+    if (update)
+      [self updateEditingState];
+  }
+}
+
+- (NSString*)textInRange:(UITextRange*)range {
+  NSRange textRange = ((FlutterTextRange*)range).range;
+  return [self.text substringWithRange:textRange];
+}
+
+- (void)replaceRange:(UITextRange*)range withText:(NSString*)text {
+  NSRange replaceRange = ((FlutterTextRange*)range).range;
+  NSRange selectedRange = _selectedTextRange.range;
+
+  // Adjust the text selection:
+  // * reduce the length by the intersection length
+  // * adjust the location by newLength - oldLength + intersectionLength
+  NSRange intersectionRange = NSIntersectionRange(replaceRange, selectedRange);
+  if (replaceRange.location <= selectedRange.location)
+    selectedRange.location += text.length - replaceRange.length;
+  if (intersectionRange.location != NSNotFound) {
+    selectedRange.location += intersectionRange.length;
+    selectedRange.length -= intersectionRange.length;
+  }
+
+  [self.inputDelegate textWillChange:self];
+  [self.inputDelegate selectionWillChange:self];
+
+  [self.text replaceCharactersInRange:replaceRange withString:text];
+  [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
+          updateEditingState:NO];
+
+  [self.inputDelegate textDidChange:self];
+  [self.inputDelegate selectionDidChange:self];
+
+  [self updateEditingState];
+}
+
+- (void)setMarkedText:(NSString*)markedText selectedRange:(NSRange)markedSelectedRange {
+  NSRange selectedRange = _selectedTextRange.range;
+  NSRange markedTextRange = ((FlutterTextRange*)self.markedTextRange).range;
+
+  if (markedText == nil)
+    markedText = @"";
+
+  if (markedTextRange.length > 0) {
+    // Replace text in the marked range with the new text.
+    [self replaceRange:self.markedTextRange withText:markedText];
+    markedTextRange.length = markedText.length;
+  } else {
+    // Replace text in the selected range with the new text.
+    [self replaceRange:_selectedTextRange withText:markedText];
+    markedTextRange = NSMakeRange(selectedRange.location, markedText.length);
+  }
+
+  self.markedTextRange =
+      markedTextRange.length > 0 ? [FlutterTextRange rangeWithNSRange:markedTextRange] : nil;
+
+  [self.inputDelegate selectionWillChange:self];
+  NSUInteger selectionLocation = markedSelectedRange.location + markedTextRange.location;
+  selectedRange = NSMakeRange(selectionLocation, markedSelectedRange.length);
+  [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
+          updateEditingState:YES];
+  [self.inputDelegate selectionDidChange:self];
+}
+
+- (void)unmarkText {
+  self.markedTextRange = nil;
+  [self updateEditingState];
+}
+
+- (UITextRange*)textRangeFromPosition:(UITextPosition*)fromPosition
+                           toPosition:(UITextPosition*)toPosition {
+  NSUInteger fromIndex = ((FlutterTextPosition*)fromPosition).index;
+  NSUInteger toIndex = ((FlutterTextPosition*)toPosition).index;
+  return [FlutterTextRange rangeWithNSRange:NSMakeRange(fromIndex, toIndex - fromIndex)];
+}
+
+- (NSUInteger)decrementOffsetPosition:(NSUInteger)position {
+  return [self.text rangeOfComposedCharacterSequenceAtIndex:MAX(0, position - 1)].location;
+}
+
+- (NSUInteger)incrementOffsetPosition:(NSUInteger)position {
+  NSRange charRange = [self.text rangeOfComposedCharacterSequenceAtIndex:position];
+  return MIN(position + charRange.length, self.text.length);
+}
+
+- (UITextPosition*)positionFromPosition:(UITextPosition*)position offset:(NSInteger)offset {
+  NSUInteger offsetPosition = ((FlutterTextPosition*)position).index;
+  if (offset >= 0) {
+    for (NSInteger i = 0; i < offset && offsetPosition < self.text.length; ++i)
+      offsetPosition = [self incrementOffsetPosition:offsetPosition];
+  } else {
+    for (NSInteger i = 0; i < ABS(offset) && offsetPosition > 0; ++i)
+      offsetPosition = [self decrementOffsetPosition:offsetPosition];
+  }
+  return [FlutterTextPosition positionWithIndex:offsetPosition];
+}
+
+- (UITextPosition*)positionFromPosition:(UITextPosition*)position
+                            inDirection:(UITextLayoutDirection)direction
+                                 offset:(NSInteger)offset {
+  // TODO(cbracken) Add RTL handling.
+  switch (direction) {
+    case UITextLayoutDirectionLeft:
+    case UITextLayoutDirectionUp:
+      return [self positionFromPosition:position offset:offset * -1];
+    case UITextLayoutDirectionRight:
+    case UITextLayoutDirectionDown:
+      return [self positionFromPosition:position offset:1];
+  }
+}
+
+- (UITextPosition*)beginningOfDocument {
+  return [FlutterTextPosition positionWithIndex:0];
+}
+
+- (UITextPosition*)endOfDocument {
+  return [FlutterTextPosition positionWithIndex:self.text.length];
+}
+
+- (NSComparisonResult)comparePosition:(UITextPosition*)position toPosition:(UITextPosition*)other {
+  NSUInteger positionIndex = ((FlutterTextPosition*)position).index;
+  NSUInteger otherIndex = ((FlutterTextPosition*)other).index;
+  if (positionIndex < otherIndex)
+    return NSOrderedAscending;
+  if (positionIndex > otherIndex)
+    return NSOrderedDescending;
+  return NSOrderedSame;
+}
+
+- (NSInteger)offsetFromPosition:(UITextPosition*)from toPosition:(UITextPosition*)toPosition {
+  return ((FlutterTextPosition*)toPosition).index - ((FlutterTextPosition*)from).index;
+}
+
+- (UITextPosition*)positionWithinRange:(UITextRange*)range
+                   farthestInDirection:(UITextLayoutDirection)direction {
+  NSUInteger index;
+  switch (direction) {
+    case UITextLayoutDirectionLeft:
+    case UITextLayoutDirectionUp:
+      index = ((FlutterTextPosition*)range.start).index;
+      break;
+    case UITextLayoutDirectionRight:
+    case UITextLayoutDirectionDown:
+      index = ((FlutterTextPosition*)range.end).index;
+      break;
+  }
+  return [FlutterTextPosition positionWithIndex:index];
+}
+
+- (UITextRange*)characterRangeByExtendingPosition:(UITextPosition*)position
+                                      inDirection:(UITextLayoutDirection)direction {
+  NSUInteger positionIndex = ((FlutterTextPosition*)position).index;
+  NSUInteger startIndex;
+  NSUInteger endIndex;
+  switch (direction) {
+    case UITextLayoutDirectionLeft:
+    case UITextLayoutDirectionUp:
+      startIndex = [self decrementOffsetPosition:positionIndex];
+      endIndex = positionIndex;
+      break;
+    case UITextLayoutDirectionRight:
+    case UITextLayoutDirectionDown:
+      startIndex = positionIndex;
+      endIndex = [self incrementOffsetPosition:positionIndex];
+      break;
+  }
+  return [FlutterTextRange rangeWithNSRange:NSMakeRange(startIndex, endIndex - startIndex)];
+}
+
+#pragma mark - UITextInput text direction handling
+
+- (UITextWritingDirection)baseWritingDirectionForPosition:(UITextPosition*)position
+                                              inDirection:(UITextStorageDirection)direction {
+  // TODO(cbracken) Add RTL handling.
+  return UITextWritingDirectionNatural;
+}
+
+- (void)setBaseWritingDirection:(UITextWritingDirection)writingDirection
+                       forRange:(UITextRange*)range {
+  // TODO(cbracken) Add RTL handling.
+}
+
+#pragma mark - UITextInput cursor, selection rect handling
+
+// The following methods are required to support force-touch cursor positioning and to position the
+// candidates view for multi-stage input methods (e.g., Japanese) when using a physical keyboard.
+
+- (CGRect)firstRectForRange:(UITextRange*)range {
+  // TODO(cbracken) Implement.
+  return CGRectZero;
+}
+
+- (CGRect)caretRectForPosition:(UITextPosition*)position {
+  // TODO(cbracken) Implement.
+  return CGRectZero;
+}
+
+- (UITextPosition*)closestPositionToPoint:(CGPoint)point {
+  // TODO(cbracken) Implement.
+  NSUInteger currentIndex = ((FlutterTextPosition*)_selectedTextRange.start).index;
+  return [FlutterTextPosition positionWithIndex:currentIndex];
+}
+
+- (NSArray*)selectionRectsForRange:(UITextRange*)range {
+  // TODO(cbracken) Implement.
+  return @[];
+}
+
+- (UITextPosition*)closestPositionToPoint:(CGPoint)point withinRange:(UITextRange*)range {
+  // TODO(cbracken) Implement.
+  return range.start;
+}
+
+- (UITextRange*)characterRangeAtPoint:(CGPoint)point {
+  // TODO(cbracken) Implement.
+  NSUInteger currentIndex = ((FlutterTextPosition*)_selectedTextRange.start).index;
+  if (currentIndex < self.text.length)
+    return [FlutterTextRange
+        rangeWithNSRange:[self.text rangeOfComposedCharacterSequenceAtIndex:currentIndex]];
+  return [FlutterTextRange rangeWithNSRange:NSMakeRange(currentIndex, 0)];
+}
+
 #pragma mark - UIKeyInput Overrides
 
 - (void)updateEditingState {
+  NSUInteger selectionBase = ((FlutterTextPosition*)_selectedTextRange.start).index;
+  NSUInteger selectionExtent = ((FlutterTextPosition*)_selectedTextRange.end).index;
+
+  NSUInteger composingBase = 0;
+  NSUInteger composingExtent = 0;
+  if (self.markedTextRange != nil) {
+    composingBase = ((FlutterTextPosition*)self.markedTextRange.start).index;
+    composingExtent = ((FlutterTextPosition*)self.markedTextRange.end).index;
+  }
   [_textInputDelegate updateEditingClient:_textInputClient
                                 withState:@{
-                                  @"selectionBase" : @(_selectionBase),
-                                  @"selectionExtent" : @(_selectionExtent),
+                                  @"selectionBase" : @(selectionBase),
+                                  @"selectionExtent" : @(selectionExtent),
                                   @"selectionAffinity" : @(_selectionAffinity),
                                   @"selectionIsDirectional" : @(false),
-                                  @"composingBase" : @(0),
-                                  @"composingExtent" : @(0),
+                                  @"composingBase" : @(composingBase),
+                                  @"composingExtent" : @(composingExtent),
                                   @"text" : [NSString stringWithString:self.text],
                                 }];
 }
 
 - (BOOL)hasText {
-  return YES;
+  return self.text.length > 0;
 }
 
 - (void)insertText:(NSString*)text {
-  int start = MAX(0, MIN(_selectionBase, _selectionExtent));
-  int end = MAX(0, MIN(_selectionBase, _selectionExtent));
-  int len = end - start;
-  [self.text replaceCharactersInRange:NSMakeRange(start, len) withString:text];
-  int caret = start + text.length;
-  _selectionBase = caret;
-  _selectionExtent = caret;
   _selectionAffinity = _kTextAffinityUpstream;
-  [self updateEditingState];
+  [self replaceRange:_selectedTextRange withText:text];
 }
 
 - (void)deleteBackward {
-  int start = MAX(0, MIN(_selectionBase, _selectionExtent));
-  int end = MAX(0, MIN(_selectionBase, _selectionExtent));
-  NSRange deleteRange = NSMakeRange(start, end - start);
-  if (deleteRange.length > 0) {
-    deleteRange = [self.text rangeOfComposedCharacterSequencesForRange:deleteRange];
-    [self.text deleteCharactersInRange:deleteRange];
-  } else if (deleteRange.location > 0) {
-    deleteRange = [self.text rangeOfComposedCharacterSequenceAtIndex:deleteRange.location - 1];
-    [self.text deleteCharactersInRange:deleteRange];
-  }
-  _selectionBase = deleteRange.location;
-  _selectionExtent = deleteRange.location;
   _selectionAffinity = _kTextAffinityDownstream;
-  [self updateEditingState];
+  if (!_selectedTextRange.isEmpty)
+    [self replaceRange:_selectedTextRange withText:@""];
 }
 
 @end


### PR DESCRIPTION
Supports:
* autocorrect, suggestions view/selection.
* Support for Chinese, Japanese, Korean and other languages using
  multi-stage input with candidate selection.
* styling the composing (mark) region for multi-stage input
* key-repeat when backspace held down
* physical and soft keyboard support for arrow key cursor movement and
  selection.
* improved third-party keyboard support

Does not yet support:
* force-touch drag cursor positioning
* auto-positioning the candidates view for multi-stage input methods
  when used with a physical keyboard (e.g., iPad Pro) currently
  positioned at 0,0.
* voice dictation