### PR TITLE
Extract common iOS asset path lookup code

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -116,7 +116,7 @@ static NSURL* URLForSwitch(const fxl::StringView name) {
     if (flutterAssetsURL == nil) {
       // If the URL was not specified on the command line, look inside the
       // FlutterApplication bundle.
-      NSString* flutterAssetsPath = [self pathForFlutterAssetsFromBundle:bundle];
+      NSString* flutterAssetsPath = [FlutterDartProject pathForFlutterAssetsFromBundle:bundle];
       if (flutterAssetsPath != nil) {
         flutterAssetsURL = [NSURL fileURLWithPath:flutterAssetsPath isDirectory:NO];
       }
@@ -154,7 +154,9 @@ static NSURL* URLForSwitch(const fxl::StringView name) {
   }
 }
 
-- (NSString*)pathForFlutterAssetsFromBundle:(NSBundle*)bundle {
+#pragma mark - Assets-related utilities
+
++ (NSString*)pathForFlutterAssetsFromBundle:(NSBundle*)bundle {
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
   if (flutterAssetsName == nil) {
     // Default to "flutter_assets"
@@ -269,7 +271,7 @@ static NSString* NSStringFromVMType(VMType type) {
     return;
   }
 
-  NSString* path = [self pathForFlutterAssetsFromBundle:_precompiledDartBundle];
+  NSString* path = [FlutterDartProject pathForFlutterAssetsFromBundle:_precompiledDartBundle];
   if (path.length == 0) {
     NSString* message = [NSString stringWithFormat:
                                       @"Could not find the 'flutter_assets' dir in "

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
@@ -30,6 +30,8 @@ typedef void (^LaunchResult)(BOOL success, NSString* message);
         embedderVMType:(VMType)type
                 result:(LaunchResult)result;
 
++ (NSString*)pathForFlutterAssetsFromBundle:(NSBundle*)bundle;
+
 @end
 
 #endif  // SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERDARTPROJECT_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/flutter_main_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_main_ios.mm
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/darwin/ios/framework/Source/flutter_main_ios.h"
+
 #include "flutter/shell/platform/darwin/common/platform_mac.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+#include "flutter/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h"
 
 namespace shell {
 
@@ -14,13 +16,7 @@ void FlutterMain() {
   NSString* libraryName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTLibraryPath"];
 
   NSBundle* mainBundle = [NSBundle mainBundle];
-
-  NSString* flutterAssetsName = [mainBundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
-  if (flutterAssetsName == nil) {
-    // Default to "flutter_assets"
-    flutterAssetsName = @"flutter_assets";
-  }
-  NSString* flutterAssetsPath = [mainBundle pathForResource:flutterAssetsName ofType:nil];
+  NSString* flutterAssetsPath = [FlutterDartProject pathForFlutterAssetsFromBundle:mainBundle];
 
   shell::PlatformMacMain(icuDataPath.UTF8String, libraryName != nil ? libraryName.UTF8String : "",
                          flutterAssetsPath.UTF8String);


### PR DESCRIPTION
Consolidates the asset path lookup logic from FlutterDartProject and FlutterMain().