### PR TITLE
a11y: Add SemanticsAction "showOnScreen"

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -17,6 +17,7 @@ class SemanticsAction {
   static const int _kScrollDownIndex = 1 << 5;
   static const int _kIncreaseIndex = 1 << 6;
   static const int _kDecreaseIndex = 1 << 7;
+  static const int _kShowOnScreen = 1 << 8;
 
   /// The numerical value for this action.
   ///
@@ -69,6 +70,12 @@ class SemanticsAction {
   /// For example, this action might be recognized by a slider control.
   static const SemanticsAction decrease = const SemanticsAction._(_kDecreaseIndex);
 
+  /// A request to fully show the semantics node on screen.
+  ///
+  /// For example, this action might be send to a node in a scrollable list that
+  /// is partially off screen to bring it on screen.
+  static const SemanticsAction showOnScreen = const SemanticsAction._(_kShowOnScreen);
+
   /// The possible semantics actions.
   ///
   /// The map's key is the [index] of the action and the value is the action
@@ -82,6 +89,7 @@ class SemanticsAction {
     _kScrollDownIndex: scrollDown,
     _kIncreaseIndex: increase,
     _kDecreaseIndex: decrease,
+    _kShowOnScreen: showOnScreen,
   };
 
   @override
@@ -103,6 +111,8 @@ class SemanticsAction {
         return 'SemanticsAction.increase';
       case _kDecreaseIndex:
         return 'SemanticsAction.decrease';
+      case _kShowOnScreen:
+        return 'SemanticsAction.showOnScreen';
     }
     return null;
   }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -40,6 +40,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider {
     private static final int SEMANTICS_ACTION_SCROLL_DOWN = 1 << 5;
     private static final int SEMANTICS_ACTION_INCREASE = 1 << 6;
     private static final int SEMANTICS_ACTION_DECREASE = 1 << 7;
+    private static final int SEMANTICS_ACTION_SHOW_ON_SCREEN = 1 << 8;
 
     private static final int SEMANTICS_ACTION_SCROLLABLE = SEMANTICS_ACTION_SCROLL_LEFT |
                                                            SEMANTICS_ACTION_SCROLL_RIGHT |
@@ -77,7 +78,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider {
 
         AccessibilityNodeInfo result = AccessibilityNodeInfo.obtain(mOwner, virtualViewId);
         result.setPackageName(mOwner.getContext().getPackageName());
-        result.setClassName("Flutter"); // Prettier than the more conventional node.getClass().getName()
+        result.setClassName("Flutter"); // TODO(goderbauer): Set proper class names
         result.setSource(mOwner, virtualViewId);
 
         if (object.parent != null) {
@@ -117,6 +118,9 @@ class AccessibilityBridge extends AccessibilityNodeProvider {
             result.addAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD);
             result.addAction(AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD);
             result.setScrollable(true);
+            // This tells Android's a11y to send scroll events when reaching the end of
+            // the visible viewport of a scrollable.
+            result.setClassName("android.widget.ScrollView");
         }
 
         result.setCheckable((object.flags & SEMANTICS_FLAG_HAS_CHECKED_STATE) != 0);
@@ -197,6 +201,12 @@ class AccessibilityBridge extends AccessibilityNodeProvider {
                     mOwner.invalidate();
                 }
                 mFocusedObject = object;
+                return true;
+            }
+            // TODO(goderbauer): Use ACTION_SHOW_ON_SCREEN from Android Support Library after
+            //     https://github.com/flutter/flutter/issues/11099 is resolved.
+            case 16908342: { // ACTION_SHOW_ON_SCREEN, added in API level 23
+                mOwner.dispatchSemanticsAction(virtualViewId, SEMANTICS_ACTION_SHOW_ON_SCREEN);
                 return true;
             }
         }


### PR DESCRIPTION
This action is triggered when the user swipes (in accessibility mode) to the last visible item of a scrollable list to bring that item fully on screen.

iOS implementation to follow.

Addresses https://github.com/flutter/flutter/issues/1714 for Android.