### PR TITLE
Allow Flutter apps on Fuchsia to shut down cleanly

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'github_git': 'https://github.com',
-  'skia_revision': '0658f765d0242434cd00ceef473529a6a634dba2',
+  'skia_revision': '42bae8faa4b9b6a3341b15c6ac7c6b466e95625c',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'skia_git': 'https://skia.googlesource.com',
   'github_git': 'https://github.com',
-  'skia_revision': '3186821c7e4448c4b586dde590760e22b46cf166',
+  'skia_revision': '0658f765d0242434cd00ceef473529a6a634dba2',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/content_handler/application_controller_impl.cc
+++ b/content_handler/application_controller_impl.cc
@@ -66,6 +66,9 @@ ApplicationControllerImpl::ApplicationControllerImpl(
 
   url_ = startup_info->launch_info->url;
   runtime_holder_.reset(new RuntimeHolder());
+  runtime_holder_->SetMainIsolateTerminatedCallback([this]() {
+    Kill();
+  });
   runtime_holder_->Init(
       fdio_ns, app::ApplicationContext::CreateFrom(std::move(startup_info)),
       std::move(request), std::move(bundle));

--- a/content_handler/application_controller_impl.cc
+++ b/content_handler/application_controller_impl.cc
@@ -66,7 +66,7 @@ ApplicationControllerImpl::ApplicationControllerImpl(
 
   url_ = startup_info->launch_info->url;
   runtime_holder_.reset(new RuntimeHolder());
-  runtime_holder_->SetMainIsolateTerminatedCallback([this]() {
+  runtime_holder_->SetMainIsolateShutdownCallback([this]() {
     Kill();
   });
   runtime_holder_->Init(

--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -291,6 +291,16 @@ Dart_Port RuntimeHolder::GetUIIsolateMainPort() {
   return runtime_->GetMainPort();
 }
 
+void RuntimeHolder::DidShutdownMainIsolate() {
+  if (main_isolate_shutdown_callback_) {
+    main_isolate_shutdown_callback_();
+  }
+}
+
+void RuntimeHolder::SetMainIsolateShutdownCallback(std::function<void()> callback) {
+  main_isolate_shutdown_callback_ = callback;
+}
+
 std::string RuntimeHolder::GetUIIsolateName() {
   if (!runtime_) {
     return "";

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -56,6 +56,8 @@ class RuntimeHolder : public blink::RuntimeDelegate,
 
   int32_t return_code() { return return_code_; }
 
+  void SetMainIsolateShutdownCallback(std::function<void()> callback);
+
  private:
   // |blink::RuntimeDelegate| implementation:
   std::string DefaultRouteName() override;
@@ -65,6 +67,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message) override;
   void DidCreateMainIsolate(Dart_Isolate isolate) override;
+  void DidShutdownMainIsolate() override;
 
   // |mozart::NativesDelegate| implementation:
   mozart::View* GetMozartView() override;
@@ -127,6 +130,8 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   fxl::WeakPtrFactory<RuntimeHolder> weak_factory_;
 
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
+
+  std::function<void()> main_isolate_shutdown_callback_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(RuntimeHolder);
 };

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -92,7 +92,7 @@ abstract class OffsetBase {
   int get hashCode => hashValues(_dx, _dy);
 
   @override
-  String toString() => "$runtimeType(${_dx?.toStringAsFixed(1)}, ${_dy?.toStringAsFixed(1)})";
+  String toString() => '$runtimeType(${_dx?.toStringAsFixed(1)}, ${_dy?.toStringAsFixed(1)})';
 }
 
 /// An immutable 2D floating-point offset.
@@ -284,7 +284,7 @@ class Offset extends OffsetBase {
   }
 
   @override
-  String toString() => "Offset(${dx?.toStringAsFixed(1)}, ${dy?.toStringAsFixed(1)})";
+  String toString() => 'Offset(${dx?.toStringAsFixed(1)}, ${dy?.toStringAsFixed(1)})';
 }
 
 /// Holds a 2D floating-point size.
@@ -405,12 +405,11 @@ class Size extends OffsetBase {
   /// [double]).
   Size operator %(double operand) => new Size(width % operand, height % operand);
 
-  /// The lesser of the [width] and the [height].
-  double get shortestSide {
-    double w = width.abs();
-    double h = height.abs();
-    return w < h ? w : h;
-  }
+  /// The lesser of the magnitudes of the [width] and the [height].
+  double get shortestSide => math.min(width.abs(), height.abs());
+
+  /// The greater of the magnitudes of the [width] and the [height].
+  double get longestSide => math.max(width.abs(), height.abs());
 
   // Convenience methods that do the equivalent of calling the similarly named
   // methods on a Rect constructed from the given origin and this size.
@@ -513,7 +512,7 @@ class Size extends OffsetBase {
   }
 
   @override
-  String toString() => "Size(${width?.toStringAsFixed(1)}, ${height?.toStringAsFixed(1)})";
+  String toString() => 'Size(${width?.toStringAsFixed(1)}, ${height?.toStringAsFixed(1)})';
 }
 
 /// An immutable, 2D, axis-aligned, floating-point rectangle whose coordinates
@@ -653,6 +652,17 @@ class Rect {
     );
   }
 
+  /// Returns a new rectangle which is the bounding box containing this
+  /// rectangle and the given rectangle.
+  Rect expandToInclude(Rect other) {
+    return new Rect.fromLTRB(
+        math.min(left, other.left),
+        math.min(top, other.top),
+        math.max(right, other.right),
+        math.max(bottom, other.bottom),
+    );
+  }
+
   /// Whether `other` has a nonzero area of overlap with this rectangle.
   bool overlaps(Rect other) {
     if (right <= other.left || other.right <= left)
@@ -662,13 +672,13 @@ class Rect {
     return true;
   }
 
-  /// The lesser of the magnitudes of the width and the height of this
+  /// The lesser of the magnitudes of the [width] and the [height] of this
   /// rectangle.
-  double get shortestSide {
-    double w = width.abs();
-    double h = height.abs();
-    return w < h ? w : h;
-  }
+  double get shortestSide => math.min(width.abs(), height.abs());
+
+  /// The greater of the magnitudes of the [width] and the [height] of this
+  /// rectangle.
+  double get longestSide => math.max(width.abs(), height.abs());
 
   /// The offset to the intersection of the top and left edges of this rectangle.
   ///
@@ -735,7 +745,7 @@ class Rect {
     if (a == null)
       return new Rect.fromLTRB(b.left * t, b.top * t, b.right * t, b.bottom * t);
     if (b == null) {
-      double k = 1.0 - t;
+      final double k = 1.0 - t;
       return new Rect.fromLTRB(a.left * k, a.top * k, a.right * k, a.bottom * k);
     }
     return new Rect.fromLTRB(
@@ -764,7 +774,7 @@ class Rect {
   int get hashCode => hashList(_value);
 
   @override
-  String toString() => "Rect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})";
+  String toString() => 'Rect.fromLTRB(${left.toStringAsFixed(1)}, ${top.toStringAsFixed(1)}, ${right.toStringAsFixed(1)}, ${bottom.toStringAsFixed(1)})';
 }
 
 /// A radius for either circular or elliptical shapes.
@@ -847,7 +857,7 @@ class Radius {
     if (a == null)
       return new Radius.elliptical(b.x * t, b.y * t);
     if (b == null) {
-      double k = 1.0 - t;
+      final double k = 1.0 - t;
       return new Radius.elliptical(a.x * k, a.y * k);
     }
     return new Radius.elliptical(
@@ -1241,13 +1251,14 @@ class RRect {
   /// Whether this rounded rectangle would draw as a circle.
   bool get isCircle => width == height && isEllipse;
 
-  /// The lesser of the magnitudes of the width and the height of this rounded
-  /// rectangle.
-  double get shortestSide {
-    double w = width.abs();
-    double h = height.abs();
-    return w < h ? w : h;
-  }
+  /// The lesser of the magnitudes of the [width] and the [height] of this
+  /// rounded rectangle.
+  double get shortestSide => math.min(width.abs(), height.abs());
+
+  /// The greater of the magnitudes of the [width] and the [height] of this
+  /// rounded rectangle.
+  double get longestSide => math.max(width.abs(), height.abs());
+
 
   /// The offset to the point halfway between the left and right and the top and
   /// bottom edges of this rectangle.
@@ -1256,7 +1267,7 @@ class RRect {
   // Returns the minimum between min and scale to which radius1 and radius2
   // should be scaled with in order not to exceed the limit.
   double _getMin(double min, double radius1, double radius2, double limit) {
-    double sum = radius1 + radius2;
+    final double sum = radius1 + radius2;
     if (sum > limit && sum != 0.0)
       return math.min(min, limit / sum);
     return min;
@@ -1270,7 +1281,7 @@ class RRect {
   void _scaleRadii() {
     if (_scaled == null) {
       double scale = 1.0;
-      final List<double> scaled = new List.from(_value);
+      final List<double> scaled = new List<double>.from(_value);
 
       scale = _getMin(scale, scaled[11], scaled[5], height);
       scale = _getMin(scale, scaled[4], scaled[6], width);
@@ -1364,7 +1375,7 @@ class RRect {
       ]);
     }
     if (b == null) {
-      double k = 1.0 - t;
+      final double k = 1.0 - t;
       return new RRect._fromList(<double>[
         a.left * k,
         a.top * k,

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -55,8 +55,8 @@ sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer, size_t trace_id) {
 
   GrContext* context = ResourceContext::Get();
   if (context) {
-    // This acts as a flag to indicate that we want a color space aware decode.
-    sk_sp<SkColorSpace> dstColorSpace = SkColorSpace::MakeSRGB();
+    // This indicates that we do not want a "linear blending" decode.
+    sk_sp<SkColorSpace> dstColorSpace = nullptr;
     return SkImage::MakeCrossContextFromEncoded(context, std::move(buffer),
                                                 false, dstColorSpace.get());
   } else {
@@ -241,8 +241,8 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage() {
   if (context) {
     SkPixmap pixmap(bitmap.info(), bitmap.pixelRef()->pixels(),
                     bitmap.pixelRef()->rowBytes());
-    // This acts as a flag to indicate that we want a color space aware decode.
-    sk_sp<SkColorSpace> dstColorSpace = SkColorSpace::MakeSRGB();
+    // This indicates that we do not want a "linear blending" decode.
+    sk_sp<SkColorSpace> dstColorSpace = nullptr;
     return SkImage::MakeCrossContextFromPixmap(context, pixmap, false,
                                                dstColorSpace.get());
   } else {

--- a/lib/ui/painting/image_decoding.cc
+++ b/lib/ui/painting/image_decoding.cc
@@ -35,8 +35,8 @@ sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer, size_t trace_id) {
 
   GrContext* context = ResourceContext::Get();
   if (context) {
-    // This acts as a flag to indicate that we want a color space aware decode.
-    sk_sp<SkColorSpace> dstColorSpace = SkColorSpace::MakeSRGB();
+    // This indicates that we do not want a "linear blending" decode.
+    sk_sp<SkColorSpace> dstColorSpace = nullptr;
     return SkImage::MakeCrossContextFromEncoded(context, std::move(buffer),
                                                 false, dstColorSpace.get());
   } else {

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -20,6 +20,7 @@ class Window;
 class IsolateClient {
  public:
   virtual void DidCreateSecondaryIsolate(Dart_Isolate isolate) = 0;
+  virtual void DidShutdownMainIsolate() = 0;
 
  protected:
   virtual ~IsolateClient();
@@ -47,6 +48,8 @@ class UIDartState : public tonic::DartState {
   PassRefPtr<FontSelector> font_selector();
   bool is_controller_state() const { return is_controller_state_; }
   void set_is_controller_state(bool value) { is_controller_state_ = value; }
+  bool shutting_down() const { return shutting_down_; }
+  void set_shutting_down(bool value) { shutting_down_ = value; }
 
  private:
   void DidSetIsolate() override;
@@ -58,6 +61,7 @@ class UIDartState : public tonic::DartState {
   std::unique_ptr<Window> window_;
   RefPtr<FontSelector> font_selector_;
   bool is_controller_state_;
+  bool shutting_down_ = false;
 };
 
 }  // namespace blink

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -49,12 +49,13 @@ DartController::~DartController() {
   if (ui_dart_state_) {
     ui_dart_state_->set_isolate_client(nullptr);
 
-    // Don't use a tonic::DartIsolateScope here since we never exit the isolate.
-    Dart_EnterIsolate(ui_dart_state_->isolate());
-    // Clear the message notify callback.
-    Dart_SetMessageNotifyCallback(nullptr);
-    Dart_ShutdownIsolate();
-    delete ui_dart_state_;
+    if (!ui_dart_state_->shutting_down()) {
+      // Don't use a tonic::DartIsolateScope here since we never exit the isolate.
+      Dart_EnterIsolate(ui_dart_state_->isolate());
+      // Clear the message notify callback.
+      Dart_SetMessageNotifyCallback(nullptr);
+      Dart_ShutdownIsolate();
+    }
   }
 }
 

--- a/runtime/dart_controller.h
+++ b/runtime/dart_controller.h
@@ -39,17 +39,13 @@ class DartController {
 
   UIDartState* dart_state() const { return ui_dart_state_; }
 
-  void IsolateShuttingDown();
-
  private:
   bool SendStartMessage(Dart_Handle root_library,
                         const std::string& entrypoint = main_entrypoint_);
 
   static const std::string main_entrypoint_;
 
-  // The DartState associated with the main isolate.  This is not deleted
-  // during isolate shutdown, instead it is deleted when the controller
-  // object is deleted.
+  // The DartState associated with the main isolate.
   UIDartState* ui_dart_state_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(DartController);

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -74,8 +74,10 @@ namespace {
 
 // Arguments passed to the Dart VM in all configurations.
 static const char* kDartLanguageArgs[] = {
-    "--enable_mirrors=false", "--background_compilation", "--await_is_keyword",
-    "--causal_async_stacks",  "--limit-ints-to-64-bits",
+    "--enable_mirrors=false",
+    "--background_compilation",
+    "--await_is_keyword",
+    "--causal_async_stacks",
 };
 
 static const char* kDartPrecompilationArgs[] = {

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -138,10 +138,22 @@ void IsolateShutdownCallback(void* callback_data) {
     Dart_Handle sticky_error = Dart_GetStickyError();
     FXL_CHECK(LogIfError(sticky_error));
   }
+
   UIDartState* dart_state = static_cast<UIDartState*>(callback_data);
-  if ((dart_state != NULL) && !dart_state->is_controller_state()) {
-    delete dart_state;
+  // If the isolate that's shutting down is the main one, tell the higher layers
+  // of the stack.
+  if ((dart_state != NULL) && dart_state->is_controller_state()) {
+    dart_state->set_shutting_down(true);
+    if (dart_state->isolate_client()) {
+      dart_state->isolate_client()->DidShutdownMainIsolate();
+    }
   }
+}
+
+// The cleanup callback frees the DartState object.
+void IsolateCleanupCallback(void* callback_data) {
+  UIDartState* dart_state = static_cast<UIDartState*>(callback_data);
+  delete dart_state;
 }
 
 bool DartFileModifiedCallback(const char* source_url, int64_t since_ms) {
@@ -579,6 +591,7 @@ void InitDartVM(const uint8_t* vm_snapshot_data,
     params.vm_snapshot_instructions = vm_snapshot_instructions;
     params.create = IsolateCreateCallback;
     params.shutdown = IsolateShutdownCallback;
+    params.cleanup = IsolateCleanupCallback;
     params.thread_exit = ThreadExitCallback;
     params.get_service_assets = GetVMServiceAssetsArchiveCallback;
     params.entropy_source = DartIO::EntropySource;

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -142,6 +142,10 @@ void RuntimeController::DidCreateSecondaryIsolate(Dart_Isolate isolate) {
   client_->DidCreateSecondaryIsolate(isolate);
 }
 
+void RuntimeController::DidShutdownMainIsolate() {
+  client_->DidShutdownMainIsolate();
+}
+
 Dart_Port RuntimeController::GetMainPort() {
   if (!dart_controller_) {
     return ILLEGAL_PORT;

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -61,6 +61,7 @@ class RuntimeController : public WindowClient, public IsolateClient {
   void HandlePlatformMessage(fxl::RefPtr<PlatformMessage> message) override;
 
   void DidCreateSecondaryIsolate(Dart_Isolate isolate) override;
+  void DidShutdownMainIsolate() override;
 
   RuntimeDelegate* client_;
   std::string language_code_;

--- a/runtime/runtime_delegate.cc
+++ b/runtime/runtime_delegate.cc
@@ -12,4 +12,6 @@ void RuntimeDelegate::DidCreateMainIsolate(Dart_Isolate isolate) {}
 
 void RuntimeDelegate::DidCreateSecondaryIsolate(Dart_Isolate isolate) {}
 
+void RuntimeDelegate::DidShutdownMainIsolate() { }
+
 }  // namespace blink

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -25,6 +25,7 @@ class RuntimeDelegate {
 
   virtual void DidCreateMainIsolate(Dart_Isolate isolate);
   virtual void DidCreateSecondaryIsolate(Dart_Isolate isolate);
+  virtual void DidShutdownMainIsolate();
 
  protected:
   virtual ~RuntimeDelegate();

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -189,7 +189,6 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
   // other threads correctly, so the textures end up blank.  For now, suppress
   // that feature, which will cause texture uploads to do CPU YUV conversion.
   options.fDisableGpuYUVConversion = true;
-  options.fRequireDecodeDisableForSRGB = false;
 
   blink::ResourceContext::Set(GrContext::Create(
       GrBackend::kOpenGL_GrBackend,

--- a/shell/common/surface.cc
+++ b/shell/common/surface.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/common/surface.h"
 #include "lib/fxl/logging.h"
+#include "third_party/skia/include/core/SkColorSpaceXformCanvas.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace shell {
@@ -12,6 +13,10 @@ SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
                            SubmitCallback submit_callback)
     : submitted_(false), surface_(surface), submit_callback_(submit_callback) {
   FXL_DCHECK(submit_callback_);
+  if (surface_) {
+    xform_canvas_ = SkCreateColorSpaceXformCanvas(surface_->getCanvas(),
+                                                  SkColorSpace::MakeSRGB());
+  }
 }
 
 SurfaceFrame::~SurfaceFrame() {
@@ -32,6 +37,9 @@ bool SurfaceFrame::Submit() {
 }
 
 SkCanvas* SurfaceFrame::SkiaCanvas() {
+  if (xform_canvas_) {
+    return xform_canvas_.get();
+  }
   return surface_ != nullptr ? surface_->getCanvas() : nullptr;
 }
 

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -33,6 +33,7 @@ class SurfaceFrame {
  private:
   bool submitted_;
   sk_sp<SkSurface> surface_;
+  std::unique_ptr<SkCanvas> xform_canvas_;
   SubmitCallback submit_callback_;
 
   bool PerformSubmit();

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -33,8 +33,11 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
   auto backend_context =
       reinterpret_cast<GrBackendContext>(GrGLCreateNativeInterface());
 
-  auto context =
-      sk_sp<GrContext>(GrContext::Create(kOpenGL_GrBackend, backend_context));
+  GrContextOptions options;
+  options.fAvoidStencilBuffers = true;
+
+  auto context = sk_sp<GrContext>(
+      GrContext::Create(kOpenGL_GrBackend, backend_context, options));
 
   if (context == nullptr) {
     FXL_LOG(ERROR) << "Failed to setup Skia Gr context.";

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -22,8 +22,6 @@ class GPUSurfaceGLDelegate {
   virtual bool GLContextPresent() = 0;
 
   virtual intptr_t GLContextFBO() const = 0;
-
-  virtual bool SurfaceSupportsSRGB() const = 0;
 };
 
 class GPUSurfaceGL : public Surface {
@@ -42,7 +40,6 @@ class GPUSurfaceGL : public Surface {
   GPUSurfaceGLDelegate* delegate_;
   sk_sp<GrContext> context_;
   sk_sp<SkSurface> onscreen_surface_;
-  sk_sp<SkSurface> offscreen_surface_;
   bool valid_ = false;
   fml::WeakPtrFactory<GPUSurfaceGL> weak_factory_;
 

--- a/shell/platform/android/android_context_gl.h
+++ b/shell/platform/android/android_context_gl.h
@@ -35,15 +35,12 @@ class AndroidContextGL : public fxl::RefCountedThreadSafe<AndroidContextGL> {
 
   bool Resize(const SkISize& size);
 
-  bool SupportsSRGB() const;
-
  private:
   fxl::RefPtr<AndroidEnvironmentGL> environment_;
   fxl::RefPtr<AndroidNativeWindow> window_;
   EGLConfig config_;
   EGLSurface surface_;
   EGLContext context_;
-  bool srgb_support_;
   bool valid_;
 
   AndroidContextGL(fxl::RefPtr<AndroidEnvironmentGL> env,

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -55,10 +55,6 @@ AndroidSurfaceGL::AndroidSurfaceGL(
 
 AndroidSurfaceGL::~AndroidSurfaceGL() = default;
 
-bool AndroidSurfaceGL::SurfaceSupportsSRGB() const {
-  return offscreen_context_->SupportsSRGB();
-}
-
 bool AndroidSurfaceGL::IsOffscreenContextValid() const {
   return offscreen_context_ && offscreen_context_->IsValid();
 }

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -47,8 +47,6 @@ class AndroidSurfaceGL : public GPUSurfaceGLDelegate, public AndroidSurface {
 
   intptr_t GLContextFBO() const override;
 
-  bool SurfaceSupportsSRGB() const override;
-
  private:
   fxl::RefPtr<AndroidContextGL> onscreen_context_;
   fxl::RefPtr<AndroidContextGL> offscreen_context_;

--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -12,6 +12,7 @@ import android.os.Bundle;
 import io.flutter.app.FlutterActivityDelegate.ViewFactory;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterView;
 
 /**
@@ -47,6 +48,18 @@ public class FlutterActivity extends Activity implements FlutterView.Provider, P
         return null;
     }
 
+    /**
+     * Hook for subclasses to customize the creation of the
+     * {@code FlutterNativeView}.
+     *
+     * <p>The default implementation returns {@code null}, which will cause the
+     * activity to use a newly instantiated native view object.</p>
+     */
+    @Override
+    public FlutterNativeView createFlutterNativeView() {
+        return null;
+    }
+
     @Override
     public final boolean hasPlugin(String key) {
         return pluginRegistry.hasPlugin(key);
@@ -66,6 +79,12 @@ public class FlutterActivity extends Activity implements FlutterView.Provider, P
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         eventDelegate.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        eventDelegate.onResume();
     }
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -255,7 +255,9 @@ public final class FlutterActivityDelegate
         if (flutterView != null) {
             boolean destroy = true;
             for (ViewDestroyListener listener : viewDestroyListeners) {
-                destroy = destroy && !listener.onViewDestroy(flutterView.getFlutterNativeView());
+                if (listener.onViewDestroy(flutterView.getFlutterNativeView())) {
+                    destroy = false;
+                }
             }
             if (destroy) {
                 flutterView.destroy();

--- a/shell/platform/android/io/flutter/app/FlutterApplication.java
+++ b/shell/platform/android/io/flutter/app/FlutterApplication.java
@@ -4,6 +4,7 @@
 
 package io.flutter.app;
 
+import android.app.Activity;
 import android.app.Application;
 
 import io.flutter.view.FlutterMain;
@@ -17,5 +18,13 @@ public class FlutterApplication extends Application {
     public void onCreate() {
         super.onCreate();
         FlutterMain.startInitialization(this);
+    }
+
+    private Activity mCurrentActivity = null;
+    public Activity getCurrentActivity() {
+        return mCurrentActivity;
+    }
+    public void setCurrentActivity(Activity mCurrentActivity) {
+        this.mCurrentActivity = mCurrentActivity;
     }
 }

--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -12,6 +12,7 @@ import android.support.v4.app.FragmentActivity;
 import io.flutter.app.FlutterActivityDelegate.ViewFactory;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterView;
 
 /**
@@ -55,6 +56,11 @@ public class FlutterFragmentActivity
      */
     @Override
     public FlutterView createFlutterView(Context context) {
+        return null;
+    }
+
+    @Override
+    public FlutterNativeView createFlutterNativeView() {
         return null;
     }
 

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -6,6 +6,7 @@ package io.flutter.plugin.common;
 
 import android.app.Activity;
 import android.content.Intent;
+import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterView;
 import io.flutter.view.TextureRegistry;
 
@@ -140,6 +141,15 @@ public interface PluginRegistry {
          * @return this {@link Registrar}.
          */
         Registrar addUserLeaveHintListener(UserLeaveHintListener listener);
+
+        /**
+         * Adds a callback allowing the plugin to take part in handling incoming
+         * calls to {@link Activity#onDestroy()}.
+         *
+         * @param listener a {@link ViewDestroyListener} callback.
+         * @return this {@link Registrar}.
+         */
+        Registrar addViewDestroyListener(ViewDestroyListener listener);
     }
 
     /**
@@ -181,5 +191,14 @@ public interface PluginRegistry {
      */
     interface UserLeaveHintListener {
         void onUserLeaveHint();
+    }
+
+    /**
+     * Delegate interface for handling an {@link Activity}'s onDestroy
+     * method being called. A plugin that implements this interface can
+     * adopt the FlutterNativeView by retaining a reference and returning true.
+     */
+    interface ViewDestroyListener {
+        boolean onViewDestroy(FlutterNativeView view);
     }
 }

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.HashMap;
 import java.util.Map;
 
-class FlutterNativeView implements BinaryMessenger {
+public class FlutterNativeView implements BinaryMessenger {
     private static final String TAG = "FlutterNativeView";
 
     private final Map<String, BinaryMessageHandler> mMessageHandlers;
@@ -21,21 +21,30 @@ class FlutterNativeView implements BinaryMessenger {
     private long mNativePlatformView;
     private FlutterView mFlutterView;
 
-    FlutterNativeView(FlutterView flutterView) {
+    public FlutterNativeView(FlutterView flutterView) {
         mFlutterView = flutterView;
         attach(this);
         assertAttached();
         mMessageHandlers = new HashMap<>();
     }
 
-    FlutterNativeView() {
+    public FlutterNativeView() {
         this(null);
+    }
+
+    public void detach() {
+        mFlutterView = null;
+        nativeDetach(mNativePlatformView);
     }
 
     public void destroy() {
         mFlutterView = null;
         nativeDestroy(mNativePlatformView);
         mNativePlatformView = 0;
+    }
+
+    public void setFlutterView(FlutterView flutterView) {
+        mFlutterView = flutterView;
     }
 
     public boolean isAttached() {
@@ -168,6 +177,7 @@ class FlutterNativeView implements BinaryMessenger {
 
     private static native long nativeAttach(FlutterNativeView view);
     private static native void nativeDestroy(long nativePlatformViewAndroid);
+    private static native void nativeDetach(long nativePlatformViewAndroid);
 
     private static native void nativeRunBundleAndSnapshot(long nativePlatformViewAndroid,
         String bundlePath,

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -319,6 +319,9 @@ public class FlutterView extends SurfaceView
         }
 
         getHolder().removeCallback(mSurfaceCallback);
+
+        mNativeView.destroy();
+        mNativeView = null;
     }
 
     @Override

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -109,6 +109,10 @@ static jlong Attach(JNIEnv* env, jclass clazz, jobject flutterView) {
   return reinterpret_cast<jlong>(storage);
 }
 
+static void Detach(JNIEnv* env, jobject jcaller, jlong platform_view) {
+  PLATFORM_VIEW->Detach();
+}
+
 static void Destroy(JNIEnv* env, jobject jcaller, jlong platform_view) {
   PLATFORM_VIEW->Detach();
   delete &PLATFORM_VIEW;
@@ -327,6 +331,16 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .signature =
               "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
           .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSource),
+      },
+      {
+          .name = "nativeDetach",
+          .signature = "(J)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::Detach),
+      },
+      {
+          .name = "nativeDestroy",
+          .signature = "(J)V",
+          .fnPtr = reinterpret_cast<void*>(&shell::Destroy),
       },
       {
           .name = "nativeGetObservatoryUri",

--- a/shell/platform/darwin/desktop/platform_view_mac.h
+++ b/shell/platform/darwin/desktop/platform_view_mac.h
@@ -33,8 +33,6 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
 
   intptr_t GLContextFBO() const override;
 
-  bool SurfaceSupportsSRGB() const override;
-
   VsyncWaiter* GetVsyncWaiter() override;
 
   bool ResourceContextMakeCurrent() override;

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -77,10 +77,6 @@ intptr_t PlatformViewMac::GLContextFBO() const {
   return 0;
 }
 
-bool PlatformViewMac::SurfaceSupportsSRGB() const {
-  return false;
-}
-
 bool PlatformViewMac::GLContextMakeCurrent() {
   TRACE_EVENT0("flutter", "PlatformViewMac::GLContextMakeCurrent");
   if (!IsValid()) {

--- a/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
@@ -291,6 +291,10 @@ FLUTTER_EXPORT
  Invoked when the last listener is deregistered from the Stream associated to
  this channel on the Flutter side.
 
+ The channel implementation may call this method with `nil` arguments
+ to separate a pair of two consecutive set up requests. Such request pairs
+ may occur during Flutter hot restart.
+
  - Parameter arguments: Arguments for the stream.
  - Returns: A FlutterError instance, if teardown fails.
  */

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -122,7 +122,7 @@ IOSGLContext::IOSGLContext(PlatformView::SurfaceConfig config, CAEAGLLayer* laye
     }
   }
 
-  NSString* drawableColorFormat = kEAGLColorFormatSRGBA8;
+  NSString* drawableColorFormat = kEAGLColorFormatRGBA8;
   layer_.get().drawableProperties = @{
     kEAGLDrawablePropertyColorFormat : drawableColorFormat,
     kEAGLDrawablePropertyRetainedBacking : @(NO),

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -36,8 +36,6 @@ class IOSSurfaceGL : public IOSSurface, public GPUSurfaceGLDelegate {
 
   intptr_t GLContextFBO() const override;
 
-  bool SurfaceSupportsSRGB() const override;
-
  private:
   IOSGLContext context_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -36,10 +36,6 @@ intptr_t IOSSurfaceGL::GLContextFBO() const {
   return IsValid() ? context_.framebuffer() : GL_NONE;
 }
 
-bool IOSSurfaceGL::SurfaceSupportsSRGB() const {
-  return true;
-}
-
 bool IOSSurfaceGL::GLContextMakeCurrent() {
   return IsValid() ? context_.MakeCurrent() : false;
 }

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -31,10 +31,6 @@ intptr_t PlatformViewEmbedder::GLContextFBO() const {
   return dispatch_table_.gl_fbo_callback();
 }
 
-bool PlatformViewEmbedder::SurfaceSupportsSRGB() const {
-  return true;
-}
-
 void PlatformViewEmbedder::Attach() {
   CreateEngine();
   NotifyCreated(std::make_unique<shell::GPUSurfaceGL>(this));

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -47,4 +47,22 @@ void PlatformViewEmbedder::RunFromSource(const std::string& assets_directory,
   FXL_LOG(INFO) << "Hot reloading is unsupported on this platform.";
 }
 
+void PlatformViewEmbedder::HandlePlatformMessage(
+    fxl::RefPtr<blink::PlatformMessage> message) {
+  if (!message) {
+    return;
+  }
+
+  if (!message->response()) {
+    return;
+  }
+
+  if (dispatch_table_.platform_message_response_callback == nullptr) {
+    message->response()->CompleteEmpty();
+    return;
+  }
+
+  dispatch_table_.platform_message_response_callback(std::move(message));
+}
+
 }  // namespace shell

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -7,17 +7,22 @@
 
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/gpu/gpu_surface_gl.h"
+#include "flutter/shell/platform/embedder/embedder.h"
 #include "lib/fxl/macros.h"
 
 namespace shell {
 
 class PlatformViewEmbedder : public PlatformView, public GPUSurfaceGLDelegate {
  public:
+  using PlatformMessageResponseCallback =
+      std::function<void(fxl::RefPtr<blink::PlatformMessage>)>;
   struct DispatchTable {
-    std::function<bool(void)> gl_make_current_callback;
-    std::function<bool(void)> gl_clear_current_callback;
-    std::function<bool(void)> gl_present_callback;
-    std::function<intptr_t(void)> gl_fbo_callback;
+    std::function<bool(void)> gl_make_current_callback;   // required
+    std::function<bool(void)> gl_clear_current_callback;  // required
+    std::function<bool(void)> gl_present_callback;        // required
+    std::function<intptr_t(void)> gl_fbo_callback;        // required
+    PlatformMessageResponseCallback
+        platform_message_response_callback;  // optional
   };
 
   PlatformViewEmbedder(DispatchTable dispatch_table);
@@ -46,6 +51,10 @@ class PlatformViewEmbedder : public PlatformView, public GPUSurfaceGLDelegate {
   void RunFromSource(const std::string& assets_directory,
                      const std::string& main,
                      const std::string& packages) override;
+
+  // |shell::PlatformView|
+  void HandlePlatformMessage(
+      fxl::RefPtr<blink::PlatformMessage> message) override;
 
  private:
   DispatchTable dispatch_table_;

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -36,9 +36,6 @@ class PlatformViewEmbedder : public PlatformView, public GPUSurfaceGLDelegate {
   // |shell::GPUSurfaceGLDelegate|
   intptr_t GLContextFBO() const override;
 
-  // |shell::GPUSurfaceGLDelegate|
-  bool SurfaceSupportsSRGB() const override;
-
   // |shell::PlatformView|
   void Attach() override;
 

--- a/testing/dart/rect_test.dart
+++ b/testing/dart/rect_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 
 void main() {
   test("rect accessors", () {
-    Rect r = new Rect.fromLTRB(1.0, 3.0, 5.0, 7.0);
+    final Rect r = new Rect.fromLTRB(1.0, 3.0, 5.0, 7.0);
     expect(r.left, equals(1.0));
     expect(r.top, equals(3.0));
     expect(r.right, equals(5.0));
@@ -16,22 +16,67 @@ void main() {
   });
 
   test("rect created by width and height", () {
-    Rect r = new Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
+    final Rect r = new Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
     expect(r.left, equals(1.0));
     expect(r.top, equals(3.0));
     expect(r.right, equals(6.0));
     expect(r.bottom, equals(10.0));
+    expect(r.shortestSide, equals(5.0));
+    expect(r.longestSide, equals(7.0));
   });
 
   test("rect intersection", () {
-    Rect r1 = new Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
-    Rect r2 = new Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
-    Rect r3 = r1.intersect(r2);
+    final Rect r1 = new Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    final Rect r2 = new Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
+    final Rect r3 = r1.intersect(r2);
     expect(r3.left, equals(50.0));
     expect(r3.top, equals(50.0));
     expect(r3.right, equals(100.0));
     expect(r3.bottom, equals(100.0));
-    Rect r4 = r2.intersect(r1);
+    final Rect r4 = r2.intersect(r1);
     expect(r4, equals(r3));
+  });
+
+  test("rect expandToInclude overlapping rects", () {
+    final Rect r1 = new Rect.fromLTRB(0.0, 0.0, 100.0, 100.0);
+    final Rect r2 = new Rect.fromLTRB(50.0, 50.0, 200.0, 200.0);
+    final Rect r3 = r1.expandToInclude(r2);
+    expect(r3.left, equals(0.0));
+    expect(r3.top, equals(0.0));
+    expect(r3.right, equals(200.0));
+    expect(r3.bottom, equals(200.0));
+    final Rect r4 = r2.expandToInclude(r1);
+    expect(r4, equals(r3));
+  });
+
+  test("rect expandToInclude crossing rects", () {
+    final Rect r1 = new Rect.fromLTRB(50.0, 0.0, 50.0, 200.0);
+    final Rect r2 = new Rect.fromLTRB(0.0, 50.0, 200.0, 50.0);
+    final Rect r3 = r1.expandToInclude(r2);
+    expect(r3.left, equals(0.0));
+    expect(r3.top, equals(0.0));
+    expect(r3.right, equals(200.0));
+    expect(r3.bottom, equals(200.0));
+    final Rect r4 = r2.expandToInclude(r1);
+    expect(r4, equals(r3));
+  });
+
+  test("size created from doubles", () {
+    final Size size = new Size(5.0, 7.0);
+    expect(size.width, equals(5.0));
+    expect(size.height, equals(7.0));
+    expect(size.shortestSide, equals(5.0));
+    expect(size.longestSide, equals(7.0));
+  });
+
+  test("rounded rect created from rect and radii", () {
+    final Rect baseRect = new Rect.fromLTWH(1.0, 3.0, 5.0, 7.0);
+    final RRect r = new RRect.fromRectXY(baseRect, 1.0, 1.0);
+    expect(r.left, equals(1.0));
+    expect(r.top, equals(3.0));
+    expect(r.right, equals(6.0));
+    expect(r.bottom, equals(10.0));
+    expect(r.shortestSide, equals(5.0));
+    expect(r.longestSide, equals(7.0));
   });
 }

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: fd3234d28554e9ff779f9fe19764fc43
+Signature: d6eb20541eb41a3b453a20228d17c9ab
 
 UNUSED LICENSES:
 
@@ -5042,6 +5042,7 @@ FILE: ../../../third_party/dart/runtime/bin/sync_socket_macos.cc
 FILE: ../../../third_party/dart/runtime/bin/sync_socket_patch.dart
 FILE: ../../../third_party/dart/runtime/bin/sync_socket_win.cc
 FILE: ../../../third_party/dart/runtime/lib/async.cc
+FILE: ../../../third_party/dart/runtime/lib/class_id_fasta.dart
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/containers/search_bar.dart
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/memory/allocations.dart
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/memory/dashboard.dart
@@ -5090,6 +5091,10 @@ FILE: ../../../third_party/dart/runtime/vm/fixed_cache_test.cc
 FILE: ../../../third_party/dart/runtime/vm/gc_compactor.cc
 FILE: ../../../third_party/dart/runtime/vm/gc_compactor.h
 FILE: ../../../third_party/dart/runtime/vm/gdb_helpers.cc
+FILE: ../../../third_party/dart/runtime/vm/image_snapshot.cc
+FILE: ../../../third_party/dart/runtime/vm/image_snapshot.h
+FILE: ../../../third_party/dart/runtime/vm/json_writer.cc
+FILE: ../../../third_party/dart/runtime/vm/json_writer.h
 FILE: ../../../third_party/dart/runtime/vm/kernel_binary.h
 FILE: ../../../third_party/dart/runtime/vm/malloc_hooks.h
 FILE: ../../../third_party/dart/runtime/vm/malloc_hooks_arm.cc
@@ -5100,6 +5105,7 @@ FILE: ../../../third_party/dart/runtime/vm/malloc_hooks_tcmalloc.cc
 FILE: ../../../third_party/dart/runtime/vm/malloc_hooks_test.cc
 FILE: ../../../third_party/dart/runtime/vm/malloc_hooks_unsupported.cc
 FILE: ../../../third_party/dart/runtime/vm/malloc_hooks_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/mixin_test.cc
 FILE: ../../../third_party/dart/runtime/vm/stack_trace.cc
 FILE: ../../../third_party/dart/runtime/vm/stack_trace.h
 FILE: ../../../third_party/dart/runtime/vm/timeline_android.cc
@@ -5111,6 +5117,7 @@ FILE: ../../../third_party/dart/runtime/vm/zone_text_buffer.cc
 FILE: ../../../third_party/dart/runtime/vm/zone_text_buffer.h
 FILE: ../../../third_party/dart/sdk/lib/_http/overrides.dart
 FILE: ../../../third_party/dart/sdk/lib/internal/linked_list.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/patch.dart
 FILE: ../../../third_party/dart/sdk/lib/io/embedder_config.dart
 FILE: ../../../third_party/dart/sdk/lib/io/namespace_impl.dart
 FILE: ../../../third_party/dart/sdk/lib/io/overrides.dart
@@ -14840,7 +14847,7 @@ FILE: ../../../third_party/skia/src/gpu/ops/GrRegionOp.cpp
 FILE: ../../../third_party/skia/src/gpu/ops/GrRegionOp.h
 FILE: ../../../third_party/skia/src/gpu/ops/GrShadowRRectOp.cpp
 FILE: ../../../third_party/skia/src/gpu/ops/GrShadowRRectOp.h
-FILE: ../../../third_party/skia/src/gpu/text/GrAtlasTextBlob_regenInOp.cpp
+FILE: ../../../third_party/skia/src/gpu/text/GrAtlasTextBlobVertexRegenerator.cpp
 FILE: ../../../third_party/skia/src/gpu/vk/GrVkCopyManager.cpp
 FILE: ../../../third_party/skia/src/gpu/vk/GrVkCopyManager.h
 FILE: ../../../third_party/skia/src/gpu/vk/GrVkCopyPipeline.cpp
@@ -17891,6 +17898,7 @@ FILE: ../../../third_party/skia/src/effects/GrCircleBlurFragmentProcessor.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrArithmeticFP.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrConfigConversionEffect.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrDitherEffect.fp
+FILE: ../../../third_party/skia/src/gpu/effects/GrLumaColorFilterEffect.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrOverdrawFragmentProcessor.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrRectBlurEffect.fp
 FILE: ../../../third_party/skia/src/sksl/lex/layout.lex
@@ -19711,6 +19719,7 @@ FILE: ../../../third_party/skia/src/gpu/GrProcessorSet.h
 FILE: ../../../third_party/skia/src/gpu/GrResourceAllocator.cpp
 FILE: ../../../third_party/skia/src/gpu/GrResourceAllocator.h
 FILE: ../../../third_party/skia/src/gpu/GrSemaphore.h
+FILE: ../../../third_party/skia/src/gpu/GrStencilClip.h
 FILE: ../../../third_party/skia/src/gpu/GrSurfaceProxyPriv.h
 FILE: ../../../third_party/skia/src/gpu/GrTextureProxyCacheAccess.h
 FILE: ../../../third_party/skia/src/gpu/GrTextureProxyPriv.h
@@ -19750,6 +19759,8 @@ FILE: ../../../third_party/skia/src/gpu/effects/GrDitherEffect.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrEllipseEffect.cpp
 FILE: ../../../third_party/skia/src/gpu/effects/GrEllipseEffect.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrEllipseEffect.h
+FILE: ../../../third_party/skia/src/gpu/effects/GrLumaColorFilterEffect.cpp
+FILE: ../../../third_party/skia/src/gpu/effects/GrLumaColorFilterEffect.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrNonlinearColorSpaceXformEffect.cpp
 FILE: ../../../third_party/skia/src/gpu/effects/GrNonlinearColorSpaceXformEffect.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrOverdrawFragmentProcessor.cpp
@@ -20129,6 +20140,7 @@ FILE: ../../../third_party/skia/src/core/SkOSFile.h
 FILE: ../../../third_party/skia/src/core/SkPaint.cpp
 FILE: ../../../third_party/skia/src/core/SkPath.cpp
 FILE: ../../../third_party/skia/src/core/SkPathEffect.cpp
+FILE: ../../../third_party/skia/src/core/SkPointPriv.h
 FILE: ../../../third_party/skia/src/core/SkRasterizer.cpp
 FILE: ../../../third_party/skia/src/core/SkRect.cpp
 FILE: ../../../third_party/skia/src/core/SkRegion.cpp

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: d6eb20541eb41a3b453a20228d17c9ab
+Signature: dd9bc4d408553c66820f24c3dc8393c5
 
 UNUSED LICENSES:
 
@@ -17594,7 +17594,6 @@ FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.e
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-EMCC-wasm-Release.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-ANGLE.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-Flutter_Android.json
-FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-Mesa.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-NoGPU.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-PDFium.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-PDFium_SkiaPaths.json
@@ -17697,7 +17696,6 @@ FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian
 FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian9-GCC-x86_64-Debug-NoGPU.json
 FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian9-GCC-x86_64-Release-ANGLE.json
 FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian9-GCC-x86_64-Release-Flutter_Android.json
-FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian9-GCC-x86_64-Release-Mesa.json
 FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian9-GCC-x86_64-Release-PDFium.json
 FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian9-GCC-x86_64-Release-PDFium_SkiaPaths.json
 FILE: ../../../third_party/skia/infra/bots/recipes/compile.expected/Build-Debian9-GCC-x86_64-Release-Shared.json
@@ -17819,6 +17817,7 @@ FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/Test-Win2k8-Cla
 FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/Test-Win2k8-Clang-GCE-CPU-AVX2-x86_64-Debug-All-FDAA.json
 FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/Test-Win2k8-Clang-GCE-CPU-AVX2-x86_64-Debug-All-FSAA.json
 FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/Test-Win2k8-Clang-GCE-CPU-AVX2-x86_64-Debug-All-NativeFonts.json
+FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/Test-Win2k8-Clang-GCE-CPU-AVX2-x86_64-Debug-All-NativeFonts_GDI.json
 FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/Test-Win8-MSVC-Golo-CPU-AVX-x86-Debug-All.json
 FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/Test-iOS-Clang-iPadPro-GPU-GT7800-arm64-Release-All.json
 FILE: ../../../third_party/skia/infra/bots/recipes/test.expected/failed_dm.json
@@ -18484,8 +18483,6 @@ FILE: ../../../third_party/skia/src/core/SkVertState.cpp
 FILE: ../../../third_party/skia/src/core/SkVertState.h
 FILE: ../../../third_party/skia/src/fonts/SkFontMgr_indirect.cpp
 FILE: ../../../third_party/skia/src/fonts/SkRemotableFontMgr.cpp
-FILE: ../../../third_party/skia/src/fonts/SkTestScalerContext.cpp
-FILE: ../../../third_party/skia/src/fonts/SkTestScalerContext.h
 FILE: ../../../third_party/skia/src/gpu/GrDefaultGeoProcFactory.cpp
 FILE: ../../../third_party/skia/src/gpu/GrDefaultGeoProcFactory.h
 FILE: ../../../third_party/skia/src/gpu/GrFragmentProcessor.h
@@ -19102,8 +19099,6 @@ FILE: ../../../third_party/skia/src/core/SkYUVPlanesCache.cpp
 FILE: ../../../third_party/skia/src/core/SkYUVPlanesCache.h
 FILE: ../../../third_party/skia/src/effects/SkImageSource.cpp
 FILE: ../../../third_party/skia/src/effects/SkTableColorFilter.cpp
-FILE: ../../../third_party/skia/src/fonts/SkRandomScalerContext.cpp
-FILE: ../../../third_party/skia/src/fonts/SkRandomScalerContext.h
 FILE: ../../../third_party/skia/src/gpu/GrAutoLocaleSetter.h
 FILE: ../../../third_party/skia/src/gpu/GrBlend.cpp
 FILE: ../../../third_party/skia/src/gpu/GrBlurUtils.cpp
@@ -19277,7 +19272,6 @@ FILE: ../../../third_party/skia/src/ports/SkFontMgr_custom_directory_factory.cpp
 FILE: ../../../third_party/skia/src/ports/SkFontMgr_custom_embedded_factory.cpp
 FILE: ../../../third_party/skia/src/ports/SkFontMgr_fontconfig_factory.cpp
 FILE: ../../../third_party/skia/src/ports/SkFontMgr_win_dw_factory.cpp
-FILE: ../../../third_party/skia/src/ports/SkFontMgr_win_gdi_factory.cpp
 FILE: ../../../third_party/skia/src/ports/SkOSLibrary.h
 FILE: ../../../third_party/skia/src/ports/SkOSLibrary_posix.cpp
 FILE: ../../../third_party/skia/src/ports/SkOSLibrary_win.cpp
@@ -19511,7 +19505,6 @@ FILE: ../../../third_party/skia/src/gpu/gl/GrGLContext.h
 FILE: ../../../third_party/skia/src/gpu/gl/GrGLExtensions.cpp
 FILE: ../../../third_party/skia/src/gpu/gl/GrGLVertexArray.cpp
 FILE: ../../../third_party/skia/src/gpu/gl/GrGLVertexArray.h
-FILE: ../../../third_party/skia/src/gpu/gl/mesa/osmesa_wrapper.h
 FILE: ../../../third_party/skia/src/gpu/glsl/GrGLSLFragmentProcessor.h
 FILE: ../../../third_party/skia/src/gpu/glsl/GrGLSLGeometryProcessor.h
 FILE: ../../../third_party/skia/src/gpu/glsl/GrGLSLPrimitiveProcessor.h
@@ -19643,6 +19636,7 @@ FILE: ../../../third_party/skia/include/gpu/GrBackendSemaphore.h
 FILE: ../../../third_party/skia/include/gpu/GrBackendSurface.h
 FILE: ../../../third_party/skia/include/gpu/mock/GrMockTypes.h
 FILE: ../../../third_party/skia/include/gpu/mtl/GrMtlTypes.h
+FILE: ../../../third_party/skia/include/private/GrSharedEnums.h
 FILE: ../../../third_party/skia/include/private/SkDeferredDisplayList.h
 FILE: ../../../third_party/skia/include/private/SkMalloc.h
 FILE: ../../../third_party/skia/include/private/SkShadowFlags.h
@@ -19684,6 +19678,8 @@ FILE: ../../../third_party/skia/src/core/SkDrawShadowInfo.h
 FILE: ../../../third_party/skia/src/core/SkDraw_vertices.cpp
 FILE: ../../../third_party/skia/src/core/SkExecutor.cpp
 FILE: ../../../third_party/skia/src/core/SkFDot6Constants.cpp
+FILE: ../../../third_party/skia/src/core/SkGaussFilter.cpp
+FILE: ../../../third_party/skia/src/core/SkGaussFilter.h
 FILE: ../../../third_party/skia/src/core/SkImageFilterPriv.h
 FILE: ../../../third_party/skia/src/core/SkImageInfoPriv.h
 FILE: ../../../third_party/skia/src/core/SkMaskBlurFilter.cpp
@@ -19846,8 +19842,10 @@ FILE: ../../../third_party/skia/src/sksl/SkSLSectionAndParameterHelper.h
 FILE: ../../../third_party/skia/src/sksl/SkSLString.cpp
 FILE: ../../../third_party/skia/src/sksl/SkSLString.h
 FILE: ../../../third_party/skia/src/sksl/SkSLStringStream.h
+FILE: ../../../third_party/skia/src/sksl/ast/SkSLASTEnum.h
 FILE: ../../../third_party/skia/src/sksl/ast/SkSLASTSwitchCase.h
 FILE: ../../../third_party/skia/src/sksl/ast/SkSLASTSwitchStatement.h
+FILE: ../../../third_party/skia/src/sksl/ir/SkSLEnum.h
 FILE: ../../../third_party/skia/src/sksl/ir/SkSLSetting.cpp
 FILE: ../../../third_party/skia/src/sksl/ir/SkSLSwitchCase.h
 FILE: ../../../third_party/skia/src/sksl/ir/SkSLSwitchStatement.h
@@ -19863,6 +19861,7 @@ FILE: ../../../third_party/skia/src/sksl/lex/RegexNode.cpp
 FILE: ../../../third_party/skia/src/sksl/lex/RegexNode.h
 FILE: ../../../third_party/skia/src/sksl/lex/RegexParser.cpp
 FILE: ../../../third_party/skia/src/sksl/lex/RegexParser.h
+FILE: ../../../third_party/skia/src/sksl/sksl_enums.include
 FILE: ../../../third_party/skia/src/utils/SkInsetConvexPolygon.cpp
 FILE: ../../../third_party/skia/src/utils/SkInsetConvexPolygon.h
 FILE: ../../../third_party/skia/src/utils/SkJSONWriter.cpp


### PR DESCRIPTION
The UIDartState is now always owned by the isolate and always freed in
the isolate cleanup callback.

In the isolate shutdown callback, if the isolate being shut down is the
main isolate, the RuntimeController is informed which in turn notifies
the RuntimeHolder and thus the ApplicationControllerImpl. The
ApplicationControllerImpl tears down the whole Flutter application.

This fixes Fuchsia bug: MI4-328