### PR TITLE
When the surface does not support SRGB, render to an offscreen texture.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -22,7 +22,7 @@ vars = {
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'github_git': 'https://github.com',
-  'skia_revision': '89d9d95570227533e4a87b41e5a7ed9fad4dd04a',
+  'skia_revision': '16d8ec66cdce2f30ce89b87066d3ac7a244c460d',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -17,8 +17,7 @@
 namespace shell {
 
 PlatformView::PlatformView(std::unique_ptr<Rasterizer> rasterizer)
-    : rasterizer_(std::move(rasterizer)),
-      size_(SkISize::Make(0, 0)){}
+    : rasterizer_(std::move(rasterizer)), size_(SkISize::Make(0, 0)) {}
 
 PlatformView::~PlatformView() {
   blink::Threads::UI()->PostTask([] { Shell::Shared().PurgePlatformViews(); });
@@ -90,7 +89,6 @@ void PlatformView::NotifyCreated(std::unique_ptr<Surface> surface,
       &latch
     ]() mutable {
       // Runs on the GPU Thread. So does the Caller Continuation.
-      surface->Setup();
       rasterizer_->Setup(std::move(surface), caller_continuation, &latch);
     });
     // Runs on the UI Thread.

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -46,8 +46,6 @@ class Surface {
 
   virtual ~Surface();
 
-  virtual bool Setup() = 0;
-
   virtual bool IsValid() = 0;
 
   virtual std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) = 0;

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -136,7 +136,7 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
                             onscreen_surface_->height())) {
     // We know that if there is an offscreen surface, it will be sized to be
     // equal to the size of the onscreen surface. And the onscreen surface size
-    // appears unchained. So bail.
+    // appears unchanged. So bail.
     return true;
   }
 
