### PR TITLE
Capture fractional pixel coordinates in the bounds of raster cache bitmaps

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -79,12 +79,12 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
 
   const SkRect logical_rect = picture->cullRect();
   const SkRect physical_rect =
-      SkRect::MakeWH(std::ceil(std::fabs(logical_rect.width() * scale.x())),
-                     std::ceil(std::fabs(logical_rect.height() * scale.y())));
+      SkRect::MakeWH(std::fabs(logical_rect.width() * scale.x()),
+                     std::fabs(logical_rect.height() * scale.y()));
 
   const SkImageInfo image_info =
-      SkImageInfo::MakeN32Premul(physical_rect.width(),      // physical width
-                                 physical_rect.height(),     // physical height
+      SkImageInfo::MakeN32Premul(std::ceil(physical_rect.width()),      // physical width
+                                 std::ceil(physical_rect.height()),     // physical height
                                  sk_ref_sp(dst_color_space)  // colorspace
       );
 


### PR DESCRIPTION
The bitmap used to hold a prerolled image in the raster cache must have an
integer width/height in pixels.  However, the picture used to draw the image
may have a non-integer width/height in physical coordinates and thus not
completely fill the bitmap.  The compositor should only select the subset
of the bitmap that reflects the portion filled by the rendered picture.