### PR TITLE
In GetTexture, do not insert missing IDs into the texture registry map

### DIFF
--- a/flow/texture.cc
+++ b/flow/texture.cc
@@ -36,7 +36,8 @@ void TextureRegistry::OnGrContextDestroyed() {
 
 std::shared_ptr<Texture> TextureRegistry::GetTexture(int64_t id) {
   ASSERT_IS_GPU_THREAD
-  return mapping_[id];
+  auto it = mapping_.find(id);
+  return it != mapping_.end() ? it->second : nullptr;
 }
 
 Texture::Texture(int64_t id) : id_(id) {}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12924