### PR TITLE
Revert "Fix vulkan include path (#4870)"

### DIFF
--- a/vulkan/skia_vulkan_header.h
+++ b/vulkan/skia_vulkan_header.h
@@ -8,4 +8,4 @@
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 #endif  // __ANDROID__
 
-#include "vulkan/vulkan.h"
+#include "third_party/vulkan/src/vulkan/vulkan.h"


### PR DESCRIPTION
Breaks Linux and Mac build bots.

This reverts commit d9ec2de7d081b24d844590ebdb5fca37b57731c6.