### PR TITLE
Native keyboard behavior implementation

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -101,6 +101,7 @@ public class TextInputPlugin implements MethodCallHandler {
         } else if (autocorrect) {
             textType |= InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
         }
+        textType |= InputType.TYPE_TEXT_FLAG_CAP_SENTENCES;
         return textType;
     }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -280,11 +280,9 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
   NSRange currentRange = ((FlutterTextRange*)range).range;
   if ( (currentRange.location > 0 && [text length] > 0 &&
       [[NSCharacterSet whitespaceCharacterSet] characterIsMember:[text characterAtIndex:0]] &&
-      [[NSCharacterSet whitespaceCharacterSet] characterIsMember:[[self text] characterAtIndex:currentRange.location-1]] ))
-  {
+      [[NSCharacterSet whitespaceCharacterSet] characterIsMember:[[self text] characterAtIndex:currentRange.location-1]] )) {
     if ([self.text characterAtIndex:currentRange.location-2] == '.' ||
-        [self.text characterAtIndex:currentRange.location-2] == ' '
-    ) {
+        [self.text characterAtIndex:currentRange.location-2] == ' ') {
         return YES;
     } else {
       NSRange replaceRangee = NSMakeRange(currentRange.location-1, 1);

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -34,6 +34,8 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inputType) {
   if ([inputType isEqualToString:@"TextInputType.text"])
     return UITextAutocapitalizationTypeSentences;
+  if ([inputType isEqualToString:@"TextInputType.multiline"])
+    return UITextAutocapitalizationTypeSentences;
   return UITextAutocapitalizationTypeNone;
 }
 
@@ -123,6 +125,7 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
 @property(nonatomic) UITextAutocorrectionType autocorrectionType;
 @property(nonatomic) UITextSpellCheckingType spellCheckingType;
 @property(nonatomic) BOOL enablesReturnKeyAutomatically;
+@property(nonatomic) BOOL shouldCapitalizeNextChar;
 @property(nonatomic) UIKeyboardAppearance keyboardAppearance;
 @property(nonatomic) UIKeyboardType keyboardType;
 @property(nonatomic) UIReturnKeyType returnKeyType;
@@ -274,6 +277,22 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
 }
 
 - (BOOL)shouldChangeTextInRange:(UITextRange*)range replacementText:(NSString*)text {
+  NSRange currentRange = ((FlutterTextRange*)range).range;
+  if ( (currentRange.location > 0 && [text length] > 0 &&
+      [[NSCharacterSet whitespaceCharacterSet] characterIsMember:[text characterAtIndex:0]] &&
+      [[NSCharacterSet whitespaceCharacterSet] characterIsMember:[[self text] characterAtIndex:currentRange.location-1]] ))
+  {
+    if ([self.text characterAtIndex:currentRange.location-2] == '.' ||
+        [self.text characterAtIndex:currentRange.location-2] == ' '
+    ) {
+        return YES;
+    } else {
+      NSRange replaceRangee = NSMakeRange(currentRange.location-1, 1);
+      [self replaceRange:[FlutterTextRange rangeWithNSRange:replaceRangee] withText:@". "];
+      self.shouldCapitalizeNextChar = YES;
+    }
+    return NO;
+  }
   if (self.returnKeyType == UIReturnKeyDone && [text isEqualToString:@"\n"]) {
     [self resignFirstResponder];
     [self removeFromSuperview];


### PR DESCRIPTION
Changes made to the engine for Android keyboard behavior i.e.
a) Capitalization at beginning of a sentence
b) Capitalization after a period

Changes made to the engine for iOS keyboard behavior i.e.
a) Period - double tap space bar after a word to insert a period and a space, with the shift key activated to start the next word with a capital letter
