### PR TITLE
Hold the TestRunner's platform view through a shared_ptr

### DIFF
--- a/shell/testing/test_runner.cc
+++ b/shell/testing/test_runner.cc
@@ -13,7 +13,7 @@
 
 namespace shell {
 
-TestRunner::TestRunner() : platform_view_(std::make_unique<PlatformViewTest>()) {
+TestRunner::TestRunner() : platform_view_(std::make_shared<PlatformViewTest>()) {
   platform_view_->Attach();
   blink::ViewportMetrics metrics;
   metrics.device_pixel_ratio = 3.0;

--- a/shell/testing/test_runner.h
+++ b/shell/testing/test_runner.h
@@ -32,7 +32,7 @@ class TestRunner {
   TestRunner();
   ~TestRunner();
 
-  std::unique_ptr<PlatformView> platform_view_;
+  std::shared_ptr<PlatformView> platform_view_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(TestRunner);
 };


### PR DESCRIPTION
flutter_tester was throwing a bad_weak_ptr while setting up the engine
because the PlatformViewTest was held in a unique_ptr