### PR TITLE
Roll topaz to 046105efd225ed61c94e65dbd4a528256a3a34a9

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -127,7 +127,7 @@ deps = {
    Var('fuchsia_git') + '/garnet' + '@' + 'b3ba6b6d6ab8ef658278cc43c9f839a8a8d1718e',
 
   'src/topaz':
-   Var('fuchsia_git') + '/topaz' + '@' + '08a3394395036a2bb9b556f5b0eb8f365d2c0fa5',
+   Var('fuchsia_git') + '/topaz' + '@' + '046105efd225ed61c94e65dbd4a528256a3a34a9',
 
   'src/third_party/benchmark':
    Var('fuchsia_git') + '/third_party/benchmark' + '@' + '296537bc48d380adf21567c5d736ab79f5363d22',

--- a/travis/licenses_golden/licenses_topaz
+++ b/travis/licenses_golden/licenses_topaz
@@ -1,4 +1,4 @@
-Signature: 7f357165eef1d3c274d05d52eac7ddda
+Signature: 8cb3458ba27bd953669ce82a810ccef6
 
 UNUSED LICENSES:
 
@@ -1185,6 +1185,7 @@ FILE: ../../../topaz/public/dart/zircon/lib/src/handle_wrapper.dart
 FILE: ../../../topaz/public/dart/zircon/lib/src/socket.dart
 FILE: ../../../topaz/public/dart/zircon/lib/src/socket_reader.dart
 FILE: ../../../topaz/public/dart/zircon/lib/src/vmo.dart
+FILE: ../../../topaz/public/lib/fidl/dart/lib/src/bindings/codec2.dart
 FILE: ../../../topaz/public/lib/proposal/dart/lib/proposal.dart
 FILE: ../../../topaz/public/lib/proposal/dart/lib/src/proposal_factory.dart
 FILE: ../../../topaz/public/lib/user/dart/lib/src/dank_user_shell_impl.dart


### PR DESCRIPTION
Lands
https://fuchsia.googlesource.com/topaz/+/046105efd225ed61c94e65dbd4a528256a3a34a9
which adds support for general handling of URI %xx escape sequences.
This enables support for paths including accents, CJK characters, emoji,
etc.