### PR TITLE
Updates in flutter/lib/snapshot for the shell refactor (Patch 6)

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -32,7 +32,7 @@ if (is_fuchsia) {
 
     dot_packages_file = "$target_gen_dir/snapshot.packages"
     outputs = [
-      dot_packages_file
+      dot_packages_file,
     ]
     deps = []
     foreach(dep, dart_deps) {
@@ -43,26 +43,27 @@ if (is_fuchsia) {
 
     script = "//build/dart/gen_dot_packages.py"
     args = [
-      "--out",
-      rebase_path(dot_packages_file, root_build_dir),
-      "--source-dir",
-      rebase_path("."),
-      "--root-build-dir",
-      rebase_path(root_build_dir),
-      "--root-gen-dir",
-      rebase_path(dart_root_gen_dir),
-      "--package-name",
-      "snapshot_root",
-      "--depfile",
-      rebase_path(depfile),
-      "--deps",
-    ] + dart_deps
+             "--out",
+             rebase_path(dot_packages_file, root_build_dir),
+             "--source-dir",
+             rebase_path("."),
+             "--root-build-dir",
+             rebase_path(root_build_dir),
+             "--root-gen-dir",
+             rebase_path(dart_root_gen_dir),
+             "--package-name",
+             "snapshot_root",
+             "--depfile",
+             rebase_path(depfile),
+             "--deps",
+           ] + dart_deps
   }
 }
 
 action("generate_snapshot_bin") {
   if (is_fuchsia) {
     snapshot_dart = "snapshot_fuchsia.dart"
+
     # TODO(rmacnak): Fuchsia cross builds use the wrong Dart target
     # architecture, and have added steps that depend on this error for
     # reasonable build times (e.g., invoking the analyzer).
@@ -105,9 +106,9 @@ action("generate_snapshot_bin") {
 
   rebased_dart_ui_path = rebase_path(dart_ui_path)
 
-  gen_snapshot_dir =
-      get_label_info("//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)",
-                     "root_out_dir")
+  gen_snapshot_dir = get_label_info(
+          "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)",
+          "root_out_dir")
   script = "//third_party/dart/runtime/tools/create_snapshot_bin.py"
 
   args = [
@@ -226,7 +227,7 @@ bin_to_assembly("isolate_snapshot_data_assembly") {
   ]
   input = "$target_gen_dir/isolate_snapshot.bin"
   output = "$target_gen_dir/isolate_snapshot_data.S"
-  symbol = "kDartIsolateCoreSnapshotData"
+  symbol = "kDartIsolateSnapshotData"
   executable = false
 }
 
@@ -236,7 +237,7 @@ bin_to_assembly("isolate_snapshot_instructions_assembly") {
   ]
   input = "$target_gen_dir/isolate_snapshot_instructions.bin"
   output = "$target_gen_dir/isolate_snapshot_instructions.S"
-  symbol = "kDartIsolateCoreSnapshotInstructions"
+  symbol = "kDartIsolateSnapshotInstructions"
   executable = true
 }
 
@@ -266,9 +267,9 @@ compile_platform("non_strong_platform") {
   ]
 
   args = [
-            "--target=flutter",
-            "dart:core",
-         ]
+    "--target=flutter",
+    "dart:core",
+  ]
 }
 
 compile_platform("strong_platform") {
@@ -282,10 +283,10 @@ compile_platform("strong_platform") {
   ]
 
   args = [
-            "--target=flutter",
-            "--strong",
-            "dart:core"
-         ]
+    "--target=flutter",
+    "--strong",
+    "dart:core",
+  ]
 }
 
 group("kernel_platform_files") {


### PR DESCRIPTION
This changes is part of a large patch for easier review. Try the whole patch in one go by checking out https://github.com/chinmaygarde/flutter_engine/tree/shell directly. This patch contains the following changes:
* Unify snapshot symbol names across platforms and apply a GN format pass.