### PR TITLE
Block image decoding on iOS in the background

### DIFF
--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -53,6 +53,7 @@ sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer, size_t trace_id) {
     return nullptr;
   }
 
+  FXL_LOG(ERROR) << "DecodeImage";
   ResourceContext* resourceContext = ResourceContext::Acquire();
   GrContext* context = resourceContext->Get();
   if (context) {
@@ -241,6 +242,7 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage() {
     }
   }
 
+  FXL_LOG(ERROR) << "GetNextFrameImage";
   ResourceContext* resourceContext = ResourceContext::Acquire();
   GrContext* context = resourceContext->Get();
   if (context) {

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -53,7 +53,8 @@ sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer, size_t trace_id) {
     return nullptr;
   }
 
-  GrContext* context = ResourceContext::Get();
+  ResourceContext* resourceContext = ResourceContext::Acquire();
+  GrContext* context = resourceContext->Get();
   if (context) {
     // This indicates that we do not want a "linear blending" decode.
     sk_sp<SkColorSpace> dstColorSpace = nullptr;
@@ -240,7 +241,8 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage() {
     }
   }
 
-  GrContext* context = ResourceContext::Get();
+  ResourceContext* resourceContext = ResourceContext::Acquire();
+  GrContext* context = resourceContext->Get();
   if (context) {
     SkPixmap pixmap(bitmap.info(), bitmap.pixelRef()->pixels(),
                     bitmap.pixelRef()->rowBytes());

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -53,8 +53,7 @@ sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer, size_t trace_id) {
     return nullptr;
   }
 
-  FXL_LOG(ERROR) << "DecodeImage";
-  ResourceContext* resourceContext = ResourceContext::Acquire();
+  std::unique_ptr<ResourceContext> resourceContext = ResourceContext::Acquire();
   GrContext* context = resourceContext->Get();
   if (context) {
     // This indicates that we do not want a "linear blending" decode.
@@ -242,8 +241,7 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage() {
     }
   }
 
-  FXL_LOG(ERROR) << "GetNextFrameImage";
-  ResourceContext* resourceContext = ResourceContext::Acquire();
+  std::unique_ptr<ResourceContext> resourceContext = ResourceContext::Acquire();
   GrContext* context = resourceContext->Get();
   if (context) {
     SkPixmap pixmap(bitmap.info(), bitmap.pixelRef()->pixels(),

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -61,6 +61,9 @@ sk_sp<SkImage> DecodeImage(sk_sp<SkData> buffer, size_t trace_id) {
     return SkImage::MakeCrossContextFromEncoded(context, std::move(buffer),
                                                 false, dstColorSpace.get());
   } else {
+    // Defer decoding until time of draw later on the GPU thread. Can happen
+    // when GL operations are currently forbidden such as in the background
+    // on iOS.
     return SkImage::MakeFromEncoded(std::move(buffer));
   }
 }
@@ -251,6 +254,9 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage() {
     return SkImage::MakeCrossContextFromPixmap(context, pixmap, false,
                                                dstColorSpace.get());
   } else {
+    // Defer decoding until time of draw later on the GPU thread. Can happen
+    // when GL operations are currently forbidden such as in the background
+    // on iOS.
     return SkImage::MakeFromBitmap(bitmap);
   }
 }

--- a/lib/ui/painting/resource_context.cc
+++ b/lib/ui/painting/resource_context.cc
@@ -16,9 +16,13 @@ static volatile bool g_freeze = false;
 
 }  // namespace
 
-ResourceContext::ResourceContext() { g_mutex.Lock(); }
+ResourceContext::ResourceContext() {
+  g_mutex.Lock();
+}
 
