### PR TITLE
Fixes related to usage of std::weak_ptr to hold PlatformViews

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -485,7 +485,7 @@ void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
 
 void Engine::UpdateSemantics(std::vector<blink::SemanticsNode> update) {
   blink::Threads::Platform()->PostTask(ftl::MakeCopyable(
-      [ platform_view = std::shared_ptr<PlatformView>{platform_view_}, update = std::move(update) ]() mutable {
+      [ platform_view = platform_view_.lock(), update = std::move(update) ]() mutable {
         if (platform_view)
           platform_view->UpdateSemantics(std::move(update));
       }));
@@ -498,7 +498,7 @@ void Engine::HandlePlatformMessage(
     return;
   }
   blink::Threads::Platform()->PostTask([
-    platform_view = std::shared_ptr<PlatformView>{platform_view_}, message = std::move(message)
+    platform_view = platform_view_.lock(), message = std::move(message)
   ]() mutable {
     if (platform_view)
       platform_view->HandlePlatformMessage(std::move(message));

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -34,7 +34,7 @@ bool IsInvalid(const ftl::WeakPtr<Rasterizer>& rasterizer) {
 }
 
 bool IsViewInvalid(const std::weak_ptr<PlatformView>& platform_view) {
-  return !(platform_view.expired());
+  return platform_view.expired();
 }
 
 template <typename T>
@@ -266,7 +266,7 @@ void Shell::GetPlatformViewIds(
     std::vector<PlatformViewInfo>* platform_view_ids) {
   std::lock_guard<std::mutex> lk(platform_views_mutex_);
   for (auto it = platform_views_.begin(); it != platform_views_.end(); it++) {
-    std::shared_ptr <PlatformView> view{*it};
+    std::shared_ptr<PlatformView> view = it->lock();
     if (!view) {
       // Skip dead views.
       continue;
@@ -317,7 +317,7 @@ void Shell::RunInPlatformViewUIThread(uintptr_t view_id,
   *view_existed = false;
 
   for (auto it = platform_views_.begin(); it != platform_views_.end(); it++) {
-    std::shared_ptr<PlatformView> view{*it};
+    std::shared_ptr<PlatformView> view = it->lock();
     if (!view) continue;
     if (reinterpret_cast<uintptr_t>(view.get()) == view_id) {
       *view_existed = true;

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -37,7 +37,7 @@ class PlatformMessageResponseAndroid : public blink::PlatformMessageResponse {
     ftl::RefPtr<PlatformMessageResponseAndroid> self(this);
     blink::Threads::Platform()->PostTask(
         ftl::MakeCopyable([ self, data = std::move(data) ]() mutable {
-          std::shared_ptr<PlatformView> view{self->view_};
+          std::shared_ptr<PlatformView> view = self->view_.lock();
           if (!view)
             return;
           static_cast<PlatformViewAndroid*>(view.get())
@@ -49,7 +49,7 @@ class PlatformMessageResponseAndroid : public blink::PlatformMessageResponse {
   void CompleteEmpty() override {
     ftl::RefPtr<PlatformMessageResponseAndroid> self(this);
     blink::Threads::Platform()->PostTask(ftl::MakeCopyable([self]() mutable {
-      std::shared_ptr<PlatformView> view{self->view_};
+      std::shared_ptr<PlatformView> view = self->view_.lock();
       if (!view)
         return;
       static_cast<PlatformViewAndroid*>(view.get())


### PR DESCRIPTION
* Call weak_ptr.lock(), which returns a null shared_ptr and does not throw
* IsViewInvalid was inverted