### PR TITLE
Use interface handles for transferring ownership of channels across threads.

### DIFF
--- a/content_handler/accessibility_bridge.cc
+++ b/content_handler/accessibility_bridge.cc
@@ -13,8 +13,9 @@
 
 namespace flutter {
 
-AccessibilityBridge::AccessibilityBridge(modular::ContextWriterPtr writer)
-    : writer_(std::move(writer)) {}
+AccessibilityBridge::AccessibilityBridge(
+    fidl::InterfaceHandle<modular::ContextWriter> writer)
+    : writer_(writer.Bind()) {}
 
 AccessibilityBridge::~AccessibilityBridge() = default;
 

--- a/content_handler/accessibility_bridge.h
+++ b/content_handler/accessibility_bridge.h
@@ -17,7 +17,7 @@ namespace flutter {
 // with the Context Service.
 class AccessibilityBridge final {
  public:
-  AccessibilityBridge(modular::ContextWriterPtr writer);
+  AccessibilityBridge(fidl::InterfaceHandle<modular::ContextWriter> writer);
 
   ~AccessibilityBridge();
 

--- a/content_handler/compositor_context.cc
+++ b/content_handler/compositor_context.cc
@@ -56,13 +56,13 @@ class ScopedFrame final : public flow::CompositorContext::ScopedFrame {
 };
 
 CompositorContext::CompositorContext(
-    const ui::ScenicPtr& scenic,
+    fidl::InterfaceHandle<ui::Scenic> scenic,
     std::string debug_label,
     zx::eventpair import_token,
     OnMetricsUpdate session_metrics_did_change_callback,
     fxl::Closure session_error_callback)
     : debug_label_(std::move(debug_label)),
-      session_connection_(scenic,
+      session_connection_(std::move(scenic),
                           debug_label_,
                           std::move(import_token),
                           std::move(session_metrics_did_change_callback),

--- a/content_handler/compositor_context.h
+++ b/content_handler/compositor_context.h
@@ -16,7 +16,7 @@ namespace flutter {
 // Fuchsia.
 class CompositorContext final : public flow::CompositorContext {
  public:
-  CompositorContext(const ui::ScenicPtr& scenic,
+  CompositorContext(fidl::InterfaceHandle<ui::Scenic> scenic,
                     std::string debug_label,
                     zx::eventpair import_token,
                     OnMetricsUpdate session_metrics_did_change_callback,

--- a/content_handler/isolate_configurator.h
+++ b/content_handler/isolate_configurator.h
@@ -21,7 +21,7 @@ class IsolateConfigurator final : mozart::NativesDelegate {
  public:
   IsolateConfigurator(
       const UniqueFDIONS& fdio_ns,
-      views_v1::ViewPtr& view,
+      fidl::InterfaceHandle<views_v1::ViewContainer> view_container,
       component::ApplicationEnvironmentPtr application_environment,
       fidl::InterfaceRequest<component::ServiceProvider>
           outgoing_services_request);
@@ -35,12 +35,13 @@ class IsolateConfigurator final : mozart::NativesDelegate {
  private:
   bool used_ = false;
   const UniqueFDIONS& fdio_ns_;
-  views_v1::ViewPtr& view_;
+  fidl::InterfaceHandle<views_v1::ViewContainer> view_container_;
   component::ApplicationEnvironmentPtr application_environment_;
   fidl::InterfaceRequest<component::ServiceProvider> outgoing_services_request_;
 
   // |mozart::NativesDelegate|
-  views_v1::View* GetMozartView() override;
+  void OfferServiceProvider(fidl::InterfaceHandle<component::ServiceProvider>,
+                            fidl::VectorPtr<fidl::StringPtr> services);
 
   void BindFuchsia();
 

--- a/content_handler/platform_view.h
+++ b/content_handler/platform_view.h
@@ -28,16 +28,16 @@ class PlatformView final : public shell::PlatformView,
                            public input::InputMethodEditorClient,
                            public input::InputListener {
  public:
-  PlatformView(
-      PlatformView::Delegate& delegate,
-      std::string debug_label,
-      blink::TaskRunners task_runners,
-      component::ServiceProviderPtr parent_environment_service_provider,
-      views_v1::ViewManagerPtr& view_manager,
-      fidl::InterfaceRequest<views_v1_token::ViewOwner> view_owner,
-      ui::ScenicPtr scenic,
-      zx::eventpair export_token,
-      modular::ContextWriterPtr accessibility_context_writer);
+  PlatformView(PlatformView::Delegate& delegate,
+               std::string debug_label,
+               blink::TaskRunners task_runners,
+               fidl::InterfaceHandle<component::ServiceProvider>
+                   parent_environment_service_provider,
+               fidl::InterfaceHandle<views_v1::ViewManager> view_manager,
+               fidl::InterfaceRequest<views_v1_token::ViewOwner> view_owner,
+               zx::eventpair export_token,
+               fidl::InterfaceHandle<modular::ContextWriter>
+                   accessibility_context_writer);
 
   ~PlatformView();
 
@@ -55,7 +55,6 @@ class PlatformView final : public shell::PlatformView,
   fidl::Binding<input::InputMethodEditorClient> ime_client_;
   input::InputMethodEditorPtr ime_;
   modular::ClipboardPtr clipboard_;
-  ui::ScenicPtr scenic_;
   AccessibilityBridge accessibility_bridge_;
   std::unique_ptr<Surface> surface_;
   blink::LogicalMetrics metrics_;

--- a/content_handler/session_connection.cc
+++ b/content_handler/session_connection.cc
@@ -10,13 +10,14 @@
 namespace flutter {
 
 SessionConnection::SessionConnection(
-    const ui::ScenicPtr& scenic,
+    fidl::InterfaceHandle<ui::Scenic> scenic_handle,
     std::string debug_label,
     zx::eventpair import_token,
     OnMetricsUpdate session_metrics_did_change_callback,
     fxl::Closure session_error_callback)
     : debug_label_(std::move(debug_label)),
-      session_(scenic.get()),
+      scenic_(scenic_handle.Bind()),
+      session_(scenic_.get()),
       root_node_(&session_),
       surface_producer_(std::make_unique<VulkanSurfaceProducer>(&session_)),
       scene_update_context_(&session_, surface_producer_.get()),

--- a/content_handler/session_connection.h
+++ b/content_handler/session_connection.h
@@ -23,7 +23,7 @@ using OnMetricsUpdate = std::function<void(double /* device pixel ratio */)>;
 // maintaining the Scenic session connection and presenting node updates.
 class SessionConnection final {
  public:
-  SessionConnection(const ui::ScenicPtr& scenic,
+  SessionConnection(fidl::InterfaceHandle<ui::Scenic> scenic,
                     std::string debug_label,
                     zx::eventpair import_token,
                     OnMetricsUpdate session_metrics_did_change_callback,
@@ -47,6 +47,7 @@ class SessionConnection final {
 
  private:
   const std::string debug_label_;
+  ui::ScenicPtr scenic_;
   scenic_lib::Session session_;
   scenic_lib::ImportNode root_node_;
   std::unique_ptr<VulkanSurfaceProducer> surface_producer_;


### PR DESCRIPTION
* Scenic is used on the GPU thread and is owned by the session connection held by the rasterizer.
* The view container is used to initialize the mozart bindings on the UI thread.
* Accessibility bridge is used on the platform thread.

Needs a patch to Tonic to change the signature of `mozart::NativesDelegate`.
