### PR TITLE
Add support for `application:openURL:options:` in FlutterPlugin

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -96,6 +96,15 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
 
+  - Returns: `YES` if this plugin handles the request.
+*/
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options;
+
+/**
+ Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
+
  - Returns: `YES` if this plugin handles the request.
  */
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -155,6 +155,21 @@
   }
 }
 
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      if ([plugin application:application
+                      openURL:url
+                      options:options]) {
+        return YES;
+      }
+    }
+  }
+  return NO;
+}
+
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {


### PR DESCRIPTION
Both the following, which we also support, are deprecated in UIKit:

* `application:handleOpenURL:`
* `application:openURL:sourceApplication:annotation:`