### PR TITLE
iOS plugin registry

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -23,6 +23,7 @@ shared_library("flutter_framework_dylib") {
     "framework/Headers/FlutterCodecs.h",
     "framework/Headers/FlutterDartProject.h",
     "framework/Headers/FlutterMacros.h",
+    "framework/Headers/FlutterPlugin.h",
     "framework/Headers/FlutterViewController.h",
     "framework/Source/FlutterAppDelegate.mm",
     "framework/Source/FlutterChannels.mm",
@@ -163,6 +164,7 @@ copy("framework_headers") {
     "framework/Headers/FlutterCodecs.h",
     "framework/Headers/FlutterDartProject.h",
     "framework/Headers/FlutterMacros.h",
+    "framework/Headers/FlutterPlugin.h",
     "framework/Headers/FlutterViewController.h",
   ]
   outputs = [

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -11,6 +11,7 @@
 #include "FlutterCodecs.h"
 #include "FlutterDartProject.h"
 #include "FlutterMacros.h"
+#include "FlutterPlugin.h"
 #include "FlutterViewController.h"
 
 #endif  // FLUTTER_FLUTTER_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 
 #include "FlutterMacros.h"
+#include "FlutterPlugin.h"
 
 /**
  * UIApplicationDelegate subclass for simple apps that want default behavior.
@@ -23,7 +24,7 @@
  * code as necessary from FlutterAppDelegate.mm.
  */
 FLUTTER_EXPORT
-@interface FlutterAppDelegate : UIResponder<UIApplicationDelegate>
+@interface FlutterAppDelegate : UIResponder<UIApplicationDelegate, FlutterPluginRegistry>
 
 @property(strong, nonatomic) UIWindow* window;
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
@@ -24,7 +24,8 @@
  * code as necessary from FlutterAppDelegate.mm.
  */
 FLUTTER_EXPORT
-@interface FlutterAppDelegate : UIResponder<UIApplicationDelegate, FlutterPluginRegistry>
+@interface FlutterAppDelegate
+    : UIResponder<UIApplicationDelegate, FlutterPluginRegistry>
 
 @property(strong, nonatomic) UIWindow* window;
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -23,6 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)applicationDidEnterBackground:(UIApplication*)application;
 - (void)applicationWillEnterForeground:(UIApplication*)application;
 - (void)applicationWillTerminate:(UIApplication*)application;
+- (void)application:(UIApplication *)application
+  didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
+- (void)application:(UIApplication *)application
+  didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+- (BOOL)application:(UIApplication *)application
+  didReceiveRemoteNotification:(NSDictionary *)userInfo
+        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id>*)options;

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -1,0 +1,42 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLUTTERPLUGIN_H_
+#define FLUTTER_FLUTTERPLUGIN_H_
+
+#include "FlutterBinaryMessenger.h"
+#include "FlutterChannels.h"
+#include "FlutterCodecs.h"
+
+NS_ASSUME_NONNULL_BEGIN
+@protocol FlutterPlugin <NSObject>
+@optional
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
+- (void)applicationDidBecomeActive:(UIApplication*)application;
+- (void)applicationWillResignActive:(UIApplication*)application;
+- (void)applicationDidEnterBackground:(UIApplication*)application;
+- (void)applicationWillEnterForeground:(UIApplication*)application;
+- (void)applicationWillTerminate:(UIApplication*)application;
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id>*)options;
+@end
+
+@protocol FlutterPluginRegistrar
+- (NSObject<FlutterBinaryMessenger>*) messenger;
+- (void)publish:(NSObject*)value;
+- (void)addMethodCallDelegate:(NSObject<FlutterPlugin>*)delegate
+                      channel:(FlutterMethodChannel*)channel;
+- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate;
+@end
+
+@protocol FlutterPluginRegistry
+- (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey;
+- (BOOL)hasPlugin:(NSString*)pluginKey;
+- (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey;
+@end
+
+NS_ASSUME_NONNULL_END;
+
+#endif  // FLUTTER_FLUTTERPLUGIN_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -12,38 +12,39 @@
 NS_ASSUME_NONNULL_BEGIN
 @protocol FlutterPluginRegistrar;
 
-@protocol FlutterPlugin <NSObject>
+@protocol FlutterPlugin<NSObject>
 @required
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar;
 @optional
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
-- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions;
+- (BOOL)application:(UIApplication*)application
+    didFinishLaunchingWithOptions:(NSDictionary*)launchOptions;
 - (void)applicationDidBecomeActive:(UIApplication*)application;
 - (void)applicationWillResignActive:(UIApplication*)application;
 - (void)applicationDidEnterBackground:(UIApplication*)application;
 - (void)applicationWillEnterForeground:(UIApplication*)application;
 - (void)applicationWillTerminate:(UIApplication*)application;
-- (void)application:(UIApplication *)application
-  didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
-- (void)application:(UIApplication *)application
-  didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
-- (BOOL)application:(UIApplication *)application
-  didReceiveRemoteNotification:(NSDictionary *)userInfo
-        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
+- (void)application:(UIApplication*)application
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings;
+- (void)application:(UIApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
+- (BOOL)application:(UIApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id>*)options;
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options;
 @end
 
-@protocol FlutterPluginRegistrar <NSObject>
-- (NSObject<FlutterBinaryMessenger>*) messenger;
+@protocol FlutterPluginRegistrar<NSObject>
+- (NSObject<FlutterBinaryMessenger>*)messenger;
 - (void)publish:(NSObject*)value;
 - (void)addMethodCallDelegate:(NSObject<FlutterPlugin>*)delegate
                       channel:(FlutterMethodChannel*)channel;
 - (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate;
 @end
 
-@protocol FlutterPluginRegistry <NSObject>
+@protocol FlutterPluginRegistry<NSObject>
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey;
 - (BOOL)hasPlugin:(NSString*)pluginKey;
 - (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey;

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar;
 @optional
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
+- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions;
 - (void)applicationDidBecomeActive:(UIApplication*)application;
 - (void)applicationWillResignActive:(UIApplication*)application;
 - (void)applicationDidEnterBackground:(UIApplication*)application;

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -10,7 +10,11 @@
 #include "FlutterCodecs.h"
 
 NS_ASSUME_NONNULL_BEGIN
+@protocol FlutterPluginRegistrar;
+
 @protocol FlutterPlugin <NSObject>
+@required
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar;
 @optional
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 - (void)applicationDidBecomeActive:(UIApplication*)application;
@@ -23,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id>*)options;
 @end
 
-@protocol FlutterPluginRegistrar
+@protocol FlutterPluginRegistrar <NSObject>
 - (NSObject<FlutterBinaryMessenger>*) messenger;
 - (void)publish:(NSObject*)value;
 - (void)addMethodCallDelegate:(NSObject<FlutterPlugin>*)delegate
@@ -31,7 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate;
 @end
 
-@protocol FlutterPluginRegistry
+@protocol FlutterPluginRegistry <NSObject>
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey;
 - (BOOL)hasPlugin:(NSString*)pluginKey;
 - (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -6,8 +6,31 @@
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #include "lib/ftl/logging.h"
 
+@interface FlutterAppDelegate()
+@property (readonly, nonatomic) NSMutableArray* pluginDelegates;
+@property (readonly, nonatomic) NSMutableDictionary* pluginPublications;
+@end
+
+@interface FlutterAppDelegateRegistrar : NSObject<FlutterPluginRegistrar>
+- (instancetype)initWithPlugin:(NSString*)pluginKey appDelegate:(FlutterAppDelegate*)delegate;
+@end
+
 @implementation FlutterAppDelegate {
   UIBackgroundTaskIdentifier _debugBackgroundTask;
+}
+
+- (instancetype)init {
+  if (self = [super init]) {
+    _pluginDelegates = [NSMutableArray new];
+    _pluginPublications = [NSMutableDictionary new];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [_pluginDelegates release];
+  [_pluginPublications release];
+  [super dealloc];
 }
 
 // Returns the key window's rootViewController, if it's a FlutterViewController.
@@ -29,13 +52,13 @@
   }
 }
 
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 - (void)applicationDidEnterBackground:(UIApplication *)application {
+  #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // The following keeps the Flutter session alive when the device screen locks
-  // in debug mode. It allows continued use of features like hot reload and 
+  // in debug mode. It allows continued use of features like hot reload and
   // taking screenshots once the device unlocks again.
   //
-  // Note the name is not an identifier and multiple instances can exist. 
+  // Note the name is not an identifier and multiple instances can exist.
   _debugBackgroundTask = [application beginBackgroundTaskWithName:@"Flutter debug task"
                                                 expirationHandler:^{
       FTL_LOG(WARNING) << "\nThe OS has terminated the Flutter debug connection for being "
@@ -43,11 +66,98 @@
                           "There are no errors with your Flutter application.\n\n"
                           "To reconnect, launch your application again via 'flutter run";
       }];
+  #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin applicationWillEnterForeground:application];
+    }
+  }
 }
 
 - (void)applicationWillEnterForeground:(UIApplication *)application {
+  #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   [application endBackgroundTask: _debugBackgroundTask];
+  #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin applicationWillEnterForeground:application];
+    }
+  }
 }
