### PR TITLE
Detach from JNI during shutdown of the UI thread on Android

### DIFF
--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -50,6 +50,9 @@ class AndroidShellHolder {
   ThreadHost thread_host_;
   std::unique_ptr<Shell> shell_;
   bool is_valid_ = false;
+  pthread_key_t thread_destruct_key_;
+
+  static void ThreadDestructCallback(void* value);
 
   FXL_DISALLOW_COPY_AND_ASSIGN(AndroidShellHolder);
 };


### PR DESCRIPTION
The APKAssetProvider will hold a reference to its Java peer
(see https://github.com/flutter/engine/commit/ac682632d7b050463e0461cbb416aaedbcba4bcf)

After dropping this reference, the UI thread must detach from JNI before exiting.