### PR TITLE
Revert "Ensure language and country codes are not empty"

### DIFF
--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -66,8 +66,8 @@ class RuntimeController : public WindowClient, public IsolateClient {
   void DidShutdownMainIsolate() override;
 
   RuntimeDelegate* client_;
-  std::string language_code_ = "en";
-  std::string country_code_ = "US";
+  std::string language_code_;
+  std::string country_code_;
   std::string user_settings_data_ = "{}";
   bool semantics_enabled_ = false;
   std::unique_ptr<DartController> dart_controller_;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -118,8 +118,6 @@ Engine::Engine(PlatformView* platform_view)
           platform_view->GetVsyncWaiter(),
           this)),
       load_script_error_(tonic::kNoError),
-      language_code_("en"),
-      country_code_("US"),
       user_settings_data_("{}"),
       activity_running_(false),
       have_surface_(false),


### PR DESCRIPTION
Reverts flutter/engine#4492

Seems to break an assumption in the framework that the locale is '_' before it has been set.