### PR TITLE
Eliminate ASL-based stdout forwarding on iOS

### DIFF
--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -74,11 +74,6 @@ DEF_SWITCH(NonInteractive,
            "non-interactive",
            "Make the shell non-interactive. By default, the shell attempts "
            "to setup a window and create an OpenGL context.")
-DEF_SWITCH(NoRedirectToSyslog,
-           "no-redirect-to-syslog",
-           "On iOS: Don't redirect stdout and stderr to syslog by default. "
-           "This is used by the tools to read device logs. However, this can "
-           "cause logs to not show up when launched from Xcode.")
 DEF_SWITCH(Packages, "packages", "Specify the path to the packages.")
 DEF_SWITCH(StartPaused,
            "start-paused",

--- a/shell/platform/darwin/common/platform_mac.mm
+++ b/shell/platform/darwin/common/platform_mac.mm
@@ -6,8 +6,6 @@
 
 #include <Foundation/Foundation.h>
 
-#include <asl.h>
-
 #include "dart/runtime/include/dart_tools_api.h"
 #include "flutter/common/threads.h"
 #include "flutter/fml/trace_event.h"
@@ -19,17 +17,6 @@
 #include "lib/ftl/command_line.h"
 
 namespace shell {
-
-static void RedirectIOConnectionsToSyslog(const ftl::CommandLine& command_line) {
-#if TARGET_OS_IPHONE
-  if (command_line.HasOption(FlagForSwitch(Switch::NoRedirectToSyslog))) {
-    return;
-  }
-
-  asl_log_descriptor(NULL, NULL, ASL_LEVEL_NOTICE, STDOUT_FILENO, ASL_LOG_DESCRIPTOR_WRITE);
-  asl_log_descriptor(NULL, NULL, ASL_LEVEL_WARNING, STDERR_FILENO, ASL_LOG_DESCRIPTOR_WRITE);
-#endif
-}
 
 static ftl::CommandLine InitializedCommandLine() {
   std::vector<std::string> args_vector;
@@ -53,8 +40,6 @@ class EmbedderState {
         << "Embedder initialization must occur on the main platform thread";
 
     auto command_line = InitializedCommandLine();
-
-    RedirectIOConnectionsToSyslog(command_line);
 
     // This is about as early as tracing of any kind can start. Add an instant
     // marker that can be used as a reference for startup.


### PR DESCRIPTION
ASL was deprecated in iOS 10 and started causing SIGPIPE issues in iOS
10.3. Under the iOS 8 SDK, syslog() stopped working as of iOS 10.3
devices, with the result that ASL stdout/stderr forwarding was the only
means of logging. The engine now builds against the iOS 10 SDK, with
deployment target of iOS 8. Under this SDK, syslog() works correctly
across all supported OS versions.

NOTE: This is a temporary fix to get developers unblocked. While this
does fix the SIGPIPE issue and put iOS logging on par with the Android
solution, the intent is to move to a dedicated communication channel
with flutter_tools that isn't log-based.