### PR TITLE
[content handler] pipeline surface submission to mozart

### DIFF
--- a/content_handler/vulkan_surface.h
+++ b/content_handler/vulkan_surface.h
@@ -49,7 +49,13 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface,
   // |flow::SceneUpdateContext::SurfaceProducerSurface|
   sk_sp<SkSurface> GetSkiaSurface() const override;
 
- private:
+  // This transfers ownership of the GrBackendSemaphore but not the underlying
+  // VkSemaphore (i.e. it is ok to let the returned GrBackendSemaphore go out of
+  // scope but it is not ok to call VkDestroySemaphore on the underlying
+  // VkSemaphore)
+  GrBackendSemaphore GetAcquireSemaphore() const;
+
+private:
   vulkan::VulkanProcTable& vk_;
   sk_sp<GrVkBackendContext> backend_context_;
   mozart::client::Session* session_;
@@ -58,6 +64,7 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface,
   sk_sp<SkSurface> sk_surface_;
   std::unique_ptr<mozart::client::Image> session_image_;
   mx::event acquire_event_;
+  vulkan::VulkanHandle<VkSemaphore> acquire_semaphore_;
   mx::event release_event_;
   mtl::MessageLoop::HandlerKey event_handler_key_ = 0;
   std::function<void(void)> pending_on_writes_committed_;
@@ -84,6 +91,9 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface,
                                 mx::vmo exported_vmo);
 
   void Reset();
+
+  vulkan::VulkanHandle<VkSemaphore>
+  SemaphoreFromEvent(const mx::event &event) const;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(VulkanSurface);
 };

--- a/content_handler/vulkan_surface_producer.cc
+++ b/content_handler/vulkan_surface_producer.cc
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 #include "flutter/content_handler/vulkan_surface_producer.h"
-#include <memory>
-#include <string>
-#include <vector>
+#include "third_party/skia/include/gpu/GrBackendSemaphore.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 #include "third_party/skia/src/gpu/vk/GrVkUtil.h"
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace flutter_runner {
 
@@ -25,13 +26,21 @@ VulkanSurfaceProducer::VulkanSurfaceProducer(
   }
 }
 
-VulkanSurfaceProducer::~VulkanSurfaceProducer() = default;
+VulkanSurfaceProducer::~VulkanSurfaceProducer() {
+  // Make sure queue is idle before we start destroying surfaces
+  VkResult wait_result =
+      VK_CALL_LOG_ERROR(vk_->QueueWaitIdle(backend_context_->fQueue));
+  FTL_DCHECK(wait_result == VK_SUCCESS);
+};
 
 bool VulkanSurfaceProducer::Initialize(
     mozart::client::Session* mozart_session) {
   vk_ = ftl::MakeRefCounted<vulkan::VulkanProcTable>();
 
-  std::vector<std::string> extensions = {VK_KHR_SURFACE_EXTENSION_NAME};
+  std::vector<std::string> extensions = {
+      VK_KHR_SURFACE_EXTENSION_NAME,
+      VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME,
+  };
   application_ = std::make_unique<vulkan::VulkanApplication>(
       *vk_, "FlutterContentHandler", std::move(extensions));
 
@@ -110,16 +119,18 @@ void VulkanSurfaceProducer::OnSurfacesPresented(
     std::vector<
         std::unique_ptr<flow::SceneUpdateContext::SurfaceProducerSurface>>
         surfaces) {
+
+  std::vector<GrBackendSemaphore> semaphores;
+  semaphores.reserve(surfaces.size());
+  for (auto &surface : surfaces) {
+    auto vk_surface = static_cast<VulkanSurface *>(surface.get());
+    semaphores.push_back(vk_surface->GetAcquireSemaphore());
+  }
+
   // Do a single flush for all canvases derived from the context.
-  context_->flush();
+  context_->flushAndSignalSemaphores(semaphores.size(), semaphores.data());
 
-  // Do a CPU wait.
-  // TODO(chinmaygarde): Remove this once we have support for Vulkan semaphores.
-  VkResult wait_result =
-      VK_CALL_LOG_ERROR(vk_->QueueWaitIdle(backend_context_->fQueue));
-  FTL_DCHECK(wait_result == VK_SUCCESS);
-
-  // Submit surface, this signals acquire events sent along the session.
+  // Submit surface
   for (auto& surface : surfaces) {
     SubmitSurface(std::move(surface));
   }

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -58,10 +58,12 @@ VulkanDevice::VulkanDevice(VulkanProcTable& p_vk,
       .pQueuePriorities = priorities,
   };
 
-  const char* extensions[] = {
-      VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+  const char *extensions[] = {
+    VK_KHR_SWAPCHAIN_EXTENSION_NAME,
 #if OS_FUCHSIA
-      VK_GOOGLE_EXTERNAL_MEMORY_MAGMA_EXTENSION_NAME,
+    VK_GOOGLE_EXTERNAL_MEMORY_MAGMA_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME,
+    VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME,
 #endif
   };
 

--- a/vulkan/vulkan_handle.h
+++ b/vulkan/vulkan_handle.h
@@ -55,7 +55,9 @@ class VulkanHandle {
   /// the lifetime of the handle extends past the lifetime of this object.
   void ReleaseOwnership() { disposer_ = nullptr; }
 
- private:
+  void Reset() { DisposeIfNecessary(); }
+
+private:
   Handle handle_;
   Disposer disposer_;
 

--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -94,6 +94,7 @@ bool VulkanProcTable::SetupInstanceProcAddresses(
     ACQUIRE_PROC(CreateMagmaSurfaceKHR, handle);
     ACQUIRE_PROC(ExportDeviceMemoryMAGMA, handle);
     ACQUIRE_PROC(GetPhysicalDeviceMagmaPresentationSupportKHR, handle);
+    ACQUIRE_PROC(ImportSemaphoreFdKHR, handle);
     return true;
   }();
 #endif  // OS_FUCHSIA
@@ -146,6 +147,7 @@ bool VulkanProcTable::SetupDeviceProcAddresses(
   ACQUIRE_PROC(WaitForFences, handle);
 #if OS_FUCHSIA
   ACQUIRE_PROC(ExportDeviceMemoryMAGMA, handle);
+  ACQUIRE_PROC(ImportSemaphoreFdKHR, handle);
 #endif  // OS_FUCHSIA
   device_ = {handle, nullptr};
   return true;

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -118,6 +118,7 @@ class VulkanProcTable : public ftl::RefCountedThreadSafe<VulkanProcTable> {
   DEFINE_PROC(CreateMagmaSurfaceKHR);
   DEFINE_PROC(ExportDeviceMemoryMAGMA);
   DEFINE_PROC(GetPhysicalDeviceMagmaPresentationSupportKHR);
+  DEFINE_PROC(ImportSemaphoreFdKHR);
 #endif  // OS_FUCHSIA
 
 #undef DEFINE_PROC


### PR DESCRIPTION
This change basically moves the singaling of the surface acquire event into the gpu driver, eliminating the VkQueueWaitIdle on surface submission

This change depends on https://skia-review.googlesource.com/c/25641/ so do not submit until Flutter has rolled Skia past that point