### PR TITLE
Make the rasterizer own the compositor context.

### DIFF
--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -62,7 +62,7 @@ class Rasterizer final {
  private:
   blink::TaskRunners task_runners_;
   std::unique_ptr<Surface> surface_;
-  std::unique_ptr<flow::CompositorContext> compositor_context_;
+  flow::CompositorContext compositor_context_;
   std::unique_ptr<flow::LayerTree> last_layer_tree_;
   fxl::Closure next_frame_callback_;
   fml::WeakPtr<Rasterizer> weak_prototype_;

--- a/shell/common/surface.cc
+++ b/shell/common/surface.cc
@@ -60,22 +60,8 @@ bool SurfaceFrame::PerformSubmit() {
   return false;
 }
 
-Surface::Surface() : Surface(std::make_unique<flow::CompositorContext>()) {}
+Surface::Surface() = default;
 
-Surface::Surface(std::unique_ptr<flow::CompositorContext> compositor_context)
-    : compositor_context_(std::move(compositor_context)) {
-  FXL_DCHECK(compositor_context_);
-  // TODO: Get rid of these explicit calls and move the logic to the c/dtors of
-  // the compositor context.
-  compositor_context_->OnGrContextCreated();
-}
-
-Surface::~Surface() {
-  compositor_context_->OnGrContextDestroyed();
-}
-
-flow::CompositorContext& Surface::GetCompositorContext() {
-  return *compositor_context_;
-}
+Surface::~Surface() = default;
 
 }  // namespace shell

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -45,8 +45,6 @@ class Surface {
  public:
   Surface();
 
-  Surface(std::unique_ptr<flow::CompositorContext> compositor_context);
-
   virtual ~Surface();
 
   virtual bool IsValid() = 0;
@@ -55,11 +53,7 @@ class Surface {
 
   virtual GrContext* GetContext() = 0;
 
-  flow::CompositorContext& GetCompositorContext();
-
  private:
-  std::unique_ptr<flow::CompositorContext> compositor_context_;
-
   FXL_DISALLOW_COPY_AND_ASSIGN(Surface);
 };
 

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -72,8 +72,6 @@ GPUSurfaceGL::~GPUSurfaceGL() {
     return;
   }
 
-  GetCompositorContext().OnGrContextDestroyed();
-
   onscreen_surface_ = nullptr;
   context_->releaseResourcesAndAbandonContext();
   context_ = nullptr;


### PR DESCRIPTION
This allows the texture registry to be accessed before render surface acquisition.