### PR TITLE
If the test specifies a .dill file, dont make the engine interpret is as source.

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -342,14 +342,12 @@ DartVM::DartVM(const Settings& settings,
   const bool is_preview_dart2 =
       platform_kernel_ != nullptr || isolate_snapshot_is_dart_2;
 
-  if (is_preview_dart2) {
-    FXL_DLOG(INFO) << "Dart 2 is enabled.";
-  } else {
-    FXL_DLOG(INFO) << "Dart 2 is NOT enabled. Platform kernel: "
-                   << static_cast<bool>(platform_kernel_)
-                   << " Isolate Snapshot is Dart 2: "
-                   << isolate_snapshot_is_dart_2;
-  }
+  FXL_DLOG(INFO) << "Dart 2 " << (is_preview_dart2 ? " is" : "is NOT")
+                 << "enabled. Platform kernel: "
+                 << static_cast<bool>(platform_kernel_)
+                 << " Isolate Snapshot is Dart 2: "
+                 << isolate_snapshot_is_dart_2;
+
   if (is_preview_dart2) {
     PushBackAll(&args, kDartStrongModeArgs, arraysize(kDartStrongModeArgs));
     if (use_checked_mode) {


### PR DESCRIPTION
We used to do the same thing in the service protocol. That was cleaned up in response to [this comment](https://github.com/flutter/engine/pull/4981#issuecomment-380927843). But it broke the tester instead.