### PR TITLE
Switch on --sync-async in Dart 2 mode

### DIFF
--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -120,9 +120,10 @@ static const char* kDartCheckedModeArgs[] = {
 
 static const char* kDartStrongModeArgs[] = {
     // clang-format off
-    "--strong",
-    "--reify_generic_functions",
     "--limit_ints_to_64_bits",
+    "--reify_generic_functions",
+    "--strong",
+    "--sync_async",
     // clang-format on
 };
 


### PR DESCRIPTION
Enable Dart 2 async semantics when running with the Dart 2 preview flag.

Breaking change was already communicated: https://groups.google.com/forum/#!topic/flutter-dev/3R9qhjNGZk4