### PR TITLE
Build the entry_points_json_files in debug mode as well

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -17,9 +17,7 @@ group("flutter") {
     public_deps += [ "$flutter_root/shell/testing" ]
   }
 
-  if (flutter_runtime_mode != "debug") {
-    public_deps += [ "$flutter_root/lib/snapshot:entry_points_json_files" ]
-  }
+  public_deps += [ "$flutter_root/lib/snapshot:entry_points_json_files" ]
 
   if (!is_fuchsia && !is_fuchsia_host) {
     if (current_toolchain == host_toolchain) {


### PR DESCRIPTION
The "flutter build apk/aot" command accepts all three modes (--debug,
--profile, --release). This implies we need the entry_points_json_files
target also in "debug" mode (currently the build fails with an exception).