### PR TITLE
Use ccache on the host if available.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -25,6 +25,7 @@ group("flutter") {
       deps += [ "//flutter/shell/platform/darwin:flutter_channels_unittests" ]
     }
     deps += [
+      "//flutter/flow:flow_unittests",
       "//flutter/fml:fml_unittests",
       "//flutter/sky/engine/wtf:wtf_unittests",
       "//flutter/synchronization:synchronization_unittests",

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -36,6 +36,8 @@ source_set("flow") {
     "layers/shader_mask_layer.h",
     "layers/transform_layer.cc",
     "layers/transform_layer.h",
+    "matrix_decomposition.cc",
+    "matrix_decomposition.h",
     "paint_utils.cc",
     "paint_utils.h",
     "process_info.h",
@@ -64,4 +66,19 @@ source_set("flow") {
       "//apps/mozart/services/composition",
     ]
   }
+}
+
+executable("flow_unittests") {
+  testonly = true
+
+  sources = [
+    "matrix_decomposition_unittests.cc",
+  ]
+
+  deps = [
+    ":flow",
+    "//dart/runtime:libdart_jit",  # for tracing
+    "//flutter/testing",
+    "//third_party/skia",
+  ]
 }

--- a/flow/matrix_decomposition.cc
+++ b/flow/matrix_decomposition.cc
@@ -1,0 +1,141 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/matrix_decomposition.h"
+
+namespace flow {
+
+static inline SkVector3 SkVector3Combine(const SkVector3& a,
+                                         float aScale,
+                                         const SkVector3& b,
+                                         float bScale) {
+  return {
+      aScale * a.fX + bScale * b.fX,  //
+      aScale * a.fY + bScale * b.fY,  //
+      aScale * a.fZ + bScale * b.fZ,  //
+  };
+}
+
+static inline SkVector3 SkVector3Cross(const SkVector3& a, const SkVector3& b) {
+  return {
+      (a.fY * b.fZ) - (a.fZ * b.fY),  //
+      (a.fZ * b.fX) - (a.fX * b.fZ),  //
+      (a.fX * b.fY) - (a.fY * b.fX)   //
+  };
+}
+
+MatrixDecomposition::MatrixDecomposition(const SkMatrix& matrix)
+    : MatrixDecomposition(SkMatrix44{matrix}) {}
+
+MatrixDecomposition::MatrixDecomposition(SkMatrix44 matrix) : valid_(false) {
+  if (matrix.get(3, 3) == 0) {
+    return;
+  }
+
+  for (int i = 0; i < 4; i++) {
+    for (int j = 0; j < 4; j++) {
+      matrix.set(j, i, matrix.get(j, i) / matrix.get(3, 3));
+    }
+  }
+
+  SkMatrix44 perpectiveMatrix = matrix;
+  for (int i = 0; i < 3; i++) {
+    perpectiveMatrix.set(3, i, 0.0);
+  }
+
+  perpectiveMatrix.set(3, 3, 1.0);
+
+  if (perpectiveMatrix.determinant() == 0.0) {
+    return;
+  }
+
+  if (matrix.get(3, 0) != 0.0 || matrix.get(3, 1) != 0.0 ||
+      matrix.get(3, 2) != 0.0) {
+    const SkVector4 rightHandSide(matrix.get(3, 0), matrix.get(3, 1),
+                                  matrix.get(3, 2), matrix.get(3, 3));
+
+    SkMatrix44 invertedTransposed(
+        SkMatrix44::Uninitialized_Constructor::kUninitialized_Constructor);
+    if (!perpectiveMatrix.invert(&invertedTransposed)) {
+      return;
+    }
+    invertedTransposed.transpose();
+
+    perspective_ = invertedTransposed * rightHandSide;
+
+    matrix.set(3, 0, 0);
+    matrix.set(3, 1, 0);
+    matrix.set(3, 2, 0);
+    matrix.set(3, 3, 1);
+  }
+
+  translation_ = {matrix.get(0, 3), matrix.get(1, 3), matrix.get(2, 3)};
+
+  matrix.set(0, 3, 0.0);
+  matrix.set(1, 3, 0.0);
+  matrix.set(2, 3, 0.0);
+
+  SkVector3 row[3];
+  for (int i = 0; i < 3; i++) {
+    row[i].set(matrix.get(0, i), matrix.get(1, i), matrix.get(2, i));
+  }
+
+  scale_.fX = row[0].length();
+  row[0].normalize();
+
+  shear_.fX = row[0].dot(row[1]);
+  row[1] = SkVector3Combine(row[1], 1.0, row[0], -shear_.fX);
+
+  scale_.fY = row[1].length();
+  row[1].normalize();
+  shear_.fX /= scale_.fY;
+
+  shear_.fY = row[0].dot(row[2]);
+  row[2] = SkVector3Combine(row[2], 1.0, row[0], -shear_.fY);
+  shear_.fZ = row[1].dot(row[2]);
+  row[2] = SkVector3Combine(row[2], 1.0, row[1], -shear_.fZ);
+
+  scale_.fZ = row[2].length();
+  row[2].normalize();
+
+  shear_.fY /= scale_.fZ;
+  shear_.fZ /= scale_.fZ;
+
+  if (row[0].dot(SkVector3Cross(row[1], row[2])) < 0) {
+    scale_.fX *= -1;
+    scale_.fY *= -1;
+    scale_.fZ *= -1;
+
+    for (int i = 0; i < 3; i++) {
+      row[i].fX *= -1;
+      row[i].fY *= -1;
+      row[i].fZ *= -1;
+    }
+  }
+
+  rotation_.set(0.5 * sqrt(fmax(1.0 + row[0].fX - row[1].fY - row[2].fZ, 0.0)),
+                0.5 * sqrt(fmax(1.0 - row[0].fX + row[1].fY - row[2].fZ, 0.0)),
+                0.5 * sqrt(fmax(1.0 - row[0].fX - row[1].fY + row[2].fZ, 0.0)),
+                0.5 * sqrt(fmax(1.0 + row[0].fX + row[1].fY + row[2].fZ, 0.0)));
+
+  if (row[2].fY > row[1].fZ) {
+    rotation_.fData[0] = -rotation_.fData[0];
+  }
+  if (row[0].fZ > row[2].fX) {
+    rotation_.fData[1] = -rotation_.fData[1];
+  }
+  if (row[1].fX > row[0].fY) {
+    rotation_.fData[2] = -rotation_.fData[2];
+  }
+
+  valid_ = true;
+}
+
+MatrixDecomposition::~MatrixDecomposition() = default;
+
+bool MatrixDecomposition::IsValid() const {
+  return valid_;
+}
+
+}  // namespace flow

