### PR TITLE
Fix build break caused by https://github.com/flutter/engine/pull/4491

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/JSONUtil.java
+++ b/shell/platform/android/io/flutter/plugin/common/JSONUtil.java
@@ -3,6 +3,7 @@ package io.flutter.plugin.common;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.HashMap;
 import java.util.Map;


### PR DESCRIPTION
I am surprised that the build path is not exercised by the Travis checks. My local machine is not setup to build the engine from scratch since it is quite involved to setup. https://github.com/flutter/flutter/issues/13964 should address this issue. For now, I tried compiling this particular file with javac locally.