### PR TITLE
Log errors on common interface channels and use interface handles for IsolateConfigurator.

### DIFF
--- a/content_handler/isolate_configurator.cc
+++ b/content_handler/isolate_configurator.cc
@@ -17,7 +17,8 @@ namespace flutter {
 IsolateConfigurator::IsolateConfigurator(
     const UniqueFDIONS& fdio_ns,
     fidl::InterfaceHandle<views_v1::ViewContainer> view_container,
-    component::ApplicationEnvironmentPtr application_environment,
+    fidl::InterfaceHandle<component::ApplicationEnvironment>
+        application_environment,
     fidl::InterfaceRequest<component::ServiceProvider>
         outgoing_services_request)
     : fdio_ns_(fdio_ns),
@@ -51,7 +52,7 @@ void IsolateConfigurator::OfferServiceProvider(
 }
 
 void IsolateConfigurator::BindFuchsia() {
-  fuchsia::dart::Initialize(application_environment_.Unbind(),
+  fuchsia::dart::Initialize(std::move(application_environment_),
                             std::move(outgoing_services_request_));
 }
 

--- a/content_handler/isolate_configurator.h
+++ b/content_handler/isolate_configurator.h
@@ -22,7 +22,8 @@ class IsolateConfigurator final : mozart::NativesDelegate {
   IsolateConfigurator(
       const UniqueFDIONS& fdio_ns,
       fidl::InterfaceHandle<views_v1::ViewContainer> view_container,
-      component::ApplicationEnvironmentPtr application_environment,
+      fidl::InterfaceHandle<component::ApplicationEnvironment>
+          application_environment,
       fidl::InterfaceRequest<component::ServiceProvider>
           outgoing_services_request);
 
@@ -36,7 +37,8 @@ class IsolateConfigurator final : mozart::NativesDelegate {
   bool used_ = false;
   const UniqueFDIONS& fdio_ns_;
   fidl::InterfaceHandle<views_v1::ViewContainer> view_container_;
-  component::ApplicationEnvironmentPtr application_environment_;
+  fidl::InterfaceHandle<component::ApplicationEnvironment>
+      application_environment_;
   fidl::InterfaceRequest<component::ServiceProvider> outgoing_services_request_;
 
   // |mozart::NativesDelegate|

--- a/content_handler/platform_view.cc
+++ b/content_handler/platform_view.cc
@@ -20,6 +20,13 @@ constexpr char kFlutterPlatformChannel[] = "flutter/platform";
 constexpr char kTextInputChannel[] = "flutter/textinput";
 constexpr char kKeyEventChannel[] = "flutter/keyevent";
 
+template <class T>
+void SetInterfaceErrorHandler(fidl::InterfacePtr<T>& interface,
+                              std::string name) {
+  interface.set_error_handler(
+      [name]() { FXL_DLOG(ERROR) << "Interface error on: " << name; });
+}
+
 PlatformView::PlatformView(
     PlatformView::Delegate& delegate,
     std::string debug_label,
@@ -32,36 +39,44 @@ PlatformView::PlatformView(
     fidl::InterfaceHandle<modular::ContextWriter> accessibility_context_writer)
     : shell::PlatformView(delegate, std::move(task_runners)),
       debug_label_(std::move(debug_label)),
+      view_manager_(view_manager_handle.Bind()),
       view_listener_(this),
       input_listener_(this),
       ime_client_(this),
       accessibility_bridge_(std::move(accessibility_context_writer)),
       surface_(std::make_unique<Surface>(debug_label_)) {
-  auto view_manager = view_manager_handle.Bind();
+  // Register all error handlers.
+  SetInterfaceErrorHandler(view_manager_, "View Manager");
+  SetInterfaceErrorHandler(view_, "View");
+  SetInterfaceErrorHandler(input_connection_, "Input Connection");
+  SetInterfaceErrorHandler(ime_, "Input Method Editor");
+  SetInterfaceErrorHandler(clipboard_, "Clipboard");
+  SetInterfaceErrorHandler(service_provider_, "Service Provider");
+  SetInterfaceErrorHandler(parent_environment_service_provider_,
+                           "Parent Environment Service Provider");
 
   // Create the view.
-  view_manager->CreateView(view_.NewRequest(),           // view
-                           std::move(view_owner),        // view owner
-                           view_listener_.NewBinding(),  // view listener
-                           std::move(export_token),      // export token
-                           debug_label_                  // diagnostic label
+  view_manager_->CreateView(view_.NewRequest(),           // view
+                            std::move(view_owner),        // view owner
+                            view_listener_.NewBinding(),  // view listener
+                            std::move(export_token),      // export token
+                            debug_label_                  // diagnostic label
   );
 
   // Get the services from the created view.
-  component::ServiceProviderPtr service_provider;
-  view_->GetServiceProvider(service_provider.NewRequest());
+  view_->GetServiceProvider(service_provider_.NewRequest());
 
   // Get the input connection from the services of the view.
-  component::ConnectToService(service_provider.get(),
+  component::ConnectToService(service_provider_.get(),
                               input_connection_.NewRequest());
 
   // Set the input listener on the input connection.
   input_connection_->SetEventListener(input_listener_.NewBinding());
 
   // Access the clipboard.
-  auto parent_environment_service_provider =
+  parent_environment_service_provider_ =
       parent_environment_service_provider_handle.Bind();
-  component::ConnectToService(parent_environment_service_provider.get(),
+  component::ConnectToService(parent_environment_service_provider_.get(),
                               clipboard_.NewRequest());
 
   // Finally! Register the native platform message handlers.

--- a/content_handler/platform_view.h
+++ b/content_handler/platform_view.h
@@ -47,13 +47,16 @@ class PlatformView final : public shell::PlatformView,
 
  private:
   const std::string debug_label_;
+  views_v1::ViewManagerPtr view_manager_;
   views_v1::ViewPtr view_;
+  component::ServiceProviderPtr service_provider_;
   fidl::Binding<views_v1::ViewListener> view_listener_;
   input::InputConnectionPtr input_connection_;
   fidl::Binding<input::InputListener> input_listener_;
   int current_text_input_client_ = 0;
   fidl::Binding<input::InputMethodEditorClient> ime_client_;
   input::InputMethodEditorPtr ime_;
+  component::ServiceProviderPtr parent_environment_service_provider_;
   modular::ClipboardPtr clipboard_;
   AccessibilityBridge accessibility_bridge_;
   std::unique_ptr<Surface> surface_;


### PR DESCRIPTION
It is not clear what the error recovery mechanism should be. I was running into errors on the clipboard channel which I dont think should be fatal, but the the view manager connection errors are more serious. At least we wont silently ignore such errors. Will devise a better strategy later.