### PR TITLE
Don’t specify a stencil buffer attachment for the onscreen FBO.

### DIFF
--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -31,7 +31,7 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
     uint8_t blue_bits = 8;
     uint8_t alpha_bits = 8;
     uint8_t depth_bits = 0;
-    uint8_t stencil_bits = 8;
+    uint8_t stencil_bits = 0;
   };
 
   void SetupResourceContextOnIOThread();


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/15456. Skia does not use the stencil attachment of the onscreen FBO anyway. So don't create one. Disabling the same also seems to get rid of the jank described in the issue.