### PR TITLE
Vulkan swap chain doesn't use GrPixelConfig and doesn't include from skia/src

### DIFF
--- a/content_handler/vulkan_surface.cc
+++ b/content_handler/vulkan_surface.cc
@@ -10,7 +10,6 @@
 #include "third_party/skia/include/gpu/GrBackendSemaphore.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrContext.h"
-#include "third_party/skia/src/gpu/vk/GrVkImage.h"
 
 namespace flutter_runner {
 

--- a/content_handler/vulkan_surface_producer.cc
+++ b/content_handler/vulkan_surface_producer.cc
@@ -11,7 +11,6 @@
 #include "third_party/skia/include/gpu/GrBackendSemaphore.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
-#include "third_party/skia/src/gpu/vk/GrVkUtil.h"
 
 namespace flutter_runner {
 

--- a/vulkan/vulkan_backbuffer.cc
+++ b/vulkan/vulkan_backbuffer.cc
@@ -6,9 +6,9 @@
 
 #include <limits>
 
+#include "flutter/vulkan/skia_vulkan_header.h"
 #include "flutter/vulkan/vulkan_proc_table.h"
 #include "third_party/skia/include/gpu/vk/GrVkTypes.h"
-#include "third_party/skia/src/gpu/vk/GrVkUtil.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_device.h
+++ b/vulkan/vulkan_device.h
@@ -49,8 +49,9 @@ class VulkanDevice {
       uint32_t* /* mask of GrVkFeatureFlags */ features) const;
 
   FXL_WARN_UNUSED_RESULT
-  bool ChooseSurfaceFormat(const VulkanSurface& surface,
-                           VkSurfaceFormatKHR* format) const;
+  int ChooseSurfaceFormat(const VulkanSurface& surface,
+                          std::vector<VkFormat> desired_formats,
+                          VkSurfaceFormatKHR* format) const;
 
   FXL_WARN_UNUSED_RESULT
   bool ChoosePresentMode(const VulkanSurface& surface,

--- a/vulkan/vulkan_swapchain.h
+++ b/vulkan/vulkan_swapchain.h
@@ -77,11 +77,15 @@ class VulkanSwapchain {
 
   std::vector<VkImage> GetImages() const;
 
-  bool CreateSwapchainImages(GrContext* skia_context);
+  bool CreateSwapchainImages(GrContext* skia_context,
+                             SkColorType color_type,
+                             sk_sp<SkColorSpace> color_space);
 
   sk_sp<SkSurface> CreateSkiaSurface(GrContext* skia_context,
                                      VkImage image,
-                                     const SkISize& size) const;
+                                     const SkISize& size,
+                                     SkColorType color_type,
+                                     sk_sp<SkColorSpace> color_space) const;
 
   VulkanBackbuffer* GetNextBackbuffer();
 


### PR DESCRIPTION
Moves decision of preferred formats and check for format's compatibility with Skia from VulkanDevice to VulkanSwapChain.

Passes SkColorType to SkSurface::MakeFromBackendRenderTarget.