### PR TITLE
Update how create a null GrVkAlloc object.

### DIFF
--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -199,7 +199,7 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(GrContext* gr_context,
 
   const GrVkImageInfo image_info = {
       .fImage = image,
-      .fAlloc = {VK_NULL_HANDLE, 0, 0, 0},
+      .fAlloc = GrVkAlloc(),
       .fImageTiling = VK_IMAGE_TILING_OPTIMAL,
       .fImageLayout = VK_IMAGE_LAYOUT_UNDEFINED,
       .fFormat = surface_format_.format,


### PR DESCRIPTION
When resetting to a null GrVkAlloc alloc use the default ctor instead of the { } initializer. This is needed so an upcoming Skia change doesn't break the flutter build.