### PR TITLE
Add texture support (eg video, camera)

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -40,6 +40,8 @@ source_set("flow") {
     "layers/picture_layer.h",
     "layers/shader_mask_layer.cc",
     "layers/shader_mask_layer.h",
+    "layers/texture_layer.cc",
+    "layers/texture_layer.h",
     "layers/transform_layer.cc",
     "layers/transform_layer.h",
     "matrix_decomposition.cc",
@@ -51,6 +53,8 @@ source_set("flow") {
     "raster_cache.h",
     "raster_cache_key.cc",
     "raster_cache_key.h",
+    "texture.cc",
+    "texture.h",
   ]
 
   public_deps = [

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -57,7 +57,12 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
   context_.EndFrame(*this, instrumentation_enabled_);
 }
 
+void CompositorContext::OnGrContextCreated() {
+  texture_registry_.OnGrContextCreated();
+}
+
 void CompositorContext::OnGrContextDestroyed() {
+  texture_registry_.OnGrContextDestroyed();
   raster_cache_.Clear();
 }
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -11,6 +11,7 @@
 #include "flutter/flow/instrumentation.h"
 #include "flutter/flow/process_info.h"
 #include "flutter/flow/raster_cache.h"
+#include "flutter/flow/texture.h"
 #include "lib/fxl/macros.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
@@ -55,9 +56,13 @@ class CompositorContext {
                            SkCanvas* canvas,
                            bool instrumentation_enabled = true);
 
+  void OnGrContextCreated();
+
   void OnGrContextDestroyed();
 
   RasterCache& raster_cache() { return raster_cache_; }
+
+  TextureRegistry& texture_registry() { return texture_registry_; }
 
   const Counter& frame_count() const { return frame_count_; }
 
@@ -69,6 +74,7 @@ class CompositorContext {
 
  private:
   RasterCache raster_cache_;
+  TextureRegistry texture_registry_;
   std::unique_ptr<ProcessInfo> process_info_;
   Counter frame_count_;
   Stopwatch frame_time_;

--- a/flow/layers/default_layer_builder.cc
+++ b/flow/layers/default_layer_builder.cc
@@ -17,6 +17,7 @@
 #include "flutter/flow/layers/physical_model_layer.h"
 #include "flutter/flow/layers/picture_layer.h"
 #include "flutter/flow/layers/shader_mask_layer.h"
+#include "flutter/flow/layers/texture_layer.h"
 #include "flutter/flow/layers/transform_layer.h"
 
 #if defined(OS_FUCHSIA)
@@ -148,6 +149,19 @@ void DefaultLayerBuilder::PushPicture(const SkPoint& offset,
   layer->set_picture(picture);
   layer->set_is_complex(picture_is_complex);
   layer->set_will_change(picture_will_change);
+  current_layer_->Add(std::move(layer));
+}
+
+void DefaultLayerBuilder::PushTexture(const SkPoint& offset,
+                                      const SkSize& size,
+                                      size_t texture_id) {
+  if (!current_layer_) {
+    return;
+  }
+  auto layer = std::make_unique<flow::TextureLayer>();
+  layer->set_offset(offset);
+  layer->set_size(size);
+  layer->set_texture_id(texture_id);
   current_layer_->Add(std::move(layer));
 }
 

--- a/flow/layers/default_layer_builder.cc
+++ b/flow/layers/default_layer_builder.cc
@@ -154,7 +154,7 @@ void DefaultLayerBuilder::PushPicture(const SkPoint& offset,
 
 void DefaultLayerBuilder::PushTexture(const SkPoint& offset,
                                       const SkSize& size,
-                                      size_t texture_id) {
+                                      int64_t texture_id) {
   if (!current_layer_) {
     return;
   }

--- a/flow/layers/default_layer_builder.h
+++ b/flow/layers/default_layer_builder.h
@@ -62,6 +62,11 @@ class DefaultLayerBuilder final : public LayerBuilder {
                    bool picture_is_complex,
                    bool picture_will_change) override;
 
+  // |flow::LayerBuilder|
+  void PushTexture(const SkPoint& offset,
+                   const SkSize& size,
+                   size_t texture_id) override;
+
 #if defined(OS_FUCHSIA)
   // |flow::LayerBuilder|
   void PushChildScene(const SkPoint& offset,

--- a/flow/layers/default_layer_builder.h
+++ b/flow/layers/default_layer_builder.h
@@ -65,7 +65,7 @@ class DefaultLayerBuilder final : public LayerBuilder {
   // |flow::LayerBuilder|
   void PushTexture(const SkPoint& offset,
                    const SkSize& size,
-                   size_t texture_id) override;
+                   int64_t texture_id) override;
 
 #if defined(OS_FUCHSIA)
   // |flow::LayerBuilder|

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -10,6 +10,7 @@
 
 #include "flutter/flow/instrumentation.h"
 #include "flutter/flow/raster_cache.h"
+#include "flutter/flow/texture.h"
 #include "flutter/glue/trace_event.h"
 #include "lib/fxl/build_config.h"
 #include "lib/fxl/logging.h"
@@ -56,6 +57,7 @@ class Layer {
     const Stopwatch& frame_time;
     const Stopwatch& engine_time;
     const CounterValues& memory_usage;
+    TextureRegistry& texture_registry;
     const bool checkerboard_offscreen_layers;
   };
 

--- a/flow/layers/layer_builder.h
+++ b/flow/layers/layer_builder.h
@@ -62,7 +62,7 @@ class LayerBuilder {
 
   virtual void PushTexture(const SkPoint& offset,
                            const SkSize& size,
-                           size_t texture_id) = 0;
+                           int64_t texture_id) = 0;
 
 #if defined(OS_FUCHSIA)
   virtual void PushChildScene(

--- a/flow/layers/layer_builder.h
+++ b/flow/layers/layer_builder.h
@@ -60,6 +60,10 @@ class LayerBuilder {
                            bool picture_is_complex,
                            bool picture_will_change) = 0;
 
+  virtual void PushTexture(const SkPoint& offset,
+                           const SkSize& size,
+                           size_t texture_id) = 0;
+
 #if defined(OS_FUCHSIA)
   virtual void PushChildScene(
       const SkPoint& offset,

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -63,9 +63,11 @@ void LayerTree::UpdateScene(SceneUpdateContext& context,
 #endif
 
 void LayerTree::Paint(CompositorContext::ScopedFrame& frame) const {
-  Layer::PaintContext context = {*frame.canvas(), frame.context().frame_time(),
+  Layer::PaintContext context = {*frame.canvas(),
+                                 frame.context().frame_time(),
                                  frame.context().engine_time(),
                                  frame.context().memory_usage(),
+                                 frame.context().texture_registry(),
                                  checkerboard_offscreen_layers_};
   TRACE_EVENT0("flutter", "LayerTree::Paint");
 

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -21,7 +21,6 @@ void TextureLayer::Paint(PaintContext& context) const {
   std::shared_ptr<Texture> texture =
       context.texture_registry.GetTexture(texture_id_);
   if (!texture) {
-    FXL_DLOG(WARNING) << "No texture with id: " << texture_id_;
     return;
   }
   sk_sp<SkImage> sk_image =

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -23,13 +23,7 @@ void TextureLayer::Paint(PaintContext& context) const {
   if (!texture) {
     return;
   }
-  sk_sp<SkImage> sk_image =
-      texture->MakeSkImage(paint_bounds().width(), paint_bounds().height(),
-                           context.canvas.getGrContext());
-  if (!sk_image) {
-    return;
-  }
-  context.canvas.drawImage(sk_image, paint_bounds().x(), paint_bounds().y());
+  texture->Paint(context.canvas, paint_bounds());
 }
 
 }  // namespace flow

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -1,0 +1,36 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/layers/texture_layer.h"
+
+#include "flutter/flow/texture.h"
+
+namespace flow {
+
+TextureLayer::TextureLayer() = default;
+
+TextureLayer::~TextureLayer() = default;
+
+void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
+                                    size_.height()));
+}
+
+void TextureLayer::Paint(PaintContext& context) const {
+  std::shared_ptr<Texture> texture =
+      context.texture_registry.GetTexture(texture_id_);
+  if (!texture) {
+    FXL_DLOG(WARNING) << "No texture with id: " << texture_id_;
+    return;
+  }
+  sk_sp<SkImage> sk_image =
+      texture->MakeSkImage(paint_bounds().width(), paint_bounds().height(),
+                           context.canvas.getGrContext());
+  if (!sk_image) {
+    return;
+  }
+  context.canvas.drawImage(sk_image, paint_bounds().x(), paint_bounds().y());
+}
+
+}  // namespace flow

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -1,0 +1,39 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLOW_LAYERS_TEXTURE_LAYER_H_
+#define FLUTTER_FLOW_LAYERS_TEXTURE_LAYER_H_
+
+#include "flutter/flow/layers/layer.h"
+#include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
+#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrTexture.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
+
+namespace flow {
+
+class TextureLayer : public Layer {
+ public:
+  TextureLayer();
+  ~TextureLayer() override;
+
+  void set_offset(const SkPoint& offset) { offset_ = offset; }
+  void set_size(const SkSize& size) { size_ = size; }
+  void set_texture_id(size_t texture_id) { texture_id_ = texture_id; }
+
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Paint(PaintContext& context) const override;
+
+ private:
+  SkPoint offset_;
+  SkSize size_;
+  size_t texture_id_ = 0;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(TextureLayer);
+};
+
+}  // namespace flow
+
+#endif  // FLUTTER_FLOW_LAYERS_TEXTURE_LAYER_H_

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -21,7 +21,7 @@ class TextureLayer : public Layer {
 
   void set_offset(const SkPoint& offset) { offset_ = offset; }
   void set_size(const SkSize& size) { size_ = size; }
-  void set_texture_id(size_t texture_id) { texture_id_ = texture_id; }
+  void set_texture_id(int64_t texture_id) { texture_id_ = texture_id; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
@@ -29,7 +29,7 @@ class TextureLayer : public Layer {
  private:
   SkPoint offset_;
   SkSize size_;
-  size_t texture_id_ = 0;
+  int64_t texture_id_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(TextureLayer);
 };

--- a/flow/texture.cc
+++ b/flow/texture.cc
@@ -39,7 +39,7 @@ std::shared_ptr<Texture> TextureRegistry::GetTexture(int64_t id) {
   return mapping_[id];
 }
 
-Texture::Texture(int64_t id): id_(id) {}
+Texture::Texture(int64_t id) : id_(id) {}
 Texture::~Texture() = default;
 
 }  // namespace flow

--- a/flow/texture.cc
+++ b/flow/texture.cc
@@ -10,15 +10,12 @@ TextureRegistry::TextureRegistry() = default;
 
 TextureRegistry::~TextureRegistry() = default;
 
-size_t TextureRegistry::RegisterTexture(std::shared_ptr<Texture> texture) {
+void TextureRegistry::RegisterTexture(std::shared_ptr<Texture> texture) {
   ASSERT_IS_GPU_THREAD
-  size_t id = counter_++;
-  mapping_[id] = texture;
-  texture->id_ = id;
-  return id;
+  mapping_[texture->Id()] = texture;
 }
 
-void TextureRegistry::UnregisterTexture(size_t id) {
+void TextureRegistry::UnregisterTexture(int64_t id) {
   ASSERT_IS_GPU_THREAD
   mapping_.erase(id);
 }
@@ -37,11 +34,12 @@ void TextureRegistry::OnGrContextDestroyed() {
   }
 }
 
-std::shared_ptr<Texture> TextureRegistry::GetTexture(size_t id) {
+std::shared_ptr<Texture> TextureRegistry::GetTexture(int64_t id) {
   ASSERT_IS_GPU_THREAD
   return mapping_[id];
 }
 
+Texture::Texture(int64_t id): id_(id) {}
 Texture::~Texture() = default;
 
 }  // namespace flow

--- a/flow/texture.cc
+++ b/flow/texture.cc
@@ -1,0 +1,47 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/texture.h"
+
+namespace flow {
+
+TextureRegistry::TextureRegistry() = default;
+
+TextureRegistry::~TextureRegistry() = default;
+
+size_t TextureRegistry::RegisterTexture(std::shared_ptr<Texture> texture) {
+  ASSERT_IS_GPU_THREAD
+  size_t id = counter_++;
+  mapping_[id] = texture;
+  texture->id_ = id;
+  return id;
+}
+
+void TextureRegistry::UnregisterTexture(size_t id) {
+  ASSERT_IS_GPU_THREAD
+  mapping_.erase(id);
+}
+
+void TextureRegistry::OnGrContextCreated() {
+  ASSERT_IS_GPU_THREAD;
+  for (auto& it : mapping_) {
+    it.second->OnGrContextCreated();
+  }
+}
+
+void TextureRegistry::OnGrContextDestroyed() {
+  ASSERT_IS_GPU_THREAD;
+  for (auto& it : mapping_) {
+    it.second->OnGrContextDestroyed();
+  }
+}
+
+std::shared_ptr<Texture> TextureRegistry::GetTexture(size_t id) {
+  ASSERT_IS_GPU_THREAD
+  return mapping_[id];
+}
+
+Texture::~Texture() = default;
+
+}  // namespace flow

--- a/flow/texture.h
+++ b/flow/texture.h
@@ -18,8 +18,8 @@
 namespace flow {
 
 class Texture {
-  friend class TextureRegistry;
-
+ protected:
+  Texture(int64_t id);
  public:
   // Called from GPU thread.
   virtual ~Texture();
@@ -35,10 +35,12 @@ class Texture {
   // Called from GPU thread.
   virtual void OnGrContextDestroyed() = 0;
 
-  size_t Id() { return id_; }
+  int64_t Id() { return id_; }
 
  private:
-  size_t id_;
+  int64_t id_;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(Texture);
 };
 
 class TextureRegistry {
@@ -47,13 +49,13 @@ class TextureRegistry {
   ~TextureRegistry();
 
   // Called from GPU thread.
-  size_t RegisterTexture(std::shared_ptr<Texture> texture);
+  void RegisterTexture(std::shared_ptr<Texture> texture);
 
   // Called from GPU thread.
-  void UnregisterTexture(size_t id);
+  void UnregisterTexture(int64_t id);
 
   // Called from GPU thread.
-  std::shared_ptr<Texture> GetTexture(size_t id);
+  std::shared_ptr<Texture> GetTexture(int64_t id);
 
   // Called from GPU thread.
   void OnGrContextCreated();
@@ -62,8 +64,9 @@ class TextureRegistry {
   void OnGrContextDestroyed();
 
  private:
-  std::map<size_t, std::shared_ptr<Texture>> mapping_;
-  size_t counter_ = 0;
+  std::map<int64_t, std::shared_ptr<Texture>> mapping_;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(TextureRegistry);
 };
 
 }  // namespace flow

--- a/flow/texture.h
+++ b/flow/texture.h
@@ -20,6 +20,7 @@ namespace flow {
 class Texture {
  protected:
   Texture(int64_t id);
+
  public:
   // Called from GPU thread.
   virtual ~Texture();

--- a/flow/texture.h
+++ b/flow/texture.h
@@ -8,12 +8,7 @@
 #include <map>
 #include "flutter/common/threads.h"
 #include "lib/fxl/synchronization/waitable_event.h"
-#include "third_party/skia/include/core/SkMatrix.h"
-#include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
-#include "third_party/skia/include/gpu/GrTexture.h"
-#include "third_party/skia/include/gpu/GrTypes.h"
+#include "third_party/skia/include/core/SkCanvas.h"
 
 namespace flow {
 
@@ -26,9 +21,7 @@ class Texture {
   virtual ~Texture();
 
   // Called from GPU thread.
-  virtual sk_sp<SkImage> MakeSkImage(int width,
-                                     int height,
-                                     GrContext* grContext) = 0;
+  virtual void Paint(SkCanvas& canvas, const SkRect& bounds) = 0;
 
   // Called from GPU thread.
   virtual void OnGrContextCreated() = 0;

--- a/flow/texture.h
+++ b/flow/texture.h
@@ -1,0 +1,71 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLOW_TEXTURE_H_
+#define FLUTTER_FLOW_TEXTURE_H_
+
+#include <map>
+#include "flutter/common/threads.h"
+#include "lib/fxl/synchronization/waitable_event.h"
+#include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
+#include "third_party/skia/include/gpu/GrContext.h"
+#include "third_party/skia/include/gpu/GrTexture.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
+
+namespace flow {
+
+class Texture {
+  friend class TextureRegistry;
+
+ public:
+  // Called from GPU thread.
+  virtual ~Texture();
+
+  // Called from GPU thread.
+  virtual sk_sp<SkImage> MakeSkImage(int width,
+                                     int height,
+                                     GrContext* grContext) = 0;
+
+  // Called from GPU thread.
+  virtual void OnGrContextCreated() = 0;
+
+  // Called from GPU thread.
+  virtual void OnGrContextDestroyed() = 0;
+
+  size_t Id() { return id_; }
+
+ private:
+  size_t id_;
+};
+
+class TextureRegistry {
+ public:
+  TextureRegistry();
+  ~TextureRegistry();
+
+  // Called from GPU thread.
+  size_t RegisterTexture(std::shared_ptr<Texture> texture);
+
+  // Called from GPU thread.
+  void UnregisterTexture(size_t id);
+
+  // Called from GPU thread.
+  std::shared_ptr<Texture> GetTexture(size_t id);
+
+  // Called from GPU thread.
+  void OnGrContextCreated();
+
+  // Called from GPU thread.
+  void OnGrContextDestroyed();
+
+ private:
+  std::map<size_t, std::shared_ptr<Texture>> mapping_;
+  size_t counter_ = 0;
+};
+
+}  // namespace flow
+
+#endif  // FLUTTER_FLOW_TEXTURE_H_

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -197,6 +197,12 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   }
   void _addPicture(double dx, double dy, Picture picture, int hints) native "SceneBuilder_addPicture";
 
+  void addTexture(int textureId, {Offset offset: Offset.zero, double width: 0.0, double height: 0.0}) {
+   _addTexture(offset.dx, offset.dy, width, height, textureId);
+  }
+
+  void _addTexture(double dx, double dy, double width, double height, int textureId) native "SceneBuilder_addTexture";
+
   /// (Fuchsia-only) Adds a scene rendered by another application to the scene
   /// for this application.
   void addChildScene({

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -197,10 +197,13 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   }
   void _addPicture(double dx, double dy, Picture picture, int hints) native "SceneBuilder_addPicture";
 
-  void addTexture(int textureId, {Offset offset: Offset.zero, double width: 0.0, double height: 0.0}) {
-   _addTexture(offset.dx, offset.dy, width, height, textureId);
+  /// Adds a backend texture to the scene.
+  ///
+  /// The texture is scaled to the given size and rasterized at the given offset.
+  void addTexture(int textureId, { Offset offset: Offset.zero, double width: 0.0, double height: 0.0 }) {
+    assert(offset != null, 'Offset argument was null');
+    _addTexture(offset.dx, offset.dy, width, height, textureId);
   }
-
   void _addTexture(double dx, double dy, double width, double height, int textureId) native "SceneBuilder_addTexture";
 
   /// (Fuchsia-only) Adds a scene rendered by another application to the scene

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -129,7 +129,7 @@ void SceneBuilder::addTexture(double dx,
                               double dy,
                               double width,
                               double height,
-                              size_t textureId) {
+                              int64_t textureId) {
   layer_builder_->PushTexture(SkPoint::Make(dx, dy),
                               SkSize::Make(width, height), textureId);
 }

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -35,6 +35,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, SceneBuilder);
   V(SceneBuilder, pushPhysicalModel)                \
   V(SceneBuilder, pop)                              \
   V(SceneBuilder, addPicture)                       \
+  V(SceneBuilder, addTexture)                       \
   V(SceneBuilder, addChildScene)                    \
   V(SceneBuilder, addPerformanceOverlay)            \
   V(SceneBuilder, setRasterizerTracingThreshold)    \
@@ -122,6 +123,15 @@ void SceneBuilder::addPicture(double dx,
                               !!(hints & 1),          // picture is complex
                               !!(hints & 2)           // picture will change
   );
+}
+
+void SceneBuilder::addTexture(double dx,
+                              double dy,
+                              double width,
+                              double height,
+                              size_t textureId) {
+  layer_builder_->PushTexture(SkPoint::Make(dx, dy),
+                              SkSize::Make(width, height), textureId);
 }
 
 void SceneBuilder::addChildScene(double dx,

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -56,7 +56,15 @@ class SceneBuilder : public fxl::RefCountedThreadSafe<SceneBuilder>,
                              double right,
                              double top,
                              double bottom);
+
   void addPicture(double dx, double dy, Picture* picture, int hints);
+
+  void addTexture(double dx,
+                  double dy,
+                  double width,
+                  double height,
+                  size_t textureId);
+
   void addChildScene(double dx,
                      double dy,
                      double width,

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -63,7 +63,7 @@ class SceneBuilder : public fxl::RefCountedThreadSafe<SceneBuilder>,
                   double dy,
                   double width,
                   double height,
-                  size_t textureId);
+                  int64_t textureId);
 
   void addChildScene(double dx,
                      double dy,

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -18,7 +18,7 @@ namespace blink {
 class RuntimeDelegate {
  public:
   virtual std::string DefaultRouteName() = 0;
-  virtual void ScheduleFrame() = 0;
+  virtual void ScheduleFrame(bool regenerate_layer_tree = true) = 0;
   virtual void Render(std::unique_ptr<flow::LayerTree> layer_tree) = 0;
   virtual void UpdateSemantics(std::vector<SemanticsNode> update) = 0;
   virtual void HandlePlatformMessage(fxl::RefPtr<PlatformMessage> message) = 0;

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -23,6 +23,7 @@ Animator::Animator(fml::WeakPtr<Rasterizer> rasterizer,
       pending_frame_semaphore_(1),
       frame_number_(1),
       paused_(false),
+      frame_requested_(false),
       frame_scheduled_(false),
       weak_factory_(this) {}
 
@@ -58,6 +59,7 @@ void Animator::BeginFrame(fxl::TimePoint frame_start_time,
   TRACE_EVENT_ASYNC_END0("flutter", "Frame Request Pending", frame_number_++);
 
   frame_scheduled_ = false;
+  frame_requested_ = false;
   pending_frame_semaphore_.Signal();
 
   if (!producer_continuation_) {
@@ -116,14 +118,35 @@ void Animator::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   });
 }
 
+bool Animator::CanReuseLastLayerTree() {
+  return !frame_requested_;
+}
+
+void Animator::DrawLastLayerTree() {
+  pending_frame_semaphore_.Signal();
+  blink::Threads::Gpu()->PostTask([rasterizer = rasterizer_]() {
+    if (rasterizer.get())
+      rasterizer->DrawLastLayerTree();
+  });
+}
+
+void Animator::RequestRedraw() {
+  RequestDrawOnVSync();
+}
+
 void Animator::RequestFrame() {
+  frame_requested_ = true;
+  RequestDrawOnVSync();
+}
+
+void Animator::RequestDrawOnVSync() {
   if (paused_) {
     return;
   }
 
   if (!pending_frame_semaphore_.TryWait()) {
-    // Multiple calls to Animator::RequestFrame will still result in a single
-    // request to the VsyncWaiter.
+    // Multiple calls to Animator::RequestDrawOnVSync will still result in a
+    // single request to the VsyncWaiter.
     return;
   }
 
@@ -149,8 +172,13 @@ void Animator::RequestFrame() {
 void Animator::AwaitVSync() {
   waiter_->AsyncWaitForVsync([self = weak_factory_.GetWeakPtr()](
       fxl::TimePoint frame_start_time, fxl::TimePoint frame_target_time) {
-    if (self)
-      self->BeginFrame(frame_start_time, frame_target_time);
+    if (self) {
+      if (self->CanReuseLastLayerTree()) {
+        self->DrawLastLayerTree();
+      } else {
+        self->BeginFrame(frame_start_time, frame_target_time);
+      }
+    }
   });
 
   engine_->NotifyIdle(dart_frame_deadline_);

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -30,6 +30,8 @@ class Animator {
 
   void RequestFrame();
 
+  void RequestRedraw();
+
   void Render(std::unique_ptr<flow::LayerTree> layer_tree);
 
   void Start();
@@ -41,6 +43,10 @@ class Animator {
 
   void BeginFrame(fxl::TimePoint frame_start_time,
                   fxl::TimePoint frame_target_time);
+
+  bool CanReuseLastLayerTree();
+  void DrawLastLayerTree();
+  void RequestDrawOnVSync();
 
   void AwaitVSync();
 
@@ -57,6 +63,7 @@ class Animator {
   LayerTreePipeline::ProducerContinuation producer_continuation_;
   int64_t frame_number_;
   bool paused_;
+  bool frame_requested_;
   bool frame_scheduled_;
 
   fml::WeakPtrFactory<Animator> weak_factory_;

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -28,9 +28,7 @@ class Animator {
     rasterizer_ = rasterizer;
   }
 
-  void RequestFrame();
-
-  void RequestRedraw();
+  void RequestFrame(bool regenerate_layer_tree = true);
 
   void Render(std::unique_ptr<flow::LayerTree> layer_tree);
 
@@ -63,7 +61,7 @@ class Animator {
   LayerTreePipeline::ProducerContinuation producer_continuation_;
   int64_t frame_number_;
   bool paused_;
-  bool frame_requested_;
+  bool regenerate_layer_tree_;
   bool frame_scheduled_;
 
   fml::WeakPtrFactory<Animator> weak_factory_;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -526,6 +526,10 @@ void Engine::ScheduleFrame() {
   animator_->RequestFrame();
 }
 
+void Engine::ScheduleRedraw() {
+  animator_->RequestRedraw();
+}
+
 void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   if (!layer_tree)
     return;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -522,12 +522,8 @@ std::string Engine::DefaultRouteName() {
   return "/";
 }
 
-void Engine::ScheduleFrame() {
-  animator_->RequestFrame();
-}
-
-void Engine::ScheduleRedraw() {
-  animator_->RequestRedraw();
+void Engine::ScheduleFrame(bool regenerate_layer_tree) {
+  animator_->RequestFrame(regenerate_layer_tree);
 }
 
 void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -74,14 +74,13 @@ class Engine : public blink::RuntimeDelegate {
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
   void DispatchSemanticsAction(int id, blink::SemanticsAction action);
   void SetSemanticsEnabled(bool enabled);
-  void ScheduleRedraw();
+  void ScheduleFrame(bool regenerate_layer_tree = true) override;
 
   void set_rasterizer(fml::WeakPtr<Rasterizer> rasterizer);
 
  private:
   // RuntimeDelegate methods:
   std::string DefaultRouteName() override;
-  void ScheduleFrame() override;
   void Render(std::unique_ptr<flow::LayerTree> layer_tree) override;
   void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
   void HandlePlatformMessage(

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -74,6 +74,7 @@ class Engine : public blink::RuntimeDelegate {
   void DispatchPointerDataPacket(const PointerDataPacket& packet);
   void DispatchSemanticsAction(int id, blink::SemanticsAction action);
   void SetSemanticsEnabled(bool enabled);
+  void ScheduleRedraw();
 
   void set_rasterizer(fml::WeakPtr<Rasterizer> rasterizer);
 

--- a/shell/common/null_rasterizer.cc
+++ b/shell/common/null_rasterizer.cc
@@ -33,6 +33,14 @@ flow::LayerTree* NullRasterizer::GetLastLayerTree() {
   return nullptr;
 }
 
+void NullRasterizer::DrawLastLayerTree() {
+  // Null rasterizer. Nothing to do.
+}
+
+flow::TextureRegistry& NullRasterizer::GetTextureRegistry() {
+  return texture_registry_;
+}
+
 void NullRasterizer::Clear(SkColor color, const SkISize& size) {
   // Null rasterizer. Nothing to do.
 }

--- a/shell/common/null_rasterizer.h
+++ b/shell/common/null_rasterizer.h
@@ -28,6 +28,10 @@ class NullRasterizer : public Rasterizer {
 
   flow::LayerTree* GetLastLayerTree() override;
 
+  void DrawLastLayerTree() override;
+
+  flow::TextureRegistry& GetTextureRegistry() override;
+
   void Draw(fxl::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) override;
 
   void AddNextFrameCallback(fxl::Closure nextFrameCallback) override;
@@ -35,6 +39,7 @@ class NullRasterizer : public Rasterizer {
  private:
   std::unique_ptr<Surface> surface_;
   fml::WeakPtrFactory<NullRasterizer> weak_factory_;
+  flow::TextureRegistry texture_registry_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(NullRasterizer);
 };

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -151,9 +151,7 @@ void PlatformView::UnregisterTexture(int64_t texture_id) {
 
 void PlatformView::MarkTextureFrameAvailable(int64_t texture_id) {
   ASSERT_IS_PLATFORM_THREAD
-  blink::Threads::UI()->PostTask([this]() {
-    engine_->ScheduleFrame(false);
-  });
+  blink::Threads::UI()->PostTask([this]() { engine_->ScheduleFrame(false); });
 }
 
 void PlatformView::SetupResourceContextOnIOThread() {

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -135,30 +135,24 @@ void PlatformView::HandlePlatformMessage(
     response->CompleteEmpty();
 }
 
-size_t PlatformView::RegisterTexture(std::shared_ptr<flow::Texture> texture) {
-  int texture_id;
-  fxl::AutoResetWaitableEvent latch;
-  blink::Threads::Gpu()->PostTask([this, &texture_id, &latch, texture]() {
-    texture_id = rasterizer_->GetTextureRegistry().RegisterTexture(texture);
-    latch.Signal();
+void PlatformView::RegisterTexture(std::shared_ptr<flow::Texture> texture) {
+  ASSERT_IS_PLATFORM_THREAD
+  blink::Threads::Gpu()->PostTask([this, texture]() {
+    rasterizer_->GetTextureRegistry().RegisterTexture(texture);
   });
-  latch.Wait();
-  return texture_id;
 }
 
-void PlatformView::UnregisterTexture(size_t texture_id) {
-  fxl::AutoResetWaitableEvent latch;
-  blink::Threads::Gpu()->PostTask([this, &latch, texture_id]() {
+void PlatformView::UnregisterTexture(int64_t texture_id) {
+  ASSERT_IS_PLATFORM_THREAD
+  blink::Threads::Gpu()->PostTask([this, texture_id]() {
     rasterizer_->GetTextureRegistry().UnregisterTexture(texture_id);
-    latch.Signal();
   });
-  latch.Wait();
 }
 
-void PlatformView::MarkTextureFrameAvailable(size_t texture_id) {
-  blink::Threads::UI()->PostTask([engine = engine_->GetWeakPtr()] {
-    if (engine)
-      engine->ScheduleRedraw();
+void PlatformView::MarkTextureFrameAvailable(int64_t texture_id) {
+  ASSERT_IS_PLATFORM_THREAD
+  blink::Threads::UI()->PostTask([this]() {
+    engine_->ScheduleFrame(false);
   });
 }
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -62,9 +62,14 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
   virtual void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message);
 
-  size_t RegisterTexture(std::shared_ptr<flow::Texture> texture);
-  void UnregisterTexture(size_t texture_id);
-  virtual void MarkTextureFrameAvailable(size_t texture_id);
+  // Called once per texture, on the platform thread.
+  void RegisterTexture(std::shared_ptr<flow::Texture> texture);
+
+  // Called once per texture, on the platform thread.
+  void UnregisterTexture(int64_t texture_id);
+
+  // Called once per texture update (e.g. video frame), on the platform thread.
+  virtual void MarkTextureFrameAvailable(int64_t texture_id);
 
   void SetRasterizer(std::unique_ptr<Rasterizer> rasterizer);
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "flutter/flow/texture.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/shell/common/engine.h"
 #include "flutter/shell/common/shell.h"
@@ -60,6 +61,10 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
   virtual void UpdateSemantics(std::vector<blink::SemanticsNode> update);
   virtual void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message);
+
+  size_t RegisterTexture(std::shared_ptr<flow::Texture> texture);
+  void UnregisterTexture(size_t texture_id);
+  virtual void MarkTextureFrameAvailable(size_t texture_id);
 
   void SetRasterizer(std::unique_ptr<Rasterizer> rasterizer);
 

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -33,6 +33,10 @@ class Rasterizer {
 
   virtual flow::LayerTree* GetLastLayerTree() = 0;
 
+  virtual void DrawLastLayerTree() = 0;
+
+  virtual flow::TextureRegistry& GetTextureRegistry() = 0;
+
   virtual void Draw(
       fxl::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) = 0;
 

--- a/shell/gpu/gpu_rasterizer.h
+++ b/shell/gpu/gpu_rasterizer.h
@@ -33,6 +33,10 @@ class GPURasterizer : public Rasterizer {
 
   flow::LayerTree* GetLastLayerTree() override;
 
+  void DrawLastLayerTree() override;
+
+  flow::TextureRegistry& GetTextureRegistry() override;
+
   void Draw(fxl::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) override;
 
   // Set a callback to be called once when the next frame is drawn.

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -17,6 +17,8 @@ shared_library("flutter_shell_native") {
     "android_context_gl.h",
     "android_environment_gl.cc",
     "android_environment_gl.h",
+    "android_external_texture_gl.h",
+    "android_external_texture_gl.cc",
     "android_native_window.cc",
     "android_native_window.h",
     "android_surface.cc",
@@ -46,6 +48,7 @@ shared_library("flutter_shell_native") {
     "$flutter_root/shell/gpu",
     "//garnet/public/lib/fxl",
     "//third_party/skia",
+    "//third_party/skia:gpu",
   ]
   if (flutter_runtime_mode == "debug") {
     deps += [ "//third_party/dart/runtime:libdart_jit" ]

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -117,6 +117,7 @@ java_library("flutter_shell_java") {
     "io/flutter/view/ResourceCleaner.java",
     "io/flutter/view/ResourceExtractor.java",
     "io/flutter/view/ResourcePaths.java",
+    "io/flutter/view/TextureRegistry.java",
     "io/flutter/view/VsyncWaiter.java",
   ]
 

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -14,8 +14,8 @@
 namespace shell {
 
 AndroidExternalTextureGL::AndroidExternalTextureGL(
-    const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture)
-    : surface_texture_(surfaceTexture) {}
+    int64_t id, const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture)
+    : Texture(id), surface_texture_(surfaceTexture) {}
 
 AndroidExternalTextureGL::~AndroidExternalTextureGL() = default;
 

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -14,7 +14,8 @@
 namespace shell {
 
 AndroidExternalTextureGL::AndroidExternalTextureGL(
-    int64_t id, const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture)
+    int64_t id,
+    const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture)
     : Texture(id), surface_texture_(surfaceTexture) {}
 
 AndroidExternalTextureGL::~AndroidExternalTextureGL() = default;

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -1,0 +1,91 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/android_external_texture_gl.h"
+
+#include <GLES/glext.h>
+
+#include "flutter/common/threads.h"
+#include "flutter/shell/platform/android/platform_view_android_jni.h"
+#include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrTexture.h"
+
+namespace shell {
+
+AndroidExternalTextureGL::AndroidExternalTextureGL(
+    const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture)
+    : surface_texture_(surfaceTexture) {}
+
+AndroidExternalTextureGL::~AndroidExternalTextureGL() = default;
+
+void AndroidExternalTextureGL::OnGrContextCreated() {
+  ASSERT_IS_GPU_THREAD;
+  state_ = AttachmentState::uninitialized;
+}
+
+void AndroidExternalTextureGL::MarkNewFrameAvailable() {
+  ASSERT_IS_GPU_THREAD;
+  new_frame_ready_ = true;
+}
+
+sk_sp<SkImage> AndroidExternalTextureGL::MakeSkImage(int width,
+                                                     int height,
+                                                     GrContext* grContext) {
+  ASSERT_IS_GPU_THREAD;
+  if (state_ == AttachmentState::detached) {
+    return nullptr;
+  }
+  if (state_ == AttachmentState::uninitialized) {
+    glGenTextures(1, &texture_name_);
+    Attach(static_cast<jint>(texture_name_));
+    state_ = AttachmentState::attached;
+  }
+  if (new_frame_ready_) {
+    Update();
+    new_frame_ready_ = false;
+  }
+  GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES, texture_name_};
+  GrBackendTexture backendTexture(width, height, kRGBA_8888_GrPixelConfig,
+                                  textureInfo);
+  return SkImage::MakeFromTexture(grContext, backendTexture,
+                                  kTopLeft_GrSurfaceOrigin,
+                                  SkAlphaType::kPremul_SkAlphaType, nullptr);
+}
+
+void AndroidExternalTextureGL::OnGrContextDestroyed() {
+  ASSERT_IS_GPU_THREAD;
+  if (state_ == AttachmentState::attached) {
+    Detach();
+  }
+  state_ = AttachmentState::detached;
+}
+
+void AndroidExternalTextureGL::Attach(jint textureName) {
+  JNIEnv* env = fml::jni::AttachCurrentThread();
+  fml::jni::ScopedJavaLocalRef<jobject> surfaceTexture =
+      surface_texture_.get(env);
+  if (!surfaceTexture.is_null()) {
+    SurfaceTextureAttachToGLContext(env, surfaceTexture.obj(), textureName);
+  }
+}
+
+void AndroidExternalTextureGL::Update() {
+  JNIEnv* env = fml::jni::AttachCurrentThread();
+  fml::jni::ScopedJavaLocalRef<jobject> surfaceTexture =
+      surface_texture_.get(env);
+  if (!surfaceTexture.is_null()) {
+    SurfaceTextureUpdateTexImage(env, surfaceTexture.obj());
+  }
+}
+
+void AndroidExternalTextureGL::Detach() {
+  JNIEnv* env = fml::jni::AttachCurrentThread();
+  fml::jni::ScopedJavaLocalRef<jobject> surfaceTexture =
+      surface_texture_.get(env);
+  if (!surfaceTexture.is_null()) {
+    SurfaceTextureDetachFromGLContext(env, surfaceTexture.obj());
+  }
+}
+
+}  // namespace shell

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -14,7 +14,8 @@ namespace shell {
 class AndroidExternalTextureGL : public flow::Texture {
  public:
   AndroidExternalTextureGL(
-      int64_t id, const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture);
+      int64_t id,
+      const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture);
 
   ~AndroidExternalTextureGL() override;
 

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -19,9 +19,7 @@ class AndroidExternalTextureGL : public flow::Texture {
 
   ~AndroidExternalTextureGL() override;
 
-  virtual sk_sp<SkImage> MakeSkImage(int width,
-                                     int height,
-                                     GrContext* grContext) override;
+  virtual void Paint(SkCanvas& canvas, const SkRect& bounds) override;
 
   virtual void OnGrContextCreated() override;
 

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -14,7 +14,7 @@ namespace shell {
 class AndroidExternalTextureGL : public flow::Texture {
  public:
   AndroidExternalTextureGL(
-      const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture);
+      int64_t id, const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture);
 
   ~AndroidExternalTextureGL() override;
 

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -1,0 +1,54 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_TEXTURE_GL_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_TEXTURE_GL_H_
+
+#include <GLES/gl.h>
+#include "flutter/flow/texture.h"
+#include "flutter/fml/platform/android/jni_weak_ref.h"
+
+namespace shell {
+
+class AndroidExternalTextureGL : public flow::Texture {
+ public:
+  AndroidExternalTextureGL(
+      const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture);
+
+  ~AndroidExternalTextureGL() override;
+
+  virtual sk_sp<SkImage> MakeSkImage(int width,
+                                     int height,
+                                     GrContext* grContext) override;
+
+  virtual void OnGrContextCreated() override;
+
+  virtual void OnGrContextDestroyed() override;
+
+  // Called on GPU thread.
+  void MarkNewFrameAvailable();
+
+ private:
+  void Attach(jint textureName);
+
+  void Update();
+
+  void Detach();
+
+  enum class AttachmentState { uninitialized, attached, detached };
+
+  fml::jni::JavaObjectWeakGlobalRef surface_texture_;
+
+  AttachmentState state_ = AttachmentState::uninitialized;
+
+  bool new_frame_ready_ = false;
+
+  GLuint texture_name_ = 0;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(AndroidExternalTextureGL);
+};
+
+}  // namespace shell
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_TEXTURE_GL_H_

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -35,6 +35,7 @@ import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.util.Preconditions;
 import io.flutter.view.FlutterMain;
 import io.flutter.view.FlutterView;
+import io.flutter.view.TextureRegistry;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -419,6 +420,11 @@ public final class FlutterActivityDelegate
 
         @Override
         public BinaryMessenger messenger() {
+            return flutterView;
+        }
+
+        @Override
+        public TextureRegistry textures() {
             return flutterView;
         }
 

--- a/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
+++ b/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
@@ -1,3 +1,7 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugin.common;
 
 import java.nio.ByteBuffer;

--- a/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
@@ -1,3 +1,7 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.plugin.common;
 
 import java.nio.ByteBuffer;

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -7,6 +7,7 @@ package io.flutter.plugin.common;
 import android.app.Activity;
 import android.content.Intent;
 import io.flutter.view.FlutterView;
+import io.flutter.view.TextureRegistry;
 
 /**
  * Registry used by plugins to set up interaction with Android APIs.
@@ -73,6 +74,12 @@ public interface PluginRegistry {
          * creating channels for communicating with the Dart side.
          */
         BinaryMessenger messenger();
+
+        /**
+         * Returns a {@link TextureRegistry} which the plugin can use for
+         * managing backend textures.
+         */
+        TextureRegistry textures();
 
         /**
          * Returns the {@link FlutterView} that's instantiated by this plugin's

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -1,0 +1,42 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.view;
+
+import android.graphics.SurfaceTexture;
+
+/**
+ * Registry of backend textures used with a single {@link FlutterView} instance.
+ * Entries may be embedded into the Flutter view using the
+ * <a href="https://docs.flutter.io/flutter/widgets/Texture-class.html">Texture</a>
+ * widget.
+ */
+public interface TextureRegistry {
+   /**
+    * Creates and registers a SurfaceTexture managed by the Flutter engine.
+    *
+    * @return A SurfaceTextureEntry.
+    */
+    SurfaceTextureEntry createSurfaceTexture();
+
+    /**
+     * A registry entry for a managed SurfaceTexture.
+     */
+    interface SurfaceTextureEntry {
+        /**
+         * @return The managed SurfaceTexture.
+         */
+        SurfaceTexture surfaceTexture();
+
+        /**
+         * @return The identity of this SurfaceTexture.
+         */
+        long id();
+
+        /**
+         * Deregisters and releases this SurfaceTexture.
+         */
+        void release();
+    }
+}

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -547,9 +547,11 @@ void PlatformViewAndroid::RunFromSource(const std::string& assets_directory,
   fml::jni::DetachFromVM();
 }
 
-void PlatformViewAndroid::RegisterExternalTexture(int64_t texture_id,
+void PlatformViewAndroid::RegisterExternalTexture(
+    int64_t texture_id,
     const fml::jni::JavaObjectWeakGlobalRef& surface_texture) {
-  RegisterTexture(std::make_shared<AndroidExternalTextureGL>(texture_id, surface_texture));
+  RegisterTexture(
+      std::make_shared<AndroidExternalTextureGL>(texture_id, surface_texture));
 }
 
 void PlatformViewAndroid::MarkTextureFrameAvailable(int64_t texture_id) {

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -18,6 +18,7 @@
 #include "flutter/runtime/dart_service_isolate.h"
 #include "flutter/shell/common/null_rasterizer.h"
 #include "flutter/shell/gpu/gpu_rasterizer.h"
+#include "flutter/shell/platform/android/android_external_texture_gl.h"
 #include "flutter/shell/platform/android/android_surface_gl.h"
 #include "flutter/shell/platform/android/android_surface_software.h"
 #include "flutter/shell/platform/android/platform_view_android_jni.h"
@@ -544,6 +545,27 @@ void PlatformViewAndroid::RunFromSource(const std::string& assets_directory,
 
   // Detaching from the VM deletes any stray local references.
   fml::jni::DetachFromVM();
+}
+
+size_t PlatformViewAndroid::RegisterExternalTexture(
+    const fml::jni::JavaObjectWeakGlobalRef& surface_texture) {
+  return RegisterTexture(
+      std::make_shared<AndroidExternalTextureGL>(surface_texture));
+}
+
+void PlatformViewAndroid::MarkTextureFrameAvailable(size_t texture_id) {
+  fxl::AutoResetWaitableEvent latch;
+  blink::Threads::Gpu()->PostTask([this, &latch, texture_id]() {
+    std::shared_ptr<AndroidExternalTextureGL> texture =
+        static_pointer_cast<AndroidExternalTextureGL>(
+            rasterizer_->GetTextureRegistry().GetTexture(texture_id));
+    if (texture) {
+      texture->MarkNewFrameAvailable();
+    }
+    latch.Signal();
+  });
+  latch.Wait();
+  PlatformView::MarkTextureFrameAvailable(texture_id);
 }
 
 fml::jni::ScopedJavaLocalRef<jobject> PlatformViewAndroid::GetBitmap(

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -547,24 +547,20 @@ void PlatformViewAndroid::RunFromSource(const std::string& assets_directory,
   fml::jni::DetachFromVM();
 }
 
-size_t PlatformViewAndroid::RegisterExternalTexture(
+void PlatformViewAndroid::RegisterExternalTexture(int64_t texture_id,
     const fml::jni::JavaObjectWeakGlobalRef& surface_texture) {
-  return RegisterTexture(
-      std::make_shared<AndroidExternalTextureGL>(surface_texture));
+  RegisterTexture(std::make_shared<AndroidExternalTextureGL>(texture_id, surface_texture));
 }
 
-void PlatformViewAndroid::MarkTextureFrameAvailable(size_t texture_id) {
-  fxl::AutoResetWaitableEvent latch;
-  blink::Threads::Gpu()->PostTask([this, &latch, texture_id]() {
+void PlatformViewAndroid::MarkTextureFrameAvailable(int64_t texture_id) {
+  blink::Threads::Gpu()->PostTask([this, texture_id]() {
     std::shared_ptr<AndroidExternalTextureGL> texture =
         static_pointer_cast<AndroidExternalTextureGL>(
             rasterizer_->GetTextureRegistry().GetTexture(texture_id));
     if (texture) {
       texture->MarkNewFrameAvailable();
     }
-    latch.Signal();
   });
-  latch.Wait();
   PlatformView::MarkTextureFrameAvailable(texture_id);
 }
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -99,6 +99,11 @@ class PlatformViewAndroid : public PlatformView {
                      const std::string& main,
                      const std::string& packages) override;
 
+  size_t RegisterExternalTexture(
+      const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
+
+  void MarkTextureFrameAvailable(size_t texture_id) override;
+
   void set_flutter_view(const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {
     flutter_view_ = flutter_view;
   }

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -99,10 +99,10 @@ class PlatformViewAndroid : public PlatformView {
                      const std::string& main,
                      const std::string& packages) override;
 
-  size_t RegisterExternalTexture(
+  void RegisterExternalTexture(int64_t texture_id,
       const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
 
-  void MarkTextureFrameAvailable(size_t texture_id) override;
+  void MarkTextureFrameAvailable(int64_t texture_id) override;
 
   void set_flutter_view(const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {
     flutter_view_ = flutter_view;

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -99,7 +99,8 @@ class PlatformViewAndroid : public PlatformView {
                      const std::string& main,
                      const std::string& packages) override;
 
-  void RegisterExternalTexture(int64_t texture_id,
+  void RegisterExternalTexture(
+      int64_t texture_id,
       const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
 
   void MarkTextureFrameAvailable(int64_t texture_id) override;

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -227,7 +227,8 @@ static void RegisterTexture(JNIEnv* env,
                             jlong platform_view,
                             jlong texture_id,
                             jobject surface_texture) {
-  PLATFORM_VIEW->RegisterExternalTexture(static_cast<int64_t>(texture_id),
+  PLATFORM_VIEW->RegisterExternalTexture(
+      static_cast<int64_t>(texture_id),
       fml::jni::JavaObjectWeakGlobalRef(env, surface_texture));
 }
 
@@ -235,7 +236,8 @@ static void MarkTextureFrameAvailable(JNIEnv* env,
                                       jobject jcaller,
                                       jlong platform_view,
                                       jlong texture_id) {
-  return PLATFORM_VIEW->MarkTextureFrameAvailable(static_cast<int64_t>(texture_id));
+  return PLATFORM_VIEW->MarkTextureFrameAvailable(
+      static_cast<int64_t>(texture_id));
 }
 
 static void UnregisterTexture(JNIEnv* env,

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -222,26 +222,27 @@ static jboolean GetIsSoftwareRendering(JNIEnv* env, jobject jcaller) {
   return blink::Settings::Get().enable_software_rendering;
 }
 
-static jlong RegisterTexture(JNIEnv* env,
-                             jobject jcaller,
-                             jlong platform_view,
-                             jobject surface_texture) {
-  return PLATFORM_VIEW->RegisterExternalTexture(
+static void RegisterTexture(JNIEnv* env,
+                            jobject jcaller,
+                            jlong platform_view,
+                            jlong texture_id,
+                            jobject surface_texture) {
+  PLATFORM_VIEW->RegisterExternalTexture(static_cast<int64_t>(texture_id),
       fml::jni::JavaObjectWeakGlobalRef(env, surface_texture));
 }
 
 static void MarkTextureFrameAvailable(JNIEnv* env,
                                       jobject jcaller,
                                       jlong platform_view,
-                                      jlong textureId) {
-  return PLATFORM_VIEW->MarkTextureFrameAvailable(textureId);
+                                      jlong texture_id) {
+  return PLATFORM_VIEW->MarkTextureFrameAvailable(static_cast<int64_t>(texture_id));
 }
 
 static void UnregisterTexture(JNIEnv* env,
                               jobject jcaller,
                               jlong platform_view,
-                              jlong textureId) {
-  PLATFORM_VIEW->UnregisterTexture(textureId);
+                              jlong texture_id) {
+  PLATFORM_VIEW->UnregisterTexture(static_cast<int64_t>(texture_id));
 }
 
 static void InvokePlatformMessageResponseCallback(JNIEnv* env,
@@ -377,7 +378,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
       },
       {
           .name = "nativeRegisterTexture",
-          .signature = "(JLandroid/graphics/SurfaceTexture;)J",
+          .signature = "(JJLandroid/graphics/SurfaceTexture;)V",
           .fnPtr = reinterpret_cast<void*>(&shell::RegisterTexture),
       },
       {

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/android/platform_view_android_jni.h"
+
 #include "flutter/common/settings.h"
 #include "flutter/fml/platform/android/jni_util.h"
 #include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
 #include "flutter/runtime/dart_service_isolate.h"
+#include "flutter/shell/platform/android/android_external_texture_gl.h"
 #include "lib/fxl/arraysize.h"
 #include "lib/fxl/logging.h"
 
@@ -17,6 +19,7 @@
 namespace shell {
 
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_view_class = nullptr;
+static fml::jni::ScopedJavaGlobalRef<jclass>* g_surface_texture_class = nullptr;
 
 // Called By Native
 
@@ -53,6 +56,27 @@ void FlutterViewUpdateSemantics(JNIEnv* env,
 static jmethodID g_on_first_frame_method = nullptr;
 void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj) {
   env->CallVoidMethod(obj, g_on_first_frame_method);
+  FXL_CHECK(env->ExceptionCheck() == JNI_FALSE);
+}
+
+static jmethodID g_attach_to_gl_context_method = nullptr;
+void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jint textureId) {
+  ASSERT_IS_GPU_THREAD;
+  env->CallVoidMethod(obj, g_attach_to_gl_context_method, textureId);
+  FXL_CHECK(env->ExceptionCheck() == JNI_FALSE);
+}
+
+static jmethodID g_update_tex_image_method = nullptr;
+void SurfaceTextureUpdateTexImage(JNIEnv* env, jobject obj) {
+  ASSERT_IS_GPU_THREAD;
+  env->CallVoidMethod(obj, g_update_tex_image_method);
+  FXL_CHECK(env->ExceptionCheck() == JNI_FALSE);
+}
+
+static jmethodID g_detach_from_gl_context_method = nullptr;
+void SurfaceTextureDetachFromGLContext(JNIEnv* env, jobject obj) {
+  ASSERT_IS_GPU_THREAD;
+  env->CallVoidMethod(obj, g_detach_from_gl_context_method);
   FXL_CHECK(env->ExceptionCheck() == JNI_FALSE);
 }
 
@@ -198,6 +222,28 @@ static jboolean GetIsSoftwareRendering(JNIEnv* env, jobject jcaller) {
   return blink::Settings::Get().enable_software_rendering;
 }
 
+static jlong RegisterTexture(JNIEnv* env,
+                             jobject jcaller,
+                             jlong platform_view,
+                             jobject surface_texture) {
+  return PLATFORM_VIEW->RegisterExternalTexture(
+      fml::jni::JavaObjectWeakGlobalRef(env, surface_texture));
+}
+
+static void MarkTextureFrameAvailable(JNIEnv* env,
+                                      jobject jcaller,
+                                      jlong platform_view,
+                                      jlong textureId) {
+  return PLATFORM_VIEW->MarkTextureFrameAvailable(textureId);
+}
+
+static void UnregisterTexture(JNIEnv* env,
+                              jobject jcaller,
+                              jlong platform_view,
+                              jlong textureId) {
+  PLATFORM_VIEW->UnregisterTexture(textureId);
+}
+
 static void InvokePlatformMessageResponseCallback(JNIEnv* env,
                                                   jobject jcaller,
                                                   jlong platform_view,
@@ -223,8 +269,13 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
 
   g_flutter_view_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
       env, env->FindClass("io/flutter/view/FlutterView"));
-
   if (g_flutter_view_class->is_null()) {
+    return false;
+  }
+
+  g_surface_texture_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
+      env, env->FindClass("android/graphics/SurfaceTexture"));
+  if (g_surface_texture_class->is_null()) {
     return false;
   }
 
@@ -324,6 +375,21 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .signature = "()Z",
           .fnPtr = reinterpret_cast<void*>(&shell::GetIsSoftwareRendering),
       },
+      {
+          .name = "nativeRegisterTexture",
+          .signature = "(JLandroid/graphics/SurfaceTexture;)J",
+          .fnPtr = reinterpret_cast<void*>(&shell::RegisterTexture),
+      },
+      {
+          .name = "nativeMarkTextureFrameAvailable",
+          .signature = "(JJ)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::MarkTextureFrameAvailable),
+      },
+      {
+          .name = "nativeUnregisterTexture",
+          .signature = "(JJ)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::UnregisterTexture),
+      },
   };
 
   if (env->RegisterNatives(g_flutter_view_class->obj(), methods,
@@ -360,6 +426,28 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
   if (g_on_first_frame_method == nullptr) {
     return false;
   }
+
+  g_attach_to_gl_context_method = env->GetMethodID(
+      g_surface_texture_class->obj(), "attachToGLContext", "(I)V");
+
+  if (g_attach_to_gl_context_method == nullptr) {
+    return false;
+  }
+
+  g_update_tex_image_method =
+      env->GetMethodID(g_surface_texture_class->obj(), "updateTexImage", "()V");
+
+  if (g_update_tex_image_method == nullptr) {
+    return false;
+  }
+
+  g_detach_from_gl_context_method = env->GetMethodID(
+      g_surface_texture_class->obj(), "detachFromGLContext", "()V");
+
+  if (g_detach_from_gl_context_method == nullptr) {
+    return false;
+  }
+
   return true;
 }
 

--- a/shell/platform/android/platform_view_android_jni.h
+++ b/shell/platform/android/platform_view_android_jni.h
@@ -29,6 +29,12 @@ void FlutterViewUpdateSemantics(JNIEnv* env,
 
 void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj);
 
+void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jint textureId);
+
+void SurfaceTextureUpdateTexImage(JNIEnv* env, jobject obj);
+
+void SurfaceTextureDetachFromGLContext(JNIEnv* env, jobject obj);
+
 }  // namespace shell
 
 #endif  // FLUTTER_SHELL_PLATFORM_ANDROID_PLATFORM_VIEW_ANDROID_JNI_H_

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -22,6 +22,7 @@ _flutter_framework_headers = [
   "framework/Headers/FlutterMacros.h",
   "framework/Headers/FlutterNavigationController.h",
   "framework/Headers/FlutterPlugin.h",
+  "framework/Headers/FlutterTexture.h",
   "framework/Headers/FlutterViewController.h",
 ]
 
@@ -62,6 +63,8 @@ shared_library("create_flutter_framework_dylib") {
     "framework/Source/platform_message_router.mm",
     "framework/Source/vsync_waiter_ios.h",
     "framework/Source/vsync_waiter_ios.mm",
+    "ios_external_texture_gl.h",
+    "ios_external_texture_gl.mm",
     "ios_gl_context.h",
     "ios_gl_context.mm",
     "ios_surface.h",
@@ -100,9 +103,10 @@ shared_library("create_flutter_framework_dylib") {
   defines = [ "FLUTTER_FRAMEWORK" ]
 
   libs = [
+    "CoreMedia.framework",
+    "CoreVideo.framework",
     "UIKit.framework",
     "OpenGLES.framework",
-    "AVFoundation.framework",
     "AudioToolbox.framework",
     "QuartzCore.framework",
   ]

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -14,6 +14,7 @@
 #include "FlutterMacros.h"
 #include "FlutterNavigationController.h"
 #include "FlutterPlugin.h"
+#include "FlutterTexture.h"
 #include "FlutterViewController.h"
 
 #endif  // FLUTTER_FLUTTER_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterAppDelegate.h
@@ -34,6 +34,12 @@ FLUTTER_EXPORT
 // Defaults to window's rootViewController.
 - (NSObject<FlutterBinaryMessenger>*)binaryMessenger;
 
+// Can be overriden by subclasses to provide a custom FlutterTextureRegistry,
+// typically a FlutterViewController, for plugin interop.
+//
+// Defaults to window's rootViewController.
+- (NSObject<FlutterTextureRegistry>*)textures;
+
 @end
 
 #endif  // FLUTTER_FLUTTERDARTPROJECT_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -149,7 +149,7 @@ NS_ASSUME_NONNULL_BEGIN
 
  - Returns: The texture registry.
  */
-- (NSObject<FlutterTextureRegistry>*)textureRegistry;
+- (NSObject<FlutterTextureRegistry>*)textures;
 
 /**
  Publishes a value for external use of the plugin.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -10,6 +10,7 @@
 #include "FlutterBinaryMessenger.h"
 #include "FlutterChannels.h"
 #include "FlutterCodecs.h"
+#include "FlutterTexture.h"
 
 NS_ASSUME_NONNULL_BEGIN
 @protocol FlutterPluginRegistrar;
@@ -141,6 +142,14 @@ NS_ASSUME_NONNULL_BEGIN
  - Returns: The messenger.
  */
 - (NSObject<FlutterBinaryMessenger>*)messenger;
+
+/**
+ Returns a `FlutterTextureRegistry` for registering textures
+ provided by the plugin.
+
+ - Returns: The texture registry.
+ */
+- (NSObject<FlutterTextureRegistry>*)textureRegistry;
 
 /**
  Publishes a value for external use of the plugin.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
@@ -1,0 +1,29 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLUTTERTEXTURE_H_
+#define FLUTTER_FLUTTERTEXTURE_H_
+
+#import <CoreMedia/CoreMedia.h>
+#import <Foundation/Foundation.h>
+
+#include "FlutterMacros.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+FLUTTER_EXPORT
+@protocol FlutterTexture<NSObject>
+- (CVPixelBufferRef)copyPixelBuffer;
+@end
+
+FLUTTER_EXPORT
+@protocol FlutterTextureRegistry<NSObject>
+- (NSUInteger)registerTexture:(NSObject<FlutterTexture>*)texture;
+- (void)textureFrameAvailable:(NSUInteger)textureId;
+- (void)unregisterTexture:(NSUInteger)textureId;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // FLUTTER_FLUTTERTEXTURE_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
@@ -19,9 +19,9 @@ FLUTTER_EXPORT
 
 FLUTTER_EXPORT
 @protocol FlutterTextureRegistry<NSObject>
-- (NSUInteger)registerTexture:(NSObject<FlutterTexture>*)texture;
-- (void)textureFrameAvailable:(NSUInteger)textureId;
-- (void)unregisterTexture:(NSUInteger)textureId;
+- (int64_t)registerTexture:(NSObject<FlutterTexture>*)texture;
+- (void)textureFrameAvailable:(int64_t)textureId;
+- (void)unregisterTexture:(int64_t)textureId;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -11,9 +11,10 @@
 #include "FlutterBinaryMessenger.h"
 #include "FlutterDartProject.h"
 #include "FlutterMacros.h"
+#include "FlutterTexture.h"
 
 FLUTTER_EXPORT
-@interface FlutterViewController : UIViewController<FlutterBinaryMessenger>
+@interface FlutterViewController : UIViewController<FlutterBinaryMessenger, FlutterTextureRegistry>
 
 - (instancetype)initWithProject:(FlutterDartProject*)project
                         nibName:(NSString*)nibNameOrNil

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -219,6 +219,14 @@
   return nil;
 }
 
+- (NSObject<FlutterTextureRegistry>*)textureRegistry {
+  UIViewController* rootViewController = _window.rootViewController;
+  if ([rootViewController conformsToProtocol:@protocol(FlutterTextureRegistry)]) {
+    return (NSObject<FlutterTextureRegistry>*)rootViewController;
+  }
+  return nil;
+}
+
 - (NSObject<FlutterPluginRegistrar>*)registrarForPlugin:(NSString*)pluginKey {
   NSAssert(self.pluginPublications[pluginKey] == nil, @"Duplicate plugin key: %@", pluginKey);
   self.pluginPublications[pluginKey] = [NSNull null];
@@ -256,6 +264,10 @@
 
 - (NSObject<FlutterBinaryMessenger>*)messenger {
   return [_appDelegate binaryMessenger];
+}
+
+- (NSObject<FlutterTextureRegistry>*)textureRegistry {
+  return [_appDelegate textureRegistry];
 }
 
 - (void)publish:(NSObject*)value {

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -219,7 +219,7 @@
   return nil;
 }
 
-- (NSObject<FlutterTextureRegistry>*)textureRegistry {
+- (NSObject<FlutterTextureRegistry>*)textures {
   UIViewController* rootViewController = _window.rootViewController;
   if ([rootViewController conformsToProtocol:@protocol(FlutterTextureRegistry)]) {
     return (NSObject<FlutterTextureRegistry>*)rootViewController;
@@ -266,8 +266,8 @@
   return [_appDelegate binaryMessenger];
 }
 
-- (NSObject<FlutterTextureRegistry>*)textureRegistry {
-  return [_appDelegate textureRegistry];
+- (NSObject<FlutterTextureRegistry>*)textures {
+  return [_appDelegate textures];
 }
 
 - (void)publish:(NSObject*)value {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "flutter/common/threads.h"
+#include "flutter/flow/texture.h"
 #include "flutter/fml/platform/darwin/platform_version.h"
 #include "flutter/fml/platform/darwin/scoped_block.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
@@ -19,6 +20,7 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/flutter_touch_mapper.h"
+#include "flutter/shell/platform/darwin/ios/ios_external_texture_gl.h"
 #include "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 #include "lib/fxl/functional/make_copyable.h"
 #include "lib/fxl/time/time_delta.h"
@@ -864,5 +866,19 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
               binaryMessageHandler:(FlutterBinaryMessageHandler)handler {
   NSAssert(channel, @"The channel must not be null");
   _platformView->platform_message_router().SetMessageHandler(channel.UTF8String, handler);
+}
+
+#pragma mark - FlutterTextureRegistry
+
+- (NSUInteger)registerTexture:(NSObject<FlutterTexture>*)texture {
+  return _platformView->RegisterExternalTexture(texture);
+}
+
+- (void)unregisterTexture:(NSUInteger)textureId {
+  _platformView->UnregisterTexture(textureId);
+}
+
+- (void)textureFrameAvailable:(NSUInteger)textureId {
+  _platformView->MarkTextureFrameAvailable(textureId);
 }
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -76,6 +76,7 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> _systemChannel;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> _settingsChannel;
   fml::scoped_nsprotocol<UIView*> _launchView;
+  int64_t _nextTextureId;
   bool _platformSupportsTouchTypes;
   bool _platformSupportsTouchPressure;
   bool _platformSupportsTouchOrientationAndTilt;
@@ -870,15 +871,17 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
 
 #pragma mark - FlutterTextureRegistry
 
-- (NSUInteger)registerTexture:(NSObject<FlutterTexture>*)texture {
-  return _platformView->RegisterExternalTexture(texture);
+- (int64_t)registerTexture:(NSObject<FlutterTexture>*)texture {
+  int64_t textureId = _nextTextureId++;
+  _platformView->RegisterExternalTexture(textureId, texture);
+  return textureId;
 }
 
-- (void)unregisterTexture:(NSUInteger)textureId {
+- (void)unregisterTexture:(int64_t)textureId {
   _platformView->UnregisterTexture(textureId);
 }
 
-- (void)textureFrameAvailable:(NSUInteger)textureId {
+- (void)textureFrameAvailable:(int64_t)textureId {
   _platformView->MarkTextureFrameAvailable(textureId);
 }
 @end

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -1,0 +1,42 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_GL_H_
+#define FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_GL_H_
+
+#import <CoreVideo/CoreVideo.h>
+#import <OpenGLES/EAGL.h>
+#import <OpenGLES/ES2/gl.h>
+#import <OpenGLES/ES2/glext.h>
+#include "flutter/flow/texture.h"
+#include "flutter/fml/platform/darwin/cf_utils.h"
+#include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h"
+
+namespace shell {
+
+class IOSExternalTextureGL : public flow::Texture {
+ public:
+  IOSExternalTextureGL(NSObject<FlutterTexture>* externalTexture);
+
+  ~IOSExternalTextureGL() override;
+
+  // Called from GPU thread.
+  virtual sk_sp<SkImage> MakeSkImage(int width,
+                                     int height,
+                                     GrContext* grContext) override;
+
+  virtual void OnGrContextCreated() override;
+
+  virtual void OnGrContextDestroyed() override;
+
+ private:
+  NSObject<FlutterTexture>* external_texture_;
+  fml::CFRef<CVOpenGLESTextureCacheRef> cache_ref_;
+  fml::CFRef<CVOpenGLESTextureRef> texture_ref_;
+  FXL_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureGL);
+};
+
+}  // namespace shell
+
+#endif  // FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_GL_H_

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -5,10 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_GL_H_
 #define FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_GL_H_
 
-#import <CoreVideo/CoreVideo.h>
-#import <OpenGLES/EAGL.h>
-#import <OpenGLES/ES2/gl.h>
-#import <OpenGLES/ES2/glext.h>
 #include "flutter/flow/texture.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
@@ -24,9 +20,7 @@ class IOSExternalTextureGL : public flow::Texture {
   ~IOSExternalTextureGL() override;
 
   // Called from GPU thread.
-  virtual sk_sp<SkImage> MakeSkImage(int width,
-                                     int height,
-                                     GrContext* grContext) override;
+  virtual void Paint(SkCanvas& canvas, const SkRect& bounds) override;
 
   virtual void OnGrContextCreated() override;
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -11,13 +11,14 @@
 #import <OpenGLES/ES2/glext.h>
 #include "flutter/flow/texture.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h"
 
 namespace shell {
 
 class IOSExternalTextureGL : public flow::Texture {
  public:
-  IOSExternalTextureGL(NSObject<FlutterTexture>* externalTexture);
+  IOSExternalTextureGL(int64_t textureId, NSObject<FlutterTexture>* externalTexture);
 
   ~IOSExternalTextureGL() override;
 
@@ -31,7 +32,7 @@ class IOSExternalTextureGL : public flow::Texture {
   virtual void OnGrContextDestroyed() override;
 
  private:
-  NSObject<FlutterTexture>* external_texture_;
+  fml::scoped_nsobject<NSObject<FlutterTexture>> external_texture_;
   fml::CFRef<CVOpenGLESTextureCacheRef> cache_ref_;
   fml::CFRef<CVOpenGLESTextureRef> texture_ref_;
   FXL_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureGL);

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -18,7 +18,8 @@ namespace shell {
 
 class IOSExternalTextureGL : public flow::Texture {
  public:
-  IOSExternalTextureGL(int64_t textureId, NSObject<FlutterTexture>* externalTexture);
+  IOSExternalTextureGL(int64_t textureId,
+                       NSObject<FlutterTexture>* externalTexture);
 
   ~IOSExternalTextureGL() override;
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -1,0 +1,75 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/darwin/ios/ios_external_texture_gl.h"
+
+#include "flutter/common/threads.h"
+#include "flutter/lib/ui/painting/resource_context.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
+#include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
+#include "third_party/skia/include/gpu/GrTexture.h"
+#include "third_party/skia/include/gpu/GrTypes.h"
+
+namespace shell {
+
+IOSExternalTextureGL::IOSExternalTextureGL(NSObject<FlutterTexture>* externalTexture)
+    : external_texture_(externalTexture) {
+  FXL_DCHECK(external_texture_);
+  [external_texture_ retain];
+}
+
+IOSExternalTextureGL::~IOSExternalTextureGL() {
+  [external_texture_ release];
+}
+
+sk_sp<SkImage> IOSExternalTextureGL::MakeSkImage(int width, int height, GrContext* grContext) {
+  ASSERT_IS_GPU_THREAD;
+  if (!cache_ref_) {
+    CVOpenGLESTextureCacheRef cache;
+    CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL,
+                                                [EAGLContext currentContext], NULL, &cache);
+    if (err == noErr) {
+      cache_ref_.Reset(cache);
+    } else {
+      FXL_LOG(WARNING) << "Failed to create GLES texture cache: " << err;
+      return nullptr;
+    }
+  }
+  fml::CFRef<CVPixelBufferRef> bufferRef;
+  bufferRef.Reset([external_texture_ copyPixelBuffer]);
+  if (bufferRef != nullptr) {
+    CVOpenGLESTextureRef texture;
+    CVReturn err = CVOpenGLESTextureCacheCreateTextureFromImage(
+        kCFAllocatorDefault, cache_ref_, bufferRef, nullptr, GL_TEXTURE_2D, GL_RGBA,
+        static_cast<int>(CVPixelBufferGetWidth(bufferRef)),
+        static_cast<int>(CVPixelBufferGetHeight(bufferRef)), GL_BGRA, GL_UNSIGNED_BYTE, 0,
+        &texture);
+    texture_ref_.Reset(texture);
+    if (err != noErr) {
+      FXL_LOG(WARNING) << "Could not create texture from pixel buffer: " << err;
+      return nullptr;
+    }
+  }
+  if (!texture_ref_) {
+    return nullptr;
+  }
+  GrGLTextureInfo textureInfo = {CVOpenGLESTextureGetTarget(texture_ref_),
+                                 CVOpenGLESTextureGetName(texture_ref_)};
+  GrBackendTexture backendTexture(width, height, kRGBA_8888_GrPixelConfig, textureInfo);
+  return SkImage::MakeFromTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin,
+                                  SkAlphaType::kPremul_SkAlphaType, nullptr);
+}
+
+void IOSExternalTextureGL::OnGrContextCreated() {
+  ASSERT_IS_GPU_THREAD
+}
+
+void IOSExternalTextureGL::OnGrContextDestroyed() {
+  ASSERT_IS_GPU_THREAD
+  texture_ref_.Reset(nullptr);
+  cache_ref_.Reset(nullptr);
+}
+
+}  // namespace shell

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -14,15 +14,12 @@
 
 namespace shell {
 
-IOSExternalTextureGL::IOSExternalTextureGL(NSObject<FlutterTexture>* externalTexture)
-    : external_texture_(externalTexture) {
+IOSExternalTextureGL::IOSExternalTextureGL(int64_t textureId, NSObject<FlutterTexture>* externalTexture)
+    : Texture(textureId), external_texture_(externalTexture) {
   FXL_DCHECK(external_texture_);
-  [external_texture_ retain];
 }
 
-IOSExternalTextureGL::~IOSExternalTextureGL() {
-  [external_texture_ release];
-}
+IOSExternalTextureGL::~IOSExternalTextureGL() = default;
 
 sk_sp<SkImage> IOSExternalTextureGL::MakeSkImage(int width, int height, GrContext* grContext) {
   ASSERT_IS_GPU_THREAD;

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -14,7 +14,8 @@
 
 namespace shell {
 
-IOSExternalTextureGL::IOSExternalTextureGL(int64_t textureId, NSObject<FlutterTexture>* externalTexture)
+IOSExternalTextureGL::IOSExternalTextureGL(int64_t textureId,
+                                           NSObject<FlutterTexture>* externalTexture)
     : Texture(textureId), external_texture_(externalTexture) {
   FXL_DCHECK(external_texture_);
 }

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -9,6 +9,7 @@
 
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/platform_message_router.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
@@ -49,6 +50,8 @@ class PlatformViewIOS : public PlatformView {
 
   void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message) override;
+
+  size_t RegisterExternalTexture(NSObject<FlutterTexture>* texture);
 
   void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
 

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -51,7 +51,7 @@ class PlatformViewIOS : public PlatformView {
   void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message) override;
 
-  size_t RegisterExternalTexture(NSObject<FlutterTexture>* texture);
+  void RegisterExternalTexture(int64_t id, NSObject<FlutterTexture>* texture);
 
   void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
 

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -13,6 +13,7 @@
 #include "flutter/shell/gpu/gpu_rasterizer.h"
 #include "flutter/shell/platform/darwin/common/process_info_mac.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
+#include "flutter/shell/platform/darwin/ios/ios_external_texture_gl.h"
 #include "lib/fxl/synchronization/waitable_event.h"
 
 namespace shell {
@@ -98,6 +99,10 @@ void PlatformViewIOS::UpdateSemantics(std::vector<blink::SemanticsNode> update) 
 
 void PlatformViewIOS::HandlePlatformMessage(fxl::RefPtr<blink::PlatformMessage> message) {
   platform_message_router_.HandlePlatformMessage(std::move(message));
+}
+
+size_t PlatformViewIOS::RegisterExternalTexture(NSObject<FlutterTexture>* texture) {
+  return RegisterTexture(std::make_shared<IOSExternalTextureGL>(texture));
 }
 
 void PlatformViewIOS::RunFromSource(const std::string& assets_directory,

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -101,7 +101,8 @@ void PlatformViewIOS::HandlePlatformMessage(fxl::RefPtr<blink::PlatformMessage> 
   platform_message_router_.HandlePlatformMessage(std::move(message));
 }
 
-void PlatformViewIOS::RegisterExternalTexture(int64_t texture_id, NSObject<FlutterTexture>* texture) {
+void PlatformViewIOS::RegisterExternalTexture(int64_t texture_id,
+                                              NSObject<FlutterTexture>* texture) {
   RegisterTexture(std::make_shared<IOSExternalTextureGL>(texture_id, texture));
 }
 

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -101,8 +101,8 @@ void PlatformViewIOS::HandlePlatformMessage(fxl::RefPtr<blink::PlatformMessage> 
   platform_message_router_.HandlePlatformMessage(std::move(message));
 }
 
-size_t PlatformViewIOS::RegisterExternalTexture(NSObject<FlutterTexture>* texture) {
-  return RegisterTexture(std::make_shared<IOSExternalTextureGL>(texture));
+void PlatformViewIOS::RegisterExternalTexture(int64_t texture_id, NSObject<FlutterTexture>* texture) {
+  RegisterTexture(std::make_shared<IOSExternalTextureGL>(texture_id, texture));
 }
 
 void PlatformViewIOS::RunFromSource(const std::string& assets_directory,

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1074,6 +1074,8 @@ FILE: ../../../flutter/flow/debug_print.h
 FILE: ../../../flutter/flow/export_node.h
 FILE: ../../../flutter/flow/layers/physical_model_layer.cc
 FILE: ../../../flutter/flow/layers/physical_model_layer.h
+FILE: ../../../flutter/flow/layers/texture_layer.cc
+FILE: ../../../flutter/flow/layers/texture_layer.h
 FILE: ../../../flutter/flow/matrix_decomposition.cc
 FILE: ../../../flutter/flow/matrix_decomposition.h
 FILE: ../../../flutter/flow/matrix_decomposition_unittests.cc
@@ -1082,6 +1084,8 @@ FILE: ../../../flutter/flow/paint_utils.h
 FILE: ../../../flutter/flow/raster_cache_key.cc
 FILE: ../../../flutter/flow/raster_cache_key.h
 FILE: ../../../flutter/flow/raster_cache_unittests.cc
+FILE: ../../../flutter/flow/texture.cc
+FILE: ../../../flutter/flow/texture.h
 FILE: ../../../flutter/fml/icu_util.cc
 FILE: ../../../flutter/fml/icu_util.h
 FILE: ../../../flutter/fml/mapping.cc
@@ -1142,6 +1146,8 @@ FILE: ../../../flutter/shell/common/null_platform_view.cc
 FILE: ../../../flutter/shell/common/null_platform_view.h
 FILE: ../../../flutter/shell/gpu/gpu_surface_software.cc
 FILE: ../../../flutter/shell/gpu/gpu_surface_software.h
+FILE: ../../../flutter/shell/platform/android/android_external_texture_gl.cc
+FILE: ../../../flutter/shell/platform/android/android_external_texture_gl.h
 FILE: ../../../flutter/shell/platform/android/android_surface_software.cc
 FILE: ../../../flutter/shell/platform/android/android_surface_software.h
 FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -1170,6 +1176,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterCodecs
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterHeadlessDartRunner.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterNavigationController.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCodecs.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterHeadlessDartRunner.mm
@@ -1181,6 +1188,8 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/flutter_codecs
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/ios_external_texture_gl.h
+FILE: ../../../flutter/shell/platform/darwin/ios/ios_external_texture_gl.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_gl_context.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_gl_context.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface.h

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1170,6 +1170,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/StandardM
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/StringCodec.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Preconditions.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
 FILE: ../../../flutter/shell/platform/android/platform_view_android_jni.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android_jni.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterBinaryMessenger.h
@@ -9459,7 +9460,6 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterApplication.
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourceCleaner.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourceExtractor.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourcePaths.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
 FILE: ../../../flutter/shell/platform/android/library_loader.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android.h

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1155,9 +1155,11 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterActivityEven
 FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/BinaryCodec.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/EventChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/FlutterException.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/JSONMessageCodec.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/MessageCodec.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/MethodCall.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -1260,8 +1262,6 @@ FILE: ../../../flutter/lib/ui/natives.dart
 FILE: ../../../flutter/lib/ui/window/window.h
 FILE: ../../../flutter/runtime/platform_impl.h
 FILE: ../../../flutter/shell/common/skia_event_tracer_impl.cc
-FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/JSONMethodCodec.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/JSONUtil.java
 FILE: ../../../flutter/shell/platform/darwin/desktop/Info.plist
 FILE: ../../../flutter/shell/platform/darwin/desktop/flutter_mac.xib
@@ -9459,6 +9459,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterApplication.
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourceCleaner.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourceExtractor.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourcePaths.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
 FILE: ../../../flutter/shell/platform/android/library_loader.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android.h


### PR DESCRIPTION
Adds support for managing textures that originate in Flutter plugins. This enables the creation of plugins for inline video, camera, OpenGL, etc.

Corresponding flutter/flutter PR: flutter/flutter/pull/12525.