### PR TITLE
Revert "include portable_unistd.h in directory_asset_bundle"

### DIFF
--- a/assets/directory_asset_bundle.cc
+++ b/assets/directory_asset_bundle.cc
@@ -7,13 +7,16 @@
 
 #include <fcntl.h>
 
+#if !defined(OS_WIN)
+#include <unistd.h>
+#endif
+
 #include <utility>
 
 #include "lib/fxl/files/eintr_wrapper.h"
 #include "lib/fxl/files/file.h"
 #include "lib/fxl/files/path.h"
 #include "lib/fxl/files/unique_fd.h"
-#include "lib/fxl/portable_unistd.h"
 
 namespace blink {
 


### PR DESCRIPTION
Reverts flutter/engine#4542