### PR TITLE
Fix broken Linux build

### DIFF
--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -79,7 +79,6 @@ sk_sp<SkData> GetImageBytesAsRGBA(sk_sp<SkImage> image) {
       FXL_LOG(ERROR) << "Pixel address is not available.";
       return nullptr;
     }
-    ASSERT(pixmap.colorType() == kRGBA_8888_SkColorType);
 
     const size_t pixmap_size = pixmap.computeByteSize();
     return SkData::MakeWithCopy(pixmap.addr32(), pixmap_size);


### PR DESCRIPTION
After we write the pixels in the correct format,
the color type of the SkPixmap is still set to
its previous value, so the existing assertion was
failing.