### PR TITLE
[fuchsia] Place Observatory in the runner's package instead of linkin…

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -2,12 +2,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("$flutter_root/common/config.gni")
+
 group("flutter") {
   testonly = true
 
   public_deps = [
-    "$flutter_root/lib/snapshot:kernel_platform_files",
     "$flutter_root/lib/snapshot:generate_snapshot_bin",
+    "$flutter_root/lib/snapshot:kernel_platform_files",
     "$flutter_root/sky",
     "$flutter_root/third_party/txt",
   ]
@@ -65,28 +67,61 @@ if (is_fuchsia) {
     deps = [
       "$flutter_root/content_handler:aot",
     ]
+    if (flutter_runtime_mode != "release") {
+      deps += [
+        "//third_party/dart/runtime/observatory:embedded_observatory_archive",
+      ]
+    }
 
     binary = "flutter_aot_runner"
 
-    meta = [ {
-      path = rebase_path("content_handler/meta/sandbox")
-      dest = "sandbox"
-    } ]
+    if (flutter_runtime_mode != "release") {
+      resources = [
+        {
+          path = rebase_path(
+                  "$root_gen_dir/observatory/embedded_archive_observatory.tar")
+          dest = "observatory.tar"
+        },
+      ]
+    }
+
+    meta = [
+      {
+        path = rebase_path("content_handler/meta/sandbox")
+        dest = "sandbox"
+      },
+    ]
   }
 
   package("flutter_jit_runner") {
     deps = [
       "$flutter_root/content_handler:jit",
     ]
+    if (flutter_runtime_mode != "release") {
+      deps += [
+        "//third_party/dart/runtime/observatory:embedded_observatory_archive",
+      ]
+    }
 
     binary = "flutter_jit_runner"
 
-    meta = [ {
-      path = rebase_path("content_handler/meta/sandbox")
-      dest = "sandbox"
-    } ]
-  }
+    if (flutter_runtime_mode != "release") {
+      resources = [
+        {
+          path = rebase_path(
+                  "$root_gen_dir/observatory/embedded_archive_observatory.tar")
+          dest = "observatory.tar"
+        },
+      ]
+    }
 
+    meta = [
+      {
+        path = rebase_path("content_handler/meta/sandbox")
+        dest = "sandbox"
+      },
+    ]
+  }
 } else {
   group("dist") {
     testonly = true

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -45,6 +45,7 @@
 #include "lib/fxl/arraysize.h"
 #include "lib/fxl/build_config.h"
 #include "lib/fxl/files/path.h"
+#include "lib/fxl/files/file.h"
 #include "lib/fxl/logging.h"
 #include "lib/fxl/time/time_delta.h"
 #include "lib/tonic/converter/dart_converter.h"
@@ -68,7 +69,7 @@ using tonic::ToDart;
 namespace dart {
 namespace observatory {
 
-#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
+#if !OS(FUCHSIA) && FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
 
 // These two symbols are defined in |observatory_archive.cc| which is generated
 // by the |//third_party/dart/runtime/observatory:archive_observatory| rule.
@@ -426,11 +427,21 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
 Dart_Handle GetVMServiceAssetsArchiveCallback() {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
   return nullptr;
-#else   // FLUTTER_RUNTIME_MODE
+#elif OS(FUCHSIA)
+  std::vector<uint8_t> observatory_assets_archive;
+  if (!files::ReadFileToVector("pkg/data/observatory.tar",
+                               &observatory_assets_archive)) {
+    FXL_LOG(ERROR) << "Fail to load Observatory archive";
+    return nullptr;
+  }
+  return tonic::DartConverter<tonic::Uint8List>::ToDart(
+      observatory_assets_archive.data(),
+      observatory_assets_archive.size());
+#else
   return tonic::DartConverter<tonic::Uint8List>::ToDart(
       ::dart::observatory::observatory_assets_archive,
       ::dart::observatory::observatory_assets_archive_len);
-#endif  // FLUTTER_RUNTIME_MODE
+#endif
 }
 
 static const char kStdoutStreamId[] = "Stdout";

--- a/sky/engine/core/BUILD.gn
+++ b/sky/engine/core/BUILD.gn
@@ -18,8 +18,9 @@ static_library("core") {
     "$flutter_root/sky/engine/platform",
   ]
 
-  if (flutter_runtime_mode != "release") {
-    # Only include observatory assets in non-release modes.
+  if (flutter_runtime_mode != "release" && !is_fuchsia) {
+    # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
+    # instead puts Observatory into the runner's package.
     deps += [ "//third_party/dart/runtime/observatory:embedded_observatory_archive" ]
   }
 


### PR DESCRIPTION
…g it in.

This allows blobfs to deduplicate it across {dart,flutter}_{jit,aot}_runner.