### PR TITLE
Include _http into sky_engine libraries for analyzer, _embedder.yaml

### DIFF
--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -7,6 +7,7 @@ import("//dart/sdk/lib/collection/collection_sources.gni")
 import("//dart/sdk/lib/convert/convert_sources.gni")
 import("//dart/sdk/lib/core/core_sources.gni")
 import("//dart/sdk/lib/developer/developer_sources.gni")
+import("//dart/sdk/lib/_http/http_sources.gni")
 import("//dart/sdk/lib/internal/internal_sources.gni")
 import("//dart/sdk/lib/io/io_sources.gni")
 import("//dart/sdk/lib/isolate/isolate_sources.gni")
@@ -64,6 +65,12 @@ copy("developer") {
   outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/developer/{{source_file_part}}" ]
 }
 
+copy("_http") {
+  lib_path = rebase_path("_http", "", dart_sdk_lib_path)
+  sources = rebase_path(http_sdk_sources, "", lib_path)
+  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/_http/{{source_file_part}}" ]
+}
+
 copy("internal") {
   lib_path = rebase_path("internal", "", dart_sdk_lib_path)
   sources = rebase_path(internal_sdk_sources, "", lib_path)
@@ -109,6 +116,7 @@ group("copy_dart_sdk") {
     ":convert",
     ":core",
     ":developer",
+    ":_http",
     ":internal",
     ":io",
     ":isolate",

--- a/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/sky/packages/sky_engine/lib/_embedder.yaml
@@ -13,6 +13,7 @@ embedded_libs:
   # API, e.g. List being Iterable by virtue of implementing
   # EfficientLengthIterable.
   # Not including this library yields analysis errors.
+  "dart:_http": "_http/http.dart"
   "dart:_internal": "internal/internal.dart"
   "dart:nativewrappers": "_empty.dart"
 


### PR DESCRIPTION
This is follow-up to https://github.com/dart-lang/sdk/commit/2948f8c1b72e9773b9eb41b9b9ff9729f521d40a.
