### PR TITLE
Teach flutter_runner about namespaces

### DIFF
--- a/content_handler/application_controller_impl.cc
+++ b/content_handler/application_controller_impl.cc
@@ -44,9 +44,9 @@ ApplicationControllerImpl::ApplicationControllerImpl(
 
   url_ = startup_info->launch_info->url;
   runtime_holder_.reset(new RuntimeHolder());
-  runtime_holder_->Init(std::move(startup_info->environment),
-                        fidl::GetProxy(&dart_service_provider_),
-                        std::move(bundle));
+  runtime_holder_->Init(
+      app::ApplicationContext::CreateFrom(std::move(startup_info)),
+      fidl::GetProxy(&dart_service_provider_), std::move(bundle));
 }
 
 ApplicationControllerImpl::~ApplicationControllerImpl() = default;

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -9,6 +9,7 @@
 
 #include <unordered_set>
 
+#include "application/lib/app/application_context.h"
 #include "application/services/application_environment.fidl.h"
 #include "application/services/service_provider.fidl.h"
 #include "apps/mozart/lib/flutter/sdk_ext/src/natives.h"
@@ -38,7 +39,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   RuntimeHolder();
   ~RuntimeHolder();
 
-  void Init(fidl::InterfaceHandle<app::ApplicationEnvironment> environment,
+  void Init(std::unique_ptr<app::ApplicationContext> context,
             fidl::InterfaceRequest<app::ServiceProvider> outgoing_services,
             std::vector<char> bundle);
   void CreateView(const std::string& script_uri,
@@ -86,8 +87,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   void OnFrameComplete();
   void Invalidate();
 
-  app::ApplicationEnvironmentPtr environment_;
-  app::ServiceProviderPtr environment_services_;
+  std::unique_ptr<app::ApplicationContext> context_;
   fidl::InterfaceRequest<app::ServiceProvider> outgoing_services_;
 
   std::vector<char> root_bundle_data_;


### PR DESCRIPTION
Rather than receiving an ApplicationEnvironment, we now receive a namespace.
Once we have FIDL2, we can plumb the namespace all the way through to Dart.