### PR TITLE
Deprecate support for big integers in standard message codec

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@@ -15,6 +15,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import android.util.Log;
+
 /**
  * MessageCodec using the Flutter standard binary encoding.
  *
@@ -27,7 +29,7 @@ import java.util.Map.Entry;
  * <ul>
  *     <li>null</li>
  *     <li>Booleans</li>
- *     <li>Bytes, Shorts, Integers, Longs, BigIntegers</li>
+ *     <li>Bytes, Shorts, Integers, Longs</li>
  *     <li>Floats, Doubles</li>
  *     <li>Strings</li>
  *     <li>byte[], int[], long[], double[]</li>
@@ -40,7 +42,7 @@ import java.util.Map.Entry;
  * <ul>
  *     <li>null: null</li>
  *     <li>Boolean: bool</li>
- *     <li>Byte, Short, Integer, Long, BigInteger: int</li>
+ *     <li>Byte, Short, Integer, Long: int</li>
  *     <li>Float, Double: double</li>
  *     <li>String: String</li>
  *     <li>byte[]: Uint8List</li>
@@ -50,6 +52,12 @@ import java.util.Map.Entry;
  *     <li>List: List</li>
  *     <li>Map: Map</li>
  * </ul>
+ *
+ * <p>Direct support for BigIntegers has been deprecated on 2018-01-08 to be made
+ * unavailable four weeks after this change is available on the Flutter alpha
+ * branch. BigIntegers were needed because the Dart 1.0 int type had no size
+ * limit. With Dart 2.0, the int type is a fixed-size, 64-bit signed integer.
+ * If you need to communicate larger integers, use String encoding instead.</p>
  */
 public final class StandardMessageCodec implements MessageCodec<Object> {
     public static final StandardMessageCodec INSTANCE = new StandardMessageCodec();
@@ -89,6 +97,7 @@ public final class StandardMessageCodec implements MessageCodec<Object> {
     private static final byte FALSE = 2;
     private static final byte INT = 3;
     private static final byte LONG = 4;
+    @Deprecated
     private static final byte BIGINT = 5;
     private static final byte DOUBLE = 6;
     private static final byte STRING = 7;
@@ -195,6 +204,7 @@ public final class StandardMessageCodec implements MessageCodec<Object> {
                 writeAlignment(stream, 8);
                 writeDouble(stream, ((Number) value).doubleValue());
             } else if (value instanceof BigInteger) {
+                Log.w("Flutter", "Support for BigIntegers has been deprecated. Use String encoding instead.");
                 stream.write(BIGINT);
                 writeBytes(stream,
                     ((BigInteger) value).toString(16).getBytes(UTF8));
@@ -301,6 +311,7 @@ public final class StandardMessageCodec implements MessageCodec<Object> {
                 result = buffer.getLong();
                 break;
             case BIGINT: {
+                Log.w("Flutter", "Support for BigIntegers has been deprecated. Use String encoding instead.");
                 final byte[] hex = readBytes(buffer);
                 result = new BigInteger(new String(hex, UTF8), 16);
                 break;

--- a/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@@ -53,7 +53,7 @@ import android.util.Log;
  *     <li>Map: Map</li>
  * </ul>
  *
- * <p>Direct support for BigIntegers has been deprecated on 2018-01-08 to be made
+ * <p>Direct support for BigIntegers has been deprecated on 2018-01-09 to be made
  * unavailable four weeks after this change is available on the Flutter alpha
  * branch. BigIntegers were needed because the Dart 1.0 int type had no size
  * limit. With Dart 2.0, the int type is a fixed-size, 64-bit signed integer.

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -8,6 +8,14 @@
 /**
  BREAKING CHANGES:
 
+ January 08, 2018: Deprecated FlutterStandardBigInteger and its use in
+ FlutterStandardMessageCodec and FlutterStandardMethodCodec. Scheduled to
+ be marked as unavailable once the deprecation has been available on the
+ flutter/flutter alpha branch for four weeks. FlutterStandardBigInteger was
+ needed because the Dart 1.0 int type had no size limit. With Dart 2.0, the
+ int type is a fixed-size, 64-bit signed integer. If you need to communicate
+ larger integers, use NSString encoding instead.
+
  December 11, 2017: Deprecated "initWithFLXArchive" and
  "initWithFLXArchiveWithScriptSnapshot" and scheculed the same to be marked as
  unavailable on January 15, 2018. Instead, "initWithFlutterAssets" and

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -8,7 +8,7 @@
 /**
  BREAKING CHANGES:
 
- January 08, 2018: Deprecated FlutterStandardBigInteger and its use in
+ January 09, 2018: Deprecated FlutterStandardBigInteger and its use in
  FlutterStandardMessageCodec and FlutterStandardMethodCodec. Scheduled to
  be marked as unavailable once the deprecation has been available on the
  flutter/flutter alpha branch for four weeks. FlutterStandardBigInteger was

--- a/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
@@ -91,7 +91,6 @@ FLUTTER_EXPORT
 
  - `nil` or `NSNull`
  - `NSNumber` (including their representation of Boolean values)
- - `FlutterStandardBigInteger`
  - `NSString`
  - `FlutterStandardTypedData`
  - `NSArray` of supported values
@@ -101,11 +100,17 @@ FLUTTER_EXPORT
 
  - `nil` or `NSNull`: null
  - `NSNumber`: `bool`, `int`, or `double`, depending on the contained value.
- - `FlutterStandardBigInteger`: `int`
  - `NSString`: `String`
  - `FlutterStandardTypedData`: `Uint8List`, `Int32List`, `Int64List`, or `Float64List`
  - `NSArray`: `List`
  - `NSDictionary`: `Map`
+
+ Support for `FlutterStandardBigInteger` has been deprecated on 2018-01-08 to be
+ made unavailable four weeks after this change is available on the Flutter alpha
+ branch. `FlutterStandardBigInteger` were needed because the Dart 1.0 `int` type
+ had no size limit. With Dart 2.0, the `int` type is a fixed-size, 64-bit signed
+ integer. If you need to communicate larger integers, use `NSString` encoding
+ instead.
  */
 FLUTTER_EXPORT
 @interface FlutterStandardMessageCodec : NSObject<FlutterMessageCodec>
@@ -253,6 +258,14 @@ FLUTTER_EXPORT
  and `FlutterStandardMethodCodec`.
  */
 FLUTTER_EXPORT
+FLUTTER_DEPRECATED(
+  "Deprecated on 2018-01-08 to be made unavailable four weeks after the "
+  "deprecation is available on the flutter/flutter alpha branch. "
+  "FlutterStandardBigInteger was needed because the Dart 1.0 int type had no "
+  "size limit. With Dart 2.0, the int type is a fixed-size, 64-bit signed "
+  "integer. If you need to communicate larger integers, use NSString encoding "
+  "instead."
+)
 @interface FlutterStandardBigInteger : NSObject
 /**
  Creates a `FlutterStandardBigInteger` from a hexadecimal representation.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
@@ -105,7 +105,7 @@ FLUTTER_EXPORT
  - `NSArray`: `List`
  - `NSDictionary`: `Map`
 
- Support for `FlutterStandardBigInteger` has been deprecated on 2018-01-08 to be
+ Support for `FlutterStandardBigInteger` has been deprecated on 2018-01-09 to be
  made unavailable four weeks after this change is available on the Flutter alpha
  branch. `FlutterStandardBigInteger` were needed because the Dart 1.0 `int` type
  had no size limit. With Dart 2.0, the `int` type is a fixed-size, 64-bit signed
@@ -259,7 +259,7 @@ FLUTTER_EXPORT
  */
 FLUTTER_EXPORT
 FLUTTER_DEPRECATED(
-  "Deprecated on 2018-01-08 to be made unavailable four weeks after the "
+  "Deprecated on 2018-01-09 to be made unavailable four weeks after the "
   "deprecation is available on the flutter/flutter alpha branch. "
   "FlutterStandardBigInteger was needed because the Dart 1.0 int type had no "
   "size limit. With Dart 2.0, the int type is a fixed-size, 64-bit signed "

--- a/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
@@ -259,13 +259,12 @@ FLUTTER_EXPORT
  */
 FLUTTER_EXPORT
 FLUTTER_DEPRECATED(
-  "Deprecated on 2018-01-09 to be made unavailable four weeks after the "
-  "deprecation is available on the flutter/flutter alpha branch. "
-  "FlutterStandardBigInteger was needed because the Dart 1.0 int type had no "
-  "size limit. With Dart 2.0, the int type is a fixed-size, 64-bit signed "
-  "integer. If you need to communicate larger integers, use NSString encoding "
-  "instead."
-)
+    "Deprecated on 2018-01-09 to be made unavailable four weeks after the "
+    "deprecation is available on the flutter/flutter alpha branch. "
+    "FlutterStandardBigInteger was needed because the Dart 1.0 int type had no "
+    "size limit. With Dart 2.0, the int type is a fixed-size, 64-bit signed "
+    "integer. If you need to communicate larger integers, use NSString encoding "
+    "instead.")
 @interface FlutterStandardBigInteger : NSObject
 /**
  Creates a `FlutterStandardBigInteger` from a hexadecimal representation.

--- a/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
@@ -163,6 +163,9 @@ using namespace shell;
 }
 @end
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 @implementation FlutterStandardBigInteger
 + (instancetype)bigIntegerWithHex:(NSString*)hex {
   return [[[FlutterStandardBigInteger alloc] initWithHex:hex] autorelease];
@@ -469,3 +472,4 @@ using namespace shell;
   }
 }
 @end
+#pragma clang diagnostic pop

--- a/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
@@ -66,6 +66,8 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt32) {
   checkEncodeDecode(@(value), [NSData dataWithBytes:bytes length:9]);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt64AsHexString) {
   FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
   UInt64 u64 = 0xfffffffffffffffa;
@@ -73,6 +75,7 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt64AsHexString) {
   FlutterStandardBigInteger* decoded = [codec decode:encoded];
   ASSERT_TRUE([decoded.hex isEqual:@"fffffffffffffffa"]);
 }
+#pragma clang diagnostic pop
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt8) {
   uint8_t bytes[5] = {0x03, 0xfe, 0xff, 0xff, 0xff};
@@ -96,11 +99,14 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt64) {
   checkEncodeDecode(@(0x1234567890abcdef), [NSData dataWithBytes:bytes length:9]);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 TEST(FlutterStandardCodec, CanEncodeAndDecodeBigInteger) {
   FlutterStandardBigInteger* value =
       [FlutterStandardBigInteger bigIntegerWithHex:@"-abcdef0123456789abcdef01234567890"];
   checkEncodeDecode(value);
 }
+#pragma clang diagnostic pop
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat32) {
   uint8_t bytes[16] = {0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
The support was originally added only because Dart 1.0 had unlimited size `int`s. With Dart 2.0, this no longer makes much sense.