### PR TITLE
Fire TextInputClient.updateEditingState on text changes (iOS)

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -196,8 +196,12 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
     [self.inputDelegate selectionDidChange:self];
   }
 
-  if (textChanged)
+  if (textChanged) {
     [self.inputDelegate textDidChange:self];
+
+    // For consistency with Android behavior, send an update to the framework.
+    [self updateEditingState];
+  }
 }
 
 #pragma mark - UIResponder Overrides


### PR DESCRIPTION
For consistency with Android, when the engine receives a
TextInput.setEditingState message from the framework, and the text has
changed, we now send a TextInputClient.updateEditingState message back
to the framework with the updated state from the engine. The framework
currently relies on this behaviour to trigger onChanged events in
certain scenarios (e.g., on tapping Paste in the selection controls).

Note: it may be more desirable for the framework to trigger the
onChanged calls without relying on the return message from the engine,
but this change ensures consistent behaviour across iOS and Android
until we've evaluated the pros/cons of such an approach.