### PR TITLE
Roll dart to 290c576264faa096a0b3206c71b2435309d9f904.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,18 +31,18 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'b5b8080b2cfb1e4943a19787ee96548a4a604f7b',
+  'dart_revision': '290c576264faa096a0b3206c71b2435309d9f904',
 
   'dart_args_tag': '0.13.7',
   'dart_async_tag': '2.0.6',
   'dart_barback_tag': '0.15.2+14',
   'dart_bazel_worker_tag': 'v0.1.9',
-  'dart_boolean_selector_tag': '1.0.2',
-  'dart_boringssl_gen_rev': '39762c7f9ee4d828ff212838fae79528b94d5443',
-  'dart_boringssl_rev': 'a62dbf88d8a3c04446db833a1eb80a620cb1514d',
+  'dart_boolean_selector_tag': '1.0.3',
+  'dart_boringssl_gen_rev': '344f455fd13d46f054726638e76026156ea73aa9',
+  'dart_boringssl_rev': '672f6fc2486745d0cabc3aaeb4e0a3cd13b37b12',
   'dart_charcode_tag': 'v1.1.1',
   'dart_cli_util_tag': '0.1.2+1',
-  'dart_collection_tag': '5943e1681204250f33a833eb5550f270357ad6c8',
+  'dart_collection_tag': '6ff408a512df30559c1a18b37cfac9fc51a4ceef',
   'dart_convert_tag': '2.0.1',
   'dart_crypto_tag': '2.0.2+1',
   'dart_csslib_tag': '0.14.1',

--- a/sky/packages/sky_engine/LICENSE
+++ b/sky/packages/sky_engine/LICENSE
@@ -2914,6 +2914,35 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 dart
 
+Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+dart
+
 Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
 
@@ -3030,36 +3059,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dart
 
 Copyright 2012, the Dart project authors. All rights reserved.
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---------------------------------------------------------------------------------
-dart
-engine
-
-Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
@@ -9403,40 +9402,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 engine
 garnet
 icu
-skia
-topaz
-
-Copyright 2016 The Chromium Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---------------------------------------------------------------------------------
-engine
-garnet
-icu
 topaz
 
 Copyright 2014 The Chromium Authors. All rights reserved.
@@ -10069,6 +10034,39 @@ necessary.  Here is a sample; alter the names:
   Ty Coon, President of Vice
 
 That's all there is to it!
+--------------------------------------------------------------------------------
+engine
+icu
+skia
+topaz
+
+Copyright 2016 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
 engine
 topaz
@@ -10832,6 +10830,37 @@ garnet
 topaz
 
 Copyright 2015 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
+garnet
+topaz
+
+Copyright 2018 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -16488,36 +16517,6 @@ topaz
 
 Copyright 2017, the Flutter project authors.  Please see the AUTHORS file
 for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
---------------------------------------------------------------------------------
-topaz
-
-Copyright 2018 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 35aeeabb739f87512e922eb11cff14a9
+Signature: 73039e1ba4d57deb77753fd9489beed7
 
 UNUSED LICENSES:
 
@@ -924,6 +924,10 @@ FILE: ../../../third_party/boringssl/src/crypto/err/x509.errordata
 FILE: ../../../third_party/boringssl/src/crypto/err/x509v3.errordata
 FILE: ../../../third_party/boringssl/src/crypto/evp/scrypt.c
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/bn/asm/x86_64-gcc.c
+FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/bn/rsaz_exp.c
+FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/bn/rsaz_exp.h
+FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64.c
+FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64.h
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/intcheck1.png
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/intcheck2.png
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/intcheck3.png
@@ -994,8 +998,6 @@ FILE: ../../../third_party/boringssl/src/util/fipstools/testdata/x86_64-LabelRew
 FILE: ../../../third_party/boringssl/src/util/fipstools/testdata/x86_64-Sections/in.s
 FILE: ../../../third_party/boringssl/src/util/fipstools/testdata/x86_64-Sections/out.s
 ----------------------------------------------------------------------------------------------------
-27287883
-
 OpenSSL License
 
  ====================================================================
