### PR TITLE
CONTRIBUTING.md: explain the need for building host with non-host

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ Once the artifacts are built, you can start using them in your application by fo
 
 ### Desktop (Mac and Linux), for tests
 
-To run the tests, you should firts clone [the main Flutter repository](https://github.com/flutter/flutter).
+To run the tests, you should first clone [the main Flutter repository](https://github.com/flutter/flutter).
 See [the instructions for contributing](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)
 to the main Flutter repository for detailed instructions. By default, Flutter will use the bundled version
 of the engine. Follow the next steps to run tests using the locally built engine:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,14 +156,14 @@ Once the artifacts are built, you can start using them in your application by fo
 To run the tests, you should first clone [the main Flutter repository](https://github.com/flutter/flutter).
 See [the instructions for contributing](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)
 to the main Flutter repository for detailed instructions. By default, Flutter will use the bundled version
-of the engine. Follow the next steps to run tests using the locally built engine:
+of the engine. Follow the next steps to run tests using the locally-built engine:
 
 * `git pull upstream master` in `src/flutter` to update the Flutter Engine repo.
 * `gclient sync` to update your dependencies.
 * `./flutter/tools/gn --unoptimized` to prepare your build files.
 * `ninja -C out/host_debug_unopt` to build a desktop unoptimized binary.
 * `--unoptimized` disables C++ compiler optimizations and does not strip debug symbols. You may skip the flag and invoke `ninja -C out/host_debug` if you would rather have the native components optimized.
-* `flutter test --local-engine=host_debug_unopt` will run tests using the locally built `flutter_tester`.
+* `flutter test --local-engine=host_debug_unopt` will run tests using the locally-built `flutter_tester`.
 
 ### Desktop (gen_snapshot for Windows)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,9 @@ Run the following steps, from the `src` directory created in the steps above:
 
 * `git pull upstream master` in `src/flutter` to update the Flutter Engine repo.
 * `gclient sync` to update your dependencies.
-* `./flutter/tools/gn --android --unoptimized` to prepare your build files (or `--android --android-cpu [x86|x64] --unoptimized` for x86/x64 emulators) .
-* `ninja -C out/android_debug_unopt` to actually build the Android binary (or `out/android_debug_unopt_x64` for x86/x64 emulators).
+* `./flutter/tools/gn --android --unoptimized` to prepare your build files for device-side executables (or `--android --android-cpu [x86|x64] --unoptimized` for x86/x64 emulators) .
+* `./flutter/tools/gn --unoptimized` to prepare the build files for host-side executables.
+* `ninja -C out/android_debug_unopt -C out/host_debug_unopt` to build all executables (use `out/android_debug_unopt_x64` for x86/x64 emulators).
 
 This builds a debug-enabled ("unoptimized") binary configured to run Dart in
 checked mode ("debug"). There are other versions, [discussed on the wiki](https://github.com/flutter/flutter/wiki/Flutter's-modes).
@@ -137,10 +138,11 @@ to test the engine.
 * Make sure you have Xcode 9.0+ installed.
 * `git pull upstream master` in `src/flutter` to update the Flutter Engine repo.
 * `gclient sync` to update dependencies.
-* `./flutter/tools/gn --ios --unoptimized` to prepare build files (or `--ios --simulator --unoptimized` for simulator).
+* `./flutter/tools/gn --ios --unoptimized` to prepare build files for device-side executables (or `--ios --simulator --unoptimized` for simulator).
   * For a discussion on the various flags and modes, [read this discussion](https://github.com/flutter/flutter/wiki/Flutter's-modes).
   * This also produces an Xcode project for working with the engine source code at `out/ios_debug_unopt`
-* `ninja -C out/ios_debug_unopt` to build iOS artifacts (or `out/ios_debug_sim_unopt` for simulator).
+* `./flutter/tools/gn --unoptimized` to prepare the build files for host-side executables.
+* `ninja -C out/ios_debug_unopt -C out/host_debug_unopt` to build all artifacts (use `out/ios_debug_sim_unopt` for Simulator).
 
 Once the artifacts are built, you can start using them in your application by following these steps:
 * `cd /path/to/flutter/examples/hello_world`
@@ -151,15 +153,17 @@ Once the artifacts are built, you can start using them in your application by fo
 
 ### Desktop (Mac and Linux), for tests
 
+To run the tests, you should firts clone [the main Flutter repository](https://github.com/flutter/flutter).
+See [the instructions for contributing](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)
+to the main Flutter repository for detailed instructions. By default, Flutter will use the bundled version
+of the engine. Follow the next steps to run tests using the locally built engine:
+
 * `git pull upstream master` in `src/flutter` to update the Flutter Engine repo.
 * `gclient sync` to update your dependencies.
 * `./flutter/tools/gn --unoptimized` to prepare your build files.
 * `ninja -C out/host_debug_unopt` to build a desktop unoptimized binary.
 * `--unoptimized` disables C++ compiler optimizations and does not strip debug symbols. You may skip the flag and invoke `ninja -C out/host_debug` if you would rather have the native components optimized.
-
-To run the tests, you'll also need to clone [the main Flutter repository](https://github.com/flutter/flutter).
-See [the instructions for contributing](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)
-to the main Flutter repository for detailed instructions.
+* `flutter test --local-engine=host_debug_unopt` will run tests using the locally built `flutter_tester`.
 
 ### Desktop (gen_snapshot for Windows)
 


### PR DESCRIPTION
As of Dart 2 all non-host builds also require a host build. This updates `CONTRIBUTING.md` accordingly.