### PR TITLE
Set a higher filter quality for drawing raster cache images

### DIFF
--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -40,11 +40,13 @@ void PictureLayer::Paint(PaintContext& context) {
   context.canvas.translate(offset_.x(), offset_.y());
 
   if (raster_cache_result_.is_valid()) {
+    SkPaint paint;
+    paint.setFilterQuality(kLow_SkFilterQuality);
     context.canvas.drawImageRect(
         raster_cache_result_.image(),             // image
         raster_cache_result_.source_rect(),       // source
         raster_cache_result_.destination_rect(),  // destination
-        nullptr,                                  // paint
+        &paint,                                   // paint
         SkCanvas::kStrict_SrcRectConstraint       // source constraint
     );
   } else {


### PR DESCRIPTION
According to Skia, kLow offers a quality improvement with little cost over
the default kNone

Fixes https://github.com/flutter/flutter/issues/12091