### PR TITLE
Remove the weak pointer factory from the service isolate's DartIsolate object

### DIFF
--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -28,8 +28,7 @@ UIDartState::UIDartState(TaskRunners task_runners,
       advisory_script_uri_(std::move(advisory_script_uri)),
       advisory_script_entrypoint_(std::move(advisory_script_entrypoint)),
       logger_prefix_(std::move(logger_prefix)),
-      skia_unref_queue_(std::move(skia_unref_queue)),
-      weak_factory_(this) {
+      skia_unref_queue_(std::move(skia_unref_queue)) {
   AddOrRemoveTaskObserver(true /* add */);
 }
 

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -100,7 +100,6 @@ class UIDartState : public tonic::DartState {
   RefPtr<FontSelector> font_selector_;
   fxl::RefPtr<flow::SkiaUnrefQueue> skia_unref_queue_;
   tonic::DartMicrotaskQueue microtask_queue_;
-  fml::WeakPtrFactory<UIDartState> weak_factory_;
 
   void AddOrRemoveTaskObserver(bool add);
 

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -103,7 +103,7 @@ class DartIsolate : public UIDartState {
   Phase phase_ = Phase::Unknown;
   const fxl::RefPtr<DartSnapshot> isolate_snapshot_;
   std::vector<std::unique_ptr<AutoFireClosure>> shutdown_callbacks_;
-  fml::WeakPtrFactory<DartIsolate> weak_factory_;
+  std::unique_ptr<fml::WeakPtrFactory<DartIsolate>> weak_factory_;
 
   FXL_WARN_UNUSED_RESULT
   bool Initialize(Dart_Isolate isolate, bool is_root_isolate);
@@ -116,6 +116,8 @@ class DartIsolate : public UIDartState {
   FXL_WARN_UNUSED_RESULT
   bool MarkIsolateRunnable();
 
+  void ResetWeakPtrFactory();
+
   // |Dart_IsolateCreateCallback|
   static Dart_Isolate DartIsolateCreateCallback(
       const char* advisory_script_uri,
@@ -124,6 +126,14 @@ class DartIsolate : public UIDartState {
       const char* package_config,
       Dart_IsolateFlags* flags,
       DartIsolate* embedder_isolate,
+      char** error);
+
+  static Dart_Isolate DartCreateAndStartServiceIsolate(
+      const char* advisory_script_uri,
+      const char* advisory_script_entrypoint,
+      const char* package_root,
+      const char* package_config,
+      Dart_IsolateFlags* flags,
       char** error);
 
   static std::pair<Dart_Isolate /* vm */,


### PR DESCRIPTION
The WeakPtrFactory must be deleted on the thread where it was created.
However, the service isolate is created and destroyed on threads from
the Dart thread pool, and the creating thread may not be the same as
the destroying thread.