### PR TITLE
Revert "Roll Dart to f1ebe2bd5cfcb6b522e5b4fd406cdabb1a2d2091. (#4800…

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'f1ebe2bd5cfcb6b522e5b4fd406cdabb1a2d2091',
+  'dart_revision': '7328726088065b53f40e02caae6fd73f94528e3e',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -75,7 +75,7 @@ vars = {
   'dart_plugin_tag': '0.2.0+2',
   'dart_pool_tag': '1.3.4',
   'dart_protobuf_tag': '0.7.1',
-  'dart_pub_rev': 'dbe8be2bb8bca9b26ba7bd583272c62f9a0153fd',
+  'dart_pub_rev': 'd2755745e88b63448d0adfbf2d04af9050f45ed3',
   'dart_pub_semver_tag': '1.3.2',
   'dart_quiver_tag': '5aaa3f58c48608af5b027444d561270b53f15dbf',
   'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',

--- a/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
+++ b/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
@@ -418,7 +418,7 @@ class WidgetCreatorTracker implements ProgramTransformer {
     clazz.constructors.forEach(handleConstructor);
   }
 
-  Component _computeFullProgram(Component deltaProgram) {
+  Program _computeFullProgram(Program deltaProgram) {
     final Set<Library> libraries = new Set<Library>();
     final List<Library> workList = <Library>[];
     for (Library library in deltaProgram.libraries) {
@@ -434,7 +434,7 @@ class WidgetCreatorTracker implements ProgramTransformer {
         }
       }
     }
-    return new Component()..libraries.addAll(libraries);
+    return new Program()..libraries.addAll(libraries);
   }
 
   /// Transform the given [program].
@@ -442,7 +442,7 @@ class WidgetCreatorTracker implements ProgramTransformer {
   /// It is safe to call this method on a delta program generated as part of
   /// performing a hot reload.
   @override
-  void transform(Component program) {
+  void transform(Program program) {
     final List<Library> libraries = program.libraries;
 
     if (libraries.isEmpty) {

--- a/runtime/dart_controller.cc
+++ b/runtime/dart_controller.cc
@@ -139,13 +139,29 @@ bool DartController::SendStartMessage(Dart_Handle root_library,
   return LogIfError(result);
 }
 
+static void CopyVectorBytes(const std::vector<uint8_t>& vector,
+                            uint8_t*& bytes) {
+  bytes = (uint8_t*)malloc(vector.size());
+  memcpy(bytes, vector.data(), vector.size());
+}
+
+static void ReleaseFetchedBytes(uint8_t* buffer) {
+  free(buffer);
+}
+
 tonic::DartErrorHandleType DartController::RunFromKernel(
     const std::vector<uint8_t>& kernel,
     const std::string& entrypoint) {
   tonic::DartState::Scope scope(dart_state());
   tonic::DartErrorHandleType error = tonic::kNoError;
   if (Dart_IsNull(Dart_RootLibrary())) {
-    Dart_Handle result = Dart_LoadScriptFromKernel(kernel.data(), kernel.size());
+    // Copy kernel bytes and pass ownership of the copy to the Dart_LoadKernel,
+    // which is expected to release them.
+    uint8_t* kernel_bytes = nullptr;
+    CopyVectorBytes(kernel, kernel_bytes);
+
+    Dart_Handle result = Dart_LoadKernel(Dart_ReadKernelBinary(
+        kernel_bytes, kernel.size(), ReleaseFetchedBytes));
     LogIfError(result);
     error = tonic::GetErrorHandleType(result);
   }

--- a/runtime/dart_init.cc
+++ b/runtime/dart_init.cc
@@ -396,8 +396,10 @@ Dart_Isolate IsolateCreateCallback(const char* script_uri,
 
     if (!kernel_data.empty()) {
       // We are running kernel code.
-      FXL_CHECK(!LogIfError(Dart_LoadScriptFromKernel(kernel_data.data(),
-                                                      kernel_data.size())));
+      uint8_t* kernel_buf = static_cast<uint8_t*>(malloc(kernel_data.size()));
+      memcpy(kernel_buf, kernel_data.data(), kernel_data.size());
+      FXL_CHECK(!LogIfError(Dart_LoadKernel(Dart_ReadKernelBinary(
+          kernel_buf, kernel_data.size(), ReleaseFetchedBytes))));
     } else if (!snapshot_data.empty()) {
       // We are running from a script snapshot.
       FXL_CHECK(!LogIfError(Dart_LoadScriptFromSnapshot(snapshot_data.data(),

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 80830a986974f5df1b4b7f0aa68fd1f8
+Signature: 8002aa37a2e3a8073ba0bce943b9db6e
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
…) (#4805)"

This reverts commit 1348ab5b63adc18148f161876a4b1cacd5ec0779.

Reason for revert: Rolling flutter -> fuchsia has created a weird dependency for some dart packages, particularly test.
Meanwhile, Fuchsia rollers are blocked on 8cdfd67473c1055b3bec6265c674cc26bb20c8b9.
So reverting this change and bringing it back in the next commit will create a point for fucshia to roll engine forward without rolling dart.