### PR TITLE
Revert "[content handler] tune VulkanSurfaceProducer allocation and r…

### DIFF
--- a/content_handler/vulkan_rasterizer.h
+++ b/content_handler/vulkan_rasterizer.h
@@ -87,8 +87,8 @@ class VulkanRasterizer : public Rasterizer {
     struct Swapchain {
       std::queue<std::unique_ptr<Surface>> queue;
       uint32_t tick_count = 0;
-      static constexpr uint32_t kMaxSurfaces = 16;
-      static constexpr uint32_t kMaxTickBeforeDiscard = 600;
+      static constexpr uint32_t kMaxSurfaces = 3;
+      static constexpr uint32_t kMaxTickBeforeDiscard = 3;
     };
 
     using size_key_t = uint64_t;


### PR DESCRIPTION
…ecycling heuristics"

This reverts commit fc70e6eb1e02ab1e6764b45690e4639bfd104cc1.