### PR TITLE
Put back ConfigureAssetBundle into RunBundleAndSource

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -241,6 +241,7 @@ void Engine::RunBundleAndSource(const std::string& bundle_path,
 
   std::vector<uint8_t> platform_kernel;
   if (!bundle_path.empty()) {
+    ConfigureAssetBundle(bundle_path);
     GetAssetAsBuffer(blink::kPlatformKernelAssetKey, &platform_kernel);
   }
   ConfigureRuntime(GetScriptUriFromPath(bundle_path), platform_kernel);


### PR DESCRIPTION
It was accidentally removed in a5e26f1f794ad138d59b3115165ba84ac413e891 and caused https://github.com/flutter/flutter/issues/12551.