### PR TITLE
Allow shadows to be colored when physical layer is drawn by engine

### DIFF
--- a/flow/layers/default_layer_builder.cc
+++ b/flow/layers/default_layer_builder.cc
@@ -109,6 +109,7 @@ void DefaultLayerBuilder::PushShaderMask(sk_sp<SkShader> shader,
 void DefaultLayerBuilder::PushPhysicalShape(const SkPath& sk_path,
                                             double elevation,
                                             SkColor color,
+                                            SkColor shadow_color,
                                             SkScalar device_pixel_ratio) {
   SkRect cullRect;
   if (!cullRect.intersect(sk_path.getBounds(), cull_rects_.top())) {
@@ -118,6 +119,7 @@ void DefaultLayerBuilder::PushPhysicalShape(const SkPath& sk_path,
   layer->set_path(sk_path);
   layer->set_elevation(elevation);
   layer->set_color(color);
+  layer->set_shadow_color(shadow_color);
   layer->set_device_pixel_ratio(device_pixel_ratio);
   PushLayer(std::move(layer), cullRect);
 }

--- a/flow/layers/default_layer_builder.h
+++ b/flow/layers/default_layer_builder.h
@@ -50,6 +50,7 @@ class DefaultLayerBuilder final : public LayerBuilder {
   void PushPhysicalShape(const SkPath& path,
                          double elevation,
                          SkColor color,
+                         SkColor shadow_color,
                          SkScalar device_pixel_ratio) override;
 
   // |flow::LayerBuilder|

--- a/flow/layers/layer_builder.h
+++ b/flow/layers/layer_builder.h
@@ -50,6 +50,7 @@ class LayerBuilder {
   virtual void PushPhysicalShape(const SkPath& path,
                                  double elevation,
                                  SkColor color,
+                                 SkColor shadow_color,
                                  SkScalar device_pixel_ratio) = 0;
 
   virtual void PushPerformanceOverlay(uint64_t enabled_options,

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -82,7 +82,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
   FXL_DCHECK(needs_painting());
 
   if (elevation_ != 0) {
-    DrawShadow(&context.canvas, path_, SK_ColorBLACK, elevation_,
+    DrawShadow(&context.canvas, path_, shadow_color_, elevation_,
                SkColorGetA(color_) != 0xff, device_pixel_ratio_);
   }
 

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -18,6 +18,7 @@ class PhysicalShapeLayer : public ContainerLayer {
 
   void set_elevation(float elevation) { elevation_ = elevation; }
   void set_color(SkColor color) { color_ = color; }
+  void set_shadow_color(SkColor shadow_color) { shadow_color_ = shadow_color; }
   void set_device_pixel_ratio(SkScalar dpr) { device_pixel_ratio_ = dpr; }
 
   static void DrawShadow(SkCanvas* canvas,
@@ -38,6 +39,7 @@ class PhysicalShapeLayer : public ContainerLayer {
  private:
   float elevation_;
   SkColor color_;
+  SkColor shadow_color_;
   SkScalar device_pixel_ratio_;
   SkPath path_;
   bool isRect_;

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -130,7 +130,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// Pushes a physical layer operation for an arbitrary shape onto the
   /// operation stack.
   ///
-  /// Rasterization will be clipped to the given shape.
+  /// Rasterization will be clipped to the given shape defined by [path]. If
+  /// [elevation] is greater than 0.0, then a shadow is drawn around the layer.
+  /// [shadowColor] defines the color of the shadow if present and [color] defines the 
+  /// color of the layer background.
   ///
   /// See [pop] for details about the operation stack.
   void pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor}) {

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -134,7 +134,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack.
   void pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor}) {
-    _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0);
+    _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000);
   }
   void _pushPhysicalShape(Path path, double elevation, int color, int shadowColor) native 
     'SceneBuilder_pushPhysicalShape';

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -133,10 +133,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// Rasterization will be clipped to the given shape.
   ///
   /// See [pop] for details about the operation stack.
-  void pushPhysicalShape({ Path path, double elevation, Color color }) {
-    _pushPhysicalShape(path, elevation, color.value);
+  void pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor}) {
+    _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0);
   }
-  void _pushPhysicalShape(Path path, double elevation, int color) native 
+  void _pushPhysicalShape(Path path, double elevation, int color, int shadowColor) native 
     'SceneBuilder_pushPhysicalShape';
 
   /// Ends the effect of the most recently pushed operation.

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -102,11 +102,13 @@ void SceneBuilder::pushShaderMask(Shader* shader,
 
 void SceneBuilder::pushPhysicalShape(const CanvasPath* path,
                                      double elevation,
-                                     int color) {
+                                     int color,
+                                     int shadow_color) {
   layer_builder_->PushPhysicalShape(
       path->path(),                 //
       elevation,                    //
       static_cast<SkColor>(color),  //
+      static_cast<SkColor>(shadow_color),
       UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio);
 }
 

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -47,7 +47,7 @@ class SceneBuilder : public fxl::RefCountedThreadSafe<SceneBuilder>,
                       double maskRectTop,
                       double maskRectBottom,
                       int blendMode);
-  void pushPhysicalShape(const CanvasPath* path, double elevation, int color);
+  void pushPhysicalShape(const CanvasPath* path, double elevation, int color, int shadowColor);
 
   void pop();
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -138,7 +138,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
             result.setAccessibilityFocused(mA11yFocusedObject.id == virtualViewId);
 
         if (object.hasFlag(Flag.IS_TEXT_FIELD)) {
-            result.setPassword(object.hasFlag(Flag.IS_PASSWORD);
+            result.setPassword(object.hasFlag(Flag.IS_PASSWORD));
             result.setClassName("android.widget.EditText");
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
                 result.setEditable(true);


### PR DESCRIPTION
When investigating https://github.com/flutter/flutter/issues/15641 I found two issues with shadows drawn by a physical layer. 

  * shadows do not match between engine and flutter.
  * shadow color is ignored by engine

The physical layer created by a `Material` widget can either be painted in the flutter package or by the engine, depending on whether the `Material` widget needs compositing.

In [`RenderPhysicalShape.paint`](https://github.com/flutter/flutter/blob/9c49255f3eeb4873e6398c805b4bb6b9737be962/packages/flutter/lib/src/rendering/proxy_box.dart#L1594), a colored shadow is painted if `needsCompositing` is false.  Below is a widget with an elevated Material and a slightly red shadow color.

source code: https://gist.github.com/jonahwilliams/26b63c58efd8e899bd3495047864cea3

<img  width="250" src="https://user-images.githubusercontent.com/8975114/37571826-049875ba-2abf-11e8-90c1-534c3034506a.png"> <img width="250" src="https://user-images.githubusercontent.com/8975114/37571829-0d5874b6-2abf-11e8-99da-794cbd61341a.png">

Same setup, but with default colors.  The shadow appears to change slightly - I'm not sure which one is correct but they should be synchronized. 

<img  width="250" src="https://user-images.githubusercontent.com/8975114/37571832-13810010-2abf-11e8-94d2-5f94057c1a3d.png"><img  width="250" src="https://user-images.githubusercontent.com/8975114/37571847-4e949126-2abf-11e8-802b-3216e0002836.png">

## With fix
The shadow is the same color whether or not the engine or flutter drew the layer.  shadows are still slightly different.

<img  width="250" src="https://user-images.githubusercontent.com/8975114/37621087-3488a300-2b7b-11e8-8a2a-6ac97dd4faeb.png"> <img width="250" src="https://user-images.githubusercontent.com/8975114/37621096-3784c8fe-2b7b-11e8-8d3e-97fdfb20c5ab.png">
