### PR TITLE
Document that Xcode 9 is required to build the engine

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,7 +136,7 @@ to test the engine.
 
 ### iOS (cross-compiling from Mac)
 
-* Make sure you have Xcode 7.3.0+ installed.
+* Make sure you have Xcode 9.0+ installed.
 * `git pull upstream master` in `src/flutter` to update the Flutter Engine repo.
 * `gclient sync` to update dependencies.
 * `./flutter/tools/gn --ios --unoptimized` to prepare build files (or `--ios --simulator --unoptimized` for simulator).


### PR DESCRIPTION
The engine build bots and engine development team now rely solely on
Xcode 9 to build the engine. The iOS 11 SDK is required (though we build
with deployment target of iOS 8) for several features such as safe area
inset support.