### PR TITLE
[Android] Lazily create the GPU rasterizer

### DIFF
--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -24,6 +24,10 @@ class Animator {
 
   ~Animator();
 
+  void set_rasterizer(fxl::WeakPtr<Rasterizer> rasterizer) {
+    rasterizer_ = rasterizer;
+  }
+
   void RequestFrame();
 
   void Render(std::unique_ptr<flow::LayerTree> layer_tree);

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -82,6 +82,10 @@ Engine::Engine(PlatformView* platform_view)
 
 Engine::~Engine() {}
 
+void Engine::set_rasterizer(fxl::WeakPtr<Rasterizer> rasterizer) {
+  animator_->set_rasterizer(rasterizer);
+}
+
 fxl::WeakPtr<Engine> Engine::GetWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -70,6 +70,8 @@ class Engine : public blink::RuntimeDelegate {
   void DispatchSemanticsAction(int id, blink::SemanticsAction action);
   void SetSemanticsEnabled(bool enabled);
 
+  void set_rasterizer(fxl::WeakPtr<Rasterizer> rasterizer);
+
  private:
   // RuntimeDelegate methods:
   std::string DefaultRouteName() override;

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -29,6 +29,13 @@ PlatformView::~PlatformView() {
   blink::Threads::UI()->PostTask([engine]() { delete engine; });
 }
 
+void PlatformView::SetRasterizer(std::unique_ptr<Rasterizer> rasterizer) {
+  Rasterizer* r = rasterizer_.release();
+  blink::Threads::Gpu()->PostTask([r]() { delete r; });
+  rasterizer_ = std::move(rasterizer);
+  engine_->set_rasterizer(rasterizer_->GetWeakRasterizerPtr());
+}
+
 void PlatformView::CreateEngine() {
   engine_.reset(new Engine(this));
 }

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -61,6 +61,8 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
   virtual void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message);
 
+  void SetRasterizer(std::unique_ptr<Rasterizer> rasterizer);
+
   Rasterizer& rasterizer() { return *rasterizer_; }
   Engine& engine() { return *engine_; }
 

--- a/shell/platform/android/android_surface.h
+++ b/shell/platform/android/android_surface.h
@@ -35,9 +35,6 @@ class AndroidSurface {
 
   virtual bool SetNativeWindow(fxl::RefPtr<AndroidNativeWindow> window,
                                PlatformView::SurfaceConfig config = {}) = 0;
-
-  virtual void SetFlutterView(
-      const fml::jni::JavaObjectWeakGlobalRef& flutter_view) = 0;
 };
 
 }  // namespace shell

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -153,7 +153,4 @@ intptr_t AndroidSurfaceGL::GLContextFBO() const {
   return 0;
 }
 
-void AndroidSurfaceGL::SetFlutterView(
-    const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {}
-
 }  // namespace shell

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -49,9 +49,6 @@ class AndroidSurfaceGL : public GPUSurfaceGLDelegate, public AndroidSurface {
 
   bool SurfaceSupportsSRGB() const override;
 
-  void SetFlutterView(
-      const fml::jni::JavaObjectWeakGlobalRef& flutter_view) override;
-
  private:
   fxl::RefPtr<AndroidContextGL> onscreen_context_;
   fxl::RefPtr<AndroidContextGL> offscreen_context_;

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -148,9 +148,4 @@ bool AndroidSurfaceSoftware::SetNativeWindow(
   return true;
 }
 
-void AndroidSurfaceSoftware::SetFlutterView(
-    const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {
-  flutter_view_ = flutter_view;
-}
-
 }  // namespace shell

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -39,9 +39,6 @@ class AndroidSurfaceSoftware : public AndroidSurface,
   bool SetNativeWindow(fxl::RefPtr<AndroidNativeWindow> window,
                        PlatformView::SurfaceConfig config) override;
 
-  void SetFlutterView(
-      const fml::jni::JavaObjectWeakGlobalRef& flutter_view) override;
-
  private:
   sk_sp<SkSurface> sk_surface_;
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -99,11 +99,10 @@ class PlatformViewAndroid : public PlatformView {
 
   void set_flutter_view(const fml::jni::JavaObjectWeakGlobalRef& flutter_view) {
     flutter_view_ = flutter_view;
-    android_surface_->SetFlutterView(flutter_view);
   }
 
  private:
-  const std::unique_ptr<AndroidSurface> android_surface_;
+  std::unique_ptr<AndroidSurface> android_surface_;
   fml::jni::JavaObjectWeakGlobalRef flutter_view_;
   // We use id 0 to mean that no response is expected.
   int next_response_id_ = 1;


### PR DESCRIPTION
In this change, hooking up a non-null rasterizer and platform surface is delayed until the `surfaceCreated` callback on the `SurfaceView` is called.

This is a very early step in the direction of getting Dart code to run while the app is in the background/offscreen with no drawing surface.

New to the engine so please let me know if this is crazy.