### PR TITLE
Eliminate iOS depth/stencil buffer code

### DIFF
--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -42,9 +42,6 @@ class IOSGLContext {
   fml::scoped_nsobject<EAGLContext> resource_context_;
   GLuint framebuffer_;
   GLuint colorbuffer_;
-  GLuint depthbuffer_;
-  GLuint stencilbuffer_;
-  GLuint depth_stencil_packed_buffer_;
   GLint storage_size_width_;
   GLint storage_size_height_;
   sk_sp<SkColorSpace> color_space_;


### PR DESCRIPTION
As of ba67d0fe718299050bf0195295aba3415c417b91, depth/stencil buffer
attachments are never used. This patch eliminates generation and binding
of depth/stencil render buffers since these code paths are no longer hit.