### PR TITLE
libtxt: skip redundant bidi processing performed by minikin

### DIFF
--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -600,7 +600,7 @@ void Layout::doLayout(const uint16_t* buf,
                       size_t start,
                       size_t count,
                       size_t bufSize,
-                      int bidiFlags,
+                      bool isRtl,
                       const FontStyle& style,
                       const MinikinPaint& paint,
                       const std::shared_ptr<FontCollection>& collection) {
@@ -613,11 +613,9 @@ void Layout::doLayout(const uint16_t* buf,
   reset();
   mAdvances.resize(count, 0);
 
-  for (const BidiText::Iter::RunInfo& runInfo :
-       BidiText(buf, start, count, bufSize, bidiFlags)) {
-    doLayoutRunCached(buf, runInfo.mRunStart, runInfo.mRunLength, bufSize,
-                      runInfo.mIsRtl, &ctx, start, collection, this, NULL);
-  }
+  doLayoutRunCached(buf, start, count, bufSize, isRtl, &ctx, start, collection,
+                    this, NULL);
+
   ctx.clearHbFonts();
 }
 
@@ -625,7 +623,7 @@ float Layout::measureText(const uint16_t* buf,
                           size_t start,
                           size_t count,
                           size_t bufSize,
-                          int bidiFlags,
+                          bool isRtl,
                           const FontStyle& style,
                           const MinikinPaint& paint,
                           const std::shared_ptr<FontCollection>& collection,
@@ -636,15 +634,8 @@ float Layout::measureText(const uint16_t* buf,
   ctx.style = style;
   ctx.paint = paint;
 
-  float advance = 0;
-  for (const BidiText::Iter::RunInfo& runInfo :
-       BidiText(buf, start, count, bufSize, bidiFlags)) {
-    float* advancesForRun =
-        advances ? advances + (runInfo.mRunStart - start) : advances;
-    advance += doLayoutRunCached(buf, runInfo.mRunStart, runInfo.mRunLength,
-                                 bufSize, runInfo.mIsRtl, &ctx, 0, collection,
-                                 NULL, advancesForRun);
-  }
+  float advance = doLayoutRunCached(buf, start, count, bufSize, isRtl, &ctx, 0,
+                                    collection, NULL, advances);
 
   ctx.clearHbFonts();
   return advance;

--- a/third_party/txt/src/minikin/Layout.h
+++ b/third_party/txt/src/minikin/Layout.h
@@ -74,7 +74,7 @@ class Layout {
                 size_t start,
                 size_t count,
                 size_t bufSize,
-                int bidiFlags,
+                bool isRtl,
                 const FontStyle& style,
                 const MinikinPaint& paint,
                 const std::shared_ptr<FontCollection>& collection);
@@ -83,7 +83,7 @@ class Layout {
                            size_t start,
                            size_t count,
                            size_t bufSize,
-                           int bidiFlags,
+                           bool isRtl,
                            const FontStyle& style,
                            const MinikinPaint& paint,
                            const std::shared_ptr<FontCollection>& collection,

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -429,9 +429,6 @@ void Paragraph::Layout(double width, bool force) {
       uint16_t* text_ptr = text_.data();
       size_t text_start = run.start;
       size_t text_count = run.end - run.start;
-      int bidiFlags = (paragraph_style_.text_direction == TextDirection::rtl)
-                          ? minikin::kBidi_RTL
-                          : minikin::kBidi_LTR;
 
       // Apply ellipsizing if the run was not completely laid out and this
       // is the last line (or lines are unlimited).
@@ -442,12 +439,12 @@ void Paragraph::Layout(double width, bool force) {
            paragraph_style_.unlimited_lines())) {
         float ellipsis_width = layout.measureText(
             reinterpret_cast<const uint16_t*>(ellipsis.data()), 0,
-            ellipsis.length(), ellipsis.length(), bidiFlags, font,
+            ellipsis.length(), ellipsis.length(), run.is_rtl(), font,
             minikin_paint, minikin_font_collection, nullptr);
 
         std::vector<float> text_advances(text_count);
         float text_width = layout.measureText(
-            text_ptr, text_start, text_count, text_.size(), bidiFlags, font,
+            text_ptr, text_start, text_count, text_.size(), run.is_rtl(), font,
             minikin_paint, minikin_font_collection, text_advances.data());
 
         // Truncate characters from the text until the ellipsis fits.
@@ -477,8 +474,9 @@ void Paragraph::Layout(double width, bool force) {
         }
       }
 
-      layout.doLayout(text_ptr, text_start, text_count, text_.size(), bidiFlags,
-                      font, minikin_paint, minikin_font_collection);
+      layout.doLayout(text_ptr, text_start, text_count, text_.size(),
+                      run.is_rtl(), font, minikin_paint,
+                      minikin_font_collection);
 
       if (layout.nGlyphs() == 0)
         continue;


### PR DESCRIPTION
The libtxt Paragraph class now runs the bidi algorithm itself, and each text
run passed to doLayout will be entirely LTR or RTL