### PR TITLE
Add note regarding byte-store option not being functional at the moment.

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -34,7 +34,9 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
       defaultsTo: '../../out/android_debug/flutter_patched_sdk')
   ..addOption('byte-store',
       help: 'Path to file byte store used to keep incremental compiler state.'
-          ' If omitted, then memory byte store is used.',
+          ' If omitted, then memory byte store is used.'
+          ' Note, that this option currently doesn''t have any efect, so memory'
+          ' byte store is always used.',
       defaultsTo: null)
   ..addFlag('aot',
       help: 'Run compiler in AOT mode (enables whole-program transformations)',


### PR DESCRIPTION
client.flutter bulidbot seems to be stuck, not picking up commit to roll dart. Sometimes having another commit helped it getting unstuck. So this PR primarily serves that purposes, adds useful note to frontend_server option too.