### PR TITLE
Add missing Skia includes

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -8,7 +8,6 @@
 #include "lib/ftl/arraysize.h"
 #include "lib/ftl/logging.h"
 #include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
 namespace shell {

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -9,6 +9,7 @@
 #include "flutter/synchronization/debug_thread_checker.h"
 #include "lib/ftl/macros.h"
 #include "lib/ftl/memory/weak_ptr.h"
+#include "third_party/skia/include/gpu/GrContext.h"
 
 namespace shell {
 


### PR DESCRIPTION
We are removing some indirect includes from SkCanvas.h.

Updating clients to pull required headers explicitly.