### PR TITLE
Remove extraneous const from PhysicalLayerRRect::getPath

### DIFF
--- a/flow/layers/physical_model_layer.cc
+++ b/flow/layers/physical_model_layer.cc
@@ -97,7 +97,7 @@ void PhysicalModelLayer::DrawShadow(SkCanvas* canvas,
                             dpr * 800.0f, 0.039f, 0.25f, color, flags);
 }
 
-const SkPath PhysicalLayerRRect::getPath() const {
+SkPath PhysicalLayerRRect::getPath() const {
   SkPath path;
   path.addRRect(rrect_);
   return path;


### PR DESCRIPTION
This caused a breakage on mac due to inconsistent signatures for
declaration and implementation.