### PR TITLE
Add tool to create multi-arch iOS gen_snapshot

### DIFF
--- a/sky/tools/create_macos_gen_snapshot.py
+++ b/sky/tools/create_macos_gen_snapshot.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# Copyright 2018 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import subprocess
+import sys
+import os
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Creates multi-arch gen_snapshot')
+
+  parser.add_argument('--dst', type=str, required=True)
+  parser.add_argument('--arm64-out-dir', type=str, required=True)
+  parser.add_argument('--armv7-out-dir', type=str, required=True)
+
+  args = parser.parse_args()
+
+  fat_gen_snapshot = os.path.join(args.dst, 'gen_snapshot')
+  arm64_gen_snapshot = os.path.join(args.arm64_out_dir, 'clang_x64', 'gen_snapshot')
+  armv7_gen_snapshot = os.path.join(args.armv7_out_dir, 'clang_x86', 'gen_snapshot')
+
+  if not os.path.isfile(arm64_gen_snapshot):
+    print 'Cannot find x86_64 (arm64) gen_snapshot at', arm64_gen_snapshot
+    return 1
+
+  if not os.path.isfile(armv7_gen_snapshot):
+    print 'Cannot find i386 (armv7) gen_snapshot at', armv7_gen_snapshot
+    return 1
+
+  subprocess.call([
+    'lipo',
+    arm64_gen_snapshot,
+    armv7_gen_snapshot,
+    '-create',
+    '-output',
+    fat_gen_snapshot,
+  ])
+
+
+if __name__ == '__main__':
+  sys.exit(main())
+


### PR DESCRIPTION
This adds create_macos_gen_snapshot.py, which can be used to generate a
multi-architecture (x86_64, i386) gen_snapshot fat binary. The resulting
binary can then be run in the desired mode using:

/usr/bin/arch -i386 path/to/gen_snapshot
/usr/bin/arch -x86_64 path/to/gen_snapshot

When creating AOT snapshots for iOS, running as an i386 binary will
generate armv7 code, whereas running as an x86_64 binary will generate
arm64 code.

The primary user of this script is the build bot.