### PR TITLE
In the service protocol, if no view is specified to flush tasks on, pick the first one.

### DIFF
--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -189,7 +189,8 @@ bool ServiceProtocol::HandleMessage(fxl::StringView method,
   // TODO(chinmaygarde): Deprecate these calls in the tools and remove these
   // fallbacks.
   if (method == kScreenshotExtensionName ||
-      method == kScreenshotSkpExtensionName) {
+      method == kScreenshotSkpExtensionName ||
+      method == kFlushUIThreadTasksExtensionName) {
     return HandleMessageOnHandler(*handlers_.begin(), method, params, response);
   }
 


### PR DESCRIPTION
This adds a same fallback mechanism to kFlushUIThreadTasksExtensionName as was already present for the screenshotting methods.