### PR TITLE
Update to use new vulkan GrBackendRenderTarget ctor.

### DIFF
--- a/content_handler/vulkan_surface.cc
+++ b/content_handler/vulkan_surface.cc
@@ -278,7 +278,7 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrContext> context,
       .fLevelCount = image_create_info.mipLevels,
   };
 
-  GrBackendRenderTarget sk_render_target(size.width(), size.height(), 0, 0,
+  GrBackendRenderTarget sk_render_target(size.width(), size.height(), 0,
                                          image_info);
 
   SkSurfaceProps sk_surface_props(


### PR DESCRIPTION
This moves to the new skia ctor for vulkan GrBackendRenderTarget which doesn't take a stencil count since vulkan doesn't bind stencil and render target together like GL does with framebuffer so it is not needed.