-#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+
+- (void)applicationWillResignActive:(UIApplication *)application {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin applicationWillResignActive:application];
+    }
+  }
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin applicationDidBecomeActive:application];
+    }
+  }
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin applicationWillTerminate:application];
+    }
+  }
+}
+
+- (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey {
+  return [[[FlutterAppDelegateRegistrar alloc] initWithPlugin:pluginKey appDelegate:self] autorelease];
+}
+
+- (BOOL)hasPlugin:(NSString*)pluginKey {
+  return _pluginPublications[pluginKey] != nil;
+}
+
+- (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey {
+  return _pluginPublications[pluginKey];
+}
+@end
+
+@implementation FlutterAppDelegateRegistrar {
+  NSString* _pluginKey;
+  FlutterAppDelegate* _appDelegate;
+}
+
+- (instancetype)initWithPlugin:(NSString*)pluginKey appDelegate:(FlutterAppDelegate*)appDelegate {
+  self = [super init];
+  NSAssert(self, @"Super init cannot be null");
+  _pluginKey = [pluginKey retain];
+  _appDelegate = [appDelegate retain];
+  return self;
+}
+
+- (NSObject<FlutterBinaryMessenger>*)messenger {
+  return [_appDelegate rootFlutterViewController];
+}
+
+- (void)publish:(NSObject*)value {
+  _appDelegate.pluginPublications[_pluginKey] = value;
+}
+
+- (void)addMethodCallDelegate:(NSObject<FlutterPlugin>*)delegate
+                      channel:(FlutterMethodChannel*)channel {
+  [channel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
+    [delegate handleMethodCall:call result:result];
+  }];
+}
+
+- (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate {
+  [_appDelegate.pluginDelegates addObject:delegate];
+}
+
+- (void)dealloc {
+  [_pluginKey release];
+  [_appDelegate release];
+  [super dealloc];
+}
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -33,6 +33,17 @@
   [super dealloc];
 }
 
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      if (![plugin application:application didFinishLaunchingWithOptions:launchOptions]) {
+        return NO;
+      }
+    }
+  }
+  return YES;
+}
+
 // Returns the key window's rootViewController, if it's a FlutterViewController.
 // Otherwise, returns nil.
 - (FlutterViewController*)rootFlutterViewController {
@@ -148,6 +159,12 @@
   return self;
 }
 
