### PR TITLE
Native keyboard behavior implementation

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -101,6 +101,7 @@ public class TextInputPlugin implements MethodCallHandler {
         } else if (autocorrect) {
             textType |= InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
         }
+        textType |= InputType.TYPE_TEXT_FLAG_CAP_SENTENCES;
         return textType;
     }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -125,6 +125,7 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
 @property(nonatomic) UITextAutocorrectionType autocorrectionType;
 @property(nonatomic) UITextSpellCheckingType spellCheckingType;
 @property(nonatomic) BOOL enablesReturnKeyAutomatically;
+@property(nonatomic) BOOL shouldCapitalizeNextChar;
 @property(nonatomic) UIKeyboardAppearance keyboardAppearance;
 @property(nonatomic) UIKeyboardType keyboardType;
 @property(nonatomic) UIReturnKeyType returnKeyType;
@@ -287,7 +288,8 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
         return YES;
     } else {
       NSRange replaceRangee = NSMakeRange(currentRange.location-1, 1);
-      [self replaceRange:[FlutterTextRange rangeWithNSRange:replaceRangee] withText:@"."];
+      [self replaceRange:[FlutterTextRange rangeWithNSRange:replaceRangee] withText:@". "];
+      self.shouldCapitalizeNextChar = YES;
     }
     return NO;
   }


### PR DESCRIPTION
Changes made to the engine for Android keyboard behavior i.e.
a) Capitalization at beginning of a sentence
b) Capitalization after a period

Changes made to the engine for iOS keyboard behavior i.e.
a) Period - double tap space bar after a word to insert a period and a space, with the shift key activated to start the next word with a capital letter
