### PR TITLE
Removed 'pub get' from the instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,6 @@ explicit `--local-engine-src-path` pointing at the `engine/src` directory. Make
 sure you have a device connected over USB and debugging enabled on that device:
 
  * `cd /path/to/flutter/examples/hello_world`
- * `../../bin/flutter packages upgrade`
  * `../../bin/flutter run --local-engine-src-path /path/to/engine/src --local-engine=android_debug_unopt` or `--local-engine=android_debug_unopt_x64`
 
 If you put the `engine` and `flutter` directories side-by-side, you can skip the
@@ -132,7 +131,6 @@ to test the engine.
 
 Once the artifacts are built, you can start using them in your application by following these steps:
 * `cd /path/to/flutter/examples/hello_world`
-* `pub get`
 * `../../bin/flutter run --local-engine-src-path /path/to/engine/src --local-engine=ios_debug_unopt` or `--local-engine=ios_debug_sim_unopt` for simulator
   * If you are debugging crashes in the engine, you can connect the `LLDB` debugger from `Xcode` by opening `ios/Runner.xcworkspace` and starting the application by clicking the Run button (CMD + R).
   * To debug non crashing code, open Xcode with `ios/Runner.xcworkspace`, expand Flutter->Runner->Supporting Files->main.m in the Runner project. Put a breakpoint in main() then set your desired breakpoint in the engine in [lldb](https://lldb.llvm.org/tutorial.html) via `breakpoint set -...`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ explicit `--local-engine-src-path` pointing at the `engine/src` directory. Make
 sure you have a device connected over USB and debugging enabled on that device:
 
  * `cd /path/to/flutter/examples/hello_world`
- * `pub get`
+ * `../../bin/flutter packages upgrade`
  * `../../bin/flutter run --local-engine-src-path /path/to/engine/src --local-engine=android_debug_unopt` or `--local-engine=android_debug_unopt_x64`
 
 If you put the `engine` and `flutter` directories side-by-side, you can skip the


### PR DESCRIPTION
According to Hixie, 'pub get' is abstracted into flutter packages upgrade, and so there shouldn't be a need to run pub get directly.  It doesn't work anyhow, saying it can't find the Flutter SDK.