### PR TITLE
Enable the Skia subpixel text flag in libtxt

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -211,6 +211,7 @@ void Paragraph::Layout(double width, bool force) {
   SkPaint paint;
   paint.setAntiAlias(true);
   paint.setTextEncoding(SkPaint::kGlyphID_TextEncoding);
+  paint.setSubpixelText(true);
 
   minikin::FontStyle font;
   minikin::MinikinPaint minikin_paint;


### PR DESCRIPTION
This flag was set in the Blink renderer (see FontPlatformData::setupPaint)