### PR TITLE
 Update skia vulkan usages to use getBackendRenderTarget.

### DIFF
--- a/content_handler/vulkan_surface_producer.cc
+++ b/content_handler/vulkan_surface_producer.cc
@@ -150,17 +150,22 @@ bool VulkanSurfaceProducer::TransitionSurfacesToExternal(
     if (!command_buffer->Begin())
       return false;
 
-    GrVkImageInfo* imageInfo;
-    vk_surface->GetSkiaSurface()->getRenderTargetHandle(
-        reinterpret_cast<GrBackendObject*>(&imageInfo),
+    GrBackendRenderTarget backendRT = vk_surface->GetSkiaSurface()->getBackendRenderTarget(
         SkSurface::kFlushRead_BackendHandleAccess);
+    if (!backendRT.isValid()) {
+      return false;
+    }
+    GrVkImageInfo imageInfo;
+    if(!backendRT.getVkImageInfo(&imageInfo)) {
+      return false;
+    }
 
     VkImageMemoryBarrier image_barrier = {
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
         .pNext = nullptr,
         .srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
         .dstAccessMask = 0,
-        .oldLayout = imageInfo->fImageLayout,
+        .oldLayout = imageInfo.fImageLayout,
         .newLayout = VK_IMAGE_LAYOUT_GENERAL,
         .srcQueueFamilyIndex = 0,
         .dstQueueFamilyIndex = VK_QUEUE_FAMILY_EXTERNAL_KHR,
@@ -176,7 +181,7 @@ bool VulkanSurfaceProducer::TransitionSurfacesToExternal(
             1, &image_barrier))
       return false;
 
-    imageInfo->updateImageLayout(image_barrier.newLayout);
+    backendRT.setVkImageLayout(image_barrier.newLayout);
 
     if (!command_buffer->End())
       return false;

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -461,7 +461,8 @@ VulkanSwapchain::AcquireResult VulkanSwapchain::AcquireSurface() {
     return error;
   }
   
-  GrBackendRenderTarget backendRT = surface->getBackendRenderTarget();
+  GrBackendRenderTarget backendRT = surface->getBackendRenderTarget(
+      SkSurface::kFlushRead_BackendHandleAccess);
   if (!backendRT.isValid()) {
     FXL_DLOG(INFO) << "Could not get backend render target.";
     return error;

--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -460,16 +460,14 @@ VulkanSwapchain::AcquireResult VulkanSwapchain::AcquireSurface() {
     FXL_DLOG(INFO) << "Could not access surface at the image index.";
     return error;
   }
-
-  GrVkImageInfo* image_info = nullptr;
-  if (!surface->getRenderTargetHandle(
-          reinterpret_cast<GrBackendObject*>(&image_info),
-          SkSurface::kFlushRead_BackendHandleAccess)) {
-    FXL_DLOG(INFO) << "Could not get render target handle.";
+  
+  GrBackendRenderTarget backendRT = surface->getBackendRenderTarget();
+  if (!backendRT.isValid()) {
+    FXL_DLOG(INFO) << "Could not get backend render target.";
     return error;
   }
+  backendRT.setVkImageLayout(destination_image_layout);
 
-  image_info->updateImageLayout(destination_image_layout);
   current_image_index_ = next_image_index;
 
   return {AcquireStatus::Success, surface};


### PR DESCRIPTION
The use of getRenderTargetHandle on SkSurface is being removed so switch over to the new API of getBackendRenderTarget.

@brianosman 