### PR TITLE
libtxt: map pixel coordinates above the text to glyph positions on the first line of text

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -955,7 +955,7 @@ std::vector<Paragraph::TextBox> Paragraph::GetRectsForRange(size_t start,
 Paragraph::PositionWithAffinity Paragraph::GetGlyphPositionAtCoordinate(
     double dx,
     double dy) const {
-  if (line_heights_.empty() || dy < 0)
+  if (line_heights_.empty())
     return PositionWithAffinity(0, DOWNSTREAM);
 
   size_t y_index;


### PR DESCRIPTION
This matches Blink's behavior