### PR TITLE
Revert "Enable Dart 2.0 fixed-size integers in Flutter (#4337)"

### DIFF
--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -74,8 +74,10 @@ namespace {
 
 // Arguments passed to the Dart VM in all configurations.
 static const char* kDartLanguageArgs[] = {
-    "--enable_mirrors=false", "--background_compilation", "--await_is_keyword",
-    "--causal_async_stacks",  "--limit-ints-to-64-bits",
+    "--enable_mirrors=false",
+    "--background_compilation",
+    "--await_is_keyword",
+    "--causal_async_stacks",
 };
 
 static const char* kDartPrecompilationArgs[] = {


### PR DESCRIPTION
This reverts commit 0b7582e6a130fc99270dafec5113a7ec46ed522a.
