### PR TITLE
enable async stack traces in all modes

### DIFF
--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -77,6 +77,7 @@ static const char* kDartLanguageArgs[] = {
     "--background_compilation",
     "--await_is_keyword",
     "--assert_initializer",
+    "--causal_async_stacks",
 };
 
 static const char* kDartPrecompilationArgs[] = {


### PR DESCRIPTION
Part of the fix for https://github.com/flutter/flutter/issues/11479.