### PR TITLE
Fix crash when removing stories.

### DIFF
--- a/flow/export_node.cc
+++ b/flow/export_node.cc
@@ -4,25 +4,57 @@
 
 #include "flutter/flow/export_node.h"
 
+#include "flutter/common/threads.h"
+#include "lib/ftl/functional/make_copyable.h"
+
 namespace flow {
+
+ExportNodeHolder::ExportNodeHolder(
+    ftl::RefPtr<fidl::dart::Handle> export_token_handle)
+    : export_node_(std::make_unique<ExportNode>(export_token_handle)) {
+  ASSERT_IS_UI_THREAD;
+}
+
+void ExportNodeHolder::Bind(SceneUpdateContext& context,
+                            mozart::client::ContainerNode& container,
+                            const SkPoint& offset,
+                            bool hit_testable) {
+  ASSERT_IS_GPU_THREAD;
+  export_node_->Bind(context, container, offset, hit_testable);
+}
+
+ExportNodeHolder::~ExportNodeHolder() {
+  ASSERT_IS_UI_THREAD;
+  blink::Threads::Gpu()->PostTask(
+      ftl::MakeCopyable([export_node = std::move(export_node_)]() {
+        export_node->Dispose(true);
+      }));
+}
 
 ExportNode::ExportNode(ftl::RefPtr<fidl::dart::Handle> export_token_handle)
     : export_token_(export_token_handle->ReleaseHandle()) {}
 
 ExportNode::~ExportNode() {
-  // TODO(MZ-190): Ensure the node is properly unregistered on the rasterizer
-  // thread by attaching it to the update context in some way.
+  // Ensure that we properly released the node.
+  FTL_DCHECK(!node_);
+  FTL_DCHECK(scene_update_context_ == nullptr);
 }
 
 void ExportNode::Bind(SceneUpdateContext& context,
                       mozart::client::ContainerNode& container,
                       const SkPoint& offset,
                       bool hit_testable) {
-  ftl::MutexLocker lock(&mutex_);
+  ASSERT_IS_GPU_THREAD;
 
   if (export_token_) {
+    // Happens first time we bind.
     node_.reset(new mozart::client::EntityNode(container.session()));
     node_->Export(std::move(export_token_));
+
+    // Add ourselves to the context so it can call Dispose() on us if the Mozart
+    // session is closed.
+    context.AddExportNode(this);
+    scene_update_context_ = &context;
   }
 
   if (node_) {
@@ -32,6 +64,26 @@ void ExportNode::Bind(SceneUpdateContext& context,
                                   ? mozart2::HitTestBehavior::kDefault
                                   : mozart2::HitTestBehavior::kSuppress);
   }
+}
+
+void ExportNode::Dispose(bool remove_from_scene_update_context) {
+  ASSERT_IS_GPU_THREAD;
+
+  // If scene_update_context_ is set, then we should still have a node left to
+  // dereference.
+  // If scene_update_context_ is null, then either:
+  // 1. A node was never created, or
+  // 2. A node was created but was already dereferenced (i.e. Dispose has
+  // already been called).
+  FTL_DCHECK(scene_update_context_ || !node_);
+
+  if (remove_from_scene_update_context && scene_update_context_) {
+    scene_update_context_->RemoveExportNode(this);
+  }
+
+  scene_update_context_ = nullptr;
+  export_token_.reset();
+  node_ = nullptr;
 }
 
 }  // namespace flow

