### PR TITLE
Revert "Use iOS scale when computing render buffer size (#4171)"

### DIFF
--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -163,16 +163,14 @@ bool IOSGLContext::PresentRenderBuffer() const {
 
 bool IOSGLContext::UpdateStorageSizeIfNecessary() {
   const CGSize layer_size = [layer_.get() bounds].size;
-  const CGFloat contents_scale = layer_.get().contentsScale;
-  const GLint size_width = layer_size.width * contents_scale;
-  const GLint size_height = layer_size.height * contents_scale;
+
+  const GLint size_width = layer_size.width;
+  const GLint size_height = layer_size.height;
 
   if (size_width == storage_size_width_ && size_height == storage_size_height_) {
     // Nothing to since the stoage size is already consistent with the layer.
     return true;
   }
-  TRACE_EVENT0("flutter", "Updating render buffer storage size");
-  FXL_DLOG(INFO) << "Updating render buffer storage size.";
 
   if (![EAGLContext setCurrentContext:context_]) {
     return false;


### PR DESCRIPTION
This reverts commit d43d35347594c893687dec7402a525d83f57db10.

Clear regression to the flutter_gallery_ios__transition_perf benchmarks:
  * average_frame_build_time_millis: 1.4x
  * missed_frame_build_budget_count: 1.2x

No regression seen for other iOS benchmarks (e.g. scrolling).