### PR TITLE
Restrict clang-format to C, C++, Obj-C, Obj-C++

### DIFF
--- a/travis/format.sh
+++ b/travis/format.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
+#
+# Code formatting presubmit
+#
+# This presubmit script ensures that code under the src/flutter directory is
+# formatted according to the Flutter engine style requirements. On failure, a
+# diff is emitted that can be applied from within the src/flutter directory
+# via:
+#
+# patch -p0 < diff.patch
+
 set -e
 echo "Checking formatting..."
 
@@ -15,13 +25,19 @@ case "$(uname -s)" in
     ;;
 esac
 
+# Tools
 CLANG_FORMAT="../buildtools/$OS/clang/bin/clang-format"
-$CLANG_FORMAT --version
 CLANG_FORMAT_DIFF="../buildtools/$OS/clang/share/clang/clang-format-diff.py"
+$CLANG_FORMAT --version
 
-DIFFS="$(git diff -U0 --no-color master | "$CLANG_FORMAT_DIFF" -p1 -binary "$CLANG_FORMAT")"
+# Compute the diffs.
+FILETYPES="*.c *.cc *.cpp *.h *.m *.mm"
+DIFF_OPTS="-U0 --no-color"
+DIFFS="$(git diff $DIFF_OPTS -- master $FILETYPES | "$CLANG_FORMAT_DIFF" -p1 -binary "$CLANG_FORMAT")"
+
 if [[ ! -z "$DIFFS" ]]; then
   echo ""
-  echo "ERROR: Some files are formatted incorrectly. To fix, apply diffs below:"
+  echo "ERROR: Some files are formatted incorrectly. To fix, apply diffs below via patch -p0:"
   echo "$DIFFS"
+  exit 1
 fi


### PR DESCRIPTION
This re-enables whitelisting of specific filetypes to avoid diffs
including irrelevant changes in case of formatting issues. It also fixes
a missing exit code.