+- (void)dealloc {
+  [_pluginKey release];
+  [_appDelegate release];
+  [super dealloc];
+}
+
 - (NSObject<FlutterBinaryMessenger>*)messenger {
   return (FlutterViewController*) _appDelegate.window.rootViewController;
 }
@@ -166,11 +183,4 @@
 - (void)addApplicationDelegate:(NSObject<FlutterPlugin>*)delegate {
   [_appDelegate.pluginDelegates addObject:delegate];
 }
-
-- (void)dealloc {
-  [_pluginKey release];
-  [_appDelegate release];
-  [super dealloc];
-}
-
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -6,9 +6,9 @@
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #include "lib/ftl/logging.h"
 
-@interface FlutterAppDelegate()
-@property (readonly, nonatomic) NSMutableArray* pluginDelegates;
-@property (readonly, nonatomic) NSMutableDictionary* pluginPublications;
+@interface FlutterAppDelegate ()
+@property(readonly, nonatomic) NSMutableArray* pluginDelegates;
+@property(readonly, nonatomic) NSMutableDictionary* pluginPublications;
 @end
 
 @interface FlutterAppDelegateRegistrar : NSObject<FlutterPluginRegistrar>
@@ -33,7 +33,8 @@
   [super dealloc];
 }
 
-- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+- (BOOL)application:(UIApplication*)application
+    didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       if (![plugin application:application didFinishLaunchingWithOptions:launchOptions]) {
@@ -63,21 +64,34 @@
   }
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application {
-  #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+- (void)applicationDidEnterBackground:(UIApplication*)application {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // The following keeps the Flutter session alive when the device screen locks
   // in debug mode. It allows continued use of features like hot reload and
   // taking screenshots once the device unlocks again.
   //
   // Note the name is not an identifier and multiple instances can exist.
-  _debugBackgroundTask = [application beginBackgroundTaskWithName:@"Flutter debug task"
-                                                expirationHandler:^{
-      FTL_LOG(WARNING) << "\nThe OS has terminated the Flutter debug connection for being "
-                          "inactive in the background for too long.\n\n"
-                          "There are no errors with your Flutter application.\n\n"
-                          "To reconnect, launch your application again via 'flutter run";
-      }];
-  #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  _debugBackgroundTask = [application
+      beginBackgroundTaskWithName:@"Flutter debug task"
+                expirationHandler:^{
+                  FTL_LOG(WARNING)
+                      << "\nThe OS has terminated the Flutter debug connection for being "
+                         "inactive in the background for too long.\n\n"
+                         "There are no errors with your Flutter application.\n\n"
+                         "To reconnect, launch your application again via 'flutter run";
+                }];
+#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin applicationDidEnterBackground:application];
+    }
+  }
+}
+
+- (void)applicationWillEnterForeground:(UIApplication*)application {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  [application endBackgroundTask:_debugBackgroundTask];
+#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       [plugin applicationWillEnterForeground:application];
@@ -85,18 +99,7 @@
   }
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application {
-  #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  [application endBackgroundTask: _debugBackgroundTask];
-  #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationWillEnterForeground:application];
-    }
-  }
-}
-
-- (void)applicationWillResignActive:(UIApplication *)application {
+- (void)applicationWillResignActive:(UIApplication*)application {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       [plugin applicationWillResignActive:application];
@@ -104,7 +107,7 @@
   }
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application {
+- (void)applicationDidBecomeActive:(UIApplication*)application {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       [plugin applicationDidBecomeActive:application];
@@ -112,7 +115,7 @@
   }
 }
 
-- (void)applicationWillTerminate:(UIApplication *)application {
+- (void)applicationWillTerminate:(UIApplication*)application {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       [plugin applicationWillTerminate:application];
@@ -120,8 +123,8 @@
   }
 }
 
-- (void)application:(UIApplication *)application
-  didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
+- (void)application:(UIApplication*)application
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       [plugin application:application didRegisterUserNotificationSettings:notificationSettings];
@@ -129,8 +132,8 @@
   }
 }
 
