### PR TITLE
Catch divide-by-zero errors early in license tool

### DIFF
--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2313,7 +2313,13 @@ class RepositoryRoot extends RepositoryDirectory {
 
 
 class Progress {
-  Progress(this.max);
+  Progress(this.max) {
+    // This may happen when a git client contains left-over empty component
+    // directories after DEPS file changes.
+    if (max <= 0)
+      throw new ArgumentError('Progress.max must be > 0 but was: $max');
+  }
+
   final int max;
   int get withLicense => _withLicense;
   int _withLicense = 0;


### PR DESCRIPTION
If Progress is instantiated with a max of 0, throw immediately to avoid
a divide-by-zero later in toString(). This typically happens if the tool
recurses over an empty top-level component, which can happen when a
component is moved around in the repo and the developer hasn't cleaned
up old empty directories from their git client.