### PR TITLE
Add missing virtual method in PlatformView

### DIFF
--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -37,6 +37,8 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
 
   virtual ~PlatformView();
 
+  virtual void Attach() = 0;
+
   void DispatchPlatformMessage(ftl::RefPtr<blink::PlatformMessage> message);
   void DispatchSemanticsAction(int32_t id, blink::SemanticsAction action);
   void SetSemanticsEnabled(bool enabled);

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -28,7 +28,7 @@ class PlatformViewAndroid : public PlatformView {
 
   ~PlatformViewAndroid() override;
 
-  void Attach();
+  virtual void Attach() override;
 
   void Detach();
 

--- a/shell/platform/darwin/desktop/platform_view_mac.h
+++ b/shell/platform/darwin/desktop/platform_view_mac.h
@@ -21,7 +21,7 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
 
   ~PlatformViewMac() override;
 
-  void Attach();
+  virtual void Attach() override;
 
   void SetupAndLoadDart();
 

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -25,7 +25,7 @@ class PlatformViewIOS : public PlatformView {
 
   ~PlatformViewIOS() override;
 
-  void Attach();
+  virtual void Attach() override;
 
   void NotifyCreated();
 

--- a/shell/testing/platform_view_test.h
+++ b/shell/testing/platform_view_test.h
@@ -19,7 +19,7 @@ class PlatformViewTest : public PlatformView {
 
   ~PlatformViewTest();
 
-  void Attach();
+  virtual void Attach() override;
 
   bool ResourceContextMakeCurrent() override;
 


### PR DESCRIPTION
Fixes Linux, iOS and Fuchsia builds broken with https://github.com/flutter/engine/pull/3833

Those platforms are storing pointers to the `PlatformView` abstract type, while Android is storing directly a pointer to the concrete implementation.