### PR TITLE
Swap setTraversalBefore to setTraversalAfter, since setTraversalBefore is broken.

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -355,7 +355,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
     String increasedValue,
     String decreasedValue,
     TextDirection textDirection,
-    int nextNodeId,
+    int previousNodeId,
     Float64List transform,
     Int32List children,
   }) {
@@ -376,7 +376,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
                 increasedValue,
                 decreasedValue,
                 textDirection != null ? textDirection.index + 1 : 0,
-                nextNodeId ?? -1,
+                previousNodeId ?? -1,
                 transform,
                 children,);
   }
@@ -396,7 +396,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
     String increasedValue,
     String decreasedValue,
     int textDirection,
-    int nextNodeId,
+    int previousNodeId,
     Float64List transform,
     Int32List children,
   ) native 'SemanticsUpdateBuilder_updateNode';

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -64,7 +64,7 @@ struct SemanticsNode {
   std::string increasedValue;
   std::string decreasedValue;
   int32_t textDirection = 0;  // 0=unknown, 1=rtl, 2=ltr
-  int32_t nextNodeId = -1;
+  int32_t previousNodeId = -1;
 
   SkRect rect = SkRect::MakeEmpty();
   SkMatrix44 transform = SkMatrix44(SkMatrix44::kIdentity_Constructor);

--- a/lib/ui/semantics/semantics_update_builder.cc
+++ b/lib/ui/semantics/semantics_update_builder.cc
@@ -49,7 +49,7 @@ void SemanticsUpdateBuilder::updateNode(int id,
                                         std::string increasedValue,
                                         std::string decreasedValue,
                                         int textDirection,
-                                        int nextNodeId,
+                                        int previousNodeId,
                                         const tonic::Float64List& transform,
                                         const tonic::Int32List& children) {
   SemanticsNode node;
@@ -65,7 +65,7 @@ void SemanticsUpdateBuilder::updateNode(int id,
   node.increasedValue = increasedValue;
   node.decreasedValue = decreasedValue;
   node.textDirection = textDirection;
-  node.nextNodeId = nextNodeId;
+  node.previousNodeId = previousNodeId;
   node.transform.setColMajord(transform.data());
   node.children = std::vector<int32_t>(
       children.data(), children.data() + children.num_elements());

--- a/lib/ui/semantics/semantics_update_builder.h
+++ b/lib/ui/semantics/semantics_update_builder.h
@@ -40,7 +40,7 @@ class SemanticsUpdateBuilder
                   std::string increasedValue,
                   std::string decreasedValue,
                   int textDirection,
-                  int nextNodeId,
+                  int previousNodeId,
                   const tonic::Float64List& transform,
                   const tonic::Int32List& children);
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -236,8 +236,8 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
 
         result.setSelected(object.hasFlag(Flag.IS_SELECTED));
         result.setText(object.getValueLabelHint());
-        result.setTraversalBefore(mOwner,
-            object.nextNodeId == -1 ? View.NO_ID : object.nextNodeId);
+        result.setTraversalAfter(mOwner,
+            object.previousNodeId == -1 ? View.NO_ID : object.previousNodeId);
 
         // Accessibility Focus
         if (mA11yFocusedObject != null && mA11yFocusedObject.id == virtualViewId) {
@@ -666,7 +666,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         String decreasedValue;
         String hint;
         TextDirection textDirection;
-        int nextNodeId;
+        int previousNodeId;
 
         boolean hadPreviousConfig = false;
         int previousFlags;
@@ -706,7 +706,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         void log(String indent, boolean recursive) {
           Log.i(TAG, indent + "SemanticsObject id=" + id + " label=" + label + " actions=" +  actions + " flags=" + flags + "\n" +
                      indent + "  +-- textDirection=" + textDirection  + "\n"+
-                     indent + "  +-- nextNodeId=" + nextNodeId  + "\n"+
+                     indent + "  +-- previousNodeId=" + previousNodeId  + "\n"+
                      indent + "  +-- rect.ltrb=(" + left + ", " + top + ", " + right + ", " + bottom + ")\n" +
                      indent + "  +-- transform=" + Arrays.toString(transform) + "\n");
           if (children != null && recursive) {
@@ -746,7 +746,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
 
             textDirection = TextDirection.fromInt(buffer.getInt());
 
-            nextNodeId = buffer.getInt();
+            previousNodeId = buffer.getInt();
 
             left = buffer.getFloat();
             top = buffer.getFloat();

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -523,7 +523,7 @@ void PlatformViewAndroid::UpdateSemantics(
         strings.push_back(node.hint);
       }
       buffer_int32[position++] = node.textDirection;
-      buffer_int32[position++] = node.nextNodeId;
+      buffer_int32[position++] = node.previousNodeId;
       buffer_float32[position++] = node.rect.left();
       buffer_float32[position++] = node.rect.top();
       buffer_float32[position++] = node.rect.right();


### PR DESCRIPTION
It seems that `setTraversalBefore` doesn't work as well as `setTraversalAfter` for some reason, although I'm using them the same way. Some apps would lock up TalkBack when traversing if `setTraversalBefore` was set, but not with the equivalent `setTraversalAfter`.

It's not entirely clear why this is, but I'm going with this to at least get it fixed for apps we know about.

Fixes https://github.com/flutter/flutter/issues/14600

See also https://github.com/flutter/flutter/pull/14607