### PR TITLE
Set FlutterTexture copyPixelBuffer return nullable

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 FLUTTER_EXPORT
 @protocol FlutterTexture<NSObject>
-- (CVPixelBufferRef)copyPixelBuffer;
+- (CVPixelBufferRef _Nullable)copyPixelBuffer;
 @end
 
 FLUTTER_EXPORT


### PR DESCRIPTION
This is to support Swift users, where nil is allowed for CVPixelBufferRef.