### PR TITLE
add tooltip method to Android AccessibilityBridge

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -671,6 +671,11 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
             case "announce":
                 mOwner.announceForAccessibility((String) data.get("message"));
                 break;
+            case "tooltip": {
+                AccessibilityEvent e = obtainAccessibilityEvent(ROOT_NODE_ID, AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
+                e.getText().add((String) data.get("message"));
+                mOwner.getParent().requestSendAccessibilityEvent(mOwner, e);
+            }
             default:
                 assert false;
         }


### PR DESCRIPTION
This allows us to trigger a TYPE_WINDOW_STATE_CHANGED event to do a soft announce of tooltips.  Existing route semantics aren't desirable because this would lead to an extra announcement when the tooltip closes.

fixes https://github.com/flutter/flutter/issues/16943