### PR TITLE
Add support for scaling the GPUSurfaceSoftware.

### DIFF
--- a/shell/common/surface.cc
+++ b/shell/common/surface.cc
@@ -64,8 +64,8 @@ double Surface::GetScale() const {
 }
 
 void Surface::SetScale(double scale) {
-  static const double kMaxScale = 1.0;
-  static const double kMinScale = 0.25;
+  static constexpr double kMaxScale = 1.0;
+  static constexpr double kMinScale = 0.25;
   if (scale > kMaxScale) {
     scale = kMaxScale;
   } else if (scale < kMinScale) {

--- a/shell/common/surface.cc
+++ b/shell/common/surface.cc
@@ -51,6 +51,27 @@ bool SurfaceFrame::PerformSubmit() {
   return false;
 }
 
+Surface::Surface() : scale_(1.0) {}
+
 Surface::~Surface() = default;
+
+bool Surface::SupportsScaling() const {
+  return false;
+}
+
+double Surface::GetScale() const {
+  return scale_;
+}
+
+void Surface::SetScale(double scale) {
+  static const double kMaxScale = 1.0;
+  static const double kMinScale = 0.25;
+  if (scale > kMaxScale) {
+    scale = kMaxScale;
+  } else if (scale < kMinScale) {
+    scale = kMinScale;
+  }
+  scale_ = scale;
+}
 
 }  // namespace shell

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -42,6 +42,8 @@ class SurfaceFrame {
 
 class Surface {
  public:
+  Surface();
+
   virtual ~Surface();
 
   virtual bool Setup() = 0;
@@ -51,6 +53,15 @@ class Surface {
   virtual std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) = 0;
 
   virtual GrContext* GetContext() = 0;
+
+  virtual bool SupportsScaling() const;
+
+  double GetScale() const;
+
+  void SetScale(double scale);
+
+ private:
+  double scale_;
 };
 
 }  // namespace shell

--- a/shell/gpu/gpu_surface_software.h
+++ b/shell/gpu/gpu_surface_software.h
@@ -32,6 +32,8 @@ class GPUSurfaceSoftware : public Surface {
 
   GrContext* GetContext() override;
 
+  bool SupportsScaling() const override;
+
  private:
   GPUSurfaceSoftwareDelegate* delegate_;
 


### PR DESCRIPTION
This add support for setting a surface scaling parameter. Only certain backends support this sort of scaling (indicated by `SupportsScaling`). Based on traces attached, a scene rendering at 1x using the software backend taking ~30 per frame takes ~7ms per frame at 0.5x for what I think is acceptable loss of fidelity during application development on the simulator. How we determine the appropriate scaling is less clear. We either do this by determining the simulator scale and then setting the scaling accordingly or measuring the time taken by the pipeline consumer and setting the scaling to a value that makes the application responsive of less powerful hardware.

[Traces](https://github.com/flutter/engine/files/926567/Traces.zip) for each of the following scenes.
![1xscale](https://cloud.githubusercontent.com/assets/44085/25103060/ddc54faa-236f-11e7-83ff-e4b980277ad2.png)
![0_5xscale](https://cloud.githubusercontent.com/assets/44085/25103058/ddc11368-236f-11e7-83ff-9a9b19b8e40c.png)
![0_25xscale](https://cloud.githubusercontent.com/assets/44085/25103059/ddc33bac-236f-11e7-8ef2-47992b10ad39.png)
