### PR TITLE
libtxt: support the use_test_font flag required by framework tests

### DIFF
--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -91,6 +91,7 @@ source_set("ui") {
     "//flutter/common",
     "//flutter/flow",
     "//flutter/glue",
+    "//flutter/runtime:test_font",
     "//flutter/sky/engine",
     "//flutter/third_party/txt",
     "//third_party/rapidjson",

--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -3,12 +3,16 @@
 // found in the LICENSE file.
 
 #include "flutter/lib/ui/text/font_collection.h"
+
 #include <mutex>
+
+#include "flutter/runtime/test_font_data.h"
 #include "third_party/rapidjson/rapidjson/document.h"
 #include "third_party/rapidjson/rapidjson/rapidjson.h"
 #include "third_party/skia/include/core/SkStream.h"
 #include "third_party/skia/include/ports/SkFontMgr.h"
 #include "txt/asset_font_manager.h"
+#include "txt/test_font_manager.h"
 
 namespace blink {
 
@@ -102,6 +106,20 @@ void FontCollection::RegisterFontsFromAssetStore(
 
   collection_->PushFront(
       sk_make_sp<txt::AssetFontManager>(std::move(font_asset_data_provider)));
+}
+
+void FontCollection::RegisterTestFonts() {
+  sk_sp<SkTypeface> test_typeface =
+      SkTypeface::MakeFromStream(GetTestFontData().release());
+
+  std::unique_ptr<txt::AssetDataProvider> asset_data_provider =
+      std::make_unique<txt::AssetDataProvider>();
+
+  asset_data_provider->RegisterTypeface(std::move(test_typeface),
+                                        GetTestFontFamilyName());
+
+  collection_->PushFront(sk_make_sp<txt::TestFontManager>(
+      std::move(asset_data_provider), GetTestFontFamilyName()));
 }
 
 }  // namespace blink

--- a/lib/ui/text/font_collection.h
+++ b/lib/ui/text/font_collection.h
@@ -24,6 +24,8 @@ class FontCollection {
   void RegisterFontsFromAssetStore(
       fxl::RefPtr<blink::ZipAssetStore> asset_store);
 
+  void RegisterTestFonts();
+
  private:
   std::shared_ptr<txt::FontCollection> collection_;
 

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -39,6 +39,23 @@ source_set("embedded_resources_cc") {
   ]
 }
 
+source_set("test_font") {
+  sources = [
+    "test_font_data.cc",
+    "test_font_data.h",
+  ]
+  deps = [
+    "//third_party/skia",
+  ]
+  defines = []
+  if (flutter_runtime_mode == "debug" || current_toolchain == host_toolchain) {
+    # Though the test font data is small, we dont want to add to the binary size
+    # on the device (in profile and release modes). We only add the same on the
+    # host test shells and the debug device shell.
+    defines += [ "EMBED_TEST_FONT_DATA=1" ]
+  }
+}
+
 source_set("runtime") {
 
   sources = [
@@ -62,14 +79,13 @@ source_set("runtime") {
     "runtime_init.h",
     "start_up.cc",
     "start_up.h",
-    "test_font_data.cc",
-    "test_font_data.h",
     "test_font_selector.cc",
     "test_font_selector.h",
   ]
 
   deps = [
     ":embedded_resources_cc",
+    ":test_font",
     "//dart/runtime:dart_api",
     "//dart/runtime/bin:embedded_dart_io",
     "//flutter/assets",
@@ -85,15 +101,6 @@ source_set("runtime") {
     "//third_party/skia",
     "//topaz/lib/tonic",
   ]
-
-  defines = []
-
-  if (flutter_runtime_mode == "debug" || current_toolchain == host_toolchain) {
-    # Though the test font data is small, we dont want to add to the binary size
-    # on the device (in profile and release modes). We only add the same on the
-    # host test shells and the debug device shell.
-    defines += [ "EMBED_TEST_FONT_DATA=1" ]
-  }
 
   # In AOT mode, precompiled snapshots contain the instruction buffer.
   # Generation of the same requires all application specific script code to be

--- a/runtime/test_font_data.cc
+++ b/runtime/test_font_data.cc
@@ -1225,4 +1225,8 @@ std::unique_ptr<SkStreamAsset> GetTestFontData() {
                                           false /* copy data */);
 }
 
+std::string GetTestFontFamilyName() {
+  return "Ahem";
+}
+
 }  // namespace blink

--- a/runtime/test_font_data.h
+++ b/runtime/test_font_data.h
@@ -6,11 +6,14 @@
 #define FLUTTER_RUNTIME_TEST_FONT_DATA_H_
 
 #include <memory>
+#include <string>
+
 #include "third_party/skia/include/core/SkStream.h"
 
 namespace blink {
 
 std::unique_ptr<SkStreamAsset> GetTestFontData();
+std::string GetTestFontFamilyName();
 
 }  // namespace blink
 

--- a/runtime/test_font_selector.cc
+++ b/runtime/test_font_selector.cc
@@ -30,9 +30,9 @@ PassRefPtr<FontData> TestFontSelector::getFontData(
   bool syntheticItalic =
       (fontDescription.style() || fontDescription.isSyntheticItalic());
   FontPlatformData platform_data(
-      test_typeface_, "Ahem", fontDescription.effectiveFontSize(),
-      syntheticBold, syntheticItalic, fontDescription.orientation(),
-      fontDescription.useSubpixelPositioning());
+      test_typeface_, GetTestFontFamilyName().c_str(),
+      fontDescription.effectiveFontSize(), syntheticBold, syntheticItalic,
+      fontDescription.orientation(), fontDescription.useSubpixelPositioning());
 
   return SimpleFontData::create(platform_data, CustomFontData::create());
 }

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -502,6 +502,8 @@ void Engine::ConfigureRuntime(const std::string& script_uri,
 void Engine::DidCreateMainIsolate(Dart_Isolate isolate) {
   if (blink::Settings::Get().use_test_fonts) {
     blink::TestFontSelector::Install();
+    if (!blink::Settings::Get().using_blink)
+      blink::FontCollection::ForProcess().RegisterTestFonts();
   } else if (asset_store_) {
     blink::AssetFontSelector::Install(asset_store_);
     if (!blink::Settings::Get().using_blink) {

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -89,6 +89,8 @@ source_set("txt") {
     "src/txt/platform.h",
     "src/txt/styled_runs.cc",
     "src/txt/styled_runs.h",
+    "src/txt/test_font_manager.cc",
+    "src/txt/test_font_manager.h",
     "src/txt/text_baseline.h",
     "src/txt/text_decoration.cc",
     "src/txt/text_decoration.h",

--- a/third_party/txt/src/txt/asset_font_manager.h
+++ b/third_party/txt/src/txt/asset_font_manager.h
@@ -30,6 +30,10 @@ class AssetFontManager : public SkFontMgr {
 
   ~AssetFontManager() override;
 
+ protected:
+  // |SkFontMgr|
+  SkFontStyleSet* onMatchFamily(const char familyName[]) const override;
+
  private:
   std::unique_ptr<AssetDataProvider> data_provider_;
 
@@ -41,9 +45,6 @@ class AssetFontManager : public SkFontMgr {
 
   // |SkFontMgr|
   SkFontStyleSet* onCreateStyleSet(int index) const override;
-
-  // |SkFontMgr|
-  SkFontStyleSet* onMatchFamily(const char familyName[]) const override;
 
   // |SkFontMgr|
   SkTypeface* onMatchFamilyStyle(const char familyName[],

--- a/third_party/txt/src/txt/test_font_manager.cc
+++ b/third_party/txt/src/txt/test_font_manager.cc
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "txt/test_font_manager.h"
+#include "lib/fxl/logging.h"
+
+namespace txt {
+
+TestFontManager::TestFontManager(
+    std::unique_ptr<AssetDataProvider> data_provider,
+    std::string test_font_family_name)
+    : AssetFontManager(std::move(data_provider)),
+      test_font_family_name_(test_font_family_name) {}
+
+TestFontManager::~TestFontManager() = default;
+
+SkFontStyleSet* TestFontManager::onMatchFamily(const char family_name[]) const {
+  return AssetFontManager::onMatchFamily(test_font_family_name_.c_str());
+}
+
+}  // namespace txt

--- a/third_party/txt/src/txt/test_font_manager.h
+++ b/third_party/txt/src/txt/test_font_manager.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TXT_TEST_FONT_MANAGER_H_
+#define TXT_TEST_FONT_MANAGER_H_
+
+#include <memory>
+#include <string>
+
+#include "lib/fxl/macros.h"
+#include "third_party/skia/include/ports/SkFontMgr.h"
+#include "txt/asset_data_provider.h"
+#include "txt/asset_font_manager.h"
+
+namespace txt {
+
+// A font manager intended for tests that matches all requested fonts using
+// one family.
+class TestFontManager : public AssetFontManager {
+ public:
+  TestFontManager(std::unique_ptr<AssetDataProvider> data_provider,
+                  std::string test_font_family_name);
+
+  ~TestFontManager() override;
+
+ private:
+  std::string test_font_family_name_;
+
+  SkFontStyleSet* onMatchFamily(const char family_name[]) const override;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(TestFontManager);
+};
+
+}  // namespace txt
+
+#endif  // TXT_TEST_FONT_MANAGER_H_

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -9565,6 +9565,8 @@ FILE: ../../../flutter/third_party/txt/src/txt/paragraph_style.cc
 FILE: ../../../flutter/third_party/txt/src/txt/paragraph_style.h
 FILE: ../../../flutter/third_party/txt/src/txt/styled_runs.cc
 FILE: ../../../flutter/third_party/txt/src/txt/styled_runs.h
+FILE: ../../../flutter/third_party/txt/src/txt/test_font_manager.cc
+FILE: ../../../flutter/third_party/txt/src/txt/test_font_manager.h
 FILE: ../../../flutter/third_party/txt/src/txt/text_baseline.h
 FILE: ../../../flutter/third_party/txt/src/txt/text_decoration.cc
 FILE: ../../../flutter/third_party/txt/src/txt/text_decoration.h


### PR DESCRIPTION
This registers a test font manager that maps all fonts to the Ahem font