### PR TITLE
Prevent Skia from trying to use stencil buffers

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -33,8 +33,11 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
   auto backend_context =
       reinterpret_cast<GrBackendContext>(GrGLCreateNativeInterface());
 
-  auto context =
-      sk_sp<GrContext>(GrContext::Create(kOpenGL_GrBackend, backend_context));
+  GrContextOptions options;
+  options.fAvoidStencilBuffers = true;
+
+  auto context = sk_sp<GrContext>(
+      GrContext::Create(kOpenGL_GrBackend, backend_context, options));
 
   if (context == nullptr) {
     FXL_LOG(ERROR) << "Failed to setup Skia Gr context.";


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/13018

When linear blending was disabled, we started rendering directly to FBO0 again. We can't attach stencil there, and the profile graph code triggers a path that (by default) uses it. This option forces us to use alternate rendering methods.

Note that the graph rendering code is constructing a fairly complex path. It would probably be much faster to render as a simpler series of drawRect calls for each box (which would get batched inside Skia).