### PR TITLE
Clear the canvas when attempting to render to the surface.

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -100,8 +100,14 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
   // for instrumentation.
   compositor_context_.engine_time().SetLapTime(layer_tree.construction_time());
 
-  auto compositor_frame = compositor_context_.AcquireFrame(
-      surface_->GetContext(), frame->SkiaCanvas(), true);
+  auto canvas = frame->SkiaCanvas();
+
+  auto compositor_frame =
+      compositor_context_.AcquireFrame(surface_->GetContext(), canvas, true);
+
+  if (canvas) {
+    canvas->clear(SK_ColorBLACK);
+  }
 
   if (compositor_frame && compositor_frame->Raster(layer_tree, false)) {
     frame->Submit();


### PR DESCRIPTION
Specific rasterizer subclasses used to clear the canvas in [different ways](https://github.com/flutter/engine/blob/6473f1b106485cb0b4ea569af383173daeef8895/shell/gpu/gpu_rasterizer.cc#L143). Since the subclasses were removed, the one clear call should be moved to the common rasterizer.