### PR TITLE
Revert Roll Fuchsia buildtools

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -101,7 +101,7 @@ vars = {
   # Build bot tooling for iOS
   'ios_tools_revision': '69b7c1b160e7107a6a98d948363772dc9caea46f',
 
-  'buildtools_revision': '85907c59e97527d79bbfdfd849d8e85c24959cc5',
+  'buildtools_revision': '5b8eb38aaf523f0124756454276cd0a5b720c17e',
 }
 
 # Only these hosts are allowed for dependencies in this DEPS file.
@@ -114,7 +114,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'a457e1429ed9e4a1869c8192b846bebb481f333a',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'd65893e469b3cdff75e0a157a5a219096ca6193a',
 
    # Fuchsia compatibility
    #

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -93,11 +93,11 @@ void InitCodecAndInvokeCodecCallback(
     sk_sp<SkData> buffer,
     size_t trace_id) {
   auto codec = InitCodec(std::move(buffer), trace_id);
-  Threads::UI()->PostTask(
-      fxl::MakeCopyable([callback = std::move(callback),
-                         codec = std::move(codec), trace_id]() mutable {
-        InvokeCodecCallback(std::move(codec), std::move(callback), trace_id);
-      }));
+  Threads::UI()->PostTask(fxl::MakeCopyable([
+    callback = std::move(callback), codec = std::move(codec), trace_id
+  ]() mutable {
+    InvokeCodecCallback(std::move(codec), std::move(callback), trace_id);
+  }));
 }
 
 void InstantiateImageCodec(Dart_NativeArguments args) {
@@ -124,13 +124,14 @@ void InstantiateImageCodec(Dart_NativeArguments args) {
 
   auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
 
-  Threads::IO()->PostTask(
-      fxl::MakeCopyable([callback = std::make_unique<DartPersistentValue>(
-                             tonic::DartState::Current(), callback_handle),
-                         buffer = std::move(buffer), trace_id]() mutable {
-        InitCodecAndInvokeCodecCallback(std::move(callback), std::move(buffer),
-                                        trace_id);
-      }));
+  Threads::IO()->PostTask(fxl::MakeCopyable([
+    callback = std::make_unique<DartPersistentValue>(
+        tonic::DartState::Current(), callback_handle),
+    buffer = std::move(buffer), trace_id
+  ]() mutable {
+    InitCodecAndInvokeCodecCallback(std::move(callback), std::move(buffer),
+                                    trace_id);
+  }));
 }
 
 bool copy_to(SkBitmap* dst, SkColorType dstColorType, const SkBitmap& src) {
@@ -252,7 +253,7 @@ void MultiFrameCodec::GetNextFrameAndInvokeCallback(
   nextFrameIndex_ = (nextFrameIndex_ + 1) % frameInfos_.size();
 
   Threads::UI()->PostTask(fxl::MakeCopyable(
-      [callback = std::move(callback), frameInfo, trace_id]() mutable {
+      [ callback = std::move(callback), frameInfo, trace_id ]() mutable {
         InvokeNextFrameCallback(frameInfo, std::move(callback), trace_id);
       }));
 
@@ -269,12 +270,13 @@ Dart_Handle MultiFrameCodec::getNextFrame(Dart_Handle callback_handle) {
     return ToDart("Callback must be a function");
   }
 
-  Threads::IO()->PostTask(
-      fxl::MakeCopyable([callback = std::make_unique<DartPersistentValue>(
-                             tonic::DartState::Current(), callback_handle),
-                         this, trace_id]() mutable {
-        GetNextFrameAndInvokeCallback(std::move(callback), trace_id);
-      }));
+  Threads::IO()->PostTask(fxl::MakeCopyable([
+    callback = std::make_unique<DartPersistentValue>(
+        tonic::DartState::Current(), callback_handle),
+    this, trace_id
+  ]() mutable {
+    GetNextFrameAndInvokeCallback(std::move(callback), trace_id);
+  }));
 
   return Dart_Null();
 }

--- a/lib/ui/painting/image_decoding.cc
+++ b/lib/ui/painting/image_decoding.cc
@@ -68,10 +68,9 @@ void DecodeImageAndInvokeImageCallback(
     sk_sp<SkData> buffer,
     size_t trace_id) {
   sk_sp<SkImage> image = DecodeImage(std::move(buffer), trace_id);
-  Threads::UI()->PostTask(fxl::MakeCopyable(
-      [callback = std::move(callback), image, trace_id]() mutable {
-        InvokeImageCallback(image, std::move(callback), trace_id);
-      }));
+  Threads::UI()->PostTask(fxl::MakeCopyable([
+    callback = std::move(callback), image, trace_id
+  ]() mutable { InvokeImageCallback(image, std::move(callback), trace_id); }));
 }
 
 void DecodeImageFromList(Dart_NativeArguments args) {
@@ -98,13 +97,14 @@ void DecodeImageFromList(Dart_NativeArguments args) {
 
   auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
 
-  Threads::IO()->PostTask(
-      fxl::MakeCopyable([callback = std::make_unique<DartPersistentValue>(
-                             tonic::DartState::Current(), callback_handle),
-                         buffer = std::move(buffer), trace_id]() mutable {
-        DecodeImageAndInvokeImageCallback(std::move(callback),
-                                          std::move(buffer), trace_id);
-      }));
+  Threads::IO()->PostTask(fxl::MakeCopyable([
+    callback = std::make_unique<DartPersistentValue>(
+        tonic::DartState::Current(), callback_handle),
+    buffer = std::move(buffer), trace_id
+  ]() mutable {
+    DecodeImageAndInvokeImageCallback(std::move(callback), std::move(buffer),
+                                      trace_id);
+  }));
 }
 
 }  // namespace

--- a/lib/ui/window/platform_message_response_dart.cc
+++ b/lib/ui/window/platform_message_response_dart.cc
@@ -19,8 +19,10 @@ PlatformMessageResponseDart::PlatformMessageResponseDart(
 
 PlatformMessageResponseDart::~PlatformMessageResponseDart() {
   if (!callback_.is_empty()) {
-    Threads::UI()->PostTask(fxl::MakeCopyable(
-        [callback = std::move(callback_)]() mutable { callback.Clear(); }));
+    Threads::UI()->PostTask(
+        fxl::MakeCopyable([callback = std::move(callback_)]() mutable {
+          callback.Clear();
+        }));
   }
 }
 
@@ -30,7 +32,7 @@ void PlatformMessageResponseDart::Complete(std::vector<uint8_t> data) {
   FXL_DCHECK(!is_complete_);
   is_complete_ = true;
   Threads::UI()->PostTask(fxl::MakeCopyable(
-      [callback = std::move(callback_), data = std::move(data)]() mutable {
+      [ callback = std::move(callback_), data = std::move(data) ]() mutable {
         tonic::DartState* dart_state = callback.dart_state().get();
         if (!dart_state)
           return;

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -107,9 +107,10 @@ void Animator::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   // Commit the pending continuation.
   producer_continuation_.Complete(std::move(layer_tree));
 
-  blink::Threads::Gpu()->PostTask([rasterizer = rasterizer_,
-                                   pipeline = layer_tree_pipeline_,
-                                   frame_id = FrameParity()]() {
+  blink::Threads::Gpu()->PostTask([
+    rasterizer = rasterizer_, pipeline = layer_tree_pipeline_,
+    frame_id = FrameParity()
+  ]() {
     if (!rasterizer.get())
       return;
     TRACE_EVENT2("flutter", "GPU Workload", "mode", "basic", "frame", frame_id);
@@ -150,29 +151,29 @@ void Animator::RequestFrame(bool regenerate_layer_tree) {
   // started an expensive operation right after posting this message however.
   // To support that, we need edge triggered wakes on VSync.
 
-  blink::Threads::UI()->PostTask([self = weak_factory_.GetWeakPtr(),
-                                  frame_number = frame_number_]() {
-    if (!self.get()) {
-      return;
-    }
-    TRACE_EVENT_ASYNC_BEGIN0("flutter", "Frame Request Pending", frame_number);
-    self->AwaitVSync();
-  });
+  blink::Threads::UI()->PostTask(
+      [ self = weak_factory_.GetWeakPtr(), frame_number = frame_number_ ]() {
+        if (!self.get()) {
+          return;
+        }
+        TRACE_EVENT_ASYNC_BEGIN0("flutter", "Frame Request Pending",
+                                 frame_number);
+        self->AwaitVSync();
+      });
   frame_scheduled_ = true;
 }
 
 void Animator::AwaitVSync() {
-  waiter_->AsyncWaitForVsync(
-      [self = weak_factory_.GetWeakPtr()](fxl::TimePoint frame_start_time,
-                                          fxl::TimePoint frame_target_time) {
-        if (self) {
-          if (self->CanReuseLastLayerTree()) {
-            self->DrawLastLayerTree();
-          } else {
-            self->BeginFrame(frame_start_time, frame_target_time);
-          }
-        }
-      });
+  waiter_->AsyncWaitForVsync([self = weak_factory_.GetWeakPtr()](
+      fxl::TimePoint frame_start_time, fxl::TimePoint frame_target_time) {
+    if (self) {
+      if (self->CanReuseLastLayerTree()) {
+        self->DrawLastLayerTree();
+      } else {
+        self->BeginFrame(frame_start_time, frame_target_time);
+      }
+    }
+  });
 
   engine_->NotifyIdle(dart_frame_deadline_);
 }

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -540,12 +540,12 @@ void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
 }
 
 void Engine::UpdateSemantics(std::vector<blink::SemanticsNode> update) {
-  blink::Threads::Platform()->PostTask(
-      fxl::MakeCopyable([platform_view = platform_view_.lock(),
-                         update = std::move(update)]() mutable {
-        if (platform_view)
-          platform_view->UpdateSemantics(std::move(update));
-      }));
+  blink::Threads::Platform()->PostTask(fxl::MakeCopyable([
+    platform_view = platform_view_.lock(), update = std::move(update)
+  ]() mutable {
+    if (platform_view)
+      platform_view->UpdateSemantics(std::move(update));
+  }));
 }
 
 void Engine::HandlePlatformMessage(
@@ -554,12 +554,12 @@ void Engine::HandlePlatformMessage(
     HandleAssetPlatformMessage(std::move(message));
     return;
   }
-  blink::Threads::Platform()->PostTask(
-      [platform_view = platform_view_.lock(),
-       message = std::move(message)]() mutable {
-        if (platform_view)
-          platform_view->HandlePlatformMessage(std::move(message));
-      });
+  blink::Threads::Platform()->PostTask([
+    platform_view = platform_view_.lock(), message = std::move(message)
+  ]() mutable {
+    if (platform_view)
+      platform_view->HandlePlatformMessage(std::move(message));
+  });
 }
 
 void Engine::HandleAssetPlatformMessage(

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -45,7 +45,7 @@ void PlatformView::CreateEngine() {
 void PlatformView::DispatchPlatformMessage(
     fxl::RefPtr<blink::PlatformMessage> message) {
   blink::Threads::UI()->PostTask(
-      [engine = engine_->GetWeakPtr(), message = std::move(message)] {
+      [ engine = engine_->GetWeakPtr(), message = std::move(message) ] {
         if (engine) {
           engine->DispatchPlatformMessage(message);
         }
@@ -54,16 +54,17 @@ void PlatformView::DispatchPlatformMessage(
 
 void PlatformView::DispatchSemanticsAction(int32_t id,
                                            blink::SemanticsAction action) {
-  blink::Threads::UI()->PostTask([engine = engine_->GetWeakPtr(), id, action] {
-    if (engine) {
-      engine->DispatchSemanticsAction(
-          id, static_cast<blink::SemanticsAction>(action));
-    }
-  });
+  blink::Threads::UI()->PostTask(
+      [ engine = engine_->GetWeakPtr(), id, action ] {
+        if (engine) {
+          engine->DispatchSemanticsAction(
+              id, static_cast<blink::SemanticsAction>(action));
+        }
+      });
 }
 
 void PlatformView::SetSemanticsEnabled(bool enabled) {
-  blink::Threads::UI()->PostTask([engine = engine_->GetWeakPtr(), enabled] {
+  blink::Threads::UI()->PostTask([ engine = engine_->GetWeakPtr(), enabled ] {
     if (engine)
       engine->SetSemanticsEnabled(enabled);
   });
@@ -77,14 +78,18 @@ void PlatformView::NotifyCreated(std::unique_ptr<Surface> surface,
                                  fxl::Closure caller_continuation) {
   fxl::AutoResetWaitableEvent latch;
 
-  auto ui_continuation = fxl::MakeCopyable([this,                          //
-                                            surface = std::move(surface),  //
-                                            caller_continuation,           //
-                                            &latch]() mutable {
-    auto gpu_continuation = fxl::MakeCopyable([this,                          //
-                                               surface = std::move(surface),  //
-                                               caller_continuation,           //
-                                               &latch]() mutable {
+  auto ui_continuation = fxl::MakeCopyable([
+    this,                          //
+    surface = std::move(surface),  //
+    caller_continuation,           //
+    &latch
+  ]() mutable {
+    auto gpu_continuation = fxl::MakeCopyable([
+      this,                          //
+      surface = std::move(surface),  //
+      caller_continuation,           //
+      &latch
+    ]() mutable {
       // Runs on the GPU Thread. So does the Caller Continuation.
       rasterizer_->Setup(std::move(surface), caller_continuation, &latch);
     });

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -262,25 +262,27 @@ void Shell::RunInPlatformViewUIThread(uintptr_t view_id,
   *view_existed = false;
 
   IteratePlatformViews(
-      [view_id,                                         // argument
-       assets_directory = std::move(assets_directory),  // argument
-       main = std::move(main),                          // argument
-       packages = std::move(packages),                  // argument
-       &view_existed,                                   // out
-       &dart_isolate_id,                                // out
-       &isolate_name                                    // out
-  ](PlatformView* view) -> bool {
-        if (reinterpret_cast<uintptr_t>(view) != view_id) {
-          // Keep looking.
-          return true;
-        }
-        *view_existed = true;
-        view->RunFromSource(assets_directory, main, packages);
-        *dart_isolate_id = view->engine().GetUIIsolateMainPort();
-        *isolate_name = view->engine().GetUIIsolateName();
-        // We found the requested view. Stop iterating over platform views.
-        return false;
-      });
+      [
+        view_id,                                         // argument
+        assets_directory = std::move(assets_directory),  // argument
+        main = std::move(main),                          // argument
+        packages = std::move(packages),                  // argument
+        &view_existed,                                   // out
+        &dart_isolate_id,                                // out
+        &isolate_name                                    // out
+      ](PlatformView * view)
+          ->bool {
+            if (reinterpret_cast<uintptr_t>(view) != view_id) {
+              // Keep looking.
+              return true;
+            }
+            *view_existed = true;
+            view->RunFromSource(assets_directory, main, packages);
+            *dart_isolate_id = view->engine().GetUIIsolateMainPort();
+            *isolate_name = view->engine().GetUIIsolateName();
+            // We found the requested view. Stop iterating over platform views.
+            return false;
+          });
 
   latch->Signal();
 }

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -50,9 +50,10 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceSoftware::AcquireFrame(
   canvas->resetMatrix();
   canvas->scale(scale, scale);
 
-  SurfaceFrame::SubmitCallback on_submit =
-      [self = weak_factory_.GetWeakPtr()](const SurfaceFrame& surface_frame,
-                                          SkCanvas* canvas) -> bool {
+  SurfaceFrame::SubmitCallback
+      on_submit = [self = weak_factory_.GetWeakPtr()](
+                      const SurfaceFrame& surface_frame, SkCanvas* canvas)
+                      ->bool {
     // If the surface itself went away, there is nothing more to do.
     if (!self || !self->IsValid() || canvas == nullptr) {
       return false;

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -27,9 +27,11 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkan::AcquireFrame(
     return nullptr;
   }
 
-  SurfaceFrame::SubmitCallback callback =
-      [weak_this = weak_factory_.GetWeakPtr()](const SurfaceFrame&,
-                                               SkCanvas* canvas) -> bool {
+  SurfaceFrame::SubmitCallback callback = [weak_this =
+                                               weak_factory_.GetWeakPtr()](
+                                              const SurfaceFrame&,
+                                              SkCanvas* canvas)
+                                              ->bool {
     // Frames are only ever acquired on the GPU thread. This is also the thread
     // on which the weak pointer factory is collected (as this instance is owned
     // by the rasterizer). So this use of weak pointers is safe.

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -38,7 +38,7 @@ class PlatformMessageResponseAndroid : public blink::PlatformMessageResponse {
   void Complete(std::vector<uint8_t> data) override {
     fxl::RefPtr<PlatformMessageResponseAndroid> self(this);
     blink::Threads::Platform()->PostTask(
-        fxl::MakeCopyable([self, data = std::move(data)]() mutable {
+        fxl::MakeCopyable([ self, data = std::move(data) ]() mutable {
           std::shared_ptr<PlatformView> view = self->view_.lock();
           if (!view)
             return;
@@ -182,11 +182,9 @@ void PlatformViewAndroid::SurfaceCreated(JNIEnv* env,
     return;
   }
 
-  NotifyCreated(
-      std::move(gpu_surface),
-      [this, backgroundColor, native_window_size = native_window->GetSize()] {
-        rasterizer().Clear(backgroundColor, native_window_size);
-      });
+  NotifyCreated(std::move(gpu_surface), [
+    this, backgroundColor, native_window_size = native_window->GetSize()
+  ] { rasterizer().Clear(backgroundColor, native_window_size); });
 }
 
 void PlatformViewAndroid::SurfaceChanged(jint width, jint height) {
@@ -213,28 +211,30 @@ void PlatformViewAndroid::RunBundleAndSnapshot(std::string bundle_path,
                                                std::string snapshot_override,
                                                std::string entrypoint,
                                                bool reuse_runtime_controller) {
-  blink::Threads::UI()->PostTask(
-      [engine = engine_->GetWeakPtr(), bundle_path = std::move(bundle_path),
-       snapshot_override = std::move(snapshot_override),
-       entrypoint = std::move(entrypoint),
-       reuse_runtime_controller = reuse_runtime_controller] {
-        if (engine)
-          engine->RunBundleAndSnapshot(
-              std::move(bundle_path), std::move(snapshot_override),
-              std::move(entrypoint), reuse_runtime_controller);
-      });
+  blink::Threads::UI()->PostTask([
+    engine = engine_->GetWeakPtr(), bundle_path = std::move(bundle_path),
+    snapshot_override = std::move(snapshot_override),
+    entrypoint = std::move(entrypoint),
+    reuse_runtime_controller = reuse_runtime_controller
+  ] {
+    if (engine)
+      engine->RunBundleAndSnapshot(
+          std::move(bundle_path), std::move(snapshot_override),
+          std::move(entrypoint), reuse_runtime_controller);
+  });
 }
 
 void PlatformViewAndroid::RunBundleAndSource(std::string bundle_path,
                                              std::string main,
                                              std::string packages) {
-  blink::Threads::UI()->PostTask(
-      [engine = engine_->GetWeakPtr(), bundle_path = std::move(bundle_path),
-       main = std::move(main), packages = std::move(packages)] {
-        if (engine)
-          engine->RunBundleAndSource(std::move(bundle_path), std::move(main),
-                                     std::move(packages));
-      });
+  blink::Threads::UI()->PostTask([
+    engine = engine_->GetWeakPtr(), bundle_path = std::move(bundle_path),
+    main = std::move(main), packages = std::move(packages)
+  ] {
+    if (engine)
+      engine->RunBundleAndSource(std::move(bundle_path), std::move(main),
+                                 std::move(packages));
+  });
 }
 
 void PlatformViewAndroid::SetViewportMetrics(jfloat device_pixel_ratio,
@@ -253,7 +253,7 @@ void PlatformViewAndroid::SetViewportMetrics(jfloat device_pixel_ratio,
   metrics.physical_padding_bottom = physical_padding_bottom;
   metrics.physical_padding_left = physical_padding_left;
 
-  blink::Threads::UI()->PostTask([engine = engine_->GetWeakPtr(), metrics] {
+  blink::Threads::UI()->PostTask([ engine = engine_->GetWeakPtr(), metrics ] {
     if (engine)
       engine->SetViewportMetrics(metrics);
   });
@@ -299,12 +299,13 @@ void PlatformViewAndroid::DispatchPointerDataPacket(JNIEnv* env,
                                                     jint position) {
   uint8_t* data = static_cast<uint8_t*>(env->GetDirectBufferAddress(buffer));
 
-  blink::Threads::UI()->PostTask(fxl::MakeCopyable(
-      [engine = engine_->GetWeakPtr(),
-       packet = std::make_unique<PointerDataPacket>(data, position)] {
-        if (engine.get())
-          engine->DispatchPointerDataPacket(*packet);
-      }));
+  blink::Threads::UI()->PostTask(fxl::MakeCopyable([
+    engine = engine_->GetWeakPtr(),
+    packet = std::make_unique<PointerDataPacket>(data, position)
+  ] {
+    if (engine.get())
+      engine->DispatchPointerDataPacket(*packet);
+  }));
 }
 
 void PlatformViewAndroid::InvokePlatformMessageResponseCallback(

--- a/shell/platform/darwin/common/platform_mac.mm
+++ b/shell/platform/darwin/common/platform_mac.mm
@@ -146,7 +146,7 @@ bool AttemptLaunchFromCommandLineSwitches(Engine* engine) {
 
   [defaults synchronize];
 
-  blink::Threads::UI()->PostTask([engine = engine->GetWeakPtr(), bundle_path, main, packages] {
+  blink::Threads::UI()->PostTask([ engine = engine->GetWeakPtr(), bundle_path, main, packages ] {
     if (engine)
       engine->RunBundleAndSource(bundle_path, main, packages);
   });

--- a/shell/platform/darwin/desktop/flutter_window.mm
+++ b/shell/platform/darwin/desktop/flutter_window.mm
@@ -79,7 +79,7 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(NSEventPh
   metrics.physical_width = size.width;
   metrics.physical_height = size.height;
 
-  blink::Threads::UI()->PostTask([engine = _platformView->engine().GetWeakPtr(), metrics] {
+  blink::Threads::UI()->PostTask([ engine = _platformView->engine().GetWeakPtr(), metrics ] {
     if (engine.get()) {
       engine->SetViewportMetrics(metrics);
     }
@@ -134,7 +134,7 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(NSEventPh
       break;
   }
 
-  blink::Threads::UI()->PostTask([engine = _platformView->engine().GetWeakPtr(), pointer_data] {
+  blink::Threads::UI()->PostTask([ engine = _platformView->engine().GetWeakPtr(), pointer_data ] {
     if (engine.get()) {
       blink::PointerDataPacket packet(1);
       packet.SetPointerData(0, pointer_data);

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -42,7 +42,7 @@ void PlatformViewMac::SetupAndLoadDart() {
 
   std::string bundle_path = command_line.GetOptionValueWithDefault(FlagForSwitch(Switch::FLX), "");
   if (!bundle_path.empty()) {
-    blink::Threads::UI()->PostTask([engine = engine().GetWeakPtr(), bundle_path] {
+    blink::Threads::UI()->PostTask([ engine = engine().GetWeakPtr(), bundle_path ] {
       if (engine)
         engine->RunBundle(bundle_path);
     });
@@ -54,7 +54,7 @@ void PlatformViewMac::SetupAndLoadDart() {
     std::string main = args[0];
     std::string packages =
         command_line.GetOptionValueWithDefault(FlagForSwitch(Switch::Packages), "");
-    blink::Threads::UI()->PostTask([engine = engine().GetWeakPtr(), main, packages] {
+    blink::Threads::UI()->PostTask([ engine = engine().GetWeakPtr(), main, packages ] {
       if (engine)
         engine->RunBundleAndSource(std::string(), main, packages);
     });
@@ -66,7 +66,7 @@ void PlatformViewMac::SetupAndLoadFromSource(const std::string& assets_directory
                                              const std::string& main,
                                              const std::string& packages) {
   blink::Threads::UI()->PostTask(
-      [engine = engine().GetWeakPtr(), assets_directory, main, packages] {
+      [ engine = engine().GetWeakPtr(), assets_directory, main, packages ] {
         if (engine)
           engine->RunBundleAndSource(assets_directory, main, packages);
       });

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -268,8 +268,9 @@ static NSString* NSStringFromVMType(VMType type) {
   }
 
   std::string bundle_path = path.UTF8String;
-  blink::Threads::UI()->PostTask([engine = engine->GetWeakPtr(), bundle_path,
-                                  entrypoint = std::string([entrypoint UTF8String])] {
+  blink::Threads::UI()->PostTask([
+    engine = engine->GetWeakPtr(), bundle_path, entrypoint = std::string([entrypoint UTF8String])
+  ] {
     if (engine)
       engine->RunBundle(bundle_path, entrypoint);
   });
@@ -295,18 +296,21 @@ static NSString* NSStringFromVMType(VMType type) {
     std::string bundle_path = _dartSource.flxArchive.absoluteURL.path.UTF8String;
 
     if (_dartSource.archiveContainsScriptSnapshot) {
-      blink::Threads::UI()->PostTask([engine = engine->GetWeakPtr(), bundle_path,
-                                      entrypoint = std::string([entrypoint UTF8String])] {
+      blink::Threads::UI()->PostTask([
+        engine = engine->GetWeakPtr(), bundle_path,
+        entrypoint = std::string([entrypoint UTF8String])
+      ] {
         if (engine)
           engine->RunBundle(bundle_path, entrypoint);
       });
     } else {
       std::string main = _dartSource.dartMain.absoluteURL.path.UTF8String;
       std::string packages = _dartSource.packages.absoluteURL.path.UTF8String;
-      blink::Threads::UI()->PostTask([engine = engine->GetWeakPtr(), bundle_path, main, packages] {
-        if (engine)
-          engine->RunBundleAndSource(bundle_path, main, packages);
-      });
+      blink::Threads::UI()->PostTask(
+          [ engine = engine->GetWeakPtr(), bundle_path, main, packages ] {
+            if (engine)
+              engine->RunBundleAndSource(bundle_path, main, packages);
+          });
     }
 
     result(YES, @"Success");

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -36,7 +36,7 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
   void Complete(std::vector<uint8_t> data) override {
     fxl::RefPtr<PlatformMessageResponseDarwin> self(this);
     blink::Threads::Platform()->PostTask(
-        fxl::MakeCopyable([self, data = std::move(data)]() mutable {
+        fxl::MakeCopyable([ self, data = std::move(data) ]() mutable {
           self->callback_.get()(shell::GetNSDataFromVector(data));
         }));
   }
@@ -553,7 +553,7 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   }
 
   blink::Threads::UI()->PostTask(fxl::MakeCopyable(
-      [engine = _platformView->engine().GetWeakPtr(), packet = std::move(packet)] {
+      [ engine = _platformView->engine().GetWeakPtr(), packet = std::move(packet) ] {
         if (engine.get())
           engine->DispatchPointerDataPacket(*packet);
       }));
@@ -579,7 +579,7 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
 
 - (void)updateViewportMetrics {
   blink::Threads::UI()->PostTask(
-      [weak_platform_view = _platformView->GetWeakPtr(), metrics = _viewportMetrics] {
+      [ weak_platform_view = _platformView->GetWeakPtr(), metrics = _viewportMetrics ] {
         if (!weak_platform_view) {
           return;
         }

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -76,10 +76,9 @@
   //
   // We are not using the PostTask for thread switching, but to make task
   // observers work.
-  blink::Threads::UI()->PostTask(
-      [callback = _pendingCallback, frame_start_time, frame_target_time]() {
-        callback(frame_start_time, frame_target_time);
-      });
+  blink::Threads::UI()->PostTask([
+    callback = _pendingCallback, frame_start_time, frame_target_time
+  ]() { callback(frame_start_time, frame_target_time); });
 
   _pendingCallback = nullptr;
 }

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -63,7 +63,7 @@ void PlatformViewIOS::SetupAndLoadFromSource(const std::string& assets_directory
                                              const std::string& main,
                                              const std::string& packages) {
   blink::Threads::UI()->PostTask(
-      [engine = engine().GetWeakPtr(), assets_directory, main, packages] {
+      [ engine = engine().GetWeakPtr(), assets_directory, main, packages ] {
         if (engine)
           engine->RunBundleAndSource(assets_directory, main, packages);
       });

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -82,18 +82,24 @@ FlutterResult FlutterEngineRun(size_t version,
     return kInvalidArguments;
   }
 
-  auto make_current = [ptr = config->open_gl.make_current,
-                       user_data]() -> bool { return ptr(user_data); };
-
-  auto clear_current = [ptr = config->open_gl.clear_current,
-                        user_data]() -> bool { return ptr(user_data); };
-
-  auto present = [ptr = config->open_gl.present, user_data]() -> bool {
+  auto make_current =
+      [ ptr = config->open_gl.make_current, user_data ]()->bool {
     return ptr(user_data);
   };
 
-  auto fbo_callback = [ptr = config->open_gl.fbo_callback,
-                       user_data]() -> intptr_t { return ptr(user_data); };
+  auto clear_current =
+      [ ptr = config->open_gl.clear_current, user_data ]()->bool {
+    return ptr(user_data);
+  };
+
+  auto present = [ ptr = config->open_gl.present, user_data ]()->bool {
+    return ptr(user_data);
+  };
+
+  auto fbo_callback =
+      [ ptr = config->open_gl.fbo_callback, user_data ]()->intptr_t {
+    return ptr(user_data);
+  };
 
   std::string icu_data_path;
   if (SAFE_ACCESS(args, icu_data_path, nullptr) != nullptr) {
@@ -131,20 +137,20 @@ FlutterResult FlutterEngineRun(size_t version,
   std::string main(args->main_path);
   std::string packages(args->packages_path);
 
-  blink::Threads::UI()->PostTask(
-      [weak_engine = platform_view->engine().GetWeakPtr(),  //
-       assets = std::move(assets),                          //
-       main = std::move(main),                              //
-       packages = std::move(packages)                       //
+  blink::Threads::UI()->PostTask([
+    weak_engine = platform_view->engine().GetWeakPtr(),  //
+    assets = std::move(assets),                          //
+    main = std::move(main),                              //
+    packages = std::move(packages)                       //
   ] {
-        if (auto engine = weak_engine) {
-          if (main.empty()) {
-            engine->RunBundle(assets);
-          } else {
-            engine->RunBundleAndSource(assets, main, packages);
-          }
-        }
-      });
+    if (auto engine = weak_engine) {
+      if (main.empty()) {
+        engine->RunBundle(assets);
+      } else {
+        engine->RunBundleAndSource(assets, main, packages);
+      }
+    }
+  });
 
   *engine_out = reinterpret_cast<FlutterEngine>(
       new PlatformViewHolder(std::move(platform_view)));
@@ -176,7 +182,7 @@ FlutterResult FlutterEngineSendWindowMetricsEvent(
   metrics.device_pixel_ratio = SAFE_ACCESS(flutter_metrics, pixel_ratio, 1.0);
 
   blink::Threads::UI()->PostTask(
-      [weak_engine = holder->view()->engine().GetWeakPtr(), metrics] {
+      [ weak_engine = holder->view()->engine().GetWeakPtr(), metrics ] {
         if (auto engine = weak_engine) {
           engine->SetViewportMetrics(metrics);
         }
@@ -224,16 +230,17 @@ FlutterResult FlutterEngineSendPointerEvent(FlutterEngine engine,
         reinterpret_cast<const uint8_t*>(current) + current->struct_size);
   }
 
-  blink::Threads::UI()->PostTask(fxl::MakeCopyable(
-      [weak_engine = reinterpret_cast<PlatformViewHolder*>(engine)
-                         ->view()
-                         ->engine()
-                         .GetWeakPtr(),
-       packet = std::move(packet)] {
-        if (auto engine = weak_engine) {
-          engine->DispatchPointerDataPacket(*packet);
-        }
-      }));
+  blink::Threads::UI()->PostTask(fxl::MakeCopyable([
+    weak_engine = reinterpret_cast<PlatformViewHolder*>(engine)
+                      ->view()
+                      ->engine()
+                      .GetWeakPtr(),
+    packet = std::move(packet)
+  ] {
+    if (auto engine = weak_engine) {
+      engine->DispatchPointerDataPacket(*packet);
+    }
+  }));
 
   return kSuccess;
 }
@@ -260,7 +267,7 @@ FlutterResult FlutterEngineSendPlatformMessage(
       nullptr);
 
   blink::Threads::UI()->PostTask(
-      [weak_engine = holder->view()->engine().GetWeakPtr(), message] {
+      [ weak_engine = holder->view()->engine().GetWeakPtr(), message ] {
         if (auto engine = weak_engine) {
           engine->DispatchPlatformMessage(message);
         }

--- a/shell/testing/test_runner.cc
+++ b/shell/testing/test_runner.cc
@@ -22,7 +22,7 @@ TestRunner::TestRunner()
   metrics.physical_height = 1800;  // 600 at 3x resolution
 
   blink::Threads::UI()->PostTask(
-      [engine = platform_view_->engine().GetWeakPtr(), metrics] {
+      [ engine = platform_view_->engine().GetWeakPtr(), metrics ] {
         if (engine)
           engine->SetViewportMetrics(metrics);
       });
@@ -39,7 +39,7 @@ TestRunner& TestRunner::Shared() {
 
 void TestRunner::Run(const TestDescriptor& test) {
   blink::Threads::UI()->PostTask(
-      [engine = platform_view_->engine().GetWeakPtr(), test] {
+      [ engine = platform_view_->engine().GetWeakPtr(), test ] {
         if (engine)
           engine->RunBundleAndSource(std::string(), test.path, test.packages);
       });

--- a/sky/engine/platform/fonts/opentype/OpenTypeVerticalData.cpp
+++ b/sky/engine/platform/fonts/opentype/OpenTypeVerticalData.cpp
@@ -238,7 +238,7 @@ void OpenTypeVerticalData::getVerticalTranslationsForGlyphs(
   bool useVORG = hasVORG();
   size_t countTopSideBearings = m_topSideBearings.size();
   float defaultVertOriginY = std::numeric_limits<float>::quiet_NaN();
-  for (float* end = &(outXYArray[count * 2]); outXYArray != end;
+  for (float *end = &(outXYArray[count * 2]); outXYArray != end;
        ++glyphs, outXYArray += 2) {
     Glyph glyph = *glyphs;
     uint16_t widthFUnit =

--- a/sky/engine/wtf/HexNumber.h
+++ b/sky/engine/wtf/HexNumber.h
@@ -102,10 +102,10 @@ inline void appendUnsignedAsHexFixedSize(unsigned number,
 
 }  // namespace WTF
 
+using WTF::Lowercase;
 using WTF::appendByteAsHex;
 using WTF::appendUnsignedAsHex;
 using WTF::appendUnsignedAsHexFixedSize;
-using WTF::Lowercase;
 using WTF::placeByteAsHex;
 using WTF::placeByteAsHexCompressIfPossible;
 

--- a/sky/engine/wtf/PartitionAlloc.h
+++ b/sky/engine/wtf/PartitionAlloc.h
@@ -697,9 +697,11 @@ class PartitionAllocatorGeneric {
 
 }  // namespace WTF
 
+using WTF::PartitionAllocatorGeneric;
+using WTF::PartitionRoot;
+using WTF::SizeSpecificPartitionAllocator;
 using WTF::partitionAlloc;
 using WTF::partitionAllocActualSize;
-using WTF::PartitionAllocatorGeneric;
 using WTF::partitionAllocGeneric;
 using WTF::partitionAllocGetSize;
 using WTF::partitionAllocInit;
@@ -708,7 +710,5 @@ using WTF::partitionAllocSupportsGetSize;
 using WTF::partitionFree;
 using WTF::partitionFreeGeneric;
 using WTF::partitionReallocGeneric;
-using WTF::PartitionRoot;
-using WTF::SizeSpecificPartitionAllocator;
 
 #endif  // SKY_ENGINE_WTF_PARTITIONALLOC_H_

--- a/sky/engine/wtf/PassOwnPtr.h
+++ b/sky/engine/wtf/PassOwnPtr.h
@@ -184,9 +184,9 @@ inline T* getPtr(const PassOwnPtr<T>& p) {
 
 }  // namespace WTF
 
+using WTF::PassOwnPtr;
 using WTF::adoptArrayPtr;
 using WTF::adoptPtr;
-using WTF::PassOwnPtr;
 using WTF::static_pointer_cast;
 
 #endif  // SKY_ENGINE_WTF_PASSOWNPTR_H_

--- a/sky/engine/wtf/PassRefPtr.h
+++ b/sky/engine/wtf/PassRefPtr.h
@@ -224,8 +224,8 @@ inline T* getPtr(const PassRefPtr<T>& p) {
 
 }  // namespace WTF
 
-using WTF::adoptRef;
 using WTF::PassRefPtr;
+using WTF::adoptRef;
 using WTF::static_pointer_cast;
 
 #endif  // SKY_ENGINE_WTF_PASSREFPTR_H_

--- a/sky/engine/wtf/PrintStream.h
+++ b/sky/engine/wtf/PrintStream.h
@@ -422,7 +422,7 @@ PointerDump<T> pointerDump(const T* ptr) {
 
 using WTF::CharacterDump;
 using WTF::PointerDump;
-using WTF::pointerDump;
 using WTF::PrintStream;
+using WTF::pointerDump;
 
 #endif  // SKY_ENGINE_WTF_PRINTSTREAM_H_

--- a/sky/engine/wtf/Threading.h
+++ b/sky/engine/wtf/Threading.h
@@ -56,7 +56,7 @@ WTF_EXPORT void unlockAtomicallyInitializedStaticMutex();
 
 }  // namespace WTF
 
-using WTF::currentThread;
 using WTF::ThreadIdentifier;
+using WTF::currentThread;
 
 #endif  // SKY_ENGINE_WTF_THREADING_H_

--- a/sky/engine/wtf/dtoa.h
+++ b/sky/engine/wtf/dtoa.h
@@ -102,11 +102,11 @@ inline double parseDouble(const UChar* string,
 
 }  // namespace WTF
 
+using WTF::NumberToLStringBuffer;
+using WTF::NumberToStringBuffer;
 using WTF::numberToFixedPrecisionString;
 using WTF::numberToFixedWidthString;
-using WTF::NumberToLStringBuffer;
 using WTF::numberToString;
-using WTF::NumberToStringBuffer;
 using WTF::parseDouble;
 
 #endif  // SKY_ENGINE_WTF_DTOA_H_

--- a/sky/engine/wtf/text/StringImpl.h
+++ b/sky/engine/wtf/text/StringImpl.h
@@ -813,11 +813,11 @@ struct DefaultHash<RefPtr<StringImpl>> {
 
 }  // namespace WTF
 
-using WTF::equal;
-using WTF::equalNonNull;
 using WTF::StringImpl;
 using WTF::TextCaseInsensitive;
 using WTF::TextCaseSensitive;
 using WTF::TextCaseSensitivity;
+using WTF::equal;
+using WTF::equalNonNull;
 
 #endif  // SKY_ENGINE_WTF_TEXT_STRINGIMPL_H_

--- a/sky/engine/wtf/text/WTFString.h
+++ b/sky/engine/wtf/text/WTFString.h
@@ -825,6 +825,11 @@ WTF_EXPORT extern const String& xmlnsWithColon;
 
 WTF_ALLOW_MOVE_AND_INIT_WITH_MEM_FUNCTIONS(String);
 
+using WTF::CString;
+using WTF::KeepTrailingZeros;
+using WTF::StrictUTF8Conversion;
+using WTF::StrictUTF8ConversionReplacingUnpairedSurrogatesWithFFFD;
+using WTF::String;
 using WTF::append;
 using WTF::appendNumber;
 using WTF::charactersAreAllASCII;
@@ -840,18 +845,13 @@ using WTF::charactersToUInt;
 using WTF::charactersToUInt64;
 using WTF::charactersToUInt64Strict;
 using WTF::charactersToUIntStrict;
-using WTF::CString;
 using WTF::emptyString;
 using WTF::equal;
 using WTF::equalIgnoringCase;
 using WTF::find;
 using WTF::isAllSpecialCharacters;
 using WTF::isSpaceOrNewline;
-using WTF::KeepTrailingZeros;
 using WTF::reverseFind;
-using WTF::StrictUTF8Conversion;
-using WTF::StrictUTF8ConversionReplacingUnpairedSurrogatesWithFFFD;
-using WTF::String;
 
 #include "flutter/sky/engine/wtf/text/AtomicString.h"
 #endif  // SKY_ENGINE_WTF_TEXT_WTFSTRING_H_

--- a/sky/engine/wtf/unicode/CharacterNames.h
+++ b/sky/engine/wtf/unicode/CharacterNames.h
@@ -93,6 +93,7 @@ const UChar zeroWidthNoBreakSpace = 0xFEFF;
 }  // namespace Unicode
 }  // namespace WTF
 
+using WTF::Unicode::HiraganaLetterSmallA;
 using WTF::Unicode::aegeanWordSeparatorDot;
 using WTF::Unicode::aegeanWordSeparatorLine;
 using WTF::Unicode::blackCircle;
@@ -107,7 +108,6 @@ using WTF::Unicode::ethiopicWordspace;
 using WTF::Unicode::fisheye;
 using WTF::Unicode::hebrewPunctuationGeresh;
 using WTF::Unicode::hebrewPunctuationGershayim;
-using WTF::Unicode::HiraganaLetterSmallA;
 using WTF::Unicode::horizontalEllipsis;
 using WTF::Unicode::hyphen;
 using WTF::Unicode::hyphenMinus;


### PR DESCRIPTION
With the update to HEAD of the Fuchsia buildtools repo, the new clang
toolchain picked up caused link-time breakage in android x86_64
libFlutter.so builds.

Sample log:
https://build.chromium.org/p/client.flutter/builders/Linux%20Engine/builds/1974/steps/build%20android_debug_x64/logs/stdio

Sample failure:
FAILED: libflutter.so libflutter.so.TOC lib.stripped/libflutter.so
../../third_party/android_tools/ndk/toolchains/x86_64-4.9/prebuilt/linux-x86_64/lib/gcc/x86_64-linux-android/4.9.x/../../../../x86_64-linux-android/bin/ld.gold: error: obj/flutter/shell/platform/android/libflutter/android_context_gl.o: unsupported reloc 42 against global symbol std::__ndk1::num_put<char, std::__ndk1::ostreambuf_iterator<char, std::__ndk1::char_traits<char> > >::id

This reverts commit 8ad42f0dae3cb1267c2b9ab99db80e4696ddbc3d. (#4331)