### PR TITLE
Use BinaryPrinter instead of KernelSerializer to accommodate IKG

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -11,7 +11,8 @@ import 'package:front_end/incremental_kernel_generator.dart';
 import 'package:front_end/compiler_options.dart';
 import 'package:front_end/kernel_generator.dart';
 import 'package:kernel/ast.dart';
-import 'package:kernel/kernel.dart' as kernel;
+import 'package:kernel/binary/ast_to_binary.dart';
+import 'package:kernel/binary/limited_ast_to_binary.dart';
 import 'package:kernel/target/flutter.dart';
 import 'package:kernel/target/targets.dart';
 import 'package:usage/uuid/uuid.dart';
@@ -82,32 +83,35 @@ abstract class CompilerInterface {
   void invalidate(Uri uri);
 }
 
-/// Class that for test mocking purposes encapsulates interaction with
-/// global kernel methods.
-class KernelSerializer {
-  /// Writes given kernel `program` to `path`.
-  Future<dynamic> writeProgramToBinary(Program program, String path) {
-    return kernel.writeProgramToBinary(program, path);
-  }
+/// Class that for test mocking purposes encapsulates creation of [BinaryPrinter].
+class BinaryPrinterFactory {
+  /// Creates new [BinaryPrinter] to write to [path] file.
+  BinaryPrinter newBinaryPrinter(String path) {
+    return new LimitedBinaryPrinter(
+      new File(path).openWrite(),
+      (_) => true /* predicate */,
+      false /* excludeUriToSource */);  }
 }
 
 class _FrontendCompiler implements CompilerInterface {
-  _FrontendCompiler(this._outputStream, { this.kernelSerializer }) {
+  _FrontendCompiler(this._outputStream, { this.printerFactory }) {
     _outputStream ??= stdout;
-    kernelSerializer ??= new KernelSerializer();
+    printerFactory ??= new BinaryPrinterFactory();
   }
 
   StringSink _outputStream;
-  KernelSerializer kernelSerializer;
+  BinaryPrinterFactory printerFactory;
 
   IncrementalKernelGenerator _generator;
   String _filename;
+  String _kernelBinaryFilename;
 
   @override
   Future<Null> compile(String filename, ArgResults options, {
     IncrementalKernelGenerator generator,
   }) async {
     _filename = filename;
+    _kernelBinaryFilename = "$filename.dill";
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln("result $boundaryKey");
     final Uri sdkRoot = _ensureFolderPath(options['sdk-root']);
@@ -123,7 +127,7 @@ class _FrontendCompiler implements CompilerInterface {
       _generator = generator != null
         ? generator
         : await IncrementalKernelGenerator.newInstance(
-            compilerOptions, Uri.base.resolve(_filename)
+          compilerOptions, Uri.base.resolve(_filename)
         );
       final DeltaProgram deltaProgram = await _generator.computeDelta();
       program = deltaProgram.newProgram;
@@ -136,9 +140,9 @@ class _FrontendCompiler implements CompilerInterface {
       program = await kernelForProgram(Uri.base.resolve(_filename), compilerOptions);
     }
     if (program != null) {
-      final String kernelBinaryFilename = _filename + ".dill";
-      await kernelSerializer.writeProgramToBinary(program, kernelBinaryFilename);
-      _outputStream.writeln("$boundaryKey $kernelBinaryFilename");
+      final BinaryPrinter printer = printerFactory.newBinaryPrinter(_kernelBinaryFilename);
+      printer.writeProgramFile(program);
+      _outputStream.writeln("$boundaryKey $_kernelBinaryFilename");
     } else
       _outputStream.writeln(boundaryKey);
     return null;
@@ -149,9 +153,8 @@ class _FrontendCompiler implements CompilerInterface {
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln("result $boundaryKey");
     final DeltaProgram deltaProgram = await _generator.computeDelta();
-    final Program program = deltaProgram.newProgram;
-    final String kernelBinaryFilename = _filename + ".dill";
-    await kernelSerializer.writeProgramToBinary(program, kernelBinaryFilename);
+    final BinaryPrinter printer = printerFactory.newBinaryPrinter(_kernelBinaryFilename);
+    printer.writeProgramFile(deltaProgram.newProgram);
     _outputStream.writeln("$boundaryKey");
     return null;
   }
@@ -188,13 +191,13 @@ Future<int> starter(List<String> args, {
   CompilerInterface compiler,
   Stream<List<int>> input, StringSink output,
   IncrementalKernelGenerator generator,
-  KernelSerializer kernelSerializer
+  BinaryPrinterFactory binaryPrinterFactory,
 }) async {
   final ArgResults options = _argParser.parse(args);
   if (options['train'])
     return 0;
 
-  compiler ??= new _FrontendCompiler(output, kernelSerializer: kernelSerializer);
+  compiler ??= new _FrontendCompiler(output, printerFactory: binaryPrinterFactory);
   input ??= stdin;
 
   if (options.rest.isNotEmpty) {
@@ -205,9 +208,9 @@ Future<int> starter(List<String> args, {
   _State state = _State.READY_FOR_INSTRUCTION;
   String boundaryKey;
   input
-      .transform(UTF8.decoder)
-      .transform(new LineSplitter())
-      .listen((String string) async {
+    .transform(UTF8.decoder)
+    .transform(new LineSplitter())
+    .listen((String string) async {
     switch (state) {
       case _State.READY_FOR_INSTRUCTION:
         const String COMPILE_INSTRUCTION_SPACE = 'compile ';

--- a/frontend_server/test/server_test.dart
+++ b/frontend_server/test/server_test.dart
@@ -6,6 +6,7 @@ import 'dart:isolate';
 import 'package:args/src/arg_results.dart';
 import 'package:frontend_server/server.dart';
 import 'package:front_end/incremental_kernel_generator.dart';
+import 'package:kernel/binary/ast_to_binary.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
@@ -14,7 +15,9 @@ class _MockedCompiler extends Mock implements CompilerInterface {}
 class _MockedIncrementalKernelGenerator extends Mock
   implements IncrementalKernelGenerator {}
 
-class _MockedKernelSerializer extends Mock implements KernelSerializer {}
+class _MockedBinaryPrinterFactory extends Mock implements BinaryPrinterFactory {}
+
+class _MockedBinaryPrinter extends Mock implements BinaryPrinter {}
 
 Future<int> main() async {
   group('basic', () {
@@ -231,11 +234,15 @@ Future<int> main() async {
       when(generator.computeDelta()).thenReturn(new Future<DeltaProgram>.value(
         new DeltaProgram(null /* program stub */)
       ));
+      final _MockedBinaryPrinterFactory printerFactory =
+        new _MockedBinaryPrinterFactory();
+      when(printerFactory.newBinaryPrinter(any))
+        .thenReturn(new _MockedBinaryPrinter());
       final int exitcode = await starter(args, compiler: null,
         input: streamController.stream,
         output: ioSink,
         generator: generator,
-        kernelSerializer: new _MockedKernelSerializer()
+        binaryPrinterFactory: printerFactory,
       );
       expect(exitcode, equals(0));
 


### PR DESCRIPTION
KernelSerializer doesn't handle serializing of the incremental kernel files correctly, switch to BinaryPrinter instead.