### PR TITLE
Account for pixel scale when checking against existing buffer storage size on iOS

### DIFF
--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -163,9 +163,10 @@ bool IOSGLContext::PresentRenderBuffer() const {
 
 bool IOSGLContext::UpdateStorageSizeIfNecessary() {
   const CGSize layer_size = [layer_.get() bounds].size;
+  const CGFloat contents_scale = layer_.get().contentsScale;
 
-  const GLint size_width = layer_size.width;
-  const GLint size_height = layer_size.height;
+  const GLint size_width = layer_size.width * contents_scale;
+  const GLint size_height = layer_size.height * contents_scale;
 
   if (size_width == storage_size_width_ && size_height == storage_size_height_) {
     // Nothing to since the stoage size is already consistent with the layer.


### PR DESCRIPTION
Avoids extraneously re-allocating renderbuffers for new CALayers with the same size as the last one.

Fixes https://github.com/flutter/flutter/issues/12061

Also indirectly fixes https://github.com/flutter/flutter/issues/12022. Can't have GL - lifecycle races if we don't need to run these eagl stuff. 

Tested with screen rotates, double-height status bar, posse app, various lifecycle transitions. 