### PR TITLE
Make font selection refer to system language

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -10,6 +10,8 @@
 #include "flutter/lib/ui/window/window.h"
 #include "flutter/runtime/dart_controller.h"
 #include "flutter/runtime/runtime_delegate.h"
+#include "flutter/sky/engine/platform/Language.h"
+#include "flutter/sky/engine/wtf/text/AtomicString.h"
 #include "lib/tonic/dart_message_handler.h"
 
 using tonic::DartState;
@@ -64,6 +66,12 @@ void RuntimeController::SetLocale(const std::string& language_code,
   language_code_ = language_code;
   country_code_ = country_code;
   GetWindow()->UpdateLocale(language_code_, country_code_);
+
+  std::string language = language_code + "-" + country_code;
+  Vector<AtomicString> languages;
+  languages.reserveInitialCapacity(1);
+  languages.append(AtomicString::fromUTF8(language.data(), language.size()));
+  overrideUserPreferredLanguages(languages);
 }
 
 void RuntimeController::SetTextScaleFactor(double text_scale_factor) {


### PR DESCRIPTION
This is fix for https://github.com/flutter/flutter/issues/12576

The language is constant in the current implementation:
https://github.com/flutter/engine/blob/master/runtime/platform_impl.cc#L14
https://github.com/flutter/engine/blob/master/sky/engine/platform/fonts/mobile/FontCacheMobile.cpp#L64

Android and iOS calls `setLocale` on localization channel.
https://github.com/flutter/engine/blob/master/shell/platform/android/io/flutter/view/FlutterView.java#L183
https://github.com/flutter/engine/blob/master/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm#L693

Set the value of `setLocale` to `overrideUserPreferredLanguages`
https://github.com/flutter/engine/blob/master/sky/engine/platform/Language.cpp#L61