### PR TITLE
Allow Flutter apps on Fuchsia to shut down cleanly

### DIFF
--- a/content_handler/application_controller_impl.cc
+++ b/content_handler/application_controller_impl.cc
@@ -66,6 +66,9 @@ ApplicationControllerImpl::ApplicationControllerImpl(
 
   url_ = startup_info->launch_info->url;
   runtime_holder_.reset(new RuntimeHolder());
+  runtime_holder_->SetMainIsolateShutdownCallback([this]() {
+    Kill();
+  });
   runtime_holder_->Init(
       fdio_ns, app::ApplicationContext::CreateFrom(std::move(startup_info)),
       std::move(request), std::move(bundle));

--- a/content_handler/application_controller_impl.cc
+++ b/content_handler/application_controller_impl.cc
@@ -66,9 +66,7 @@ ApplicationControllerImpl::ApplicationControllerImpl(
 
   url_ = startup_info->launch_info->url;
   runtime_holder_.reset(new RuntimeHolder());
-  runtime_holder_->SetMainIsolateShutdownCallback([this]() {
-    Kill();
-  });
+  runtime_holder_->SetMainIsolateShutdownCallback([this]() { Kill(); });
   runtime_holder_->Init(
       fdio_ns, app::ApplicationContext::CreateFrom(std::move(startup_info)),
       std::move(request), std::move(bundle));

--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -291,6 +291,16 @@ Dart_Port RuntimeHolder::GetUIIsolateMainPort() {
   return runtime_->GetMainPort();
 }
 
+void RuntimeHolder::DidShutdownMainIsolate() {
+  if (main_isolate_shutdown_callback_) {
+    main_isolate_shutdown_callback_();
+  }
+}
+
+void RuntimeHolder::SetMainIsolateShutdownCallback(std::function<void()> callback) {
+  main_isolate_shutdown_callback_ = callback;
+}
+
 std::string RuntimeHolder::GetUIIsolateName() {
   if (!runtime_) {
     return "";

--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -297,7 +297,8 @@ void RuntimeHolder::DidShutdownMainIsolate() {
   }
 }
 
-void RuntimeHolder::SetMainIsolateShutdownCallback(std::function<void()> callback) {
+void RuntimeHolder::SetMainIsolateShutdownCallback(
+    std::function<void()> callback) {
   main_isolate_shutdown_callback_ = callback;
 }
 

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -56,6 +56,8 @@ class RuntimeHolder : public blink::RuntimeDelegate,
 
   int32_t return_code() { return return_code_; }
 
+  void SetMainIsolateShutdownCallback(std::function<void()> callback);
+
  private:
   // |blink::RuntimeDelegate| implementation:
   std::string DefaultRouteName() override;
@@ -65,6 +67,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message) override;
   void DidCreateMainIsolate(Dart_Isolate isolate) override;
+  void DidShutdownMainIsolate() override;
 
   // |mozart::NativesDelegate| implementation:
   mozart::View* GetMozartView() override;
@@ -127,6 +130,8 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   fxl::WeakPtrFactory<RuntimeHolder> weak_factory_;
 
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
+
+  std::function<void()> main_isolate_shutdown_callback_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(RuntimeHolder);
 };

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -20,6 +20,7 @@ class Window;
 class IsolateClient {
  public:
   virtual void DidCreateSecondaryIsolate(Dart_Isolate isolate) = 0;
+  virtual void DidShutdownMainIsolate() = 0;
 
  protected:
   virtual ~IsolateClient();
@@ -47,6 +48,8 @@ class UIDartState : public tonic::DartState {
   PassRefPtr<FontSelector> font_selector();
   bool is_controller_state() const { return is_controller_state_; }
   void set_is_controller_state(bool value) { is_controller_state_ = value; }
+  bool shutting_down() const { return shutting_down_; }
+  void set_shutting_down(bool value) { shutting_down_ = value; }
 
  private:
   void DidSetIsolate() override;
@@ -58,6 +61,7 @@ class UIDartState : public tonic::DartState {
   std::unique_ptr<Window> window_;
   RefPtr<FontSelector> font_selector_;
   bool is_controller_state_;
+  bool shutting_down_ = false;
 };
 
 }  // namespace blink

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -50,7 +50,8 @@ DartController::~DartController() {
     ui_dart_state_->set_isolate_client(nullptr);
 
     if (!ui_dart_state_->shutting_down()) {
-      // Don't use a tonic::DartIsolateScope here since we never exit the isolate.
+      // Don't use a tonic::DartIsolateScope here since we never exit the
+      // isolate.
       Dart_EnterIsolate(ui_dart_state_->isolate());
       // Clear the message notify callback.
       Dart_SetMessageNotifyCallback(nullptr);

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -49,12 +49,13 @@ DartController::~DartController() {
   if (ui_dart_state_) {
     ui_dart_state_->set_isolate_client(nullptr);
 
-    // Don't use a tonic::DartIsolateScope here since we never exit the isolate.
-    Dart_EnterIsolate(ui_dart_state_->isolate());
-    // Clear the message notify callback.
-    Dart_SetMessageNotifyCallback(nullptr);
-    Dart_ShutdownIsolate();
-    delete ui_dart_state_;
+    if (!ui_dart_state_->shutting_down()) {
+      // Don't use a tonic::DartIsolateScope here since we never exit the isolate.
+      Dart_EnterIsolate(ui_dart_state_->isolate());
+      // Clear the message notify callback.
+      Dart_SetMessageNotifyCallback(nullptr);
+      Dart_ShutdownIsolate();
+    }
   }
 }
 

--- a/runtime/dart_controller.h
+++ b/runtime/dart_controller.h
@@ -39,17 +39,13 @@ class DartController {
 
   UIDartState* dart_state() const { return ui_dart_state_; }
 
-  void IsolateShuttingDown();
-
  private:
   bool SendStartMessage(Dart_Handle root_library,
                         const std::string& entrypoint = main_entrypoint_);
 
   static const std::string main_entrypoint_;
 
-  // The DartState associated with the main isolate.  This is not deleted
-  // during isolate shutdown, instead it is deleted when the controller
-  // object is deleted.
+  // The DartState associated with the main isolate.
   UIDartState* ui_dart_state_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(DartController);

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -142,6 +142,10 @@ void RuntimeController::DidCreateSecondaryIsolate(Dart_Isolate isolate) {
   client_->DidCreateSecondaryIsolate(isolate);
 }
 
+void RuntimeController::DidShutdownMainIsolate() {
+  client_->DidShutdownMainIsolate();
+}
+
 Dart_Port RuntimeController::GetMainPort() {
   if (!dart_controller_) {
     return ILLEGAL_PORT;

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -61,6 +61,7 @@ class RuntimeController : public WindowClient, public IsolateClient {
   void HandlePlatformMessage(fxl::RefPtr<PlatformMessage> message) override;
 
   void DidCreateSecondaryIsolate(Dart_Isolate isolate) override;
+  void DidShutdownMainIsolate() override;
 
   RuntimeDelegate* client_;
   std::string language_code_;

--- a/runtime/runtime_delegate.cc
+++ b/runtime/runtime_delegate.cc
@@ -12,4 +12,6 @@ void RuntimeDelegate::DidCreateMainIsolate(Dart_Isolate isolate) {}
 
 void RuntimeDelegate::DidCreateSecondaryIsolate(Dart_Isolate isolate) {}
 
+void RuntimeDelegate::DidShutdownMainIsolate() { }
+
 }  // namespace blink

--- a/runtime/runtime_delegate.cc
+++ b/runtime/runtime_delegate.cc
@@ -12,6 +12,6 @@ void RuntimeDelegate::DidCreateMainIsolate(Dart_Isolate isolate) {}
 
 void RuntimeDelegate::DidCreateSecondaryIsolate(Dart_Isolate isolate) {}
 
-void RuntimeDelegate::DidShutdownMainIsolate() { }
+void RuntimeDelegate::DidShutdownMainIsolate() {}
 
 }  // namespace blink

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -25,6 +25,7 @@ class RuntimeDelegate {
 
   virtual void DidCreateMainIsolate(Dart_Isolate isolate);
   virtual void DidCreateSecondaryIsolate(Dart_Isolate isolate);
+  virtual void DidShutdownMainIsolate();
 
  protected:
   virtual ~RuntimeDelegate();


### PR DESCRIPTION
The UIDartState is now always owned by the isolate and always freed in
the isolate cleanup callback.

In the isolate shutdown callback, if the isolate being shut down is the
main isolate, the RuntimeController is informed which in turn notifies
the RuntimeHolder and thus the ApplicationControllerImpl. The
ApplicationControllerImpl tears down the whole Flutter application.

This fixes Fuchsia bug: MI4-328