### PR TITLE
Rename library to dart.ui

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 /// An opaque object representing a composited scene.
 ///

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 /// Base class for [Size] and [Offset], which are both ways to describe
 /// a distance as a two-dimensional axis-aligned vector.

--- a/lib/ui/hash_codes.dart
+++ b/lib/ui/hash_codes.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 class _HashEnd { const _HashEnd(); }
 const _HashEnd _hashEnd = const _HashEnd();

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 String _decodeUTF8(ByteData message) {
   return message != null ? UTF8.decoder.convert(message.buffer.asUint8List()) : null;

--- a/lib/ui/lerp.dart
+++ b/lib/ui/lerp.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 /// Linearly interpolate between two numbers.
 double lerpDouble(num a, num b, double t) {

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 // Corelib 'print' implementation.
 void _print(arg) {

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 Color _scaleAlpha(Color a, double factor) {
   return a.withAlpha((a.alpha * factor).round());

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 /// How the pointer has changed since the last report.
 enum PointerChange {

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 /// The possible actions that can be conveyed from the operating system
 /// accessibility APIs to a semantics node.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 /// Whether to slant the glyphs in the font
 enum FontStyle {

--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -9,7 +9,7 @@
 /// This library exposes the lowest-level services that Flutter frameworks use
 /// to bootstrap applications, such as classes for driving the input, graphics
 /// text, layout, and rendering subsystems.
-library dart_ui;
+library dart.ui;
 
 import 'dart:_internal';
 import 'dart:async';

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of dart_ui;
+part of dart.ui;
 
 /// Signature of callbacks that have no arguments and return no data.
 typedef void VoidCallback();


### PR DESCRIPTION
This name is consistent with how the other `dart:` libraries are named now.