### PR TITLE
Use VkExportMemoryAllocateInfoKHR for allocating exportable memory

### DIFF
--- a/content_handler/vulkan_surface.cc
+++ b/content_handler/vulkan_surface.cc
@@ -199,10 +199,13 @@ bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrContext> context,
       break;
     }
   }
-
+  VkExportMemoryAllocateInfoKHR export_allocate_info = {
+      .sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR,
+      .pNext = nullptr,
+      .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_FUCHSIA_VMO_BIT_KHR};
   const VkMemoryAllocateInfo alloc_info = {
       .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
-      .pNext = nullptr,
+      .pNext = &export_allocate_info,
       .allocationSize = memory_reqs.size,
       .memoryTypeIndex = memory_type,
   };


### PR DESCRIPTION
This is needed by some drivers, according to the Valid Usage for the  VkMemoryGet*InfoKHR functions in the vulkan spec.