### PR TITLE
Add missing virtual destructors to virtual classes

### DIFF
--- a/flow/process_info.h
+++ b/flow/process_info.h
@@ -15,6 +15,8 @@ namespace flow {
 /// can choose to provide this information however.
 class ProcessInfo {
  public:
+  virtual ~ProcessInfo() = default;
+
   virtual bool SampleNow() = 0;
 
   /// Virtual memory size in bytes.

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -46,6 +46,8 @@ class SceneUpdateContext {
 
   class SurfaceProducer {
    public:
+    virtual ~SurfaceProducer() = default;
+
     virtual std::unique_ptr<SurfaceProducerSurface> ProduceSurface(
         const SkISize& size) = 0;
 

--- a/vulkan/vulkan_native_surface.h
+++ b/vulkan/vulkan_native_surface.h
@@ -14,6 +14,8 @@ namespace vulkan {
 
 class VulkanNativeSurface {
  public:
+  virtual ~VulkanNativeSurface() = default;
+
   virtual const char* GetExtensionName() const = 0;
 
   virtual uint32_t GetSkiaExtensionName() const = 0;


### PR DESCRIPTION
These were previously undetected because Wdelete-non-virtual-dtor
didn't work with std::unique_ptr, but that's no longer the case.