### PR TITLE
Use GrBackendRenderTarget rather than the deprecated GrBackendRenderTargetDesc.

### DIFF
--- a/content_handler/vulkan_surface.cc
+++ b/content_handler/vulkan_surface.cc
@@ -204,24 +204,17 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrContext> context,
       .fLevelCount = image_create_info.mipLevels,
   };
 
-  GrBackendRenderTargetDesc sk_render_target_desc;
-  sk_render_target_desc.fWidth = size.width();
-  sk_render_target_desc.fHeight = size.height();
-  sk_render_target_desc.fConfig = kSBGRA_8888_GrPixelConfig;
-  sk_render_target_desc.fOrigin = kTopLeft_GrSurfaceOrigin;
-  sk_render_target_desc.fSampleCnt = 0;
-  sk_render_target_desc.fStencilBits = 0;
-  sk_render_target_desc.fRenderTargetHandle =
-      reinterpret_cast<GrBackendObject>(&image_info);
+  GrBackendRenderTarget sk_render_target(size.width(), size.height(), 0, 0, image_info);
 
   SkSurfaceProps sk_surface_props(
       SkSurfaceProps::InitType::kLegacyFontHost_InitType);
 
   auto sk_surface =
-      SkSurface::MakeFromBackendRenderTarget(context.get(),          //
-                                             sk_render_target_desc,  //
-                                             nullptr,                //
-                                             &sk_surface_props       //
+      SkSurface::MakeFromBackendRenderTarget(context.get(),            //
+                                             sk_render_target,         //
+                                             kTopLeft_GrSurfaceOrigin  //
+                                             nullptr,                  //
+                                             &sk_surface_props         //
                                              );
 
   if (!sk_surface || sk_surface->getCanvas() == nullptr) {

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -9,6 +9,7 @@
 #include "flutter/vulkan/vulkan_image.h"
 #include "flutter/vulkan/vulkan_proc_table.h"
 #include "flutter/vulkan/vulkan_surface.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
 #include "third_party/skia/src/gpu/vk/GrVkUtil.h"
 
@@ -205,26 +206,18 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(GrContext* gr_context,
       .fLevelCount = 1,
   };
 
-  GrBackendRenderTargetDesc desc;
-  desc.fWidth = size.fWidth;
-  desc.fHeight = size.fHeight;
-  desc.fConfig = pixel_config;
-  desc.fOrigin = kTopLeft_GrSurfaceOrigin;
-
   // TODO(chinmaygarde): Setup the stencil buffer and the sampleCnt.
-  desc.fSampleCnt = 0;
-  desc.fStencilBits = 0;
-
-  desc.fRenderTargetHandle = reinterpret_cast<GrBackendObject>(&image_info);
-
+  GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight, 0, 0,
+                                              image_info);
   SkSurfaceProps props(SkSurfaceProps::InitType::kLegacyFontHost_InitType);
 
   return SkSurface::MakeFromBackendRenderTarget(
-      gr_context,  // context
-      desc,        // backend render target description
+      gr_context,             // context
+      backend_render_target,  // backend render target
+      kTopLeft_GrSurfaceOrigin,
       SkColorSpaceFromVkFormat(surface_format_.format),  // colorspace
       &props                                             // surface properties
-      );
+  );
 }
 
 bool VulkanSwapchain::CreateSwapchainImages(GrContext* skia_context) {


### PR DESCRIPTION
This patch is an updated version of https://github.com/flutter/engine/pull/4021 submitted by @bsalomon.