### PR TITLE
Default return key behaviour to 'done' on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -7,9 +7,14 @@
 
 #import <Foundation/Foundation.h>
 
+typedef NS_ENUM(NSInteger, FlutterTextInputAction) {
+  FlutterTextInputActionDone,
+};
+
 @protocol FlutterTextInputDelegate<NSObject>
 
 - (void)updateEditingClient:(int)client withState:(NSDictionary*)state;
+- (void)performAction:(FlutterTextInputAction)action withClient:(int)client;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -244,6 +244,16 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   [self updateEditingState];
 }
 
+- (BOOL)shouldChangeTextInRange:(UITextRange*)range replacementText:(NSString*)text {
+  if (self.returnKeyType == UIReturnKeyDone && [text isEqualToString:@"\n"]) {
+    [self resignFirstResponder];
+    [self removeFromSuperview];
+    [_textInputDelegate performAction:FlutterTextInputActionDone withClient:_textInputClient];
+    return NO;
+  }
+  return YES;
+}
+
 - (void)setMarkedText:(NSString*)markedText selectedRange:(NSRange)markedSelectedRange {
   NSRange selectedRange = _selectedTextRange.range;
   NSRange markedTextRange = ((FlutterTextRange*)self.markedTextRange).range;

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -141,7 +141,7 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
     _enablesReturnKeyAutomatically = NO;
     _keyboardAppearance = UIKeyboardAppearanceDefault;
     _keyboardType = UIKeyboardTypeDefault;
-    _returnKeyType = UIReturnKeyDefault;
+    _returnKeyType = UIReturnKeyDone;
     _secureTextEntry = NO;
   }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -415,6 +415,17 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(UITouc
                               arguments:@[ @(client), state ]];
 }
 
+- (void)performAction:(FlutterTextInputAction)action withClient:(int)client {
+  NSString* actionString;
+  switch (action) {
+    case FlutterTextInputActionDone:
+      actionString = @"TextInputAction.done";
+      break;
+  }
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.performAction"
+                              arguments:@[ @(client), actionString ]];
+}
+
 #pragma mark - Orientation updates
 
 - (void)onOrientationPreferencesUpdated:(NSNotification*)notification {


### PR DESCRIPTION
This change brings iOS return key behaviour in line with current behaviour on
Android.

* Implements TextInputClient.performAction for iOS Adds FlutterTextInputAction
* enum Defaults return key to 'Done' Ends editing and hides the keyboard if
* 'Done' is pressed

Future work is planned to support configurable return/action key behaviour.
See: #9573, #9210, #8028.