### PR TITLE
Expose keyboard height as view inset on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -641,9 +641,7 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
     _viewportMetrics.physical_padding_top = self.view.safeAreaInsets.top * scale;
     _viewportMetrics.physical_padding_left = self.view.safeAreaInsets.left * scale;
     _viewportMetrics.physical_padding_right = self.view.safeAreaInsets.right * scale;
-    // TODO(cbracken): Once framework has been updated to use view insets for the keyboard, enable
-    // bottom safe area padding.
-    // _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
+    _viewportMetrics.physical_padding_bottom = self.view.safeAreaInsets.bottom * scale;
 #pragma clang diagnostic pop
   } else {
     _viewportMetrics.physical_padding_top = [self statusBarPadding] * scale;
@@ -657,19 +655,11 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   CGFloat bottom = CGRectGetHeight([[info objectForKey:UIKeyboardFrameEndUserInfoKey] CGRectValue]);
   CGFloat scale = [UIScreen mainScreen].scale;
   _viewportMetrics.physical_view_inset_bottom = bottom * scale;
-
-  // TODO(cbracken): Once framework has been updated to use view insets for keyboard padding,
-  // eliminate this line.
-  _viewportMetrics.physical_padding_bottom = bottom * scale;
   [self updateViewportMetrics];
 }
 
 - (void)keyboardWillBeHidden:(NSNotification*)notification {
   _viewportMetrics.physical_view_inset_bottom = 0;
-
-  // TODO(cbracken): Once framework has been updated to use view insets for keyboard padding,
-  // eliminate this line.
-  _viewportMetrics.physical_padding_bottom = 0;
   [self updateViewportMetrics];
 }
 


### PR DESCRIPTION
Keyboard height is now treated as a view inset, which could be used to
shrink the content area of the app as is done in the Material Scaffold,
rather than padding, which is used to indicate content areas where user
interaction should be avoided.