### PR TITLE
Remove use of a SceneBuilder member after deletion

### DIFF
--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -166,7 +166,6 @@ fxl::RefPtr<Scene> SceneBuilder::build() {
                     layer_builder_->GetCheckerboardRasterCacheImages(),
                     layer_builder_->GetCheckerboardOffscreenLayers());
   ClearDartWrapper();
-  layer_builder_.reset();
   return scene;
 }
 


### PR DESCRIPTION
ClearDartWrapper will delete this SceneBuilder, causing deletion of the
LayerBuilder