### PR TITLE
Fix analyzer warning.

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -214,7 +214,7 @@ class _FrontendCompiler implements CompilerInterface {
 
       final String depfile = options['depfile'];
       if (depfile != null) {
-        await _writeDepfile(program, _kernelBinaryFilename, depfile);
+        _writeDepfile(program, _kernelBinaryFilename, depfile);
       }
 
       _kernelBinaryFilename = _kernelBinaryFilenameIncremental;

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -337,7 +337,7 @@ String _escapePath(String path) {
 }
 
 // https://ninja-build.org/manual.html#_depfile
-Future<void> _writeDepfile(Program program, String output, String depfile) async {
+void _writeDepfile(Program program, String output, String depfile) async {
   final IOSink file = new File(depfile).openWrite();
   file.write(_escapePath(output));
   file.write(':');

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -214,7 +214,7 @@ class _FrontendCompiler implements CompilerInterface {
 
       final String depfile = options['depfile'];
       if (depfile != null) {
-        _writeDepfile(program, _kernelBinaryFilename, depfile);
+        await _writeDepfile(program, _kernelBinaryFilename, depfile);
       }
 
       _kernelBinaryFilename = _kernelBinaryFilenameIncremental;
@@ -337,7 +337,8 @@ String _escapePath(String path) {
 }
 
 // https://ninja-build.org/manual.html#_depfile
-void _writeDepfile(Program program, String output, String depfile) async {
+// TODO(dartbug.com/32320) Clean up analyzer directive below once that is fixed.
+Future<void> _writeDepfile(Program program, String output, String depfile) async { // ignore: missing_return
   final IOSink file = new File(depfile).openWrite();
   file.write(_escapePath(output));
   file.write(':');


### PR DESCRIPTION
Fix analyzer warning:
```
  warning • This function declares a return type of 'Future<void>', but doesn't end with a return statement at flutter/frontend_server/lib/server.dart:340:1 • missing_return
```

This is follow-up to 86ec3db218df50190caebcc13ae7f7122bc1032b