### PR TITLE
Use iOS scale when computing render buffer size

### DIFF
--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -163,14 +163,16 @@ bool IOSGLContext::PresentRenderBuffer() const {
 
 bool IOSGLContext::UpdateStorageSizeIfNecessary() {
   const CGSize layer_size = [layer_.get() bounds].size;
-
-  const GLint size_width = layer_size.width;
-  const GLint size_height = layer_size.height;
+  const CGFloat contents_scale = layer_.get().contentsScale;
+  const GLint size_width = layer_size.width * contents_scale;
+  const GLint size_height = layer_size.height * contents_scale;
 
   if (size_width == storage_size_width_ && size_height == storage_size_height_) {
     // Nothing to since the stoage size is already consistent with the layer.
     return true;
   }
+  TRACE_EVENT0("flutter", "Updating render buffer storage size");
+  FXL_DLOG(INFO) << "Updating render buffer storage size.";
 
   if (![EAGLContext setCurrentContext:context_]) {
     return false;


### PR DESCRIPTION
When checking whether render buffer size has changed, apply the device
scale factor used to convert points to pixels to ensure we're not
needlessly re-allocating render buffer storage.

Adds trace + debug log to make this easier to detect in future.

Originally introduced in 2d530da, but
rolled back in 0a6e415 to test whether
it was responsible for regressions to
flutter_gallery_ios__transition_perf benchmarks:
  * average_frame_build_time_millis
  * missed_frame_build_budget_count