### PR TITLE
Make Paragraph methods really return List<int> if they are declared as such.

### DIFF
--- a/lib/ui/text/paragraph_impl_blink.cc
+++ b/lib/ui/text/paragraph_impl_blink.cc
@@ -145,7 +145,7 @@ int ParagraphImplBlink::absoluteOffsetForPosition(
 Dart_Handle ParagraphImplBlink::getPositionForOffset(double dx, double dy) {
   LayoutPoint point(dx, dy);
   PositionWithAffinity position = m_renderView->positionForPoint(point);
-  Dart_Handle result = Dart_NewList(2);
+  Dart_Handle result = Dart_NewListOf(Dart_CoreType_Int, 2);
   Dart_ListSetAt(result, 0, ToDart(absoluteOffsetForPosition(position)));
   Dart_ListSetAt(result, 1, ToDart(static_cast<int>(position.affinity())));
   return result;
@@ -171,7 +171,7 @@ Dart_Handle ParagraphImplBlink::getWordBoundary(unsigned offset) {
     start = it->previous();
   }
 
-  Dart_Handle result = Dart_NewList(2);
+  Dart_Handle result = Dart_NewListOf(Dart_CoreType_Int, 2);
   Dart_ListSetAt(result, 0, ToDart(start));
   Dart_ListSetAt(result, 1, ToDart(end));
   return result;

--- a/lib/ui/text/paragraph_impl_txt.cc
+++ b/lib/ui/text/paragraph_impl_txt.cc
@@ -74,7 +74,7 @@ std::vector<TextBox> ParagraphImplTxt::getRectsForRange(unsigned start,
 }
 
 Dart_Handle ParagraphImplTxt::getPositionForOffset(double dx, double dy) {
-  Dart_Handle result = Dart_NewList(2);
+  Dart_Handle result = Dart_NewListOf(Dart_CoreType_Int, 2);
   txt::Paragraph::PositionWithAffinity pos =
       m_paragraph->GetGlyphPositionAtCoordinate(dx, dy);
   Dart_ListSetAt(result, 0, ToDart(pos.position));
@@ -84,7 +84,7 @@ Dart_Handle ParagraphImplTxt::getPositionForOffset(double dx, double dy) {
 
 Dart_Handle ParagraphImplTxt::getWordBoundary(unsigned offset) {
   txt::Paragraph::Range<size_t> point = m_paragraph->GetWordBoundary(offset);
-  Dart_Handle result = Dart_NewList(2);
+  Dart_Handle result = Dart_NewListOf(Dart_CoreType_Int, 2);
   Dart_ListSetAt(result, 0, ToDart(point.start));
   Dart_ListSetAt(result, 1, ToDart(point.end));
   return result;


### PR DESCRIPTION
Changed methods `_getPositionForOffset` and `getWordBoundary` to use
`Dart_NewListOf(Dart_CoreType_Int, ...)`.