### PR TITLE
Roll lib/tonic dependency forward

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -125,7 +125,7 @@ deps = {
    Var('fuchsia_git') + '/ftl' + '@' + 'bd6e605513008bc074d0e8022446cea8a06a3ce7',
 
   'src/lib/tonic':
-   Var('fuchsia_git') + '/tonic' + '@' + '32e37b1478ea334ee215bd909cd35b85a6197c65',
+   Var('fuchsia_git') + '/tonic' + '@' + '7a9263c95612e04ae8d066fa73b56dc938b5a37b',
 
   'src/lib/zip':
    Var('fuchsia_git') + '/zip' + '@' + '92dc87ca645fe8e9f5151ef6dac86d8311a7222f',

--- a/travis/licenses_golden/licenses_lib
+++ b/travis/licenses_golden/licenses_lib
@@ -1,4 +1,4 @@
-Signature: e508b1d82a2cef89ddc6e9fd90843b0a
+Signature: ae15db9c182e88d1e8b76e7fb41c34e1
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
This is to pick up the [fix](https://fuchsia.googlesource.com/tonic/+/7a9263c95612e04ae8d066fa73b56dc938b5a37b) for kernel-based Dart hot reload.