### PR TITLE
Use Dart_Closure instead of looking up _getMainClosure

### DIFF
--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -72,6 +72,8 @@ bool DartController::SendStartMessage(Dart_Handle root_library) {
 
   // In order to support pausing the isolate at start, we indirectly invoke
   // main by sending a message to the isolate.
+
+  // Get the closure of main().
   Dart_Handle main_closure =
       Dart_GetClosure(root_library, Dart_NewStringFromCString("main"));
   if (LogIfError(main_closure))

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -70,7 +70,7 @@ bool DartController::SendStartMessage(Dart_Handle root_library) {
     Dart_EnterIsolate(isolate);
   }
 
-  // In order to support pausing the isolate at start, we indirectly invoke    +  Dart_Handle main_closure =
+  // In order to support pausing the isolate at start, we indirectly invoke
   // main by sending a message to the isolate.
   Dart_Handle main_closure =
       Dart_GetClosure(root_library, Dart_NewStringFromCString("main"));

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -70,25 +70,14 @@ bool DartController::SendStartMessage(Dart_Handle root_library) {
     Dart_EnterIsolate(isolate);
   }
 
-  // In order to support pausing the isolate at start, we indirectly invoke
-  // main by sending a message to the isolate.
-  // Grab the 'dart:ui' library.
-  Dart_Handle ui_library = Dart_LookupLibrary(ToDart("dart:ui"));
-  DART_CHECK_VALID(ui_library);
+  Dart_Handle main_closure =
+      Dart_GetClosure(root_library, Dart_NewStringFromCString("main"));
+  if (LogIfError(main_closure))
+    return true;
 
   // Grab the 'dart:isolate' library.
   Dart_Handle isolate_lib = Dart_LookupLibrary(ToDart("dart:isolate"));
   DART_CHECK_VALID(isolate_lib);
-
-  // Import the root library into the 'dart:ui' library so that we can
-  // reach main.
-  Dart_LibraryImportLibrary(ui_library, root_library, Dart_Null());
-
-  // Get the closure of main().
-  Dart_Handle main_closure =
-      Dart_Invoke(ui_library, ToDart("_getMainClosure"), 0, NULL);
-  if (LogIfError(main_closure))
-    return true;
 
   // Send the start message containing the entry point by calling
   // _startMainIsolate in dart:isolate.

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -70,6 +70,8 @@ bool DartController::SendStartMessage(Dart_Handle root_library) {
     Dart_EnterIsolate(isolate);
   }
 
+  // In order to support pausing the isolate at start, we indirectly invoke    +  Dart_Handle main_closure =
+  // main by sending a message to the isolate.
   Dart_Handle main_closure =
       Dart_GetClosure(root_library, Dart_NewStringFromCString("main"));
   if (LogIfError(main_closure))


### PR DESCRIPTION
Dart VM implemented simpler solution to problem of finding ```main``` entry point.

This PR switches Flutter engine away from outdated mechanism to new way.