### PR TITLE
Adjust bottom padding correctly on iOS keyboard hide

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -190,18 +190,13 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
                object:nil];
 
   [center addObserver:self
-             selector:@selector(keyboardFrameDidChange:)
-                 name:UIKeyboardDidShowNotification
+             selector:@selector(keyboardWillChangeFrame:)
+                 name:UIKeyboardWillChangeFrameNotification
                object:nil];
 
   [center addObserver:self
              selector:@selector(keyboardWillBeHidden:)
                  name:UIKeyboardWillHideNotification
-               object:nil];
-
-  [center addObserver:self
-             selector:@selector(keyboardFrameDidChange:)
-                 name:UIKeyboardDidChangeFrameNotification
                object:nil];
 
   [center addObserver:self
@@ -399,7 +394,7 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(UITouc
 
 #pragma mark - Keyboard events
 
-- (void)keyboardFrameDidChange:(NSNotification*)notification {
+- (void)keyboardWillChangeFrame:(NSNotification*)notification {
   NSDictionary* info = [notification userInfo];
   CGFloat bottom =
       CGRectGetHeight([[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue]);


### PR DESCRIPTION
Handle willChangeFrame to handle keyboard show, resize, reposition
(split, move floating keyboard) events. Handle willBeHidden events for
keyboard dismissal.

Fixes incorrect bottom padding introduced in
f2581c9bcc32f9e2e7372eb7e94a8aa9f5aab0b2 due to didChangeFrame
notification firing after willBeHidden on keyboard dismissal.