### PR TITLE
Prepare to package entry points JSON files as artifacts

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -48,6 +48,9 @@ ArgParser _argParser = new ArgParser(allowTrailingOptions: true)
       help:
           'Enable global type flow analysis and related transformations in AOT mode.',
       defaultsTo: false)
+  ..addOption('entry-points',
+      help: 'Path to JSON file with the list of entry points',
+      allowMultiple: true)
   ..addFlag('link-platform',
       help:
           'When in batch mode, link platform kernel file into result kernel file.'
@@ -206,21 +209,11 @@ class _FrontendCompiler implements CompilerInterface {
           sdkRoot.resolve(platformKernelDill)
         ];
       }
-      final bool aot = options['aot'];
-      final List<String> entryPoints = <String>[];
-      if (aot) {
-        for (String entryPointsFile in <String>[
-          'entry_points.json',
-          'entry_points_extra.json',
-        ]) {
-          entryPoints.add(sdkRoot.resolve(entryPointsFile).toFilePath());
-        }
-      }
       program = await _runWithPrintRedirection(() => compileToKernel(
           _mainSource, compilerOptions,
-          aot: aot,
+          aot: options['aot'],
           useGlobalTypeFlowAnalysis: options['tfa'],
-          entryPoints: entryPoints));
+          entryPoints: options['entry-points']));
     }
     runFlutterSpecificKernelTransforms(program);
     if (program != null) {

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -297,7 +297,7 @@ group("kernel_platform_files") {
 
 generate_entry_points_json_with_gen_snapshot("entry_points_json") {
   input = "$flutter_root/lib/snapshot/snapshot.dart"
-  output = "$root_out_dir/flutter_patched_sdk/entry_points.json"
+  output = "$root_out_dir/dart_entry_points/entry_points.json"
   dart_ui = "$flutter_root/lib/ui/ui.dart"
   vmservice_io = "//third_party/dart/runtime/bin/vmservice/vmservice_io.dart"
   dart_vm_entry_points_txt = "$flutter_root/runtime/dart_vm_entry_points.txt"
@@ -321,7 +321,7 @@ generate_entry_points_json_with_gen_snapshot("entry_points_json") {
 }
 
 copy_entry_points_extra_json("entry_points_extra_json") {
-  output = "$root_out_dir/flutter_patched_sdk/entry_points_extra.json"
+  output = "$root_out_dir/dart_entry_points/entry_points_extra.json"
 }
 
 group("entry_points_json_files") {


### PR DESCRIPTION
Flutter downloads only one version of flutter_patched_sdk, which was obtained from host_debug build on Linux. Generated entry points JSON files are different in profile and release builds (as release build omits observatory), so these files should be downloaded independently of flutter_patched_sdk.

This PR moves generated entry points JSON files from flutter_patched_sdk to a separate directory (out/*/dart_entry_points) and adds an option to specify entry points to frontend_server (as Flutter tools will need to pass custom locations of entry points files outside of flutter_patched_sdk).
