### PR TITLE
[Android] Pulls the native platform view out of FlutterView

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -113,6 +113,7 @@ java_library("flutter_shell_java") {
     "io/flutter/util/Preconditions.java",
     "io/flutter/view/AccessibilityBridge.java",
     "io/flutter/view/FlutterMain.java",
+    "io/flutter/view/FlutterNativeView.java",
     "io/flutter/view/FlutterView.java",
     "io/flutter/view/ResourceCleaner.java",
     "io/flutter/view/ResourceExtractor.java",

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -1,0 +1,200 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.view;
+
+import android.util.Log;
+import io.flutter.plugin.common.*;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.HashMap;
+import java.util.Map;
+
+class FlutterNativeView implements BinaryMessenger {
+    private static final String TAG = "FlutterNativeView";
+
+    private final Map<String, BinaryMessageHandler> mMessageHandlers;
+    private int mNextReplyId = 1;
+    private final Map<Integer, BinaryReply> mPendingReplies = new HashMap<>();
+
+    private long mNativePlatformView;
+    private FlutterView mFlutterView;
+
+    FlutterNativeView(FlutterView flutterView) {
+        mFlutterView = flutterView;
+        attach(this);
+        assertAttached();
+        mMessageHandlers = new HashMap<>();
+    }
+
+    FlutterNativeView() {
+        this(null);
+    }
+
+    public void destroy() {
+        mFlutterView = null;
+        nativeDestroy(mNativePlatformView);
+        mNativePlatformView = 0;
+    }
+
+    public boolean isAttached() {
+        return mNativePlatformView != 0;
+    }
+
+    public long get() {
+        return mNativePlatformView;
+    }
+
+    public void assertAttached() {
+        if (!isAttached())
+            throw new AssertionError("Platform view is not attached");
+    }
+
+    public void runFromBundle(String bundlePath, String snapshotOverride, String entrypoint, boolean reuseRuntimeController) {
+        assertAttached();
+        nativeRunBundleAndSnapshot(mNativePlatformView, bundlePath, snapshotOverride, entrypoint, reuseRuntimeController);
+    }
+
+    public void runFromSource(final String assetsDirectory, final String main, final String packages) {
+        assertAttached();
+        nativeRunBundleAndSource(mNativePlatformView, assetsDirectory, main, packages);
+    }
+
+    public static String getObservatoryUri() {
+        return nativeGetObservatoryUri();
+    }
+
+    @Override
+    public void send(String channel, ByteBuffer message) {
+      send(channel, message, null);
+    }
+
+    @Override
+    public void send(String channel, ByteBuffer message, BinaryReply callback) {
+        if (!isAttached()) {
+            Log.d(TAG, "FlutterView.send called on a detached view, channel=" + channel);
+            return;
+        }
+
+        int replyId = 0;
+        if (callback != null) {
+            replyId = mNextReplyId++;
+            mPendingReplies.put(replyId, callback);
+        }
+        if (message == null) {
+            nativeDispatchEmptyPlatformMessage(mNativePlatformView, channel, replyId);
+        } else {
+            nativeDispatchPlatformMessage(mNativePlatformView, channel, message,
+                message.position(), replyId);
+        }
+    }
+
+    @Override
+    public void setMessageHandler(String channel, BinaryMessageHandler handler) {
+        if (handler == null) {
+            mMessageHandlers.remove(channel);
+        } else {
+            mMessageHandlers.put(channel, handler);
+        }
+    }
+
+    private void attach(FlutterNativeView view) {
+        mNativePlatformView = nativeAttach(view);
+    }
+
+    // Called by native to send us a platform message.
+    private void handlePlatformMessage(final String channel, byte[] message, final int replyId) {
+        assertAttached();
+        BinaryMessageHandler handler = mMessageHandlers.get(channel);
+        if (handler != null) {
+            try {
+                final ByteBuffer buffer = (message == null ? null : ByteBuffer.wrap(message));
+                handler.onMessage(buffer,
+                    new BinaryReply() {
+                        private final AtomicBoolean done = new AtomicBoolean(false);
+                        @Override
+                        public void reply(ByteBuffer reply) {
+                            if (!isAttached()) {
+                                Log.d(TAG, "handlePlatformMessage replying to a detached view, channel=" + channel);
+                                return;
+                            }
+                            if (done.getAndSet(true)) {
+                                throw new IllegalStateException("Reply already submitted");
+                            }
+                            if (reply == null) {
+                                nativeInvokePlatformMessageEmptyResponseCallback(mNativePlatformView,
+                                    replyId);
+                            } else {
+                                nativeInvokePlatformMessageResponseCallback(mNativePlatformView,
+                                    replyId, reply, reply.position());
+                            }
+                        }
+                    });
+            } catch (Exception ex) {
+                Log.e(TAG, "Uncaught exception in binary message listener", ex);
+                nativeInvokePlatformMessageEmptyResponseCallback(mNativePlatformView, replyId);
+            }
+            return;
+        }
+        nativeInvokePlatformMessageEmptyResponseCallback(mNativePlatformView, replyId);
+    }
+
+    // Called by native to respond to a platform message that we sent.
+    private void handlePlatformMessageResponse(int replyId, byte[] reply) {
+        BinaryReply callback = mPendingReplies.remove(replyId);
+        if (callback != null) {
+            try {
+                callback.reply(reply == null ? null : ByteBuffer.wrap(reply));
+            } catch (Exception ex) {
+                Log.e(TAG, "Uncaught exception in binary message reply handler", ex);
+            }
+        }
+    }
+
+    // Called by native to update the semantics/accessibility tree.
+    private void updateSemantics(ByteBuffer buffer, String[] strings) {
+        if (mFlutterView == null)
+            return;
+        mFlutterView.updateSemantics(buffer, strings);
+    }
+
+    // Called by native to notify first Flutter frame rendered.
+    private void onFirstFrame() {
+        if (mFlutterView == null)
+            return;
+        mFlutterView.onFirstFrame();
+    }
+
+    private static native long nativeAttach(FlutterNativeView view);
+    private static native void nativeDestroy(long nativePlatformViewAndroid);
+
+    private static native void nativeRunBundleAndSnapshot(long nativePlatformViewAndroid,
+        String bundlePath,
+        String snapshotOverride,
+        String entrypoint,
+        boolean reuseRuntimeController);
+
+    private static native void nativeRunBundleAndSource(long nativePlatformViewAndroid,
+        String bundlePath,
+        String main,
+        String packages);
+
+    private static native String nativeGetObservatoryUri();
+
+    // Send an empty platform message to Dart.
+    private static native void nativeDispatchEmptyPlatformMessage(long nativePlatformViewAndroid,
+        String channel, int responseId);
+
+    // Send a data-carrying platform message to Dart.
+    private static native void nativeDispatchPlatformMessage(long nativePlatformViewAndroid,
+        String channel, ByteBuffer message, int position, int responseId);
+
+    // Send an empty response to a platform message received from Dart.
+    private static native void nativeInvokePlatformMessageEmptyResponseCallback(
+        long nativePlatformViewAndroid, int responseId);
+
+    // Send a data-carrying response to a platform message received from Dart.
+    private static native void nativeInvokePlatformMessageResponseCallback(
+        long nativePlatformViewAndroid, int responseId, ByteBuffer message, int position);
+}

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -19,6 +19,8 @@
 namespace shell {
 
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_view_class = nullptr;
+static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_native_view_class =
+    nullptr;
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_surface_texture_class = nullptr;
 
 // Called By Native
@@ -92,7 +94,7 @@ static jlong Attach(JNIEnv* env, jclass clazz, jobject flutterView) {
   return reinterpret_cast<jlong>(storage);
 }
 
-static void Detach(JNIEnv* env, jobject jcaller, jlong platform_view) {
+static void Destroy(JNIEnv* env, jobject jcaller, jlong platform_view) {
   PLATFORM_VIEW->Detach();
   delete &PLATFORM_VIEW;
 }
@@ -276,28 +278,72 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
     return false;
   }
 
+  g_flutter_native_view_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
+      env, env->FindClass("io/flutter/view/FlutterNativeView"));
+  if (g_flutter_native_view_class->is_null()) {
+    return false;
+  }
+
   g_surface_texture_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
       env, env->FindClass("android/graphics/SurfaceTexture"));
   if (g_surface_texture_class->is_null()) {
     return false;
   }
 
