### PR TITLE
Fix API typo

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -114,7 +114,7 @@ public class FlutterActivity extends Activity implements FlutterView.Provider, P
 
     // @Override - added in API level 23
     public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-        eventDelegate.onRequestPermissionResult(requestCode, permissions, grantResults);
+        eventDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -31,7 +31,7 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-import io.flutter.plugin.common.PluginRegistry.RequestPermissionResultListener;
+import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.util.Preconditions;
 import io.flutter.view.FlutterMain;
@@ -122,9 +122,9 @@ public final class FlutterActivityDelegate
     }
 
     @Override
-    public boolean onRequestPermissionResult(
+    public boolean onRequestPermissionsResult(
             int requestCode, String[] permissions, int[] grantResults) {
-        return flutterView.getPluginRegistry().onRequestPermissionResult(requestCode, permissions, grantResults);
+        return flutterView.getPluginRegistry().onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -129,7 +129,7 @@ public final class FlutterActivityDelegate
     @Deprecated
     public boolean onRequestPermissionResult(
             int requestCode, String[] permissions, int[] grantResults) {
-        return flutterView.getPluginRegistry().onRequestPermissionsResult(requestCode, permissions, grantResults);
+        return onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -29,9 +29,7 @@ import android.view.WindowManager.LayoutParams;
 import android.widget.FrameLayout;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.util.Preconditions;
 import io.flutter.view.FlutterMain;
@@ -123,6 +121,13 @@ public final class FlutterActivityDelegate
 
     @Override
     public boolean onRequestPermissionsResult(
+            int requestCode, String[] permissions, int[] grantResults) {
+        return flutterView.getPluginRegistry().onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    @Override
+    @Deprecated
+    public boolean onRequestPermissionResult(
             int requestCode, String[] permissions, int[] grantResults) {
         return flutterView.getPluginRegistry().onRequestPermissionsResult(requestCode, permissions, grantResults);
     }

--- a/shell/platform/android/io/flutter/app/FlutterActivityEvents.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityEvents.java
@@ -8,7 +8,7 @@ import android.content.ComponentCallbacks2;
 import android.content.Intent;
 import android.os.Bundle;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
-import io.flutter.plugin.common.PluginRegistry.RequestPermissionResultListener;
+import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 
 /**
  * A collection of Android {@code Activity} methods that are relevant to the
@@ -21,7 +21,7 @@ import io.flutter.plugin.common.PluginRegistry.RequestPermissionResultListener;
  * {@code FlutterActivity}.</p>
  */
 public interface FlutterActivityEvents
-        extends ComponentCallbacks2, ActivityResultListener, RequestPermissionResultListener {
+        extends ComponentCallbacks2, ActivityResultListener, RequestPermissionsResultListener {
     /**
      * @see android.app.Activity#onCreate(android.os.Bundle)
      */

--- a/shell/platform/android/io/flutter/app/FlutterActivityEvents.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityEvents.java
@@ -8,6 +8,7 @@ import android.content.ComponentCallbacks2;
 import android.content.Intent;
 import android.os.Bundle;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
+import io.flutter.plugin.common.PluginRegistry.RequestPermissionResultListener;
 import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 
 /**
@@ -21,7 +22,10 @@ import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
  * {@code FlutterActivity}.</p>
  */
 public interface FlutterActivityEvents
-        extends ComponentCallbacks2, ActivityResultListener, RequestPermissionsResultListener {
+        extends ComponentCallbacks2,
+                ActivityResultListener,
+                RequestPermissionResultListener,
+                RequestPermissionsResultListener {
     /**
      * @see android.app.Activity#onCreate(android.os.Bundle)
      */

--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -113,7 +113,7 @@ public class FlutterFragmentActivity
     // @Override - added in API level 23
     public void onRequestPermissionsResult(
             int requestCode, String[] permissions, int[] grantResults) {
-        eventDelegate.onRequestPermissionResult(requestCode, permissions, grantResults);
+        eventDelegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 public class FlutterPluginRegistry
   implements PluginRegistry,
+             PluginRegistry.RequestPermissionResultListener,
              PluginRegistry.RequestPermissionsResultListener,
              PluginRegistry.ActivityResultListener,
              PluginRegistry.NewIntentListener,
@@ -113,6 +114,18 @@ public class FlutterPluginRegistry
         }
 
         @Override
+        @Deprecated
+        public Registrar addRequestPermissionResultListener(
+                final RequestPermissionResultListener listener) {
+            return addRequestPermissionsResultListener(new RequestPermissionsResultListener() {
+                @Override
+                public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+                    return listener.onRequestPermissionResult(requestCode, permissions, grantResults);
+                }
+            });
+        }
+
+        @Override
         public Registrar addRequestPermissionsResultListener(
                 RequestPermissionsResultListener listener) {
             mRequestPermissionsResultListeners.add(listener);
@@ -152,6 +165,12 @@ public class FlutterPluginRegistry
             }
         }
         return false;
+    }
+
+    @Deprecated
+    @Override
+    public boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) {
+      return onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 public class FlutterPluginRegistry
   implements PluginRegistry,
-             PluginRegistry.RequestPermissionResultListener,
+             PluginRegistry.RequestPermissionsResultListener,
              PluginRegistry.ActivityResultListener,
              PluginRegistry.NewIntentListener,
              PluginRegistry.UserLeaveHintListener,
@@ -33,7 +33,7 @@ public class FlutterPluginRegistry
     private FlutterView mFlutterView;
 
     private final Map<String, Object> mPluginMap = new LinkedHashMap<>(0);
-    private final List<RequestPermissionResultListener> mRequestPermissionResultListeners = new ArrayList<>(0);
+    private final List<RequestPermissionsResultListener> mRequestPermissionsResultListeners = new ArrayList<>(0);
     private final List<ActivityResultListener> mActivityResultListeners = new ArrayList<>(0);
     private final List<NewIntentListener> mNewIntentListeners = new ArrayList<>(0);
     private final List<UserLeaveHintListener> mUserLeaveHintListeners = new ArrayList<>(0);
@@ -113,9 +113,9 @@ public class FlutterPluginRegistry
         }
 
         @Override
-        public Registrar addRequestPermissionResultListener(
-                RequestPermissionResultListener listener) {
-            mRequestPermissionResultListeners.add(listener);
+        public Registrar addRequestPermissionsResultListener(
+                RequestPermissionsResultListener listener) {
+            mRequestPermissionsResultListeners.add(listener);
             return this;
         }
 
@@ -145,9 +145,9 @@ public class FlutterPluginRegistry
     }
 
     @Override
-    public boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) {
-        for (RequestPermissionResultListener listener : mRequestPermissionResultListeners) {
-            if (listener.onRequestPermissionResult(requestCode, permissions, grantResults)) {
+    public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        for (RequestPermissionsResultListener listener : mRequestPermissionsResultListeners) {
+            if (listener.onRequestPermissionsResult(requestCode, permissions, grantResults)) {
                 return true;
             }
         }

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -126,6 +126,13 @@ public interface PluginRegistry {
         Registrar addRequestPermissionsResultListener(RequestPermissionsResultListener listener);
 
         /**
+         * @deprecated This method will be removed. Use
+         * {@link #addRequestPermissionsResultListener(RequestPermissionsResultListener)} instead.
+         */
+        @Deprecated
+        Registrar addRequestPermissionResultListener(RequestPermissionResultListener listener);
+
+        /**
          * Adds a callback allowing the plugin to take part in handling incoming
          * calls to {@link Activity#onActivityResult(int, int, Intent)}.
          *
@@ -171,6 +178,15 @@ public interface PluginRegistry {
          * @return true if the result has been handled.
          */
         boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
+    }
+
+    /**
+     * This interface is deprecated, and will be removed.
+     * Use {@link RequestPermissionsResultListener} instead.
+     */
+    interface RequestPermissionResultListener {
+        @Deprecated
+        boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults);
     }
 
     /**

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -126,7 +126,12 @@ public interface PluginRegistry {
         Registrar addRequestPermissionsResultListener(RequestPermissionsResultListener listener);
 
         /**
-         * @deprecated This method will be removed. Use
+         * Adds a callback allowing the plugin to take part in handling incoming
+         * calls to {@link Activity#onRequestPermissionsResult(int, String[], int[])}
+         * or {android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])}.
+         *
+         * @deprecated on 2018-01-02 because of misspelling. This method will be made unavailable
+         * on 2018-02-06. Use
          * {@link #addRequestPermissionsResultListener(RequestPermissionsResultListener)} instead.
          */
         @Deprecated
@@ -181,10 +186,18 @@ public interface PluginRegistry {
     }
 
     /**
-     * This interface is deprecated, and will be removed.
-     * Use {@link RequestPermissionsResultListener} instead.
+     * Delegate interface for handling result of permissions requests on
+     * behalf of the main {@link Activity}.
+     *
+     * Deprecated on 2018-01-02 because of misspelling. This interface will be made
+     * unavailable on 2018-02-06. Use {@link RequestPermissionsResultListener} instead.
      */
     interface RequestPermissionResultListener {
+        /**
+         * @return true if the result has been handled.
+         * @deprecated on 2018-01-02 because of misspelling. This method will be made
+         * unavailable on 2018-02-06. Use {@link RequestPermissionsResultListener} instead.
+         */
         @Deprecated
         boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults);
     }

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -120,10 +120,10 @@ public interface PluginRegistry {
          * calls to {@link Activity#onRequestPermissionsResult(int, String[], int[])}
          * or {android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])}.
          *
-         * @param listener a {@link RequestPermissionResultListener} callback.
+         * @param listener a {@link RequestPermissionsResultListener} callback.
          * @return this {@link Registrar}.
          */
-        Registrar addRequestPermissionResultListener(RequestPermissionResultListener listener);
+        Registrar addRequestPermissionsResultListener(RequestPermissionsResultListener listener);
 
         /**
          * Adds a callback allowing the plugin to take part in handling incoming
@@ -163,14 +163,14 @@ public interface PluginRegistry {
     }
 
     /**
-     * Delegate interface for handling results of permission requests on
+     * Delegate interface for handling result of permissions requests on
      * behalf of the main {@link Activity}.
      */
-    interface RequestPermissionResultListener {
+    interface RequestPermissionsResultListener {
         /**
          * @return true if the result has been handled.
          */
-        boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults);
+        boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
     }
 
     /**

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -134,7 +134,7 @@ public interface PluginRegistry {
          * @return this {@link Registrar}.
 
          * @deprecated on 2018-01-02 because of misspelling. This method will be made unavailable
-         * on 2018-02-06. Use
+         * on 2018-02-06 (or at least four weeks after the deprecation is released). Use
          * {@link #addRequestPermissionsResultListener(RequestPermissionsResultListener)} instead.
          */
         @Deprecated
@@ -193,13 +193,15 @@ public interface PluginRegistry {
      * behalf of the main {@link Activity}.
      *
      * Deprecated on 2018-01-02 because of misspelling. This interface will be made
-     * unavailable on 2018-02-06. Use {@link RequestPermissionsResultListener} instead.
+     * unavailable on 2018-02-06 (or at least four weeks after the deprecation is released).
+     * Use {@link RequestPermissionsResultListener} instead.
      */
     interface RequestPermissionResultListener {
         /**
          * @return true if the result has been handled.
          * @deprecated on 2018-01-02 because of misspelling. This method will be made
-         * unavailable on 2018-02-06. Use {@link RequestPermissionsResultListener} instead.
+         * unavailable on 2018-02-06 (or at least four weeks after the deprecation is released).
+         * Use {@link RequestPermissionsResultListener} instead.
          */
         @Deprecated
         boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults);

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -130,6 +130,9 @@ public interface PluginRegistry {
          * calls to {@link Activity#onRequestPermissionsResult(int, String[], int[])}
          * or {android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])}.
          *
+         * @param listener a {@link RequestPermissionResultListener} callback.
+         * @return this {@link Registrar}.
+
          * @deprecated on 2018-01-02 because of misspelling. This method will be made unavailable
          * on 2018-02-06. Use
          * {@link #addRequestPermissionsResultListener(RequestPermissionsResultListener)} instead.


### PR DESCRIPTION
Breaking change (posted [here](https://groups.google.com/forum/#!topic/flutter-dev/Bor3wxKb1J4))

Plugin registry on Android by mistake renamed the Android concept RequestPermission**s**Result to RequestPermissionResult which is unnecessarily confusing.

Fixes https://github.com/flutter/flutter/issues/10853