### PR TITLE
Change kernel platform generation dependency name

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -6,7 +6,7 @@ group("flutter") {
   testonly = true
 
   deps = [
-    "//flutter/lib/snapshot:flutter_patched_sdk",
+    "//flutter/lib/snapshot:compile_platform",
     "//flutter/lib/snapshot:generate_snapshot_bin",
     "//flutter/sky",
     "//flutter/third_party/txt",

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -413,7 +413,8 @@ action("compile_platform") {
 
   args = [
             "--target=flutter",
-            "dart:core"
+            "dart:core",
+            "dart:vmservice_sky",
          ] + rebase_path(sources, root_build_dir) +
          rebase_path(outputs, root_build_dir)
 }


### PR DESCRIPTION
This is follow-up to https://github.com/flutter/engine/commit/37f571ee09b24f0248e3ab5d530acdb8ec2db018 where new compile_platform target was added, that is now responsible for platform kernel file generation.

This PR actually makes sure that that new target is actually used for default build.

Also this PR fixes the issue with Flutter release build where gen_snapshot failed because vm_service was absent from platform.dill included into application .dill file.