### PR TITLE
[MA-225][DNO-95] remove message loop handlers when destroying VulkanS…

### DIFF
--- a/content_handler/vulkan_rasterizer.cc
+++ b/content_handler/vulkan_rasterizer.cc
@@ -52,6 +52,12 @@ VulkanRasterizer::VulkanSurfaceProducer::VulkanSurfaceProducer() {
     FTL_LOG(ERROR) << "VulkanSurfaceProducer failed to initialize";
 }
 
+VulkanRasterizer::VulkanSurfaceProducer::~VulkanSurfaceProducer() {
+  for (auto &surface_info : pending_surfaces_)
+    mtl::MessageLoop::GetCurrent()->RemoveHandler(
+        surface_info.second.handler_key);
+}
+
 std::unique_ptr<VulkanRasterizer::VulkanSurfaceProducer::Surface>
 VulkanRasterizer::VulkanSurfaceProducer::CreateSurface(uint32_t width,
                                                        uint32_t height) {

--- a/content_handler/vulkan_rasterizer.h
+++ b/content_handler/vulkan_rasterizer.h
@@ -39,6 +39,7 @@ class VulkanRasterizer : public Rasterizer {
         private mtl::MessageLoopHandler {
    public:
     VulkanSurfaceProducer();
+    ~VulkanSurfaceProducer() override;
     sk_sp<SkSurface> ProduceSurface(SkISize size,
                                     mozart::ImagePtr* out_image) override;
 


### PR DESCRIPTION
…urfaceProducer to avoid callbacks on deleted pointers