### PR TITLE
libtxt: use Helvetica as a fallback font on iOS 8 and earlier

### DIFF
--- a/third_party/txt/src/txt/platform_mac.mm
+++ b/third_party/txt/src/txt/platform_mac.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include <TargetConditionals.h>
+#include "flutter/fml/platform/darwin/platform_version.h"
 #include "txt/platform.h"
 
 #if TARGET_OS_EMBEDDED || TARGET_OS_SIMULATOR
@@ -16,7 +17,11 @@
 namespace txt {
 
 std::string GetDefaultFontFamily() {
-  return [FONT_CLASS systemFontOfSize:14].familyName.UTF8String;
+  if (fml::IsPlatformVersionAtLeast(9)) {
+    return [FONT_CLASS systemFontOfSize:14].familyName.UTF8String;
+  } else {
+    return "Helvetica";
+  }
 }
 
 }  // namespace txt


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/16055