### PR TITLE
Support hot and cold reload when using the APK asset provider on Android

### DIFF
--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -40,13 +40,11 @@ class Engine : public blink::RuntimeDelegate {
                  const std::string& entrypoint = main_entrypoint_,
                  bool reuse_runtime_controller = false);
 
-  // Uses the given snapshot instead of looking inside the bundle for the
-  // snapshot. If |snapshot_override| is empty, this function looks for the
-  // snapshot in the bundle itself.
-  void RunBundleAndSnapshot(const std::string& bundle_path,
-                            const std::string& snapshot_override,
-                            const std::string& entrypoint = main_entrypoint_,
-                            bool reuse_runtime_controller = false);
+  // Uses the given provider to locate assets.
+  void RunBundleWithAssets(fxl::RefPtr<blink::AssetProvider> asset_provider,
+                           const std::string& bundle_path,
+                           const std::string& entrypoint = main_entrypoint_,
+                           bool reuse_runtime_controller = false);
 
   // Uses the given source code instead of looking inside the bundle for the
   // source code.
@@ -94,6 +92,10 @@ class Engine : public blink::RuntimeDelegate {
 
   void StopAnimator();
   void StartAnimatorIfPossible();
+
+  void DoRunBundle(const std::string& script_uri,
+                   const std::string& entrypoint,
+                   bool reuse_runtime_controller);
 
   void ConfigureAssetBundle(const std::string& path);
   void ConfigureRuntime(const std::string& script_uri,

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -126,10 +126,6 @@ VsyncWaiter* PlatformView::GetVsyncWaiter() {
   return vsync_waiter_.get();
 }
 
-fxl::RefPtr<blink::AssetProvider> PlatformView::GetAssetProvider() {
-  return asset_provider_;
-}
-
 void PlatformView::UpdateSemantics(blink::SemanticsNodeUpdates update) {}
 
 void PlatformView::HandlePlatformMessage(

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "flutter/assets/asset_provider.h"
 #include "flutter/flow/texture.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/shell/common/engine.h"
@@ -65,8 +64,6 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
   virtual void HandlePlatformMessage(
       fxl::RefPtr<blink::PlatformMessage> message);
 
-  virtual fxl::RefPtr<blink::AssetProvider> GetAssetProvider();
-
   // Called once per texture, on the platform thread.
   void RegisterTexture(std::shared_ptr<flow::Texture> texture);
 
@@ -100,7 +97,6 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
   flow::TextureRegistry texture_registry_;
   std::unique_ptr<Engine> engine_;
   std::unique_ptr<VsyncWaiter> vsync_waiter_;
-  fxl::RefPtr<blink::AssetProvider> asset_provider_;
 
   SkISize size_;
 


### PR DESCRIPTION
* deprecate snapshot_override, which is an obsolete predecessor of hot reload
* give the APKAssetProvider to the engine in the initial call to RunBundle
* later calls to Engine::RunBundleAndSource or Engine::SetAssetBundlePath
  will replace the APK asset provider with a DirectoryAssetBundle that uses
  the newly pushed assets