### PR TITLE
In case of empty Dart data responses, don’t call the buffer method on null.

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -729,7 +729,7 @@ class Window {
     final Zone registrationZone = Zone.current;
 
     return (Uint8List data) {
-      registrationZone.runUnaryGuarded(callback, data.buffer.asByteData());
+      registrationZone.runUnaryGuarded(callback, data != null ? data.buffer.asByteData() : null);
     };
   }
 }


### PR DESCRIPTION
Fixes regression introduced in https://github.com/flutter/engine/pull/5101.