### PR TITLE
Update Flutter licenses golden file

### DIFF
--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -1223,6 +1223,8 @@ FILE: ../../../flutter/third_party/txt/src/txt/platform_mac.mm
 FILE: ../../../flutter/vulkan/skia_vulkan_header.h
 FILE: ../../../flutter/vulkan/vulkan_native_surface_magma.cc
 FILE: ../../../flutter/vulkan/vulkan_native_surface_magma.h
+FILE: ../../../flutter/vulkan/vulkan_provider.cc
+FILE: ../../../flutter/vulkan/vulkan_provider.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2017 The Chromium Authors. All rights reserved.
 


### PR DESCRIPTION
vulcan_provider.{cc.h} were added in
fb9782a5294e700e45e372da0cd25165697b2e45. This updates the licenses
golden file to include them and fix the current breakage on Travis.