### PR TITLE
Fix crash in iOS accessibility

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -55,7 +55,7 @@ class AccessibilityBridge final {
  private:
   SemanticsObject* GetOrCreateObject(int32_t id);
   void VisitObjectsRecursively(SemanticsObject* object, std::unordered_set<int>* visited_objects);
-  void ReleaseObjects(const std::unordered_map<int, SemanticsObject*>& objects);
+  void ReleaseObjects(std::unordered_map<int, SemanticsObject*>& objects);
 
   UIView* view_;
   PlatformViewIOS* platform_view_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -265,16 +265,17 @@ void AccessibilityBridge::UpdateSemantics(std::vector<blink::SemanticsNode> node
   }
 
   if (doomed_focused_object != nil) {
-    // Previously focused element is no longer in the tree, let iOS figure out what to focus next.
+    // Previously focused element is no longer in the tree.
+    // Passing `nil` as argument to let iOS figure out what to focus next.
     // TODO(goderbauer): Figure out which element should be focused next and post
     //     UIAccessibilityLayoutChangedNotification with that element instead.
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
   } else {
+    // Passing `nil` as argument to keep focus where it is.
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
   }
 
   ReleaseObjects(doomed_objects);
-  doomed_objects.clear();
 }
 
 void AccessibilityBridge::DispatchSemanticsAction(int32_t uid, blink::SemanticsAction action) {
@@ -297,12 +298,13 @@ void AccessibilityBridge::VisitObjectsRecursively(SemanticsObject* object,
     VisitObjectsRecursively(child, visited_objects);
 }
 
-void AccessibilityBridge::ReleaseObjects(const std::unordered_map<int, SemanticsObject*>& objects) {
+void AccessibilityBridge::ReleaseObjects(std::unordered_map<int, SemanticsObject*>& objects) {
   for (const auto& entry : objects) {
     SemanticsObject* object = entry.second;
     [object neuter];
     [object release];
   }
+  objects.clear();
 }
 
 }  // namespace shell

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -257,7 +257,10 @@ void AccessibilityBridge::UpdateSemantics(std::vector<blink::SemanticsNode> node
   } else {
     view_.accessibilityElements = nil;
   }
-  UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
+  // TODO(goderbauer): If the previously focused element is still on screen we should fire a
+  //     UIAccessibilityLayoutChangedNotification instead. If the element is no longer on screen
+  //     we should use the semantics tree to figure out which element to focus instead.
+  UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, nil);
 }
 
 void AccessibilityBridge::DispatchSemanticsAction(int32_t uid, blink::SemanticsAction action) {


### PR DESCRIPTION
Previously, whenever an action would remove the focused element from the screen the app would crash. This change tells iOS to focus the first on-screen element after every change to the semantics tree. This avoids the crash.

In a future iteration, we should tell iOS which element it needs to focus by looking at the semantics tree (instead of leaving it up to the iOS).