### PR TITLE
A per target function profiler.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -2,6 +2,18 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+source_set("trace_event") {
+  sources = [
+    "trace_event.cc",
+    "trace_event.h",
+  ]
+
+  deps = [
+    "//dart/runtime:dart_api",
+    "//garnet/public/lib/fxl",
+  ]
+}
+
 source_set("fml") {
   sources = [
     "icu_util.cc",
@@ -19,16 +31,17 @@ source_set("fml") {
     "thread.cc",
     "thread.h",
     "thread_local.h",
-    "trace_event.cc",
-    "trace_event.h",
   ]
 
   deps = [
-    "//dart/runtime:dart_api",
     "//garnet/public/lib/fxl",
 
     # These need to be in sync with the Fuchsia buildroot.
     "//third_party/icu",
+  ]
+
+  public_deps = [
+    ":trace_event",
   ]
 
   configs += [ "//third_party/icu:icu_config" ]

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -9,8 +9,6 @@
 #include <cstdint>
 #include <string>
 
-#include "lib/fxl/macros.h"
-
 #ifndef TRACE_EVENT_HIDE_MACROS
 
 #define TRACE_EVENT0(category_group, name)           \
@@ -115,7 +113,8 @@ class ScopedInstantEnd {
  private:
   const std::string label_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(ScopedInstantEnd);
+  ScopedInstantEnd(const ScopedInstantEnd&) = delete;
+  ScopedInstantEnd& operator=(const ScopedInstantEnd&) = delete;
 };
 
 }  // namespace tracing

--- a/function_profiler/BUILD.gn
+++ b/function_profiler/BUILD.gn
@@ -1,0 +1,14 @@
+# Copyright 2017 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("function_profiler") {
+  sources = [
+    "function_profiler.cc",
+    "function_profiler.h",
+  ]
+
+  deps = [
+    "//flutter/fml:trace_event",
+  ]
+}

--- a/function_profiler/README.md
+++ b/function_profiler/README.md
@@ -1,0 +1,4 @@
+Function Profiler
+=================
+
+To trace all the functions of a particular target, add the `//flutter/function_profiler` target as a `deps` member of that target. Then to its `cflags`, add the `-finstrument-functions` flag. All the functions will then end up in the timeline under the `func-profiler` category.

--- a/function_profiler/function_profiler.cc
+++ b/function_profiler/function_profiler.cc
@@ -1,0 +1,50 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#if !__has_attribute(no_instrument_function)
+
+#error "Function profiling must be available."
+
+#endif  // !__has_attribute(no_instrument_function)
+
+// We don't need the macros since they only help in adding scoped traces which
+// we wont be able to use.
+#define TRACE_EVENT_HIDE_MACROS
+
+#include "flutter/function_profiler/function_profiler.h"
+#include <dlfcn.h>
+#include "flutter/fml/trace_event.h"
+
+static const char* kProfilerCategory = "func-profiler";
+
+#define FUNC_ENTER __cyg_profile_func_enter
+#define FUNC_EXIT __cyg_profile_func_exit
+
+extern "C" {
+// NO_INSTRUMENT_FUNCTION only present to prevent cases where the user
+// accidently decides to profile the profiler.
+static const char* GetSymbolName(const void* addr) NO_INSTRUMENT_FUNCTION;
+void FUNC_ENTER(void* this_fn, void* call_site) NO_INSTRUMENT_FUNCTION;
+void FUNC_EXIT(void* this_fn, void* call_site) NO_INSTRUMENT_FUNCTION;
+}
+
+static const char* GetSymbolName(const void* addr) {
+  Dl_info info;
+  if (dladdr(addr, &info) == 0) {
+    return nullptr;
+  }
+  return info.dli_sname;
+}
+
+void FUNC_ENTER(void* this_fn, void* call_site) {
+  if (auto name = GetSymbolName(call_site)) {
+    fml::tracing::TraceEvent0(kProfilerCategory, name);
+  }
+}
+
+void FUNC_EXIT(void* this_fn, void* call_site) {
+  if (auto name = GetSymbolName(call_site)) {
+    fml::tracing::TraceEventEnd(name);
+  }
+}

--- a/function_profiler/function_profiler.h
+++ b/function_profiler/function_profiler.h
@@ -1,0 +1,14 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FUNCTION_PROFILER_FUNCTION_PROFILER_H_
+#define FLUTTER_FUNCTION_PROFILER_FUNCTION_PROFILER_H_
+
+#if __has_attribute(no_instrument_function)
+#define NO_INSTRUMENT_FUNCTION __attribute__((no_instrument_function))
+#else  // __has_attribute(no_instrument_function)
+#define NO_INSTRUMENT_FUNCTION
+#endif  // __has_attribute(no_instrument_function)
+
+#endif  // FLUTTER_FUNCTION_PROFILER_FUNCTION_PROFILER_H_


### PR DESCRIPTION
I was using this to trace all the functions in a particular target (`//third_party/skia:gpu` in my case). This version traces everything to the timeline. However, the Dart timeline API needs the call site addresses to be eagerly resolved. This still works fine for relatively small targets on iOS. However, on Android, it seemed to be taking long enough for the traces collected to be not of much use. We could do something like what the Dart timeline does. It performs the the resolution when the timeline is requested from observatory. But that requires modifications to the current Dart tools API.