--- a/flow/matrix_decomposition.h
+++ b/flow/matrix_decomposition.h
@@ -1,0 +1,51 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLOW_MATRIX_DECOMPOSITION_H_
+#define FLUTTER_FLOW_MATRIX_DECOMPOSITION_H_
+
+#include "lib/ftl/macros.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkMatrix44.h"
+#include "third_party/skia/include/core/SkPoint3.h"
+
+namespace flow {
+
+/// Decomposes a given non-degenerate transformation matrix into a sequence of
+/// operations that produced it. The validity of the decomposition must always
+/// be checked before attempting to access any of the decomposed elements.
+class MatrixDecomposition {
+ public:
+  MatrixDecomposition(const SkMatrix& matrix);
+
+  MatrixDecomposition(SkMatrix44 matrix);
+
+  ~MatrixDecomposition();
+
+  bool IsValid() const;
+
+  const SkVector3& translation() const { return translation_; };
+
+  const SkVector3& scale() { return scale_; };
+
+  const SkVector3& shear() { return shear_; };
+
+  const SkVector4& perspective() { return perspective_; };
+
+  const SkVector4& rotation() { return rotation_; };
+
+ private:
+  bool valid_;
+  SkVector3 translation_;
+  SkVector3 scale_;
+  SkVector3 shear_;
+  SkVector4 perspective_;
+  SkVector4 rotation_;
+
+  FTL_DISALLOW_COPY_AND_ASSIGN(MatrixDecomposition);
+};
+
+}  // namespace flow
+
+#endif  // FLUTTER_FLOW_MATRIX_DECOMPOSITION_H_

