### PR TITLE
Add SemanticsFlag.isHidden

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -227,6 +227,7 @@ class SemanticsFlag {
   static const int _kIsObscuredIndex = 1 << 10;
   static const int _kScopesRouteIndex= 1 << 11;
   static const int _kNamesRouteIndex = 1 << 12;
+  static const int _kIsHiddenIndex = 1 << 13;
 
   const SemanticsFlag._(this.index);
 
@@ -311,41 +312,43 @@ class SemanticsFlag {
 
   /// Whether the semantics node is the root of a subtree for which a route name
   /// should be announced.
-  /// 
-  /// When a node with this flag is removed from the semantics tree, the 
+  ///
+  /// When a node with this flag is removed from the semantics tree, the
   /// framework will select the last in depth-first, paint order node with this
   /// flag.  When a node with this flag is added to the semantics tree, it is
   /// selected automatically, unless there were multiple nodes with this flag
   /// added.  In this case, the last added node in depth-first, paint order
   /// will be selected.
-  /// 
+  ///
   /// From this selected node, the framework will search in depth-first, paint
-  /// order for the first node with a [namesRoute] flag and a non-null, 
-  /// non-empty label. The [namesRoute] and [scopesRoute] flags may be on the 
-  /// same node. The label of the found node will be announced as an edge 
+  /// order for the first node with a [namesRoute] flag and a non-null,
+  /// non-empty label. The [namesRoute] and [scopesRoute] flags may be on the
+  /// same node. The label of the found node will be announced as an edge
   /// transition. If no non-empty, non-null label is found then:
-  ///   
+  ///
   ///   * VoiceOver will make a chime announcement.
   ///   * TalkBack will make no announcement
   ///
   /// Semantic nodes annotated with this flag are generally not a11y focusable.
-  /// 
-  /// This is used in widgets such as Routes, Drawers, and Dialogs to 
+  ///
+  /// This is used in widgets such as Routes, Drawers, and Dialogs to
   /// communicate significant changes in the visible screen.
   static const SemanticsFlag scopesRoute = const SemanticsFlag._(_kScopesRouteIndex);
 
   /// Whether the semantics node label is the name of a visually distinct
   /// route.
-  /// 
+  ///
   /// This is used by certain widgets like Drawers and Dialogs, to indicate
   /// that the node's semantic label can be used to announce an edge triggered
   /// semantics update.
   ///
   /// Semantic nodes annotated with this flag will still recieve a11y focus.
-  /// 
-  /// Updating this label within the same active route subtree will not cause 
+  ///
+  /// Updating this label within the same active route subtree will not cause
   /// additional announcements.
   static const SemanticsFlag namesRoute = const SemanticsFlag._(_kNamesRouteIndex);
+
+  static const SemanticsFlag isHidden = const SemanticsFlag._(_kIsHiddenIndex);
 
   /// The possible semantics flags.
   ///
@@ -364,6 +367,7 @@ class SemanticsFlag {
     _kIsObscuredIndex: isObscured,
     _kScopesRouteIndex: scopesRoute,
     _kNamesRouteIndex: namesRoute,
+    _kIsHiddenIndex: isHidden,
   };
 
   @override
@@ -395,6 +399,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.scopesRoute';
       case _kNamesRouteIndex:
         return 'SemanticsFlag.namesRoute';
+      case _kIsHiddenIndex:
+        return 'SemanticsFlag.isHidden';
     }
     return null;
   }

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -348,6 +348,22 @@ class SemanticsFlag {
   /// additional announcements.
   static const SemanticsFlag namesRoute = const SemanticsFlag._(_kNamesRouteIndex);
 
+  /// Whether the semantics node is considered hidden.
+  ///
+  /// Hidden elements are currently not visible on screen. They may be covered
+  /// by other elements or positioned outside of the visible area of a viewport.
+  ///
+  /// Hidden elements cannot gain accessibility focus though regular touch. The
+  /// only way they can be focused is by moving the focus to them via linear
+  /// navigation.
+  ///
+  /// Platforms are free to completely ignore hidden elements and new platforms
+  /// are encouraged to do so.
+  ///
+  /// Instead of marking an element as hidden it should usually be excluded from
+  /// the semantics tree altogether. Hidden elements are only included in the
+  /// semantics tree to work around platform limitations and they are mainly
+  /// used to implement accessibility scrolling on iOS.
   static const SemanticsFlag isHidden = const SemanticsFlag._(_kIsHiddenIndex);
 
   /// The possible semantics flags.

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -58,6 +58,7 @@ enum class SemanticsFlags : int32_t {
   kIsObscured = 1 << 10,
   kScopesRoute = 1 << 11,
   kNamesRoute = 1 << 12,
+  kIsHidden = 1 << 13,
 };
 
 struct SemanticsNode {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -516,23 +516,23 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes) {
       newChildren[newChildCount - i - 1] = child;
     }
 
-   [childOrdersToUpdate addObject:object];
-   if (object.parent)
-     [childOrdersToUpdate addObject:object.parent];
+    [childOrdersToUpdate addObject:object];
+    if (object.parent)
+      [childOrdersToUpdate addObject:object.parent];
   }
 
   // Bring children into traversal order.
