### PR TITLE
Roll buildroot to 06e2d5a3e84459931ca9bedd3171c76f9953ebfa

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -115,7 +115,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '9881cb0513c95c341e432670dbd1add0c76b7da9',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '06e2d5a3e84459931ca9bedd3171c76f9953ebfa',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Inlcudes:
* Enable -Wunguaraded-availability for iOS builds (flutter/buildroot#126)
* Eliminate is_nacl from build config (flutter/buildroot#127)