### PR TITLE
Handle Apple-specific GLES headers

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -4,8 +4,13 @@
 
 #include "gpu_surface_gl.h"
 
+#if OS_MACOSX || OS_IOS
+#include <OpenGLES/ES2/gl.h>
+#include <OpenGLES/ES2/glext.h>
+#else
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
+#endif
 
 #include "flutter/glue/trace_event.h"
 #include "lib/fxl/arraysize.h"


### PR DESCRIPTION
In 60befc2cdec54818ce738fd07236624dc1b287a2, includes were added for
GLES. On macOS/iOS, these headers are named slightly differently.