### PR TITLE
Add anchor events for developer centric timeline

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -30,7 +30,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'd9a26967e0b73191b158fcdff2dc8bc303c06a1b',
+  'dart_revision': '62045a4590a333ae557f8f261a909ee75449cd70',
 
   'dart_args_tag': '0.13.7',
   'dart_async_tag': 'daf66909019d2aaec1721fc39d94ea648a9fdc1d',

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -88,19 +88,28 @@ void RuntimeController::NotifyIdle(int64_t deadline) {
 
 void RuntimeController::DispatchPlatformMessage(
     fxl::RefPtr<PlatformMessage> message) {
-  TRACE_EVENT0("flutter", "RuntimeController::DispatchPlatformMessage");
+  TRACE_EVENT1("flutter",
+               "RuntimeController::DispatchPlatformMessage",
+               "mode",
+               "basic");
   GetWindow()->DispatchPlatformMessage(std::move(message));
 }
 
 void RuntimeController::DispatchPointerDataPacket(
     const PointerDataPacket& packet) {
-  TRACE_EVENT0("flutter", "RuntimeController::DispatchPointerDataPacket");
+  TRACE_EVENT1("flutter",
+               "RuntimeController::DispatchPointerDataPacket",
+               "mode",
+               "basic");
   GetWindow()->DispatchPointerDataPacket(packet);
 }
 
 void RuntimeController::DispatchSemanticsAction(int32_t id,
                                                 SemanticsAction action) {
-  TRACE_EVENT0("flutter", "RuntimeController::DispatchSemanticsAction");
+  TRACE_EVENT1("flutter",
+               "RuntimeController::DispatchSemanticsAction",
+               "mode",
+               "basic");
   GetWindow()->DispatchSemanticsAction(id, action);
 }
 

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -27,7 +27,8 @@ RuntimeController::RuntimeController(RuntimeDelegate* client)
 RuntimeController::~RuntimeController() {}
 
 void RuntimeController::CreateDartController(
-    const std::string& script_uri, const uint8_t* isolate_snapshot_data,
+    const std::string& script_uri,
+    const uint8_t* isolate_snapshot_data,
     const uint8_t* isolate_snapshot_instr,
     const std::vector<uint8_t>& platform_kernel) {
   FXL_DCHECK(!dart_controller_);
@@ -47,7 +48,8 @@ void RuntimeController::CreateDartController(
 
   window->UpdateLocale(language_code_, country_code_);
 
-  if (semantics_enabled_) window->UpdateSemanticsEnabled(semantics_enabled_);
+  if (semantics_enabled_)
+    window->UpdateSemanticsEnabled(semantics_enabled_);
 }
 
 void RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {
@@ -56,7 +58,8 @@ void RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {
 
 void RuntimeController::SetLocale(const std::string& language_code,
                                   const std::string& country_code) {
-  if (language_code_ == language_code && country_code_ == country_code) return;
+  if (language_code_ == language_code && country_code_ == country_code)
+    return;
 
   language_code_ = language_code;
   country_code_ = country_code;
@@ -64,7 +67,8 @@ void RuntimeController::SetLocale(const std::string& language_code,
 }
 
 void RuntimeController::SetSemanticsEnabled(bool enabled) {
-  if (semantics_enabled_ == enabled) return;
+  if (semantics_enabled_ == enabled)
+    return;
   semantics_enabled_ = enabled;
   GetWindow()->UpdateSemanticsEnabled(semantics_enabled_);
 }
@@ -111,14 +115,17 @@ std::string RuntimeController::DefaultRouteName() {
   return client_->DefaultRouteName();
 }
 
-void RuntimeController::ScheduleFrame() { client_->ScheduleFrame(); }
+void RuntimeController::ScheduleFrame() {
+  client_->ScheduleFrame();
+}
 
 void RuntimeController::Render(Scene* scene) {
   client_->Render(scene->takeLayerTree());
 }
 
 void RuntimeController::UpdateSemantics(SemanticsUpdate* update) {
-  if (semantics_enabled_) client_->UpdateSemantics(update->takeNodes());
+  if (semantics_enabled_)
+    client_->UpdateSemantics(update->takeNodes());
 }
 
 void RuntimeController::HandlePlatformMessage(

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -27,8 +27,7 @@ RuntimeController::RuntimeController(RuntimeDelegate* client)
 RuntimeController::~RuntimeController() {}
 
 void RuntimeController::CreateDartController(
-    const std::string& script_uri,
-    const uint8_t* isolate_snapshot_data,
+    const std::string& script_uri, const uint8_t* isolate_snapshot_data,
     const uint8_t* isolate_snapshot_instr,
     const std::vector<uint8_t>& platform_kernel) {
   FXL_DCHECK(!dart_controller_);
@@ -48,8 +47,7 @@ void RuntimeController::CreateDartController(
 
   window->UpdateLocale(language_code_, country_code_);
 
-  if (semantics_enabled_)
-    window->UpdateSemanticsEnabled(semantics_enabled_);
+  if (semantics_enabled_) window->UpdateSemanticsEnabled(semantics_enabled_);
 }
 
 void RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {
@@ -58,8 +56,7 @@ void RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {
 
 void RuntimeController::SetLocale(const std::string& language_code,
                                   const std::string& country_code) {
-  if (language_code_ == language_code && country_code_ == country_code)
-    return;
+  if (language_code_ == language_code && country_code_ == country_code) return;
 
   language_code_ = language_code;
   country_code_ = country_code;
@@ -67,8 +64,7 @@ void RuntimeController::SetLocale(const std::string& language_code,
 }
 
 void RuntimeController::SetSemanticsEnabled(bool enabled) {
-  if (semantics_enabled_ == enabled)
-    return;
+  if (semantics_enabled_ == enabled) return;
   semantics_enabled_ = enabled;
   GetWindow()->UpdateSemanticsEnabled(semantics_enabled_);
 }
@@ -88,27 +84,21 @@ void RuntimeController::NotifyIdle(int64_t deadline) {
 
 void RuntimeController::DispatchPlatformMessage(
     fxl::RefPtr<PlatformMessage> message) {
-  TRACE_EVENT1("flutter",
-               "RuntimeController::DispatchPlatformMessage",
-               "mode",
+  TRACE_EVENT1("flutter", "RuntimeController::DispatchPlatformMessage", "mode",
                "basic");
   GetWindow()->DispatchPlatformMessage(std::move(message));
 }
 
 void RuntimeController::DispatchPointerDataPacket(
     const PointerDataPacket& packet) {
-  TRACE_EVENT1("flutter",
-               "RuntimeController::DispatchPointerDataPacket",
-               "mode",
-               "basic");
+  TRACE_EVENT1("flutter", "RuntimeController::DispatchPointerDataPacket",
+               "mode", "basic");
   GetWindow()->DispatchPointerDataPacket(packet);
 }
 
 void RuntimeController::DispatchSemanticsAction(int32_t id,
                                                 SemanticsAction action) {
-  TRACE_EVENT1("flutter",
-               "RuntimeController::DispatchSemanticsAction",
-               "mode",
+  TRACE_EVENT1("flutter", "RuntimeController::DispatchSemanticsAction", "mode",
                "basic");
   GetWindow()->DispatchSemanticsAction(id, action);
 }
@@ -121,17 +111,14 @@ std::string RuntimeController::DefaultRouteName() {
   return client_->DefaultRouteName();
 }
 
-void RuntimeController::ScheduleFrame() {
-  client_->ScheduleFrame();
-}
+void RuntimeController::ScheduleFrame() { client_->ScheduleFrame(); }
 
 void RuntimeController::Render(Scene* scene) {
   client_->Render(scene->takeLayerTree());
 }
 
 void RuntimeController::UpdateSemantics(SemanticsUpdate* update) {
-  if (semantics_enabled_)
-    client_->UpdateSemantics(update->takeNodes());
+  if (semantics_enabled_) client_->UpdateSemantics(update->takeNodes());
 }
 
 void RuntimeController::HandlePlatformMessage(

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -11,7 +11,8 @@
 
 namespace shell {
 
-Animator::Animator(fxl::WeakPtr<Rasterizer> rasterizer, VsyncWaiter* waiter,
+Animator::Animator(fxl::WeakPtr<Rasterizer> rasterizer,
+                   VsyncWaiter* waiter,
                    Engine* engine)
     : rasterizer_(rasterizer),
       waiter_(waiter),
@@ -27,7 +28,9 @@ Animator::Animator(fxl::WeakPtr<Rasterizer> rasterizer, VsyncWaiter* waiter,
 
 Animator::~Animator() = default;
 
-void Animator::Stop() { paused_ = true; }
+void Animator::Stop() {
+  paused_ = true;
+}
 
 void Animator::Start() {
   if (!paused_) {
@@ -40,7 +43,9 @@ void Animator::Start() {
 
 // This ID is used by the timeline component to correctly align
 // GPU Workloads events with their respective Framework Workload.
-const char* Animator::FrameId() { return (frame_number_ % 2) ? "0" : "1"; }
+const char* Animator::FrameId() {
+  return (frame_number_ % 2) ? "0" : "1";
+}
 
 static int64_t FxlToDartOrEarlier(fxl::TimePoint time) {
   int64_t dart_now = Dart_TimelineGetMicros();
@@ -104,7 +109,8 @@ void Animator::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
     rasterizer = rasterizer_, pipeline = layer_tree_pipeline_,
     frame_id = FrameId()
   ]() {
-    if (!rasterizer.get()) return;
+    if (!rasterizer.get())
+      return;
     TRACE_EVENT2("flutter", "GPU Workload", "mode", "basic", "frame", frame_id);
     rasterizer->Draw(pipeline);
   });
@@ -143,7 +149,8 @@ void Animator::RequestFrame() {
 void Animator::AwaitVSync() {
   waiter_->AsyncWaitForVsync([self = weak_factory_.GetWeakPtr()](
       fxl::TimePoint frame_start_time, fxl::TimePoint frame_target_time) {
-    if (self) self->BeginFrame(frame_start_time, frame_target_time);
+    if (self)
+      self->BeginFrame(frame_start_time, frame_target_time);
   });
 
   engine_->NotifyIdle(dart_frame_deadline_);

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -11,8 +11,7 @@
 
 namespace shell {
 
-Animator::Animator(fxl::WeakPtr<Rasterizer> rasterizer,
-                   VsyncWaiter* waiter,
+Animator::Animator(fxl::WeakPtr<Rasterizer> rasterizer, VsyncWaiter* waiter,
                    Engine* engine)
     : rasterizer_(rasterizer),
       waiter_(waiter),
@@ -28,9 +27,7 @@ Animator::Animator(fxl::WeakPtr<Rasterizer> rasterizer,
 
 Animator::~Animator() = default;
 
-void Animator::Stop() {
-  paused_ = true;
-}
+void Animator::Stop() { paused_ = true; }
 
 void Animator::Start() {
   if (!paused_) {
@@ -43,9 +40,7 @@ void Animator::Start() {
 
 // This ID is used by the timeline component to correctly align
 // GPU Workloads events with their respective Framework Workload.
-const char *Animator::FrameId() {
-  return (frame_number_ % 2) ? "0" : "1";
-}
+const char* Animator::FrameId() { return (frame_number_ % 2) ? "0" : "1"; }
 
 static int64_t FxlToDartOrEarlier(fxl::TimePoint time) {
   int64_t dart_now = Dart_TimelineGetMicros();
@@ -83,10 +78,8 @@ void Animator::BeginFrame(fxl::TimePoint frame_start_time,
   last_begin_frame_time_ = frame_start_time;
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
   {
-    TRACE_EVENT2("flutter",
-                 "Framework Workload",
-                 "mode", "basic",
-                 "frame", FrameId());
+    TRACE_EVENT2("flutter", "Framework Workload", "mode", "basic", "frame",
+                 FrameId());
     engine_->BeginFrame(last_begin_frame_time_);
   }
 
@@ -107,18 +100,14 @@ void Animator::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   // Commit the pending continuation.
   producer_continuation_.Complete(std::move(layer_tree));
 
-  blink::Threads::Gpu()->PostTask(
-      [ rasterizer = rasterizer_,
-        pipeline = layer_tree_pipeline_,
-        frame_id = FrameId() ]() {
-        if (!rasterizer.get())
-          return;
-        TRACE_EVENT2("flutter",
-                     "GPU Workload",
-                     "mode", "basic",
-                     "frame", frame_id);
-        rasterizer->Draw(pipeline);
-      });
+  blink::Threads::Gpu()->PostTask([
+    rasterizer = rasterizer_, pipeline = layer_tree_pipeline_,
+    frame_id = FrameId()
+  ]() {
+    if (!rasterizer.get()) return;
+    TRACE_EVENT2("flutter", "GPU Workload", "mode", "basic", "frame", frame_id);
+    rasterizer->Draw(pipeline);
+  });
 }
 
 void Animator::RequestFrame() {
@@ -154,8 +143,7 @@ void Animator::RequestFrame() {
 void Animator::AwaitVSync() {
   waiter_->AsyncWaitForVsync([self = weak_factory_.GetWeakPtr()](
       fxl::TimePoint frame_start_time, fxl::TimePoint frame_target_time) {
-    if (self)
-      self->BeginFrame(frame_start_time, frame_target_time);
+    if (self) self->BeginFrame(frame_start_time, frame_target_time);
   });
 
   engine_->NotifyIdle(dart_frame_deadline_);

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -41,10 +41,10 @@ void Animator::Start() {
   RequestFrame();
 }
 
-// This ID is used by the timeline component to correctly align
+// This Parity is used by the timeline component to correctly align
 // GPU Workloads events with their respective Framework Workload.
-const char* Animator::FrameId() {
-  return (frame_number_ % 2) ? "0" : "1";
+const char* Animator::FrameParity() {
+  return (frame_number_ % 2) ? "even" : "odd";
 }
 
 static int64_t FxlToDartOrEarlier(fxl::TimePoint time) {
@@ -84,7 +84,7 @@ void Animator::BeginFrame(fxl::TimePoint frame_start_time,
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
   {
     TRACE_EVENT2("flutter", "Framework Workload", "mode", "basic", "frame",
-                 FrameId());
+                 FrameParity());
     engine_->BeginFrame(last_begin_frame_time_);
   }
 
@@ -107,7 +107,7 @@ void Animator::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
 
   blink::Threads::Gpu()->PostTask([
     rasterizer = rasterizer_, pipeline = layer_tree_pipeline_,
-    frame_id = FrameId()
+    frame_id = FrameParity()
   ]() {
     if (!rasterizer.get())
       return;

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -18,8 +18,7 @@ namespace shell {
 
 class Animator {
  public:
-  Animator(fxl::WeakPtr<Rasterizer> rasterizer,
-           VsyncWaiter* waiter,
+  Animator(fxl::WeakPtr<Rasterizer> rasterizer, VsyncWaiter* waiter,
            Engine* engine);
 
   ~Animator();
@@ -40,7 +39,7 @@ class Animator {
 
   void AwaitVSync();
 
-  const char *FrameId();
+  const char* FrameId();
 
   fxl::WeakPtr<Rasterizer> rasterizer_;
   VsyncWaiter* waiter_;

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -18,7 +18,8 @@ namespace shell {
 
 class Animator {
  public:
-  Animator(fxl::WeakPtr<Rasterizer> rasterizer, VsyncWaiter* waiter,
+  Animator(fxl::WeakPtr<Rasterizer> rasterizer,
+           VsyncWaiter* waiter,
            Engine* engine);
 
   ~Animator();

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -40,7 +40,7 @@ class Animator {
 
   void AwaitVSync();
 
-  const char* FrameId();
+  const char* FrameParity();
 
   fxl::WeakPtr<Rasterizer> rasterizer_;
   VsyncWaiter* waiter_;

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -40,6 +40,8 @@ class Animator {
 
   void AwaitVSync();
 
+  const char *FrameId();
+
   fxl::WeakPtr<Rasterizer> rasterizer_;
   VsyncWaiter* waiter_;
   Engine* engine_;

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -59,8 +59,17 @@ static void OnNativeVsync(JNIEnv* env,
   // Vsync" checkbox in the timeline can be enabled.
   // See: https://github.com/catapult-project/catapult/blob/2091404475cbba9b786
   // 442979b6ec631305275a6/tracing/tracing/extras/vsync/vsync_auditor.html#L26
-  TRACE_EVENT0("flutter", "VSYNC");
-  TRACE_EVENT_INSTANT0("flutter", "VSYNC");
+  {
+      // Every 10 bits we can potentially increase the size of the output
+      // by 3 digis.
+      // sizeof(jlong) * 8 (number of bits)
+      // sizeof(jlong) * 8 / 10 (number of groups of 10 bits)
+      // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
+      // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
+      char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
+      sprintf(deadline, "%lld", frameTargetTimeNanos / 1000); // microseconds
+      TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
+  }
   fxl::WeakPtr<VsyncWaiterAndroid>* weak =
       reinterpret_cast<fxl::WeakPtr<VsyncWaiterAndroid>*>(cookie);
   VsyncWaiterAndroid* waiter = weak->get();

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -59,6 +59,9 @@ static void OnNativeVsync(JNIEnv* env,
   // Vsync" checkbox in the timeline can be enabled.
   // See: https://github.com/catapult-project/catapult/blob/2091404475cbba9b786
   // 442979b6ec631305275a6/tracing/tracing/extras/vsync/vsync_auditor.html#L26
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+  TRACE_EVENT1("flutter", "VSYNC", "mode", "basic");
+#else
   {
     // Every 10 bits we can potentially increase the size of the output
     // by 3 digis.
@@ -70,6 +73,7 @@ static void OnNativeVsync(JNIEnv* env,
     sprintf(deadline, "%lld", frameTargetTimeNanos / 1000);  // microseconds
     TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
   }
+#endif
   fxl::WeakPtr<VsyncWaiterAndroid>* weak =
       reinterpret_cast<fxl::WeakPtr<VsyncWaiterAndroid>*>(cookie);
   VsyncWaiterAndroid* waiter = weak->get();

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/android/vsync_waiter_android.h"
 
+#include <cmath>
 #include <utility>
 
 #include "flutter/common/threads.h"
@@ -63,13 +64,8 @@ static void OnNativeVsync(JNIEnv* env,
   TRACE_EVENT1("flutter", "VSYNC", "mode", "basic");
 #else
   {
-    // Every 10 bits we can potentially increase the size of the output
-    // by 3 digis.
-    // sizeof(jlong) * 8 (number of bits)
-    // sizeof(jlong) * 8 / 10 (number of groups of 10 bits)
-    // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
-    // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
-    char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
+    constexpr size_t num_chars = sizeof(jlong) * CHAR_BIT * 3.4 + 2;
+    char deadline[num_chars];
     sprintf(deadline, "%lld", frameTargetTimeNanos / 1000);  // microseconds
     TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
   }

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -60,15 +60,15 @@ static void OnNativeVsync(JNIEnv* env,
   // See: https://github.com/catapult-project/catapult/blob/2091404475cbba9b786
   // 442979b6ec631305275a6/tracing/tracing/extras/vsync/vsync_auditor.html#L26
   {
-      // Every 10 bits we can potentially increase the size of the output
-      // by 3 digis.
-      // sizeof(jlong) * 8 (number of bits)
-      // sizeof(jlong) * 8 / 10 (number of groups of 10 bits)
-      // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
-      // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
-      char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
-      sprintf(deadline, "%lld", frameTargetTimeNanos / 1000); // microseconds
-      TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
+    // Every 10 bits we can potentially increase the size of the output
+    // by 3 digis.
+    // sizeof(jlong) * 8 (number of bits)
+    // sizeof(jlong) * 8 / 10 (number of groups of 10 bits)
+    // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
+    // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
+    char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
+    sprintf(deadline, "%lld", frameTargetTimeNanos / 1000);  // microseconds
+    TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
   }
   fxl::WeakPtr<VsyncWaiterAndroid>* weak =
       reinterpret_cast<fxl::WeakPtr<VsyncWaiterAndroid>*>(cookie);

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -52,6 +52,22 @@
 
   _displayLink.paused = YES;
 
+  // Note: The tag name must be "VSYNC" (it is special) so that the "Highlight
+  // Vsync" checkbox in the timeline can be enabled.
+  // See: https://github.com/catapult-project/catapult/blob/2091404475cbba9b786
+  // 442979b6ec631305275a6/tracing/tracing/extras/vsync/vsync_auditor.html#L26
+  {
+    // Every 10 bits we can potentially increase the size of the output
+    // by 3 digis.
+    // sizeof(jlong) * 8 (number of bits)
+    // sizeof(jlong) * 8 / 10 (number of groups of 10 bits)
+    // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
+    // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
+    char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
+    sprintf(deadline, "%lld", frame_target_time / 1000); // microseconds
+    TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
+  }
+
   // Note: Even though we know we are on the UI thread already (since the
   // display link was scheduled on the UI thread in the contructor), we use
   // the PostTask mechanism because the callback may have side-effects that need

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -60,14 +60,9 @@
   TRACE_EVENT1("flutter", "VSYNC", "mode", "basic");
 #else
   {
-    // Every 10 bits we can potentially increase the size of the output
-    // by 3 digis.
-    // sizeof(jlong) * 8 (number of bits)
-    // sizeof(jlong) * 8 / 10 (number of groups of 10 bits)
-    // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
-    // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
-    char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
-    sprintf(deadline, "%lld", frameTargetTimeNanos / 1000);  // microseconds
+    constexpr size_t num_chars = sizeof(fxl::TimePoint) * CHAR_BIT * 3.4 + 2;
+    char deadline[num_chars];
+    sprintf(deadline, "%lld", frame_target_time / 1000);  // microseconds
     TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
   }
 #endif

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -56,6 +56,9 @@
   // Vsync" checkbox in the timeline can be enabled.
   // See: https://github.com/catapult-project/catapult/blob/2091404475cbba9b786
   // 442979b6ec631305275a6/tracing/tracing/extras/vsync/vsync_auditor.html#L26
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+  TRACE_EVENT1("flutter", "VSYNC", "mode", "basic");
+#else
   {
     // Every 10 bits we can potentially increase the size of the output
     // by 3 digis.
@@ -64,9 +67,10 @@
     // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
     // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
     char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
-    sprintf(deadline, "%lld", frame_target_time / 1000);  // microseconds
+    sprintf(deadline, "%lld", frameTargetTimeNanos / 1000);  // microseconds
     TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
   }
+#endif
 
   // Note: Even though we know we are on the UI thread already (since the
   // display link was scheduled on the UI thread in the contructor), we use

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -64,7 +64,7 @@
     // sizeof(jlong) * 8 / 10 * 3 (number of digits - 1)
     // sizeof(jlong) * 8 / 10 * 3 + 2 (number of digits + \0)
     char deadline[sizeof(jlong) * 8 / 10 * 3 + 2];
-    sprintf(deadline, "%lld", frame_target_time / 1000); // microseconds
+    sprintf(deadline, "%lld", frame_target_time / 1000);  // microseconds
     TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
   }
 

--- a/travis/licenses_golden/licenses_dart
+++ b/travis/licenses_golden/licenses_dart
@@ -1,4 +1,4 @@
-Signature: 6acb5ec35f946b04626e9b127e818708
+Signature: 1dbfd20015aaf7761e4f14c34f720089
 
 UNUSED LICENSES:
 
@@ -1499,6 +1499,8 @@ FILE: ../../../dart/runtime/bin/error_exit.h
 FILE: ../../../dart/runtime/bin/gzip.cc
 FILE: ../../../dart/runtime/bin/gzip.h
 FILE: ../../../dart/runtime/bin/isolate_data.cc
+FILE: ../../../dart/runtime/bin/main_options.cc
+FILE: ../../../dart/runtime/bin/main_options.h
 FILE: ../../../dart/runtime/bin/namespace.cc
 FILE: ../../../dart/runtime/bin/namespace.h
 FILE: ../../../dart/runtime/bin/namespace_android.cc
@@ -1507,6 +1509,8 @@ FILE: ../../../dart/runtime/bin/namespace_linux.cc
 FILE: ../../../dart/runtime/bin/namespace_macos.cc
 FILE: ../../../dart/runtime/bin/namespace_patch.dart
 FILE: ../../../dart/runtime/bin/namespace_win.cc
+FILE: ../../../dart/runtime/bin/options.cc
+FILE: ../../../dart/runtime/bin/options.h
 FILE: ../../../dart/runtime/bin/secure_socket_filter.cc
 FILE: ../../../dart/runtime/bin/secure_socket_filter.h
 FILE: ../../../dart/runtime/bin/secure_socket_utils.cc
@@ -1593,6 +1597,7 @@ FILE: ../../../dart/runtime/vm/timeline_win.cc
 FILE: ../../../dart/runtime/vm/zone_text_buffer.cc
 FILE: ../../../dart/runtime/vm/zone_text_buffer.h
 FILE: ../../../dart/sdk/lib/internal/linked_list.dart
+FILE: ../../../dart/sdk/lib/io/embedder_config.dart
 FILE: ../../../dart/sdk/lib/io/namespace_impl.dart
 FILE: ../../../dart/sdk/lib/io/sync_socket.dart
 FILE: ../../../dart/sdk/lib/vmservice/named_lookup.dart


### PR DESCRIPTION
By adding these events the new developer centric timeline will be able
to identify and correlate events related to the different stages of the
drawing pipeline.

This Pull Request is for review purposes, it needs to wait for the corresponding changes in the Dart VM to land first.