### PR TITLE
libtxt: track the range of code units represented by the current glyph

### DIFF
--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -71,11 +71,13 @@ class Paragraph {
 
   template <typename T>
   struct Range {
+    Range() : start(), end() {}
     Range(T s, T e) : start(s), end(e) {}
     T start, end;
     bool operator==(const Range<T>& other) const {
       return start == other.start && end == other.end;
     }
+    T width() { return end - start; }
   };
 
   // Minikin Layout doLayout() and LineBreaker addStyleRun() has an


### PR DESCRIPTION
This simplifies iteration over graphemes and fixes an off-by-one error seen
when handling RTL runs.