### PR TITLE
Update to use new vulkan GrBackendRenderTarget ctor (part 2)

### DIFF
--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -232,7 +232,7 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
   };
 
   // TODO(chinmaygarde): Setup the stencil buffer and the sampleCnt.
-  GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight, 0, 0,
+  GrBackendRenderTarget backend_render_target(size.fWidth, size.fHeight, 0,
                                               image_info);
   SkSurfaceProps props(SkSurfaceProps::InitType::kLegacyFontHost_InitType);
 


### PR DESCRIPTION
This moves to the new skia ctor for vulkan GrBackendRenderTarget which doesn't take a stencil count since vulkan doesn't bind stencil and render target together like GL does with framebuffer so it is not needed.

This is the same idea as pull, https://github.com/flutter/engine/pull/4962, but the github UI was only allowing me to change one file via the online edit :(