### PR TITLE
Keep resident runner connected on iOS when screen locks in debug mode

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
@@ -15,6 +15,8 @@
  * This class provides the following behaviors:
  *   * Status bar touches are forwarded to the key window's root view
  *     FlutterViewController, in order to trigger scroll to top.
+ *   * Keeps the Flutter connection open in debug mode when the phone screen
+ *     locks.
  *
  * App delegates for Flutter applications are *not* required to inherit from
  * this class. Developers of custom app delegate classes should copy and paste

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -4,8 +4,11 @@
 
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+#include "lib/ftl/logging.h"
 
-@implementation FlutterAppDelegate
+@implementation FlutterAppDelegate {
+  UIBackgroundTaskIdentifier debugBackgroundTask;
+}
 
 // Returns the key window's rootViewController, if it's a FlutterViewController.
 // Otherwise, returns nil.
@@ -24,6 +27,29 @@
   if (self.rootFlutterViewController != nil) {
     [self.rootFlutterViewController handleStatusBarTouches:event];
   }
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  // The following keeps the Flutter session alive when the device screen locks
+  // in debug mode. It allows continued use of features like hot reload and 
+  // taking screenshots once the device unlocks again.
+  //
+  // Note the name is not an identifier and multiple instances can exist. 
+  debugBackgroundTask = [application beginBackgroundTaskWithName:@"Flutter debug task"
+                                               expirationHandler:^{
+      FTL_DLOG(WARNING) << "\nThe OS has terminated the Flutter debug connection for being "
+                           "inactive in the background for too long.\n\n"
+                           "There are no errors with your Flutter application.\n\n"
+                           "To reconnect, launch your application again via 'flutter run";
+      }];
+#endif
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  [application endBackgroundTask: debugBackgroundTask];
+#endif
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -7,7 +7,7 @@
 #include "lib/ftl/logging.h"
 
 @implementation FlutterAppDelegate {
-  UIBackgroundTaskIdentifier debugBackgroundTask;
+  UIBackgroundTaskIdentifier _debugBackgroundTask;
 }
 
 // Returns the key window's rootViewController, if it's a FlutterViewController.
@@ -29,27 +29,25 @@
   }
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+- (void)applicationDidEnterBackground:(UIApplication *)application {
   // The following keeps the Flutter session alive when the device screen locks
   // in debug mode. It allows continued use of features like hot reload and 
   // taking screenshots once the device unlocks again.
   //
   // Note the name is not an identifier and multiple instances can exist. 
-  debugBackgroundTask = [application beginBackgroundTaskWithName:@"Flutter debug task"
-                                               expirationHandler:^{
-      FTL_DLOG(WARNING) << "\nThe OS has terminated the Flutter debug connection for being "
-                           "inactive in the background for too long.\n\n"
-                           "There are no errors with your Flutter application.\n\n"
-                           "To reconnect, launch your application again via 'flutter run";
+  _debugBackgroundTask = [application beginBackgroundTaskWithName:@"Flutter debug task"
+                                                expirationHandler:^{
+      FTL_LOG(WARNING) << "\nThe OS has terminated the Flutter debug connection for being "
+                          "inactive in the background for too long.\n\n"
+                          "There are no errors with your Flutter application.\n\n"
+                          "To reconnect, launch your application again via 'flutter run";
       }];
-#endif
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  [application endBackgroundTask: debugBackgroundTask];
-#endif
+  [application endBackgroundTask: _debugBackgroundTask];
 }
+#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 
 @end


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/9351