### PR TITLE
Android plugin registry

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -90,6 +90,7 @@ java_library("flutter_shell_java") {
     "io/flutter/plugin/common/MethodCall.java",
     "io/flutter/plugin/common/MethodChannel.java",
     "io/flutter/plugin/common/MethodCodec.java",
+    "io/flutter/plugin/common/PluginRegistry.java",
     "io/flutter/plugin/common/StandardMessageCodec.java",
     "io/flutter/plugin/common/StandardMethodCodec.java",
     "io/flutter/plugin/common/StringCodec.java",

--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -30,6 +30,7 @@ public class FlutterActivity extends Activity implements PluginRegistry {
     private final List<RequestPermissionResultListener> requestPermissionResultListeners = new ArrayList<>(0);
     private final List<ActivityResultListener> activityResultListeners = new ArrayList<>(0);
     private final List<NewIntentListener> newIntentListeners = new ArrayList<>(0);
+    private final List<UserLeaveHintListener> userLeaveHintListeners = new ArrayList<>(0);
     private FlutterView flutterView;
 
     private String[] getArgsFromIntent(Intent intent) {
@@ -176,6 +177,13 @@ public class FlutterActivity extends Activity implements PluginRegistry {
         }
     }
 
+    @Override
+    public void onUserLeaveHint() {
+        for (UserLeaveHintListener listener : userLeaveHintListeners) {
+            listener.onUserLeaveHint();
+        }
+    }
+
     public boolean loadIntent(Intent intent) {
         String action = intent.getAction();
         if (Intent.ACTION_RUN.equals(action)) {
@@ -259,6 +267,11 @@ public class FlutterActivity extends Activity implements PluginRegistry {
 
         public Registrar addNewIntentListener(NewIntentListener listener) {
             newIntentListeners.add(listener);
+            return this;
+        }
+
+        public Registrar addUserLeaveHintListener(UserLeaveHintListener listener) {
+            userLeaveHintListeners.add(listener);
             return this;
         }
     };

--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -10,45 +10,27 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.Window;
 import android.view.WindowManager;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.view.FlutterMain;
 import io.flutter.view.FlutterView;
-import java.util.ArrayList;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Base class for activities that use Flutter.
- *
- * <p>Delegates to {@link PluginRegistry} for handling common lifecycle
- * and notification callbacks.</p>
  */
-public class FlutterActivity extends Activity {
-    private final PluginRegistry pluginRegistry;
+public class FlutterActivity extends Activity implements PluginRegistry {
+    private final Map<String, Object> pluginMap = new LinkedHashMap<>(0);
+    private final List<RequestPermissionResultListener> requestPermissionResultListeners = new ArrayList<>(0);
+    private final List<ActivityResultListener> activityResultListeners = new ArrayList<>(0);
+    private final List<NewIntentListener> newIntentListeners = new ArrayList<>(0);
     private FlutterView flutterView;
-
-    /**
-     * Creates a FlutterActivity with no plugins.
-     */
-    public FlutterActivity() {
-        this(new PluginRegistry());
-    }
-
-    /**
-     * Creates a FlutterActivity delegating to the plugins of the specified
-     * {@link PluginRegistry}.
-     *
-     * <p>By default, Flutter applications to call this constructor with an
-     * auto-generated PluginRegistry subclass.</p>
-     */
-    public FlutterActivity(PluginRegistry pluginRegistry) {
-        assert(pluginRegistry != null);
-        this.pluginRegistry = pluginRegistry;
-    }
-
-    public PluginRegistry getPluginRegistry() {
-      return pluginRegistry;
-    }
 
     private String[] getArgsFromIntent(Intent intent) {
         // Before adding more entries to this list, consider that arbitrary
@@ -94,8 +76,26 @@ public class FlutterActivity extends Activity {
         setContentView(flutterView);
 
         onFlutterReady();
+    }
 
-        pluginRegistry.registerPlugins(this, flutterView);
+    @Override
+    public boolean hasPlugin(String key) {
+        return pluginMap.containsKey(key);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T valuePublishedByPlugin(String pluginKey) {
+        return (T) pluginMap.get(pluginKey);
+    }
+
+    @Override
+    public Registrar registrarFor(String pluginKey) {
+        if (pluginMap.containsKey(pluginKey)) {
+            throw new IllegalStateException("Plugin key " + pluginKey + " is already in use");
+        }
+        pluginMap.put(pluginKey, null);
+        return new FlutterRegistrar(pluginKey);
     }
 
     /**
@@ -149,18 +149,30 @@ public class FlutterActivity extends Activity {
     }
 
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        pluginRegistry.onRequestPermissionResult(requestCode, permissions, grantResults);
+        for (RequestPermissionResultListener listener : requestPermissionResultListeners) {
+            if (listener.onRequestPermissionResult(requestCode, permissions, grantResults)) {
+                return;
+            }
+        }
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        pluginRegistry.onActivityResult(requestCode, resultCode, data);
+        for (ActivityResultListener listener : activityResultListeners) {
+            if (listener.onActivityResult(requestCode, resultCode, data)) {
+                return;
+            }
+        }
     }
 
     @Override
     protected void onNewIntent(Intent intent) {
         if (!loadIntent(intent)) {
-          pluginRegistry.onNewIntent(intent);
+            for (NewIntentListener listener : newIntentListeners) {
+                if (listener.onNewIntent(intent)) {
+                    return;
+                }
+            }
         }
     }
 
@@ -201,4 +213,53 @@ public class FlutterActivity extends Activity {
         if (level == TRIM_MEMORY_RUNNING_LOW)
             flutterView.onMemoryPressure();
     }
+
+    private class FlutterRegistrar implements Registrar  {
+        private final String pluginKey;
+
+        FlutterRegistrar(String pluginKey) {
+            this.pluginKey = pluginKey;
+        }
+
+        public Activity activity() {
+            return FlutterActivity.this;
+        }
+
+        public BinaryMessenger messenger() {
+            return getFlutterView();
+        }
+
+        /**
+         * Publishes a value associated with the plugin being registered.
+         *
+         * <p>The published value is available to interested clients via
+         * {@link PluginRegistry#valuePublishedByPlugin(String)}.</p>
+         *
+         * <p>Publication should be done only when there is an interesting value
+         * to be shared with other code. This would typically be an instance of
+         * the plugin's main class itself that must be wired up to receive
+         * notifications or events from an Android API.
+         *
+         * <p>Overwrites any previously published value.</p>
+         */
+        public Registrar publish(Object value) {
+            pluginMap.put(pluginKey, value);
+            return this;
+        }
+
+        public Registrar addRequestPermissionResultListener(RequestPermissionResultListener listener) {
+            requestPermissionResultListeners.add(listener);
+            return this;
+        }
+
+        public Registrar addActivityResultListener(ActivityResultListener listener) {
+            activityResultListeners.add(listener);
+            return this;
+        }
+
+        public Registrar addNewIntentListener(NewIntentListener listener) {
+            newIntentListeners.add(listener);
+            return this;
+        }
+    };
 }

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -13,13 +13,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Registry used by plugins to register their interaction with Android APIs.
+ * Registry used by plugins to set up interaction with Android APIs.
  *
  * <p>Flutter applications by default include an auto-generated
- * PluginRegistry sub-class that overrides {@link #registerPlugins(PluginContext)}
+ * PluginRegistry subclass that overrides {@link #registerPlugins(PluginContext)}
  * with contributions from each plugin mentioned in the application's pubspec
- * file. Their main {@link Activity} is a {@link io.flutter.app.FlutterActivity}
- * constructed with that subclass.</p>
+ * file. An instance of the generated PluginRegistry is, again by default,
+ * proved as argument to the application's main {@link Activity} which is a
+ * {@link io.flutter.app.FlutterActivity} subclass.</p>
  */
 public class PluginRegistry {
     private final Map<String, Object> map = new LinkedHashMap<>(0);
@@ -28,9 +29,10 @@ public class PluginRegistry {
     private final List<NewIntentListener> newIntentListeners = new ArrayList<>(0);
 
     /**
-     * Registers the plugins of this registry by delegation to the #registerPlugins
-     * hook method. Plugins install components and uses the provided {@link Activity}
-     * and {@link BinaryMessenger} for Flutter/platform.
+     * Registers the plugins of this registry by delegation to the
+     * {@link #registerPlugins(PluginContext)} hook method. Plugins install
+     * components and uses the provided {@link Activity} and
+     * {@link BinaryMessenger} for Flutter/platform.
      *
      * <p>Intended to be called by the main {@link Activity}'s {@code onCreate}
      * method.

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -111,6 +111,15 @@ public interface PluginRegistry {
          * @return this {@link Registrar}.
          */
         Registrar addNewIntentListener(NewIntentListener listener);
+
+        /**
+         * Adds a callback allowing the plugin to take part in handling incoming
+         * calls to {@Activity#onUserLeaveHint()}.
+         *
+         * @param listener a {@link UserLeaveHintListener} callback.
+         * @return this {@link Registrar}.
+         */
+        Registrar addUserLeaveHintListener(UserLeaveHintListener listener);
     }
 
     /**
@@ -144,5 +153,13 @@ public interface PluginRegistry {
          * @return true if the new intent has been handled.
          */
         boolean onNewIntent(Intent intent);
+    }
+
+    /**
+     * Delegate interface for handling user leave hints on behalf of the main
+     * {@link Activity}.
+     */
+    interface UserLeaveHintListener {
+        void onUserLeaveHint();
     }
 }

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -1,0 +1,199 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugin.common;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Registry used by plugins to register their interaction with Android APIs.
+ *
+ * <p>Flutter applications by default include an auto-generated
+ * PluginRegistry sub-class that overrides {@link #registerPlugins(PluginContext)}
+ * with contributions from each plugin mentioned in the application's pubspec
+ * file. Their main {@link Activity} is a {@link io.flutter.app.FlutterActivity}
+ * constructed with that subclass.</p>
+ */
+public class PluginRegistry {
+    private final Map<String, Object> map = new LinkedHashMap<>(0);
+    private final List<RequestPermissionResultListener> requestPermissionResultListeners = new ArrayList<>(0);
+    private final List<ActivityResultListener> activityResultListeners = new ArrayList<>(0);
+    private final List<NewIntentListener> newIntentListeners = new ArrayList<>(0);
+
+    /**
+     * Registers the plugins of this registry by delegation to the #registerPlugins
+     * hook method. Plugins install components and uses the provided {@link Activity}
+     * and {@link BinaryMessenger} for Flutter/platform.
+     *
+     * <p>Intended to be called by the main {@link Activity}'s {@code onCreate}
+     * method.
+     */
+    public final void registerPlugins(Activity activity, BinaryMessenger messenger) {
+      registerPlugins(new PluginContext(activity, messenger));
+    }
+
+    /**
+     * Hook method for registering plugins. Subclasses are expected to call a
+     * static method on each plugin's main implementation class in turn,
+     * providing the {@link PluginContext} as argument.
+     */
+    protected void registerPlugins(PluginContext context) {
+    }
+
+    /**
+     * Returns whether an entry for the specified key has been put.
+     */
+    public final boolean containsKey(String key) {
+      return map.containsKey(key);
+    }
+
+    /**
+     * Returns the value associated to the specified key.
+     * <p>The static type of the value is determed by the call site.</p>
+     *
+     * @return the value, possibly null.
+     */
+    @SuppressWarnings("unchecked")
+    public final <T> T get(String key) {
+      return (T) map.get(key);
+    }
+
+    /**
+     * Delegates handling of request permissions results to registered plugins.
+     *
+     * <p>Intended to be called by the application's main {@link Activity}.</a>
+     *
+     * @see {@link Activity#onRequestPermissionResult(int,String[],int[])}
+     */
+    public final void onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) {
+      for (RequestPermissionResultListener listener: requestPermissionResultListeners) {
+        if (listener.onRequestPermissionResult(requestCode, permissions, grantResults)) {
+          break;
+        }
+      }
+    }
+
+    /**
+     * Delegates handling of activity results to registered plugins.
+     *
+     * <p>Intended to be called by the application's main {@link Activity}.</a>
+     *
+     * @see {@link Activity#onActivityResult(int,int,Intent)}
+     */
+    public final void onActivityResult(int requestCode, int resultCode, Intent data) {
+      for (ActivityResultListener listener: activityResultListeners) {
+        if (listener.onActivityResult(requestCode, resultCode, data)) {
+          break;
+        }
+      }
+    }
+
+    /**
+     * Delegates handling of new intents to registered plugins.
+     *
+     * <p>Intended to be called by the application's main {@link Activity}.</a>
+     *
+     * @see {@link Activity#onNewIntent(Intent)}
+     */
+    public final void onNewIntent(Intent intent) {
+      for (NewIntentListener listener: newIntentListeners) {
+        if (listener.onNewIntent(intent)) {
+          break;
+        }
+      }
+    }
+
+    /**
+     * Context used by plugins when registering. Provides access to the
+     * application context (via {@link #activity()}), Flutter/Android messaging
+     * (via {@link #messenger()} and {@link #newMethodChannel(String)}), and
+     * allows plugins to register callbacks to activity lifecycle methods.
+     */
+    public final class PluginContext {
+      private final Activity activity;
+      private final BinaryMessenger messenger;
+
+      PluginContext(Activity activity, BinaryMessenger messenger) {
+        this.activity = activity;
+        this.messenger = messenger;
+      }
+
+      /**
+       * Registers a key and value for lookup by interested clients which are
+       * expected to know the type of value for a given key.
+       *
+       * <p>Plugins should prefix keys by inverted domain names to avoid clashes:
+       * {@code com.example.myplugin.SomeKey}.</p>
+       */
+      public final void put(String key, Object value) {
+        if (map.containsKey(key)) {
+          throw new IllegalArgumentException("Double registration of " + key);
+        }
+        map.put(key, value);
+      }
+
+      public void addRequestPermissionResultListener(RequestPermissionResultListener listener) {
+        requestPermissionResultListeners.add(listener);
+      }
+
+      public void addActivityResultListener(ActivityResultListener listener) {
+        activityResultListeners.add(listener);
+      }
+
+      public void addNewIntentListener(NewIntentListener listener) {
+        newIntentListeners.add(listener);
+      }
+
+      public Activity activity() {
+        return activity;
+      }
+
+      public BinaryMessenger messenger() {
+        return messenger;
+      }
+
+      public MethodChannel newMethodChannel(String name) {
+        return new MethodChannel(messenger, name);
+      }
+    }
+
+    /**
+     * Delegate interface for handling results of permission requests on
+     * behalf of an {@link Activity}.
+     */
+    public interface RequestPermissionResultListener {
+      /**
+       * @return true if the result has been handled.
+       */
+      boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults);
+    }
+
+    /**
+     * Delegate interface for handling activity results on behalf of an
+     * {@link Activity}.
+     */
+    public interface ActivityResultListener {
+      /**
+       * @return true if the result has been handled.
+       */
+      boolean onActivityResult(int requestCode, int resultCode, Intent data);
+    }
+
+    /**
+     * Delegate interface for handling new intents on behalf of an
+     * {@link Activity}.
+     */
+    public interface NewIntentListener {
+      /**
+       * @return true if the new intent has been handled.
+       */
+      boolean onNewIntent(Intent intent);
+    }
+}

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1427,6 +1427,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/MessageCo
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/MethodCall.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/MethodCodec.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/StandardMethodCodec.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/StringCodec.java


### PR DESCRIPTION
Add gearing between plugins and the application context defined by custom Application and Activity classes supplied by the app author. Design constraints/goals:

- Avoid forcing apps to use FlutterApplication/FlutterActivity just to integrate plugins.
- Avoid being in the way of advanced plugin/Activity interaction (use of gearing should not be mandatory).
- Allow consuming simple/common plugins without forcing app author to write Android-specific code.
- Provide convenience for simple and common cases, including plugin-defined callbacks for common Activity lifecycle methods.
- Make the "simple/common cases" an extensible notion without incurring breaking changes when extended.

Android only in this PR. Accompanying flutter/flutter PR: https://github.com/flutter/flutter/pull/9715.
Partially addresses https://github.com/flutter/flutter/issues/9215