### PR TITLE
Fix target name for flutter_patched_sdk.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -7,7 +7,7 @@ group("flutter") {
 
   deps = [
     "//flutter/lib/snapshot:generate_snapshot_bin",
-    "//flutter/lib/snapshot:patched_sdk",
+    "//flutter/lib/snapshot:flutter_patched_sdk",
     "//flutter/sky",
   ]
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -313,7 +313,7 @@ template("generate_vm_patched_sdk") {
   }
 }
 
-generate_vm_patched_sdk("patched_sdk") {
+generate_vm_patched_sdk("flutter_patched_sdk") {
   libraries = [
     [
       "async",


### PR DESCRIPTION
Currently 0-builds (repeating builds without any changes to the source) redoes the flutter_patched_sdk step. This is because there is conflict between patched_sdk and flutter_patched_sdk depfile, both being patched_sdk.d. The depfile name is derived from target name, so this cl changes target name for flutter to flutter_patched_sdk.