### PR TITLE
Support cleaner Dart isolate shutdown handling.

### DIFF
--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -20,6 +20,7 @@ class Window;
 class IsolateClient {
  public:
   virtual void DidCreateSecondaryIsolate(Dart_Isolate isolate) = 0;
+  virtual void WillShutDownIsolate(Dart_Isolate isolate) = 0;
 
  protected:
   virtual ~IsolateClient();
@@ -35,6 +36,9 @@ class UIDartState : public tonic::DartState {
   UIDartState* CreateForChildIsolate();
 
   IsolateClient* isolate_client() { return isolate_client_; }
+  void set_isolate_client(IsolateClient* isolate_client) {
+    isolate_client_ = isolate_client;
+  }
   Dart_Port main_port() const { return main_port_; }
   const std::string& debug_name() const { return debug_name_; }
   Window* window() const { return window_.get(); }

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -49,6 +49,8 @@ DartController::DartController() : ui_dart_state_(nullptr),
 
 DartController::~DartController() {
   if (ui_dart_state_) {
+    ui_dart_state_->set_isolate_client(nullptr);
+
     // Don't use a tonic::DartIsolateScope here since we never exit the isolate.
     Dart_EnterIsolate(ui_dart_state_->isolate());
     // Clear the message notify callback.
@@ -210,6 +212,10 @@ void DartController::CreateIsolateFor(const std::string& script_uri,
                                                std::move(ui_class_provider));
   }
   Dart_ExitIsolate();
+}
+
+void DartController::IsolateShuttingDown() {
+  ui_dart_state_ = nullptr;
 }
 
 }  // namespace blink

--- a/runtime/dart_controller.h
+++ b/runtime/dart_controller.h
@@ -35,6 +35,8 @@ class DartController {
 
   UIDartState* dart_state() const { return ui_dart_state_; }
 
+  void IsolateShuttingDown();
+
  private:
   bool SendStartMessage(Dart_Handle root_library);
 

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -132,7 +132,11 @@ void IsolateShutdownCallback(void* callback_data) {
     Dart_Handle sticky_error = Dart_GetStickyError();
     FXL_CHECK(LogIfError(sticky_error));
   }
-  tonic::DartState* dart_state = static_cast<tonic::DartState*>(callback_data);
+  UIDartState* dart_state = static_cast<UIDartState*>(callback_data);
+  IsolateClient *isolate_client_ = dart_state->isolate_client();
+  if (isolate_client_) {
+    isolate_client_->WillShutDownIsolate(dart_state->isolate());
+  }
   delete dart_state;
 }
 

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -133,6 +133,10 @@ void RuntimeController::DidCreateSecondaryIsolate(Dart_Isolate isolate) {
   client_->DidCreateSecondaryIsolate(isolate);
 }
 
+void RuntimeController::WillShutDownIsolate(Dart_Isolate isolate) {
+  dart_controller_->IsolateShuttingDown();
+}
+
 Dart_Port RuntimeController::GetMainPort() {
   if (!dart_controller_) {
     return ILLEGAL_PORT;

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -61,6 +61,7 @@ class RuntimeController : public WindowClient, public IsolateClient {
   void HandlePlatformMessage(fxl::RefPtr<PlatformMessage> message) override;
 
   void DidCreateSecondaryIsolate(Dart_Isolate isolate) override;
+  void WillShutDownIsolate(Dart_Isolate isolate) override;
 
   RuntimeDelegate* client_;
   std::string language_code_;


### PR DESCRIPTION
If an isolate shuts down (for example if an app calls
Isolate.current.kill()), the UIDartState* on DartController will refer
to a freed object. This wires through notification that the is shutting
down through to the DartController so it can clean up appropriately.