### PR TITLE
Ensure that public framework headers can be cleanly imported from outside the engine root.

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -9,22 +9,29 @@ import("//build/config/ios/ios_sdk.gni")
 
 _flutter_framework_dir = "$root_out_dir/Flutter.framework"
 
-shared_library("flutter_framework_dylib") {
+# The headers that will be copied to the Flutter.framework and be accessed
+# from outside the Flutter engine source root.
+_flutter_framework_headers = [
+  "framework/Headers/Flutter.h",
+  "framework/Headers/FlutterAppDelegate.h",
+  "framework/Headers/FlutterBinaryMessenger.h",
+  "framework/Headers/FlutterChannels.h",
+  "framework/Headers/FlutterCodecs.h",
+  "framework/Headers/FlutterDartProject.h",
+  "framework/Headers/FlutterMacros.h",
+  "framework/Headers/FlutterNavigationController.h",
+  "framework/Headers/FlutterPlugin.h",
+  "framework/Headers/FlutterViewController.h",
+]
+
+_flutter_framework_headers_copy_dir = "$_flutter_framework_dir/Headers"
+
+shared_library("create_flutter_framework_dylib") {
   visibility = [ ":*" ]
 
   output_name = "Flutter"
 
   sources = [
-    "framework/Headers/Flutter.h",
-    "framework/Headers/FlutterAppDelegate.h",
-    "framework/Headers/FlutterBinaryMessenger.h",
-    "framework/Headers/FlutterChannels.h",
-    "framework/Headers/FlutterCodecs.h",
-    "framework/Headers/FlutterDartProject.h",
-    "framework/Headers/FlutterMacros.h",
-    "framework/Headers/FlutterPlugin.h",
-    "framework/Headers/FlutterViewController.h",
-    "framework/Headers/FlutterNavigationController.h",
     "framework/Source/FlutterAppDelegate.mm",
     "framework/Source/FlutterChannels.mm",
     "framework/Source/FlutterCodecs.mm",
@@ -32,6 +39,7 @@ shared_library("flutter_framework_dylib") {
     "framework/Source/FlutterDartProject_Internal.h",
     "framework/Source/FlutterDartSource.h",
     "framework/Source/FlutterDartSource.mm",
+    "framework/Source/FlutterNavigationController.mm",
     "framework/Source/FlutterPlatformPlugin.h",
     "framework/Source/FlutterPlatformPlugin.mm",
     "framework/Source/FlutterStandardCodec.mm",
@@ -42,7 +50,6 @@ shared_library("flutter_framework_dylib") {
     "framework/Source/FlutterView.h",
     "framework/Source/FlutterView.mm",
     "framework/Source/FlutterViewController.mm",
-    "framework/Source/FlutterNavigationController.mm",
     "framework/Source/accessibility_bridge.h",
     "framework/Source/accessibility_bridge.mm",
     "framework/Source/flutter_main_ios.h",
@@ -65,6 +72,8 @@ shared_library("flutter_framework_dylib") {
     "platform_view_ios.mm",
   ]
 
+  sources += _flutter_framework_headers
+
   deps = [
     "$flutter_root/flow",
     "$flutter_root/fml",
@@ -84,9 +93,7 @@ shared_library("flutter_framework_dylib") {
     deps += [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
   }
 
-  public_configs = [
-    "$flutter_root:config",
-  ]
+  public_configs = [ "$flutter_root:config" ]
 
   defines = [ "FLUTTER_FRAMEWORK" ]
 
@@ -99,8 +106,9 @@ shared_library("flutter_framework_dylib") {
   ]
 }
 
-copy("framework_dylib") {
+copy("copy_framework_dylib") {
   visibility = [ ":*" ]
+
   sources = [
     "$root_out_dir/libFlutter.dylib",
   ]
@@ -109,11 +117,11 @@ copy("framework_dylib") {
   ]
 
   deps = [
-    ":flutter_framework_dylib",
+    ":create_flutter_framework_dylib",
   ]
 }
 
-action("framework_install_name") {
+action("copy_dylib_and_update_framework_install_name") {
   visibility = [ ":*" ]
   stamp_file = "$root_out_dir/flutter_install_name_stamp"
   script = "$flutter_root/sky/tools/change_install_name.py"
@@ -135,11 +143,11 @@ action("framework_install_name") {
   ]
 
   deps = [
-    ":framework_dylib",
+    ":copy_framework_dylib",
   ]
 }
 
-copy("framework_info_plist") {
+copy("copy_framework_info_plist") {
   visibility = [ ":*" ]
   sources = [
     "framework/Info.plist",
@@ -149,7 +157,7 @@ copy("framework_info_plist") {
   ]
 }
 
-copy("framework_module_map") {
+copy("copy_framework_module_map") {
   visibility = [ ":*" ]
   sources = [
     "framework/module.modulemap",
@@ -159,26 +167,23 @@ copy("framework_module_map") {
   ]
 }
 
-copy("framework_headers") {
+action("copy_framework_headers") {
+  script = "$flutter_root/sky/tools/install_framework_headers.py"
   visibility = [ ":*" ]
-  sources = [
-    "framework/Headers/Flutter.h",
-    "framework/Headers/FlutterAppDelegate.h",
-    "framework/Headers/FlutterBinaryMessenger.h",
-    "framework/Headers/FlutterChannels.h",
-    "framework/Headers/FlutterCodecs.h",
-    "framework/Headers/FlutterDartProject.h",
-    "framework/Headers/FlutterMacros.h",
-    "framework/Headers/FlutterPlugin.h",
-    "framework/Headers/FlutterViewController.h",
-    "framework/Headers/FlutterNavigationController.h",
-  ]
-  outputs = [
-    "$_flutter_framework_dir/Headers/{{source_file_part}}",
-  ]
+  sources = _flutter_framework_headers
+  outputs = []
+  foreach(header, _flutter_framework_headers) {
+    header_basename = rebase_path(header, "framework/headers")
+    outputs += [ "$_flutter_framework_headers_copy_dir/$header_basename" ]
+  }
+  args = [
+           "--location",
+           rebase_path("$_flutter_framework_headers_copy_dir"),
+           "--headers",
+         ] + rebase_path(_flutter_framework_headers)
 }
 
-copy("framework_icu") {
+copy("copy_framework_icu") {
   visibility = [ ":*" ]
   set_sources_assignment_filter([])
   sources = [
@@ -190,7 +195,7 @@ copy("framework_icu") {
   ]
 }
 
-copy("framework_podspec") {
+copy("copy_framework_podspec") {
   visibility = [ ":*" ]
   sources = [
     "framework/Flutter.podspec",
@@ -200,14 +205,24 @@ copy("framework_podspec") {
   ]
 }
 
+shared_library("copy_and_verify_framework_headers") {
+  visibility = [ ":*" ]
+  include_dirs = [ "$_flutter_framework_headers_copy_dir" ]
+  sources = [
+    "framework/Source/FlutterUmbrellaImport.m",
+  ]
+  deps = [
+    ":copy_framework_headers",
+  ]
+}
+
 group("flutter_framework") {
-  public_deps = [
-    ":framework_dylib",
-    ":framework_headers",
-    ":framework_icu",
-    ":framework_info_plist",
-    ":framework_install_name",
-    ":framework_module_map",
-    ":framework_podspec",
+  deps = [
+    ":copy_and_verify_framework_headers",
+    ":copy_dylib_and_update_framework_install_name",
+    ":copy_framework_icu",
+    ":copy_framework_info_plist",
+    ":copy_framework_module_map",
+    ":copy_framework_podspec",
   ]
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
@@ -1,4 +1,4 @@
-// Copyright 2017 The Flutter Authors. All rights reserved.
+// Copyright 2017 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
@@ -1,0 +1,9 @@
+// Copyright 2017 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// The only point of this file is to ensure that the Flutter framework umbrella header can be
+// cleanly imported from an Objective-C translation unit. The target that uses this file copies the
+// headers to a path that simulats how users would actually consume the framework outside of the
+// engine source root.
+#import "Flutter.h"

--- a/sky/tools/install_framework_headers.py
+++ b/sky/tools/install_framework_headers.py
@@ -35,8 +35,9 @@ def main():
     os.makedirs(args.location)
 
   # Copy all files specified in the args.
-  for file in args.headers:
-    shutil.copyfile(file, os.path.join(args.location, os.path.basename(file)))
+  for header_file in args.headers:
+    shutil.copyfile(header_file,
+      os.path.join(args.location, os.path.basename(header_file)))
 
 
 

--- a/sky/tools/install_framework_headers.py
+++ b/sky/tools/install_framework_headers.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+# Copyright 2017 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import errno
+import os
+import shutil
+import subprocess
+import sys
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description='Removes existing files and installs the specified headers' +
+                  'at the given location.')
+
+  parser.add_argument('--headers',
+    nargs='+', help='The headers to install at the location.', required=True)
+  parser.add_argument('--location', type=str, required=True)
+
+  args = parser.parse_args()
+
+  # Remove old headers.
+  try:
+    shutil.rmtree(os.path.normpath(args.location))
+  except OSError as e:
+    # Ignore only "not found" errors.
+    if e.errno != errno.ENOENT:
+      raise e
+
+  # Create the directory to copy the files to.
+  if not os.path.isdir(args.location):
+    os.makedirs(args.location)
+
+  # Copy all files specified in the args.
+  for file in args.headers:
+    shutil.copyfile(file, os.path.join(args.location, os.path.basename(file)))
+
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/sky/tools/install_framework_headers.py
+++ b/sky/tools/install_framework_headers.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 The Flutter Authors. All rights reserved.
+# Copyright 2017 The Chromium Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1172,6 +1172,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCodecs.
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterNavigationController.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec_Internal.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/flutter_codecs_unittest.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.mm
@@ -1534,7 +1535,6 @@ FILE: ../../../flutter/flow/layers/default_layer_builder.cc
 FILE: ../../../flutter/flow/layers/default_layer_builder.h
 FILE: ../../../flutter/flow/layers/layer_builder.cc
 FILE: ../../../flutter/flow/layers/layer_builder.h
-FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
 FILE: ../../../flutter/shell/platform/embedder/embedder.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2017 The Flutter Authors. All rights reserved.

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1534,6 +1534,7 @@ FILE: ../../../flutter/flow/layers/default_layer_builder.cc
 FILE: ../../../flutter/flow/layers/default_layer_builder.h
 FILE: ../../../flutter/flow/layers/layer_builder.cc
 FILE: ../../../flutter/flow/layers/layer_builder.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterUmbrellaImport.m
 FILE: ../../../flutter/shell/platform/embedder/embedder.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2017 The Flutter Authors. All rights reserved.


### PR DESCRIPTION
The new GN rules also ensure that deletions of exported headers correctly remove the stale entry from the set of exported headers. Previously, this required developers to test applications that consumed the framework (causing issues like https://github.com/flutter/engine/pull/4262).