-ResourceContext::~ResourceContext() { g_mutex.Unlock(); }
+ResourceContext::~ResourceContext() {
+  g_mutex.Unlock();
+}
 
 void ResourceContext::Set(GrContext* context) {
   FXL_DCHECK(!g_context);

--- a/lib/ui/painting/resource_context.cc
+++ b/lib/ui/painting/resource_context.cc
@@ -5,13 +5,20 @@
 #include "flutter/lib/ui/painting/resource_context.h"
 
 #include "lib/fxl/logging.h"
+#include "lib/fxl/synchronization/mutex.h"
 
 namespace blink {
 namespace {
 
 static GrContext* g_context = nullptr;
+static fxl::Mutex g_mutex;
+static volatile bool g_freeze = false;
 
 }  // namespace
+
+ResourceContext::ResourceContext() { g_mutex.Lock(); }
+
+ResourceContext::~ResourceContext() { g_mutex.Unlock(); }
 
 void ResourceContext::Set(GrContext* context) {
   FXL_DCHECK(!g_context);
@@ -19,7 +26,21 @@ void ResourceContext::Set(GrContext* context) {
 }
 
 GrContext* ResourceContext::Get() {
-  return g_context;
+  return g_freeze ? nullptr : g_context;
+}
+
+ResourceContext* ResourceContext::Acquire() {
+  return new ResourceContext;
+}
+
+void ResourceContext::Freeze() {
+  fxl::MutexLocker lock(&g_mutex);
+  g_freeze = true;
+}
+
+void ResourceContext::Unfreeze() {
+  fxl::MutexLocker lock(&g_mutex);
+  g_freeze = false;
 }
 
 }  // namespace blink

--- a/lib/ui/painting/resource_context.cc
+++ b/lib/ui/painting/resource_context.cc
@@ -16,29 +16,20 @@ static volatile bool g_freeze = false;
 
 }  // namespace
 
-ResourceContext::ResourceContext() {
-  FXL_DLOG(ERROR) << "Locking";
-  g_mutex.Lock();
-}
+ResourceContext::ResourceContext() { g_mutex.Lock(); }
 
-ResourceContext::~ResourceContext() {
-  FXL_DLOG(ERROR) << "Unlocking";
-  g_mutex.Unlock();
-}
+ResourceContext::~ResourceContext() { g_mutex.Unlock(); }
 
 void ResourceContext::Set(GrContext* context) {
   FXL_DCHECK(!g_context);
-  FXL_DLOG(ERROR) << "Setting";
   g_context = context;
 }
 
 GrContext* ResourceContext::Get() {
-  FXL_DLOG(ERROR) << "Getting";
   return g_freeze ? nullptr : g_context;
 }
 
-ResourceContext* ResourceContext::Acquire() {
-  FXL_DLOG(ERROR) << "Acquiring";
+std::unique_ptr<ResourceContext> ResourceContext::Acquire() {
   return std::make_unique<ResourceContext>();
 }
 

--- a/lib/ui/painting/resource_context.cc
+++ b/lib/ui/painting/resource_context.cc
@@ -16,21 +16,30 @@ static volatile bool g_freeze = false;
 
 }  // namespace
 
-ResourceContext::ResourceContext() { g_mutex.Lock(); }
+ResourceContext::ResourceContext() {
+  FXL_DLOG(ERROR) << "Locking";
+  g_mutex.Lock();
+}
 
-ResourceContext::~ResourceContext() { g_mutex.Unlock(); }
+ResourceContext::~ResourceContext() {
+  FXL_DLOG(ERROR) << "Unlocking";
+  g_mutex.Unlock();
+}
 
 void ResourceContext::Set(GrContext* context) {
   FXL_DCHECK(!g_context);
+  FXL_DLOG(ERROR) << "Setting";
   g_context = context;
 }
 
 GrContext* ResourceContext::Get() {
+  FXL_DLOG(ERROR) << "Getting";
   return g_freeze ? nullptr : g_context;
 }
 
 ResourceContext* ResourceContext::Acquire() {
-  return new ResourceContext;
+  FXL_DLOG(ERROR) << "Acquiring";
+  return std::make_unique<ResourceContext>();
 }
 
 void ResourceContext::Freeze() {

--- a/lib/ui/painting/resource_context.h
+++ b/lib/ui/painting/resource_context.h
@@ -12,13 +12,42 @@ namespace blink {
 
 class ResourceContext {
  public:
+  /**
+   * Globally set the GrContext singleton instance.
+   */
   static void Set(GrContext* context);
-  static ResourceContext* Acquire();
+
+  /**
+   * Acquire a GrContext wrapping ResourceContext that's also an exclusive mutex
+   * on GrContext operations.
+   *
+   * Destructing the ResourceContext frees the mutex.
+   */
+  static std::unique_ptr<ResourceContext> Acquire();
+
+  /**
+   * Synchronously signal a freeze on GrContext operations.
+   *
+   * ResourceContext instances will return nullptr on GrContext Get until unfrozen.
+   */
   static void Freeze();
+
+  /**
+   * Synchronously unfreeze GrContext operations.
+   *
+   * ResourceContext instances will continue to return the global GrContext
+   * instance on Get.
+   */
   static void Unfreeze();
 
   ResourceContext();
   ~ResourceContext();
+
+  /**
+   * Returns global GrContext instance. May return null when operations are frozen.
+   *
+   * Happens on iOS when background operations on GrContext are forbidden.
+   */
   GrContext* Get();
 
   FXL_DISALLOW_COPY_AND_ASSIGN(ResourceContext);

--- a/lib/ui/painting/resource_context.h
+++ b/lib/ui/painting/resource_context.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_RESOURCE_CONTEXT_H_
 #define FLUTTER_LIB_UI_PAINTING_RESOURCE_CONTEXT_H_
 
+#include "lib/fxl/macros.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 
 namespace blink {
@@ -12,7 +13,15 @@ namespace blink {
 class ResourceContext {
  public:
   static void Set(GrContext* context);
-  static GrContext* Get();
+  static ResourceContext* Acquire();
+  static void Freeze();
+  static void Unfreeze();
+
+  ResourceContext();
+  ~ResourceContext();
+  GrContext* Get();
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(ResourceContext);
 };
 
 }  // namespace blink

--- a/lib/ui/painting/resource_context.h
+++ b/lib/ui/painting/resource_context.h
@@ -28,7 +28,8 @@ class ResourceContext {
   /**
    * Synchronously signal a freeze on GrContext operations.
    *
-   * ResourceContext instances will return nullptr on GrContext Get until unfrozen.
+   * ResourceContext instances will return nullptr on GrContext Get until
+   * unfrozen.
    */
   static void Freeze();
 
@@ -44,7 +45,8 @@ class ResourceContext {
   ~ResourceContext();
 
   /**
-   * Returns global GrContext instance. May return null when operations are frozen.
+   * Returns global GrContext instance. May return null when operations are
+   * frozen.
    *
    * Happens on iOS when background operations on GrContext are forbidden.
    */

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -165,7 +165,8 @@ void PlatformView::SetupResourceContextOnIOThread() {
 
 void PlatformView::SetupResourceContextOnIOThreadPerform(
     fxl::AutoResetWaitableEvent* latch) {
-  std::unique_ptr<blink::ResourceContext> resourceContext = blink::ResourceContext::Acquire();
+  std::unique_ptr<blink::ResourceContext> resourceContext =
+      blink::ResourceContext::Acquire();
   if (resourceContext->Get() != nullptr) {
     // The resource context was already setup. This could happen if platforms
     // try to setup a context multiple times, or, if there are multiple platform

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -165,7 +165,8 @@ void PlatformView::SetupResourceContextOnIOThread() {
 
 void PlatformView::SetupResourceContextOnIOThreadPerform(
     fxl::AutoResetWaitableEvent* latch) {
-  if (blink::ResourceContext::Get() != nullptr) {
+  blink::ResourceContext* resourceContext = blink::ResourceContext::Acquire();
+  if (resourceContext->Get() != nullptr) {
     // The resource context was already setup. This could happen if platforms
     // try to setup a context multiple times, or, if there are multiple platform
     // views. In any case, there is nothing else to do. So just signal the
@@ -197,8 +198,8 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
 
   // Do not cache textures created by the image decoder.  These textures should
   // be deleted when they are no longer referenced by an SkImage.
-  if (blink::ResourceContext::Get())
-    blink::ResourceContext::Get()->setResourceCacheLimits(0, 0);
+  if (resourceContext->Get())
+    resourceContext->Get()->setResourceCacheLimits(0, 0);
 
   latch->Signal();
 }

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -165,6 +165,7 @@ void PlatformView::SetupResourceContextOnIOThread() {
 
 void PlatformView::SetupResourceContextOnIOThreadPerform(
     fxl::AutoResetWaitableEvent* latch) {
+  FXL_LOG(ERROR) << "SetupResourceContextOnIOThreadPerform";
   blink::ResourceContext* resourceContext = blink::ResourceContext::Acquire();
   if (resourceContext->Get() != nullptr) {
     // The resource context was already setup. This could happen if platforms

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -165,8 +165,7 @@ void PlatformView::SetupResourceContextOnIOThread() {
 
 void PlatformView::SetupResourceContextOnIOThreadPerform(
     fxl::AutoResetWaitableEvent* latch) {
-  FXL_LOG(ERROR) << "SetupResourceContextOnIOThreadPerform";
-  blink::ResourceContext* resourceContext = blink::ResourceContext::Acquire();
+  std::unique_ptr<blink::ResourceContext> resourceContext = blink::ResourceContext::Acquire();
   if (resourceContext->Get() != nullptr) {
     // The resource context was already setup. This could happen if platforms
     // try to setup a context multiple times, or, if there are multiple platform

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -11,6 +11,7 @@
 #include "flutter/fml/platform/darwin/platform_version.h"
 #include "flutter/fml/platform/darwin/scoped_block.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
+#include "flutter/lib/ui/painting/resource_context.h"
 #include "flutter/shell/platform/darwin/common/buffer_conversions.h"
 #include "flutter/shell/platform/darwin/common/platform_mac.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h"
@@ -398,6 +399,8 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
 - (void)applicationDidEnterBackground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationDidEnterBackground");
   [self surfaceUpdated:NO];
+  // GrContext operations are blocked when the app is in the background.
+  blink::ResourceContext::Freeze();
   [_lifecycleChannel.get() sendMessage:@"AppLifecycleState.paused"];
 }
 
@@ -405,6 +408,7 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
   TRACE_EVENT0("flutter", "applicationWillEnterForeground");
   if (_viewportMetrics.physical_width)
     [self surfaceUpdated:YES];
+  blink::ResourceContext::Unfreeze();
   [_lifecycleChannel.get() sendMessage:@"AppLifecycleState.inactive"];
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11862

Let ResourceContext act like a MutexLocker and have a synchronous freeze and unfreeze mechanism on the same mutex. 