### PR TITLE
Relabel the performance overlay graphs

### DIFF
--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -106,11 +106,11 @@ void PerformanceOverlayLayer::Paint(PaintContext& context) const {
   VisualizeStopWatch(context.canvas, context.frame_time, x, y, width,
                      height - padding,
                      options_ & kVisualizeRasterizerStatistics,
-                     options_ & kDisplayRasterizerStatistics, "Rasterizer");
+                     options_ & kDisplayRasterizerStatistics, "GPU");
 
   VisualizeStopWatch(context.canvas, context.engine_time, x, y + height, width,
                      height - padding, options_ & kVisualizeEngineStatistics,
-                     options_ & kDisplayEngineStatistics, "Engine");
+                     options_ & kDisplayEngineStatistics, "UI");
 
   VisualizeCounterValuesBytes(
       context.canvas, context.memory_usage, x, y + (2 * height), width,


### PR DESCRIPTION
The existing names are a bit confusing, especially `Engine` where the time is actually spent in the framework. Match the thread/chrome tracing names.