### PR TITLE
Make Engine::RunBundle* reuse an existing RuntimeController

### DIFF
--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -112,15 +112,18 @@ static void ReleaseFetchedBytes(uint8_t* buffer) {
 tonic::DartErrorHandleType DartController::RunFromKernel(
     const std::vector<uint8_t>& kernel) {
   tonic::DartState::Scope scope(dart_state());
-  // Copy kernel bytes and pass ownership of the copy to the Dart_LoadKernel,
-  // which is expected to release them.
-  uint8_t* kernel_bytes = nullptr;
-  CopyVectorBytes(kernel, kernel_bytes);
+  tonic::DartErrorHandleType error = tonic::kNoError;
+  if (Dart_IsNull(Dart_RootLibrary())) {
+    // Copy kernel bytes and pass ownership of the copy to the Dart_LoadKernel,
+    // which is expected to release them.
+    uint8_t* kernel_bytes = nullptr;
+    CopyVectorBytes(kernel, kernel_bytes);
 
-  Dart_Handle result = Dart_LoadKernel(
-      Dart_ReadKernelBinary(kernel_bytes, kernel.size(), ReleaseFetchedBytes));
-  LogIfError(result);
-  tonic::DartErrorHandleType error = tonic::GetErrorHandleType(result);
+    Dart_Handle result = Dart_LoadKernel(Dart_ReadKernelBinary(
+        kernel_bytes, kernel.size(), ReleaseFetchedBytes));
+    LogIfError(result);
+    error = tonic::GetErrorHandleType(result);
+  }
   if (SendStartMessage(Dart_RootLibrary())) {
     return tonic::kUnknownErrorType;
   }
@@ -141,9 +144,12 @@ tonic::DartErrorHandleType DartController::RunFromScriptSnapshot(
     const uint8_t* buffer,
     size_t size) {
   tonic::DartState::Scope scope(dart_state());
-  Dart_Handle result = Dart_LoadScriptFromSnapshot(buffer, size);
-  LogIfError(result);
-  tonic::DartErrorHandleType error = tonic::GetErrorHandleType(result);
+  tonic::DartErrorHandleType error = tonic::kNoError;
+  if (Dart_IsNull(Dart_RootLibrary())) {
+    Dart_Handle result = Dart_LoadScriptFromSnapshot(buffer, size);
+    LogIfError(result);
+    error = tonic::GetErrorHandleType(result);
+  }
   if (SendStartMessage(Dart_RootLibrary())) {
     return tonic::kUnknownErrorType;
   }
@@ -154,12 +160,15 @@ tonic::DartErrorHandleType DartController::RunFromSource(
     const std::string& main,
     const std::string& packages) {
   tonic::DartState::Scope scope(dart_state());
-  tonic::FileLoader& loader = dart_state()->file_loader();
-  if (!packages.empty() && !loader.LoadPackagesMap(ResolvePath(packages)))
-    FXL_LOG(WARNING) << "Failed to load package map: " << packages;
-  Dart_Handle result = loader.LoadScript(main);
-  LogIfError(result);
-  tonic::DartErrorHandleType error = tonic::GetErrorHandleType(result);
+  tonic::DartErrorHandleType error = tonic::kNoError;
+  if (Dart_IsNull(Dart_RootLibrary())) {
+    tonic::FileLoader& loader = dart_state()->file_loader();
+    if (!packages.empty() && !loader.LoadPackagesMap(ResolvePath(packages)))
+      FXL_LOG(WARNING) << "Failed to load package map: " << packages;
+    Dart_Handle result = loader.LoadScript(main);
+    LogIfError(result);
+    error = tonic::GetErrorHandleType(result);
+  }
   if (SendStartMessage(Dart_RootLibrary())) {
     return tonic::kCompilationErrorType;
   }

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -493,14 +493,16 @@ void Engine::ConfigureAssetBundle(const std::string& path) {
 
 void Engine::ConfigureRuntime(const std::string& script_uri,
                               const std::vector<uint8_t>& platform_kernel) {
-  runtime_ = blink::RuntimeController::Create(this);
-  runtime_->CreateDartController(
-      std::move(script_uri), default_isolate_snapshot_data,
-      default_isolate_snapshot_instr, platform_kernel);
-  runtime_->SetViewportMetrics(viewport_metrics_);
-  runtime_->SetLocale(language_code_, country_code_);
-  runtime_->SetTextScaleFactor(text_scale_factor_);
-  runtime_->SetSemanticsEnabled(semantics_enabled_);
+  if (!runtime_) {
+    runtime_ = blink::RuntimeController::Create(this);
+    runtime_->CreateDartController(
+        std::move(script_uri), default_isolate_snapshot_data,
+        default_isolate_snapshot_instr, platform_kernel);
+    runtime_->SetViewportMetrics(viewport_metrics_);
+    runtime_->SetLocale(language_code_, country_code_);
+    runtime_->SetTextScaleFactor(text_scale_factor_);
+    runtime_->SetSemanticsEnabled(semantics_enabled_);
+  }
 }
 
 void Engine::DidCreateMainIsolate(Dart_Isolate isolate) {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -173,11 +173,16 @@ public class FlutterView extends SurfaceView
             StringCodec.INSTANCE);
         mFlutterSystemChannel = new BasicMessageChannel<>(this, "flutter/system",
             JSONMessageCodec.INSTANCE);
-        PlatformPlugin platformPlugin = new PlatformPlugin((Activity) getContext());
-        MethodChannel flutterPlatformChannel = new MethodChannel(this,
-            "flutter/platform", JSONMethodCodec.INSTANCE);
-        flutterPlatformChannel.setMethodCallHandler(platformPlugin);
-        addActivityLifecycleListener(platformPlugin);
+
+        // TODO(plugins): Change PlatformPlugin to accept a Context. Disable the
+        // operations that require an Activity when a Context is passed.
+        if (getContext() instanceof Activity) {
+            PlatformPlugin platformPlugin = new PlatformPlugin((Activity) getContext());
+            MethodChannel flutterPlatformChannel = new MethodChannel(this,
+                "flutter/platform", JSONMethodCodec.INSTANCE);
+            flutterPlatformChannel.setMethodCallHandler(platformPlugin);
+            addActivityLifecycleListener(platformPlugin);
+        }
         mTextInputPlugin = new TextInputPlugin(this);
 
         setLocale(getResources().getConfiguration().locale);
@@ -285,7 +290,7 @@ public class FlutterView extends SurfaceView
       message.put("textScaleFactor", textScaleFactor);
       mFlutterSystemChannel.send(message);
     }
-    
+
     private void setLocale(Locale locale) {
         mFlutterLocalizationChannel.invokeMethod("setLocale",
             Arrays.asList(locale.getLanguage(), locale.getCountry()));


### PR DESCRIPTION
This change does three things
- If a RunBundle* method is called on an Engine that already has a RuntimeController set up, then it doesn't make a new one.
- If an Engine's main isolate already has the root library loaded, then it doesn't try to load it again.
- If a FlutterView's getContext() is not an Activity (for example if it is a Service) then it doesn't wire up the flutter/platform plugin, which appears to need Activity specific stuff.

This allows a background service triggered by a repeating AlarmManager alarm to run Dart code from the application's bundle in an engine owned by the service. Since a RuntimeController is only created when needed, the engine's main isolate is reused when the alarm is repeated.