### PR TITLE
Remove manual checks for arguments correctly handled by u_hasBinaryProperty.

### DIFF
--- a/third_party/txt/src/minikin/Emoji.cpp
+++ b/third_party/txt/src/minikin/Emoji.cpp
@@ -18,27 +18,11 @@
 
 namespace minikin {
 
-bool isNewEmoji(uint32_t c) {
-  // Emoji characters new in Unicode emoji 5.0.
-  // From http://www.unicode.org/Public/emoji/5.0/emoji-data.txt
-  // TODO: Remove once emoji-data.text 5.0 is in ICU or update to 6.0.
-  if (c < 0x1F6F7 || c > 0x1F9E6) {
-    // Optimization for characters outside the new emoji range.
-    return false;
-  }
-  return (0x1F6F7 <= c && c <= 0x1F6F8) || c == 0x1F91F ||
-         (0x1F928 <= c && c <= 0x1F92F) || (0x1F931 <= c && c <= 0x1F932) ||
-         c == 0x1F94C || (0x1F95F <= c && c <= 0x1F96B) ||
-         (0x1F992 <= c && c <= 0x1F997) || (0x1F9D0 <= c && c <= 0x1F9E6);
-}
-
 bool isEmoji(uint32_t c) {
-  return isNewEmoji(c) || u_hasBinaryProperty(c, UCHAR_EMOJI);
+  return u_hasBinaryProperty(c, UCHAR_EMOJI);
 }
 
 bool isEmojiModifier(uint32_t c) {
-  // Emoji modifier are not expected to change, so there's a small change we
-  // need to customize this.
   return u_hasBinaryProperty(c, UCHAR_EMOJI_MODIFIER);
 }
 
@@ -49,23 +33,11 @@ bool isEmojiBase(uint32_t c) {
   if (c == 0x1F91D || c == 0x1F93C) {
     return true;
   }
-  // Emoji Modifier Base characters new in Unicode emoji 5.0.
-  // From http://www.unicode.org/Public/emoji/5.0/emoji-data.txt
-  // TODO: Remove once emoji-data.text 5.0 is in ICU or update to 6.0.
-  if (c == 0x1F91F || (0x1F931 <= c && c <= 0x1F932) ||
-      (0x1F9D1 <= c && c <= 0x1F9DD)) {
-    return true;
-  }
   return u_hasBinaryProperty(c, UCHAR_EMOJI_MODIFIER_BASE);
 }
 
 UCharDirection emojiBidiOverride(const void* /* context */, UChar32 c) {
-  if (isNewEmoji(c)) {
-    // All new emoji characters in Unicode 10.0 are of the bidi class ON.
-    return U_OTHER_NEUTRAL;
-  } else {
-    return u_charDirection(c);
-  }
+  return u_charDirection(c);
 }
 
 }  // namespace minikin


### PR DESCRIPTION
After the DEPS updates, we use Unicode 9.0 and so these workarounds are not necessary. I re-ran all the EmojiTests to verify.