### PR TITLE
libtxt: post-process glyph positions in order to accurately right-justify text

### DIFF
--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -228,6 +228,8 @@ class Paragraph {
                   double x_advance,
                   size_t code_unit_index,
                   size_t code_unit_width);
+
+    void Shift(double delta);
   };
 
   struct GlyphLine {
@@ -298,7 +300,7 @@ class Paragraph {
 
   // Calculate the starting X offset of a line based on the line's width and
   // alignment.
-  double GetLineXOffset(size_t line);
+  double GetLineXOffset(size_t line_number, double line_total_advance);
 
   // Creates and draws the decorations onto the canvas.
   void PaintDecorations(SkCanvas* canvas, const PaintRecord& record);


### PR DESCRIPTION
Previously libtxt was applying right justification during line layout based on
the line width returned by the Minikin line breaker.  However, this width does
not include the width of leading or trailing whitespace.

So in a right justified line the starting offset of the first glyph would not
account for the advance of the leading whitespace, resulting in text being
clipped.

This PR applies line justification after the glyphs are laid out and the full
advance of the text is known.

Fixes https://github.com/flutter/flutter/issues/16333