### PR TITLE
Re-enable Dart_TimelineGetMicros on init on macOS

### DIFF
--- a/shell/platform/darwin/common/platform_mac.mm
+++ b/shell/platform/darwin/common/platform_mac.mm
@@ -34,11 +34,7 @@ class EmbedderState {
   EmbedderState(std::string icu_data_path,
                 std::string application_library_path,
                 std::string bundle_path) {
-#if TARGET_OS_IPHONE
-    // This calls crashes on MacOS because we haven't run Dart_Initialize yet.
-    // See https://github.com/flutter/flutter/issues/4006
     blink::engine_main_enter_ts = Dart_TimelineGetMicros();
-#endif
     FXL_DCHECK([NSThread isMainThread])
         << "Embedder initialization must occur on the main platform thread";
 


### PR DESCRIPTION
Previously, a call to Dart_TimelineGetMicros() before a call to
Dart_Initialize() resulted in a crash. This was fixed in
dart-lang/sdk@7434bcad57b567c4b62d48b11b99c323cb245d66.

Related:
* flutter/flutter#4006: SkyShell.app on Mac crashes on startup
* dart-lang/sdk#26486:  [dart_tools_api.h] Dart_TimelineGetMicros crashes on Mac if called before Dart_Initialize