### PR TITLE
Fix corner case errors in platform channels

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
@@ -154,12 +154,7 @@ public final class BasicMessageChannel<T> {
                 handler.onMessage(codec.decodeMessage(message), new Reply<T>() {
                     @Override
                     public void reply(T reply) {
-                        try {
-                            callback.reply(codec.encodeMessage(reply));
-                        } catch (RuntimeException e) {
-                            Log.e(TAG + name, "Failed to encode reply", e);
-                            callback.reply(null);
-                        }
+                        callback.reply(codec.encodeMessage(reply));
                     }
                 });
             } catch (RuntimeException e) {

--- a/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
+++ b/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
@@ -17,8 +17,8 @@ public interface BinaryMessenger {
      * Sends a binary message to the Flutter application.
      *
      * @param channel the name {@link String} of the logical channel used for the message.
-     * @param message the message payload, a {@link ByteBuffer} with the message bytes between position
-     * zero and current position, or null.
+     * @param message the message payload, a direct-allocated {@link ByteBuffer} with the message bytes
+     * between position zero and current position, or null.
      */
     void send(String channel, ByteBuffer message);
 
@@ -28,8 +28,8 @@ public interface BinaryMessenger {
      * <p>Any uncaught exception thrown by the reply callback will be caught and logged.</p>
      *
      * @param channel the name {@link String} of the logical channel used for the message.
-     * @param message the message payload, a {@link ByteBuffer} with the message bytes between position
-     * zero and current position, or null.
+     * @param message the message payload, a direct-allocated {@link ByteBuffer} with the message bytes
+     * between position zero and current position, or null.
      * @param callback a {@link BinaryReply} callback invoked when the Flutter application responds to the
      * message, possibly null.
      */
@@ -79,8 +79,8 @@ public interface BinaryMessenger {
         /**
          * Handles the specified reply.
          *
-         * @param reply the reply payload, a {@link ByteBuffer} or null. Senders of outgoing
-         * replies must place the reply bytes between position zero and current position.
+         * @param reply the reply payload, a direct-allocated {@link ByteBuffer} or null. Senders of
+         * outgoing replies must place the reply bytes between position zero and current position.
          * Reply receivers can read from the buffer directly.
          */
         void reply(ByteBuffer reply);

--- a/shell/platform/android/io/flutter/plugin/common/JSONMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/JSONMessageCodec.java
@@ -26,7 +26,12 @@ public final class JSONMessageCodec implements MessageCodec<Object> {
         if (message == null) {
             return null;
         }
-        return StringCodec.INSTANCE.encodeMessage(JSONUtil.wrap(message).toString());
+        final Object wrapped = JSONUtil.wrap(message);
+        if (wrapped instanceof String) {
+          return StringCodec.INSTANCE.encodeMessage(JSONObject.quote((String) wrapped));
+        } else {
+          return StringCodec.INSTANCE.encodeMessage(wrapped.toString());
+        }
     }
 
     @Override

--- a/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
@@ -36,7 +36,7 @@ public final class JSONMethodCodec implements MethodCodec {
             if (json instanceof JSONObject) {
                 final JSONObject map = (JSONObject) json;
                 final Object method = map.get("method");
-                final Object arguments = map.get("args");
+                final Object arguments = unwrap(map.opt("args"));
                 if (method instanceof String) {
                     return new MethodCall((String) method, arguments);
                 }
@@ -73,16 +73,20 @@ public final class JSONMethodCodec implements MethodCodec {
                 }
                 if (array.length() == 3) {
                     final Object code = array.get(0);
-                    final Object message = array.get(1);
-                    final Object details = array.get(2);
+                    final Object message = unwrap(array.opt(1));
+                    final Object details = unwrap(array.opt(2));
                     if (code instanceof String && (message == null || message instanceof String)) {
                         throw new FlutterException((String) code, (String) message, details);
                     }
                 }
             }
-            throw new IllegalArgumentException("Invalid method call: " + json);
+            throw new IllegalArgumentException("Invalid envelope: " + json);
         } catch (JSONException e) {
             throw new IllegalArgumentException("Invalid JSON", e);
         }
+    }
+
+    Object unwrap(Object value) {
+      return (value == JSONObject.NULL) ? null : value;
     }
 }

--- a/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
@@ -36,7 +36,7 @@ public final class JSONMethodCodec implements MethodCodec {
             if (json instanceof JSONObject) {
                 final JSONObject map = (JSONObject) json;
                 final Object method = map.get("method");
-                final Object arguments = unwrap(map.opt("args"));
+                final Object arguments = unwrapNull(map.opt("args"));
                 if (method instanceof String) {
                     return new MethodCall((String) method, arguments);
                 }
@@ -58,7 +58,7 @@ public final class JSONMethodCodec implements MethodCodec {
         Object errorDetails) {
         return JSONMessageCodec.INSTANCE.encodeMessage(new JSONArray()
             .put(errorCode)
-            .put(errorMessage)
+            .put(JSONUtil.wrap(errorMessage))
             .put(JSONUtil.wrap(errorDetails)));
     }
 
@@ -69,12 +69,12 @@ public final class JSONMethodCodec implements MethodCodec {
             if (json instanceof JSONArray) {
                 final JSONArray array = (JSONArray) json;
                 if (array.length() == 1) {
-                    return array.get(0);
+                    return unwrapNull(array.opt(0));
                 }
                 if (array.length() == 3) {
                     final Object code = array.get(0);
-                    final Object message = unwrap(array.opt(1));
-                    final Object details = unwrap(array.opt(2));
+                    final Object message = unwrapNull(array.opt(1));
+                    final Object details = unwrapNull(array.opt(2));
                     if (code instanceof String && (message == null || message instanceof String)) {
                         throw new FlutterException((String) code, (String) message, details);
                     }
@@ -86,7 +86,7 @@ public final class JSONMethodCodec implements MethodCodec {
         }
     }
 
-    Object unwrap(Object value) {
+    Object unwrapNull(Object value) {
       return (value == JSONObject.NULL) ? null : value;
     }
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterCodecs.mm
@@ -82,6 +82,9 @@
     [message getBytes:&first length:1];
     isSimpleValue = first != '{' && first != '[';
     if (isSimpleValue) {
+      // NSJSONSerialization does not support top-level simple values.
+      // We expand encoding to singleton array, then decode that and extract
+      // the single entry.
       UInt8 begin = '[';
       UInt8 end = ']';
       NSMutableData* expandedMessage = [NSMutableData dataWithLength:message.length + 2];
@@ -114,8 +117,7 @@
 }
 
 - (NSData*)encodeSuccessEnvelope:(id)result {
-  return
-      [[FlutterJSONMessageCodec sharedInstance] encode:@[ result == nil ? [NSNull null] : result ]];
+  return [[FlutterJSONMessageCodec sharedInstance] encode:@[[self wrapNil:result]]];
 }
 
 - (NSData*)encodeErrorEnvelope:(FlutterError*)error {


### PR DESCRIPTION
Fix of some corner cases of channel communication, mostly dealing with the JSON code (handling null entries and handling the lack of support for serializing top-level simple values on iOS).

Encoding/decoding errors are now treated as programming errors on Android as well as on iOS. Dart side follows suite in a companion PR on flutter/flutter (https://github.com/flutter/flutter/pull/9621).

These changes make a new flutter+engine integration test suite run (reference TBD).