### PR TITLE
Revert "Enable libtxt as the default text renderer (#4697)"

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -120,7 +120,7 @@ void Shell::InitStandalone(fxl::CommandLine command_line,
       command_line.HasOption(FlagForSwitch(Switch::EnableSoftwareRendering));
 
   settings.using_blink =
-      command_line.HasOption(FlagForSwitch(Switch::EnableBlink));
+      !command_line.HasOption(FlagForSwitch(Switch::EnableTxt));
 
   settings.endless_trace_buffer =
       command_line.HasOption(FlagForSwitch(Switch::EndlessTraceBuffer));

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -63,9 +63,9 @@ DEF_SWITCH(SkiaDeterministicRendering,
            "Skips the call to SkGraphics::Init(), thus avoiding swapping out"
            "some Skia function pointers based on available CPU features. This"
            "is used to obtain 100% deterministic behavior in Skia rendering.")
-DEF_SWITCH(EnableBlink,
-           "enable-blink",
-           "Enable Blink as the text shaping library instead of libtxt.")
+DEF_SWITCH(EnableTxt,
+           "enable-txt",
+           "Enable libtxt as the text shaping library instead of Blink.")
 DEF_SWITCH(FLX, "flx", "Specify the FLX path.")
 DEF_SWITCH(FlutterAssetsDir,
            "flutter-assets-dir",


### PR DESCRIPTION
This reverts commit 33b88173f3820690169348859bbdc29133179e0b.

The libtxt font collection cache is consuming too much memory at startup.