### PR TITLE
Roll topaz to 531e2778d86b213bc663ea51bb0e0dde33d8ac8c

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -127,7 +127,7 @@ deps = {
    Var('fuchsia_git') + '/garnet' + '@' + 'b3ba6b6d6ab8ef658278cc43c9f839a8a8d1718e',
 
   'src/topaz':
-   Var('fuchsia_git') + '/topaz' + '@' + '046105efd225ed61c94e65dbd4a528256a3a34a9',
+   Var('fuchsia_git') + '/topaz' + '@' + '531e2778d86b213bc663ea51bb0e0dde33d8ac8c',
 
   'src/third_party/benchmark':
    Var('fuchsia_git') + '/third_party/benchmark' + '@' + '296537bc48d380adf21567c5d736ab79f5363d22',

--- a/travis/licenses_golden/licenses_topaz
+++ b/travis/licenses_golden/licenses_topaz
@@ -1,4 +1,4 @@
-Signature: 8cb3458ba27bd953669ce82a810ccef6
+Signature: 4728e5f9d4d6e0bccb12726a4f88a58c
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Includes https://fuchsia-review.googlesource.com/c/topaz/+/121856, which
enables path sanitization for Dart source loaded directly from from
file:// URIs (e.g., main entry points from flutter_tester).