### PR TITLE
Restore setting dart_target_arch to fix Windows build.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -98,19 +98,21 @@ def to_gn_args(args):
         # Building host artifacts
         gn_args['target_cpu'] = 'x64'
 
-    # No cross-compilation on Windows (for now).
-    if sys.platform.startswith(('cygwin', 'win')):
-      if 'target_os' in gn_args:
-        gn_args['target_os'] = 'win'
-      if 'target_cpu' in gn_args:
-        gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
-
     # On iOS Devices, use the Dart bytecode interpreter so we don't incur
     # snapshotting and linking costs of the precompiler during development.
     # We can still use the JIT on the simulator though.
     use_dbc = args.target_os == 'ios' and not args.simulator and args.runtime_mode == 'debug'
     if use_dbc:
       gn_args['dart_target_arch'] = 'dbc'
+    else:
+      gn_args['dart_target_arch'] = gn_args['target_cpu']
+
+    # No cross-compilation on Windows (for now).
+    if sys.platform.startswith(('cygwin', 'win')):
+      if 'target_os' in gn_args:
+        gn_args['target_os'] = 'win'
+      if 'target_cpu' in gn_args:
+        gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
     # Modify host_toolchain into dart_host_toolchain so it matches word size of target_cpu
     target_is_32_bit = gn_args['target_cpu'] == 'arm' or gn_args['target_cpu'] == 'x86'


### PR DESCRIPTION
The Windows build does not have an appropriate target_cpu because it is incomplete and does not build the engine.