### PR TITLE
Create a window toolkit agnostic Flutter engine API.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,8 +6,8 @@ group("flutter") {
   testonly = true
 
   deps = [
-    "//flutter/lib/snapshot:generate_snapshot_bin",
     "//flutter/lib/snapshot:flutter_patched_sdk",
+    "//flutter/lib/snapshot:generate_snapshot_bin",
     "//flutter/sky",
   ]
 
@@ -33,6 +33,9 @@ group("flutter") {
   if (current_toolchain == host_toolchain) {
     if (is_mac) {
       deps += [ "//flutter/shell/platform/darwin:flutter_channels_unittests" ]
+    }
+    if (!is_win) {
+      deps += [ "//flutter/shell/platform/embedder:flutter_engine" ]
     }
     deps += [
       "//flutter/flow:flow_unittests",

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("embedder") {
+  sources = [
+    "embedder.cc",
+    "embedder.h",
+    "embedder_include.c",
+    "platform_view_embedder.cc",
+    "platform_view_embedder.h",
+  ]
+
+  deps = [
+    "//dart/runtime:libdart_jit",
+    "//dart/runtime/bin:embedded_dart_io",
+    "//flutter/common",
+    "//flutter/fml",
+    "//flutter/shell/common",
+    "//flutter/shell/gpu",
+    "//lib/ftl",
+    "//lib/tonic",
+    "//third_party/skia",
+  ]
+}
+
+shared_library("flutter_engine") {
+  deps = [
+    ":embedder",
+  ]
+}

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -1,0 +1,230 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define FLUTTER_EXPORT __attribute__((visibility("default")))
+
+#include "flutter/shell/platform/embedder/embedder.h"
+#include <type_traits>
+#include "flutter/common/threads.h"
+#include "flutter/shell/platform/embedder/platform_view_embedder.h"
+#include "lib/ftl/functional/make_copyable.h"
+
+#define SAFE_ACCESS(pointer, member, default_value)                      \
+  ({                                                                     \
+    auto _return_value =                                                 \
+        static_cast<__typeof__(pointer->member)>((default_value));       \
+    if (offsetof(std::remove_pointer<decltype(pointer)>::type, member) + \
+            sizeof(pointer->member) <=                                   \
+        pointer->struct_size) {                                          \
+      _return_value = pointer->member;                                   \
+    }                                                                    \
+    _return_value;                                                       \
+  })
+
+bool IsRendererValid(const FlutterRendererConfig* config) {
+  if (config == nullptr || config->type != kOpenGL) {
+    return false;
+  }
+
+  const FlutterOpenGLRendererConfig* open_gl_config = &config->open_gl;
+
+  if (SAFE_ACCESS(open_gl_config, make_current, nullptr) == nullptr ||
+      SAFE_ACCESS(open_gl_config, clear_current, nullptr) == nullptr ||
+      SAFE_ACCESS(open_gl_config, present, nullptr) == nullptr ||
+      SAFE_ACCESS(open_gl_config, fbo_callback, nullptr) == nullptr) {
+    return false;
+  }
+
+  return true;
+}
+
+class PlatformViewHolder {
+ public:
+  PlatformViewHolder(std::shared_ptr<shell::PlatformViewEmbedder> ptr)
+      : platform_view_(std::move(ptr)) {}
+
+  std::shared_ptr<shell::PlatformViewEmbedder> view() const {
+    return platform_view_;
+  }
+
+ private:
+  std::shared_ptr<shell::PlatformViewEmbedder> platform_view_;
+
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewHolder);
+};
+
+FlutterResult FlutterEngineRun(size_t version,
+                               const FlutterRendererConfig* config,
+                               const FlutterProjectArgs* args,
+                               void* user_data,
+                               FlutterEngine* engine_out) {
+  if (version != FLUTTER_ENGINE_VERSION) {
+    return kInvalidLibraryVersion;
+  }
+
+  if (engine_out == nullptr) {
+    return kInvalidArguments;
+  }
+
+  if (args == nullptr) {
+    return kInvalidArguments;
+  }
+
+  if (SAFE_ACCESS(args, assets_path, nullptr) == nullptr ||
+      SAFE_ACCESS(args, main_path, nullptr) == nullptr ||
+      SAFE_ACCESS(args, packages_path, nullptr) == nullptr) {
+    return kInvalidArguments;
+  }
+
+  if (!IsRendererValid(config)) {
+    return kInvalidArguments;
+  }
+
+  auto make_current =
+      [ ptr = config->open_gl.make_current, user_data ]()->bool {
+    return ptr(user_data);
+  };
+
+  auto clear_current =
+      [ ptr = config->open_gl.clear_current, user_data ]()->bool {
+    return ptr(user_data);
+  };
+
+  auto present = [ ptr = config->open_gl.present, user_data ]()->bool {
+    return ptr(user_data);
+  };
+
+  auto fbo_callback =
+      [ ptr = config->open_gl.fbo_callback, user_data ]()->intptr_t {
+    return ptr(user_data);
+  };
+
+  static std::once_flag once_shell_initialization;
+  std::call_once(once_shell_initialization, [&]() {
+    ftl::CommandLine null_command_line;
+    shell::Shell::InitStandalone(
+        ftl::CommandLine{},
+        "",  // icu data path default lookup.
+        ""   // application library not supported in JIT mode.
+    );
+  });
+
+  shell::PlatformViewEmbedder::DispatchTable table = {
+      .gl_make_current_callback = make_current,
+      .gl_clear_current_callback = clear_current,
+      .gl_present_callback = present,
+      .gl_fbo_callback = fbo_callback};
+
+  auto platform_view = std::make_shared<shell::PlatformViewEmbedder>(table);
+  platform_view->Attach();
+
+  std::string assets(args->assets_path);
+  std::string main(args->main_path);
+  std::string packages(args->packages_path);
+
+  blink::Threads::UI()->PostTask([
+    weak_engine = platform_view->engine().GetWeakPtr(),  //
+    assets = std::move(assets),                          //
+    main = std::move(main),                              //
+    packages = std::move(packages)                       //
+  ] {
+    if (auto engine = weak_engine) {
+      engine->RunBundleAndSource(assets, main, packages);
+    }
+  });
+
+  *engine_out = reinterpret_cast<FlutterEngine>(
+      new PlatformViewHolder(std::move(platform_view)));
+
+  return kSuccess;
+}
+
+FlutterResult FlutterEngineShutdown(FlutterEngine engine) {
+  if (engine == nullptr) {
+    return kInvalidArguments;
+  }
+  // TODO(chinmaygarde): This is currently unsupported since none of the mobile
+  // shells need to do this. Add support and patch this call.
+  delete reinterpret_cast<PlatformViewHolder*>(engine);
+  return kSuccess;
+}
+
+FlutterResult FlutterEngineSendWindowMetricsEvent(
+    FlutterEngine engine,
+    const FlutterWindowMetricsEvent* flutter_metrics) {
+  if (engine == nullptr || flutter_metrics == nullptr) {
+    return kInvalidArguments;
+  }
+
+  auto holder = reinterpret_cast<PlatformViewHolder*>(engine);
+
+  blink::ViewportMetrics metrics;
+
+  metrics.physical_width = SAFE_ACCESS(flutter_metrics, width, 0.0);
+  metrics.physical_height = SAFE_ACCESS(flutter_metrics, height, 0.0);
+  metrics.device_pixel_ratio = SAFE_ACCESS(flutter_metrics, pixel_ratio, 1.0);
+
+  blink::Threads::UI()->PostTask(
+      [ weak_engine = holder->view()->engine().GetWeakPtr(), metrics ] {
+        if (auto engine = weak_engine) {
+          engine->SetViewportMetrics(metrics);
+        }
+      });
+  return kSuccess;
+}
+
+inline blink::PointerData::Change ToPointerDataChange(
+    FlutterPointerPhase phase) {
+  switch (phase) {
+    case kCancel:
+      return blink::PointerData::Change::kCancel;
+    case kUp:
+      return blink::PointerData::Change::kUp;
+    case kDown:
+      return blink::PointerData::Change::kDown;
+    case kMove:
+      return blink::PointerData::Change::kMove;
+  }
+  return blink::PointerData::Change::kCancel;
+}
+
+FlutterResult FlutterEngineSendPointerEvent(FlutterEngine engine,
+                                            const FlutterPointerEvent* pointers,
+                                            size_t events_count) {
+  if (engine == nullptr || pointers == nullptr || events_count == 0) {
+    return kInvalidArguments;
+  }
+
+  auto packet = std::make_unique<blink::PointerDataPacket>(events_count);
+
+  const FlutterPointerEvent* current = pointers;
+
+  for (size_t i = 0; i < events_count; ++i) {
+    blink::PointerData pointer_data;
+    pointer_data.Clear();
+    pointer_data.time_stamp = SAFE_ACCESS(current, timestamp, 0);
+    pointer_data.change = ToPointerDataChange(
+        SAFE_ACCESS(current, phase, FlutterPointerPhase::kCancel));
+    pointer_data.kind = blink::PointerData::DeviceKind::kMouse;
+    pointer_data.physical_x = SAFE_ACCESS(current, x, 0.0);
+    pointer_data.physical_y = SAFE_ACCESS(current, y, 0.0);
+    packet->SetPointerData(i, pointer_data);
+    current = reinterpret_cast<const FlutterPointerEvent*>(
+        reinterpret_cast<const uint8_t*>(current) + current->struct_size);
+  }
+
+  blink::Threads::UI()->PostTask(ftl::MakeCopyable([
+    weak_engine = reinterpret_cast<PlatformViewHolder*>(engine)
+                      ->view()
+                      ->engine()
+                      .GetWeakPtr(),
+    packet = std::move(packet)
+  ] {
+    if (auto engine = weak_engine) {
+      engine->DispatchPointerDataPacket(*packet);
+    }
+  }));
+
+  return kSuccess;
+}

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1,0 +1,121 @@
+// Copyright 2017 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_EMBEDDER_H_
+#define FLUTTER_EMBEDDER_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#ifndef FLUTTER_EXPORT
+#define FLUTTER_EXPORT
+#endif  // FLUTTER_EXPORT
+
+#define FLUTTER_ENGINE_VERSION 1
+
+typedef enum {
+  kSuccess = 0,
+  kInvalidLibraryVersion,
+  kInvalidArguments,
+} FlutterResult;
+
+typedef enum {
+  kOpenGL,
+} FlutterRendererType;
+
+typedef struct _FlutterEngine* FlutterEngine;
+
+typedef bool (*BoolCallback)(void* /* user data */);
+typedef uint32_t (*UIntCallback)(void* /* user data */);
+
+typedef struct {
+  // The size of this struct. Must be sizeof(FlutterOpenGLRendererConfig).
+  size_t struct_size;
+  BoolCallback make_current;
+  BoolCallback clear_current;
+  BoolCallback present;
+  UIntCallback fbo_callback;
+} FlutterOpenGLRendererConfig;
+
+typedef struct {
+  FlutterRendererType type;
+  union {
+    FlutterOpenGLRendererConfig open_gl;
+  };
+} FlutterRendererConfig;
+
+typedef struct {
+  // The size of this struct. Must be sizeof(FlutterProjectArgs).
+  size_t struct_size;
+  // The path to the FLX file containing project assets. The string can be
+  // collected after the call to |FlutterEngineRun| returns. The string must be
+  // NULL terminated.
+  const char* assets_path;
+  // The path to the Dart file containing the |main| entry point. The string can
+  // be collected after the call to |FlutterEngineRun| returns. The string must
+  // be NULL terminated.
+  const char* main_path;
+  // The path to the |.packages| for the project. The string can be collected
+  // after the call to |FlutterEngineRun| returns. The string must be NULL
+  // terminated.
+  const char* packages_path;
+} FlutterProjectArgs;
+
+typedef struct {
+  // The size of this struct. Must be sizeof(FlutterWindowMetricsEvent).
+  size_t struct_size;
+  // Physical width of the window.
+  size_t width;
+  // Physical height of the window.
+  size_t height;
+  // Scale factor for the physical screen.
+  double pixel_ratio;
+} FlutterWindowMetricsEvent;
+
+typedef enum {
+  kCancel,
+  kUp,
+  kDown,
+  kMove,
+} FlutterPointerPhase;
+
+typedef struct {
+  // The size of this struct. Must be sizeof(FlutterPointerEvent).
+  size_t struct_size;
+  FlutterPointerPhase phase;
+  size_t timestamp;  // in microseconds.
+  double x;
+  double y;
+} FlutterPointerEvent;
+
+FLUTTER_EXPORT
+FlutterResult FlutterEngineRun(size_t version,
+                               const FlutterRendererConfig* config,
+                               const FlutterProjectArgs* args,
+                               void* user_data,
+                               FlutterEngine* engine_out);
+
+FLUTTER_EXPORT
+FlutterResult FlutterEngineShutdown(FlutterEngine engine);
+
+FLUTTER_EXPORT
+FlutterResult FlutterEngineSendWindowMetricsEvent(
+    FlutterEngine engine,
+    const FlutterWindowMetricsEvent* event);
+
+FLUTTER_EXPORT
+FlutterResult FlutterEngineSendPointerEvent(FlutterEngine engine,
+                                            const FlutterPointerEvent* events,
+                                            size_t events_count);
+
+#if defined(__cplusplus)
+}  // extern "C"
+#endif
+
+#endif  // FLUTTER_EMBEDDER_H_

--- a/shell/platform/embedder/embedder_include.c
+++ b/shell/platform/embedder/embedder_include.c
@@ -1,0 +1,8 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/embedder.h"
+
+// This file is only present to ensure that the public embedder header can be
+// cleanly included in a C file.

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -1,0 +1,55 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/embedder/platform_view_embedder.h"
+#include "flutter/shell/gpu/gpu_rasterizer.h"
+
+namespace shell {
+
+PlatformViewEmbedder::PlatformViewEmbedder(DispatchTable dispatch_table)
+    : PlatformView(std::make_unique<GPURasterizer>(nullptr)),
+      dispatch_table_(dispatch_table) {}
+
+PlatformViewEmbedder::~PlatformViewEmbedder() {
+  NotifyDestroyed();
+}
+
+bool PlatformViewEmbedder::GLContextMakeCurrent() {
+  return dispatch_table_.gl_make_current_callback();
+}
+
+bool PlatformViewEmbedder::GLContextClearCurrent() {
+  return dispatch_table_.gl_clear_current_callback();
+}
+
+bool PlatformViewEmbedder::GLContextPresent() {
+  return dispatch_table_.gl_present_callback();
+}
+
+intptr_t PlatformViewEmbedder::GLContextFBO() const {
+  return dispatch_table_.gl_fbo_callback();
+}
+
+bool PlatformViewEmbedder::SurfaceSupportsSRGB() const {
+  return true;
+}
+
+void PlatformViewEmbedder::Attach() {
+  CreateEngine();
+  PostAddToShellTask();
+  NotifyCreated(std::make_unique<shell::GPUSurfaceGL>(this));
+}
+
+bool PlatformViewEmbedder::ResourceContextMakeCurrent() {
+  // Unsupported.
+  return false;
+}
+
+void PlatformViewEmbedder::RunFromSource(const std::string& assets_directory,
+                                         const std::string& main,
+                                         const std::string& packages) {
+  FTL_LOG(INFO) << "Hot reloading is unsupported on this platform.";
+}
+
+}  // namespace shell

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -1,0 +1,61 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_PLATFORM_VIEW_EMBEDDER_H_
+#define FLUTTER_SHELL_PLATFORM_EMBEDDER_PLATFORM_VIEW_EMBEDDER_H_
+
+#include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/gpu/gpu_surface_gl.h"
+#include "lib/ftl/macros.h"
+
+namespace shell {
+
+class PlatformViewEmbedder : public PlatformView, public GPUSurfaceGLDelegate {
+ public:
+  struct DispatchTable {
+    std::function<bool(void)> gl_make_current_callback;
+    std::function<bool(void)> gl_clear_current_callback;
+    std::function<bool(void)> gl_present_callback;
+    std::function<intptr_t(void)> gl_fbo_callback;
+  };
+
+  PlatformViewEmbedder(DispatchTable dispatch_table);
+
+  ~PlatformViewEmbedder();
+
+  // |shell::GPUSurfaceGLDelegate|
+  bool GLContextMakeCurrent() override;
+
+  // |shell::GPUSurfaceGLDelegate|
+  bool GLContextClearCurrent() override;
+
+  // |shell::GPUSurfaceGLDelegate|
+  bool GLContextPresent() override;
+
+  // |shell::GPUSurfaceGLDelegate|
+  intptr_t GLContextFBO() const override;
+
+  // |shell::GPUSurfaceGLDelegate|
+  bool SurfaceSupportsSRGB() const override;
+
+  // |shell::PlatformView|
+  void Attach() override;
+
+  // |shell::PlatformView|
+  bool ResourceContextMakeCurrent() override;
+
+  // |shell::PlatformView|
+  void RunFromSource(const std::string& assets_directory,
+                     const std::string& main,
+                     const std::string& packages) override;
+
+ private:
+  DispatchTable dispatch_table_;
+
+  FTL_DISALLOW_COPY_AND_ASSIGN(PlatformViewEmbedder);
+};
+
+}  // namespace shell
+
+#endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_PLATFORM_VIEW_EMBEDDER_H_

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1479,6 +1479,10 @@ FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_gl.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_gl.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_software.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_software.mm
+FILE: ../../../flutter/shell/platform/embedder/embedder.cc
+FILE: ../../../flutter/shell/platform/embedder/embedder_include.c
+FILE: ../../../flutter/shell/platform/embedder/platform_view_embedder.cc
+FILE: ../../../flutter/shell/platform/embedder/platform_view_embedder.h
 FILE: ../../../flutter/vulkan/vulkan_native_surface_magma.cc
 FILE: ../../../flutter/vulkan/vulkan_native_surface_magma.h
 ----------------------------------------------------------------------------------------------------
@@ -1767,6 +1771,41 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
 ----------------------------------------------------------------------------------------------------
 Copyright 2013 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: engine
+ORIGIN: ../../../flutter/shell/platform/embedder/embedder.h + ../../../LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../flutter/shell/platform/embedder/embedder.h
+----------------------------------------------------------------------------------------------------
+Copyright 2017 The Flutter Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -9425,4 +9464,4 @@ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
-Total license count: 209
+Total license count: 210


### PR DESCRIPTION
* The Flutter engine will be shipped as a shared library.
* The engine is renderer and window toolkit agnostic.
* The simple public C API is described in `embedder.h`.
* ABI breaking changes will be indicated by changing the FLUTTER_ENGINE_VERSION.
* A simple GLFW based example of this API is available at https://gist.github.com/chinmaygarde/8abf44921f7d87f6da7bf026267c4792