### PR TITLE
Hold a global reference to the AssetManager Java object backing the APKAssetProvider

### DIFF
--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -10,7 +10,8 @@ namespace blink {
 APKAssetProvider::APKAssetProvider(JNIEnv* env,
                                    jobject jassetManager,
                                    std::string directory)
-    : directory_(std::move(directory)) {
+    : java_asset_manager_(env, jassetManager),
+      directory_(std::move(directory)) {
   assetManager_ = AAssetManager_fromJava(env, jassetManager);
 }
 

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -9,6 +9,7 @@
 #include <jni.h>
 
 #include "flutter/assets/asset_resolver.h"
+#include "flutter/fml/platform/android/scoped_java_ref.h"
 #include "lib/fxl/memory/ref_counted.h"
 
 namespace blink {
@@ -21,6 +22,7 @@ class APKAssetProvider final : public AssetResolver {
   virtual ~APKAssetProvider();
 
  private:
+  fml::jni::ScopedJavaGlobalRef<jobject> java_asset_manager_;
   AAssetManager* assetManager_;
   const std::string directory_;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/16222