### PR TITLE
Add a test_fixtures GN rule that allows unittests to reference fixtures.

### DIFF
--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -7,13 +7,13 @@ source_set("testing") {
 
   sources = [
     "$flutter_root/testing/run_all_unittests.cc",
+    "$flutter_root/testing/testing.cc",
+    "$flutter_root/testing/testing.h",
   ]
 
   public_deps = [
     "//third_party/gtest",
   ]
 
-  public_configs = [
-    "$flutter_root:config",
-  ]
+  public_configs = [ "$flutter_root:config" ]
 }

--- a/testing/build/gen_fixtures_location_symbol.py
+++ b/testing/build/gen_fixtures_location_symbol.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# Copyright 2017 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import subprocess
+import sys
+import os
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description='Create the symbol specifying the location of test fixtures.')
+
+  parser.add_argument('--fixtures_location_file', type=str, required=True)
+  parser.add_argument('--fixtures_location', type=str, required=True)
+
+  args = parser.parse_args()
+
+  with open(args.fixtures_location_file, 'w') as file:
+    file.write("namespace testing {const char* GetFixturesPath() {return \"%s\";}}"
+      % args.fixtures_location)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/testing/build/gen_fixtures_location_symbol.py
+++ b/testing/build/gen_fixtures_location_symbol.py
@@ -19,7 +19,7 @@ def main():
   args = parser.parse_args()
 
   with open(args.fixtures_location_file, 'w') as file:
-    file.write("namespace testing {const char* GetFixturesPath() {return \"%s\";}}"
+    file.write('namespace testing {const char* GetFixturesPath() {return "%s";}}'
       % args.fixtures_location)
 
 

--- a/testing/testing.cc
+++ b/testing/testing.cc
@@ -1,0 +1,11 @@
+// Copyright 2017 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "testing.h"
+
+namespace testing {
+
+//
+
+}  // namespace testing

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -1,0 +1,55 @@
+# Copyright 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+template("test_fixtures") {
+  testonly = true
+
+  assert(defined(invoker.fixtures), "Test fixtures must be specified.")
+
+  fixtures_name_target_name = target_name + "_gen_fixtures_name"
+  fixtures_source_set_target_name = target_name + "_gen_fixtures_source_set"
+  fixtures_copy_target_name = target_name + "_copy_fixtures"
+
+  fixtures_location = "$target_gen_dir/fixtures"
+  fixtures_location_file = "$target_gen_dir/test_fixtures_location.cc"
+
+  action(fixtures_name_target_name) {
+    script = "$flutter_root/testing/build/gen_fixtures_location_symbol.py"
+
+    outputs = [
+      fixtures_location_file,
+    ]
+
+    args = [
+      "--fixtures_location_file",
+      rebase_path(fixtures_location_file),
+      "--fixtures_location",
+      rebase_path(fixtures_location),
+    ]
+  }
+
+  source_set(fixtures_source_set_target_name) {
+    sources = [
+      fixtures_location_file,
+    ]
+
+    deps = [
+      ":$fixtures_name_target_name",
+    ]
+  }
+
+  copy(fixtures_copy_target_name) {
+    sources = invoker.fixtures
+    outputs = [
+      "$fixtures_location/{{source_file_part}}",
+    ]
+  }
+
+  group(target_name) {
+    deps = [
+      ":$fixtures_copy_target_name",
+      ":$fixtures_source_set_target_name",
+    ]
+  }
+}

--- a/testing/testing.h
+++ b/testing/testing.h
@@ -1,0 +1,19 @@
+// Copyright 2017 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TESTING_TESTING_H_
+#define TESTING_TESTING_H_
+
+#include "gtest/gtest.h"
+
+namespace testing {
+
+// Returns the directory containing the test fixture for the target if this
+// target has fixtures configured. If there are no fixtures, this is a link
+// error.
+const char* GetFixturesPath();
+
+}  // namespace testing
+
+#endif  // TESTING_TESTING_H_


### PR DESCRIPTION
Adding the following target as a GN dependency to your unit test target will copy the specified fixtures to a known location, generate a file that contains a symbol specifying where that location is, and, add that symbol as a source set dependency. This way, you can specify `testing::GetFixturesPath` in your unit-test and work with the file from there. If you don't specify the fixtures target as dependency, asking for fixtures will result in a linker error.

```
test_fixtures("fixtures") {
  fixtures = [ "fixtures/simple.txt" ]
}
```

In the future, we can rework how fixtures are packaged and referenced so that we can do things like run them on devices and such. So far, all our unit-test target are run on the host.