### PR TITLE
Add API guard to a11y setTraversalAfter

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -242,8 +242,10 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
 
         result.setSelected(object.hasFlag(Flag.IS_SELECTED));
         result.setText(object.getValueLabelHint());
-        if (object.previousNodeId != -1)
+        if (object.previousNodeId != -1
+            && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
             result.setTraversalAfter(mOwner, object.previousNodeId);
+        }
 
         // Accessibility Focus
         if (mA11yFocusedObject != null && mA11yFocusedObject.id == virtualViewId) {


### PR DESCRIPTION
It's only available in API level 22 or higher.

Ideally, we would be using the Compat version from the Android Support Libraries, but we can't until https://github.com/flutter/flutter/issues/11099 is resolved.

Fixers https://github.com/flutter/flutter/issues/15539.

/cc @mehmetf @gspencergoog 