### PR TITLE
Use android.view.View as default class for a11y nodes

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -126,7 +126,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
 
         AccessibilityNodeInfo result = AccessibilityNodeInfo.obtain(mOwner, virtualViewId);
         result.setPackageName(mOwner.getContext().getPackageName());
-        result.setClassName("Flutter"); // TODO(goderbauer): Set proper class names
+        result.setClassName("android.view.View");
         result.setSource(mOwner, virtualViewId);
         result.setFocusable(object.isFocusable());
         if (mInputFocusedObject != null)


### PR DESCRIPTION
"Flutter" is not an officially recognized class name and it might cause a11y tests to fail in the future.

/cc @gspencergoog 