### PR TITLE
Roll Dart back to 4dd4fd745e588eef64b8d85811d847ab72633cb7

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'b73110886e12035e6da0bcd97694008f22cc811d',
+  'dart_revision': '4dd4fd745e588eef64b8d85811d847ab72633cb7',
 
   'dart_args_tag': '0.13.7',
   'dart_async_tag': '2.0.0',
@@ -56,7 +56,7 @@ vars = {
   'dart_http_parser_tag': '3.1.1',
   'dart_http_tag': '0.11.3+14',
   'dart_http_throttle_tag': '1.0.1',
-  'dart_intl_tag': '0.15.2',
+  'dart_intl_tag': '0.15.1',
   'dart_isolate_tag': '1.1.0',
   'dart_json_rpc_2_tag': '2.0.4',
   'dart_linter_tag': '0.1.39',

--- a/build/flutter_app.gni
+++ b/build/flutter_app.gni
@@ -257,7 +257,7 @@ template("flutter_aot_app") {
       "--url-mapping",
       "dart:mozart.internal," + rebase_path(mozart_dart_sdk_ext_lib),
       "--url-mapping",
-      "dart:vmservice_io," + rebase_path(
+      "dart:vmservice_sky," + rebase_path(
               "$dart_root_gen_dir/dart-pkg/sky_engine/sdk_ext/vmservice_io.dart"),
 
       "--entry-points-manifest",

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -125,7 +125,7 @@ bool DartServiceIsolate::Startup(std::string server_ip,
     result = Dart_FinalizeLoading(false);
     SHUTDOWN_ON_ERROR(result);
   } else {
-    Dart_Handle uri = Dart_NewStringFromCString("dart:vmservice_io");
+    Dart_Handle uri = Dart_NewStringFromCString("dart:vmservice_sky");
     Dart_Handle library = Dart_LookupLibrary(uri);
     SHUTDOWN_ON_ERROR(library);
     result = Dart_SetRootLibrary(library);
@@ -187,7 +187,7 @@ Dart_Handle DartServiceIsolate::GetSource(const char* name) {
 }
 
 Dart_Handle DartServiceIsolate::LoadScript(const char* name) {
-  Dart_Handle url = Dart_NewStringFromCString("dart:vmservice_io");
+  Dart_Handle url = Dart_NewStringFromCString("dart:vmservice_sky");
   Dart_Handle source = GetSource(name);
   return Dart_LoadScript(url, Dart_Null(), source, 0, 0);
 }

--- a/runtime/dart_vm_entry_points.txt
+++ b/runtime/dart_vm_entry_points.txt
@@ -34,4 +34,4 @@ dart:ui,SemanticsUpdate,SemanticsUpdate.
 dart:ui,SemanticsUpdateBuilder,SemanticsUpdateBuilder.
 dart:ui,Shader,Shader.
 dart:ui,TextBox,TextBox._
-dart:vmservice_io,::,main
+dart:vmservice_sky,::,main

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 2825f6905f169b1cbf039c5a6d98594b
+Signature: 9a3bc541ecff71120c05366d013e0a66
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
The deprecation annotations added by https://github.com/dart-lang/sdk/commit/0b58c4bd10df3f41baa19b1dc2aa25c76137b09c creates many analyzer hints in the framework, which will take time to sort out. @floitschG @lrhn @amirh @Hixie 