### PR TITLE
libtxt: improvements to GetWordBoundary

### DIFF
--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -193,6 +193,7 @@ class Paragraph {
   std::shared_ptr<FontCollection> font_collection_;
 
   minikin::LineBreaker breaker_;
+  mutable std::unique_ptr<icu::BreakIterator> word_breaker_;
 
   struct LineRange {
     LineRange(size_t s, size_t e, bool h) : start(s), end(e), hard_break(h) {}


### PR DESCRIPTION
* fix an off-by-one when the offset itself is a word boundary
* lazily create the word break iterator