### PR TITLE
Revert "account for pixel scale when checking against existing buffer…

### DIFF
--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -163,10 +163,9 @@ bool IOSGLContext::PresentRenderBuffer() const {
 
 bool IOSGLContext::UpdateStorageSizeIfNecessary() {
   const CGSize layer_size = [layer_.get() bounds].size;
-  const CGFloat contents_scale = layer_.get().contentsScale;
 
-  const GLint size_width = layer_size.width * contents_scale;
-  const GLint size_height = layer_size.height * contents_scale;
+  const GLint size_width = layer_size.width;
+  const GLint size_height = layer_size.height;
 
   if (size_width == storage_size_width_ && size_height == storage_size_height_) {
     // Nothing to since the stoage size is already consistent with the layer.


### PR DESCRIPTION
… storage size (#4103)"

This reverts commit 2d530daeca438ca24562d290616c0aec5ab76b88 as it looks
like a potential cause of performance benchmark regressions on
https://flutter-dashboard.appspot.com/benchmarks.html:
 - flutter_gallery_ios__transition_perf average_frame_build_time_millis
 - flutter_gallery_ios__transition_perf missed_frame_build_budget_count