### PR TITLE
Run "pub get" for the frontend_server package before building.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -424,6 +424,33 @@ hooks = [
     'action': ['python', 'src/tools/dart/update.py'],
   },
   {
+    'name': 'frontend_server_packages',
+    'pattern': '.',
+    'condition': 'host_os == "linux"',
+    'cwd': 'src/flutter/frontend_server/',
+    'action': [
+      '../../../src/third_party/dart/tools/sdks/linux/dart-sdk/bin/pub', 'get',
+    ],
+  },
+  {
+    'name': 'frontend_server_packages',
+    'pattern': '.',
+    'condition': 'host_os == "mac"',
+    'cwd': 'src/flutter/frontend_server/',
+    'action': [
+      '../../../src/third_party/dart/tools/sdks/mac/dart-sdk/bin/pub', 'get',
+    ],
+  },
+  {
+    'name': 'frontend_server_packages',
+    'pattern': '.',
+    'condition': 'host_os == "windows"',
+    'cwd': 'src/flutter/frontend_server/',
+    'action': [
+      '../../../src/third_party/dart/tools/sdks/win/dart-sdk/bin/pub.bat', 'get',
+    ],
+  },
+  {
     # Ensure that we don't accidentally reference any .pyc files whose
     # corresponding .py files have already been deleted.
     'name': 'remove_stale_pyc_files',


### PR DESCRIPTION
In https://github.com/flutter/engine/pull/4554 I removed the .packages file in the frontend_server directory, because it was out of sync with the pubspec.yaml. It seems like the right solution is to run `pub get` when we get the dependencies, i.e. when we run `gclient sync`.

Being out of sync is a problem because it means that running "pub get" in that directory changes what packages are being used, and changes the `.packages` file, which leads to having to revert changes before committing code, etc. Having to regularly update this file doesn't make much sense either, since the files that were missing were files that are obtained from the network (e.g. the `io` package as used by the `test` package).

Previously, (see https://github.com/flutter/engine/pull/3982#issuecomment-323213199), we did not do this because we did not want the build to call into the network. This still does not call into the network during the _build_ phase, only during `gclient sync` (which is when all the dependencies are brought down).

Currently the network dependencies only matter for running tests. We should make sure this remains the case. Ideally we wouldn't even depend on those.