### PR TITLE
Make Canvas cullRect optional and make Rect.largest a static field.

### DIFF
--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -625,16 +625,6 @@ class Rect {
       ..[3] = math.max(a.dy, b.dy);
   }
 
-  /// Construct the largest finite rectangle.
-  Rect.largest() {
-    const double skScalarMax = 3.402823466e+38; // from Skia's SkScalar.h
-    _value
-      ..[0] = -skScalarMax
-      ..[1] = -skScalarMax
-      ..[2] = skScalarMax
-      ..[3] = skScalarMax;
-  }
-
   static const int _kDataSize = 4;
   final Float32List _value = new Float32List(_kDataSize);
 
@@ -662,6 +652,14 @@ class Rect {
 
   /// A rectangle with left, top, right, and bottom edges all at zero.
   static final Rect zero = new Rect._();
+
+  static const double _skScalarMax = 3.402823466e+38; // from Skia's SkScalar.h
+
+  /// A rectangle that covers the entire coordinate space.
+  ///
+  /// This actually covers the space from about -3e38,-3e38 to about 3e38,3e38.
+  /// This is the space over which graphics operations are valid.
+  static final Rect largest = new Rect.fromLTRB(-_skScalarMax, -_skScalarMax, _skScalarMax, _skScalarMax);
 
   /// Whether any of the coordinates of this rectangle are equal to positive infinity.
   // included for consistency with Offset and Size

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1771,18 +1771,19 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// given picture recorder.
   ///
   /// Graphical operations that affect pixels entirely outside the given
-  /// cullRect might be discarded by the implementation. However, the
+  /// `cullRect` might be discarded by the implementation. However, the
   /// implementation might draw outside these bounds if, for example, a command
   /// draws partially inside and outside the `cullRect`. To ensure that pixels
-  /// outside a given region are discarded, consider using a [clipRect].
+  /// outside a given region are discarded, consider using a [clipRect]. The
+  /// `cullRect` is optional; by default, all operations are kept.
   ///
   /// To end the recording, call [PictureRecorder.endRecording] on the
   /// given recorder.
-  Canvas(PictureRecorder recorder, Rect cullRect) {
+  Canvas(PictureRecorder recorder, [ Rect cullRect ]) {
     assert(recorder != null);
     if (recorder.isRecording)
       throw new ArgumentError('"recorder" must not already be associated with another Canvas.');
-    assert(cullRect != null);
+    cullRect ??= Rect.largest;
     _constructor(recorder, cullRect.left, cullRect.top, cullRect.right, cullRect.bottom);
   }
   void _constructor(PictureRecorder recorder,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/7201.

The change from `new Rect.largest()` to `Rect.largest` saves a few
allocations since we'll be using these with every Canvas.

cc @jason-simmons (This is slightly incompatible with https://github.com/flutter/flutter/pull/14027, but allows us to make that even simpler -- just omit the second argument to the Canvas constructor.)