### PR TITLE
Forward frame construction time to the compositor context.

### DIFF
--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -270,6 +270,8 @@ void RuntimeHolder::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
     return;  // Only draw once per frame.
   is_ready_to_draw_ = false;
 
+  layer_tree->set_construction_time(ftl::TimePoint::Now() -
+                                    last_begin_frame_time_);
   layer_tree->set_frame_size(SkISize::Make(viewport_metrics_.physical_width,
                                            viewport_metrics_.physical_height));
   layer_tree->set_scene_version(scene_version_);
@@ -647,7 +649,8 @@ void RuntimeHolder::BeginFrame() {
 
   FTL_DCHECK(!is_ready_to_draw_);
   is_ready_to_draw_ = true;
-  runtime_->BeginFrame(ftl::TimePoint::Now());
+  last_begin_frame_time_ = ftl::TimePoint::Now();
+  runtime_->BeginFrame(last_begin_frame_time_);
   const bool was_ready_to_draw = is_ready_to_draw_;
   is_ready_to_draw_ = false;
 

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -118,6 +118,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   mozart::InputMethodEditorPtr input_method_editor_;
   fidl::Binding<mozart::InputMethodEditorClient> text_input_binding_;
   int current_text_input_client_ = 0;
+  ftl::TimePoint last_begin_frame_time_;
 
   ftl::WeakPtrFactory<RuntimeHolder> weak_factory_;
 

--- a/content_handler/software_rasterizer.cc
+++ b/content_handler/software_rasterizer.cc
@@ -40,6 +40,8 @@ void SoftwareRasterizer::Draw(std::unique_ptr<flow::LayerTree> layer_tree,
     return;
   }
 
+  compositor_context_.engine_time().SetLapTime(layer_tree->construction_time());
+
   const SkISize& frame_size = layer_tree->frame_size();
 
   auto update = mozart::SceneUpdate::New();
@@ -59,8 +61,8 @@ void SoftwareRasterizer::Draw(std::unique_ptr<flow::LayerTree> layer_tree,
     return;
   }
 
-  flow::CompositorContext::ScopedFrame frame =
-      compositor_context_.AcquireFrame(nullptr, nullptr);
+  flow::CompositorContext::ScopedFrame frame = compositor_context_.AcquireFrame(
+      nullptr, nullptr, true /* instrumentation enabled */);
 
   layer_tree->Preroll(frame);
 

--- a/content_handler/vulkan_rasterizer.cc
+++ b/content_handler/vulkan_rasterizer.cc
@@ -53,7 +53,7 @@ VulkanRasterizer::VulkanSurfaceProducer::VulkanSurfaceProducer() {
 }
 
 VulkanRasterizer::VulkanSurfaceProducer::~VulkanSurfaceProducer() {
-  for (auto &surface_info : pending_surfaces_)
+  for (auto& surface_info : pending_surfaces_)
     mtl::MessageLoop::GetCurrent()->RemoveHandler(
         surface_info.second.handler_key);
 }
@@ -442,6 +442,8 @@ bool VulkanRasterizer::Draw(std::unique_ptr<flow::LayerTree> layer_tree) {
     return false;
   }
 
+  compositor_context_.engine_time().SetLapTime(layer_tree->construction_time());
+
   const SkISize& frame_size = layer_tree->frame_size();
 
   auto update = mozart::SceneUpdate::New();
@@ -462,8 +464,8 @@ bool VulkanRasterizer::Draw(std::unique_ptr<flow::LayerTree> layer_tree) {
     return false;
   }
 
-  flow::CompositorContext::ScopedFrame frame =
-      compositor_context_.AcquireFrame(nullptr, nullptr);
+  flow::CompositorContext::ScopedFrame frame = compositor_context_.AcquireFrame(
+      nullptr, nullptr, true /* instrumentation enabled */);
 
   layer_tree->Preroll(frame);
 


### PR DESCRIPTION
This enables performance counters that track layer tree construction time (i.e. the time spent in Dart code constructing the layer tree for presentation). The time spent in the rasterizer was already tracked correctly.

We do not have these counters wired up already because the content handler is quite a bit different from the shells used on iOS, Android and Mac. At some point, we'd seriously want to consider using the same shells everywhere. We'll get a lot of the frame scheduling and pipelining stuff for free. I believe the content handler was written separately because we did not want to use the Flutter shells at that time because of the dependency on `//base`. This is no longer the case.