### PR TITLE
Specify the packages file path when running engine dart tests.

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -343,7 +343,7 @@ DartVM::DartVM(const Settings& settings,
       platform_kernel_ != nullptr || isolate_snapshot_is_dart_2;
 
   FXL_DLOG(INFO) << "Dart 2 " << (is_preview_dart2 ? " is" : "is NOT")
-                 << "enabled. Platform kernel: "
+                 << " enabled. Platform kernel: "
                  << static_cast<bool>(platform_kernel_)
                  << " Isolate Snapshot is Dart 2: "
                  << isolate_snapshot_is_dart_2;

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -16,8 +16,8 @@ popd
 ! out/host_debug_unopt/flutter_tester --disable-observatory --disable-diagnostic --non-interactive --enable-checked-mode --packages=flutter/testing/dart/.packages flutter/testing/fail_test.dart
 
 for TEST_SCRIPT in flutter/testing/dart/*.dart; do
-    out/host_debug_unopt/flutter_tester --disable-observatory --disable-diagnostic --non-interactive --enable-checked-mode $TEST_SCRIPT
-    out/host_debug_unopt/flutter_tester --disable-observatory --disable-diagnostic --non-interactive $TEST_SCRIPT
+    out/host_debug_unopt/flutter_tester --disable-observatory --disable-diagnostic --non-interactive --enable-checked-mode --packages=flutter/testing/dart/.packages $TEST_SCRIPT
+    out/host_debug_unopt/flutter_tester --disable-observatory --disable-diagnostic --non-interactive --packages=flutter/testing/dart/.packages $TEST_SCRIPT
 done
 
 pushd flutter


### PR DESCRIPTION
This used to work only on Linux earlier because the packages file resolution rules were different for the different testers. Because of this, the target on the buildbot that referenced this file was disabled on Mac. Now the rules across testers on all platforms are the same because they are created from the same target. After this lands, we should enable the ["engine unit tests"](https://uberchromegw.corp.google.com/i/client.flutter/builders/Linux%20Engine/builds/2529) target on Mac and Windows.