### PR TITLE
Fix default value for 'packages' option to be null

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -46,7 +46,7 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
       defaultsTo: true)
   ..addOption('packages',
       help: '.packages file to use for compilation',
-      defaultsTo: '.packages');
+      defaultsTo: null);
 
 String _usage = '''
 Usage: server [options] [input.dart]


### PR DESCRIPTION
This is to fix broken snapshot generation step that broke buildbots.