@@ -209,8 +209,8 @@ bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
   }
 
   if (!onscreen_surface_supports_sgrb_) {
-    // Because the surface did not support SRGB, we rendered offscreen surface.
-    // Now we must ensure that the texture is copied onscreen.
+    // Because the surface did not support sRGB, we rendered to an offscreen
+    // surface. Now we must ensure that the texture is copied onscreen.
     TRACE_EVENT0("flutter", "CopyTextureOnscreen");
     FTL_DCHECK(offscreen_surface_ != nullptr);
     SkPaint paint;

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -8,6 +8,7 @@
 #include "lib/ftl/arraysize.h"
 #include "lib/ftl/logging.h"
 #include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrContextOptions.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
@@ -21,50 +22,157 @@ static const int kGrCacheMaxCount = 8192;
 static const size_t kGrCacheMaxByteSize = 512 * (1 << 20);
 
 GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
-    : delegate_(delegate), weak_factory_(this) {}
-
-GPUSurfaceGL::~GPUSurfaceGL() = default;
-
-bool GPUSurfaceGL::Setup() {
-  if (delegate_ == nullptr) {
-    // Invalid delegate.
-    return false;
-  }
-
-  if (context_ != nullptr) {
-    // Already setup.
-    return false;
-  }
-
+    : delegate_(delegate),
+      onscreen_surface_supports_sgrb_(delegate_->SurfaceSupportsSRGB()),
+      weak_factory_(this) {
   if (!delegate_->GLContextMakeCurrent()) {
-    // Could not make the context current to create the native interface.
-    return false;
+    FTL_LOG(ERROR)
+        << "Could not make the context current to setup the gr context.";
+    return;
   }
 
-  // Create the native interface.
   auto backend_context =
       reinterpret_cast<GrBackendContext>(GrGLCreateNativeInterface());
 
   GrContextOptions options;
   options.fRequireDecodeDisableForSRGB = false;
 
-  context_ =
-      sk_sp<GrContext>(GrContext::Create(kOpenGL_GrBackend, backend_context,
-                                         options));
-  if (context_ == nullptr) {
-    FTL_LOG(INFO) << "Failed to setup Skia Gr context.";
-    return false;
+  auto context = sk_sp<GrContext>(
+      GrContext::Create(kOpenGL_GrBackend, backend_context, options));
+
+  if (context == nullptr) {
+    FTL_LOG(ERROR) << "Failed to setup Skia Gr context.";
+    return;
   }
+
+  context_ = std::move(context);
 
   context_->setResourceCacheLimits(kGrCacheMaxCount, kGrCacheMaxByteSize);
 
   delegate_->GLContextClearCurrent();
 
-  return true;
+  valid_ = true;
+}
+
+GPUSurfaceGL::~GPUSurfaceGL() {
+  if (!valid_) {
+    return;
+  }
+
+  if (!delegate_->GLContextMakeCurrent()) {
+    FTL_LOG(ERROR) << "Could not make the context current to destroy the "
+                      "GrContext resources.";
+    return;
+  }
+
+  onscreen_surface_ = nullptr;
+  offscreen_surface_ = nullptr;
+  context_->releaseResourcesAndAbandonContext();
+  context_ = nullptr;
+
+  delegate_->GLContextClearCurrent();
 }
 
 bool GPUSurfaceGL::IsValid() {
-  return context_ != nullptr;
+  return valid_;
+}
+
+static sk_sp<SkSurface> WrapOnscreenSurface(GrContext* context,
+                                            const SkISize& size,
+                                            intptr_t fbo,
+                                            bool supports_srgb) {
+  const GrGLFramebufferInfo framebuffer_info = {
+      .fFBOID = fbo,
+  };
+
+  const GrPixelConfig pixel_config =
+      supports_srgb ? kSRGBA_8888_GrPixelConfig : kRGBA_8888_GrPixelConfig;
+
+  GrBackendRenderTarget render_target(size.fWidth,      // width
+                                      size.fHeight,     // height
+                                      0,                // sample count
+                                      0,                // stencil bits (TODO)
+                                      pixel_config,     // pixel config
+                                      framebuffer_info  // framebuffer info
+                                      );
+
+  sk_sp<SkColorSpace> colorspace =
+      supports_srgb ? SkColorSpace::MakeSRGB() : nullptr;
+
+  SkSurfaceProps surface_props(
+      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+
+  return SkSurface::MakeFromBackendRenderTarget(
+      context,                                       // gr context
+      render_target,                                 // render target
+      GrSurfaceOrigin::kBottomLeft_GrSurfaceOrigin,  // origin
+      colorspace,                                    // colorspace
+      &surface_props                                 // surface properties
+      );
+}
+
+static sk_sp<SkSurface> CreateOffscreenSurface(GrContext* context,
+                                               const SkISize& size) {
+  const SkImageInfo image_info =
+      SkImageInfo::MakeS32(size.fWidth, size.fHeight, kOpaque_SkAlphaType);
+
+  const SkSurfaceProps surface_props(
+      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
+
+  return SkSurface::MakeRenderTarget(
+      context,                      // context
+      SkBudgeted::kNo,              // budgeted
+      image_info,                   // image info
+      0,                            // sample count
+      kBottomLeft_GrSurfaceOrigin,  // surface origin
+      &surface_props                // surface props
+      );
+}
+
+bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
+  if (onscreen_surface_ != nullptr &&
+      size == SkISize::Make(onscreen_surface_->width(),
+                            onscreen_surface_->height())) {
+    // We know that if there is an offscreen surface, it will be sized to be
+    // equal to the size of the onscreen surface. And the onscreen surface size
+    // appears unchained. So bail.
+    return true;
+  }
+
+  // We need to do some updates.
+  TRACE_EVENT0("flutter", "UpdateSurfacesSize");
+
+  // Either way, we need to get rid of previous surfaces.
+  onscreen_surface_ = nullptr;
+  offscreen_surface_ = nullptr;
+
+  if (size.isEmpty()) {
+    FTL_LOG(ERROR) << "Cannot create surfaces of empty size.";
+    return false;
+  }
+
+  sk_sp<SkSurface> onscreen_surface, offscreen_surface;
+
+  onscreen_surface =
+      WrapOnscreenSurface(context_.get(), size, delegate_->GLContextFBO(),
+                          onscreen_surface_supports_sgrb_);
+  if (onscreen_surface == nullptr) {
+    FTL_LOG(ERROR) << "Could not wrap onscreen surface.";
+    return false;
+  }
+
+  if (!onscreen_surface_supports_sgrb_) {
+    offscreen_surface = CreateOffscreenSurface(context_.get(), size);
+    if (offscreen_surface == nullptr) {
+      FTL_LOG(ERROR) << "Could not create offscreen surface.";
+      return false;
+    }
+  }
+
+  onscreen_surface_ = std::move(onscreen_surface);
+  offscreen_surface_ = std::move(offscreen_surface);
+
+  return true;
 }
 
 std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
@@ -73,10 +181,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
   }
 
   if (!delegate_->GLContextMakeCurrent()) {
+    FTL_LOG(ERROR)
+        << "Could not make the context current to acquire the frame.";
     return nullptr;
   }
 
-  sk_sp<SkSurface> surface = AcquireSurface(size);
+  sk_sp<SkSurface> surface = AcquireRenderSurface(size);
 
   if (surface == nullptr) {
     return nullptr;
@@ -84,10 +194,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
 
   auto weak_this = weak_factory_.GetWeakPtr();
 
-  SurfaceFrame::SubmitCallback submit_callback = [weak_this](
-      const SurfaceFrame& surface_frame, SkCanvas* canvas) {
-    return weak_this ? weak_this->PresentSurface(canvas) : false;
-  };
+  SurfaceFrame::SubmitCallback submit_callback =
+      [weak_this](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
+        return weak_this ? weak_this->PresentSurface(canvas) : false;
+      };
 
   return std::make_unique<SurfaceFrame>(surface, submit_callback);
 }
@@ -97,9 +207,22 @@ bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
     return false;
   }
 
+  if (!onscreen_surface_supports_sgrb_) {
+    // Because the surface did not support SRGB, we rendered offscreen surface.
+    // Now we must ensure that the texture is copied onscreen.
+    TRACE_EVENT0("flutter", "CopyTextureOnscreen");
+    FTL_DCHECK(offscreen_surface_ != nullptr);
+    onscreen_surface_->getCanvas()->drawImage(
+        offscreen_surface_->makeImageSnapshot(),  // image
+        0,                                        // left
+        0,                                        // top
+        nullptr                                   // paint (TODO)
+        );
+  }
+
   {
     TRACE_EVENT0("flutter", "SkCanvas::Flush");
-    canvas->flush();
+    onscreen_surface_->getCanvas()->flush();
   }
 
   delegate_->GLContextPresent();
@@ -107,64 +230,13 @@ bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
   return true;
 }
 
-bool GPUSurfaceGL::SelectPixelConfig(GrPixelConfig* config) {
-  if (delegate_->ColorSpace() && delegate_->ColorSpace()->gammaCloseToSRGB()) {
-    FTL_DCHECK(context_->caps()->isConfigRenderable(kSRGBA_8888_GrPixelConfig,
-                                                    false));
-    *config = kSRGBA_8888_GrPixelConfig;
-    return true;
-  }
-
-  // FIXME:
-  // If sRGB support is not available, we should instead fall back to software.
-  if (context_->caps()->isConfigRenderable(kRGBA_8888_GrPixelConfig, false)) {
-    *config = kRGBA_8888_GrPixelConfig;
-    return true;
-  }
-
-  if (context_->caps()->isConfigRenderable(kRGBA_4444_GrPixelConfig, false)) {
-    *config = kRGBA_4444_GrPixelConfig;
-    return true;
-  }
-
-  return false;
-}
-
-sk_sp<SkSurface> GPUSurfaceGL::CreateSurface(const SkISize& size) {
-  if (delegate_ == nullptr || context_ == nullptr) {
+sk_sp<SkSurface> GPUSurfaceGL::AcquireRenderSurface(const SkISize& size) {
+  if (!CreateOrUpdateSurfaces(size)) {
     return nullptr;
   }
 
-  GrBackendRenderTargetDesc desc;
-  if (!SelectPixelConfig(&desc.fConfig)) {
-    return nullptr;
-  }
-
-  desc.fWidth = size.width();
-  desc.fHeight = size.height();
-  desc.fStencilBits = 8;
-  desc.fOrigin = kBottomLeft_GrSurfaceOrigin;
-  desc.fRenderTargetHandle = delegate_->GLContextFBO();
-
-  return SkSurface::MakeFromBackendRenderTarget(context_.get(), desc,
-                                                delegate_->ColorSpace(), nullptr);
-}
-
-sk_sp<SkSurface> GPUSurfaceGL::AcquireSurface(const SkISize& size) {
-  // There is no cached surface.
-  if (cached_surface_ == nullptr) {
-    cached_surface_ = CreateSurface(size);
-    return cached_surface_;
-  }
-
-  // There is a surface previously created of the same size.
-  if (cached_surface_->width() == size.width() &&
-      cached_surface_->height() == size.height()) {
-    return cached_surface_;
-  }
-
-  cached_surface_ = CreateSurface(size);
-  return cached_surface_;
+  return onscreen_surface_supports_sgrb_ ? onscreen_surface_
+                                         : offscreen_surface_;
 }
 
 GrContext* GPUSurfaceGL::GetContext() {

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -23,8 +23,7 @@ class GPUSurfaceGLDelegate {
 
   virtual intptr_t GLContextFBO() const = 0;
 
-  // TODO: Update Mac desktop and make this pure virtual.
-  virtual sk_sp<SkColorSpace> ColorSpace() const { return nullptr; }
+  virtual bool SurfaceSupportsSRGB() const = 0;
 };
 
 class GPUSurfaceGL : public Surface {
@@ -32,8 +31,6 @@ class GPUSurfaceGL : public Surface {
   GPUSurfaceGL(GPUSurfaceGLDelegate* delegate);
 
   ~GPUSurfaceGL() override;
-
-  bool Setup() override;
 
   bool IsValid() override;
 
@@ -43,13 +40,16 @@ class GPUSurfaceGL : public Surface {
 
  private:
   GPUSurfaceGLDelegate* delegate_;
+  bool onscreen_surface_supports_sgrb_;
   sk_sp<GrContext> context_;
-  sk_sp<SkSurface> cached_surface_;
+  sk_sp<SkSurface> onscreen_surface_;
+  sk_sp<SkSurface> offscreen_surface_;
+  bool valid_ = false;
   ftl::WeakPtrFactory<GPUSurfaceGL> weak_factory_;
 
-  sk_sp<SkSurface> CreateSurface(const SkISize& size);
+  bool CreateOrUpdateSurfaces(const SkISize& size);
 
-  sk_sp<SkSurface> AcquireSurface(const SkISize& size);
+  sk_sp<SkSurface> AcquireRenderSurface(const SkISize& size);
 
   bool PresentSurface(SkCanvas* canvas);
 

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -14,10 +14,6 @@ GPUSurfaceSoftware::GPUSurfaceSoftware(GPUSurfaceSoftwareDelegate* delegate)
 
 GPUSurfaceSoftware::~GPUSurfaceSoftware() = default;
 
-bool GPUSurfaceSoftware::Setup() {
-  return IsValid();
-}
-
 bool GPUSurfaceSoftware::IsValid() {
   return delegate_ != nullptr;
 }

--- a/shell/gpu/gpu_surface_software.h
+++ b/shell/gpu/gpu_surface_software.h
@@ -24,8 +24,6 @@ class GPUSurfaceSoftware : public Surface {
 
   ~GPUSurfaceSoftware() override;
 
-  bool Setup() override;
-
   bool IsValid() override;
 
   std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) override;

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -55,6 +55,10 @@ AndroidSurfaceGL::AndroidSurfaceGL(
 
 AndroidSurfaceGL::~AndroidSurfaceGL() = default;
 
+bool AndroidSurfaceGL::SurfaceSupportsSRGB() const {
+  return offscreen_context_->SupportsSRGB();
+}
+
 bool AndroidSurfaceGL::IsOffscreenContextValid() const {
   return offscreen_context_ && offscreen_context_->IsValid();
 }
@@ -81,12 +85,7 @@ bool AndroidSurfaceGL::IsValid() const {
 
 std::unique_ptr<Surface> AndroidSurfaceGL::CreateGPUSurface() {
   auto surface = std::make_unique<GPUSurfaceGL>(this);
-
-  if (!surface->Setup()) {
-    return nullptr;
-  }
-
-  return surface;
+  return surface->IsValid() ? std::move(surface) : nullptr;
 }
 
 SkISize AndroidSurfaceGL::OnScreenSurfaceSize() const {

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -47,13 +47,7 @@ class AndroidSurfaceGL : public GPUSurfaceGLDelegate, public AndroidSurface {
 
   intptr_t GLContextFBO() const override;
 
-  sk_sp<SkColorSpace> ColorSpace() const override {
-    // TODO:
-    // We can render more consistently across devices when Android makes it
-    // possible to query for the color space of the display.
-    return onscreen_context_->SupportsSRGB() ? SkColorSpace::MakeSRGB()
-                                             : nullptr;
-  }
+  bool SurfaceSupportsSRGB() const override;
 
   void SetFlutterView(
       const fml::jni::JavaObjectWeakGlobalRef& flutter_view) override;

--- a/shell/platform/darwin/desktop/platform_view_mac.h
+++ b/shell/platform/darwin/desktop/platform_view_mac.h
@@ -33,6 +33,8 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
 
   intptr_t GLContextFBO() const override;
 
+  bool SurfaceSupportsSRGB() const override;
+
   VsyncWaiter* GetVsyncWaiter() override;
 
   bool ResourceContextMakeCurrent() override;

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -23,8 +23,7 @@ PlatformViewMac::PlatformViewMac(NSOpenGLView* gl_view)
     : PlatformView(std::make_unique<GPURasterizer>(std::make_unique<ProcessInfoMac>())),
       opengl_view_([gl_view retain]),
       resource_loading_context_([[NSOpenGLContext alloc] initWithFormat:gl_view.pixelFormat
-                                                           shareContext:gl_view.openGLContext]) {
-}
+                                                           shareContext:gl_view.openGLContext]) {}
 
 PlatformViewMac::~PlatformViewMac() = default;
 
@@ -77,6 +76,10 @@ void PlatformViewMac::SetupAndLoadFromSource(const std::string& assets_directory
 intptr_t PlatformViewMac::GLContextFBO() const {
   // Default window bound framebuffer FBO 0.
   return 0;
+}
+
+bool PlatformViewMac::SurfaceSupportsSRGB() const {
+  return false;
 }
 
 bool PlatformViewMac::GLContextMakeCurrent() {

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -36,9 +36,7 @@ class IOSSurfaceGL : public IOSSurface, public GPUSurfaceGLDelegate {
 
   intptr_t GLContextFBO() const override;
 
-  sk_sp<SkColorSpace> ColorSpace() const override {
-    return context_.ColorSpace();
-  }
+  bool SurfaceSupportsSRGB() const override;
 
  private:
   IOSGLContext context_;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -36,6 +36,10 @@ intptr_t IOSSurfaceGL::GLContextFBO() const {
   return IsValid() ? context_.framebuffer() : GL_NONE;
 }
 
+bool IOSSurfaceGL::SurfaceSupportsSRGB() const {
+  return true;
+}
+
 bool IOSSurfaceGL::GLContextMakeCurrent() {
   return IsValid() ? context_.MakeCurrent() : false;
 }

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: d07ddbe451cf7cb7a46904d92963fecc
+Signature: a0ac508508961cd3261f0a1d8d0e5c84
 
 UNUSED LICENSES:
 
@@ -25557,8 +25557,6 @@ FILE: ../../../third_party/skia/src/gpu/GrSKSLPrettyPrint.h
 FILE: ../../../third_party/skia/src/gpu/GrSurfacePriv.h
 FILE: ../../../third_party/skia/src/gpu/GrTRecorder.h
 FILE: ../../../third_party/skia/src/gpu/GrTexturePriv.h
-FILE: ../../../third_party/skia/src/gpu/GrTraceMarker.cpp
-FILE: ../../../third_party/skia/src/gpu/GrTraceMarker.h
 FILE: ../../../third_party/skia/src/gpu/GrTracing.h
 FILE: ../../../third_party/skia/src/gpu/GrXferProcessor.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrBicubicEffect.cpp
@@ -25788,13 +25786,10 @@ FILE: ../../../third_party/skia/src/gpu/GrSoftwarePathRenderer.cpp
 FILE: ../../../third_party/skia/src/gpu/GrSoftwarePathRenderer.h
 FILE: ../../../third_party/skia/src/gpu/GrSurface.cpp
 FILE: ../../../third_party/skia/src/gpu/GrTextureStripAtlas.h
-FILE: ../../../third_party/skia/src/gpu/effects/Gr1DKernelEffect.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrConfigConversionEffect.cpp
 FILE: ../../../third_party/skia/src/gpu/effects/GrConfigConversionEffect.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrGaussianConvolutionFragmentProcessor.cpp
 FILE: ../../../third_party/skia/src/gpu/effects/GrGaussianConvolutionFragmentProcessor.h
-FILE: ../../../third_party/skia/src/gpu/effects/GrSingleTextureEffect.cpp
-FILE: ../../../third_party/skia/src/gpu/effects/GrSingleTextureEffect.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrTextureDomain.cpp
 FILE: ../../../third_party/skia/src/gpu/effects/GrTextureDomain.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrTextureStripAtlas.cpp
@@ -26681,12 +26676,14 @@ FILE: ../../../third_party/skia/gm/simple_magnification.cpp
 FILE: ../../../third_party/skia/gm/srgb.cpp
 FILE: ../../../third_party/skia/gm/testgradient.cpp
 FILE: ../../../third_party/skia/gm/thinconcavepaths.cpp
+FILE: ../../../third_party/skia/gm/tosrgb_colorfilter.cpp
 FILE: ../../../third_party/skia/gm/xform_image_gen.cpp
 FILE: ../../../third_party/skia/include/core/SkColorSpaceXformCanvas.h
 FILE: ../../../third_party/skia/include/core/SkExecutor.h
 FILE: ../../../third_party/skia/include/core/SkFontArguments.h
 FILE: ../../../third_party/skia/include/core/SkVertices.h
 FILE: ../../../third_party/skia/include/effects/SkHighContrastFilter.h
+FILE: ../../../third_party/skia/include/effects/SkToSRGBColorFilter.h
 FILE: ../../../third_party/skia/include/encode/SkEncoder.h
 FILE: ../../../third_party/skia/include/encode/SkJpegEncoder.h
 FILE: ../../../third_party/skia/include/encode/SkPngEncoder.h
@@ -26718,6 +26715,8 @@ FILE: ../../../third_party/skia/src/core/SkColorSpaceXformImageGenerator.cpp
 FILE: ../../../third_party/skia/src/core/SkColorSpaceXformImageGenerator.h
 FILE: ../../../third_party/skia/src/core/SkColorSpaceXformer.cpp
 FILE: ../../../third_party/skia/src/core/SkColorSpaceXformer.h
+FILE: ../../../third_party/skia/src/core/SkCoverageDelta.cpp
+FILE: ../../../third_party/skia/src/core/SkCoverageDelta.h
 FILE: ../../../third_party/skia/src/core/SkDrawShadowRec.h
 FILE: ../../../third_party/skia/src/core/SkDraw_vertices.cpp
 FILE: ../../../third_party/skia/src/core/SkExecutor.cpp
@@ -26736,6 +26735,7 @@ FILE: ../../../third_party/skia/src/effects/GrCircleBlurFragmentProcessor.cpp
 FILE: ../../../third_party/skia/src/effects/GrCircleBlurFragmentProcessor.h
 FILE: ../../../third_party/skia/src/effects/SkDashImpl.h
 FILE: ../../../third_party/skia/src/effects/SkHighContrastFilter.cpp
+FILE: ../../../third_party/skia/src/effects/SkToSRGBColorFilter.cpp
 FILE: ../../../third_party/skia/src/gpu/GrAHardwareBufferImageGenerator.cpp
 FILE: ../../../third_party/skia/src/gpu/GrAHardwareBufferImageGenerator.h
 FILE: ../../../third_party/skia/src/gpu/GrBackendSurface.cpp
@@ -27137,7 +27137,6 @@ FILE: ../../../third_party/skia/src/core/SkScan_AntiPath.cpp
 FILE: ../../../third_party/skia/src/core/SkScan_Hairline.cpp
 FILE: ../../../third_party/skia/src/core/SkScan_Path.cpp
 FILE: ../../../third_party/skia/src/core/SkSpriteBlitter.h
-FILE: ../../../third_party/skia/src/core/SkSpriteBlitterTemplate.h
 FILE: ../../../third_party/skia/src/core/SkSpriteBlitter_ARGB32.cpp
 FILE: ../../../third_party/skia/src/core/SkStream.cpp
 FILE: ../../../third_party/skia/src/core/SkString.cpp
@@ -27909,6 +27908,7 @@ LIBRARY: skia
 ORIGIN: ../../../third_party/skia/src/core/SkScan_AAAPath.cpp + ../../../third_party/skia/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/skia/src/core/SkScan_AAAPath.cpp
+FILE: ../../../third_party/skia/src/core/SkScan_DAAPath.cpp
 ----------------------------------------------------------------------------------------------------
 Copyright 2016 The Android Open Source Project
 


### PR DESCRIPTION
Unlike the prototype, the offscreen rendering is managed at the platform agnostic layer. This version is also able to survive context loss and resizes.

If the surface supports SRGB (determined via platform specific checks), rendering canvas will be backed by a surface that wraps the platform FBO. If not, an offscreen surface will be created and a copy performed onscreen per present.

I still have to fix the following but this patch is good for review:
* The stencil counts are not communicated to the surface that wraps the platform FBO.
* The check specified in [this patch](https://skia-review.googlesource.com/c/27440/) needs to be performed and the appropriate paint specified.