### PR TITLE
Only log about resource context setup failures on debug builds.

### DIFF
--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -159,8 +159,8 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
   bool current = ResourceContextMakeCurrent();
 
   if (!current) {
-    FTL_LOG(WARNING)
-        << "WARNING: Could not setup an OpenGL context on the resource loader.";
+    FTL_DLOG(WARNING)
+        << "WARNING: Could not setup a context on the resource loader.";
     latch->Signal();
     return;
   }


### PR DESCRIPTION
We were unnecessarily alarming users when they used the software backend. Fixes https://github.com/flutter/flutter/issues/9394