### PR TITLE
Refactor to weak reference to SurfaceTexture

### DIFF
--- a/flow/platform_surface.cc
+++ b/flow/platform_surface.cc
@@ -10,7 +10,8 @@ PlatformSurfaceRegistry::PlatformSurfaceRegistry() = default;
 
 PlatformSurfaceRegistry::~PlatformSurfaceRegistry() = default;
 
-size_t PlatformSurfaceRegistry::RegisterPlatformSurface(std::shared_ptr<PlatformSurface> surface) {
+size_t PlatformSurfaceRegistry::RegisterPlatformSurface(
+    std::shared_ptr<PlatformSurface> surface) {
   ASSERT_IS_GPU_THREAD
   size_t id = counter_++;
   mapping_[id] = surface;
@@ -37,7 +38,8 @@ void PlatformSurfaceRegistry::OnGrContextDestroyed() {
   }
 }
 
-std::shared_ptr<PlatformSurface> PlatformSurfaceRegistry::GetPlatformSurface(size_t id) {
+std::shared_ptr<PlatformSurface> PlatformSurfaceRegistry::GetPlatformSurface(
+    size_t id) {
   ASSERT_IS_GPU_THREAD
   return mapping_[id];
 }

--- a/shell/platform/android/android_platform_surface_gl.h
+++ b/shell/platform/android/android_platform_surface_gl.h
@@ -6,14 +6,14 @@
 #define FLUTTER_SHELL_PLATFORM_ANDROID_PLATFORM_SURFACE_GL_H_
 
 #include "flutter/flow/platform_surface.h"
+#include "flutter/fml/platform/android/jni_weak_ref.h"
 
 namespace shell {
 
-class PlatformViewAndroid;
-
 class AndroidPlatformSurfaceGL : public flow::PlatformSurface {
  public:
-  AndroidPlatformSurfaceGL(PlatformViewAndroid* platformView);
+  AndroidPlatformSurfaceGL(
+      const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
 
   ~AndroidPlatformSurfaceGL() override;
 
@@ -29,9 +29,15 @@ class AndroidPlatformSurfaceGL : public flow::PlatformSurface {
   void MarkNewFrameAvailable();
 
  private:
+  void Attach(jint texName);
+
+  void Update();
+
+  void Detach();
+
   enum class AttachmentState { uninitialized, attached, detached };
 
-  PlatformViewAndroid* platform_view_;
+  fml::jni::JavaObjectWeakGlobalRef surface_texture_;
 
   AttachmentState state_ = AttachmentState::uninitialized;
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -514,9 +514,10 @@ void PlatformViewAndroid::RunFromSource(const std::string& assets_directory,
   fml::jni::DetachFromVM();
 }
 
-size_t PlatformViewAndroid::CreatePlatformSurface() {
+size_t PlatformViewAndroid::CreatePlatformSurface(
+    const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {
   return RegisterPlatformSurface(
-      std::make_shared<AndroidPlatformSurfaceGL>(this));
+      std::make_shared<AndroidPlatformSurfaceGL>(flutter_view));
 }
 
 void PlatformViewAndroid::MarkPlatformSurfaceFrameAvailable(size_t surface_id) {
@@ -531,31 +532,6 @@ void PlatformViewAndroid::MarkPlatformSurfaceFrameAvailable(size_t surface_id) {
   });
   latch.Wait();
   PlatformView::MarkPlatformSurfaceFrameAvailable(surface_id);
-}
-
-void PlatformViewAndroid::AttachTexImage(size_t surface_id,
-                                         uint32_t texture_id) {
-  JNIEnv* env = fml::jni::AttachCurrentThread();
-  fml::jni::ScopedJavaLocalRef<jobject> view = flutter_view_.get(env);
-  if (!view.is_null()) {
-    FlutterViewAttachTexImage(env, view.obj(), surface_id, texture_id);
-  }
-}
-
-void PlatformViewAndroid::UpdateTexImage(size_t surface_id) {
-  JNIEnv* env = fml::jni::AttachCurrentThread();
-  fml::jni::ScopedJavaLocalRef<jobject> view = flutter_view_.get(env);
-  if (!view.is_null()) {
-    FlutterViewUpdateTexImage(env, view.obj(), surface_id);
-  }
-}
-
-void PlatformViewAndroid::DetachTexImage(size_t surface_id) {
-  JNIEnv* env = fml::jni::AttachCurrentThread();
-  fml::jni::ScopedJavaLocalRef<jobject> view = flutter_view_.get(env);
-  if (!view.is_null()) {
-    FlutterViewDetachTexImage(env, view.obj(), surface_id);
-  }
 }
 
 fml::jni::ScopedJavaLocalRef<jobject> PlatformViewAndroid::GetBitmap(

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -515,9 +515,9 @@ void PlatformViewAndroid::RunFromSource(const std::string& assets_directory,
 }
 
 size_t PlatformViewAndroid::CreatePlatformSurface(
-    const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {
+    const fml::jni::JavaObjectWeakGlobalRef& surface_texture) {
   return RegisterPlatformSurface(
-      std::make_shared<AndroidPlatformSurfaceGL>(flutter_view));
+      std::make_shared<AndroidPlatformSurfaceGL>(surface_texture));
 }
 
 void PlatformViewAndroid::MarkPlatformSurfaceFrameAvailable(size_t surface_id) {
@@ -527,7 +527,9 @@ void PlatformViewAndroid::MarkPlatformSurfaceFrameAvailable(size_t surface_id) {
         static_pointer_cast<AndroidPlatformSurfaceGL>(
             rasterizer_->GetPlatformSurfaceRegistry().GetPlatformSurface(
                 surface_id));
-    surface->MarkNewFrameAvailable();
+    if (surface) {
+      surface->MarkNewFrameAvailable();
+    }
     latch.Signal();
   });
   latch.Wait();

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -97,15 +97,10 @@ class PlatformViewAndroid : public PlatformView {
                      const std::string& main,
                      const std::string& packages) override;
 
-  size_t CreatePlatformSurface();
+  size_t CreatePlatformSurface(
+      const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
 
   void MarkPlatformSurfaceFrameAvailable(size_t surface_id) override;
-
-  void AttachTexImage(size_t surface_id, uint32_t texture_id);
-
-  void UpdateTexImage(size_t surface_id);
-
-  void DetachTexImage(size_t surface_id);
 
   void set_flutter_view(const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {
     flutter_view_ = flutter_view;

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -61,7 +61,7 @@ void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj) {
 static jmethodID g_attach_to_gl_context_method = nullptr;
 void SurfaceTextureAttachToGLContext(JNIEnv* env,
                                      jobject obj,
-                                     jlong textureId) {
+                                     jint textureId) {
   ASSERT_IS_GPU_THREAD;
   env->CallVoidMethod(obj, g_attach_to_gl_context_method, textureId);
   FXL_CHECK(env->ExceptionCheck() == JNI_FALSE);

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -59,9 +59,7 @@ void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj) {
 }
 
 static jmethodID g_attach_to_gl_context_method = nullptr;
-void SurfaceTextureAttachToGLContext(JNIEnv* env,
-                                     jobject obj,
-                                     jint textureId) {
+void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jint textureId) {
   ASSERT_IS_GPU_THREAD;
   env->CallVoidMethod(obj, g_attach_to_gl_context_method, textureId);
   FXL_CHECK(env->ExceptionCheck() == JNI_FALSE);

--- a/shell/platform/android/platform_view_android_jni.h
+++ b/shell/platform/android/platform_view_android_jni.h
@@ -29,14 +29,11 @@ void FlutterViewUpdateSemantics(JNIEnv* env,
 
 void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj);
 
-void FlutterViewAttachTexImage(JNIEnv* env,
-                               jobject obj,
-                               jlong imageId,
-                               jlong textureId);
+void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jlong textureId);
 
-void FlutterViewUpdateTexImage(JNIEnv* env, jobject obj, jlong imageId);
+void SurfaceTextureUpdateTexImage(JNIEnv* env, jobject obj);
 
-void FlutterViewDetachTexImage(JNIEnv* env, jobject obj, jlong imageId);
+void SurfaceTextureDetachFromGLContext(JNIEnv* env, jobject obj);
 
 }  // namespace shell
 

--- a/shell/platform/android/platform_view_android_jni.h
+++ b/shell/platform/android/platform_view_android_jni.h
@@ -29,7 +29,7 @@ void FlutterViewUpdateSemantics(JNIEnv* env,
 
 void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj);
 
-void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jlong textureId);
+void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jint textureId);
 
 void SurfaceTextureUpdateTexImage(JNIEnv* env, jobject obj);
 


### PR DESCRIPTION
Avoids having a (chatty) interface between AndroidPlatformSurfaceGL and PlatformViewAndroid. Instead, the former has a direct, weak reference to the Java SurfaceTexture.