### PR TITLE
Apply antialiasing in calls to SkCanvas::clipRect

### DIFF
--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -157,7 +157,7 @@ void Canvas::transform(const tonic::Float64List& matrix4) {
 void Canvas::clipRect(double left, double top, double right, double bottom) {
   if (!canvas_)
     return;
-  canvas_->clipRect(SkRect::MakeLTRB(left, top, right, bottom));
+  canvas_->clipRect(SkRect::MakeLTRB(left, top, right, bottom), SkClipOp::kIntersect, true);
 }
 
 void Canvas::clipRRect(const RRect& rrect) {


### PR DESCRIPTION
Without this, the cull rect calculated by an SkPicture may be truncated
to integer pixel coordinates.  The raster cache relies on a precise cull
rect in logical coordinates.

See https://bugs.chromium.org/p/skia/issues/detail?id=6954