### PR TITLE
Improve auto-correct disabling on Android when obscureText is true

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -86,8 +86,11 @@ public class TextInputPlugin implements MethodCallHandler {
             textType |= InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
         else if (inputType.equals("TextInputType.url"))
             textType |= InputType.TYPE_TEXT_VARIATION_URI;
-        if (obscureText)
+        if (obscureText) {
+            // Note: both required. Some devices ignore TYPE_TEXT_FLAG_NO_SUGGESTIONS.
             textType |= InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+            textType |= InputType.TYPE_TEXT_VARIATION_PASSWORD;
+        }
         return textType;
     }
 


### PR DESCRIPTION
Some keyboards (e.g., on some Samsung devices, SwiftKey) ignore
InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS and require
InputType.TYPE_TEXT_VARIATION_PASSWORD.