### PR TITLE
libtxt: handle newlines during invocation of the minikin line breaker

### DIFF
--- a/third_party/txt/benchmarks/paragraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_benchmarks.cc
@@ -402,8 +402,7 @@ static void BM_ParagraphMinikinAddStyleRun(benchmark::State& state) {
     for (int i = 0; i < 20; ++i) {
       breaker.addStyleRun(
           &paint, font_collection->GetMinikinFontCollectionForFamily("Roboto"),
-          font, state.range(0) / 20 * i, state.range(0) / 20 * (i + 1), false,
-          0);
+          font, state.range(0) / 20 * i, state.range(0) / 20 * (i + 1), false);
     }
   }
   state.SetComplexityN(state.range(0));

--- a/third_party/txt/src/minikin/LineBreaker.cpp
+++ b/third_party/txt/src/minikin/LineBreaker.cpp
@@ -120,8 +120,7 @@ float LineBreaker::addStyleRun(MinikinPaint* paint,
                                FontStyle style,
                                size_t start,
                                size_t end,
-                               bool isRtl,
-                               double letterSpacing) {
+                               bool isRtl) {
   float width = 0.0f;
   int bidiFlags = isRtl ? kBidi_Force_RTL : kBidi_Force_LTR;
 
@@ -169,8 +168,6 @@ float LineBreaker::addStyleRun(MinikinPaint* paint,
       if (isWordSpace(c))
         mSpaceCount += 1;
       mWidth += mCharWidths[i];
-      if (c == '\n')
-        mWidth += INT_MAX;
       if (!isLineEndSpace(c)) {
         postBreak = mWidth;
         postSpaceCount = mSpaceCount;
@@ -367,7 +364,7 @@ void LineBreaker::pushBreak(int offset, float width, uint8_t hyphenEdit) {
 void LineBreaker::addReplacement(size_t start, size_t end, float width) {
   mCharWidths[start] = width;
   std::fill(&mCharWidths[start + 1], &mCharWidths[end], 0.0f);
-  addStyleRun(nullptr, nullptr, FontStyle(), start, end, false, 0);
+  addStyleRun(nullptr, nullptr, FontStyle(), start, end, false);
 }
 
 // Get the width of a space. May return 0 if there are no spaces.

--- a/third_party/txt/src/minikin/LineBreaker.h
+++ b/third_party/txt/src/minikin/LineBreaker.h
@@ -169,8 +169,7 @@ class LineBreaker {
                     FontStyle style,
                     size_t start,
                     size_t end,
-                    bool isRtl,
-                    double letterSpacing = 0);
+                    bool isRtl);
 
   void addReplacement(size_t start, size_t end, float width);
 

--- a/third_party/txt/src/txt/paragraph_builder.cc
+++ b/third_party/txt/src/txt/paragraph_builder.cc
@@ -85,21 +85,8 @@ void ParagraphBuilder::AddText(const char* text) {
   AddText(u16_text);
 }
 
-void ParagraphBuilder::SplitNewlineRuns() {
-  std::list<size_t> newline_positions;
-  for (size_t i = 0; i < text_.size(); ++i) {
-    if (text_[i] == '\n') {
-      newline_positions.push_back(i);
-    }
-  }
-  if (newline_positions.size() > 0)
-    runs_.SplitNewlineRuns(newline_positions);
-}
-
 std::unique_ptr<Paragraph> ParagraphBuilder::Build() {
   runs_.EndRunIfNeeded(text_.size());
-
-  SplitNewlineRuns();
 
   std::unique_ptr<Paragraph> paragraph = std::make_unique<Paragraph>();
   paragraph->SetText(std::move(text_), std::move(runs_));

--- a/third_party/txt/src/txt/paragraph_builder.h
+++ b/third_party/txt/src/txt/paragraph_builder.h
@@ -79,10 +79,6 @@ class ParagraphBuilder {
   StyledRuns runs_;
   ParagraphStyle paragraph_style_;
 
-  // Break any newline '\n' characters into their own runs. This allows
-  // Paragraph::Layout to cleanly discover and handle newlines.
-  void SplitNewlineRuns();
-
   FXL_DISALLOW_COPY_AND_ASSIGN(ParagraphBuilder);
 };
 

--- a/third_party/txt/src/txt/styled_runs.cc
+++ b/third_party/txt/src/txt/styled_runs.cc
@@ -71,40 +71,4 @@ StyledRuns::Run StyledRuns::GetRun(size_t index) const {
   return Run{styles_[run.style_index], run.start, run.end};
 }
 
-void StyledRuns::SplitNewlineRuns(std::list<size_t> newline_positions) {
-  std::vector<IndexedRun> result;
-  for (size_t i = 0; i < runs_.size(); ++i) {
-    if (runs_[i].end <= newline_positions.front() ||
-        newline_positions.empty()) {
-      result.push_back(runs_[i]);
-    } else {
-      size_t start = runs_[i].start;
-      size_t end = runs_[i].end;
-      while (end > newline_positions.front() && !newline_positions.empty() &&
-             start < end) {
-        IndexedRun temp_run;
-        temp_run.style_index = runs_[i].style_index;
-        temp_run.start = start;
-        temp_run.end = newline_positions.front();
-        newline_positions.pop_front();
-        result.push_back(temp_run);
-
-        temp_run.start = temp_run.end;
-        temp_run.end = temp_run.end + 1;
-        result.push_back(temp_run);
-
-        start = temp_run.end;
-      }
-      if (start < end) {
-        IndexedRun temp_run;
-        temp_run.style_index = runs_[i].style_index;
-        temp_run.start = start;
-        temp_run.end = end;
-        result.push_back(temp_run);
-      }
-    }
-  }
-  runs_ = result;
-}
-
 }  // namespace txt

--- a/third_party/txt/src/txt/styled_runs.h
+++ b/third_party/txt/src/txt/styled_runs.h
@@ -60,9 +60,6 @@ class StyledRuns {
 
   Run GetRun(size_t index) const;
 
-  // Break any newline '\n' characters into their own runs.
-  void SplitNewlineRuns(std::list<size_t> newline_positions);
-
  private:
   FRIEND_TEST(ParagraphTest, SimpleParagraph);
   FRIEND_TEST(ParagraphTest, SimpleRedParagraph);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -1332,32 +1332,16 @@ TEST_F(ParagraphTest, NewlineParagraph) {
 
   ASSERT_TRUE(Snapshot());
 
-  ASSERT_EQ(paragraph->runs_.size(), 9ull);
-  ASSERT_EQ(paragraph->runs_.GetRun(1).end - paragraph->runs_.GetRun(1).start,
-            1ull);
-  ASSERT_EQ(paragraph->runs_.GetRun(3).end - paragraph->runs_.GetRun(3).start,
-            1ull);
-  ASSERT_EQ(paragraph->runs_.GetRun(5).end - paragraph->runs_.GetRun(5).start,
-            1ull);
-  ASSERT_EQ(paragraph->runs_.GetRun(7).end - paragraph->runs_.GetRun(7).start,
-            1ull);
-
-  ASSERT_EQ(paragraph->records_.size(), 10ull);
+  ASSERT_EQ(paragraph->records_.size(), 7ull);
   EXPECT_DOUBLE_EQ(paragraph->records_[0].offset().x(), 0);
-  EXPECT_DOUBLE_EQ(paragraph->records_[1].offset().x(), 127.69921875);
-  EXPECT_DOUBLE_EQ(paragraph->records_[1].offset().y(),
-                   paragraph->records_[0].offset().y());
+  EXPECT_DOUBLE_EQ(paragraph->records_[1].offset().x(), 0);
+  EXPECT_DOUBLE_EQ(paragraph->records_[1].offset().y(), 126);
   EXPECT_DOUBLE_EQ(paragraph->records_[2].offset().x(), 0);
   EXPECT_DOUBLE_EQ(paragraph->records_[3].offset().x(), 0);
-  EXPECT_DOUBLE_EQ(paragraph->records_[4].offset().x(), 586.9921875);
-  EXPECT_DOUBLE_EQ(paragraph->records_[3].offset().y(),
-                   paragraph->records_[4].offset().y());
+  EXPECT_DOUBLE_EQ(paragraph->records_[4].offset().x(), 0);
+  EXPECT_DOUBLE_EQ(paragraph->records_[3].offset().y(), 266);
   EXPECT_DOUBLE_EQ(paragraph->records_[5].offset().x(), 0);
-  EXPECT_DOUBLE_EQ(paragraph->records_[6].offset().x(), 127.69921875);
-  EXPECT_DOUBLE_EQ(paragraph->records_[7].offset().x(), 0);
-  EXPECT_DOUBLE_EQ(paragraph->records_[8].offset().x(), 0);
-  EXPECT_DOUBLE_EQ(paragraph->records_[7].offset().y(), 336);
-  EXPECT_DOUBLE_EQ(paragraph->records_[8].offset().y(), 406);
+  EXPECT_DOUBLE_EQ(paragraph->records_[6].offset().x(), 0);
 }
 
 TEST_F(ParagraphTest, EmojiParagraph) {


### PR DESCRIPTION
minikin::LineBreaker does not convert newline characters into line breaks
in its output.  Previously libtxt's version of LineBreaker container a patch
that added a large width offset for a newline in order to force wrapping to
the next line.  This works if the offset exceeds the paragraph's width
constraint.  But if the paragraph is laid out with infinite width, then the
text after the newline will continue on the current output line.

This change separates the paragraph's text into newline delimited blocks and
feeds each block separately to the minikin LineBreaker.

Also, libtxt was breaking the input styled text runs at newline boundaries.
This is no longer necessary.