### PR TITLE
Prepare to enable global type flow analysis in AOT

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -10,6 +10,7 @@ group("flutter") {
   public_deps = [
     "$flutter_root/lib/snapshot:generate_snapshot_bin",
     "$flutter_root/lib/snapshot:kernel_platform_files",
+    "$flutter_root/lib/snapshot:entry_points_json_files",
     "$flutter_root/sky",
     "$flutter_root/third_party/txt",
   ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -14,7 +14,7 @@ group("flutter") {
     "$flutter_root/third_party/txt",
   ]
 
-  if (flutter_aot) {
+  if (flutter_runtime_mode != "debug") {
     public_deps += [
       "$flutter_root/lib/snapshot:entry_points_json_files",
     ]

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -10,10 +10,15 @@ group("flutter") {
   public_deps = [
     "$flutter_root/lib/snapshot:generate_snapshot_bin",
     "$flutter_root/lib/snapshot:kernel_platform_files",
-    "$flutter_root/lib/snapshot:entry_points_json_files",
     "$flutter_root/sky",
     "$flutter_root/third_party/txt",
   ]
+
+  if (flutter_aot) {
+    public_deps += [
+      "$flutter_root/lib/snapshot:entry_points_json_files",
+    ]
+  }
 
   if (!is_fuchsia && !is_fuchsia_host) {
     if (current_toolchain == host_toolchain) {

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -206,9 +206,9 @@ class _FrontendCompiler implements CompilerInterface {
         ];
       }
       final bool aot = options['aot'];
-      final List<String> entryPoints = [];
+      final List<String> entryPoints = <String>[];
       if (aot) {
-        for (String entryPointsFile in [
+        for (String entryPointsFile in <String>[
           'entry_points.json',
           'entry_points_extra.json',
         ]) {

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -44,6 +44,10 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
   ..addFlag('strong',
       help: 'Run compiler in strong mode (uses strong mode semantics)',
       defaultsTo: false)
+  ..addFlag('tfa',
+      help:
+          'Enable global type flow analysis and related transformations in AOT mode.',
+      defaultsTo: false)
   ..addFlag('link-platform',
       help:
           'When in batch mode, link platform kernel file into result kernel file.'
@@ -145,7 +149,7 @@ class _FrontendCompiler implements CompilerInterface {
   BinaryPrinterFactory printerFactory;
 
   CompilerOptions _compilerOptions;
-  Uri _entryPoint;
+  Uri _mainSource;
   ArgResults _options;
 
   IncrementalCompiler _generator;
@@ -155,7 +159,7 @@ class _FrontendCompiler implements CompilerInterface {
   final bool trackWidgetCreation;
   WidgetCreatorTracker widgetCreatorTracker;
 
-  void setEntrypointFilename(String filename) {
+  void setMainSourceFilename(String filename) {
     final Uri filenameUri = Uri.base.resolveUri(new Uri.file(filename));
     _kernelBinaryFilenameFull = _options['output-dill'] ?? '$filename.dill';
     _kernelBinaryFilenameIncremental =
@@ -164,7 +168,7 @@ class _FrontendCompiler implements CompilerInterface {
         ? '${_options["output-dill"]}.incremental.dill'
         : '$filename.incremental.dill';
     _kernelBinaryFilename = _kernelBinaryFilenameFull;
-    _entryPoint = filenameUri;
+    _mainSource = filenameUri;
   }
 
   @override
@@ -174,7 +178,7 @@ class _FrontendCompiler implements CompilerInterface {
     IncrementalCompiler generator,
   }) async {
     _options = options;
-    setEntrypointFilename(filename);
+    setMainSourceFilename(filename);
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln('result $boundaryKey');
     final Uri sdkRoot = _ensureFolderPath(options['sdk-root']);
@@ -201,8 +205,21 @@ class _FrontendCompiler implements CompilerInterface {
           sdkRoot.resolve(platformKernelDill)
         ];
       }
-      program = await _runWithPrintRedirection(() =>
-          compileToKernel(_entryPoint, compilerOptions, aot: options['aot']));
+      final bool aot = options['aot'];
+      final List<String> entryPoints = [];
+      if (aot) {
+        for (String entryPointsFile in [
+          'entry_points.json',
+          'entry_points_extra.json',
+        ]) {
+          entryPoints.add(sdkRoot.resolve(entryPointsFile).toFilePath());
+        }
+      }
+      program = await _runWithPrintRedirection(() => compileToKernel(
+          _mainSource, compilerOptions,
+          aot: aot,
+          useGlobalTypeFlowAnalysis: options['tfa'],
+          entryPoints: entryPoints));
     }
     runFlutterSpecificKernelTransforms(program);
     if (program != null) {
@@ -279,9 +296,10 @@ class _FrontendCompiler implements CompilerInterface {
     _outputStream.writeln('result $boundaryKey');
     await invalidateIfBootstrapping();
     if (filename != null) {
-      setEntrypointFilename(filename);
+      setMainSourceFilename(filename);
     }
-    final Program deltaProgram = await _generator.compile(entryPoint: _entryPoint);
+    final Program deltaProgram =
+        await _generator.compile(entryPoint: _mainSource);
     runFlutterSpecificKernelTransforms(deltaProgram);
     final IOSink sink = new File(_kernelBinaryFilename).openWrite();
     final BinaryPrinter printer = printerFactory.newBinaryPrinter(sink);
@@ -309,7 +327,7 @@ class _FrontendCompiler implements CompilerInterface {
   }
 
   IncrementalCompiler _createGenerator(Uri bootstrapDill) {
-    return new IncrementalCompiler(_compilerOptions, _entryPoint,
+    return new IncrementalCompiler(_compilerOptions, _mainSource,
         bootstrapDill: bootstrapDill);
   }
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -4,6 +4,7 @@
 
 import("$flutter_root/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
+import("//third_party/dart/utils/generate_entry_points_json.gni")
 
 if (is_fuchsia) {
   import("//build/dart/toolchain.gni")
@@ -291,5 +292,41 @@ group("kernel_platform_files") {
   public_deps = [
     ":non_strong_platform",
     ":strong_platform",
+  ]
+}
+
+generate_entry_points_json_with_gen_snapshot("entry_points_json") {
+  input = "$flutter_root/lib/snapshot/snapshot.dart"
+  output = "$root_out_dir/flutter_patched_sdk/entry_points.json"
+  dart_ui = "$flutter_root/lib/ui/ui.dart"
+  vmservice_io = "//third_party/dart/runtime/bin/vmservice/vmservice_io.dart"
+  dart_vm_entry_points_txt = "$flutter_root/runtime/dart_vm_entry_points.txt"
+  dart_io_entries_txt = "//third_party/dart/runtime/bin/dart_io_entries.txt"
+
+  extra_inputs = [
+    dart_ui,
+    vmservice_io,
+    dart_vm_entry_points_txt,
+    dart_io_entries_txt,
+  ]
+
+  extra_args = [
+    "--await_is_keyword",
+    "--url_mapping=dart:ui," + rebase_path(dart_ui),
+    "--url_mapping=dart:vmservice_io," + rebase_path(vmservice_io),
+    "--causal_async_stacks",
+    "--embedder_entry_points_manifest=" + rebase_path(dart_vm_entry_points_txt),
+    "--embedder_entry_points_manifest=" + rebase_path(dart_io_entries_txt),
+  ]
+}
+
+copy_entry_points_extra_json("entry_points_extra_json") {
+  output = "$root_out_dir/flutter_patched_sdk/entry_points_extra.json"
+}
+
+group("entry_points_json_files") {
+  public_deps = [
+    ":entry_points_json",
+    ":entry_points_extra_json",
   ]
 }


### PR DESCRIPTION
* Generate Flutter-specific entry points JSON file while building engine.
* Add ''--tfa' option to front-end server.
* Rename _entryPoint field in front-end server to _mainSource to avoid disambiguation.
