### PR TITLE
[fuchsia] Changes for running Dart 2 on flutter_runner.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -79,47 +79,165 @@ if (is_fuchsia) {
       "$flutter_root/content_handler:aot",
     ]
     if (flutter_runtime_mode != "release") {
-      deps += [ "//third_party/dart/runtime/observatory:embedded_archive_observatory" ]
+      deps += [
+        "//third_party/dart/runtime/observatory:embedded_archive_observatory",
+      ]
     }
 
     binary = "flutter_aot_runner"
 
     if (flutter_runtime_mode != "release") {
-      resources = [ {
-            path = rebase_path(
-                    "$root_gen_dir/observatory/embedded_archive_observatory.tar")
-            dest = "observatory.tar"
-          } ]
+      resources = [
+        {
+          path = rebase_path(
+                  "$root_gen_dir/observatory/embedded_archive_observatory.tar")
+          dest = "observatory.tar"
+        },
+      ]
     }
 
-    meta = [ {
-          path = rebase_path("content_handler/meta/sandbox")
-          dest = "sandbox"
-        } ]
+    meta = [
+      {
+        path = rebase_path("content_handler/meta/sandbox")
+        dest = "sandbox"
+      },
+    ]
+  }
+
+  package("flutter2_aot_runner") {
+    deps = [
+      "$flutter_root/content_handler:aot",
+    ]
+    if (flutter_runtime_mode != "release") {
+      deps += [
+        "//third_party/dart/runtime/observatory:embedded_archive_observatory",
+      ]
+    }
+
+    binary = "flutter_aot_runner"
+
+    if (flutter_runtime_mode != "release") {
+      resources = [
+        {
+          path = rebase_path(
+                  "$root_gen_dir/observatory/embedded_archive_observatory.tar")
+          dest = "observatory.tar"
+        },
+      ]
+    }
+
+    meta = [
+      {
+        path = rebase_path("content_handler/meta/sandbox")
+        dest = "sandbox"
+      },
+    ]
   }
 
   package("flutter_jit_runner") {
+    snapshot_label = "$flutter_root/lib/snapshot:generate_snapshot_bin"
+    snapshot_gen_dir = get_label_info(snapshot_label, "target_gen_dir")
+
     deps = [
       "$flutter_root/content_handler:jit",
+      snapshot_label,
     ]
     if (flutter_runtime_mode != "release") {
-      deps += [ "//third_party/dart/runtime/observatory:embedded_archive_observatory" ]
+      deps += [
+        "//third_party/dart/runtime/observatory:embedded_archive_observatory",
+      ]
     }
 
     binary = "flutter_jit_runner"
 
+    resources = [
+      {
+        path = rebase_path("$snapshot_gen_dir/vm_isolate_snapshot.bin")
+        dest = "vm_snapshot_data.bin"
+      },
+      {
+        path = rebase_path("$snapshot_gen_dir/vm_snapshot_instructions.bin")
+        dest = "vm_snapshot_instructions.bin"
+      },
+      {
+        path = rebase_path("$snapshot_gen_dir/isolate_snapshot.bin")
+        dest = "isolate_core_snapshot_data.bin"
+      },
+      {
+        path =
+            rebase_path("$snapshot_gen_dir/isolate_snapshot_instructions.bin")
+        dest = "isolate_core_snapshot_instructions.bin"
+      },
+    ]
     if (flutter_runtime_mode != "release") {
-      resources = [ {
-            path = rebase_path(
-                    "$root_gen_dir/observatory/embedded_archive_observatory.tar")
-            dest = "observatory.tar"
-          } ]
+      resources += [
+        {
+          path = rebase_path(
+                  "$root_gen_dir/observatory/embedded_archive_observatory.tar")
+          dest = "observatory.tar"
+        },
+      ]
     }
 
-    meta = [ {
-          path = rebase_path("content_handler/meta/sandbox")
-          dest = "sandbox"
-        } ]
+    meta = [
+      {
+        path = rebase_path("content_handler/meta/sandbox")
+        dest = "sandbox"
+      },
+    ]
+  }
+
+  package("flutter2_jit_runner") {
+    snapshot_label = "//topaz/runtime/flutter_runner/kernel:kernel_core_snapshot"
+    snapshot_gen_dir = get_label_info(snapshot_label, "target_gen_dir")
+
+    deps = [
+      "$flutter_root/content_handler:jit",
+      snapshot_label,
+    ]
+    if (flutter_runtime_mode != "release") {
+      deps += [
+        "//third_party/dart/runtime/observatory:embedded_archive_observatory",
+      ]
+    }
+
+    binary = "flutter_jit_runner"
+
+    resources = [
+      {
+        path = rebase_path("$snapshot_gen_dir/vm_isolate_snapshot.bin")
+        dest = "vm_snapshot_data.bin"
+      },
+      {
+        path = rebase_path("$snapshot_gen_dir/vm_snapshot_instructions.bin")
+        dest = "vm_snapshot_instructions.bin"
+      },
+      {
+        path = rebase_path("$snapshot_gen_dir/isolate_snapshot.bin")
+        dest = "isolate_core_snapshot_data.bin"
+      },
+      {
+        path =
+            rebase_path("$snapshot_gen_dir/isolate_snapshot_instructions.bin")
+        dest = "isolate_core_snapshot_instructions.bin"
+      },
+    ]
+    if (flutter_runtime_mode != "release") {
+      resources += [
+        {
+          path = rebase_path(
+                  "$root_gen_dir/observatory/embedded_archive_observatory.tar")
+          dest = "observatory.tar"
+        },
+      ]
+    }
+
+    meta = [
+      {
+        path = rebase_path("content_handler/meta/sandbox")
+        dest = "sandbox"
+      },
+    ]
   }
 } else {
   group("dist") {

--- a/common/settings.cc
+++ b/common/settings.cc
@@ -11,16 +11,13 @@ namespace blink {
 std::string Settings::ToString() const {
   std::stringstream stream;
   stream << "Settings: " << std::endl;
-  stream << "aot_snapshot_path: " << aot_snapshot_path << std::endl;
   stream << "script_snapshot_path: " << script_snapshot_path << std::endl;
-  stream << "aot_vm_snapshot_data_filename: " << aot_vm_snapshot_data_filename
+  stream << "vm_snapshot_data_path: " << vm_snapshot_data_path << std::endl;
+  stream << "vm_snapshot_instr_path: " << vm_snapshot_instr_path << std::endl;
+  stream << "isolate_snapshot_data_path: " << isolate_snapshot_data_path
          << std::endl;
-  stream << "aot_vm_snapshot_instr_filename: " << aot_vm_snapshot_instr_filename
+  stream << "isolate_snapshot_instr_path: " << isolate_snapshot_instr_path
          << std::endl;
-  stream << "aot_isolate_snapshot_data_filename: "
-         << aot_isolate_snapshot_data_filename << std::endl;
-  stream << "aot_isolate_snapshot_instr_filename: "
-         << aot_isolate_snapshot_instr_filename << std::endl;
   stream << "application_library_path: " << application_library_path
          << std::endl;
   stream << "main_dart_file_path: " << main_dart_file_path << std::endl;

--- a/common/settings.h
+++ b/common/settings.h
@@ -24,13 +24,12 @@ using TaskObserverRemove = std::function<void(intptr_t /* key */)>;
 struct Settings {
   // VM settings
   std::string script_snapshot_path;
-  std::string kernel_snapshot_path;
+  std::string platform_kernel_path;
 
-  std::string aot_snapshot_path;
-  std::string aot_vm_snapshot_data_filename;
-  std::string aot_vm_snapshot_instr_filename;
-  std::string aot_isolate_snapshot_data_filename;
-  std::string aot_isolate_snapshot_instr_filename;
+  std::string vm_snapshot_data_path;
+  std::string vm_snapshot_instr_path;
+  std::string isolate_snapshot_data_path;
+  std::string isolate_snapshot_instr_path;
 
   std::string application_library_path;
   std::string application_kernel_asset;

--- a/content_handler/application.cc
+++ b/content_handler/application.cc
@@ -123,6 +123,13 @@ Application::Application(
   application_context_ =
       component::ApplicationContext::CreateFrom(std::move(startup_info));
 
+  settings_.vm_snapshot_data_path = "pkg/data/vm_snapshot_data.bin";
+  settings_.vm_snapshot_instr_path = "pkg/data/vm_snapshot_instructions.bin";
+  settings_.isolate_snapshot_data_path =
+      "pkg/data/isolate_core_snapshot_data.bin";
+  settings_.isolate_snapshot_instr_path =
+      "pkg/data/isolate_core_snapshot_instructions.bin";
+
   settings_.enable_observatory = true;
 
   settings_.icu_data_path = "";
@@ -132,6 +139,7 @@ Application::Application(
   settings_.assets_dir = application_assets_directory_.get();
 
   settings_.script_snapshot_path = "snapshot_blob.bin";
+  settings_.application_kernel_asset = "kernel_blob.dill";
 
   settings_.log_tag = debug_label_ + std::string{"(flutter)"};
 

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -114,7 +114,8 @@ source_set("runtime") {
   # In AOT mode, precompiled snapshots contain the instruction buffer.
   # Generation of the same requires all application specific script code to be
   # specified up front. In such cases, there can be no generic snapshot.
-  if (!flutter_aot) {
+  # In Fuchsia, we load from a file instead of linking.
+  if (!flutter_aot && !is_fuchsia) {
     deps += [ "$flutter_root/lib/snapshot" ]
   }
 }

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -22,11 +22,9 @@ const char* DartSnapshot::kIsolateInstructionsSymbol =
     "kDartIsolateSnapshotInstructions";
 
 std::unique_ptr<DartSnapshotBuffer> ResolveVMData(const Settings& settings) {
-  if (settings.aot_snapshot_path.size() > 0) {
-    auto path = fml::paths::JoinPaths(
-        {settings.aot_snapshot_path, settings.aot_vm_snapshot_data_filename});
+  if (settings.vm_snapshot_data_path.size() > 0) {
     if (auto source = DartSnapshotBuffer::CreateWithContentsOfFile(
-            path.c_str(), false /* executable */)) {
+            settings.vm_snapshot_data_path.c_str(), false /* executable */)) {
       return source;
     }
   }
@@ -38,11 +36,9 @@ std::unique_ptr<DartSnapshotBuffer> ResolveVMData(const Settings& settings) {
 
 std::unique_ptr<DartSnapshotBuffer> ResolveVMInstructions(
     const Settings& settings) {
-  if (settings.aot_snapshot_path.size() > 0) {
-    auto path = fml::paths::JoinPaths(
-        {settings.aot_snapshot_path, settings.aot_vm_snapshot_instr_filename});
+  if (settings.vm_snapshot_instr_path.size() > 0) {
     if (auto source = DartSnapshotBuffer::CreateWithContentsOfFile(
-            path.c_str(), true /* executable */)) {
+            settings.vm_snapshot_instr_path.c_str(), true /* executable */)) {
       return source;
     }
   }
@@ -63,12 +59,10 @@ std::unique_ptr<DartSnapshotBuffer> ResolveVMInstructions(
 
 std::unique_ptr<DartSnapshotBuffer> ResolveIsolateData(
     const Settings& settings) {
-  if (settings.aot_snapshot_path.size() > 0) {
-    auto path =
-        fml::paths::JoinPaths({settings.aot_snapshot_path,
-                               settings.aot_isolate_snapshot_data_filename});
+  if (settings.isolate_snapshot_data_path.size() > 0) {
     if (auto source = DartSnapshotBuffer::CreateWithContentsOfFile(
-            path.c_str(), false /* executable */)) {
+            settings.isolate_snapshot_data_path.c_str(),
+            false /* executable */)) {
       return source;
     }
   }
@@ -80,12 +74,10 @@ std::unique_ptr<DartSnapshotBuffer> ResolveIsolateData(
 
 std::unique_ptr<DartSnapshotBuffer> ResolveIsolateInstructions(
     const Settings& settings) {
-  if (settings.aot_snapshot_path.size() > 0) {
-    auto path =
-        fml::paths::JoinPaths({settings.aot_snapshot_path,
-                               settings.aot_isolate_snapshot_instr_filename});
+  if (settings.isolate_snapshot_instr_path.size() > 0) {
     if (auto source = DartSnapshotBuffer::CreateWithContentsOfFile(
-            path.c_str(), true /* executable */)) {
+            settings.isolate_snapshot_instr_path.c_str(),
+            true /* executable */)) {
       return source;
     }
   }

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -266,7 +266,7 @@ DartVM::DartVM(const Settings& settings,
       vm_snapshot_(std::move(vm_snapshot)),
       isolate_snapshot_(std::move(isolate_snapshot)),
       platform_kernel_mapping_(
-          std::make_unique<fml::FileMapping>(settings.kernel_snapshot_path)),
+          std::make_unique<fml::FileMapping>(settings.platform_kernel_path)),
       weak_factory_(this) {
   TRACE_EVENT0("flutter", "DartVMInitializer");
   FXL_DLOG(INFO) << "Attempting Dart VM launch for mode: "
@@ -342,7 +342,7 @@ DartVM::DartVM(const Settings& settings,
   const bool is_preview_dart2 =
       platform_kernel_ != nullptr || isolate_snapshot_is_dart_2;
 
-  FXL_DLOG(INFO) << "Dart 2 " << (is_preview_dart2 ? " is" : "is NOT")
+  FXL_DLOG(INFO) << "Dart 2 " << (is_preview_dart2 ? "is" : "is NOT")
                  << " enabled. Platform kernel: "
                  << static_cast<bool>(platform_kernel_)
                  << " Isolate Snapshot is Dart 2: "

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string>
 
+#include "flutter/fml/paths.h"
 #include "lib/fxl/strings/string_view.h"
 
 // Include once for the default enum definition.
@@ -172,21 +173,37 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
   command_line.GetOptionValue(FlagForSwitch(Switch::Packages),
                               &settings.packages_file_path);
 
+  std::string aot_snapshot_path;
   command_line.GetOptionValue(FlagForSwitch(Switch::AotSnapshotPath),
-                              &settings.aot_snapshot_path);
+                              &aot_snapshot_path);
 
+  std::string aot_vm_snapshot_data_filename;
   command_line.GetOptionValue(FlagForSwitch(Switch::AotVmSnapshotData),
-                              &settings.aot_vm_snapshot_data_filename);
+                              &aot_vm_snapshot_data_filename);
 
+  std::string aot_vm_snapshot_instr_filename;
   command_line.GetOptionValue(FlagForSwitch(Switch::AotVmSnapshotInstructions),
-                              &settings.aot_vm_snapshot_instr_filename);
+                              &aot_vm_snapshot_instr_filename);
 
+  std::string aot_isolate_snapshot_data_filename;
   command_line.GetOptionValue(FlagForSwitch(Switch::AotIsolateSnapshotData),
-                              &settings.aot_isolate_snapshot_data_filename);
+                              &aot_isolate_snapshot_data_filename);
 
+  std::string aot_isolate_snapshot_instr_filename;
   command_line.GetOptionValue(
       FlagForSwitch(Switch::AotIsolateSnapshotInstructions),
-      &settings.aot_isolate_snapshot_instr_filename);
+      &aot_isolate_snapshot_instr_filename);
+
+  if (aot_snapshot_path.size() > 0) {
+    settings.vm_snapshot_data_path = fml::paths::JoinPaths(
+        {aot_snapshot_path, aot_vm_snapshot_data_filename});
+    settings.vm_snapshot_instr_path = fml::paths::JoinPaths(
+        {aot_snapshot_path, aot_vm_snapshot_instr_filename});
+    settings.isolate_snapshot_data_path = fml::paths::JoinPaths(
+        {aot_snapshot_path, aot_isolate_snapshot_data_filename});
+    settings.isolate_snapshot_instr_path = fml::paths::JoinPaths(
+        {aot_snapshot_path, aot_isolate_snapshot_instr_filename});
+  }
 
   command_line.GetOptionValue(FlagForSwitch(Switch::CacheDirPath),
                               &settings.temp_directory_path);

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -64,10 +64,11 @@ void FlutterMain::Init(JNIEnv* env,
     auto application_kernel_path =
         fml::paths::JoinPaths({settings.assets_path, "kernel_blob.bin"});
 
-    if (files::IsFile(platform_kernel_path) &&
-        files::IsFile(application_kernel_path)) {
-      settings.kernel_snapshot_path = platform_kernel_path;
+    if (files::IsFile(application_kernel_path)) {
       settings.application_kernel_asset = application_kernel_path;
+      if (files::IsFile(platform_kernel_path)) {
+        settings.platform_kernel_path = platform_kernel_path;
+      }
     }
   }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -97,7 +97,7 @@ static blink::Settings DefaultSettingsForProcess() {
           NSURL* vmKernelSnapshotURL = [NSURL URLWithString:@(kVMKernelSnapshotFileName)
                                               relativeToURL:[NSURL fileURLWithPath:assetsPath]];
           if ([[NSFileManager defaultManager] fileExistsAtPath:vmKernelSnapshotURL.path]) {
-            settings.kernel_snapshot_path = vmKernelSnapshotURL.path.UTF8String;
+            settings.platform_kernel_path = vmKernelSnapshotURL.path.UTF8String;
           }
         }
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -154,11 +154,12 @@ FlutterResult FlutterEngineRun(size_t version,
       fml::paths::JoinPaths({settings.assets_path, "platform.dill"});
   std::string application_kernel_path = fml::paths::JoinPaths(
       {settings.assets_path, kApplicationKernelSnapshotFileName});
-  if (files::IsFile(platform_kernel_path) &&
-      files::IsFile(application_kernel_path)) {
+  if (files::IsFile(application_kernel_path)) {
     // Run from a kernel snapshot.
-    settings.application_kernel_asset = kApplicationKernelSnapshotFileName;
-    settings.kernel_snapshot_path = platform_kernel_path;
+    settings.platform_kernel_path = platform_kernel_path;
+    if (files::IsFile(platform_kernel_path)) {
+      settings.application_kernel_asset = kApplicationKernelSnapshotFileName;
+    }
   } else {
     // Run from a main Dart file.
     settings.main_dart_file_path = args->main_path;

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -254,7 +254,7 @@ int main(int argc, char* argv[]) {
 
   settings.icu_data_path = "icudtl.dat";
 
-  settings.kernel_snapshot_path =
+  settings.platform_kernel_path =
       fml::paths::JoinPaths({settings.assets_path, "platform.dill"});
 
   // The tools that read logs get confused if there is a log tag specified.


### PR DESCRIPTION
 - Remove assumption in a few places that we're in Dart 2 mode only if there's a platform kernel.
 - Load core snapshots from the package instead of linking them in.