### PR TITLE
Initialize service isolate from kernel file, rather than from embedded sources.

### DIFF
--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -266,10 +266,8 @@ void RuntimeHolder::CreateView(
     isolate_snapshot_instr = reinterpret_cast<const uint8_t*>(
         dlsym(dylib_handle_, "_kDartIsolateSnapshotInstructions"));
   }
-  std::vector<uint8_t> empty_platform_kernel;
   runtime_->CreateDartController(script_uri, isolate_snapshot_data,
-                                 isolate_snapshot_instr,
-                                 std::move(empty_platform_kernel));
+                                 isolate_snapshot_instr);
 
   runtime_->SetViewportMetrics(viewport_metrics_);
 

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -43,8 +43,7 @@ std::string ResolvePath(std::string path) {
 
 }  // namespace
 
-DartController::DartController()
-    : ui_dart_state_(nullptr), platform_kernel_bytes(nullptr) {}
+DartController::DartController() : ui_dart_state_(nullptr) {}
 
 DartController::~DartController() {
   if (ui_dart_state_) {
@@ -56,9 +55,6 @@ DartController::~DartController() {
     Dart_SetMessageNotifyCallback(nullptr);
     Dart_ShutdownIsolate();
     delete ui_dart_state_;
-  }
-  if (platform_kernel_bytes) {
-    free(platform_kernel_bytes);
   }
 }
 
@@ -185,21 +181,16 @@ void DartController::CreateIsolateFor(
     const std::string& script_uri,
     const uint8_t* isolate_snapshot_data,
     const uint8_t* isolate_snapshot_instr,
-    const std::vector<uint8_t>& platform_kernel,
     std::unique_ptr<UIDartState> state) {
   char* error = nullptr;
 
-  Dart_Isolate isolate;
-  if (!platform_kernel.empty()) {
-    // Copy kernel bytes so they won't go away after we exit this method.
-    // This is needed because original kernel data has to be available
-    // during code execution.
-    CopyVectorBytes(platform_kernel, platform_kernel_bytes);
+  void* platform_kernel = GetKernelPlatformBinary();
 
+  Dart_Isolate isolate;
+  if (platform_kernel != nullptr) {
     isolate = Dart_CreateIsolateFromKernel(
         script_uri.c_str(), "main",
-        Dart_ReadKernelBinary(platform_kernel_bytes, platform_kernel.size(),
-                              ReleaseFetchedBytes),
+        platform_kernel,
         nullptr /* flags */, static_cast<tonic::DartState*>(state.get()),
         &error);
   } else {

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -177,11 +177,10 @@ tonic::DartErrorHandleType DartController::RunFromSource(
   return error;
 }
 
-void DartController::CreateIsolateFor(
-    const std::string& script_uri,
-    const uint8_t* isolate_snapshot_data,
-    const uint8_t* isolate_snapshot_instr,
-    std::unique_ptr<UIDartState> state) {
+void DartController::CreateIsolateFor(const std::string& script_uri,
+                                      const uint8_t* isolate_snapshot_data,
+                                      const uint8_t* isolate_snapshot_instr,
+                                      std::unique_ptr<UIDartState> state) {
   char* error = nullptr;
 
   void* platform_kernel = GetKernelPlatformBinary();
@@ -189,10 +188,8 @@ void DartController::CreateIsolateFor(
   Dart_Isolate isolate;
   if (platform_kernel != nullptr) {
     isolate = Dart_CreateIsolateFromKernel(
-        script_uri.c_str(), "main",
-        platform_kernel,
-        nullptr /* flags */, static_cast<tonic::DartState*>(state.get()),
-        &error);
+        script_uri.c_str(), "main", platform_kernel, nullptr /* flags */,
+        static_cast<tonic::DartState*>(state.get()), &error);
   } else {
     isolate =
         Dart_CreateIsolate(script_uri.c_str(), "main", isolate_snapshot_data,

--- a/runtime/dart_controller.h
+++ b/runtime/dart_controller.h
@@ -35,7 +35,6 @@ class DartController {
   void CreateIsolateFor(const std::string& script_uri,
                         const uint8_t* isolate_snapshot_data,
                         const uint8_t* isolate_snapshot_instr,
-                        const std::vector<uint8_t>& platform_kernel,
                         std::unique_ptr<UIDartState> ui_dart_state);
 
   UIDartState* dart_state() const { return ui_dart_state_; }
@@ -52,11 +51,6 @@ class DartController {
   // during isolate shutdown, instead it is deleted when the controller
   // object is deleted.
   UIDartState* ui_dart_state_;
-
-  // Kernel binary image of platform core libraries. This is copied and
-  // maintained for dart script lifespan, so that kernel loading mechanism can
-  // incrementally build the dart objects from it.
-  uint8_t* platform_kernel_bytes;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(DartController);
 };

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -200,7 +200,7 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
 #else   // FLUTTER_RUNTIME_MODE
   UIDartState* dart_state = new UIDartState(nullptr, nullptr);
 
-  bool is_running_from_kernel = kernel_platform != nullptr;
+  bool is_running_from_kernel = GetKernelPlatformBinary() != nullptr;
 
   Dart_Isolate isolate =
       is_running_from_kernel

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -124,6 +124,11 @@ static ServiceIsolateHook g_service_isolate_hook = nullptr;
 static RegisterNativeServiceProtocolExtensionHook
     g_register_native_service_protocol_extensions_hook = nullptr;
 
+// Kernel representation of core dart libraries(loaded from platform.dill).
+static void* kernel_platform = nullptr;
+// Bytes actually read from platform.dill that are referenced by kernel_platform
+static std::vector<uint8_t> platform_data;
+
 void IsolateShutdownCallback(void* callback_data) {
   if (tonic::DartStickyError::IsSet()) {
     tonic::DartApiScope api_scope;
@@ -194,10 +199,19 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
   return nullptr;
 #else   // FLUTTER_RUNTIME_MODE
   UIDartState* dart_state = new UIDartState(nullptr, nullptr);
-  Dart_Isolate isolate =
-      Dart_CreateIsolate(script_uri, "main", g_default_isolate_snapshot_data,
-                         g_default_isolate_snapshot_instructions, nullptr,
-                         static_cast<tonic::DartState*>(dart_state), error);
+
+  bool is_running_from_kernel = kernel_platform != nullptr;
+
+  Dart_Isolate isolate = is_running_from_kernel
+      ? Dart_CreateIsolateFromKernel(script_uri, "main", kernel_platform,
+            nullptr /* flags */,
+            static_cast<tonic::DartState*>(dart_state),
+            error)
+      : Dart_CreateIsolate(script_uri, "main",
+            g_default_isolate_snapshot_data,
+            g_default_isolate_snapshot_instructions, nullptr,
+            static_cast<tonic::DartState*>(dart_state), error);
+
   FXL_CHECK(isolate) << error;
   dart_state->set_debug_name_prefix(script_uri);
   dart_state->SetIsolate(isolate);
@@ -216,12 +230,13 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
       const bool disable_websocket_origin_check = false;
       const bool service_isolate_booted = DartServiceIsolate::Startup(
           ip, port, tonic::DartState::HandleLibraryTag,
-          IsRunningPrecompiledCode(), disable_websocket_origin_check, error);
+          IsRunningPrecompiledCode() || is_running_from_kernel,
+          disable_websocket_origin_check, error);
       FXL_CHECK(service_isolate_booted) << error;
     }
 
     if (g_service_isolate_hook)
-      g_service_isolate_hook(IsRunningPrecompiledCode());
+      g_service_isolate_hook(IsRunningPrecompiledCode(), is_running_from_kernel);
   }
   Dart_ExitIsolate();
 
@@ -252,7 +267,6 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
   // Are we running from a Dart source file?
   const bool running_from_source = StringEndsWith(entry_uri, ".dart");
 
-  void* kernel_platform = nullptr;
   std::vector<uint8_t> kernel_data;
   std::vector<uint8_t> snapshot_data;
   std::string entry_path;
@@ -272,14 +286,6 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
               GetUnzipperProviderForPath(std::move(bundle_path)));
       zip_asset_store->GetAsBuffer(kKernelAssetKey, &kernel_data);
       zip_asset_store->GetAsBuffer(kSnapshotAssetKey, &snapshot_data);
-
-      std::vector<uint8_t> platform_data;
-      zip_asset_store->GetAsBuffer(kPlatformKernelAssetKey, &platform_data);
-      if (!platform_data.empty()) {
-        kernel_platform = Dart_ReadKernelBinary(
-            platform_data.data(), platform_data.size(), ReleaseFetchedBytes);
-        FXL_DCHECK(kernel_platform != NULL);
-      }
     }
   }
 
@@ -454,10 +460,15 @@ static void EmbedderInformationCallback(Dart_EmbedderInformation* info) {
   info->name = "Flutter";
 }
 
+void* GetKernelPlatformBinary() {
+  return kernel_platform;
+}
+
 void InitDartVM(const uint8_t* vm_snapshot_data,
                 const uint8_t* vm_snapshot_instructions,
                 const uint8_t* default_isolate_snapshot_data,
-                const uint8_t* default_isolate_snapshot_instructions) {
+                const uint8_t* default_isolate_snapshot_instructions,
+                const std::string& bundle_path) {
   TRACE_EVENT0("flutter", __func__);
 
   g_default_isolate_snapshot_data = default_isolate_snapshot_data;
@@ -533,6 +544,17 @@ void InitDartVM(const uint8_t* vm_snapshot_data,
 #if defined(OS_FUCHSIA)
   PushBackAll(&args, kDartFuchsiaTraceArgs, arraysize(kDartFuchsiaTraceArgs));
 #endif
+
+  if (!bundle_path.empty()) {
+    auto zip_asset_store = fxl::MakeRefCounted<ZipAssetStore>(
+        GetUnzipperProviderForPath(std::move(bundle_path)));
+    zip_asset_store->GetAsBuffer(kPlatformKernelAssetKey, &platform_data);
+    if (!platform_data.empty()) {
+      kernel_platform = Dart_ReadKernelBinary(
+          platform_data.data(), platform_data.size(), ReleaseFetchedBytes);
+      FXL_DCHECK(kernel_platform != nullptr);
+    }
+  }
 
   for (size_t i = 0; i < settings.dart_flags.size(); i++)
     args.push_back(settings.dart_flags[i].c_str());

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -202,15 +202,15 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
 
   bool is_running_from_kernel = kernel_platform != nullptr;
 
-  Dart_Isolate isolate = is_running_from_kernel
-      ? Dart_CreateIsolateFromKernel(script_uri, "main", kernel_platform,
-            nullptr /* flags */,
-            static_cast<tonic::DartState*>(dart_state),
-            error)
-      : Dart_CreateIsolate(script_uri, "main",
-            g_default_isolate_snapshot_data,
-            g_default_isolate_snapshot_instructions, nullptr,
-            static_cast<tonic::DartState*>(dart_state), error);
+  Dart_Isolate isolate =
+      is_running_from_kernel
+          ? Dart_CreateIsolateFromKernel(
+                script_uri, "main", kernel_platform, nullptr /* flags */,
+                static_cast<tonic::DartState*>(dart_state), error)
+          : Dart_CreateIsolate(
+                script_uri, "main", g_default_isolate_snapshot_data,
+                g_default_isolate_snapshot_instructions, nullptr,
+                static_cast<tonic::DartState*>(dart_state), error);
 
   FXL_CHECK(isolate) << error;
   dart_state->set_debug_name_prefix(script_uri);
@@ -236,7 +236,8 @@ Dart_Isolate ServiceIsolateCreateCallback(const char* script_uri,
     }
 
     if (g_service_isolate_hook)
-      g_service_isolate_hook(IsRunningPrecompiledCode(), is_running_from_kernel);
+      g_service_isolate_hook(IsRunningPrecompiledCode(),
+                             is_running_from_kernel);
   }
   Dart_ExitIsolate();
 

--- a/runtime/dart_init.h
+++ b/runtime/dart_init.h
@@ -28,7 +28,7 @@ bool IsRunningPrecompiledCode();
 
 using EmbedderTracingCallback = fxl::Closure;
 
-typedef void (*ServiceIsolateHook)(bool, bool);
+typedef void (*ServiceIsolateHook)(bool);
 typedef void (*RegisterNativeServiceProtocolExtensionHook)(bool);
 
 struct EmbedderTracingCallbacks {

--- a/runtime/dart_init.h
+++ b/runtime/dart_init.h
@@ -11,6 +11,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace blink {
 
@@ -27,7 +28,7 @@ bool IsRunningPrecompiledCode();
 
 using EmbedderTracingCallback = fxl::Closure;
 
-typedef void (*ServiceIsolateHook)(bool);
+typedef void (*ServiceIsolateHook)(bool, bool);
 typedef void (*RegisterNativeServiceProtocolExtensionHook)(bool);
 
 struct EmbedderTracingCallbacks {
@@ -41,7 +42,10 @@ struct EmbedderTracingCallbacks {
 void InitDartVM(const uint8_t* vm_snapshot_data,
                 const uint8_t* vm_snapshot_instructions,
                 const uint8_t* default_isolate_snapshot_data,
-                const uint8_t* default_isolate_snapshot_instructions);
+                const uint8_t* default_isolate_snapshot_instructions,
+                const std::string& bundle_path);
+
+void* GetKernelPlatformBinary();
 
 void SetEmbedderTracingCallbacks(
     std::unique_ptr<EmbedderTracingCallbacks> callbacks);

--- a/runtime/dart_service_isolate.h
+++ b/runtime/dart_service_isolate.h
@@ -18,7 +18,7 @@ class DartServiceIsolate {
   static bool Startup(std::string server_ip,
                       intptr_t server_port,
                       Dart_LibraryTagHandler embedder_tag_handler,
-                      bool running_precompiled,
+                      bool running_from_sources,
                       bool disable_origin_check,
                       char** error);
 

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -29,14 +29,12 @@ RuntimeController::~RuntimeController() {}
 void RuntimeController::CreateDartController(
     const std::string& script_uri,
     const uint8_t* isolate_snapshot_data,
-    const uint8_t* isolate_snapshot_instr,
-    const std::vector<uint8_t>& platform_kernel) {
+    const uint8_t* isolate_snapshot_instr) {
   FXL_DCHECK(!dart_controller_);
 
   dart_controller_.reset(new DartController());
   dart_controller_->CreateIsolateFor(
       script_uri, isolate_snapshot_data, isolate_snapshot_instr,
-      platform_kernel,
       std::make_unique<UIDartState>(this, std::make_unique<Window>(this)));
 
   UIDartState* dart_state = dart_controller_->dart_state();

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -28,8 +28,7 @@ class RuntimeController : public WindowClient, public IsolateClient {
 
   void CreateDartController(const std::string& script_uri,
                             const uint8_t* isolate_snapshot_data,
-                            const uint8_t* isolate_snapshot_instr,
-                            const std::vector<uint8_t>& kernel_platform);
+                            const uint8_t* isolate_snapshot_instr);
   DartController* dart_controller() const { return dart_controller_.get(); }
 
   void SetViewportMetrics(const ViewportMetrics& metrics);

--- a/runtime/runtime_init.cc
+++ b/runtime/runtime_init.cc
@@ -20,7 +20,8 @@ PlatformImpl* g_platform_impl = nullptr;
 void InitRuntime(const uint8_t* vm_snapshot_data,
                  const uint8_t* vm_snapshot_instructions,
                  const uint8_t* default_isolate_snapshot_data,
-                 const uint8_t* default_isolate_snapshot_instructions) {
+                 const uint8_t* default_isolate_snapshot_instructions,
+                 const std::string& bundle_path) {
   TRACE_EVENT0("flutter", "InitRuntime");
 
   FXL_CHECK(!g_platform_impl);
@@ -28,7 +29,8 @@ void InitRuntime(const uint8_t* vm_snapshot_data,
   InitEngine(g_platform_impl);
   InitDartVM(vm_snapshot_data, vm_snapshot_instructions,
              default_isolate_snapshot_data,
-             default_isolate_snapshot_instructions);
+             default_isolate_snapshot_instructions,
+             bundle_path);
 }
 
 }  // namespace blink

--- a/runtime/runtime_init.cc
+++ b/runtime/runtime_init.cc
@@ -29,8 +29,7 @@ void InitRuntime(const uint8_t* vm_snapshot_data,
   InitEngine(g_platform_impl);
   InitDartVM(vm_snapshot_data, vm_snapshot_instructions,
              default_isolate_snapshot_data,
-             default_isolate_snapshot_instructions,
-             bundle_path);
+             default_isolate_snapshot_instructions, bundle_path);
 }
 
 }  // namespace blink

--- a/runtime/runtime_init.h
+++ b/runtime/runtime_init.h
@@ -6,13 +6,15 @@
 #define FLUTTER_RUNTIME_RUNTIME_INIT_H_
 
 #include <inttypes.h>
+#include <string>
 
 namespace blink {
 
 void InitRuntime(const uint8_t* vm_snapshot_data,
                  const uint8_t* vm_snapshot_instructions,
                  const uint8_t* default_isolate_snapshot_data,
-                 const uint8_t* default_isolate_snapshot_instructions);
+                 const uint8_t* default_isolate_snapshot_instructions,
+                 const std::string& bundle_path);
 
 }  // namespace blink
 

--- a/shell/common/diagnostic/diagnostic_server.cc
+++ b/shell/common/diagnostic/diagnostic_server.cc
@@ -61,7 +61,8 @@ void SendNull(Dart_Port port_id) {
 
 DART_NATIVE_CALLBACK_STATIC(DiagnosticServer, HandleSkiaPictureRequest);
 
-void DiagnosticServer::Start(uint32_t port, bool ipv6,
+void DiagnosticServer::Start(uint32_t port,
+                             bool ipv6,
                              bool running_from_kernel) {
   if (!g_natives) {
     g_natives = new DartLibraryNatives();
@@ -75,8 +76,8 @@ void DiagnosticServer::Start(uint32_t port, bool ipv6,
 
   Dart_Handle diagnostic_library;
   if (running_from_kernel) {
-    diagnostic_library = Dart_LookupLibrary(
-        Dart_NewStringFromCString("dart:diagnostic_server"));
+    diagnostic_library =
+        Dart_LookupLibrary(Dart_NewStringFromCString("dart:diagnostic_server"));
   } else {
     const char* source = nullptr;
     int source_length =

--- a/shell/common/diagnostic/diagnostic_server.cc
+++ b/shell/common/diagnostic/diagnostic_server.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/common/threads.h"
 #include "flutter/flow/compositor_context.h"
+#include "flutter/runtime/dart_init.h"
 #include "flutter/runtime/embedder_resources.h"
 #include "flutter/shell/common/engine.h"
 #include "flutter/shell/common/picture_serializer.h"
@@ -61,9 +62,7 @@ void SendNull(Dart_Port port_id) {
 
 DART_NATIVE_CALLBACK_STATIC(DiagnosticServer, HandleSkiaPictureRequest);
 
-void DiagnosticServer::Start(uint32_t port,
-                             bool ipv6,
-                             bool running_from_kernel) {
+void DiagnosticServer::Start(uint32_t port, bool ipv6) {
   if (!g_natives) {
     g_natives = new DartLibraryNatives();
     g_natives->Register({
@@ -75,7 +74,7 @@ void DiagnosticServer::Start(uint32_t port,
       &flutter::runtime::__sky_embedder_diagnostic_server_resources_[0]);
 
   Dart_Handle diagnostic_library;
-  if (running_from_kernel) {
+  if (blink::GetKernelPlatformBinary() != nullptr) {
     diagnostic_library =
         Dart_LookupLibrary(Dart_NewStringFromCString("dart:diagnostic_server"));
   } else {

--- a/shell/common/diagnostic/diagnostic_server.h
+++ b/shell/common/diagnostic/diagnostic_server.h
@@ -11,7 +11,7 @@ namespace shell {
 
 class DiagnosticServer {
  public:
-  static void Start(uint32_t port, bool ipv6, bool running_from_kernel);
+  static void Start(uint32_t port, bool ipv6);
   static void HandleSkiaPictureRequest(Dart_Handle send_port);
 
  private:

--- a/shell/common/diagnostic/diagnostic_server.h
+++ b/shell/common/diagnostic/diagnostic_server.h
@@ -11,7 +11,7 @@ namespace shell {
 
 class DiagnosticServer {
  public:
-  static void Start(uint32_t port, bool ipv6);
+  static void Start(uint32_t port, bool ipv6, bool running_from_kernel);
   static void HandleSkiaPictureRequest(Dart_Handle send_port);
 
  private:

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -130,7 +130,7 @@ static const uint8_t* MemMapSnapshot(const std::string& aot_snapshot_path,
 static const uint8_t* default_isolate_snapshot_data = nullptr;
 static const uint8_t* default_isolate_snapshot_instr = nullptr;
 
-void Engine::Init() {
+void Engine::Init(const std::string& bundle_path) {
   const uint8_t* vm_snapshot_data;
   const uint8_t* vm_snapshot_instr;
 #if !FLUTTER_AOT
@@ -183,7 +183,8 @@ void Engine::Init() {
 
   blink::InitRuntime(vm_snapshot_data, vm_snapshot_instr,
                      default_isolate_snapshot_data,
-                     default_isolate_snapshot_instr);
+                     default_isolate_snapshot_instr,
+                     bundle_path);
 }
 
 const std::string Engine::main_entrypoint_ = "main";
@@ -193,10 +194,7 @@ void Engine::RunBundle(const std::string& bundle_path,
                        bool reuse_runtime_controller) {
   TRACE_EVENT0("flutter", "Engine::RunBundle");
   ConfigureAssetBundle(bundle_path);
-  std::vector<uint8_t> platform_kernel;
-  GetAssetAsBuffer(blink::kPlatformKernelAssetKey, &platform_kernel);
-  ConfigureRuntime(GetScriptUriFromPath(bundle_path), platform_kernel,
-                   reuse_runtime_controller);
+  ConfigureRuntime(GetScriptUriFromPath(bundle_path), reuse_runtime_controller);
 
   if (blink::IsRunningPrecompiledCode()) {
     runtime_->dart_controller()->RunFromPrecompiledSnapshot(entrypoint);
@@ -224,8 +222,7 @@ void Engine::RunBundleAndSnapshot(const std::string& bundle_path,
     return;
   }
   ConfigureAssetBundle(bundle_path);
-  ConfigureRuntime(GetScriptUriFromPath(bundle_path), std::vector<uint8_t>(),
-                   reuse_runtime_controller);
+  ConfigureRuntime(GetScriptUriFromPath(bundle_path), reuse_runtime_controller);
   if (blink::IsRunningPrecompiledCode()) {
     runtime_->dart_controller()->RunFromPrecompiledSnapshot(entrypoint);
   } else {
@@ -248,15 +245,9 @@ void Engine::RunBundleAndSource(const std::string& bundle_path,
   if (packages_path.empty())
     packages_path = FindPackagesPath(main);
 
-  std::vector<uint8_t> platform_kernel;
-  if (!bundle_path.empty()) {
-    ConfigureAssetBundle(bundle_path);
-    GetAssetAsBuffer(blink::kPlatformKernelAssetKey, &platform_kernel);
-  }
-  ConfigureRuntime(GetScriptUriFromPath(bundle_path), platform_kernel,
-                   reuse_runtime_controller);
+  ConfigureRuntime(GetScriptUriFromPath(bundle_path), reuse_runtime_controller);
 
-  if (!platform_kernel.empty()) {
+  if (blink::GetKernelPlatformBinary() != nullptr) {
     std::vector<uint8_t> kernel;
     if (!files::ReadFileToVector(main, &kernel)) {
       load_script_error_ = tonic::kUnknownErrorType;
@@ -483,7 +474,6 @@ void Engine::ConfigureAssetBundle(const std::string& path) {
 }
 
 void Engine::ConfigureRuntime(const std::string& script_uri,
-                              const std::vector<uint8_t>& platform_kernel,
                               bool reuse_runtime_controller) {
   if (runtime_ && reuse_runtime_controller) {
     return;
@@ -491,7 +481,7 @@ void Engine::ConfigureRuntime(const std::string& script_uri,
   runtime_ = blink::RuntimeController::Create(this);
   runtime_->CreateDartController(
       std::move(script_uri), default_isolate_snapshot_data,
-      default_isolate_snapshot_instr, platform_kernel);
+      default_isolate_snapshot_instr);
   runtime_->SetViewportMetrics(viewport_metrics_);
   runtime_->SetLocale(language_code_, country_code_);
   runtime_->SetUserSettingsData(user_settings_data_);

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -183,8 +183,7 @@ void Engine::Init(const std::string& bundle_path) {
 
   blink::InitRuntime(vm_snapshot_data, vm_snapshot_instr,
                      default_isolate_snapshot_data,
-                     default_isolate_snapshot_instr,
-                     bundle_path);
+                     default_isolate_snapshot_instr, bundle_path);
 }
 
 const std::string Engine::main_entrypoint_ = "main";
@@ -479,9 +478,9 @@ void Engine::ConfigureRuntime(const std::string& script_uri,
     return;
   }
   runtime_ = blink::RuntimeController::Create(this);
-  runtime_->CreateDartController(
-      std::move(script_uri), default_isolate_snapshot_data,
-      default_isolate_snapshot_instr);
+  runtime_->CreateDartController(std::move(script_uri),
+                                 default_isolate_snapshot_data,
+                                 default_isolate_snapshot_instr);
   runtime_->SetViewportMetrics(viewport_metrics_);
   runtime_->SetLocale(language_code_, country_code_);
   runtime_->SetUserSettingsData(user_settings_data_);

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -92,9 +92,8 @@ class Engine : public blink::RuntimeDelegate {
   void StartAnimatorIfPossible();
 
   void ConfigureAssetBundle(const std::string& path);
-  void ConfigureRuntime(
-      const std::string& script_uri,
-      bool reuse_runtime_controller = false);
+  void ConfigureRuntime(const std::string& script_uri,
+                        bool reuse_runtime_controller = false);
 
   bool HandleLifecyclePlatformMessage(blink::PlatformMessage* message);
   bool HandleNavigationPlatformMessage(

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -33,7 +33,7 @@ class Engine : public blink::RuntimeDelegate {
 
   fxl::WeakPtr<Engine> GetWeakPtr();
 
-  static void Init();
+  static void Init(const std::string& bundle_path);
 
   void RunBundle(const std::string& bundle_path,
                  const std::string& entrypoint = main_entrypoint_,
@@ -94,7 +94,6 @@ class Engine : public blink::RuntimeDelegate {
   void ConfigureAssetBundle(const std::string& path);
   void ConfigureRuntime(
       const std::string& script_uri,
-      const std::vector<uint8_t>& platform_kernel = std::vector<uint8_t>(),
       bool reuse_runtime_controller = false);
 
   bool HandleLifecyclePlatformMessage(blink::PlatformMessage* message);

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -62,7 +62,7 @@ void ServiceIsolateHook(bool running_precompiled, bool running_from_kernel) {
     const blink::Settings& settings = blink::Settings::Get();
     if (settings.enable_diagnostic)
       DiagnosticServer::Start(settings.diagnostic_port, settings.ipv6,
-          running_from_kernel);
+                              running_from_kernel);
   }
 }
 
@@ -196,7 +196,8 @@ void Shell::InitStandalone(fxl::CommandLine command_line,
   Init(std::move(command_line), bundle_path);
 }
 
-void Shell::Init(fxl::CommandLine command_line, const std::string& bundle_path) {
+void Shell::Init(fxl::CommandLine command_line,
+                 const std::string& bundle_path) {
 #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
   bool trace_skia = command_line.HasOption(FlagForSwitch(Switch::TraceSkia));
   InitSkiaEventTracer(trace_skia);
@@ -204,7 +205,8 @@ void Shell::Init(fxl::CommandLine command_line, const std::string& bundle_path) 
 
   FXL_DCHECK(!g_shell);
   g_shell = new Shell(std::move(command_line));
-  blink::Threads::UI()->PostTask([bundle_path]() { Engine::Init(bundle_path); });
+  blink::Threads::UI()->PostTask(
+      [bundle_path]() { Engine::Init(bundle_path); });
 }
 
 Shell& Shell::Shared() {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -57,12 +57,11 @@ bool GetSwitchValue(const fxl::CommandLine& command_line,
   return false;
 }
 
-void ServiceIsolateHook(bool running_precompiled, bool running_from_kernel) {
+void ServiceIsolateHook(bool running_precompiled) {
   if (!running_precompiled) {
     const blink::Settings& settings = blink::Settings::Get();
     if (settings.enable_diagnostic)
-      DiagnosticServer::Start(settings.diagnostic_port, settings.ipv6,
-                              running_from_kernel);
+      DiagnosticServer::Start(settings.diagnostic_port, settings.ipv6);
   }
 }
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -57,11 +57,12 @@ bool GetSwitchValue(const fxl::CommandLine& command_line,
   return false;
 }
 
-void ServiceIsolateHook(bool running_precompiled) {
+void ServiceIsolateHook(bool running_precompiled, bool running_from_kernel) {
   if (!running_precompiled) {
     const blink::Settings& settings = blink::Settings::Get();
     if (settings.enable_diagnostic)
-      DiagnosticServer::Start(settings.diagnostic_port, settings.ipv6);
+      DiagnosticServer::Start(settings.diagnostic_port, settings.ipv6,
+          running_from_kernel);
   }
 }
 
@@ -96,7 +97,8 @@ Shell::~Shell() {}
 
 void Shell::InitStandalone(fxl::CommandLine command_line,
                            std::string icu_data_path,
-                           std::string application_library_path) {
+                           std::string application_library_path,
+                           std::string bundle_path) {
   TRACE_EVENT0("flutter", "Shell::InitStandalone");
 
   fml::icu::InitializeICU(icu_data_path);
@@ -191,10 +193,10 @@ void Shell::InitStandalone(fxl::CommandLine command_line,
 
   blink::Settings::Set(settings);
 
-  Init(std::move(command_line));
+  Init(std::move(command_line), bundle_path);
 }
 
-void Shell::Init(fxl::CommandLine command_line) {
+void Shell::Init(fxl::CommandLine command_line, const std::string& bundle_path) {
 #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
   bool trace_skia = command_line.HasOption(FlagForSwitch(Switch::TraceSkia));
   InitSkiaEventTracer(trace_skia);
@@ -202,7 +204,7 @@ void Shell::Init(fxl::CommandLine command_line) {
 
   FXL_DCHECK(!g_shell);
   g_shell = new Shell(std::move(command_line));
-  blink::Threads::UI()->PostTask(Engine::Init);
+  blink::Threads::UI()->PostTask([bundle_path]() { Engine::Init(bundle_path); });
 }
 
 Shell& Shell::Shared() {

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -72,7 +72,8 @@ class Shell {
                          std::string* isolate_name);
 
  private:
-  static void Init(fxl::CommandLine command_line, const std::string& bundle_path);
+  static void Init(fxl::CommandLine command_line,
+                   const std::string& bundle_path);
 
   Shell(fxl::CommandLine command_line);
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -28,7 +28,8 @@ class Shell {
 
   static void InitStandalone(fxl::CommandLine command_line,
                              std::string icu_data_path = "",
-                             std::string application_library_path = "");
+                             std::string application_library_path = "",
+                             std::string bundle_path = "");
 
   static Shell& Shared();
 
@@ -71,7 +72,7 @@ class Shell {
                          std::string* isolate_name);
 
  private:
-  static void Init(fxl::CommandLine command_line);
+  static void Init(fxl::CommandLine command_line, const std::string& bundle_path);
 
   Shell(fxl::CommandLine command_line);
 

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -19,7 +19,8 @@ namespace shell {
 static void Init(JNIEnv* env,
                  jclass clazz,
                  jobject context,
-                 jobjectArray jargs) {
+                 jobjectArray jargs,
+                 jstring bundlePath) {
   // Prepare command line arguments and initialize the shell.
   std::vector<std::string> args;
   args.push_back("flutter_tester");
@@ -30,7 +31,9 @@ static void Init(JNIEnv* env,
   auto command_line = fxl::CommandLineFromIterators(args.begin(), args.end());
   std::string icu_data_path =
       command_line.GetOptionValueWithDefault("icu-data-file-path", "");
-  Shell::InitStandalone(std::move(command_line), std::move(icu_data_path));
+  Shell::InitStandalone(std::move(command_line), std::move(icu_data_path),
+                        /* application_library_path= */ "",
+                        fml::jni::JavaStringToString(env, bundlePath));
 }
 
 static void RecordStartTimestamp(JNIEnv* env,
@@ -45,7 +48,7 @@ bool RegisterFlutterMain(JNIEnv* env) {
   static const JNINativeMethod methods[] = {
       {
           .name = "nativeInit",
-          .signature = "(Landroid/content/Context;[Ljava/lang/String;)V",
+          .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/lang/String;)V",
           .fnPtr = reinterpret_cast<void*>(&Init),
       },
       {

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -48,7 +48,8 @@ bool RegisterFlutterMain(JNIEnv* env) {
   static const JNINativeMethod methods[] = {
       {
           .name = "nativeInit",
-          .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/lang/String;)V",
+          .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/"
+                       "lang/String;)V",
           .fnPtr = reinterpret_cast<void*>(&Init),
       },
       {

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -188,7 +188,9 @@ public class FlutterMain {
                 shellArgs.add("--log-tag=" + sSettings.getLogTag());
             }
 
-            nativeInit(applicationContext, shellArgs.toArray(new String[0]));
+            String appBundlePath = findAppBundlePath(applicationContext);
+            nativeInit(applicationContext, shellArgs.toArray(new String[0]),
+                appBundlePath);
 
             sInitialized = true;
         } catch (Exception e) {
@@ -197,7 +199,7 @@ public class FlutterMain {
         }
     }
 
-    private static native void nativeInit(Context context, String[] args);
+    private static native void nativeInit(Context context, String[] args, String bundlePath);
     private static native void nativeRecordStartTimestamp(long initTimeMillis);
 
     /**


### PR DESCRIPTION
Currently service isolate is initialized from the source code parsed by VM.
This CL changes it so service isolate created during Dart initialization
is created from the kernel platform.dill file if it is present in the application
bundle. Then this platform kernel file is kept in dart_init module and reused
for application sciprt isolates.