### PR TITLE
Fix supported color type check on iOS simulators

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -87,7 +87,7 @@ static SkColorType FirstSupportedColorType(GrContext* context, GLenum* format) {
     *format = (y);                                 \
     return (x);                                    \
   }
-#if OS_MACOSX
+#if OS_MACOSX && !OS_IOS
   RETURN_IF_RENDERABLE(kRGBA_8888_SkColorType, GL_RGBA8);
 #else
   RETURN_IF_RENDERABLE(kRGBA_8888_SkColorType, GL_RGBA8_OES);


### PR DESCRIPTION
Since OS_MACOSX and OS_IOS are both enabled for simulator builds, ensure
we're using constants conistent with our #includes.