### PR TITLE
libtxt: fixes to text style inheritance

### DIFF
--- a/third_party/txt/src/txt/paragraph_builder.h
+++ b/third_party/txt/src/txt/paragraph_builder.h
@@ -78,6 +78,9 @@ class ParagraphBuilder {
   std::shared_ptr<FontCollection> font_collection_;
   StyledRuns runs_;
   ParagraphStyle paragraph_style_;
+  size_t paragraph_style_index_;
+
+  size_t PeekStyleIndex() const;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(ParagraphBuilder);
 };

--- a/third_party/txt/src/txt/styled_runs.cc
+++ b/third_party/txt/src/txt/styled_runs.cc
@@ -47,11 +47,12 @@ size_t StyledRuns::AddStyle(const TextStyle& style) {
   return style_index;
 }
 
-const TextStyle& StyledRuns::PeekStyle() const {
-  return styles_.back();
+const TextStyle& StyledRuns::GetStyle(size_t style_index) const {
+  return styles_[style_index];
 }
 
 void StyledRuns::StartRun(size_t style_index, size_t start) {
+  EndRunIfNeeded(start);
   runs_.push_back(IndexedRun{style_index, start, start});
 }
 

--- a/third_party/txt/src/txt/styled_runs.h
+++ b/third_party/txt/src/txt/styled_runs.h
@@ -50,8 +50,7 @@ class StyledRuns {
 
   size_t AddStyle(const TextStyle& style);
 
-  // Returns the last TextStyle on the stack.
-  const TextStyle& PeekStyle() const;
+  const TextStyle& GetStyle(size_t style_index) const;
 
   void StartRun(size_t style_index, size_t start);
 


### PR DESCRIPTION
* newly pushed styles should inherit from the top of the paragraph's style
  stack, not the most recently added style in StyledRuns
* make the paragraph-level style a default that is not pushed onto the stack
  and can not be popped