### PR TITLE
Define which SemanticsNodes are a11y focusable on Android

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -95,6 +95,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         result.setPackageName(mOwner.getContext().getPackageName());
         result.setClassName("Flutter"); // TODO(goderbauer): Set proper class names
         result.setSource(mOwner, virtualViewId);
+        result.setFocusable(object.isFocusable());
 
         if (object.parent != null) {
             assert object.id > 0;
@@ -144,7 +145,6 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         }
         if ((object.actions & SEMANTICS_ACTION_INCREASE) != 0
                 || (object.actions & SEMANTICS_ACTION_DECREASE) != 0 ) {
-            result.setFocusable(true);
             result.setClassName("android.widget.SeekBar");
             if ((object.actions & SEMANTICS_ACTION_INCREASE) != 0) {
                 result.addAction(AccessibilityNodeInfo.ACTION_SCROLL_FORWARD);
@@ -507,6 +507,10 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
                 }
             }
             return this;
+        }
+
+        boolean isFocusable() {
+            return flags != 0 || label != null || (actions & ~SEMANTICS_ACTION_SCROLLABLE) != 0;
         }
 
         void updateRecursively(float[] ancestorTransform, Set<SemanticsObject> visitedObjects, boolean forceUpdate) {


### PR DESCRIPTION
A node is considered a11y focusable if it contains information that are interesting to the user. A node that doesn't add any semantic information of its own should not be focusable. It's expected that such a node has children, who have semantics information and are therefore focusable.

See also `MergeSemantics` to merge the child semantics of a node into the parent.

Fixes https://github.com/flutter/flutter/issues/11179.