### PR TITLE
iOS a11y text entry (~70% of it)

### DIFF
--- a/content_handler/accessibility_bridge.cc
+++ b/content_handler/accessibility_bridge.cc
@@ -20,8 +20,9 @@ AccessibilityBridge::AccessibilityBridge(app::ApplicationContext* context)
     : writer_(context->ConnectToEnvironmentService<maxwell::ContextWriter>()) {}
 
 void AccessibilityBridge::UpdateSemantics(
-    const std::vector<blink::SemanticsNode>& update) {
-  for (const auto& node : update) {
+    const blink::SemanticsNodeUpdates& update) {
+  for (const auto& update : update) {
+    const auto& node = update.second;
     semantics_nodes_[node.id] = node;
   }
   std::vector<int> visited_nodes;

--- a/content_handler/accessibility_bridge.h
+++ b/content_handler/accessibility_bridge.h
@@ -21,7 +21,7 @@ class AccessibilityBridge {
 
   // Update the internal representation of the semantics nodes, and write the
   // semantics to Context Service.
-  void UpdateSemantics(const std::vector<blink::SemanticsNode>& update);
+  void UpdateSemantics(const blink::SemanticsNodeUpdates& update);
 
  private:
   // Walk the semantics node tree starting at |id|, and store the id of each

--- a/content_handler/runtime_holder.cc
+++ b/content_handler/runtime_holder.cc
@@ -370,7 +370,7 @@ void RuntimeHolder::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   }));
 }
 
-void RuntimeHolder::UpdateSemantics(std::vector<blink::SemanticsNode> update) {
+void RuntimeHolder::UpdateSemantics(blink::SemanticsNodeUpdates update) {
   accessibility_bridge_->UpdateSemantics(update);
 }
 

--- a/content_handler/runtime_holder.h
+++ b/content_handler/runtime_holder.h
@@ -65,7 +65,7 @@ class RuntimeHolder : public blink::RuntimeDelegate,
   std::string DefaultRouteName() override;
   void ScheduleFrame(bool regenerate_layer_tree = true) override;
   void Render(std::unique_ptr<flow::LayerTree> layer_tree) override;
-  void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
+  void UpdateSemantics(blink::SemanticsNodeUpdates update) override;
   void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message) override;
   void DidCreateMainIsolate(Dart_Isolate isolate) override;

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "third_party/skia/include/core/SkMatrix44.h"
@@ -69,6 +70,14 @@ struct SemanticsNode {
   SkMatrix44 transform = SkMatrix44(SkMatrix44::kIdentity_Constructor);
   std::vector<int32_t> children;
 };
+
+/**
+ * Contains semantic nodes that need to be updated.
+ *
+ * The keys in the map are stable node IDd, and the values contain
+ * semantic information for the node corresponding to the ID.
+ */
+using SemanticsNodeUpdates = std::unordered_map<int32_t, SemanticsNode>;
 
 }  // namespace blink
 

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -71,12 +71,10 @@ struct SemanticsNode {
   std::vector<int32_t> children;
 };
 
-/**
- * Contains semantic nodes that need to be updated.
- *
- * The keys in the map are stable node IDd, and the values contain
- * semantic information for the node corresponding to the ID.
- */
+// Contains semantic nodes that need to be updated.
+//
+// The keys in the map are stable node IDd, and the values contain
+// semantic information for the node corresponding to the ID.
 using SemanticsNodeUpdates = std::unordered_map<int32_t, SemanticsNode>;
 
 }  // namespace blink

--- a/lib/ui/semantics/semantics_update.cc
+++ b/lib/ui/semantics/semantics_update.cc
@@ -21,16 +21,16 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, SemanticsUpdate);
 DART_BIND_ALL(SemanticsUpdate, FOR_EACH_BINDING)
 
 fxl::RefPtr<SemanticsUpdate> SemanticsUpdate::create(
-    std::vector<SemanticsNode> nodes) {
+    SemanticsNodeUpdates nodes) {
   return fxl::MakeRefCounted<SemanticsUpdate>(std::move(nodes));
 }
 
-SemanticsUpdate::SemanticsUpdate(std::vector<SemanticsNode> nodes)
+SemanticsUpdate::SemanticsUpdate(SemanticsNodeUpdates nodes)
     : nodes_(std::move(nodes)) {}
 
 SemanticsUpdate::~SemanticsUpdate() = default;
 
-std::vector<SemanticsNode> SemanticsUpdate::takeNodes() {
+SemanticsNodeUpdates SemanticsUpdate::takeNodes() {
   return std::move(nodes_);
 }
 

--- a/lib/ui/semantics/semantics_update.h
+++ b/lib/ui/semantics/semantics_update.h
@@ -5,8 +5,6 @@
 #ifndef FLUTTER_LIB_UI_SEMANTICS_SEMANTICS_UPDATE_H_
 #define FLUTTER_LIB_UI_SEMANTICS_SEMANTICS_UPDATE_H_
 
-#include <vector>
-
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "lib/tonic/dart_wrappable.h"
 
@@ -23,18 +21,18 @@ class SemanticsUpdate : public fxl::RefCountedThreadSafe<SemanticsUpdate>,
 
  public:
   ~SemanticsUpdate() override;
-  static fxl::RefPtr<SemanticsUpdate> create(std::vector<SemanticsNode> nodes);
+  static fxl::RefPtr<SemanticsUpdate> create(SemanticsNodeUpdates nodes);
 
-  std::vector<SemanticsNode> takeNodes();
+  SemanticsNodeUpdates takeNodes();
 
   void dispose();
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  explicit SemanticsUpdate(std::vector<SemanticsNode> nodes);
+  explicit SemanticsUpdate(SemanticsNodeUpdates nodes);
 
-  std::vector<SemanticsNode> nodes_;
+  SemanticsNodeUpdates nodes_;
 };
 
 }  // namespace blink

