### PR TITLE
Update gn path for FIDL move

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -36,7 +36,7 @@ copy("generate_dart_ui") {
 if (is_fuchsia) {
   action("generate_package_map") {
     dart_deps = [
-      "//lib/fidl/dart:dart",
+      "//garnet/public/lib/fidl/dart",
       "//lib/flutter/packages/flutter:flutter",
       "//lib/widgets/packages/widgets:lib.widgets",
       "//application/lib/app/dart:dart",


### PR DESCRIPTION
We're moving the FIDL library to a new path. This patch updates the GN
dependency.