### PR TITLE
Allow FirstFrameListeners to remove themselves from the FlutterView's list

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -767,7 +767,9 @@ public class FlutterView extends SurfaceView
 
     // Called by native to notify first Flutter frame rendered.
     public void onFirstFrame() {
-        for (FirstFrameListener listener : mFirstFrameListeners) {
+        // Allow listeners to remove themselves when they are called.
+        List<FirstFrameListener> listeners = new ArrayList<>(mFirstFrameListeners);
+        for (FirstFrameListener listener : listeners) {
             listener.onFirstFrame();
         }
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/15884