### PR TITLE
Roll dart to 7764e6962e22afcf4b58c4e3cef3147330f3c884.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'github_git': 'https://github.com',
   'skia_git': 'https://skia.googlesource.com',
-  'skia_revision': '52e16d984898f18c84de773507da875a7954b922',
+  'skia_revision': '9874bf1bcecd0113087bd8a51cf838da0efa3bfe',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'ef926f98f525b085e1488be8c42b1c3f0a24c50d',
+  'dart_revision': '7764e6962e22afcf4b58c4e3cef3147330f3c884',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -46,7 +46,7 @@ vars = {
   'dart_convert_tag': '2.0.1',
   'dart_crypto_tag': '2.0.2+1',
   'dart_csslib_tag': '0.14.1',
-  'dart_dart2js_info_tag': '0.5.5+1',
+  'dart_dart2js_info_tag': '0.5.6',
   'dart_dart_style_tag': '1.0.10',
   'dart_dartdoc_tag': 'v0.18.1',
   'dart_fixnum_tag': '0.10.5',
@@ -60,7 +60,7 @@ vars = {
   'dart_intl_tag': '0.15.2',
   'dart_isolate_tag': '1.1.0',
   'dart_json_rpc_2_tag': '2.0.6',
-  'dart_linter_tag': '0.1.46',
+  'dart_linter_tag': '0.1.47',
   'dart_logging_tag': '0.11.3+1',
   'dart_markdown_tag': '1.1.1',
   'dart_matcher_tag': '0.12.1+4',
@@ -76,7 +76,7 @@ vars = {
   'dart_pool_tag': '1.3.4',
   'dart_protobuf_tag': '0.7.1',
   'dart_pub_rev': '4947e0b3cb3ec77e4e8fe0d3141ce4dc60f43256',
-  'dart_pub_semver_tag': '1.3.4',
+  'dart_pub_semver_tag': '1.3.6',
   'dart_quiver_tag': '5aaa3f58c48608af5b027444d561270b53f15dbf',
   'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',
   'dart_root_certificates_rev': '16ef64be64c7dfdff2b9f4b910726e635ccc519e',

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1809,6 +1809,7 @@ class RepositorySkiaThirdPartyDirectory extends RepositoryGenericThirdPartyDirec
   bool shouldRecurse(fs.IoNode entry) {
     return entry.name != 'giflib' // contains nothing that ends up in the binary executable
         && entry.name != 'freetype' // we use our own version
+        && entry.name != 'freetype2' // we use our own version
         && entry.name != 'icu' // we use our own version
         && entry.name != 'libjpeg-turbo' // we use our own version
         && entry.name != 'libpng' // we use our own version

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 35f9050d548a4901197f2e7d61e60f2d
+Signature: 5e7a29bc2be55a7311df8f5a7dff2d34
 
 UNUSED LICENSES:
 
@@ -13984,6 +13984,7 @@ FILE: ../../../third_party/skia/bench/StreamBench.cpp
 FILE: ../../../third_party/skia/bench/SwizzleBench.cpp
 FILE: ../../../third_party/skia/bench/TileImageFilterBench.cpp
 FILE: ../../../third_party/skia/bench/pack_int_uint16_t_Bench.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkRasterWidget.h
 FILE: ../../../third_party/skia/experimental/svg/model/SkPEG.h
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGAttribute.cpp
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGAttribute.h
@@ -14028,6 +14029,7 @@ FILE: ../../../third_party/skia/experimental/svg/model/SkSVGTransformableNode.h
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGTypes.h
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGValue.cpp
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGValue.h
+FILE: ../../../third_party/skia/experimental/tools/generate-unicode-test-txt
 FILE: ../../../third_party/skia/experimental/xps_to_png/xps_to_png.cs
 FILE: ../../../third_party/skia/fuzz/Fuzz.h
 FILE: ../../../third_party/skia/fuzz/FuzzGradients.cpp
@@ -17175,9 +17177,26 @@ FILE: ../../../third_party/skia/animations/redcross#1.jpg
 FILE: ../../../third_party/skia/animations/text#1.xml
 FILE: ../../../third_party/skia/bench/microbench.json
 FILE: ../../../third_party/skia/bench/skpbench.json
+FILE: ../../../third_party/skia/debugger/QT/Icons/.qrc
+FILE: ../../../third_party/skia/debugger/QT/Icons/blank.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/breakpoint.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/breakpoint_16x16.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/delete.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/inspector.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/next.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/pause.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/play.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/previous.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/profile.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/reload.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/rewind.png
+FILE: ../../../third_party/skia/debugger/QT/Icons/skia.png
+FILE: ../../../third_party/skia/debugger/QT/SkIcons.qrc
+FILE: ../../../third_party/skia/debugger/QT/qrc_SkIcons.cpp
 FILE: ../../../third_party/skia/docs/SkAutoCanvasRestore_Reference.bmh
 FILE: ../../../third_party/skia/docs/SkBitmap_Reference.bmh
 FILE: ../../../third_party/skia/docs/SkCanvas_Reference.bmh
+FILE: ../../../third_party/skia/docs/SkIPoint16_Reference.bmh
 FILE: ../../../third_party/skia/docs/SkIPoint_Reference.bmh
 FILE: ../../../third_party/skia/docs/SkIRect_Reference.bmh
 FILE: ../../../third_party/skia/docs/SkImageInfo_Reference.bmh
@@ -17223,7 +17242,6 @@ FILE: ../../../third_party/skia/infra/bots/assets/go/VERSION
 FILE: ../../../third_party/skia/infra/bots/assets/linux_vulkan_intel_driver_debug/VERSION
 FILE: ../../../third_party/skia/infra/bots/assets/linux_vulkan_intel_driver_release/VERSION
 FILE: ../../../third_party/skia/infra/bots/assets/linux_vulkan_sdk/VERSION
-FILE: ../../../third_party/skia/infra/bots/assets/mips64el_toolchain_linux/VERSION
 FILE: ../../../third_party/skia/infra/bots/assets/node/VERSION
 FILE: ../../../third_party/skia/infra/bots/assets/procdump_win/VERSION
 FILE: ../../../third_party/skia/infra/bots/assets/protoc/VERSION
@@ -17283,14 +17301,12 @@ FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.e
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-arm64-Release-Android_ASAN.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-universal-devrel-Android_SKQP.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-x86_64-Debug-Chromebook_GLES.json
-FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-x86_64-Debug-SK_CPU_LIMIT_SSE41.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-x86_64-Debug-SK_USE_DISCARDABLE_SCALEDIMAGECACHE.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-x86_64-Release-Fast.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-x86_64-Release-Mini.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-x86_64-Release-NoDEPS.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-Clang-x86_64-Release-Vulkan.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-EMCC-wasm-Release.json
-FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-loongson3a-Release.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Debug-EmbededResouces.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-ANGLE.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Build-Debian9-GCC-x86_64-Release-Flutter_Android.json
@@ -17329,7 +17345,6 @@ FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.e
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Test-Debian9-Clang-GCE-CPU-AVX2-x86_64-Debug-All-SafeStack.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Test-Debian9-Clang-GCE-CPU-AVX2-x86_64-Release-All-TSAN.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Test-Debian9-GCC-GCE-CPU-AVX2-x86_64-Release-All.json
-FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Test-Mac-Clang-MacMini7.1-CPU-AVX-x86_64-Debug-All-ASAN.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Test-Ubuntu16-Clang-NUC7i5BNK-GPU-IntelIris640-x86_64-Debug-All-Vulkan.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Test-Ubuntu17-GCC-Golo-GPU-QuadroP400-x86_64-Release-All-Valgrind_AbandonGpuContext_SK_CPU_LIMIT_SSE41.json
 FILE: ../../../third_party/skia/infra/bots/recipe_modules/flavor/examples/full.expected/Test-Win10-Clang-Golo-GPU-QuadroP400-x86_64-Release-All-Vulkan_ProcDump.json
@@ -18067,6 +18082,8 @@ FILE: ../../../third_party/skia/bench/RotatedRectBench.cpp
 FILE: ../../../third_party/skia/bench/SKPBench.cpp
 FILE: ../../../third_party/skia/bench/SKPBench.h
 FILE: ../../../third_party/skia/bench/nanobench.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkDrawCommandGeometryWidget.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkDrawCommandGeometryWidget.h
 FILE: ../../../third_party/skia/dm/DMGpuSupport.h
 FILE: ../../../third_party/skia/dm/DMJsonWriter.cpp
 FILE: ../../../third_party/skia/dm/DMJsonWriter.h
@@ -18324,6 +18341,22 @@ FILE: ../../../third_party/skia/bench/MorphologyBench.cpp
 FILE: ../../../third_party/skia/bench/RTreeBench.cpp
 FILE: ../../../third_party/skia/bench/RefCntBench.cpp
 FILE: ../../../third_party/skia/bench/TableBench.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkCanvasWidget.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkCanvasWidget.h
+FILE: ../../../third_party/skia/debugger/QT/SkDebuggerGUI.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkDebuggerGUI.h
+FILE: ../../../third_party/skia/debugger/QT/SkGLWidget.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkGLWidget.h
+FILE: ../../../third_party/skia/debugger/QT/SkInspectorWidget.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkInspectorWidget.h
+FILE: ../../../third_party/skia/debugger/QT/SkListWidget.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkListWidget.h
+FILE: ../../../third_party/skia/debugger/QT/SkRasterWidget.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkSettingsWidget.cpp
+FILE: ../../../third_party/skia/debugger/QT/SkSettingsWidget.h
+FILE: ../../../third_party/skia/debugger/SkDebugger.cpp
+FILE: ../../../third_party/skia/debugger/SkDebugger.h
+FILE: ../../../third_party/skia/debugger/debuggermain.cpp
 FILE: ../../../third_party/skia/gm/bigmatrix.cpp
 FILE: ../../../third_party/skia/gm/blurrect.cpp
 FILE: ../../../third_party/skia/gm/colorfilterimagefilter.cpp
@@ -19265,7 +19298,6 @@ FILE: ../../../third_party/skia/experimental/svg/model/SkSVGRadialGradient.cpp
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGRadialGradient.h
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGUse.cpp
 FILE: ../../../third_party/skia/experimental/svg/model/SkSVGUse.h
-FILE: ../../../third_party/skia/experimental/tools/gerrit-change-id-to-number
 FILE: ../../../third_party/skia/fuzz/FuzzCanvas.cpp
 FILE: ../../../third_party/skia/gm/alpha_image.cpp
 FILE: ../../../third_party/skia/gm/atlastext.cpp
@@ -19433,6 +19465,7 @@ FILE: ../../../third_party/skia/src/gpu/ccpr/GrCCPathProcessor.cpp
 FILE: ../../../third_party/skia/src/gpu/ccpr/GrCCPathProcessor.h
 FILE: ../../../third_party/skia/src/gpu/ccpr/GrCCQuadraticShader.cpp
 FILE: ../../../third_party/skia/src/gpu/ccpr/GrCCQuadraticShader.h
+FILE: ../../../third_party/skia/src/gpu/ccpr/GrCCTriangleShader.h
 FILE: ../../../third_party/skia/src/gpu/ccpr/GrCoverageCountingPathRenderer.cpp
 FILE: ../../../third_party/skia/src/gpu/ccpr/GrCoverageCountingPathRenderer.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrAtlasedShaderHelpers.h
@@ -19669,17 +19702,14 @@ FILE: ../../../third_party/skia/experimental/sksg/paint/SkSGGradient.cpp
 FILE: ../../../third_party/skia/experimental/sksg/paint/SkSGGradient.h
 FILE: ../../../third_party/skia/fuzz/FuzzCommon.cpp
 FILE: ../../../third_party/skia/fuzz/FuzzPathMeasure.cpp
-FILE: ../../../third_party/skia/fuzz/FuzzRegionOp.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzImageFilterDeserialize.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzPathDeserialize.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzRegionDeserialize.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzRegionSetPath.cpp
 FILE: ../../../third_party/skia/gm/hugepath.cpp
-FILE: ../../../third_party/skia/gm/localmatrixshader.cpp
 FILE: ../../../third_party/skia/gm/makeRasterImage.cpp
 FILE: ../../../third_party/skia/gm/orientation.cpp
 FILE: ../../../third_party/skia/gm/pathmeasure.cpp
-FILE: ../../../third_party/skia/gm/polygonoffset.cpp
 FILE: ../../../third_party/skia/gm/scaledemoji.cpp
 FILE: ../../../third_party/skia/gm/shadermaskfilter.cpp
 FILE: ../../../third_party/skia/gm/sharedcorners.cpp
@@ -19689,7 +19719,6 @@ FILE: ../../../third_party/skia/include/core/SkCoverageMode.h
 FILE: ../../../third_party/skia/include/effects/SkShaderMaskFilter.h
 FILE: ../../../third_party/skia/include/effects/SkTrimPathEffect.h
 FILE: ../../../third_party/skia/include/private/GrSurfaceProxyRef.h
-FILE: ../../../third_party/skia/include/private/GrVkTypesPriv.h
 FILE: ../../../third_party/skia/include/private/SkSafe32.h
 FILE: ../../../third_party/skia/infra/cts/run_testlab.go
 FILE: ../../../third_party/skia/samplecode/SampleAnimatedImage.cpp
@@ -19703,7 +19732,6 @@ FILE: ../../../third_party/skia/src/core/SkCubicMap.cpp
 FILE: ../../../third_party/skia/src/core/SkCubicMap.h
 FILE: ../../../third_party/skia/src/core/SkDeferredDisplayList.cpp
 FILE: ../../../third_party/skia/src/core/SkGlyph.cpp
-FILE: ../../../third_party/skia/src/core/SkIPoint16.h
 FILE: ../../../third_party/skia/src/core/SkMaskFilterBase.h
 FILE: ../../../third_party/skia/src/core/SkPath_serial.cpp
 FILE: ../../../third_party/skia/src/core/SkRRectPriv.h
@@ -19711,9 +19739,11 @@ FILE: ../../../third_party/skia/src/core/SkRectPriv.h
 FILE: ../../../third_party/skia/src/core/SkRemoteGlyphCache.cpp
 FILE: ../../../third_party/skia/src/core/SkRemoteGlyphCache.h
 FILE: ../../../third_party/skia/src/core/SkSafeRange.h
-FILE: ../../../third_party/skia/src/core/SkSurfaceCharacterization.cpp
 FILE: ../../../third_party/skia/src/core/SkTypeface_remote.cpp
 FILE: ../../../third_party/skia/src/core/SkTypeface_remote.h
+FILE: ../../../third_party/skia/src/effects/GrAlphaThresholdFragmentProcessor.cpp
+FILE: ../../../third_party/skia/src/effects/GrAlphaThresholdFragmentProcessor.fp
+FILE: ../../../third_party/skia/src/effects/GrAlphaThresholdFragmentProcessor.h
 FILE: ../../../third_party/skia/src/effects/SkShaderMaskFilter.cpp
 FILE: ../../../third_party/skia/src/effects/SkTrimPE.h
 FILE: ../../../third_party/skia/src/effects/SkTrimPathEffect.cpp
@@ -19729,9 +19759,6 @@ FILE: ../../../third_party/skia/src/gpu/GrUninstantiateProxyTracker.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrAARectEffect.cpp
 FILE: ../../../third_party/skia/src/gpu/effects/GrAARectEffect.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrAARectEffect.h
-FILE: ../../../third_party/skia/src/gpu/effects/GrAlphaThresholdFragmentProcessor.cpp
-FILE: ../../../third_party/skia/src/gpu/effects/GrAlphaThresholdFragmentProcessor.fp
-FILE: ../../../third_party/skia/src/gpu/effects/GrAlphaThresholdFragmentProcessor.h
 FILE: ../../../third_party/skia/src/gpu/effects/GrArithmeticFP.cpp
 FILE: ../../../third_party/skia/src/gpu/effects/GrArithmeticFP.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrArithmeticFP.h
@@ -19773,8 +19800,6 @@ FILE: ../../../third_party/skia/src/gpu/effects/GrYUVtoRGBEffect.fp
 FILE: ../../../third_party/skia/src/gpu/effects/GrYUVtoRGBEffect.h
 FILE: ../../../third_party/skia/src/gpu/text/GrAtlasManager.cpp
 FILE: ../../../third_party/skia/src/gpu/text/GrAtlasManager.h
-FILE: ../../../third_party/skia/src/gpu/vk/GrVkImageLayout.h
-FILE: ../../../third_party/skia/src/gpu/vk/GrVkTypesPriv.cpp
 FILE: ../../../third_party/skia/src/opts/SkOpts_hsw.cpp
 FILE: ../../../third_party/skia/src/opts/SkRasterPipeline_opts.h
 FILE: ../../../third_party/skia/src/pdf/SkClusterator.cpp
@@ -19896,8 +19921,8 @@ FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzDrawFunctions.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzGradients.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzImage.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzJPEGEncoder.cpp
-FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzMockGPUCanvas.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzNullCanvas.cpp
+FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzNullGLCanvas.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzPNGEncoder.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzPathMeasure.cpp
 FILE: ../../../third_party/skia/fuzz/oss_fuzz/FuzzRasterN32Canvas.cpp
@@ -20096,6 +20121,7 @@ FILE: ../../../third_party/skia/src/core/SkXfermode.cpp
 FILE: ../../../third_party/skia/src/core/SkXfermodePriv.h
 FILE: ../../../third_party/skia/src/effects/Sk1DPathEffect.cpp
 FILE: ../../../third_party/skia/src/effects/Sk2DPathEffect.cpp
+FILE: ../../../third_party/skia/src/effects/SkBlurMaskFilter.cpp
 FILE: ../../../third_party/skia/src/effects/SkCornerPathEffect.cpp
 FILE: ../../../third_party/skia/src/effects/SkDashPathEffect.cpp
 FILE: ../../../third_party/skia/src/effects/SkDiscretePathEffect.cpp

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 5e7a29bc2be55a7311df8f5a7dff2d34
+Signature: bea26d7863b6f1cfa1d0c0ae3775bf93
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Changes since last roll:

```
7764e6962e Initial API to build analysis contexts (replaces ContextLocator.locateContexts)
5ea271bb01 Clean up documentation of implicit new/const insertions tests.
cf93009caf Removed the magic const feature from implicit-creation.md
bd39320b3b Recover from error on undefined continue label.
5d89a1ac32 Add tests for mixin application constructor forwarding.
e6962790a1 Use import URIs when invalidating files
23c59bd819 Fix compare_failures
290cc58e71 Use actual receiver when error-wrapping a null-aware property get.
34763bc4c9 Reland "[VM] Introduction of type testing stubs - Part 1-4"
a86b864fa9 Handle updated .packages in incremental compiler
f555ae505a Trust type annotations in strong mode
0a4a3bed68 When cloning YieldStatement, copy the flags
91bbc798fa Skip abstract forwarding stubs
7689dc9e06 Bring in the latest pub_semver
f71d204185 Fix expected type in substByContext
5e99872770 Improve missing/invalid type reference recovery
899dbe4dae Forward type arguments in one-shot interceptors.
1fd3011f47 dart2js: Add more whole-program information to dump-info
5e23c2843d Revert "[infra] Temporarily disable Windows SDK builder on CQ"
2471888d4a Serialize any MethodInvocation as possible const.
b430570364 dart2js: handle constant casts with type variable substitutions
3575b810b3 Only add const in a constant context (issue 32819)
09f7d2aee5 dart2js: naive support for instantiations in constants - ignore the actual instantiation
4dd5e6e6ad js_runtime: fix _JsonMap keys list type
71ffe976a9 Correctly handle constant fields when computing constness (take 2)
d58b0e2d44 [VM] Mark bigint test slow after small Smi change
1e997ee6b7 Revert "Reland "[VM] Introduction of type testing stubs - Part 1-4""
00097adce0 Remove reference to deprecated setter
cb065a116f [infra] Update checked-in SDK version to 2.0.0-dev.46.0
0e9a77a360 [VM] Reduce Smi size to 32 bit on 64 bit platforms
34bfefd508 [gardening] Update status file
969c0de335 Avoid crash on EOF error in file with Windows line encoding
8054409a02 Reland "[VM] Introduction of type testing stubs - Part 1-4"
```