### PR TITLE
Eliminate dependency on chromium build tools repo

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -98,11 +98,7 @@ vars = {
   'dart_web_socket_channel_tag': '1.0.6',
   'dart_yaml_tag': '2.1.12',
 
-  # Chromium build tooling used for Mac/iOS builds
-  'chromium_build_revision': 'b6fbb0db634b8e8380b718eba27f077d94a6d09c',
-
   # Build bot tooling for iOS
-  # TODO(cbracken) delete once migrated to chromium tooling above
   'ios_tools_revision': '69b7c1b160e7107a6a98d948363772dc9caea46f',
 
   'buildtools_revision': '5b8eb38aaf523f0124756454276cd0a5b720c17e',
@@ -154,9 +150,6 @@ deps = {
 
   'src/ios_tools':
    Var('chromium_git') + '/chromium/src/ios.git' + '@' + Var('ios_tools_revision'),
-
-  'third_party/chromium_build':
-   Var('chromium_git') + '/chromium/src/build.git' + '@' + Var('chromium_build_revision'),
 
   'src/third_party/icu':
    Var('chromium_git') + '/chromium/deps/icu.git' + '@' + '08cb956852a5ccdba7f9c941728bb833529ba3c6',

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1200,12 +1200,6 @@ class RepositoryGenericThirdPartyDirectory extends RepositoryDirectory {
 
   @override
   bool get subdirectoriesAreLicenseRoots => true;
-
-  @override
-  bool shouldRecurse(fs.IoNode entry) {
-    return entry.name != 'chromium_build' // only used by build
-        && super.shouldRecurse(entry);
-  }
 }
 
 class RepositoryReachOutFile extends RepositoryLicensedFile {


### PR DESCRIPTION
The hermetic Xcode tooling in that repo is not yet easily usable for
Xcode 9. There are two main issues:

1. The tooling currently assumes that macOS host builds should use
   Xcode 8, whereas iOS builds should use Xcode 9. Flutter builds should
   use Xcode 9 in all cases.
2. The tooling currently includes a bail-out condition for iOS builds
   that exits non-zero immediately (Chrome hasn't yet migrated its iOS
   build to this tooling).

In the meantime, I've manually updated the bot infra with Xcode 9 and
we'll continue to use the current find_xcode.py tooling until Chrome's
new Mac/iOS tooling is ready.