@@ -1123,40 +1125,6 @@ ISC license used for completely new code in BoringSSL:
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-Some files from Intel carry the following license:
-
-# Copyright (c) 2012, Intel Corporation
-
-# All rights reserved.
-
-# Redistribution and use in source and binary forms, with or without
-# modification, are permitted provided that the following conditions are
-# met:
-
-# *  Redistributions of source code must retain the above copyright
-#    notice, this list of conditions and the following disclaimer.
-
-# *  Redistributions in binary form must reproduce the above copyright
-#    notice, this list of conditions and the following disclaimer in the
-#    documentation and/or other materials provided with the
-#    distribution.
-
-# *  Neither the name of the Intel Corporation nor the names of its
-#    contributors may be used to endorse or promote products derived from
-#    this software without specific prior written permission.
-
-# THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION ""AS IS"" AND ANY
-# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The code in third_party/fiat carries the MIT license:
 
@@ -1782,9 +1750,7 @@ FILE: ../../../third_party/boringssl/src/crypto/bn_extra/bn_asn1.c
 FILE: ../../../third_party/boringssl/src/crypto/cmac/cmac_test.cc
 FILE: ../../../third_party/boringssl/src/crypto/conf/internal.h
 FILE: ../../../third_party/boringssl/src/crypto/curve25519/asm/x25519-asm-arm.S
-FILE: ../../../third_party/boringssl/src/crypto/curve25519/asm/x25519-asm-x86_64.S
 FILE: ../../../third_party/boringssl/src/crypto/curve25519/ed25519_test.cc
-FILE: ../../../third_party/boringssl/src/crypto/curve25519/x25519-x86_64.c
 FILE: ../../../third_party/boringssl/src/crypto/curve25519/x25519_test.cc
 FILE: ../../../third_party/boringssl/src/crypto/err/err_data_generate.go
 FILE: ../../../third_party/boringssl/src/crypto/evp/pbkdf_test.cc
@@ -1962,6 +1928,33 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: boringssl
+ORIGIN: ../../../third_party/boringssl/src/crypto/cipher_extra/e_aesccm.c
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/boringssl/src/crypto/cipher_extra/e_aesccm.c
+FILE: ../../../third_party/boringssl/src/crypto/cpu-aarch64-fuchsia.c
+FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/tls/internal.h
+FILE: ../../../third_party/boringssl/src/crypto/self_test.cc
+FILE: ../../../third_party/boringssl/src/fipstools/cavp_kas_test.cc
+FILE: ../../../third_party/boringssl/src/fipstools/cavp_tlskdf_test.cc
+FILE: ../../../third_party/boringssl/src/ssl/handoff.cc
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2018, Google Inc.
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ====================================================================================================
 
 ====================================================================================================
@@ -2888,42 +2881,18 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ====================================================================================================
 LIBRARY: boringssl
-ORIGIN: ../../../third_party/boringssl/src/crypto/fipsmodule/bn/rsaz_exp.c
-TYPE: LicenseType.bsd
+ORIGIN: ../../../third_party/boringssl/src/crypto/fipsmodule/bn/rsaz_exp.c + ../../../third_party/boringssl/src/LICENSE
+TYPE: LicenseType.unknown
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/bn/rsaz_exp.c
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/bn/rsaz_exp.h
 ----------------------------------------------------------------------------------------------------
-Copyright (c) 2012, Intel Corporation
+Copyright 2013-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright (c) 2012, Intel Corporation. All Rights Reserved.
 
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-*  Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-
-*  Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in the
-   documentation and/or other materials provided with the
-   distribution.
-
-*  Neither the name of the Intel Corporation nor the names of its
-   contributors may be used to endorse or promote products derived from
-   this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION ""AS IS"" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+https://www.openssl.org/source/license.html
 ====================================================================================================
 
 ====================================================================================================
@@ -3127,24 +3096,18 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ====================================================================================================
 LIBRARY: boringssl
-ORIGIN: ../../../third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64.c
+ORIGIN: ../../../third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64.c + ../../../third_party/boringssl/src/LICENSE
 TYPE: LicenseType.unknown
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64.c
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/ec/p256-x86_64.h
 ----------------------------------------------------------------------------------------------------
