### PR TITLE
Fix crash when iOS accessibility is turned off and then on again

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -221,6 +221,7 @@ AccessibilityBridge::AccessibilityBridge(UIView* view, PlatformViewIOS* platform
     : view_(view), platform_view_(platform_view) {}
 
 AccessibilityBridge::~AccessibilityBridge() {
+  view_.accessibilityElements = nil;
   ReleaseObjects(objects_);
   objects_.clear();
 }


### PR DESCRIPTION
We have to tell the view to forget all `accessibilityElements` before releasing them.