### PR TITLE
Revert "Hold a global reference to the AssetManager Java object backi…

### DIFF
--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -10,8 +10,7 @@ namespace blink {
 APKAssetProvider::APKAssetProvider(JNIEnv* env,
                                    jobject jassetManager,
                                    std::string directory)
-    : java_asset_manager_(env, jassetManager),
-      directory_(std::move(directory)) {
+    : directory_(std::move(directory)) {
   assetManager_ = AAssetManager_fromJava(env, jassetManager);
 }
 

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -9,7 +9,6 @@
 #include <jni.h>
 
 #include "flutter/assets/asset_resolver.h"
-#include "flutter/fml/platform/android/scoped_java_ref.h"
 #include "lib/fxl/memory/ref_counted.h"
 
 namespace blink {
@@ -22,7 +21,6 @@ class APKAssetProvider final : public AssetResolver {
   virtual ~APKAssetProvider();
 
  private:
-  fml::jni::ScopedJavaGlobalRef<jobject> java_asset_manager_;
   AAssetManager* assetManager_;
   const std::string directory_;
 


### PR DESCRIPTION
…ng the APKAssetProvider (#5078)"

This reverts commit ac682632d7b050463e0461cbb416aaedbcba4bcf.

It causes engine crashes in some Android Espresso tests.