### PR TITLE
Revert "Roll Dart for FIDL2"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'cdc696f9a71f2a6c2c3b3f4dad229a5981305149',
+  'dart_revision': '4da52281aa35b6c1951b3e269a6934412b15b105',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',


### PR DESCRIPTION
Reverts flutter/engine#4906 as it didn't run through all proper presubmit checks that would have flagged issues with license checks.