### PR TITLE
Fix Mac desktop platform for use with std::weak_ptr in the PlatformView.

### DIFF
--- a/shell/platform/darwin/desktop/flutter_window.mm
+++ b/shell/platform/darwin/desktop/flutter_window.mm
@@ -37,7 +37,7 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(NSEventPh
 }
 
 @implementation FlutterWindow {
-  std::unique_ptr<shell::PlatformViewMac> _platformView;
+  std::shared_ptr<shell::PlatformViewMac> _platformView;
   bool _mouseIsDown;
 }
 
@@ -55,7 +55,7 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(NSEventPh
 - (void)setupPlatformView {
   FTL_DCHECK(_platformView == nullptr) << "The platform view must not already be set.";
 
-  _platformView.reset(new shell::PlatformViewMac(self.renderSurface));
+  _platformView = std::make_shared<shell::PlatformViewMac>(self.renderSurface);
   _platformView->Attach();
   _platformView->SetupResourceContextOnIOThread();
   _platformView->NotifyCreated(std::make_unique<shell::GPUSurfaceGL>(_platformView.get()));


### PR DESCRIPTION
Regression introduced in https://github.com/flutter/engine/pull/3833. All platforms were fixed except the Mac desktop in https://github.com/flutter/engine/pull/3833.