### PR TITLE
Set ui, io, and gpu thread names.

### DIFF
--- a/content_handler/app.cc
+++ b/content_handler/app.cc
@@ -7,6 +7,7 @@
 #include <thread>
 #include <utility>
 
+#include "dart/runtime/include/dart_tools_api.h"
 #include "flutter/common/settings.h"
 #include "flutter/common/threads.h"
 #include "flutter/sky/engine/platform/fonts/fuchsia/FontCacheFuchsia.h"


### PR DESCRIPTION
Same as #4182 but moves thread name setting until after Dart is initialized().