### PR TITLE
Train frontend_server snapshot

### DIFF
--- a/frontend_server/BUILD.gn
+++ b/frontend_server/BUILD.gn
@@ -7,7 +7,8 @@ import("//third_party/dart/utils/application_snapshot.gni")
 application_snapshot("frontend_server") {
   main_dart = "bin/starter.dart"
   dot_packages = rebase_path(".packages")
-  training_args = [ "--train", "--sdk-root=$root_gen_dir" ]
+  flutter_patched_sdk = rebase_path("$root_gen_dir/../flutter_patched_sdk")
+  training_args = [ "--train", "--sdk-root=$flutter_patched_sdk" ]
 
   frontend_server_files = exec_script("//third_party/dart/tools/list_dart_files.py",
      [ "absolute", rebase_path("."), ], "list lines")

--- a/frontend_server/BUILD.gn
+++ b/frontend_server/BUILD.gn
@@ -7,7 +7,7 @@ import("//third_party/dart/utils/application_snapshot.gni")
 application_snapshot("frontend_server") {
   main_dart = "bin/starter.dart"
   dot_packages = rebase_path(".packages")
-  flutter_patched_sdk = rebase_path("$root_gen_dir/../flutter_patched_sdk")
+  flutter_patched_sdk = rebase_path("$root_out_dir/flutter_patched_sdk")
   training_args = [ "--train", "--sdk-root=$flutter_patched_sdk" ]
 
   frontend_server_files = exec_script("//third_party/dart/tools/list_dart_files.py",

--- a/frontend_server/BUILD.gn
+++ b/frontend_server/BUILD.gn
@@ -7,7 +7,7 @@ import("//third_party/dart/utils/application_snapshot.gni")
 application_snapshot("frontend_server") {
   main_dart = "bin/starter.dart"
   dot_packages = rebase_path(".packages")
-  training_args = [ "--train" ]
+  training_args = [ "--train", "--sdk-root=$root_gen_dir" ]
 
   frontend_server_files = exec_script("//third_party/dart/tools/list_dart_files.py",
      [ "absolute", rebase_path("."), ], "list lines")

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -259,7 +259,7 @@ Future<int> starter(
   }
 
   if (options['train']) {
-    String sdkRoot = options['sdk-root'];
+    final String sdkRoot = options['sdk-root'];
     options = _argParser.parse(<String>['--incremental', '--sdk-root=$sdkRoot']);
     compiler ??= new _FrontendCompiler(output, printerFactory: binaryPrinterFactory);
     await compiler.compile(Platform.script.toFilePath(), options, generator: generator);

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -260,15 +260,9 @@ Future<int> starter(
 
   if (options['train']) {
     String sdkRoot = options['sdk-root'];
-    if (sdkRoot.startsWith("//out/") && sdkRoot.endsWith("/gen")) {
-      // This becomes '../../out/whatnot/flutter_patched_sdk'
-      sdkRoot = '../..${sdkRoot.substring(1, sdkRoot.length-4)}/flutter_patched_sdk';
-    }
     options = _argParser.parse(<String>['--incremental', '--sdk-root=$sdkRoot']);
-    compiler ??=
-    new _FrontendCompiler(output, printerFactory: binaryPrinterFactory);
-    await compiler.compile(Platform.script.toFilePath(), options,
-        generator: generator);
+    compiler ??= new _FrontendCompiler(output, printerFactory: binaryPrinterFactory);
+    await compiler.compile(Platform.script.toFilePath(), options, generator: generator);
     compiler.acceptLastDelta();
     await compiler.recompileDelta();
     compiler.acceptLastDelta();

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -259,6 +259,23 @@ Future<int> starter(
   }
 
   if (options['train']) {
+    String sdkRoot = options['sdk-root'];
+    if (sdkRoot.startsWith("//out/") && sdkRoot.endsWith("/gen")) {
+      // This becomes '../../out/whatnot/flutter_patched_sdk'
+      sdkRoot = '../..${sdkRoot.substring(1, sdkRoot.length-4)}/flutter_patched_sdk';
+    }
+    options = _argParser.parse(<String>['--incremental', '--sdk-root=$sdkRoot']);
+    compiler ??=
+    new _FrontendCompiler(output, printerFactory: binaryPrinterFactory);
+    await compiler.compile(Platform.script.toFilePath(), options,
+        generator: generator);
+    compiler.acceptLastDelta();
+    await compiler.recompileDelta();
+    compiler.acceptLastDelta();
+    await compiler.recompileDelta();
+    compiler.acceptLastDelta();
+    await compiler.recompileDelta();
+    compiler.acceptLastDelta();
     return 0;
   }
 

--- a/frontend_server/test/server_test.dart
+++ b/frontend_server/test/server_test.dart
@@ -26,8 +26,10 @@ class _MockedBinaryPrinter extends Mock implements BinaryPrinter {}
 
 Future<int> main() async {
   group('basic', () {
-    test('train completes', () async {
-      expect(await starter(<String>['--train']), equals(0));
+    final CompilerInterface compiler = new _MockedCompiler();
+
+    test('train with mocked compiler completes', () async {
+      expect(await starter(<String>['--train'], compiler: compiler), equals(0));
     });
   });
 


### PR DESCRIPTION
When running with --preview-dart-2 the frontend_server is used for compilation.
The frontend_server is compiled to a snapshot and trained with "--train", but then contains the following code "if (options['train']) { return 0; }" meaning that it isn't trained at all.

This PR trains it on itself resulting in the following improvements in the "hot_mode_dev_cycle" "hotReloadInitialDevFSSyncMilliseconds" benchmark:

```
On x64 Android emulator:

dart bin/run.dart -t hot_mode_dev_cycle__preview_dart_2_benchmark
hotReloadInitialDevFSSyncMilliseconds goes from an average (3 runs) of 5905 to 4178

dart bin/run.dart -t hot_mode_dev_cycle__benchmark
hotReloadInitialDevFSSyncMilliseconds takes an average (3 runs) of 5375.



On Nexus 4 running Android 4.4.4:

dart bin/run.dart -t hot_mode_dev_cycle__preview_dart_2_benchmark
hotReloadInitialDevFSSyncMilliseconds goes from an average (3 runs) of 8493 to 6863

dart bin/run.dart -t hot_mode_dev_cycle__benchmark
hotReloadInitialDevFSSyncMilliseconds takes an average (3 runs) of 9218.
```