### PR TITLE
Support iPhone X safe area insets

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -77,6 +77,7 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
   bool _platformSupportsTouchTypes;
   bool _platformSupportsTouchPressure;
   bool _platformSupportsTouchOrientationAndTilt;
+  bool _platformSupportsSafeAreaInsets;
   BOOL _initialized;
   BOOL _connected;
 }
@@ -125,6 +126,7 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
   _platformSupportsTouchTypes = fml::IsPlatformVersionAtLeast(9);
   _platformSupportsTouchPressure = fml::IsPlatformVersionAtLeast(9);
   _platformSupportsTouchOrientationAndTilt = fml::IsPlatformVersionAtLeast(9, 1);
+  _platformSupportsSafeAreaInsets = fml::IsPlatformVersionAtLeast(11, 0);
 
   _orientationPreferences = UIInterfaceOrientationMaskAll;
   _statusBarStyle = UIStatusBarStyleDefault;
@@ -602,11 +604,16 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   _viewportMetrics.physical_width = viewSize.width * scale;
   _viewportMetrics.physical_height = viewSize.height * scale;
 
-  if (@available(iOS 11, *)) {
+  // TODO(cbracken) once clang toolchain compiler-rt has been updated, replace with
+  // if (@available(iOS 11, *)) {
+  if (_platformSupportsSafeAreaInsets) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
     _viewportMetrics.physical_padding_top = self.view.safeAreaInsets.top * scale;
     _viewportMetrics.physical_padding_left = self.view.safeAreaInsets.left * scale;
     _viewportMetrics.physical_padding_right = self.view.safeAreaInsets.right * scale;
     _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
+#pragma clang diagnostic pop
   } else {
     _viewportMetrics.physical_padding_top = [self statusBarPadding] * scale;
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -601,7 +601,15 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   _viewportMetrics.device_pixel_ratio = scale;
   _viewportMetrics.physical_width = viewSize.width * scale;
   _viewportMetrics.physical_height = viewSize.height * scale;
-  _viewportMetrics.physical_padding_top = [self statusBarPadding] * scale;
+
+  if (@available(iOS 11, *)) {
+    _viewportMetrics.physical_padding_top = self.view.safeAreaInsets.top * scale;
+    _viewportMetrics.physical_padding_left = self.view.safeAreaInsets.left * scale;
+    _viewportMetrics.physical_padding_right = self.view.safeAreaInsets.right * scale;
+    _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
+  } else {
+    _viewportMetrics.physical_padding_top = [self statusBarPadding] * scale;
+  }
   [self updateViewportMetrics];
 
   // This must run after updateViewportMetrics so that the surface creation tasks are queued after


### PR DESCRIPTION
Support iPhone X safe area insets

This change exposes the view safe area insets (introduced in iOS 11) to
the framework via MediaQuery.of(context).padding. Safe area insets are
the view insets (padding) inside of which content can be relied on to
display without truncation/clipping, as would occur with e.g. the iPhone
X sensor notch.

As this API was added in iOS 11, we place it behind a runtime guard
checking OS level.