### PR TITLE
Support correct keyboards for multi-line text editing.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -166,7 +166,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
         switch (actionCode) {
             case EditorInfo.IME_ACTION_NONE:
                 mFlutterChannel.invokeMethod("TextInputClient.performAction",
-                    Arrays.asList(mClient, "TextInputAction.none"));
+                    Arrays.asList(mClient, "TextInputAction.newline"));
                 break;
             default:
             case EditorInfo.IME_ACTION_DONE:

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.text.Editable;
 import android.text.Selection;
 import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.view.KeyEvent;
 
@@ -162,8 +163,17 @@ class InputConnectionAdaptor extends BaseInputConnection {
     @Override
     public boolean performEditorAction(int actionCode) {
         // TODO(abarth): Support more actions.
-        mFlutterChannel.invokeMethod("TextInputClient.performAction",
-            Arrays.asList(mClient, "TextInputAction.done"));
+        switch (actionCode) {
+            case EditorInfo.IME_ACTION_NONE:
+                mFlutterChannel.invokeMethod("TextInputClient.performAction",
+                    Arrays.asList(mClient, "TextInputAction.none"));
+                break;
+            default:
+            case EditorInfo.IME_ACTION_DONE:
+                mFlutterChannel.invokeMethod("TextInputClient.performAction",
+                    Arrays.asList(mClient, "TextInputAction.done"));
+                break;
+        }
         return true;
     }
 }

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -93,7 +93,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     public boolean deleteSurroundingText(int beforeLength, int afterLength) {
         if (Selection.getSelectionStart(mEditable) == -1 ||
             Selection.getSelectionStart(mEditable) == -1)
-            return true;
+            return true;9c518cb751e34b0
 
         boolean result = super.deleteSurroundingText(beforeLength, afterLength);
         updateEditingState();

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -88,9 +88,8 @@ public class TextInputPlugin implements MethodCallHandler {
             return InputType.TYPE_CLASS_PHONE;
 
         int textType = InputType.TYPE_CLASS_TEXT;
-        if (inputType.equals("TextInputType.multiline")) {
+        if (inputType.equals("TextInputType.multiline"))
             textType |= InputType.TYPE_TEXT_FLAG_MULTI_LINE;
-        }
         else if (inputType.equals("TextInputType.emailAddress"))
             textType |= InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
         else if (inputType.equals("TextInputType.url"))

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -105,7 +105,7 @@ public class TextInputPlugin implements MethodCallHandler {
     }
 
     private static int inputActionFromTextInputAction(String inputAction) {
-        if (inputAction.equals("TextInputAction.none"))
+        if (inputAction.equals("TextInputAction.newline"))
             return EditorInfo.IME_ACTION_NONE;
         return EditorInfo.IME_ACTION_DONE;
     }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -88,7 +88,10 @@ public class TextInputPlugin implements MethodCallHandler {
             return InputType.TYPE_CLASS_PHONE;
 
         int textType = InputType.TYPE_CLASS_TEXT;
-        if (inputType.equals("TextInputType.emailAddress"))
+        if (inputType.equals("TextInputType.multiline")) {
+            textType |= InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+        }
+        else if (inputType.equals("TextInputType.emailAddress"))
             textType |= InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
         else if (inputType.equals("TextInputType.url"))
             textType |= InputType.TYPE_TEXT_VARIATION_URI;
@@ -102,6 +105,12 @@ public class TextInputPlugin implements MethodCallHandler {
         return textType;
     }
 
+    private static int inputActionFromTextInputAction(String inputAction) {
+        if (inputAction.equals("TextInputAction.none"))
+            return EditorInfo.IME_ACTION_NONE;
+        return EditorInfo.IME_ACTION_DONE;
+    }
+
     public InputConnection createInputConnection(FlutterView view, EditorInfo outAttrs)
         throws JSONException {
         if (mClient == 0)
@@ -111,9 +120,22 @@ public class TextInputPlugin implements MethodCallHandler {
             mConfiguration.getString("inputType"),
             mConfiguration.optBoolean("obscureText"),
             mConfiguration.optBoolean("autocorrect", true));
-        if (!mConfiguration.isNull("actionLabel"))
-          outAttrs.actionLabel = mConfiguration.getString("actionLabel");
-        outAttrs.imeOptions = EditorInfo.IME_ACTION_DONE | EditorInfo.IME_FLAG_NO_FULLSCREEN;
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN;
+        int enterAction;
+        if (mConfiguration.isNull("inputAction")) {
+            // If an explicit input action isn't set, then default to none for multi-line fields
+            // and done for single line fields.
+            enterAction =
+                (InputType.TYPE_TEXT_FLAG_MULTI_LINE & outAttrs.inputType) != 0 ?
+                    EditorInfo.IME_ACTION_NONE : EditorInfo.IME_ACTION_DONE;
+        } else {
+            enterAction = inputActionFromTextInputAction(mConfiguration.getString("inputAction"));
+        }
+        if (!mConfiguration.isNull("actionLabel")) {
+            outAttrs.actionLabel = mConfiguration.getString("actionLabel");
+            outAttrs.actionId = enterAction;
+        }
+        outAttrs.imeOptions |= enterAction;
 
         InputConnectionAdaptor connection = new InputConnectionAdaptor(view, mClient, mFlutterChannel, mEditable);
         outAttrs.initialSelStart = Math.max(Selection.getSelectionStart(mEditable), 0);

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -124,9 +124,9 @@ public class TextInputPlugin implements MethodCallHandler {
         if (mConfiguration.isNull("inputAction")) {
             // If an explicit input action isn't set, then default to none for multi-line fields
             // and done for single line fields.
-            enterAction =
-                (InputType.TYPE_TEXT_FLAG_MULTI_LINE & outAttrs.inputType) != 0 ?
-                    EditorInfo.IME_ACTION_NONE : EditorInfo.IME_ACTION_DONE;
+            enterAction = (InputType.TYPE_TEXT_FLAG_MULTI_LINE & outAttrs.inputType) != 0
+                ? EditorInfo.IME_ACTION_NONE
+                : EditorInfo.IME_ACTION_DONE;
         } else {
             enterAction = inputActionFromTextInputAction(mConfiguration.getString("inputAction"));
         }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -9,6 +9,7 @@
 
 typedef NS_ENUM(NSInteger, FlutterTextInputAction) {
   FlutterTextInputActionDone,
+  FlutterTextInputActionNewline,
 };
 
 @protocol FlutterTextInputDelegate<NSObject>

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -12,6 +12,8 @@ static const char _kTextAffinityUpstream[] = "TextAffinity.upstream";
 static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   if ([inputType isEqualToString:@"TextInputType.text"])
     return UIKeyboardTypeDefault;
+  if ([inputType isEqualToString:@"TextInputType.multiline"])
+    return UIKeyboardTypeDefault;
   if ([inputType isEqualToString:@"TextInputType.number"])
     return UIKeyboardTypeDecimalPad;
   if ([inputType isEqualToString:@"TextInputType.phone"])
@@ -21,6 +23,12 @@ static UIKeyboardType ToUIKeyboardType(NSString* inputType) {
   if ([inputType isEqualToString:@"TextInputType.url"])
     return UIKeyboardTypeURL;
   return UIKeyboardTypeDefault;
+}
+
+static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
+  if ([inputType isEqualToString:@"TextInputType.multiline"])
+    return UIReturnKeyDefault;
+  return UIReturnKeyDone;
 }
 
 static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inputType) {
@@ -569,6 +577,7 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
 
 - (void)setTextInputClient:(int)client withConfiguration:(NSDictionary*)configuration {
   _view.keyboardType = ToUIKeyboardType(configuration[@"inputType"]);
+  _view.returnKeyType = ToUIReturnKeyType(configuration[@"inputType"]);
   _view.autocapitalizationType = ToUITextAutocapitalizationType(configuration[@"inputType"]);
   _view.secureTextEntry = [configuration[@"obscureText"] boolValue];
   NSString* autocorrect = configuration[@"autocorrect"];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -280,6 +280,8 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
     [_textInputDelegate performAction:FlutterTextInputActionDone withClient:_textInputClient];
     return NO;
   }
+  if (self.returnKeyType == UIReturnKeyDefault && [text isEqualToString:@"\n"])
+    [_textInputDelegate performAction:FlutterTextInputActionNewline withClient:_textInputClient];
   return YES;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -626,6 +626,9 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
     case FlutterTextInputActionDone:
       actionString = @"TextInputAction.done";
       break;
+    case FlutterTextInputActionNewline:
+      actionString = @"TextInputAction.newline";
+      break;
   }
   [_textInputChannel.get() invokeMethod:@"TextInputClient.performAction"
                               arguments:@[ @(client), actionString ]];


### PR DESCRIPTION
This addresses part of [#8028](https://github.com/flutter/flutter/issues/8028), implementing the Engine-side support for it.

After fixing this, there are still some cursor placement problems: it appears that the whitespace collapsing code is ignoring the trailing newlines when someone tries to move to the next line. (it's not a TextPosition affinity problem, as we appear to always use downstream affinity).  This may be moot, since we're replacing Blink for text rendering.