### PR TITLE
Temporaribly disable bottom safe area padding on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -615,7 +615,10 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
     _viewportMetrics.physical_padding_top = self.view.safeAreaInsets.top * scale;
     _viewportMetrics.physical_padding_left = self.view.safeAreaInsets.left * scale;
     _viewportMetrics.physical_padding_right = self.view.safeAreaInsets.right * scale;
-    _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
+    // TODO(cbracken) enable bottom padding once safe area and keyboard view
+    // occlusion are differentiated as two different Window getters (margin,
+    // padding).
+    // _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
 #pragma clang diagnostic pop
   } else {
     _viewportMetrics.physical_padding_top = [self statusBarPadding] * scale;
@@ -639,17 +642,7 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
 }
 
 - (void)keyboardWillBeHidden:(NSNotification*)notification {
-  // TODO(cbracken) once clang toolchain compiler-rt has been updated, replace with
-  // if (@available(iOS 11, *)) {
-  if (_platformSupportsSafeAreaInsets) {
-    CGFloat scale = [UIScreen mainScreen].scale;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunguarded-availability-new"
-    _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
-#pragma clang diagnostic pop
-  } else {
-    _viewportMetrics.physical_padding_bottom = 0;
-  }
+  _viewportMetrics.physical_padding_bottom = 0;
   [self updateViewportMetrics];
 }
 


### PR DESCRIPTION
There are two different sets of view insets that applications may want
to track in order to avoid unwanted interaction with system UI:

1. OS UI that effectively shrinks the Flutter view from a UX point of
   view: e.g., when the keyboard opens, it occludes the bottom of the
   screen and the view should be adjusted such that the bottom, for the
   purposes of scrolling is just above the keyboard.
2. OS UI that is overlaid over the application, but into which the
   application should draw. e.g., the Home indicator on the iPhone X
   typically appears near the bottom of the screen, overlaid over app
   content. Content should be rendered within this 'safe area' but apps
   should avoid requiring user interaction there. For example, list
   views may want to include some small amount of additional padding to
   ensure the last list item can scroll above this area.

Since Flutter does not currently distinguish between these two cases,
this patch disables the bottom safe area inset until API is added to
support these separately.