### PR TITLE
Cache render buffer extents when no depth/stencil buffer

### DIFF
--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -193,7 +193,7 @@ bool IOSGLContext::UpdateStorageSizeIfNecessary() {
   bool rebind_color_buffer = false;
 
   if (depthbuffer_ != GL_NONE || stencilbuffer_ != GL_NONE ||
-      depth_stencil_packed_buffer_ != GL_NONE) {
+      depth_stencil_packed_buffer_ != GL_NONE || colorbuffer_ != GL_NONE) {
     // Fetch the dimensions of the color buffer whose backing was just updated
     // so that backing of the attachments can be updated
     glGetRenderbufferParameteriv(GL_RENDERBUFFER, GL_RENDERBUFFER_WIDTH, &width);


### PR DESCRIPTION
Previously iOS render buffer storage width and height were not cached if
not using a depth/stencil buffer. This adds a similar check for
colorBuffer to avoid reallocating render buffer storage.