### PR TITLE
Support iOS scroll-to-top tap on iPhone X

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -803,10 +803,18 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
 constexpr CGFloat kStandardStatusBarHeight = 20.0;
 
 - (void)handleStatusBarTouches:(UIEvent*)event {
+  CGFloat standardStatusBarHeight = kStandardStatusBarHeight;
+  if (_platformSupportsSafeAreaInsets) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+    standardStatusBarHeight = self.view.safeAreaInsets.top;
+#pragma clang diagnostic pop
+  }
+
   // If the status bar is double-height, don't handle status bar taps. iOS
   // should open the app associated with the status bar.
   CGRect statusBarFrame = [UIApplication sharedApplication].statusBarFrame;
-  if (statusBarFrame.size.height != kStandardStatusBarHeight) {
+  if (statusBarFrame.size.height != standardStatusBarHeight) {
     return;
   }
 


### PR DESCRIPTION
This adds support for scrolling the primary scroll view to the top on
status bar touches, on the iPhone X.

Notes:
1. The iPhone X status bar doesn't change height when in in-call/etc.
   mode, and unlike other iPhones, does scroll to top when in in-call mode.
2. No matter which model of iOS device, the top safe area inset doesn't
   change when in in-call mode. In in-call mode, the OS reduces the app
   view height by 20px off the top, and the double-height 'in-call' status
   bar covers this new inset (outside the view) and there continues to be a
   20px safe area in the app.

On iOS 11, rather than comparing status bar height to a hardcoded 20px
'standard height' we now compare to the top safe area inset (which is
always the standard status bar height, regardless of device). On iOS
versions prior to iOS 11, we use the previous logic.

Fixes flutter/flutter#13439