### PR TITLE
[Fuchsia] Don't force a full Dart SDK build during host build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -12,7 +12,7 @@ group("flutter") {
     "$flutter_root/third_party/txt",
   ]
 
-  if (!is_fuchsia) {
+  if (!is_fuchsia && !is_fuchsia_host) {
     if (current_toolchain == host_toolchain) {
       public_deps += [
         "$flutter_root/frontend_server",


### PR DESCRIPTION
This rule forces a build of the Dart SDK with the current host toolchain, which isn't needed.