### PR TITLE
Roll dart to 95e9e890a9

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '06949dc98556adb807e270c47cbb9407ec781064',
+  'dart_revision': '95e9e890a996b9a61ade6cc81830dd7cf295ec9d',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -60,7 +60,7 @@ vars = {
   'dart_intl_tag': '0.15.2',
   'dart_isolate_tag': '1.1.0',
   'dart_json_rpc_2_tag': '2.0.6',
-  'dart_linter_tag': '0.1.44',
+  'dart_linter_tag': '0.1.45',
   'dart_logging_tag': '0.11.3+1',
   'dart_markdown_tag': '1.1.1',
   'dart_matcher_tag': '0.12.1+4',
@@ -75,7 +75,7 @@ vars = {
   'dart_plugin_tag': '0.2.0+2',
   'dart_pool_tag': '1.3.4',
   'dart_protobuf_tag': '0.7.1',
-  'dart_pub_rev': 'dbe8be2bb8bca9b26ba7bd583272c62f9a0153fd',
+  'dart_pub_rev': '875d35005a7d33f367d70a3e31e9d3bad5d1ebd8',
   'dart_pub_semver_tag': '1.3.2',
   'dart_quiver_tag': '5aaa3f58c48608af5b027444d561270b53f15dbf',
   'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: a714ae47f09ddeaf5ab4e20e34c3743a
+Signature: 93a18f7523d168b169c0648c3927b9c1
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Changes since last dart roll:

```
95e9e890a9 [kernel/vm] Implement NSM-forwarding in the VM.
7450e2ad60 Fix parsing of invalid interpolation in string literal
cd03f35a0b Prepare for analyzer 0.31.2-alpha.1, front_end 0.1.0-alpha.11, and kernel 0.3.0-alpha.11.
38b0825a55 [kernel] Add target for Flutter on Fuchsia.
2fd9969c96 extend unstable API to pass in the location of the libraries-specification
1caf7b7ecd Revert "Create new AnalysisSession instance on changes."
c90ca298ed Provide a message for InconsistentAnalysisException.
b6944e3165 Make use of environment overrides in fasta's implementation of config specific imports
26c06cdd82 Clean up Dart 2 type issues related to YAML support
4989976a81 Add CFE support for noSuchMethod forwarders
014bd821e6 Retry when fixes cannot be computed because of an inconsistent session (issue 32635)
04f5d1b974 Recover from missing while in do/while statement
dc5a8b2e91 Improve the fix to add an explicit cast
c7cdb72f32 Move CloneWithoutBody to Kernel API
2be1456309 [fasta] Fix not being able to output a program because of erroneousProgram
17a778c9cb Changed AudioScheduledSourceNode.start to start2. Fixes https://github.com/dart-lang/sdk/issues/32624
ae9b76dba6 [kernel] Add flag for NSM-forwarding stubs.
691bb9b299 [vm/compiler] Add a comment about MakeTemporary limitation.
83bfbcdd96 Incremental compilation: computing class hierarchy for reachable things only
0dd2a8dbdb Incremental compiler: Only include libraries loaded from dill if used
b4206bb92c Remove dartk
bb2bf609be Incremental compiler: Deal with disappearing package
2e366e8c9a [fasta] Refactor incremental_load_from_dill_test
4f40e43d7a Incremental compiler: Add test that mixes in something from the sdk
83c0a75564 [fasta] Add failing test to incremental compiler test suite
3a81263fee [ VM / Dart 2] Split DartAPI_PropagateError into DartAPI_PropagateError and DartAPI_PropagateCompileError since the compile time error from the missing semicolon prevented the code from being executed in Dart 2.
4905a2da7c Fix pub issues links from bde48c67ec6bd76a475ead02f45a16c1c0309529
bde48c67ec Update pub dependency
95089a2eeb cleanup CHANGELOG for -dev.39 and -dev.40
068be3b656 [ VM / Dart 2 ] Fixed issue where TokenPosition::kNoSource was being registered as the position of native methods. Fixes DartAPI_CurrentStackTraceInfo
5430010395 Use writeFieldDeclaration() and writeFunctionDeclaration() to write extracted widget.
1d774b7f77 Add "environment_overrides" section to libraries-specification.
36d4fd37a7 Mark test as flaky
f2806ab624 [Corelib, VM runtime] Fix handling of zero operand in Bigint operations (fixes #32465). Fix VM, dart2js, and dcc Bigint implementations. Add shift tests. Re-enable Bigint intrinsics on VM.
9f0e391e28 Rename writeParameterSource() to writeParameter() and make 'type' optional.
8136c957a1 Improve fasta parser library declaration recovery
b3c4b1c2ef Remove pkg/browser from SDK source – use mirror
179db6dc6a Remove usage of pkg:browser from tools/dart2js/sourceMapViewer
a81f4babcc Revert "[ VM / Dart 2 ] Fixed StackTraceFormat test to expect file URIs in stacks generated by the Dart frontend."
ae130bc187 [ VM / Dart 2 ] Fixed StackTraceFormat test to expect file URIs in stacks generated by the Dart frontend.
2546f2235e Fix status lines for html group tests - group was duplicated in logs.
8658a7403e Check for references/writes to superclass members.
15bf72615d Fix for using isFinal/isConst with type in writeFieldDeclaration().
a8986cf45a Support for parameters for extracted widget.
aac5d04198 [infra] Add optimization_counter_threshold builder tag to the test matrix
fe5e2444ad [ VM / Dart 2 ] Fixed DartAPI_InvokeCrossLibrary test.
dddb578fbb Update Safari status for two tests
521846c832 [VM] When generating the token position list for each line (for a [Script]), only scan relevant classes/functions/fields
8630c69c9f Add typeInfo expression accessor
587e4f8723 Parse local function metadata
8493f68271 Adjusted status for lib_2/async/future_or_type_test.dart
7c05f1e608 Add more tests for FutureOr used as a type.
1fc73bf1a6 Compute ClassFunctionType from signature function in Dart 2
ad5f5abb13 Remove dart2js self analysis tests
31dd6683f8 [VM] Optimize performance of dart_boostrap in debug-kernel-strong mode.
38dc57504b [status] Update corelib_2 status for bigint test
6469f4c78a Support for extracting widget from a function.
00ec3b0867 [vm] Fix several kernel-specific memory leaks.
b7c3c32f63 [vm] Do not assign type to phi if it was loaded from a different local
d26c310a27 Rework parsing of local const declarations
06638dd17f [ VM / Dart 2 ] Removed DartAPI_NativeFieldAccess and DartAPI_InjectNativeFields1 as they were using Dart_CreateNativeWrapper which doesn't make sense in the context of Dart 2. Also did some status file cleanup and reorganization.
a5966ad988 Fix dart2js libraries.yaml
ec65830504 [ VM / Dart 2 ] Fixed DartAPI_LookupLibrary test which was treating the script in Dart_LoadScript as kernel instead of source.
8abeb56ebb Basic 'Extract Widget' refactoring.
996277d427 Entity-fy the non-frequence minifier so it can be supported under the CFE.
0e764393f3 A few more Dart2 related fixes
965cb81c0f Add AnalysisSessionHelper and move getClass() into it.
1c5d2e9016 Bump linter to 0.1.45
86b1646475 webSQL is not suported by Firefox fixed test supported should of true should not be expected.
3d34f4d4fe Updated CHANGELOG with Chrome 63 roll changes and fixed status file test now passes.
08d305bbd7 Inline modifiers into endTopLevelFields and endFields events
efab00ce5c Fix type issues caused by running with --preview-dart-2
adb9f8cc0b Inline modifiers into beginClassDeclaration and beginNamedMixinApplication
b75fb574ee Fix async_compiler_input_provider_test for Windows
fd005e17bc Rework parsing of local function declarations
8eb749e032 Fix sourcemaps/name_test for kernel
581c512345 Fixed DOMRectList not having a prototype field.
031ef989ac Provide better error message when a linked dependency doesn't exist
d9878ae0da fix regression in DDC handling of top-level field named 'name'
ac322d0fb4 Move LibraryElement caching to AnalysisSession.
2047d44631 Handle the case where there is no selection(issue 32563)
```