### PR TITLE
Roll dart sdk to e6d7d67f4b35556805dd083fed15bf3ed41f7e33.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '2765fcf2aecd3841d082fedaeafc00a73a965f8c',
+  'dart_revision': 'e6d7d67f4b35556805dd083fed15bf3ed41f7e33',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("$flutter_root/lib/ui/dart_ui.gni")
+import("//build/compiled_action.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 import("//third_party/dart/utils/generate_entry_points_json.gni")
 
@@ -255,6 +256,53 @@ group("kernel_platform_files") {
     ":non_strong_platform",
     ":strong_platform",
   ]
+}
+
+# Template to generate entry points JSON file using gen_snapshot tool.
+# List of entry points is generated as a by-product while doing precompilation.
+#
+# This template expects the following arguments:
+#  - input: Name of the input dart script for precompilation.
+#  - output: Name of the output entry points JSON file.
+#  - extra_args: Extra arguments to pass to dart_bootstrap (optional).
+#  - extra_inputs: Extra input dependencies (optional).
+#
+template("generate_entry_points_json_with_gen_snapshot") {
+  assert(defined(invoker.input), "Must define input dart script")
+  assert(defined(invoker.output), "Must define output json file")
+  extra_args = []
+  if (defined(invoker.extra_args)) {
+    extra_args += invoker.extra_args
+  }
+  extra_inputs = []
+  if (defined(invoker.extra_inputs)) {
+    extra_inputs += invoker.extra_inputs
+  }
+  compiled_action(target_name) {
+    # Printing precompiler entry points is folded into precompilation, so gen_snapshot is invoked
+    # with correct arguments to generate app-aot snapshot.
+
+    input = invoker.input
+    output = invoker.output
+
+    tool = "//third_party/dart/runtime/bin:gen_snapshot"
+    inputs = [
+      input,
+    ] + extra_inputs
+    outputs = [
+      output,
+    ]
+    args = [
+      "--print-precompiler-entry-points=" + rebase_path(output),
+      "--snapshot-kind=app-aot-blobs",
+      "--vm_snapshot_data=" + rebase_path("$target_gen_dir/dummy.vm_data.snapshot"),
+      "--vm_snapshot_instructions=" + rebase_path("$target_gen_dir/dummy.vm_instr.snapshot"),
+      "--isolate_snapshot_data=" + rebase_path("$target_gen_dir/dummy.isolate_data.snapshot"),
+      "--isolate_snapshot_instructions=" + rebase_path("$target_gen_dir/dummy.isolate_instr.snapshot"),
+    ] + extra_args + [
+      rebase_path(input),
+    ]
+  }
 }
 
 generate_entry_points_json_with_gen_snapshot("entry_points_json") {

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: f8b0fa85dcfda661056db3508100fa23
+Signature: 77a39e3d3c589aa9c295c23e102794e6
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Changes since last dart roll:

```
e6d7d67f4b Revert 4f18af12c7c6d53f02cf32cb9b5ea848b86e1d77 as it causes test breakages.
4877587346 [GN] Uses dart_action.gni instead of compiled_action.gni.
4b89ba24fb Meta CHANGELOG markdown cleanup.
3d688deba7 Bump analysis server version to 1.20.2
0dc81ae4eb Publish package:meta 1.1.5
7e54844fe7 [vm] Fix build for gcc 7.3.0.
9d10a6ad4a Issue 33034. Fix statement completion with missing condition right parenthesis.
3fd2d5fb05 [vm] Use compiler warnings to insist callers check for errors from Dart_Invoke*/Load*/Compile*.
afb490adbc [dart:io] Provide modern Dart-styled constants
2929b71aa2 [kernel/vm] Address follow-up review comments for bytecode generation
73768a5342 General TypeInfo and IdentifierContext cleanup
e93b2ee250 Improve typedef identifier recovery
46a9ed0617 Added example about calling a tear-off with a wrong-shape argument list
0c839cf3f8 [fasta] Add 'as' expressions to the Forest API
16f6ce2fee [release] Prepare changelog for 2.0.0-dev.53.0
d13bf49870 Check type-variable bounds on generic methods
794fe1e14f Add stacktrace tests for synchronous async
fb779df11c [frontend-server] Disable depfile test on Windows.
```