### PR TITLE
Run clang-format checks before other phases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ sudo: false
 before_script:
   - ./travis/setup.sh
 script:
+  - ./travis/format.sh
   - ./travis/build.sh
   - ./travis/test.sh
-  - ./travis/format.sh
 
 # We don't build the engine or run the tests for the engine on Travis
 # See testing/run_tests.sh if that's what you're looking for though.


### PR DESCRIPTION
We now run clang-format checks before running licenses and other tests.
Since clang-format runs quickly, this allows these diffs to be caught
first, without much real delay to other checks.