### PR TITLE
Invoke deferred invalidation callback before destroying it.

### DIFF
--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -98,6 +98,10 @@ RuntimeHolder::~RuntimeHolder() {
       ftl::MakeCopyable([rasterizer = std::move(rasterizer_)](){
           // Deletes rasterizer.
       }));
+  if (deferred_invalidation_callback_) {
+    // Must be called before being destroyed.
+    deferred_invalidation_callback_();
+  }
 }
 
 void RuntimeHolder::Init(


### PR DESCRIPTION
If it is not invoked, it triggers a fatal fidl runtime check.