### PR TITLE
Add Flutter defines option to GN for Skia

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -61,6 +61,7 @@ def to_gn_args(args):
     gn_args = {}
 
     # Skia GN args.
+    gn_args['skia_enable_flutter_defines'] = True # Enable Flutter API guards in Skia.
     gn_args['skia_use_dng_sdk'] = False    # RAW image handling.
     gn_args['skia_use_sfntly'] = False     # PDF handling.
     gn_args['skia_use_libwebp'] = False    # Needs third_party/libwebp.


### PR DESCRIPTION
Once https://skia-review.googlesource.com/c/23042/ lands (and is rolled), this gives us the ability to stage Skia API changes in a similar manner to other clients. In the meantime, this will trigger a GN warning about an arg that isn't declared by any GN file.