### PR TITLE
[iOS accessibility] Dispatch taps to selected element

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -173,8 +173,10 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark - UIAccessibilityAction overrides
 
 - (BOOL)accessibilityActivate {
-  // TODO(tvolkert): Implement
-  return NO;
+  if (!_node.HasAction(blink::SemanticsAction::kTap))
+    return NO;
+  _bridge->DispatchSemanticsAction(_uid, blink::SemanticsAction::kTap);
+  return YES;
 }
 
 - (void)accessibilityIncrement {


### PR DESCRIPTION
Previously, taps were sent to the topmost tap handler in the center of the accessibility frame of the selected element and therefore might have been handled by a different element than the desired one.