### PR TITLE
Update buildtools to c8db819853bcf8ce1635a8b7a395820f39b5a9fc and restrict downloaded artifacts.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -32,7 +32,7 @@ vars = {
   'dart_observatory_packages_revision': '26aad88f1c1915d39bbcbff3cad589e2402fdcf1',
   'dart_root_certificates_revision': 'a4c7c6f23a664a37bc1b6f15a819e3f2a292791a',
 
-  'buildtools_revision': '5655267acc2b1c672aec43bfbd28c645908fcd74',
+  'buildtools_revision': 'c8db819853bcf8ce1635a8b7a395820f39b5a9fc',
 }
 
 # Only these hosts are allowed for dependencies in this DEPS file.
@@ -156,7 +156,13 @@ hooks = [
   {
     'name': 'buildtools',
     'pattern': '.',
-    'action': ['python', 'src/tools/buildtools/update.py'],
+    'action': [
+      'python',
+      'src/tools/buildtools/update.py',
+      '--ninja',
+      '--gn',
+      '--toolchain'
+    ],
   },
   {
     # Pull dart sdk if needed

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -75,7 +75,7 @@ TEST(MessageLoop, NonDelayedTasksAreRunInOrder) {
     auto& loop = fml::MessageLoop::GetCurrent();
     size_t current = 0;
     for (size_t i = 0; i < count; i++) {
-      loop.GetTaskRunner()->PostTask([&terminated, count, i, &current]() {
+      loop.GetTaskRunner()->PostTask([&terminated, i, &current]() {
         ASSERT_EQ(current, i);
         current++;
         if (count == i + 1) {
@@ -105,7 +105,7 @@ TEST(MessageLoop, DelayedTasksAtSameTimeAreRunInOrder) {
         ftl::TimePoint::Now() + ftl::TimeDelta::FromMilliseconds(2);
     for (size_t i = 0; i < count; i++) {
       loop.GetTaskRunner()->PostTaskForTime(
-          [&terminated, count, i, &current]() {
+          [&terminated, i, &current]() {
             ASSERT_EQ(current, i);
             current++;
             if (count == i + 1) {
@@ -187,13 +187,13 @@ TEST(MessageLoop, TIME_SENSITIVE(SingleDelayedTaskForTime)) {
 TEST(MessageLoop, TIME_SENSITIVE(MultipleDelayedTasksWithIncreasingDeltas)) {
   const auto count = 10;
   int checked = false;
-  std::thread thread([&checked, count]() {
+  std::thread thread([&checked]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     auto& loop = fml::MessageLoop::GetCurrent();
     for (int target_ms = 0 + 2; target_ms < count + 2; target_ms++) {
       auto begin = ftl::TimePoint::Now();
       loop.GetTaskRunner()->PostDelayedTask(
-          [begin, target_ms, &checked, count]() {
+          [begin, target_ms, &checked]() {
             auto delta = ftl::TimePoint::Now() - begin;
             auto ms = delta.ToMillisecondsF();
             ASSERT_GE(ms, target_ms - 2);
@@ -214,13 +214,13 @@ TEST(MessageLoop, TIME_SENSITIVE(MultipleDelayedTasksWithIncreasingDeltas)) {
 TEST(MessageLoop, TIME_SENSITIVE(MultipleDelayedTasksWithDecreasingDeltas)) {
   const auto count = 10;
   int checked = false;
-  std::thread thread([&checked, count]() {
+  std::thread thread([&checked]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     auto& loop = fml::MessageLoop::GetCurrent();
     for (int target_ms = count + 2; target_ms > 0 + 2; target_ms--) {
       auto begin = ftl::TimePoint::Now();
       loop.GetTaskRunner()->PostDelayedTask(
-          [begin, target_ms, &checked, count]() {
+          [begin, target_ms, &checked]() {
             auto delta = ftl::TimePoint::Now() - begin;
             auto ms = delta.ToMillisecondsF();
             ASSERT_GE(ms, target_ms - 2);
@@ -265,7 +265,7 @@ TEST(MessageLoop, TaskObserverFire) {
     size_t obs_count = 0;
     CustomTaskObserver obs([&obs_count]() { obs_count++; });
     for (size_t i = 0; i < count; i++) {
-      loop.GetTaskRunner()->PostTask([&terminated, count, i, &task_count]() {
+      loop.GetTaskRunner()->PostTask([&terminated, i, &task_count]() {
         ASSERT_EQ(task_count, i);
         task_count++;
         if (count == i + 1) {


### PR DESCRIPTION
This updates our compilers, gn and ninja. Also, we now explicitly specify the buildtools artifacts we actually use instead of downloading everything from the catalog.

The build error was due to unused lambda captures being reported as warnings (which we turn into errors).