### PR TITLE
Increase the Android GPU thread priority and add error logging

### DIFF
--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -74,9 +74,24 @@ AndroidShellHolder::AndroidShellHolder(
 
   if (is_valid_) {
     task_runners.GetGPUTaskRunner()->PostTask(
-        []() { ::setpriority(PRIO_PROCESS, gettid(), -2); });
+        []() {
+          // Android describes -8 as "most important display threads, for
+          // compositing the screen and retrieving input events". Conservatively
+          // set the GPU thread to slightly lower priority than it.
+          if (::setpriority(PRIO_PROCESS, gettid(), -5) != 0) {
+            // Defensive fallback. Depending on the OEM, it may not be possible
+            // to set priority to -5.
+            if (::setpriority(PRIO_PROCESS, gettid(), -2) != 0) {
+              FXL_LOG(ERROR) << "Failed to set GPU task runner priority";
+            }
+          }
+        });
     task_runners.GetUITaskRunner()->PostTask(
-        []() { ::setpriority(PRIO_PROCESS, gettid(), -1); });
+        []() {
+          if (::setpriority(PRIO_PROCESS, gettid(), -1) != 0) {
+            FXL_LOG(ERROR) << "Failed to set UI task runner priority";
+          }
+        });
   }
 }
 


### PR DESCRIPTION
Confirmed that it worked via `adb shell ps -t -p`
```
u0_a74    12585 214   1373468 208748 20    0     0     0     sys_epoll_ 00000000 S io.flutter.demo.gallery
u0_a74    12590 12585 1373468 208748 20    0     0     0     do_sigtime 00000000 S Signal Catcher
u0_a74    12591 12585 1373468 208748 20    0     0     0     unix_strea 00000000 S JDWP
u0_a74    12592 12585 1373468 208748 20    0     0     0     futex_wait 00000000 S ReferenceQueueD
u0_a74    12593 12585 1373468 208748 20    0     0     0     futex_wait 00000000 S FinalizerDaemon
u0_a74    12594 12585 1373468 208748 20    0     0     0     futex_wait 00000000 S FinalizerWatchd
u0_a74    12595 12585 1373468 208748 20    0     0     0     futex_wait 00000000 S HeapTaskDaemon
u0_a74    12596 12585 1373468 208748 20    0     0     0     binder_thr 00000000 S Binder_1
u0_a74    12597 12585 1373468 208748 20    0     0     0     binder_thr 00000000 S Binder_2
u0_a74    12598 12585 1373468 208748 30    10    0     0     futex_wait 00000000 S AsyncTask #1
u0_a74    12599 12585 1373468 208748 19    -1    0     0     sys_epoll_ 00000000 S 1.ui
u0_a74    12600 12585 1373468 208748 15    -5    0     0     sys_epoll_ 00000000 S 1.gpu
u0_a74    12601 12585 1373468 208748 20    0     0     0     sys_epoll_ 00000000 S 1.io
u0_a74    12602 12585 1373468 208748 20    0     0     0     sys_epoll_ 00000000 S er.demo.gallery
u0_a74    12603 12585 1373468 208748 20    0     0     0     futex_wait 00000000 S er.demo.gallery
u0_a74    12621 12585 1373468 208748 16    -4    0     0     sys_epoll_ 00000000 S RenderThread
u0_a74    12622 12585 1373468 208748 10    -10   0     0     futex_wait 00000000 S GL updater
u0_a74    12623 12585 1373468 208748 10    -10   0     0     futex_wait 00000000 S GL updater
u0_a74    12650 12585 1373468 208748 20    0     0     0     futex_wait 00000000 S er.demo.gallery
u0_a74    12706 12585 1373468 208748 15    -5    0     0     futex_wait 00000000 S 1.gpu
```