### PR TITLE
libtxt: improvements to glyph cluster handling and grapheme breaking

### DIFF
--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -1076,7 +1076,9 @@ void Layout::doLayoutRun(const uint16_t* buf,
         float xoff = HBFixedToFloat(positions[i].x_offset);
         float yoff = -HBFixedToFloat(positions[i].y_offset);
         xoff += yoff * ctx->paint.skewX;
-        LayoutGlyph glyph = {font_ix, glyph_ix, x + xoff, y + yoff};
+        LayoutGlyph glyph = {
+            font_ix, glyph_ix, x + xoff, y + yoff,
+            static_cast<ssize_t>(info[i].cluster - clusterOffset)};
         mGlyphs.push_back(glyph);
         float xAdvance = HBFixedToFloat(positions[i].x_advance);
         if ((ctx->paint.paintFlags & LinearTextFlag) == 0) {
@@ -1137,7 +1139,8 @@ void Layout::appendLayout(Layout* src, size_t start, float extraAdvance) {
     unsigned int glyph_id = srcGlyph.glyph_id;
     float x = x0 + srcGlyph.x;
     float y = srcGlyph.y;
-    LayoutGlyph glyph = {font_ix, glyph_id, x, y};
+    LayoutGlyph glyph = {font_ix, glyph_id, x, y,
+                         static_cast<ssize_t>(srcGlyph.cluster + start)};
     mGlyphs.push_back(glyph);
   }
   for (size_t i = 0; i < src->mAdvances.size(); i++) {
@@ -1172,6 +1175,12 @@ FontFakery Layout::getFakery(int i) const {
 unsigned int Layout::getGlyphId(int i) const {
   const LayoutGlyph& glyph = mGlyphs[i];
   return glyph.glyph_id;
+}
+
+// libtxt extension
+unsigned int Layout::getGlyphCluster(int i) const {
+  const LayoutGlyph& glyph = mGlyphs[i];
+  return glyph.cluster;
 }
 
 float Layout::getX(int i) const {

--- a/third_party/txt/src/minikin/Layout.h
+++ b/third_party/txt/src/minikin/Layout.h
@@ -37,6 +37,10 @@ struct LayoutGlyph {
   unsigned int glyph_id;
   float x;
   float y;
+
+  // libtxt extension: record the cluster (character index) that corresponds
+  // to this glyph
+  ssize_t cluster;
 };
 
 // Internal state used during layout operation
@@ -94,6 +98,7 @@ class Layout {
   const MinikinFont* getFont(int i) const;
   FontFakery getFakery(int i) const;
   unsigned int getGlyphId(int i) const;
+  uint32_t getGlyphCluster(int i) const;  // libtxt extension
   float getX(int i) const;
   float getY(int i) const;
 

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -184,7 +184,6 @@ class Paragraph {
   std::shared_ptr<FontCollection> font_collection_;
 
   minikin::LineBreaker breaker_;
-  std::unique_ptr<icu::BreakIterator> grapheme_breaker_;
   mutable std::unique_ptr<icu::BreakIterator> word_breaker_;
 
   struct LineRange {


### PR DESCRIPTION
* Extend Minikin to record the cluster identifier corresponding to each glyph
* Use the cluster values to determine the range of input code units that map
  to a glyph
* Use Minikin's libraries to find boundaries between graphemes within a
  ligature

Fixes https://github.com/flutter/flutter/issues/16151