### PR TITLE
Fix unguarded availability warnings for iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -198,7 +198,7 @@
 
 - (void)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
-               completionHandler:(void (^)(BOOL succeeded))completionHandler {
+               completionHandler:(void (^)(BOOL succeeded))completionHandler NS_AVAILABLE_IOS(9_0) {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       if ([plugin application:application

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -106,9 +106,8 @@ IOSGLContext::IOSGLContext(PlatformView::SurfaceConfig config, CAEAGLLayer* laye
   // should use iOS APIs to perform the final correction step based on the
   // device properties.  Ex: We can indicate that we have rendered in P3, and
   // the framework will do the final adjustment for us.
-  NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
   color_space_ = SkColorSpace::MakeSRGB();
-  if (version.majorVersion >= 10) {
+  if (@available(iOS 10, *)) {
     UIDisplayGamut displayGamut = [UIScreen mainScreen].traitCollection.displayGamut;
     switch (displayGamut) {
       case UIDisplayGamutP3:


### PR DESCRIPTION
Place all iOS code that relies on APIs introduced in iOS versions later
than our base SDK version (iOS 8) behind @available checks. This allows
us to enable the -Wunguarded-availability compiler flag for iOS builds
in the buildroot repo.