### PR TITLE
Roll dart to 4bcf8ad411bd90da16d44ad399bf350e8423eac9

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '52afcba357ad398e8c24f3e3363ac6ff5293df63',
+  'dart_revision': 'e5d20a7749a15361ccfe47bc4c4e4becb88180b4',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -48,7 +48,7 @@ vars = {
   'dart_csslib_tag': '0.14.1',
   'dart_dart2js_info_tag': '0.5.5+1',
   'dart_dart_style_tag': '1.0.10',
-  'dart_dartdoc_tag': 'v0.18.0',
+  'dart_dartdoc_tag': 'v0.18.1',
   'dart_fixnum_tag': '0.10.5',
   'dart_glob_tag': '1.1.5',
   'dart_html_tag': '0.13.3',
@@ -68,15 +68,15 @@ vars = {
   'dart_mockito_tag': 'a92db054fba18bc2d605be7670aee74b7cadc00a',
   'dart_mustache4dart_tag': 'v2.1.0',
   'dart_oauth2_tag': '1.1.0',
-  'dart_observatory_pub_packages_rev': '4c282bb240b68f407c8c7779a65c68eeb0139dc6',
+  'dart_observatory_pub_packages_rev': 'd3a3aebefbd35aa30fe7bbc2889b772b398f7d7f',
   'dart_package_config_tag': '1.0.3',
   'dart_package_resolver_tag': '1.0.2+1',
   'dart_path_tag': '1.5.1',
   'dart_plugin_tag': '0.2.0+2',
   'dart_pool_tag': '1.3.4',
   'dart_protobuf_tag': '0.7.1',
-  'dart_pub_rev': '875d35005a7d33f367d70a3e31e9d3bad5d1ebd8',
-  'dart_pub_semver_tag': '1.3.2',
+  'dart_pub_rev': '4947e0b3cb3ec77e4e8fe0d3141ce4dc60f43256',
+  'dart_pub_semver_tag': '1.3.3',
   'dart_quiver_tag': '5aaa3f58c48608af5b027444d561270b53f15dbf',
   'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',
   'dart_root_certificates_rev': '16ef64be64c7dfdff2b9f4b910726e635ccc519e',

--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'e5d20a7749a15361ccfe47bc4c4e4becb88180b4',
+  'dart_revision': '4bcf8ad411bd90da16d44ad399bf350e8423eac9',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -76,7 +76,7 @@ vars = {
   'dart_pool_tag': '1.3.4',
   'dart_protobuf_tag': '0.7.1',
   'dart_pub_rev': '4947e0b3cb3ec77e4e8fe0d3141ce4dc60f43256',
-  'dart_pub_semver_tag': '1.3.3',
+  'dart_pub_semver_tag': '1.3.4',
   'dart_quiver_tag': '5aaa3f58c48608af5b027444d561270b53f15dbf',
   'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',
   'dart_root_certificates_rev': '16ef64be64c7dfdff2b9f4b910726e635ccc519e',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 6d40c6cdc2b0a27173677e57f49fb54a
+Signature: 0d52e4a9a84f4a44a99ad88c668cabc8
 
 UNUSED LICENSES:
 
@@ -4202,482 +4202,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 LIBRARY: dart
 LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/runtime/bin/vmservice/loader.dart + ../../../third_party/dart/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/runtime/bin/address_sanitizer.cc
-FILE: ../../../third_party/dart/runtime/bin/builtin_common.cc
-FILE: ../../../third_party/dart/runtime/bin/embedded_dart_io.cc
-FILE: ../../../third_party/dart/runtime/bin/embedded_dart_io.h
-FILE: ../../../third_party/dart/runtime/bin/observatory_assets_empty.cc
-FILE: ../../../third_party/dart/runtime/bin/vmservice/loader.dart
-FILE: ../../../third_party/dart/runtime/lib/async_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/compact_hash.dart
-FILE: ../../../third_party/dart/runtime/lib/developer.cc
-FILE: ../../../third_party/dart/runtime/lib/developer.dart
-FILE: ../../../third_party/dart/runtime/lib/timeline.cc
-FILE: ../../../third_party/dart/runtime/lib/timeline.dart
-FILE: ../../../third_party/dart/runtime/lib/vmservice.cc
-FILE: ../../../third_party/dart/runtime/observatory/lib/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/cli.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/debugger.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/allocation_profile/allocation_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/analytics.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/cli/command.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger_location.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging_list.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/persistent_handles.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/ports.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/timeline_page.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/view_footer.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/sample_profile/sample_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/web/timeline.js
-FILE: ../../../third_party/dart/runtime/vm/atomic_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.h
-FILE: ../../../third_party/dart/runtime/vm/log.cc
-FILE: ../../../third_party/dart/runtime/vm/log.h
-FILE: ../../../third_party/dart/runtime/vm/log_test.cc
-FILE: ../../../third_party/dart/runtime/vm/os_thread.cc
-FILE: ../../../third_party/dart/runtime/vm/profiler_service.cc
-FILE: ../../../third_party/dart/runtime/vm/profiler_service.h
-FILE: ../../../third_party/dart/runtime/vm/program_visitor.cc
-FILE: ../../../third_party/dart/runtime/vm/program_visitor.h
-FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.cc
-FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.h
-FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode_inl.h
-FILE: ../../../third_party/dart/runtime/vm/regexp_bytecodes.h
-FILE: ../../../third_party/dart/runtime/vm/regexp_interpreter.cc
-FILE: ../../../third_party/dart/runtime/vm/regexp_interpreter.h
-FILE: ../../../third_party/dart/runtime/vm/scope_timer.h
-FILE: ../../../third_party/dart/runtime/vm/service_event.cc
-FILE: ../../../third_party/dart/runtime/vm/service_event.h
-FILE: ../../../third_party/dart/runtime/vm/service_isolate.cc
-FILE: ../../../third_party/dart/runtime/vm/source_report.cc
-FILE: ../../../third_party/dart/runtime/vm/source_report.h
-FILE: ../../../third_party/dart/runtime/vm/source_report_test.cc
-FILE: ../../../third_party/dart/runtime/vm/thread.cc
-FILE: ../../../third_party/dart/runtime/vm/thread.h
-FILE: ../../../third_party/dart/runtime/vm/thread_barrier.h
-FILE: ../../../third_party/dart/runtime/vm/thread_barrier_test.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_registry.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_registry.h
-FILE: ../../../third_party/dart/runtime/vm/timeline.cc
-FILE: ../../../third_party/dart/runtime/vm/timeline.h
-FILE: ../../../third_party/dart/runtime/vm/timeline_analysis.cc
-FILE: ../../../third_party/dart/runtime/vm/timeline_analysis.h
-FILE: ../../../third_party/dart/runtime/vm/timeline_test.cc
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/developer_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/d8.js
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/jsshell.js
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/shared/async_await_error_codes.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/base64.dart
-FILE: ../../../third_party/dart/sdk/lib/dart_client.platform
-FILE: ../../../third_party/dart/sdk/lib/dart_server.platform
-FILE: ../../../third_party/dart/sdk/lib/dart_shared.platform
-FILE: ../../../third_party/dart/sdk/lib/developer/developer.dart
-FILE: ../../../third_party/dart/sdk/lib/developer/extension.dart
-FILE: ../../../third_party/dart/sdk/lib/developer/timeline.dart
-FILE: ../../../third_party/dart/sdk/lib/io/io_resource_info.dart
-FILE: ../../../third_party/dart/sdk/lib/io/security_context.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/asset.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/vmservice.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/common.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/html_import_annotation_recorder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/import_inliner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/messages.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/mirrors_remover.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/script_compactor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/test_compatibility.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/web_components.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/custom_element_proxy.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/html_import_annotation.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/init.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/src/custom_element.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/src/init.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/src/normalize_path.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/web_components.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: dart
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/runtime/bin/vmservice/server.dart + ../../../third_party/dart/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/WATCHLISTS
-FILE: ../../../third_party/dart/runtime/bin/eventhandler_win.cc
-FILE: ../../../third_party/dart/runtime/bin/file.cc
-FILE: ../../../third_party/dart/runtime/bin/file.h
-FILE: ../../../third_party/dart/runtime/bin/file_system_entity_patch.dart
-FILE: ../../../third_party/dart/runtime/bin/file_system_watcher.cc
-FILE: ../../../third_party/dart/runtime/bin/file_system_watcher.h
-FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_android.cc
-FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_linux.cc
-FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_macos.cc
-FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_win.cc
-FILE: ../../../third_party/dart/runtime/bin/filter.cc
-FILE: ../../../third_party/dart/runtime/bin/filter.h
-FILE: ../../../third_party/dart/runtime/bin/filter_patch.dart
-FILE: ../../../third_party/dart/runtime/bin/gen_snapshot.cc
-FILE: ../../../third_party/dart/runtime/bin/io_natives.cc
-FILE: ../../../third_party/dart/runtime/bin/io_service.cc
-FILE: ../../../third_party/dart/runtime/bin/io_service.h
-FILE: ../../../third_party/dart/runtime/bin/io_service_no_ssl.cc
-FILE: ../../../third_party/dart/runtime/bin/io_service_no_ssl.h
-FILE: ../../../third_party/dart/runtime/bin/io_service_patch.dart
-FILE: ../../../third_party/dart/runtime/bin/process.cc
-FILE: ../../../third_party/dart/runtime/bin/process_patch.dart
-FILE: ../../../third_party/dart/runtime/bin/socket.cc
-FILE: ../../../third_party/dart/runtime/bin/socket.h
-FILE: ../../../third_party/dart/runtime/bin/socket_base_linux.cc
-FILE: ../../../third_party/dart/runtime/bin/socket_base_macos.cc
-FILE: ../../../third_party/dart/runtime/bin/socket_base_win.cc
-FILE: ../../../third_party/dart/runtime/bin/socket_linux.cc
-FILE: ../../../third_party/dart/runtime/bin/socket_macos.cc
-FILE: ../../../third_party/dart/runtime/bin/socket_patch.dart
-FILE: ../../../third_party/dart/runtime/bin/socket_win.cc
-FILE: ../../../third_party/dart/runtime/bin/stdio.cc
-FILE: ../../../third_party/dart/runtime/bin/stdio.h
-FILE: ../../../third_party/dart/runtime/bin/stdio_android.cc
-FILE: ../../../third_party/dart/runtime/bin/stdio_linux.cc
-FILE: ../../../third_party/dart/runtime/bin/stdio_macos.cc
-FILE: ../../../third_party/dart/runtime/bin/stdio_patch.dart
-FILE: ../../../third_party/dart/runtime/bin/stdio_win.cc
-FILE: ../../../third_party/dart/runtime/bin/vmservice/server.dart
-FILE: ../../../third_party/dart/runtime/bin/vmservice/vmservice_io.dart
-FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.cc
-FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.h
-FILE: ../../../third_party/dart/runtime/include/dart_mirrors_api.h
-FILE: ../../../third_party/dart/runtime/include/dart_native_api.h
-FILE: ../../../third_party/dart/runtime/lib/collection_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/core_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/deferred_load_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/function.dart
-FILE: ../../../third_party/dart/runtime/lib/internal_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/invocation_mirror.h
-FILE: ../../../third_party/dart/runtime/lib/libgen_in.cc
-FILE: ../../../third_party/dart/runtime/lib/mirror_reference.dart
-FILE: ../../../third_party/dart/runtime/lib/null_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/schedule_microtask_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/simd128.cc
-FILE: ../../../third_party/dart/runtime/lib/stacktrace.cc
-FILE: ../../../third_party/dart/runtime/lib/stacktrace.dart
-FILE: ../../../third_party/dart/runtime/lib/symbol_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/timer_impl.dart
-FILE: ../../../third_party/dart/runtime/lib/typed_data.cc
-FILE: ../../../third_party/dart/runtime/lib/typed_data_patch.dart
-FILE: ../../../third_party/dart/runtime/lib/uri.cc
-FILE: ../../../third_party/dart/runtime/lib/uri_patch.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/application.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/location_manager.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_instances.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile/virtual_tree.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile_table.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/curly_block.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/eval_box.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/flag_list.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/any_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/json_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/local_var_descriptors_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/native_memory_profiler.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_common.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectstore_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/observatory_application.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/pc_descriptors_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sample_buffer_control.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_inset.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_value.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_inset.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/stack_trace_tree_config.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/token_stream_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/type_arguments_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/unknown_ref.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_view.dart
-FILE: ../../../third_party/dart/runtime/observatory/lib/tracer.dart
-FILE: ../../../third_party/dart/runtime/platform/atomic.h
-FILE: ../../../third_party/dart/runtime/platform/atomic_android.h
-FILE: ../../../third_party/dart/runtime/platform/atomic_linux.h
-FILE: ../../../third_party/dart/runtime/platform/atomic_macos.h
-FILE: ../../../third_party/dart/runtime/platform/atomic_win.h
-FILE: ../../../third_party/dart/runtime/platform/signal_blocker.h
-FILE: ../../../third_party/dart/runtime/vm/allocation.h
-FILE: ../../../third_party/dart/runtime/vm/class_finalizer.cc
-FILE: ../../../third_party/dart/runtime/vm/code_patcher_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/code_patcher_arm_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/aot/aot_call_specializer.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm64_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_test.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/inliner.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/compiler/jit/jit_call_specializer.cc
-FILE: ../../../third_party/dart/runtime/vm/constants_arm.h
-FILE: ../../../third_party/dart/runtime/vm/constants_ia32.h
-FILE: ../../../third_party/dart/runtime/vm/constants_x64.h
-FILE: ../../../third_party/dart/runtime/vm/dart.cc
-FILE: ../../../third_party/dart/runtime/vm/dart_api_impl.cc
-FILE: ../../../third_party/dart/runtime/vm/deferred_objects.cc
-FILE: ../../../third_party/dart/runtime/vm/deferred_objects.h
-FILE: ../../../third_party/dart/runtime/vm/deopt_instructions.cc
-FILE: ../../../third_party/dart/runtime/vm/deopt_instructions.h
-FILE: ../../../third_party/dart/runtime/vm/guard_field_test.cc
-FILE: ../../../third_party/dart/runtime/vm/instructions.h
-FILE: ../../../third_party/dart/runtime/vm/instructions_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/instructions_arm.h
-FILE: ../../../third_party/dart/runtime/vm/instructions_arm_test.cc
-FILE: ../../../third_party/dart/runtime/vm/isolate.cc
-FILE: ../../../third_party/dart/runtime/vm/isolate.h
-FILE: ../../../third_party/dart/runtime/vm/json_stream.cc
-FILE: ../../../third_party/dart/runtime/vm/json_stream.h
-FILE: ../../../third_party/dart/runtime/vm/mirrors_api_impl.cc
-FILE: ../../../third_party/dart/runtime/vm/native_api_impl.cc
-FILE: ../../../third_party/dart/runtime/vm/native_symbol.h
-FILE: ../../../third_party/dart/runtime/vm/native_symbol_android.cc
-FILE: ../../../third_party/dart/runtime/vm/native_symbol_linux.cc
-FILE: ../../../third_party/dart/runtime/vm/native_symbol_macos.cc
-FILE: ../../../third_party/dart/runtime/vm/native_symbol_win.cc
-FILE: ../../../third_party/dart/runtime/vm/object_id_ring.cc
-FILE: ../../../third_party/dart/runtime/vm/object_id_ring.h
-FILE: ../../../third_party/dart/runtime/vm/object_id_ring_test.cc
-FILE: ../../../third_party/dart/runtime/vm/object_store.cc
-FILE: ../../../third_party/dart/runtime/vm/os_test.cc
-FILE: ../../../third_party/dart/runtime/vm/profiler.cc
-FILE: ../../../third_party/dart/runtime/vm/profiler.h
-FILE: ../../../third_party/dart/runtime/vm/profiler_test.cc
-FILE: ../../../third_party/dart/runtime/vm/random.cc
-FILE: ../../../third_party/dart/runtime/vm/random.h
-FILE: ../../../third_party/dart/runtime/vm/reusable_handles.h
-FILE: ../../../third_party/dart/runtime/vm/service.cc
-FILE: ../../../third_party/dart/runtime/vm/service.h
-FILE: ../../../third_party/dart/runtime/vm/service_isolate.h
-FILE: ../../../third_party/dart/runtime/vm/service_test.cc
-FILE: ../../../third_party/dart/runtime/vm/signal_handler.h
-FILE: ../../../third_party/dart/runtime/vm/signal_handler_android.cc
-FILE: ../../../third_party/dart/runtime/vm/signal_handler_linux.cc
-FILE: ../../../third_party/dart/runtime/vm/signal_handler_macos.cc
-FILE: ../../../third_party/dart/runtime/vm/signal_handler_win.cc
-FILE: ../../../third_party/dart/runtime/vm/simulator.h
-FILE: ../../../third_party/dart/runtime/vm/simulator_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/simulator_arm.h
-FILE: ../../../third_party/dart/runtime/vm/stack_frame_arm.h
-FILE: ../../../third_party/dart/runtime/vm/stack_frame_ia32.h
-FILE: ../../../third_party/dart/runtime/vm/stack_frame_x64.h
-FILE: ../../../third_party/dart/runtime/vm/stub_code_arm.cc
-FILE: ../../../third_party/dart/runtime/vm/stub_code_arm_test.cc
-FILE: ../../../third_party/dart/runtime/vm/stub_code_ia32.cc
-FILE: ../../../third_party/dart/runtime/vm/stub_code_x64.cc
-FILE: ../../../third_party/dart/runtime/vm/tags.h
-FILE: ../../../third_party/dart/runtime/vm/thread_interrupter.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_interrupter.h
-FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_android.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_linux.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_macos.cc
-FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_win.cc
-FILE: ../../../third_party/dart/runtime/vm/weak_table.cc
-FILE: ../../../third_party/dart/runtime/vm/weak_table.h
-FILE: ../../../third_party/dart/sdk/lib/_chrome/dart2js/chrome_dart2js.dart
-FILE: ../../../third_party/dart/sdk/lib/_chrome/dart2js/chrome_dart2js.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/http.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/http_headers.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/http_impl.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/http_parser.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/http_session.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/websocket.dart
-FILE: ../../../third_party/dart/sdk/lib/_http/websocket_impl.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/annotations.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/collection_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/convert_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/internal_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/io_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_helper.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_mirrors.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_names.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_primitives.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_rti.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/native_typed_data.dart
-FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/typed_data_patch.dart
-FILE: ../../../third_party/dart/sdk/lib/async/deferred_load.dart
-FILE: ../../../third_party/dart/sdk/lib/async/schedule_microtask.dart
-FILE: ../../../third_party/dart/sdk/lib/async/stream.dart
-FILE: ../../../third_party/dart/sdk/lib/async/stream_transformers.dart
-FILE: ../../../third_party/dart/sdk/lib/async/zone.dart
-FILE: ../../../third_party/dart/sdk/lib/collection/collections.dart
-FILE: ../../../third_party/dart/sdk/lib/collection/hash_map.dart
-FILE: ../../../third_party/dart/sdk/lib/collection/hash_set.dart
-FILE: ../../../third_party/dart/sdk/lib/collection/linked_hash_map.dart
-FILE: ../../../third_party/dart/sdk/lib/collection/linked_hash_set.dart
-FILE: ../../../third_party/dart/sdk/lib/collection/linked_list.dart
-FILE: ../../../third_party/dart/sdk/lib/collection/list.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/ascii.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/byte_conversion.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/chunked_conversion.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/codec.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/convert.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/converter.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/encoding.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/html_escape.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/json.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/latin1.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/line_splitter.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/string_conversion.dart
-FILE: ../../../third_party/dart/sdk/lib/convert/utf.dart
-FILE: ../../../third_party/dart/sdk/lib/core/annotations.dart
-FILE: ../../../third_party/dart/sdk/lib/core/null.dart
-FILE: ../../../third_party/dart/sdk/lib/core/stacktrace.dart
-FILE: ../../../third_party/dart/sdk/lib/core/string_sink.dart
-FILE: ../../../third_party/dart/sdk/lib/core/symbol.dart
-FILE: ../../../third_party/dart/sdk/lib/internal/list.dart
-FILE: ../../../third_party/dart/sdk/lib/internal/print.dart
-FILE: ../../../third_party/dart/sdk/lib/internal/symbol.dart
-FILE: ../../../third_party/dart/sdk/lib/io/bytes_builder.dart
-FILE: ../../../third_party/dart/sdk/lib/io/data_transformer.dart
-FILE: ../../../third_party/dart/sdk/lib/io/file.dart
-FILE: ../../../third_party/dart/sdk/lib/io/file_impl.dart
-FILE: ../../../third_party/dart/sdk/lib/io/file_system_entity.dart
-FILE: ../../../third_party/dart/sdk/lib/io/io_service.dart
-FILE: ../../../third_party/dart/sdk/lib/io/io_sink.dart
-FILE: ../../../third_party/dart/sdk/lib/io/link.dart
-FILE: ../../../third_party/dart/sdk/lib/io/secure_socket.dart
-FILE: ../../../third_party/dart/sdk/lib/io/socket.dart
-FILE: ../../../third_party/dart/sdk/lib/io/stdio.dart
-FILE: ../../../third_party/dart/sdk/lib/io/string_transformer.dart
-FILE: ../../../third_party/dart/sdk/lib/js/dart2js/js_dart2js.dart
-FILE: ../../../third_party/dart/sdk/lib/math/jenkins_smi_hash.dart
-FILE: ../../../third_party/dart/sdk/lib/math/point.dart
-FILE: ../../../third_party/dart/sdk/lib/math/rectangle.dart
-FILE: ../../../third_party/dart/sdk/lib/mirrors/mirrors.dart
-FILE: ../../../third_party/dart/sdk/lib/typed_data/typed_data.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/client.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/constants.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/message.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/message_router.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/running_isolate.dart
-FILE: ../../../third_party/dart/sdk/lib/vmservice/running_isolates.dart
-FILE: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/build/import_crawler.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/polyfill.dart
-FILE: ../../../third_party/dart/utils/compiler/create_snapshot_entry.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: dart
-LIBRARY: observatory_pub_packages
 ORIGIN: ../../../third_party/dart/runtime/lib/bigint.dart + ../../../third_party/dart/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/runtime/lib/bigint.dart
@@ -4795,13 +4319,7 @@ FILE: ../../../third_party/dart/sdk/lib/io/process.dart
 FILE: ../../../third_party/dart/sdk/lib/io/service_object.dart
 FILE: ../../../third_party/dart/sdk/lib/isolate/capability.dart
 FILE: ../../../third_party/dart/sdk/lib/profiler/profiler.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/.status
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/lib/src/css_class_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/dart_support.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/interop.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/interop_support.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/src/mirror_initializer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/src/static_initializer.dart
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
@@ -5492,8 +5010,6 @@ FILE: ../../../third_party/dart/runtime/vm/stack_trace.h
 FILE: ../../../third_party/dart/runtime/vm/timeline_android.cc
 FILE: ../../../third_party/dart/runtime/vm/timeline_fuchsia.cc
 FILE: ../../../third_party/dart/runtime/vm/timeline_linux.cc
-FILE: ../../../third_party/dart/runtime/vm/timeline_macos.cc
-FILE: ../../../third_party/dart/runtime/vm/timeline_win.cc
 FILE: ../../../third_party/dart/runtime/vm/zone_text_buffer.cc
 FILE: ../../../third_party/dart/runtime/vm/zone_text_buffer.h
 FILE: ../../../third_party/dart/sdk/lib/_http/overrides.dart
@@ -5955,6 +5471,462 @@ FILE: ../../../third_party/dart/sdk/lib/internal/sort.dart
 FILE: ../../../third_party/dart/utils/peg/pegparser.dart
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2011, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/vmservice/loader.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/bin/address_sanitizer.cc
+FILE: ../../../third_party/dart/runtime/bin/builtin_common.cc
+FILE: ../../../third_party/dart/runtime/bin/embedded_dart_io.cc
+FILE: ../../../third_party/dart/runtime/bin/embedded_dart_io.h
+FILE: ../../../third_party/dart/runtime/bin/observatory_assets_empty.cc
+FILE: ../../../third_party/dart/runtime/bin/vmservice/loader.dart
+FILE: ../../../third_party/dart/runtime/lib/async_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/compact_hash.dart
+FILE: ../../../third_party/dart/runtime/lib/developer.cc
+FILE: ../../../third_party/dart/runtime/lib/developer.dart
+FILE: ../../../third_party/dart/runtime/lib/timeline.cc
+FILE: ../../../third_party/dart/runtime/lib/timeline.dart
+FILE: ../../../third_party/dart/runtime/lib/vmservice.cc
+FILE: ../../../third_party/dart/runtime/observatory/lib/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/cli.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/allocation_profile/allocation_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/analytics.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/cli/command.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/debugger/debugger_location.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/logging_list.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/persistent_handles.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/ports.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/timeline_page.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/view_footer.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/sample_profile/sample_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/web/timeline.js
+FILE: ../../../third_party/dart/runtime/vm/atomic_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/precompiler.h
+FILE: ../../../third_party/dart/runtime/vm/log.cc
+FILE: ../../../third_party/dart/runtime/vm/log.h
+FILE: ../../../third_party/dart/runtime/vm/log_test.cc
+FILE: ../../../third_party/dart/runtime/vm/os_thread.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler_service.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler_service.h
+FILE: ../../../third_party/dart/runtime/vm/program_visitor.cc
+FILE: ../../../third_party/dart/runtime/vm/program_visitor.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_assembler_bytecode_inl.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_bytecodes.h
+FILE: ../../../third_party/dart/runtime/vm/regexp_interpreter.cc
+FILE: ../../../third_party/dart/runtime/vm/regexp_interpreter.h
+FILE: ../../../third_party/dart/runtime/vm/scope_timer.h
+FILE: ../../../third_party/dart/runtime/vm/service_event.cc
+FILE: ../../../third_party/dart/runtime/vm/service_event.h
+FILE: ../../../third_party/dart/runtime/vm/service_isolate.cc
+FILE: ../../../third_party/dart/runtime/vm/source_report.cc
+FILE: ../../../third_party/dart/runtime/vm/source_report.h
+FILE: ../../../third_party/dart/runtime/vm/source_report_test.cc
+FILE: ../../../third_party/dart/runtime/vm/thread.cc
+FILE: ../../../third_party/dart/runtime/vm/thread.h
+FILE: ../../../third_party/dart/runtime/vm/thread_barrier.h
+FILE: ../../../third_party/dart/runtime/vm/thread_barrier_test.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_registry.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_registry.h
+FILE: ../../../third_party/dart/runtime/vm/timeline.cc
+FILE: ../../../third_party/dart/runtime/vm/timeline.h
+FILE: ../../../third_party/dart/runtime/vm/timeline_analysis.cc
+FILE: ../../../third_party/dart/runtime/vm/timeline_analysis.h
+FILE: ../../../third_party/dart/runtime/vm/timeline_test.cc
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/developer_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/d8.js
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/preambles/jsshell.js
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/shared/async_await_error_codes.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/base64.dart
+FILE: ../../../third_party/dart/sdk/lib/dart_client.platform
+FILE: ../../../third_party/dart/sdk/lib/dart_server.platform
+FILE: ../../../third_party/dart/sdk/lib/dart_shared.platform
+FILE: ../../../third_party/dart/sdk/lib/developer/developer.dart
+FILE: ../../../third_party/dart/sdk/lib/developer/extension.dart
+FILE: ../../../third_party/dart/sdk/lib/developer/timeline.dart
+FILE: ../../../third_party/dart/sdk/lib/io/io_resource_info.dart
+FILE: ../../../third_party/dart/sdk/lib/io/security_context.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/asset.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/vmservice.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: dart
+ORIGIN: ../../../third_party/dart/runtime/bin/vmservice/server.dart + ../../../third_party/dart/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/WATCHLISTS
+FILE: ../../../third_party/dart/runtime/bin/eventhandler_win.cc
+FILE: ../../../third_party/dart/runtime/bin/file.cc
+FILE: ../../../third_party/dart/runtime/bin/file.h
+FILE: ../../../third_party/dart/runtime/bin/file_system_entity_patch.dart
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher.h
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_android.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/file_system_watcher_win.cc
+FILE: ../../../third_party/dart/runtime/bin/filter.cc
+FILE: ../../../third_party/dart/runtime/bin/filter.h
+FILE: ../../../third_party/dart/runtime/bin/filter_patch.dart
+FILE: ../../../third_party/dart/runtime/bin/gen_snapshot.cc
+FILE: ../../../third_party/dart/runtime/bin/io_natives.cc
+FILE: ../../../third_party/dart/runtime/bin/io_service.cc
+FILE: ../../../third_party/dart/runtime/bin/io_service.h
+FILE: ../../../third_party/dart/runtime/bin/io_service_no_ssl.cc
+FILE: ../../../third_party/dart/runtime/bin/io_service_no_ssl.h
+FILE: ../../../third_party/dart/runtime/bin/io_service_patch.dart
+FILE: ../../../third_party/dart/runtime/bin/process.cc
+FILE: ../../../third_party/dart/runtime/bin/process_patch.dart
+FILE: ../../../third_party/dart/runtime/bin/socket.cc
+FILE: ../../../third_party/dart/runtime/bin/socket.h
+FILE: ../../../third_party/dart/runtime/bin/socket_base_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_base_win.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/socket_patch.dart
+FILE: ../../../third_party/dart/runtime/bin/socket_win.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio.h
+FILE: ../../../third_party/dart/runtime/bin/stdio_android.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_linux.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_macos.cc
+FILE: ../../../third_party/dart/runtime/bin/stdio_patch.dart
+FILE: ../../../third_party/dart/runtime/bin/stdio_win.cc
+FILE: ../../../third_party/dart/runtime/bin/vmservice/server.dart
+FILE: ../../../third_party/dart/runtime/bin/vmservice/vmservice_io.dart
+FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.cc
+FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.h
+FILE: ../../../third_party/dart/runtime/include/dart_mirrors_api.h
+FILE: ../../../third_party/dart/runtime/include/dart_native_api.h
+FILE: ../../../third_party/dart/runtime/lib/collection_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/core_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/deferred_load_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/function.dart
+FILE: ../../../third_party/dart/runtime/lib/internal_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/invocation_mirror.h
+FILE: ../../../third_party/dart/runtime/lib/libgen_in.cc
+FILE: ../../../third_party/dart/runtime/lib/mirror_reference.dart
+FILE: ../../../third_party/dart/runtime/lib/null_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/schedule_microtask_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/simd128.cc
+FILE: ../../../third_party/dart/runtime/lib/stacktrace.cc
+FILE: ../../../third_party/dart/runtime/lib/stacktrace.dart
+FILE: ../../../third_party/dart/runtime/lib/symbol_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/timer_impl.dart
+FILE: ../../../third_party/dart/runtime/lib/typed_data.cc
+FILE: ../../../third_party/dart/runtime/lib/typed_data_patch.dart
+FILE: ../../../third_party/dart/runtime/lib/uri.cc
+FILE: ../../../third_party/dart/runtime/lib/uri_patch.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/application.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/location_manager.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_instances.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/class_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/code_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/context_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile/virtual_tree.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/cpu_profile_table.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/curly_block.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/error_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/eval_box.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/field_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/flag_list.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/function_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/heap_snapshot.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/helpers/any_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/icdata_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/instance_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/isolate_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/json_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/library_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/local_var_descriptors_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/megamorphiccache_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/native_memory_profiler.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_common.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/object_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectpool_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/objectstore_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/observatory_application.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/pc_descriptors_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sample_buffer_control.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_inset.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/script_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_value.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/sentinel_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/source_inset.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/stack_trace_tree_config.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/token_stream_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/type_arguments_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/unknown_ref.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/vm_view.dart
+FILE: ../../../third_party/dart/runtime/observatory/lib/tracer.dart
+FILE: ../../../third_party/dart/runtime/platform/atomic.h
+FILE: ../../../third_party/dart/runtime/platform/atomic_android.h
+FILE: ../../../third_party/dart/runtime/platform/atomic_linux.h
+FILE: ../../../third_party/dart/runtime/platform/atomic_macos.h
+FILE: ../../../third_party/dart/runtime/platform/atomic_win.h
+FILE: ../../../third_party/dart/runtime/platform/signal_blocker.h
+FILE: ../../../third_party/dart/runtime/vm/allocation.h
+FILE: ../../../third_party/dart/runtime/vm/class_finalizer.cc
+FILE: ../../../third_party/dart/runtime/vm/code_patcher_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/code_patcher_arm_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/aot/aot_call_specializer.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm64_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_arm_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_test.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/assembler_x64.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/block_scheduler.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/constant_propagator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/flow_graph_compiler_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/il_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/inliner.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/linearscan.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/locations.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/backend/type_propagator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/intrinsifier_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/jit/jit_call_specializer.cc
+FILE: ../../../third_party/dart/runtime/vm/constants_arm.h
+FILE: ../../../third_party/dart/runtime/vm/constants_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/constants_x64.h
+FILE: ../../../third_party/dart/runtime/vm/dart.cc
+FILE: ../../../third_party/dart/runtime/vm/dart_api_impl.cc
+FILE: ../../../third_party/dart/runtime/vm/deferred_objects.cc
+FILE: ../../../third_party/dart/runtime/vm/deferred_objects.h
+FILE: ../../../third_party/dart/runtime/vm/deopt_instructions.cc
+FILE: ../../../third_party/dart/runtime/vm/deopt_instructions.h
+FILE: ../../../third_party/dart/runtime/vm/guard_field_test.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions.h
+FILE: ../../../third_party/dart/runtime/vm/instructions_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/instructions_arm.h
+FILE: ../../../third_party/dart/runtime/vm/instructions_arm_test.cc
+FILE: ../../../third_party/dart/runtime/vm/isolate.cc
+FILE: ../../../third_party/dart/runtime/vm/isolate.h
+FILE: ../../../third_party/dart/runtime/vm/json_stream.cc
+FILE: ../../../third_party/dart/runtime/vm/json_stream.h
+FILE: ../../../third_party/dart/runtime/vm/mirrors_api_impl.cc
+FILE: ../../../third_party/dart/runtime/vm/native_api_impl.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol.h
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_android.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/native_symbol_win.cc
+FILE: ../../../third_party/dart/runtime/vm/object_id_ring.cc
+FILE: ../../../third_party/dart/runtime/vm/object_id_ring.h
+FILE: ../../../third_party/dart/runtime/vm/object_id_ring_test.cc
+FILE: ../../../third_party/dart/runtime/vm/object_store.cc
+FILE: ../../../third_party/dart/runtime/vm/os_test.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler.cc
+FILE: ../../../third_party/dart/runtime/vm/profiler.h
+FILE: ../../../third_party/dart/runtime/vm/profiler_test.cc
+FILE: ../../../third_party/dart/runtime/vm/random.cc
+FILE: ../../../third_party/dart/runtime/vm/random.h
+FILE: ../../../third_party/dart/runtime/vm/reusable_handles.h
+FILE: ../../../third_party/dart/runtime/vm/service.cc
+FILE: ../../../third_party/dart/runtime/vm/service.h
+FILE: ../../../third_party/dart/runtime/vm/service_isolate.h
+FILE: ../../../third_party/dart/runtime/vm/service_test.cc
+FILE: ../../../third_party/dart/runtime/vm/signal_handler.h
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_android.cc
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/signal_handler_win.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator.h
+FILE: ../../../third_party/dart/runtime/vm/simulator_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/simulator_arm.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_arm.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_ia32.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_x64.h
+FILE: ../../../third_party/dart/runtime/vm/stub_code_arm.cc
+FILE: ../../../third_party/dart/runtime/vm/stub_code_arm_test.cc
+FILE: ../../../third_party/dart/runtime/vm/stub_code_ia32.cc
+FILE: ../../../third_party/dart/runtime/vm/stub_code_x64.cc
+FILE: ../../../third_party/dart/runtime/vm/tags.h
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter.h
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_android.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_linux.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_macos.cc
+FILE: ../../../third_party/dart/runtime/vm/thread_interrupter_win.cc
+FILE: ../../../third_party/dart/runtime/vm/weak_table.cc
+FILE: ../../../third_party/dart/runtime/vm/weak_table.h
+FILE: ../../../third_party/dart/sdk/lib/_chrome/dart2js/chrome_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/_chrome/dart2js/chrome_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_headers.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_parser.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/http_session.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/websocket.dart
+FILE: ../../../third_party/dart/sdk/lib/_http/websocket_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/collection_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/convert_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/internal_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/io_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_helper.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_mirrors.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_names.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_primitives.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/js_rti.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/native_typed_data.dart
+FILE: ../../../third_party/dart/sdk/lib/_internal/js_runtime/lib/typed_data_patch.dart
+FILE: ../../../third_party/dart/sdk/lib/async/deferred_load.dart
+FILE: ../../../third_party/dart/sdk/lib/async/schedule_microtask.dart
+FILE: ../../../third_party/dart/sdk/lib/async/stream.dart
+FILE: ../../../third_party/dart/sdk/lib/async/stream_transformers.dart
+FILE: ../../../third_party/dart/sdk/lib/async/zone.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/collections.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/hash_set.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/linked_hash_map.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/linked_hash_set.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/linked_list.dart
+FILE: ../../../third_party/dart/sdk/lib/collection/list.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/ascii.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/byte_conversion.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/chunked_conversion.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/codec.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/convert.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/converter.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/encoding.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/html_escape.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/json.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/latin1.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/line_splitter.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/string_conversion.dart
+FILE: ../../../third_party/dart/sdk/lib/convert/utf.dart
+FILE: ../../../third_party/dart/sdk/lib/core/annotations.dart
+FILE: ../../../third_party/dart/sdk/lib/core/null.dart
+FILE: ../../../third_party/dart/sdk/lib/core/stacktrace.dart
+FILE: ../../../third_party/dart/sdk/lib/core/string_sink.dart
+FILE: ../../../third_party/dart/sdk/lib/core/symbol.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/list.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/print.dart
+FILE: ../../../third_party/dart/sdk/lib/internal/symbol.dart
+FILE: ../../../third_party/dart/sdk/lib/io/bytes_builder.dart
+FILE: ../../../third_party/dart/sdk/lib/io/data_transformer.dart
+FILE: ../../../third_party/dart/sdk/lib/io/file.dart
+FILE: ../../../third_party/dart/sdk/lib/io/file_impl.dart
+FILE: ../../../third_party/dart/sdk/lib/io/file_system_entity.dart
+FILE: ../../../third_party/dart/sdk/lib/io/io_service.dart
+FILE: ../../../third_party/dart/sdk/lib/io/io_sink.dart
+FILE: ../../../third_party/dart/sdk/lib/io/link.dart
+FILE: ../../../third_party/dart/sdk/lib/io/secure_socket.dart
+FILE: ../../../third_party/dart/sdk/lib/io/socket.dart
+FILE: ../../../third_party/dart/sdk/lib/io/stdio.dart
+FILE: ../../../third_party/dart/sdk/lib/io/string_transformer.dart
+FILE: ../../../third_party/dart/sdk/lib/js/dart2js/js_dart2js.dart
+FILE: ../../../third_party/dart/sdk/lib/math/jenkins_smi_hash.dart
+FILE: ../../../third_party/dart/sdk/lib/math/point.dart
+FILE: ../../../third_party/dart/sdk/lib/math/rectangle.dart
+FILE: ../../../third_party/dart/sdk/lib/mirrors/mirrors.dart
+FILE: ../../../third_party/dart/sdk/lib/typed_data/typed_data.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/client.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/constants.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/message.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/message_router.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/running_isolate.dart
+FILE: ../../../third_party/dart/sdk/lib/vmservice/running_isolates.dart
+FILE: ../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart
+FILE: ../../../third_party/dart/utils/compiler/create_snapshot_entry.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -15027,64 +14999,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 LIBRARY: observatory_pub_packages
 LIBRARY: pkg
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/instrumentation/file_instrumentation.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/LICENSE
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/delegate/event_sink.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/instrumentation/file_instrumentation.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/plugin/command_line.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/plugin/options.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/plugin/resolver_provider.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/plugin/task.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/analysis_options_provider.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/embedder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/error_processor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/path_filter.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/sdk_ext.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/context/cache.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/context/context.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/context/source.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/type_system.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/visitors.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/plugin/command_line_plugin.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/plugin/engine_plugin.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/plugin/options_plugin.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/plugin/plugin_configuration.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/services/lint.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/format.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/format.fbs
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/idl.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/public_namespace_computer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/resynthesize.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/summarize_elements.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/summary_sdk.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/dart.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/dart_work_manager.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/driver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/general.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/html.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/html_work_manager.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/incremental_element_builder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/inputs.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/manager.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/model.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/options.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/options_work_manager.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/strong/checker.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/strong_mode.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/util/absolute_path.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/util/asserts.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/util/glob.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/util/lru_map.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/util/yaml.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/task/dart.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/task/general.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/task/html.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/task/model.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/summary/check_test.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/summary/generate.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/summary/idl_model.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/task_dependency_graph/check_test.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/task_dependency_graph/generate.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/task_dependency_graph/tasks.dot
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/async_memoizer.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/cancelable_operation.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/delegate/event_sink.dart
@@ -15103,85 +15019,14 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/as
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_splitter.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/subscription_stream.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/cli_util/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/cli_util/lib/cli_util.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/comparators.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/convert.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/hex.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/hex/decoder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/hex/encoder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/percent.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/percent/decoder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/percent/encoder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/example/hash.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/digest.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/digest_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/hash.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/bin/format.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/example/format.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/fast_hash.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/line_splitting/line_splitter.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/line_splitting/rule_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/line_splitting/solve_state.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/line_splitting/solve_state_queue.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/nesting_builder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/nesting_level.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/rule/argument.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/rule/combinator.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/rule/metadata.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/rule/rule.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/rule/type_argument.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/tool/grind.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/build/initializer_plugin.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/build/loader_replacer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/initialize.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/src/init_method.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/src/initialize_tracker.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/src/initializer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/src/mirror_loader.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/src/static_loader.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/lib/transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/test_package/lib/bar.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/test_package/lib/foo.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/example/http_server.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/example/runner_pool.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/isolate.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/isolate_runner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/load_balancer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/ports.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/registry.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/runner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/src/errors.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/src/lists.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/isolate/lib/src/raw_receive_port_multiplexer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/package_config/lib/discovery.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/package_config/lib/discovery_analysis.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/package_config/lib/packages.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/package_config/lib/packages_file.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/package_config/lib/src/packages_impl.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/package_config/lib/src/packages_io_impl.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/package_config/lib/src/util.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/plugin/lib/manager.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/plugin/lib/plugin.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/plugin/lib/src/plugin_impl.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/location_mixin.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/unparsed_frame.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/src/eager_span_scanner.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/expected_function.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/group_context.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/example/example.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/example/example.html
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/.status
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/lib/src/shared.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/benchmark/path_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/file_watcher.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/file_watcher/native.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/file_watcher/polling.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/benchmark/benchmark.dart
 FILE: ../../../third_party/pkg/when/lib/when.dart
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2015, the Dart project authors.  Please see the AUTHORS file
@@ -15220,7 +15065,6 @@ LIBRARY: skia
 LIBRARY: vulkan
 ORIGIN: ../../../flutter/third_party/txt/LICENSE
 TYPE: LicenseType.apache
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/.analysis_options
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/async.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/cache.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/check.dart
@@ -15234,7 +15078,6 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/qu
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/async/concat.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/async/countdown_timer.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/async/enumerate.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/async/future_group.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/async/future_stream.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/async/iteration.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/async/metronome.dart
@@ -15267,6 +15110,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/qu
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/pattern/glob.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/time/clock.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/time/duration_unit_constants.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/src/time/util.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/strings.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/quiver/lib/time.dart
 FILE: ../../../third_party/skia/src/images/SkWebpEncoder.cpp
@@ -15480,14 +15324,8 @@ limitations under the License.
 
 ====================================================================================================
 LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/LICENSE
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/doc/support/viz.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/doc/support/web_app.dart.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/doc/tasks.html
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/package_bundle_reader.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/summary/build_sdk_summaries.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/.analysis_options
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/.test_config
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/.analysis_options
@@ -15501,6 +15339,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/cs
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/af.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/am.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ar.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ar_DZ.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/az.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/be.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/bg.json
@@ -15523,6 +15362,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/en_IE.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/en_IN.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/en_ISO.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/en_MY.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/en_SG.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/en_US.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/en_ZA.json
@@ -15538,6 +15378,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/fil.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/fr.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/fr_CA.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/fr_CH.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ga.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/gl.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/gsw.json
@@ -15552,6 +15393,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/in.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/is.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/it.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/it_CH.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/iw.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ja.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ka.json
@@ -15580,11 +15422,13 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/or.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/pa.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/pl.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ps.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/pt.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/pt_BR.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/pt_PT.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ro.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/ru.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/sd.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/sh.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/si.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/patterns/sk.json
@@ -15611,6 +15455,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/af.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/am.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/ar.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/ar_DZ.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/az.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/be.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/bg.json
@@ -15633,6 +15478,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/en_IE.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/en_IN.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/en_ISO.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/en_MY.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/en_SG.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/en_US.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/en_ZA.json
@@ -15648,6 +15494,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/fil.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/fr.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/fr_CA.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/fr_CH.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/ga.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/gl.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/gsw.json
@@ -15662,6 +15509,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/in.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/is.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/it.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/it_CH.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/iw.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/ja.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/ka.json
@@ -15689,6 +15537,7 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/in
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/or.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/pa.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/pl.json
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/ps.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/pt.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/pt_BR.json
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/data/dates/symbols/pt_PT.json
@@ -15747,509 +15596,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/benchmark/errors_in_all_libraries.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/benchmark/errors_in_all_libraries.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/ast_factory.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/resolution_map.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/standard_ast_factory.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/standard_resolution_map.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/syntactic_entity.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/plugin/embedded_resolver_provider.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/config.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/custom_resolver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/context/builder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/ast/ast_factory.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/ast/resolution_map.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/resolver/inheritance_manager.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/sdk/sdk.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/error/pending_error.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/bazel.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/package.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/source/source_resource.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/api_signature.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/bazel_summary.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/flat_buffers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/link.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/name_filter.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/prelink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/pub_summary.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/summarize_ast.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/summarize_const_expr.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/summary_file_builder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/strong/ast_properties.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/task/yaml.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/util/fast_uri.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/task/yaml.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/summary/dump_inferred_types.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/summary/inspect.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/tool/summary/stats.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_parser_exception.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/delegate/stream.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/null_stream_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/capture_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/capture_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/error.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/release_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/release_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/value.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/single_subscription_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_completer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer/handler_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer/stream_transformer_wrapper.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer/typed.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_subscription_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_zip.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/typed/future.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/typed/stream.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/typed/stream_subscription.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/typed_stream_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/empty_unmodifiable_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/equality_map.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/equality_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/functions.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/typed_wrappers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/union_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/union_set_controller.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/accumulator_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/byte_accumulator_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/lib/src/string_accumulator_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/tool/node_format_service.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/intl/compact_number_format.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/plural_rules.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/src/order_matchers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/meta/lib/meta.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/observable.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/change_record.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/list_diff.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/observable.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/observable_list.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/observable_map.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/property_change_record.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/to_observable.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/src/relative_span_scanner.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/doc/support/dart.js + ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/doc/support/dart.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/example/parser_driver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/example/resolver_driver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/example/scanner_driver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/analyzer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/error.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/string_source.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/args.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/parser.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/usage.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/async.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/result.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/stream_zip.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/barback.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_forwarder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_id.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_node.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_node_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/internal_asset.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/barback.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/build_result.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/errors.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/asset_cascade.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/group_runner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/package_graph.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/phase.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/phase_forwarder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/phase_output.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/transform_node.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/log.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/package_provider.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/serialize.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/barback_settings.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transform_logger.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transformer_group.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/cancelable_future.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/file_pool.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/multiset.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/stream_pool.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/stream_replayer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/browser/lib/dart.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/browser/lib/interop.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/messages/build_logger.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/algorithms.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/collection.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/equality.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/iterable_zip.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/algorithms.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/equality.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/iterable_zip.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/unmodifiable_wrappers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/wrappers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/wrappers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/css.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/src/css_printer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/src/polyfill.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/src/tree_printer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/glob/lib/src/stream_pool.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/src/pretty_print.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/context.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/parsed_path.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/path_exception.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style/posix.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style/url.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style/windows.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/builder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/parser.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/printer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/refactor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/source_maps.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/src/vlq.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/chain.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/frame.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/lazy_trace.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/stack_zone_specification.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/trace.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/vm_trace.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/stack_trace.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/typed_data/lib/typed_buffers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/typed_data/lib/typed_data.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/compact_vm_config.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/html_config.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/html_enhanced_config.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/html_individual_config.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/configuration.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/pretty_print.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/simple_configuration.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/test_case.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/unittest.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/vm_config.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/lib/src/utf_stream.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/example/watch.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/async_queue.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/constructable_file_system_event.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/directory_watcher.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/directory_watcher/linux.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/directory_watcher/mac_os.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/directory_watcher/polling.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/path_set.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/resubscribable.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/stat.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/watch_event.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/watcher.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/yaml_exception.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/context/declared_variables.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/context/declared_variables.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/ast.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/token.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/ast/visitor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/constant/value.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/element/element.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/element/type.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/dart/element/visitor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/error/error.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/error/listener.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/exception/exception.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/file_system/file_system.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/file_system/memory_file_system.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/file_system/physical_file_system.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/instrumentation/instrumentation.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/package_map_provider.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/package_map_resolver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/source/pub_package_map_provider.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/cancelable_future.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/codegen/html.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/codegen/text_formatter.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/codegen/tools.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/ast/ast.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/ast/token.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/ast/utilities.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/constant/evaluation.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/constant/utilities.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/constant/value.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/element/builder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/element/element.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/element/handle.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/element/member.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/element/type.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/element/utilities.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/error/syntactic_errors.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/resolver/scope.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/scanner/reader.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/dart/scanner/scanner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/error/codes.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/ast.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/constant.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/element.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/element_handle.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/element_resolver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/engine.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/error.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/error_verifier.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/incremental_logger.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/incremental_resolution_validator.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/incremental_resolver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/interner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/java_core.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/java_engine.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/java_engine_io.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/java_io.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/parser.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/resolver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/scanner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/sdk.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/sdk_io.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/source.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/source_io.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/static_type_analyzer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/utilities_collection.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/utilities_dart.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/generated/utilities_general.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/summary/base.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/lib/src/util/utilities_timing.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/command_runner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_parser.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_results.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/help_command.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/option.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/usage_exception.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/example/aggregate_transformer/lib/transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/example/lazy_transformer/lib/transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/example/markdown_converter/lib/transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/node_status.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/node_streams.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/static_asset_cascade.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/transformer_classifier.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/internal_asset.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/aggregate_transform.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/aggregate_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/base_transform.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_aggregate_transform.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_aggregate_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_transform.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/lazy_aggregate_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/lazy_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transform.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/wrapping_aggregate_transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/lib/ascii.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/lib/charcode.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/lib/html_entity.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/assets.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/benchmarks.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/messages/messages.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/resolver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/async_benchmark_base.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/dart_sdk.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/delete_file.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/entry_point.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/messages.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/remove_sourcemap_comment.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/resolver.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/resolver_impl.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/lib/src/resolvers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/priority_queue.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/canonicalized_map.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/priority_queue.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/queue_list.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/benchmark/benchmark.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/dart_style.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/argument_list_visitor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/call_chain_visitor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/chunk.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/chunk_builder.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/dart_formatter.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/debug.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/error_listener.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/formatter_exception.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/formatter_options.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/io.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/line_writer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/source_code.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/source_visitor.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/lib/src/whitespace.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/glob/lib/glob.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/glob/lib/src/ast.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/glob/lib/src/list_tree.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/glob/lib/src/parser.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/glob/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/date_time_patterns.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/logging/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/matcher.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/mirror_matchers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/src/util.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/benchmark/benchmark.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/characters.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/internal_style.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/lib/pool.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/lib/src/source_map_span.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/source_span.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/colors.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/file.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/location.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span_exception.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span_mixin.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span_with_context.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/src/exception.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/src/line_scanner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/src/span_scanner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/src/string_scanner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/src/utils.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/lib/string_scanner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/.status
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/internal_test_case.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/prints_matcher.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/throws_matcher.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/throws_matchers.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/util.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/test_environment.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/example/ga.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/usage_impl.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/usage_impl_html.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/usage_impl_io.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/uuid.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/usage.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/usage_html.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/usage_io.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/tool/grind.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/lib/src/directory_watcher/windows.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/equality.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/event.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/loader.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/null_span.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/parser.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/scanner.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/style.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/token.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/yaml_document.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/yaml_node_wrapper.dart
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
-for details. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/example/test_runner.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/LICENSE
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/example/test_runner.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/example/test_runner.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/example/simple_transformer/lib/transformer.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/crypto.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/hash_sink.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/hmac.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/md5.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/sha1.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/lib/src/sha256.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/bin/css.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/parser.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/src/analyzer.dart
@@ -16315,8 +15665,6 @@ FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/ut
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/lib/src/utf_16_code_unit_decoder.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/lib/src/util.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/lib/utf.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/src/yaml_node.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/lib/yaml.dart
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
 for details. All rights reserved.
@@ -16350,18 +15698,306 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: observatory_pub_packages
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_parser.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/command_runner.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_parser.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_results.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/help_command.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/option.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/usage_exception.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/.status
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/example/aggregate_transformer/lib/transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/example/lazy_transformer/lib/transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/example/markdown_converter/lib/transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/node_status.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/node_streams.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/static_asset_cascade.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/transformer_classifier.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/internal_asset.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/aggregate_transform.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/aggregate_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/base_transform.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_aggregate_transform.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_aggregate_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_transform.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/declaring_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/lazy_aggregate_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/lazy_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transform.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/wrapping_aggregate_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/lib/ascii.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/lib/charcode.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/lib/html_entity.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/priority_queue.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/canonicalized_map.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/priority_queue.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/queue_list.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/.status
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/date_time_patterns.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/logging/.status
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/matcher.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/mirror_matchers.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/src/util.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/benchmark/benchmark.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/characters.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/internal_style.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/lib/pool.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/source_span.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/colors.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/file.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/location.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span_exception.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span_mixin.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/span_with_context.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/.status
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/internal_test_case.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/prints_matcher.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/throws_matcher.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/throws_matchers.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/util.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/test_environment.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/example/ga.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/usage_impl.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/usage_impl_html.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/usage_impl_io.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/src/uuid.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/usage.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/usage_html.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/lib/usage_io.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/tool/grind.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2014, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: observatory_pub_packages
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_parser_exception.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/arg_parser_exception.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/delegate/stream.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/null_stream_sink.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/capture_sink.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/capture_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/error.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/release_sink.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/release_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/result.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/result/value.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/single_subscription_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_completer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer/handler_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer/stream_transformer_wrapper.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_sink_transformer/typed.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_subscription_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/stream_zip.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/typed/future.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/typed/stream_subscription.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/typed_stream_transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/empty_unmodifiable_set.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/equality_map.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/equality_set.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/functions.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/union_set.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/union_set_controller.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/intl/compact_number_format.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/src/plural_rules.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/src/order_matchers.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/meta/lib/meta.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/observable.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/change_record.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/list_diff.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/observable.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/observable_list.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/observable_map.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/property_change_record.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/observable/lib/src/to_observable.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2016, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: observatory_pub_packages
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/parser.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/args.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/parser.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/lib/src/usage.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/async.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/barback.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_forwarder.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_id.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_node.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_node_set.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/asset_set.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/asset/internal_asset.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/barback.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/build_result.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/errors.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/asset_cascade.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/group_runner.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/package_graph.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/phase.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/phase_forwarder.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/phase_output.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/graph/transform_node.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/log.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/package_provider.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/serialize.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/barback_settings.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transform_logger.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transformer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/transformer/transformer_group.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/cancelable_future.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/file_pool.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/multiset.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/stream_pool.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/barback/lib/src/utils/stream_replayer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/browser/lib/dart.js
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/browser/lib/interop.js
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/algorithms.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/collection.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/equality.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/iterable_zip.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/algorithms.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/equality.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/iterable_zip.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/unmodifiable_wrappers.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/wrappers.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/wrappers.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/css.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/src/css_printer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/src/polyfill.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/csslib/lib/src/tree_printer.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/lib/src/pretty_print.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/context.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/parsed_path.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/path_exception.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style/posix.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style/url.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/lib/src/style/windows.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/chain.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/frame.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/lazy_trace.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/stack_zone_specification.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/trace.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/src/vm_trace.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/lib/stack_trace.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/compact_vm_config.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/html_config.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/html_enhanced_config.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/html_individual_config.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/configuration.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/matcher/pretty_print.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/simple_configuration.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/test_case.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/src/utils.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/unittest.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/lib/vm_config.dart
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/lib/src/utf_stream.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2013, the Dart project authors.  Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: observatory_pub_packages
 ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/.analysis_options
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/.analysis_options
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/convert/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/crypto/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/initialize/tool/rename_build_outputs.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/typed_data/.test_config
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/utf/.test_config
 ----------------------------------------------------------------------------------------------------
 Copyright 2015, the Dart project authors. All rights reserved.
@@ -16398,9 +16034,6 @@ ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/async_cache.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/async/lib/src/byte_collector.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/cli_util/example/main.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/cli_util/lib/cli_logging.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/cli_util/lib/src/utils.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/combined_wrappers/combined_iterable.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/combined_wrappers/combined_list.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/collection/lib/src/combined_wrappers/combined_map.dart
@@ -16441,32 +16074,23 @@ LIBRARY: observatory_pub_packages
 ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/browser/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/charcode/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/code_transformers/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/dist/dart-style.d.ts
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/web/index.html
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/dart_style/web/main.dart
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/glob/.test_config
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/matcher/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/.analysis_options
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/path/.test_config
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/compiler.xml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/encodings.xml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/libraries/Dart_Packages.xml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/libraries/Dart_SDK.xml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/misc.xml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/modules.xml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/pool.iml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/vcs.xml
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.idea/workspace.xml
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/pool/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_maps/.test_config
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/.analysis_options
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/source_span/.test_config
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/stack_trace/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/string_scanner/.test_config
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/unittest/.analysis_options
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/usage/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/watcher/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/benchmark/output.json
 ----------------------------------------------------------------------------------------------------
 Copyright 2014, the Dart project authors. All rights reserved.
 Redistribution and use in source and binary forms, with or without
@@ -16704,7 +16328,7 @@ met:
 LIBRARY: observatory_pub_packages
 ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/LICENSE
 TYPE: LicenseType.mit
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/.analysis_options
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/.test_config
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/lib/dom.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/lib/dom_parsing.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/html/lib/parser.dart
@@ -16747,7 +16371,44 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ====================================================================================================
 LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/date_symbol_data_local.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/analyzer/LICENSE
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/date_symbol_data_custom.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/date_symbol_data_custom.dart
+----------------------------------------------------------------------------------------------------
+Copyright (c) 2017, the Dart project authors.
+Please see the AUTHORS file
+for details. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: observatory_pub_packages
+ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/date_symbol_data_local.dart + ../../../third_party/dart/third_party/observatory_pub_packages/packages/args/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/date_symbol_data_local.dart
 FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/intl/lib/number_symbols_data.dart
@@ -16852,152 +16513,6 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/e2e_test/html_imports/lib/theme.html
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/bower.json
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/package.json
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2012 The Polymer Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/CustomElements.js
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/CustomElements.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/CustomElements.min.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/HTMLImports.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/HTMLImports.min.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/MutationObserver.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/MutationObserver.min.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/ShadowDOM.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/ShadowDOM.min.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/webcomponents-lite.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/webcomponents-lite.min.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/webcomponents.js
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/webcomponents.min.js
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2014 The Polymer Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/interop_support.html + ../../../third_party/dart/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/web_components/lib/interop_support.html
-----------------------------------------------------------------------------------------------------
-Copyright 2014 The Dart project authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: observatory_pub_packages
-ORIGIN: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/libyaml-license.txt
-TYPE: LicenseType.mit
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/.analysis_options
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/.test_config
-FILE: ../../../third_party/dart/third_party/observatory_pub_packages/packages/yaml/benchmark/output.json
-----------------------------------------------------------------------------------------------------
-Copyright (c) 2006 Kirill Simonov
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 ====================================================================================================
 
 ====================================================================================================
@@ -22399,4 +21914,4 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 ====================================================================================================
-Total license count: 320
+Total license count: 317

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 0d52e4a9a84f4a44a99ad88c668cabc8
+Signature: c38fa8133a5c87e15329c5b7f037824d
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Commit log in this range:
4bcf8ad411 [fasta] Handle static get in ConstnessEvaluator
26423147ab [infra] Add dart2js-chrome to the CQ again
b879d4df14 [fasta] Fix insertion of noSuchMethod forwarders for private members
e3ace23c87 [infra] Remove dart2js-chrome from the CQ temporarily
d0ad78db24 Improve recovery when "set" found in function body
5367304ba5 Cleanup in incremental compiler
8ac9fa5de2 Rename simple to basic; get rid of name in tests
4b2b15f53e Clarify that mixin application drops static members
cb08bf287d [infra] Expect certain errors to pass when runtime is "none"
b793c8a387 [fasta] Require explicit handling of all expression kinds in ConstnessEvaluator
4c6379eaff [infra] Support preview_dart_2 in status update tool
1b696eb6f5 [infra] Print variable name for unknown variables
1dfb1c2f64 Implement Dart 2 static subtyping
163f8b9678 Cleanup async stack recording
b07a4bc264 improve deduping of cached types in DDC/K
54f7680389 fix DDC dynamic call profiler to ignore SDK frames
a4c5607281 fix #32594, `debugger()` will work even if dart_sdk.js is blackboxed
c5caf7e294 dart2js: Pass through type arguments in parameter defaulting stubs
a0a06e172c Bring in the latest pub_semver
4089111540 Revert "Revert "Don't do implicit new/const code generation with --preview-dart-2 enabled.""
e5d20a7749 Add type to loadLibrary tearoff
bec3801a02 Improve recovery when mixin app missing "with" clause
701e02b2fa Update AstBuilder to handle named function declaration
ddbe2eece1 Change assertions in SSA so that it checks up to 100 instructions. This cuts down compilation time for some very slow tests by a third.
d39e5ccf4d [vm/compiler] Fix assignment of type to phi, take 2
a173784a31 Readd web-components: it is used for unit tests of dart:html
57d6ec265d Improve AstBuilder for-in recovery
0ea0c42313 Extract AnalysisDriverResolutionTest and corresponding Kernel version into separate files.
ca7edd065c Improve invalid function body recovery
83418436b7 Issue 32740. Support for implicit call() invocation in top-level inference.
38fae026b4 Allow to output full component via computeDelta
c98df5b065 Check that type alias equality relies on the underlying type, not the `typedef`ed name.
155e55cbb1 Remove defaultValue parameter from Stream.first/lastWhere.
0588816fda Move type_representation_test to rti/ folder
0ba21c25b7 Clean up Map#operator[] documentation
e01fbecdf5 Fix type in NativeTypedArrayOfDouble
8d78982c3f Move file system access support from AnalysisContext to ContextRoot
7b51acd37f [vm/kernel/aot] Treat 'return;' as 'return null;' in TFA
3ba478a258 Remove SDK browser DEP
bfb9fae597 [vm] Don't keep events in memory when using systrace/traceutil.
1daa81339f Improve fasta parser enum declaration recovery
fabc51bbf7 Silence parser recovery tests.
feceb2c59e Restore ErrorCode default constructor, rename the one with named parameters to 'temporary'.
616acb06ec Deprecate the option to enable using a URI in a part-of directive
374058aa79 Improve fasta parser try/catch error messages and recovery
79a349fa07 Don't put libraries of all analyzed units into the current session.
a0470fefb6 Remove implicit_creation/implicit_new_or_const_composite_test from the status file under darkp as the test now passes.
0c892a8bc8 Improve signatures of tear-offs
9858ea1f8d Explicitly store isIntercepted in full emitter tearoffs
a60b4d6f56 [kernel/vm/aot] De-duplicate identical mixin applications
3db2338283 [vm] Remove old --break_at_isolate_spawn.
5941ebc33b [observatory] Filter platform dil files.
996a66d247 Fix build bot failure in dartkp mode (language_2/implicit_creation/implicit_new_or_const_test now passes)
76db5505ec Bring in the latest pub and pub_semver
c1432bf7a3 [observatory] Remove references to pkg:browser from web/index.html

