### PR TITLE
Only add Fuchsia-specific stuff when the current OS is Fuchsia.

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -5,9 +5,7 @@
 import("//flutter/lib/snapshot/toolchain.gni")
 import("//flutter/lib/ui/dart_ui.gni")
 
-target_is_fuchsia = target_os == "fuchsia"
-
-if (target_is_fuchsia) {
+if (is_fuchsia) {
   import("//apps/mozart/lib/flutter/sdk_ext/sdk_ext.gni")
   import("//lib/fidl/dart/sdk_ext/sdk_ext.gni")
 }
@@ -22,7 +20,7 @@ copy("generate_dart_ui") {
   ]
 }
 
-if (target_is_fuchsia) {
+if (is_fuchsia) {
   action("generate_package_map") {
     dart_deps = [
       "//lib/fidl/dart:dart",
@@ -58,7 +56,7 @@ if (target_is_fuchsia) {
 }
 
 action("generate_snapshot_bin") {
-  if (target_is_fuchsia) {
+  if (is_fuchsia) {
     snapshot_dart = "snapshot_fuchsia.dart"
     # TODO(rmacnak): Fuchsia cross builds use the wrong Dart target
     # architecture, and have added steps that depend on this error for
@@ -81,7 +79,7 @@ action("generate_snapshot_bin") {
              "//dart/runtime/tools/create_snapshot_bin.py",
              snapshot_dart,
            ] + dart_ui_files
-  if (target_is_fuchsia) {
+  if (is_fuchsia) {
     deps += [ ":generate_package_map" ]
     inputs += [ "fuchsia_compilation_trace.txt" ]
   }
@@ -142,7 +140,7 @@ action("generate_snapshot_bin") {
     ]
   }
 
-  if (target_is_fuchsia) {
+  if (is_fuchsia) {
     inputs += fidl_dart_sdk_ext_files + mozart_dart_sdk_ext_files
     fidl_internal_path = rebase_path(fidl_dart_sdk_ext_lib)
     mozart_internal_path = rebase_path(mozart_dart_sdk_ext_lib)


### PR DESCRIPTION
This allows the shell to be built normally for a Fuchsia host.