### PR TITLE
Engine API to support animated images

### DIFF
--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -24,6 +24,8 @@ source_set("ui") {
     "painting/image_decoding.h",
     "painting/image_filter.cc",
     "painting/image_filter.h",
+    "painting/image_frames.cc",
+    "painting/image_frames.h",
     "painting/image_shader.cc",
     "painting/image_shader.h",
     "painting/mask_filter.cc",

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -12,6 +12,7 @@
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/painting/image_decoding.h"
 #include "flutter/lib/ui/painting/image_filter.h"
+#include "flutter/lib/ui/painting/image_frames.h"
 #include "flutter/lib/ui/painting/image_shader.h"
 #include "flutter/lib/ui/painting/mask_filter.h"
 #include "flutter/lib/ui/painting/path.h"
@@ -56,6 +57,7 @@ void DartUI::InitForGlobal() {
     DartRuntimeHooks::RegisterNatives(g_natives);
     ImageDecoding::RegisterNatives(g_natives);
     ImageFilter::RegisterNatives(g_natives);
+    ImageFrames::RegisterNatives(g_natives);
     ImageShader::RegisterNatives(g_natives);
     MaskFilter::RegisterNatives(g_natives);
     Paragraph::RegisterNatives(g_natives);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -825,7 +825,7 @@ class Paint {
 
 /// Opaque handle to raw decoded image data (pixels).
 ///
-/// To obtain an Image object, use [decodeImageFromList].
+/// To obtain an Image object, use [ImageFrames.nextFrame].
 ///
 /// To draw an Image, use one of the methods on the [Canvas] class, such as
 /// [Canvas.drawImage].
@@ -840,6 +840,12 @@ abstract class Image extends NativeFieldWrapperClass2 {
   /// after this method is called.
   void dispose() native "Image_dispose";
 
+  /// For frames of animated images the duration of the current frame in
+  /// milliseconds.
+  ///
+  /// For non animated frames this will be -1.
+  int get durationMillis native "Image_duration";
+
   @override
   String toString() => '[$width\u00D7$height]';
 }
@@ -848,8 +854,36 @@ abstract class Image extends NativeFieldWrapperClass2 {
 typedef void ImageDecoderCallback(Image result);
 
 /// Convert an image file from a byte array into an [Image] object.
+/// 
+/// This method will no longer be used once we switch to use ImageFrames.
+/// TODO(amirh): replace all usages of this with decodeImageFramesFromList.
 void decodeImageFromList(Uint8List list, ImageDecoderCallback callback)
     native "decodeImageFromList";
+
+/// Handle to the frames of an animated image.
+///
+/// To obtain an ImageFrames object use [decodeImageFramesFromList].
+abstract class ImageFrames extends NativeFieldWrapperClass2 {
+  /// The number of frames the animated image contains.
+  int get frameCount native "ImageFrames_frameCount";
+
+  /// Decodes the next frame of the image and returns an [Image] handle to it.
+  Image getNextFrame() native "ImageFrames_getNextFrame";
+
+  /// Release the resources used by this object. The object is no longer usable
+  /// after this method is called.
+  ///
+  /// This does not dispose images returned by nextFrame, and they should be
+  /// disposed separately.
+  void dispose() native "ImageFrames_dispose";
+}
+
+/// Callback signature for [decodeImageFramesFromList].
+typedef void ImageFramesDecoderCallback(ImageFrames result);
+
+/// Convert an image file from a byte array into an [ImageFrames] object.
+void decodeImageFramesFromList(Uint8List list, ImageFramesDecoderCallback callback)
+    native "decodeImageFramesFromList";
 
 /// Determines the winding rule that decides how the interior of a [Path] is
 /// calculated.

--- a/lib/ui/painting/image.h
+++ b/lib/ui/painting/image.h
@@ -30,7 +30,10 @@ class CanvasImage final : public fxl::RefCountedThreadSafe<CanvasImage>,
   void dispose();
 
   const sk_sp<SkImage>& image() const { return image_; }
-  void set_image(sk_sp<SkImage> image) { image_ = std::move(image); }
+  void set_image(sk_sp<SkImage> image, int durationMillis) {
+    image_ = std::move(image);
+    durationMillis_ = durationMillis;
+  }
 
   virtual size_t GetAllocationSize() override;
 
@@ -40,6 +43,9 @@ class CanvasImage final : public fxl::RefCountedThreadSafe<CanvasImage>,
   CanvasImage();
 
   sk_sp<SkImage> image_;
+  // For frames of animated images the duration of this frame.
+  // For non animated images this is set to -1.
+  int durationMillis_;
 };
 
 }  // namespace blink

--- a/lib/ui/painting/image_decoding.cc
+++ b/lib/ui/painting/image_decoding.cc
@@ -70,10 +70,9 @@ void DecodeImageAndInvokeImageCallback(
     sk_sp<SkData> buffer,
     size_t trace_id) {
   sk_sp<SkImage> image = DecodeImage(std::move(buffer), trace_id);
-  Threads::UI()->PostTask(fxl::MakeCopyable(
-      [callback = std::move(callback), image, trace_id]() mutable {
-        InvokeImageCallback(image, std::move(callback), trace_id);
-      }));
+  Threads::UI()->PostTask(fxl::MakeCopyable([
+    callback = std::move(callback), image, trace_id
+  ]() mutable { InvokeImageCallback(image, std::move(callback), trace_id); }));
 }
 
 void DecodeImageFromList(Dart_NativeArguments args) {
@@ -100,13 +99,14 @@ void DecodeImageFromList(Dart_NativeArguments args) {
 
   auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
 
-  Threads::IO()->PostTask(
-      fxl::MakeCopyable([callback = std::make_unique<DartPersistentValue>(
-                             tonic::DartState::Current(), callback_handle),
-                         buffer = std::move(buffer), trace_id]() mutable {
-        DecodeImageAndInvokeImageCallback(std::move(callback),
-                                          std::move(buffer), trace_id);
-      }));
+  Threads::IO()->PostTask(fxl::MakeCopyable([
+    callback = std::make_unique<DartPersistentValue>(
+        tonic::DartState::Current(), callback_handle),
+    buffer = std::move(buffer), trace_id
+  ]() mutable {
+    DecodeImageAndInvokeImageCallback(std::move(callback), std::move(buffer),
+                                      trace_id);
+  }));
 }
 
 void InvokeImageFramesCallback(sk_sp<SkImage> image,
@@ -136,7 +136,7 @@ void DecodeImageFramesAndInvokeImageCallback(
     size_t trace_id) {
   sk_sp<SkImage> image = DecodeImage(std::move(buffer), trace_id);
   Threads::UI()->PostTask(fxl::MakeCopyable(
-      [callback = std::move(callback), image, trace_id]() mutable {
+      [ callback = std::move(callback), image, trace_id ]() mutable {
         InvokeImageFramesCallback(image, std::move(callback), trace_id);
       }));
 }
@@ -165,13 +165,14 @@ void DecodeImageFramesFromList(Dart_NativeArguments args) {
 
   auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
 
-  Threads::IO()->PostTask(
-      fxl::MakeCopyable([callback = std::make_unique<DartPersistentValue>(
-                             tonic::DartState::Current(), callback_handle),
-                         buffer = std::move(buffer), trace_id]() mutable {
-        DecodeImageFramesAndInvokeImageCallback(std::move(callback),
-                                                std::move(buffer), trace_id);
-      }));
+  Threads::IO()->PostTask(fxl::MakeCopyable([
+    callback = std::make_unique<DartPersistentValue>(
+        tonic::DartState::Current(), callback_handle),
+    buffer = std::move(buffer), trace_id
+  ]() mutable {
+    DecodeImageFramesAndInvokeImageCallback(std::move(callback),
+                                            std::move(buffer), trace_id);
+  }));
 }
 
 }  // namespace

--- a/lib/ui/painting/image_decoding.cc
+++ b/lib/ui/painting/image_decoding.cc
@@ -7,6 +7,7 @@
 #include "flutter/common/threads.h"
 #include "flutter/glue/trace_event.h"
 #include "flutter/lib/ui/painting/image.h"
+#include "flutter/lib/ui/painting/image_frames.h"
 #include "flutter/lib/ui/painting/resource_context.h"
 #include "lib/fxl/build_config.h"
 #include "lib/fxl/functional/make_copyable.h"
@@ -24,6 +25,7 @@ namespace blink {
 namespace {
 
 static constexpr const char* kDecodeImageTraceTag = "DecodeImage";
+static constexpr const char* kDecodeImageFramesTraceTag = "DecodeImageFrames";
 
 sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer, size_t trace_id) {
   TRACE_FLOW_STEP("flutter", kDecodeImageTraceTag, trace_id);
@@ -57,7 +59,7 @@ void InvokeImageCallback(sk_sp<SkImage> image,
     DartInvoke(callback->value(), {Dart_Null()});
   } else {
     fxl::RefPtr<CanvasImage> resultImage = CanvasImage::Create();
-    resultImage->set_image(std::move(image));
+    resultImage->set_image(std::move(image), -1);
     DartInvoke(callback->value(), {ToDart(resultImage)});
   }
   TRACE_FLOW_END("flutter", kDecodeImageTraceTag, trace_id);
@@ -107,11 +109,77 @@ void DecodeImageFromList(Dart_NativeArguments args) {
   }));
 }
 
+
+void InvokeImageFramesCallback(sk_sp<SkImage> image,
+                         std::unique_ptr<DartPersistentValue> callback,
+                         size_t trace_id) {
+  tonic::DartState* dart_state = callback->dart_state().get();
+  if (!dart_state) {
+    TRACE_FLOW_END("flutter", kDecodeImageFramesTraceTag, trace_id);
+    return;
+  }
+  tonic::DartState::Scope scope(dart_state);
+  if (!image) {
+    DartInvoke(callback->value(), {Dart_Null()});
+  } else {
+    fxl::RefPtr<CanvasImage> resultImage = CanvasImage::Create();
+    resultImage->set_image(std::move(image), -1);
+    fxl::RefPtr<SingleFrameImageFrames> resultImageFrames = SingleFrameImageFrames::Create(resultImage);
+    DartInvoke(callback->value(), {ToDart(resultImageFrames)});
+  }
+  TRACE_FLOW_END("flutter", kDecodeImageTraceTag, trace_id);
+}
+
+void DecodeImageFramesAndInvokeImageCallback(
+    std::unique_ptr<DartPersistentValue> callback,
+    sk_sp<SkData> buffer,
+    size_t trace_id) {
+  sk_sp<SkImage> image = DecodeImage(std::move(buffer), trace_id);
+  Threads::UI()->PostTask(fxl::MakeCopyable([
+    callback = std::move(callback), image, trace_id
+  ]() mutable { InvokeImageFramesCallback(image, std::move(callback), trace_id); }));
+}
+
+void DecodeImageFramesFromList(Dart_NativeArguments args) {
+  static size_t trace_counter = 1;
+  const size_t trace_id = trace_counter++;
+  TRACE_FLOW_BEGIN("flutter", kDecodeImageFramesTraceTag, trace_id);
+
+  Dart_Handle exception = nullptr;
+
+  tonic::Uint8List list =
+      tonic::DartConverter<tonic::Uint8List>::FromArguments(args, 0, exception);
+  if (exception) {
+    TRACE_FLOW_END("flutter", kDecodeImageFramesTraceTag, trace_id);
+    Dart_ThrowException(exception);
+    return;
+  }
+
+  Dart_Handle callback_handle = Dart_GetNativeArgument(args, 1);
+  if (!Dart_IsClosure(callback_handle)) {
+    TRACE_FLOW_END("flutter", kDecodeImageFramesTraceTag, trace_id);
+    Dart_ThrowException(ToDart("Callback must be a function"));
+    return;
+  }
+
+  auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
+
+  Threads::IO()->PostTask(fxl::MakeCopyable([
+    callback = std::make_unique<DartPersistentValue>(
+        tonic::DartState::Current(), callback_handle),
+    buffer = std::move(buffer), trace_id
+  ]() mutable {
+    DecodeImageFramesAndInvokeImageCallback(std::move(callback), std::move(buffer),
+                                      trace_id);
+  }));
+}
+
 }  // namespace
 
 void ImageDecoding::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({
       {"decodeImageFromList", DecodeImageFromList, 2, true},
+      {"decodeImageFramesFromList", DecodeImageFramesFromList, 2, true},
   });
 }
 

--- a/lib/ui/painting/image_decoding.cc
+++ b/lib/ui/painting/image_decoding.cc
@@ -70,9 +70,10 @@ void DecodeImageAndInvokeImageCallback(
     sk_sp<SkData> buffer,
     size_t trace_id) {
   sk_sp<SkImage> image = DecodeImage(std::move(buffer), trace_id);
-  Threads::UI()->PostTask(fxl::MakeCopyable([
-    callback = std::move(callback), image, trace_id
-  ]() mutable { InvokeImageCallback(image, std::move(callback), trace_id); }));
+  Threads::UI()->PostTask(fxl::MakeCopyable(
+      [callback = std::move(callback), image, trace_id]() mutable {
+        InvokeImageCallback(image, std::move(callback), trace_id);
+      }));
 }
 
 void DecodeImageFromList(Dart_NativeArguments args) {
@@ -99,20 +100,18 @@ void DecodeImageFromList(Dart_NativeArguments args) {
 
   auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
 
-  Threads::IO()->PostTask(fxl::MakeCopyable([
-    callback = std::make_unique<DartPersistentValue>(
-        tonic::DartState::Current(), callback_handle),
-    buffer = std::move(buffer), trace_id
-  ]() mutable {
-    DecodeImageAndInvokeImageCallback(std::move(callback), std::move(buffer),
-                                      trace_id);
-  }));
+  Threads::IO()->PostTask(
+      fxl::MakeCopyable([callback = std::make_unique<DartPersistentValue>(
+                             tonic::DartState::Current(), callback_handle),
+                         buffer = std::move(buffer), trace_id]() mutable {
+        DecodeImageAndInvokeImageCallback(std::move(callback),
+                                          std::move(buffer), trace_id);
+      }));
 }
 
-
 void InvokeImageFramesCallback(sk_sp<SkImage> image,
-                         std::unique_ptr<DartPersistentValue> callback,
-                         size_t trace_id) {
+                               std::unique_ptr<DartPersistentValue> callback,
+                               size_t trace_id) {
   tonic::DartState* dart_state = callback->dart_state().get();
   if (!dart_state) {
     TRACE_FLOW_END("flutter", kDecodeImageFramesTraceTag, trace_id);
@@ -124,7 +123,8 @@ void InvokeImageFramesCallback(sk_sp<SkImage> image,
   } else {
     fxl::RefPtr<CanvasImage> resultImage = CanvasImage::Create();
     resultImage->set_image(std::move(image), -1);
-    fxl::RefPtr<SingleFrameImageFrames> resultImageFrames = SingleFrameImageFrames::Create(resultImage);
+    fxl::RefPtr<SingleFrameImageFrames> resultImageFrames =
+        SingleFrameImageFrames::Create(resultImage);
     DartInvoke(callback->value(), {ToDart(resultImageFrames)});
   }
   TRACE_FLOW_END("flutter", kDecodeImageTraceTag, trace_id);
@@ -135,9 +135,10 @@ void DecodeImageFramesAndInvokeImageCallback(
     sk_sp<SkData> buffer,
     size_t trace_id) {
   sk_sp<SkImage> image = DecodeImage(std::move(buffer), trace_id);
-  Threads::UI()->PostTask(fxl::MakeCopyable([
-    callback = std::move(callback), image, trace_id
-  ]() mutable { InvokeImageFramesCallback(image, std::move(callback), trace_id); }));
+  Threads::UI()->PostTask(fxl::MakeCopyable(
+      [callback = std::move(callback), image, trace_id]() mutable {
+        InvokeImageFramesCallback(image, std::move(callback), trace_id);
+      }));
 }
 
 void DecodeImageFramesFromList(Dart_NativeArguments args) {
@@ -164,14 +165,13 @@ void DecodeImageFramesFromList(Dart_NativeArguments args) {
 
   auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
 
-  Threads::IO()->PostTask(fxl::MakeCopyable([
-    callback = std::make_unique<DartPersistentValue>(
-        tonic::DartState::Current(), callback_handle),
-    buffer = std::move(buffer), trace_id
-  ]() mutable {
-    DecodeImageFramesAndInvokeImageCallback(std::move(callback), std::move(buffer),
-                                      trace_id);
-  }));
+  Threads::IO()->PostTask(
+      fxl::MakeCopyable([callback = std::make_unique<DartPersistentValue>(
+                             tonic::DartState::Current(), callback_handle),
+                         buffer = std::move(buffer), trace_id]() mutable {
+        DecodeImageFramesAndInvokeImageCallback(std::move(callback),
+                                                std::move(buffer), trace_id);
+      }));
 }
 
 }  // namespace

--- a/lib/ui/painting/image_frames.cc
+++ b/lib/ui/painting/image_frames.cc
@@ -15,9 +15,9 @@ namespace blink {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, ImageFrames);
 
-#define FOR_EACH_BINDING(V)   \
-  V(ImageFrames, frameCount)  \
-  V(ImageFrames, getNextFrame)   \
+#define FOR_EACH_BINDING(V)    \
+  V(ImageFrames, frameCount)   \
+  V(ImageFrames, getNextFrame) \
   V(ImageFrames, dispose)
 
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)

--- a/lib/ui/painting/image_frames.cc
+++ b/lib/ui/painting/image_frames.cc
@@ -1,4 +1,4 @@
-// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2017 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/lib/ui/painting/image_frames.cc
+++ b/lib/ui/painting/image_frames.cc
@@ -1,0 +1,33 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/painting/image_frames.h"
+
+#include "flutter/common/threads.h"
+#include "flutter/lib/ui/painting/utils.h"
+#include "lib/tonic/converter/dart_converter.h"
+#include "lib/tonic/dart_args.h"
+#include "lib/tonic/dart_binding_macros.h"
+#include "lib/tonic/dart_library_natives.h"
+
+namespace blink {
+
+IMPLEMENT_WRAPPERTYPEINFO(ui, ImageFrames);
+
+#define FOR_EACH_BINDING(V)   \
+  V(ImageFrames, frameCount)  \
+  V(ImageFrames, getNextFrame)   \
+  V(ImageFrames, dispose)
+
+FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
+
+void ImageFrames::RegisterNatives(tonic::DartLibraryNatives* natives) {
+  natives->Register({FOR_EACH_BINDING(DART_REGISTER_NATIVE)});
+}
+
+void ImageFrames::dispose() {
+  ClearDartWrapper();
+}
+
+}  // namespace blink

--- a/lib/ui/painting/image_frames.h
+++ b/lib/ui/painting/image_frames.h
@@ -1,0 +1,55 @@
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_PAINTING_ANIMATED_IMAGE_H_
+#define FLUTTER_LIB_UI_PAINTING_ANIMATED_IMAGE_H_
+
+#include "flutter/lib/ui/painting/image.h"
+#include "lib/tonic/dart_wrappable.h"
+#include "third_party/skia/include/core/SkImage.h"
+
+namespace tonic {
+class DartLibraryNatives;
+}  // namespace tonic
+
+namespace blink {
+
+class ImageFrames : public fxl::RefCountedThreadSafe<ImageFrames>,
+                          public tonic::DartWrappable {
+  DEFINE_WRAPPERTYPEINFO();
+
+ public:
+
+  virtual int frameCount() = 0;
+
+  virtual fxl::RefPtr<CanvasImage> getNextFrame() = 0;
+
+  void dispose();
+
+  static void RegisterNatives(tonic::DartLibraryNatives* natives);
+
+};
+
+class SingleFrameImageFrames final : public ImageFrames {
+  FRIEND_MAKE_REF_COUNTED(SingleFrameImageFrames);
+
+ public:
+
+  static fxl::RefPtr<SingleFrameImageFrames> Create(fxl::RefPtr<CanvasImage> frame) {
+    return fxl::MakeRefCounted<SingleFrameImageFrames>(frame);
+  }
+
+  int frameCount() { return 1; }
+
+  fxl::RefPtr<CanvasImage> getNextFrame() { return frame_; }
+
+ private:
+  SingleFrameImageFrames(fxl::RefPtr<CanvasImage> frame) { frame_ = frame; }
+
+  fxl::RefPtr<CanvasImage> frame_;
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_PAINTING_ANIMATED_IMAGE_H_

--- a/lib/ui/painting/image_frames.h
+++ b/lib/ui/painting/image_frames.h
@@ -16,11 +16,10 @@ class DartLibraryNatives;
 namespace blink {
 
 class ImageFrames : public fxl::RefCountedThreadSafe<ImageFrames>,
-                          public tonic::DartWrappable {
+                    public tonic::DartWrappable {
   DEFINE_WRAPPERTYPEINFO();
 
  public:
-
   virtual int frameCount() = 0;
 
   virtual fxl::RefPtr<CanvasImage> getNextFrame() = 0;
@@ -28,15 +27,14 @@ class ImageFrames : public fxl::RefCountedThreadSafe<ImageFrames>,
   void dispose();
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
-
 };
 
 class SingleFrameImageFrames final : public ImageFrames {
   FRIEND_MAKE_REF_COUNTED(SingleFrameImageFrames);
 
  public:
-
-  static fxl::RefPtr<SingleFrameImageFrames> Create(fxl::RefPtr<CanvasImage> frame) {
+  static fxl::RefPtr<SingleFrameImageFrames> Create(
+      fxl::RefPtr<CanvasImage> frame) {
     return fxl::MakeRefCounted<SingleFrameImageFrames>(frame);
   }
 

--- a/lib/ui/painting/image_frames.h
+++ b/lib/ui/painting/image_frames.h
@@ -1,4 +1,4 @@
-// Copyright 2013 The Chromium Authors. All rights reserved.
+// Copyright 2017 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -40,7 +40,7 @@ fxl::RefPtr<CanvasImage> Picture::toImage(int width, int height) {
   // TODO(abarth): We should pass in an SkColorSpace at some point.
   image->set_image(SkImage::MakeFromPicture(
       picture_, SkISize::Make(width, height), nullptr, nullptr,
-      SkImage::BitDepth::kU8, SkColorSpace::MakeSRGB()));
+      SkImage::BitDepth::kU8, SkColorSpace::MakeSRGB()), -1);
   return image;
 }
 

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -39,8 +39,9 @@ fxl::RefPtr<CanvasImage> Picture::toImage(int width, int height) {
   fxl::RefPtr<CanvasImage> image = CanvasImage::Create();
   // TODO(abarth): We should pass in an SkColorSpace at some point.
   image->set_image(SkImage::MakeFromPicture(
-      picture_, SkISize::Make(width, height), nullptr, nullptr,
-      SkImage::BitDepth::kU8, SkColorSpace::MakeSRGB()), -1);
+                       picture_, SkISize::Make(width, height), nullptr, nullptr,
+                       SkImage::BitDepth::kU8, SkColorSpace::MakeSRGB()),
+                   -1);
   return image;
 }
 

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1133,6 +1133,8 @@ FILE: ../../../flutter/fml/trace_event.cc
 FILE: ../../../flutter/fml/trace_event.h
 FILE: ../../../flutter/lib/ui/compositing/scene_host.cc
 FILE: ../../../flutter/lib/ui/compositing/scene_host.h
+FILE: ../../../flutter/lib/ui/painting/image_frames.cc
+FILE: ../../../flutter/lib/ui/painting/image_frames.h
 FILE: ../../../flutter/lib/ui/painting/utils.cc
 FILE: ../../../flutter/lib/ui/painting/vertices.cc
 FILE: ../../../flutter/lib/ui/painting/vertices.h


### PR DESCRIPTION
* Adds a decodeImageFramesFromList native method that returns an handle that can be used to fetch next frames for animated file formats supported by Skia.
* Adds a duration field to ui.Image.

The plan is to have 2 sub-classes implementing ImageFrames in the native code, a multi-frame and single-frame versions.
The single-frame implementation just holds a references to a CanvasImage (the current ui.Image object).
The multi-frame will control a SkiaCodec and allow fetching next frames.

In this CL only the single-frame version is implemented.

Plan for following CLs:
 * Completely stop using decodeImageFromList (and instead always use decodeImageFramesFromList).
 * After that we could delete decodeImageFromList (and a bunch of underlying code in image_decoding.cc)
 * Next implement the multi-frame version of ImageFrames.
 * Next implement animation control in the framework.

https://github.com/flutter/flutter/issues/204