-- (void)application:(UIApplication *)application
-  didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+- (void)application:(UIApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       [plugin application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
@@ -138,21 +141,23 @@
   }
 }
 
-- (void)application:(UIApplication *)application
-  didReceiveRemoteNotification:(NSDictionary *)userInfo
-        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
+- (void)application:(UIApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler]) {
+      if ([plugin application:application
+              didReceiveRemoteNotification:userInfo
+                    fetchCompletionHandler:completionHandler]) {
         return;
       }
     }
   }
 }
 
-- (BOOL)application:(UIApplication *)application
-            openURL:(NSURL *)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       if ([plugin application:application openURL:url options:options]) {
@@ -164,7 +169,8 @@
 }
 
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey {
-  return [[[FlutterAppDelegateRegistrar alloc] initWithPlugin:pluginKey appDelegate:self] autorelease];
+  return
+      [[[FlutterAppDelegateRegistrar alloc] initWithPlugin:pluginKey appDelegate:self] autorelease];
 }
 
 - (BOOL)hasPlugin:(NSString*)pluginKey {
@@ -196,7 +202,7 @@
 }
 
 - (NSObject<FlutterBinaryMessenger>*)messenger {
-  return (FlutterViewController*) _appDelegate.window.rootViewController;
+  return (FlutterViewController*)_appDelegate.window.rootViewController;
 }
 
 - (void)publish:(NSObject*)value {

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -149,7 +149,7 @@
 }
 
 - (NSObject<FlutterBinaryMessenger>*)messenger {
-  return [_appDelegate rootFlutterViewController];
+  return (FlutterViewController*) _appDelegate.window.rootViewController;
 }
 
 - (void)publish:(NSObject*)value {

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -109,6 +109,19 @@
   }
 }
 
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      if ([plugin application:application openURL:url options:options]) {
+        return YES;
+      }
+    }
+  }
+  return NO;
+}
+
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey {
   return [[[FlutterAppDelegateRegistrar alloc] initWithPlugin:pluginKey appDelegate:self] autorelease];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -120,6 +120,36 @@
   }
 }
 
