### PR TITLE
[fuchsia] Set up namespace properly

### DIFF
--- a/content_handler/application_controller_impl.h
+++ b/content_handler/application_controller_impl.h
@@ -54,7 +54,7 @@ class ApplicationControllerImpl : public component::ApplicationController,
   void StartRuntimeIfReady();
   void SendReturnCode(int32_t return_code);
 
-  fdio_ns_t* SetupNamespace(component::FlatNamespace flat);
+  fdio_ns_t* SetupNamespace(component::FlatNamespace* flat);
 
   App* app_;
   fidl::Binding<component::ApplicationController> binding_;


### PR DESCRIPTION
When we converted this code to FIDL2, we moved the FlatNamespace into
SetupNamespace, which meant it grabed the service root handle instead of
leaving it in-place for ApplicationContext::CreateFrom to pick it up.
Now, we pass this object by pointer, which is what we did in FIDL1.