--- a/flow/matrix_decomposition_unittests.cc
+++ b/flow/matrix_decomposition_unittests.cc
@@ -1,0 +1,88 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/matrix_decomposition.h"
+#include "third_party/gtest/include/gtest/gtest.h"
+
+TEST(MatrixDecomposition, Rotation) {
+  SkMatrix44 matrix = SkMatrix44::I();
+
+  const auto angle = M_PI_4;
+  matrix.setRotateAbout(0.0, 0.0, 1.0, angle);
+
+  flow::MatrixDecomposition decomposition(matrix);
+  ASSERT_TRUE(decomposition.IsValid());
+
+  const auto sine = sin(angle * 0.5);
+
+  ASSERT_FLOAT_EQ(0, decomposition.rotation().fData[0]);
+  ASSERT_FLOAT_EQ(0, decomposition.rotation().fData[1]);
+  ASSERT_FLOAT_EQ(sine, decomposition.rotation().fData[2]);
+  ASSERT_FLOAT_EQ(cos(angle * 0.5), decomposition.rotation().fData[3]);
+}
+
+TEST(MatrixDecomposition, Scale) {
+  SkMatrix44 matrix = SkMatrix44::I();
+
+  const auto scale = 5.0;
+  matrix.setScale(scale + 0, scale + 1, scale + 2);
+
+  flow::MatrixDecomposition decomposition(matrix);
+  ASSERT_TRUE(decomposition.IsValid());
+
+  ASSERT_FLOAT_EQ(scale + 0, decomposition.scale().fX);
+  ASSERT_FLOAT_EQ(scale + 1, decomposition.scale().fY);
+  ASSERT_FLOAT_EQ(scale + 2, decomposition.scale().fZ);
+}
+
+TEST(MatrixDecomposition, Translate) {
+  SkMatrix44 matrix = SkMatrix44::I();
+
+  const auto translate = 125.0;
+  matrix.setTranslate(translate + 0, translate + 1, translate + 2);
+
+  flow::MatrixDecomposition decomposition(matrix);
+  ASSERT_TRUE(decomposition.IsValid());
+
+  ASSERT_FLOAT_EQ(translate + 0, decomposition.translation().fX);
+  ASSERT_FLOAT_EQ(translate + 1, decomposition.translation().fY);
+  ASSERT_FLOAT_EQ(translate + 2, decomposition.translation().fZ);
+}
+
+TEST(MatrixDecomposition, Combination) {
+  SkMatrix44 matrix = SkMatrix44::I();
+
+  const auto rotation = M_PI_4;
+  const auto scale = 5;
+  const auto translate = 125.0;
+
+  SkMatrix44 m1 = SkMatrix44::I();
+  m1.setRotateAbout(0, 0, 1, rotation);
+
+  SkMatrix44 m2 = SkMatrix44::I();
+  m2.setScale(scale);
+
+  SkMatrix44 m3 = SkMatrix44::I();
+  m3.setTranslate(translate, translate, translate);
+
+  SkMatrix44 combined = m3 * m2 * m1;
+
+  flow::MatrixDecomposition decomposition(combined);
+  ASSERT_TRUE(decomposition.IsValid());
+
+  ASSERT_FLOAT_EQ(translate, decomposition.translation().fX);
+  ASSERT_FLOAT_EQ(translate, decomposition.translation().fY);
+  ASSERT_FLOAT_EQ(translate, decomposition.translation().fZ);
+
+  ASSERT_FLOAT_EQ(scale, decomposition.scale().fX);
+  ASSERT_FLOAT_EQ(scale, decomposition.scale().fY);
+  ASSERT_FLOAT_EQ(scale, decomposition.scale().fZ);
+
+  const auto sine = sin(rotation * 0.5);
+
+  ASSERT_FLOAT_EQ(0, decomposition.rotation().fData[0]);
+  ASSERT_FLOAT_EQ(0, decomposition.rotation().fData[1]);
+  ASSERT_FLOAT_EQ(sine, decomposition.rotation().fData[2]);
+  ASSERT_FLOAT_EQ(cos(rotation * 0.5), decomposition.rotation().fData[3]);
+}


### PR DESCRIPTION
Significantly speeds up builds when compiling different engine variants (most of the host targets are the same anyway). Make sure `ccache` is installed and check stats with `ccache -s`. Needs https://github.com/flutter/buildroot/pull/66 to land in the buildroot to enable `ccache` on Mac toolchains. It is already enabled for Android and Linux.

It is recommended that you bump up the ccache max size from the default
of 5 GB (especially if you are also using ccache for Fuchsia or other
large project). This can be done via bumping up `max_size` in your
config file (usually `~/.ccache/ccache.conf`).

Also removes the defunct --use-glfw flag.