### PR TITLE
replace nextNodeId/previousNodeId with hitTestPosition

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -488,8 +488,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
     String increasedValue,
     String decreasedValue,
     TextDirection textDirection,
-    int nextNodeId,
-    int previousNodeId,
+    int hitTestPosition,
     Float64List transform,
     Int32List children,
   }) {
@@ -513,8 +512,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
                 increasedValue,
                 decreasedValue,
                 textDirection != null ? textDirection.index + 1 : 0,
-                nextNodeId ?? -1,
-                previousNodeId ?? -1,
+                hitTestPosition,
                 transform,
                 children,);
   }
@@ -537,8 +535,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
     String increasedValue,
     String decreasedValue,
     int textDirection,
-    int nextNodeId,
-    int previousNodeId,
+    int hitTestPosition,
     Float64List transform,
     Int32List children,
   ) native 'SemanticsUpdateBuilder_updateNode';

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -82,8 +82,7 @@ struct SemanticsNode {
   std::string increasedValue;
   std::string decreasedValue;
   int32_t textDirection = 0;  // 0=unknown, 1=rtl, 2=ltr
-  int32_t nextNodeId = -1;
-  int32_t previousNodeId = -1;
+  int32_t hitTestPosition = -1;
 
   SkRect rect = SkRect::MakeEmpty();
   SkMatrix44 transform = SkMatrix44(SkMatrix44::kIdentity_Constructor);

--- a/lib/ui/semantics/semantics_update_builder.cc
+++ b/lib/ui/semantics/semantics_update_builder.cc
@@ -52,8 +52,7 @@ void SemanticsUpdateBuilder::updateNode(int id,
                                         std::string increasedValue,
                                         std::string decreasedValue,
                                         int textDirection,
-                                        int nextNodeId,
-                                        int previousNodeId,
+                                        int hitTestPosition,
                                         const tonic::Float64List& transform,
                                         const tonic::Int32List& children) {
   SemanticsNode node;
@@ -72,8 +71,7 @@ void SemanticsUpdateBuilder::updateNode(int id,
   node.increasedValue = increasedValue;
   node.decreasedValue = decreasedValue;
   node.textDirection = textDirection;
-  node.nextNodeId = nextNodeId;
-  node.previousNodeId = previousNodeId;
+  node.hitTestPosition = hitTestPosition;
   node.transform.setColMajord(transform.data());
   node.children = std::vector<int32_t>(
       children.data(), children.data() + children.num_elements());

--- a/lib/ui/semantics/semantics_update_builder.h
+++ b/lib/ui/semantics/semantics_update_builder.h
@@ -43,8 +43,7 @@ class SemanticsUpdateBuilder
                   std::string increasedValue,
                   std::string decreasedValue,
                   int textDirection,
-                  int nextNodeId,
-                  int previousNodeId,
+                  int hitTestPosition,
                   const tonic::Float64List& transform,
                   const tonic::Int32List& children);
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -251,10 +251,6 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
 
         result.setSelected(object.hasFlag(Flag.IS_SELECTED));
         result.setText(object.getValueLabelHint());
-        if (object.previousNodeId != -1
-            && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            result.setTraversalAfter(mOwner, object.previousNodeId);
-        }
 
         // Accessibility Focus
         if (mA11yFocusedObject != null && mA11yFocusedObject.id == virtualViewId) {
@@ -744,7 +740,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         String decreasedValue;
         String hint;
         TextDirection textDirection;
-        int previousNodeId;
+        int hitTestPosition;
 
         boolean hadPreviousConfig = false;
         int previousFlags;
@@ -797,7 +793,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         void log(String indent, boolean recursive) {
           Log.i(TAG, indent + "SemanticsObject id=" + id + " label=" + label + " actions=" +  actions + " flags=" + flags + "\n" +
                      indent + "  +-- textDirection=" + textDirection  + "\n"+
-                     indent + "  +-- previousNodeId=" + previousNodeId  + "\n"+
+                     indent + "  +-- hitTestPosition=" + hitTestPosition  + "\n"+
                      indent + "  +-- rect.ltrb=(" + left + ", " + top + ", " + right + ", " + bottom + ")\n" +
                      indent + "  +-- transform=" + Arrays.toString(transform) + "\n");
           if (children != null && recursive) {
@@ -844,7 +840,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
 
             textDirection = TextDirection.fromInt(buffer.getInt());
 
-            previousNodeId = buffer.getInt();
+            hitTestPosition = buffer.getInt();
 
             left = buffer.getFloat();
             top = buffer.getFloat();

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -243,7 +243,7 @@ void PlatformViewAndroid::UpdateSemantics(blink::SemanticsNodeUpdates update) {
         strings.push_back(node.hint);
       }
       buffer_int32[position++] = node.textDirection;
-      buffer_int32[position++] = node.previousNodeId;
+      buffer_int32[position++] = node.hitTestPosition;
       buffer_float32[position++] = node.rect.left();
       buffer_float32[position++] = node.rect.top();
       buffer_float32[position++] = node.rect.right();


### PR DESCRIPTION
This only removes the old fields and adds the new `hitTestPosition` field. The actual implementation of hit testing will be done after the framework starts passing the values. Without the values there's no way to test the correctness of the algorithm.

This PR _must_ be submitted after https://github.com/flutter/flutter/pull/16253