### PR TITLE
No longer need to use fuchsia_shared_library

### DIFF
--- a/build/flutter_app.gni
+++ b/build/flutter_app.gni
@@ -4,7 +4,6 @@
 
 assert(is_fuchsia)
 
-import("//build/toolchain/shared.gni")
 import("//build/dart/dart_package.gni")
 import("//flutter/lib/ui/dart_ui.gni")
 import("//apps/mozart/lib/flutter/sdk_ext/sdk_ext.gni")
@@ -286,7 +285,7 @@ template("flutter_aot_app") {
   dylib_label = target_name + "_dylib"
 
   outer_target_name = target_name
-  fuchsia_shared_library(dylib_label) {
+  shared_library(dylib_label) {
     deps = [
       ":$assembly_label",
     ]
@@ -301,7 +300,7 @@ template("flutter_aot_app") {
   }
 
   dylib_path =
-      get_label_info(":$dylib_label(${target_toolchain}-shared)",
+      get_label_info(":$dylib_label($shlib_toolchain)",
                      "root_out_dir") + "/lib.unstripped/lib$target_name.so"
 
   action(target_name) {


### PR DESCRIPTION
Use $shlib_toolchain to find the shared_library output file.

Change-Id: Ic9310b1483183c16451cce7737c9d61960b1095b