### PR TITLE
Remove only use of SkPaint::kGenA8FromLCD

### DIFF
--- a/sky/engine/platform/fonts/win/FontPlatformDataWin.cpp
+++ b/sky/engine/platform/fonts/win/FontPlatformDataWin.cpp
@@ -54,8 +54,7 @@ void FontPlatformData::setupPaint(SkPaint* paint,
   uint32_t textFlags = paintTextFlags();
   uint32_t flags = paint->getFlags();
   static const uint32_t textFlagsMask = SkPaint::kAntiAlias_Flag |
-                                        SkPaint::kLCDRenderText_Flag |
-                                        SkPaint::kGenA8FromLCD_Flag;
+                                        SkPaint::kLCDRenderText_Flag;
   flags &= ~textFlagsMask;
 
   if (ts <= kMaxSizeForEmbeddedBitmap)


### PR DESCRIPTION
Skia is removing SkPaint::kGenA8FromLCD (this information is now part of the SkPixelGeometry on SkSurface). This flag never appears to be mentioned anywhere else in the code and appears to be left over from being copied from blink (this code in blink used to set this flag conditionally).