### PR TITLE
libtxt: refactor glyph position calculation

### DIFF
--- a/lib/ui/text/paragraph_impl_txt.cc
+++ b/lib/ui/text/paragraph_impl_txt.cc
@@ -75,10 +75,10 @@ std::vector<TextBox> ParagraphImplTxt::getRectsForRange(unsigned start,
 
 Dart_Handle ParagraphImplTxt::getPositionForOffset(double dx, double dy) {
   Dart_Handle result = Dart_NewList(2);
-  Dart_ListSetAt(
-      result, 0,
-      ToDart(m_paragraph->GetGlyphPositionAtCoordinate(dx, dy, true)));
-  Dart_ListSetAt(result, 1, ToDart(static_cast<int>(EAffinity::DOWNSTREAM)));
+  txt::Paragraph::PositionWithAffinity pos =
+      m_paragraph->GetGlyphPositionAtCoordinate(dx, dy, true);
+  Dart_ListSetAt(result, 0, ToDart(pos.position));
+  Dart_ListSetAt(result, 1, ToDart(static_cast<int>(pos.affinity)));
   return result;
 }
 

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -54,6 +54,15 @@ class Paragraph {
 
   ~Paragraph();
 
+  enum Affinity { UPSTREAM, DOWNSTREAM };
+
+  struct PositionWithAffinity {
+    const size_t position;
+    const Affinity affinity;
+
+    PositionWithAffinity(size_t p, Affinity a) : position(p), affinity(a) {}
+  };
+
   // Minikin Layout doLayout() and LineBreaker addStyleRun() has an
   // O(N^2) (according to benchmarks) time complexity where N is the total
   // number of characters. However, this is not significant for reasonably sized
@@ -116,7 +125,7 @@ class Paragraph {
   // typical use-case for this is when the cursor is meant to be on either side
   // of any given character. This allows the transition border to be middle of
   // each character.
-  size_t GetGlyphPositionAtCoordinate(
+  PositionWithAffinity GetGlyphPositionAtCoordinate(
       double dx,
       double dy,
       bool using_glyph_center_as_boundary = false) const;
@@ -180,9 +189,18 @@ class Paragraph {
   // TODO(garyq): Can we access this info without redundantly storing it here?
   std::vector<double> line_widths_;
   std::vector<double> line_heights_;
-  // Holds the laid out x positions of each glyph, as well as padding to make
-  // math on it simpler.
-  std::vector<std::vector<double>> glyph_position_x_;
+
+  struct GlyphPosition {
+    double start;
+    double advance;
+
+    GlyphPosition(double s, double a) : start(s), advance(a) {}
+
+    double glyph_end() const { return start + advance; }
+  };
+
+  // Holds the laid out x positions of each glyph.
+  std::vector<std::vector<GlyphPosition>> glyph_position_x_;
 
   // Set of glyph IDs that correspond to whitespace.
   std::set<GlyphID> whitespace_set_;

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -341,11 +341,11 @@ TEST_F(ParagraphTest, LeftAlignParagraph) {
             paragraph->GetParagraphStyle().text_align);
 
   // Tests for GetGlyphPositionAtCoordinate()
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(0, 0), 0ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 1), 0ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 35), 68ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 70), 134ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(2000, 35), 134ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(0, 0).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 1).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 35).position, 68ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 70).position, 134ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(2000, 35).position, 134ull);
 
   ASSERT_TRUE(Snapshot());
 }
@@ -884,28 +884,34 @@ TEST_F(ParagraphTest, GetGlyphPositionAtCoordinateParagraph) {
   // the original text because the final trailing whitespaces are sometimes not
   // drawn (namely, when using "justify" alignment) and therefore are not active
   // glyphs.
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(-10000, -10000), 0ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(-1, -1), 0ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(0, 0), 0ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(3, 3), 0ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(35, 1), 1ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(300, 2), 10ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(301, 2.2), 10ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(302, 2.6), 10ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(301, 2.1), 10ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(100000, 20), 18ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(450, 20), 16ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(100000, 90), 36ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(-100000, 90), 18ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(20, -80), 0ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 90), 18ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 180), 36ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(10000, 180), 54ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(70, 180), 38ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 270), 54ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(35, 90), 19ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(10000, 10000), 77ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(85, 10000), 74ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(-10000, -10000).position,
+            0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(-1, -1).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(0, 0).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(3, 3).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(35, 1).position, 1ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(300, 2).position, 10ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(301, 2.2).position, 10ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(302, 2.6).position, 10ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(301, 2.1).position, 10ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(100000, 20).position,
+            18ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(450, 20).position, 16ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(100000, 90).position,
+            36ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(-100000, 90).position,
+            18ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(20, -80).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 90).position, 18ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 180).position, 36ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(10000, 180).position,
+            54ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(70, 180).position, 38ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 270).position, 54ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(35, 90).position, 19ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(10000, 10000).position,
+            77ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(85, 10000).position, 74ull);
 }
 
 TEST_F(ParagraphTest, GetRectsForRangeParagraph) {


### PR DESCRIPTION
* Remove padding values in line_heights and glyph_position_x.  Each value
  in glyph_position_x now represents an actual glyph in the layout.

* Remove code intended to handle extra characters beyond the end of the
  last line.  The LineBreaker should ensure that the end of the last run
  matches the end of the last line.

* Return the upstream/downstream affinity of the cursor position in
  GetGlyphPositionAtCoordinate.

* Account for the space at the end of a word wrapped line in
  GetGlyphPositionAtCoordinate / GetCoordinatesForGlyphPosition