### PR TITLE
Only make ERROR and FATAL log levels visible by default.

### DIFF
--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -47,7 +47,7 @@ bool AssetManager::GetAsBuffer(const std::string& asset_name,
       return true;
     }
   }
-  FXL_DLOG(ERROR) << "Could not find asset: " << asset_name;
+  FXL_DLOG(WARNING) << "Could not find asset: " << asset_name;
   return false;
 }
 

--- a/common/settings.h
+++ b/common/settings.h
@@ -71,6 +71,7 @@ struct Settings {
   bool enable_software_rendering = false;
   bool using_blink = false;
   bool skia_deterministic_rendering_on_cpu = false;
+  bool verbose_logging = false;
   std::string log_tag = "flutter";
   std::string icu_data_path;
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -23,6 +23,7 @@
 #include "lib/fxl/files/path.h"
 #include "lib/fxl/files/unique_fd.h"
 #include "lib/fxl/functional/make_copyable.h"
+#include "lib/fxl/log_settings.h"
 #include "lib/fxl/logging.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "third_party/skia/include/core/SkGraphics.h"
@@ -149,6 +150,11 @@ std::unique_ptr<Shell> Shell::Create(
     blink::Settings settings,
     Shell::CreateCallback<PlatformView> on_create_platform_view,
     Shell::CreateCallback<Rasterizer> on_create_rasterizer) {
+  fxl::LogSettings log_settings;
+  log_settings.min_log_level =
+      settings.verbose_logging ? fxl::LOG_INFO : fxl::LOG_ERROR;
+  fxl::SetLogSettings(log_settings);
+
   if (!task_runners.IsValid() || !on_create_platform_view ||
       !on_create_rasterizer) {
     return nullptr;

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -155,6 +155,9 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
   settings.skia_deterministic_rendering_on_cpu =
       command_line.HasOption(FlagForSwitch(Switch::SkiaDeterministicRendering));
 
+  settings.verbose_logging =
+      command_line.HasOption(FlagForSwitch(Switch::VerboseLogging));
+
   command_line.GetOptionValue(FlagForSwitch(Switch::FLX), &settings.flx_path);
 
   command_line.GetOptionValue(FlagForSwitch(Switch::FlutterAssetsDir),

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -113,6 +113,11 @@ DEF_SWITCH(UseTestFonts,
            "will make font resolution default to the Ahem test font on all "
            "platforms (See https://www.w3.org/Style/CSS/Test/Fonts/Ahem/). "
            "This option is only available on the desktop test shells.")
+DEF_SWITCH(VerboseLogging,
+           "verbose-logging",
+           "By default, only errors are logged. This flag enabled logging at "
+           "all severity levels. This is NOT a per shell flag and affect log "
+           "levels for all shells in the process.")
 DEF_SWITCH(RunForever,
            "run-forever",
            "In non-interactive mode, keep the shell running after the Dart "


### PR DESCRIPTION
Adds the --verbose-logging flag to enable logging at all other severities.