### PR TITLE
Fallback to compose shapes as their bounding rectangles.

### DIFF
--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -23,6 +23,12 @@ class PhysicalShapeLayer : public ContainerLayer {
       frameRRect_ = SkRRect::MakeRect(rect);
     } else if (path.isRRect(&frameRRect_)) {
       isRect_ = frameRRect_.isRect();
+    } else {
+      // Fuchsia's compositor currently only supports rounded rectangle frames.
+      // For shapes that cannot be represented as a rounded rectangle we
+      // default to use the bounding rectangle.
+      // TODO(amirh): fix this once Fuchsia supports arbitrary shaped frames.
+      frameRRect_ = SkRRect::MakeRect(path.getBounds());
     }
   }
 


### PR DESCRIPTION
Scenic doesn't currently support arbitrary shaped frames.

* I let this case fall through the cracks in the recent forth and back here...