### PR TITLE
Roll dart version to 06949dc98556adb807e270c47cbb9407ec781064

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'f1ebe2bd5cfcb6b522e5b4fd406cdabb1a2d2091',
+  'dart_revision': '06949dc98556adb807e270c47cbb9407ec781064',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 80830a986974f5df1b4b7f0aa68fd1f8
+Signature: a3593f9d3adf185eaa6a15b0f50df584
 
 UNUSED LICENSES:
 
@@ -4615,7 +4615,6 @@ FILE: ../../../third_party/dart/sdk/lib/core/null.dart
 FILE: ../../../third_party/dart/sdk/lib/core/stacktrace.dart
 FILE: ../../../third_party/dart/sdk/lib/core/string_sink.dart
 FILE: ../../../third_party/dart/sdk/lib/core/symbol.dart
-FILE: ../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/internal/list.dart
 FILE: ../../../third_party/dart/sdk/lib/internal/print.dart
 FILE: ../../../third_party/dart/sdk/lib/internal/symbol.dart
@@ -5309,6 +5308,7 @@ FILE: ../../../third_party/dart/sdk/lib/core/string.dart
 FILE: ../../../third_party/dart/sdk/lib/core/type.dart
 FILE: ../../../third_party/dart/sdk/lib/core/uri.dart
 FILE: ../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/html/dartium/nativewrappers.dart
 FILE: ../../../third_party/dart/sdk/lib/html/html_common/conversions.dart
 FILE: ../../../third_party/dart/sdk/lib/html/html_common/css_class_set.dart
@@ -5333,7 +5333,6 @@ FILE: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart
-FILE: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart


### PR DESCRIPTION
Includes the following changes
- Flip analyzer and server to preview-dart-2 by default
- [vm] Move writing snapshot magic value from embedder to VM
- Fix bug in BigInt.from with certain double value
- [vm] Clean up any remaining API scopes in Dart_ShutdownIsolate.
- [analyzer] Don't expect type arguments for class type parameters of static methods.