### PR TITLE
Implement Scene::toImage for creating a raster image representation of a scene.

### DIFF
--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -13,6 +13,7 @@
 #include "flutter/flow/layers/layer.h"
 #include "lib/fxl/macros.h"
 #include "lib/fxl/time/time_delta.h"
+#include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkSize.h"
 
 namespace flow {
@@ -32,6 +33,8 @@ class LayerTree {
 #endif
 
   void Paint(CompositorContext::ScopedFrame& frame) const;
+
+  sk_sp<SkPicture> Flatten(const SkRect& bounds);
 
   Layer* root_layer() const { return root_layer_.get(); }
 

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -17,6 +17,20 @@ class Scene extends NativeFieldWrapperClass2 {
   /// To create a Scene object, use a [SceneBuilder].
   Scene._();
 
+
+  /// Creates a raster image representation of the current state of the scene.
+  /// This is a slow operation that is performed on a background thread.
+  Future<Image> toImage(int width, int height) {
+    if (width <= 0 || height <= 0) {
+      return null;
+    }
+    return _futurize(
+      (_Callback<Image> callback) => _toImage(width, height, callback)
+    );
+  }
+
+  void _toImage(int width, int height, _Callback<Image> callback) native 'Scene_toImage';
+
   /// Releases the resources used by this scene.
   ///
   /// After calling this function, the scene is cannot be used further.

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -29,7 +29,7 @@ class Scene extends NativeFieldWrapperClass2 {
     );
   }
 
-  void _toImage(int width, int height, _Callback<Image> callback) native 'Scene_toImage';
+  String _toImage(int width, int height, _Callback<Image> callback) native 'Scene_toImage';
 
   /// Releases the resources used by this scene.
   ///

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -21,9 +21,8 @@ class Scene extends NativeFieldWrapperClass2 {
   /// Creates a raster image representation of the current state of the scene.
   /// This is a slow operation that is performed on a background thread.
   Future<Image> toImage(int width, int height) {
-    if (width <= 0 || height <= 0) {
-      return null;
-    }
+    if (width <= 0 || height <= 0)
+      throw new Exception('Invalid image dimensions.');
     return _futurize(
       (_Callback<Image> callback) => _toImage(width, height, callback)
     );

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -4,18 +4,26 @@
 
 #include "flutter/lib/ui/compositing/scene.h"
 
+#include "flutter/fml/trace_event.h"
+#include "flutter/lib/ui/painting/image.h"
+#include "lib/fxl/functional/make_copyable.h"
 #include "lib/tonic/converter/dart_converter.h"
 #include "lib/tonic/dart_args.h"
 #include "lib/tonic/dart_binding_macros.h"
 #include "lib/tonic/dart_library_natives.h"
-#include "third_party/skia/include/core/SkCanvas.h"
-#include "third_party/skia/include/core/SkPictureRecorder.h"
+#include "lib/tonic/dart_persistent_value.h"
+#include "lib/tonic/dart_wrappable.h"
+#include "lib/tonic/logging/dart_invoke.h"
+#include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/include/core/SkSurface.h"
 
 namespace blink {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Scene);
 
-#define FOR_EACH_BINDING(V) V(Scene, dispose)
+#define FOR_EACH_BINDING(V) \
+  V(Scene, toImage)         \
+  V(Scene, dispose)
 
 DART_BIND_ALL(Scene, FOR_EACH_BINDING)
 
@@ -44,6 +52,124 @@ Scene::~Scene() {}
 
 void Scene::dispose() {
   ClearDartWrapper();
+}
+
+static sk_sp<SkImage> CreateSceneSnapshot(GrContext* context,
+                                          sk_sp<SkPicture> picture,
+                                          const SkSize& size) {
+  TRACE_EVENT0("flutter", "CreateSceneSnapshot");
+  auto image_info =
+      SkImageInfo::MakeN32Premul(SkISize::Make(size.width(), size.height()));
+
+  sk_sp<SkSurface> surface;
+
+  if (context) {
+    surface = SkSurface::MakeRenderTarget(context, SkBudgeted::kNo, image_info);
+  }
+
+  if (!surface) {
+    surface = SkSurface::MakeRaster(image_info);
+  }
+
+  if (!surface) {
+    return nullptr;
+  }
+
+  auto canvas = surface->getCanvas();
+
+  if (!canvas) {
+    return nullptr;
+  }
+
+  if (picture) {
+    canvas->drawPicture(picture.get());
+  }
+
+  auto snapshot = surface->makeImageSnapshot();
+
+  if (!snapshot) {
+    return nullptr;
+  }
+
+  return snapshot->makeRasterImage();
+}
+
+void Scene::toImage(uint32_t width,
+                    uint32_t height,
+                    Dart_Handle raw_image_callback) {
+  TRACE_EVENT0("flutter", "Scene::toImage");
+  if (Dart_IsNull(raw_image_callback) || !Dart_IsClosure(raw_image_callback)) {
+    return;
+  }
+
+  if (!m_layerTree || width == 0 || height == 0) {
+    // Already in a Dart scope.
+    tonic::DartInvoke(raw_image_callback, {Dart_Null()});
+    return;
+  }
+
+  auto dart_state = UIDartState::Current();
+
+  auto image_callback = std::make_unique<tonic::DartPersistentValue>(
+      dart_state, raw_image_callback);
+
+  // We can't create an image on this task runner because we don't have a
+  // graphics context. Even if we did, it would be slow anyway. Also, this
+  // thread owns the sole reference to the layer tree. So we flatten the layer
+  // tree into a picture and use that as the thread transport mechanism.
+
+  auto bounds_size = SkSize::Make(width, height);
+  auto picture = m_layerTree->Flatten(SkRect::MakeSize(bounds_size));
+  if (!picture) {
+    // Already in Dart scope.
+    tonic::DartInvoke(raw_image_callback, {Dart_Null()});
+  }
+
+  auto resource_context = dart_state->GetResourceContext();
+  auto ui_task_runner = dart_state->GetTaskRunners().GetUITaskRunner();
+  auto unref_queue = dart_state->GetSkiaUnrefQueue();
+
+  // The picture has been prepared on the UI thread.
+  dart_state->GetTaskRunners().GetIOTaskRunner()->PostTask(
+      fxl::MakeCopyable([picture = std::move(picture),                    //
+                         bounds_size,                                     //
+                         resource_context = std::move(resource_context),  //
+                         ui_task_runner = std::move(ui_task_runner),      //
+                         image_callback = std::move(image_callback),      //
+                         unref_queue = std::move(unref_queue)             //
+  ]() mutable {
+        // Snapshot the picture on the IO thread that contains an optional
+        // GrContext.
+        auto image = CreateSceneSnapshot(resource_context.get(),
+                                         std::move(picture), bounds_size);
+
+        // Send the image back to the UI thread for submission back to the
+        // framework.
+        ui_task_runner->PostTask(
+            fxl::MakeCopyable([image = std::move(image),                    //
+                               image_callback = std::move(image_callback),  //
+                               unref_queue = std::move(unref_queue)         //
+        ]() mutable {
+              auto dart_state = image_callback->dart_state().get();
+              if (!dart_state) {
+                // The root isolate could have died in the meantime.
+                return;
+              }
+              tonic::DartState::Scope scope(dart_state);
+
+              if (!image) {
+                tonic::DartInvoke(image_callback->Get(), {Dart_Null()});
+                return;
+              }
+
+              auto dart_image = CanvasImage::Create();
+              dart_image->set_image({std::move(image), std::move(unref_queue)});
+              auto raw_dart_image = tonic::ToDart(std::move(dart_image));
+
+              // All done!
+              tonic::DartInvoke(image_callback->Get(), {raw_dart_image});
+            }));
+      }));
 }
 
 std::unique_ptr<flow::LayerTree> Scene::takeLayerTree() {

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -123,6 +123,7 @@ void Scene::toImage(uint32_t width,
   if (!picture) {
     // Already in Dart scope.
     tonic::DartInvoke(raw_image_callback, {Dart_Null()});
+    return;
   }
 
   auto resource_context = dart_state->GetResourceContext();

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -32,7 +32,9 @@ class Scene : public fxl::RefCountedThreadSafe<Scene>,
 
   std::unique_ptr<flow::LayerTree> takeLayerTree();
 
-  void toImage(uint32_t width, uint32_t height, Dart_Handle image_callback);
+  Dart_Handle toImage(uint32_t width,
+                      uint32_t height,
+                      Dart_Handle image_callback);
 
   void dispose();
 

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -32,6 +32,8 @@ class Scene : public fxl::RefCountedThreadSafe<Scene>,
 
   std::unique_ptr<flow::LayerTree> takeLayerTree();
 
+  void toImage(uint32_t width, uint32_t height, Dart_Handle image_callback);
+
   void dispose();
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);


### PR DESCRIPTION
This currently creates a raster snapshot of the image. Applications thats need to re-render the image in a subsequent frame would need to perform an additional host to device transfer. This is not a use case that is anticipated to be very common. However, we have requested an enhancement to the Skia API that would allow us to create a cross context image that can possibly be resident on the GPU.