--- a/lib/ui/semantics/semantics_update_builder.cc
+++ b/lib/ui/semantics/semantics_update_builder.cc
@@ -69,7 +69,7 @@ void SemanticsUpdateBuilder::updateNode(int id,
   node.transform.setColMajord(transform.data());
   node.children = std::vector<int32_t>(
       children.data(), children.data() + children.num_elements());
-  nodes_.push_back(node);
+  nodes_[id] = node;
 }
 
 fxl::RefPtr<SemanticsUpdate> SemanticsUpdateBuilder::build() {

--- a/lib/ui/semantics/semantics_update_builder.h
+++ b/lib/ui/semantics/semantics_update_builder.h
@@ -51,7 +51,7 @@ class SemanticsUpdateBuilder
  private:
   explicit SemanticsUpdateBuilder();
 
-  std::vector<SemanticsNode> nodes_;
+  SemanticsNodeUpdates nodes_;
 };
 
 }  // namespace blink

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -20,7 +20,7 @@ class RuntimeDelegate {
   virtual std::string DefaultRouteName() = 0;
   virtual void ScheduleFrame(bool regenerate_layer_tree = true) = 0;
   virtual void Render(std::unique_ptr<flow::LayerTree> layer_tree) = 0;
-  virtual void UpdateSemantics(std::vector<SemanticsNode> update) = 0;
+  virtual void UpdateSemantics(blink::SemanticsNodeUpdates update) = 0;
   virtual void HandlePlatformMessage(fxl::RefPtr<PlatformMessage> message) = 0;
 
   virtual void DidCreateMainIsolate(Dart_Isolate isolate);

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -662,7 +662,7 @@ void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   animator_->Render(std::move(layer_tree));
 }
 
