### PR TITLE
Silence Warning

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -297,8 +297,8 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
   std::vector<SemanticsObject*>* children = [_semanticsObject children];
   for (size_t i = 0; i < children->size(); i++) {
     SemanticsObject* child = (*children)[i];
-    if (![child hasChildren] && child == element ||
-        [child hasChildren] && [child accessibilityContainer] == element)
+    if ((![child hasChildren] && child == element) ||
+        ([child hasChildren] && [child accessibilityContainer] == element))
       return i + 1;
   }
   return NSNotFound;


### PR DESCRIPTION
Follow-up to https://github.com/flutter/engine/pull/4110

```
../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm:300:30: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
    if (![child hasChildren] && child == element ||
        ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~ ~~
../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm:300:30: note: place parentheses around the '&&' expression to silence this warning
    if (![child hasChildren] && child == element ||
                             ^
        (                                       )
../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm:301:29: error: '&&' within '||' [-Werror,-Wlogical-op-parentheses]
        [child hasChildren] && [child accessibilityContainer] == element)
        ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm:301:29: note: place parentheses around the '&&' expression to silence this warning
        [child hasChildren] && [child accessibilityContainer] == element)
                            ^
        (                                                               )
```