### PR TITLE
Add macros to mark APIs as being deprecated or unavailable.

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -6,9 +6,9 @@
 #define FLUTTER_FLUTTER_H_
 
 /**
- CHANGELOG:
+ BREAKING CHANGES:
 
- November 29, 2017: Added a CHANGELOG section.
+ November 29, 2017: Added a BREAKING CHANGES section.
  */
 
 #include "FlutterAppDelegate.h"

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -5,6 +5,12 @@
 #ifndef FLUTTER_FLUTTER_H_
 #define FLUTTER_FLUTTER_H_
 
+/**
+ CHANGELOG:
+
+ November 29, 2017: Added a CHANGELOG section.
+ */
+
 #include "FlutterAppDelegate.h"
 #include "FlutterBinaryMessenger.h"
 #include "FlutterChannels.h"

--- a/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
@@ -20,4 +20,21 @@
 #define NS_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
 #endif  // defined(NS_ASSUME_NONNULL_BEGIN)
 
+/**
+ Indicates that the API has been deprecated for the specifed reason. Code that
+ uses the deprecated API will continue to work as before. However, the API will
+ soon become unavailable and users are encouraged to immediately take the
+ appropriate action mentioned in the deprecation message and the changelog
+ section present in the Flutter.h umbrella header.
+ */
+#define FLUTTER_DEPRECATED(msg) __attribute__((__deprecated__(msg)))
+
+/**
+ Indicates that the previously deprecated API is now unavailable. Code that
+ uses the API will not work and the declaration of the API is only a stub meant
+ to display the given message detailing the actions for the user to take
+ immediately.
+ */
+#define FLUTTER_UNAVAILABLE(msg) __attribute__((__unavailable__(msg)))
+
 #endif  // FLUTTER_FLUTTERMACROS_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
@@ -24,8 +24,8 @@
  Indicates that the API has been deprecated for the specifed reason. Code that
  uses the deprecated API will continue to work as before. However, the API will
  soon become unavailable and users are encouraged to immediately take the
- appropriate action mentioned in the deprecation message and the changelog
- section present in the Flutter.h umbrella header.
+ appropriate action mentioned in the deprecation message and the BREAKING
+ CHANGES section present in the Flutter.h umbrella header.
  */
 #define FLUTTER_DEPRECATED(msg) __attribute__((__deprecated__(msg)))
 


### PR DESCRIPTION
This contains the macros mentioned in the draft detailing how we could manage breaking changes in the public Flutter engine APIs. The draft is [available here](https://docs.google.com/document/d/1sRjFf5zuRzUJrt_Rzl5x59ZQ47eY0GMj5GyOW0PFe04/edit?hl=en#).