### PR TITLE
Don't crash when we get unexpected pointer events.

### DIFF
--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -582,9 +582,19 @@ void RuntimeHolder::OnEvent(mozart::InputEventPtr event,
           pointer_data.change = blink::PointerData::Change::kHover;
         break;
       case blink::PointerData::Change::kAdd:
+        if (down_pointers_.count(pointer_data.device) != 0) {
+          FXL_DLOG(ERROR) << "Received add event for down pointer.";
+        }
+        break;
       case blink::PointerData::Change::kRemove:
+        if (down_pointers_.count(pointer_data.device) != 0) {
+          FXL_DLOG(ERROR) << "Received remove event for down pointer.";
+        }
+        break;
       case blink::PointerData::Change::kHover:
-        FXL_DCHECK(down_pointers_.count(pointer_data.device) == 0);
+        if (down_pointers_.count(pointer_data.device) != 0) {
+          FXL_DLOG(ERROR) << "Received hover event for down pointer.";
+        }
         break;
     }
 


### PR DESCRIPTION
Just log them as errors