-  static const JNINativeMethod methods[] = {
+  static const JNINativeMethod native_view_methods[] = {
       {
           .name = "nativeAttach",
-          .signature = "(Lio/flutter/view/FlutterView;)J",
+          .signature = "(Lio/flutter/view/FlutterNativeView;)J",
           .fnPtr = reinterpret_cast<void*>(&shell::Attach),
       },
       {
-          .name = "nativeDetach",
+          .name = "nativeDestroy",
           .signature = "(J)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::Detach),
+          .fnPtr = reinterpret_cast<void*>(&shell::Destroy),
+      },
+      {
+          .name = "nativeRunBundleAndSnapshot",
+          .signature =
+              "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSnapshot),
+      },
+      {
+          .name = "nativeRunBundleAndSource",
+          .signature =
+              "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSource),
       },
       {
           .name = "nativeGetObservatoryUri",
           .signature = "()Ljava/lang/String;",
           .fnPtr = reinterpret_cast<void*>(&shell::GetObservatoryUri),
       },
+      {
+          .name = "nativeDispatchEmptyPlatformMessage",
+          .signature = "(JLjava/lang/String;I)V",
+          .fnPtr =
+              reinterpret_cast<void*>(&shell::DispatchEmptyPlatformMessage),
+      },
+      {
+          .name = "nativeDispatchPlatformMessage",
+          .signature = "(JLjava/lang/String;Ljava/nio/ByteBuffer;II)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::DispatchPlatformMessage),
+      },
+      {
+          .name = "nativeInvokePlatformMessageResponseCallback",
+          .signature = "(JILjava/nio/ByteBuffer;I)V",
+          .fnPtr = reinterpret_cast<void*>(
+              &shell::InvokePlatformMessageResponseCallback),
+      },
+      {
+          .name = "nativeInvokePlatformMessageEmptyResponseCallback",
+          .signature = "(JI)V",
+          .fnPtr = reinterpret_cast<void*>(
+              &shell::InvokePlatformMessageEmptyResponseCallback),
+      },
+  };
+
+  static const JNINativeMethod view_methods[] = {
       {
           .name = "nativeSurfaceCreated",
           .signature = "(JLandroid/view/Surface;I)V",
@@ -314,18 +360,6 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .fnPtr = reinterpret_cast<void*>(&shell::SurfaceDestroyed),
       },
       {
-          .name = "nativeRunBundleAndSnapshot",
-          .signature =
-              "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSnapshot),
-      },
-      {
-          .name = "nativeRunBundleAndSource",
-          .signature =
-              "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSource),
-      },
-      {
           .name = "nativeSetViewportMetrics",
           .signature = "(JFIIIIII)V",
           .fnPtr = reinterpret_cast<void*>(&shell::SetViewportMetrics),
@@ -334,17 +368,6 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .name = "nativeGetBitmap",
           .signature = "(J)Landroid/graphics/Bitmap;",
           .fnPtr = reinterpret_cast<void*>(&shell::GetBitmap),
-      },
-      {
-          .name = "nativeDispatchPlatformMessage",
-          .signature = "(JLjava/lang/String;Ljava/nio/ByteBuffer;II)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::DispatchPlatformMessage),
-      },
-      {
-          .name = "nativeDispatchEmptyPlatformMessage",
-          .signature = "(JLjava/lang/String;I)V",
-          .fnPtr =
-              reinterpret_cast<void*>(&shell::DispatchEmptyPlatformMessage),
       },
       {
           .name = "nativeDispatchPointerDataPacket",
@@ -360,18 +383,6 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .name = "nativeSetSemanticsEnabled",
           .signature = "(JZ)V",
           .fnPtr = reinterpret_cast<void*>(&shell::SetSemanticsEnabled),
-      },
-      {
-          .name = "nativeInvokePlatformMessageResponseCallback",
-          .signature = "(JILjava/nio/ByteBuffer;I)V",
-          .fnPtr = reinterpret_cast<void*>(
-              &shell::InvokePlatformMessageResponseCallback),
-      },
-      {
-          .name = "nativeInvokePlatformMessageEmptyResponseCallback",
-          .signature = "(JI)V",
-          .fnPtr = reinterpret_cast<void*>(
-              &shell::InvokePlatformMessageEmptyResponseCallback),
       },
       {
           .name = "nativeGetIsSoftwareRenderingEnabled",
@@ -395,36 +406,43 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
       },
   };
 
-  if (env->RegisterNatives(g_flutter_view_class->obj(), methods,
-                           arraysize(methods)) != 0) {
+  if (env->RegisterNatives(g_flutter_native_view_class->obj(),
+                           native_view_methods,
+                           arraysize(native_view_methods)) != 0) {
+    return false;
+  }
+
+  if (env->RegisterNatives(g_flutter_view_class->obj(), view_methods,
+                           arraysize(view_methods)) != 0) {
     return false;
   }
 
   g_handle_platform_message_method =
-      env->GetMethodID(g_flutter_view_class->obj(), "handlePlatformMessage",
-                       "(Ljava/lang/String;[BI)V");
+      env->GetMethodID(g_flutter_native_view_class->obj(),
+                       "handlePlatformMessage", "(Ljava/lang/String;[BI)V");
 
   if (g_handle_platform_message_method == nullptr) {
     return false;
   }
 
-  g_handle_platform_message_response_method = env->GetMethodID(
-      g_flutter_view_class->obj(), "handlePlatformMessageResponse", "(I[B)V");
+  g_handle_platform_message_response_method =
+      env->GetMethodID(g_flutter_native_view_class->obj(),
+                       "handlePlatformMessageResponse", "(I[B)V");
 
   if (g_handle_platform_message_response_method == nullptr) {
     return false;
   }
 
   g_update_semantics_method =
-      env->GetMethodID(g_flutter_view_class->obj(), "updateSemantics",
+      env->GetMethodID(g_flutter_native_view_class->obj(), "updateSemantics",
                        "(Ljava/nio/ByteBuffer;[Ljava/lang/String;)V");
 
   if (g_update_semantics_method == nullptr) {
     return false;
   }
 
-  g_on_first_frame_method =
-      env->GetMethodID(g_flutter_view_class->obj(), "onFirstFrame", "()V");
+  g_on_first_frame_method = env->GetMethodID(g_flutter_native_view_class->obj(),
+                                             "onFirstFrame", "()V");
 
   if (g_on_first_frame_method == nullptr) {
     return false;

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1172,6 +1172,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/StandardM
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/common/StringCodec.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Preconditions.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterNativeView.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
 FILE: ../../../flutter/shell/platform/android/platform_view_android_jni.cc
 FILE: ../../../flutter/shell/platform/android/platform_view_android_jni.h


### PR DESCRIPTION
This change pulls the reference to the native platform view out of FlutterView into a new class FlutterNativeView. FlutterView then has a FlutterNativeView field instead of a direct reference to the native platform view. This is to enable subsequent changes toward transferring the isolate owned by the native platform view back and forth between a main activity and a background service.