### PR TITLE
Run setAssetBundlePath outside of UI thread.

### DIFF
--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -203,6 +203,9 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
 }
 
 void PlatformView::SetAssetBundlePath(const std::string& assets_directory) {
+  // Since this code is executed as vm root service handler, it doesn't run on
+  // UI thread. Assets are consumed on UI thread, so this has to be scheduled
+  // there.
   // Don't wait for this task to complete as UI thread can be blocked with
   // application suspended at a breakpoint.
   blink::Threads::UI()->PostTask([engine = engine_->GetWeakPtr(),

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -202,4 +202,14 @@ void PlatformView::SetupResourceContextOnIOThreadPerform(
   latch->Signal();
 }
 
+void PlatformView::SetAssetBundlePath(const std::string& assets_directory) {
+  // Don't wait for this task to complete as UI thread can be blocked with
+  // application suspended at a breakpoint.
+  blink::Threads::UI()->PostTask([engine = engine_->GetWeakPtr(),
+      assets_directory] {
+    if (engine)
+      engine->SetAssetBundlePath(assets_directory);
+  });
+}
+
 }  // namespace shell

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -82,7 +82,7 @@ class PlatformView : public std::enable_shared_from_this<PlatformView> {
                              const std::string& main,
                              const std::string& packages) = 0;
 
-  virtual void SetAssetBundlePath(const std::string& assets_directory) = 0;
+  virtual void SetAssetBundlePath(const std::string& assets_directory);
 
  protected:
   explicit PlatformView(std::unique_ptr<Rasterizer> rasterizer);

--- a/shell/common/platform_view_service_protocol.cc
+++ b/shell/common/platform_view_service_protocol.cc
@@ -420,7 +420,6 @@ bool PlatformViewServiceProtocol::SetAssetBundlePath(const char* method,
       std::stoull((view_id + kViewIdPrefxLength), nullptr, 16);
 
   // Ask the Shell to update asset bundle path in the specified view.
-  // This will run a task on the UI thread before returning.
   Shell& shell = Shell::Shared();
   bool view_existed = false;
   Dart_Port main_port = ILLEGAL_PORT;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -88,14 +88,6 @@ class Shell {
                                  std::string* isolate_name,
                                  fxl::AutoResetWaitableEvent* latch);
 
-  void SetAssetBundlePathInPlatformViewUIThread(
-      uintptr_t view_id,
-      const std::string& main,
-      bool* view_existed,
-      int64_t* dart_isolate_id,
-      std::string* isolate_name,
-      fxl::AutoResetWaitableEvent* latch);
-
   FXL_DISALLOW_COPY_AND_ASSIGN(Shell);
 };
 

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -79,9 +79,9 @@ public class FlutterNativeView implements BinaryMessenger {
         nativeRunBundleAndSource(mNativePlatformView, assetsDirectory, main, packages);
     }
 
-    public void setAssetBundlePathOnUI(final String assetsDirectory) {
+    public void setAssetBundlePath(final String assetsDirectory) {
         assertAttached();
-        nativeSetAssetBundlePathOnUI(mNativePlatformView, assetsDirectory);
+        nativeSetAssetBundlePath(mNativePlatformView, assetsDirectory);
     }
 
     public static String getObservatoryUri() {
@@ -205,7 +205,7 @@ public class FlutterNativeView implements BinaryMessenger {
         String main,
         String packages);
 
-    private static native void nativeSetAssetBundlePathOnUI(long nativePlatformViewAndroid,
+    private static native void nativeSetAssetBundlePath(long nativePlatformViewAndroid,
         String bundlePath);
 
     private static native String nativeGetObservatoryUri();

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -659,7 +659,7 @@ public class FlutterView extends SurfaceView
         Runnable runnable = new Runnable() {
             public void run() {
                 assertAttached();
-                mNativeView.setAssetBundlePathOnUI(assetsDirectory);
+                mNativeView.setAssetBundlePath(assetsDirectory);
                 synchronized (this) {
                     notify();
                 }

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -250,14 +250,6 @@ void PlatformViewAndroid::RunBundleAndSource(std::string bundle_path,
   });
 }
 
-void PlatformViewAndroid::SetAssetBundlePathOnUI(std::string bundle_path) {
-  blink::Threads::UI()->PostTask(
-      [ engine = engine_->GetWeakPtr(), bundle_path = std::move(bundle_path) ] {
-        if (engine)
-          engine->SetAssetBundlePath(std::move(bundle_path));
-      });
-}
-
 void PlatformViewAndroid::SetViewportMetrics(jfloat device_pixel_ratio,
                                              jint physical_width,
                                              jint physical_height,
@@ -593,40 +585,6 @@ void PlatformViewAndroid::RunFromSource(const std::string& assets_directory,
     FXL_CHECK(java_packages);
     env->CallVoidMethod(local_flutter_view.obj(), run_from_source_method_id,
                         java_assets_directory, java_main, java_packages);
-  }
-
-  // Detaching from the VM deletes any stray local references.
-  fml::jni::DetachFromVM();
-}
-
-void PlatformViewAndroid::SetAssetBundlePath(
-    const std::string& assets_directory) {
-  JNIEnv* env = fml::jni::AttachCurrentThread();
-  FXL_CHECK(env);
-
-  {
-    fml::jni::ScopedJavaLocalRef<jobject> local_flutter_view =
-        flutter_view_.get(env);
-    if (local_flutter_view.is_null()) {
-      // Collected.
-      return;
-    }
-
-    // Grab the class of the flutter view.
-    jclass flutter_view_class = env->GetObjectClass(local_flutter_view.obj());
-    FXL_CHECK(flutter_view_class);
-
-    // Grab the setAssetBundlePath method id.
-    jmethodID method_id = env->GetMethodID(
-        flutter_view_class, "setAssetBundlePathOnUI", "(Ljava/lang/String;)V");
-    FXL_CHECK(method_id);
-
-    // Invoke setAssetBundlePath on the Android UI thread.
-    jstring java_assets_directory = env->NewStringUTF(assets_directory.c_str());
-    FXL_CHECK(java_assets_directory);
-
-    env->CallVoidMethod(local_flutter_view.obj(), method_id,
-                        java_assets_directory);
   }
 
   // Detaching from the VM deletes any stray local references.

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -108,10 +108,6 @@ class PlatformViewAndroid : public PlatformView {
                      const std::string& main,
                      const std::string& packages) override;
 
-  void SetAssetBundlePathOnUI(std::string bundle_path);
-
-  void SetAssetBundlePath(const std::string& assets_directory) override;
-
   void RegisterExternalTexture(
       int64_t texture_id,
       const fml::jni::JavaObjectWeakGlobalRef& surface_texture);

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -188,7 +188,6 @@ void SetAssetBundlePath(JNIEnv* env,
                         jobject jcaller,
                         jlong platform_view,
                         jstring bundlePath) {
-  FXL_LOG(ERROR) << "platform_view_android_jni.cc::SetAssetBundlePath is calling SetAssetBundlePath that should be platform_view_android.cc";
   return PLATFORM_VIEW->SetAssetBundlePath(
       fml::jni::JavaStringToString(env, bundlePath));
 }

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -184,11 +184,12 @@ void RunBundleAndSource(JNIEnv* env,
       fml::jni::JavaStringToString(env, packages));
 }
 
-void SetAssetBundlePathOnUI(JNIEnv* env,
-                            jobject jcaller,
-                            jlong platform_view,
-                            jstring bundlePath) {
-  return PLATFORM_VIEW->SetAssetBundlePathOnUI(
+void SetAssetBundlePath(JNIEnv* env,
+                        jobject jcaller,
+                        jlong platform_view,
+                        jstring bundlePath) {
+  FXL_LOG(ERROR) << "platform_view_android_jni.cc::SetAssetBundlePath is calling SetAssetBundlePath that should be platform_view_android.cc";
+  return PLATFORM_VIEW->SetAssetBundlePath(
       fml::jni::JavaStringToString(env, bundlePath));
 }
 
@@ -364,9 +365,9 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
           .fnPtr = reinterpret_cast<void*>(&shell::RunBundleAndSource),
       },
       {
-          .name = "nativeSetAssetBundlePathOnUI",
+          .name = "nativeSetAssetBundlePath",
           .signature = "(JLjava/lang/String;)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::SetAssetBundlePathOnUI),
+          .fnPtr = reinterpret_cast<void*>(&shell::SetAssetBundlePath),
       },
       {
           .name = "nativeDetach",

--- a/shell/platform/darwin/desktop/platform_view_mac.h
+++ b/shell/platform/darwin/desktop/platform_view_mac.h
@@ -41,8 +41,6 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
                      const std::string& main,
                      const std::string& packages) override;
 
-  void SetAssetBundlePath(const std::string& assets_directory) override;
-
  private:
   fml::scoped_nsobject<NSOpenGLView> opengl_view_;
   fml::scoped_nsobject<NSOpenGLContext> resource_loading_context_;
@@ -52,8 +50,6 @@ class PlatformViewMac : public PlatformView, public GPUSurfaceGLDelegate {
   void SetupAndLoadFromSource(const std::string& assets_directory,
                               const std::string& main,
                               const std::string& packages);
-
-  void SetAssetBundlePathOnUI(const std::string& assets_directory);
 
   FXL_DISALLOW_COPY_AND_ASSIGN(PlatformViewMac);
 };

--- a/shell/platform/darwin/desktop/platform_view_mac.mm
+++ b/shell/platform/darwin/desktop/platform_view_mac.mm
@@ -73,13 +73,6 @@ void PlatformViewMac::SetupAndLoadFromSource(const std::string& assets_directory
       });
 }
 
-void PlatformViewMac::SetAssetBundlePathOnUI(const std::string& assets_directory) {
-  blink::Threads::UI()->PostTask([ engine = engine().GetWeakPtr(), assets_directory ] {
-    if (engine)
-      engine->SetAssetBundlePath(assets_directory);
-  });
-}
-
 intptr_t PlatformViewMac::GLContextFBO() const {
   // Default window bound framebuffer FBO 0.
   return 0;
@@ -153,18 +146,6 @@ void PlatformViewMac::RunFromSource(const std::string& assets_directory,
 
   dispatch_async(dispatch_get_main_queue(), ^{
     SetupAndLoadFromSource(assets_directory, main, packages);
-    latch->Signal();
-  });
-
-  latch->Wait();
-  delete latch;
-}
-
-void PlatformViewMac::SetAssetBundlePath(const std::string& assets_directory) {
-  auto latch = new fxl::ManualResetWaitableEvent();
-
-  dispatch_async(dispatch_get_main_queue(), ^{
-    SetAssetBundlePathOnUI(assets_directory);
     latch->Signal();
   });
 

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -60,8 +60,6 @@ class PlatformViewIOS : public PlatformView {
                      const std::string& main,
                      const std::string& packages) override;
 
-  void SetAssetBundlePath(const std::string& assets_directory) override;
-
   /**
    * Exposes the `FlutterTextInputPlugin` singleton for the
    * `AccessibilityBridge` to be able to interact with the text entry system.
@@ -95,8 +93,6 @@ class PlatformViewIOS : public PlatformView {
   void SetupAndLoadFromSource(const std::string& assets_directory,
                               const std::string& main,
                               const std::string& packages);
-
-  void SetAssetBundlePathOnUI(const std::string& assets_directory);
 
   FXL_DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
 };

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -69,13 +69,6 @@ void PlatformViewIOS::SetupAndLoadFromSource(const std::string& assets_directory
       });
 }
 
-void PlatformViewIOS::SetAssetBundlePathOnUI(const std::string& assets_directory) {
-  blink::Threads::UI()->PostTask([ engine = engine().GetWeakPtr(), assets_directory ] {
-    if (engine)
-      engine->SetAssetBundlePath(assets_directory);
-  });
-}
-
 fml::WeakPtr<PlatformViewIOS> PlatformViewIOS::GetWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }
@@ -120,18 +113,6 @@ void PlatformViewIOS::RunFromSource(const std::string& assets_directory,
 
   dispatch_async(dispatch_get_main_queue(), ^{
     SetupAndLoadFromSource(assets_directory, main, packages);
-    latch->Signal();
-  });
-
-  latch->Wait();
-  delete latch;
-}
-
-void PlatformViewIOS::SetAssetBundlePath(const std::string& assets_directory) {
-  auto latch = new fxl::ManualResetWaitableEvent();
-
-  dispatch_async(dispatch_get_main_queue(), ^{
-    SetAssetBundlePathOnUI(assets_directory);
     latch->Signal();
   });
 


### PR DESCRIPTION
Waiting for setAssetBundlePath running this on UI thread could result in timeout since application could be suspended on breakpoint with UI loop not running. So we just post setAssetBundlePath call on UI event queue and don't wait.

Refactor and remove extra layers of running-on-UI methods.

This fixes https://github.com/flutter/flutter/issues/13396