### PR TITLE
Add nil check for country code and language code

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -724,7 +724,8 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   NSLocale* currentLocale = [NSLocale currentLocale];
   NSString* languageCode = [currentLocale objectForKey:NSLocaleLanguageCode];
   NSString* countryCode = [currentLocale objectForKey:NSLocaleCountryCode];
-  [_localizationChannel.get() invokeMethod:@"setLocale" arguments:@[ languageCode, countryCode ]];
+  if (languageCode && countryCode)
+    [_localizationChannel.get() invokeMethod:@"setLocale" arguments:@[ languageCode, countryCode ]];
 }
 
 #pragma mark - Set user settings


### PR DESCRIPTION
NSLocale objectForKey: may return nil for NSLocaleLanguageCode and
NSLocateCountryCode in certain cases.

This adds a defensive nil check for such cases.