### PR TITLE
libtxt: update some unit tests

### DIFF
--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -902,7 +902,7 @@ TEST_F(ParagraphTest, GetGlyphPositionAtCoordinateParagraph) {
             36ull);
   ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(-100000, 90).position,
             18ull);
-  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(20, -80).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(20, -80).position, 1ull);
   ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 90).position, 18ull);
   ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(1, 180).position, 36ull);
   ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(10000, 180).position,
@@ -1449,7 +1449,8 @@ TEST_F(ParagraphTest, RepeatLayoutParagraph) {
   const char* text =
       "Sentence to layout at diff widths to get diff line counts. short words "
       "short words short words short words short words short words short words "
-      "short words short words short words short words short words short words";
+      "short words short words short words short words short words short words "
+      "end";
   auto icu_text = icu::UnicodeString::fromUTF8(text);
   std::u16string u16_text(icu_text.getBuffer(),
                           icu_text.getBuffer() + icu_text.length());


### PR DESCRIPTION
* GetGlyphPositionAtCoordinate maps points within the right half of a
  glyph to the next position
* The second pass in RepeatLayoutParagraph was at the borderline between 5
  and 6 lines in the Minikin line breaker.  Add text to ensure that the text
  fills 12 lines at half width and 6 lines at full width.