### PR TITLE
Support the ApplicationController::Wait interface.

### DIFF
--- a/content_handler/application_controller_impl.cc
+++ b/content_handler/application_controller_impl.cc
@@ -66,6 +66,7 @@ ApplicationControllerImpl::ApplicationControllerImpl(
 ApplicationControllerImpl::~ApplicationControllerImpl() = default;
 
 void ApplicationControllerImpl::Kill() {
+  SendReturnCode(runtime_holder_->return_code());
   runtime_holder_.reset();
   app_->Destroy(this);
   // |this| has been deleted at this point.
@@ -73,6 +74,17 @@ void ApplicationControllerImpl::Kill() {
 
 void ApplicationControllerImpl::Detach() {
   binding_.set_connection_error_handler(ftl::Closure());
+}
+
+void ApplicationControllerImpl::Wait(const WaitCallback& callback) {
+  wait_callbacks_.push_back(callback);
+}
+
+void ApplicationControllerImpl::SendReturnCode(int32_t return_code) {
+  for (const auto& iter : wait_callbacks_) {
+    iter(return_code);
+  }
+  wait_callbacks_.clear();
 }
 
 void ApplicationControllerImpl::CreateView(

--- a/content_handler/application_controller_impl.h
+++ b/content_handler/application_controller_impl.h
@@ -37,6 +37,7 @@ class ApplicationControllerImpl : public app::ApplicationController,
 
   void Kill() override;
   void Detach() override;
+  void Wait(const WaitCallback& callback) override;
 
   // |mozart::ViewProvider| implementation
 
@@ -49,6 +50,7 @@ class ApplicationControllerImpl : public app::ApplicationController,
 
  private:
   void StartRuntimeIfReady();
+  void SendReturnCode(int32_t return_code);
 
   App* app_;
   fidl::Binding<app::ApplicationController> binding_;
@@ -59,6 +61,8 @@ class ApplicationControllerImpl : public app::ApplicationController,
 
   std::string url_;
   std::unique_ptr<RuntimeHolder> runtime_holder_;
+
+  std::vector<WaitCallback> wait_callbacks_;
 
   FTL_DISALLOW_COPY_AND_ASSIGN(ApplicationControllerImpl);
 };

--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -264,6 +264,9 @@ void RuntimeHolder::CreateView(
     runtime_->dart_controller()->RunFromScriptSnapshot(snapshot.data(),
                                                        snapshot.size());
   }
+
+  runtime_->dart_controller()->dart_state()->SetReturnCodeCallback(
+      [this](int32_t return_code) { return_code_ = return_code; });
 }
 
 Dart_Port RuntimeHolder::GetUIIsolateMainPort() {

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -49,6 +49,8 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   Dart_Port GetUIIsolateMainPort();
   std::string GetUIIsolateName();
 
+  int32_t return_code() { return return_code_; }
+
  private:
   // |blink::RuntimeDelegate| implementation:
   std::string DefaultRouteName() override;
@@ -113,6 +115,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   bool frame_outstanding_ = false;
   bool frame_scheduled_ = false;
   bool frame_rendering_ = false;
+  int32_t return_code_ = 0;
 
   ftl::WeakPtrFactory<RuntimeHolder> weak_factory_;
 


### PR DESCRIPTION
This only operates correctly when the application is killed using the
Kill() method. Flutter applications on Fuchsia currently don't have any
way to shut themselves down, see:
https://github.com/flutter/flutter/issues/11934