### PR TITLE
Make Travis happy again

### DIFF
--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -130,7 +130,7 @@ void IsolateShutdownCallback(void* callback_data) {
     FXL_CHECK(LogIfError(sticky_error));
   }
   UIDartState* dart_state = static_cast<UIDartState*>(callback_data);
-  IsolateClient *isolate_client_ = dart_state->isolate_client();
+  IsolateClient* isolate_client_ = dart_state->isolate_client();
   if (isolate_client_) {
     isolate_client_->WillShutDownIsolate(dart_state->isolate());
   }


### PR DESCRIPTION
Was broken by https://github.com/flutter/engine/pull/4096, which was created while we were transitioning to enforcing clang-format and it slipped right through the cracks.