### PR TITLE
Add support for blocking platform message send

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
@@ -72,6 +72,10 @@ public final class BasicMessageChannel<T> {
     /**
      * Sends the specified message to the Flutter application, then blocks waiting for a reply.
      *
+     * <p>This method should be used only when the semantics of the caller's context precludes
+     * the use of asynchronous alternatives. Examples include implementing
+     * {@link android.app.Activity#onSaveInstanceState(android.os.Bundle)}.</p>
+     *
      * @param message the message, possibly null.
      * @return the reply, possibly null.
      */

--- a/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
@@ -70,6 +70,16 @@ public final class BasicMessageChannel<T> {
     }
 
     /**
+     * Sends the specified message to the Flutter application, then blocks waiting for a reply.
+     *
+     * @param message the message, possibly null.
+     * @return the reply, possibly null.
+     */
+    public T sendBlocking(T message) {
+        return codec.decodeMessage(messenger.sendBlocking(name, codec.encodeMessage(message)));
+    }
+
+    /**
      * Registers a message handler on this channel for receiving messages sent from the Flutter
      * application.
      *

--- a/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
+++ b/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
@@ -42,7 +42,7 @@ public interface BinaryMessenger {
     /**
      * Sends a binary message to the Flutter application and blocks waiting for a reply.
      *
-     * <p>The method should be used only when the semantics of the caller's context precludes the use of
+     * <p>This method should be used only when the semantics of the caller's context precludes the use of
      * asynchronous alternatives. Examples include implementing
      * {@link android.app.Activity#onSaveInstanceState(android.os.Bundle)}.</p>
      *

--- a/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
+++ b/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
@@ -40,7 +40,7 @@ public interface BinaryMessenger {
     void send(String channel, ByteBuffer message, BinaryReply callback);
 
     /**
-     * Synchronously sends a binary message to the Flutter application and blocks waiting for a reply.
+     * Sends a binary message to the Flutter application and blocks waiting for a reply.
      *
      * <p>The method should be used only when the semantics of the caller's context precludes the use of
      * asynchronous alternatives. Examples include implementing
@@ -51,7 +51,7 @@ public interface BinaryMessenger {
      * bytes between position zero and current position, or null.
      * @return a {@link ByteBuffer} containing the reply payload, or null.
      */
-    ByteBuffer sendSync(String channel, ByteBuffer message);
+    ByteBuffer sendBlocking(String channel, ByteBuffer message);
 
     /**
      * Registers a handler to be invoked when the Flutter application sends a message

--- a/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
+++ b/shell/platform/android/io/flutter/plugin/common/BinaryMessenger.java
@@ -40,6 +40,20 @@ public interface BinaryMessenger {
     void send(String channel, ByteBuffer message, BinaryReply callback);
 
     /**
+     * Synchronously sends a binary message to the Flutter application and blocks waiting for a reply.
+     *
+     * <p>The method should be used only when the semantics of the caller's context precludes the use of
+     * asynchronous alternatives. Examples include implementing
+     * {@link android.app.Activity#onSaveInstanceState(android.os.Bundle)}.</p>
+     *
+     * @param channel the name {@link String} of the logical channel used for the message.
+     * @param message the message payload, a direct-allocated {@link ByteBuffer} with the message
+     * bytes between position zero and current position, or null.
+     * @return a {@link ByteBuffer} containing the reply payload, or null.
+     */
+    ByteBuffer sendSync(String channel, ByteBuffer message);
+
+    /**
      * Registers a handler to be invoked when the Flutter application sends a message
      * to its host platform.
      *

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -84,6 +84,25 @@ public final class MethodChannel {
     }
 
     /**
+     * Invokes a method on this channel, blocking while waiting for a result.
+     *
+     * @param method the name String of the method.
+     * @param arguments the arguments for the invocation, possibly null.
+     * @return the invocation result, possibly null.
+     * @throws UnsupportedOperationException, if no method handler has been registered
+     * on the Dart side.
+     */
+    public Object invokeMethodSync(String method, Object arguments) {
+        final ByteBuffer reply = messenger.sendSync(name,
+            codec.encodeMethodCall(new MethodCall(method, arguments)));
+        if (reply == null) {
+            throw new UnsupportedOperationException(
+                "Method " + method + " not implemented by Dart code");
+        }
+        return codec.decodeEnvelope(reply);
+    }
+
+    /**
      * Registers a method call handler on this channel.
      *
      * <p>Overrides any existing handler registration for (the name of) this channel.</p>

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -86,6 +86,10 @@ public final class MethodChannel {
     /**
      * Invokes a method on this channel, blocking while waiting for a result.
      *
+     * <p>This method should be used only when the semantics of the caller's context precludes
+     * the use of asynchronous alternatives. Examples include implementing
+     * {@link android.app.Activity#onSaveInstanceState(android.os.Bundle)}.</p>
+     *
      * @param method the name String of the method.
      * @param arguments the arguments for the invocation, possibly null.
      * @return the invocation result, possibly null.

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -92,8 +92,8 @@ public final class MethodChannel {
      * @throws UnsupportedOperationException, if no method handler has been registered
      * on the Dart side.
      */
-    public Object invokeMethodSync(String method, Object arguments) {
-        final ByteBuffer reply = messenger.sendSync(name,
+    public Object invokeMethodBlocking(String method, Object arguments) {
+        final ByteBuffer reply = messenger.sendBlocking(name,
             codec.encodeMethodCall(new MethodCall(method, arguments)));
         if (reply == null) {
             throw new UnsupportedOperationException(

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -91,17 +91,17 @@ class FlutterNativeView implements BinaryMessenger {
     }
 
     @Override
-    public ByteBuffer sendSync(String channel, ByteBuffer message) {
+    public ByteBuffer sendBlocking(String channel, ByteBuffer message) {
         if (!isAttached()) {
-            Log.d(TAG, "FlutterView.sendSync called on a detached view, channel=" + channel);
+            Log.d(TAG, "FlutterView.sendBlocking called on a detached view, channel=" + channel);
             return null;
         }
         final byte[] reply;
         if (message == null) {
-            reply = nativeDispatchEmptyPlatformMessageSync(mNativePlatformView, channel);
+            reply = nativeDispatchEmptyPlatformMessageBlocking(mNativePlatformView, channel);
         } else {
-            reply = nativeDispatchPlatformMessageSync(
-                    mNativePlatformView, channel, message, message.position());
+            reply = nativeDispatchPlatformMessageBlocking(
+                mNativePlatformView, channel, message, message.position());
         }
         return (reply == null ? null : ByteBuffer.wrap(reply));
     }
@@ -207,12 +207,12 @@ class FlutterNativeView implements BinaryMessenger {
         String channel, ByteBuffer message, int position, int responseId);
 
     // Send an empty platform message to Dart and block waiting for the reply.
-    private static native byte[] nativeDispatchEmptyPlatformMessageSync(
+    private static native byte[] nativeDispatchEmptyPlatformMessageBlocking(
         long nativePlatformViewAndroid, String channel);
 
     // Send a data-carrying platform message to Dart and block waiting for the reply.
-    private static native byte[] nativeDispatchPlatformMessageSync(long nativePlatformViewAndroid,
-        String channel, ByteBuffer message, int position);
+    private static native byte[] nativeDispatchPlatformMessageBlocking(
+        long nativePlatformViewAndroid, String channel, ByteBuffer message, int position);
 
     // Send an empty response to a platform message received from Dart.
     private static native void nativeInvokePlatformMessageEmptyResponseCallback(

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -812,6 +812,11 @@ public class FlutterView extends SurfaceView
     }
 
     @Override
+    public ByteBuffer sendSync(String channel, ByteBuffer message) {
+        return mNativeView.sendSync(channel, message);
+    }
+
+    @Override
     public void setMessageHandler(String channel, BinaryMessageHandler handler) {
         mNativeView.setMessageHandler(channel, handler);
     }

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -812,8 +812,8 @@ public class FlutterView extends SurfaceView
     }
 
     @Override
-    public ByteBuffer sendSync(String channel, ByteBuffer message) {
-        return mNativeView.sendSync(channel, message);
+    public ByteBuffer sendBlocking(String channel, ByteBuffer message) {
+        return mNativeView.sendBlocking(channel, message);
     }
 
     @Override

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -329,7 +329,7 @@ void PlatformViewAndroid::DispatchEmptyPlatformMessage(JNIEnv* env,
                                                   std::move(response)));
 }
 
-jbyteArray PlatformViewAndroid::DispatchPlatformMessageSync(
+jbyteArray PlatformViewAndroid::DispatchPlatformMessageBlocking(
     JNIEnv* env,
     std::string name,
     jobject java_message_data,
@@ -347,7 +347,7 @@ jbyteArray PlatformViewAndroid::DispatchPlatformMessageSync(
   return response->ToJavaByteArray(env);
 }
 
-jbyteArray PlatformViewAndroid::DispatchEmptyPlatformMessageSync(
+jbyteArray PlatformViewAndroid::DispatchEmptyPlatformMessageBlocking(
     JNIEnv* env,
     std::string name) {
   fxl::RefPtr<LatchedPlatformMessageResponseAndroid> response =

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -68,6 +68,41 @@ class PlatformMessageResponseAndroid : public blink::PlatformMessageResponse {
   std::weak_ptr<PlatformView> view_;
 };
 
+class LatchedPlatformMessageResponseAndroid
+    : public blink::PlatformMessageResponse {
+  FRIEND_MAKE_REF_COUNTED(LatchedPlatformMessageResponseAndroid);
+
+ public:
+  void Complete(std::vector<uint8_t> data) override {
+    reply_ = std::move(data);
+    hasReply_ = true;
+    latch_.Signal();
+  }
+
+  void CompleteEmpty() override {
+    hasReply_ = false;
+    latch_.Signal();
+  }
+
+  void Wait() { latch_.Wait(); }
+
+  jbyteArray ToJavaByteArray(JNIEnv* env) {
+    if (hasReply_) {
+      jbyteArray reply_array = env->NewByteArray(reply_.size());
+      env->SetByteArrayRegion(reply_array, 0, reply_.size(),
+                              reinterpret_cast<const jbyte*>(reply_.data()));
+      return reply_array;
+    } else {
+      return nullptr;
+    }
+  }
+
+ private:
+  fxl::AutoResetWaitableEvent latch_;
+  bool hasReply_;
+  std::vector<uint8_t> reply_;
+};
+
 static std::unique_ptr<AndroidSurface> InitializePlatformSurfaceGL() {
   const PlatformView::SurfaceConfig offscreen_config = {
       .red_bits = 8,
@@ -292,6 +327,35 @@ void PlatformViewAndroid::DispatchEmptyPlatformMessage(JNIEnv* env,
   PlatformView::DispatchPlatformMessage(
       fxl::MakeRefCounted<blink::PlatformMessage>(std::move(name),
                                                   std::move(response)));
+}
+
+jbyteArray PlatformViewAndroid::DispatchPlatformMessageSync(
+    JNIEnv* env,
+    std::string name,
+    jobject java_message_data,
+    jint java_message_position) {
+  uint8_t* message_data =
+      static_cast<uint8_t*>(env->GetDirectBufferAddress(java_message_data));
+  std::vector<uint8_t> message =
+      std::vector<uint8_t>(message_data, message_data + java_message_position);
+  fxl::RefPtr<LatchedPlatformMessageResponseAndroid> response =
+      fxl::MakeRefCounted<LatchedPlatformMessageResponseAndroid>();
+  PlatformView::DispatchPlatformMessage(
+      fxl::MakeRefCounted<blink::PlatformMessage>(
+          std::move(name), std::move(message), response));
+  response->Wait();
+  return response->ToJavaByteArray(env);
+}
+
+jbyteArray PlatformViewAndroid::DispatchEmptyPlatformMessageSync(
+    JNIEnv* env,
+    std::string name) {
+  fxl::RefPtr<LatchedPlatformMessageResponseAndroid> response =
+      fxl::MakeRefCounted<LatchedPlatformMessageResponseAndroid>();
+  PlatformView::DispatchPlatformMessage(
+      fxl::MakeRefCounted<blink::PlatformMessage>(std::move(name), response));
+  response->Wait();
+  return response->ToJavaByteArray(env);
 }
 
 void PlatformViewAndroid::DispatchPointerDataPacket(JNIEnv* env,

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -65,6 +65,13 @@ class PlatformViewAndroid : public PlatformView {
                                     std::string name,
                                     jint response_id);
 
+  jbyteArray DispatchPlatformMessageSync(JNIEnv* env,
+                                         std::string name,
+                                         jobject message_data,
+                                         jint message_position);
+
+  jbyteArray DispatchEmptyPlatformMessageSync(JNIEnv* env, std::string name);
+
   void DispatchPointerDataPacket(JNIEnv* env, jobject buffer, jint position);
 
   void InvokePlatformMessageResponseCallback(JNIEnv* env,

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -65,12 +65,13 @@ class PlatformViewAndroid : public PlatformView {
                                     std::string name,
                                     jint response_id);
 
-  jbyteArray DispatchPlatformMessageSync(JNIEnv* env,
-                                         std::string name,
-                                         jobject message_data,
-                                         jint message_position);
+  jbyteArray DispatchPlatformMessageBlocking(JNIEnv* env,
+                                             std::string name,
+                                             jobject message_data,
+                                             jint message_position);
 
-  jbyteArray DispatchEmptyPlatformMessageSync(JNIEnv* env, std::string name);
+  jbyteArray DispatchEmptyPlatformMessageBlocking(JNIEnv* env,
+                                                  std::string name);
 
   void DispatchPointerDataPacket(JNIEnv* env, jobject buffer, jint position);
 

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -198,7 +198,7 @@ static void DispatchPlatformMessage(JNIEnv* env,
                                     jobject message,
                                     jint position,
                                     jint responseId) {
-  return PLATFORM_VIEW->DispatchPlatformMessage(
+  PLATFORM_VIEW->DispatchPlatformMessage(
       env, fml::jni::JavaStringToString(env, channel), message, position,
       responseId);
 }
@@ -208,8 +208,26 @@ static void DispatchEmptyPlatformMessage(JNIEnv* env,
                                          jlong platform_view,
                                          jstring channel,
                                          jint responseId) {
-  return PLATFORM_VIEW->DispatchEmptyPlatformMessage(
+  PLATFORM_VIEW->DispatchEmptyPlatformMessage(
       env, fml::jni::JavaStringToString(env, channel), responseId);
+}
+
+static jbyteArray DispatchPlatformMessageSync(JNIEnv* env,
+                                              jobject jcaller,
+                                              jlong platform_view,
+                                              jstring channel,
+                                              jobject message,
+                                              jint position) {
+  return PLATFORM_VIEW->DispatchPlatformMessageSync(
+      env, fml::jni::JavaStringToString(env, channel), message, position);
+}
+
+static jbyteArray DispatchEmptyPlatformMessageSync(JNIEnv* env,
+                                                   jobject jcaller,
+                                                   jlong platform_view,
+                                                   jstring channel) {
+  return PLATFORM_VIEW->DispatchEmptyPlatformMessageSync(
+      env, fml::jni::JavaStringToString(env, channel));
 }
 
 static void DispatchPointerDataPacket(JNIEnv* env,
@@ -343,6 +361,17 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .name = "nativeDispatchPlatformMessage",
           .signature = "(JLjava/lang/String;Ljava/nio/ByteBuffer;II)V",
           .fnPtr = reinterpret_cast<void*>(&shell::DispatchPlatformMessage),
+      },
+      {
+          .name = "nativeDispatchEmptyPlatformMessageSync",
+          .signature = "(JLjava/lang/String;)[B",
+          .fnPtr =
+              reinterpret_cast<void*>(&shell::DispatchEmptyPlatformMessageSync),
+      },
+      {
+          .name = "nativeDispatchPlatformMessageSync",
+          .signature = "(JLjava/lang/String;Ljava/nio/ByteBuffer;I)[B",
+          .fnPtr = reinterpret_cast<void*>(&shell::DispatchPlatformMessageSync),
       },
       {
           .name = "nativeInvokePlatformMessageResponseCallback",

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -212,21 +212,21 @@ static void DispatchEmptyPlatformMessage(JNIEnv* env,
       env, fml::jni::JavaStringToString(env, channel), responseId);
 }
 
-static jbyteArray DispatchPlatformMessageSync(JNIEnv* env,
-                                              jobject jcaller,
-                                              jlong platform_view,
-                                              jstring channel,
-                                              jobject message,
-                                              jint position) {
-  return PLATFORM_VIEW->DispatchPlatformMessageSync(
+static jbyteArray DispatchPlatformMessageBlocking(JNIEnv* env,
+                                                  jobject jcaller,
+                                                  jlong platform_view,
+                                                  jstring channel,
+                                                  jobject message,
+                                                  jint position) {
+  return PLATFORM_VIEW->DispatchPlatformMessageBlocking(
       env, fml::jni::JavaStringToString(env, channel), message, position);
 }
 
-static jbyteArray DispatchEmptyPlatformMessageSync(JNIEnv* env,
-                                                   jobject jcaller,
-                                                   jlong platform_view,
-                                                   jstring channel) {
-  return PLATFORM_VIEW->DispatchEmptyPlatformMessageSync(
+static jbyteArray DispatchEmptyPlatformMessageBlocking(JNIEnv* env,
+                                                       jobject jcaller,
+                                                       jlong platform_view,
+                                                       jstring channel) {
+  return PLATFORM_VIEW->DispatchEmptyPlatformMessageBlocking(
       env, fml::jni::JavaStringToString(env, channel));
 }
 
@@ -363,15 +363,16 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .fnPtr = reinterpret_cast<void*>(&shell::DispatchPlatformMessage),
       },
       {
-          .name = "nativeDispatchEmptyPlatformMessageSync",
+          .name = "nativeDispatchEmptyPlatformMessageBlocking",
           .signature = "(JLjava/lang/String;)[B",
-          .fnPtr =
-              reinterpret_cast<void*>(&shell::DispatchEmptyPlatformMessageSync),
+          .fnPtr = reinterpret_cast<void*>(
+              &shell::DispatchEmptyPlatformMessageBlocking),
       },
       {
-          .name = "nativeDispatchPlatformMessageSync",
+          .name = "nativeDispatchPlatformMessageBlocking",
           .signature = "(JLjava/lang/String;Ljava/nio/ByteBuffer;I)[B",
-          .fnPtr = reinterpret_cast<void*>(&shell::DispatchPlatformMessageSync),
+          .fnPtr =
+              reinterpret_cast<void*>(&shell::DispatchPlatformMessageBlocking),
       },
       {
           .name = "nativeInvokePlatformMessageResponseCallback",

--- a/shell/platform/darwin/ios/framework/Headers/FlutterBinaryMessenger.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterBinaryMessenger.h
@@ -66,6 +66,19 @@ FLUTTER_EXPORT
 - (void)sendOnChannel:(NSString*)channel
               message:(NSData* _Nullable)message
           binaryReply:(FlutterBinaryReply _Nullable)callback;
+/**
+ Sends a binary message to the Flutter side on the specified channel, blocking
+ while waiting for a reply.
+
+ Should be used only when the semantics of the caller's context precludes
+ the use of asynchronous alternatives.
+
+ - Parameters:
+   - channel: The channel name.
+   - message: The message.
+- Returns: The reply.
+ */
+- (NSData* _Nullable)sendBlockingOnChannel:(NSString*)channel message:(NSData* _Nullable)message;
 
 /**
  Registers a message handler for incoming binary messages from the Flutter side

--- a/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
@@ -112,6 +112,19 @@ FLUTTER_EXPORT
 - (void)sendMessage:(id _Nullable)message reply:(FlutterReply _Nullable)callback;
 
 /**
+ Sends the specified message to the Flutter side, blocking while waiting for
+ a reply.
+
+ Should be used only when the semantics of the caller's context precludes
+ the use of asynchronous alternatives.
+
+ - Parameters:
+   - message: The message. Must be supported by the codec of this channel.
+ - Returns: The reply.
+ */
+- (id _Nullable)sendBlockingMessage:(id _Nullable)message;
+
+/**
  Registers a message handler with this channel.
 
  Replaces any existing handler. Use a `nil` handler for unregistering the
@@ -243,6 +256,25 @@ FLUTTER_EXPORT
 - (void)invokeMethod:(NSString*)method
            arguments:(id _Nullable)arguments
               result:(FlutterResult _Nullable)callback;
+
+/**
+ Invokes the specified Flutter method with the specified arguments, blocking
+ while waiting for a reply.
+
+ Should be used only when the semantics of the caller's context precludes
+ the use of asynchronous alternatives.
+
+ - Parameters:
+   - method: The name of the method to invoke.
+   - arguments: The arguments. Must be a value supported by the codec of this
+     channel.
+ - Returns: The result of the invocation. The result will be a `FlutterError`
+     instance, if the method call resulted in an error on the Flutter side.
+     Will be `FlutterMethodNotImplemented`, if the method called was not
+     implemented on the Flutter side. Any other value, including `nil`, should
+     be interpreted as successful results.
+ */
+- (id _Nullable)invokeBlockingMethod:(NSString*)method arguments:(id _Nullable)arguments;
 
 /**
  Registers a handler for method calls from the Flutter side.

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -56,6 +56,10 @@
   [_messenger sendOnChannel:_name message:[_codec encode:message] binaryReply:reply];
 }
 
+- (id)sendBlockingMessage:(id)message {
+  return [_codec decode:[_messenger sendBlockingOnChannel:_name message:[_codec encode:message]]];
+}
+
 - (void)setMessageHandler:(FlutterMessageHandler)handler {
   if (!handler) {
     [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:nil];
@@ -201,6 +205,14 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
     }
   };
   [_messenger sendOnChannel:_name message:message binaryReply:reply];
+}
+
+- (id)invokeBlockingMethod:(NSString*)method arguments:(id)arguments {
+  FlutterMethodCall* methodCall =
+      [FlutterMethodCall methodCallWithMethodName:method arguments:arguments];
+  NSData* message = [_codec encodeMethodCall:methodCall];
+  NSData* reply = [_messenger sendBlockingOnChannel:_name message:message];
+  return (reply == nil) ? FlutterMethodNotImplemented : [_codec decodeEnvelope:reply];
 }
 
 - (void)setMethodCallHandler:(FlutterMethodCallHandler)handler {


### PR DESCRIPTION
Adds support for blocking message send/reply from platform code and into Flutter. This facility is needed in situations where platform-specific code receives a (synchronous) request for a value whose computation involves executing Dart code.

One example is saving UI view state on Android, cf. https://github.com/flutter/flutter/issues/6827.