### PR TITLE
[fuchsia] Update package() BUILD.gn syntax

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -64,6 +64,7 @@ if (is_fuchsia) {
   import("//packages/package.gni")
 
   package("package") {
+    system_image = true
     testonly = true
 
     package_name = "flutter"


### PR DESCRIPTION
Update the package() template to match the new syntax. This change keeps this
package working the same way it does currently (i.e., being included in the
system image). In the future, we'll want to remove this annotation and separate
this package from the system image.