### PR TITLE
Roll dart to 2765fcf2aecd3841d082fedaeafc00a73a965f8c.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '4c9b71205262699764c5db74e95bc9e702451f4e',
+  'dart_revision': '2765fcf2aecd3841d082fedaeafc00a73a965f8c',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 57bfee000ae8dd1b3e18e0ce5be64a62
+Signature: 2ea54a158c7d339350e9373e9c57bdec
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
This picks up revert to NSM handling. Changes since last roll:
```
2765fcf2ae Revert "Revert "Revert "Fix incorrect handling of NSM forwarders and pull all logic into CFE."""
c129fde29a [frontend-server] Add a test for dep-file generation.
f64ba0cadd Add @isTest and @isTestGroup to package:meta
3fcb85a545 Update passing test in status file.
05a7b6e05f Add some status entries for crashing tests related to issue https://github.com/dart-lang/sdk/issues/33029
4b1180a39d [VM] When --preview-dart-2 option is specified make the options '--snapshot_kind=script --snapshot=xyz' produce a kernel dill file which is the equivalent of a script snapshot in Dart2 world.
384a59595c Recognize synthetic catch-clause and unhandled exceptions.
c448d35ee5 Update prefix test statuses on analyzer.
```