### PR TITLE
Hide Symbol exported from dart:_internal

### DIFF
--- a/lib/ui/ui.dart
+++ b/lib/ui/ui.dart
@@ -11,7 +11,7 @@
 /// text, layout, and rendering subsystems.
 library dart.ui;
 
-import 'dart:_internal';
+import 'dart:_internal' hide Symbol;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer' as developer;


### PR DESCRIPTION
dart:core and dart:_internal each export a class called Symbol. 

dart:core.Symbol is a public interface, and dart:_internal.Symbol is a hidden implementation of the public interface.

This is silently ignored by the VM but some tools (e.g. fasta) report a warning when processing dart:ui sources.

See https://github.com/dart-lang/sdk/issues/30127 for more details.