### PR TITLE
Roll dart to b298fc6d8f6a0e1aa841dbbdda26663d6012a79a.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'b298fc6d8f6a0e1aa841dbbdda26663d6012a79a',
+  'dart_revision': '4c9b71205262699764c5db74e95bc9e702451f4e',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -48,7 +48,7 @@ vars = {
   'dart_csslib_tag': '0.14.1',
   'dart_dart2js_info_tag': '0.5.6+2',
   'dart_dart_style_tag': '1.0.12',
-  'dart_dartdoc_tag': 'v0.18.1',
+  'dart_dartdoc_tag': 'v0.19.0',
   'dart_fixnum_tag': '0.10.5',
   'dart_glob_tag': '1.1.5',
   'dart_html_tag': '0.13.3',
@@ -65,7 +65,7 @@ vars = {
   'dart_matcher_tag': '0.12.1+4',
   'dart_mime_tag': '0.9.6',
   'dart_mockito_tag': 'a92db054fba18bc2d605be7670aee74b7cadc00a',
-  'dart_mustache4dart_tag': 'v2.1.0',
+  'dart_mustache4dart_tag': 'v2.1.1',
   'dart_oauth2_tag': '1.1.0',
   'dart_observatory_pub_packages_rev': 'd3a3aebefbd35aa30fe7bbc2889b772b398f7d7f',
   'dart_package_config_tag': '1.0.3',

--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '011676641a8b4b77bb372384c712709cbf037675',
+  'dart_revision': 'b298fc6d8f6a0e1aa841dbbdda26663d6012a79a',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -47,7 +47,7 @@ vars = {
   'dart_crypto_tag': '2.0.2+1',
   'dart_csslib_tag': '0.14.1',
   'dart_dart2js_info_tag': '0.5.6+2',
-  'dart_dart_style_tag': '1.0.11',
+  'dart_dart_style_tag': '1.0.12',
   'dart_dartdoc_tag': 'v0.18.1',
   'dart_fixnum_tag': '0.10.5',
   'dart_glob_tag': '1.1.5',

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -409,7 +409,10 @@ bool DartIsolate::MarkIsolateRunnable() {
   // There must be no current isolate to mark an isolate as being runnable.
   Dart_ExitIsolate();
 
-  if (!Dart_IsolateMakeRunnable(isolate())) {
+  char* error = Dart_IsolateMakeRunnable(isolate());
+  if (error) {
+    FXL_DLOG(ERROR) << error;
+    ::free(error);
     // Failed. Restore the isolate.
     Dart_EnterIsolate(isolate());
     return false;

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -137,11 +137,10 @@ bool DartServiceIsolate::Startup(std::string server_ip,
   // Make runnable.
   Dart_ExitScope();
   Dart_ExitIsolate();
-  bool retval = Dart_IsolateMakeRunnable(isolate);
-  if (!retval) {
+  *error = Dart_IsolateMakeRunnable(isolate);
+  if (*error) {
     Dart_EnterIsolate(isolate);
     Dart_ShutdownIsolate();
-    *error = strdup("Invalid isolate state - Unable to make it runnable.");
     return false;
   }
   Dart_EnterIsolate(isolate);

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -383,7 +383,11 @@ DartVM::DartVM(const Settings& settings,
   for (size_t i = 0; i < settings.dart_flags.size(); i++)
     args.push_back(settings.dart_flags[i].c_str());
 
-  FXL_CHECK(Dart_SetVMFlags(args.size(), args.data()));
+  char* flags_error = Dart_SetVMFlags(args.size(), args.data());
+  if (flags_error) {
+    FXL_LOG(FATAL) << "Error while setting Dart VM flags: " << flags_error;
+    ::free(flags_error);
+  }
 
   DartUI::InitForGlobal();
 

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 759192b81fc370d3de4de0d021329916
+Signature: 0bb9afe000319cd63fc59230bab57873
 
 UNUSED LICENSES:
 
@@ -5663,7 +5663,6 @@ FILE: ../../../third_party/dart/runtime/bin/vmservice/server.dart
 FILE: ../../../third_party/dart/runtime/bin/vmservice/vmservice_io.dart
 FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.cc
 FILE: ../../../third_party/dart/runtime/bin/vmservice_impl.h
-FILE: ../../../third_party/dart/runtime/include/dart_mirrors_api.h
 FILE: ../../../third_party/dart/runtime/include/dart_native_api.h
 FILE: ../../../third_party/dart/runtime/lib/collection_patch.dart
 FILE: ../../../third_party/dart/runtime/lib/core_patch.dart
@@ -5800,7 +5799,6 @@ FILE: ../../../third_party/dart/runtime/vm/isolate.cc
 FILE: ../../../third_party/dart/runtime/vm/isolate.h
 FILE: ../../../third_party/dart/runtime/vm/json_stream.cc
 FILE: ../../../third_party/dart/runtime/vm/json_stream.h
-FILE: ../../../third_party/dart/runtime/vm/mirrors_api_impl.cc
 FILE: ../../../third_party/dart/runtime/vm/native_api_impl.cc
 FILE: ../../../third_party/dart/runtime/vm/native_symbol.h
 FILE: ../../../third_party/dart/runtime/vm/native_symbol_android.cc


### PR DESCRIPTION
Changes since last roll:
```
4c9b712052 Revert "Don't encode strings up front; don't toString uris"
a1fbf62742 [build] Place 'extern "C"' before __attribute__, as required by gcc.
258c5172df [vm] Remove dart_mirrors_api.h.
384c55c29e Update dartdoc & dependencies to v0.19.0.
b298fc6d8f Revert "[kernel] Change dill representation of doubles"
9a7e1f64a2 Revert "Revert "Fix incorrect handling of NSM forwarders and pull all logic into CFE.""
cbca4006f8 fix #30907, add library constants for all SDK libraries
61c226b4ea Only create Goma's analyzer on Linux.
24dd9b4176 Revert "Fix incorrect handling of NSM forwarders and pull all logic into CFE."
bed71b7776 Migrate and clean up the prefix negative tests.
1fcd896ed9 [VM] Avoid deadlock by allowing us to run kernel isolate from a script snapshot, fixes all dartk-sim* builders
0bc6e7217a Update expression compilation expectations.
9038b8f45f CFE support for compiling individual expressions in a context.
7d5025e814 Fix incorrect handling of NSM forwarders and pull all logic into CFE.
e2247e5e00 Put the '@' outside the revision variables.
9381424204 Fix presubmit on Windows. Dart executable is not called .bat
2a8c3515b2 Avoid strong+checked mode: strong mode supersedes checked mode
b7698dcbce Update status for Windows
8baa82413b [infra] Remove --no-preview-dart-2 flag from gardening tools
47e9039512 Don't encode strings up front; don't toString uris
4a0ac85cc3 Update co19 status
ce7329849d Fix build breakages - use platform independent path specification is test so that   it works on windows - skip test for precompiled and dartk builds as the test uses   spawnUri which is not supported in these modes
ee6351a147 [VM] Set up package config value when invoking the front end for compilation, this should fix issue 32950 "(Isolate.spawnUri() ignores packageConfig argument in Dart 2 mode.'
d1286a367e Strong mode update for swarm
fd27cc3435 Don't store bytes in the file cache.
73abd61304 Re-land "Clean up the use of deprecated API in the analyzer_plugin package".
607f4f5769 [vm] Get more helpful errors from Dart_SetVMFlags and Dart_MakeIsolateRunnable.
f044637c8b [infra] Upgrade checked in SDKs to 2.0.0-dev.52.0
dcf10816aa [infra] Add script that updates checked in SDKs
f8bea2a7e6 dart2js: Register inlined native methods for dump info
7fe8659613 dump-info: Use relative paths for library canonicalUri...
dcf4886500 [frontend-server] Add verbose option.
5087ffa481 [release] Move DDC sync-async flip to correct section in the release notes
fe7056ebaa [release] Update changelog for 2.0.0-dev.52.0
```