### PR TITLE
Fix more Linux unittest targets.

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -134,4 +134,7 @@ executable("shell_unittests") {
     "//third_party/skia",
     "//topaz/lib/tonic",
   ]
+  if (is_linux) {
+    ldflags = [ "-rdynamic" ]
+  }
 }

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -50,6 +50,10 @@ executable("embedder_unittests") {
     ":fixtures",
     "$flutter_root/testing",
   ]
+
+  if (is_linux) {
+    ldflags = [ "-rdynamic" ]
+  }
 }
 
 shared_library("flutter_engine") {


### PR DESCRIPTION
All these test boot the Dart VM and must access Dart core snapshots compiled in.