### PR TITLE
Avoid registering both the platform view and the rasterizer in the shell.

### DIFF
--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -74,7 +74,6 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
   explicit PlatformView(std::unique_ptr<Rasterizer> rasterizer);
 
   void CreateEngine();
-  void PostAddToShellTask();
 
   void SetupResourceContextOnIOThreadPerform(
       fxl::AutoResetWaitableEvent* event);

--- a/shell/gpu/gpu_rasterizer.cc
+++ b/shell/gpu/gpu_rasterizer.cc
@@ -17,16 +17,9 @@
 namespace shell {
 
 GPURasterizer::GPURasterizer(std::unique_ptr<flow::ProcessInfo> info)
-    : compositor_context_(std::move(info)), weak_factory_(this) {
-  auto weak_ptr = weak_factory_.GetWeakPtr();
-  blink::Threads::Gpu()->PostTask(
-      [weak_ptr]() { Shell::Shared().AddRasterizer(weak_ptr); });
-}
+    : compositor_context_(std::move(info)), weak_factory_(this) {}
 
-GPURasterizer::~GPURasterizer() {
-  weak_factory_.InvalidateWeakPtrs();
-  Shell::Shared().PurgeRasterizers();
-}
+GPURasterizer::~GPURasterizer() = default;
 
 fxl::WeakPtr<Rasterizer> GPURasterizer::GetWeakRasterizerPtr() {
   return weak_factory_.GetWeakPtr();

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -139,8 +139,6 @@ void PlatformViewAndroid::Attach() {
   SetupResourceContextOnIOThread();
 
   UpdateThreadPriorities();
-
-  PostAddToShellTask();
 }
 
 void PlatformViewAndroid::Detach() {

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -29,7 +29,6 @@ PlatformViewMac::~PlatformViewMac() = default;
 
 void PlatformViewMac::Attach() {
   CreateEngine();
-  PostAddToShellTask();
 }
 
 void PlatformViewMac::SetupAndLoadDart() {

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -37,7 +37,6 @@ bool PlatformViewEmbedder::SurfaceSupportsSRGB() const {
 
 void PlatformViewEmbedder::Attach() {
   CreateEngine();
-  PostAddToShellTask();
   NotifyCreated(std::make_unique<shell::GPUSurfaceGL>(this));
 }
 

--- a/shell/testing/platform_view_test.cc
+++ b/shell/testing/platform_view_test.cc
@@ -14,7 +14,6 @@ PlatformViewTest::PlatformViewTest()
 
 void PlatformViewTest::Attach() {
   CreateEngine();
-  PostAddToShellTask();
 }
 
 PlatformViewTest::~PlatformViewTest() = default;


### PR DESCRIPTION
Instead, the rasterizer can be accessed via the platform view.