### PR TITLE
frontend_server: Specify sdkSummary

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -182,10 +182,13 @@ class _FrontendCompiler implements CompilerInterface {
     final String boundaryKey = new Uuid().generateV4();
     _outputStream.writeln('result $boundaryKey');
     final Uri sdkRoot = _ensureFolderPath(options['sdk-root']);
+    final String platformKernelDill =
+        options['strong'] ? 'platform_strong.dill' : 'platform.dill';
     final CompilerOptions compilerOptions = new CompilerOptions()
       ..sdkRoot = sdkRoot
       ..packagesFileUri = options['packages'] != null ? Uri.base.resolveUri(new Uri.file(options['packages'])) : null
       ..strongMode = options['strong']
+      ..sdkSummary = sdkRoot.resolve(platformKernelDill)
       ..target = new FlutterTarget(new TargetFlags(strongMode: options['strong']))
       ..reportMessages = true;
 
@@ -199,8 +202,6 @@ class _FrontendCompiler implements CompilerInterface {
       if (options['link-platform']) {
         // TODO(aam): Remove linkedDependencies once platform is directly embedded
         // into VM snapshot and http://dartbug.com/30111 is fixed.
-        final String platformKernelDill =
-            options['strong'] ? 'platform_strong.dill' : 'platform.dill';
         compilerOptions.linkedDependencies = <Uri>[
           sdkRoot.resolve(platformKernelDill)
         ];


### PR DESCRIPTION
Without specifying sdkSummary it defaults to vm_outline.dill which is not what we want if using mixins from the sdk. This PR specifies the sdkSummary, and problems should go away.

See
https://github.com/dart-lang/sdk/issues/32368
https://github.com/flutter/flutter/issues/14931

and also try adding `import 'package:collection/collection.dart';` to `flutter_gallery/lib/main.dart`, run flutter in preview dart 2 mode, dump `flutter_gallery/build/app.dill` and look for `library from "package:collection/src/queue_list.dart"` in the output.

Without this PR it will be something like
```
[...]
    method /* from  */ setRange(core2::int start, core2::int end, generic-covariant-impl generic-covariant-interface core2::Iterable<que::_Object&ListMixin^^#T0::#T0> iterable, [core2::int skipCount]) → void
      ;
    method /* from  */ addAll(generic-covariant-impl generic-covariant-interface core2::Iterable<que::_Object&ListMixin^^#T0::#T0> iterable) → void
      ;
[...]
```

with this PR it will be something like
```
[...]
   method /* from  */ setRange(core2::int start, core2::int end, generic-covariant-impl generic-covariant-interface core2::Iterable<que::_Object&ListMixin^^#T0::#T0> iterable, [core2::int skipCount = 0]) → void {
      core2::RangeError::checkValidRange(start, end, this.{core2::List::length});
      core2::int length = end.{core2::num::-}(start);
      if(length.{core2::num::==}(0))
[...]
```

/cc @aam @mraleph 