### PR TITLE
Provide an entropy source to the Dart engine

### DIFF
--- a/lib/io/BUILD.gn
+++ b/lib/io/BUILD.gn
@@ -14,4 +14,8 @@ source_set("io") {
     "//garnet/public/lib/fxl",
     "//topaz/lib/tonic/converter",
   ]
+
+  configs += [
+    "//dart/runtime:dart_config",
+  ]
 }

--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/lib/io/dart_io.h"
 
+#include "dart/runtime/bin/crypto.h"
 #include "dart/runtime/bin/io_natives.h"
 #include "dart/runtime/include/dart_api.h"
 #include "lib/tonic/converter/dart_converter.h"
@@ -16,6 +17,10 @@ void DartIO::InitForIsolate() {
   DART_CHECK_VALID(Dart_SetNativeResolver(Dart_LookupLibrary(ToDart("dart:io")),
                                           dart::bin::IONativeLookup,
                                           dart::bin::IONativeSymbol));
+}
+
+bool DartIO::EntropySource(uint8_t* buffer, intptr_t length) {
+  return dart::bin::Crypto::GetRandomBytes(length, buffer);
 }
 
 }  // namespace blink

--- a/lib/io/dart_io.h
+++ b/lib/io/dart_io.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_LIB_IO_DART_IO_H_
 #define FLUTTER_LIB_IO_DART_IO_H_
 
+#include <cstdint>
+
 #include "lib/fxl/macros.h"
 
 namespace blink {
@@ -12,6 +14,7 @@ namespace blink {
 class DartIO {
  public:
   static void InitForIsolate();
+  static bool EntropySource(uint8_t* buffer, intptr_t length);
 
  private:
   FXL_DISALLOW_IMPLICIT_CONSTRUCTORS(DartIO);

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -565,6 +565,7 @@ void InitDartVM(const uint8_t* vm_snapshot_data,
     params.shutdown = IsolateShutdownCallback;
     params.thread_exit = ThreadExitCallback;
     params.get_service_assets = GetVMServiceAssetsArchiveCallback;
+    params.entropy_source = DartIO::EntropySource;
     char* init_error = Dart_Initialize(&params);
     if (init_error != nullptr)
       FXL_LOG(FATAL) << "Error while initializing the Dart VM: " << init_error;


### PR DESCRIPTION
This is required by the _CryptoUtils class used by the recently repackaged
Dart HTTP libraries