### PR TITLE
[Android] Allow persisting a FlutterNativeView across activities.

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import io.flutter.app.FlutterActivityDelegate.ViewFactory;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterView;
 
 /**
@@ -47,6 +48,18 @@ public class FlutterActivity extends Activity implements FlutterView.Provider, P
         return null;
     }
 
+    /**
+     * Hook for subclasses to customize the creation of the
+     * {@code FlutterNativeView}.
+     *
+     * <p>The default implementation returns {@code null}, which will cause the
+     * activity to use a newly instantiated native view object.</p>
+     */
+    @Override
+    public FlutterNativeView createFlutterNativeView() {
+        return null;
+    }
+
     @Override
     public final boolean hasPlugin(String key) {
         return pluginRegistry.hasPlugin(key);
@@ -66,6 +79,12 @@ public class FlutterActivity extends Activity implements FlutterView.Provider, P
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         eventDelegate.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        eventDelegate.onResume();
     }
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterApplication.java
+++ b/shell/platform/android/io/flutter/app/FlutterApplication.java
@@ -4,6 +4,7 @@
 
 package io.flutter.app;
 
+import android.app.Activity;
 import android.app.Application;
 
 import io.flutter.view.FlutterMain;
@@ -17,5 +18,13 @@ public class FlutterApplication extends Application {
     public void onCreate() {
         super.onCreate();
         FlutterMain.startInitialization(this);
+    }
+
+    private Activity mCurrentActivity = null;
+    public Activity getCurrentActivity() {
+        return mCurrentActivity;
+    }
+    public void setCurrentActivity(Activity mCurrentActivity) {
+        this.mCurrentActivity = mCurrentActivity;
     }
 }

--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -12,6 +12,7 @@ import android.support.v4.app.FragmentActivity;
 import io.flutter.app.FlutterActivityDelegate.ViewFactory;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterView;
 
 /**
@@ -55,6 +56,11 @@ public class FlutterFragmentActivity
      */
     @Override
     public FlutterView createFlutterView(Context context) {
+        return null;
+    }
+
+    @Override
+    public FlutterNativeView createFlutterNativeView() {
         return null;
     }
 

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -6,6 +6,7 @@ package io.flutter.plugin.common;
 
 import android.app.Activity;
 import android.content.Intent;
+import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterView;
 import io.flutter.view.TextureRegistry;
 
@@ -140,6 +141,15 @@ public interface PluginRegistry {
          * @return this {@link Registrar}.
          */
         Registrar addUserLeaveHintListener(UserLeaveHintListener listener);
+
+        /**
+         * Adds a callback allowing the plugin to take part in handling incoming
+         * calls to {@link Activity#onDestroy()}.
+         *
+         * @param listener a {@link ViewDestroyListener} callback.
+         * @return this {@link Registrar}.
+         */
+        Registrar addViewDestroyListener(ViewDestroyListener listener);
     }
 
     /**
@@ -181,5 +191,14 @@ public interface PluginRegistry {
      */
     interface UserLeaveHintListener {
         void onUserLeaveHint();
+    }
+
+    /**
+     * Delegate interface for handling an {@link Activity}'s onDestroy
+     * method being called. A plugin that implements this interface can
+     * adopt the FlutterNativeView by retaining a reference and returning true.
+     */
+    interface ViewDestroyListener {
+        boolean onViewDestroy(FlutterNativeView view);
     }
 }

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.HashMap;
 import java.util.Map;
 
-class FlutterNativeView implements BinaryMessenger {
+public class FlutterNativeView implements BinaryMessenger {
     private static final String TAG = "FlutterNativeView";
 
     private final Map<String, BinaryMessageHandler> mMessageHandlers;
@@ -21,21 +21,30 @@ class FlutterNativeView implements BinaryMessenger {
     private long mNativePlatformView;
     private FlutterView mFlutterView;
 
-    FlutterNativeView(FlutterView flutterView) {
+    public FlutterNativeView(FlutterView flutterView) {
         mFlutterView = flutterView;
         attach(this);
         assertAttached();
         mMessageHandlers = new HashMap<>();
     }
 
-    FlutterNativeView() {
+    public FlutterNativeView() {
         this(null);
+    }
+
+    public void detach() {
+        mFlutterView = null;
+        nativeDetach(mNativePlatformView);
     }
 
     public void destroy() {
         mFlutterView = null;
         nativeDestroy(mNativePlatformView);
         mNativePlatformView = 0;
+    }
+
+    public void setFlutterView(FlutterView flutterView) {
+        mFlutterView = flutterView;
     }
 
     public boolean isAttached() {
@@ -168,6 +177,7 @@ class FlutterNativeView implements BinaryMessenger {
 
     private static native long nativeAttach(FlutterNativeView view);
     private static native void nativeDestroy(long nativePlatformViewAndroid);
+    private static native void nativeDetach(long nativePlatformViewAndroid);
 
     private static native void nativeRunBundleAndSnapshot(long nativePlatformViewAndroid,
         String bundlePath,

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -109,6 +109,10 @@ static jlong Attach(JNIEnv* env, jclass clazz, jobject flutterView) {
   return reinterpret_cast<jlong>(storage);
 }
 
+static void Detach(JNIEnv* env, jobject jcaller, jlong platform_view) {
+  PLATFORM_VIEW->Detach();
+}
+
 static void Destroy(JNIEnv* env, jobject jcaller, jlong platform_view) {
   PLATFORM_VIEW->Detach();
   delete &PLATFORM_VIEW;
@@ -327,6 +331,16 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .signature =
               "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
           .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSource),
+      },
+      {
+          .name = "nativeDetach",
+          .signature = "(J)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::Detach),
+      },
+      {
+          .name = "nativeDestroy",
+          .signature = "(J)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::Destroy),
       },
       {
           .name = "nativeGetObservatoryUri",


### PR DESCRIPTION
Allows a plugin to adopt a FlutterNativeView when the main activity is being destroyed. This is accomplished by a plugin adding a ViewDestroyListener to the plugin Registrar. That plugin can then e.g. hand off the FlutterNativeView to a background service for safe-keeping and to run Dart code on. Also allows an Application to recycle a FlutterNativeView from a background service for the main activity if/when the main activity comes back. This is accomplished by extending FlutterActivityDelegate.ViewFactory with a new method createFlutterNativeView() that an application can override to provide a FlutterNativeView that was cached in a plugin's background service.