### PR TITLE
Enable downscale of large images when uploading on IO thread

### DIFF
--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -63,7 +63,7 @@ static sk_sp<SkImage> DecodeImage(fml::WeakPtr<GrContext> context,
     // This indicates that we do not want a "linear blending" decode.
     sk_sp<SkColorSpace> dstColorSpace = nullptr;
     return SkImage::MakeCrossContextFromEncoded(
-        context.get(), std::move(buffer), false, dstColorSpace.get());
+        context.get(), std::move(buffer), false, dstColorSpace.get(), true);
   } else {
     // Defer decoding until time of draw later on the GPU thread. Can happen
     // when GL operations are currently forbidden such as in the background


### PR DESCRIPTION
This clamps images to the GPU's maximum texture size, ensuring that we can always upload. Otherwise, we could fail to create a texture, and then do a long (tiled) upload on the GPU thread.

Fixes https://github.com/flutter/flutter/issues/16454