### PR TITLE
Update ICU to ToT and ensure that slimmed down versions of data files are shipped on the mobile platforms.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -113,7 +113,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '4c89f3144ad56ff2de492700cb607d73e52aa8b2',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'baaae21dbb12b3d75c99498de79d503989d17e79',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -154,7 +154,7 @@ deps = {
    Var('chromium_git') + '/chromium/src/ios.git' + '@' + Var('ios_tools_revision'),
 
   'src/third_party/icu':
-   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'c3f79166089e5360c09e3053fce50e6e296c3204',
+   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + '08cb956852a5ccdba7f9c941728bb833529ba3c6',
 
   'src/dart':
    Var('chromium_git') + '/external/github.com/dart-lang/sdk.git' + '@' + Var('dart_revision'),

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -130,7 +130,7 @@ copy("flutter_shell_assets") {
   visibility = [ ":*" ]
 
   sources = [
-    "$root_build_dir/icudtl.dat",
+    "//third_party/icu/android/icudtl.dat",
   ]
 
   outputs = [

--- a/shell/platform/darwin/desktop/BUILD.gn
+++ b/shell/platform/darwin/desktop/BUILD.gn
@@ -48,11 +48,7 @@ if (!is_fuchsia_host) {
 
   resource_copy_mac("mac_desktop_resources") {
     app_name = "FlutterTester"
-    if (is_fuchsia_host) {
-      resources = [ "//third_party/icu/common/icudtl.dat" ]
-    } else {
-      resources = [ "//third_party/icu/android/icudtl.dat" ]
-    }
+    resources = [ "//third_party/icu/common/icudtl.dat" ]
     bundle_directory = "."
   }
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -178,7 +178,7 @@ copy("framework_icu") {
   visibility = [ ":*" ]
   set_sources_assignment_filter([])
   sources = [
-    "//third_party/icu/android/icudtl.dat",
+    "//third_party/icu/ios/icudtl.dat",
   ]
   set_sources_assignment_filter(sources_assignment_filter)
   outputs = [

--- a/sky/engine/wtf/text/StringImpl.cpp
+++ b/sky/engine/wtf/text/StringImpl.cpp
@@ -765,7 +765,7 @@ PassRefPtr<StringImpl> StringImpl::upper(const AtomicString& localeIdentifier)
     icu::UnicodeString target(false, source16, length);
     translit->transliterate(target);
 
-    return create(target.getBuffer(), target.length());
+    return create(reinterpret_cast<const UChar*>(target.getBuffer()), target.length());
 }
 
 PassRefPtr<StringImpl> StringImpl::fill(UChar character)


### PR DESCRIPTION
This reduces the size of the ICU data files from 10.3 MB to 6.6 MB (uncompressed). Also allows us to remove version specific hacks from libTXT and dependencies.