- for (SemanticsObject* object in childOrdersToUpdate) {
-   [object.children sortUsingComparator:^(SemanticsObject* a, SemanticsObject* b) {
-     // Should a go before b?
-     CGRect rectA = [a globalRect];
-     CGRect rectB = [b globalRect];
-     CGFloat top = rectA.origin.y - rectB.origin.y;
-     if (top == 0.0)
-       return IntToComparisonResult(rectA.origin.x - rectB.origin.x < 0.0);
-     return IntToComparisonResult(top);
-   }];
- }
+  for (SemanticsObject* object in childOrdersToUpdate) {
+    [object.children sortUsingComparator:^(SemanticsObject* a, SemanticsObject* b) {
+      // Should a go before b?
+      CGRect rectA = [a globalRect];
+      CGRect rectB = [b globalRect];
+      CGFloat top = rectA.origin.y - rectB.origin.y;
+      if (top == 0.0)
+        return IntToComparisonResult(rectA.origin.x - rectB.origin.x < 0.0);
+      return IntToComparisonResult(top);
+    }];
+  }
 
   [childOrdersToUpdate release];
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -41,12 +41,12 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 NSComparisonResult IntToComparisonResult(int32_t value) {
- if (value > 0)
-   return (NSComparisonResult)NSOrderedDescending;
- if (value < 0)
-   return (NSComparisonResult)NSOrderedAscending;
+  if (value > 0)
+    return (NSComparisonResult)NSOrderedDescending;
+  if (value < 0)
+    return (NSComparisonResult)NSOrderedAscending;
 
- return (NSComparisonResult)NSOrderedSame;
+  return (NSComparisonResult)NSOrderedSame;
 }
 
 }  // namespace

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -40,14 +40,14 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   return blink::SemanticsAction::kScrollUp;
 }
 
-//NSComparisonResult IntToComparisonResult(int32_t value) {
-//  if (value > 0)
-//    return (NSComparisonResult)NSOrderedDescending;
-//  if (value < 0)
-//    return (NSComparisonResult)NSOrderedAscending;
-//
-//  return (NSComparisonResult)NSOrderedSame;
-//}
+NSComparisonResult IntToComparisonResult(int32_t value) {
+ if (value > 0)
+   return (NSComparisonResult)NSOrderedDescending;
+ if (value < 0)
+   return (NSComparisonResult)NSOrderedAscending;
+
+ return (NSComparisonResult)NSOrderedSame;
+}
 
 }  // namespace
 
@@ -249,7 +249,7 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   // convert.
   CGFloat scale = [[[self bridge] -> view() window] screen].scale;
   auto result =
-  CGRectMake(rect.x() / scale, rect.y() / scale, rect.width() / scale, rect.height() / scale);
+      CGRectMake(rect.x() / scale, rect.y() / scale, rect.width() / scale, rect.height() / scale);
   return UIAccessibilityConvertFrameToScreenCoordinates(result, [self bridge] -> view());
 }
 
@@ -305,7 +305,6 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark UIAccessibilityFocus overrides
 
 - (void)accessibilityElementDidBecomeFocused {
-  NSLog(@"Focused: %d, %@", [self uid], [self accessibilityLabel]);
   if ([self node].HasFlag(blink::SemanticsFlags::kIsHidden)) {
     [self bridge] -> DispatchSemanticsAction([self uid], blink::SemanticsAction::kShowOnScreen);
   }
@@ -514,26 +513,26 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes) {
       SemanticsObject* child = GetOrCreateObject(node.children[i], nodes);
       child.parent = object;
       // Reverting to get hit testing order (as tie breaker for sorting below).
-      newChildren[i] = child;
+      newChildren[newChildCount - i - 1] = child;
     }
 
-//    [childOrdersToUpdate addObject:object];
-//    if (object.parent)
-//      [childOrdersToUpdate addObject:object.parent];
+   [childOrdersToUpdate addObject:object];
+   if (object.parent)
+     [childOrdersToUpdate addObject:object.parent];
   }
 
   // Bring children into traversal order.
-//  for (SemanticsObject* object in childOrdersToUpdate) {
-//    [object.children sortUsingComparator:^(SemanticsObject* a, SemanticsObject* b) {
-//      // Should a go before b?
-//      CGRect rectA = [a globalRect];
-//      CGRect rectB = [b globalRect];
-//      CGFloat top = rectA.origin.y - rectB.origin.y;
-//      if (top == 0.0)
-//        return IntToComparisonResult(rectA.origin.x - rectB.origin.x < 0.0);
-//      return IntToComparisonResult(top);
-//    }];
-//  }
+ for (SemanticsObject* object in childOrdersToUpdate) {
+   [object.children sortUsingComparator:^(SemanticsObject* a, SemanticsObject* b) {
+     // Should a go before b?
+     CGRect rectA = [a globalRect];
+     CGRect rectB = [b globalRect];
+     CGFloat top = rectA.origin.y - rectB.origin.y;
+     if (top == 0.0)
+       return IntToComparisonResult(rectA.origin.x - rectB.origin.x < 0.0);
+     return IntToComparisonResult(top);
+   }];
+ }
 
   [childOrdersToUpdate release];
 


### PR DESCRIPTION
This is in preparation for implicit a11y scrolling on iOS (https://github.com/flutter/flutter/issues/11983).

On Android, hidden elements are dropped on the floor. The OS never learns about them.
On iOS, hidden elements are exposed to the OS, but they don't have an accessibilityFrame and therefore cannot be focused with touch. The only way to focus them is via linear navigation. If they gain focus, the framework is asked to bring the hidden element on screen.

Framework wiring in https://github.com/flutter/flutter/pull/16772.