### PR TITLE
When pasting an item of type kTextPlainFormat from the pasteboard, ensure there acutally is a string in the pasteboard.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -177,8 +177,11 @@ using namespace shell;
 
 - (NSDictionary*)getClipboardData:(NSString*)format {
   UIPasteboard* pasteboard = [UIPasteboard generalPasteboard];
-  if (!format || [format isEqualToString:@(kTextPlainFormat)])
-    return @{ @"text" : pasteboard.string };
+  if (!format || [format isEqualToString:@(kTextPlainFormat)]) {
+    NSString* stringInPasteboard = pasteboard.string;
+    // The pasteboard may contain an item but it may not be a string (an image for instance).
+    return stringInPasteboard == nil ? nil : @{@"text" : stringInPasteboard};
+  }
   return nil;
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/9651