### PR TITLE
Remove the canvas save/restore calls in Paragraph::Paint

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -773,7 +773,6 @@ void Paragraph::SetFontCollection(
 // The x,y coordinates will be the very top left corner of the rendered
 // paragraph.
 void Paragraph::Paint(SkCanvas* canvas, double x, double y) {
-  SkAutoCanvasRestore canvas_restore(canvas, true);
   canvas->translate(x, y);
   SkPaint paint;
   for (const PaintRecord& record : records_) {
@@ -782,6 +781,7 @@ void Paragraph::Paint(SkCanvas* canvas, double x, double y) {
     canvas->drawTextBlob(record.text(), offset.x(), offset.y(), paint);
     PaintDecorations(canvas, record);
   }
+  canvas->translate(-x, -y);
 }
 
 void Paragraph::PaintDecorations(SkCanvas* canvas, const PaintRecord& record) {


### PR DESCRIPTION
This is a workaround for https://github.com/flutter/flutter/issues/15702

Skia was not drawing the paragraph's text blobs in some cases when a
save/restore sequence is done around the canvas->translate call.  The
problem does not occur if an offsetting call to translate is made instead
of the save/restore.  Will need to work with Skia to find the root cause.