### PR TITLE
Roll dart to 3e6b8717fedce5cc28a21616f4591683c211f752

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '2676c132cbfd88befcecc544b2e902c255e44b34',
+  'dart_revision': '3e6b8717fedce5cc28a21616f4591683c211f752',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 3fc14486250c20c91df483399a9ffd9b
+Signature: e57916cfc106e31b9115fb6ab9ec28cb
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
3e6b8717fe   Fixed GamePadList not working in DDC and hide MessagePort.start operation.
edb6e776f1   Update parseFields to use typeInfo
fdc787efc8    Adjusted issue numbers of a test
22d99d8920  Update status for LUCI versions of dart2js chrome builders
20ea3f5d69   Pass a list of context messages in onProblem callback.
bbb281ff3b    Error reporting functions take a list of context messages.
83ef97f873    Wrap a formatted message with line and column in a FormattedMessage.
b2d7749643  Fix issue with missing sources
765242d1b0  Add an issue template to the SDK
3acccedc40   Mark IsolateReload_TearOff_Parameter_Count_Mismatch failing
006fda374b   Update test matrix with correct path to dart on Mac OS
4d7327b7b7  Run inference test in strong mode
c502578096  Replace skipTypeReferenceOpt with computeType
7ed7e57aaa  Assert that inference isn't expected on abstract methods.