### PR TITLE
Call SkSurface::flush instead of getting a backend handle in vulkan_s…

### DIFF
--- a/vulkan/vulkan_swapchain.cc
+++ b/vulkan/vulkan_swapchain.cc
@@ -486,15 +486,9 @@ bool VulkanSwapchain::Submit() {
 
   // ---------------------------------------------------------------------------
   // Step 0:
-  // Notify to Skia that we will read from its backend object.
+  // Make sure Skia has flushed all work for the surface to the gpu.
   // ---------------------------------------------------------------------------
-  GrVkImageInfo* image_info = nullptr;
-  if (!surface->getRenderTargetHandle(
-          reinterpret_cast<GrBackendObject*>(&image_info),
-          SkSurface::kFlushRead_BackendHandleAccess)) {
-    FXL_DLOG(INFO) << "Could not get render target handle.";
-    return false;
-  }
+  surface->flush();
 
   // ---------------------------------------------------------------------------
   // Step 1:


### PR DESCRIPTION
…wapchain.

The old code called getBackendRenderTargetHandle() with a Read access to trigger the surface to flush, however the returned GrVkImageInfo was never used. This new process is equivalent to just calling flush on the surface so do that instead.

@brianosman 