### PR TITLE
Import intrusively ref counted shared pointers into FML.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -6,6 +6,7 @@ source_set("fml") {
   sources = [
     "build_config.h",
     "compiler_specific.h",
+    "eintr_wrapper.h",
     "file.h",
     "icu_util.cc",
     "icu_util.h",

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -4,6 +4,7 @@
 
 source_set("fml") {
   sources = [
+    "build_config.h",
     "compiler_specific.h",
     "file.h",
     "icu_util.cc",

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -13,6 +13,10 @@ source_set("fml") {
     "memory/weak_ptr.h",
     "memory/weak_ptr_internal.cc",
     "memory/weak_ptr_internal.h",
+    "memory/ref_counted.h",
+    "memory/ref_counted_internal.h",
+    "memory/ref_ptr.h",
+    "memory/ref_ptr_internal.h",
     "message_loop.cc",
     "message_loop.h",
     "message_loop_impl.cc",
@@ -130,6 +134,7 @@ executable("fml_unittests") {
 
   sources = [
     "memory/weak_ptr_unittest.cc",
+    "memory/ref_counted_unittest.cc",
     "message_loop_unittests.cc",
     "thread_local_unittests.cc",
     "thread_unittests.cc",

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -4,6 +4,7 @@
 
 source_set("fml") {
   sources = [
+    "compiler_specific.h",
     "file.h",
     "icu_util.cc",
     "icu_util.h",

--- a/fml/build_config.h
+++ b/fml/build_config.h
@@ -1,0 +1,110 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file adds defines about the platform we're currently building on.
+//  Operating System:
+//    OS_WIN / OS_MACOSX / OS_LINUX / OS_POSIX (MACOSX or LINUX) /
+//    OS_NACL (NACL_SFI or NACL_NONSFI) / OS_NACL_SFI / OS_NACL_NONSFI
+//  Compiler:
+//    COMPILER_MSVC / COMPILER_GCC
+//  Processor:
+//    ARCH_CPU_X86 / ARCH_CPU_X86_64 / ARCH_CPU_X86_FAMILY (X86 or X86_64)
+//    ARCH_CPU_32_BITS / ARCH_CPU_64_BITS
+
+#ifndef FLUTTER_FML_BUILD_CONFIG_H_
+#define FLUTTER_FML_BUILD_CONFIG_H_
+
+#if defined(__Fuchsia__)
+#define OS_FUCHSIA 1
+#elif defined(ANDROID)
+#define OS_ANDROID 1
+#elif defined(__APPLE__)
+// only include TargetConditions after testing ANDROID as some android builds
+// on mac don't have this header available and it's not needed unless the target
+// is really mac/ios.
+#include <TargetConditionals.h>
+#define OS_MACOSX 1
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#define OS_IOS 1
+#endif  // defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#elif defined(__linux__)
+#define OS_LINUX 1
+// include a system header to pull in features.h for glibc/uclibc macros.
+#include <unistd.h>
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
+// we really are using glibc, not uClibc pretending to be glibc
+#define LIBC_GLIBC 1
+#endif
+#elif defined(_WIN32)
+#define OS_WIN 1
+#elif defined(__FreeBSD__)
+#define OS_FREEBSD 1
+#elif defined(__OpenBSD__)
+#define OS_OPENBSD 1
+#elif defined(__sun)
+#define OS_SOLARIS 1
+#elif defined(__QNXNTO__)
+#define OS_QNX 1
+#else
+#error Please add support for your platform in flutter/fml/build_config.h
+#endif
+
+// For access to standard BSD features, use OS_BSD instead of a
+// more specific macro.
+#if defined(OS_FREEBSD) || defined(OS_OPENBSD)
+#define OS_BSD 1
+#endif
+
+// For access to standard POSIXish features, use OS_POSIX instead of a
+// more specific macro.
+#if defined(OS_MACOSX) || defined(OS_LINUX) || defined(OS_FREEBSD) ||    \
+    defined(OS_OPENBSD) || defined(OS_SOLARIS) || defined(OS_ANDROID) || \
+    defined(OS_NACL) || defined(OS_QNX)
+#define OS_POSIX 1
+#endif
+
+// Processor architecture detection.  For more info on what's defined, see:
+//   http://msdn.microsoft.com/en-us/library/b0084kay.aspx
+//   http://www.agner.org/optimize/calling_conventions.pdf
+//   or with gcc, run: "echo | gcc -E -dM -"
+#if defined(_M_X64) || defined(__x86_64__)
+#define ARCH_CPU_X86_FAMILY 1
+#define ARCH_CPU_X86_64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(_M_IX86) || defined(__i386__)
+#define ARCH_CPU_X86_FAMILY 1
+#define ARCH_CPU_X86 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__ARMEL__)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARMEL 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__aarch64__)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARM64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__pnacl__)
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__MIPSEL__)
+#if defined(__LP64__)
+#define ARCH_CPU_MIPS64_FAMILY 1
+#define ARCH_CPU_MIPS64EL 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#else
+#define ARCH_CPU_MIPS_FAMILY 1
+#define ARCH_CPU_MIPSEL 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#endif
+#else
+#error Please add support for your architecture in flutter/fml/build_config.h
+#endif
+
+#endif  // FLUTTER_FML_BUILD_CONFIG_H_

--- a/fml/compiler_specific.h
+++ b/fml/compiler_specific.h
@@ -1,0 +1,79 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_COMPILER_SPECIFIC_H_
+#define FLUTTER_FML_COMPILER_SPECIFIC_H_
+
+#if !defined(__GNUC__) && !defined(__clang__) && !defined(_MSC_VER)
+#error Unsupported compiler.
+#endif
+
+// Annotate a variable indicating it's ok if the variable is not used.
+// (Typically used to silence a compiler warning when the assignment
+// is important for some other reason.)
+// Use like:
+//   int x = ...;
+//   FML_ALLOW_UNUSED_LOCAL(x);
+#define FML_ALLOW_UNUSED_LOCAL(x) false ? (void)x : (void)0
+
+// Annotate a typedef or function indicating it's ok if it's not used.
+// Use like:
+//   typedef Foo Bar ALLOW_UNUSED_TYPE;
+#if defined(__GNUC__) || defined(__clang__)
+#define FML_ALLOW_UNUSED_TYPE __attribute__((unused))
+#else
+#define FML_ALLOW_UNUSED_TYPE
+#endif
+
+// Annotate a function indicating it should not be inlined.
+// Use like:
+//   NOINLINE void DoStuff() { ... }
+#if defined(__GNUC__) || defined(__clang__)
+#define FML_NOINLINE __attribute__((noinline))
+#elif defined(_MSC_VER)
+#define FML_NOINLINE __declspec(noinline)
+#endif
+
+// Specify memory alignment for structs, classes, etc.
+// Use like:
+//   class FML_ALIGNAS(16) MyClass { ... }
+//   FML_ALIGNAS(16) int array[4];
+#if defined(__GNUC__) || defined(__clang__)
+#define FML_ALIGNAS(byte_alignment) __attribute__((aligned(byte_alignment)))
+#elif defined(_MSC_VER)
+#define FML_ALIGNAS(byte_alignment) __declspec(align(byte_alignment))
+#endif
+
+// Return the byte alignment of the given type (available at compile time).
+// Use like:
+//   FML_ALIGNOF(int32)  // this would be 4
+#if defined(__GNUC__) || defined(__clang__)
+#define FML_ALIGNOF(type) __alignof__(type)
+#elif defined(_MSC_VER)
+#define FML_ALIGNOF(type) __alignof(type)
+#endif
+
+// Annotate a function indicating the caller must examine the return value.
+// Use like:
+//   int foo() FML_WARN_UNUSED_RESULT;
+// To explicitly ignore a result, see |ignore_result()| in base/macros.h.
+#if defined(__GNUC__) || defined(__clang__)
+#define FML_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#else
+#define FML_WARN_UNUSED_RESULT
+#endif
+
+// Tell the compiler a function is using a printf-style format string.
+// |format_param| is the one-based index of the format string parameter;
+// |dots_param| is the one-based index of the "..." parameter.
+// For v*printf functions (which take a va_list), pass 0 for dots_param.
+// (This is undocumented but matches what the system C headers do.)
+#if defined(__GNUC__) || defined(__clang__)
+#define FML_PRINTF_FORMAT(format_param, dots_param) \
+  __attribute__((format(printf, format_param, dots_param)))
+#else
+#define FML_PRINTF_FORMAT(format_param, dots_param)
+#endif
+
+#endif  // FLUTTER_FML_COMPILER_SPECIFIC_H_

--- a/fml/eintr_wrapper.h
+++ b/fml/eintr_wrapper.h
@@ -1,0 +1,60 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_EINTR_WRAPPER_H_
+#define FLUTTER_FML_EINTR_WRAPPER_H_
+
+#include "flutter/fml/build_config.h"
+
+#include <errno.h>
+
+#if defined(OS_WIN)
+
+// Windows has no concept of EINTR.
+#define FML_HANDLE_EINTR(x) (x)
+#define FML_IGNORE_EINTR(x) (x)
+
+#else
+
+#if defined(NDEBUG)
+
+#define FML_HANDLE_EINTR(x)                                 \
+  ({                                                        \
+    decltype(x) eintr_wrapper_result;                       \
+    do {                                                    \
+      eintr_wrapper_result = (x);                           \
+    } while (eintr_wrapper_result == -1 && errno == EINTR); \
+    eintr_wrapper_result;                                   \
+  })
+
+#else
+
+#define FML_HANDLE_EINTR(x)                                  \
+  ({                                                         \
+    int eintr_wrapper_counter = 0;                           \
+    decltype(x) eintr_wrapper_result;                        \
+    do {                                                     \
+      eintr_wrapper_result = (x);                            \
+    } while (eintr_wrapper_result == -1 && errno == EINTR && \
+             eintr_wrapper_counter++ < 100);                 \
+    eintr_wrapper_result;                                    \
+  })
+
+#endif  // NDEBUG
+
+#define FML_IGNORE_EINTR(x)                               \
+  ({                                                      \
+    decltype(x) eintr_wrapper_result;                     \
+    do {                                                  \
+      eintr_wrapper_result = (x);                         \
+      if (eintr_wrapper_result == -1 && errno == EINTR) { \
+        eintr_wrapper_result = 0;                         \
+      }                                                   \
+    } while (0);                                          \
+    eintr_wrapper_result;                                 \
+  })
+
+#endif  // defined(OS_WIN)
+
+#endif  // FLUTTER_FML_EINTR_WRAPPER_H_

--- a/fml/file.h
+++ b/fml/file.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_FML_FILE_H_
 #define FLUTTER_FML_FILE_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/unique_fd.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 

--- a/fml/icu_util.cc
+++ b/fml/icu_util.cc
@@ -7,9 +7,9 @@
 #include <memory>
 #include <mutex>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/paths.h"
-#include "lib/fxl/build_config.h"
 #include "lib/fxl/logging.h"
 #include "third_party/icu/source/common/unicode/udata.h"
 

--- a/fml/icu_util.cc
+++ b/fml/icu_util.cc
@@ -87,7 +87,7 @@ class ICUContext {
   bool valid_;
   std::unique_ptr<Mapping> mapping_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(ICUContext);
+  FML_DISALLOW_COPY_AND_ASSIGN(ICUContext);
 };
 
 void InitializeICUOnce(const std::string& icu_data_path) {

--- a/fml/icu_util.h
+++ b/fml/icu_util.h
@@ -7,7 +7,7 @@
 
 #include <string>
 
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 
 namespace fml {
 namespace icu {

--- a/fml/macros.h
+++ b/fml/macros.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_FML_MACROS_H_
 #define FLUTTER_FML_MACROS_H_
 
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 
 #ifndef FML_USED_ON_EMBEDDER
 
@@ -16,5 +16,28 @@
 #define FML_EMBEDDER_ONLY
 
 #endif  // FML_USED_ON_EMBEDDER
+
+#define FML_DISALLOW_COPY(TypeName) TypeName(const TypeName&) = delete
+
+#define FML_DISALLOW_ASSIGN(TypeName) \
+  TypeName& operator=(const TypeName&) = delete
+
+#define FML_DISALLOW_MOVE(TypeName) \
+  TypeName(TypeName&&) = delete;    \
+  TypeName& operator=(TypeName&&) = delete
+
+#define FML_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  TypeName(const TypeName&) = delete;          \
+  TypeName& operator=(const TypeName&) = delete
+
+#define FML_DISALLOW_COPY_ASSIGN_AND_MOVE(TypeName) \
+  TypeName(const TypeName&) = delete;               \
+  TypeName(TypeName&&) = delete;                    \
+  TypeName& operator=(const TypeName&) = delete;    \
+  TypeName& operator=(TypeName&&) = delete
+
+#define FML_DISALLOW_IMPLICIT_CONSTRUCTORS(TypeName) \
+  TypeName() = delete;                               \
+  FML_DISALLOW_COPY_ASSIGN_AND_MOVE(TypeName)
 
 #endif  // FLUTTER_FML_MACROS_H_

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -10,8 +10,8 @@
 #include <vector>
 
 #include "flutter/fml//unique_fd.h"
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/macros.h"
-#include "lib/fxl/build_config.h"
 
 namespace fml {
 

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -10,8 +10,8 @@
 #include <vector>
 
 #include "flutter/fml//unique_fd.h"
+#include "flutter/fml/macros.h"
 #include "lib/fxl/build_config.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 
@@ -26,7 +26,7 @@ class Mapping {
   virtual const uint8_t* GetMapping() const = 0;
 
  private:
-  FXL_DISALLOW_COPY_AND_ASSIGN(Mapping);
+  FML_DISALLOW_COPY_AND_ASSIGN(Mapping);
 };
 
 bool PlatformHasResourcesBundle();
@@ -53,7 +53,7 @@ class FileMapping : public Mapping {
   fml::UniqueFD mapping_handle_;
 #endif
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(FileMapping);
+  FML_DISALLOW_COPY_AND_ASSIGN(FileMapping);
 };
 
 class DataMapping : public Mapping {
@@ -69,7 +69,7 @@ class DataMapping : public Mapping {
  private:
   std::vector<uint8_t> data_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(DataMapping);
+  FML_DISALLOW_COPY_AND_ASSIGN(DataMapping);
 };
 
 }  // namespace fml

--- a/fml/memory/ref_counted.h
+++ b/fml/memory/ref_counted.h
@@ -7,9 +7,9 @@
 #ifndef FLUTTER_FML_MEMORY_REF_COUNTED_H_
 #define FLUTTER_FML_MEMORY_REF_COUNTED_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted_internal.h"
 #include "flutter/fml/memory/ref_ptr.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 
@@ -117,7 +117,7 @@ class RefCountedThreadSafe : public internal::RefCountedThreadSafeBase {
   void Adopt() { internal::RefCountedThreadSafeBase::Adopt(); }
 #endif
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(RefCountedThreadSafe);
+  FML_DISALLOW_COPY_AND_ASSIGN(RefCountedThreadSafe);
 };
 
 // If you subclass |RefCountedThreadSafe| and want to keep your destructor

--- a/fml/memory/ref_counted.h
+++ b/fml/memory/ref_counted.h
@@ -1,0 +1,136 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Provides a base class for reference-counted classes.
+
+#ifndef FLUTTER_FML_MEMORY_REF_COUNTED_H_
+#define FLUTTER_FML_MEMORY_REF_COUNTED_H_
+
+#include "flutter/fml/memory/ref_counted_internal.h"
+#include "flutter/fml/memory/ref_ptr.h"
+#include "lib/fxl/macros.h"
+
+namespace fml {
+
+// A base class for (thread-safe) reference-counted classes. Use like:
+//
+//   class Foo : public RefCountedThreadSafe<Foo> {
+//     ...
+//   };
+//
+// |~Foo()| *may* be made private (e.g., to avoid accidental deletion of objects
+// while there are still references to them), |Foo| should friend
+// |RefCountedThreadSafe<Foo>|; use |FML_FRIEND_REF_COUNTED_THREAD_SAFE()| for
+// this:
+//
+//   class Foo : public RefCountedThreadSafe<Foo> {
+//     ...
+//    private:
+//     FML_FRIEND_REF_COUNTED_THREAD_SAFE(Foo);
+//     ~Foo();
+//     ...
+//   };
+//
+// Similarly, |Foo(...)| may be made private. In this case, there should either
+// be a static factory method performing the requisite adoption:
+//
+//   class Foo : public RefCountedThreadSafe<Foo> {
+//     ...
+//    public:
+//     inline static RefPtr<Foo> Create() { return AdoptRef(new Foo()); }
+//     ...
+//    private:
+//     Foo();
+//     ...
+//   };
+//
+// Or, to allow |MakeRefCounted()| to be used, use
+// |FML_FRIEND_MAKE_REF_COUNTED()|:
+//
+//   class Foo : public RefCountedThreadSafe<Foo> {
+//     ...
+//    private:
+//     FML_FRIEND_MAKE_REF_COUNTED(Foo);
+//     Foo();
+//     Foo(const Bar& bar, bool maybe);
+//     ...
+//   };
+//
+// For now, we only have thread-safe reference counting, since that's all we
+// need. It's easy enough to add thread-unsafe versions if necessary.
+template <typename T>
+class RefCountedThreadSafe : public internal::RefCountedThreadSafeBase {
+ public:
+  // Adds a reference to this object.
+  // Inherited from the internal superclass:
+  //   void AddRef() const;
+
+  // Releases a reference to this object. This will destroy this object once the
+  // last reference is released.
+  void Release() const {
+    if (internal::RefCountedThreadSafeBase::Release())
+      delete static_cast<const T*>(this);
+  }
+
+  // Returns true if there is exactly one reference to this object. Use of this
+  // is subtle, and should usually be avoided. To assert that there is only one
+  // reference (typically held by the calling thread, possibly in a local
+  // variable), use |AssertHasOneRef()| instead. However, a use is:
+  //
+  //   if (foo->HasOneRef()) {
+  //     // Do something "fast", since |foo| is the only reference and no other
+  //     // thread can get another reference.
+  //     ...
+  //   } else {
+  //     // Do something slower, but still valid even if there were only one
+  //     // reference.
+  //     ...
+  //   }
+  //
+  // Inherited from the internal superclass:
+  //   bool HasOneRef();
+
+  // Asserts that there is exactly one reference to this object; does nothing in
+  // Release builds (when |NDEBUG| is defined).
+  // Inherited from the internal superclass:
+  //   void AssertHasOneRef();
+
+ protected:
+  // Constructor. Note that the object is constructed with a reference count of
+  // 1, and then must be adopted (see |AdoptRef()| in ref_ptr.h).
+  RefCountedThreadSafe() {}
+
+  // Destructor. Note that this object should only be destroyed via |Release()|
+  // (see above), or something that calls |Release()| (see, e.g., |RefPtr<>| in
+  // ref_ptr.h).
+  ~RefCountedThreadSafe() {}
+
+ private:
+#ifndef NDEBUG
+  template <typename U>
+  friend RefPtr<U> AdoptRef(U*);
+  // Marks the initial reference (assumed on construction) as adopted. This is
+  // only required for Debug builds (when |NDEBUG| is not defined).
+  // TODO(vtl): Should this really be private? This makes manual ref-counting
+  // and also writing one's own ref pointer class impossible.
+  void Adopt() { internal::RefCountedThreadSafeBase::Adopt(); }
+#endif
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(RefCountedThreadSafe);
+};
+
+// If you subclass |RefCountedThreadSafe| and want to keep your destructor
+// private, use this. (See the example above |RefCountedThreadSafe|.)
+#define FML_FRIEND_REF_COUNTED_THREAD_SAFE(T) \
+  friend class ::fml::RefCountedThreadSafe<T>
+
+// If you want to keep your constructor(s) private and still want to use
+// |MakeRefCounted<T>()|, use this. (See the example above
+// |RefCountedThreadSafe|.)
+#define FML_FRIEND_MAKE_REF_COUNTED(T) \
+  friend class ::fml::internal::MakeRefCountedHelper<T>
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_MEMORY_REF_COUNTED_H_

--- a/fml/memory/ref_counted_internal.h
+++ b/fml/memory/ref_counted_internal.h
@@ -1,0 +1,107 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Internal implementation details for ref_counted.h.
+
+#ifndef FLUTTER_FML_MEMORY_REF_COUNTED_INTERNAL_H_
+#define FLUTTER_FML_MEMORY_REF_COUNTED_INTERNAL_H_
+
+#include <atomic>
+
+#include "lib/fxl/logging.h"
+#include "lib/fxl/macros.h"
+
+namespace fml {
+namespace internal {
+
+// See ref_counted.h for comments on the public methods.
+class RefCountedThreadSafeBase {
+ public:
+  void AddRef() const {
+#ifndef NDEBUG
+    FXL_DCHECK(!adoption_required_);
+    FXL_DCHECK(!destruction_started_);
+#endif
+    ref_count_.fetch_add(1u, std::memory_order_relaxed);
+  }
+
+  bool HasOneRef() const {
+    return ref_count_.load(std::memory_order_acquire) == 1u;
+  }
+
+  void AssertHasOneRef() const { FXL_DCHECK(HasOneRef()); }
+
+ protected:
+  RefCountedThreadSafeBase();
+  ~RefCountedThreadSafeBase();
+
+  // Returns true if the object should self-delete.
+  bool Release() const {
+#ifndef NDEBUG
+    FXL_DCHECK(!adoption_required_);
+    FXL_DCHECK(!destruction_started_);
+#endif
+    FXL_DCHECK(ref_count_.load(std::memory_order_acquire) != 0u);
+    // TODO(vtl): We could add the following:
+    //     if (ref_count_.load(std::memory_order_relaxed) == 1u) {
+    // #ifndef NDEBUG
+    //       destruction_started_= true;
+    // #endif
+    //       return true;
+    //     }
+    // This would be correct. On ARM (an Nexus 4), in *single-threaded* tests,
+    // this seems to make the destruction case marginally faster (barely
+    // measurable), and while the non-destruction case remains about the same
+    // (possibly marginally slower, but my measurements aren't good enough to
+    // have any confidence in that). I should try multithreaded/multicore tests.
+    if (ref_count_.fetch_sub(1u, std::memory_order_release) == 1u) {
+      std::atomic_thread_fence(std::memory_order_acquire);
+#ifndef NDEBUG
+      destruction_started_ = true;
+#endif
+      return true;
+    }
+    return false;
+  }
+
+#ifndef NDEBUG
+  void Adopt() {
+    FXL_DCHECK(adoption_required_);
+    adoption_required_ = false;
+  }
+#endif
+
+ private:
+  mutable std::atomic_uint_fast32_t ref_count_;
+
+#ifndef NDEBUG
+  mutable bool adoption_required_;
+  mutable bool destruction_started_;
+#endif
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(RefCountedThreadSafeBase);
+};
+
+inline RefCountedThreadSafeBase::RefCountedThreadSafeBase()
+    : ref_count_(1u)
+#ifndef NDEBUG
+      ,
+      adoption_required_(true),
+      destruction_started_(false)
+#endif
+{
+}
+
+inline RefCountedThreadSafeBase::~RefCountedThreadSafeBase() {
+#ifndef NDEBUG
+  FXL_DCHECK(!adoption_required_);
+  // Should only be destroyed as a result of |Release()|.
+  FXL_DCHECK(destruction_started_);
+#endif
+}
+
+}  // namespace internal
+}  // namespace fml
+
+#endif  // FLUTTER_FML_MEMORY_REF_COUNTED_INTERNAL_H_

--- a/fml/memory/ref_counted_internal.h
+++ b/fml/memory/ref_counted_internal.h
@@ -9,8 +9,8 @@
 
 #include <atomic>
 
+#include "flutter/fml/macros.h"
 #include "lib/fxl/logging.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 namespace internal {
@@ -80,7 +80,7 @@ class RefCountedThreadSafeBase {
   mutable bool destruction_started_;
 #endif
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(RefCountedThreadSafeBase);
+  FML_DISALLOW_COPY_AND_ASSIGN(RefCountedThreadSafeBase);
 };
 
 inline RefCountedThreadSafeBase::RefCountedThreadSafeBase()

--- a/fml/memory/ref_counted_unittest.cc
+++ b/fml/memory/ref_counted_unittest.cc
@@ -8,8 +8,8 @@
 
 #include "flutter/fml/memory/ref_counted.h"
 
+#include "flutter/fml/macros.h"
 #include "gtest/gtest.h"
-#include "lib/fxl/macros.h"
 
 #if defined(__clang__)
 #define ALLOW_PESSIMIZING_MOVE(code_line)                                   \
@@ -50,7 +50,7 @@ class MyClass : public RefCountedThreadSafe<MyClass> {
 
   bool* was_destroyed_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(MyClass);
+  FML_DISALLOW_COPY_AND_ASSIGN(MyClass);
 };
 
 class MySubclass final : public MyClass {
@@ -65,7 +65,7 @@ class MySubclass final : public MyClass {
   }
   ~MySubclass() override {}
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(MySubclass);
+  FML_DISALLOW_COPY_AND_ASSIGN(MySubclass);
 };
 
 TEST(RefCountedTest, Constructors) {
@@ -548,7 +548,7 @@ class MyPublicClass : public RefCountedThreadSafe<MyPublicClass> {
   bool has_num_;
   int num_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(MyPublicClass);
+  FML_DISALLOW_COPY_AND_ASSIGN(MyPublicClass);
 };
 
 // You can also just keep constructors and destructors public. Make sure that

--- a/fml/memory/ref_counted_unittest.cc
+++ b/fml/memory/ref_counted_unittest.cc
@@ -1,0 +1,607 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file tests both ref_counted.h and ref_ptr.h (which the former includes).
+// TODO(vtl): Possibly we could separate these tests out better, since a lot of
+// it is actually testing |RefPtr|.
+
+#include "flutter/fml/memory/ref_counted.h"
+
+#include "gtest/gtest.h"
+#include "lib/fxl/macros.h"
+
+#if defined(__clang__)
+#define ALLOW_PESSIMIZING_MOVE(code_line)                                   \
+  _Pragma("clang diagnostic push")                                          \
+      _Pragma("clang diagnostic ignored \"-Wpessimizing-move\"") code_line; \
+  _Pragma("clang diagnostic pop")
+#else
+#define ALLOW_PESSIMIZING_MOVE(code_line) code_line;
+#endif
+
+#if defined(__clang__)
+#define ALLOW_SELF_MOVE(code_line)                                   \
+  _Pragma("clang diagnostic push")                                   \
+      _Pragma("clang diagnostic ignored \"-Wself-move\"") code_line; \
+  _Pragma("clang diagnostic pop")
+#else
+#define ALLOW_SELF_MOVE(code_line) code_line;
+#endif
+
+namespace fml {
+namespace {
+
+class MyClass : public RefCountedThreadSafe<MyClass> {
+ protected:
+  MyClass(MyClass** created, bool* was_destroyed)
+      : was_destroyed_(was_destroyed) {
+    if (created)
+      *created = this;
+  }
+  virtual ~MyClass() {
+    if (was_destroyed_)
+      *was_destroyed_ = true;
+  }
+
+ private:
+  FML_FRIEND_REF_COUNTED_THREAD_SAFE(MyClass);
+  FML_FRIEND_MAKE_REF_COUNTED(MyClass);
+
+  bool* was_destroyed_;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(MyClass);
+};
+
+class MySubclass final : public MyClass {
+ private:
+  FML_FRIEND_REF_COUNTED_THREAD_SAFE(MySubclass);
+  FML_FRIEND_MAKE_REF_COUNTED(MySubclass);
+
+  MySubclass(MySubclass** created, bool* was_destroyed)
+      : MyClass(nullptr, was_destroyed) {
+    if (created)
+      *created = this;
+  }
+  ~MySubclass() override {}
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(MySubclass);
+};
+
+TEST(RefCountedTest, Constructors) {
+  bool was_destroyed;
+
+  {
+    // Default.
+    RefPtr<MyClass> r;
+    EXPECT_TRUE(r.get() == nullptr);
+    EXPECT_FALSE(r);
+  }
+
+  {
+    // Nullptr.
+    RefPtr<MyClass> r(nullptr);
+    EXPECT_TRUE(r.get() == nullptr);
+    EXPECT_FALSE(r);
+  }
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    // Adopt, then RVO.
+    RefPtr<MyClass> r(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    EXPECT_TRUE(created);
+    EXPECT_EQ(created, r.get());
+    EXPECT_TRUE(r);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    // Adopt, then move.
+    ALLOW_PESSIMIZING_MOVE(RefPtr<MyClass> r(
+        std::move(MakeRefCounted<MyClass>(&created, &was_destroyed))))
+    EXPECT_TRUE(created);
+    EXPECT_EQ(created, r.get());
+    EXPECT_TRUE(r);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MyClass> r1(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    // Copy.
+    RefPtr<MyClass> r2(r1);
+    EXPECT_TRUE(created);
+    EXPECT_EQ(created, r1.get());
+    EXPECT_EQ(created, r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MyClass> r1(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    // From raw pointer.
+    RefPtr<MyClass> r2(created);
+    EXPECT_TRUE(created);
+    EXPECT_EQ(created, r1.get());
+    EXPECT_EQ(created, r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MySubclass* created = nullptr;
+    was_destroyed = false;
+    // Adopt, then "move".
+    RefPtr<MyClass> r(MakeRefCounted<MySubclass>(&created, &was_destroyed));
+    EXPECT_TRUE(created);
+    EXPECT_EQ(static_cast<MyClass*>(created), r.get());
+    EXPECT_TRUE(r);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MySubclass* created = nullptr;
+    was_destroyed = false;
+    // Adopt, then "move".
+    ALLOW_PESSIMIZING_MOVE(RefPtr<MyClass> r(
+        std::move(MakeRefCounted<MySubclass>(&created, &was_destroyed))))
+    EXPECT_TRUE(created);
+    EXPECT_EQ(static_cast<MyClass*>(created), r.get());
+    EXPECT_TRUE(r);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MySubclass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MySubclass> r1(MakeRefCounted<MySubclass>(&created, &was_destroyed));
+    // "Copy".
+    RefPtr<MyClass> r2(r1);
+    EXPECT_TRUE(created);
+    EXPECT_EQ(static_cast<MyClass*>(created), r1.get());
+    EXPECT_EQ(static_cast<MyClass*>(created), r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MySubclass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MySubclass> r1(MakeRefCounted<MySubclass>(&created, &was_destroyed));
+    // From raw pointer.
+    RefPtr<MyClass> r2(created);
+    EXPECT_TRUE(created);
+    EXPECT_EQ(static_cast<MyClass*>(created), r1.get());
+    EXPECT_EQ(static_cast<MyClass*>(created), r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+}
+
+TEST(RefCountedTest, NullAssignmentToNull) {
+  RefPtr<MyClass> r1;
+  // No-op null assignment using |nullptr|.
+  r1 = nullptr;
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_FALSE(r1);
+
+  RefPtr<MyClass> r2;
+  // No-op null assignment using copy constructor.
+  r1 = r2;
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r2.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r2);
+
+  // No-op null assignment using move constructor.
+  r1 = std::move(r2);
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r2.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r2);
+
+  RefPtr<MySubclass> r3;
+  // No-op null assignment using "copy" constructor.
+  r1 = r3;
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r3.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r3);
+
+  // No-op null assignment using "move" constructor.
+  r1 = std::move(r3);
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r3.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r3);
+}
+
+TEST(RefCountedTest, NonNullAssignmentToNull) {
+  bool was_destroyed;
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MyClass> r1(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    RefPtr<MyClass> r2;
+    // Copy assignment (to null ref pointer).
+    r2 = r1;
+    EXPECT_EQ(created, r1.get());
+    EXPECT_EQ(created, r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MyClass> r1(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    RefPtr<MyClass> r2;
+    // Move assignment (to null ref pointer).
+    r2 = std::move(r1);
+    EXPECT_TRUE(r1.get() == nullptr);
+    EXPECT_EQ(created, r2.get());
+    EXPECT_FALSE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MySubclass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MySubclass> r1(MakeRefCounted<MySubclass>(&created, &was_destroyed));
+    RefPtr<MyClass> r2;
+    // "Copy" assignment (to null ref pointer).
+    r2 = r1;
+    EXPECT_EQ(created, r1.get());
+    EXPECT_EQ(static_cast<MyClass*>(created), r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MySubclass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MySubclass> r1(MakeRefCounted<MySubclass>(&created, &was_destroyed));
+    RefPtr<MyClass> r2;
+    // "Move" assignment (to null ref pointer).
+    r2 = std::move(r1);
+    EXPECT_TRUE(r1.get() == nullptr);
+    EXPECT_EQ(static_cast<MyClass*>(created), r2.get());
+    EXPECT_FALSE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+}
+
+TEST(RefCountedTest, NullAssignmentToNonNull) {
+  bool was_destroyed = false;
+  RefPtr<MyClass> r1(MakeRefCounted<MyClass>(nullptr, &was_destroyed));
+  // Null assignment (to non-null ref pointer) using |nullptr|.
+  r1 = nullptr;
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_TRUE(was_destroyed);
+
+  was_destroyed = false;
+  r1 = MakeRefCounted<MyClass>(nullptr, &was_destroyed);
+  RefPtr<MyClass> r2;
+  // Null assignment (to non-null ref pointer) using copy constructor.
+  r1 = r2;
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r2.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r2);
+  EXPECT_TRUE(was_destroyed);
+
+  was_destroyed = false;
+  r1 = MakeRefCounted<MyClass>(nullptr, &was_destroyed);
+  // Null assignment using move constructor.
+  r1 = std::move(r2);
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r2.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r2);
+  EXPECT_TRUE(was_destroyed);
+
+  was_destroyed = false;
+  r1 = MakeRefCounted<MyClass>(nullptr, &was_destroyed);
+  RefPtr<MySubclass> r3;
+  // Null assignment (to non-null ref pointer) using "copy" constructor.
+  r1 = r3;
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r3.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r3);
+  EXPECT_TRUE(was_destroyed);
+
+  was_destroyed = false;
+  r1 = MakeRefCounted<MyClass>(nullptr, &was_destroyed);
+  // Null assignment (to non-null ref pointer) using "move" constructor.
+  r1 = std::move(r3);
+  EXPECT_TRUE(r1.get() == nullptr);
+  EXPECT_TRUE(r3.get() == nullptr);
+  EXPECT_FALSE(r1);
+  EXPECT_FALSE(r3);
+  EXPECT_TRUE(was_destroyed);
+}
+
+TEST(RefCountedTest, NonNullAssignmentToNonNull) {
+  bool was_destroyed1;
+  bool was_destroyed2;
+
+  {
+    was_destroyed1 = false;
+    was_destroyed2 = false;
+    RefPtr<MyClass> r1(MakeRefCounted<MyClass>(nullptr, &was_destroyed1));
+    RefPtr<MyClass> r2(MakeRefCounted<MyClass>(nullptr, &was_destroyed2));
+    // Copy assignment (to non-null ref pointer).
+    r2 = r1;
+    EXPECT_EQ(r1.get(), r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed1);
+    EXPECT_TRUE(was_destroyed2);
+  }
+  EXPECT_TRUE(was_destroyed1);
+
+  {
+    was_destroyed1 = false;
+    was_destroyed2 = false;
+    RefPtr<MyClass> r1(MakeRefCounted<MyClass>(nullptr, &was_destroyed1));
+    RefPtr<MyClass> r2(MakeRefCounted<MyClass>(nullptr, &was_destroyed2));
+    // Move assignment (to non-null ref pointer).
+    r2 = std::move(r1);
+    EXPECT_TRUE(r1.get() == nullptr);
+    EXPECT_FALSE(r2.get() == nullptr);
+    EXPECT_FALSE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed1);
+    EXPECT_TRUE(was_destroyed2);
+  }
+  EXPECT_TRUE(was_destroyed1);
+
+  {
+    was_destroyed1 = false;
+    was_destroyed2 = false;
+    RefPtr<MySubclass> r1(MakeRefCounted<MySubclass>(nullptr, &was_destroyed1));
+    RefPtr<MyClass> r2(MakeRefCounted<MyClass>(nullptr, &was_destroyed2));
+    // "Copy" assignment (to non-null ref pointer).
+    r2 = r1;
+    EXPECT_EQ(r1.get(), r2.get());
+    EXPECT_TRUE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed1);
+    EXPECT_TRUE(was_destroyed2);
+  }
+  EXPECT_TRUE(was_destroyed1);
+
+  {
+    was_destroyed1 = false;
+    was_destroyed2 = false;
+    RefPtr<MySubclass> r1(MakeRefCounted<MySubclass>(nullptr, &was_destroyed1));
+    RefPtr<MyClass> r2(MakeRefCounted<MyClass>(nullptr, &was_destroyed2));
+    // Move assignment (to non-null ref pointer).
+    r2 = std::move(r1);
+    EXPECT_TRUE(r1.get() == nullptr);
+    EXPECT_FALSE(r2.get() == nullptr);
+    EXPECT_FALSE(r1);
+    EXPECT_TRUE(r2);
+    EXPECT_FALSE(was_destroyed1);
+    EXPECT_TRUE(was_destroyed2);
+  }
+  EXPECT_TRUE(was_destroyed1);
+}
+
+TEST(RefCountedTest, SelfAssignment) {
+  bool was_destroyed;
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MyClass> r(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    // Copy.
+    r = r;
+    EXPECT_EQ(created, r.get());
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+
+  {
+    MyClass* created = nullptr;
+    was_destroyed = false;
+    RefPtr<MyClass> r(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    // Move.
+    ALLOW_SELF_MOVE(r = std::move(r))
+    EXPECT_EQ(created, r.get());
+    EXPECT_FALSE(was_destroyed);
+  }
+  EXPECT_TRUE(was_destroyed);
+}
+
+TEST(RefCountedTest, Swap) {
+  MyClass* created1 = nullptr;
+  bool was_destroyed1 = false;
+  RefPtr<MyClass> r1(MakeRefCounted<MyClass>(&created1, &was_destroyed1));
+  EXPECT_TRUE(created1);
+  EXPECT_EQ(created1, r1.get());
+
+  MyClass* created2 = nullptr;
+  bool was_destroyed2 = false;
+  RefPtr<MyClass> r2(MakeRefCounted<MyClass>(&created2, &was_destroyed2));
+  EXPECT_TRUE(created2);
+  EXPECT_EQ(created2, r2.get());
+  EXPECT_NE(created1, created2);
+
+  r1.swap(r2);
+  EXPECT_EQ(created2, r1.get());
+  EXPECT_EQ(created1, r2.get());
+}
+
+TEST(RefCountedTest, GetAndDereferenceOperators) {
+  // Note: We check here that .get(), operator*, and operator-> are const, but
+  // return non-const pointers/refs.
+
+  MyClass* created = nullptr;
+  const RefPtr<MyClass> r(MakeRefCounted<MyClass>(&created, nullptr));
+  MyClass* ptr = r.get();  // Assign to non-const pointer.
+  EXPECT_EQ(created, ptr);
+  ptr = r.operator->();  // Assign to non-const pointer.
+  EXPECT_EQ(created, ptr);
+  MyClass& ref = *r;  // "Assign" to non-const reference.
+  EXPECT_EQ(created, &ref);
+}
+
+// You can manually call |AddRef()| and |Release()| if you want.
+TEST(RefCountedTest, AddRefRelease) {
+  MyClass* created = nullptr;
+  bool was_destroyed = false;
+  {
+    RefPtr<MyClass> r(MakeRefCounted<MyClass>(&created, &was_destroyed));
+    EXPECT_EQ(created, r.get());
+    created->AddRef();
+  }
+  EXPECT_FALSE(was_destroyed);
+  created->Release();
+  EXPECT_TRUE(was_destroyed);
+}
+
+TEST(RefCountedTest, Mix) {
+  MySubclass* created = nullptr;
+  bool was_destroyed = false;
+  RefPtr<MySubclass> r1(MakeRefCounted<MySubclass>(&created, &was_destroyed));
+  ASSERT_FALSE(was_destroyed);
+  EXPECT_TRUE(created->HasOneRef());
+  created->AssertHasOneRef();
+
+  RefPtr<MySubclass> r2 = r1;
+  ASSERT_FALSE(was_destroyed);
+  EXPECT_FALSE(created->HasOneRef());
+
+  r1 = nullptr;
+  ASSERT_FALSE(was_destroyed);
+  created->AssertHasOneRef();
+
+  {
+    RefPtr<MyClass> r3 = r2;
+    EXPECT_FALSE(created->HasOneRef());
+    {
+      RefPtr<MyClass> r4(r3);
+      r2 = nullptr;
+      ASSERT_FALSE(was_destroyed);
+      EXPECT_FALSE(created->HasOneRef());
+    }
+    ASSERT_FALSE(was_destroyed);
+    EXPECT_TRUE(created->HasOneRef());
+    created->AssertHasOneRef();
+
+    r1 = RefPtr<MySubclass>(static_cast<MySubclass*>(r3.get()));
+    ASSERT_FALSE(was_destroyed);
+    EXPECT_FALSE(created->HasOneRef());
+  }
+  ASSERT_FALSE(was_destroyed);
+  EXPECT_TRUE(created->HasOneRef());
+  created->AssertHasOneRef();
+
+  EXPECT_EQ(created, r1.get());
+
+  r1 = nullptr;
+  EXPECT_TRUE(was_destroyed);
+}
+
+class MyPublicClass : public RefCountedThreadSafe<MyPublicClass> {
+ public:
+  // Overloaded constructors work with |MakeRefCounted()|.
+  MyPublicClass() : has_num_(false), num_(0) {}
+  explicit MyPublicClass(int num) : has_num_(true), num_(num) {}
+
+  ~MyPublicClass() {}
+
+  bool has_num() const { return has_num_; }
+  int num() const { return num_; }
+
+ private:
+  bool has_num_;
+  int num_;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(MyPublicClass);
+};
+
+// You can also just keep constructors and destructors public. Make sure that
+// works (mostly that it compiles).
+TEST(RefCountedTest, PublicCtorAndDtor) {
+  RefPtr<MyPublicClass> r1 = MakeRefCounted<MyPublicClass>();
+  ASSERT_TRUE(r1);
+  EXPECT_FALSE(r1->has_num());
+
+  RefPtr<MyPublicClass> r2 = MakeRefCounted<MyPublicClass>(123);
+  ASSERT_TRUE(r2);
+  EXPECT_TRUE(r2->has_num());
+  EXPECT_EQ(123, r2->num());
+  EXPECT_NE(r1.get(), r2.get());
+
+  r1 = r2;
+  EXPECT_TRUE(r1->has_num());
+  EXPECT_EQ(123, r1->num());
+  EXPECT_EQ(r1.get(), r2.get());
+
+  r2 = nullptr;
+  EXPECT_FALSE(r2);
+  EXPECT_TRUE(r1->has_num());
+  EXPECT_EQ(123, r1->num());
+
+  r1 = nullptr;
+  EXPECT_FALSE(r1);
+}
+
+// The danger with having a public constructor or destructor is that certain
+// things will compile. You should get some protection by assertions in Debug
+// builds.
+#ifndef NDEBUG
+TEST(RefCountedTest, DebugChecks) {
+  {
+    MyPublicClass* p = new MyPublicClass();
+    EXPECT_DEATH_IF_SUPPORTED(delete p, "!adoption_required_");
+  }
+
+  {
+    MyPublicClass* p = new MyPublicClass();
+    EXPECT_DEATH_IF_SUPPORTED(RefPtr<MyPublicClass> r(p),
+                              "!adoption_required_");
+  }
+
+  {
+    RefPtr<MyPublicClass> r(MakeRefCounted<MyPublicClass>());
+    EXPECT_DEATH_IF_SUPPORTED(delete r.get(), "destruction_started_");
+  }
+}
+#endif
+
+// TODO(vtl): Add (threaded) stress tests.
+
+}  // namespace
+}  // namespace fml

--- a/fml/memory/ref_ptr.h
+++ b/fml/memory/ref_ptr.h
@@ -1,0 +1,251 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Provides a smart pointer class for intrusively reference-counted objects.
+
+#ifndef FLUTTER_FML_MEMORY_REF_PTR_H_
+#define FLUTTER_FML_MEMORY_REF_PTR_H_
+
+#include <cstddef>
+
+#include <functional>
+#include <utility>
+
+#include "flutter/fml/memory/ref_ptr_internal.h"
+#include "lib/fxl/compiler_specific.h"
+#include "lib/fxl/logging.h"
+#include "lib/fxl/macros.h"
+
+namespace fml {
+
+// A smart pointer class for intrusively reference-counted objects (e.g., those
+// subclassing |RefCountedThreadSafe| -- see ref_counted.h).
+//
+// Such objects require *adoption* to obtain the first |RefPtr|, which is
+// accomplished using |AdoptRef| (see below). (This is due to such objects being
+// constructed with a reference count of 1. The adoption requirement is
+// enforced, at least in Debug builds, by assertions.)
+//
+// E.g., if |Foo| is an intrusively reference-counted class:
+//
+//   // The |AdoptRef| may be put in a static factory method (e.g., if |Foo|'s
+//   // constructor is private).
+//   RefPtr<Foo> my_foo_ptr(AdoptRef(new Foo()));
+//
+//   // Now OK, since "my Foo" has been adopted ...
+//   RefPtr<Foo> another_ptr_to_my_foo(my_foo_ptr.get());
+//
+//   // ... though this would preferable in this situation.
+//   RefPtr<Foo> yet_another_ptr_to_my_foo(my_foo_ptr);
+//
+// Unlike Chromium's |scoped_refptr|, |RefPtr| is only explicitly constructible
+// from a plain pointer (and not assignable). It is however implicitly
+// constructible from |nullptr|. So:
+//
+//   RefPtr<Foo> foo(plain_ptr_to_adopted_foo);    // OK.
+//   foo = plain_ptr_to_adopted_foo;               // Not OK (doesn't compile).
+//   foo = RefPtr<Foo>(plain_ptr_to_adopted_foo);  // OK.
+//   foo = nullptr;                                // OK.
+//
+// And if we have |void MyFunction(RefPtr<Foo> foo)|, calling it using
+// |MyFunction(nullptr)| is also valid.
+//
+// Implementation note: For copy/move constructors/operator=s, we often have
+// templated versions, so that the operation can be done on a |RefPtr<U>|, where
+// |U| is a subclass of |T|. However, we also have non-templated versions with
+// |U = T|, since the templated versions don't count as copy/move
+// constructors/operator=s for the purposes of causing the default copy
+// constructor/operator= to be deleted. E.g., if we didn't declare any
+// non-templated versions, we'd get the default copy constructor/operator= (we'd
+// only not get the default move constructor/operator= by virtue of having a
+// destructor)! (In fact, it'd suffice to only declare a non-templated move
+// constructor or move operator=, which would cause the copy
+// constructor/operator= to be deleted, but for clarity we include explicit
+// non-templated versions of everything.)
+template <typename T>
+class RefPtr final {
+ public:
+  RefPtr() : ptr_(nullptr) {}
+  RefPtr(std::nullptr_t) : ptr_(nullptr) {}
+
+  // Explicit constructor from a plain pointer (to an object that must have
+  // already been adopted). (Note that in |T::T()|, references to |this| cannot
+  // be taken, since the object being constructed will not have been adopted
+  // yet.)
+  template <typename U>
+  explicit RefPtr(U* p) : ptr_(p) {
+    if (ptr_)
+      ptr_->AddRef();
+  }
+
+  // Copy constructor.
+  RefPtr(const RefPtr<T>& r) : ptr_(r.ptr_) {
+    if (ptr_)
+      ptr_->AddRef();
+  }
+
+  template <typename U>
+  RefPtr(const RefPtr<U>& r) : ptr_(r.ptr_) {
+    if (ptr_)
+      ptr_->AddRef();
+  }
+
+  // Move constructor.
+  RefPtr(RefPtr<T>&& r) : ptr_(r.ptr_) { r.ptr_ = nullptr; }
+
+  template <typename U>
+  RefPtr(RefPtr<U>&& r) : ptr_(r.ptr_) {
+    r.ptr_ = nullptr;
+  }
+
+  // Destructor.
+  ~RefPtr() {
+    if (ptr_)
+      ptr_->Release();
+  }
+
+  T* get() const { return ptr_; }
+
+  T& operator*() const {
+    FXL_DCHECK(ptr_);
+    return *ptr_;
+  }
+
+  T* operator->() const {
+    FXL_DCHECK(ptr_);
+    return ptr_;
+  }
+
+  // Copy assignment.
+  RefPtr<T>& operator=(const RefPtr<T>& r) {
+    // Call |AddRef()| first so self-assignments work.
+    if (r.ptr_)
+      r.ptr_->AddRef();
+    T* old_ptr = ptr_;
+    ptr_ = r.ptr_;
+    if (old_ptr)
+      old_ptr->Release();
+    return *this;
+  }
+
+  template <typename U>
+  RefPtr<T>& operator=(const RefPtr<U>& r) {
+    // Call |AddRef()| first so self-assignments work.
+    if (r.ptr_)
+      r.ptr_->AddRef();
+    T* old_ptr = ptr_;
+    ptr_ = r.ptr_;
+    if (old_ptr)
+      old_ptr->Release();
+    return *this;
+  }
+
+  // Move assignment.
+  // Note: Like |std::shared_ptr|, we support self-move and move assignment is
+  // equivalent to |RefPtr<T>(std::move(r)).swap(*this)|.
+  RefPtr<T>& operator=(RefPtr<T>&& r) {
+    RefPtr<T>(std::move(r)).swap(*this);
+    return *this;
+  }
+
+  template <typename U>
+  RefPtr<T>& operator=(RefPtr<U>&& r) {
+    RefPtr<T>(std::move(r)).swap(*this);
+    return *this;
+  }
+
+  void swap(RefPtr<T>& r) {
+    T* p = ptr_;
+    ptr_ = r.ptr_;
+    r.ptr_ = p;
+  }
+
+  // Returns a new |RefPtr<T>| with the same contents as this pointer. Useful
+  // when a function takes a |RefPtr<T>&&| argument and the caller wants to
+  // retain its reference (rather than moving it).
+  RefPtr<T> Clone() const { return *this; }
+
+  explicit operator bool() const { return !!ptr_; }
+
+  template <typename U>
+  bool operator==(const RefPtr<U>& rhs) const {
+    return ptr_ == rhs.ptr_;
+  }
+
+  template <typename U>
+  bool operator!=(const RefPtr<U>& rhs) const {
+    return !operator==(rhs);
+  }
+
+  template <typename U>
+  bool operator<(const RefPtr<U>& rhs) const {
+    return ptr_ < rhs.ptr_;
+  }
+
+ private:
+  template <typename U>
+  friend class RefPtr;
+
+  friend RefPtr<T> AdoptRef<T>(T*);
+
+  enum AdoptTag { ADOPT };
+  RefPtr(T* ptr, AdoptTag) : ptr_(ptr) { FXL_DCHECK(ptr_); }
+
+  T* ptr_;
+};
+
+// Adopts a newly-created |T|. Typically used in a static factory method, like:
+//
+//   // static
+//   RefPtr<Foo> Foo::Create() {
+//     return AdoptRef(new Foo());
+//   }
+template <typename T>
+inline RefPtr<T> AdoptRef(T* ptr) {
+#ifndef NDEBUG
+  ptr->Adopt();
+#endif
+  return RefPtr<T>(ptr, RefPtr<T>::ADOPT);
+}
+
+// Constructs a |RefPtr<T>| from a plain pointer (to an object that must
+// have already been adoped).  Avoids having to spell out the full type name.
+//
+//   Foo* foo = ...;
+//   auto foo_ref = Ref(foo);
+//
+// (|foo_ref| will be of type |RefPtr<Foo>|.)
+template <typename T>
+inline RefPtr<T> Ref(T* ptr) {
+  return RefPtr<T>(ptr);
+}
+
+// Creates an intrusively reference counted |T|, producing a |RefPtr<T>| (and
+// performing the required adoption). Use like:
+//
+//   auto my_foo = MakeRefCounted<Foo>(ctor_arg1, ctor_arg2);
+//
+// (|my_foo| will be of type |RefPtr<Foo>|.)
+template <typename T, typename... Args>
+RefPtr<T> MakeRefCounted(Args&&... args) {
+  return internal::MakeRefCountedHelper<T>::MakeRefCounted(
+      std::forward<Args>(args)...);
+}
+
+}  // namespace fml
+
+// Inject custom std::hash<> function object for |RefPtr<T>|.
+namespace std {
+template <typename T>
+struct hash<fml::RefPtr<T>> {
+  using argument_type = fml::RefPtr<T>;
+  using result_type = std::size_t;
+
+  result_type operator()(const argument_type& ptr) const {
+    return std::hash<T*>()(ptr.get());
+  }
+};
+}  // namespace std
+
+#endif  // FLUTTER_FML_MEMORY_REF_PTR_H_

--- a/fml/memory/ref_ptr.h
+++ b/fml/memory/ref_ptr.h
@@ -14,7 +14,6 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_ptr_internal.h"
-#include "lib/fxl/compiler_specific.h"
 #include "lib/fxl/logging.h"
 
 namespace fml {

--- a/fml/memory/ref_ptr.h
+++ b/fml/memory/ref_ptr.h
@@ -12,10 +12,10 @@
 #include <functional>
 #include <utility>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_ptr_internal.h"
 #include "lib/fxl/compiler_specific.h"
 #include "lib/fxl/logging.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 

--- a/fml/memory/ref_ptr_internal.h
+++ b/fml/memory/ref_ptr_internal.h
@@ -1,0 +1,39 @@
+// Copyright 2016 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_MEMORY_REF_PTR_INTERNAL_H_
+#define FLUTTER_FML_MEMORY_REF_PTR_INTERNAL_H_
+
+#include <utility>
+
+#include "lib/fxl/fxl_export.h"
+#include "lib/fxl/macros.h"
+
+namespace fml {
+
+template <typename T>
+class RefPtr;
+
+template <typename T>
+FXL_EXPORT RefPtr<T> AdoptRef(T* ptr);
+
+namespace internal {
+
+// This is a wrapper class that can be friended for a particular |T|, if you
+// want to make |T|'s constructor private, but still use |MakeRefCounted()|
+// (below). (You can't friend partial specializations.) See |MakeRefCounted()|
+// and |FML_FRIEND_MAKE_REF_COUNTED()|.
+template <typename T>
+class MakeRefCountedHelper final {
+ public:
+  template <typename... Args>
+  static RefPtr<T> MakeRefCounted(Args&&... args) {
+    return AdoptRef<T>(new T(std::forward<Args>(args)...));
+  }
+};
+
+}  // namespace internal
+}  // namespace fml
+
+#endif  // FLUTTER_FML_MEMORY_REF_PTR_INTERNAL_H_

--- a/fml/memory/ref_ptr_internal.h
+++ b/fml/memory/ref_ptr_internal.h
@@ -8,7 +8,6 @@
 #include <utility>
 
 #include "flutter/fml/macros.h"
-#include "lib/fxl/fxl_export.h"
 
 namespace fml {
 
@@ -16,7 +15,7 @@ template <typename T>
 class RefPtr;
 
 template <typename T>
-FXL_EXPORT RefPtr<T> AdoptRef(T* ptr);
+RefPtr<T> AdoptRef(T* ptr);
 
 namespace internal {
 

--- a/fml/memory/ref_ptr_internal.h
+++ b/fml/memory/ref_ptr_internal.h
@@ -7,8 +7,8 @@
 
 #include <utility>
 
+#include "flutter/fml/macros.h"
 #include "lib/fxl/fxl_export.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 

--- a/fml/memory/thread_checker.h
+++ b/fml/memory/thread_checker.h
@@ -16,8 +16,8 @@
 #include <pthread.h>
 #endif
 
+#include "flutter/fml/macros.h"
 #include "lib/fxl/logging.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 

--- a/fml/memory/thread_checker.h
+++ b/fml/memory/thread_checker.h
@@ -8,7 +8,7 @@
 #ifndef FLUTTER_FML_MEMORY_THREAD_CHECKER_H_
 #define FLUTTER_FML_MEMORY_THREAD_CHECKER_H_
 
-#include "lib/fxl/build_config.h"
+#include "flutter/fml/build_config.h"
 
 #if defined(OS_WIN)
 #include <windows.h>

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -182,7 +182,7 @@ class WeakPtrFactory {
   fml::RefPtr<fml::internal::WeakPtrFlag> flag_;
   DebugThreadChecker checker_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(WeakPtrFactory);
+  FML_DISALLOW_COPY_AND_ASSIGN(WeakPtrFactory);
 };
 
 }  // namespace fml

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -10,10 +10,10 @@
 
 #include <utility>
 
+#include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/memory/thread_checker.h"
 #include "flutter/fml/memory/weak_ptr_internal.h"
 #include "lib/fxl/logging.h"
-#include "lib/fxl/memory/ref_counted.h"
 
 namespace fml {
 
@@ -103,12 +103,12 @@ class WeakPtr {
   friend class WeakPtrFactory<T>;
 
   explicit WeakPtr(T* ptr,
-                   fxl::RefPtr<fml::internal::WeakPtrFlag>&& flag,
+                   fml::RefPtr<fml::internal::WeakPtrFlag>&& flag,
                    DebugThreadChecker checker)
       : ptr_(ptr), flag_(std::move(flag)), checker_(checker) {}
 
   T* ptr_;
-  fxl::RefPtr<fml::internal::WeakPtrFlag> flag_;
+  fml::RefPtr<fml::internal::WeakPtrFlag> flag_;
   DebugThreadChecker checker_;
 
   // Copy/move construction/assignment supported.
@@ -160,7 +160,7 @@ template <typename T>
 class WeakPtrFactory {
  public:
   explicit WeakPtrFactory(T* ptr)
-      : ptr_(ptr), flag_(fxl::MakeRefCounted<fml::internal::WeakPtrFlag>()) {
+      : ptr_(ptr), flag_(fml::MakeRefCounted<fml::internal::WeakPtrFlag>()) {
     FXL_DCHECK(ptr_);
   }
 
@@ -179,7 +179,7 @@ class WeakPtrFactory {
   // Note: See weak_ptr_internal.h for an explanation of why we store the
   // pointer here, instead of in the "flag".
   T* const ptr_;
-  fxl::RefPtr<fml::internal::WeakPtrFlag> flag_;
+  fml::RefPtr<fml::internal::WeakPtrFlag> flag_;
   DebugThreadChecker checker_;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(WeakPtrFactory);

--- a/fml/memory/weak_ptr_internal.h
+++ b/fml/memory/weak_ptr_internal.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_FML_MEMORY_WEAK_PTR_INTERNAL_H_
 #define FLUTTER_FML_MEMORY_WEAK_PTR_INTERNAL_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 namespace internal {
@@ -32,7 +32,7 @@ class FXL_EXPORT WeakPtrFlag : public fml::RefCountedThreadSafe<WeakPtrFlag> {
  private:
   bool is_valid_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(WeakPtrFlag);
+  FML_DISALLOW_COPY_AND_ASSIGN(WeakPtrFlag);
 };
 
 }  // namespace internal

--- a/fml/memory/weak_ptr_internal.h
+++ b/fml/memory/weak_ptr_internal.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_FML_MEMORY_WEAK_PTR_INTERNAL_H_
 #define FLUTTER_FML_MEMORY_WEAK_PTR_INTERNAL_H_
 
+#include "flutter/fml/memory/ref_counted.h"
 #include "lib/fxl/macros.h"
-#include "lib/fxl/memory/ref_counted.h"
 
 namespace fml {
 namespace internal {
@@ -19,7 +19,7 @@ namespace internal {
 // This class in not thread-safe, though references may be released on any
 // thread (allowing weak pointers to be destroyed/reset/reassigned on any
 // thread).
-class FXL_EXPORT WeakPtrFlag : public fxl::RefCountedThreadSafe<WeakPtrFlag> {
+class FXL_EXPORT WeakPtrFlag : public fml::RefCountedThreadSafe<WeakPtrFlag> {
  public:
   WeakPtrFlag();
 

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -6,7 +6,6 @@
 #define FLUTTER_FML_MESSAGE_LOOP_H_
 
 #include "flutter/fml/macros.h"
-#include "lib/fxl/macros.h"
 #include "lib/fxl/tasks/task_runner.h"
 
 namespace fml {
@@ -52,7 +51,7 @@ class MessageLoop {
 
   fxl::RefPtr<MessageLoopImpl> GetLoopImpl() const;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(MessageLoop);
+  FML_DISALLOW_COPY_AND_ASSIGN(MessageLoop);
 };
 
 }  // namespace fml

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -9,8 +9,8 @@
 #include <algorithm>
 #include <vector>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/trace_event.h"
-#include "lib/fxl/build_config.h"
 
 #if OS_MACOSX
 #include "flutter/fml/platform/darwin/message_loop_darwin.h"

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -12,9 +12,9 @@
 #include <queue>
 #include <utility>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop.h"
 #include "lib/fxl/functional/closure.h"
-#include "lib/fxl/macros.h"
 #include "lib/fxl/memory/ref_counted.h"
 #include "lib/fxl/time/time_point.h"
 
@@ -81,7 +81,7 @@ class MessageLoopImpl : public fxl::RefCountedThreadSafe<MessageLoopImpl> {
 
   void RunExpiredTasks();
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(MessageLoopImpl);
+  FML_DISALLOW_COPY_AND_ASSIGN(MessageLoopImpl);
 };
 
 }  // namespace fml

--- a/fml/native_library.h
+++ b/fml/native_library.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_FML_NATIVE_LIBRARY_H_
 #define FLUTTER_FML_NATIVE_LIBRARY_H_
 
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 #include "lib/fxl/memory/ref_counted.h"
 #include "lib/fxl/memory/ref_ptr.h"
 
@@ -42,7 +42,7 @@ class NativeLibrary : public fxl::RefCountedThreadSafe<NativeLibrary> {
 
   Handle GetHandle() const;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(NativeLibrary);
+  FML_DISALLOW_COPY_AND_ASSIGN(NativeLibrary);
   FRIEND_REF_COUNTED_THREAD_SAFE(NativeLibrary);
   FRIEND_MAKE_REF_COUNTED(NativeLibrary);
 };

--- a/fml/paths.cc
+++ b/fml/paths.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/fml/paths.h"
 
-#include "lib/fxl/build_config.h"
+#include "flutter/fml/build_config.h"
 
 namespace fml {
 namespace paths {

--- a/fml/platform/android/jni_util.h
+++ b/fml/platform/android/jni_util.h
@@ -9,8 +9,8 @@
 
 #include <vector>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 namespace jni {

--- a/fml/platform/android/message_loop_android.cc
+++ b/fml/platform/android/message_loop_android.cc
@@ -8,7 +8,6 @@
 #include <unistd.h>
 
 #include "flutter/fml/platform/linux/timerfd.h"
-#include "lib/fxl/files/eintr_wrapper.h"
 
 namespace fml {
 

--- a/fml/platform/android/message_loop_android.h
+++ b/fml/platform/android/message_loop_android.h
@@ -9,9 +9,9 @@
 
 #include <atomic>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/unique_fd.h"
-#include "lib/fxl/macros.h"
 #include "lib/fxl/memory/unique_object.h"
 
 namespace fml {
@@ -42,7 +42,7 @@ class MessageLoopAndroid : public MessageLoopImpl {
 
   FRIEND_MAKE_REF_COUNTED(MessageLoopAndroid);
   FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopAndroid);
-  FXL_DISALLOW_COPY_AND_ASSIGN(MessageLoopAndroid);
+  FML_DISALLOW_COPY_AND_ASSIGN(MessageLoopAndroid);
 };
 
 }  // namespace fml

--- a/fml/platform/android/scoped_java_ref.h
+++ b/fml/platform/android/scoped_java_ref.h
@@ -8,7 +8,7 @@
 #include <jni.h>
 #include <stddef.h>
 
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 
 namespace fml {
 namespace jni {
@@ -27,7 +27,7 @@ class ScopedJavaLocalFrame {
   // it's safe to cache the non-threadsafe JNIEnv* inside this object.
   JNIEnv* env_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(ScopedJavaLocalFrame);
+  FML_DISALLOW_COPY_AND_ASSIGN(ScopedJavaLocalFrame);
 };
 
 // Forward declare the generic java reference template class.
@@ -65,7 +65,7 @@ class JavaRef<jobject> {
  private:
   jobject obj_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(JavaRef);
+  FML_DISALLOW_COPY_AND_ASSIGN(JavaRef);
 };
 
 // Generic base class for ScopedJavaLocalRef and ScopedJavaGlobalRef. Useful
@@ -83,7 +83,7 @@ class JavaRef : public JavaRef<jobject> {
   JavaRef(JNIEnv* env, T obj) : JavaRef<jobject>(env, obj) {}
 
  private:
-  FXL_DISALLOW_COPY_AND_ASSIGN(JavaRef);
+  FML_DISALLOW_COPY_AND_ASSIGN(JavaRef);
 };
 
 // Holds a local reference to a Java object. The local reference is scoped

--- a/fml/platform/darwin/cf_utils.h
+++ b/fml/platform/darwin/cf_utils.h
@@ -7,7 +7,7 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 
 namespace fml {
 
@@ -43,7 +43,7 @@ class CFRef {
  private:
   T instance_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(CFRef);
+  FML_DISALLOW_COPY_AND_ASSIGN(CFRef);
 };
 
 }  // namespace fml

--- a/fml/platform/darwin/message_loop_darwin.h
+++ b/fml/platform/darwin/message_loop_darwin.h
@@ -9,9 +9,9 @@
 
 #include <atomic>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 
@@ -35,7 +35,7 @@ class MessageLoopDarwin : public MessageLoopImpl {
 
   FRIEND_MAKE_REF_COUNTED(MessageLoopDarwin);
   FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopDarwin);
-  FXL_DISALLOW_COPY_AND_ASSIGN(MessageLoopDarwin);
+  FML_DISALLOW_COPY_AND_ASSIGN(MessageLoopDarwin);
 };
 
 }  // namespace fml

--- a/fml/platform/darwin/platform_version.h
+++ b/fml/platform/darwin/platform_version.h
@@ -6,7 +6,7 @@
 #define FLUTTER_FML_PLATFORM_DARWIN_PLATFORM_VERSION_H_
 
 #include <sys/types.h>
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 
 namespace fml {
 

--- a/fml/platform/darwin/resource_mapping_darwin.h
+++ b/fml/platform/darwin/resource_mapping_darwin.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_FML_PLATFORM_DARWIN_RESOURCE_MAPPING_DARWIN_H_
 #define FLUTTER_FML_PLATFORM_DARWIN_RESOURCE_MAPPING_DARWIN_H_
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 
@@ -23,7 +23,7 @@ class ResourceMappingDarwin : public Mapping {
  private:
   FileMapping actual_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(ResourceMappingDarwin);
+  FML_DISALLOW_COPY_AND_ASSIGN(ResourceMappingDarwin);
 };
 
 }  // namespace fml

--- a/fml/platform/darwin/scoped_block.h
+++ b/fml/platform/darwin/scoped_block.h
@@ -7,7 +7,7 @@
 
 #include <Block.h>
 
-#include "lib/fxl/compiler_specific.h"
+#include "flutter/fml/compiler_specific.h"
 
 namespace fml {
 
@@ -72,7 +72,7 @@ class ScopedBlock {
     block_ = temp;
   }
 
-  B release() FXL_WARN_UNUSED_RESULT {
+  B release() FML_WARN_UNUSED_RESULT {
     B temp = block_;
     block_ = nullptr;
     return temp;

--- a/fml/platform/darwin/scoped_nsobject.h
+++ b/fml/platform/darwin/scoped_nsobject.h
@@ -10,8 +10,8 @@
 // singled out because it is most typically included from other header files.
 #import <Foundation/NSObject.h>
 
+#include "flutter/fml/macros.h"
 #include "lib/fxl/compiler_specific.h"
-#include "lib/fxl/macros.h"
 
 @class NSAutoreleasePool;
 
@@ -155,7 +155,7 @@ template <>
 class scoped_nsobject<NSAutoreleasePool> {
  private:
   explicit scoped_nsobject(NSAutoreleasePool* object = nil);
-  FXL_DISALLOW_COPY_AND_ASSIGN(scoped_nsobject);
+  FML_DISALLOW_COPY_AND_ASSIGN(scoped_nsobject);
 };
 
 }  // namespace fml

--- a/fml/platform/darwin/scoped_nsobject.h
+++ b/fml/platform/darwin/scoped_nsobject.h
@@ -10,8 +10,8 @@
 // singled out because it is most typically included from other header files.
 #import <Foundation/NSObject.h>
 
+#include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "lib/fxl/compiler_specific.h"
 
 @class NSAutoreleasePool;
 
@@ -81,7 +81,7 @@ class scoped_nsprotocol {
   // scoped_nsprotocol<>::release() is like scoped_ptr<>::release.  It is NOT a
   // wrapper for [object_ release].  To force a scoped_nsprotocol<> to call
   // [object_ release], use scoped_nsprotocol<>::reset().
-  NST release() FXL_WARN_UNUSED_RESULT {
+  NST release() FML_WARN_UNUSED_RESULT {
     NST temp = object_;
     object_ = nil;
     return temp;

--- a/fml/platform/linux/message_loop_linux.cc
+++ b/fml/platform/linux/message_loop_linux.cc
@@ -7,15 +7,15 @@
 #include <sys/epoll.h>
 #include <unistd.h>
 
+#include "flutter/fml/eintr_wrapper.h"
 #include "flutter/fml/platform/linux/timerfd.h"
-#include "lib/fxl/files/eintr_wrapper.h"
 
 namespace fml {
 
 static constexpr int kClockType = CLOCK_MONOTONIC;
 
 MessageLoopLinux::MessageLoopLinux()
-    : epoll_fd_(HANDLE_EINTR(::epoll_create(1 /* unused */))),
+    : epoll_fd_(FML_HANDLE_EINTR(::epoll_create(1 /* unused */))),
       timer_fd_(::timerfd_create(kClockType, TFD_NONBLOCK | TFD_CLOEXEC)),
       running_(false) {
   FXL_CHECK(epoll_fd_.is_valid());
@@ -49,7 +49,7 @@ void MessageLoopLinux::Run() {
   while (running_) {
     struct epoll_event event = {};
 
-    int epoll_result = HANDLE_EINTR(
+    int epoll_result = FML_HANDLE_EINTR(
         ::epoll_wait(epoll_fd_.get(), &event, 1, -1 /* timeout */));
 
     // Errors are fatal.

--- a/fml/platform/linux/message_loop_linux.h
+++ b/fml/platform/linux/message_loop_linux.h
@@ -7,9 +7,9 @@
 
 #include <atomic>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/unique_fd.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 
@@ -35,7 +35,7 @@ class MessageLoopLinux : public MessageLoopImpl {
 
   FRIEND_MAKE_REF_COUNTED(MessageLoopLinux);
   FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopLinux);
-  FXL_DISALLOW_COPY_AND_ASSIGN(MessageLoopLinux);
+  FML_DISALLOW_COPY_AND_ASSIGN(MessageLoopLinux);
 };
 
 }  // namespace fml

--- a/fml/platform/linux/timerfd.cc
+++ b/fml/platform/linux/timerfd.cc
@@ -7,7 +7,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "lib/fxl/files/eintr_wrapper.h"
+#include "flutter/fml/eintr_wrapper.h"
 
 #if FML_TIMERFD_AVAILABLE == 0
 
@@ -48,7 +48,7 @@ bool TimerRearm(int fd, fxl::TimePoint time_point) {
 bool TimerDrain(int fd) {
   // 8 bytes must be read from a signalled timer file descriptor when signalled.
   uint64_t fire_count = 0;
-  ssize_t size = HANDLE_EINTR(::read(fd, &fire_count, sizeof(uint64_t)));
+  ssize_t size = FML_HANDLE_EINTR(::read(fd, &fire_count, sizeof(uint64_t)));
   if (size != sizeof(uint64_t)) {
     return false;
   }

--- a/fml/platform/posix/file_posix.cc
+++ b/fml/platform/posix/file_posix.cc
@@ -8,7 +8,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include "lib/fxl/files/eintr_wrapper.h"
+#include "flutter/fml/eintr_wrapper.h"
 
 namespace fml {
 
@@ -47,11 +47,11 @@ fml::UniqueFD OpenFile(const fml::UniqueFD& base_directory,
   }
 
   return fml::UniqueFD{
-      HANDLE_EINTR(::openat(base_directory.get(), path, flags))};
+      FML_HANDLE_EINTR(::openat(base_directory.get(), path, flags))};
 }
 
 fml::UniqueFD Duplicate(fml::UniqueFD::element_type descriptor) {
-  return fml::UniqueFD{HANDLE_EINTR(::dup(descriptor))};
+  return fml::UniqueFD{FML_HANDLE_EINTR(::dup(descriptor))};
 }
 
 bool IsDirectory(const fml::UniqueFD& directory) {

--- a/fml/platform/posix/mapping_posix.cc
+++ b/fml/platform/posix/mapping_posix.cc
@@ -11,8 +11,8 @@
 
 #include <type_traits>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/unique_fd.h"
-#include "lib/fxl/build_config.h"
 #include "lib/fxl/files/eintr_wrapper.h"
 
 #if OS_MACOSX

--- a/fml/platform/posix/mapping_posix.cc
+++ b/fml/platform/posix/mapping_posix.cc
@@ -12,8 +12,8 @@
 #include <type_traits>
 
 #include "flutter/fml/build_config.h"
+#include "flutter/fml/eintr_wrapper.h"
 #include "flutter/fml/unique_fd.h"
-#include "lib/fxl/files/eintr_wrapper.h"
 
 #if OS_MACOSX
 
@@ -41,8 +41,9 @@ std::unique_ptr<Mapping> GetResourceMapping(const std::string& resource_name) {
 }
 
 FileMapping::FileMapping(const std::string& path, bool executable)
-    : FileMapping(fml::UniqueFD{HANDLE_EINTR(::open(path.c_str(), O_RDONLY))},
-                  executable) {}
+    : FileMapping(
+          fml::UniqueFD{FML_HANDLE_EINTR(::open(path.c_str(), O_RDONLY))},
+          executable) {}
 
 FileMapping::FileMapping(const fml::UniqueFD& handle, bool executable)
     : size_(0), mapping_(nullptr) {

--- a/fml/platform/win/message_loop_win.h
+++ b/fml/platform/win/message_loop_win.h
@@ -9,8 +9,8 @@
 
 #include <windows.h>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
-#include "lib/fxl/macros.h"
 #include "lib/fxl/memory/unique_object.h"
 
 namespace fml {
@@ -38,7 +38,7 @@ class MessageLoopWin : public MessageLoopImpl {
 
   FRIEND_MAKE_REF_COUNTED(MessageLoopWin);
   FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopWin);
-  FXL_DISALLOW_COPY_AND_ASSIGN(MessageLoopWin);
+  FML_DISALLOW_COPY_AND_ASSIGN(MessageLoopWin);
 };
 
 }  // namespace fml

--- a/fml/task_runner.h
+++ b/fml/task_runner.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_FML_TASK_RUNNER_H_
 #define FLUTTER_FML_TASK_RUNNER_H_
 
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 #include "lib/fxl/memory/ref_counted.h"
 #include "lib/fxl/tasks/task_runner.h"
 
@@ -35,7 +35,7 @@ class TaskRunner final : public fxl::TaskRunner {
 
   FRIEND_MAKE_REF_COUNTED(TaskRunner);
   FRIEND_REF_COUNTED_THREAD_SAFE(TaskRunner);
-  FXL_DISALLOW_COPY_AND_ASSIGN(TaskRunner);
+  FML_DISALLOW_COPY_AND_ASSIGN(TaskRunner);
 };
 
 }  // namespace fml

--- a/fml/thread.cc
+++ b/fml/thread.cc
@@ -6,7 +6,7 @@
 
 #include "flutter/fml/thread.h"
 
-#include "lib/fxl/build_config.h"
+#include "flutter/fml/build_config.h"
 
 #if defined(OS_WIN)
 #include <windows.h>

--- a/fml/thread.h
+++ b/fml/thread.h
@@ -9,8 +9,8 @@
 #include <memory>
 #include <thread>
 
+#include "flutter/fml/macros.h"
 #include "flutter/fml/task_runner.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 
@@ -31,7 +31,7 @@ class Thread {
 
   static void SetCurrentThreadName(const std::string& name);
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(Thread);
+  FML_DISALLOW_COPY_AND_ASSIGN(Thread);
 };
 
 }  // namespace fml

--- a/fml/thread_local.h
+++ b/fml/thread_local.h
@@ -7,9 +7,9 @@
 
 #include <functional>
 
+#include "flutter/fml/macros.h"
 #include "lib/fxl/build_config.h"
 #include "lib/fxl/logging.h"
-#include "lib/fxl/macros.h"
 
 #define FML_THREAD_LOCAL_PTHREADS OS_MACOSX || OS_LINUX || OS_ANDROID
 
@@ -55,7 +55,7 @@ class ThreadLocal {
     ThreadLocalDestroyCallback destroy_;
     intptr_t value_;
 
-    FXL_DISALLOW_COPY_AND_ASSIGN(Box);
+    FML_DISALLOW_COPY_AND_ASSIGN(Box);
   };
 
   static inline void ThreadLocalDestroy(void* value) {
@@ -106,7 +106,7 @@ class ThreadLocal {
   pthread_key_t _key;
   ThreadLocalDestroyCallback destroy_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(ThreadLocal);
+  FML_DISALLOW_COPY_AND_ASSIGN(ThreadLocal);
 };
 
 #else  // FML_THREAD_LOCAL_PTHREADS
@@ -144,7 +144,7 @@ class ThreadLocal {
   ThreadLocalDestroyCallback destroy_;
   intptr_t value_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(ThreadLocal);
+  FML_DISALLOW_COPY_AND_ASSIGN(ThreadLocal);
 };
 
 #endif  // FML_THREAD_LOCAL_PTHREADS

--- a/fml/thread_local.h
+++ b/fml/thread_local.h
@@ -7,8 +7,8 @@
 
 #include <functional>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/macros.h"
-#include "lib/fxl/build_config.h"
 #include "lib/fxl/logging.h"
 
 #define FML_THREAD_LOCAL_PTHREADS OS_MACOSX || OS_LINUX || OS_ANDROID

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -9,7 +9,7 @@
 #include <cstdint>
 #include <string>
 
-#include "lib/fxl/macros.h"
+#include "flutter/fml/macros.h"
 
 #ifndef TRACE_EVENT_HIDE_MACROS
 
@@ -115,7 +115,7 @@ class ScopedInstantEnd {
  private:
   const std::string label_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(ScopedInstantEnd);
+  FML_DISALLOW_COPY_AND_ASSIGN(ScopedInstantEnd);
 };
 
 }  // namespace tracing

--- a/fml/unique_fd.cc
+++ b/fml/unique_fd.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/fml/unique_fd.h"
 
-#include "lib/fxl/files/eintr_wrapper.h"
+#include "flutter/fml/eintr_wrapper.h"
 
 namespace fml {
 namespace internal {
@@ -24,7 +24,7 @@ void UniqueFDTraits::Free(HANDLE fd) {
 namespace unix {
 
 void UniqueFDTraits::Free(int fd) {
-  IGNORE_EINTR(fd);
+  FML_IGNORE_EINTR(fd);
 }
 
 }  // namespace unix

--- a/fml/unique_fd.h
+++ b/fml/unique_fd.h
@@ -5,8 +5,8 @@
 #ifndef FLUTTER_FML_UNIQUE_FD_H_
 #define FLUTTER_FML_UNIQUE_FD_H_
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/unique_object.h"
-#include "lib/fxl/build_config.h"
 
 #if OS_WIN
 

--- a/fml/unique_object.h
+++ b/fml/unique_object.h
@@ -7,9 +7,9 @@
 
 #include <utility>
 
+#include "flutter/fml/macros.h"
 #include "lib/fxl/compiler_specific.h"
 #include "lib/fxl/logging.h"
-#include "lib/fxl/macros.h"
 
 namespace fml {
 
@@ -114,7 +114,7 @@ class UniqueObject {
 
   Data data_;
 
-  FXL_DISALLOW_COPY_AND_ASSIGN(UniqueObject);
+  FML_DISALLOW_COPY_AND_ASSIGN(UniqueObject);
 };
 
 template <class T, class Traits>

--- a/fml/unique_object.h
+++ b/fml/unique_object.h
@@ -7,8 +7,8 @@
 
 #include <utility>
 
+#include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
-#include "lib/fxl/compiler_specific.h"
 #include "lib/fxl/logging.h"
 
 namespace fml {
@@ -78,7 +78,7 @@ class UniqueObject {
   // Release the object. The return value is the current object held by this
   // object. After this operation, this object will hold an invalid value, and
   // will not own the object any more.
-  T release() FXL_WARN_UNUSED_RESULT {
+  T release() FML_WARN_UNUSED_RESULT {
     T old_generic = data_.generic;
     data_.generic = Traits::InvalidValue();
     return old_generic;

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -10054,6 +10054,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: engine
 ORIGIN: ../../../topaz/LICENSE
 TYPE: LicenseType.bsd
+FILE: ../../../flutter/fml/build_config.h
+FILE: ../../../flutter/fml/compiler_specific.h
+FILE: ../../../flutter/fml/eintr_wrapper.h
+FILE: ../../../flutter/fml/memory/ref_counted.h
+FILE: ../../../flutter/fml/memory/ref_counted_internal.h
+FILE: ../../../flutter/fml/memory/ref_counted_unittest.cc
+FILE: ../../../flutter/fml/memory/ref_ptr.h
+FILE: ../../../flutter/fml/memory/ref_ptr_internal.h
 FILE: ../../../flutter/fml/memory/thread_checker.h
 FILE: ../../../flutter/fml/memory/weak_ptr.h
 FILE: ../../../flutter/fml/memory/weak_ptr_internal.cc


### PR DESCRIPTION
Also make the the existing weak pointer factories use the FML variants.

This is one of a series of patches importing what we need from FXL so we can eventually get rid of the dependency.

Also renamed friend-ing macros on shared pointers to use the FXL_ prefix so that files that import both FXL and FML headers don't have macro collisions.