### PR TITLE
Don't crash on iOS if there is only a single SemanticsNode

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -206,11 +206,12 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
 #pragma mark - UIAccessibilityElement protocol
 
 - (id)accessibilityContainer {
-  if ([self hasChildren]) {
+  if ([self hasChildren] || _uid == kRootNodeId) {
     if (_container == nil)
       _container = [[SemanticsObjectContainer alloc] initWithSemanticsObject:self bridge:_bridge];
     return _container;
   }
+  NSAssert(_parent != nil, @"illegal access to parent");
   return [_parent accessibilityContainer];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -211,7 +211,7 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
       _container = [[SemanticsObjectContainer alloc] initWithSemanticsObject:self bridge:_bridge];
     return _container;
   }
-  NSAssert(_parent != nil, @"illegal access to parent");
+  NSAssert(_parent != nil, @"Illegal access to non-existent parent of root semantics node");
   return [_parent accessibilityContainer];
 }
 


### PR DESCRIPTION
Previously, the code assumed that the root SemanticsNode will always have a child. This is not true as can be seen in the hello_world example app, which would crash when a11y is turned on.