### PR TITLE
[fuchsia] Allow flutter_app to be included in non-Fuchsia toolchains.

### DIFF
--- a/build/flutter_app.gni
+++ b/build/flutter_app.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-assert(is_fuchsia)
+assert(is_fuchsia || is_fuchsia_host)
 
 import("//build/dart/dart_package.gni")
 import("//build/dart/toolchain.gni")


### PR DESCRIPTION
A flutter_app target might be declared in a build file alongside some host tool.
The intent of the assertion seemed to be restricting the use of the template to the Fuchsia codebase.