### PR TITLE
Set the asset bundle path when initializing the shell in the embedder API

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -153,7 +153,8 @@ FlutterResult FlutterEngineRun(size_t version,
     shell::Shell::InitStandalone(
         std::move(command_line),
         icu_data_path,  // icu data path default lookup.
-        ""              // application library not supported in JIT mode.
+        "",             // application library not supported in JIT mode.
+        args->assets_path
     );
   });
 


### PR DESCRIPTION
This is required so that Dart initialization can find the platform kernel
assets when running in Dart 2 mode