### PR TITLE
Revert "Update to newer version of the FTL. (#3786)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -63,7 +63,7 @@ deps = {
    # and not have to specific specific hashes.
 
   'src/lib/ftl':
-   Var('fuchsia_git') + '/ftl' + '@' + '91ad0f90f60066aa1c0e56d52e02cf3b4b10fbfd',
+   Var('fuchsia_git') + '/ftl' + '@' + 'f1357b6eaa9a23cffec1645dfeba610b5f926b1d',
 
   'src/lib/tonic':
    Var('fuchsia_git') + '/tonic' + '@' + '5b3d521980ca00274ad7e67f9f8b203cd4b20039',

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -7,8 +7,6 @@
 #include <sstream>
 #include <string>
 
-#include "lib/ftl/strings/string_view.h"
-
 // Include once for the default enum definition.
 #include "flutter/shell/common/switches.h"
 
@@ -16,7 +14,7 @@
 
 struct SwitchDesc {
   shell::Switch sw;
-  const ftl::StringView flag;
+  const char* flag;
   const char* help;
 };
 
@@ -48,7 +46,7 @@ void PrintUsage(const std::string& executable_name) {
   uint32_t max_width = 2;
   for (uint32_t i = 0; i < flags_count; i++) {
     auto desc = gSwitchDescs[i];
-    max_width = std::max<uint32_t>(desc.flag.size() + 2, max_width);
+    max_width = std::max<uint32_t>(strlen(desc.flag) + 2, max_width);
   }
 
   const uint32_t help_width = column_width - max_width - 3;
@@ -58,7 +56,7 @@ void PrintUsage(const std::string& executable_name) {
     auto desc = gSwitchDescs[i];
 
     std::cerr << std::setw(max_width)
-              << std::string("--") + desc.flag.ToString() << " : ";
+              << std::string("--") + std::string(desc.flag) << " : ";
 
     std::istringstream stream(desc.help);
     int32_t remaining = help_width;
@@ -80,13 +78,13 @@ void PrintUsage(const std::string& executable_name) {
   std::cerr << std::string(column_width, '-') << std::endl;
 }
 
-const ftl::StringView FlagForSwitch(Switch swtch) {
+const char* FlagForSwitch(Switch swtch) {
   for (uint32_t i = 0; i < static_cast<uint32_t>(Switch::Sentinel); i++) {
     if (gSwitchDescs[i].sw == swtch) {
       return gSwitchDescs[i].flag;
     }
   }
-  return ftl::StringView();
+  return nullptr;
 }
 
 }  // namespace shell

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "lib/ftl/strings/string_view.h"
-
 #ifndef SHELL_COMMON_SWITCHES_H_
 #define SHELL_COMMON_SWITCHES_H_
 
@@ -108,7 +106,7 @@ DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);
 
-const ftl::StringView FlagForSwitch(Switch sw);
+const char* FlagForSwitch(Switch sw);
 
 }  // namespace shell
 

--- a/shell/platform/darwin/common/platform_mac.mm
+++ b/shell/platform/darwin/common/platform_mac.mm
@@ -17,7 +17,6 @@
 #include "flutter/shell/common/tracing_controller.h"
 #include "flutter/sky/engine/wtf/MakeUnique.h"
 #include "lib/ftl/command_line.h"
