### PR TITLE
Add flushUIThreadTasks service RPC

### DIFF
--- a/shell/common/platform_view_service_protocol.cc
+++ b/shell/common/platform_view_service_protocol.cc
@@ -128,6 +128,9 @@ void PlatformViewServiceProtocol::RegisterHook(bool running_precompiled_code) {
   }
   Dart_RegisterRootServiceRequestCallback(kRunInViewExtensionName, &RunInView,
                                           nullptr);
+  // [benchmark helper] Wait for the UI Thread to idle.
+  Dart_RegisterRootServiceRequestCallback(kWaitUIThreadIdleExtensionName,
+                                          &WaitUIThreadIdle, nullptr);
 }
 
 const char* PlatformViewServiceProtocol::kRunInViewExtensionName =
@@ -202,11 +205,10 @@ bool PlatformViewServiceProtocol::ListViews(const char* method,
                                             intptr_t num_params,
                                             void* user_data,
                                             const char** json_object) {
-  // Ask the Shell for the list of platform views. This will run a task on
-  // the UI thread before returning.
+  // Ask the Shell for the list of platform views.
   Shell& shell = Shell::Shared();
   std::vector<Shell::PlatformViewInfo> platform_views;
-  shell.WaitForPlatformViewIds(&platform_views);
+  shell.GetPlatformViewIds(&platform_views);
 
   std::stringstream response;
 
@@ -312,6 +314,31 @@ void PlatformViewServiceProtocol::ScreenshotGpuTask(SkBitmap* bitmap) {
   canvas->clear(SK_ColorBLACK);
   layer_tree->Raster(frame);
   canvas->flush();
+}
+
+const char* PlatformViewServiceProtocol::kWaitUIThreadIdleExtensionName =
+    "_flutter.waitUIThreadIdle";
+
+// This API should not be invoked by production code.
+// It can potentially starve the service isolate if the main isolate pauses
+// at a breakpoint or is in an infinite loop.
+bool PlatformViewServiceProtocol::WaitUIThreadIdle(const char* method,
+                                                   const char** param_keys,
+                                                   const char** param_values,
+                                                   intptr_t num_params,
+                                                   void* user_data,
+                                                   const char** json_object) {
+  ftl::AutoResetWaitableEvent latch;
+  blink::Threads::UI()->PostTask([&latch]() {
+    // This task is empty because we just need to synchronize this RPC with the
+    // UI Thread
+    latch.Signal();
+  });
+
+  latch.Wait();
+
+  *json_object = strdup("{\"type\":\"Success\"}");
+  return true;
 }
 
 }  // namespace shell

--- a/shell/common/platform_view_service_protocol.cc
+++ b/shell/common/platform_view_service_protocol.cc
@@ -129,8 +129,8 @@ void PlatformViewServiceProtocol::RegisterHook(bool running_precompiled_code) {
   Dart_RegisterRootServiceRequestCallback(kRunInViewExtensionName, &RunInView,
                                           nullptr);
   // [benchmark helper] Wait for the UI Thread to idle.
-  Dart_RegisterRootServiceRequestCallback(kWaitUIThreadIdleExtensionName,
-                                          &WaitUIThreadIdle, nullptr);
+  Dart_RegisterRootServiceRequestCallback(kFlushUIThreadTasksExtensionName,
+                                          &FlushUIThreadTasks, nullptr);
 }
 
 const char* PlatformViewServiceProtocol::kRunInViewExtensionName =
@@ -316,13 +316,16 @@ void PlatformViewServiceProtocol::ScreenshotGpuTask(SkBitmap* bitmap) {
   canvas->flush();
 }
 
-const char* PlatformViewServiceProtocol::kWaitUIThreadIdleExtensionName =
-    "_flutter.waitUIThreadIdle";
+const char* PlatformViewServiceProtocol::kFlushUIThreadTasksExtensionName =
+    "_flutter.flushUIThreadTasks";
 
 // This API should not be invoked by production code.
 // It can potentially starve the service isolate if the main isolate pauses
 // at a breakpoint or is in an infinite loop.
