### PR TITLE
Remove dependency from VM isolate name convention

### DIFF
--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -34,6 +34,7 @@ UIDartState* UIDartState::CreateForChildIsolate() {
 }
 
 void UIDartState::DidSetIsolate() {
+  FTL_DCHECK(!debug_name_prefix_.empty());
   main_port_ = Dart_GetMainPortId();
   std::ostringstream debug_name;
   debug_name << debug_name_prefix_ << "$main-" << main_port_;

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -35,11 +35,9 @@ UIDartState* UIDartState::CreateForChildIsolate() {
 
 void UIDartState::DidSetIsolate() {
   main_port_ = Dart_GetMainPortId();
-  tonic::DartApiScope api_scope;
-  Dart_Handle debug_name = Dart_DebugName();
-  if (Dart_IsString(debug_name)) {
-    debug_name_ = tonic::StdStringFromDart(debug_name);
-  }
+  std::ostringstream debug_name;
+  debug_name << debug_name_prefix_ << "$main-" << main_port_;
+  debug_name_ = debug_name.str();
 }
 
 UIDartState* UIDartState::Current() {
@@ -50,8 +48,13 @@ void UIDartState::set_font_selector(PassRefPtr<FontSelector> selector) {
   font_selector_ = selector;
 }
 
+
 PassRefPtr<FontSelector> UIDartState::font_selector() {
   return font_selector_;
+}
+
+void UIDartState::set_debug_name_prefix(const std::string& debug_name_prefix) {
+  debug_name_prefix_ = debug_name_prefix;
 }
 
 }  // namespace blink

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -39,6 +39,7 @@ class UIDartState : public tonic::DartState {
   const std::string& debug_name() const { return debug_name_; }
   Window* window() const { return window_.get(); }
 
+  void set_debug_name_prefix(const std::string& debug_name_prefix);
   void set_font_selector(PassRefPtr<FontSelector> selector);
   PassRefPtr<FontSelector> font_selector();
 
@@ -47,6 +48,7 @@ class UIDartState : public tonic::DartState {
 
   IsolateClient* isolate_client_;
   Dart_Port main_port_;
+  std::string debug_name_prefix_;
   std::string debug_name_;
   std::unique_ptr<Window> window_;
   RefPtr<FontSelector> font_selector_;

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -196,6 +196,7 @@ void DartController::CreateIsolateFor(const std::string& script_uri,
 
   Dart_SetShouldPauseOnStart(Settings::Get().start_paused);
 
+  ui_dart_state_->set_debug_name_prefix(script_uri);
   ui_dart_state_->SetIsolate(isolate);
   FTL_CHECK(!LogIfError(
       Dart_SetLibraryTagHandler(tonic::DartState::HandleLibraryTag)));


### PR DESCRIPTION
Dart_DebugName should be used just to make debug outputs more readable.

We remove the dependency from this API and form the UIDartState debug
name in the engine using the predefined format:
```
<script_uri>$main-<main_port>
```
which was created in:

https://github.com/dart-lang/sdk/blob/master/runtime/vm/isolate.cc#L1100
https://github.com/dart-lang/sdk/blob/eac18a324c168de509f056a2bfcd3cdb56a312e4/runtime/vm/dart_api_impl.cc#L1101

This will allow the engine to change the format of the isolate name
without breaking the engine.
Related https://codereview.chromium.org/3004563003/