### PR TITLE
Call SkGraphics::Init earlier on Fuchsia.

### DIFF
--- a/content_handler/application_runner.cc
+++ b/content_handler/application_runner.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/lib/ui/text/font_collection.h"
 #include "fuchsia_font_manager.h"
+#include "third_party/skia/include/core/SkGraphics.h"
 #include "lib/icu_data/cpp/icu_data.h"
 
 namespace flutter {
@@ -15,6 +16,9 @@ namespace flutter {
 ApplicationRunner::ApplicationRunner(fxl::Closure on_termination_callback)
     : on_termination_callback_(std::move(on_termination_callback)),
       host_context_(component::ApplicationContext::CreateFromStartupInfo()) {
+
+  SkGraphics::Init();
+
   SetupICU();
 
   SetupGlobalFonts();


### PR DESCRIPTION
Fuchsia uses Skia before the Shell. The first thing the shell does is to call this method. However, Skia's use before this point initializes some cache keys using the default hash function. These hash functions are swapped out in the init call which causes hash validation error in debug.