### PR TITLE
Follow up PR that updates lib licenses hash

### DIFF
--- a/travis/licenses_golden/licenses_lib
+++ b/travis/licenses_golden/licenses_lib
@@ -1,4 +1,4 @@
-Signature: 094cf05a80bb243b58e419e46b50190a
+Signature: 962e1f59598f0257ec8ebddb7688f04d
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
This is follow-up to https://github.com/flutter/engine/commit/1b367b06f1c7cab0be10a7a8ad381ccb7b124acf with updated license lib hash.