### PR TITLE
Fix filename handling for Windows.

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -136,7 +136,7 @@ class _FrontendCompiler implements CompilerInterface {
     ArgResults options, {
     IncrementalKernelGenerator generator,
   }) async {
-    Uri _filenameUri = Uri.base.resolve(new Uri.file(_filename).toString());
+    Uri _filenameUri = Uri.base.resolve(new Uri.file(filename).toString());
     _kernelBinaryFilename = "$filename.dill";
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln("result $boundaryKey");

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -136,7 +136,7 @@ class _FrontendCompiler implements CompilerInterface {
     ArgResults options, {
     IncrementalKernelGenerator generator,
   }) async {
-    Uri _filenameUri = Uri.base.resolve(new Uri.file(filename).toString());
+    final Uri _filenameUri = Uri.base.resolve(new Uri.file(filename).toString());
     _kernelBinaryFilename = "$filename.dill";
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln("result $boundaryKey");

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -128,7 +128,6 @@ class _FrontendCompiler implements CompilerInterface {
   BinaryPrinterFactory printerFactory;
 
   IncrementalKernelGenerator _generator;
-  String _filename;
   String _kernelBinaryFilename;
 
   @override
@@ -137,7 +136,7 @@ class _FrontendCompiler implements CompilerInterface {
     ArgResults options, {
     IncrementalKernelGenerator generator,
   }) async {
-    _filename = filename;
+    Uri _filenameUri = Uri.base.resolve(new Uri.file(_filename).toString());
     _kernelBinaryFilename = "$filename.dill";
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln("result $boundaryKey");
@@ -157,7 +156,7 @@ class _FrontendCompiler implements CompilerInterface {
       _generator = generator != null
           ? generator
           : await IncrementalKernelGenerator.newInstance(
-              compilerOptions, Uri.base.resolve(_filename),
+              compilerOptions, _filenameUri,
               useMinimalGenerator: true);
       final DeltaProgram deltaProgram =
           await _runWithPrintRedirection(() => _generator.computeDelta());
@@ -170,9 +169,8 @@ class _FrontendCompiler implements CompilerInterface {
           sdkRoot.resolve('platform.dill')
         ];
       }
-      program = await _runWithPrintRedirection(() => compileToKernel(
-          Uri.base.resolve(_filename), compilerOptions,
-          aot: options['aot']));
+      program = await _runWithPrintRedirection(() =>
+          compileToKernel(_filenameUri, compilerOptions, aot: options['aot']));
     }
     if (program != null) {
       final IOSink sink = new File(_kernelBinaryFilename).openWrite();
@@ -219,12 +217,11 @@ class _FrontendCompiler implements CompilerInterface {
   }
 
   Uri _ensureFolderPath(String path) {
-    // This is a URI, not a file path, so the forward slash is correct even
-    // on Windows.
-    if (!path.endsWith('/')) {
-      path = '$path/';
+    String uriPath = new Uri.file(path).toString();
+    if (!uriPath.endsWith('/')) {
+      uriPath = '$uriPath/';
     }
-    return Uri.base.resolve(path);
+    return Uri.base.resolve(uriPath);
   }
 
   /// Runs the given function [f] in a Zone that redirects all prints into


### PR DESCRIPTION
frontend server when invoked from Flutter tools actually gets file paths, rather than uris.  That is breaking things on Windows.

This change changes frontend server expectations to receive file names, rather than uris.

Bug: https://github.com/flutter/flutter/issues/13708