### PR TITLE
Initial plugin support for background downloads + content fetching

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -130,6 +130,22 @@ NS_ASSUME_NONNULL_BEGIN
                completionHandler:(void (^)(BOOL succeeded))completionHandler
     API_AVAILABLE(ios(9.0));
 
+/**
+ Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
+
+ - Returns: `YES` if this plugin handles the request.
+ */
+- (BOOL)application:(UIApplication *)application
+    handleEventsForBackgroundURLSession:(nonnull NSString *)identifier
+  completionHandler:(nonnull void (^)())completionHandler;
+
+/**
+ Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
+
+ - Returns: `YES` if this plugin handles the request.
+ */
+- (BOOL)application:(UIApplication *)application
+    performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 @end
 
 /**

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
  Defines a set of optional callback methods and a method to set up the plugin
  and register it to be called by other application components.
  */
-@protocol FlutterPlugin<NSObject>
+@protocol FlutterPlugin <NSObject>
 @required
 /**
  Registers this plugin.
@@ -135,23 +135,23 @@ NS_ASSUME_NONNULL_BEGIN
 
  - Returns: `YES` if this plugin handles the request.
  */
-- (BOOL)application:(UIApplication *)application
-    handleEventsForBackgroundURLSession:(nonnull NSString *)identifier
-  completionHandler:(nonnull void (^)())completionHandler;
+- (BOOL)application:(UIApplication*)application
+    handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
+                      completionHandler:(nonnull void (^)())completionHandler;
 
 /**
  Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
 
  - Returns: `YES` if this plugin handles the request.
  */
-- (BOOL)application:(UIApplication *)application
+- (BOOL)application:(UIApplication*)application
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 @end
 
 /**
  Registration context for a single `FlutterPlugin`.
  */
-@protocol FlutterPluginRegistrar<NSObject>
+@protocol FlutterPluginRegistrar <NSObject>
 /**
  Returns a `FlutterBinaryMessenger` for creating Dart/iOS communication
  channels to be used by the plugin.
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
  Plugins are identified by unique string keys, typically the name of the
  plugin's main class.
  */
-@protocol FlutterPluginRegistry<NSObject>
+@protocol FlutterPluginRegistry <NSObject>
 /**
  Returns a registrar for registering a plugin.
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -210,6 +210,32 @@
   }
 }
 
+- (void)application:(UIApplication*)application
+    handleEventsForBackgroundURLSession:(nonnull NSString *)identifier
+                completionHandler:(nonnull void (^)())completionHandler {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      if ([plugin application:application
+              handleEventsForBackgroundURLSession:identifier
+                         completionHandler:completionHandler]) {
+        return;
+      }
+    }
+  }
+}
+
+- (void)application:(UIApplication*)application
+    performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
+  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    if ([plugin respondsToSelector:_cmd]) {
+      if ([plugin application:application
+              performFetchWithCompletionHandler:completionHandler]) {
+        return;
+      }
+    }
+  }
+}
+
 // TODO(xster): move when doing https://github.com/flutter/flutter/issues/3671.
 - (NSObject<FlutterBinaryMessenger>*)binaryMessenger {
   UIViewController* rootViewController = _window.rootViewController;

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -11,7 +11,7 @@
 @property(readonly, nonatomic) NSMutableDictionary* pluginPublications;
 @end
 
-@interface FlutterAppDelegateRegistrar : NSObject<FlutterPluginRegistrar>
+@interface FlutterAppDelegateRegistrar : NSObject <FlutterPluginRegistrar>
 - (instancetype)initWithPlugin:(NSString*)pluginKey appDelegate:(FlutterAppDelegate*)delegate;
 @end
 
@@ -211,13 +211,13 @@
 }
 
 - (void)application:(UIApplication*)application
-    handleEventsForBackgroundURLSession:(nonnull NSString *)identifier
-                completionHandler:(nonnull void (^)())completionHandler {
+    handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
+                      completionHandler:(nonnull void (^)())completionHandler {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
       if ([plugin application:application
               handleEventsForBackgroundURLSession:identifier
-                         completionHandler:completionHandler]) {
+                                completionHandler:completionHandler]) {
         return;
       }
     }
@@ -228,8 +228,7 @@
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
     if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
-              performFetchWithCompletionHandler:completionHandler]) {
+      if ([plugin application:application performFetchWithCompletionHandler:completionHandler]) {
         return;
       }
     }
@@ -312,11 +311,11 @@
 }
 
 - (NSString*)lookupKeyForAsset:(NSString*)asset {
-   return [FlutterDartProject lookupKeyForAsset:asset];
+  return [FlutterDartProject lookupKeyForAsset:asset];
 }
 
 - (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package {
-   return [FlutterDartProject lookupKeyForAsset:asset fromPackage:package];
+  return [FlutterDartProject lookupKeyForAsset:asset fromPackage:package];
 }
 
 @end


### PR DESCRIPTION
Added handleEventsForBackgroundURLSession and performFetchWithCompletionHandler handlers in FlutterAppDelegate to allow for plugins to perform background downloads and fetch small amounts of data opportunistically.