### PR TITLE
Change to new SkFontMgr API

### DIFF
--- a/runtime/asset_font_selector.cc
+++ b/runtime/asset_font_selector.cc
@@ -228,10 +228,11 @@ sk_sp<SkTypeface> AssetFontSelector::getTypefaceAsset(
   }
 
   sk_sp<SkFontMgr> font_mgr(SkFontMgr::RefDefault());
-  SkMemoryStream* typeface_stream = new SkMemoryStream(
-      typeface_asset->data.data(), typeface_asset->data.size());
-  typeface_asset->typeface =
-      sk_sp<SkTypeface>(font_mgr->createFromStream(typeface_stream));
+  std::unique_ptr<SkStreamAsset> typeface_stream =
+      std::make_unique<SkMemoryStream>(typeface_asset->data.data(),
+                                       typeface_asset->data.size());
+  typeface_asset->typeface = font_mgr->makeFromStream(
+      std::move(typeface_stream));
   if (typeface_asset->typeface == nullptr) {
     typeface_cache_.insert(std::make_pair(asset_path, nullptr));
     return nullptr;

--- a/runtime/asset_font_selector.cc
+++ b/runtime/asset_font_selector.cc
@@ -231,8 +231,8 @@ sk_sp<SkTypeface> AssetFontSelector::getTypefaceAsset(
   std::unique_ptr<SkStreamAsset> typeface_stream =
       std::make_unique<SkMemoryStream>(typeface_asset->data.data(),
                                        typeface_asset->data.size());
-  typeface_asset->typeface = font_mgr->makeFromStream(
-      std::move(typeface_stream));
+  typeface_asset->typeface =
+      font_mgr->makeFromStream(std::move(typeface_stream));
   if (typeface_asset->typeface == nullptr) {
     typeface_cache_.insert(std::make_pair(asset_path, nullptr));
     return nullptr;

--- a/third_party/txt/src/txt/asset_font_manager.cc
+++ b/third_party/txt/src/txt/asset_font_manager.cc
@@ -67,31 +67,35 @@ SkTypeface* AssetFontManager::onMatchFaceStyle(const SkTypeface*,
   return nullptr;
 }
 
-SkTypeface* AssetFontManager::onCreateFromData(SkData*, int ttcIndex) const {
+sk_sp<SkTypeface> AssetFontManager::onMakeFromData(sk_sp<SkData>,
+                                                   int ttcIndex) const {
   FXL_DCHECK(false);
   return nullptr;
 }
 
-SkTypeface* AssetFontManager::onCreateFromStream(SkStreamAsset*,
-                                                 int ttcIndex) const {
+sk_sp<SkTypeface> AssetFontManager::onMakeFromStreamIndex(
+    std::unique_ptr<SkStreamAsset>,
+    int ttcIndex) const {
   FXL_DCHECK(false);
   return nullptr;
 }
 
-SkTypeface* AssetFontManager::onCreateFromStream(SkStreamAsset*,
-                                                 const SkFontArguments&) const {
+sk_sp<SkTypeface> AssetFontManager::onMakeFromStreamArgs(
+    std::unique_ptr<SkStreamAsset>,
+    const SkFontArguments&) const {
   FXL_DCHECK(false);
   return nullptr;
 }
 
-SkTypeface* AssetFontManager::onCreateFromFile(const char path[],
-                                               int ttcIndex) const {
+sk_sp<SkTypeface> AssetFontManager::onMakeFromFile(const char path[],
+                                                     int ttcIndex) const {
   FXL_DCHECK(false);
   return nullptr;
 }
 
-SkTypeface* AssetFontManager::onLegacyCreateTypeface(const char familyName[],
-                                                     SkFontStyle) const {
+sk_sp<SkTypeface> AssetFontManager::onLegacyMakeTypeface(
+    const char familyName[],
+    SkFontStyle) const {
   FXL_DCHECK(false);
   return nullptr;
 }

--- a/third_party/txt/src/txt/asset_font_manager.cc
+++ b/third_party/txt/src/txt/asset_font_manager.cc
@@ -88,7 +88,7 @@ sk_sp<SkTypeface> AssetFontManager::onMakeFromStreamArgs(
 }
 
 sk_sp<SkTypeface> AssetFontManager::onMakeFromFile(const char path[],
-                                                     int ttcIndex) const {
+                                                   int ttcIndex) const {
   FXL_DCHECK(false);
   return nullptr;
 }

--- a/third_party/txt/src/txt/asset_font_manager.h
+++ b/third_party/txt/src/txt/asset_font_manager.h
@@ -61,21 +61,23 @@ class AssetFontManager : public SkFontMgr {
                                const SkFontStyle&) const override;
 
   // |SkFontMgr|
-  SkTypeface* onCreateFromData(SkData*, int ttcIndex) const override;
+  sk_sp<SkTypeface> onMakeFromData(sk_sp<SkData>, int ttcIndex) const override;
 
   // |SkFontMgr|
-  SkTypeface* onCreateFromStream(SkStreamAsset*, int ttcIndex) const override;
+  sk_sp<SkTypeface> onMakeFromStreamIndex(std::unique_ptr<SkStreamAsset>,
+                                          int ttcIndex) const override;
 
   // |SkFontMgr|
-  SkTypeface* onCreateFromStream(SkStreamAsset*,
-                                 const SkFontArguments&) const override;
+  sk_sp<SkTypeface> onMakeFromStreamArgs(std::unique_ptr<SkStreamAsset>,
+                                         const SkFontArguments&) const override;
 
   // |SkFontMgr|
-  SkTypeface* onCreateFromFile(const char path[], int ttcIndex) const override;
+  sk_sp<SkTypeface> onMakeFromFile(const char path[],
+                                   int ttcIndex) const override;
 
   // |SkFontMgr|
-  SkTypeface* onLegacyCreateTypeface(const char familyName[],
-                                     SkFontStyle) const override;
+  sk_sp<SkTypeface> onLegacyMakeTypeface(const char familyName[],
+                                         SkFontStyle) const override;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(AssetFontManager);
 };


### PR DESCRIPTION
These changes clarify ownership rules and work today. They will be necessary once SK_SUPPORT_LEGACY_FONTMGR_API goes away.