### PR TITLE
Set AccessibilityFocus

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -94,6 +94,8 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         result.setClassName("Flutter"); // TODO(goderbauer): Set proper class names
         result.setSource(mOwner, virtualViewId);
         result.setFocusable(object.isFocusable());
+        if (mFocusedObject != null)
+            result.setAccessibilityFocused(mFocusedObject.id == virtualViewId);
 
         if (object.parent != null) {
             assert object.id > 0;


### PR DESCRIPTION
This ensures that accessibility hints are played properly.

Fixes https://github.com/flutter/flutter/issues/12636.