### PR TITLE
Switch to new encode API on SkPixelSerializer

### DIFF
--- a/shell/common/platform_view_service_protocol.cc
+++ b/shell/common/platform_view_service_protocol.cc
@@ -246,7 +246,7 @@ static sk_sp<SkData> EncodeBitmapAsPNG(const SkBitmap& bitmap) {
   }
 
   PngPixelSerializer serializer;
-  sk_sp<SkData> data(serializer.encode(pixmap));
+  sk_sp<SkData> data(serializer.encodeToData(pixmap));
 
   return data;
 }


### PR DESCRIPTION
Previous API is deprecated, soon to be deleted.