### PR TITLE
Exclude ios_tools from license script

### DIFF
--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2103,6 +2103,7 @@ class RepositoryRoot extends RepositoryDirectory {
     return entry.name != 'testing' // only used by tests
         && entry.name != 'build' // only used by build
         && entry.name != 'buildtools' // only used by build
+        && entry.name != 'ios_tools' // only used by build
         && entry.name != 'tools' // not distributed in binary
         && entry.name != 'out' // output of build
         && super.shouldRecurse(entry);


### PR DESCRIPTION
ios_tools exists to provide find_xcode.py, which is used only on the Mac
Engine bot to select the correct version of Xcode to build with.