### PR TITLE
Use children's labels if element doesn't have one

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -96,7 +96,12 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
 
 - (NSString*)accessibilityLabel {
   if (_node.label.empty()) {
-    return nil;
+    NSMutableString *label = [NSMutableString string];
+    for (auto& child : _children) {
+      [label appendString: [child accessibilityLabel]];
+      [label appendString: @"\n"];
+    }
+    return label;
   }
   return @(_node.label.data());
 }


### PR DESCRIPTION
Android seems to do this by default. This way, if you select a table cell it will read the content of that cell.