### PR TITLE
Smarter text/selection will/didChange events

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -162,25 +162,34 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
 }
 
 - (void)setTextInputState:(NSDictionary*)state {
-  [self.inputDelegate selectionWillChange:self];
-  [self.inputDelegate textWillChange:self];
-
-  [self.text setString:state[@"text"]];
+  NSString* newText = state[@"text"];
+  BOOL textChanged = ![self.text isEqualToString:newText];
+  if (textChanged) {
+    [self.inputDelegate textWillChange:self];
+    [self.text setString:newText];
+  }
 
   NSInteger selectionBase = [state[@"selectionBase"] intValue];
   NSInteger selectionExtent = [state[@"selectionExtent"] intValue];
   NSUInteger start = MIN(MAX(0, MIN(selectionBase, selectionExtent)), (NSInteger)self.text.length);
   NSUInteger end = MIN(MAX(0, MAX(selectionBase, selectionExtent)), (NSInteger)self.text.length);
   NSRange selectedRange = NSMakeRange(start, end - start);
-  [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
-          updateEditingState:NO];
 
-  _selectionAffinity = _kTextAffinityDownstream;
-  if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
-    _selectionAffinity = _kTextAffinityUpstream;
+  NSRange oldSelectedRange = [(FlutterTextRange*)self.selectedTextRange range];
+  BOOL selectionChanged = selectedRange.location != oldSelectedRange.location || selectedRange.length != oldSelectedRange.length;
 
-  [self.inputDelegate selectionDidChange:self];
-  [self.inputDelegate textDidChange:self];
+  if (selectionChanged) {
+    [self.inputDelegate selectionWillChange:self];
+    [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
+            updateEditingState:NO];
+    _selectionAffinity = _kTextAffinityDownstream;
+    if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
+      _selectionAffinity = _kTextAffinityUpstream;
+    [self.inputDelegate selectionDidChange:self];
+  }
+
+  if (textChanged)
+    [self.inputDelegate textDidChange:self];
 }
 
 #pragma mark - UIResponder Overrides

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -176,7 +176,8 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   NSRange selectedRange = NSMakeRange(start, end - start);
 
   NSRange oldSelectedRange = [(FlutterTextRange*)self.selectedTextRange range];
-  BOOL selectionChanged = selectedRange.location != oldSelectedRange.location || selectedRange.length != oldSelectedRange.length;
+  BOOL selectionChanged = selectedRange.location != oldSelectedRange.location ||
+                          selectedRange.length != oldSelectedRange.length;
 
   if (selectionChanged) {
     [self.inputDelegate selectionWillChange:self];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -176,10 +176,8 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   NSRange selectedRange = NSMakeRange(start, end - start);
 
   NSRange oldSelectedRange = [(FlutterTextRange*)self.selectedTextRange range];
-  BOOL selectionChanged = selectedRange.location != oldSelectedRange.location ||
-                          selectedRange.length != oldSelectedRange.length;
-
-  if (selectionChanged) {
+  if (selectedRange.location != oldSelectedRange.location ||
+      selectedRange.length != oldSelectedRange.length) {
     [self.inputDelegate selectionWillChange:self];
     [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
             updateEditingState:NO];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -174,7 +174,6 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   NSUInteger start = MIN(MAX(0, MIN(selectionBase, selectionExtent)), (NSInteger)self.text.length);
   NSUInteger end = MIN(MAX(0, MAX(selectionBase, selectionExtent)), (NSInteger)self.text.length);
   NSRange selectedRange = NSMakeRange(start, end - start);
-
   NSRange oldSelectedRange = [(FlutterTextRange*)self.selectedTextRange range];
   if (selectedRange.location != oldSelectedRange.location ||
       selectedRange.length != oldSelectedRange.length) {


### PR DESCRIPTION
Check incoming text editing state and only fire textWillChange:,
textDidChange:, selectionWillChange:, selectionDidChange: when the text
or selection actually changes.

On selectionWillChange: in a text field where auto-correct is enabled,
iOS will attempt to auto-correct the word preceding the cursor. This
change also updates the text before calling selectionWillChange: to
prevent auto-correction on the preceding value of the text field.