### PR TITLE
Disable linear blending on iOS simulator

### DIFF
--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -63,7 +63,7 @@ sk_sp<SkSurface> IOSSurfaceSoftware::AcquireBackingStore(const SkISize& size) {
     return sk_surface_;
   }
 
-  SkImageInfo info = SkImageInfo::MakeS32(size.fWidth, size.fHeight, kPremul_SkAlphaType);
+  SkImageInfo info = SkImageInfo::MakeN32(size.fWidth, size.fHeight, kPremul_SkAlphaType);
   sk_surface_ = SkSurface::MakeRaster(info, nullptr);
   return sk_surface_;
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/13308

Overlooked this case when I previously removed linear blending. MakeS32 creates a surface with a color space attached (triggering the linear blending behavior). MakeN32 creates a legacy surface (no color space), which matches what the other backend bindings do (including the GL surface factory, and the raster cache).