### PR TITLE
Revert "[GN] Don't set dart_host_toolchain"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -114,7 +114,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5eb993a6018110a47486b211b30a4369bca4b722',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '77c6728e5ac9fc7d08b163ed5bf8bc64fc463f21',
 
    # Fuchsia compatibility
    #

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -91,7 +91,7 @@ action("generate_snapshot_bin") {
 
   deps = [
     ":generate_dart_ui",
-    "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)",
+    "//third_party/dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
   ]
   depfile = "$target_gen_dir/core_snapshot.d"
 
@@ -119,7 +119,7 @@ action("generate_snapshot_bin") {
   rebased_dart_ui_path = rebase_path(dart_ui_path)
 
   gen_snapshot_dir =
-      get_label_info("//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)",
+      get_label_info("//third_party/dart/runtime/bin:gen_snapshot($dart_host_toolchain)",
                      "root_out_dir")
   script = "//third_party/dart/runtime/tools/create_snapshot_bin.py"
 

--- a/tools/gn
+++ b/tools/gn
@@ -132,12 +132,22 @@ def to_gn_args(args):
       if 'target_cpu' in gn_args:
         gn_args['target_cpu'] = cpu_for_target_arch(gn_args['target_cpu'])
 
-    # Make sure the host toolchain has the same bit width as the target
-    # toolchain. This ensures that Dart's gen_snapshot generates the right
-    # code for the target.
+    # Modify host_toolchain into dart_host_toolchain so it matches word size of target_cpu
     target_is_32_bit = gn_args['target_cpu'] == 'arm' or gn_args['target_cpu'] == 'x86'
     if target_is_32_bit:
-      gn_args['host_cpu'] = 'x86';
+      if sys.platform.startswith('linux'):
+        gn_args['dart_host_toolchain'] = "//build/toolchain/linux:clang_x86"
+      elif sys.platform.startswith('darwin'):
+        gn_args['dart_host_toolchain'] = "//build/toolchain/mac:clang_i386"
+      elif sys.platform.startswith('win'):
+        gn_args['dart_host_toolchain'] = "//build/toolchain/win:x86"
+    else:
+      if sys.platform.startswith('linux'):
+        gn_args['dart_host_toolchain'] = "//build/toolchain/linux:clang_x64"
+      elif sys.platform.startswith('darwin'):
+        gn_args['dart_host_toolchain'] = "//build/toolchain/mac:clang_x64"
+      elif sys.platform.startswith('win'):
+        gn_args['dart_host_toolchain'] = "//build/toolchain/win:x64"
 
     gn_args['flutter_runtime_mode'] = args.runtime_mode
     gn_args['flutter_aot'] = aot


### PR DESCRIPTION
Reverts flutter/engine#4308

Breaks the engine build on the mac bot (https://build.chromium.org/p/client.flutter/builders/Mac%20Engine/builds/1949):
```
ERROR Unresolved dependencies.
//flutter/lib/snapshot:generate_snapshot_bin(//build/toolchain/android:clang_arm)
  needs //third_party/dart/runtime/bin:gen_snapshot(//build/toolchain/mac:clang_x86)
//third_party/dart/runtime/bin:generate_snapshot_bin(//build/toolchain/android:clang_arm)
  needs //third_party/dart/runtime/bin:gen_snapshot(//build/toolchain/mac:clang_x86)
```
Same error on my MacBook when trying to execute `./flutter/tools/gn --android --unoptimized`.