### PR TITLE
libtxt: add boxes representing empty lines in GetRectsForRange

### DIFF
--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -63,8 +63,8 @@ class Paragraph {
   };
 
   struct TextBox {
-    const SkRect rect;
-    const TextDirection direction;
+    SkRect rect;
+    TextDirection direction;
 
     TextBox(SkRect r, TextDirection d) : rect(r), direction(d) {}
   };
@@ -187,8 +187,10 @@ class Paragraph {
   mutable std::unique_ptr<icu::BreakIterator> word_breaker_;
 
   struct LineRange {
-    LineRange(size_t s, size_t e, bool h) : start(s), end(e), hard_break(h) {}
+    LineRange(size_t s, size_t e, size_t ewn, bool h)
+        : start(s), end(e), end_including_newline(ewn), hard_break(h) {}
     size_t start, end;
+    size_t end_including_newline;
     bool hard_break;
   };
   std::vector<LineRange> line_ranges_;


### PR DESCRIPTION
If the start/end range passed to GetRectsForRange includes lines of text that did not render any glyphs, then GetRectsForRange should add a placeholder for that line.  In particular, the framework expects this so that it can position the cursor on an empty line when editing text.

Fixes https://github.com/flutter/flutter/issues/16418