### PR TITLE
Implement all known blink::PointerData fields on iOS.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -75,7 +75,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '4cf93efdd098f6c3bc26b9f38f2306fa0560ead6',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'b0caefa339171dfa48b72b1064652d7c11cfe857',
 
    # Fuchsia compatibility
    #

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -42,6 +42,8 @@ source_set("fml") {
       "platform/darwin/message_loop_darwin.h",
       "platform/darwin/message_loop_darwin.mm",
       "platform/darwin/paths_darwin.mm",
+      "platform/darwin/platform_version.h",
+      "platform/darwin/platform_version.mm",
       "platform/darwin/resource_mapping_darwin.h",
       "platform/darwin/resource_mapping_darwin.mm",
       "platform/darwin/scoped_block.h",

--- a/fml/platform/darwin/platform_version.h
+++ b/fml/platform/darwin/platform_version.h
@@ -1,0 +1,17 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_PLATFORM_DARWIN_PLATFORM_VERSION_H_
+#define FLUTTER_FML_PLATFORM_DARWIN_PLATFORM_VERSION_H_
+
+#include <sys/types.h>
+#include "lib/ftl/macros.h"
+
+namespace fml {
+
+bool IsPlatformVersionAtLeast(size_t major, size_t minor = 0, size_t patch = 0);
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_PLATFORM_DARWIN_PLATFORM_VERSION_H_

--- a/fml/platform/darwin/platform_version.mm
+++ b/fml/platform/darwin/platform_version.mm
@@ -1,0 +1,19 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/platform/darwin/platform_version.h"
+#include <Foundation/NSProcessInfo.h>
+
+namespace fml {
+
+bool IsPlatformVersionAtLeast(size_t major, size_t minor, size_t patch) {
+  const NSOperatingSystemVersion version = {
+      .majorVersion = static_cast<NSInteger>(major),
+      .minorVersion = static_cast<NSInteger>(minor),
+      .patchVersion = static_cast<NSInteger>(patch),
+  };
+  return [[NSProcessInfo processInfo] isOperatingSystemAtLeastVersion:version];
+}
+
+}  // namespace fml

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1401,6 +1401,8 @@ FILE: ../../../flutter/fml/platform/darwin/cf_utils.h
 FILE: ../../../flutter/fml/platform/darwin/message_loop_darwin.h
 FILE: ../../../flutter/fml/platform/darwin/message_loop_darwin.mm
 FILE: ../../../flutter/fml/platform/darwin/paths_darwin.mm
+FILE: ../../../flutter/fml/platform/darwin/platform_version.h
+FILE: ../../../flutter/fml/platform/darwin/platform_version.mm
 FILE: ../../../flutter/fml/platform/darwin/resource_mapping_darwin.h
 FILE: ../../../flutter/fml/platform/darwin/resource_mapping_darwin.mm
 FILE: ../../../flutter/fml/platform/darwin/scoped_block.mm


### PR DESCRIPTION
Adds all the appropriate runtime version checks. I am not able to test the stylus altitude and azimuth readings because I don't have one (can we get one please). I have tried to match documented behavior though.