### PR TITLE
libtxt: move to the next run if the current run ends before the start of the line block

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -239,6 +239,10 @@ bool Paragraph::ComputeLineBreaks() {
       StyledRuns::Run run = runs_.GetRun(run_index);
       if (run.start >= block_end)
         break;
+      if (run.end < block_start) {
+        run_index++;
+        continue;
+      }
 
       minikin::FontStyle font;
       minikin::MinikinPaint paint;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/15975