### PR TITLE
Support .packages option in frontend_server, bundle_path in main_mac.

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -11,7 +11,6 @@ import 'package:args/args.dart';
 // that would replace api used below. This api was made private in
 // an effort to discourage further use.
 // ignore_for_file: implementation_imports
-import 'package:front_end/src/api_prototype/byte_store.dart';
 import 'package:front_end/src/api_prototype/compiler_options.dart';
 import 'package:front_end/src/api_prototype/incremental_kernel_generator.dart';
 

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -32,10 +32,6 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
   ..addOption('sdk-root',
       help: 'Path to sdk root',
       defaultsTo: '../../out/android_debug/flutter_patched_sdk')
-  ..addOption('byte-store',
-      help: 'Path to file byte store used to keep incremental compiler state.'
-          ' If omitted, then memory byte store is used.',
-      defaultsTo: null)
   ..addFlag('aot',
       help: 'Run compiler in AOT mode (enables whole-program transformations)',
       defaultsTo: false)
@@ -48,7 +44,10 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
           ' Intended use is to satisfy different loading strategies implemented'
           ' by gen_snapshot(which needs platform embedded) vs'
           ' Flutter engine(which does not)',
-      defaultsTo: true);
+      defaultsTo: true)
+  ..addOption('packages',
+      help: '.packages file to use for compilation',
+      defaultsTo: '.packages');
 
 String _usage = '''
 Usage: server [options] [input.dart]
@@ -144,12 +143,9 @@ class _FrontendCompiler implements CompilerInterface {
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln("result $boundaryKey");
     final Uri sdkRoot = _ensureFolderPath(options['sdk-root']);
-    final String byteStorePath = options['byte-store'];
     final CompilerOptions compilerOptions = new CompilerOptions()
-      ..byteStore = byteStorePath != null
-          ? new FileByteStore(byteStorePath)
-          : new MemoryByteStore()
       ..sdkRoot = sdkRoot
+      ..packagesFileUri = options['packages'] != null ? Uri.base.resolveUri(new Uri.file(options['packages'])) : null
       ..strongMode = options['strong']
       ..target = new FlutterTarget(new TargetFlags(strongMode: options['strong']))
       ..reportMessages = true;

--- a/frontend_server/test/server_test.dart
+++ b/frontend_server/test/server_test.dart
@@ -75,29 +75,6 @@ Future<int> main() async {
       expect(capturedArgs.single['strong'], equals(true));
     });
 
-    test('compile from command line with file byte store', () async {
-      final List<String> args = <String>[
-        'server.dart',
-        '--sdk-root',
-        'sdkroot',
-        '--byte-store',
-        'path/to/bytestore'
-      ];
-      final int exitcode = await starter(args, compiler: compiler);
-      expect(exitcode, equals(0));
-      final List<ArgResults> capturedArgs =
-          verify(
-              compiler.compile(
-                argThat(equals('server.dart')),
-                captureAny,
-                generator: any,
-              )
-          ).captured;
-      expect(capturedArgs.single['sdk-root'], equals('sdkroot'));
-      expect(capturedArgs.single['byte-store'], equals('path/to/bytestore'));
-      expect(capturedArgs.single['strong'], equals(false));
-    });
-
     test('compile from command line with link platform', () async {
       final List<String> args = <String>[
         'server.dart',
@@ -121,14 +98,12 @@ Future<int> main() async {
     });
   });
 
-  group('interactive file store compile with mocked compiler', () {
+  group('interactive compile with mocked compiler', () {
     final CompilerInterface compiler = new _MockedCompiler();
 
     final List<String> args = <String>[
       '--sdk-root',
       'sdkroot',
-      '--byte-store',
-      'path/to/bytestore',
     ];
 
     test('compile one file', () async {
@@ -140,8 +115,6 @@ Future<int> main() async {
             expect(invocation.positionalArguments[0], equals('server.dart'));
             expect(invocation.positionalArguments[1]['sdk-root'],
                 equals('sdkroot'));
-            expect(invocation.positionalArguments[1]['byte-store'],
-                equals('path/to/bytestore'));
             expect(invocation.positionalArguments[1]['strong'], equals(false));
             compileCalled.sendPort.send(true);
           }

--- a/shell/platform/darwin/desktop/main_mac.mm
+++ b/shell/platform/darwin/desktop/main_mac.mm
@@ -12,13 +12,31 @@
 #include "flutter/shell/platform/darwin/common/platform_mac.h"
 #include "flutter/shell/platform/darwin/desktop/flutter_application.h"
 #include "flutter/shell/testing/testing.h"
+#include "lib/fxl/logging.h"
+#include "lib/fxl/command_line.h"
+
+
+static fxl::CommandLine InitializedCommandLine() {
+    std::vector<std::string> args_vector;
+
+    for (NSString* arg in [NSProcessInfo processInfo].arguments) {
+        args_vector.emplace_back(arg.UTF8String);
+    }
+
+    return fxl::CommandLineFromIterators(args_vector.begin(), args_vector.end());
+}
 
 int main(int argc, const char* argv[]) {
   [FlutterApplication sharedApplication];
 
-  shell::PlatformMacMain("", "", "");
+  // Can't use shell::Shell::Shared().GetCommandLine() because it is initialized only
+  // in shell::PlatformMacMain call below.
+  auto command_line = InitializedCommandLine();
 
-  const auto& command_line = shell::Shell::Shared().GetCommandLine();
+  std::string bundle_path = "";
+  command_line.GetOptionValue(FlagForSwitch(shell::Switch::FlutterAssetsDir), &bundle_path);
+
+  shell::PlatformMacMain("", "", bundle_path);
 
   // Print help.
   if (command_line.HasOption(shell::FlagForSwitch(shell::Switch::Help))) {

--- a/shell/platform/darwin/desktop/main_mac.mm
+++ b/shell/platform/darwin/desktop/main_mac.mm
@@ -12,18 +12,17 @@
 #include "flutter/shell/platform/darwin/common/platform_mac.h"
 #include "flutter/shell/platform/darwin/desktop/flutter_application.h"
 #include "flutter/shell/testing/testing.h"
-#include "lib/fxl/logging.h"
 #include "lib/fxl/command_line.h"
-
+#include "lib/fxl/logging.h"
 
 static fxl::CommandLine InitializedCommandLine() {
-    std::vector<std::string> args_vector;
+  std::vector<std::string> args_vector;
 
-    for (NSString* arg in [NSProcessInfo processInfo].arguments) {
-        args_vector.emplace_back(arg.UTF8String);
-    }
+  for (NSString* arg in [NSProcessInfo processInfo].arguments) {
+    args_vector.emplace_back(arg.UTF8String);
+  }
 
-    return fxl::CommandLineFromIterators(args_vector.begin(), args_vector.end());
+  return fxl::CommandLineFromIterators(args_vector.begin(), args_vector.end());
 }
 
 int main(int argc, const char* argv[]) {


### PR DESCRIPTION
This is needed to be able to run `flutter test` in `--preview-dart-2` mode.

This is towards fixing https://github.com/flutter/flutter/issues/14105

Similar change needs to be made in windows and linux test runners.

Removal of `byte-store` is clean-up that is long overdue.