### PR TITLE
Call SkGraphics::Init on shell initialization.

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -22,6 +22,7 @@
 #include "flutter/shell/common/skia_event_tracer_impl.h"
 #include "flutter/shell/common/switches.h"
 #include "lib/ftl/files/unique_fd.h"
+#include "third_party/skia/include/core/SkGraphics.h"
 
 namespace shell {
 namespace {
@@ -99,6 +100,8 @@ void Shell::InitStandalone(ftl::CommandLine command_line,
   TRACE_EVENT0("flutter", "Shell::InitStandalone");
 
   fml::icu::InitializeICU(icu_data_path);
+
+  SkGraphics::Init();
 
   blink::Settings settings;
   settings.application_library_path = application_library_path;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -101,12 +101,12 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
   }
 
   // Create the CGImageRef representation on the pixmap.
-  fml::CFRef<CGImageRef> pixmap_image(CGImageCreate(pixmap.width(),      // width
-                                                    pixmap.height(),     // height
-                                                    8,                   // bits per component
-                                                    32,                  // bits per pixel
-                                                    4 * pixmap.width(),  // bytes per row
-                                                    colorspace,          // colorspace
+  fml::CFRef<CGImageRef> pixmap_image(CGImageCreate(pixmap.width(),     // width
+                                                    pixmap.height(),    // height
+                                                    8,                  // bits per component
+                                                    32,                 // bits per pixel
+                                                    pixmap.rowBytes(),  // bytes per row
+                                                    colorspace,         // colorspace
                                                     kCGImageAlphaPremultipliedLast,  // bitmap info
                                                     pixmap_data_provider,      // data provider
                                                     nullptr,                   // decode array


### PR DESCRIPTION
This ensures SkOpts are initialized before we start using Skia.