### PR TITLE
expose SkParsePath::FromSVGString and ToSVGString

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Google Inc.
 Jim Simon <jim.j.simon@gmail.com>
 Ali Bitek <alibitek@protonmail.ch>
 Jacob Greenfield <jacob.greenfield.256@gmail.com>
+Dan Field <dfield@gmail.com>

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1615,14 +1615,14 @@ class Path extends NativeFieldWrapperClass2 {
   Path _transform(Float64List matrix4) native 'Path_transform';
 
   static Path parseSvgPathData(String svgPathData, [Path onError(String source)]) {
-    Path path = new Path();
+    final path = new Path();
     if (path._setFromSvgPathData(svgPathData)) {
       return path;
     } else if (onError != null) {
       return onError(svgPathData);
     }
 
-    throw new FormatException("Unable to parse path data");
+    throw const FormatException('Unable to parse path data');
    }
   bool _setFromSvgPathData(String svgPathData) native 'Path_setFromSvgPathData';
  	

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1613,6 +1613,19 @@ class Path extends NativeFieldWrapperClass2 {
     return _transform(matrix4);
   }
   Path _transform(Float64List matrix4) native 'Path_transform';
+
+  static Path parseSvgPathData(String svgPathData, {Path onError(String source)}) {
+    Path path = new Path();
+    if (path._setFromSvgPathData(svgPathData)) {
+      return path;
+    } else if (onError != null) {
+      return onError(svgPathData);
+    }
+
+    throw new FormatException("Unable to parse path data");
+   }
+  bool _setFromSvgPathData(String svgPathData) native 'Path_setFromSvgPathData';
+ 	
 }
 
 /// Styles to use for blurs in [MaskFilter] objects.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1614,6 +1614,9 @@ class Path extends NativeFieldWrapperClass2 {
   }
   Path _transform(Float64List matrix4) native 'Path_transform';
 
+  /// Creates a new [Path] with the commands specified in SVG path syntax
+  /// format.  If the string cannot be passed, will call onError if onError is
+  /// not null, or else throw a [FormatException]
   static Path parseSvgPathData(String svgPathData, [Path onError(String source)]) {
     final Path path = new Path();
     if (path._setFromSvgPathData(svgPathData)) {
@@ -1626,6 +1629,11 @@ class Path extends NativeFieldWrapperClass2 {
    }
   bool _setFromSvgPathData(String svgPathData) native 'Path_setFromSvgPathData';
  	
+  @override
+  String toString() {
+    return 'Path(${_toSvgString()})';
+  }
+  String _toSvgString() native 'Path_toSvgString';
 }
 
 /// Styles to use for blurs in [MaskFilter] objects.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1614,7 +1614,7 @@ class Path extends NativeFieldWrapperClass2 {
   }
   Path _transform(Float64List matrix4) native 'Path_transform';
 
-  static Path parseSvgPathData(String svgPathData, {Path onError(String source)}) {
+  static Path parseSvgPathData(String svgPathData, [Path onError(String source)]) {
     Path path = new Path();
     if (path._setFromSvgPathData(svgPathData)) {
       return path;

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1615,7 +1615,7 @@ class Path extends NativeFieldWrapperClass2 {
   Path _transform(Float64List matrix4) native 'Path_transform';
 
   static Path parseSvgPathData(String svgPathData, [Path onError(String source)]) {
-    final path = new Path();
+    final Path path = new Path();
     if (path._setFromSvgPathData(svgPathData)) {
       return path;
     } else if (onError != null) {

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -51,7 +51,9 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Path);
   V(Path, reset)                     \
   V(Path, setFillType)               \
   V(Path, shift)                     \
-  V(Path, transform)
+  V(Path, transform)                 \
+  V(Path, setFromSvgPathData)        \
+  V(Path, toSvgString)
 
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
 
@@ -239,4 +241,15 @@ fxl::RefPtr<CanvasPath> CanvasPath::transform(tonic::Float64List& matrix4) {
   return path;
 }
 
+bool CanvasPath::setFromSvgPathData(const std::string& svgPathData) {
+  path_.reset();
+  bool success = SkParsePath::FromSVGString(svgPathData.c_str(), &path_);
+  return success;
+}
+
+Dart_Handle CanvasPath::toSvgString() {
+  SkString str;
+  SkParsePath::ToSVGString(path_, &str);
+  return ToDart(str.c_str());
+}
 }  // namespace blink

--- a/lib/ui/painting/path.h
+++ b/lib/ui/painting/path.h
@@ -10,6 +10,8 @@
 #include "lib/tonic/typed_data/float32_list.h"
 #include "lib/tonic/typed_data/float64_list.h"
 #include "third_party/skia/include/core/SkPath.h"
+#include "third_party/skia/include/core/SkString.h"
+#include "third_party/skia/include/utils/SkParsePath.h"
 
 namespace tonic {
 class DartLibraryNatives;
@@ -84,6 +86,8 @@ class CanvasPath : public fxl::RefCountedThreadSafe<CanvasPath>,
   bool contains(double x, double y);
   fxl::RefPtr<CanvasPath> shift(double dx, double dy);
   fxl::RefPtr<CanvasPath> transform(tonic::Float64List& matrix4);
+  bool setFromSvgPathData(const std::string& svgPathData);
+  Dart_Handle toSvgString();
 
   const SkPath& path() const { return path_; }
 


### PR DESCRIPTION
Skia has [logic written already to parse and create `SkPath`s from an SVG path data string](https://github.com/google/skia/blob/master/src/utils/SkParsePath.cpp) (e.g. `M10 10 H 90 V 90 H 10 L 10 10` to draw a square shaped path).

While this logic could be re-implemented in Dart, it's not trivial and would require multiple round trips from Dart -> C++ (for each path command that needs to be applied to the path), whereas this method would only require two (one to create the Path object, and one to parse/set the path data).  I tried a method that would require one round trip, but didn't see a good way to signal an error back to Dart without using `Dart_ThrowException` - this way allows for better error handling in Dart and doesn't cause any concerns about destructors running on the C++ side.

I added a `toString` on Path that makes use of the `ToSVGString` from Skia, which is helpful for debugging purposes (`print(path)` would show you what commands have been applied to the path rather than just showing `Instance of Path`).

the `Path.parseSvgPathData` is modeled after, e.g., `double.parse` and `int.parse` 

Strongly related to  flutter/flutter#15501 - my ultimate goal here is to facilitate SVG path parsing to be able to render SVGs more easily in flutter.
