### PR TITLE
Set file modified callback.

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -387,6 +387,8 @@ DartVM::DartVM(const Settings& settings,
 
   DartUI::InitForGlobal();
 
+  Dart_SetFileModifiedCallback(&DartFileModifiedCallback);
+
   {
     TRACE_EVENT0("flutter", "Dart_Initialize");
     Dart_InitializeParams params = {};


### PR DESCRIPTION
This fixes dart1 hot reload regression caused by 58e84c8bf.