### PR TITLE
- Remove call to DartDebugger::InitDebugger in InitDartVM

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -95,10 +95,6 @@ source_set("runtime") {
     defines += [ "EMBED_TEST_FONT_DATA=1" ]
   }
 
-  if (flutter_runtime_mode != "release") {
-    deps += [ "//topaz/lib/tonic/debugger" ]
-  }
-
   # In AOT mode, precompiled snapshots contain the instruction buffer.
   # Generation of the same requires all application specific script code to be
   # specified up front. In such cases, there can be no generic snapshot.

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -22,7 +22,6 @@
 #include "lib/tonic/dart_message_handler.h"
 #include "lib/tonic/dart_state.h"
 #include "lib/tonic/dart_wrappable.h"
-#include "lib/tonic/debugger/dart_debugger.h"
 #include "lib/tonic/file_loader/file_loader.h"
 #include "lib/tonic/logging/dart_error.h"
 #include "lib/tonic/logging/dart_invoke.h"

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -36,7 +36,6 @@
 #include "lib/tonic/dart_state.h"
 #include "lib/tonic/dart_sticky_error.h"
 #include "lib/tonic/dart_wrappable.h"
-#include "lib/tonic/debugger/dart_debugger.h"
 #include "lib/tonic/file_loader/file_loader.h"
 #include "lib/tonic/logging/dart_error.h"
 #include "lib/tonic/logging/dart_invoke.h"
@@ -537,14 +536,6 @@ void InitDartVM(const uint8_t* vm_snapshot_data,
     args.push_back(settings.dart_flags[i].c_str());
 
   FXL_CHECK(Dart_SetVMFlags(args.size(), args.data()));
-
-#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
-  if (!IsRunningPrecompiledCode()) {
-    TRACE_EVENT0("flutter", "DartDebugger::InitDebugger");
-    // This should be called before calling Dart_Initialize.
-    tonic::DartDebugger::InitDebugger();
-  }
-#endif
 
   DartUI::InitForGlobal();
 

--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -42,7 +42,4 @@ static_library("core") {
     "//topaz/lib/tonic",
   ]
 
-  if (flutter_runtime_mode != "release") {
-    public_deps += [ "//topaz/lib/tonic/debugger" ]
-  }
 }


### PR DESCRIPTION
- Remove call to DartDebugger::InitDebugger as this debug API is not used
- Remove linking of dart_debugger.cc into the engine as this code is not used
(all debugging is done using the service API, this debugger implementation uses the deprecated dart debugger API)