### PR TITLE
Make dart:ui more consistent with other built in libraries

### DIFF
--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -73,7 +73,7 @@ copy("copy_dart_ui") {
   sources = dart_ui_files
 
   outputs = [
-    "$root_gen_dir/dart-pkg/sky_engine/lib/dart_ui/{{source_file_part}}",
+    "$root_gen_dir/dart-pkg/sky_engine/lib/ui/{{source_file_part}}",
   ]
 }
 

--- a/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/sky/packages/sky_engine/lib/_embedder.yaml
@@ -8,7 +8,7 @@ embedded_libs:
   "dart:isolate": "isolate/isolate.dart"
   "dart:math": "math/math.dart"
   "dart:typed_data": "typed_data/typed_data.dart"
-  "dart:ui": "dart_ui/ui.dart"
+  "dart:ui": "ui/ui.dart"
   # The internal library is needed as some implementations bleed into the public
   # API, e.g. List being Iterable by virtue of implementing
   # EfficientLengthIterable.


### PR DESCRIPTION
The other libraries don't repeat the "dart" name in their path inside the
package.