### PR TITLE
Remove named field initialization of GrVkImageInfo

### DIFF
--- a/content_handler/vulkan_surface.cc
+++ b/content_handler/vulkan_surface.cc
@@ -270,12 +270,12 @@ bool VulkanSurface::SetupSkiaSurface(sk_sp<GrContext> context,
   }
 
   const GrVkImageInfo image_info = {
-      .fImage = vk_image_,
-      .fAlloc = {vk_memory_, 0, memory_reqs.size, 0},
-      .fImageTiling = image_create_info.tiling,
-      .fImageLayout = image_create_info.initialLayout,
-      .fFormat = image_create_info.format,
-      .fLevelCount = image_create_info.mipLevels,
+      vk_image_,                            // image
+      {vk_memory_, 0, memory_reqs.size, 0}, // alloc
+      image_create_info.tiling,             // tiling
+      image_create_info.initialLayout,      // layout
+      image_create_info.format,             // format
+      image_create_info.mipLevels,          // level count
   };
 
   GrBackendRenderTarget sk_render_target(size.width(), size.height(), 0,

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -223,12 +223,12 @@ sk_sp<SkSurface> VulkanSwapchain::CreateSkiaSurface(
   }
 
   const GrVkImageInfo image_info = {
-      .fImage = image,
-      .fAlloc = GrVkAlloc(),
-      .fImageTiling = VK_IMAGE_TILING_OPTIMAL,
-      .fImageLayout = VK_IMAGE_LAYOUT_UNDEFINED,
-      .fFormat = surface_format_.format,
-      .fLevelCount = 1,
+      image,                     // image
+      GrVkAlloc(),               // alloc
+      VK_IMAGE_TILING_OPTIMAL,   // tiling
+      VK_IMAGE_LAYOUT_UNDEFINED, // layout
+      surface_format_.format,    // format
+      1,                         // level count
   };
 
   // TODO(chinmaygarde): Setup the stencil buffer and the sampleCnt.


### PR DESCRIPTION
This syntax fails in conjunction with the new 6-argument constructor
that's been added. Fields were already initialized in the correct
order, so simply omit the field names. Once the constructor lands,
this will switch to calling that.