### PR TITLE
 Front-end server: use VM-specific package:vm/kernel_front_end

### DIFF
--- a/frontend_server/.packages
+++ b/frontend_server/.packages
@@ -44,6 +44,7 @@ test:../../third_party/dart/third_party/pkg/test/lib/
 typed_data:../../third_party/dart/third_party/pkg/typed_data/lib/
 usage:../../third_party/dart/third_party/pkg/usage/lib/
 utf:../../third_party/dart/third_party/pkg/utf/lib/
+vm:../../third_party/dart/pkg/vm/lib/
 watcher:../../third_party/dart/third_party/pkg/watcher/lib/
 web_socket_channel:../../third_party/dart/third_party/pkg/web_socket_channel/lib/
 when:../../third_party/pkg/when/lib/

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -37,7 +37,9 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
       help: 'Path to file byte store used to keep incremental compiler state.'
           ' If omitted, then memory byte store is used.',
       defaultsTo: null)
-  ..addFlag('aot', help: 'Run compiler in AOT mode', defaultsTo: false)
+  ..addFlag('aot',
+      help: 'Run compiler in AOT mode (enables whole-program transformations)',
+      defaultsTo: false)
   ..addFlag('link-platform',
       help: 'When in batch mode, link platform kernel file into result kernel file.'
           ' Intended use is to satisfy different loading strategies implemented'

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -31,8 +31,7 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
       help: 'Path to file byte store used to keep incremental compiler state.'
           ' If omitted, then memory byte store is used.',
       defaultsTo: null)
-  ..addFlag('aot',
-      help: 'Run compiler in AOT mode', defaultsTo: false)
+  ..addFlag('aot', help: 'Run compiler in AOT mode', defaultsTo: false)
   ..addFlag('link-platform',
       help: 'When in batch mode, link platform kernel file into result kernel file.'
           ' Intended use is to satisfy different loading strategies implemented'
@@ -173,7 +172,9 @@ class _FrontendCompiler implements CompilerInterface {
           sdkRoot.resolve('platform.dill')
         ];
       }
-      program = await compileToKernel(Uri.base.resolve(_filename), compilerOptions, aot: options['aot']);
+      program = await compileToKernel(
+          Uri.base.resolve(_filename), compilerOptions,
+          aot: options['aot']);
     }
     if (program != null) {
       final IOSink sink = new File(_kernelBinaryFilename).openWrite();

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -10,13 +10,13 @@ import 'package:front_end/compilation_message.dart';
 import 'package:front_end/byte_store.dart';
 import 'package:front_end/compiler_options.dart';
 import 'package:front_end/incremental_kernel_generator.dart';
-import 'package:front_end/kernel_generator.dart';
 import 'package:kernel/ast.dart';
 import 'package:kernel/binary/ast_to_binary.dart';
 import 'package:kernel/binary/limited_ast_to_binary.dart';
 import 'package:kernel/target/flutter.dart';
 import 'package:kernel/target/targets.dart';
 import 'package:usage/uuid/uuid.dart';
+import 'package:vm/kernel_front_end.dart' show compileToKernel;
 
 ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
   ..addFlag('train',
@@ -31,6 +31,8 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
       help: 'Path to file byte store used to keep incremental compiler state.'
           ' If omitted, then memory byte store is used.',
       defaultsTo: null)
+  ..addFlag('aot',
+      help: 'Run compiler in AOT mode', defaultsTo: false)
   ..addFlag('link-platform',
       help: 'When in batch mode, link platform kernel file into result kernel file.'
           ' Intended use is to satisfy different loading strategies implemented'
@@ -171,7 +173,7 @@ class _FrontendCompiler implements CompilerInterface {
           sdkRoot.resolve('platform.dill')
         ];
       }
-      program = await kernelForProgram(Uri.base.resolve(_filename), compilerOptions);
+      program = await compileToKernel(Uri.base.resolve(_filename), compilerOptions, aot: options['aot']);
     }
     if (program != null) {
       final IOSink sink = new File(_kernelBinaryFilename).openWrite();

--- a/frontend_server/pubspec.yaml
+++ b/frontend_server/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   source_span: any
   typed_data: any
   usage: any
+  vm: any
 
 dev_dependencies:
   analyzer: any

--- a/frontend_server/pubspec.yaml
+++ b/frontend_server/pubspec.yaml
@@ -91,6 +91,8 @@ dependency_overrides:
     path: ../../third_party/dart/third_party/pkg/typed_data
   usage:
     path: ../../third_party/dart/third_party/pkg/usage
+  vm:
+    path: ../../third_party/dart/pkg/vm/
 
   analyzer:
     path: ../../third_party/dart/pkg/analyzer


### PR DESCRIPTION
* Use the VM-specific wrapper for the kernel front-end to support VM-specific kernel transformations.
* Also, pass a flag to distinguish AOT mode from JIT mode to enable whole-program optimizations.
