### PR TITLE
Update the iOS mark region on setTextInputState

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -206,6 +206,14 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
     [self.inputDelegate selectionDidChange:self];
   }
 
+  NSInteger composingBase = [state[@"composingBase"] intValue];
+  NSInteger composingExtent = [state[@"composingExtent"] intValue];
+  NSRange composingRange = [self clampSelection:NSMakeRange(MIN(composingBase, composingExtent),
+                                                            ABS(composingBase - composingExtent))
+                                        forText:self.text];
+  self.markedTextRange =
+      composingRange.length > 0 ? [FlutterTextRange rangeWithNSRange:composingRange] : nil;
+
   if (textChanged) {
     [self.inputDelegate textDidChange:self];
 


### PR DESCRIPTION
Previously, we failed to clear/update the mark text range on updates
from the framework. This resulted in a crash if the incoming text value
was shorter than the current mark range when iOS attempts to extract the
mark range substring from the text.

Fixes flutter/flutter#12585