### PR TITLE
Add `ipv6` flag to shell.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -19,6 +19,7 @@ struct Settings {
   uint32_t observatory_port = 0;
   bool enable_diagnostic = false;
   uint32_t diagnostic_port = 0;
+  bool ipv6 = false;
   bool start_paused = false;
   bool trace_startup = false;
   bool endless_trace_buffer = false;

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -196,7 +196,7 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
     DartRuntimeHooks::Install(DartRuntimeHooks::SecondaryIsolate, script_uri);
     const Settings& settings = Settings::Get();
     if (settings.enable_observatory) {
-      std::string ip = "127.0.0.1";
+      std::string ip = settings.ipv6 ? "::1" : "127.0.0.1";
       const intptr_t port = settings.observatory_port;
       const bool disable_websocket_origin_check = false;
       const bool service_isolate_booted = DartServiceIsolate::Startup(

--- a/shell/common/diagnostic/diagnostic_server.cc
+++ b/shell/common/diagnostic/diagnostic_server.cc
@@ -61,7 +61,7 @@ void SendNull(Dart_Port port_id) {
 
 DART_NATIVE_CALLBACK_STATIC(DiagnosticServer, HandleSkiaPictureRequest);
 
-void DiagnosticServer::Start(uint32_t port) {
+void DiagnosticServer::Start(uint32_t port, bool ipv6) {
   if (!g_natives) {
     g_natives = new DartLibraryNatives();
     g_natives->Register({
@@ -92,7 +92,8 @@ void DiagnosticServer::Start(uint32_t port) {
 
   FTL_CHECK(!LogIfError(Dart_FinalizeLoading(false)));
 
-  DartInvokeField(Dart_RootLibrary(), "diagnosticServerStart", {ToDart(port)});
+  DartInvokeField(Dart_RootLibrary(), "diagnosticServerStart",
+                  {ToDart(port), ToDart(ipv6)});
 }
 
 void DiagnosticServer::HandleSkiaPictureRequest(Dart_Handle send_port) {

--- a/shell/common/diagnostic/diagnostic_server.dart
+++ b/shell/common/diagnostic/diagnostic_server.dart
@@ -11,13 +11,17 @@ import 'dart:typed_data';
 void handleSkiaPictureRequest(SendPort sendPort)
     native 'DiagnosticServer_HandleSkiaPictureRequest';
 
-void diagnosticServerStart(int port) {
-  HttpServer.bind('127.0.0.1', port).then((HttpServer server) {
+void diagnosticServerStart(int port, [bool ipv6 = false]) {
+  InternetAddress address = ipv6
+      ? InternetAddress.LOOPBACK_IP_V6
+      : InternetAddress.LOOPBACK_IP_V4;
+  HttpServer.bind(address, port).then((HttpServer server) {
     server.listen(dispatchRequest, cancelOnError: true);
 
-    String ip = server.address.address.toString();
+    String ip = address.address;
     String port = server.port.toString();
-    print('Diagnostic server listening on http://$ip:$port/');
+    String url = ipv6 ? 'http://[$ip]:$port/' : 'http://$ip:$port/';
+    print('Diagnostic server listening on $url');
   });
 }
 

--- a/shell/common/diagnostic/diagnostic_server.h
+++ b/shell/common/diagnostic/diagnostic_server.h
@@ -11,7 +11,7 @@ namespace shell {
 
 class DiagnosticServer {
  public:
-  static void Start(uint32_t port);
+  static void Start(uint32_t port, bool ipv6);
   static void HandleSkiaPictureRequest(Dart_Handle send_port);
 
  private:

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -61,7 +61,7 @@ void ServiceIsolateHook(bool running_precompiled) {
   if (!running_precompiled) {
     const blink::Settings& settings = blink::Settings::Get();
     if (settings.enable_diagnostic)
-      DiagnosticServer::Start(settings.diagnostic_port);
+      DiagnosticServer::Start(settings.diagnostic_port, settings.ipv6);
   }
 }
 
@@ -135,6 +135,9 @@ void Shell::InitStandalone(ftl::CommandLine command_line,
           << settings.diagnostic_port;
     }
   }
+
+  settings.ipv6 =
+      command_line.HasOption(FlagForSwitch(Switch::IPv6));
 
   settings.start_paused =
       command_line.HasOption(FlagForSwitch(Switch::StartPaused));

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -44,6 +44,10 @@ DEF_SWITCH(DisableDiagnostic,
            "disable-diagnostic",
            "Disable the diagnostic server. The diagnostic server is never "
            "available in release mode.")
+DEF_SWITCH(IPv6,
+           "ipv6",
+           "Bind to the IPv6 localhost address for the Dart Observatory and "
+           "the diagnostic server.")
 DEF_SWITCH(EnableDartProfiling,
            "enable-dart-profiling",
            "Enable Dart profiling. Profiling information can be viewed from "

--- a/travis/licenses_golden/licenses_lib
+++ b/travis/licenses_golden/licenses_lib
@@ -1,4 +1,4 @@
-Signature: 2e357099218fb032e67ca629b821b91e
+Signature: 3ae89e9ac728aa7a3ff5f76fd967ee87
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
It controls whether the observatory and diagnostic server will
bind to the IPv6 loopback address rather than the IPv4.

Fixes https://github.com/flutter/flutter/issues/9813