### PR TITLE
Add the ‘vulkan’ suffix to the out directory when the —enable-vulkan flag is specified.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -27,6 +27,9 @@ def get_out_dir(args):
     if args.android_cpu != 'arm':
         target_dir.append(args.android_cpu)
 
+    if args.enable_vulkan:
+        target_dir.append('vulkan')
+
     return os.path.join('out', '_'.join(target_dir))
 
 def to_command_line(gn_args):


### PR DESCRIPTION
Earlier, when the —enable-vulkan flag was specified, the out directory name was determined by the other flags specified to `flutter/tools/gn`. But, the build itself was Vulkan enabled. Now that we are going to add the vulkan target to buildbot, we want to clearly delineate a Vulkan enabled build from a non-Vulkan enabled one.