### PR TITLE
[fuchsia] depend on correct observatory target

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -75,7 +75,7 @@ if (is_fuchsia) {
     ]
     if (flutter_runtime_mode != "release") {
       deps += [
-        "//third_party/dart/runtime/observatory:embedded_observatory_archive",
+        "//third_party/dart/runtime/observatory:embedded_archive_observatory",
       ]
     }
 
@@ -105,7 +105,7 @@ if (is_fuchsia) {
     ]
     if (flutter_runtime_mode != "release") {
       deps += [
-        "//third_party/dart/runtime/observatory:embedded_observatory_archive",
+        "//third_party/dart/runtime/observatory:embedded_archive_observatory",
       ]
     }
 


### PR DESCRIPTION
The Fuchsia Package targets depend on the observatory FAR archive, which is generated by a rule with a deceptively similar name.