### PR TITLE
Revert VulkanSurface and GPUSurfaceGL no longer use GrPixelConfig (#4…

### DIFF
--- a/content_handler/vulkan_surface.cc
+++ b/content_handler/vulkan_surface.cc
@@ -152,8 +152,6 @@ bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrContext> context,
     return false;
   }
 
-  const SkColorType color_type = kBGRA_8888_SkColorType;
-
   // Create the image.
   const VkImageCreateInfo image_create_info = {
       .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -257,13 +255,12 @@ bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrContext> context,
     return false;
   }
 
-  return SetupSkiaSurface(std::move(context), size, color_type,
-                          image_create_info, memory_reqs);
+  return SetupSkiaSurface(std::move(context), size, image_create_info,
+                          memory_reqs);
 }
 
 bool VulkanSurface::SetupSkiaSurface(sk_sp<GrContext> context,
                                      const SkISize& size,
-                                     SkColorType color_type,
                                      const VkImageCreateInfo& image_create_info,
                                      const VkMemoryRequirements& memory_reqs) {
   if (context == nullptr) {
@@ -289,7 +286,6 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrContext> context,
       SkSurface::MakeFromBackendRenderTarget(context.get(),             //
                                              sk_render_target,          //
                                              kTopLeft_GrSurfaceOrigin,  //
-                                             color_type,                //
                                              nullptr,                   //
                                              &sk_surface_props          //
       );

--- a/content_handler/vulkan_surface.h
+++ b/content_handler/vulkan_surface.h
@@ -80,7 +80,6 @@ class VulkanSurface : public flow::SceneUpdateContext::SurfaceProducerSurface {
 
   bool SetupSkiaSurface(sk_sp<GrContext> context,
                         const SkISize& size,
-                        SkColorType color_type,
                         const VkImageCreateInfo& image_create_info,
                         const VkMemoryRequirements& memory_reqs);
 


### PR DESCRIPTION
…814)

While followup patches were able to get things working on iOS and macOS,
Fuchsia is broken by this patch. Reverting until we've got a solution
for fuchsia_tester.

This reverts commit 9b837652b12ad89ca8ac3ced88a7ed21dbfa4ba4.
This reverts commit 604f51e675d6a912b7370950958c94b96323cd82.
This reverts commit 60befc2cdec54818ce738fd07236624dc1b287a2.