### PR TITLE
Add empty pubspec.yaml files.

### DIFF
--- a/examples/hello_flutter/pubspec.yaml
+++ b/examples/hello_flutter/pubspec.yaml
@@ -1,0 +1,3 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.

--- a/examples/spinning_square/pubspec.yaml
+++ b/examples/spinning_square/pubspec.yaml
@@ -1,0 +1,3 @@
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.


### PR DESCRIPTION
They help the analysis service identify packages and are now mandatory on Fuchsia.