### PR TITLE
Name flutter_runner processes after the app they're running

### DIFF
--- a/content_handler/app.cc
+++ b/content_handler/app.cc
@@ -25,6 +25,13 @@ void QuitMessageLoop() {
   mtl::MessageLoop::GetCurrent()->QuitNow();
 }
 
+std::string GetLabelFromURL(const std::string& url) {
+  size_t last_slash = url.rfind('/');
+  if (last_slash == std::string::npos || last_slash + 1 == url.length())
+    return url;
+  return url.substr(last_slash + 1);
+}
+
 }  // namespace
 
 App::App() {
@@ -116,6 +123,11 @@ void App::StartApplication(
     app::ApplicationPackagePtr application,
     app::ApplicationStartupInfoPtr startup_info,
     fidl::InterfaceRequest<app::ApplicationController> controller) {
+  // Name this process after the url of the application being launched.
+  std::string label =
+      "flutter:" + GetLabelFromURL(startup_info->launch_info->url);
+  mx::process::self().set_property(MX_PROP_NAME, label.c_str(), label.size());
+
   std::unique_ptr<ApplicationControllerImpl> impl =
       std::make_unique<ApplicationControllerImpl>(this, std::move(application),
                                                   std::move(startup_info),


### PR DESCRIPTION
Currently in `ps` all apps running under the Flutter content handler
show up as `flutter_runner`. This makes them hard to identify. This
change names the process after the final path component URL of the
application that's launched, prefixed with "flutter:".

In theory we could run more than one Flutter application in a single
content handler process, but we don't right now. If we do this logic
would have to change.