### PR TITLE
Ensure Platform.localeName isn't '_'

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -41,7 +41,11 @@ void _updateWindowMetrics(double devicePixelRatio,
 
 typedef String LocaleClosure();
 
-String _localeClosure() => window._locale.toString();
+String _localeClosure() {
+  const String enUS = 'en_US';
+  final String locale = window?._locale?.toString() ?? enUS;
+  return (locale == '_') ? enUS : locale;
+}
 
 LocaleClosure _getLocaleClosure() => _localeClosure;
 


### PR DESCRIPTION
Another attempt to fix https://github.com/flutter/flutter/issues/13748 that only modifies what is directly fed into `Platform.localeName`.