### PR TITLE
Run frontend server from temp directory to force absolute URIs in Kernel file.

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -257,6 +257,7 @@ Future<int> starter(List<String> args, {
 
   compiler ??= new _FrontendCompiler(output, printerFactory: binaryPrinterFactory);
   input ??= stdin;
+  Directory.current = Directory.systemTemp;
 
   if (options.rest.isNotEmpty) {
     await compiler.compile(options.rest[0], options, generator: generator);

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -257,7 +257,13 @@ Future<int> starter(List<String> args, {
 
   compiler ??= new _FrontendCompiler(output, printerFactory: binaryPrinterFactory);
   input ??= stdin;
+
+  // Has to be a directory, that won't have any of the compiled application
+  // sources, so that no relative paths could show up in the kernel file.
   Directory.current = Directory.systemTemp;
+  Directory workingDirectory = new Directory("flutter_frontend_server");
+  workingDirectory.createSync();
+  Directory.current = workingDirectory;
 
   if (options.rest.isNotEmpty) {
     await compiler.compile(options.rest[0], options, generator: generator);

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -261,7 +261,7 @@ Future<int> starter(List<String> args, {
   // Has to be a directory, that won't have any of the compiled application
   // sources, so that no relative paths could show up in the kernel file.
   Directory.current = Directory.systemTemp;
-  Directory workingDirectory = new Directory("flutter_frontend_server");
+  final Directory workingDirectory = new Directory("flutter_frontend_server");
   workingDirectory.createSync();
   Directory.current = workingDirectory;
 


### PR DESCRIPTION
This is workaround for https://github.com/dart-lang/sdk/issues/31468.