### PR TITLE
Roll garnet dependency to pick up a win bot fix

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -122,7 +122,7 @@ deps = {
    # and not have to specific specific hashes.
 
   'src/garnet':
-   Var('fuchsia_git') + '/garnet' + '@' + '1ec17c0bdae1e2981902e837f6ea7162ff0cad84',
+   Var('fuchsia_git') + '/garnet' + '@' + '73eeb0583e7967016ad7386a90353bf6937488b9',
 
   'src/lib/tonic':
    Var('fuchsia_git') + '/tonic' + '@' + '124cc47529d884bb72f4911212b3f09e6b9f330b',

--- a/travis/licenses_golden/licenses_garnet
+++ b/travis/licenses_golden/licenses_garnet
@@ -1,4 +1,4 @@
-Signature: f0c0cab5b7975873c0dddd1946007b8e
+Signature: 8ed0caa147658e269898dc0019c368c3
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
This has a fix for https://build.chromium.org/p/client.flutter/builders/Windows%20Engine/builds/682