### PR TITLE
Avoid to freeze the system if hot reloading during debug

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -474,7 +474,7 @@ void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
 
 void Engine::UpdateSemantics(std::vector<blink::SemanticsNode> update) {
   blink::Threads::Platform()->PostTask(ftl::MakeCopyable(
-      [ platform_view = platform_view_, update = std::move(update) ]() mutable {
+      [ platform_view = std::shared_ptr<PlatformView>{platform_view_}, update = std::move(update) ]() mutable {
         if (platform_view)
           platform_view->UpdateSemantics(std::move(update));
       }));
@@ -487,7 +487,7 @@ void Engine::HandlePlatformMessage(
     return;
   }
   blink::Threads::Platform()->PostTask([
-    platform_view = platform_view_, message = std::move(message)
+    platform_view = std::shared_ptr<PlatformView>{platform_view_}, message = std::move(message)
   ]() mutable {
     if (platform_view)
       platform_view->HandlePlatformMessage(std::move(message));

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -95,7 +95,7 @@ class Engine : public blink::RuntimeDelegate {
   void HandleAssetPlatformMessage(ftl::RefPtr<blink::PlatformMessage> message);
   bool GetAssetAsBuffer(const std::string& name, std::vector<uint8_t>* data);
 
-  ftl::WeakPtr<PlatformView> platform_view_;
+  std::weak_ptr<PlatformView> platform_view_;
   std::unique_ptr<Animator> animator_;
   std::unique_ptr<blink::RuntimeController> runtime_;
   tonic::DartErrorHandleType load_script_error_;

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -18,8 +18,7 @@ namespace shell {
 
 PlatformView::PlatformView(std::unique_ptr<Rasterizer> rasterizer)
     : rasterizer_(std::move(rasterizer)),
-      size_(SkISize::Make(0, 0)),
-      weak_factory_(this) {}
+      size_(SkISize::Make(0, 0)){}
 
 PlatformView::~PlatformView() {
   blink::Threads::UI()->PostTask([] { Shell::Shared().PurgePlatformViews(); });
@@ -39,7 +38,7 @@ void PlatformView::CreateEngine() {
 // Subclasses should call this after the object is fully constructed.
 void PlatformView::PostAddToShellTask() {
   blink::Threads::UI()->PostTask(
-      [self = GetWeakPtr()] { Shell::Shared().AddPlatformView(self); });
+      [self = shared_from_this()] { Shell::Shared().AddPlatformView(self); });
 }
 
 void PlatformView::DispatchPlatformMessage(
@@ -118,8 +117,8 @@ void PlatformView::NotifyDestroyed() {
   latch.Wait();
 }
 
-ftl::WeakPtr<PlatformView> PlatformView::GetWeakPtr() {
-  return weak_factory_.GetWeakPtr();
+std::weak_ptr<PlatformView> PlatformView::GetWeakPtr() {
+  return shared_from_this();
 }
 
 VsyncWaiter* PlatformView::GetVsyncWaiter() {

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -22,7 +22,7 @@ namespace shell {
 
 class Rasterizer;
 
-class PlatformView {
+class PlatformView : public std::enable_shared_from_this<PlatformView> {
  public:
   struct SurfaceConfig {
     uint8_t red_bits = 8;
@@ -48,7 +48,7 @@ class PlatformView {
 
   void NotifyDestroyed();
 
-  ftl::WeakPtr<PlatformView> GetWeakPtr();
+  std::weak_ptr<PlatformView> GetWeakPtr();
 
   // The VsyncWaiter will live at least as long as the PlatformView.
   virtual VsyncWaiter* GetVsyncWaiter();
@@ -81,8 +81,7 @@ class PlatformView {
   std::unique_ptr<VsyncWaiter> vsync_waiter_;
   SkISize size_;
 
- private:
-  ftl::WeakPtrFactory<PlatformView> weak_factory_;
+private:
 
   FTL_DISALLOW_COPY_AND_ASSIGN(PlatformView);
 };

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -15,6 +15,8 @@
 #include "lib/ftl/synchronization/waitable_event.h"
 #include "lib/ftl/tasks/task_runner.h"
 
+#include <mutex>
+
 namespace shell {
 
 class PlatformView;
@@ -43,10 +45,10 @@ class Shell {
   // List of PlatformViews.
 
   // These APIs must only be accessed on UI thread.
-  void AddPlatformView(const ftl::WeakPtr<PlatformView>& platform_view);
+  void AddPlatformView(const std::shared_ptr<PlatformView>& platform_view);
   void PurgePlatformViews();
   void GetPlatformViews(
-      std::vector<ftl::WeakPtr<PlatformView>>* platform_views);
+      std::vector<std::weak_ptr<PlatformView>>* platform_views);
 
   struct PlatformViewInfo {
     uintptr_t view_id;
@@ -76,10 +78,6 @@ class Shell {
   void InitGpuThread();
   void InitUIThread();
 
-  void WaitForPlatformViewsIdsUIThread(
-      std::vector<PlatformViewInfo>* platform_views,
-      ftl::AutoResetWaitableEvent* latch);
-
   void RunInPlatformViewUIThread(uintptr_t view_id,
                                  const std::string& main,
                                  const std::string& packages,
@@ -101,7 +99,9 @@ class Shell {
   TracingController tracing_controller_;
 
   std::vector<ftl::WeakPtr<Rasterizer>> rasterizers_;
-  std::vector<ftl::WeakPtr<PlatformView>> platform_views_;
+  std::vector<std::weak_ptr<PlatformView>> platform_views_;
+
+  std::mutex platform_views_mutex_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(Shell);
 };

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -28,6 +28,8 @@ class PlatformViewAndroid : public PlatformView {
 
   ~PlatformViewAndroid() override;
 
+  void Attach();
+
   void Detach();
 
   void SurfaceCreated(JNIEnv* env, jobject jsurface, jint backgroundColor);

--- a/shell/platform/darwin/desktop/flutter_window.mm
+++ b/shell/platform/darwin/desktop/flutter_window.mm
@@ -56,6 +56,7 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(NSEventPh
   FTL_DCHECK(_platformView == nullptr) << "The platform view must not already be set.";
 
   _platformView.reset(new shell::PlatformViewMac(self.renderSurface));
+  _platformView->Attach();
   _platformView->SetupResourceContextOnIOThread();
   _platformView->NotifyCreated(std::make_unique<shell::GPUSurfaceGL>(_platformView.get()));
 }

--- a/shell/platform/darwin/desktop/platform_view_mac.h
+++ b/shell/platform/darwin/desktop/platform_view_mac.h
@@ -21,6 +21,8 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
 
   ~PlatformViewMac() override;
 
+  void Attach();
+
   void SetupAndLoadDart();
 
   bool GLContextMakeCurrent() override;

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -24,11 +24,14 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
       opengl_view_([gl_view retain]),
       resource_loading_context_([[NSOpenGLContext alloc] initWithFormat:gl_view.pixelFormat
                                                            shareContext:gl_view.openGLContext]) {
-  CreateEngine();
-  PostAddToShellTask();
 }
 
 PlatformViewMac::~PlatformViewMac() = default;
+
+void PlatformViewMac::Attach() {
+  CreateEngine();
+  PostAddToShellTask();
+}
 
 void PlatformViewMac::SetupAndLoadDart() {
   if (AttemptLaunchFromCommandLineSwitches(&engine())) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -120,6 +120,7 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
   _statusBarStyle = UIStatusBarStyleDefault;
   _platformView =
       std::make_unique<shell::PlatformViewIOS>(reinterpret_cast<CAEAGLLayer*>(self.view.layer));
+  _platformView->Attach();
   _platformView->SetupResourceContextOnIOThread();
 
   _localizationChannel.reset([[FlutterMethodChannel alloc]

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -25,6 +25,8 @@ class PlatformViewIOS : public PlatformView {
 
   ~PlatformViewIOS() override;
 
+  void Attach();
+
   void NotifyCreated();
 
   void ToggleAccessibility(UIView* view, bool enabled);

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -21,11 +21,14 @@ PlatformViewIOS::PlatformViewIOS(CALayer* layer)
     : PlatformView(std::make_unique<GPURasterizer>(std::make_unique<ProcessInfoMac>())),
       ios_surface_(IOSSurface::Create(surface_config_, layer)),
       weak_factory_(this) {
-  CreateEngine();
-  PostAddToShellTask();
 }
 
 PlatformViewIOS::~PlatformViewIOS() = default;
+
+void PlatformViewIOS::Attach() {
+  CreateEngine();
+  PostAddToShellTask();
+}
 
 void PlatformViewIOS::NotifyCreated() {
   PlatformView::NotifyCreated(ios_surface_->CreateGPUSurface());

--- a/shell/testing/platform_view_test.cc
+++ b/shell/testing/platform_view_test.cc
@@ -11,6 +11,9 @@ namespace shell {
 
 PlatformViewTest::PlatformViewTest()
     : PlatformView(std::unique_ptr<Rasterizer>(new NullRasterizer())) {
+}
+
+void PlatformViewTest::Attach() {
   CreateEngine();
   PostAddToShellTask();
 }

--- a/shell/testing/platform_view_test.h
+++ b/shell/testing/platform_view_test.h
@@ -19,6 +19,8 @@ class PlatformViewTest : public PlatformView {
 
   ~PlatformViewTest();
 
+  void Attach();
+
   bool ResourceContextMakeCurrent() override;
 
   void RunFromSource(const std::string& assets_directory,

--- a/shell/testing/test_runner.cc
+++ b/shell/testing/test_runner.cc
@@ -13,7 +13,8 @@
 
 namespace shell {
 
-TestRunner::TestRunner() : platform_view_(new PlatformViewTest()) {
+TestRunner::TestRunner() : platform_view_(std::make_unique<PlatformViewTest>()) {
+  platform_view_->Attach();
   blink::ViewportMetrics metrics;
   metrics.device_pixel_ratio = 3.0;
   metrics.physical_width = 2400; // 800 at 3x resolution


### PR DESCRIPTION
Trying to hot reload during debug freezes the system, due to the fact that `WaitForPlatformViewIds` tries to execute code on the main thread while it is locked, this in turn freezes the Service Isolate making impossible to continue debug or try to solve the situation.