### PR TITLE
Fix iOS last up event velocity calculation - version 2

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -414,9 +414,10 @@ static inline PointerChangeMapperPhase PointerChangePhaseFromUITouchPhase(UITouc
     if (touch.phase == UITouchPhaseEnded) {
       CGPoint endedLocation = [touch locationInView:nil];
       CGPoint lastMovedLocation = [touch previousLocationInView:nil];
-      CGFloat distanceSquared = pow(endedLocation.x - lastMovedLocation.x, 2)
-          + pow(endedLocation.y - lastMovedLocation.y, 2);
-      if (distanceSquared < pow(touch.majorRadiusTolerance, 2))
+      CGFloat distanceSquared =
+          (endedLocation.x - lastMovedLocation.x) * (endedLocation.x - lastMovedLocation.x)
+          - (endedLocation.y - lastMovedLocation.y) * (endedLocation.y - lastMovedLocation.y)
+      if (distanceSquared < touch.majorRadiusTolerance * touch.majorRadiusTolerance))
         windowCoordinates = lastMovedLocation;
     }
 


### PR DESCRIPTION
Alternate to https://github.com/flutter/flutter/pull/11345 for fix of https://github.com/flutter/flutter/issues/10977 by checking if last moved -> ended settling is within threshold. 

Will add tests after a first pass.