### PR TITLE
Revert "Migrate all uses of gtest to googletest (#4728)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -124,7 +124,7 @@ deps = {
    # and not have to specific specific hashes.
 
   'src/garnet':
-   Var('fuchsia_git') + '/garnet' + '@' + '78f46d051a38ed251970b3e3ffe8803815407cc0',
+   Var('fuchsia_git') + '/garnet' + '@' + 'b3ba6b6d6ab8ef658278cc43c9f839a8a8d1718e',
 
   'src/topaz':
    Var('fuchsia_git') + '/topaz' + '@' + 'e331f910c1003d154a4de6e1b5356f8d785fd6ec',
@@ -132,8 +132,8 @@ deps = {
   'src/third_party/benchmark':
    Var('fuchsia_git') + '/third_party/benchmark' + '@' + '296537bc48d380adf21567c5d736ab79f5363d22',
 
-  'src/third_party/googletest':
-   Var('fuchsia_git') + '/third_party/googletest' + '@' + '2072b0053d3537fa5e8d222e34c759987aae1320',
+  'src/third_party/gtest':
+   Var('fuchsia_git') + '/third_party/gtest' + '@' + 'c00f82917331efbbd27124b537e4ccc915a02b72',
 
   'src/third_party/rapidjson':
    Var('fuchsia_git') + '/third_party/rapidjson' + '@' + '9defbb0209a534ffeb3a2b79d5ee440a77407292',

--- a/flow/matrix_decomposition_unittests.cc
+++ b/flow/matrix_decomposition_unittests.cc
@@ -10,7 +10,7 @@
 #include <cmath>
 
 #include "flutter/flow/matrix_decomposition.h"
-#include "gtest/gtest.h"
+#include "third_party/gtest/include/gtest/gtest.h"
 
 TEST(MatrixDecomposition, Rotation) {
   SkMatrix44 matrix = SkMatrix44::I();

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/raster_cache.h"
-#include "gtest/gtest.h"
+#include "third_party/gtest/include/gtest/gtest.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
 

--- a/sky/engine/wtf/BUILD.gn
+++ b/sky/engine/wtf/BUILD.gn
@@ -268,6 +268,6 @@ executable("wtf_unittests") {
 
     # Does not use $flutter_root/testing because it needs and provides its own main
     # function in RunAllTests.cpp.
-    "//third_party/googletest:gtest",
+    "//third_party/gtest",
   ]
 }

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -12,7 +12,7 @@ source_set("testing") {
   ]
 
   public_deps = [
-    "//third_party/googletest:gtest",
+    "//third_party/gtest",
   ]
 
   public_configs = [ "$flutter_root:config" ]

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -177,7 +177,7 @@ executable("txt_unittests") {
 
   deps = [
            ":txt",
-           "//third_party/googletest:gtest",
+           "//third_party/gtest",
          ] + txt_common_executable_deps
 }
 

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -24,7 +24,7 @@
 #include "lib/fxl/macros.h"
 #include "minikin/FontCollection.h"
 #include "minikin/FontFamily.h"
-#include "third_party/googletest/googletest/include/gtest/gtest_prod.h" // nogncheck
+#include "third_party/gtest/include/gtest/gtest_prod.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/ports/SkFontMgr.h"
 #include "txt/asset_font_manager.h"

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -28,7 +28,7 @@
 #include "paint_record.h"
 #include "paragraph_style.h"
 #include "styled_runs.h"
-#include "third_party/googletest/googletest/include/gtest/gtest_prod.h"  // nogncheck
+#include "third_party/gtest/include/gtest/gtest_prod.h"
 #include "third_party/skia/include/core/SkRect.h"
 #include "utils/WindowsUtils.h"
 

--- a/third_party/txt/src/txt/styled_runs.h
+++ b/third_party/txt/src/txt/styled_runs.h
@@ -21,7 +21,7 @@
 #include <vector>
 
 #include "text_style.h"
-#include "third_party/googletest/googletest/include/gtest/gtest_prod.h"  // nogncheck
+#include "third_party/gtest/include/gtest/gtest_prod.h"
 #include "utils/WindowsUtils.h"
 
 namespace txt {

--- a/travis/licenses_golden/licenses_garnet
+++ b/travis/licenses_golden/licenses_garnet
@@ -1,4 +1,4 @@
-Signature: 10d96b2edb99912e94c1d4f3b1a85071
+Signature: c026b4e5f1684c9cf9432f9ef2b62acc
 
 UNUSED LICENSES:
 
@@ -45,25 +45,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: garnet
 ORIGIN: ../../../garnet/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../garnet/.cargo/config
 FILE: ../../../garnet/.dir-locals.el
-FILE: ../../../garnet/Cargo.lock
-FILE: ../../../garnet/Cargo.toml
 FILE: ../../../garnet/manifest/garnet
 FILE: ../../../garnet/manifest/minimal
+FILE: ../../../garnet/manifest/skia
 FILE: ../../../garnet/manifest/third_party
-FILE: ../../../garnet/public/lib/amber/fidl/amber.fidl
-FILE: ../../../garnet/public/lib/auth/fidl/auth_provider.fidl
-FILE: ../../../garnet/public/lib/auth/fidl/auth_provider_factory.fidl
-FILE: ../../../garnet/public/lib/auth/fidl/token_manager.fidl
+FILE: ../../../garnet/public/lib/auth/fidl/account_manager/account_provider.fidl
+FILE: ../../../garnet/public/lib/auth/fidl/token_manager/token_provider.fidl
 FILE: ../../../garnet/public/lib/bluetooth/fidl/common.fidl
 FILE: ../../../garnet/public/lib/bluetooth/fidl/control.fidl
-FILE: ../../../garnet/public/lib/bluetooth/fidl/gatt.fidl
 FILE: ../../../garnet/public/lib/bluetooth/fidl/low_energy.fidl
 FILE: ../../../garnet/public/lib/cobalt/fidl/cobalt.fidl
 FILE: ../../../garnet/public/lib/cobalt/fidl/cobalt_controller.fidl
 FILE: ../../../garnet/public/lib/device_settings/fidl/device_settings.fidl
-FILE: ../../../garnet/public/lib/fidl/go/src/fidl/bindings2/test_types.fidl2
 FILE: ../../../garnet/public/lib/fidl/go/src/fidl/compiler/generated/fidl_files/fidl_files.core.go
 FILE: ../../../garnet/public/lib/fidl/go/src/fidl/compiler/generated/fidl_types/fidl_types.core.go
 FILE: ../../../garnet/public/lib/fidl/rust/fidl/Cargo.toml
@@ -71,9 +65,6 @@ FILE: ../../../garnet/public/lib/fidl/rust/fidl/src/endpoints.rs
 FILE: ../../../garnet/public/lib/fidl/tools/sublime/FIDL.sublime-syntax
 FILE: ../../../garnet/public/lib/fidl/tools/vim/ftdetect/fidl.vim
 FILE: ../../../garnet/public/lib/fidl/tools/vim/syntax/fidl.vim
-FILE: ../../../garnet/public/lib/fsl/fidl/sized_vmo_transport.fidl
-FILE: ../../../garnet/public/lib/fsl/io/fd.cc
-FILE: ../../../garnet/public/lib/fsl/io/fd.h
 FILE: ../../../garnet/public/lib/fsl/socket/blocking_drain_unittest.cc
 FILE: ../../../garnet/public/lib/fsl/socket/strings_unittest.cc
 FILE: ../../../garnet/public/lib/fsl/tasks/fd_waiter.cc
@@ -83,8 +74,6 @@ FILE: ../../../garnet/public/lib/fsl/threading/thread.cc
 FILE: ../../../garnet/public/lib/fsl/threading/thread.h
 FILE: ../../../garnet/public/lib/fsl/threading/thread_unittest.cc
 FILE: ../../../garnet/public/lib/fsl/vmo/file_unittest.cc
-FILE: ../../../garnet/public/lib/fsl/vmo/sized_vmo.cc
-FILE: ../../../garnet/public/lib/fsl/vmo/sized_vmo.h
 FILE: ../../../garnet/public/lib/fxl/files/directory_unittest.cc
 FILE: ../../../garnet/public/lib/fxl/files/file_descriptor_unittest.cc
 FILE: ../../../garnet/public/lib/fxl/files/path_win.cc
@@ -114,19 +103,19 @@ FILE: ../../../garnet/public/lib/fxl/time/time_point_unittest.cc
 FILE: ../../../garnet/public/lib/images/fidl/image_info.fidl
 FILE: ../../../garnet/public/lib/images/fidl/image_pipe.fidl
 FILE: ../../../garnet/public/lib/images/fidl/memory_type.fidl
-FILE: ../../../garnet/public/lib/mdns/fidl/mdns.fidl
 FILE: ../../../garnet/public/lib/media/audio/lpcm_output_stream.cc
 FILE: ../../../garnet/public/lib/media/audio/lpcm_output_stream.h
 FILE: ../../../garnet/public/lib/media/audio/perceived_level.h
 FILE: ../../../garnet/public/lib/media/audio/types.cc
 FILE: ../../../garnet/public/lib/media/audio/types.h
 FILE: ../../../garnet/public/lib/media/c/audio.h
-FILE: ../../../garnet/public/lib/media/fidl/audio_capturer.fidl
 FILE: ../../../garnet/public/lib/media/fidl/audio_policy_service.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_source_channel.fidl
 FILE: ../../../garnet/public/lib/media/fidl/net_media_player.fidl
 FILE: ../../../garnet/public/lib/media/fidl/net_media_service.fidl
 FILE: ../../../garnet/public/lib/media/timeline/fidl_type_conversions.h
 FILE: ../../../garnet/public/lib/netconnector/cpp/net_stub_responder.h
+FILE: ../../../garnet/public/lib/netconnector/fidl/mdns.fidl
 FILE: ../../../garnet/public/lib/netstack/c/netconfig.h
 FILE: ../../../garnet/public/lib/power/fidl/power_manager.fidl
 FILE: ../../../garnet/public/lib/svc/cpp/service_namespace.h
@@ -144,7 +133,6 @@ FILE: ../../../garnet/public/lib/test_runner/cpp/reporting/reporter.h
 FILE: ../../../garnet/public/lib/test_runner/cpp/test_runner.h
 FILE: ../../../garnet/public/lib/test_runner/cpp/test_runner_store_impl.cc
 FILE: ../../../garnet/public/lib/test_runner/cpp/test_runner_store_impl.h
-FILE: ../../../garnet/public/lib/time_service/fidl/time_service.fidl
 FILE: ../../../garnet/public/lib/ui/fun/sketchy/fidl/canvas.fidl
 FILE: ../../../garnet/public/lib/ui/fun/sketchy/fidl/ops.fidl
 FILE: ../../../garnet/public/lib/ui/fun/sketchy/fidl/resources.fidl
@@ -159,7 +147,6 @@ FILE: ../../../garnet/public/lib/ui/input/fidl/text_input.fidl
 FILE: ../../../garnet/public/lib/ui/input/fidl/usages.fidl
 FILE: ../../../garnet/public/lib/ui/input/input_device_impl.cc
 FILE: ../../../garnet/public/lib/ui/input/input_device_impl.h
-FILE: ../../../garnet/public/lib/ui/mozart/fidl/presentation_info.fidl
 FILE: ../../../garnet/public/lib/ui/presentation/fidl/presentation.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/client/host_image_cycler.cc
 FILE: ../../../garnet/public/lib/ui/scenic/client/host_image_cycler.h
@@ -173,6 +160,7 @@ FILE: ../../../garnet/public/lib/ui/scenic/fidl/display_info.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl/events.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl/nodes.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl/ops.fidl
+FILE: ../../../garnet/public/lib/ui/scenic/fidl/presentation_info.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl/renderer.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl/resources.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl/scene_manager.fidl
@@ -181,6 +169,12 @@ FILE: ../../../garnet/public/lib/ui/scenic/fidl/shapes.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl/types.fidl
 FILE: ../../../garnet/public/lib/ui/scenic/fidl_helpers.cc
 FILE: ../../../garnet/public/lib/ui/scenic/fidl_helpers.h
+FILE: ../../../garnet/public/lib/ui/scenic/skia/host_canvas_cycler.cc
+FILE: ../../../garnet/public/lib/ui/scenic/skia/host_canvas_cycler.h
+FILE: ../../../garnet/public/lib/ui/scenic/skia/host_surfaces.cc
+FILE: ../../../garnet/public/lib/ui/scenic/skia/host_surfaces.h
+FILE: ../../../garnet/public/lib/ui/scenic/skia/image_info.cc
+FILE: ../../../garnet/public/lib/ui/scenic/skia/image_info.h
 FILE: ../../../garnet/public/lib/ui/scenic/types.h
 FILE: ../../../garnet/public/lib/ui/sketchy/canvas.cc
 FILE: ../../../garnet/public/lib/ui/sketchy/canvas.h
@@ -189,12 +183,11 @@ FILE: ../../../garnet/public/lib/ui/sketchy/resources.cc
 FILE: ../../../garnet/public/lib/ui/sketchy/resources.h
 FILE: ../../../garnet/public/lib/ui/sketchy/types.cc
 FILE: ../../../garnet/public/lib/ui/sketchy/types.h
+FILE: ../../../garnet/public/lib/ui/view_framework/skia_view.cc
+FILE: ../../../garnet/public/lib/ui/view_framework/skia_view.h
 FILE: ../../../garnet/public/lib/wlan/fidl/wlan_mlme.fidl
 FILE: ../../../garnet/public/lib/wlan/fidl/wlan_mlme_ext.fidl
 FILE: ../../../garnet/public/lib/wlan/fidl/wlan_service.fidl
-FILE: ../../../garnet/tools/vboot_reference/futility_cmds.c
-FILE: ../../../garnet/tools/vboot_reference/uuid/uuid.cc
-FILE: ../../../garnet/tools/vboot_reference/uuid/uuid.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2017 The Fuchsia Authors. All rights reserved.
 
@@ -292,6 +285,7 @@ FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/map_serialization.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/message_header_validator.cc
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/message_header_validator.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/message_internal.h
+FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/no_interface.cc
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/router.cc
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/router.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/shared_data.h
@@ -303,6 +297,7 @@ FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/validation_errors.cc
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/validation_errors.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/map.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/message.h
+FILE: ../../../garnet/public/lib/fidl/cpp/bindings/no_interface.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/string.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/struct_ptr.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/type_converter.h
@@ -367,112 +362,6 @@ FILE: ../../../garnet/public/lib/ui/views/fidl/view_trees.fidl
 FILE: ../../../garnet/public/lib/ui/views/fidl/views.fidl
 ----------------------------------------------------------------------------------------------------
 Copyright 2015 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: garnet
-ORIGIN: ../../../garnet/public/lib/fidl/cpp/internal/header.h + ../../../garnet/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../garnet/public/lib/fidl/cpp/binding.h
-FILE: ../../../garnet/public/lib/fidl/cpp/binding_set.h
-FILE: ../../../garnet/public/lib/fidl/cpp/binding_set_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/binding_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/clone.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/clone.h
-FILE: ../../../garnet/public/lib/fidl/cpp/clone_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/coding_traits.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/coding_traits.h
-FILE: ../../../garnet/public/lib/fidl/cpp/decoder.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/decoder.h
-FILE: ../../../garnet/public/lib/fidl/cpp/encoder.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/encoder.h
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_handle.h
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_handle_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_ptr.h
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_ptr_set.h
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_ptr_set_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_ptr_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_request.h
-FILE: ../../../garnet/public/lib/fidl/cpp/interface_request_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/header.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/implementation.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/message_handler.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/message_handler.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/message_reader.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/message_reader.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/message_reader_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/pending_response.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/pending_response.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/proxy_controller.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/proxy_controller.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/proxy_controller_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/stub.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/stub.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/stub_controller.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/stub_controller.h
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/stub_controller_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/weak_stub_controller.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/internal/weak_stub_controller.h
-FILE: ../../../garnet/public/lib/fidl/cpp/string.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/string.h
-FILE: ../../../garnet/public/lib/fidl/cpp/string_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/cpp/traits.h
-FILE: ../../../garnet/public/lib/fidl/cpp/vector.h
-FILE: ../../../garnet/public/lib/fidl/cpp/vector_unittest.cc
-FILE: ../../../garnet/public/lib/fidl/go/src/fidl/bindings2/encoding.go
-FILE: ../../../garnet/public/lib/fidl/go/src/fidl/bindings2/encoding_test.go
-FILE: ../../../garnet/public/lib/fidl/go/src/fidl/bindings2/message.go
-FILE: ../../../garnet/public/lib/fidl/go/src/fidl/bindings2/test_types.go
-FILE: ../../../garnet/public/lib/fidl/rust/fidl/src/encoding2.rs
-FILE: ../../../garnet/public/lib/fxl/syslogger_init.cc
-FILE: ../../../garnet/public/lib/fxl/syslogger_init.h
-FILE: ../../../garnet/public/lib/fxl/syslogger_init_unittest.cc
-FILE: ../../../garnet/public/lib/gralloc/fidl/gralloc.fidl
-FILE: ../../../garnet/public/lib/images/fidl/encoded_image.fidl
-FILE: ../../../garnet/public/lib/logger/fidl/logger.fidl
-FILE: ../../../garnet/public/lib/mdns/cpp/service_subscriber.cc
-FILE: ../../../garnet/public/lib/mdns/cpp/service_subscriber.h
-FILE: ../../../garnet/public/lib/syslog/cpp/logger.cc
-FILE: ../../../garnet/public/lib/syslog/cpp/logger.h
-FILE: ../../../garnet/public/lib/syslog/cpp/logger_init.cc
-FILE: ../../../garnet/public/lib/syslog/cpp/logger_unittest.cc
-FILE: ../../../garnet/public/lib/ui/mozart/fidl/commands.fidl
-FILE: ../../../garnet/public/lib/ui/mozart/fidl/dummy_system/commands.fidl
-FILE: ../../../garnet/public/lib/ui/mozart/fidl/dummy_system/events.fidl
-FILE: ../../../garnet/public/lib/ui/mozart/fidl/events.fidl
-FILE: ../../../garnet/public/lib/ui/mozart/fidl/mozart.fidl
-FILE: ../../../garnet/public/lib/ui/mozart/fidl/session.fidl
-FILE: ../../../garnet/public/lib/ui/presentation/fidl/display_usage.fidl
-FILE: ../../../garnet/public/lib/ui/views/fidl/commands.fidl
-FILE: ../../../garnet/public/lib/ui/views/fidl/events.fidl
-----------------------------------------------------------------------------------------------------
-Copyright 2018 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -609,6 +498,42 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: garnet
+ORIGIN: ../../../garnet/public/lib/ui/skia/type_converters.cc + ../../../LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../garnet/public/lib/ui/skia/type_converters.cc
+FILE: ../../../garnet/public/lib/ui/skia/type_converters.h
+----------------------------------------------------------------------------------------------------
+Copyright 2016 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: garnet
 ORIGIN: ../../../third_party/icu/scripts/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../garnet/public/lib/fidl/go/src/fidl/bindings/async_waiter.go
@@ -661,11 +586,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: garnet
 ORIGIN: ../../../topaz/LICENSE
 TYPE: LicenseType.bsd
+FILE: ../../../garnet/public/lib/fidl/c/waiter/async_waiter.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/formatting.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/message_validator.cc
+FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/synchronous_connector.cc
+FILE: ../../../garnet/public/lib/fidl/cpp/bindings/internal/synchronous_connector.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/message_validator.h
 FILE: ../../../garnet/public/lib/fidl/cpp/bindings/synchronous_interface_ptr.h
+FILE: ../../../garnet/public/lib/fidl/cpp/waiter/default.h
 FILE: ../../../garnet/public/lib/fidl/rust/fidl/src/client.rs
+FILE: ../../../garnet/public/lib/fidl/rust/fidl/src/cookiemap.rs
 FILE: ../../../garnet/public/lib/fidl/rust/fidl/src/encoding.rs
 FILE: ../../../garnet/public/lib/fidl/rust/fidl/src/error.rs
 FILE: ../../../garnet/public/lib/fidl/rust/fidl/src/interface.rs
@@ -711,6 +641,7 @@ FILE: ../../../garnet/public/lib/fsl/vmo/strings_unittest.cc
 FILE: ../../../garnet/public/lib/fsl/vmo/vector.h
 FILE: ../../../garnet/public/lib/fsl/vmo/vector_unittest.cc
 FILE: ../../../garnet/public/lib/fsl/vmo/vmo.cc
+FILE: ../../../garnet/public/lib/fsl/waiter/default.cc
 FILE: ../../../garnet/public/lib/fxl/arraysize.h
 FILE: ../../../garnet/public/lib/fxl/arraysize_unittest.cc
 FILE: ../../../garnet/public/lib/fxl/build_config.h
@@ -820,6 +751,15 @@ FILE: ../../../garnet/public/lib/icu_data/fidl/icu_data.fidl
 FILE: ../../../garnet/public/lib/media/audio/perceived_level.cc
 FILE: ../../../garnet/public/lib/media/fidl/audio_renderer.fidl
 FILE: ../../../garnet/public/lib/media/fidl/audio_server.fidl
+FILE: ../../../garnet/public/lib/media/fidl/flog/flog.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_demux_channel.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_packet_consumer_channel.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_packet_producer_channel.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_player_channel.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_renderer_channel.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_sink_channel.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_timeline_control_point_channel.fidl
+FILE: ../../../garnet/public/lib/media/fidl/logs/media_type_converter_channel.fidl
 FILE: ../../../garnet/public/lib/media/fidl/media_capturer.fidl
 FILE: ../../../garnet/public/lib/media/fidl/media_metadata.fidl
 FILE: ../../../garnet/public/lib/media/fidl/media_player.fidl
@@ -835,8 +775,9 @@ FILE: ../../../garnet/public/lib/media/fidl/problem.fidl
 FILE: ../../../garnet/public/lib/media/fidl/seeking_reader.fidl
 FILE: ../../../garnet/public/lib/media/fidl/timeline_controller.fidl
 FILE: ../../../garnet/public/lib/media/fidl/timelines.fidl
-FILE: ../../../garnet/public/lib/media/fidl/tts_service.fidl
 FILE: ../../../garnet/public/lib/media/fidl/video_renderer.fidl
+FILE: ../../../garnet/public/lib/media/flog/flog.cc
+FILE: ../../../garnet/public/lib/media/flog/flog.h
 FILE: ../../../garnet/public/lib/media/timeline/fidl_type_conversions.cc
 FILE: ../../../garnet/public/lib/media/timeline/timeline.h
 FILE: ../../../garnet/public/lib/media/timeline/timeline_function.cc
@@ -855,11 +796,12 @@ FILE: ../../../garnet/public/lib/media/transport/shared_buffer_set.cc
 FILE: ../../../garnet/public/lib/media/transport/shared_buffer_set.h
 FILE: ../../../garnet/public/lib/media/transport/shared_buffer_set_allocator.cc
 FILE: ../../../garnet/public/lib/media/transport/shared_buffer_set_allocator.h
+FILE: ../../../garnet/public/lib/netconnector/cpp/async_wait.cc
+FILE: ../../../garnet/public/lib/netconnector/cpp/async_wait.h
 FILE: ../../../garnet/public/lib/netconnector/cpp/message_relay.cc
 FILE: ../../../garnet/public/lib/netconnector/cpp/message_relay.h
 FILE: ../../../garnet/public/lib/netconnector/fidl/netconnector.fidl
 FILE: ../../../garnet/public/lib/network/fidl/url_body.fidl
-FILE: ../../../garnet/public/lib/syslog/cpp/run_all_unittests.cc
 FILE: ../../../garnet/public/lib/test_runner/cpp/scope.cc
 FILE: ../../../garnet/public/lib/test_runner/cpp/scope.h
 FILE: ../../../garnet/public/lib/test_runner/cpp/test_runner.cc
@@ -875,6 +817,10 @@ FILE: ../../../garnet/public/lib/ui/geometry/fidl/geometry.fidl
 FILE: ../../../garnet/public/lib/ui/input/cpp/formatting.cc
 FILE: ../../../garnet/public/lib/ui/input/cpp/formatting.h
 FILE: ../../../garnet/public/lib/ui/presentation/fidl/presenter.fidl
+FILE: ../../../garnet/public/lib/ui/skia/skia_font_loader.cc
+FILE: ../../../garnet/public/lib/ui/skia/skia_font_loader.h
+FILE: ../../../garnet/public/lib/ui/skia/skia_vmo_data.cc
+FILE: ../../../garnet/public/lib/ui/skia/skia_vmo_data.h
 FILE: ../../../garnet/public/lib/ui/view_framework/view_provider_app.cc
 FILE: ../../../garnet/public/lib/ui/view_framework/view_provider_app.h
 FILE: ../../../garnet/public/lib/ui/views/fidl/view_containers.fidl

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 82f1b51fbaae89c69886cffe433be160 
+Signature: 760da5baa5ca7f39360c7d0ccdc84a44
 
 UNUSED LICENSES:
 
@@ -32,214 +32,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-ORIGIN: ../../../third_party/googletest/googlemock/scripts/generator/LICENSE
-TYPE: LicenseType.apache
-----------------------------------------------------------------------------------------------------
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   "License" shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   "Licensor" shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   "Legal Entity" shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   "control" means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   "You" (or "Your") shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   "Source" form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   "Object" form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   "Work" shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   "Derivative Works" shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   "Contribution" shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, "submitted"
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as "Not a Contribution."
-
-   "Contributor" shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a "NOTICE" text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets "[]"
-   replaced with your own identifying information. (Don't include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same "printed page" as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [2007] Neal Norwitz
-Portions Copyright [2007] Google Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
 ====================================================================================================
 
 ====================================================================================================
@@ -491,7 +283,7 @@ USED LICENSES:
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/CHANGES
@@ -542,84 +334,43 @@ FILE: ../../../third_party/boringssl/src/third_party/googletest/xcode/Samples/Fr
 FILE: ../../../third_party/boringssl/src/third_party/googletest/xcode/Samples/FrameworkSample/widget.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/xcode/Samples/FrameworkSample/widget_test.cc
 FILE: ../../../third_party/boringssl/src/third_party/googletest/xcode/gtest.xcodeproj/project.pbxproj
-FILE: ../../../third_party/googletest/WORKSPACE
-FILE: ../../../third_party/googletest/appveyor.yml
-FILE: ../../../third_party/googletest/googlemock/CHANGES
-FILE: ../../../third_party/googletest/googlemock/CONTRIBUTORS
-FILE: ../../../third_party/googletest/googlemock/cmake/gmock.pc.in
-FILE: ../../../third_party/googletest/googlemock/cmake/gmock_main.pc.in
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-matchers.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-matchers.h.pump
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-nice-strict.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-nice-strict.h.pump
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/custom/gmock-generated-actions.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/custom/gmock-generated-actions.h.pump
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/gmock-port.h
-FILE: ../../../third_party/googletest/googlemock/msvc/2005/gmock.sln
-FILE: ../../../third_party/googletest/googlemock/msvc/2005/gmock.vcproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2005/gmock_config.vsprops
-FILE: ../../../third_party/googletest/googlemock/msvc/2005/gmock_main.vcproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2005/gmock_test.vcproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2010/gmock.sln
-FILE: ../../../third_party/googletest/googlemock/msvc/2010/gmock.vcxproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2010/gmock_config.props
-FILE: ../../../third_party/googletest/googlemock/msvc/2010/gmock_main.vcxproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2010/gmock_test.vcxproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2015/gmock.sln
-FILE: ../../../third_party/googletest/googlemock/msvc/2015/gmock.vcxproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2015/gmock_config.props
-FILE: ../../../third_party/googletest/googlemock/msvc/2015/gmock_main.vcxproj
-FILE: ../../../third_party/googletest/googlemock/msvc/2015/gmock_test.vcxproj
-FILE: ../../../third_party/googletest/googlemock/src/gmock-all.cc
-FILE: ../../../third_party/googletest/googlemock/src/gmock.cc
-FILE: ../../../third_party/googletest/googlemock/src/gmock_main.cc
-FILE: ../../../third_party/googletest/googletest/CHANGES
-FILE: ../../../third_party/googletest/googletest/CONTRIBUTORS
-FILE: ../../../third_party/googletest/googletest/cmake/gtest.pc.in
-FILE: ../../../third_party/googletest/googletest/cmake/gtest_main.pc.in
-FILE: ../../../third_party/googletest/googletest/codegear/gtest.cbproj
-FILE: ../../../third_party/googletest/googletest/codegear/gtest.groupproj
-FILE: ../../../third_party/googletest/googletest/codegear/gtest_main.cbproj
-FILE: ../../../third_party/googletest/googletest/codegear/gtest_unittest.cbproj
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-param-test.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-param-test.h.pump
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-test-part.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-filepath.h
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest-md.sln
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest-md.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest-md.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest.sln
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_main-md.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_main-md.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_main.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_main.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_prod_test-md.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_prod_test-md.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_prod_test.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_prod_test.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_unittest-md.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_unittest-md.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_unittest.vcxproj
-FILE: ../../../third_party/googletest/googletest/msvc/2010/gtest_unittest.vcxproj.filters
-FILE: ../../../third_party/googletest/googletest/src/gtest-all.cc
-FILE: ../../../third_party/googletest/googletest/src/gtest-filepath.cc
-FILE: ../../../third_party/googletest/googletest/src/gtest-port.cc
-FILE: ../../../third_party/googletest/googletest/src/gtest-test-part.cc
-FILE: ../../../third_party/googletest/googletest/xcode/Config/DebugProject.xcconfig
-FILE: ../../../third_party/googletest/googletest/xcode/Config/FrameworkTarget.xcconfig
-FILE: ../../../third_party/googletest/googletest/xcode/Config/General.xcconfig
-FILE: ../../../third_party/googletest/googletest/xcode/Config/ReleaseProject.xcconfig
-FILE: ../../../third_party/googletest/googletest/xcode/Config/StaticLibraryTarget.xcconfig
-FILE: ../../../third_party/googletest/googletest/xcode/Config/TestTarget.xcconfig
-FILE: ../../../third_party/googletest/googletest/xcode/Resources/Info.plist
-FILE: ../../../third_party/googletest/googletest/xcode/Samples/FrameworkSample/Info.plist
-FILE: ../../../third_party/googletest/googletest/xcode/Samples/FrameworkSample/WidgetFramework.xcodeproj/project.pbxproj
-FILE: ../../../third_party/googletest/googletest/xcode/Samples/FrameworkSample/widget.cc
-FILE: ../../../third_party/googletest/googletest/xcode/Samples/FrameworkSample/widget.h
-FILE: ../../../third_party/googletest/googletest/xcode/Samples/FrameworkSample/widget_test.cc
-FILE: ../../../third_party/googletest/googletest/xcode/gtest.xcodeproj/project.pbxproj
+FILE: ../../../third_party/gtest/CHANGES
+FILE: ../../../third_party/gtest/CONTRIBUTORS
+FILE: ../../../third_party/gtest/codegear/gtest.cbproj
+FILE: ../../../third_party/gtest/codegear/gtest.groupproj
+FILE: ../../../third_party/gtest/codegear/gtest_main.cbproj
+FILE: ../../../third_party/gtest/codegear/gtest_unittest.cbproj
+FILE: ../../../third_party/gtest/include/gtest/gtest-param-test.h
+FILE: ../../../third_party/gtest/include/gtest/gtest-param-test.h.pump
+FILE: ../../../third_party/gtest/include/gtest/gtest-test-part.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-filepath.h
+FILE: ../../../third_party/gtest/msvc/gtest-md.sln
+FILE: ../../../third_party/gtest/msvc/gtest-md.vcproj
+FILE: ../../../third_party/gtest/msvc/gtest.sln
+FILE: ../../../third_party/gtest/msvc/gtest.vcproj
+FILE: ../../../third_party/gtest/msvc/gtest_main-md.vcproj
+FILE: ../../../third_party/gtest/msvc/gtest_main.vcproj
+FILE: ../../../third_party/gtest/msvc/gtest_prod_test-md.vcproj
+FILE: ../../../third_party/gtest/msvc/gtest_prod_test.vcproj
+FILE: ../../../third_party/gtest/msvc/gtest_unittest-md.vcproj
+FILE: ../../../third_party/gtest/msvc/gtest_unittest.vcproj
+FILE: ../../../third_party/gtest/src/gtest-all.cc
+FILE: ../../../third_party/gtest/src/gtest-filepath.cc
+FILE: ../../../third_party/gtest/src/gtest-port.cc
+FILE: ../../../third_party/gtest/src/gtest-test-part.cc
+FILE: ../../../third_party/gtest/xcode/Config/DebugProject.xcconfig
+FILE: ../../../third_party/gtest/xcode/Config/FrameworkTarget.xcconfig
+FILE: ../../../third_party/gtest/xcode/Config/General.xcconfig
+FILE: ../../../third_party/gtest/xcode/Config/ReleaseProject.xcconfig
+FILE: ../../../third_party/gtest/xcode/Config/StaticLibraryTarget.xcconfig
+FILE: ../../../third_party/gtest/xcode/Config/TestTarget.xcconfig
+FILE: ../../../third_party/gtest/xcode/Resources/Info.plist
+FILE: ../../../third_party/gtest/xcode/Samples/FrameworkSample/Info.plist
+FILE: ../../../third_party/gtest/xcode/Samples/FrameworkSample/WidgetFramework.xcodeproj/project.pbxproj
+FILE: ../../../third_party/gtest/xcode/Samples/FrameworkSample/widget.cc
+FILE: ../../../third_party/gtest/xcode/Samples/FrameworkSample/widget.h
+FILE: ../../../third_party/gtest/xcode/Samples/FrameworkSample/widget_test.cc
+FILE: ../../../third_party/gtest/xcode/gtest.xcodeproj/project.pbxproj
 ----------------------------------------------------------------------------------------------------
 Copyright 2008, Google Inc.
 All rights reserved.
@@ -653,13 +404,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/codegear/gtest_all.cc
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/codegear/gtest_all.cc
 FILE: ../../../third_party/boringssl/src/third_party/googletest/codegear/gtest_link.cc
-FILE: ../../../third_party/googletest/googletest/codegear/gtest_all.cc
-FILE: ../../../third_party/googletest/googletest/codegear/gtest_link.cc
+FILE: ../../../third_party/gtest/codegear/gtest_all.cc
+FILE: ../../../third_party/gtest/codegear/gtest_link.cc
 ----------------------------------------------------------------------------------------------------
 Copyright 2009, Google Inc.
 All rights reserved.
@@ -693,32 +444,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest-printers.h
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest-printers.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest-spi.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/src/gtest-printers.cc
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-actions.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-cardinalities.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-actions.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-actions.h.pump
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-function-mockers.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-generated-function-mockers.h.pump
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-matchers.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-more-actions.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-spec-builders.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/gmock-generated-internal-utils.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/gmock-generated-internal-utils.h.pump
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/gmock-internal-utils.h
-FILE: ../../../third_party/googletest/googlemock/src/gmock-cardinalities.cc
-FILE: ../../../third_party/googletest/googlemock/src/gmock-internal-utils.cc
-FILE: ../../../third_party/googletest/googlemock/src/gmock-matchers.cc
-FILE: ../../../third_party/googletest/googlemock/src/gmock-spec-builders.cc
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-printers.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-spi.h
-FILE: ../../../third_party/googletest/googletest/src/gtest-printers.cc
+FILE: ../../../third_party/gtest/include/gtest/gtest-printers.h
+FILE: ../../../third_party/gtest/include/gtest/gtest-spi.h
+FILE: ../../../third_party/gtest/src/gtest-printers.cc
 ----------------------------------------------------------------------------------------------------
 Copyright 2007, Google Inc.
 All rights reserved.
@@ -752,15 +486,15 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest_pred_impl.h
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest_pred_impl.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest_prod.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/src/gtest_main.cc
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest_pred_impl.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest_prod.h
-FILE: ../../../third_party/googletest/googletest/src/gtest_main.cc
+FILE: ../../../third_party/gtest/include/gtest/gtest_pred_impl.h
+FILE: ../../../third_party/gtest/include/gtest/gtest_prod.h
+FILE: ../../../third_party/gtest/src/gtest_main.cc
 ----------------------------------------------------------------------------------------------------
 Copyright 2006, Google Inc.
 All rights reserved.
@@ -794,19 +528,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/custom/gtest-port.h
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/custom/gtest-port.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/custom/gtest-printers.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/custom/gtest.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-port-arch.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/custom/gmock-matchers.h
-FILE: ../../../third_party/googletest/googlemock/include/gmock/internal/custom/gmock-port.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/custom/gtest-port.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/custom/gtest-printers.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/custom/gtest.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-port-arch.h
+FILE: ../../../third_party/gtest/include/gtest/internal/custom/gtest-port.h
+FILE: ../../../third_party/gtest/include/gtest/internal/custom/gtest-printers.h
+FILE: ../../../third_party/gtest/include/gtest/internal/custom/gtest.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-port-arch.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2015, Google Inc.
 All rights reserved.
@@ -840,7 +572,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-death-test-internal.h
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest-death-test.h
@@ -865,28 +597,28 @@ FILE: ../../../third_party/boringssl/src/third_party/googletest/samples/sample5_
 FILE: ../../../third_party/boringssl/src/third_party/googletest/src/gtest-death-test.cc
 FILE: ../../../third_party/boringssl/src/third_party/googletest/src/gtest-internal-inl.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/src/gtest.cc
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-death-test.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-message.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-death-test-internal.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-internal.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-port.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-string.h
-FILE: ../../../third_party/googletest/googletest/samples/sample1.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample1.h
-FILE: ../../../third_party/googletest/googletest/samples/sample1_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample2.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample2.h
-FILE: ../../../third_party/googletest/googletest/samples/sample2_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample3-inl.h
-FILE: ../../../third_party/googletest/googletest/samples/sample3_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample4.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample4.h
-FILE: ../../../third_party/googletest/googletest/samples/sample4_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample5_unittest.cc
-FILE: ../../../third_party/googletest/googletest/src/gtest-death-test.cc
-FILE: ../../../third_party/googletest/googletest/src/gtest-internal-inl.h
-FILE: ../../../third_party/googletest/googletest/src/gtest.cc
+FILE: ../../../third_party/gtest/include/gtest/gtest-death-test.h
+FILE: ../../../third_party/gtest/include/gtest/gtest-message.h
+FILE: ../../../third_party/gtest/include/gtest/gtest.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-death-test-internal.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-internal.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-port.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-string.h
+FILE: ../../../third_party/gtest/samples/sample1.cc
+FILE: ../../../third_party/gtest/samples/sample1.h
+FILE: ../../../third_party/gtest/samples/sample1_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample2.cc
+FILE: ../../../third_party/gtest/samples/sample2.h
+FILE: ../../../third_party/gtest/samples/sample2_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample3-inl.h
+FILE: ../../../third_party/gtest/samples/sample3_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample4.cc
+FILE: ../../../third_party/gtest/samples/sample4.h
+FILE: ../../../third_party/gtest/samples/sample4_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample5_unittest.cc
+FILE: ../../../third_party/gtest/src/gtest-death-test.cc
+FILE: ../../../third_party/gtest/src/gtest-internal-inl.h
+FILE: ../../../third_party/gtest/src/gtest.cc
 ----------------------------------------------------------------------------------------------------
 Copyright 2005, Google Inc.
 All rights reserved.
@@ -920,11 +652,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-linked_ptr.h
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-linked_ptr.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-linked_ptr.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-linked_ptr.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2003 Google Inc.
 All rights reserved.
@@ -958,7 +690,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-param-util-generated.h
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/gtest-typed-test.h
@@ -972,17 +704,17 @@ FILE: ../../../third_party/boringssl/src/third_party/googletest/samples/sample6_
 FILE: ../../../third_party/boringssl/src/third_party/googletest/samples/sample7_unittest.cc
 FILE: ../../../third_party/boringssl/src/third_party/googletest/samples/sample8_unittest.cc
 FILE: ../../../third_party/boringssl/src/third_party/googletest/src/gtest-typed-test.cc
-FILE: ../../../third_party/googletest/googletest/include/gtest/gtest-typed-test.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-param-util-generated.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-param-util-generated.h.pump
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-param-util.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-type-util.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-type-util.h.pump
-FILE: ../../../third_party/googletest/googletest/samples/prime_tables.h
-FILE: ../../../third_party/googletest/googletest/samples/sample6_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample7_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample8_unittest.cc
-FILE: ../../../third_party/googletest/googletest/src/gtest-typed-test.cc
+FILE: ../../../third_party/gtest/include/gtest/gtest-typed-test.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-param-util-generated.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-param-util-generated.h.pump
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-param-util.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-type-util.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-type-util.h.pump
+FILE: ../../../third_party/gtest/samples/prime_tables.h
+FILE: ../../../third_party/gtest/samples/sample6_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample7_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample8_unittest.cc
+FILE: ../../../third_party/gtest/src/gtest-typed-test.cc
 ----------------------------------------------------------------------------------------------------
 Copyright 2008 Google Inc.
 All Rights Reserved.
@@ -1016,13 +748,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-tuple.h
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-tuple.h
 FILE: ../../../third_party/boringssl/src/third_party/googletest/include/gtest/internal/gtest-tuple.h.pump
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-tuple.h
-FILE: ../../../third_party/googletest/googletest/include/gtest/internal/gtest-tuple.h.pump
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-tuple.h
+FILE: ../../../third_party/gtest/include/gtest/internal/gtest-tuple.h.pump
 ----------------------------------------------------------------------------------------------------
 Copyright 2009 Google Inc.
 All Rights Reserved.
@@ -1056,13 +788,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: boringssl
-LIBRARY: googletest
+LIBRARY: gtest
 ORIGIN: ../../../third_party/boringssl/src/third_party/googletest/samples/sample10_unittest.cc
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/boringssl/src/third_party/googletest/samples/sample10_unittest.cc
 FILE: ../../../third_party/boringssl/src/third_party/googletest/samples/sample9_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample10_unittest.cc
-FILE: ../../../third_party/googletest/googletest/samples/sample9_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample10_unittest.cc
+FILE: ../../../third_party/gtest/samples/sample9_unittest.cc
 ----------------------------------------------------------------------------------------------------
 Copyright 2009 Google Inc. All Rights Reserved.
 
@@ -8808,42 +8540,6 @@ may be used:
     "The Graphics Interchange Format(c) is the Copyright property of
     CompuServe Incorporated. GIF(sm) is a Service Mark property of
     CompuServe Incorporated."
-====================================================================================================
-
-====================================================================================================
-LIBRARY: googletest
-ORIGIN: ../../../third_party/googletest/googlemock/include/gmock/gmock-more-matchers.h
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/googletest/googlemock/include/gmock/gmock-more-matchers.h
-----------------------------------------------------------------------------------------------------
-Copyright 2013, Google Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-    * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 
 ====================================================================================================
@@ -22881,4 +22577,4 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 ====================================================================================================
-Total license count: 320
+Total license count: 318

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 760da5baa5ca7f39360c7d0ccdc84a44
+Signature: 35aeeabb739f87512e922eb11cff14a9
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Reverts flutter/engine#4728, the Garnet roll is causing build failure on Windows because of changes in libfxl.