### PR TITLE
Always consume items from the pipeline in the null rasterizer.

### DIFF
--- a/shell/common/null_rasterizer.cc
+++ b/shell/common/null_rasterizer.cc
@@ -39,7 +39,12 @@ void NullRasterizer::Clear(SkColor color, const SkISize& size) {
 
 void NullRasterizer::Draw(
     ftl::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) {
-  // Null rasterizer. Nothing to do.
+  FTL_ALLOW_UNUSED_LOCAL(
+      pipeline->Consume([](std::unique_ptr<flow::LayerTree>) {
+        // Drop the layer tree on the floor. We only need the pipeline empty so
+        // that frame requests are not deferred indefinitely due to
+        // backpressure.
+      }));
 }
 
 }  // namespace shell

--- a/shell/common/null_rasterizer.h
+++ b/shell/common/null_rasterizer.h
@@ -31,8 +31,8 @@ class NullRasterizer : public Rasterizer {
   void Draw(ftl::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) override;
 
  private:
-  ftl::WeakPtrFactory<NullRasterizer> weak_factory_;
   std::unique_ptr<Surface> surface_;
+  ftl::WeakPtrFactory<NullRasterizer> weak_factory_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(NullRasterizer);
 };


### PR DESCRIPTION
Now, frame requests past the pipeline depth will never be deferred due
to back pressure. This backend is only used in the test runner.

Also fix variable declaration order for the weak factory.