--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -26,8 +26,9 @@ void ChildSceneLayer::UpdateScene(SceneUpdateContext& context) {
   // or whether we should leave this up to the Flutter application to decide.
   // In some situations, it might be useful to allow children to draw
   // outside of their layout bounds.
-  if (export_node_) {
-    context.AddChildScene(export_node_.get(), offset_, hit_testable_);
+  if (export_node_holder_) {
+    context.AddChildScene(export_node_holder_->export_node(), offset_,
+                          hit_testable_);
   }
 }
 

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -10,6 +10,7 @@
 
 namespace flow {
 
+// Layer that represents an embedded child.
 class ChildSceneLayer : public Layer {
  public:
   ChildSceneLayer();
@@ -19,8 +20,9 @@ class ChildSceneLayer : public Layer {
 
   void set_size(const SkSize& size) { size_ = size; }
 
-  void set_export_node(ftl::RefPtr<ExportNode> export_node) {
-    export_node_ = std::move(export_node);
+  void set_export_node_holder(
+      ftl::RefPtr<ExportNodeHolder> export_node_holder) {
+    export_node_holder_ = std::move(export_node_holder);
   }
 
   void set_hit_testable(bool hit_testable) { hit_testable_ = hit_testable; }
@@ -34,7 +36,7 @@ class ChildSceneLayer : public Layer {
  private:
   SkPoint offset_;
   SkSize size_;
-  ftl::RefPtr<ExportNode> export_node_;
+  ftl::RefPtr<ExportNodeHolder> export_node_holder_;
   bool hit_testable_ = true;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(ChildSceneLayer);

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -35,6 +35,8 @@ namespace flow {
 
 class ContainerLayer;
 
+// Represents a single composited layer. Created on the UI thread but then
+// subquently used on the Rasterizer thread.
 class Layer {
  public:
   Layer();

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -19,6 +19,7 @@
 namespace flow {
 
 class Layer;
+class ExportNodeHolder;
 class ExportNode;
 
 class SceneUpdateContext {
@@ -123,6 +124,14 @@ class SceneUpdateContext {
                      SkPoint offset,
                      bool hit_testable);
 
+  // Adds reference to |export_node| so we can call export_node->Dispose() in
+  // our destructor. Caller is responsible for calling RemoveExportNode() before
+  // |export_node| is destroyed.
+  void AddExportNode(ExportNode* export_node);
+
+  // Removes reference to |export_node|.
+  void RemoveExportNode(ExportNode* export_node);
+
   // TODO(chinmaygarde): This method must submit the surfaces as soon as paint
   // tasks are done. However, given that there is no support currently for
   // Vulkan semaphores, we need to submit all the surfaces after an explicit
@@ -173,6 +182,9 @@ class SceneUpdateContext {
   mozart2::MetricsPtr metrics_;
 
   std::vector<PaintTask> paint_tasks_;
+
+  // Save ExportNodes so we can dispose them in our destructor.
+  std::set<ExportNode*> export_nodes_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(SceneUpdateContext);
 };

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -239,7 +239,7 @@ void SceneBuilder::addChildScene(double dx,
   std::unique_ptr<flow::ChildSceneLayer> layer(new flow::ChildSceneLayer());
   layer->set_offset(SkPoint::Make(dx, dy));
   layer->set_size(SkSize::Make(width, height));
-  layer->set_export_node(sceneHost->exportNode());
+  layer->set_export_node_holder(sceneHost->export_node_holder());
   layer->set_hit_testable(hitTestable);
   m_currentLayer->Add(std::move(layer));
 #endif

--- a/lib/ui/compositing/scene_host.cc
+++ b/lib/ui/compositing/scene_host.cc
@@ -37,7 +37,8 @@ ftl::RefPtr<SceneHost> SceneHost::create(
 }
 
 SceneHost::SceneHost(ftl::RefPtr<fidl::dart::Handle> export_token_handle) {
-  export_node_ = ftl::MakeRefCounted<flow::ExportNode>(export_token_handle);
+  export_node_holder_ =
+      ftl::MakeRefCounted<flow::ExportNodeHolder>(export_token_handle);
 }
 #else
 ftl::RefPtr<SceneHost> SceneHost::create(Dart_Handle export_token_handle) {

--- a/lib/ui/compositing/scene_host.h
+++ b/lib/ui/compositing/scene_host.h
@@ -35,8 +35,8 @@ class SceneHost : public ftl::RefCountedThreadSafe<SceneHost>,
   ~SceneHost() override;
 
 #if defined(OS_FUCHSIA)
-  const ftl::RefPtr<flow::ExportNode>& exportNode() const {
-    return export_node_;
+  const ftl::RefPtr<flow::ExportNodeHolder>& export_node_holder() const {
+    return export_node_holder_;
   }
 #endif
 
@@ -46,7 +46,7 @@ class SceneHost : public ftl::RefCountedThreadSafe<SceneHost>,
 
  private:
 #if defined(OS_FUCHSIA)
-  ftl::RefPtr<flow::ExportNode> export_node_;
+  ftl::RefPtr<flow::ExportNodeHolder> export_node_holder_;
 #endif
 
 #if defined(OS_FUCHSIA)


### PR DESCRIPTION
Ensure that a Mozart EntityNode (that corresponds
to an ExportNode) is always released on the
Rasterizer thread.

MZ-259