### PR TITLE
Specify GL texture format and SkColorType when creating external texture SkImages.

### DIFF
--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -42,11 +42,11 @@ void AndroidExternalTextureGL::Paint(SkCanvas& canvas, const SkRect& bounds) {
     Update();
     new_frame_ready_ = false;
   }
-  GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES, texture_name_};
-  GrBackendTexture backendTexture(1, 1, kRGBA_8888_GrPixelConfig, textureInfo);
+  GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES, texture_name_, GL_RGBA8_OES};
+  GrBackendTexture backendTexture(1, 1, GrMipMapped::kNo, textureInfo);
   sk_sp<SkImage> image = SkImage::MakeFromTexture(
       canvas.getGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin,
-      SkAlphaType::kPremul_SkAlphaType, nullptr);
+      kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
   if (image) {
     SkAutoCanvasRestore autoRestore(&canvas, true);
     canvas.translate(bounds.x(), bounds.y());

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -57,12 +57,13 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas, const SkRect& bounds) {
     return;
   }
   GrGLTextureInfo textureInfo = {CVOpenGLESTextureGetTarget(texture_ref_),
-                                 CVOpenGLESTextureGetName(texture_ref_)};
-  GrBackendTexture backendTexture(bounds.width(), bounds.height(), kRGBA_8888_GrPixelConfig,
+                                 CVOpenGLESTextureGetName(texture_ref_),
+                                 GL_RGBA8_OES};
+  GrBackendTexture backendTexture(bounds.width(), bounds.height(), GrMipMapped::kNo,
                                   textureInfo);
   sk_sp<SkImage> image =
       SkImage::MakeFromTexture(canvas.getGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin,
-                               SkAlphaType::kPremul_SkAlphaType, nullptr);
+                               kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
   if (image) {
     canvas.drawImage(image, bounds.x(), bounds.y());
   }


### PR DESCRIPTION
Skia is deprecating GrPixelConfig. Instead we take a GL (or VK) texture format in GrBackendTexture. When a SkImage is created it is specified with a SkColorType. The image factory will succeed if the texture format and color type are compatible.