### PR TITLE
Depend on //lib/mtl rather than a subtarget

### DIFF
--- a/sky/engine/web/BUILD.gn
+++ b/sky/engine/web/BUILD.gn
@@ -19,7 +19,7 @@ source_set("web") {
   ]
 
   if (is_fuchsia) {
-    deps += [ "//lib/mtl/tasks" ]
+    deps += [ "//lib/mtl" ]
   } else {
     deps += [ "//flutter/fml" ]
   }


### PR DESCRIPTION
This will make it easier to change mtl into a shared library.