### PR TITLE
Roll third_party/dart to @70e5deacb54aea29566 to pick up revert which broke flutter

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'bb33ba10d6a4a52d164c5e3deb169232b07f0bf0',
+  'dart_revision': '70e5deacb54aea295665215837adaedd3d6a5bfa',
 
   'dart_args_tag': '0.13.7',
   'dart_async_tag': '2.0.0',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: a4c565121c4fd07173a7e4985a3d989c
+Signature: b108e763a65063b8c05f481815a71277
 
 UNUSED LICENSES:
 
@@ -4445,8 +4445,7 @@ FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32_test.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_x86.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler.h


### PR DESCRIPTION

The revert in https://github.com/dart-lang/sdk/commit/d38c08d97358ebe4ee30e557bfee339dddda9b7a fixes broken flutter tests.