### PR TITLE
Make deprecated API unavailable

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -130,6 +130,8 @@ public final class FlutterActivityDelegate
      * unavailable on 2018-02-28, following deprecation. This comment is left as
      * a temporary tombstone for reference, to be removed on 2018-03-28 (or at
      * least four weeks after release of unavailability).
+     *
+     * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
      */
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -125,12 +125,12 @@ public final class FlutterActivityDelegate
         return flutterView.getPluginRegistry().onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
-    @Override
-    @Deprecated
-    public boolean onRequestPermissionResult(
-            int requestCode, String[] permissions, int[] grantResults) {
-        return onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
+    /*
+     * Method onRequestPermissionResult(int, String[], int[]) was made
+     * unavailable on 2018-02-28, following deprecation. This comment is left as
+     * a temporary tombstone for reference, to be removed on 2018-03-28 (or at
+     * least four weeks after release of unavailability).
+     */
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/shell/platform/android/io/flutter/app/FlutterActivityEvents.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityEvents.java
@@ -8,7 +8,6 @@ import android.content.ComponentCallbacks2;
 import android.content.Intent;
 import android.os.Bundle;
 import io.flutter.plugin.common.PluginRegistry.ActivityResultListener;
-import io.flutter.plugin.common.PluginRegistry.RequestPermissionResultListener;
 import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 
 /**
@@ -24,7 +23,6 @@ import io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener;
 public interface FlutterActivityEvents
         extends ComponentCallbacks2,
                 ActivityResultListener,
-                RequestPermissionResultListener,
                 RequestPermissionsResultListener {
     /**
      * @see android.app.Activity#onCreate(android.os.Bundle)

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -122,6 +122,8 @@ public class FlutterPluginRegistry
         * was made unavailable on 2018-02-28, following deprecation.
         * This comment is left as a temporary tombstone for reference, to be removed
         * on 2018-03-28 (or at least four weeks after release of unavailability).
+        *
+        * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
         */
 
         @Override
@@ -171,6 +173,8 @@ public class FlutterPluginRegistry
      * unavailable on 2018-02-28, following deprecation. This comment is left as
      * a temporary tombstone for reference, to be removed on 2018-03-28 (or at
      * least four weeks after release of unavailability).
+     *
+     * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
      */
 
     @Override

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 public class FlutterPluginRegistry
   implements PluginRegistry,
-             PluginRegistry.RequestPermissionResultListener,
              PluginRegistry.RequestPermissionsResultListener,
              PluginRegistry.ActivityResultListener,
              PluginRegistry.NewIntentListener,
@@ -118,17 +117,12 @@ public class FlutterPluginRegistry
             return this;
         }
 
-        @Override
-        @Deprecated
-        public Registrar addRequestPermissionResultListener(
-                final RequestPermissionResultListener listener) {
-            return addRequestPermissionsResultListener(new RequestPermissionsResultListener() {
-                @Override
-                public boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
-                    return listener.onRequestPermissionResult(requestCode, permissions, grantResults);
-                }
-            });
-        }
+       /*
+        * Method addRequestPermissionResultListener(RequestPermissionResultListener)
+        * was made unavailable on 2018-02-28, following deprecation.
+        * This comment is left as a temporary tombstone for reference, to be removed
+        * on 2018-03-28 (or at least four weeks after release of unavailability).
+        */
 
         @Override
         public Registrar addRequestPermissionsResultListener(
@@ -172,11 +166,12 @@ public class FlutterPluginRegistry
         return false;
     }
 
-    @Deprecated
-    @Override
-    public boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults) {
-      return onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
+    /*
+     * Method onRequestPermissionResult(int, String[], int[]) was made
+     * unavailable on 2018-02-28, following deprecation. This comment is left as
+     * a temporary tombstone for reference, to be removed on 2018-03-28 (or at
+     * least four weeks after release of unavailability).
+     */
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -132,7 +132,12 @@ public interface PluginRegistry {
          */
         Registrar addRequestPermissionsResultListener(RequestPermissionsResultListener listener);
 
-        /**
+        /*
+         * Method addRequestPermissionResultListener(RequestPermissionResultListener listener)
+         * was made unavailable on 2018-02-28, leaving this comment as a temporary
+         * tombstone for reference. This comment will be removed on 2018-03-28
+         * (or at least four weeks after the unavailability is released).
+         *
          * Adds a callback allowing the plugin to take part in handling incoming
          * calls to {@code Activity#onRequestPermissionsResult(int, String[], int[])}
          * or {@code android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])}.
@@ -144,8 +149,6 @@ public interface PluginRegistry {
          * on 2018-02-06 (or at least four weeks after the deprecation is released). Use
          * {@link #addRequestPermissionsResultListener(RequestPermissionsResultListener)} instead.
          */
-        @Deprecated
-        Registrar addRequestPermissionResultListener(RequestPermissionResultListener listener);
 
         /**
          * Adds a callback allowing the plugin to take part in handling incoming
@@ -195,7 +198,12 @@ public interface PluginRegistry {
         boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
     }
 
-    /**
+    /*
+     * interface RequestPermissionResultListener was made unavailable on
+     * 2018-02-28, leaving this comment as a temporary tombstone for reference.
+     * This comment will be removed on 2018-03-28 (or at least four weeks after
+     * the unavailability is released).
+     *
      * Delegate interface for handling result of permissions requests on
      * behalf of the main {@link Activity}.
      *
@@ -203,16 +211,6 @@ public interface PluginRegistry {
      * unavailable on 2018-02-06 (or at least four weeks after the deprecation is released).
      * Use {@link RequestPermissionsResultListener} instead.
      */
-    interface RequestPermissionResultListener {
-        /**
-         * @return true if the result has been handled.
-         * @deprecated on 2018-01-02 because of misspelling. This method will be made
-         * unavailable on 2018-02-06 (or at least four weeks after the deprecation is released).
-         * Use {@link RequestPermissionsResultListener} instead.
-         */
-        @Deprecated
-        boolean onRequestPermissionResult(int requestCode, String[] permissions, int[] grantResults);
-    }
 
     /**
      * Delegate interface for handling activity results on behalf of the main

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -138,6 +138,8 @@ public interface PluginRegistry {
          * tombstone for reference. This comment will be removed on 2018-03-28
          * (or at least four weeks after the unavailability is released).
          *
+         * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
+         *
          * Adds a callback allowing the plugin to take part in handling incoming
          * calls to {@code Activity#onRequestPermissionsResult(int, String[], int[])}
          * or {@code android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])}.
@@ -203,6 +205,8 @@ public interface PluginRegistry {
      * 2018-02-28, leaving this comment as a temporary tombstone for reference.
      * This comment will be removed on 2018-03-28 (or at least four weeks after
      * the unavailability is released).
+     *
+     * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
      *
      * Delegate interface for handling result of permissions requests on
      * behalf of the main {@link Activity}.


### PR DESCRIPTION
Deprecation grace period is over.
https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
