### PR TITLE
Update the Vulkan backend to account for GPUSurface API updates.

### DIFF
--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -15,11 +15,6 @@ GPUSurfaceVulkan::GPUSurfaceVulkan(
 
 GPUSurfaceVulkan::~GPUSurfaceVulkan() = default;
 
-bool GPUSurfaceVulkan::Setup() {
-  // This backend does not have an explicit setup task post initialization.
-  return window_.IsValid();
-}
-
 bool GPUSurfaceVulkan::IsValid() {
   return window_.IsValid();
 }

--- a/shell/gpu/gpu_surface_vulkan.h
+++ b/shell/gpu/gpu_surface_vulkan.h
@@ -21,8 +21,6 @@ class GPUSurfaceVulkan : public Surface {
 
   ~GPUSurfaceVulkan() override;
 
-  bool Setup() override;
-
   bool IsValid() override;
 
   std::unique_ptr<SurfaceFrame> AcquireFrame(const SkISize& size) override;

--- a/shell/platform/android/android_surface_vulkan.cc
+++ b/shell/platform/android/android_surface_vulkan.cc
@@ -49,10 +49,6 @@ std::unique_ptr<Surface> AndroidSurfaceVulkan::CreateGPUSurface() {
     return nullptr;
   }
 
-  if (!gpu_surface->Setup()) {
-    return nullptr;
-  }
-
   return gpu_surface;
 }
 


### PR DESCRIPTION
We used to need a two step setup process for GL setup on Android and this was reflected in the GPUSurface API. No other backend needed it. Since I got rid of the odd initialization on Android, I removed the API too. Didn't check the Android Vulkan backend.