### PR TITLE
Correct touch coordinates with iOS In-call Status Bar

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -483,7 +483,7 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
     }
 
     FXL_DCHECK(device_id != 0);
-    CGPoint windowCoordinates = [touch locationInView:nil];
+    CGPoint windowCoordinates = [touch locationInView:self.view];
 
     blink::PointerData pointer_data;
     pointer_data.Clear();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12707

iOS has an expanded status bar called In-call Status Bar.

When In-call status bar is enabled, FlutterView is resized to smaller,
but the coordinates of the touch is not shifted, it will cause a gap.

The engine use UITouch.locationInView to get coordinates.
https://developer.apple.com/documentation/uikit/uitouch/1618116-locationinview

Passing nil to UITouch.locationInView returns the touch location in the window’s coordinates.

In order to get the coordinates according to the resized FlutterView,
it is necessary to pass self.view to UITouch.locationInView.

Even with the normal status bar, this way gets the correct coordinates.
Because FlutterView covers the whole window.

I confirmed that this fix works correctly on iOS,
both of normal and in-call, and rotated.

But I am not an expert in iOS,
I would like someone familiar with iOS to check this fix.