### PR TITLE
libtxt: in GetRectsForRange, add placeholders only for newline characters

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1045,8 +1045,7 @@ std::vector<Paragraph::TextBox> Paragraph::GetRectsForRange(size_t start,
         SkRect::MakeLTRB(left, top, right, bottom), run.direction);
   }
 
-  // Add empty rectangles representing any line within the range that did not
-  // render any glyphs.
+  // Add empty rectangles representing any newline characters within the range.
   for (size_t line_number = 0; line_number < line_ranges_.size(); ++line_number) {
     const LineRange& line = line_ranges_[line_number];
     if (line.start >= end)
@@ -1054,14 +1053,14 @@ std::vector<Paragraph::TextBox> Paragraph::GetRectsForRange(size_t start,
     if (line.end_including_newline <= start)
       continue;
     if (line_boxes.find(line_number) == line_boxes.end()) {
-      // If the range starts after the beginning of this line, then place the
-      // rectangle at the end of the line's width.  This is intended to
-      // handle ranges encompassing the newline character at the end of a line.
-      SkScalar x = (start > line.start) ? line_widths_[line_number] : 0;
-      SkScalar top = (line_number > 0) ? line_heights_[line_number - 1] : 0;
-      SkScalar bottom = line_heights_[line_number];
-      line_boxes[line_number].emplace_back(
-          SkRect::MakeLTRB(x, top, x, bottom), TextDirection::ltr);
+      if (line.end != line.end_including_newline &&
+          line.end >= start && line.end_including_newline <= end) {
+        SkScalar x = line_widths_[line_number];
+        SkScalar top = (line_number > 0) ? line_heights_[line_number - 1] : 0;
+        SkScalar bottom = line_heights_[line_number];
+        line_boxes[line_number].emplace_back(
+            SkRect::MakeLTRB(x, top, x, bottom), TextDirection::ltr);
+      }
     }
   }
 


### PR DESCRIPTION
If the range passed to GetRectsForRange includes a newline character, then
the framework expects to see a rectangle representing the newline so it knows
where to position the cursor at the end of the line.

If the range covers other non-printing characters but not the newline, then
GetRectsForRange should not produce a rectangle for the line.