### PR TITLE
Add fml::WeakPtr and update users in Shell.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -8,6 +8,9 @@ source_set("fml") {
     "icu_util.h",
     "mapping.cc",
     "mapping.h",
+    "memory/weak_ptr.h",
+    "memory/weak_ptr_internal.cc",
+    "memory/weak_ptr_internal.h",
     "message_loop.cc",
     "message_loop.h",
     "message_loop_impl.cc",
@@ -24,8 +27,8 @@ source_set("fml") {
   ]
 
   deps = [
-    "//third_party/dart/runtime:dart_api",
     "//garnet/public/lib/fxl",
+    "//third_party/dart/runtime:dart_api",
 
     # These need to be in sync with the Fuchsia buildroot.
     "//third_party/icu",
@@ -33,9 +36,7 @@ source_set("fml") {
 
   configs += [ "//third_party/icu:icu_config" ]
 
-  public_configs = [
-    "$flutter_root:config",
-  ]
+  public_configs = [ "$flutter_root:config" ]
 
   libs = []
 
@@ -108,15 +109,16 @@ executable("fml_unittests") {
   testonly = true
 
   sources = [
+    "memory/weak_ptr_unittest.cc",
     "message_loop_unittests.cc",
     "thread_local_unittests.cc",
     "thread_unittests.cc",
   ]
 
   deps = [
-    "//third_party/dart/runtime:libdart_jit",
     "$flutter_root/fml",
     "$flutter_root/testing",
     "//garnet/public/lib/fxl",
+    "//third_party/dart/runtime:libdart_jit",
   ]
 }

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -1,0 +1,178 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file provides weak pointers and weak pointer factories that work like
+// Chromium's |base::WeakPtr<T>| and |base::WeakPtrFactory<T>|.
+
+#ifndef FLUTTER_FML_MEMORY_WEAK_PTR_H_
+#define FLUTTER_FML_MEMORY_WEAK_PTR_H_
+
+#include <utility>
+
+#include "flutter/fml/memory/weak_ptr_internal.h"
+#include "lib/fxl/logging.h"
+#include "lib/fxl/memory/ref_counted.h"
+
+namespace fml {
+
+// Forward declaration, so |WeakPtr<T>| can friend it.
+template <typename T>
+class WeakPtrFactory;
+
+// Class for "weak pointers" that can be invalidated. Valid weak pointers can
+// only originate from a |WeakPtrFactory| (see below), though weak pointers are
+// copyable and movable.
+//
+// Weak pointers are not in general thread-safe. They may only be *used* on a
+// single thread, namely the same thread as the "originating" |WeakPtrFactory|
+// (which can invalidate the weak pointers that it generates).
+//
+// However, weak pointers may be passed to other threads, reset on other
+// threads, or destroyed on other threads. They may also be reassigned on other
+// threads (in which case they should then only be used on the thread
+// corresponding to the new "originating" |WeakPtrFactory|).
+template <typename T>
+class WeakPtr {
+ public:
+  WeakPtr() : ptr_(nullptr) {}
+
+  // Copy constructor.
+  WeakPtr(const WeakPtr<T>& r) = default;
+
+  template <typename U>
+  WeakPtr(const WeakPtr<U>& r) : ptr_(r.ptr_), flag_(r.flag_) {}
+
+  // Move constructor.
+  WeakPtr(WeakPtr<T>&& r) = default;
+
+  template <typename U>
+  WeakPtr(WeakPtr<U>&& r) : ptr_(r.ptr_), flag_(std::move(r.flag_)) {}
+
+  ~WeakPtr() = default;
+
+  // The following methods are thread-friendly, in the sense that they may be
+  // called subject to additional synchronization.
+
+  // Copy assignment.
+  WeakPtr<T>& operator=(const WeakPtr<T>& r) = default;
+
+  // Move assignment.
+  WeakPtr<T>& operator=(WeakPtr<T>&& r) = default;
+
+  void reset() { flag_ = nullptr; }
+
+  // The following methods should only be called on the same thread as the
+  // "originating" |WeakPtrFactory|.
+
+  explicit operator bool() const { return flag_ && flag_->is_valid(); }
+
+  T* get() const { return *this ? ptr_ : nullptr; }
+
+  T& operator*() const {
+    FXL_DCHECK(*this);
+    return *get();
+  }
+
+  T* operator->() const {
+    FXL_DCHECK(*this);
+    return get();
+  }
+
+ private:
+  template <typename U>
+  friend class WeakPtr;
+
+  friend class WeakPtrFactory<T>;
+
+  explicit WeakPtr(T* ptr, fxl::RefPtr<fml::internal::WeakPtrFlag>&& flag)
+      : ptr_(ptr), flag_(std::move(flag)) {}
+
+  T* ptr_;
+  fxl::RefPtr<fml::internal::WeakPtrFlag> flag_;
+
+  // Copy/move construction/assignment supported.
+};
+
+// Class that produces (valid) |WeakPtr<T>|s. Typically, this is used as a
+// member variable of |T| (preferably the last one -- see below), and |T|'s
+// methods control how weak pointers to it are vended. This class is not
+// thread-safe, and should only be created, destroyed and used on a single
+// thread.
+//
+// Example:
+//
+//  class Controller {
+//   public:
+//    Controller() : ..., weak_factory_(this) {}
+//    ...
+//
+//    void SpawnWorker() { Worker::StartNew(weak_factory_.GetWeakPtr()); }
+//    void WorkComplete(const Result& result) { ... }
+//
+//   private:
+//    ...
+//
+//    // Member variables should appear before the |WeakPtrFactory|, to ensure
+//    // that any |WeakPtr|s to |Controller| are invalidated before its member
+//    // variables' destructors are executed.
+//    WeakPtrFactory<Controller> weak_factory_;
+//  };
+//
+//  class Worker {
+//   public:
+//    static void StartNew(const WeakPtr<Controller>& controller) {
+//      Worker* worker = new Worker(controller);
+//      // Kick off asynchronous processing....
+//    }
+//
+//   private:
+//    Worker(const WeakPtr<Controller>& controller) : controller_(controller) {}
+//
+//    void DidCompleteAsynchronousProcessing(const Result& result) {
+//      if (controller_)
+//        controller_->WorkComplete(result);
+//    }
+//
+//    WeakPtr<Controller> controller_;
+//  };
+template <typename T>
+class WeakPtrFactory {
+ public:
+  explicit WeakPtrFactory(T* ptr) : ptr_(ptr) { FXL_DCHECK(ptr_); }
+  ~WeakPtrFactory() { InvalidateWeakPtrs(); }
+
+  // Gets a new weak pointer, which will be valid until either
+  // |InvalidateWeakPtrs()| is called or this object is destroyed.
+  WeakPtr<T> GetWeakPtr() {
+    if (!flag_)
+      flag_ = fxl::MakeRefCounted<fml::internal::WeakPtrFlag>();
+    return WeakPtr<T>(ptr_, flag_.Clone());
+  }
+
+  // Call this method to invalidate all existing weak pointers. (Note that
+  // additional weak pointers can be produced even after this is called.)
+  void InvalidateWeakPtrs() {
+    if (!flag_)
+      return;
+    flag_->Invalidate();
+    flag_ = nullptr;
+  }
+
+  // Call this method to determine if any weak pointers exist. (Note that a
+  // "false" result is definitive, but a "true" result may not be if weak
+  // pointers are held/reset/destroyed/reassigned on other threads.)
+  bool HasWeakPtrs() const { return flag_ && !flag_->HasOneRef(); }
+
+ private:
+  // Note: See weak_ptr_internal.h for an explanation of why we store the
+  // pointer here, instead of in the "flag".
+  T* const ptr_;
+  fxl::RefPtr<fml::internal::WeakPtrFlag> flag_;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(WeakPtrFactory);
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_MEMORY_WEAK_PTR_H_

--- a/fml/memory/weak_ptr_internal.cc
+++ b/fml/memory/weak_ptr_internal.cc
@@ -1,0 +1,26 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/memory/weak_ptr_internal.h"
+
+#include "lib/fxl/logging.h"
+
+namespace fml {
+namespace internal {
+
+WeakPtrFlag::WeakPtrFlag() : is_valid_(true) {}
+
+WeakPtrFlag::~WeakPtrFlag() {
+  // Should be invalidated before destruction.
+  FXL_DCHECK(!is_valid_);
+}
+
+void WeakPtrFlag::Invalidate() {
+  // Invalidation should happen exactly once.
+  FXL_DCHECK(is_valid_);
+  is_valid_ = false;
+}
+
+}  // namespace internal
+}  // namespace fml

--- a/fml/memory/weak_ptr_internal.h
+++ b/fml/memory/weak_ptr_internal.h
@@ -1,0 +1,41 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_MEMORY_WEAK_PTR_INTERNAL_H_
+#define FLUTTER_FML_MEMORY_WEAK_PTR_INTERNAL_H_
+
+#include "lib/fxl/macros.h"
+#include "lib/fxl/memory/ref_counted.h"
+
+namespace fml {
+namespace internal {
+
+// |WeakPtr<T>|s have a reference to a |WeakPtrFlag| to determine whether they
+// are valid (non-null) or not. We do not store a |T*| in this object since
+// there may also be |WeakPtr<U>|s to the same object, where |U| is a superclass
+// of |T|.
+//
+// This class in not thread-safe, though references may be released on any
+// thread (allowing weak pointers to be destroyed/reset/reassigned on any
+// thread).
+class FXL_EXPORT WeakPtrFlag : public fxl::RefCountedThreadSafe<WeakPtrFlag> {
+ public:
+  WeakPtrFlag();
+
+  ~WeakPtrFlag();
+
+  bool is_valid() const { return is_valid_; }
+
+  void Invalidate();
+
+ private:
+  bool is_valid_;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(WeakPtrFlag);
+};
+
+}  // namespace internal
+}  // namespace fml
+
+#endif  // FLUTTER_FML_MEMORY_WEAK_PTR_INTERNAL_H_

--- a/fml/memory/weak_ptr_unittest.cc
+++ b/fml/memory/weak_ptr_unittest.cc
@@ -1,0 +1,197 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/memory/weak_ptr.h"
+
+#include <utility>
+
+#include "gtest/gtest.h"
+
+namespace fml {
+namespace {
+
+TEST(WeakPtrTest, Basic) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  WeakPtr<int> ptr = factory.GetWeakPtr();
+  EXPECT_EQ(&data, ptr.get());
+}
+
+TEST(WeakPtrTest, CopyConstruction) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  WeakPtr<int> ptr = factory.GetWeakPtr();
+  WeakPtr<int> ptr2(ptr);
+  EXPECT_EQ(&data, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, MoveConstruction) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  WeakPtr<int> ptr = factory.GetWeakPtr();
+  WeakPtr<int> ptr2(std::move(ptr));
+  EXPECT_EQ(nullptr, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, CopyAssignment) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  WeakPtr<int> ptr = factory.GetWeakPtr();
+  WeakPtr<int> ptr2;
+  EXPECT_EQ(nullptr, ptr2.get());
+  ptr2 = ptr;
+  EXPECT_EQ(&data, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, MoveAssignment) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  WeakPtr<int> ptr = factory.GetWeakPtr();
+  WeakPtr<int> ptr2;
+  EXPECT_EQ(nullptr, ptr2.get());
+  ptr2 = std::move(ptr);
+  EXPECT_EQ(nullptr, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, Testable) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  WeakPtr<int> ptr;
+  EXPECT_EQ(nullptr, ptr.get());
+  EXPECT_FALSE(ptr);
+  ptr = factory.GetWeakPtr();
+  EXPECT_EQ(&data, ptr.get());
+  EXPECT_TRUE(ptr);
+}
+
+TEST(WeakPtrTest, OutOfScope) {
+  WeakPtr<int> ptr;
+  EXPECT_EQ(nullptr, ptr.get());
+  {
+    int data = 0;
+    WeakPtrFactory<int> factory(&data);
+    ptr = factory.GetWeakPtr();
+  }
+  EXPECT_EQ(nullptr, ptr.get());
+}
+
+TEST(WeakPtrTest, Multiple) {
+  WeakPtr<int> a;
+  WeakPtr<int> b;
+  {
+    int data = 0;
+    WeakPtrFactory<int> factory(&data);
+    a = factory.GetWeakPtr();
+    b = factory.GetWeakPtr();
+    EXPECT_EQ(&data, a.get());
+    EXPECT_EQ(&data, b.get());
+  }
+  EXPECT_EQ(nullptr, a.get());
+  EXPECT_EQ(nullptr, b.get());
+}
+
+TEST(WeakPtrTest, MultipleStaged) {
+  WeakPtr<int> a;
+  {
+    int data = 0;
+    WeakPtrFactory<int> factory(&data);
+    a = factory.GetWeakPtr();
+    { WeakPtr<int> b = factory.GetWeakPtr(); }
+    EXPECT_NE(a.get(), nullptr);
+  }
+  EXPECT_EQ(nullptr, a.get());
+}
+
+struct Base {
+  double member = 0.;
+};
+struct Derived : public Base {};
+
+TEST(WeakPtrTest, Dereference) {
+  Base data;
+  data.member = 123456.;
+  WeakPtrFactory<Base> factory(&data);
+  WeakPtr<Base> ptr = factory.GetWeakPtr();
+  EXPECT_EQ(&data, ptr.get());
+  EXPECT_EQ(data.member, (*ptr).member);
+  EXPECT_EQ(data.member, ptr->member);
+}
+
+TEST(WeakPtrTest, UpcastCopyConstruction) {
+  Derived data;
+  WeakPtrFactory<Derived> factory(&data);
+  WeakPtr<Derived> ptr = factory.GetWeakPtr();
+  WeakPtr<Base> ptr2(ptr);
+  EXPECT_EQ(&data, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, UpcastMoveConstruction) {
+  Derived data;
+  WeakPtrFactory<Derived> factory(&data);
+  WeakPtr<Derived> ptr = factory.GetWeakPtr();
+  WeakPtr<Base> ptr2(std::move(ptr));
+  EXPECT_EQ(nullptr, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, UpcastCopyAssignment) {
+  Derived data;
+  WeakPtrFactory<Derived> factory(&data);
+  WeakPtr<Derived> ptr = factory.GetWeakPtr();
+  WeakPtr<Base> ptr2;
+  EXPECT_EQ(nullptr, ptr2.get());
+  ptr2 = ptr;
+  EXPECT_EQ(&data, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, UpcastMoveAssignment) {
+  Derived data;
+  WeakPtrFactory<Derived> factory(&data);
+  WeakPtr<Derived> ptr = factory.GetWeakPtr();
+  WeakPtr<Base> ptr2;
+  EXPECT_EQ(nullptr, ptr2.get());
+  ptr2 = std::move(ptr);
+  EXPECT_EQ(nullptr, ptr.get());
+  EXPECT_EQ(&data, ptr2.get());
+}
+
+TEST(WeakPtrTest, InvalidateWeakPtrs) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  WeakPtr<int> ptr = factory.GetWeakPtr();
+  EXPECT_EQ(&data, ptr.get());
+  EXPECT_TRUE(factory.HasWeakPtrs());
+  factory.InvalidateWeakPtrs();
+  EXPECT_EQ(nullptr, ptr.get());
+  EXPECT_FALSE(factory.HasWeakPtrs());
+
+  // Test that the factory can create new weak pointers after a
+  // |InvalidateWeakPtrs()| call, and that they remain valid until the next
+  // |InvalidateWeakPtrs()| call.
+  WeakPtr<int> ptr2 = factory.GetWeakPtr();
+  EXPECT_EQ(&data, ptr2.get());
+  EXPECT_TRUE(factory.HasWeakPtrs());
+  factory.InvalidateWeakPtrs();
+  EXPECT_EQ(nullptr, ptr2.get());
+  EXPECT_FALSE(factory.HasWeakPtrs());
+}
+
+TEST(WeakPtrTest, HasWeakPtrs) {
+  int data = 0;
+  WeakPtrFactory<int> factory(&data);
+  {
+    WeakPtr<int> ptr = factory.GetWeakPtr();
+    EXPECT_TRUE(factory.HasWeakPtrs());
+  }
+  EXPECT_FALSE(factory.HasWeakPtrs());
+}
+
+}  // namespace
+}  // namespace fml

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -11,7 +11,7 @@
 
 namespace shell {
 
-Animator::Animator(fxl::WeakPtr<Rasterizer> rasterizer,
+Animator::Animator(fml::WeakPtr<Rasterizer> rasterizer,
                    VsyncWaiter* waiter,
                    Engine* engine)
     : rasterizer_(rasterizer),

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -18,13 +18,13 @@ namespace shell {
 
 class Animator {
  public:
-  Animator(fxl::WeakPtr<Rasterizer> rasterizer,
+  Animator(fml::WeakPtr<Rasterizer> rasterizer,
            VsyncWaiter* waiter,
            Engine* engine);
 
   ~Animator();
 
-  void set_rasterizer(fxl::WeakPtr<Rasterizer> rasterizer) {
+  void set_rasterizer(fml::WeakPtr<Rasterizer> rasterizer) {
     rasterizer_ = rasterizer;
   }
 
@@ -46,7 +46,7 @@ class Animator {
 
   const char* FrameParity();
 
-  fxl::WeakPtr<Rasterizer> rasterizer_;
+  fml::WeakPtr<Rasterizer> rasterizer_;
   VsyncWaiter* waiter_;
   Engine* engine_;
 
@@ -59,7 +59,7 @@ class Animator {
   bool paused_;
   bool frame_scheduled_;
 
-  fxl::WeakPtrFactory<Animator> weak_factory_;
+  fml::WeakPtrFactory<Animator> weak_factory_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(Animator);
 };

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -82,11 +82,11 @@ Engine::Engine(PlatformView* platform_view)
 
 Engine::~Engine() {}
 
-void Engine::set_rasterizer(fxl::WeakPtr<Rasterizer> rasterizer) {
+void Engine::set_rasterizer(fml::WeakPtr<Rasterizer> rasterizer) {
   animator_->set_rasterizer(rasterizer);
 }
 
-fxl::WeakPtr<Engine> Engine::GetWeakPtr() {
+fml::WeakPtr<Engine> Engine::GetWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -31,7 +31,7 @@ class Engine : public blink::RuntimeDelegate {
 
   ~Engine() override;
 
-  fxl::WeakPtr<Engine> GetWeakPtr();
+  fml::WeakPtr<Engine> GetWeakPtr();
 
   static void Init(const std::string& bundle_path);
 
@@ -75,7 +75,7 @@ class Engine : public blink::RuntimeDelegate {
   void DispatchSemanticsAction(int id, blink::SemanticsAction action);
   void SetSemanticsEnabled(bool enabled);
 
-  void set_rasterizer(fxl::WeakPtr<Rasterizer> rasterizer);
+  void set_rasterizer(fml::WeakPtr<Rasterizer> rasterizer);
 
  private:
   // RuntimeDelegate methods:
@@ -122,7 +122,7 @@ class Engine : public blink::RuntimeDelegate {
   // TODO(eseidel): This should move into an AnimatorStateMachine.
   bool activity_running_;
   bool have_surface_;
-  fxl::WeakPtrFactory<Engine> weak_factory_;
+  fml::WeakPtrFactory<Engine> weak_factory_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(Engine);
 };

--- a/shell/common/null_rasterizer.cc
+++ b/shell/common/null_rasterizer.cc
@@ -25,7 +25,7 @@ void NullRasterizer::Teardown(
   teardown_completion_event->Signal();
 }
 
-fxl::WeakPtr<Rasterizer> NullRasterizer::GetWeakRasterizerPtr() {
+fml::WeakPtr<Rasterizer> NullRasterizer::GetWeakRasterizerPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/shell/common/null_rasterizer.h
+++ b/shell/common/null_rasterizer.h
@@ -24,7 +24,7 @@ class NullRasterizer : public Rasterizer {
 
   void Clear(SkColor color, const SkISize& size) override;
 
-  fxl::WeakPtr<Rasterizer> GetWeakRasterizerPtr() override;
+  fml::WeakPtr<Rasterizer> GetWeakRasterizerPtr() override;
 
   flow::LayerTree* GetLastLayerTree() override;
 
@@ -34,7 +34,7 @@ class NullRasterizer : public Rasterizer {
 
  private:
   std::unique_ptr<Surface> surface_;
-  fxl::WeakPtrFactory<NullRasterizer> weak_factory_;
+  fml::WeakPtrFactory<NullRasterizer> weak_factory_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(NullRasterizer);
 };

--- a/shell/common/platform_view_service_protocol.cc
+++ b/shell/common/platform_view_service_protocol.cc
@@ -250,8 +250,8 @@ static sk_sp<SkData> EncodeBitmapAsPNG(const SkBitmap& bitmap) {
   return data;
 }
 
-static fxl::WeakPtr<Rasterizer> GetRandomRasterizer() {
-  fxl::WeakPtr<Rasterizer> rasterizer;
+static fml::WeakPtr<Rasterizer> GetRandomRasterizer() {
+  fml::WeakPtr<Rasterizer> rasterizer;
   Shell::Shared().IteratePlatformViews(
       [&rasterizer](PlatformView* view) -> bool {
         rasterizer = view->rasterizer().GetWeakRasterizerPtr();

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -8,10 +8,10 @@
 #include <memory>
 
 #include "flutter/flow/layers/layer_tree.h"
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/surface.h"
 #include "flutter/synchronization/pipeline.h"
 #include "lib/fxl/functional/closure.h"
-#include "lib/fxl/memory/weak_ptr.h"
 #include "lib/fxl/synchronization/waitable_event.h"
 
 namespace shell {
@@ -29,7 +29,7 @@ class Rasterizer {
 
   virtual void Clear(SkColor color, const SkISize& size) = 0;
 
-  virtual fxl::WeakPtr<Rasterizer> GetWeakRasterizerPtr() = 0;
+  virtual fml::WeakPtr<Rasterizer> GetWeakRasterizerPtr() = 0;
 
   virtual flow::LayerTree* GetLastLayerTree() = 0;
 

--- a/shell/common/vsync_waiter_fallback.h
+++ b/shell/common/vsync_waiter_fallback.h
@@ -5,9 +5,9 @@
 #ifndef FLUTTER_SHELL_COMMON_VSYNC_WAITER_FALLBACK_H_
 #define FLUTTER_SHELL_COMMON_VSYNC_WAITER_FALLBACK_H_
 
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/vsync_waiter.h"
 #include "lib/fxl/macros.h"
-#include "lib/fxl/memory/weak_ptr.h"
 #include "lib/fxl/time/time_point.h"
 
 namespace shell {
@@ -23,7 +23,7 @@ class VsyncWaiterFallback : public VsyncWaiter {
   fxl::TimePoint phase_;
   Callback callback_;
 
-  fxl::WeakPtrFactory<VsyncWaiterFallback> weak_factory_;
+  fml::WeakPtrFactory<VsyncWaiterFallback> weak_factory_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterFallback);
 };

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -27,14 +27,13 @@ source_set("gpu") {
     "$flutter_root/glue",
     "$flutter_root/shell/common",
     "$flutter_root/synchronization",
+    "//flutter/fml",
     "//garnet/public/lib/fxl",
     "//third_party/skia",
     "//third_party/skia:gpu",
   ]
 
-  public_configs = [
-    "$flutter_root:config",
-  ]
+  public_configs = [ "$flutter_root:config" ]
 
   if (shell_enable_vulkan) {
     deps += [ "$flutter_root/vulkan" ]

--- a/shell/gpu/gpu_rasterizer.cc
+++ b/shell/gpu/gpu_rasterizer.cc
@@ -21,7 +21,7 @@ GPURasterizer::GPURasterizer(std::unique_ptr<flow::ProcessInfo> info)
 
 GPURasterizer::~GPURasterizer() = default;
 
-fxl::WeakPtr<Rasterizer> GPURasterizer::GetWeakRasterizerPtr() {
+fml::WeakPtr<Rasterizer> GPURasterizer::GetWeakRasterizerPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/shell/gpu/gpu_rasterizer.h
+++ b/shell/gpu/gpu_rasterizer.h
@@ -29,7 +29,7 @@ class GPURasterizer : public Rasterizer {
   void Teardown(
       fxl::AutoResetWaitableEvent* teardown_completion_event) override;
 
-  fxl::WeakPtr<Rasterizer> GetWeakRasterizerPtr() override;
+  fml::WeakPtr<Rasterizer> GetWeakRasterizerPtr() override;
 
   flow::LayerTree* GetLastLayerTree() override;
 
@@ -46,7 +46,7 @@ class GPURasterizer : public Rasterizer {
   // next time. NULL if there is no callback or the callback was set back to
   // NULL after being called.
   fxl::Closure nextFrameCallback_;
-  fxl::WeakPtrFactory<GPURasterizer> weak_factory_;
+  fml::WeakPtrFactory<GPURasterizer> weak_factory_;
 
   void DoDraw(std::unique_ptr<flow::LayerTree> layer_tree);
 

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -5,10 +5,10 @@
 #ifndef SHELL_GPU_GPU_SURFACE_GL_H_
 #define SHELL_GPU_GPU_SURFACE_GL_H_
 
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/surface.h"
 #include "flutter/synchronization/debug_thread_checker.h"
 #include "lib/fxl/macros.h"
-#include "lib/fxl/memory/weak_ptr.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 
 namespace shell {
@@ -44,7 +44,7 @@ class GPUSurfaceGL : public Surface {
   sk_sp<SkSurface> onscreen_surface_;
   sk_sp<SkSurface> offscreen_surface_;
   bool valid_ = false;
-  fxl::WeakPtrFactory<GPUSurfaceGL> weak_factory_;
+  fml::WeakPtrFactory<GPUSurfaceGL> weak_factory_;
 
   bool CreateOrUpdateSurfaces(const SkISize& size);
 

--- a/shell/gpu/gpu_surface_software.h
+++ b/shell/gpu/gpu_surface_software.h
@@ -5,9 +5,9 @@
 #ifndef FLUTTER_SHELL_GPU_GPU_SURFACE_SOFTWARE_H_
 #define FLUTTER_SHELL_GPU_GPU_SURFACE_SOFTWARE_H_
 
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/surface.h"
 #include "lib/fxl/macros.h"
-#include "lib/fxl/memory/weak_ptr.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace shell {
@@ -35,7 +35,7 @@ class GPUSurfaceSoftware : public Surface {
  private:
   GPUSurfaceSoftwareDelegate* delegate_;
 
-  fxl::WeakPtrFactory<GPUSurfaceSoftware> weak_factory_;
+  fml::WeakPtrFactory<GPUSurfaceSoftware> weak_factory_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(GPUSurfaceSoftware);
 };

--- a/shell/gpu/gpu_surface_vulkan.h
+++ b/shell/gpu/gpu_surface_vulkan.h
@@ -6,11 +6,11 @@
 #define SHELL_GPU_GPU_SURFACE_VULKAN_H_
 
 #include <memory>
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/surface.h"
 #include "flutter/vulkan/vulkan_native_surface.h"
 #include "flutter/vulkan/vulkan_window.h"
 #include "lib/fxl/macros.h"
-#include "lib/fxl/memory/weak_ptr.h"
 
 namespace shell {
 
@@ -29,7 +29,7 @@ class GPUSurfaceVulkan : public Surface {
 
  private:
   vulkan::VulkanWindow window_;
-  fxl::WeakPtrFactory<GPUSurfaceVulkan> weak_factory_;
+  fml::WeakPtrFactory<GPUSurfaceVulkan> weak_factory_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(GPUSurfaceVulkan);
 };

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -26,8 +26,8 @@ VsyncWaiterAndroid::~VsyncWaiterAndroid() = default;
 void VsyncWaiterAndroid::AsyncWaitForVsync(Callback callback) {
   FXL_DCHECK(!callback_);
   callback_ = std::move(callback);
-  fxl::WeakPtr<VsyncWaiterAndroid>* weak =
-      new fxl::WeakPtr<VsyncWaiterAndroid>();
+  fml::WeakPtr<VsyncWaiterAndroid>* weak =
+      new fml::WeakPtr<VsyncWaiterAndroid>();
   *weak = weak_factory_.GetWeakPtr();
 
   blink::Threads::Platform()->PostTask([weak] {
@@ -70,8 +70,8 @@ static void OnNativeVsync(JNIEnv* env,
     TRACE_EVENT2("flutter", "VSYNC", "mode", "basic", "deadline", deadline);
   }
 #endif
-  fxl::WeakPtr<VsyncWaiterAndroid>* weak =
-      reinterpret_cast<fxl::WeakPtr<VsyncWaiterAndroid>*>(cookie);
+  fml::WeakPtr<VsyncWaiterAndroid>* weak =
+      reinterpret_cast<fml::WeakPtr<VsyncWaiterAndroid>*>(cookie);
   VsyncWaiterAndroid* waiter = weak->get();
   delete weak;
   if (waiter) {

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -6,9 +6,9 @@
 #define SHELL_PLATFORM_ANDROID_VSYNC_WAITER_ANDROID_H_
 
 #include <jni.h>
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/vsync_waiter.h"
 #include "lib/fxl/macros.h"
-#include "lib/fxl/memory/weak_ptr.h"
 
 namespace shell {
 
@@ -26,9 +26,8 @@ class VsyncWaiterAndroid : public VsyncWaiter {
 
  private:
   Callback callback_;
-  fxl::WeakPtr<VsyncWaiterAndroid> self_;
-
-  fxl::WeakPtrFactory<VsyncWaiterAndroid> weak_factory_;
+  fml::WeakPtr<VsyncWaiterAndroid> self_;
+  fml::WeakPtrFactory<VsyncWaiterAndroid> weak_factory_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(VsyncWaiterAndroid);
 };

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -44,7 +44,7 @@
   return YES;
 }
 
-void SnapshotRasterizer(fxl::WeakPtr<shell::Rasterizer> rasterizer,
+void SnapshotRasterizer(fml::WeakPtr<shell::Rasterizer> rasterizer,
                         CGContextRef context,
                         bool is_opaque) {
   if (!rasterizer) {
@@ -89,8 +89,8 @@ void SnapshotRasterizer(fxl::WeakPtr<shell::Rasterizer> rasterizer,
   SkCGDrawBitmap(context, bitmap, 0, 0);
 }
 
-static fxl::WeakPtr<shell::Rasterizer> GetRandomRasterizer() {
-  fxl::WeakPtr<shell::Rasterizer> rasterizer;
+static fml::WeakPtr<shell::Rasterizer> GetRandomRasterizer() {
+  fml::WeakPtr<shell::Rasterizer> rasterizer;
   shell::Shell::Shared().IteratePlatformViews([&rasterizer](shell::PlatformView* view) -> bool {
     rasterizer = view->rasterizer().GetWeakRasterizerPtr();
     // We just grab the first rasterizer so there is no need to iterate

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -7,13 +7,13 @@
 
 #include <memory>
 
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/platform_message_router.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
 #include "lib/fxl/functional/closure.h"
 #include "lib/fxl/macros.h"
-#include "lib/fxl/memory/weak_ptr.h"
 
 @class CALayer;
 @class UIView;
@@ -39,7 +39,7 @@ class PlatformViewIOS : public PlatformView {
     return platform_message_router_;
   }
 
-  fxl::WeakPtr<PlatformViewIOS> GetWeakPtr();
+  fml::WeakPtr<PlatformViewIOS> GetWeakPtr();
 
   void UpdateSurfaceSize();
 
@@ -65,7 +65,7 @@ class PlatformViewIOS : public PlatformView {
   PlatformMessageRouter platform_message_router_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fxl::Closure firstFrameCallback_;
-  fxl::WeakPtrFactory<PlatformViewIOS> weak_factory_;
+  fml::WeakPtrFactory<PlatformViewIOS> weak_factory_;
   NSObject<FlutterBinaryMessenger>* binary_messenger_;
 
   void SetupAndLoadFromSource(const std::string& assets_directory,

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -68,7 +68,7 @@ void PlatformViewIOS::SetupAndLoadFromSource(const std::string& assets_directory
       });
 }
 
-fxl::WeakPtr<PlatformViewIOS> PlatformViewIOS::GetWeakPtr() {
+fml::WeakPtr<PlatformViewIOS> PlatformViewIOS::GetWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -9498,6 +9498,44 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 
 ====================================================================================================
+LIBRARY: engine
+ORIGIN: ../../../topaz/lib/tonic/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../flutter/fml/memory/weak_ptr.h
+FILE: ../../../flutter/fml/memory/weak_ptr_internal.cc
+FILE: ../../../flutter/fml/memory/weak_ptr_internal.h
+FILE: ../../../flutter/fml/memory/weak_ptr_unittest.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2016 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
 LIBRARY: txt
 ORIGIN: ../../../flutter/third_party/txt/LICENSE
 TYPE: LicenseType.apache
@@ -9780,4 +9818,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ====================================================================================================
-Total license count: 211
+Total license count: 212


### PR DESCRIPTION
This is based on a conversation I had with @abarth on Friday:

Due to a misunderstanding in the way the `fxl::WeakPtr`s were meant to be used, the engine frequently accessed the weak pointer factory on the non-originating thread. This raised thread safety concerns in the engine (especially around shell initialization).

To make sure we were using components on the correct threads, the [following assertions](https://gist.github.com/chinmaygarde/c30d1269a322be6f38f907515df9e977) were added to the weak pointer implementation and the factory. This immediately caught the offending uses of the weak pointers.

However, the patch cannot land in FXL because one of the features of the FXL weak pointers and the associated factory is that the concept of the "originating" thread can change from the time the factory is constructed and is then subsequently used. 

Flutter adheres to a stricter set of rules which dictate that certain components may only be created, destroyed and used on specific threads. The advantage of using this qualified feature set is that the proposed patches can land.

The patches cannot land in FXL because that will break existing users. So Flutter is making its own copy of the weak pointer and its factory so it can add the assertions.

The assertions themselves are not part of this patch because the shell will not initialize with them in place. I will add those in a subsequent patch and fix the offending users.