### PR TITLE
Correct behaviour for rangeForCharacterAtIndex

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -338,7 +338,7 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
  * text. */
 - (NSRange)rangeForCharacterAtIndex:(NSUInteger)index {
   if (index < self.text.length)
-    [self.text rangeOfComposedCharacterSequenceAtIndex:index];
+    return [self.text rangeOfComposedCharacterSequenceAtIndex:index];
   return NSMakeRange(index, 0);
 }
 


### PR DESCRIPTION
Previously it always fell through to a zero-length character range at
the specified position.