### PR TITLE
Add --trace-skia parameter to flutter run

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -196,7 +196,9 @@ void Shell::InitStandalone(fxl::CommandLine command_line,
 
 void Shell::Init(fxl::CommandLine command_line) {
 #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
-  InitSkiaEventTracer();
+  bool trace_skia  =
+      command_line.HasOption(FlagForSwitch(Switch::TraceSkia));
+  InitSkiaEventTracer(trace_skia);
 #endif
 
   FXL_DCHECK(!g_shell);

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -196,8 +196,7 @@ void Shell::InitStandalone(fxl::CommandLine command_line,
 
 void Shell::Init(fxl::CommandLine command_line) {
 #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
-  bool trace_skia  =
-      command_line.HasOption(FlagForSwitch(Switch::TraceSkia));
+  bool trace_skia = command_line.HasOption(FlagForSwitch(Switch::TraceSkia));
   InitSkiaEventTracer(trace_skia);
 #endif
 

--- a/shell/common/skia_event_tracer_impl.cc
+++ b/shell/common/skia_event_tracer_impl.cc
@@ -9,8 +9,8 @@
 
 #include <vector>
 
-#include "lib/fxl/logging.h"
 #include "dart/runtime/include/dart_tools_api.h"
+#include "lib/fxl/logging.h"
 #include "third_party/skia/include/utils/SkEventTracer.h"
 #include "third_party/skia/src/core/SkTraceEventCommon.h"
 
@@ -22,8 +22,7 @@ class FlutterEventTracer : public SkEventTracer {
   static constexpr uint8_t kYes = 1;
   static constexpr uint8_t kNo = 0;
 
-  FlutterEventTracer(bool enabled)
-    : enabled_(enabled ? kYes : kNo) {};
+  FlutterEventTracer(bool enabled) : enabled_(enabled ? kYes : kNo){};
 
   SkEventTracer::Handle addTraceEvent(char phase,
                                       const uint8_t* category_enabled_flag,
@@ -74,9 +73,7 @@ class FlutterEventTracer : public SkEventTracer {
     return kSkiaTag;
   }
 
-  void enable() {
-    enabled_ = kYes;
-  }
+  void enable() { enabled_ = kYes; }
 
  private:
   uint8_t enabled_;
@@ -84,12 +81,12 @@ class FlutterEventTracer : public SkEventTracer {
 };
 
 bool enableSkiaTracingCallback(const char* method,
-                            const char** param_keys,
-                            const char** param_values,
-                            intptr_t num_params,
-                            void* user_data,
-                            const char** json_object) {
-  FlutterEventTracer *tracer = static_cast<FlutterEventTracer*>(user_data);
+                               const char** param_keys,
+                               const char** param_values,
+                               intptr_t num_params,
+                               void* user_data,
+                               const char** json_object) {
+  FlutterEventTracer* tracer = static_cast<FlutterEventTracer*>(user_data);
   tracer->enable();
   *json_object = strdup("{\"type\":\"Success\"}");
   return true;
@@ -98,7 +95,7 @@ bool enableSkiaTracingCallback(const char* method,
 }  // namespace skia
 
 void InitSkiaEventTracer(bool enabled) {
-  skia::FlutterEventTracer *tracer = new skia::FlutterEventTracer(enabled);
+  skia::FlutterEventTracer* tracer = new skia::FlutterEventTracer(enabled);
   Dart_RegisterRootServiceRequestCallback("_flutter.enableSkiaTracing",
                                           skia::enableSkiaTracingCallback,
                                           static_cast<void*>(tracer));

--- a/shell/common/skia_event_tracer_impl.cc
+++ b/shell/common/skia_event_tracer_impl.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "lib/fxl/logging.h"
+#include "dart/runtime/include/dart_tools_api.h"
 #include "third_party/skia/include/utils/SkEventTracer.h"
 #include "third_party/skia/src/core/SkTraceEventCommon.h"
 
@@ -18,8 +19,11 @@ namespace skia {
 class FlutterEventTracer : public SkEventTracer {
  public:
   static constexpr const char* kSkiaTag = "skia";
+  static constexpr uint8_t kYes = 1;
+  static constexpr uint8_t kNo = 0;
 
-  FlutterEventTracer() = default;
+  FlutterEventTracer(bool enabled)
+    : enabled_(enabled ? kYes : kNo) {};
 
   SkEventTracer::Handle addTraceEvent(char phase,
                                       const uint8_t* category_enabled_flag,
@@ -62,8 +66,7 @@ class FlutterEventTracer : public SkEventTracer {
   }
 
   const uint8_t* getCategoryGroupEnabled(const char* name) override {
-    static const uint8_t kYes = 1;
-    return &kYes;
+    return &enabled_;
   }
 
   const char* getCategoryGroupName(
@@ -71,14 +74,35 @@ class FlutterEventTracer : public SkEventTracer {
     return kSkiaTag;
   }
 
+  void enable() {
+    enabled_ = kYes;
+  }
+
  private:
+  uint8_t enabled_;
   FXL_DISALLOW_COPY_AND_ASSIGN(FlutterEventTracer);
 };
 
+bool enableSkiaTracingCallback(const char* method,
+                            const char** param_keys,
+                            const char** param_values,
+                            intptr_t num_params,
+                            void* user_data,
+                            const char** json_object) {
+  FlutterEventTracer *tracer = static_cast<FlutterEventTracer*>(user_data);
+  tracer->enable();
+  *json_object = strdup("{\"type\":\"Success\"}");
+  return true;
+}
+
 }  // namespace skia
 
-void InitSkiaEventTracer() {
+void InitSkiaEventTracer(bool enabled) {
+  skia::FlutterEventTracer *tracer = new skia::FlutterEventTracer(enabled);
+  Dart_RegisterRootServiceRequestCallback("_flutter.enableSkiaTracing",
+                                          skia::enableSkiaTracingCallback,
+                                          static_cast<void*>(tracer));
   // Initialize the binding to Skia's tracing events. Skia will
   // take ownership of and clean up the memory allocated here.
-  SkEventTracer::SetInstance(new skia::FlutterEventTracer());
+  SkEventTracer::SetInstance(tracer);
 }

--- a/shell/common/skia_event_tracer_impl.h
+++ b/shell/common/skia_event_tracer_impl.h
@@ -5,6 +5,6 @@
 #ifndef FLUTTER_SHELL_COMMON_SKIA_EVENT_TRACER_IMPL_H_
 #define FLUTTER_SHELL_COMMON_SKIA_EVENT_TRACER_IMPL_H_
 
-void InitSkiaEventTracer();
+void InitSkiaEventTracer(bool enabled);
 
 #endif  // FLUTTER_SHELL_COMMON_SKIA_EVENT_TRACER_IMPL_H_

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -84,6 +84,11 @@ DEF_SWITCH(TraceStartup,
            "trace-startup",
            "Trace early application lifecycle. Automatically switches to an "
            "endless trace buffer.")
+DEF_SWITCH(TraceSkia,
+           "trace-skia",
+           "Trace Skia calls. This is useful when debugging the GPU threed."
+           "By default, Skia tracing is not enable to reduce the number of "
+           "traced events")
 DEF_SWITCH(UseTestFonts,
            "use-test-fonts",
            "Running tests that layout and measure text will not yield "

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -266,6 +266,9 @@ public final class FlutterActivityDelegate
         if (intent.getBooleanExtra("enable-software-rendering", false)) {
             args.add("--enable-software-rendering");
         }
+        if (intent.getBooleanExtra("trace-skia", false)) {
+            args.add("--trace-skia");
+        }
         if (!args.isEmpty()) {
             String[] argsArray = new String[args.size()];
             return args.toArray(argsArray);


### PR DESCRIPTION
Skia tracing is extremely useful for internal debug, but reduces the
amount of space available in the Dart Timeline buffers.
Disable skia tracing by default and expose them via the --trace-skia
flag.

Related https://github.com/flutter/flutter/pull/12070