-#include "lib/ftl/strings/string_view.h"
 
 namespace shell {
 
@@ -107,7 +106,7 @@ static bool FlagsValidForCommandLineLaunch(const std::string& bundle_path,
   return true;
 }
 
-static std::string ResolveCommandLineLaunchFlag(const ftl::StringView name) {
+static std::string ResolveCommandLineLaunchFlag(const char* name) {
   const auto& command_line = shell::Shell::Shared().GetCommandLine();
 
   std::string command_line_option;
@@ -116,7 +115,7 @@ static std::string ResolveCommandLineLaunchFlag(const ftl::StringView name) {
   }
 
   const char* saved_default =
-      [[NSUserDefaults standardUserDefaults] stringForKey:@(name.data())].UTF8String;
+      [[NSUserDefaults standardUserDefaults] stringForKey:@(name)].UTF8String;
 
   if (saved_default != NULL) {
     return saved_default;
@@ -137,9 +136,9 @@ bool AttemptLaunchFromCommandLineSwitches(Engine* engine) {
     // one go. We dont want to end up in a situation where we take one value
     // from the command line and the others from user defaults. In case, any
     // new flags are specified, forget about all the old ones.
-    [defaults removeObjectForKey:@(FlagForSwitch(Switch::FLX).data())];
-    [defaults removeObjectForKey:@(FlagForSwitch(Switch::MainDartFile).data())];
-    [defaults removeObjectForKey:@(FlagForSwitch(Switch::Packages).data())];
+    [defaults removeObjectForKey:@(FlagForSwitch(Switch::FLX))];
+    [defaults removeObjectForKey:@(FlagForSwitch(Switch::MainDartFile))];
+    [defaults removeObjectForKey:@(FlagForSwitch(Switch::Packages))];
 
     [defaults synchronize];
   }
@@ -155,9 +154,9 @@ bool AttemptLaunchFromCommandLineSwitches(Engine* engine) {
   // Save the newly resolved dart main file and the package root to user
   // defaults so that the next time the user launches the application in the
   // simulator without the tooling, the application boots up.
-  [defaults setObject:@(bundle_path.c_str()) forKey:@(FlagForSwitch(Switch::FLX).data())];
-  [defaults setObject:@(main.c_str()) forKey:@(FlagForSwitch(Switch::MainDartFile).data())];
-  [defaults setObject:@(packages.c_str()) forKey:@(FlagForSwitch(Switch::Packages).data())];
+  [defaults setObject:@(bundle_path.c_str()) forKey:@(FlagForSwitch(Switch::FLX))];
+  [defaults setObject:@(main.c_str()) forKey:@(FlagForSwitch(Switch::MainDartFile))];
+  [defaults setObject:@(packages.c_str()) forKey:@(FlagForSwitch(Switch::Packages))];
 
   [defaults synchronize];
 

--- a/travis/licenses_golden/licenses_lib
+++ b/travis/licenses_golden/licenses_lib
@@ -1,4 +1,4 @@
-Signature: 7ffffa05515fafdaeed6100ba3a75e3e
+Signature: 4dcd5e5c7ba17499b85da8a9b3fa6637
 
 UNUSED LICENSES:
 
@@ -78,7 +78,6 @@ FILE: ../../../lib/ftl/files/symlink.h
 FILE: ../../../lib/ftl/files/symlink_posix.cc
 FILE: ../../../lib/ftl/files/unique_fd.cc
 FILE: ../../../lib/ftl/files/unique_fd.h
-FILE: ../../../lib/ftl/functional/auto_call.h
 FILE: ../../../lib/ftl/functional/closure.h
 FILE: ../../../lib/ftl/functional/make_copyable.h
 FILE: ../../../lib/ftl/functional/make_copyable_unittest.cc
@@ -225,11 +224,6 @@ ORIGIN: ../../../lib/ftl/files/path_win.cc + ../../../lib/ftl/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../lib/ftl/files/path_win.cc
 FILE: ../../../lib/ftl/files/symlink_win.cc
-FILE: ../../../lib/ftl/functional/apply.h
-FILE: ../../../lib/ftl/functional/apply_unittest.cc
-FILE: ../../../lib/ftl/functional/auto_call_unittest.cc
-FILE: ../../../lib/ftl/functional/cancelable_callback.h
-FILE: ../../../lib/ftl/functional/cancelable_callback_unittest.cc
 FILE: ../../../lib/ftl/inttypes.h
 FILE: ../../../lib/ftl/portable_unistd.h
 FILE: ../../../lib/ftl/random/rand_unittest.cc


### PR DESCRIPTION
This reverts commit 1e9e134d7d7444506f3103d673fcd26e4066e80a.

Broke Windows and Mac engine builds.