### PR TITLE
Engine support for arbitrary shape physical layers

### DIFF
--- a/flow/layers/default_layer_builder.cc
+++ b/flow/layers/default_layer_builder.cc
@@ -122,6 +122,22 @@ void DefaultLayerBuilder::PushPhysicalModel(const SkRRect& sk_rrect,
   PushLayer(std::move(layer), cullRect);
 }
 
+void DefaultLayerBuilder::PushPhysicalModel(const SkPath& sk_path,
+                                            double elevation,
+                                            SkColor color,
+                                            SkScalar device_pixel_ratio) {
+  SkRect cullRect;
+  if (!cullRect.intersect(sk_path.getBounds(), cull_rects_.top())) {
+    cullRect = SkRect::MakeEmpty();
+  }
+  auto layer = std::make_unique<flow::PhysicalModelLayer>();
+  layer->set_shape(std::make_unique<PhysicalLayerPath>(sk_path));
+  layer->set_elevation(elevation);
+  layer->set_color(color);
+  layer->set_device_pixel_ratio(device_pixel_ratio);
+  PushLayer(std::move(layer), cullRect);
+}
+
 void DefaultLayerBuilder::PushPerformanceOverlay(uint64_t enabled_options,
                                                  const SkRect& rect) {
   if (!current_layer_) {

--- a/flow/layers/default_layer_builder.cc
+++ b/flow/layers/default_layer_builder.cc
@@ -115,7 +115,7 @@ void DefaultLayerBuilder::PushPhysicalModel(const SkRRect& sk_rrect,
     cullRect = SkRect::MakeEmpty();
   }
   auto layer = std::make_unique<flow::PhysicalModelLayer>();
-  layer->set_rrect(sk_rrect);
+  layer->set_shape(std::make_unique<PhysicalLayerRRect>(sk_rrect));
   layer->set_elevation(elevation);
   layer->set_color(color);
   layer->set_device_pixel_ratio(device_pixel_ratio);

--- a/flow/layers/default_layer_builder.h
+++ b/flow/layers/default_layer_builder.h
@@ -53,6 +53,12 @@ class DefaultLayerBuilder final : public LayerBuilder {
                          SkScalar device_pixel_ratio) override;
 
   // |flow::LayerBuilder|
+  void PushPhysicalModel(const SkPath& path,
+                         double elevation,
+                         SkColor color,
+                         SkScalar device_pixel_ratio) override;
+
+  // |flow::LayerBuilder|
   void PushPerformanceOverlay(uint64_t enabled_options,
                               const SkRect& rect) override;
 

--- a/flow/layers/layer_builder.h
+++ b/flow/layers/layer_builder.h
@@ -52,6 +52,11 @@ class LayerBuilder {
                                  SkColor color,
                                  SkScalar device_pixel_ratio) = 0;
 
+  virtual void PushPhysicalModel(const SkPath& path,
+                                 double elevation,
+                                 SkColor color,
+                                 SkScalar device_pixel_ratio) = 0;
+
   virtual void PushPerformanceOverlay(uint64_t enabled_options,
                                       const SkRect& rect) = 0;
 

--- a/flow/layers/physical_model_layer.cc
+++ b/flow/layers/physical_model_layer.cc
@@ -19,7 +19,7 @@ void PhysicalModelLayer::Preroll(PrerollContext* context,
   PrerollChildren(context, matrix, &child_paint_bounds);
 
   if (elevation_ == 0) {
-    set_paint_bounds(rrect_.getBounds());
+    set_paint_bounds(shape_->getBounds());
   } else {
 #if defined(OS_FUCHSIA)
     // Let the system compositor draw all shadows for us.
@@ -29,7 +29,7 @@ void PhysicalModelLayer::Preroll(PrerollContext* context,
     // The margin is hardcoded to an arbitrary maximum for now because Skia
     // doesn't provide a way to calculate it.  We fill this whole region
     // and clip children to it so we don't need to join the child paint bounds.
-    SkRect bounds(rrect_.getBounds());
+    SkRect bounds(shape_->getBounds());
     bounds.outset(20.0, 20.0);
     set_paint_bounds(bounds);
 #endif  // defined(OS_FUCHSIA)
@@ -57,8 +57,7 @@ void PhysicalModelLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "PhysicalModelLayer::Paint");
   FXL_DCHECK(needs_painting());
 
-  SkPath path;
-  path.addRRect(rrect_);
+  SkPath path = shape_->getPath();
 
   if (elevation_ != 0) {
     DrawShadow(&context.canvas, path, SK_ColorBLACK, elevation_,
@@ -70,15 +69,15 @@ void PhysicalModelLayer::Paint(PaintContext& context) const {
   context.canvas.drawPath(path, paint);
 
   SkAutoCanvasRestore save(&context.canvas, false);
-  if (rrect_.isRect()) {
+  if (shape_->isRect()) {
     context.canvas.save();
   } else {
-    context.canvas.saveLayer(&rrect_.getBounds(), nullptr);
+    context.canvas.saveLayer(&shape_->getBounds(), nullptr);
   }
-  context.canvas.clipRRect(rrect_, true);
+  shape_->clipCanvas(context.canvas);
   PaintChildren(context);
-  if (context.checkerboard_offscreen_layers && !rrect_.isRect())
-    DrawCheckerboard(&context.canvas, rrect_.getBounds());
+  if (context.checkerboard_offscreen_layers && !shape_->isRect())
+    DrawCheckerboard(&context.canvas, shape_->getBounds());
 }
 
 void PhysicalModelLayer::DrawShadow(SkCanvas* canvas,
@@ -96,6 +95,12 @@ void PhysicalModelLayer::DrawShadow(SkCanvas* canvas,
   SkShadowUtils::DrawShadow(canvas, path, dpr * elevation,
                             SkPoint3::Make(shadow_x, shadow_y, dpr * 600.0f),
                             dpr * 800.0f, 0.039f, 0.25f, color, flags);
+}
+
+const SkPath PhysicalLayerRRect::getPath() const {
+  SkPath path;
+  path.addRRect(rrect_);
+  return path;
 }
 
 }  // namespace flow

--- a/flow/layers/physical_model_layer.h
+++ b/flow/layers/physical_model_layer.h
@@ -9,12 +9,16 @@
 
 namespace flow {
 
+class PhysicalLayerShape;
+
 class PhysicalModelLayer : public ContainerLayer {
  public:
   PhysicalModelLayer();
   ~PhysicalModelLayer() override;
 
-  void set_rrect(const SkRRect& rrect) { rrect_ = rrect; }
+  void set_shape(std::unique_ptr<PhysicalLayerShape> shape) {
+    shape_ = std::move(shape);
+  }
   void set_elevation(float elevation) { elevation_ = elevation; }
   void set_color(SkColor color) { color_ = color; }
   void set_device_pixel_ratio(SkScalar dpr) { device_pixel_ratio_ = dpr; }
@@ -35,10 +39,81 @@ class PhysicalModelLayer : public ContainerLayer {
 #endif  // defined(OS_FUCHSIA)
 
  private:
-  SkRRect rrect_;
+  std::unique_ptr<PhysicalLayerShape> shape_;
   float elevation_;
   SkColor color_;
   SkScalar device_pixel_ratio_;
+};
+
+// Common interface for the shape operations needed by PhysicalModelLayer.
+class PhysicalLayerShape {
+ public:
+  virtual const SkRect& getBounds() const = 0;
+  virtual const SkPath getPath() const = 0;
+  virtual void clipCanvas(SkCanvas& canvas) const = 0;
+  virtual bool isRect() const = 0;
+#if defined(OS_FUCHSIA)
+  virtual const SkRRect& getFrameRRect() const = 0;
+#endif  // defined(OS_FUCHSIA)
+};
+
+class PhysicalLayerRRect : public PhysicalLayerShape {
+ public:
+  PhysicalLayerRRect(const SkRRect& rrect) { rrect_ = rrect; }
+
+  // |flow::PhysicalLayerShape|
+  const SkRect& getBounds() const { return rrect_.getBounds(); }
+
+  // |flow::PhysicalLayerShape|
+  const SkPath getPath() const;
+
+  // |flow::PhysicalLayerShape|
+  void clipCanvas(SkCanvas& canvas) const { canvas.clipRRect(rrect_, true); }
+
+  // |flow::PhysicalLayerShape|
+  bool isRect() const { return rrect_.isRect(); }
+
+#if defined(OS_FUCHSIA)
+  // |flow::PhysicalLayerShape|
+  const SkRRect& getFrameRRect() const { return rrect_; }
+#endif  // defined(OS_FUCHSIA)
+
+ private:
+  SkRRect rrect_;
+};
+
+class PhysicalLayerPath : public PhysicalLayerShape {
+ public:
+  PhysicalLayerPath(const SkPath& path) {
+    path_ = path;
+#if defined(OS_FUCHSIA)
+    frameRRect_ = SkRRect::MakeRect(path.getBounds());
+#endif  // defined(OS_FUCHSIA)
+  }
+
+  // |flow::PhysicalLayerShape|
+  const SkRect& getBounds() const { return path_.getBounds(); }
+
+  // |flow::PhysicalLayerShape|
+  const SkPath getPath() const { return path_; }
+
+  // |flow::PhysicalLayerShape|
+  void clipCanvas(SkCanvas& canvas) const { canvas.clipPath(path_, true); }
+
+  // |flow::PhysicalLayerShape|
+  bool isRect() const { return false; }
+
+#if defined(OS_FUCHSIA)
+  // Scenic does not currently support compositing arbitrary shaped layers,
+  // so we just use the path's bounding rectangle.
+  // |flow::PhysicalLayerShape|
+  const SkRRect& getFrameRRect() const { return frameRRect_; }
+#endif  // defined(OS_FUCHSIA)
+ private:
+  SkPath path_;
+#if defined(OS_FUCHSIA)
+  SkRRect frameRRect_;
+#endif  // defined(OS_FUCHSIA)
 };
 
 }  // namespace flow

--- a/flow/layers/physical_model_layer.h
+++ b/flow/layers/physical_model_layer.h
@@ -54,7 +54,7 @@ class PhysicalModelLayer : public ContainerLayer {
 class PhysicalLayerShape {
  public:
   virtual const SkRect& getBounds() const = 0;
-  virtual const SkPath getPath() const = 0;
+  virtual SkPath getPath() const = 0;
   virtual void clipCanvas(SkCanvas& canvas) const = 0;
   virtual bool isRect() const = 0;
 #if defined(OS_FUCHSIA)
@@ -70,7 +70,7 @@ class PhysicalLayerRRect final : public PhysicalLayerShape {
   const SkRect& getBounds() const override { return rrect_.getBounds(); }
 
   // |flow::PhysicalLayerShape|
-  const SkPath getPath() const override;
+  SkPath getPath() const override;
 
   // |flow::PhysicalLayerShape|
   void clipCanvas(SkCanvas& canvas) const override {
@@ -102,7 +102,7 @@ class PhysicalLayerPath final : public PhysicalLayerShape {
   const SkRect& getBounds() const override { return path_.getBounds(); }
 
   // |flow::PhysicalLayerShape|
-  const SkPath getPath() const override { return path_; }
+  SkPath getPath() const override { return path_; }
 
   // |flow::PhysicalLayerShape|
   void clipCanvas(SkCanvas& canvas) const override {

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -127,7 +127,8 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
                        double maskRectBottom,
                        int blendMode) native "SceneBuilder_pushShaderMask";
 
-  /// Pushes a physical model operation onto the operation stack.
+  /// Pushes a physical model operation for a rounded rectangle onto the
+  /// operation stack.
   ///
   /// Rasterization will be clipped to the given shape.
   ///
@@ -138,6 +139,18 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   void _pushPhysicalModel(Float32List rrect,
                           double elevation,
                           int color) native "SceneBuilder_pushPhysicalModel";
+
+  /// Pushes a physical model operation for an arbitrary shape onto the
+  /// operation stack.
+  ///
+  /// Rasterization will be clipped to the given shape.
+  ///
+  /// See [pop] for details about the operation stack.
+  void pushPhysicalShape({ Path path, double elevation, Color color }) {
+    _pushPhysicalShape(path, elevation, color.value);
+  }
+  void _pushPhysicalShape(Path path, double elevation, int color) native 
+    "SceneBuilder_pushPhysicalShape";
 
   /// Ends the effect of the most recently pushed operation.
   ///

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -33,6 +33,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, SceneBuilder);
   V(SceneBuilder, pushBackdropFilter)               \
   V(SceneBuilder, pushShaderMask)                   \
   V(SceneBuilder, pushPhysicalModel)                \
+  V(SceneBuilder, pushPhysicalShape)                \
   V(SceneBuilder, pop)                              \
   V(SceneBuilder, addPicture)                       \
   V(SceneBuilder, addTexture)                       \
@@ -105,6 +106,16 @@ void SceneBuilder::pushPhysicalModel(const RRect& rrect,
                                      int color) {
   layer_builder_->PushPhysicalModel(
       rrect.sk_rrect,               //
+      elevation,                    //
+      static_cast<SkColor>(color),  //
+      UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio);
+}
+
+void SceneBuilder::pushPhysicalShape(const CanvasPath* path,
+                                     double elevation,
+                                     int color) {
+  layer_builder_->PushPhysicalModel(
+      path->path(),                 //
       elevation,                    //
       static_cast<SkColor>(color),  //
       UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio);

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -48,6 +48,7 @@ class SceneBuilder : public fxl::RefCountedThreadSafe<SceneBuilder>,
                       double maskRectBottom,
                       int blendMode);
   void pushPhysicalModel(const RRect& rrect, double elevation, int color);
+  void pushPhysicalShape(const CanvasPath* path, double elevation, int color);
 
   void pop();
 


### PR DESCRIPTION
Note that we just use the bounding rectangle on Fuchsia as it currently does not support arbitrary shape physical layers.