### PR TITLE
Roll dart to cd0c4e4fe1e5b69ac15c0a670f9dde2ee9733fc7.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '8d4074175fb95cd4da810b4bf652a956449bac37',
+  'dart_revision': 'cd0c4e4fe1e5b69ac15c0a670f9dde2ee9733fc7',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -47,7 +47,7 @@ vars = {
   'dart_crypto_tag': '2.0.2+1',
   'dart_csslib_tag': '0.14.1',
   'dart_dart2js_info_tag': '0.5.6+2',
-  'dart_dart_style_tag': '1.0.10',
+  'dart_dart_style_tag': '1.0.11',
   'dart_dartdoc_tag': 'v0.18.1',
   'dart_fixnum_tag': '0.10.5',
   'dart_glob_tag': '1.1.5',
@@ -74,7 +74,7 @@ vars = {
   'dart_plugin_tag': '0.2.0+2',
   'dart_pool_tag': '1.3.4',
   'dart_protobuf_tag': '0.7.1',
-  'dart_pub_rev': '4947e0b3cb3ec77e4e8fe0d3141ce4dc60f43256',
+  'dart_pub_rev': '2e821bff00c00889afe5200e3a33f280ce942336',
   'dart_pub_semver_tag': '1.3.7',
   'dart_quiver_tag': '5aaa3f58c48608af5b027444d561270b53f15dbf',
   'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 5433171f523e5dae35d19cc125a1f099
+Signature: 73c6433a75e1b3fcb7afbe95d40895a4
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Changes since last roll:

```
cd0c4e4fe1 Kernel service just returns errors. Leaves printing to the VM.
010d8144bc Add missing copyright notice
70547d8197 Change linter subscriptions from functions to AstVisitor(s).
88a098c71c Improve fasta parser field name recovery
bd76221d58 fix #31489, JS interop to `prototype` getter in dartdevk
ca419a9251 dart2js status refresh
da49615c2c Don't filter out references to constructors.
cc968df178 [test] Fix analyzer warning in the recently added test
1c5d1a56e7 Clean up some hints
5a9a479a73 Fix #32966 too little stack overflow context to be useful
2786b9ff43 [vm/aot] Add detailed error messages and stack traces for null checks
fbfe5691cb Change completionTarget.forOffset to accept & wrap dangling AstNodes.
cb15b43c32 Add support for getting parse results synchronously
e0ddab3c4c Fix bots after preview-dart2 was switched on by default.
88099ffcc3 Stop importing front_end into analyzer_plugin.
115850ca1d Revert "Clean up the use of deprecated API in the analyzer_plugin package"
f95df2a26b [dartfmt] Bump dart:style to 1.0.11
c97d36c127 Add all concrete AST nodes for lints to subscribe.
1afe71c08a Enable preview-dart-2 as default for analyzer.
45e390003f [kernel] Report error for dangling node reference in metadata
c1c90358a2 Record a missing file offset
16be5d1e33 [VM] Fix missing update of off-heap class sizes
c8ad75d44a [VM] Make classes movable in sliding compactor
c59b390806 Update status
93511d523c Track RTI for noSuchMethod
f6db874416 fix some dartdevk behavior to match dartdevc in more cases
c0015fe23f [gardening] Skip tests that are meaningless in AOT configuration.
9f7a247c33 Remove dangling pubspec.lock from pkg/dev_compiler/test/
004ee9cd12 Fix how we use Comparable.compare, so we have a function with the appropriate type in JSArray.sort
30b53ceaab fix #30852, cyclic init errors in some cases in dartdevc
94f45c8876 Bring in the latest pub
328163bba9 [kernel] CloneVisitor should preserve isDefault on switch cases.
613c6d066c [vm][windows] Implement VirtualMemory::FreeSubSegment
7c6594c0bd fix #32302, friendlier `Type.toString()` in dartdevc
e7848a8cda [vm/kernel] Avoid dangling references to DartTypes from constant pool
d47203a71b Fix a crash in type inference
1030189d56 Add NodeLintRule and UnitLintRule that replace AstVisitor in lints.
9e9b50d19d Improve error messages for annotations involving undefined names (issue 27788)
d7ff30c3e1 Add a missing call to greatestClosure
c844011647 Don't skip pkg/kernel/test/metadata_test
```