### PR TITLE
Place LICENSE as sibling of podspec

### DIFF
--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -213,6 +213,16 @@ copy("copy_framework_podspec") {
   ]
 }
 
+copy("copy_license") {
+  visibility = [ ":*" ]
+  sources = [
+    "//LICENSE",
+  ]
+  outputs = [
+    "$root_out_dir/LICENSE",
+  ]
+}
+
 shared_library("copy_and_verify_framework_headers") {
   visibility = [ ":*" ]
   include_dirs = [ "$_flutter_framework_headers_copy_dir" ]
@@ -232,5 +242,6 @@ group("flutter_framework") {
     ":copy_framework_info_plist",
     ":copy_framework_module_map",
     ":copy_framework_podspec",
+    ":copy_license",
   ]
 }

--- a/shell/platform/darwin/ios/framework/Flutter.podspec
+++ b/shell/platform/darwin/ios/framework/Flutter.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
                        DESC
   s.homepage         = 'https://flutter.io'
-  s.license          = { :type => 'MIT', :file => File.join(File.dirname(__FILE__), '../../../../../LICENSE') }
+  s.license          = { :type => 'MIT' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
   s.ios.deployment_target = '7.0'

--- a/shell/platform/darwin/ios/framework/Flutter.podspec
+++ b/shell/platform/darwin/ios/framework/Flutter.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
                        DESC
   s.homepage         = 'https://flutter.io'
-  s.license          = { :type => 'MIT', :file => '../../../../../LICENSE' }
+  s.license          = { :type => 'MIT', :file => File.join(File.dirname(__FILE__), '../../../../../LICENSE') }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
   s.ios.deployment_target = '7.0'


### PR DESCRIPTION
This change is needed in order to land https://github.com/flutter/flutter/pull/14748.

Following that change to the Flutter repo, local pods will be located via symlinks, allowing developers to check in and share the resulting `Podfile.lock`, as it will now be free of absolute paths to files on the developers' machines.

When a local pod's podspec uses relative paths, those paths are resolved by `pod` relative to the symlink used to locate the podspec itself. But that fails when the relative path contains a prefix of `..` path elements.

This change also makes resolving the LICENSE file work when local engine is used along with other pods.