### PR TITLE
Only verify clang-format on changed files

### DIFF
--- a/travis/format.sh
+++ b/travis/format.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -e
 echo "Checking formatting..."
-cd ..
 
 case "$(uname -s)" in
   Darwin)
@@ -16,24 +15,13 @@ case "$(uname -s)" in
     ;;
 esac
 
-CLANG_FORMAT="buildtools/$OS/clang/bin/clang-format"
+CLANG_FORMAT="../buildtools/$OS/clang/bin/clang-format"
 $CLANG_FORMAT --version
+CLANG_FORMAT_DIFF="../buildtools/$OS/clang/share/clang/clang-format-diff.py"
 
-FILES="$(find flutter/ -name '*.cpp' -or -name '*.h' -or -name '*.c' -or -name '*.cc' -or -name '*.m' -or -name '*.mm')"
-FAILED_CHECKS=0
-
-for FILE in $FILES; do
-  set +e
-  RESULT="$(diff -u "$FILE" <($CLANG_FORMAT --style=file "$FILE"))"
-  set -e
-  if ! [ -z "$RESULT" ]; then
-    echo "$RESULT"
-    FAILED_CHECKS=$(($counter+1))
-  fi
-done
-
-if [ $FAILED_CHECKS -ne 0 ]; then
-  echo "Some files are formatted incorrectly. To fix, apply diffs from above."
+DIFFS="$(git diff -U0 --no-color master | "$CLANG_FORMAT_DIFF" -p1 -binary "$CLANG_FORMAT")"
+if [[ ! -z "$DIFFS" ]]; then
+  echo ""
+  echo "ERROR: Some files are formatted incorrectly. To fix, apply diffs below:"
+  echo "$DIFFS"
 fi
-
-exit $FAILED_CHECKS


### PR DESCRIPTION
Each time we update the clang toolchain, we've needed to deal with diffs
resulting from new clang-format defaults and improvements to existing
settings. This reduces diff checking to just the diffed lines.