### PR TITLE
Revert "Roll Dart to ef926f98f525b085e1488be8c42b1c3f0a24c50d"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'ef926f98f525b085e1488be8c42b1c3f0a24c50d',
+  'dart_revision': '09e1766e6caa537e1271fbce04ebcbf8212b6569',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',

--- a/tools/licenses/pubspec.lock
+++ b/tools/licenses/pubspec.lock
@@ -58,4 +58,4 @@ packages:
     source: hosted
     version: "1.1.5"
 sdks:
-  dart: ">=1.21.0 <=2.0.0-edge.af1436931b93e755d38223c487d33a0a1f5eadf5"
+  dart: ">=1.21.0 <=2.0.0-edge.0d5cf900b021bf5c9fa593ffa12b15bcd1cc5fe0"

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 5e7a29bc2be55a7311df8f5a7dff2d34
+Signature: 93afdbdd65d1aea7e59730d0a9fe9f4b
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Reverts flutter/engine#4951.

Engine build is currently broken, so reverting Dart SDK roll for now.