### PR TITLE
libtxt: miscellaneous cleanup

### DIFF
--- a/third_party/txt/benchmarks/paragraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_benchmarks.cc
@@ -175,6 +175,7 @@ static void BM_ParagraphTextBigO(benchmark::State& state) {
   std::u16string u16_text(text.data(), text.data() + text.size());
 
   txt::ParagraphStyle paragraph_style;
+  paragraph_style.font_family = "Roboto";
 
   txt::TextStyle text_style;
   text_style.font_family = "Roboto";
@@ -315,7 +316,9 @@ static void BM_ParagraphPaintDecoration(benchmark::State& state) {
 
   txt::TextStyle text_style;
   text_style.font_family = "Roboto";
-  text_style.decoration = TextDecoration(0x1 | 0x2 | 0x4);
+  text_style.decoration = TextDecoration::kUnderline |
+                          TextDecoration::kOverline |
+                          TextDecoration::kLineThrough;
   text_style.decoration_style = TextDecorationStyle(kSolid);
   text_style.color = SK_ColorBLACK;
 

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -300,10 +300,7 @@ class Paragraph {
   double GetLineXOffset(size_t line);
 
   // Creates and draws the decorations onto the canvas.
-  void PaintDecorations(SkCanvas* canvas,
-                        double x,
-                        double y,
-                        size_t record_index);
+  void PaintDecorations(SkCanvas* canvas, const PaintRecord& record);
 
   FXL_DISALLOW_COPY_AND_ASSIGN(Paragraph);
 };

--- a/third_party/txt/src/txt/text_style.h
+++ b/third_party/txt/src/txt/text_style.h
@@ -30,7 +30,7 @@ namespace txt {
 class TextStyle {
  public:
   SkColor color = SK_ColorWHITE;
-  TextDecoration decoration = TextDecoration::kNone;
+  int decoration = TextDecoration::kNone;
   // Does not make sense to draw a transparent object, so we use it as a default
   // value to indicate no decoration color was set.
   SkColor decoration_color = SK_ColorTRANSPARENT;

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -140,7 +140,9 @@ TEST_F(ParagraphTest, RainbowParagraph) {
   text_style2.font_weight = txt::FontWeight::w600;
   text_style2.color = SK_ColorGREEN;
   text_style2.font_family = "Roboto";
-  text_style2.decoration = txt::TextDecoration(0x1 | 0x2 | 0x4);
+  text_style2.decoration = TextDecoration::kUnderline |
+                           TextDecoration::kOverline |
+                           TextDecoration::kLineThrough;
   text_style2.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style2);
 
@@ -156,7 +158,9 @@ TEST_F(ParagraphTest, RainbowParagraph) {
   text_style4.font_size = 14;
   text_style4.color = SK_ColorBLUE;
   text_style4.font_family = "Roboto";
-  text_style4.decoration = txt::TextDecoration(0x1 | 0x2 | 0x4);
+  text_style4.decoration = TextDecoration::kUnderline |
+                           TextDecoration::kOverline |
+                           TextDecoration::kLineThrough;
   text_style4.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style4);
 
@@ -291,7 +295,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(LeftAlignParagraph)) {
   text_style.word_spacing = 5;
   text_style.color = SK_ColorBLACK;
   text_style.height = 1;
-  text_style.decoration = txt::TextDecoration(0x1);
+  text_style.decoration = TextDecoration::kUnderline;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);
 
@@ -388,7 +392,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
   text_style.word_spacing = 5;
   text_style.color = SK_ColorBLACK;
   text_style.height = 1;
-  text_style.decoration = txt::TextDecoration(0x1);
+  text_style.decoration = TextDecoration::kUnderline;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);
 
@@ -492,7 +496,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(CenterAlignParagraph)) {
   text_style.word_spacing = 5;
   text_style.color = SK_ColorBLACK;
   text_style.height = 1;
-  text_style.decoration = txt::TextDecoration(0x1);
+  text_style.decoration = TextDecoration::kUnderline;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);
 
@@ -598,7 +602,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(JustifyAlignParagraph)) {
   text_style.word_spacing = 5;
   text_style.color = SK_ColorBLACK;
   text_style.height = 1;
-  text_style.decoration = txt::TextDecoration(0x1);
+  text_style.decoration = TextDecoration::kUnderline;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);
 
@@ -665,7 +669,9 @@ TEST_F(ParagraphTest, DecorationsParagraph) {
   text_style.word_spacing = 5;
   text_style.color = SK_ColorBLACK;
   text_style.height = 2;
-  text_style.decoration = txt::TextDecoration(0x1 | 0x2 | 0x4);
+  text_style.decoration = TextDecoration::kUnderline |
+                          TextDecoration::kOverline |
+                          TextDecoration::kLineThrough;
   text_style.decoration_style = txt::TextDecorationStyle::kSolid;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);
@@ -705,7 +711,8 @@ TEST_F(ParagraphTest, DecorationsParagraph) {
 
   for (size_t i = 0; i < 6; ++i) {
     ASSERT_EQ(paragraph->records_[i].style().decoration,
-              txt::TextDecoration(0x1 | 0x2 | 0x4));
+              TextDecoration::kUnderline | TextDecoration::kOverline |
+                  TextDecoration::kLineThrough);
   }
 
   ASSERT_EQ(paragraph->records_[0].style().decoration_style,
@@ -782,7 +789,9 @@ TEST_F(ParagraphTest, ChineseParagraph) {
   text_style.font_size = 35;
   text_style.letter_spacing = 2;
   text_style.font_family = "Source Han Serif CN";
-  text_style.decoration = txt::TextDecoration(0x1 | 0x2 | 0x4);
+  text_style.decoration = TextDecoration::kUnderline |
+                          TextDecoration::kOverline |
+                          TextDecoration::kLineThrough;
   text_style.decoration_style = txt::TextDecorationStyle::kSolid;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);
@@ -825,7 +834,9 @@ TEST_F(ParagraphTest, DISABLED_ArabicParagraph) {
   text_style.font_size = 35;
   text_style.letter_spacing = 2;
   text_style.font_family = "Katibeh";
-  text_style.decoration = txt::TextDecoration(0x1 | 0x2 | 0x4);
+  text_style.decoration = TextDecoration::kUnderline |
+                          TextDecoration::kOverline |
+                          TextDecoration::kLineThrough;
   text_style.decoration_style = txt::TextDecorationStyle::kSolid;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);


### PR DESCRIPTION
* use TextDecoration enums
* replace GetBlobLength with a function that returns runs based on typeface
* a few other minor style fixes