### PR TITLE
Revert "Pass TextDirection to ParagraphBuilder."

### DIFF
--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -51,17 +51,15 @@ const int tsHeightMask = 1 << tsHeightIndex;
 // ParagraphStyle
 
 const int psTextAlignIndex = 1;
-const int psTextDirectionIndex = 2;
-const int psFontWeightIndex = 3;
-const int psFontStyleIndex = 4;
-const int psMaxLinesIndex = 5;
-const int psFontFamilyIndex = 6;
-const int psFontSizeIndex = 7;
-const int psLineHeightIndex = 8;
-const int psEllipsisIndex = 9;
+const int psFontWeightIndex = 2;
+const int psFontStyleIndex = 3;
+const int psMaxLinesIndex = 4;
+const int psFontFamilyIndex = 5;
+const int psFontSizeIndex = 6;
+const int psLineHeightIndex = 7;
+const int psEllipsisIndex = 8;
 
 const int psTextAlignMask = 1 << psTextAlignIndex;
-const int psTextDirectionMask = 1 << psTextDirectionIndex;
 const int psFontWeightMask = 1 << psFontWeightIndex;
 const int psFontStyleMask = 1 << psFontStyleIndex;
 const int psMaxLinesMask = 1 << psMaxLinesIndex;
@@ -114,9 +112,6 @@ PassRefPtr<RenderStyle> decodeParagraphStyle(
 
   if (mask & psTextAlignMask)
     style->setTextAlign(static_cast<ETextAlign>(encoded[psTextAlignIndex]));
-
-  if (mask & psTextDirectionMask)
-    style->setDirection(static_cast<TextDirection>(encoded[psTextDirectionIndex]));
 
   if (mask & (psFontWeightMask | psFontStyleMask | psFontFamilyMask |
               psFontSizeMask)) {

--- a/sky/engine/core/rendering/style/RenderStyleConstants.h
+++ b/sky/engine/core/rendering/style/RenderStyleConstants.h
@@ -149,7 +149,7 @@ enum EWhiteSpace {
     NORMAL, PRE, PRE_WRAP, PRE_LINE, NOWRAP, KHTML_NOWRAP
 };
 
-// The order of this enum must match the order of the values in dart:ui's TextAlign.
+// The order of this enum must match the order of the text align values in CSSValueKeywords.in.
 enum ETextAlign {
     LEFT, RIGHT, CENTER, JUSTIFY, TASTART, TAEND,
 };

--- a/sky/engine/platform/text/TextDirection.h
+++ b/sky/engine/platform/text/TextDirection.h
@@ -28,7 +28,6 @@
 
 namespace blink {
 
-// The order of this enum must match the order of the values in dart:ui's TextDirection.
 enum TextDirection { RTL, LTR };
 
 inline bool isLeftToRightDirection(TextDirection direction) { return direction == LTR; }


### PR DESCRIPTION
Reverts flutter/engine#4001

I'm temporarily reverting this because the framework isn't yet ready for it (I forgot that the analyzer would complain about the missing case statements).