### PR TITLE
Retrieve the last error from the proper thread

### DIFF
--- a/shell/platform/linux/main_linux.cc
+++ b/shell/platform/linux/main_linux.cc
@@ -102,8 +102,14 @@ void RunNonInteractive(ftl::CommandLine initial_command_line,
       test_runner.platform_view().engine().GetLoadScriptError();
   if (error == tonic::kNoError)
     error = task_observer.last_error();
-  if (error == tonic::kNoError)
-    error = tonic::DartMicrotaskQueue::GetForCurrentThread()->GetLastError();
+  if (error == tonic::kNoError) {
+    ftl::AutoResetWaitableEvent latch;
+    blink::Threads::UI()->PostTask([&error, &latch] {
+      error = tonic::DartMicrotaskQueue::GetForCurrentThread()->GetLastError();
+      latch.Signal();
+    });
+    latch.Wait();
+  }
 
   // The script has completed and the engine may not be in a clean state,
   // so just stop the process.


### PR DESCRIPTION
Previously, the last error was a global static. Now it is a thread-specific
value, which means we need to visit the UI thread to read the value.