### PR TITLE
Don't send platform messages to isolates that are not running.

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -78,6 +78,13 @@ RuntimeController::~RuntimeController() {
   }
 }
 
+bool RuntimeController::IsRootIsolateRunning() const {
+  if (root_isolate_) {
+    return root_isolate_->GetPhase() == DartIsolate::Phase::Running;
+  }
+  return false;
+}
+
 std::unique_ptr<RuntimeController> RuntimeController::Clone() const {
   return std::unique_ptr<RuntimeController>(new RuntimeController(
       client_,            //

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -46,6 +46,8 @@ class RuntimeController final : public WindowClient {
 
   bool NotifyIdle(int64_t deadline);
 
+  bool IsRootIsolateRunning() const;
+
   bool DispatchPlatformMessage(fxl::RefPtr<PlatformMessage> message);
 
   bool DispatchPointerDataPacket(const PointerDataPacket& packet);

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -259,7 +259,8 @@ void Engine::DispatchPlatformMessage(
     return;
   }
 
-  if (runtime_controller_->DispatchPlatformMessage(std::move(message))) {
+  if (runtime_controller_->IsRootIsolateRunning() &&
+      runtime_controller_->DispatchPlatformMessage(std::move(message))) {
     return;
   }
 


### PR DESCRIPTION
Isolates may be launched and awaiting snapshot association. We don't
want to send such isolates any messages before their "main" method is
called. In such cases, the engine may intercept and store certain
launch specific information.