### PR TITLE
Throw an exception if a secondary isolate tries to send a platform message

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -681,11 +681,14 @@ class Window {
   void sendPlatformMessage(String name,
                            ByteData data,
                            PlatformMessageResponseCallback callback) {
-    _sendPlatformMessage(name, _zonedPlatformMessageResponseCallback(callback), data);
+    final String error =
+        _sendPlatformMessage(name, _zonedPlatformMessageResponseCallback(callback), data);
+    if (error != null)
+      throw new Exception(error);
   }
-  void _sendPlatformMessage(String name,
-                            PlatformMessageResponseCallback callback,
-                            ByteData data) native 'Window_sendPlatformMessage';
+  String _sendPlatformMessage(String name,
+                              PlatformMessageResponseCallback callback,
+                              ByteData data) native 'Window_sendPlatformMessage';
 
   /// Called whenever this window receives a message from a platform-specific
   /// plugin.

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -54,11 +54,17 @@ void UpdateSemantics(Dart_NativeArguments args) {
   UIDartState::Current()->window()->client()->UpdateSemantics(update);
 }
 
-void SendPlatformMessage(Dart_Handle window,
-                         const std::string& name,
-                         Dart_Handle callback,
-                         const tonic::DartByteData& data) {
+Dart_Handle SendPlatformMessage(Dart_Handle window,
+                                const std::string& name,
+                                Dart_Handle callback,
+                                const tonic::DartByteData& data) {
   UIDartState* dart_state = UIDartState::Current();
+
+  if (!dart_state->window()) {
+    // Must release the TypedData buffer before allocating other Dart objects.
+    data.Release();
+    return ToDart("Platform messages can only be sent from the main isolate");
+  }
 
   fxl::RefPtr<PlatformMessageResponse> response;
   if (!Dart_IsNull(callback)) {
@@ -67,16 +73,18 @@ void SendPlatformMessage(Dart_Handle window,
         dart_state->GetTaskRunners().GetUITaskRunner());
   }
   if (Dart_IsNull(data.dart_handle())) {
-    UIDartState::Current()->window()->client()->HandlePlatformMessage(
+    dart_state->window()->client()->HandlePlatformMessage(
         fxl::MakeRefCounted<PlatformMessage>(name, response));
   } else {
     const uint8_t* buffer = static_cast<const uint8_t*>(data.data());
 
-    UIDartState::Current()->window()->client()->HandlePlatformMessage(
+    dart_state->window()->client()->HandlePlatformMessage(
         fxl::MakeRefCounted<PlatformMessage>(
             name, std::vector<uint8_t>(buffer, buffer + data.length_in_bytes()),
             response));
   }
+
+  return Dart_Null();
 }
 
 void _SendPlatformMessage(Dart_NativeArguments args) {


### PR DESCRIPTION
Platform messages are only support in the UI isolate.  Secondary isolates
do not have a window that can receive incoming messages, and outgoing messages
are not tagged with a destination isolate and thus will always be dispatched
to the UI isolate.

Fixes https://github.com/flutter/flutter/issues/16846