### PR TITLE
Use color correct Skia in Flutter (part 2)

### DIFF
--- a/content_handler/vulkan_rasterizer.cc
+++ b/content_handler/vulkan_rasterizer.cc
@@ -127,7 +127,7 @@ VulkanRasterizer::VulkanSurfaceProducer::CreateSurface(uint32_t width,
   GrBackendRenderTargetDesc desc;
   desc.fWidth = width;
   desc.fHeight = height;
-  desc.fConfig = kSBGRA_8888_GrPixelConfig;
+  desc.fConfig = kSRGBA_8888_GrPixelConfig;
   desc.fOrigin = kTopLeft_GrSurfaceOrigin;
   desc.fSampleCnt = 0;
   desc.fStencilBits = 0;
@@ -136,8 +136,8 @@ VulkanRasterizer::VulkanSurfaceProducer::CreateSurface(uint32_t width,
 
   SkSurfaceProps props(SkSurfaceProps::InitType::kLegacyFontHost_InitType);
 
-  auto sk_surface = SkSurface::MakeFromBackendRenderTarget(context_.get(), desc,
-                                                           nullptr, &props);
+  auto sk_surface = SkSurface::MakeFromBackendRenderTarget(
+      context_.get(), desc, SkColorSpace::MakeSRGB(), &props);
   if (!sk_surface) {
     FTL_LOG(ERROR) << "MakeFromBackendRenderTarget Failed";
     return nullptr;

--- a/shell/common/picture_serializer.cc
+++ b/shell/common/picture_serializer.cc
@@ -6,9 +6,9 @@
 
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "third_party/skia/include/core/SkData.h"
-#include "third_party/skia/include/core/SkImageEncoder.h"
 #include "third_party/skia/include/core/SkPixelSerializer.h"
 #include "third_party/skia/include/core/SkStream.h"
+#include "third_party/skia/include/encode/SkPngEncoder.h"
 
 namespace shell {
 
@@ -19,8 +19,9 @@ bool PngPixelSerializer::onUseEncodedData(const void*, size_t) {
 SkData* PngPixelSerializer::onEncode(const SkPixmap& pixmap) {
   SkDynamicMemoryWStream stream;
 
-  bool encode_result = SkEncodeImage(
-      &stream, pixmap, SkEncodedImageFormat::kPNG, 80 /* quality */);
+  SkPngEncoder::Options options;
+  options.fUnpremulBehavior = SkTransferFunctionBehavior::kRespect;
+  bool encode_result = SkPngEncoder::Encode(&stream, pixmap, options);
 
   return encode_result ? stream.detachAsData().release() : nullptr;
 }

--- a/shell/common/platform_view_service_protocol.cc
+++ b/shell/common/platform_view_service_protocol.cc
@@ -298,7 +298,9 @@ void PlatformViewServiceProtocol::ScreenshotGpuTask(SkBitmap* bitmap) {
     return;
 
   const SkISize& frame_size = layer_tree->frame_size();
-  if (!bitmap->tryAllocN32Pixels(frame_size.width(), frame_size.height()))
+  SkImageInfo info = SkImageInfo::MakeS32(
+      frame_size.width(), frame_size.height(), kPremul_SkAlphaType);
+  if (!bitmap->tryAllocPixels(info))
     return;
 
   sk_sp<SkSurface> surface = SkSurface::MakeRasterDirect(

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -23,8 +23,7 @@ class GPUSurfaceGLDelegate {
 
   virtual intptr_t GLContextFBO() const = 0;
 
-  // TODO: Update Mac desktop and make this pure virtual.
-  virtual sk_sp<SkColorSpace> ColorSpace() const { return nullptr; }
+  virtual sk_sp<SkColorSpace> ColorSpace() const = 0;
 };
 
 class GPUSurfaceGL : public Surface {

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -106,8 +106,9 @@ bool AndroidSurfaceSoftware::PresentBackingStore(
 
   SkColorType color_type;
   sk_sp<SkColorSpace> color_space;
-  if (GetSkColorTypeAndSkColorSpace(native_buffer.format, &color_type,
-                                                          &color_space)) {
+  if (GetSkColorTypeAndSkColorSpace(native_buffer.format,
+                                    &color_type,
+                                    &color_space)) {
     SkImageInfo native_image_info = SkImageInfo::Make(
         native_buffer.width, native_buffer.height, color_type,
         kPremul_SkAlphaType, color_space);

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -18,13 +18,16 @@ namespace shell {
 
 namespace {
 
-bool GetSkColorType(int32_t buffer_format, SkColorType* color_type) {
+bool GetSkColorTypeAndSkColorSpace(int32_t buffer_format,
+                                   SkColorType* color_type) {
   switch (buffer_format) {
     case WINDOW_FORMAT_RGB_565:
       *color_type = kRGB_565_SkColorType;
+      *color_space = nullptr;
       return true;
     case WINDOW_FORMAT_RGBA_8888:
       *color_type = kRGBA_8888_SkColorType;
+      *color_space = SkColorSpace::MakeSRGB();
       return true;
     default:
       return false;
@@ -35,7 +38,8 @@ bool GetSkColorType(int32_t buffer_format, SkColorType* color_type) {
 
 AndroidSurfaceSoftware::AndroidSurfaceSoftware()
     : AndroidSurface(),
-      target_color_type_(kRGBA_8888_SkColorType) {}
+      target_color_type_(kRGBA_8888_SkColorType),
+      target_color_space_(SkColorSpace::MakeSRGB()) {}
 
 AndroidSurfaceSoftware::~AndroidSurfaceSoftware() = default;
 
@@ -75,11 +79,10 @@ sk_sp<SkSurface> AndroidSurfaceSoftware::AcquireBackingStore(
     return sk_surface_;
   }
 
-  SkImageInfo image_info = SkImageInfo::Make(
-      size.fWidth, size.fHeight, target_color_type_, kPremul_SkAlphaType);
+  SkImageInfo image_info = SkImageInfo::Make(size.fWidth, size.fHeight,
+      target_color_type_, kPremul_SkAlphaType, target_color_space_);
 
   sk_surface_ = SkSurface::MakeRaster(image_info);
-
   return sk_surface_;
 }
 
@@ -101,9 +104,12 @@ bool AndroidSurfaceSoftware::PresentBackingStore(
   }
 
   SkColorType color_type;
-  if (GetSkColorType(native_buffer.format, &color_type)) {
+  sk_sp<SkColorSpace> color_space;
+  if (GetSkColorTypeAndSkColorSpace(native_buffer.format, &color_type,
+                                                          &color_space)) {
     SkImageInfo native_image_info = SkImageInfo::Make(
-        native_buffer.width, native_buffer.height, color_type, kPremul_SkAlphaType);
+        native_buffer.width, native_buffer.height, color_type,
+        kPremul_SkAlphaType, color_space);
 
     std::unique_ptr<SkCanvas> canvas = SkCanvas::MakeRasterDirect(
         native_image_info,

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -19,7 +19,8 @@ namespace shell {
 namespace {
 
 bool GetSkColorTypeAndSkColorSpace(int32_t buffer_format,
-                                   SkColorType* color_type) {
+                                   SkColorType* color_type,
+                                   sk_sp<SkColorSpace>* color_space) {
   switch (buffer_format) {
     case WINDOW_FORMAT_RGB_565:
       *color_type = kRGB_565_SkColorType;
@@ -151,7 +152,9 @@ bool AndroidSurfaceSoftware::SetNativeWindow(
   int32_t window_format = ANativeWindow_getFormat(native_window_->handle());
   if (window_format < 0)
     return false;
-  if (!GetSkColorType(window_format, &target_color_type_))
+  if (!GetSkColorTypeAndSkColorSpace(window_format,
+                                     &target_color_type_,
+                                     &target_color_space_))
     return false;
   return true;
 }

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -49,6 +49,7 @@ class AndroidSurfaceSoftware : public AndroidSurface,
 
   ftl::RefPtr<AndroidNativeWindow> native_window_;
   SkColorType target_color_type_;
+  sk_sp<SkColorSpace> target_color_space_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(AndroidSurfaceSoftware);
 };

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -567,7 +567,8 @@ void PlatformViewAndroid::GetBitmapGpuTask(jobject* pixels_out,
 
   SkImageInfo image_info =
       SkImageInfo::Make(frame_size.width(), frame_size.height(),
-                        kRGBA_8888_SkColorType, kPremul_SkAlphaType);
+                        kRGBA_8888_SkColorType, kPremul_SkAlphaType,
+                        SkColorSpace::MakeSRGB());
 
   sk_sp<SkSurface> surface = SkSurface::MakeRasterDirect(
       image_info, pixels, frame_size.width() * sizeof(jint));

--- a/shell/platform/darwin/desktop/platform_view_mac.h
+++ b/shell/platform/darwin/desktop/platform_view_mac.h
@@ -31,6 +31,8 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
 
   intptr_t GLContextFBO() const override;
 
+  sk_sp<SkColorSpace> ColorSpace() const override { return color_space_; }
+
   VsyncWaiter* GetVsyncWaiter() override;
 
   bool ResourceContextMakeCurrent() override;
@@ -42,6 +44,7 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
  private:
   fml::scoped_nsobject<NSOpenGLView> opengl_view_;
   fml::scoped_nsobject<NSOpenGLContext> resource_loading_context_;
+  sk_sp<SkColorSpace> color_space_;
 
   bool IsValid() const;
 

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -26,6 +26,29 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
                                                            shareContext:gl_view.openGLContext]) {
   CreateEngine();
   PostAddToShellTask();
+
+  // Determine the best SkColorSpace to render to based on the properties of the monitor.
+  CGColorSpaceRef cs = CGDisplayCopyColorSpace(CGMainDisplayID());
+  CFDataRef dataRef = CGColorSpaceCopyICCProfile(cs);
+  const uint8_t* data = CFDataGetBytePtr(dataRef);
+  size_t size = CFDataGetLength(dataRef);
+  
+  color_space_ = SkColorSpace::MakeICC(data, size);
+  
+  CFRelease(cs);
+  CFRelease(dataRef);
+
+  if (!color_space) {
+    color_space_ = SkColorSpace::MakeSRGB();
+  } else if (!color_space_->gammaCloseToSRGB() && !color_space_->gammaIsLinear()) {
+    SkMatrix44 toXYZD50(SkMatrix44::kUninitialized_Constructor);
+    if (color_space_->toXYZD50(&toXYZD50)) {
+      color_space_ = SkColorSpace::MakeRGB(SkColorSpace::kSRGB_RenderTargetGamma,
+                                           toXYZD50);
+    } else {
+      color_space_ = SkColorSpace::MakeSRGB();
+    }
+  }
 }
 
 PlatformViewMac::~PlatformViewMac() = default;

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -32,15 +32,17 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
   CFDataRef dataRef = CGColorSpaceCopyICCProfile(cs);
   const uint8_t* data = CFDataGetBytePtr(dataRef);
   size_t size = CFDataGetLength(dataRef);
-  
+
   color_space_ = SkColorSpace::MakeICC(data, size);
-  
+
   CFRelease(cs);
   CFRelease(dataRef);
 
-  if (!color_space) {
+  if (!color_space_) {
+    FTL_LOG(WARNING) << "Could not determine monitor color space";
     color_space_ = SkColorSpace::MakeSRGB();
   } else if (!color_space_->gammaCloseToSRGB() && !color_space_->gammaIsLinear()) {
+    FTL_LOG(WARNING) << "Monitor color space has unsupported transfer function";
     SkMatrix44 toXYZD50(SkMatrix44::kUninitialized_Constructor);
     if (color_space_->toXYZD50(&toXYZD50)) {
       color_space_ = SkColorSpace::MakeRGB(SkColorSpace::kSRGB_RenderTargetGamma,

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -62,7 +62,8 @@ void SnapshotRasterizer(ftl::WeakPtr<shell::Rasterizer> rasterizer,
   }
   auto info = SkImageInfo::MakeN32(
       size.width(), size.height(),
-      is_opaque ? SkAlphaType::kOpaque_SkAlphaType : SkAlphaType::kPremul_SkAlphaType);
+      is_opaque ? SkAlphaType::kOpaque_SkAlphaType : SkAlphaType::kPremul_SkAlphaType,
+      SkColorSpace::MakeSRGB());
 
   // Create the backing store and prepare for use.
   SkBitmap bitmap;


### PR DESCRIPTION
*Color correct Android software backend
*Color correct mac desktop backend
*Respecting color space when converting frames to PNG
*Minor Vulkan change

@brianosman @liyuqian