### PR TITLE
Move texture registry ownership to platform view

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -58,11 +58,11 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 }
 
 void CompositorContext::OnGrContextCreated() {
-  texture_registry_.OnGrContextCreated();
+  texture_registry_->OnGrContextCreated();
 }
 
 void CompositorContext::OnGrContextDestroyed() {
-  texture_registry_.OnGrContextDestroyed();
+  texture_registry_->OnGrContextDestroyed();
   raster_cache_.Clear();
 }
 

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -62,7 +62,7 @@ class CompositorContext {
 
   RasterCache& raster_cache() { return raster_cache_; }
 
-  TextureRegistry& texture_registry() { return texture_registry_; }
+  TextureRegistry& texture_registry() { return *texture_registry_; }
 
   const Counter& frame_count() const { return frame_count_; }
 
@@ -72,9 +72,11 @@ class CompositorContext {
 
   const CounterValues& memory_usage() const { return memory_usage_; }
 
+  void SetTextureRegistry(TextureRegistry* textureRegistry) { texture_registry_ = textureRegistry; }
+
  private:
   RasterCache raster_cache_;
-  TextureRegistry texture_registry_;
+  TextureRegistry* texture_registry_;
   std::unique_ptr<ProcessInfo> process_info_;
   Counter frame_count_;
   Stopwatch frame_time_;

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -72,7 +72,9 @@ class CompositorContext {
 
   const CounterValues& memory_usage() const { return memory_usage_; }
 
-  void SetTextureRegistry(TextureRegistry* textureRegistry) { texture_registry_ = textureRegistry; }
+  void SetTextureRegistry(TextureRegistry* textureRegistry) {
+    texture_registry_ = textureRegistry;
+  }
 
  private:
   RasterCache raster_cache_;

--- a/shell/common/null_rasterizer.cc
+++ b/shell/common/null_rasterizer.cc
@@ -38,7 +38,7 @@ void NullRasterizer::DrawLastLayerTree() {
 }
 
 flow::TextureRegistry& NullRasterizer::GetTextureRegistry() {
-  return texture_registry_;
+  return *texture_registry_;
 }
 
 void NullRasterizer::Clear(SkColor color, const SkISize& size) {
@@ -57,6 +57,10 @@ void NullRasterizer::Draw(
 
 void NullRasterizer::AddNextFrameCallback(fxl::Closure nextFrameCallback) {
   // Null rasterizer. Nothing to do.
+}
+
+void NullRasterizer::SetTextureRegistry(flow::TextureRegistry* textureRegistry) {
+  texture_registry_ = textureRegistry;
 }
 
 }  // namespace shell

--- a/shell/common/null_rasterizer.cc
+++ b/shell/common/null_rasterizer.cc
@@ -59,7 +59,8 @@ void NullRasterizer::AddNextFrameCallback(fxl::Closure nextFrameCallback) {
   // Null rasterizer. Nothing to do.
 }
 
-void NullRasterizer::SetTextureRegistry(flow::TextureRegistry* textureRegistry) {
+void NullRasterizer::SetTextureRegistry(
+    flow::TextureRegistry* textureRegistry) {
   texture_registry_ = textureRegistry;
 }
 

--- a/shell/common/null_rasterizer.h
+++ b/shell/common/null_rasterizer.h
@@ -36,10 +36,12 @@ class NullRasterizer : public Rasterizer {
 
   void AddNextFrameCallback(fxl::Closure nextFrameCallback) override;
 
+  void SetTextureRegistry(flow::TextureRegistry* textureRegistry) override;
+
  private:
   std::unique_ptr<Surface> surface_;
   fml::WeakPtrFactory<NullRasterizer> weak_factory_;
-  flow::TextureRegistry texture_registry_;
+  flow::TextureRegistry* texture_registry_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(NullRasterizer);
 };

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -22,6 +22,7 @@ PlatformView::PlatformView(std::unique_ptr<Rasterizer> rasterizer)
 }
 
 PlatformView::~PlatformView() {
+  FXL_DLOG(INFO) << "Destroying platform view";
   Shell::Shared().RemovePlatformView(this);
 
   Rasterizer* rasterizer = rasterizer_.release();
@@ -32,9 +33,11 @@ PlatformView::~PlatformView() {
 }
 
 void PlatformView::SetRasterizer(std::unique_ptr<Rasterizer> rasterizer) {
+  FXL_DLOG(INFO) << "Setting rasterizer";
   Rasterizer* r = rasterizer_.release();
   blink::Threads::Gpu()->PostTask([r]() { delete r; });
   rasterizer_ = std::move(rasterizer);
+  rasterizer_->SetTextureRegistry(&texture_registry_);
   engine_->set_rasterizer(rasterizer_->GetWeakRasterizerPtr());
 }
 
@@ -78,6 +81,7 @@ void PlatformView::NotifyCreated(std::unique_ptr<Surface> surface,
                                  fxl::Closure caller_continuation) {
   fxl::AutoResetWaitableEvent latch;
 
+  FXL_LOG(INFO) << "Platform view Notify created";
   auto ui_continuation = fxl::MakeCopyable([
     this,                          //
     surface = std::move(surface),  //
@@ -105,7 +109,7 @@ void PlatformView::NotifyCreated(std::unique_ptr<Surface> surface,
 
 void PlatformView::NotifyDestroyed() {
   fxl::AutoResetWaitableEvent latch;
-
+  FXL_LOG(INFO) << "Platform view Notify destroyed";
   auto engine_continuation = [this, &latch]() {
     rasterizer_->Teardown(&latch);
   };

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -22,7 +22,6 @@ PlatformView::PlatformView(std::unique_ptr<Rasterizer> rasterizer)
 }
 
 PlatformView::~PlatformView() {
-  FXL_DLOG(INFO) << "Destroying platform view";
   Shell::Shared().RemovePlatformView(this);
 
   Rasterizer* rasterizer = rasterizer_.release();
@@ -33,7 +32,6 @@ PlatformView::~PlatformView() {
 }
 
 void PlatformView::SetRasterizer(std::unique_ptr<Rasterizer> rasterizer) {
-  FXL_DLOG(INFO) << "Setting rasterizer";
   Rasterizer* r = rasterizer_.release();
   blink::Threads::Gpu()->PostTask([r]() { delete r; });
   rasterizer_ = std::move(rasterizer);
@@ -81,7 +79,6 @@ void PlatformView::NotifyCreated(std::unique_ptr<Surface> surface,
                                  fxl::Closure caller_continuation) {
   fxl::AutoResetWaitableEvent latch;
 
-  FXL_LOG(INFO) << "Platform view Notify created";
   auto ui_continuation = fxl::MakeCopyable([
     this,                          //
     surface = std::move(surface),  //
@@ -109,7 +106,7 @@ void PlatformView::NotifyCreated(std::unique_ptr<Surface> surface,
 
 void PlatformView::NotifyDestroyed() {
   fxl::AutoResetWaitableEvent latch;
-  FXL_LOG(INFO) << "Platform view Notify destroyed";
+
   auto engine_continuation = [this, &latch]() {
     rasterizer_->Teardown(&latch);
   };

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -91,7 +91,6 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
   SurfaceConfig surface_config_;
   std::unique_ptr<Rasterizer> rasterizer_;
   flow::TextureRegistry texture_registry_;
-
   std::unique_ptr<Engine> engine_;
   std::unique_ptr<VsyncWaiter> vsync_waiter_;
   SkISize size_;

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -90,6 +90,8 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
 
   SurfaceConfig surface_config_;
   std::unique_ptr<Rasterizer> rasterizer_;
+  flow::TextureRegistry texture_registry_;
+
   std::unique_ptr<Engine> engine_;
   std::unique_ptr<VsyncWaiter> vsync_waiter_;
   SkISize size_;

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -42,6 +42,8 @@ class Rasterizer {
 
   // Set a callback to be called once when the next frame is drawn.
   virtual void AddNextFrameCallback(fxl::Closure nextFrameCallback) = 0;
+
+  virtual void SetTextureRegistry(flow::TextureRegistry* textureRegistry) = 0;
 };
 
 }  // namespace shell

--- a/shell/gpu/gpu_rasterizer.cc
+++ b/shell/gpu/gpu_rasterizer.cc
@@ -19,7 +19,9 @@ namespace shell {
 GPURasterizer::GPURasterizer(std::unique_ptr<flow::ProcessInfo> info)
     : compositor_context_(std::move(info)), weak_factory_(this) {}
 
-GPURasterizer::~GPURasterizer() = default;
+GPURasterizer::~GPURasterizer() {
+    FXL_LOG(INFO) << "Deleting the rasterizer";
+};
 
 fml::WeakPtr<Rasterizer> GPURasterizer::GetWeakRasterizerPtr() {
   return weak_factory_.GetWeakPtr();
@@ -159,6 +161,10 @@ void GPURasterizer::NotifyNextFrameOnce() {
     });
     nextFrameCallback_ = nullptr;
   }
+}
+
+void GPURasterizer::SetTextureRegistry(flow::TextureRegistry* textureRegistry) {
+  compositor_context_.SetTextureRegistry(std::move(textureRegistry));
 }
 
 }  // namespace shell

--- a/shell/gpu/gpu_rasterizer.cc
+++ b/shell/gpu/gpu_rasterizer.cc
@@ -19,9 +19,7 @@ namespace shell {
 GPURasterizer::GPURasterizer(std::unique_ptr<flow::ProcessInfo> info)
     : compositor_context_(std::move(info)), weak_factory_(this) {}
 
-GPURasterizer::~GPURasterizer() {
-    FXL_LOG(INFO) << "Deleting the rasterizer";
-};
+GPURasterizer::~GPURasterizer() = default;
 
 fml::WeakPtr<Rasterizer> GPURasterizer::GetWeakRasterizerPtr() {
   return weak_factory_.GetWeakPtr();

--- a/shell/gpu/gpu_rasterizer.h
+++ b/shell/gpu/gpu_rasterizer.h
@@ -42,6 +42,8 @@ class GPURasterizer : public Rasterizer {
   // Set a callback to be called once when the next frame is drawn.
   void AddNextFrameCallback(fxl::Closure nextFrameCallback) override;
 
+  void SetTextureRegistry(flow::TextureRegistry* textureRegistry) override;
+
  private:
   std::unique_ptr<Surface> surface_;
   flow::CompositorContext compositor_context_;


### PR DESCRIPTION
This enables the texture registry to survive activity pause on Android.