### PR TITLE
Avoid spurious descheduling when posting message loop tasks.

### DIFF
--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -112,15 +112,17 @@ void MessageLoopImpl::RegisterTask(ftl::Closure task,
     return;
   }
 
-  ftl::MutexLocker lock(&delayed_tasks_mutex_);
-  ftl::TimePoint previous_wakeup;
-  if (delayed_tasks_.empty()) {
-    previous_wakeup = ftl::TimePoint::Max();
-  } else {
-    previous_wakeup = delayed_tasks_.top().target_time;
+  ftl::TimePoint previous_wakeup, new_wakeup;
+  {
+    ftl::MutexLocker lock(&delayed_tasks_mutex_);
+    if (delayed_tasks_.empty()) {
+      previous_wakeup = ftl::TimePoint::Max();
+    } else {
+      previous_wakeup = delayed_tasks_.top().target_time;
+    }
+    delayed_tasks_.push({++order_, std::move(task), target_time});
+    new_wakeup = delayed_tasks_.top().target_time;
   }
-  delayed_tasks_.push({++order_, std::move(task), target_time});
-  ftl::TimePoint new_wakeup = delayed_tasks_.top().target_time;
   if (new_wakeup < previous_wakeup) {
     WakeUp(new_wakeup);
   }
@@ -130,6 +132,7 @@ void MessageLoopImpl::RunExpiredTasks() {
   TRACE_EVENT0("fml", "MessageLoop::RunExpiredTasks");
   std::vector<ftl::Closure> invocations;
 
+  ftl::TimePoint new_wakeup;
   {
     ftl::MutexLocker lock(&delayed_tasks_mutex_);
 
@@ -147,9 +150,13 @@ void MessageLoopImpl::RunExpiredTasks() {
       delayed_tasks_.pop();
     }
 
-    WakeUp(delayed_tasks_.empty() ? ftl::TimePoint::Max()
-                                  : delayed_tasks_.top().target_time);
+    if (delayed_tasks_.empty()) {
+      new_wakeup = ftl::TimePoint::Max();
+    } else {
+      new_wakeup = delayed_tasks_.top().target_time;
+    }
   }
+  WakeUp(new_wakeup);
 
   for (const auto& invocation : invocations) {
     invocation();

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -137,6 +137,7 @@ void MessageLoopImpl::RunExpiredTasks() {
     ftl::MutexLocker lock(&delayed_tasks_mutex_);
 
     if (delayed_tasks_.empty()) {
+      FTL_DCHECK(terminated_);  // No spurious wakeups except shutdown.
       return;
     }
 

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -112,8 +112,11 @@ void MessageLoopImpl::RegisterTask(ftl::Closure task,
     return;
   }
   ftl::MutexLocker lock(&delayed_tasks_mutex_);
+  bool was_empty = delayed_task_.empty();
   delayed_tasks_.push({++order_, std::move(task), target_time});
-  WakeUp(delayed_tasks_.top().target_time);
+  if (was_empty) {
+    WakeUp(delayed_tasks_.top().target_time);
+  }
 }
 
 void MessageLoopImpl::RunExpiredTasks() {

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -140,6 +140,34 @@ TEST(MessageLoop, CheckRunsTaskOnCurrentThread) {
   thread.join();
 }
 
+TEST(MessageLoop, TIME_SENSITIVE(NewTaskDueBeforePendingTask)) {
+  intptr_t tasks_run = 0;
+  std::thread thread([&tasks_run]() {
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    auto& loop = fml::MessageLoop::GetCurrent();
+    auto begin = ftl::TimePoint::Now();
+    loop.GetTaskRunner()->PostDelayedTask(
+        [&tasks_run]() {
+          ASSERT_EQ(tasks_run, 1);
+          tasks_run++;
+          fml::MessageLoop::GetCurrent().Terminate();
+        },
+        ftl::TimeDelta::FromMilliseconds(15));
+    loop.GetTaskRunner()->PostDelayedTask(
+        [begin, &tasks_run]() {
+          ASSERT_EQ(tasks_run, 0);
+          tasks_run++;
+          auto delta = ftl::TimePoint::Now() - begin;
+          auto ms = delta.ToMillisecondsF();
+          ASSERT_LE(ms, 15);  // Did not wait for previous wakeup time.
+        },
+        ftl::TimeDelta::FromMilliseconds(5));
+    loop.Run();
+  });
+  thread.join();
+  ASSERT_EQ(tasks_run, 2);
+}
+
 TEST(MessageLoop, TIME_SENSITIVE(SingleDelayedTaskByDelta)) {
   bool checked = false;
   std::thread thread([&checked]() {

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -3,6 +3,7 @@
 set -ex
 
 out/host_debug_unopt/ftl_unittests
+out/host_debug_unopt/fml_unittests
 out/host_debug_unopt/synchronization_unittests
 out/host_debug_unopt/wtf_unittests
 


### PR DESCRIPTION
Closes dart-lang/sdk#29971