### PR TITLE
Update iOS HapticFeedback.vibrate implementation

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -77,7 +77,7 @@ using namespace shell;
 }
 
 - (void)vibrateHapticFeedback {
-  AudioServicesPlayAlertSound(kSystemSoundID_Vibrate);
+  AudioServicesPlaySystemSound(kSystemSoundID_Vibrate);
 }
 
 - (void)setSystemChromePreferredOrientations:(NSArray*)orientations {


### PR DESCRIPTION
Use AudioServicesPlaySystemSound instead of AudioServicesPlayAlertSound.
This avoids the potential of a system beep on devices without support
for haptic feedback.