-Copyright (c) 2014, Intel Corporation.
+Copyright 2014-2016 The OpenSSL Project Authors. All Rights Reserved.
+Copyright (c) 2014, Intel Corporation. All Rights Reserved.
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
-OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+Licensed under the OpenSSL license (the "License").  You may not use
+this file except in compliance with the License.  You can obtain a copy
+in the file LICENSE in the source distribution or at
+https://www.openssl.org/source/license.html
 ====================================================================================================
 
 ====================================================================================================
@@ -3160,6 +3123,60 @@ FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/modes/internal.h
 FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/modes/ofb.c
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2008 The OpenSSL Project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in
+   the documentation and/or other materials provided with the
+   distribution.
+
+3. All advertising materials mentioning features or use of this
+   software must display the following acknowledgment:
+   "This product includes software developed by the OpenSSL Project
+   for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+
+4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+   endorse or promote products derived from this software without
+   prior written permission. For written permission, please contact
+   openssl-core@openssl.org.
+
+5. Products derived from this software may not be called "OpenSSL"
+   nor may "OpenSSL" appear in their names without prior written
+   permission of the OpenSSL Project.
+
+6. Redistributions of any form whatsoever must retain the following
+   acknowledgment:
+   "This product includes software developed by the OpenSSL Project
+   for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+
+THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: boringssl
+ORIGIN: ../../../third_party/boringssl/src/crypto/fipsmodule/modes/ccm.c
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/modes/ccm.c
+FILE: ../../../third_party/boringssl/src/decrepit/xts/xts.c
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2011 The OpenSSL Project.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -3310,30 +3327,6 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: boringssl
-ORIGIN: ../../../third_party/boringssl/src/crypto/fipsmodule/tls/internal.h
-TYPE: LicenseType.unknown
-FILE: ../../../third_party/boringssl/src/crypto/fipsmodule/tls/internal.h
-FILE: ../../../third_party/boringssl/src/crypto/self_test.cc
-FILE: ../../../third_party/boringssl/src/fipstools/cavp_kas_test.cc
-FILE: ../../../third_party/boringssl/src/fipstools/cavp_tlskdf_test.cc
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2018, Google Inc.
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
-SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
-OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ====================================================================================================
 
 ====================================================================================================
