### PR TITLE
Eliminate UITextInput.textContentType

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -109,7 +109,6 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
 @property(nonatomic) UIKeyboardType keyboardType;
 @property(nonatomic) UIReturnKeyType returnKeyType;
 @property(nonatomic, getter=isSecureTextEntry) BOOL secureTextEntry;
-@property(nonatomic, copy) UITextContentType textContentType;
 
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
 


### PR DESCRIPTION
textContentType was added in iOS 10, and we target iOS 8. Either way the
framework doesn't (yet) include support for this; keyboard type covers
most bases.