### PR TITLE
Update VM entry points list to include previously omitted entries.

### DIFF
--- a/runtime/dart_vm_entry_points.txt
+++ b/runtime/dart_vm_entry_points.txt
@@ -1,3 +1,4 @@
+dart:_internal,::,_printClosure
 dart:async,::,_setScheduleImmediateClosure
 dart:io,::,_setupHooks
 dart:io,_Platform,set:_nativeScript
@@ -10,6 +11,7 @@ dart:ui,::,_dispatchPointerDataPacket
 dart:ui,::,_dispatchSemanticsAction
 dart:ui,::,_drawFrame
 dart:ui,::,_getGetBaseURLClosure
+dart:ui,::,_baseURL
 dart:ui,::,_getMainClosure
 dart:ui,::,_getPrintClosure
 dart:ui,::,_getScheduleMicrotaskClosure


### PR DESCRIPTION
This fixes obfuscated snapshot mode.