### PR TITLE
Use SkCrossContextImageData to safely pass decoded images to the rasterizer

### DIFF
--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -7,6 +7,7 @@
 #include "flutter/lib/ui/window/window.h"
 #include "flutter/sky/engine/platform/fonts/FontSelector.h"
 #include "lib/tonic/converter/dart_converter.h"
+#include "third_party/skia/include/gpu/GrContext.h"
 
 using tonic::ToDart;
 
@@ -52,6 +53,14 @@ void UIDartState::set_font_selector(PassRefPtr<FontSelector> selector) {
 
 PassRefPtr<FontSelector> UIDartState::font_selector() {
   return font_selector_;
+}
+
+void UIDartState::set_rasterizer_grcontext(sk_sp<GrContext> context) {
+  rasterizer_grcontext_ = std::move(context);
+}
+
+sk_sp<GrContext> UIDartState::rasterizer_grcontext() {
+  return rasterizer_grcontext_;
 }
 
 }  // namespace blink

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -12,6 +12,9 @@
 #include "lib/ftl/build_config.h"
 #include "lib/tonic/dart_persistent_value.h"
 #include "lib/tonic/dart_state.h"
+#include "third_party/skia/include/core/SkRefCnt.h"
+
+class GrContext;
 
 namespace blink {
 class FontSelector;
@@ -42,6 +45,9 @@ class UIDartState : public tonic::DartState {
   void set_font_selector(PassRefPtr<FontSelector> selector);
   PassRefPtr<FontSelector> font_selector();
 
+  void set_rasterizer_grcontext(sk_sp<GrContext> context);
+  sk_sp<GrContext> rasterizer_grcontext();
+
  private:
   void DidSetIsolate() override;
 
@@ -50,6 +56,7 @@ class UIDartState : public tonic::DartState {
   std::string debug_name_;
   std::unique_ptr<Window> window_;
   RefPtr<FontSelector> font_selector_;
+  sk_sp<GrContext> rasterizer_grcontext_;
 };
 
 }  // namespace blink

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -275,8 +275,9 @@ tonic::DartErrorHandleType Engine::GetLoadScriptError() {
   return load_script_error_;
 }
 
-void Engine::OnOutputSurfaceCreated(const ftl::Closure& gpu_continuation) {
-  blink::Threads::Gpu()->PostTask(gpu_continuation);
+void Engine::OnOutputSurfaceCreated(sk_sp<GrContext> rasterizer_grcontext) {
+  runtime_->dart_controller()->dart_state()->set_rasterizer_grcontext(
+      std::move(rasterizer_grcontext));
   have_surface_ = true;
   StartAnimatorIfPossible();
   if (runtime_)
@@ -284,6 +285,7 @@ void Engine::OnOutputSurfaceCreated(const ftl::Closure& gpu_continuation) {
 }
 
 void Engine::OnOutputSurfaceDestroyed(const ftl::Closure& gpu_continuation) {
+  runtime_->dart_controller()->dart_state()->set_rasterizer_grcontext(nullptr);
   have_surface_ = false;
   StopAnimator();
   blink::Threads::Gpu()->PostTask(gpu_continuation);

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -61,7 +61,7 @@ class Engine : public blink::RuntimeDelegate {
   tonic::DartErrorHandleType GetUIIsolateLastError();
   tonic::DartErrorHandleType GetLoadScriptError();
 
-  void OnOutputSurfaceCreated(const ftl::Closure& gpu_continuation);
+  void OnOutputSurfaceCreated(sk_sp<GrContext> rasterizer_grcontext);
   void OnOutputSurfaceDestroyed(const ftl::Closure& gpu_continuation);
   void SetViewportMetrics(const blink::ViewportMetrics& metrics);
   void DispatchPlatformMessage(ftl::RefPtr<blink::PlatformMessage> message);


### PR DESCRIPTION
Previously we were creating texture backed images on the IO thread using the
resource GrContext and then rendering them with the rasterizer's GrContext.
This is not officially supported by Skia.

The UIDartState will now hold a reference to the GrContext used by the
rasterizer associated with this isolate.