### PR TITLE
Modernize GrContext creation.

### DIFF
--- a/content_handler/vulkan_surface_producer.cc
+++ b/content_handler/vulkan_surface_producer.cc
@@ -103,9 +103,7 @@ bool VulkanSurfaceProducer::Initialize(scenic_lib::Session* mozart_session) {
   logical_device_->ReleaseDeviceOwnership();
   application_->ReleaseInstanceOwnership();
 
-  context_.reset(GrContext::Create(
-      kVulkan_GrBackend,
-      reinterpret_cast<GrBackendContext>(backend_context_.get())));
+  context_ = GrContext::MakeVulkan(backend_context);
 
   context_->setResourceCacheLimits(vulkan::kGrCacheMaxCount,
                                    vulkan::kGrCacheMaxByteSize);

--- a/lib/ui/painting/resource_context.cc
+++ b/lib/ui/painting/resource_context.cc
@@ -24,9 +24,9 @@ ResourceContext::~ResourceContext() {
   g_mutex.Unlock();
 }
 
-void ResourceContext::Set(GrContext* context) {
+void ResourceContext::Set(sk_sp<GrContext> context) {
   FXL_DCHECK(!g_context);
-  g_context = context;
+  g_context = context.release();
 }
 
 GrContext* ResourceContext::Get() {

--- a/lib/ui/painting/resource_context.h
+++ b/lib/ui/painting/resource_context.h
@@ -15,7 +15,7 @@ class ResourceContext {
   /**
    * Globally set the GrContext singleton instance.
    */
-  static void Set(GrContext* context);
+  static void Set(sk_sp<GrContext> context);
 
   /**
    * Acquire a GrContext wrapping ResourceContext that's also an exclusive mutex

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -47,7 +47,7 @@ void PlatformView::CreateEngine() {
 void PlatformView::DispatchPlatformMessage(
     fxl::RefPtr<blink::PlatformMessage> message) {
   blink::Threads::UI()->PostTask(
-      [ engine = engine_->GetWeakPtr(), message = std::move(message) ] {
+      [engine = engine_->GetWeakPtr(), message = std::move(message)] {
         if (engine) {
           engine->DispatchPlatformMessage(message);
         }
@@ -58,7 +58,7 @@ void PlatformView::DispatchSemanticsAction(int32_t id,
                                            blink::SemanticsAction action,
                                            std::vector<uint8_t> args) {
   blink::Threads::UI()->PostTask(
-      [ engine = engine_->GetWeakPtr(), id, action, args = std::move(args) ] {
+      [engine = engine_->GetWeakPtr(), id, action, args = std::move(args)] {
         if (engine) {
           engine->DispatchSemanticsAction(
               id, static_cast<blink::SemanticsAction>(action), std::move(args));
@@ -67,7 +67,7 @@ void PlatformView::DispatchSemanticsAction(int32_t id,
 }
 
 void PlatformView::SetSemanticsEnabled(bool enabled) {
-  blink::Threads::UI()->PostTask([ engine = engine_->GetWeakPtr(), enabled ] {
+  blink::Threads::UI()->PostTask([engine = engine_->GetWeakPtr(), enabled] {
     if (engine)
       engine->SetSemanticsEnabled(enabled);
   });
@@ -81,18 +81,14 @@ void PlatformView::NotifyCreated(std::unique_ptr<Surface> surface,
                                  fxl::Closure caller_continuation) {
   fxl::AutoResetWaitableEvent latch;
 
-  auto ui_continuation = fxl::MakeCopyable([
-    this,                          //
-    surface = std::move(surface),  //
-    caller_continuation,           //
-    &latch
-  ]() mutable {
-    auto gpu_continuation = fxl::MakeCopyable([
-      this,                          //
-      surface = std::move(surface),  //
-      caller_continuation,           //
-      &latch
-    ]() mutable {
+  auto ui_continuation = fxl::MakeCopyable([this,                          //
+                                            surface = std::move(surface),  //
+                                            caller_continuation,           //
+                                            &latch]() mutable {
+    auto gpu_continuation = fxl::MakeCopyable([this,                          //
+                                               surface = std::move(surface),  //
+                                               caller_continuation,           //
+                                               &latch]() mutable {
       // Runs on the GPU Thread. So does the Caller Continuation.
       rasterizer_->Setup(std::move(surface), caller_continuation, &latch);
     });
@@ -195,10 +191,8 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
   // that feature, which will cause texture uploads to do CPU YUV conversion.
   options.fDisableGpuYUVConversion = true;
 
-  blink::ResourceContext::Set(GrContext::Create(
-      GrBackend::kOpenGL_GrBackend,
-      reinterpret_cast<GrBackendContext>(GrGLCreateNativeInterface()),
-      options));
+  blink::ResourceContext::Set(
+      GrContext::MakeGL(GrGLMakeNativeInterface(), options));
 
   // Do not cache textures created by the image decoder.  These textures should
   // be deleted when they are no longer referenced by an SkImage.

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -30,14 +30,10 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
     return;
   }
 
-  auto backend_context =
-      reinterpret_cast<GrBackendContext>(GrGLCreateNativeInterface());
-
   GrContextOptions options;
   options.fAvoidStencilBuffers = true;
 
-  auto context = sk_sp<GrContext>(
-      GrContext::Create(kOpenGL_GrBackend, backend_context, options));
+  auto context = GrContext::MakeGL(GrGLMakeNativeInterface(), options);
 
   if (context == nullptr) {
     FXL_LOG(ERROR) << "Failed to setup Skia Gr context.";
@@ -80,7 +76,6 @@ static GrPixelConfig FirstSupportedConfig(GrContext* context) {
   if (context->caps()->isConfigRenderable((x), false)) { \
     return (x);                                          \
   }
-
   RETURN_IF_RENDERABLE(kRGBA_8888_GrPixelConfig);
   RETURN_IF_RENDERABLE(kRGBA_4444_GrPixelConfig);
   RETURN_IF_RENDERABLE(kRGB_565_GrPixelConfig);

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -103,9 +103,7 @@ bool VulkanWindow::CreateSkiaGrContext() {
     return false;
   }
 
-  sk_sp<GrContext> context(GrContext::Create(
-      kVulkan_GrBackend,
-      reinterpret_cast<GrBackendContext>(backend_context.get())));
+  sk_sp<GrContext> context = GrContext::MakeVulkan(backend_context);
 
   if (context == nullptr) {
     return false;


### PR DESCRIPTION
Use backend-specific factories that take and return sk_sp<>s rather than bare pointers.