### PR TITLE
Add SkColorSpace to Picture.toImage()

### DIFF
--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -40,7 +40,7 @@ ftl::RefPtr<CanvasImage> Picture::toImage(int width, int height) {
   // TODO(abarth): We should pass in an SkColorSpace at some point.
   image->set_image(
       SkImage::MakeFromPicture(picture_, SkISize::Make(width, height), nullptr,
-                               nullptr, SkImage::BitDepth::kU8, nullptr));
+                               nullptr, SkImage::BitDepth::kU8, SkColorSpace::MakeSRGB()));
   return image;
 }
 


### PR DESCRIPTION
Skia doesn't actually create the image if we don't supply a color space.