### PR TITLE
Get active Context from the Registrar on Android

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 Google Inc.
 Jim Simon <jim.j.simon@gmail.com>
+Ali Bitek <alibitek@protonmail.ch>

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -92,6 +92,11 @@ public class FlutterPluginRegistry
         }
 
         @Override
+        public Context activeContext() {
+            return (mActivity != null) ? mActivity : mAppContext;
+        }
+
+        @Override
         public BinaryMessenger messenger() {
             return mNativeView;
         }

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -81,6 +81,13 @@ public interface PluginRegistry {
         Context context();
 
         /**
+        * Returns the active {@link Context}.
+        *
+        * @return the current {@link #activity() Activity}, if not null, otherwise the {@link #context() Application}.
+        */
+        Context activeContext();
+
+        /**
          * Returns a {@link BinaryMessenger} which the plugin can use for
          * creating channels for communicating with the Dart side.
          */


### PR DESCRIPTION
A convenience method that would reduce code duplication when developing Flutter plugins that often need to get a reference to a Context. (either a foreground Context obtained via an Activity class or a background Context from the Application).

For example, [code](https://github.com/alibitek/plugins/blob/892401e50b50838b8d7bd36b1b26fa050c3516cc/packages/android_intent/android/src/main/java/io/flutter/plugins/androidintent/AndroidIntentPlugin.java#L109) such as:
```java
  @Override
  public void onMethodCall(MethodCall call, Result result) {
    Context context =
(mRegistrar.activity() != null) ? mRegistrar.activity() : mRegistrar.context();
   ...
  }
```

would be replaced by:
https://github.com/flutter/plugins/pull/332/commits/811770dba8a67996c8cc46b7f87a2a38e654d8d4
```java
  @Override
  public void onMethodCall(MethodCall call, Result result) {
    Context context = mRegistrar.activeContext();
   ...
  }
```
without each plugin having to reimplement the `activeContext()` method.
  