### PR TITLE
Turn off smart minimal IKG compilation

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -158,7 +158,8 @@ class _FrontendCompiler implements CompilerInterface {
       _generator = generator != null
         ? generator
         : await IncrementalKernelGenerator.newInstance(
-          compilerOptions, Uri.base.resolve(_filename)
+          compilerOptions, Uri.base.resolve(_filename),
+          useMinimalGenerator: true
         );
       final DeltaProgram deltaProgram = await _generator.computeDelta();
       program = deltaProgram.newProgram;


### PR DESCRIPTION
There seems to be problems with running hot reload tests with new IKG compiler:
```
 $FH/flutter/dev/devicelab  ‹master*› 
╰─➤  dart bin/run.dart -t hot_mode_dev_cycle__preview_dart_2_benchmark
════╡ ••• Running task "hot_mode_dev_cycle__preview_dart_2_benchmark" ••• ╞═════
...

[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [   +3 ms] Compiling dart to kernel with 1 updated files
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [  +39 ms] compile debug message: Unhandled exception:
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: NoSuchMethodError: The getter 'canonicalName' was called on null.
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: Receiver: null
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: Tried calling: canonicalName
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #1      ReferenceIndex.replaceLibrary (package:front_end/src/incremental/reference_index.dart:80)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #2      IncrementalKernelGeneratorImpl._compileLibrariesWithBodyChanges.<anonymous closure> (package:front_end/src/incremental_kernel_generator_impl.dart:368)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #3      PerformanceLog.run (package:front_end/src/base/performance_logger.dart:34)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #4      IncrementalKernelGeneratorImpl._compileLibrariesWithBodyChanges (package:front_end/src/incremental_kernel_generator_impl.dart:353)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #5      IncrementalKernelGeneratorImpl.computeDelta.<anonymous closure>.<anonymous closure> (package:front_end/src/incremental_kernel_generator_impl.dart:197)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #6      PerformanceLog.runAsync (package:front_end/src/base/performance_logger.dart:52)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #7      IncrementalKernelGeneratorImpl.computeDelta.<anonymous closure> (package:front_end/src/incremental_kernel_generator_impl.dart:195)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #8      PerformanceLog.runAsync (package:front_end/src/base/performance_logger.dart:52)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #9      IncrementalKernelGeneratorImpl._runWithFrontEndContext.<anonymous closure> (package:front_end/src/incremental_kernel_generator_impl.dart:543)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #10     CompilerContext.runInContext.<anonymous closure> (package:front_end/src/fasta/compiler_context.dart:89)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #11     _rootRun (dart:async/zone.dart:1126)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #12     _CustomZone.run (dart:async/zone.dart:1023)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #13     runZoned (dart:async/zone.dart:1501)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #14     CompilerContext.runInContext (package:front_end/src/fasta/compiler_context.dart:89)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #15     CompilerContext.runWithOptions (package:front_end/src/fasta/compiler_context.dart:96)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #16     IncrementalKernelGeneratorImpl._runWithFrontEndContext (package:front_end/src/incremental_kernel_generator_impl.dart:541)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #17     IncrementalKernelGeneratorImpl.computeDelta (package:front_end/src/incremental_kernel_generator_impl.dart:179)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #18     _FrontendCompiler.recompileDelta (package:frontend_server/server.dart:190)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #19     starter.<anonymous closure> (package:frontend_server/server.dart:292)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: <asynchronous suspension>
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #20     _RootZone.runUnaryGuarded (dart:async/zone.dart:1316)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #21     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:330)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #22     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:257)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #23     _SinkTransformerStreamSubscription._add (dart:async/stream_transformers.dart:68)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #24     _EventSinkWrapper.add (dart:async/stream_transformers.dart:15)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #25     _StringAdapterSink.add (dart:convert/string_conversion.dart:268)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #26     _LineSplitterSink._addLines (dart:convert/line_splitter.dart:154)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #27     _LineSplitterSink.addSlice (dart:convert/line_splitter.dart:129)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #28     StringConversionSinkMixin.add (dart:convert/string_conversion.dart:189)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #29     _SinkTransformerStreamSubscription._handleData (dart:async/stream_transformers.dart:120)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #30     _RootZone.runUnaryGuarded (dart:async/zone.dart:1316)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #31     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:330)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #32     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:257)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #33     _SinkTransformerStreamSubscription._add (dart:async/stream_transformers.dart:68)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #34     _EventSinkWrapper.add (dart:async/stream_transformers.dart:15)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #35     _StringAdapterSink.add (dart:convert/string_conversion.dart:268)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #36     _StringAdapterSink.addSlice (dart:convert/string_conversion.dart:273)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #37     _Utf8ConversionSink.addSlice (dart:convert/string_conversion.dart:348)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #38     _Utf8ConversionSink.add (dart:convert/string_conversion.dart:341)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #39     _ConverterStreamEventSink.add (dart:convert/chunked_conversion.dart:86)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #40     _SinkTransformerStreamSubscription._handleData (dart:async/stream_transformers.dart:120)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #41     _RootZone.runUnaryGuarded (dart:async/zone.dart:1316)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #42     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:330)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #43     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:257)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #44     _StreamController&&_SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:762)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #45     _StreamController._add (dart:async/stream_controller.dart:638)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #46     _StreamController.add (dart:async/stream_controller.dart:584)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #47     _Socket._onData (dart:io-patch/socket_patch.dart:1653)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #48     _RootZone.runUnaryGuarded (dart:async/zone.dart:1316)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #49     _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:330)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #50     _BufferingStreamSubscription._add (dart:async/stream_impl.dart:257)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #51     _StreamController&&_SyncStreamControllerDispatch._sendData (dart:async/stream_controller.dart:762)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #52     _StreamController._add (dart:async/stream_controller.dart:638)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #53     _StreamController.add (dart:async/stream_controller.dart:584)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #54     new _RawSocket.<anonymous closure> (dart:io-patch/socket_patch.dart:1231)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #55     _NativeSocket.issueReadEvent.issue (dart:io-patch/socket_patch.dart:784)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #56     _microtaskLoop (dart:async/schedule_microtask.dart:41)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #57     _startMicrotaskLoop (dart:async/schedule_microtask.dart:50)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #58     _runPendingImmediateCallback (dart:isolate-patch/dart:isolate/isolate_patch.dart:111)
[hot_mode_dev_cycle__preview_dart_2_benchmark] [STDOUT] stdout: [        ] compile debug message: #59     _RawReceivePortImpl._handleMessage (dart:isolate-patch/dart:isolate/isolate_patch.dart:164)
```