### PR TITLE
Remove use of SkPath::setConvexity in GraphicsContext.

### DIFF
--- a/sky/engine/platform/graphics/GraphicsContext.cpp
+++ b/sky/engine/platform/graphics/GraphicsContext.cpp
@@ -1421,17 +1421,6 @@ void GraphicsContext::setPathFromConvexPoints(SkPath* path,
     path->lineTo(WebCoreFloatToSkScalar(points[i].x()),
                  WebCoreFloatToSkScalar(points[i].y()));
   }
-
-  /*  The code used to just blindly call this
-          path->setIsConvex(true);
-      But webkit can sometimes send us non-convex 4-point values, so we mark the
-     path's convexity as unknown, so it will get computed by skia at draw time.
-      See crbug.com 108605
-  */
-  SkPath::Convexity convexity = SkPath::kConvex_Convexity;
-  if (numPoints == 4)
-    convexity = SkPath::kUnknown_Convexity;
-  path->setConvexity(convexity);
 }
 
 void GraphicsContext::setRadii(SkVector* radii,


### PR DESCRIPTION
I'd like to remove this method from Skia. I don't expect any significant performance impact from removing this code carried over from WebKit.