### PR TITLE
Add `PluginRegistry.Registrar#view()`

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -289,6 +289,11 @@ public final class FlutterActivityDelegate
             return flutterView;
         }
 
+        @Override
+        public FlutterView view() {
+            return flutterView;
+        }
+
         /**
          * Publishes a value associated with the plugin being registered.
          *

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -6,6 +6,7 @@ package io.flutter.plugin.common;
 
 import android.app.Activity;
 import android.content.Intent;
+import io.flutter.view.FlutterView;
 
 /**
  * Registry used by plugins to set up interaction with Android APIs.
@@ -72,6 +73,12 @@ public interface PluginRegistry {
          * creating channels for communicating with the Dart side.
          */
         BinaryMessenger messenger();
+
+        /**
+         * Returns the {@link FlutterView} that's instantiated by this plugin's
+         * {@link #activity() activity}.
+         */
+        FlutterView view();
 
         /**
          * Publishes a value associated with the plugin being registered.


### PR DESCRIPTION
Sometimes, plugin instances need access to the `FlutterView`.
They can currently cast the `messenger()`, but that's fragile.
This adds API support for getting the view from the registry.