### PR TITLE
Enable VK_GOOGLE_external_memory_magma extension on Fuchsia

### DIFF
--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -60,6 +60,9 @@ VulkanDevice::VulkanDevice(VulkanProcTable& p_vk,
 
   const char* extensions[] = {
       VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+#if OS_FUCHSIA
+      VK_GOOGLE_EXTERNAL_MEMORY_MAGMA_EXTENSION_NAME,
+#endif
   };
 
   auto enabled_layers = DeviceLayersToEnable(vk, physical_device_);


### PR DESCRIPTION
Newer version of the vulkan validation layer check that this
extension is enabled before allowing vkExportDeviceMemoryMAGMA.

This depends on https://fuchsia-review.googlesource.com/#/c/third_party/mesa/+/52407/ in Fuchsia, which was just committed.