### PR TITLE
preserve Window callback zones

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -24,27 +24,30 @@ void _updateWindowMetrics(double devicePixelRatio,
     .._physicalSize = new Size(width, height)
     .._padding = new WindowPadding._(
       top: top, right: right, bottom: bottom, left: left);
-  if (window.onMetricsChanged != null)
-    window.onMetricsChanged();
+  _invoke(window.onMetricsChanged, window._onMetricsChangedZone);
 }
 
 void _updateLocale(String languageCode, String countryCode) {
   window._locale = new Locale(languageCode, countryCode);
-  if (window.onLocaleChanged != null)
-    window.onLocaleChanged();
+  _invoke(window.onLocaleChanged, window._onLocaleChangedZone);
 }
 
 void _updateSemanticsEnabled(bool enabled) {
   window._semanticsEnabled = enabled;
-  if (window.onSemanticsEnabledChanged != null)
-    window.onSemanticsEnabledChanged();
+  _invoke(window.onSemanticsEnabledChanged, window._onSemanticsEnabledChangedZone);
 }
 
 void _dispatchPlatformMessage(String name, ByteData data, int responseId) {
   if (window.onPlatformMessage != null) {
-    window.onPlatformMessage(name, data, (ByteData responseData) {
-      window._respondToPlatformMessage(responseId, responseData);
-    });
+    _invoke3<String, ByteData, PlatformMessageResponseCallback>(
+      window.onPlatformMessage,
+      window._onPlatformMessageZone,
+      name,
+      data,
+      (ByteData responseData) {
+        window._respondToPlatformMessage(responseId, responseData);
+      },
+    );
   } else {
     window._respondToPlatformMessage(responseId, null);
   }
@@ -52,22 +55,90 @@ void _dispatchPlatformMessage(String name, ByteData data, int responseId) {
 
 void _dispatchPointerDataPacket(ByteData packet) {
   if (window.onPointerDataPacket != null)
-    window.onPointerDataPacket(_unpackPointerDataPacket(packet));
+    _invokeOnPointerDataPacket(_unpackPointerDataPacket(packet));
+}
+
+void _invokeOnPointerDataPacket(PointerDataPacket packet) {
+  _invoke1<PointerDataPacket>(window.onPointerDataPacket, window._onPointerDataPacketZone, packet);
 }
 
 void _dispatchSemanticsAction(int id, int action) {
-  if (window.onSemanticsAction != null)
-    window.onSemanticsAction(id, SemanticsAction.values[action]);
+  if (window.onSemanticsAction != null) {
+    _invoke2<int, SemanticsAction>(
+      window.onSemanticsAction,
+      window._onSemanticsActionZone,
+      id,
+      SemanticsAction.values[action],
+    );
+  }
 }
 
 void _beginFrame(int microseconds) {
   if (window.onBeginFrame != null)
-    window.onBeginFrame(new Duration(microseconds: microseconds));
+    _invoke1<Duration>(window.onBeginFrame, window._onBeginFrameZone, new Duration(microseconds: microseconds));
 }
 
 void _drawFrame() {
   if (window.onDrawFrame != null)
-    window.onDrawFrame();
+    _invoke(window.onDrawFrame, window._onDrawFrameZone);
+}
+
+/// Invokes [callback] inside the given [zone].
+void _invoke(void callback(), Zone zone) {
+  if (callback == null)
+    return;
+
+  assert(zone != null);
+
+  if (identical(zone, Zone.current)) {
+    callback();
+  } else {
+    zone.runGuarded(callback);
+  }
+}
+
+/// Invokes [callback] inside the given [zone] passing it [arg].
+void _invoke1<A>(void callback(A a), Zone zone, A arg) {
+  if (callback == null)
+    return;
+
+  assert(zone != null);
+
+  if (identical(zone, Zone.current)) {
+    callback(arg);
+  } else {
+    zone.runUnaryGuarded<Null, A>(callback, arg);
+  }
+}
+
+/// Invokes [callback] inside the given [zone] passing it [arg1] and [arg2].
+void _invoke2<A1, A2>(void callback(A1 a1, A2 a2), Zone zone, A1 arg1, A2 arg2) {
+  if (callback == null)
+    return;
+
+  assert(zone != null);
+
+  if (identical(zone, Zone.current)) {
+    callback(arg1, arg2);
+  } else {
+    zone.runBinaryGuarded<Null, A1, A2>(callback, arg1, arg2);
+  }
+}
+
+/// Invokes [callback] inside the given [zone] passing it [arg1], [arg2] and [arg3].
+void _invoke3<A1, A2, A3>(void callback(A1 a1, A2 a2, A3 a3), Zone zone, A1 arg1, A2 arg2, A3 arg3) {
+  if (callback == null)
+    return;
+
+  assert(zone != null);
+
+  if (identical(zone, Zone.current)) {
+    callback(arg1, arg2, arg3);
+  } else {
+    zone.runGuarded(() {
+      callback(arg1, arg2, arg3);
+    });
+  }
 }
 
 // If this value changes, update the encoding code in the following files:

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -55,11 +55,7 @@ void _dispatchPlatformMessage(String name, ByteData data, int responseId) {
 
 void _dispatchPointerDataPacket(ByteData packet) {
   if (window.onPointerDataPacket != null)
-    _invokeOnPointerDataPacket(_unpackPointerDataPacket(packet));
-}
-
-void _invokeOnPointerDataPacket(PointerDataPacket packet) {
-  _invoke1<PointerDataPacket>(window.onPointerDataPacket, window._onPointerDataPacketZone, packet);
+    _invoke1<PointerDataPacket>(window.onPointerDataPacket, window._onPointerDataPacketZone, _unpackPointerDataPacket(packet));
 }
 
 void _dispatchSemanticsAction(int id, int action) {

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -63,24 +63,20 @@ void _invokeOnPointerDataPacket(PointerDataPacket packet) {
 }
 
 void _dispatchSemanticsAction(int id, int action) {
-  if (window.onSemanticsAction != null) {
-    _invoke2<int, SemanticsAction>(
-      window.onSemanticsAction,
-      window._onSemanticsActionZone,
-      id,
-      SemanticsAction.values[action],
-    );
-  }
+  _invoke2<int, SemanticsAction>(
+    window.onSemanticsAction,
+    window._onSemanticsActionZone,
+    id,
+    SemanticsAction.values[action],
+  );
 }
 
 void _beginFrame(int microseconds) {
-  if (window.onBeginFrame != null)
-    _invoke1<Duration>(window.onBeginFrame, window._onBeginFrameZone, new Duration(microseconds: microseconds));
+  _invoke1<Duration>(window.onBeginFrame, window._onBeginFrameZone, new Duration(microseconds: microseconds));
 }
 
 void _drawFrame() {
-  if (window.onDrawFrame != null)
-    _invoke(window.onDrawFrame, window._onDrawFrameZone);
+  _invoke(window.onDrawFrame, window._onDrawFrameZone);
 }
 
 /// Invokes [callback] inside the given [zone].

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -214,11 +214,8 @@ class Window {
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
   VoidCallback get onMetricsChanged => _onMetricsChanged;
-
   VoidCallback _onMetricsChanged;
   Zone _onMetricsChangedZone;
-
-  /// Updates the callback.
   set onMetricsChanged(VoidCallback callback) {
     _onMetricsChanged = callback;
     _onMetricsChangedZone = Zone.current;
@@ -248,11 +245,8 @@ class Window {
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this callback is invoked.
   VoidCallback get onLocaleChanged => _onLocaleChanged;
-
   VoidCallback _onLocaleChanged;
   Zone _onLocaleChangedZone;
-
-  /// Updates the callback.
   set onLocaleChanged(VoidCallback callback) {
     _onLocaleChanged = callback;
     _onLocaleChangedZone = Zone.current;
@@ -278,11 +272,8 @@ class Window {
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
   FrameCallback get onBeginFrame => _onBeginFrame;
-
   FrameCallback _onBeginFrame;
   Zone _onBeginFrameZone;
-
-  /// Updates the callback.
   set onBeginFrame(FrameCallback callback) {
     _onBeginFrame = callback;
     _onBeginFrameZone = Zone.current;
@@ -303,11 +294,8 @@ class Window {
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
   VoidCallback get onDrawFrame => _onDrawFrame;
-
   VoidCallback _onDrawFrame;
   Zone _onDrawFrameZone;
-
-  /// Updates the callback.
   set onDrawFrame(VoidCallback callback) {
     _onDrawFrame = callback;
     _onDrawFrameZone = Zone.current;
@@ -323,11 +311,8 @@ class Window {
   ///  * [GestureBinding], the Flutter framework class which manages pointer
   ///    events.
   PointerDataPacketCallback get onPointerDataPacket => _onPointerDataPacket;
-
   PointerDataPacketCallback _onPointerDataPacket;
   Zone _onPointerDataPacketZone;
-
-  /// Updates the callback.
   set onPointerDataPacket(PointerDataPacketCallback callback) {
     _onPointerDataPacket = callback;
     _onPointerDataPacketZone = Zone.current;
@@ -386,11 +371,8 @@ class Window {
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
   VoidCallback get onSemanticsEnabledChanged => _onSemanticsEnabledChanged;
-
   VoidCallback _onSemanticsEnabledChanged;
   Zone _onSemanticsEnabledChangedZone;
-
-  /// Updates the callback.
   set onSemanticsEnabledChanged(VoidCallback callback) {
     _onSemanticsEnabledChanged = callback;
     _onSemanticsEnabledChangedZone = Zone.current;
@@ -405,11 +387,8 @@ class Window {
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
   SemanticsActionCallback get onSemanticsAction => _onSemanticsAction;
-
   SemanticsActionCallback _onSemanticsAction;
   Zone _onSemanticsActionZone;
-
-  /// Updates the callback.
   set onSemanticsAction(SemanticsActionCallback callback) {
     _onSemanticsAction = callback;
     _onSemanticsActionZone = Zone.current;
@@ -456,11 +435,8 @@ class Window {
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.
   PlatformMessageCallback get onPlatformMessage => _onPlatformMessage;
-
   PlatformMessageCallback _onPlatformMessage;
   Zone _onPlatformMessageZone;
-
-  /// Updates the callback.
   set onPlatformMessage(PlatformMessageCallback callback) {
     _onPlatformMessage = callback;
     _onPlatformMessageZone = Zone.current;

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -473,7 +473,8 @@ class Window {
   /// Wraps the given [callback] in another callback that ensures that the
   /// original callback is called in the zone it was registered in.
   static PlatformMessageResponseCallback _zonedPlatformMessageResponseCallback(PlatformMessageResponseCallback callback) {
-    if (callback == null) return null;
+    if (callback == null)
+      return null;
 
     // Store the zone in which the callback is being registered.
     final Zone registrationZone = Zone.current;

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -210,13 +210,19 @@ class Window {
   /// [physicalSize], or [padding] values change, for example when the device is
   /// rotated or when the application is resized (e.g. when showing applications
   /// side-by-side on Android).
+  ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
   VoidCallback get onMetricsChanged => _onMetricsChanged;
 
-  set onMetricsChanged(VoidCallback callback) {
-    _onMetricsChanged = _zonedVoidCallback(callback);
-  }
-
   VoidCallback _onMetricsChanged;
+  Zone _onMetricsChangedZone;
+
+  /// Updates the callback.
+  set onMetricsChanged(VoidCallback callback) {
+    _onMetricsChanged = callback;
+    _onMetricsChangedZone = Zone.current;
+  }
 
   /// The system-reported locale.
   ///
@@ -234,17 +240,23 @@ class Window {
 
   /// A callback that is invoked whenever [locale] changes value.
   ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
+  ///
   /// See also:
   ///
   ///  * [WidgetsBindingObserver], for a mechanism at the widgets layer to
   ///    observe when this callback is invoked.
   VoidCallback get onLocaleChanged => _onLocaleChanged;
 
-  set onLocaleChanged(VoidCallback callback) {
-    _onLocaleChanged = _zonedVoidCallback(callback);
-  }
-
   VoidCallback _onLocaleChanged;
+  Zone _onLocaleChangedZone;
+
+  /// Updates the callback.
+  set onLocaleChanged(VoidCallback callback) {
+    _onLocaleChanged = callback;
+    _onLocaleChangedZone = Zone.current;
+  }
 
   /// A callback that is invoked to notify the application that it is an
   /// appropriate time to provide a scene using the [SceneBuilder] API and the
@@ -256,6 +268,9 @@ class Window {
   /// after draining any microtasks (e.g. completions of any [Future]s) queued
   /// by the [onBeginFrame] handler.
   ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
+  ///
   /// See also:
   ///
   ///  * [SchedulerBinding], the Flutter framework class which manages the
@@ -264,16 +279,22 @@ class Window {
   ///    painting.
   FrameCallback get onBeginFrame => _onBeginFrame;
 
-  set onBeginFrame(FrameCallback callback) {
-    _onBeginFrame = _zonedFrameCallback(callback);
-  }
-
   FrameCallback _onBeginFrame;
+  Zone _onBeginFrameZone;
+
+  /// Updates the callback.
+  set onBeginFrame(FrameCallback callback) {
+    _onBeginFrame = callback;
+    _onBeginFrameZone = Zone.current;
+  }
 
   /// A callback that is invoked for each frame after [onBeginFrame] has
   /// completed and after the microtask queue has been drained. This can be
   /// used to implement a second phase of frame rendering that happens
   /// after any deferred work queued by the [onBeginFrame] phase.
+  ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
   ///
   /// See also:
   ///
@@ -283,13 +304,19 @@ class Window {
   ///    painting.
   VoidCallback get onDrawFrame => _onDrawFrame;
 
+  VoidCallback _onDrawFrame;
+  Zone _onDrawFrameZone;
+
+  /// Updates the callback.
   set onDrawFrame(VoidCallback callback) {
-    _onDrawFrame = _zonedVoidCallback(callback);
+    _onDrawFrame = callback;
+    _onDrawFrameZone = Zone.current;
   }
 
-  VoidCallback _onDrawFrame;
-
   /// A callback that is invoked when pointer data is available.
+  ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
   ///
   /// See also:
   ///
@@ -297,11 +324,14 @@ class Window {
   ///    events.
   PointerDataPacketCallback get onPointerDataPacket => _onPointerDataPacket;
 
-  set onPointerDataPacket(PointerDataPacketCallback callback) {
-    _onPointerDataPacket = _zonedPointerDataPacketCallback(callback);
-  }
-
   PointerDataPacketCallback _onPointerDataPacket;
+  Zone _onPointerDataPacketZone;
+
+  /// Updates the callback.
+  set onPointerDataPacket(PointerDataPacketCallback callback) {
+    _onPointerDataPacket = callback;
+    _onPointerDataPacketZone = Zone.current;
+  }
 
   /// The route or path that the operating system requested when the application
   /// was launched.
@@ -352,26 +382,38 @@ class Window {
   bool _semanticsEnabled = false;
 
   /// A callback that is invoked when the value of [semanticsEnabled] changes.
+  ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
   VoidCallback get onSemanticsEnabledChanged => _onSemanticsEnabledChanged;
 
-  set onSemanticsEnabledChanged(VoidCallback callback) {
-    _onSemanticsEnabledChanged = _zonedVoidCallback(callback);
-  }
-
   VoidCallback _onSemanticsEnabledChanged;
+  Zone _onSemanticsEnabledChangedZone;
+
+  /// Updates the callback.
+  set onSemanticsEnabledChanged(VoidCallback callback) {
+    _onSemanticsEnabledChanged = callback;
+    _onSemanticsEnabledChangedZone = Zone.current;
+  }
 
   /// A callback that is invoked whenever the user requests an action to be
   /// performed.
   ///
   /// This callback is used when the user expresses the action they wish to
   /// perform based on the semantics supplied by [updateSemantics].
+  ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
   SemanticsActionCallback get onSemanticsAction => _onSemanticsAction;
 
-  set onSemanticsAction(SemanticsActionCallback callback) {
-    _onSemanticsAction = _zonedSemanticsActionCallback(callback);
-  }
-
   SemanticsActionCallback _onSemanticsAction;
+  Zone _onSemanticsActionZone;
+
+  /// Updates the callback.
+  set onSemanticsAction(SemanticsActionCallback callback) {
+    _onSemanticsAction = callback;
+    _onSemanticsActionZone = Zone.current;
+  }
 
   /// Change the retained semantics data about this window.
   ///
@@ -388,6 +430,9 @@ class Window {
   /// `data` parameter contains the message payload and is typically UTF-8
   /// encoded JSON but can be arbitrary data. If the plugin replies to the
   /// message, `callback` will be called with the response.
+  ///
+  /// The framework invokes [callback] in the same zone in which this method
+  /// was called.
   void sendPlatformMessage(String name,
                            ByteData data,
                            PlatformMessageResponseCallback callback) {
@@ -407,67 +452,23 @@ class Window {
   /// Message handlers must call the function given in the `callback` parameter.
   /// If the handler does not need to respond, the handler should pass `null` to
   /// the callback.
+  ///
+  /// The framework invokes this callback in the same zone in which the
+  /// callback was set.
   PlatformMessageCallback get onPlatformMessage => _onPlatformMessage;
 
-  set onPlatformMessage(PlatformMessageCallback callback) {
-    _onPlatformMessage = _zonedPlatformMessageCallback(callback);
-  }
-
   PlatformMessageCallback _onPlatformMessage;
+  Zone _onPlatformMessageZone;
+
+  /// Updates the callback.
+  set onPlatformMessage(PlatformMessageCallback callback) {
+    _onPlatformMessage = callback;
+    _onPlatformMessageZone = Zone.current;
+  }
 
   /// Called by [_dispatchPlatformMessage].
   void _respondToPlatformMessage(int responseId, ByteData data)
       native "Window_respondToPlatformMessage";
-
-  /// Wraps the given [callback] in another callback that ensures that the
-  /// original callback is called in the zone it was registered in.
-  static VoidCallback _zonedVoidCallback(VoidCallback callback) {
-    // Store the zone in which the callback is being registered.
-    final Zone registrationZone = Zone.current;
-
-    return () {
-      registrationZone.runGuarded(callback);
-    };
-  }
-
-  /// Wraps the given [callback] in another callback that ensures that the
-  /// original callback is called in the zone it was registered in.
-  static FrameCallback _zonedFrameCallback(FrameCallback callback) {
-    if (callback == null) return null;
-
-    // Store the zone in which the callback is being registered.
-    final Zone registrationZone = Zone.current;
-
-    return (Duration duration) {
-      registrationZone.runUnaryGuarded(callback, duration);
-    };
-  }
-
-  /// Wraps the given [callback] in another callback that ensures that the
-  /// original callback is called in the zone it was registered in.
-  static PointerDataPacketCallback _zonedPointerDataPacketCallback(PointerDataPacketCallback callback) {
-    if (callback == null) return null;
-
-    // Store the zone in which the callback is being registered.
-    final Zone registrationZone = Zone.current;
-
-    return (PointerDataPacket packet) {
-      registrationZone.runUnaryGuarded(callback, packet);
-    };
-  }
-
-  /// Wraps the given [callback] in another callback that ensures that the
-  /// original callback is called in the zone it was registered in.
-  static SemanticsActionCallback _zonedSemanticsActionCallback(SemanticsActionCallback callback) {
-    if (callback == null) return null;
-
-    // Store the zone in which the callback is being registered.
-    final Zone registrationZone = Zone.current;
-
-    return (int id, SemanticsAction action) {
-      registrationZone.runBinaryGuarded(callback, id, action);
-    };
-  }
 
   /// Wraps the given [callback] in another callback that ensures that the
   /// original callback is called in the zone it was registered in.
@@ -479,21 +480,6 @@ class Window {
 
     return (ByteData data) {
       registrationZone.runUnaryGuarded(callback, data);
-    };
-  }
-
-  /// Wraps the given [callback] in another callback that ensures that the
-  /// original callback is called in the zone it was registered in.
-  static PlatformMessageCallback _zonedPlatformMessageCallback(PlatformMessageCallback callback) {
-    if (callback == null) return null;
-
-    // Store the zone in which the callback is being registered.
-    final Zone registrationZone = Zone.current;
-
-    return (String name, ByteData data, PlatformMessageResponseCallback responseCallback) {
-      registrationZone.runGuarded(() {
-        callback(name, data, responseCallback);
-      });
     };
   }
 }

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -1,0 +1,189 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:convert';
+import 'dart:developer' as developer;
+import 'dart:math' as math;
+import 'dart:nativewrappers';
+
+import 'package:test/test.dart';
+
+// HACK: these parts are to get access to private functions tested here.
+part '../../lib/ui/compositing.dart';
+part '../../lib/ui/geometry.dart';
+part '../../lib/ui/hash_codes.dart';
+part '../../lib/ui/hooks.dart';
+part '../../lib/ui/lerp.dart';
+part '../../lib/ui/natives.dart';
+part '../../lib/ui/painting.dart';
+part '../../lib/ui/pointer.dart';
+part '../../lib/ui/semantics.dart';
+part '../../lib/ui/text.dart';
+part '../../lib/ui/window.dart';
+
+void main() {
+  group('window callback zones', () {
+    VoidCallback originalOnMetricsChanged;
+    VoidCallback originalOnLocaleChanged;
+    FrameCallback originalOnBeginFrame;
+    VoidCallback originalOnDrawFrame;
+    PointerDataPacketCallback originalOnPointerDataPacket;
+    VoidCallback originalOnSemanticsEnabledChanged;
+    SemanticsActionCallback originalOnSemanticsAction;
+    PlatformMessageCallback originalOnPlatformMessage;
+
+    setUp(() {
+      originalOnMetricsChanged = window.onMetricsChanged;
+      originalOnLocaleChanged = window.onLocaleChanged;
+      originalOnBeginFrame = window.onBeginFrame;
+      originalOnDrawFrame = window.onDrawFrame;
+      originalOnPointerDataPacket = window.onPointerDataPacket;
+      originalOnSemanticsEnabledChanged = window.onSemanticsEnabledChanged;
+      originalOnSemanticsAction = window.onSemanticsAction;
+      originalOnPlatformMessage = window.onPlatformMessage;
+    });
+
+    tearDown(() {
+      window.onMetricsChanged = originalOnMetricsChanged;
+      window.onLocaleChanged = originalOnLocaleChanged;
+      window.onBeginFrame = originalOnBeginFrame;
+      window.onDrawFrame = originalOnDrawFrame;
+      window.onPointerDataPacket = originalOnPointerDataPacket;
+      window.onSemanticsEnabledChanged = originalOnSemanticsEnabledChanged;
+      window.onSemanticsAction = originalOnSemanticsAction;
+      window.onPlatformMessage = originalOnPlatformMessage;
+    });
+
+    test('onMetricsChanged preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onMetricsChanged = () {
+          runZone = Zone.current;
+        };
+      });
+
+      window.onMetricsChanged();
+      _updateWindowMetrics(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onLocaleChanged preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onLocaleChanged = () {
+          runZone = Zone.current;
+        };
+      });
+
+      _updateLocale('en', 'US');
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onBeginFrame preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onBeginFrame = (_) {
+          runZone = Zone.current;
+        };
+      });
+
+      _beginFrame(0);
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onDrawFrame preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onDrawFrame = () {
+          runZone = Zone.current;
+        };
+      });
+
+      _drawFrame();
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onPointerDataPacket preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onPointerDataPacket = (_) {
+          runZone = Zone.current;
+        };
+      });
+
+      _invokeOnPointerDataPacket(null);
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onSemanticsEnabledChanged preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onSemanticsEnabledChanged = () {
+          runZone = Zone.current;
+        };
+      });
+
+      _updateSemanticsEnabled(window._semanticsEnabled);
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onSemanticsAction preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onSemanticsAction = (_, __) {
+          runZone = Zone.current;
+        };
+      });
+
+      _dispatchSemanticsAction(0, 0);
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onPlatformMessage preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onPlatformMessage = (_, __, ___) {
+          runZone = Zone.current;
+        };
+      });
+
+      _dispatchPlatformMessage(null, null, null);
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+  });
+}

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -133,7 +133,7 @@ void main() {
         };
       });
 
-      _invokeOnPointerDataPacket(null);
+      _dispatchPointerDataPacket(new ByteData.view(new Uint8List(0).buffer));
       expect(runZone, isNotNull);
       expect(runZone, same(innerZone));
     });

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('window.sendPlatformMessage preserves callback zone', () {
+    runZoned(() {
+      final Zone innerZone = Zone.current;
+      window.sendPlatformMessage('test', new ByteData.view(new Uint8List(0).buffer), expectAsync((ByteData data) {
+        final Zone runZone = Zone.current;
+        expect(runZone, isNotNull);
+        expect(runZone, same(innerZone));
+      }));
+    });
+  });
+}


### PR DESCRIPTION
Run Window callbacks in the zone they are registered in. This is consistent with how other native API work, such as `scheduleMicrotask`, `Timer`, and `dart:io`. This also enables the developers to use the `Zone` API to capture and log unhandled Dart errors.

/cc @Hixie 