### PR TITLE
Move the test runner to a higher DPI screen.

### DIFF
--- a/shell/testing/test_runner.cc
+++ b/shell/testing/test_runner.cc
@@ -15,8 +15,9 @@ namespace shell {
 
 TestRunner::TestRunner() : platform_view_(new PlatformViewTest()) {
   blink::ViewportMetrics metrics;
-  metrics.physical_width = 800;
-  metrics.physical_height = 600;
+  metrics.device_pixel_ratio = 3.0;
+  metrics.physical_width = 2400; // 800 at 3x resolution
+  metrics.physical_height = 1800; // 600 at 3x resolution
 
   blink::Threads::UI()->PostTask(
       [ engine = platform_view_->engine().GetWeakPtr(), metrics ] {


### PR DESCRIPTION
Having the device pixel ratio of the test shell be 1.0x makes it
unlikely that we will catch errors relating to mishandling of the
device pixel ratio in the test shell.

This patch arbitrarily increases the device pixel resolution while
keeping the logical resolution the same.

I made the new resolution an integer because that minimises
the likelihood of confusing floating point errors in the tests.