### PR TITLE
Use metrics provided by scene events.

### DIFF
--- a/content_handler/rasterizer.h
+++ b/content_handler/rasterizer.h
@@ -21,8 +21,10 @@ class Rasterizer {
 
   static std::unique_ptr<Rasterizer> Create();
 
-  virtual void SetSession(fidl::InterfaceHandle<mozart2::Session> session,
-                          mx::eventpair import_token) = 0;
+  virtual void SetScene(
+      fidl::InterfaceHandle<mozart2::SceneManager> scene_manager,
+      mx::eventpair import_token,
+      ftl::Closure metrics_changed_callback) = 0;
 
   virtual void Draw(std::unique_ptr<flow::LayerTree> layer_tree,
                     ftl::Closure callback) = 0;

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -89,6 +89,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   void PostBeginFrame();
   void BeginFrame();
   void OnFrameComplete();
+  void OnRedrawFrame();
   void Invalidate();
 
   std::unique_ptr<app::ApplicationContext> context_;

--- a/content_handler/vulkan_rasterizer.h
+++ b/content_handler/vulkan_rasterizer.h
@@ -22,8 +22,9 @@ class VulkanRasterizer : public Rasterizer {
 
   bool IsValid() const;
 
-  void SetSession(fidl::InterfaceHandle<mozart2::Session> session,
-                  mx::eventpair import_token) override;
+  void SetScene(fidl::InterfaceHandle<mozart2::SceneManager> scene_manager,
+                mx::eventpair import_token,
+                ftl::Closure metrics_changed_callback) override;
 
   void Draw(std::unique_ptr<flow::LayerTree> layer_tree,
             ftl::Closure callback) override;

--- a/flow/export_node.cc
+++ b/flow/export_node.cc
@@ -17,7 +17,6 @@ ExportNode::~ExportNode() {
 void ExportNode::Bind(SceneUpdateContext& context,
                       mozart::client::ContainerNode& container,
                       const SkPoint& offset,
-                      float scale,
                       bool hit_testable) {
   ftl::MutexLocker lock(&mutex_);
 
@@ -29,7 +28,6 @@ void ExportNode::Bind(SceneUpdateContext& context,
   if (node_) {
     container.AddChild(*node_);
     node_->SetTranslation(offset.x(), offset.y(), 0.f);
-    node_->SetScale(scale, scale, 1.f);
     node_->SetHitTestBehavior(hit_testable
                                   ? mozart2::HitTestBehavior::kDefault
                                   : mozart2::HitTestBehavior::kSuppress);

--- a/flow/export_node.h
+++ b/flow/export_node.h
@@ -34,7 +34,6 @@ class ExportNode : public ftl::RefCountedThreadSafe<ExportNode> {
   void Bind(SceneUpdateContext& context,
             mozart::client::ContainerNode& container,
             const SkPoint& offset,
-            float scale,
             bool hit_testable);
 
  private:

--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -26,15 +26,8 @@ void ChildSceneLayer::UpdateScene(SceneUpdateContext& context) {
   // or whether we should leave this up to the Flutter application to decide.
   // In some situations, it might be useful to allow children to draw
   // outside of their layout bounds.
-  //
-  // float inverse_device_pixel_ratio = 1.f / device_pixel_ratio_;
-  // SkRect bounds =
-  //     SkRect::MakeXYWH(offset_.x(), offset_.y(),
-  //                      physical_size_.width() * inverse_device_pixel_ratio,
-  //                      physical_size_.height() * inverse_device_pixel_ratio);
   if (export_node_) {
-    context.AddChildScene(export_node_.get(), offset_, device_pixel_ratio_,
-                          hit_testable_);
+    context.AddChildScene(export_node_.get(), offset_, hit_testable_);
   }
 }
 

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -17,13 +17,7 @@ class ChildSceneLayer : public Layer {
 
   void set_offset(const SkPoint& offset) { offset_ = offset; }
 
-  void set_device_pixel_ratio(float device_pixel_ratio) {
-    device_pixel_ratio_ = device_pixel_ratio;
-  }
-
-  void set_physical_size(const SkISize& physical_size) {
-    physical_size_ = physical_size;
-  }
+  void set_size(const SkSize& size) { size_ = size; }
 
   void set_export_node(ftl::RefPtr<ExportNode> export_node) {
     export_node_ = std::move(export_node);
@@ -39,8 +33,7 @@ class ChildSceneLayer : public Layer {
 
  private:
   SkPoint offset_;
-  float device_pixel_ratio_ = 1.0;
-  SkISize physical_size_;
+  SkSize size_;
   ftl::RefPtr<ExportNode> export_node_;
   bool hit_testable_ = true;
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -34,6 +34,7 @@ void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
       frame.gr_context(), color_space, SkRect::MakeEmpty(),
   };
+
   root_layer_->Preroll(&context, SkMatrix::I());
 }
 
@@ -42,18 +43,20 @@ void LayerTree::UpdateScene(SceneUpdateContext& context,
                             mozart::client::ContainerNode& container) {
   TRACE_EVENT0("flutter", "LayerTree::UpdateScene");
 
+  SceneUpdateContext::Transform transform(context, 1.f / device_pixel_ratio_,
+                                          1.f / device_pixel_ratio_, 1.f);
   SceneUpdateContext::Frame frame(
       context,
       SkRRect::MakeRect(
-          SkRect::MakeIWH(frame_size_.width(), frame_size_.height())),
-      SK_ColorTRANSPARENT, 0.f, 1.f, 1.f);
+          SkRect::MakeWH(frame_size_.width(), frame_size_.height())),
+      SK_ColorTRANSPARENT, 0.f);
   if (root_layer_->needs_system_composite()) {
     root_layer_->UpdateScene(context);
   }
   if (root_layer_->needs_painting()) {
     frame.AddPaintedLayer(root_layer_.get());
   }
-  container.AddChild(frame.entity_node());
+  container.AddChild(transform.entity_node());
 }
 #endif
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -31,6 +31,10 @@ class LayerTree {
                bool ignore_raster_cache = false);
 
 #if defined(OS_FUCHSIA)
+  void set_device_pixel_ratio(float device_pixel_ratio) {
+    device_pixel_ratio_ = device_pixel_ratio;
+  }
+
   void UpdateScene(SceneUpdateContext& context,
                    mozart::client::ContainerNode& container);
 #endif
@@ -79,6 +83,10 @@ class LayerTree {
   uint32_t rasterizer_tracing_threshold_;
   bool checkerboard_raster_cache_images_;
   bool checkerboard_offscreen_layers_;
+
+#if defined(OS_FUCHSIA)
+  float device_pixel_ratio_ = 1.f;
+#endif
 
   FTL_DISALLOW_COPY_AND_ASSIGN(LayerTree);
 };

--- a/flow/layers/physical_model_layer.cc
+++ b/flow/layers/physical_model_layer.cc
@@ -34,13 +34,6 @@ void PhysicalModelLayer::Preroll(PrerollContext* context,
     set_paint_bounds(bounds);
 #endif  // defined(OS_FUCHSIA)
   }
-
-#if defined(OS_FUCHSIA)
-  if (needs_system_composite()) {
-    scale_x_ = matrix.getScaleX();
-    scale_y_ = matrix.getScaleY();
-  }
-#endif  // defined(OS_FUCHSIA)
 }
 
 #if defined(OS_FUCHSIA)
@@ -48,8 +41,7 @@ void PhysicalModelLayer::Preroll(PrerollContext* context,
 void PhysicalModelLayer::UpdateScene(SceneUpdateContext& context) {
   FTL_DCHECK(needs_system_composite());
 
-  SceneUpdateContext::Frame frame(context, rrect_, color_, elevation_, scale_x_,
-                                  scale_y_);
+  SceneUpdateContext::Frame frame(context, rrect_, color_, elevation_);
   for (auto& layer : layers()) {
     if (layer->needs_painting()) {
       frame.AddPaintedLayer(layer.get());

--- a/flow/layers/physical_model_layer.h
+++ b/flow/layers/physical_model_layer.h
@@ -38,11 +38,6 @@ class PhysicalModelLayer : public ContainerLayer {
   float elevation_;
   SkColor color_;
   SkScalar device_pixel_ratio_;
-
-#if defined(OS_FUCHSIA)
-  SkScalar scale_x_;
-  SkScalar scale_y_;
-#endif  // defined(OS_FUCHSIA)
 };
 
 }  // namespace flow

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -201,25 +201,22 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// for this application.
   void addChildScene({
     Offset offset: Offset.zero,
-    double devicePixelRatio: 1.0,
-    int physicalWidth: 0,
-    int physicalHeight: 0,
+    double width: 0.0,
+    double height: 0.0,
     SceneHost sceneHost,
     bool hitTestable: true
   }) {
     _addChildScene(offset.dx,
                    offset.dy,
-                   devicePixelRatio,
-                   physicalWidth,
-                   physicalHeight,
+                   width,
+                   height,
                    sceneHost,
                    hitTestable);
   }
   void _addChildScene(double dx,
                       double dy,
-                      double devicePixelRatio,
-                      int physicalWidth,
-                      int physicalHeight,
+                      double width,
+                      double height,
                       SceneHost sceneHost,
                       bool hitTestable) native "SceneBuilder_addChildScene";
 

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -224,24 +224,21 @@ void SceneBuilder::addPicture(double dx,
 
 void SceneBuilder::addChildScene(double dx,
                                  double dy,
-                                 double devicePixelRatio,
-                                 int physicalWidth,
-                                 int physicalHeight,
+                                 double width,
+                                 double height,
                                  SceneHost* sceneHost,
                                  bool hitTestable) {
 #if defined(OS_FUCHSIA)
   if (!m_currentLayer)
     return;
 
-  SkRect sceneRect = SkRect::MakeXYWH(dx, dy, physicalWidth / devicePixelRatio,
-                                      physicalHeight / devicePixelRatio);
+  SkRect sceneRect = SkRect::MakeXYWH(dx, dy, width, height);
   if (!SkRect::Intersects(sceneRect, m_cullRects.top()))
     return;
 
   std::unique_ptr<flow::ChildSceneLayer> layer(new flow::ChildSceneLayer());
   layer->set_offset(SkPoint::Make(dx, dy));
-  layer->set_device_pixel_ratio(devicePixelRatio);
-  layer->set_physical_size(SkISize::Make(physicalWidth, physicalHeight));
+  layer->set_size(SkSize::Make(width, height));
   layer->set_export_node(sceneHost->exportNode());
   layer->set_hit_testable(hitTestable);
   m_currentLayer->Add(std::move(layer));

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -59,9 +59,8 @@ class SceneBuilder : public ftl::RefCountedThreadSafe<SceneBuilder>,
   void addPicture(double dx, double dy, Picture* picture, int hints);
   void addChildScene(double dx,
                      double dy,
-                     double devicePixelRatio,
-                     int physicalWidth,
-                     int physicalHeight,
+                     double width,
+                     double height,
                      SceneHost* sceneHost,
                      bool hitTestable);
 


### PR DESCRIPTION
Compute the necessary texture resolution using more accurate scaling
information provided by Mozart scene node metrics events instead of the
device pixel ratio provided by the Mozart view properties (which we
might remove in the future).

This allows us to allocate smaller textures when a Flutter view is
being scaled down.