+- (void)application:(UIApplication *)application
+  didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin application:application didRegisterUserNotificationSettings:notificationSettings];
+    }
+  }
+}
+
+- (void)application:(UIApplication *)application
+  didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      [plugin application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    }
+  }
+}
+
+- (void)application:(UIApplication *)application
+  didReceiveRemoteNotification:(NSDictionary *)userInfo
+        fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      if ([plugin application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler]) {
+        return;
+      }
+    }
+  }
+}
+
 - (BOOL)application:(UIApplication *)application
             openURL:(NSURL *)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -169,6 +169,8 @@
 }
 
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey {
+  NSAssert(self.pluginPublications[pluginKey] == nil, @"Duplicate plugin key: %@", pluginKey);
+  self.pluginPublications[pluginKey] = [NSNull null];
   return
       [[[FlutterAppDelegateRegistrar alloc] initWithPlugin:pluginKey appDelegate:self] autorelease];
 }
@@ -189,7 +191,7 @@
 
 - (instancetype)initWithPlugin:(NSString*)pluginKey appDelegate:(FlutterAppDelegate*)appDelegate {
   self = [super init];
-  NSAssert(self, @"Super init cannot be null");
+  NSAssert(self, @"Super init cannot be nil");
   _pluginKey = [pluginKey retain];
   _appDelegate = [appDelegate retain];
   return self;

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1260,6 +1260,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/Flutter.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1260,7 +1260,6 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/Flutter.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
-FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
@@ -1437,6 +1436,7 @@ FILE: ../../../flutter/shell/platform/android/platform_view_android_jni.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterBinaryMessenger.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCodecs.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm


### PR DESCRIPTION
Add gearing between plugins and the application context defined by custom AppDelegate class supplied by the app author. Design constraints/goals:

- Avoid forcing apps to use FlutterAppDelegate just to integrate plugins.
- Avoid being in the way of advanced plugin/app interaction (use of gearing should not be mandatory).
- Allow consuming simple/common plugins without forcing app author to write iOS-specific code.
- Provide convenience for simple and common cases, including plugin-defined callbacks for common UIApplication lifecycle methods.
- Make the "simple/common cases" an extensible notion without incurring breaking changes when extended.

iOS only in this PR. Accompanying flutter/flutter PR: https://github.com/flutter/flutter/pull/9818.
Android side: https://github.com/flutter/engine/pull/3641

Partially addresses https://github.com/flutter/flutter/issues/9682 and https://github.com/flutter/flutter/issues/9161