### PR TITLE
Use safe area padding on hide keyboard on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -636,7 +636,17 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
 }
 
 - (void)keyboardWillBeHidden:(NSNotification*)notification {
-  _viewportMetrics.physical_padding_bottom = 0;
+  // TODO(cbracken) once clang toolchain compiler-rt has been updated, replace with
+  // if (@available(iOS 11, *)) {
+  if (_platformSupportsSafeAreaInsets) {
+    CGFloat scale = [UIScreen mainScreen].scale;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
+#pragma clang diagnostic pop
+  } else {
+    _viewportMetrics.physical_padding_bottom = 0;
+  }
   [self updateViewportMetrics];
 }
 


### PR DESCRIPTION
On hide keyboard, reset the bottom padding to the safe area inset on
devices running iOS 11 or higher.