### PR TITLE
Revert "Revert "Fix filename handling for Windows. (#4482)" (#4484)"

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -136,7 +136,7 @@ class _FrontendCompiler implements CompilerInterface {
     ArgResults options, {
     IncrementalKernelGenerator generator,
   }) async {
-    final Uri _filenameUri = Uri.base.resolve(new Uri.file(filename).toString());
+    final Uri filenameUri = Uri.base.resolveUri(new Uri.file(filename));
     _kernelBinaryFilename = "$filename.dill";
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln("result $boundaryKey");
@@ -156,7 +156,7 @@ class _FrontendCompiler implements CompilerInterface {
       _generator = generator != null
           ? generator
           : await IncrementalKernelGenerator.newInstance(
-              compilerOptions, _filenameUri,
+              compilerOptions, filenameUri,
               useMinimalGenerator: true);
       final DeltaProgram deltaProgram =
           await _runWithPrintRedirection(() => _generator.computeDelta());

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -170,7 +170,7 @@ class _FrontendCompiler implements CompilerInterface {
         ];
       }
       program = await _runWithPrintRedirection(() =>
-          compileToKernel(_filenameUri, compilerOptions, aot: options['aot']));
+          compileToKernel(filenameUri, compilerOptions, aot: options['aot']));
     }
     if (program != null) {
       final IOSink sink = new File(_kernelBinaryFilename).openWrite();


### PR DESCRIPTION
This reverts commit 929e5b3900e2aab0c0f05889fd44b3a9525e846a.

Re-landing now since issue with `gen_snapshot` (as described in https://github.com/flutter/flutter/issues/13708) was fixed.
  