### PR TITLE
Perform exit from server, not starter.

### DIFF
--- a/frontend_server/bin/starter.dart
+++ b/frontend_server/bin/starter.dart
@@ -1,10 +1,7 @@
 library frontend_server;
 
-import 'dart:async';
-import 'dart:io';
-
 import 'package:frontend_server/server.dart';
 
-Future<Null> main(List<String> args) async {
-  exit(await starter(args));
+void main(List<String> args){
+  starter(args);
 }

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -104,9 +104,9 @@ Future<int> starter(
   compiler ??= new _FlutterFrontendCompiler(output, trackWidgetCreation: options['track-widget-creation']);
 
   if (options.rest.isNotEmpty) {
-    return await compiler.compile(options.rest[0], options)
+    exit(await compiler.compile(options.rest[0], options)
         ? 0
-        : 254;
+        : 254);
   }
 
   frontend.listenAndCompile(compiler, input ?? stdin, options, () { exit(0); } );


### PR DESCRIPTION
Awaiting in starter results in hanging in incremental compilation scenario.

This is follow-up(fix) to https://github.com/flutter/engine/pull/4952.