### PR TITLE
Make frontend_server depend on dart/pkg/* files

### DIFF
--- a/frontend_server/BUILD.gn
+++ b/frontend_server/BUILD.gn
@@ -12,5 +12,8 @@ application_snapshot("frontend_server") {
   frontend_server_files = exec_script("//third_party/dart/tools/list_dart_files.py",
      [ "absolute", rebase_path("."), ], "list lines")
 
+  frontend_server_files += exec_script("//third_party/dart/tools/list_dart_files.py",
+     [ "absolute", rebase_path("../../third_party/dart/pkg"), ], "list lines")
+
   inputs = frontend_server_files
 }


### PR DESCRIPTION
It speeds up local development workflow when doing changes to the front end
when ninja automatically rebuilds the frontend_server.dart.snapshot.