-bool PlatformViewServiceProtocol::WaitUIThreadIdle(const char* method,
+//
+// It should be invoked from the VM Service and and blocks it until UI thread
+// tasks are processed.
+bool PlatformViewServiceProtocol::FlushUIThreadTasks(const char* method,
                                                    const char** param_keys,
                                                    const char** param_values,
                                                    intptr_t num_params,

--- a/shell/common/platform_view_service_protocol.h
+++ b/shell/common/platform_view_service_protocol.h
@@ -20,6 +20,8 @@ class PlatformViewServiceProtocol {
 
  private:
   static const char* kRunInViewExtensionName;
+  // It should be invoked from the VM Service and and blocks it until previous
+  // UI thread tasks are processed.
   static bool RunInView(const char* method,
                         const char** param_keys,
                         const char** param_values,
@@ -36,6 +38,8 @@ class PlatformViewServiceProtocol {
                         const char** json_object);
 
   static const char* kScreenshotExtensionName;
+  // It should be invoked from the VM Service and and blocks it until previous
+  // GPU thread tasks are processed.
   static bool Screenshot(const char* method,
                          const char** param_keys,
                          const char** param_values,
@@ -47,13 +51,16 @@ class PlatformViewServiceProtocol {
   // This API should not be invoked by production code.
   // It can potentially starve the service isolate if the main isolate pauses
   // at a breakpoint or is in an infinite loop.
-  static const char* kWaitUIThreadIdleExtensionName;
-  static bool WaitUIThreadIdle(const char* method,
-                               const char** param_keys,
-                               const char** param_values,
-                               intptr_t num_params,
-                               void* user_data,
-                               const char** json_object);
+  //
+  // It should be invoked from the VM Service and and blocks it until previous
+  // GPU thread tasks are processed.
+  static const char* kFlushUIThreadTasksExtensionName;
+  static bool FlushUIThreadTasks(const char* method,
+                                 const char** param_keys,
+                                 const char** param_values,
+                                 intptr_t num_params,
+                                 void* user_data,
+                                 const char** json_object);
 };
 
 }  // namespace shell

--- a/shell/common/platform_view_service_protocol.h
+++ b/shell/common/platform_view_service_protocol.h
@@ -43,6 +43,17 @@ class PlatformViewServiceProtocol {
                          void* user_data,
                          const char** json_object);
   static void ScreenshotGpuTask(SkBitmap* bitmap);
+
+  // This API should not be invoked by production code.
+  // It can potentially starve the service isolate if the main isolate pauses
+  // at a breakpoint or is in an infinite loop.
+  static const char* kWaitUIThreadIdleExtensionName;
+  static bool WaitUIThreadIdle(const char* method,
+                              const char** param_keys,
+                              const char** param_values,
+                              intptr_t num_params,
+                              void* user_data,
+                              const char** json_object);
 };
 
 }  // namespace shell

--- a/shell/common/platform_view_service_protocol.h
+++ b/shell/common/platform_view_service_protocol.h
@@ -49,11 +49,11 @@ class PlatformViewServiceProtocol {
   // at a breakpoint or is in an infinite loop.
   static const char* kWaitUIThreadIdleExtensionName;
   static bool WaitUIThreadIdle(const char* method,
-                              const char** param_keys,
-                              const char** param_values,
-                              intptr_t num_params,
-                              void* user_data,
-                              const char** json_object);
+                               const char** param_keys,
+                               const char** param_values,
+                               intptr_t num_params,
+                               void* user_data,
+                               const char** json_object);
 };
 
 }  // namespace shell

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -262,7 +262,7 @@ void Shell::GetPlatformViews(
   *platform_views = platform_views_;
 }
 
-void Shell::WaitForPlatformViewIds(
+void Shell::GetPlatformViewIds(
     std::vector<PlatformViewInfo>* platform_view_ids) {
   std::lock_guard<std::mutex> lk(platform_views_mutex_);
   for (auto it = platform_views_.begin(); it != platform_views_.end(); it++) {

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -44,7 +44,7 @@ class Shell {
 
   // List of PlatformViews.
 
-  // These APIs must only be accessed on UI thread.
+  // These APIs can be called from any thread.
   void AddPlatformView(const std::shared_ptr<PlatformView>& platform_view);
   void PurgePlatformViews();
   void GetPlatformViews(
@@ -58,7 +58,7 @@ class Shell {
 
   // These APIs can be called from any thread.
   // Return the list of platform view ids at the time of this call.
-  void WaitForPlatformViewIds(std::vector<PlatformViewInfo>* platform_view_ids);
+  void GetPlatformViewIds(std::vector<PlatformViewInfo>* platform_view_ids);
 
   // Attempt to run a script inside a flutter view indicated by |view_id|.
   // Will set |view_existed| to true if the view was found and false otherwise.


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/3833 the `_flutter.listViews` RPC moved from thread based to lock based synchronization.
The thread based synchronization side effect was used by flutter benchmarks in https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/vmservice.dart#L1223 and
https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/run_hot.dart#L156 to ensure the completeness of the restart/reload and so correct timing.

A new RPC `_flutter.flushUIThreadTasks` is introduced to allow the flutter benchmarks to reintroduce thread based synchronization.

Related https://github.com/flutter/flutter/issues/11241