### PR TITLE
Do not enter text for key events that are not associated with a character

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -139,7 +139,9 @@ class InputConnectionAdaptor extends BaseInputConnection {
                 }
             } else {
                 // Enter a character.
-                commitText(String.valueOf(event.getNumber()), 1);
+                int character = event.getUnicodeChar();
+                if (character != 0)
+                    commitText(String.valueOf((char) character), 1);
             }
         }
         return result;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/10723