@@ -3876,59 +3869,6 @@ FILE: ../../../third_party/boringssl/src/decrepit/dh/dh_decrepit.c
 FILE: ../../../third_party/boringssl/src/decrepit/dsa/dsa_decrepit.c
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 1998-2002 The OpenSSL Project.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-   notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-   notice, this list of conditions and the following disclaimer in
-   the documentation and/or other materials provided with the
-   distribution.
-
-3. All advertising materials mentioning features or use of this
-   software must display the following acknowledgment:
-   "This product includes software developed by the OpenSSL Project
-   for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
-
-4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
-   endorse or promote products derived from this software without
-   prior written permission. For written permission, please contact
-   openssl-core@openssl.org.
-
-5. Products derived from this software may not be called "OpenSSL"
-   nor may "OpenSSL" appear in their names without prior written
-   permission of the OpenSSL Project.
-
-6. Redistributions of any form whatsoever must retain the following
-   acknowledgment:
-   "This product includes software developed by the OpenSSL Project
-   for use in the OpenSSL Toolkit (http://www.openssl.org/)"
-
-THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
-EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
-ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: boringssl
-ORIGIN: ../../../third_party/boringssl/src/decrepit/xts/xts.c
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/boringssl/src/decrepit/xts/xts.c
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2011 The OpenSSL Project.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -6349,6 +6289,7 @@ ORIGIN: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc + ../../.
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h
+FILE: ../../../third_party/dart/runtime/vm/datastream.cc
 FILE: ../../../third_party/dart/runtime/vm/finalizable_data.h
 FILE: ../../../third_party/dart/sdk/lib/typed_data/unmodifiable_typed_data.dart
 ----------------------------------------------------------------------------------------------------

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 73039e1ba4d57deb77753fd9489beed7
+Signature: 4e2bc017cf33139e3cac7a97e5e22e91
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Changes since last roll:
```
290c576264 Remove inherited setters for mixed-in fields and copy their covariance-bits.
52b66e17fe Make fasta command line work on Windows
cb2e4b183e [fasta] Rename some methods in Forest API
2fcdfc1f23 Rename bug32353{,_2}_test.dart to issue32353{,_2}_test.dart
414a3318ea Add jsonDecode, jsonEncode, base64Decode, base64Encode, base64UrlEncode functions.
6cef6625ef [kernel] Record supertypes after the query intervals in CHA are built
f820555d19 Add test of type checks on redirecting initializer arguments
c31e628c4c Check types of arguments passed to redirecting initializers
009b6673ce [vm/kernel] Make 'unsupported tag' errors more verbose
70d715f115 Substitute return type too
40738b8884 fix #32481, generate signatures for mock members induced by nSM
b6460f34f6 Upgrade analyzer_plugin for republish with recent bugfix
439badf2c0 Revert "[build] Declare dependency of the version strings on the current Git commit."
7a0b6f8f4a Fix the analyzer bots
c080951d45 [build] Declare dependency of the version strings on the current Git commit.
693390a776 Index and search implicit references to optional positional parameters.
80a571d546 Take the --preview-dart-2 defaults from the context and options classes, not the cli tool defaults. Also, allow --no-preview-dart-2 from dartanalyzer.
8d47a6e86f Add a fix for lints that recommend using final (issue 32473)
0b48112d3e Fix nsm forwarding bug
977f4c706f Issue 32397. Fix for top-level inference and implicit creation.
b8093e3323 Generate signature of instantiated generic function from uninstantiated function
528d9d2e1f Do not hint when only a responsive asset exists (issue 32250)
5eb6d980b5 Do not hint when using a deprecated parameter in the defining function (issue 32468)
aff70cafc1 [vm] Fix reading of Object::extractor_parameter_types() from a snapshot
23fccf2e59 [VM] ARM64 unboxed 64 bit fix signed/unsigned const shift
e66733dd60 Simplify test case bug32353_test and decouple it from dart:io
e067f7fdfa The dart-dfe target is no longer being benchmarked.
7ce30c5289 Fix status files after 26e689de05b4
978840a42f [infra] Use a jessie sysroot for sanitizer builds
ad62702e93 Update status
11c77930e0 [infra] Turn on C++14 in the compiler config
30a87ce3fa [VM] ARM64: Add unboxed 64 bit integers
d2b7787186 [infra] Use downloaded sysroots by default
76b8e397ed Revert "Reland "[VM runtime] Switch intrinsics from old to new Bigint implementation.""
26e689de05 More work on signatures
5f51db3efb More status preparations to make the CQ clean
2cb80620bd Revert "[vm/simarm] Fix VRECPS/VRSQRTSQS instruction implementation."
feac6cfc20 Deal with Function type parameter contexts in closure conversion.
76a672e8ea mark lib_2/html/fileapi_entry_test flaky on ddc+mac
97bbe2f20b [vm] Avoid using objects in VM isolate heap for de-duplication
e1909cb52a Update Outline protocol - change offset/length, add codeOffset/codeLength.
602a8c2a7b Clean up usage of deprecated constants
5c94ec7b43 avoid generating unused constructors in dart:html
7aa3e54acf [vm] Fix computation of hashCode of a closure with null receiver
b93c74092a Make isInterceptedCall a field
c956cc152f Prepare co19 for d8-hostchecked-dart2js-with-cfe.
4c881188b2 Disable the .whereType method until generic methods are turned on.
16e8194147 Prepare additional lib, html, samples statuses: this embeds of d8-hostcheck results
0013f6acf8 Prepare co19 for the FE switch
22ccad1aa6 [vm] Stream writing snapshots as assembly to reduce peak memory usage.
eea08cfabe Add optional 'file' for getElementDeclarations.
b7cb8a1daa Mark 2 more tests as flaky
8240134d66 [infra] Roll boringssl forward. Use clang for arm on Linux.
e775ae9c30 Mark flaky co19 test
3da9c349d4 [vm/simarm] Fix VRECPS/VRSQRTSQS instruction implementation.
d059e97974 Add platform.dill files to the hostchecked try bots.
b3c12d4e3a Dart 2 Libraries Wave 3
021a29d68f Move analyzer-specific status lines into language_2_analyzer.status
b457d71713 Canonicalize representation of a message without location.
383517d292 [VM runtime] Fix type canonicalization (fixes #32425). A reused type argument vector that is longer than necessary needs to be shortened to the correct length upon type canonicalization. The runtime call comparing two instance runtime types also needs to consider reused vectors. Add regression test.
0fdbc331f6 Fix dynamic type dependencies in codegen
ef5909b986 Remove now unused dartk_wrappers
50ba330a04 Fix for suggesting both class and its default constructor.
e3ecc87eb9 [VM / Kernel ] Fixed issue where enum classes were not being marked as such in the VM. Enum class fields are now eagerly initialized.
4c58384b50 Prepare html, isolate, lib, and lib_2 status files to turn on CFE on dart2js by default
24507da9da Fix stack overflow when analyzing type variables in generic methods.
0e30facfc3 Update versions of the following packages to the latest versions - boolean_selector - collection
211bf1ee5f [vm/kernel/aot] Cache specializations of cone types in TFA
1c8841e52a [vm/kernel/aot] Fully support named parameters in type flow analysis
618cd897e6 Gardening: Adjust test status to fix bots again. Didn't fix the right status file last time and I couldn't test this since it's on Windows. :-(
23a7b62c42 Use type of receiver for setter target identification
f5b5ae86b6 Respect comments when inserting imports (issue 32432)
7290c950d0 Change name of 'signature' to ':signature' to not conflict with a DOM member.
7f9d5d318a Gardening: Change test status for standalone_2/namespace_test on Windows. Has been passing for as far back as I can see in the history.
55f7687908 [infra] Enable front end CQ builder
e8018bfdea Mark tests as flaky
9d17f3a92d Tests no longer crash
90c08d5287 Update co19 status for Chrome 65 roll
440b58d644 Start running analyzer tests with --preview-dart-2.
dc0f4c840c Fix status of map_literal1_test on analyzer
aecf5bf56e [VM] Remove locking in code called by signal handler, ensure profiler thread sees valid [Redirection] list
a55cdaee08 A bit of gardening
db08061424 Handle implicit tear-off of .call when an implicit downcast is required
8f4db274f1 Compute which selectors that need type arguments
83c8c21abe Gracefully handle local function modifiers
8831dd1308 Remove failing assertion
a3218d0b72 Roll back change to pkg/dev_compiler/analysis_options.yaml
50a6bb559d Update co19 status on IE11 after co19 update
6b91b4f2d2 Remove RuntimeTypesNeed.classUsesTypeVariableLiteral
f69da8e36b Move tests to /model/
d17db1d5f3 Pass type inference context down to field initializer when type inferred via override
675048d0b6 Add pragma class to dart:core.
94aa20dd07 Update status for $compiler == fasta
615f40bc1d Ensure that `null` is not used as a context in more places.
f3687198b8 Update dart2js_extra: normalize further and update to match runtime==chrome expectations
18aa6b570f Delete recursive import test, improve comment of dummy_compiler_test.
7fe8bdb2ee Refactor tests
932a99a731 Prepare pkg.status to enable dart2js CFE by default
dab7da78cd fix implicit casts in DDC
1b9b3453de fix DDC ES6 module export names, part of #32272
69f8d4ef0d Fix parsing of super expressions (issue 32393)
2ace7c9e9a Update dart2js-minified status for co19 no-such-method test
a1cacec5fc Update status after co19 roll
6b44182344 Only widgets in libraries can be rendered.
8d6b050e28 [VM] Guard against duplicate entries in the static [Redirection::list_]
be87175fee Implement Flutter Outline rendering API.
619434d38d Remember that C() is a compile-time constant expression.
18fe31ab11 Remove useOptimizedMixins from dart2js
9f56e28372 Mixin Applications with a Vengeance
3f71dc5dd2 Add preview_dart_2 to supported set of status file variables
bda78a0f41 Deprecated old upper-case constants.
```

Previous roll https://github.com/flutter/engine/pull/4767 was reverted, but now 290c576264 is landed with the fix.