### PR TITLE
Make microtask queue be per thread

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -57,7 +57,7 @@ deps = {
    Var('fuchsia_git') + '/ftl' + '@' + 'f1357b6eaa9a23cffec1645dfeba610b5f926b1d',
 
   'src/lib/tonic':
-   Var('fuchsia_git') + '/tonic' + '@' + '82075233dc0cd23b1c8af5f694eb86dd9bd10f35',
+   Var('fuchsia_git') + '/tonic' + '@' + '02431161f012a18c32f885e04b1eda51e6c11f8e',
 
   'src/lib/zip':
    Var('fuchsia_git') + '/zip' + '@' + '92dc87ca645fe8e9f5151ef6dac86d8311a7222f',

--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -172,7 +172,7 @@ void ScheduleMicrotask(Dart_NativeArguments args) {
   Dart_Handle closure = Dart_GetNativeArgument(args, 0);
   if (LogIfError(closure) || !Dart_IsClosure(closure))
     return;
-  tonic::DartMicrotaskQueue::ScheduleMicrotask(closure);
+  tonic::DartMicrotaskQueue::GetForCurrentThread()->ScheduleMicrotask(closure);
 }
 
 }  // namespace blink

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -223,7 +223,7 @@ void Window::BeginFrame(ftl::TimePoint frameTime) {
                       Dart_NewInteger(microseconds),
                   });
 
-  tonic::DartMicrotaskQueue::RunMicrotasks();
+  tonic::DartMicrotaskQueue::GetForCurrentThread()->RunMicrotasks();
 
   DartInvokeField(library_.value(), "_drawFrame", {});
 }

--- a/shell/platform/linux/main_linux.cc
+++ b/shell/platform/linux/main_linux.cc
@@ -103,7 +103,7 @@ void RunNonInteractive(ftl::CommandLine initial_command_line,
   if (error == tonic::kNoError)
     error = task_observer.last_error();
   if (error == tonic::kNoError)
-    error = tonic::DartMicrotaskQueue::GetLastError();
+    error = tonic::DartMicrotaskQueue::GetForCurrentThread()->GetLastError();
 
   // The script has completed and the engine may not be in a clean state,
   // so just stop the process.

--- a/sky/engine/web/Sky.cpp
+++ b/sky/engine/web/Sky.cpp
@@ -56,7 +56,7 @@ namespace blink {
 namespace {
 
 void didProcessTask() {
-  tonic::DartMicrotaskQueue::RunMicrotasks();
+  tonic::DartMicrotaskQueue::GetForCurrentThread()->RunMicrotasks();
   // FIXME: Report memory usage to dart?
 }
 
@@ -131,11 +131,13 @@ void InitEngine(Platform* platform) {
   // this, initializing this lazily probably doesn't buy us much.
   WTF::UTF8Encoding();
 
+  tonic::DartMicrotaskQueue::StartForCurrentThread();
   addMessageLoopObservers();
 }
 
 void ShutdownEngine() {
   removeMessageLoopObservers();
+  tonic::DartMicrotaskQueue::GetForCurrentThread()->Destroy();
 
   // FIXME: Shutdown dart?
 


### PR DESCRIPTION
Previously, it was a static. Doesn't have much effect in practice because we
only use this microtask queue for main isolates, which exist on a single
thread.