### PR TITLE
libtxt: use a fixed set of font manager roles instead of a list of font managers

### DIFF
--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -25,7 +25,7 @@ FontCollection& FontCollection::ForProcess() {
 
 FontCollection::FontCollection()
     : collection_(std::make_shared<txt::FontCollection>()) {
-  collection_->PushBack(SkFontMgr::RefDefault());
+  collection_->SetDefaultFontManager(SkFontMgr::RefDefault());
 }
 
 FontCollection::~FontCollection() = default;
@@ -106,7 +106,7 @@ void FontCollection::RegisterFontsFromAssetProvider(
     }
   }
 
-  collection_->PushFront(
+  collection_->SetAssetFontManager(
       sk_make_sp<txt::AssetFontManager>(std::move(font_asset_data_provider)));
 }
 
@@ -120,7 +120,7 @@ void FontCollection::RegisterTestFonts() {
   asset_data_provider->RegisterTypeface(std::move(test_typeface),
                                         GetTestFontFamilyName());
 
-  collection_->PushFront(sk_make_sp<txt::TestFontManager>(
+  collection_->SetTestFontManager(sk_make_sp<txt::TestFontManager>(
       std::move(asset_data_provider), GetTestFontFamilyName()));
 
   collection_->DisableFontFallback();

--- a/third_party/txt/benchmarks/utils.cc
+++ b/third_party/txt/benchmarks/utils.cc
@@ -44,7 +44,7 @@ void SetCommandLine(fxl::CommandLine cmd) {
 
 std::shared_ptr<FontCollection> GetTestFontCollection() {
   auto collection = std::make_shared<FontCollection>();
-  collection->PushBack(sk_make_sp<AssetFontManager>(
+  collection->SetAssetFontManager(sk_make_sp<AssetFontManager>(
       std::make_unique<DirectoryAssetDataProvider>(GetFontDir())));
   return collection;
 }

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -39,9 +39,9 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
 
   size_t GetFontManagersCount() const;
 
-  void PushFront(sk_sp<SkFontMgr> skia_font_manager);
-
-  void PushBack(sk_sp<SkFontMgr> skia_font_manager);
+  void SetDefaultFontManager(sk_sp<SkFontMgr> font_manager);
+  void SetAssetFontManager(sk_sp<SkFontMgr> font_manager);
+  void SetTestFontManager(sk_sp<SkFontMgr> font_manager);
 
   std::shared_ptr<minikin::FontCollection> GetMinikinFontCollectionForFamily(
       const std::string& family);
@@ -53,13 +53,17 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
   void DisableFontFallback();
 
  private:
-  std::deque<sk_sp<SkFontMgr>> skia_font_managers_;
+  sk_sp<SkFontMgr> default_font_manager_;
+  sk_sp<SkFontMgr> asset_font_manager_;
+  sk_sp<SkFontMgr> test_font_manager_;
   std::unordered_map<std::string, std::shared_ptr<minikin::FontCollection>>
       font_collections_cache_;
   std::unordered_map<SkFontID, std::shared_ptr<minikin::FontFamily>>
       fallback_fonts_;
   std::shared_ptr<minikin::FontFamily> null_family_;
   bool enable_font_fallback_;
+
+  std::vector<sk_sp<SkFontMgr>> GetFontManagerOrder() const;
 
   const std::shared_ptr<minikin::FontFamily>& GetFontFamilyForTypeface(
       const sk_sp<SkTypeface>& typeface);

--- a/third_party/txt/tests/render_test.cc
+++ b/third_party/txt/tests/render_test.cc
@@ -30,7 +30,7 @@ namespace txt {
 
 RenderTest::RenderTest()
     : snapshots_(0), font_collection_(std::make_shared<FontCollection>()) {
-  font_collection_->PushBack(sk_make_sp<AssetFontManager>(
+  font_collection_->SetAssetFontManager(sk_make_sp<AssetFontManager>(
       std::make_unique<txt::DirectoryAssetDataProvider>(GetFontDir())));
 }
 


### PR DESCRIPTION
Prior to this, the engine was adding font managers to the list every time the
app restarts (e.g. after a suspend-and-resume cycle), causing a leak.