### PR TITLE
Rename Mozart SceneManager to "Scenic".

### DIFF
--- a/content_handler/BUILD.gn
+++ b/content_handler/BUILD.gn
@@ -46,7 +46,7 @@ template("flutter_content_handler") {
              "//application/lib/svc",
              "//apps/icu_data/lib",
              "//apps/mozart/lib/flutter/sdk_ext",
-             "//apps/mozart/lib/scene:client",
+             "//apps/mozart/lib/scenic:client",
              "//apps/mozart/services/input",
              "//apps/mozart/services/views",
              "//apps/tracing/lib/trace:provider",

--- a/content_handler/rasterizer.h
+++ b/content_handler/rasterizer.h
@@ -7,7 +7,7 @@
 
 #include <memory>
 
-#include "apps/mozart/services/scene/session.fidl.h"
+#include "apps/mozart/services/scenic/session.fidl.h"
 #include "flutter/flow/layers/layer_tree.h"
 #include "lib/ftl/functional/closure.h"
 #include "lib/ftl/macros.h"
@@ -22,7 +22,7 @@ class Rasterizer {
   static std::unique_ptr<Rasterizer> Create();
 
   virtual void SetScene(
-      fidl::InterfaceHandle<mozart2::SceneManager> scene_manager,
+      fidl::InterfaceHandle<scenic::SceneManager> scene_manager,
       mx::eventpair import_token,
       ftl::Closure metrics_changed_callback) = 0;
 

--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -206,7 +206,7 @@ void RuntimeHolder::CreateView(
   input_connection_->SetEventListener(std::move(input_listener));
 
   // Setup the session.
-  fidl::InterfaceHandle<mozart2::SceneManager> scene_manager;
+  fidl::InterfaceHandle<scenic::SceneManager> scene_manager;
   view_manager_->GetSceneManager(scene_manager.NewRequest());
 
   blink::Threads::Gpu()->PostTask(ftl::MakeCopyable([

--- a/content_handler/session_connection.cc
+++ b/content_handler/session_connection.cc
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 #include "flutter/content_handler/session_connection.h"
-#include "apps/mozart/lib/scene/session_helpers.h"
+#include "apps/mozart/lib/scenic/fidl_helpers.h"
 
 namespace flutter_runner {
 
-SessionConnection::SessionConnection(mozart2::SceneManagerPtr scene_manager,
+SessionConnection::SessionConnection(scenic::SceneManagerPtr scene_manager,
                                      mx::eventpair import_token)
     : session_(scene_manager.get()),
       root_node_(&session_),
@@ -18,12 +18,11 @@ SessionConnection::SessionConnection(mozart2::SceneManagerPtr scene_manager,
   session_.set_connection_error_handler(
       std::bind(&SessionConnection::OnSessionError, this));
   session_.set_event_handler(std::bind(&SessionConnection::OnSessionEvents,
-                                       this, std::placeholders::_1,
-                                       std::placeholders::_2));
+                                       this, std::placeholders::_1));
 
   root_node_.Bind(std::move(import_token));
-  root_node_.SetEventMask(mozart2::kMetricsEventMask);
-  session_.Present(0, [](mozart2::PresentationInfoPtr info) {});
+  root_node_.SetEventMask(scenic::kMetricsEventMask);
+  session_.Present(0, [](scenic::PresentationInfoPtr info) {});
 
   present_callback_ =
       std::bind(&SessionConnection::OnPresent, this, std::placeholders::_1);
@@ -39,9 +38,8 @@ void SessionConnection::OnSessionError() {
   FTL_CHECK(false) << "Session connection was terminated.";
 }
 
-void SessionConnection::OnSessionEvents(uint64_t presentation_time,
-                                        fidl::Array<mozart2::EventPtr> events) {
-  mozart2::MetricsPtr new_metrics;
+void SessionConnection::OnSessionEvents(fidl::Array<scenic::EventPtr> events) {
+  scenic::MetricsPtr new_metrics;
   for (const auto& event : events) {
     if (event->is_metrics() &&
         event->get_metrics()->node_id == root_node_.id()) {
@@ -69,7 +67,7 @@ void SessionConnection::Present(flow::CompositorContext::ScopedFrame& frame,
   // tasks.
   session_.Present(0,                 // presentation_time. Placeholder for now.
                    present_callback_  // callback
-                   );
+  );
 
   // Execute paint tasks and signal fences.
   auto surfaces_to_submit = scene_update_context_.ExecutePaintTasks(frame);
@@ -82,7 +80,7 @@ void SessionConnection::Present(flow::CompositorContext::ScopedFrame& frame,
   EnqueueClearOps();
 }
 
-void SessionConnection::OnPresent(mozart2::PresentationInfoPtr info) {
+void SessionConnection::OnPresent(scenic::PresentationInfoPtr info) {
   ASSERT_IS_GPU_THREAD;
   auto callback = pending_on_present_callback_;
   pending_on_present_callback_ = nullptr;
@@ -93,7 +91,7 @@ void SessionConnection::EnqueueClearOps() {
   ASSERT_IS_GPU_THREAD;
   // We are going to be sending down a fresh node hierarchy every frame. So just
   // enqueue a detach op on the imported root node.
-  session_.Enqueue(mozart::NewDetachChildrenOp(root_node_.id()));
+  session_.Enqueue(scenic_lib::NewDetachChildrenOp(root_node_.id()));
 }
 
 }  // namespace flutter_runner

--- a/content_handler/session_connection.h
+++ b/content_handler/session_connection.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_CONTENT_HANDLER_SESSION_CONNECTION_H_
 #define FLUTTER_CONTENT_HANDLER_SESSION_CONNECTION_H_
 
-#include "apps/mozart/lib/scene/client/resources.h"
-#include "apps/mozart/lib/scene/client/session.h"
+#include "apps/mozart/lib/scenic/client/resources.h"
+#include "apps/mozart/lib/scenic/client/session.h"
 #include "flutter/common/threads.h"
 #include "flutter/content_handler/vulkan_surface_producer.h"
 #include "flutter/flow/compositor_context.h"
@@ -20,7 +20,7 @@ namespace flutter_runner {
 
 class SessionConnection {
  public:
-  SessionConnection(mozart2::SceneManagerPtr scene_manager,
+  SessionConnection(scenic::SceneManagerPtr scene_manager,
                     mx::eventpair import_token);
 
   ~SessionConnection();
@@ -35,7 +35,7 @@ class SessionConnection {
     return scene_update_context_;
   }
 
-  mozart::client::ImportNode& root_node() {
+  scenic_lib::ImportNode& root_node() {
     ASSERT_IS_GPU_THREAD;
     return root_node_;
   }
@@ -44,21 +44,20 @@ class SessionConnection {
                ftl::Closure on_present_callback);
 
  private:
-  mozart::client::Session session_;
-  mozart::client::ImportNode root_node_;
-  mozart::client::Session::PresentCallback present_callback_;
+  scenic_lib::Session session_;
+  scenic_lib::ImportNode root_node_;
+  scenic_lib::Session::PresentCallback present_callback_;
   ftl::Closure pending_on_present_callback_;
   std::unique_ptr<VulkanSurfaceProducer> surface_producer_;
   flow::SceneUpdateContext scene_update_context_;
   ftl::Closure metrics_changed_callback_;
 
   void OnSessionError();
-  void OnSessionEvents(uint64_t presentation_time,
-                       fidl::Array<mozart2::EventPtr> events);
+  void OnSessionEvents(fidl::Array<scenic::EventPtr> events);
 
   void EnqueueClearOps();
 
-  void OnPresent(mozart2::PresentationInfoPtr info);
+  void OnPresent(scenic::PresentationInfoPtr info);
 
   FTL_DISALLOW_COPY_AND_ASSIGN(SessionConnection);
 };

--- a/content_handler/vulkan_rasterizer.cc
+++ b/content_handler/vulkan_rasterizer.cc
@@ -54,13 +54,13 @@ bool VulkanRasterizer::IsValid() const {
 }
 
 void VulkanRasterizer::SetScene(
-    fidl::InterfaceHandle<mozart2::SceneManager> scene_manager,
+    fidl::InterfaceHandle<scenic::SceneManager> scene_manager,
     mx::eventpair import_token,
     ftl::Closure metrics_changed_callback) {
   ASSERT_IS_GPU_THREAD;
   FTL_DCHECK(valid_ && !session_connection_);
   session_connection_ = std::make_unique<SessionConnection>(
-      mozart2::SceneManagerPtr::Create(std::move(scene_manager)),
+      scenic::SceneManagerPtr::Create(std::move(scene_manager)),
       std::move(import_token));
   session_connection_->set_metrics_changed_callback(
       std::move(metrics_changed_callback));

--- a/content_handler/vulkan_rasterizer.h
+++ b/content_handler/vulkan_rasterizer.h
@@ -22,7 +22,7 @@ class VulkanRasterizer : public Rasterizer {
 
   bool IsValid() const;
 
-  void SetScene(fidl::InterfaceHandle<mozart2::SceneManager> scene_manager,
+  void SetScene(fidl::InterfaceHandle<scenic::SceneManager> scene_manager,
                 mx::eventpair import_token,
                 ftl::Closure metrics_changed_callback) override;
 

--- a/content_handler/vulkan_surface.cc
+++ b/content_handler/vulkan_surface.cc
@@ -14,7 +14,7 @@ namespace flutter_runner {
 VulkanSurface::VulkanSurface(vulkan::VulkanProcTable& p_vk,
                              sk_sp<GrContext> context,
                              sk_sp<GrVkBackendContext> backend_context,
-                             mozart::client::Session* session,
+                             scenic_lib::Session* session,
                              const SkISize& size)
     : vk_(p_vk),
       backend_context_(std::move(backend_context)),
@@ -226,30 +226,30 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrContext> context,
   return true;
 }
 
-bool VulkanSurface::PushSessionImageSetupOps(mozart::client::Session* session,
+bool VulkanSurface::PushSessionImageSetupOps(scenic_lib::Session* session,
                                              mx::vmo exported_vmo) {
   if (sk_surface_ == nullptr) {
     return false;
   }
 
-  mozart::client::Memory memory(session, std::move(exported_vmo),
-                                mozart2::MemoryType::VK_DEVICE_MEMORY);
+  scenic_lib::Memory memory(session, std::move(exported_vmo),
+                                scenic::MemoryType::VK_DEVICE_MEMORY);
 
-  auto image_info = mozart2::ImageInfo::New();
+  auto image_info = scenic::ImageInfo::New();
   image_info->width = sk_surface_->width();
   image_info->height = sk_surface_->height();
   image_info->stride = 4 * sk_surface_->width();
-  image_info->pixel_format = mozart2::ImageInfo::PixelFormat::BGRA_8;
-  image_info->color_space = mozart2::ImageInfo::ColorSpace::SRGB;
-  image_info->tiling = mozart2::ImageInfo::Tiling::LINEAR;
+  image_info->pixel_format = scenic::ImageInfo::PixelFormat::BGRA_8;
+  image_info->color_space = scenic::ImageInfo::ColorSpace::SRGB;
+  image_info->tiling = scenic::ImageInfo::Tiling::LINEAR;
 
-  session_image_ = std::make_unique<mozart::client::Image>(
+  session_image_ = std::make_unique<scenic_lib::Image>(
       memory, 0 /* memory offset */, std::move(image_info));
 
   return session_image_ != nullptr;
 }
 
-mozart::client::Image* VulkanSurface::GetImage() {
+scenic_lib::Image* VulkanSurface::GetImage() {
   ASSERT_IS_GPU_THREAD;
   if (!valid_) {
     return 0;

--- a/content_handler/vulkan_surface.h
+++ b/content_handler/vulkan_surface.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <memory>
-#include "apps/mozart/lib/scene/client/resources.h"
+#include "apps/mozart/lib/scenic/client/resources.h"
 #include "flutter/flow/scene_update_context.h"
 #include "flutter/vulkan/vulkan_handle.h"
 #include "flutter/vulkan/vulkan_proc_table.h"
@@ -25,7 +25,7 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface,
   VulkanSurface(vulkan::VulkanProcTable& p_vk,
                 sk_sp<GrContext> context,
                 sk_sp<GrVkBackendContext> backend_context,
-                mozart::client::Session* session,
+                scenic_lib::Session* session,
                 const SkISize& size);
 
   ~VulkanSurface() override;
@@ -44,7 +44,7 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface,
       std::function<void(void)> on_writes_committed) override;
 
   // |flow::SceneUpdateContext::SurfaceProducerSurface|
-  mozart::client::Image* GetImage() override;
+  scenic_lib::Image* GetImage() override;
 
   // |flow::SceneUpdateContext::SurfaceProducerSurface|
   sk_sp<SkSurface> GetSkiaSurface() const override;
@@ -52,11 +52,11 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface,
  private:
   vulkan::VulkanProcTable& vk_;
   sk_sp<GrVkBackendContext> backend_context_;
-  mozart::client::Session* session_;
+  scenic_lib::Session* session_;
   vulkan::VulkanHandle<VkImage> vk_image_;
   vulkan::VulkanHandle<VkDeviceMemory> vk_memory_;
   sk_sp<SkSurface> sk_surface_;
-  std::unique_ptr<mozart::client::Image> session_image_;
+  std::unique_ptr<scenic_lib::Image> session_image_;
   mx::event acquire_event_;
   mx::event release_event_;
   mtl::MessageLoop::HandlerKey event_handler_key_ = 0;
@@ -80,7 +80,7 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface,
 
   bool CreateFences();
 
-  bool PushSessionImageSetupOps(mozart::client::Session* session,
+  bool PushSessionImageSetupOps(scenic_lib::Session* session,
                                 mx::vmo exported_vmo);
 
   void Reset();

--- a/content_handler/vulkan_surface_pool.cc
+++ b/content_handler/vulkan_surface_pool.cc
@@ -11,7 +11,7 @@ namespace flutter_runner {
 VulkanSurfacePool::VulkanSurfacePool(vulkan::VulkanProcTable& p_vk,
                                      sk_sp<GrContext> context,
                                      sk_sp<GrVkBackendContext> backend_context,
-                                     mozart::client::Session* mozart_session)
+                                     scenic_lib::Session* mozart_session)
     : vk_(p_vk),
       context_(std::move(context)),
       backend_context_(std::move(backend_context)),

--- a/content_handler/vulkan_surface_pool.h
+++ b/content_handler/vulkan_surface_pool.h
@@ -19,7 +19,7 @@ class VulkanSurfacePool {
   VulkanSurfacePool(vulkan::VulkanProcTable& vk,
                     sk_sp<GrContext> context,
                     sk_sp<GrVkBackendContext> backend_context,
-                    mozart::client::Session* mozart_session);
+                    scenic_lib::Session* mozart_session);
 
   ~VulkanSurfacePool();
 
@@ -53,7 +53,7 @@ class VulkanSurfacePool {
   vulkan::VulkanProcTable& vk_;
   sk_sp<GrContext> context_;
   sk_sp<GrVkBackendContext> backend_context_;
-  mozart::client::Session* mozart_session_;
+  scenic_lib::Session* mozart_session_;
   std::unordered_map<SkISize, SurfacesSet, SkISizeHash> available_surfaces_;
   std::unordered_map<
       uintptr_t,

--- a/content_handler/vulkan_surface_producer.cc
+++ b/content_handler/vulkan_surface_producer.cc
@@ -13,7 +13,7 @@
 namespace flutter_runner {
 
 VulkanSurfaceProducer::VulkanSurfaceProducer(
-    mozart::client::Session* mozart_session) {
+    scenic_lib::Session* mozart_session) {
   valid_ = Initialize(mozart_session);
 
   if (valid_) {
@@ -28,7 +28,7 @@ VulkanSurfaceProducer::VulkanSurfaceProducer(
 VulkanSurfaceProducer::~VulkanSurfaceProducer() = default;
 
 bool VulkanSurfaceProducer::Initialize(
-    mozart::client::Session* mozart_session) {
+    scenic_lib::Session* mozart_session) {
   vk_ = ftl::MakeRefCounted<vulkan::VulkanProcTable>();
 
   std::vector<std::string> extensions = {VK_KHR_SURFACE_EXTENSION_NAME};

--- a/content_handler/vulkan_surface_producer.h
+++ b/content_handler/vulkan_surface_producer.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_CONTENT_HANDLER_VULKAN_SURFACE_PRODUCER_H_
 #define FLUTTER_CONTENT_HANDLER_VULKAN_SURFACE_PRODUCER_H_
 
-#include "apps/mozart/lib/scene/client/resources.h"
-#include "apps/mozart/lib/scene/client/session.h"
+#include "apps/mozart/lib/scenic/client/resources.h"
+#include "apps/mozart/lib/scenic/client/session.h"
 #include "flutter/content_handler/vulkan_surface.h"
 #include "flutter/content_handler/vulkan_surface_pool.h"
 #include "flutter/flow/scene_update_context.h"
@@ -21,7 +21,7 @@ namespace flutter_runner {
 
 class VulkanSurfaceProducer : public flow::SceneUpdateContext::SurfaceProducer {
  public:
-  VulkanSurfaceProducer(mozart::client::Session* mozart_session);
+  VulkanSurfaceProducer(scenic_lib::Session* mozart_session);
 
   ~VulkanSurfaceProducer();
 
@@ -56,7 +56,7 @@ class VulkanSurfaceProducer : public flow::SceneUpdateContext::SurfaceProducer {
   std::unique_ptr<VulkanSurfacePool> surface_pool_;
   bool valid_ = false;
 
-  bool Initialize(mozart::client::Session* mozart_session);
+  bool Initialize(scenic_lib::Session* mozart_session);
 
   FTL_DISALLOW_COPY_AND_ASSIGN(VulkanSurfaceProducer);
 };

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -72,8 +72,8 @@ source_set("flow") {
     ]
 
     deps += [
-      "//apps/mozart/lib/scene:client",
-      "//apps/mozart/services/scene",
+      "//apps/mozart/lib/scenic:client",
+      "//apps/mozart/services/scenic",
       "//garnet/public/lib/fidl/dart/sdk_ext",
     ]
 

--- a/flow/export_node.cc
+++ b/flow/export_node.cc
@@ -16,7 +16,7 @@ ExportNodeHolder::ExportNodeHolder(
 }
 
 void ExportNodeHolder::Bind(SceneUpdateContext& context,
-                            mozart::client::ContainerNode& container,
+                            scenic_lib::ContainerNode& container,
                             const SkPoint& offset,
                             bool hit_testable) {
   ASSERT_IS_GPU_THREAD;
@@ -41,14 +41,14 @@ ExportNode::~ExportNode() {
 }
 
 void ExportNode::Bind(SceneUpdateContext& context,
-                      mozart::client::ContainerNode& container,
+                      scenic_lib::ContainerNode& container,
                       const SkPoint& offset,
                       bool hit_testable) {
   ASSERT_IS_GPU_THREAD;
 
   if (export_token_) {
     // Happens first time we bind.
-    node_.reset(new mozart::client::EntityNode(container.session()));
+    node_.reset(new scenic_lib::EntityNode(container.session()));
     node_->Export(std::move(export_token_));
 
     // Add ourselves to the context so it can call Dispose() on us if the Mozart
@@ -61,8 +61,8 @@ void ExportNode::Bind(SceneUpdateContext& context,
     container.AddChild(*node_);
     node_->SetTranslation(offset.x(), offset.y(), 0.f);
     node_->SetHitTestBehavior(hit_testable
-                                  ? mozart2::HitTestBehavior::kDefault
-                                  : mozart2::HitTestBehavior::kSuppress);
+                                  ? scenic::HitTestBehavior::kDefault
+                                  : scenic::HitTestBehavior::kSuppress);
   }
 }
 

--- a/flow/export_node.h
+++ b/flow/export_node.h
@@ -9,7 +9,7 @@
 
 #include <mx/eventpair.h>
 
-#include "apps/mozart/lib/scene/client/resources.h"
+#include "apps/mozart/lib/scenic/client/resources.h"
 #include "flutter/flow/scene_update_context.h"
 #include "lib/fidl/dart/sdk_ext/src/handle.h"
 #include "lib/ftl/build_config.h"
@@ -31,7 +31,7 @@ class ExportNodeHolder : public ftl::RefCountedThreadSafe<ExportNodeHolder> {
 
   // Calls Bind() on the wrapped ExportNode.
   void Bind(SceneUpdateContext& context,
-            mozart::client::ContainerNode& container,
+            scenic_lib::ContainerNode& container,
             const SkPoint& offset,
             bool hit_testable);
 
@@ -57,7 +57,7 @@ class ExportNode {
   // Binds the export token to the entity node and adds it as a child of
   // the specified container. Must be called on the Rasterizer thread.
   void Bind(SceneUpdateContext& context,
-            mozart::client::ContainerNode& container,
+            scenic_lib::ContainerNode& container,
             const SkPoint& offset,
             bool hit_testable);
 
@@ -72,7 +72,7 @@ class ExportNode {
   // Member variables can only be read or modified on Rasterizer thread.
   SceneUpdateContext* scene_update_context_ = nullptr;
   mx::eventpair export_token_;
-  std::unique_ptr<mozart::client::EntityNode> node_;
+  std::unique_ptr<scenic_lib::EntityNode> node_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(ExportNode);
 };

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -6,7 +6,7 @@
 
 #if defined(OS_FUCHSIA)
 
-#include "apps/mozart/lib/scene/session_helpers.h"  // nogncheck
+#include "apps/mozart/lib/scenic/fidl_helpers.h"  // nogncheck
 
 #endif  // defined(OS_FUCHSIA)
 
@@ -33,7 +33,7 @@ void ClipPathLayer::UpdateScene(SceneUpdateContext& context) {
   // TODO(MZ-140): Must be able to specify paths as shapes to nodes.
   //               Treating the shape as a rectangle for now.
   auto bounds = clip_path_.getBounds();
-  mozart::client::Rectangle shape(context.session(),  // session
+  scenic_lib::Rectangle shape(context.session(),  // session
                                   bounds.width(),     //  width
                                   bounds.height()     //  height
                                   );

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -24,7 +24,7 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 void ClipRectLayer::UpdateScene(SceneUpdateContext& context) {
   FTL_DCHECK(needs_system_composite());
 
-  mozart::client::Rectangle shape(context.session(),   // session
+  scenic_lib::Rectangle shape(context.session(),   // session
                                   clip_rect_.width(),  //  width
                                   clip_rect_.height()  //  height
                                   );

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -25,7 +25,7 @@ void ClipRRectLayer::UpdateScene(SceneUpdateContext& context) {
   FTL_DCHECK(needs_system_composite());
 
   // TODO(MZ-137): Need to be able to express the radii as vectors.
-  mozart::client::RoundedRectangle shape(
+  scenic_lib::RoundedRectangle shape(
       context.session(),                                   // session
       clip_rrect_.width(),                                 //  width
       clip_rrect_.height(),                                //  height

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -25,8 +25,8 @@
 
 #if defined(OS_FUCHSIA)
 
-#include "apps/mozart/lib/scene/client/resources.h"  //nogncheck
-#include "apps/mozart/lib/scene/client/session.h"    //nogncheck
+#include "apps/mozart/lib/scenic/client/resources.h"  //nogncheck
+#include "apps/mozart/lib/scenic/client/session.h"    //nogncheck
 #include "flutter/flow/scene_update_context.h"       //nogncheck
 
 #endif  // defined(OS_FUCHSIA)

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -40,7 +40,7 @@ void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
 
 #if defined(OS_FUCHSIA)
 void LayerTree::UpdateScene(SceneUpdateContext& context,
-                            mozart::client::ContainerNode& container) {
+                            scenic_lib::ContainerNode& container) {
   TRACE_EVENT0("flutter", "LayerTree::UpdateScene");
 
   SceneUpdateContext::Transform transform(context, 1.f / device_pixel_ratio_,

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -36,7 +36,7 @@ class LayerTree {
   }
 
   void UpdateScene(SceneUpdateContext& context,
-                   mozart::client::ContainerNode& container);
+                   scenic_lib::ContainerNode& container);
 #endif
 
   void Paint(CompositorContext::ScopedFrame& frame);

--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -12,7 +12,7 @@
 
 namespace flow {
 
-SceneUpdateContext::SceneUpdateContext(mozart::client::Session* session,
+SceneUpdateContext::SceneUpdateContext(scenic_lib::Session* session,
                                        SurfaceProducer* surface_producer)
     : session_(session), surface_producer_(surface_producer) {
   FTL_DCHECK(surface_producer_ != nullptr);
@@ -48,7 +48,7 @@ void SceneUpdateContext::RemoveExportNode(ExportNode* export_node) {
   export_nodes_.erase(export_node);
 }
 
-void SceneUpdateContext::CreateFrame(mozart::client::EntityNode& entity_node,
+void SceneUpdateContext::CreateFrame(scenic_lib::EntityNode& entity_node,
                                      const SkRRect& rrect,
                                      SkColor color,
                                      const SkRect& paint_bounds,
@@ -64,7 +64,7 @@ void SceneUpdateContext::CreateFrame(mozart::client::EntityNode& entity_node,
   // and possibly for its texture.
   // TODO(MZ-137): Need to be able to express the radii as vectors.
   SkRect shape_bounds = rrect.getBounds();
-  mozart::client::RoundedRectangle shape(
+  scenic_lib::RoundedRectangle shape(
       session_,                                      // session
       rrect.width(),                                 // width
       rrect.height(),                                // height
@@ -73,7 +73,7 @@ void SceneUpdateContext::CreateFrame(mozart::client::EntityNode& entity_node,
       rrect.radii(SkRRect::kLowerRight_Corner).x(),  // bottom_right_radius
       rrect.radii(SkRRect::kLowerLeft_Corner).x()    // bottom_left_radius
       );
-  mozart::client::ShapeNode shape_node(session_);
+  scenic_lib::ShapeNode shape_node(session_);
   shape_node.SetShape(shape);
   shape_node.SetTranslation(shape_bounds.width() * 0.5f + shape_bounds.left(),
                             shape_bounds.height() * 0.5f + shape_bounds.top(),
@@ -101,9 +101,9 @@ void SceneUpdateContext::CreateFrame(mozart::client::EntityNode& entity_node,
   if (inner_bounds != shape_bounds && rrect.contains(inner_bounds)) {
     SetShapeColor(shape_node, color);
 
-    mozart::client::Rectangle inner_shape(session_, inner_bounds.width(),
+    scenic_lib::Rectangle inner_shape(session_, inner_bounds.width(),
                                           inner_bounds.height());
-    mozart::client::ShapeNode inner_node(session_);
+    scenic_lib::ShapeNode inner_node(session_);
     inner_node.SetShape(inner_shape);
     inner_node.SetTranslation(inner_bounds.width() * 0.5f + inner_bounds.left(),
                               inner_bounds.height() * 0.5f + inner_bounds.top(),
@@ -120,16 +120,16 @@ void SceneUpdateContext::CreateFrame(mozart::client::EntityNode& entity_node,
 }
 
 void SceneUpdateContext::SetShapeTextureOrColor(
-    mozart::client::ShapeNode& shape_node,
+    scenic_lib::ShapeNode& shape_node,
     SkColor color,
     SkScalar scale_x,
     SkScalar scale_y,
     const SkRect& paint_bounds,
     std::vector<Layer*> paint_layers) {
-  mozart::client::Image* image = GenerateImageIfNeeded(
+  scenic_lib::Image* image = GenerateImageIfNeeded(
       color, scale_x, scale_y, paint_bounds, std::move(paint_layers));
   if (image != nullptr) {
-    mozart::client::Material material(session_);
+    scenic_lib::Material material(session_);
     material.SetTexture(*image);
     shape_node.SetMaterial(material);
     return;
@@ -138,18 +138,18 @@ void SceneUpdateContext::SetShapeTextureOrColor(
   SetShapeColor(shape_node, color);
 }
 
-void SceneUpdateContext::SetShapeColor(mozart::client::ShapeNode& shape_node,
+void SceneUpdateContext::SetShapeColor(scenic_lib::ShapeNode& shape_node,
                                        SkColor color) {
   if (SkColorGetA(color) == 0)
     return;
 
-  mozart::client::Material material(session_);
+  scenic_lib::Material material(session_);
   material.SetColor(SkColorGetR(color), SkColorGetG(color), SkColorGetB(color),
                     SkColorGetA(color));
   shape_node.SetMaterial(material);
 }
 
-mozart::client::Image* SceneUpdateContext::GenerateImageIfNeeded(
+scenic_lib::Image* SceneUpdateContext::GenerateImageIfNeeded(
     SkColor color,
     SkScalar scale_x,
     SkScalar scale_y,
@@ -227,10 +227,10 @@ SceneUpdateContext::Entity::~Entity() {
 }
 
 SceneUpdateContext::Clip::Clip(SceneUpdateContext& context,
-                               mozart::client::Shape& shape,
+                               scenic_lib::Shape& shape,
                                const SkRect& shape_bounds)
     : Entity(context) {
-  mozart::client::ShapeNode shape_node(context.session());
+  scenic_lib::ShapeNode shape_node(context.session());
   shape_node.SetShape(shape);
   shape_node.SetTranslation(shape_bounds.width() * 0.5f + shape_bounds.left(),
                             shape_bounds.height() * 0.5f + shape_bounds.top(),

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -8,7 +8,7 @@
 #include <memory>
 #include <vector>
 
-#include "apps/mozart/lib/scene/client/resources.h"
+#include "apps/mozart/lib/scenic/client/resources.h"
 #include "flutter/flow/compositor_context.h"
 #include "lib/ftl/build_config.h"
 #include "lib/ftl/logging.h"
@@ -39,7 +39,7 @@ class SceneUpdateContext {
     virtual void SignalWritesFinished(
         std::function<void(void)> on_writes_committed) = 0;
 
-    virtual mozart::client::Image* GetImage() = 0;
+    virtual scenic_lib::Image* GetImage() = 0;
 
     virtual sk_sp<SkSurface> GetSkiaSurface() const = 0;
   };
@@ -59,19 +59,19 @@ class SceneUpdateContext {
     ~Entity();
 
     SceneUpdateContext& context() { return context_; }
-    mozart::client::EntityNode& entity_node() { return entity_node_; }
+    scenic_lib::EntityNode& entity_node() { return entity_node_; }
 
    private:
     SceneUpdateContext& context_;
     Entity* const previous_entity_;
 
-    mozart::client::EntityNode entity_node_;
+    scenic_lib::EntityNode entity_node_;
   };
 
   class Clip : public Entity {
    public:
     Clip(SceneUpdateContext& context,
-         mozart::client::Shape& shape,
+         scenic_lib::Shape& shape,
          const SkRect& shape_bounds);
     ~Clip();
   };
@@ -108,15 +108,15 @@ class SceneUpdateContext {
     SkRect paint_bounds_;
   };
 
-  SceneUpdateContext(mozart::client::Session* session,
+  SceneUpdateContext(scenic_lib::Session* session,
                      SurfaceProducer* surface_producer);
 
   ~SceneUpdateContext();
 
-  mozart::client::Session* session() { return session_; }
+  scenic_lib::Session* session() { return session_; }
 
   bool has_metrics() const { return !!metrics_; }
-  void set_metrics(mozart2::MetricsPtr metrics) {
+  void set_metrics(scenic::MetricsPtr metrics) {
     metrics_ = std::move(metrics);
   }
 
@@ -153,19 +153,19 @@ class SceneUpdateContext {
     std::vector<Layer*> layers;
   };
 
-  void CreateFrame(mozart::client::EntityNode& entity_node,
+  void CreateFrame(scenic_lib::EntityNode& entity_node,
                    const SkRRect& rrect,
                    SkColor color,
                    const SkRect& paint_bounds,
                    std::vector<Layer*> paint_layers);
-  void SetShapeTextureOrColor(mozart::client::ShapeNode& shape_node,
+  void SetShapeTextureOrColor(scenic_lib::ShapeNode& shape_node,
                               SkColor color,
                               SkScalar scale_x,
                               SkScalar scale_y,
                               const SkRect& paint_bounds,
                               std::vector<Layer*> paint_layers);
-  void SetShapeColor(mozart::client::ShapeNode& shape_node, SkColor color);
-  mozart::client::Image* GenerateImageIfNeeded(
+  void SetShapeColor(scenic_lib::ShapeNode& shape_node, SkColor color);
+  scenic_lib::Image* GenerateImageIfNeeded(
       SkColor color,
       SkScalar scale_x,
       SkScalar scale_y,
@@ -176,10 +176,10 @@ class SceneUpdateContext {
   float top_scale_x_ = 1.f;
   float top_scale_y_ = 1.f;
 
-  mozart::client::Session* const session_;
+  scenic_lib::Session* const session_;
   SurfaceProducer* const surface_producer_;
 
-  mozart2::MetricsPtr metrics_;
+  scenic::MetricsPtr metrics_;
 
   std::vector<PaintTask> paint_tasks_;
 


### PR DESCRIPTION
Multi-repo renaming, with no functionality change other than removing deprecated argument to SessionListener.OnEvent()