-void Engine::UpdateSemantics(std::vector<blink::SemanticsNode> update) {
+void Engine::UpdateSemantics(blink::SemanticsNodeUpdates update) {
   blink::Threads::Platform()->PostTask(fxl::MakeCopyable([
     platform_view = platform_view_.lock(), update = std::move(update)
   ]() mutable {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -85,7 +85,7 @@ class Engine : public blink::RuntimeDelegate {
   // RuntimeDelegate methods:
   std::string DefaultRouteName() override;
   void Render(std::unique_ptr<flow::LayerTree> layer_tree) override;
-  void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
+  void UpdateSemantics(blink::SemanticsNodeUpdates update) override;
   void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message) override;
   void DidCreateMainIsolate(Dart_Isolate isolate) override;

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -130,7 +130,7 @@ VsyncWaiter* PlatformView::GetVsyncWaiter() {
   return vsync_waiter_.get();
 }
 
-void PlatformView::UpdateSemantics(std::vector<blink::SemanticsNode> update) {}
+void PlatformView::UpdateSemantics(blink::SemanticsNodeUpdates update) {}
 
 void PlatformView::HandlePlatformMessage(
     fxl::RefPtr<blink::PlatformMessage> message) {

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -60,7 +60,7 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
 
   virtual bool ResourceContextMakeCurrent() = 0;
 
-  virtual void UpdateSemantics(std::vector<blink::SemanticsNode> update);
+  virtual void UpdateSemantics(blink::SemanticsNodeUpdates update);
   virtual void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message);
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -460,7 +460,7 @@ bool PlatformViewAndroid::ResourceContextMakeCurrent() {
 }
 
 void PlatformViewAndroid::UpdateSemantics(
-    std::vector<blink::SemanticsNode> update) {
+    blink::SemanticsNodeUpdates update) {
   constexpr size_t kBytesPerNode = 33 * sizeof(int32_t);
   constexpr size_t kBytesPerChild = sizeof(int32_t);
 

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -93,7 +93,7 @@ class PlatformViewAndroid : public PlatformView {
 
   bool ResourceContextMakeCurrent() override;
 
-  void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
+  void UpdateSemantics(blink::SemanticsNodeUpdates update) override;
 
   void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message) override;

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -55,6 +55,8 @@ shared_library("create_flutter_framework_dylib") {
     "framework/Source/FlutterViewController.mm",
     "framework/Source/accessibility_bridge.h",
     "framework/Source/accessibility_bridge.mm",
+    "framework/Source/accessibility_text_entry.h",
+    "framework/Source/accessibility_text_entry.mm",
     "framework/Source/flutter_main_ios.h",
     "framework/Source/flutter_main_ios.mm",
     "framework/Source/flutter_touch_mapper.h",

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h
@@ -5,6 +5,8 @@
 #ifndef SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTPLUGIN_H_
 #define SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERTEXTINPUTPLUGIN_H_
 
+#import <UIKit/UIKit.h>
+
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h"
 
@@ -12,6 +14,33 @@
 
 @property(nonatomic, assign) id<FlutterTextInputDelegate> textInputDelegate;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
+
+/**
+ * The `UITextInput` implementation used to control text entry.
+ *
+ * This is used by `AccessibilityBridge` to forward interactions with iOS'
+ * accessibility system.
+ */
+- (UIView<UITextInput>*)textInputView;
+
+@end
+
+/** An indexed position in the buffer of a Flutter text editing widget. */
+@interface FlutterTextPosition : UITextPosition
+
+@property(nonatomic, readonly) NSUInteger index;
+
++ (instancetype)positionWithIndex:(NSUInteger)index;
+- (instancetype)initWithIndex:(NSUInteger)index;
+
+@end
+
+/** A range of text in the buffer of a Flutter text editing widget. */
+@interface FlutterTextRange : UITextRange<NSCopying>
+
+@property(nonatomic, readonly) NSRange range;
+
++ (instancetype)rangeWithNSRange:(NSRange)range;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -197,6 +197,7 @@ class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
   [_textInputChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
     [_textInputPlugin.get() handleMethodCall:call result:result];
   }];
+  _platformView->SetTextInputPlugin(_textInputPlugin);
 
   [self setupNotificationCenterObservers];
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -10,9 +10,12 @@
 #include <unordered_set>
 #include <vector>
 
+#import <UIKit/UIKit.h>
+
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 #include "lib/fxl/macros.h"
 #include "third_party/skia/include/core/SkMatrix44.h"
@@ -22,6 +25,9 @@ namespace shell {
 class AccessibilityBridge;
 }  // namespace shell
 
+/**
+ * A node in the iOS semantics tree.
+ */
 @interface SemanticsObject : NSObject
 
 /**
@@ -35,10 +41,55 @@ class AccessibilityBridge;
  */
 @property(nonatomic, strong) SemanticsObject* parent;
 
+/**
+ * The accessibility bridge that this semantics object is attached to. This
+ * object may use the bridge to access contextual application information.
+ */
+@property(nonatomic, readonly) shell::AccessibilityBridge* bridge;
+
+/**
+ * The semantics node used to produce this semantics object.
+ */
+@property(nonatomic, readonly) blink::SemanticsNode node;
+
+/**
+ * Updates this semantics object using data from the `node` argument.
+ */
+- (void)setSemanticsNode:(const blink::SemanticsNode*)node NS_REQUIRES_SUPER;
+
+/**
+ * Whether this semantics object has child semantics objects.
+ */
+@property(nonatomic, readonly) BOOL hasChildren;
+
+/**
+ * Direct children of this semantics object. Each child's `parent` property must
+ * be equal to this object.
+ */
+@property(nonatomic, readonly) std::vector<SemanticsObject*>* children;
+
+- (BOOL)nodeWillCauseLayoutChange:(const blink::SemanticsNode*)node;
+
+#pragma mark - Designated initializers
+
 - (instancetype)init __attribute__((unavailable("Use initWithBridge instead")));
 - (instancetype)initWithBridge:(shell::AccessibilityBridge*)bridge
                            uid:(int32_t)uid NS_DESIGNATED_INITIALIZER;
 
+@end
+
+/**
+ * The default implementation of `SemanticsObject` for most accessibility elements
+ * in the iOS accessibility tree.
+ *
+ * Use this implementation for nodes that do not need to be expressed via UIKit-specific
+ * protocols (it only implements NSObject).
+ *
+ * See also:
+ *  * TextInputSemanticsObject, which implements `UITextInput` protocol to expose
+ *    editable text widgets to a11y.
+ */
+@interface FlutterSemanticsObject : SemanticsObject
 @end
 
 namespace shell {
@@ -49,13 +100,14 @@ class AccessibilityBridge final {
   AccessibilityBridge(UIView* view, PlatformViewIOS* platform_view);
   ~AccessibilityBridge();
 
-  void UpdateSemantics(std::vector<blink::SemanticsNode> nodes);
+  void UpdateSemantics(blink::SemanticsNodeUpdates nodes);
   void DispatchSemanticsAction(int32_t id, blink::SemanticsAction action);
+  UIView<UITextInput>* textInputView();
 
   UIView* view() const { return view_; }
 
  private:
-  SemanticsObject* GetOrCreateObject(int32_t id);
+  SemanticsObject* GetOrCreateObject(int32_t id, blink::SemanticsNodeUpdates& updates);
   void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
                                         NSMutableArray<NSNumber*>* doomed_uids);
   void ReleaseObjects(std::unordered_map<int, SemanticsObject*>& objects);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h"
 
 #include <utility>
 #include <vector>
@@ -93,10 +94,8 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
 @end
 
 @implementation SemanticsObject {
-  shell::AccessibilityBridge* _bridge;
-  blink::SemanticsNode _node;
-  std::vector<SemanticsObject*> _children;
   SemanticsObjectContainer* _container;
+  std::vector<SemanticsObject*> _children;
 }
 
 #pragma mark - Override base class designated initializers
@@ -123,6 +122,15 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
   return self;
 }
 
+- (void)dealloc {
+  _bridge = nullptr;
+  _children.clear();
+  [_parent release];
+  if (_container != nil)
+    [_container release];
+  [super dealloc];
+}
+
 #pragma mark - Semantic object methods
 
 - (void)setSemanticsNode:(const blink::SemanticsNode*)node {
@@ -132,8 +140,8 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
 /**
  * Whether calling `setSemanticsNode:` with `node` would cause a layout change.
  */
-- (BOOL)willCauseLayoutChange:(const blink::SemanticsNode*)node {
-  return _node.rect != node->rect || _node.transform != node->transform;
+- (BOOL)nodeWillCauseLayoutChange:(const blink::SemanticsNode*)node {
+  return [self node].rect != node->rect || [self node].transform != node->transform;
 }
 
 - (std::vector<SemanticsObject*>*)children {
@@ -144,71 +152,43 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
   return _children.size() != 0;
 }
 
-- (void)dealloc {
-  _bridge = nullptr;
-  _children.clear();
-  [_parent release];
-  if (_container != nil)
-    [_container release];
-  [super dealloc];
-}
-
 #pragma mark - UIAccessibility overrides
 
 - (BOOL)isAccessibilityElement {
   // Note: hit detection will only apply to elements that report
   // -isAccessibilityElement of YES. The framework will continue scanning the
   // entire element tree looking for such a hit.
-  return _node.flags != 0 || !_node.label.empty() || !_node.value.empty() || !_node.hint.empty() ||
-         (_node.actions & ~blink::kScrollableSemanticsActions) != 0;
+  return [self node].flags != 0 || ![self node].label.empty() || ![self node].value.empty() ||
+         ![self node].hint.empty() ||
+         ([self node].actions & ~blink::kScrollableSemanticsActions) != 0;
 }
 
 - (NSString*)accessibilityLabel {
-  if (_node.label.empty())
+  if ([self node].label.empty())
     return nil;
-  return @(_node.label.data());
+  return @([self node].label.data());
 }
 
 - (NSString*)accessibilityHint {
-  if (_node.hint.empty())
+  if ([self node].hint.empty())
     return nil;
-  return @(_node.hint.data());
+  return @([self node].hint.data());
 }
 
 - (NSString*)accessibilityValue {
-  if (_node.value.empty())
+  if ([self node].value.empty())
     return nil;
-  return @(_node.value.data());
-}
-
-- (UIAccessibilityTraits)accessibilityTraits {
-  UIAccessibilityTraits traits = UIAccessibilityTraitNone;
-  if (_node.HasAction(blink::SemanticsAction::kIncrease) ||
-      _node.HasAction(blink::SemanticsAction::kDecrease)) {
-    traits |= UIAccessibilityTraitAdjustable;
-  }
-  if (_node.HasFlag(blink::SemanticsFlags::kIsSelected) ||
-      _node.HasFlag(blink::SemanticsFlags::kIsChecked)) {
-    traits |= UIAccessibilityTraitSelected;
-  }
-  if (_node.HasFlag(blink::SemanticsFlags::kIsButton)) {
-    traits |= UIAccessibilityTraitButton;
-  }
-  if (_node.HasFlag(blink::SemanticsFlags::kHasEnabledState) &&
-      !_node.HasFlag(blink::SemanticsFlags::kIsEnabled)) {
-    traits |= UIAccessibilityTraitNotEnabled;
-  }
-  return traits;
+  return @([self node].value.data());
 }
 
 - (CGRect)accessibilityFrame {
-  SkMatrix44 globalTransform = _node.transform;
-  for (SemanticsObject* parent = _parent; parent; parent = parent.parent) {
-    globalTransform = parent->_node.transform * globalTransform;
+  SkMatrix44 globalTransform = [self node].transform;
+  for (SemanticsObject* parent = [self parent]; parent; parent = parent.parent) {
+    globalTransform = parent.node.transform * globalTransform;
   }
 
   SkPoint quad[4];
-  _node.rect.toQuad(quad);
+  [self node].rect.toQuad(quad);
   for (auto& point : quad) {
     SkScalar vector[4] = {point.x(), point.y(), 0, 1};
     globalTransform.mapScalars(vector);
@@ -220,53 +200,97 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
   // `rect` is in the physical pixel coordinate system. iOS expects the accessibility frame in
   // the logical pixel coordinate system. Therefore, we divide by the `scale` (pixel ratio) to
   // convert.
-  CGFloat scale = [[_bridge->view() window] screen].scale;
+  CGFloat scale = [[[self bridge]->view() window] screen].scale;
   auto result =
       CGRectMake(rect.x() / scale, rect.y() / scale, rect.width() / scale, rect.height() / scale);
-  return UIAccessibilityConvertFrameToScreenCoordinates(result, _bridge->view());
+  return UIAccessibilityConvertFrameToScreenCoordinates(result, [self bridge]->view());
 }
 
 #pragma mark - UIAccessibilityElement protocol
 
 - (id)accessibilityContainer {
-  if ([self hasChildren] || _uid == kRootNodeId) {
+  if ([self hasChildren] || [self uid] == kRootNodeId) {
     if (_container == nil)
-      _container = [[SemanticsObjectContainer alloc] initWithSemanticsObject:self bridge:_bridge];
+      _container =
+          [[SemanticsObjectContainer alloc] initWithSemanticsObject:self bridge:[self bridge]];
     return _container;
   }
-  NSAssert(_parent != nil, @"Illegal access to non-existent parent of root semantics node");
-  return [_parent accessibilityContainer];
+  NSAssert([self parent] != nil, @"Illegal access to non-existent parent of root semantics node");
+  return [[self parent] accessibilityContainer];
 }
 
 #pragma mark - UIAccessibilityAction overrides
 
 - (BOOL)accessibilityActivate {
-  if (!_node.HasAction(blink::SemanticsAction::kTap))
+  if (![self node].HasAction(blink::SemanticsAction::kTap))
     return NO;
-  _bridge->DispatchSemanticsAction(_uid, blink::SemanticsAction::kTap);
+  [self bridge]->DispatchSemanticsAction([self uid], blink::SemanticsAction::kTap);
   return YES;
 }
 
 - (void)accessibilityIncrement {
-  if (_node.HasAction(blink::SemanticsAction::kIncrease)) {
-    _node.value = _node.increasedValue;
-    _bridge->DispatchSemanticsAction(_uid, blink::SemanticsAction::kIncrease);
+  if ([self node].HasAction(blink::SemanticsAction::kIncrease)) {
+    [self node].value = [self node].increasedValue;
+    [self bridge]->DispatchSemanticsAction([self uid], blink::SemanticsAction::kIncrease);
   }
 }
 
 - (void)accessibilityDecrement {
-  if (_node.HasAction(blink::SemanticsAction::kDecrease)) {
-    _node.value = _node.decreasedValue;
-    _bridge->DispatchSemanticsAction(_uid, blink::SemanticsAction::kDecrease);
+  if ([self node].HasAction(blink::SemanticsAction::kDecrease)) {
+    [self node].value = [self node].decreasedValue;
+    [self bridge]->DispatchSemanticsAction([self uid], blink::SemanticsAction::kDecrease);
   }
 }
 
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
   blink::SemanticsAction action = GetSemanticsActionForScrollDirection(direction);
-  if (!_node.HasAction(action))
+  if (![self node].HasAction(action))
     return NO;
-  _bridge->DispatchSemanticsAction(_uid, action);
+  [self bridge]->DispatchSemanticsAction([self uid], action);
   return YES;
+}
+
+@end
+
+@implementation FlutterSemanticsObject {
+}
+
+#pragma mark - Override base class designated initializers
+
+// Method declared as unavailable in the interface
+- (instancetype)init {
+  [self release];
+  [super doesNotRecognizeSelector:_cmd];
+  return nil;
+}
+
+#pragma mark - Designated initializers
+
+- (instancetype)initWithBridge:(shell::AccessibilityBridge*)bridge uid:(int32_t)uid {
+  self = [super initWithBridge:bridge uid:uid];
+  return self;
+}
+
+#pragma mark - UIAccessibility overrides
+
+- (UIAccessibilityTraits)accessibilityTraits {
+  UIAccessibilityTraits traits = UIAccessibilityTraitNone;
+  if ([self node].HasAction(blink::SemanticsAction::kIncrease) ||
+      [self node].HasAction(blink::SemanticsAction::kDecrease)) {
+    traits |= UIAccessibilityTraitAdjustable;
+  }
+  if ([self node].HasFlag(blink::SemanticsFlags::kIsSelected) ||
+      [self node].HasFlag(blink::SemanticsFlags::kIsChecked)) {
+    traits |= UIAccessibilityTraitSelected;
+  }
+  if ([self node].HasFlag(blink::SemanticsFlags::kIsButton)) {
+    traits |= UIAccessibilityTraitButton;
+  }
+  if ([self node].HasFlag(blink::SemanticsFlags::kHasEnabledState) &&
+      ![self node].HasFlag(blink::SemanticsFlags::kIsEnabled)) {
+    traits |= UIAccessibilityTraitNotEnabled;
+  }
+  return traits;
 }
 
 @end
@@ -372,21 +396,26 @@ AccessibilityBridge::~AccessibilityBridge() {
   [accessibility_channel_.get() setMessageHandler:nil];
 }
 
-void AccessibilityBridge::UpdateSemantics(std::vector<blink::SemanticsNode> nodes) {
+UIView<UITextInput>* AccessibilityBridge::textInputView() {
+  return [platform_view_->text_input_plugin() textInputView];
+}
+
+void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes) {
   // Children are received in paint order (inverse hit testing order). We need to bring them into
   // traversal order (top left to bottom right, with hit testing order as tie breaker).
   NSMutableSet<SemanticsObject*>* childOrdersToUpdate = [[[NSMutableSet alloc] init] autorelease];
   BOOL layoutChanged = NO;
 
-  for (const blink::SemanticsNode& node : nodes) {
-    SemanticsObject* object = GetOrCreateObject(node.id);
-    layoutChanged = layoutChanged || [object willCauseLayoutChange:&node];
+  for (const auto& entry : nodes) {
+    const blink::SemanticsNode& node = entry.second;
+    SemanticsObject* object = GetOrCreateObject(node.id, nodes);
+    layoutChanged = layoutChanged || [object nodeWillCauseLayoutChange:&node];
     [object setSemanticsNode:&node];
     const size_t childrenCount = node.children.size();
     auto& children = *[object children];
     children.resize(childrenCount);
     for (size_t i = 0; i < childrenCount; ++i) {
-      SemanticsObject* child = GetOrCreateObject(node.children[i]);
+      SemanticsObject* child = GetOrCreateObject(node.children[i], nodes);
       child.parent = object;
       // Reverting to get hit testing order (as tie breaker for sorting below).
       children[childrenCount - i - 1] = child;
@@ -431,11 +460,42 @@ void AccessibilityBridge::DispatchSemanticsAction(int32_t uid, blink::SemanticsA
   platform_view_->DispatchSemanticsAction(uid, action, args);
 }
 
-SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid) {
+SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid,
+                                                        blink::SemanticsNodeUpdates& updates) {
   SemanticsObject* object = objects_.get()[@(uid)];
   if (!object) {
-    object = [[[SemanticsObject alloc] initWithBridge:this uid:uid] autorelease];
+    // New node case: simply create a new SemanticsObject.
+    blink::SemanticsNode node = updates[uid];
+    if (node.HasFlag(blink::SemanticsFlags::kIsTextField)) {
+      // Text fields are backed by objects that implement UITextInput.
+      object = [[[TextInputSemanticsObject alloc] initWithBridge:this uid:uid] autorelease];
+    } else {
+      object = [[[FlutterSemanticsObject alloc] initWithBridge:this uid:uid] autorelease];
+    }
+
     objects_.get()[@(uid)] = object;
+  } else {
+    // Existing node case
+    auto nodeEntry = updates.find(object.node.id);
+    if (nodeEntry != updates.end()) {
+      // There's an update for this node
+      blink::SemanticsNode node = nodeEntry->second;
+      BOOL isTextField = node.HasFlag(blink::SemanticsFlags::kIsTextField);
+      BOOL wasTextField = object.node.HasFlag(blink::SemanticsFlags::kIsTextField);
+      if (wasTextField != isTextField) {
+        // The node changed its type from text field to something else, or vice versa. In this
+        // case, we cannot reuse the existing SemanticsObject implementation. Instead, we replace
+        // it with a new instance.
+        [objects_ removeObjectForKey:@(node.id)];
+        if (isTextField) {
+          // Text fields are backed by objects that implement UITextInput.
+          object = [[[TextInputSemanticsObject alloc] initWithBridge:this uid:uid] autorelease];
+        } else {
+          object = [[[FlutterSemanticsObject alloc] initWithBridge:this uid:uid] autorelease];
+        }
+        objects_.get()[@(node.id)] = object;
+      }
+    }
   }
   return object;
 }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -199,10 +199,10 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
   // `rect` is in the physical pixel coordinate system. iOS expects the accessibility frame in
   // the logical pixel coordinate system. Therefore, we divide by the `scale` (pixel ratio) to
   // convert.
-  CGFloat scale = [[[self bridge]->view() window] screen].scale;
+  CGFloat scale = [[[self bridge] -> view() window] screen].scale;
   auto result =
       CGRectMake(rect.x() / scale, rect.y() / scale, rect.width() / scale, rect.height() / scale);
-  return UIAccessibilityConvertFrameToScreenCoordinates(result, [self bridge]->view());
+  return UIAccessibilityConvertFrameToScreenCoordinates(result, [self bridge] -> view());
 }
 
 #pragma mark - UIAccessibilityElement protocol
@@ -223,21 +223,21 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
 - (BOOL)accessibilityActivate {
   if (![self node].HasAction(blink::SemanticsAction::kTap))
     return NO;
-  [self bridge]->DispatchSemanticsAction([self uid], blink::SemanticsAction::kTap);
+  [self bridge] -> DispatchSemanticsAction([self uid], blink::SemanticsAction::kTap);
   return YES;
 }
 
 - (void)accessibilityIncrement {
   if ([self node].HasAction(blink::SemanticsAction::kIncrease)) {
     [self node].value = [self node].increasedValue;
-    [self bridge]->DispatchSemanticsAction([self uid], blink::SemanticsAction::kIncrease);
+    [self bridge] -> DispatchSemanticsAction([self uid], blink::SemanticsAction::kIncrease);
   }
 }
 
 - (void)accessibilityDecrement {
   if ([self node].HasAction(blink::SemanticsAction::kDecrease)) {
     [self node].value = [self node].decreasedValue;
-    [self bridge]->DispatchSemanticsAction([self uid], blink::SemanticsAction::kDecrease);
+    [self bridge] -> DispatchSemanticsAction([self uid], blink::SemanticsAction::kDecrease);
   }
 }
 
@@ -245,7 +245,7 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
   blink::SemanticsAction action = GetSemanticsActionForScrollDirection(direction);
   if (![self node].HasAction(action))
     return NO;
-  [self bridge]->DispatchSemanticsAction([self uid], action);
+  [self bridge] -> DispatchSemanticsAction([self uid], action);
   return YES;
 }
 
@@ -485,6 +485,8 @@ SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid,
         // The node changed its type from text field to something else, or vice versa. In this
         // case, we cannot reuse the existing SemanticsObject implementation. Instead, we replace
         // it with a new instance.
+        auto positionInChildlist =
+            std::find(object.parent.children->begin(), object.parent.children->end(), object);
         [objects_ removeObjectForKey:@(node.id)];
         if (isTextField) {
           // Text fields are backed by objects that implement UITextInput.
@@ -492,6 +494,7 @@ SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid,
         } else {
           object = [[[FlutterSemanticsObject alloc] initWithBridge:this uid:uid] autorelease];
         }
+        *positionInChildlist = object;
         objects_.get()[@(node.id)] = object;
       }
     }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -126,8 +126,7 @@ bool GeometryComparator(SemanticsObject* a, SemanticsObject* b) {
   _bridge = nullptr;
   _children.clear();
   [_parent release];
-  if (_container != nil)
-    [_container release];
+  [_container release];
   [super dealloc];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h
@@ -1,0 +1,36 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_ACCESSIBILITY_TEXT_ENTRY_H_
+#define SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_ACCESSIBILITY_TEXT_ENTRY_H_
+
+/**
+ * An implementation of `UITextInput` used for text fields that do not currently
+ * have input focus.
+ *
+ * This class is used by `TextInputSemanticsObject`.
+ */
+@interface FlutterInactiveTextInput : UIView<UITextInput>
+
+@property(nonatomic, copy) NSString* text;
+@property(nonatomic, readonly) NSMutableString* markedText;
+@property(readwrite, copy) UITextRange* selectedTextRange;
+@property(nonatomic, strong) UITextRange* markedTextRange;
+@property(nonatomic, copy) NSDictionary* markedTextStyle;
+@property(nonatomic, assign) id<UITextInputDelegate> inputDelegate;
+
+@end
+
+/**
+ * An implementation of `SemanticsObject` specialized for expressing text
+ * fields.
+ *
+ * Delegates to `FlutterTextInputView` when the object corresponds to a text
+ * field that currently owns input focus. Delegates to
+ * `FlutterInactiveTextInput` otherwise.
+ */
+@interface TextInputSemanticsObject : SemanticsObject<UITextInput>
+@end
+
+#endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_ACCESSIBILITY_TEXT_ENTRY_H_

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -1,0 +1,405 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <UIKit/UIKit.h>
+
+#include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h"
+
+@implementation FlutterInactiveTextInput {
+}
+
+@synthesize tokenizer = _tokenizer;
+@synthesize beginningOfDocument = _beginningOfDocument;
+@synthesize endOfDocument = _endOfDocument;
+
+- (instancetype)init {
+  return [super init];
+}
+
+- (BOOL)hasText {
+  return self.text.length > 0;
+}
+
+- (NSString*)textInRange:(UITextRange*)range {
+  NSRange textRange = ((FlutterTextRange*)range).range;
+  return [self.text substringWithRange:textRange];
+}
+
+- (void)replaceRange:(UITextRange*)range withText:(NSString*)text {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+}
+
+- (void)setMarkedText:(NSString*)markedText selectedRange:(NSRange)markedSelectedRange {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+}
+
+- (void)unmarkText {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+}
+
+- (UITextRange*)textRangeFromPosition:(UITextPosition*)fromPosition
+                           toPosition:(UITextPosition*)toPosition {
+  NSUInteger fromIndex = ((FlutterTextPosition*)fromPosition).index;
+  NSUInteger toIndex = ((FlutterTextPosition*)toPosition).index;
+  return [FlutterTextRange rangeWithNSRange:NSMakeRange(fromIndex, toIndex - fromIndex)];
+}
+
+- (UITextPosition*)positionFromPosition:(UITextPosition*)position offset:(NSInteger)offset {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return nil;
+}
+
+- (UITextPosition*)positionFromPosition:(UITextPosition*)position
+                            inDirection:(UITextLayoutDirection)direction
+                                 offset:(NSInteger)offset {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return nil;
+}
+
+- (NSComparisonResult)comparePosition:(UITextPosition*)position toPosition:(UITextPosition*)other {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return NSOrderedSame;
+}
+
+- (NSInteger)offsetFromPosition:(UITextPosition*)from toPosition:(UITextPosition*)toPosition {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return 0;
+}
+
+- (UITextPosition*)positionWithinRange:(UITextRange*)range
+                   farthestInDirection:(UITextLayoutDirection)direction {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return nil;
+}
+
+- (UITextRange*)characterRangeByExtendingPosition:(UITextPosition*)position
+                                      inDirection:(UITextLayoutDirection)direction {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return nil;
+}
+
+- (UITextWritingDirection)baseWritingDirectionForPosition:(UITextPosition*)position
+                                              inDirection:(UITextStorageDirection)direction {
+  // Not editable. Does not apply.
+  return UITextWritingDirectionNatural;
+}
+
+- (void)setBaseWritingDirection:(UITextWritingDirection)writingDirection
+                       forRange:(UITextRange*)range {
+  // Not editable. Does not apply.
+}
+
+- (CGRect)firstRectForRange:(UITextRange*)range {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return CGRectZero;
+}
+
+- (CGRect)caretRectForPosition:(UITextPosition*)position {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return CGRectZero;
+}
+
+- (UITextPosition*)closestPositionToPoint:(CGPoint)point {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return nil;
+}
+
+- (UITextPosition*)closestPositionToPoint:(CGPoint)point withinRange:(UITextRange*)range {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return nil;
+}
+
+- (NSArray*)selectionRectsForRange:(UITextRange*)range {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return @[];
+}
+
+- (UITextRange*)characterRangeAtPoint:(CGPoint)point {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+  return nil;
+}
+
+- (void)insertText:(NSString*)text {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+}
+
+- (void)deleteBackward {
+  // This method is required but not called by accessibility API for
+  // features we are using it for. It may need to be implemented if
+  // requirements change.
+}
+
+@end
+
+@implementation TextInputSemanticsObject {
+  FlutterInactiveTextInput* _inactive_text_input;
+}
+
+- (instancetype)initWithBridge:(shell::AccessibilityBridge*)bridge uid:(int32_t)uid {
+  self = [super initWithBridge:bridge uid:uid];
+
+  if (self) {
+    _inactive_text_input = [[FlutterInactiveTextInput alloc] init];
+  }
+
+  return self;
+}
+
+- (void)dealloc {
+  [_inactive_text_input release];
+  [super dealloc];
+}
+
+#pragma mark - SemanticsObject overrides
+
+- (void)setSemanticsNode:(const blink::SemanticsNode*)node {
+  [super setSemanticsNode:node];
+  _inactive_text_input.text = @(node->value.data());
+  if ([self node].HasFlag(blink::SemanticsFlags::kIsFocused)) {
+    // The text input view must have a non-trivial size for the accessibility
+    // system to send text editing events.
+    [self bridge]->textInputView().frame = CGRectMake(0.0, 0.0, 1.0, 1.0);
+  }
+}
+
+#pragma mark - UIAccessibility overrides
+
+/**
+ * The UITextInput whose accessibility properties we present to UIKit as
+ * substitutes for Flutter's text field properties.
+ *
+ * When the field is currently focused (i.e. it is being edited), we use
+ * the FlutterTextInputView used by FlutterTextInputPlugin. Otherwise,
+ * we use an FlutterInactiveTextInput.
+ */
+- (UIView<UITextInput>*)textInputSurrogate {
+  if ([self node].HasFlag(blink::SemanticsFlags::kIsFocused)) {
+    return [self bridge]->textInputView();
+  } else {
+    return _inactive_text_input;
+  }
+}
+
+- (UIView*)textInputView {
+  return [self textInputSurrogate];
+}
+
+- (void)accessibilityElementDidBecomeFocused {
+  [[self textInputSurrogate] accessibilityElementDidBecomeFocused];
+}
+
+- (void)accessibilityElementDidLoseFocus {
+  [[self textInputSurrogate] accessibilityElementDidLoseFocus];
+}
+
+- (BOOL)accessibilityElementIsFocused {
+  return [self node].HasFlag(blink::SemanticsFlags::kIsFocused);
+}
+
+- (BOOL)accessibilityActivate {
+  return [[self textInputSurrogate] accessibilityActivate];
+}
+
+- (NSString*)accessibilityLabel {
+  return [self textInputSurrogate].accessibilityLabel;
+}
+
+- (NSString*)accessibilityHint {
+  return [self textInputSurrogate].accessibilityHint;
+}
+
+- (NSString*)accessibilityValue {
+  return [self textInputSurrogate].accessibilityValue;
+}
+
+- (UIAccessibilityTraits)accessibilityTraits {
+  // Adding UIAccessibilityTraitKeyboardKey to the trait list so that iOS treats it like
+  // a keyboard entry control, thus adding support for text editing features, such as
+  // pinch to select text, and up/down fling to move cursor.
+  return [self textInputSurrogate].accessibilityTraits | UIAccessibilityTraitKeyboardKey;
+}
+
+#pragma mark - UITextInput overrides
+
+- (NSString*)textInRange:(UITextRange*)range {
+  return [[self textInputSurrogate] textInRange:range];
+}
+
+- (void)replaceRange:(UITextRange*)range withText:(NSString*)text {
+  return [[self textInputSurrogate] replaceRange:range withText:text];
+}
+
+- (BOOL)shouldChangeTextInRange:(UITextRange*)range replacementText:(NSString*)text {
+  return [[self textInputSurrogate] shouldChangeTextInRange:range replacementText:text];
+}
+
+- (UITextRange*)selectedTextRange {
+  return [[self textInputSurrogate] selectedTextRange];
+}
+
+- (void)setSelectedTextRange:(UITextRange*)range {
+  [[self textInputSurrogate] setSelectedTextRange:range];
+}
+
+- (UITextRange*)markedTextRange {
+  return [[self textInputSurrogate] markedTextRange];
+}
+
+- (NSDictionary*)markedTextStyle {
+  return [[self textInputSurrogate] markedTextStyle];
+}
+
+- (void)setMarkedTextStyle:(NSDictionary*)style {
+  [[self textInputSurrogate] setMarkedTextStyle:style];
+}
+
+- (void)setMarkedText:(NSString*)markedText selectedRange:(NSRange)selectedRange {
+  [[self textInputSurrogate] setMarkedText:markedText selectedRange:selectedRange];
+}
+
+- (void)unmarkText {
+  [[self textInputSurrogate] unmarkText];
+}
+
+- (UITextStorageDirection)selectionAffinity {
+  return [[self textInputSurrogate] selectionAffinity];
+}
+
+- (UITextPosition*)beginningOfDocument {
+  return [[self textInputSurrogate] beginningOfDocument];
+}
+
+- (UITextPosition*)endOfDocument {
+  return [[self textInputSurrogate] endOfDocument];
+}
+
+- (id<UITextInputDelegate>)inputDelegate {
+  return [[self textInputSurrogate] inputDelegate];
+}
+
+- (void)setInputDelegate:(id<UITextInputDelegate>)delegate {
+  [[self textInputSurrogate] setInputDelegate:delegate];
+}
+
+- (id<UITextInputTokenizer>)tokenizer {
+  return [[self textInputSurrogate] tokenizer];
+}
+
+- (UITextRange*)textRangeFromPosition:(UITextPosition*)fromPosition
+                           toPosition:(UITextPosition*)toPosition {
+  return [[self textInputSurrogate] textRangeFromPosition:fromPosition toPosition:toPosition];
+}
+
+- (UITextPosition*)positionFromPosition:(UITextPosition*)position offset:(NSInteger)offset {
+  return [[self textInputSurrogate] positionFromPosition:position offset:offset];
+}
+
+- (UITextPosition*)positionFromPosition:(UITextPosition*)position
+                            inDirection:(UITextLayoutDirection)direction
+                                 offset:(NSInteger)offset {
+  return
+      [[self textInputSurrogate] positionFromPosition:position inDirection:direction offset:offset];
+}
+
+- (NSComparisonResult)comparePosition:(UITextPosition*)position toPosition:(UITextPosition*)other {
+  return [[self textInputSurrogate] comparePosition:position toPosition:other];
+}
+
+- (NSInteger)offsetFromPosition:(UITextPosition*)from toPosition:(UITextPosition*)toPosition {
+  return [[self textInputSurrogate] offsetFromPosition:from toPosition:toPosition];
+}
+
+- (UITextPosition*)positionWithinRange:(UITextRange*)range
+                   farthestInDirection:(UITextLayoutDirection)direction {
+  return [[self textInputSurrogate] positionWithinRange:range farthestInDirection:direction];
+}
+
+- (UITextRange*)characterRangeByExtendingPosition:(UITextPosition*)position
+                                      inDirection:(UITextLayoutDirection)direction {
+  return
+      [[self textInputSurrogate] characterRangeByExtendingPosition:position inDirection:direction];
+}
+
+- (UITextWritingDirection)baseWritingDirectionForPosition:(UITextPosition*)position
+                                              inDirection:(UITextStorageDirection)direction {
+  return [[self textInputSurrogate] baseWritingDirectionForPosition:position inDirection:direction];
+}
+
+- (void)setBaseWritingDirection:(UITextWritingDirection)writingDirection
+                       forRange:(UITextRange*)range {
+  [[self textInputSurrogate] setBaseWritingDirection:writingDirection forRange:range];
+}
+
+- (CGRect)firstRectForRange:(UITextRange*)range {
+  return [[self textInputSurrogate] firstRectForRange:range];
+}
+
+- (CGRect)caretRectForPosition:(UITextPosition*)position {
+  return [[self textInputSurrogate] caretRectForPosition:position];
+}
+
+- (UITextPosition*)closestPositionToPoint:(CGPoint)point {
+  return [[self textInputSurrogate] closestPositionToPoint:point];
+}
+
+- (UITextPosition*)closestPositionToPoint:(CGPoint)point withinRange:(UITextRange*)range {
+  return [[self textInputSurrogate] closestPositionToPoint:point withinRange:range];
+}
+
+- (NSArray*)selectionRectsForRange:(UITextRange*)range {
+  return [[self textInputSurrogate] selectionRectsForRange:range];
+}
+
+- (UITextRange*)characterRangeAtPoint:(CGPoint)point {
+  return [[self textInputSurrogate] characterRangeAtPoint:point];
+}
+
+- (void)insertText:(NSString*)text {
+  [[self textInputSurrogate] insertText:text];
+}
+
+- (void)deleteBackward {
+  [[self textInputSurrogate] deleteBackward];
+}
+
+#pragma mark - UIKeyInput overrides
+
+- (BOOL)hasText {
+  return [[self textInputSurrogate] hasText];
+}
+
+@end

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -27,6 +27,10 @@
   return [self.text substringWithRange:textRange];
 }
 
+- (NSString*)accessibilityLabel {
+  return self.text;
+}
+
 - (void)replaceRange:(UITextRange*)range withText:(NSString*)text {
   // This method is required but not called by accessibility API for
   // features we are using it for. It may need to be implemented if

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -10,6 +10,7 @@
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/platform_message_router.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
@@ -53,13 +54,30 @@ class PlatformViewIOS : public PlatformView {
 
   void RegisterExternalTexture(int64_t id, NSObject<FlutterTexture>* texture);
 
-  void UpdateSemantics(std::vector<blink::SemanticsNode> update) override;
+  void UpdateSemantics(blink::SemanticsNodeUpdates update) override;
 
   void RunFromSource(const std::string& assets_directory,
                      const std::string& main,
                      const std::string& packages) override;
 
   void SetAssetBundlePath(const std::string& assets_directory) override;
+
+  /**
+   * Exposes the `FlutterTextInputPlugin` singleton for the
+   * `AccessibilityBridge` to be able to interact with the text entry system.
+   */
+  fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin() {
+    return text_input_plugin_;
+  }
+
+  /**
+   * Sets the `FlutterTextInputPlugin` singleton returned by
+   * `text_input_plugin`.
+   */
+  void SetTextInputPlugin(
+      fml::scoped_nsprotocol<FlutterTextInputPlugin*> textInputPlugin) {
+    text_input_plugin_ = textInputPlugin;
+  }
 
   NSObject<FlutterBinaryMessenger>* binary_messenger() const {
     return binary_messenger_;
@@ -72,6 +90,7 @@ class PlatformViewIOS : public PlatformView {
   fxl::Closure firstFrameCallback_;
   fml::WeakPtrFactory<PlatformViewIOS> weak_factory_;
   NSObject<FlutterBinaryMessenger>* binary_messenger_;
+  fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;
 
   void SetupAndLoadFromSource(const std::string& assets_directory,
                               const std::string& main,

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -99,7 +99,7 @@ bool PlatformViewIOS::ResourceContextMakeCurrent() {
   return ios_surface_ != nullptr ? ios_surface_->ResourceContextMakeCurrent() : false;
 }
 
-void PlatformViewIOS::UpdateSemantics(std::vector<blink::SemanticsNode> update) {
+void PlatformViewIOS::UpdateSemantics(blink::SemanticsNodeUpdates update) {
   if (accessibility_bridge_)
     accessibility_bridge_->UpdateSemantics(std::move(update));
 }

--- a/tools/licenses/pubspec.lock
+++ b/tools/licenses/pubspec.lock
@@ -2,60 +2,52 @@
 # See http://pub.dartlang.org/doc/glossary.html#lockfile
 packages:
   archive:
-    dependency: "direct main"
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.33"
   args:
-    dependency: "direct main"
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.13.7"
   charcode:
-    dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.1"
   collection:
-    dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.14.5"
   convert:
-    dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   crypto:
-    dependency: "direct main"
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2+1"
   path:
-    dependency: "direct main"
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.1"
   typed_data:
-    dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.5"
 sdks:
-  dart: ">=1.21.0 <=2.0.0-dev.16.0"
+  dart: ">=1.21.0 <2.0.0"

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1959,6 +1959,42 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
+ORIGIN: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h + ../../../LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+----------------------------------------------------------------------------------------------------
+Copyright 2018 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: engine
 ORIGIN: ../../../flutter/sky/engine/core/editing/CompositionUnderline.h
 TYPE: LicenseType.bsd
 FILE: ../../../flutter/sky/engine/core/editing/CompositionUnderline.h
@@ -9960,4 +9996,4 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
-Total license count: 215
+Total license count: 216


### PR DESCRIPTION
This fixes many points from https://github.com/flutter/flutter/issues/12786.

What works:
 - When "tabbed" or "dragged" into
   - Text fields are announced as "Text field"
   - The hint "double tap to edit"
   - Content of text field is announced 
   - It is announced weather a text field is in edit mode
   - The insert mode (e.g. character mode) is not announced.
 - Entered characters are echoed back
 - After inserting space the last word is echoed back
 - Swiping up or down moves the courser
 - Selecting text with reverse-pinch

What doesn't work:
 - **No announcement** when a text field gains focused via the "tap" gesture
 - The position of the cursor is **not** announced 
 - Copy&paste does **not** work when rotor is in edit mode

/cc @cbracken who implemented our iOS text entry system
