### PR TITLE
Simplify state management in the Android text editing plugin

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -174,7 +174,7 @@ public class FlutterView extends SurfaceView
             "flutter/platform", JSONMethodCodec.INSTANCE);
         flutterPlatformChannel.setMethodCallHandler(platformPlugin);
         addActivityLifecycleListener(platformPlugin);
-        mTextInputPlugin = new TextInputPlugin((Activity) getContext(), this);
+        mTextInputPlugin = new TextInputPlugin(this);
 
         setLocale(getResources().getConfiguration().locale);
 


### PR DESCRIPTION
In particular, this avoids some unnecessary calls to InputMethodManager.restartInput
that caused noticeable lag when moving the cursor.

Fixes https://github.com/flutter/flutter/issues/9928