### PR TITLE
Revert "Fix RunBundleAndSource to run from kernel. (#4184)"

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -234,23 +234,11 @@ void Engine::RunBundleAndSource(const std::string& bundle_path,
   std::string packages_path = packages;
   if (packages_path.empty())
     packages_path = FindPackagesPath(main);
-
-  std::vector<uint8_t> platform_kernel;
-  if (!bundle_path.empty()) {
-    GetAssetAsBuffer(blink::kPlatformKernelAssetKey, &platform_kernel);
-  }
-  ConfigureRuntime(GetScriptUriFromPath(bundle_path), platform_kernel);
-
-  if (!platform_kernel.empty()) {
-    std::vector<uint8_t> kernel;
-    if (!files::ReadFileToVector(main, &kernel)) {
-      load_script_error_ = tonic::kUnknownErrorType;
-    }
-    load_script_error_ = runtime_->dart_controller()->RunFromKernel(kernel);
-  } else {
-    load_script_error_ =
-        runtime_->dart_controller()->RunFromSource(main, packages_path);
-  }
+  if (!bundle_path.empty())
+    ConfigureAssetBundle(bundle_path);
+  ConfigureRuntime(GetScriptUriFromPath(main));
+  load_script_error_ =
+      runtime_->dart_controller()->RunFromSource(main, packages_path);
 }
 
 void Engine::BeginFrame(fxl::TimePoint frame_time) {


### PR DESCRIPTION
This reverts commit a5e26f1f794ad138d59b3115165ba84ac413e891.

There are issues with incremental kernel file we are trying to restart
from(dartbug.com/31043). Until that is fixed, this original PR(4184)
breaks hot_mode_dev_cycle__preview_dart_2 benchmark test.

The plan would be to roll this forward once dartbug.com/31043 is fixed.