### PR TITLE
Run Travis analysis/licences scripts under bash

### DIFF
--- a/travis/analyze.sh
+++ b/travis/analyze.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 echo "Analyzing dart:ui library..."
 RESULTS=`dartanalyzer                                                          \
   --options flutter/analysis_options.yaml                                      \

--- a/travis/licenses.sh
+++ b/travis/licenses.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 shopt -s nullglob
 


### PR DESCRIPTION
/bin/sh, for example, doesn't support pushd/popd.