### PR TITLE
Update the embedder GN target to use a source set instead of a complete static library.

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -4,9 +4,7 @@
 
 import("$flutter_root/testing/testing.gni")
 
-static_library("embedder") {
-  complete_static_lib = true
-
+source_set("embedder") {
   sources = [
     "embedder.cc",
     "embedder.h",


### PR DESCRIPTION
Creating a dylib from a “complete” static library does not propagate symbol visibility definitions. I also got rid of the static library and used a source set instead because we don’t need to do the extra work for other targets.