### PR TITLE
Fixes crash on Android when activating NowOnTap/Assistant

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -855,8 +855,10 @@ public class FlutterView extends SurfaceView
 
     @Override
     public AccessibilityNodeProvider getAccessibilityNodeProvider() {
-        ensureAccessibilityEnabled();
-        return mAccessibilityNodeProvider;
+        if (mAccessibilityEnabled)
+            return mAccessibilityNodeProvider;
+        // TODO(goderbauer): when a11y is off this should return a one-off snapshot of the a11y tree.
+        return null;
     }
 
     private AccessibilityBridge mAccessibilityNodeProvider;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/11292.

This will tell Assistant (and any other thing that asks for a one-off snapshot of the semantics tree) that there is currently nothing on screen, which is better than throwing an exception.

Ideally, callers of `getAccessibilityNodeProvider` should be able to get a one-off snapshot of the semantics tree. But our current setup doesn't support that, see https://github.com/flutter/flutter/issues/11292#issuecomment-356792594