### PR TITLE
Allow entrypoints called something other than "main".

### DIFF
--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -62,7 +62,10 @@ DartController::~DartController() {
   }
 }
 
-bool DartController::SendStartMessage(Dart_Handle root_library) {
+const std::string DartController::main_entrypoint_ = "main";
+
+bool DartController::SendStartMessage(Dart_Handle root_library,
+                                      const std::string& entrypoint) {
   if (LogIfError(root_library))
     return true;
 
@@ -79,8 +82,8 @@ bool DartController::SendStartMessage(Dart_Handle root_library) {
   // main by sending a message to the isolate.
 
   // Get the closure of main().
-  Dart_Handle main_closure =
-      Dart_GetClosure(root_library, Dart_NewStringFromCString("main"));
+  Dart_Handle main_closure = Dart_GetClosure(
+      root_library, Dart_NewStringFromCString(entrypoint.c_str()));
   if (LogIfError(main_closure))
     return true;
 
@@ -110,7 +113,8 @@ static void ReleaseFetchedBytes(uint8_t* buffer) {
 }
 
 tonic::DartErrorHandleType DartController::RunFromKernel(
-    const std::vector<uint8_t>& kernel) {
+    const std::vector<uint8_t>& kernel,
+    const std::string& entrypoint) {
   tonic::DartState::Scope scope(dart_state());
   tonic::DartErrorHandleType error = tonic::kNoError;
   if (Dart_IsNull(Dart_RootLibrary())) {
@@ -124,17 +128,18 @@ tonic::DartErrorHandleType DartController::RunFromKernel(
     LogIfError(result);
     error = tonic::GetErrorHandleType(result);
   }
-  if (SendStartMessage(Dart_RootLibrary())) {
+  if (SendStartMessage(Dart_RootLibrary(), entrypoint)) {
     return tonic::kUnknownErrorType;
   }
   return error;
 }
 
-tonic::DartErrorHandleType DartController::RunFromPrecompiledSnapshot() {
+tonic::DartErrorHandleType DartController::RunFromPrecompiledSnapshot(
+    const std::string& entrypoint) {
   TRACE_EVENT0("flutter", "DartController::RunFromPrecompiledSnapshot");
   FXL_DCHECK(Dart_CurrentIsolate() == nullptr);
   tonic::DartState::Scope scope(dart_state());
-  if (SendStartMessage(Dart_RootLibrary())) {
+  if (SendStartMessage(Dart_RootLibrary(), entrypoint)) {
     return tonic::kUnknownErrorType;
   }
   return tonic::kNoError;
@@ -142,7 +147,8 @@ tonic::DartErrorHandleType DartController::RunFromPrecompiledSnapshot() {
 
 tonic::DartErrorHandleType DartController::RunFromScriptSnapshot(
     const uint8_t* buffer,
-    size_t size) {
+    size_t size,
+    const std::string& entrypoint) {
   tonic::DartState::Scope scope(dart_state());
   tonic::DartErrorHandleType error = tonic::kNoError;
   if (Dart_IsNull(Dart_RootLibrary())) {
@@ -150,7 +156,7 @@ tonic::DartErrorHandleType DartController::RunFromScriptSnapshot(
     LogIfError(result);
     error = tonic::GetErrorHandleType(result);
   }
-  if (SendStartMessage(Dart_RootLibrary())) {
+  if (SendStartMessage(Dart_RootLibrary(), entrypoint)) {
     return tonic::kUnknownErrorType;
   }
   return error;

--- a/runtime/dart_controller.h
+++ b/runtime/dart_controller.h
@@ -20,10 +20,15 @@ class DartController {
   DartController();
   ~DartController();
 
-  tonic::DartErrorHandleType RunFromKernel(const std::vector<uint8_t>& kernel);
-  tonic::DartErrorHandleType RunFromPrecompiledSnapshot();
-  tonic::DartErrorHandleType RunFromScriptSnapshot(const uint8_t* buffer,
-                                                   size_t size);
+  tonic::DartErrorHandleType RunFromKernel(
+      const std::vector<uint8_t>& kernel,
+      const std::string& entrypoint = main_entrypoint_);
+  tonic::DartErrorHandleType RunFromPrecompiledSnapshot(
+      const std::string& entrypoint = main_entrypoint_);
+  tonic::DartErrorHandleType RunFromScriptSnapshot(
+      const uint8_t* buffer,
+      size_t size,
+      const std::string& entrypoint = main_entrypoint_);
   tonic::DartErrorHandleType RunFromSource(const std::string& main,
                                            const std::string& packages);
 
@@ -38,7 +43,10 @@ class DartController {
   void IsolateShuttingDown();
 
  private:
-  bool SendStartMessage(Dart_Handle root_library);
+  bool SendStartMessage(Dart_Handle root_library,
+                        const std::string& entrypoint = main_entrypoint_);
+
+  static const std::string main_entrypoint_;
 
   // The DartState associated with the main isolate.  This is not deleted
   // during isolate shutdown, instead it is deleted when the controller

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -186,7 +186,10 @@ void Engine::Init() {
                      default_isolate_snapshot_instr);
 }
 
-void Engine::RunBundle(const std::string& bundle_path) {
+const std::string Engine::main_entrypoint_ = "main";
+
+void Engine::RunBundle(const std::string& bundle_path,
+                       const std::string& entrypoint) {
   TRACE_EVENT0("flutter", "Engine::RunBundle");
   ConfigureAssetBundle(bundle_path);
   std::vector<uint8_t> platform_kernel;
@@ -194,38 +197,39 @@ void Engine::RunBundle(const std::string& bundle_path) {
   ConfigureRuntime(GetScriptUriFromPath(bundle_path), platform_kernel);
 
   if (blink::IsRunningPrecompiledCode()) {
-    runtime_->dart_controller()->RunFromPrecompiledSnapshot();
+    runtime_->dart_controller()->RunFromPrecompiledSnapshot(entrypoint);
   } else {
     std::vector<uint8_t> kernel;
     if (GetAssetAsBuffer(blink::kKernelAssetKey, &kernel)) {
-      runtime_->dart_controller()->RunFromKernel(kernel);
+      runtime_->dart_controller()->RunFromKernel(kernel, entrypoint);
       return;
     }
     std::vector<uint8_t> snapshot;
     if (!GetAssetAsBuffer(blink::kSnapshotAssetKey, &snapshot))
       return;
-    runtime_->dart_controller()->RunFromScriptSnapshot(snapshot.data(),
-                                                       snapshot.size());
+    runtime_->dart_controller()->RunFromScriptSnapshot(
+        snapshot.data(), snapshot.size(), entrypoint);
   }
 }
 
 void Engine::RunBundleAndSnapshot(const std::string& bundle_path,
-                                  const std::string& snapshot_override) {
+                                  const std::string& snapshot_override,
+                                  const std::string& entrypoint) {
   TRACE_EVENT0("flutter", "Engine::RunBundleAndSnapshot");
   if (snapshot_override.empty()) {
-    RunBundle(bundle_path);
+    RunBundle(bundle_path, entrypoint);
     return;
   }
   ConfigureAssetBundle(bundle_path);
   ConfigureRuntime(GetScriptUriFromPath(bundle_path));
   if (blink::IsRunningPrecompiledCode()) {
-    runtime_->dart_controller()->RunFromPrecompiledSnapshot();
+    runtime_->dart_controller()->RunFromPrecompiledSnapshot(entrypoint);
   } else {
     std::vector<uint8_t> snapshot;
     if (!files::ReadFileToVector(snapshot_override, &snapshot))
       return;
-    runtime_->dart_controller()->RunFromScriptSnapshot(snapshot.data(),
-                                                       snapshot.size());
+    runtime_->dart_controller()->RunFromScriptSnapshot(
+        snapshot.data(), snapshot.size(), entrypoint);
   }
 }
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -35,13 +35,15 @@ class Engine : public blink::RuntimeDelegate {
 
   static void Init();
 
-  void RunBundle(const std::string& bundle_path);
+  void RunBundle(const std::string& bundle_path,
+                 const std::string& entrypoint = main_entrypoint_);
 
   // Uses the given snapshot instead of looking inside the bundle for the
   // snapshot. If |snapshot_override| is empty, this function looks for the
   // snapshot in the bundle itself.
   void RunBundleAndSnapshot(const std::string& bundle_path,
-                            const std::string& snapshot_override);
+                            const std::string& snapshot_override,
+                            const std::string& entrypoint = main_entrypoint_);
 
   // Uses the given source code instead of looking inside the bundle for the
   // source code.
@@ -99,6 +101,8 @@ class Engine : public blink::RuntimeDelegate {
 
   void HandleAssetPlatformMessage(fxl::RefPtr<blink::PlatformMessage> message);
   bool GetAssetAsBuffer(const std::string& name, std::vector<uint8_t>* data);
+
+  static const std::string main_entrypoint_;
 
   std::weak_ptr<PlatformView> platform_view_;
   std::unique_ptr<Animator> animator_;

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -561,9 +561,13 @@ public class FlutterView extends SurfaceView
     }
 
     public void runFromBundle(String bundlePath, String snapshotOverride) {
+        runFromBundle(bundlePath, snapshotOverride, "main");
+    }
+
+    public void runFromBundle(String bundlePath, String snapshotOverride, String entrypoint) {
         assertAttached();
         preRun();
-        nativeRunBundleAndSnapshot(mNativePlatformView, bundlePath, snapshotOverride);
+        nativeRunBundleAndSnapshot(mNativePlatformView, bundlePath, snapshotOverride, entrypoint);
         postRun();
     }
 
@@ -622,7 +626,8 @@ public class FlutterView extends SurfaceView
 
     private static native void nativeRunBundleAndSnapshot(long nativePlatformViewAndroid,
         String bundlePath,
-        String snapshotOverride);
+        String snapshotOverride,
+        String entrypoint);
 
     private static native void nativeRunBundleAndSource(long nativePlatformViewAndroid,
         String bundlePath,

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -209,14 +209,17 @@ void PlatformViewAndroid::SurfaceDestroyed() {
 }
 
 void PlatformViewAndroid::RunBundleAndSnapshot(std::string bundle_path,
-                                               std::string snapshot_override) {
+                                               std::string snapshot_override,
+                                               std::string entrypoint) {
   blink::Threads::UI()->PostTask([
     engine = engine_->GetWeakPtr(), bundle_path = std::move(bundle_path),
-    snapshot_override = std::move(snapshot_override)
+    snapshot_override = std::move(snapshot_override),
+    entrypoint = std::move(entrypoint)
   ] {
     if (engine)
       engine->RunBundleAndSnapshot(std::move(bundle_path),
-                                   std::move(snapshot_override));
+                                   std::move(snapshot_override),
+                                   std::move(entrypoint));
   });
 }
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -39,7 +39,8 @@ class PlatformViewAndroid : public PlatformView {
   void SurfaceDestroyed();
 
   void RunBundleAndSnapshot(std::string bundle_path,
-                            std::string snapshot_override);
+                            std::string snapshot_override,
+                            std::string entrypoint);
 
   void RunBundleAndSource(std::string bundle_path,
                           std::string main,

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -104,10 +104,12 @@ static void RunBundleAndSnapshot(JNIEnv* env,
                                  jobject jcaller,
                                  jlong platform_view,
                                  jstring bundlePath,
-                                 jstring snapshotOverride) {
+                                 jstring snapshotOverride,
+                                 jstring entrypoint) {
   return PLATFORM_VIEW->RunBundleAndSnapshot(
-      fml::jni::JavaStringToString(env, bundlePath),       //
-      fml::jni::JavaStringToString(env, snapshotOverride)  //
+      fml::jni::JavaStringToString(env, bundlePath),        //
+      fml::jni::JavaStringToString(env, snapshotOverride),  //
+      fml::jni::JavaStringToString(env, entrypoint)         //
   );
 }
 
@@ -257,7 +259,8 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
       },
       {
           .name = "nativeRunBundleAndSnapshot",
-          .signature = "(JLjava/lang/String;Ljava/lang/String;)V",
+          .signature =
+              "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
           .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSnapshot),
       },
       {


### PR DESCRIPTION
Expose up through the Android FlutterView the ability to start an Isolate at an entrypoint other than "main" in the root library. This will be useful for writing a API/plugin to set up background services.