### PR TITLE
Roll dart to pick up change where platform.dill was removed

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '9ee73fe322ce3875a6b1f16ba16d64b11c680e90',
+  'dart_revision': '3e08354f85be273f24d39bd8dcbe780c09a05500',
 
   'dart_args_tag': '0.13.7',
   'dart_async_tag': '2.0.0',
@@ -48,7 +48,7 @@ vars = {
   'dart_csslib_tag': '0.14.1',
   'dart_dart2js_info_tag': '0.5.5+1',
   'dart_dart_style_tag': '1.0.7',
-  'dart_dartdoc_tag': 'v0.13.0+3',
+  'dart_dartdoc_tag': 'v0.14.1',
   'dart_fixnum_tag': '0.10.5',
   'dart_glob_tag': '1.1.5',
   'dart_html_tag': '0.13.2',

--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '3e08354f85be273f24d39bd8dcbe780c09a05500',
+  'dart_revision': '90587a6837c5ad4a64d571397a8ba65a7cc3f44f',
 
   'dart_args_tag': '0.13.7',
   'dart_async_tag': '2.0.0',

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -148,7 +148,7 @@ class _FrontendCompiler implements CompilerInterface {
       // TODO(aam): Remove linkedDependencies once platform is directly embedded
       // into VM snapshot and http://dartbug.com/30111 is fixed.
       compilerOptions.linkedDependencies = <Uri>[
-        sdkRoot.resolve('platform.dill')
+        sdkRoot.resolve('vm_platform.dill')
       ];
       program = await kernelForProgram(Uri.base.resolve(_filename), compilerOptions);
     }

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -148,7 +148,7 @@ class _FrontendCompiler implements CompilerInterface {
       // TODO(aam): Remove linkedDependencies once platform is directly embedded
       // into VM snapshot and http://dartbug.com/30111 is fixed.
       compilerOptions.linkedDependencies = <Uri>[
-        sdkRoot.resolve('vm_platform.dill')
+        sdkRoot.resolve('platform.dill')
       ];
       program = await kernelForProgram(Uri.base.resolve(_filename), compilerOptions);
     }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -327,6 +327,9 @@ template("generate_vm_patched_sdk") {
     deps = concatenation_target_names + ["//dart/runtime/vm:kernel_platform_files"]
     input_patches_dir = "$target_gen_dir/patches"
     patched_sdk_dir = "flutter_patched_sdk"
+    outputs = [
+        "$root_out_dir/${patched_sdk_dir}/lib/libraries.json",
+    ]
   }
 }
 
@@ -387,5 +390,38 @@ generate_vm_patched_sdk("flutter_patched_sdk") {
       typed_data_runtime_sources,
       "//dart/runtime/lib",
     ],
+  ]
+}
+
+action("compile_platform") {
+  script = "//dart/tools/compile_platform.py"
+
+  sources = [
+    "$root_out_dir/flutter_patched_sdk/lib/libraries.json",
+  ]
+
+  outputs = [
+    "$root_out_dir/flutter_patched_sdk/platform.dill",
+    "$root_out_dir/flutter_patched_sdk/vm_outline.dill",
+  ]
+
+  inputs = []
+
+  deps = [
+    ":flutter_patched_sdk",
+  ]
+
+  depfile = "$root_out_dir/flutter_patched_sdk/platform.dill.d"
+
+  args = [
+            "--target=flutter",
+            "dart:core"
+         ] + rebase_path(sources, root_build_dir) +
+         rebase_path(outputs, root_build_dir)
+}
+
+group("kernel_platform_files") {
+  public_deps = [
+    ":compile_platform",
   ]
 }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -324,7 +324,7 @@ template("generate_vm_patched_sdk") {
   # libraries.
   generate_patched_sdk(target_name) {
     mode = "flutter"
-    deps = concatenation_target_names + ["//dart/runtime/vm:patched_sdk"]
+    deps = concatenation_target_names + ["//dart/runtime/vm:kernel_platform_files"]
     input_patches_dir = "$target_gen_dir/patches"
     patched_sdk_dir = "flutter_patched_sdk"
   }

--- a/travis/licenses_golden/licenses_dart
+++ b/travis/licenses_golden/licenses_dart
@@ -1,4 +1,4 @@
-Signature: f3cd5a5999d16cdd546a78a609013a24
+Signature: ec2f9d17b9193fc1d549c977d8f8cc81
 
 UNUSED LICENSES:
 

--- a/travis/licenses_golden/licenses_dart
+++ b/travis/licenses_golden/licenses_dart
@@ -1,4 +1,4 @@
-Signature: cda91405b88ecd9ce6b78876552348c6
+Signature: f3cd5a5999d16cdd546a78a609013a24
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
@peter-ahe-google this should fix flutter-engine-linux build failure.