### PR TITLE
Use a view container handle instead of a reference to the view interface ptr when configuring an isolate.

### DIFF
--- a/content_handler/engine.cc
+++ b/content_handler/engine.cc
@@ -173,14 +173,14 @@ Engine::Engine(Delegate& delegate,
   // Shell has been created. Before we run the engine, setup the isolate
   // configurator.
   {
-    PlatformView* platform_view =
-        static_cast<PlatformView*>(shell_->GetPlatformView().get());
-    auto& view = platform_view->GetMozartView();
-    fidl::InterfaceHandle<views_v1::ViewContainer> view_container;
-    view->GetContainer(view_container.NewRequest());
+    auto view_container =
+        static_cast<PlatformView*>(shell_->GetPlatformView().get())
+            ->TakeViewContainer();
+
     component::ApplicationEnvironmentPtr application_environment;
     application_context.ConnectToEnvironmentService(
         application_environment.NewRequest());
+
     isolate_configurator_ = std::make_unique<IsolateConfigurator>(
         std::move(fdio_ns),                   //
         std::move(view_container),            //

--- a/content_handler/platform_view.cc
+++ b/content_handler/platform_view.cc
@@ -66,6 +66,10 @@ PlatformView::PlatformView(
   // Get the services from the created view.
   view_->GetServiceProvider(service_provider_.NewRequest());
 
+  // Get the view conatiner. This will need to be returned to the isolate
+  // configurator so that it can setup Mozart bindings later.
+  view_->GetContainer(view_container_.NewRequest());
+
   // Get the input connection from the services of the view.
   component::ConnectToService(service_provider_.get(),
                               input_connection_.NewRequest());
@@ -96,9 +100,9 @@ void PlatformView::RegisterPlatformMessageHandlers() {
                 std::placeholders::_1);
 }
 
-views_v1::ViewPtr& PlatformView::GetMozartView() {
-  FXL_DCHECK(view_.is_bound());
-  return view_;
+fidl::InterfaceHandle<views_v1::ViewContainer>
+PlatformView::TakeViewContainer() {
+  return std::move(view_container_);
 }
 
 // |views_v1::ViewListener|

--- a/content_handler/platform_view.h
+++ b/content_handler/platform_view.h
@@ -43,12 +43,13 @@ class PlatformView final : public shell::PlatformView,
 
   void UpdateViewportMetrics(double pixel_ratio);
 
-  views_v1::ViewPtr& GetMozartView();
+  fidl::InterfaceHandle<views_v1::ViewContainer> TakeViewContainer();
 
  private:
   const std::string debug_label_;
   views_v1::ViewManagerPtr view_manager_;
   views_v1::ViewPtr view_;
+  fidl::InterfaceHandle<views_v1::ViewContainer> view_container_;
   component::ServiceProviderPtr service_provider_;
   fidl::Binding<views_v1::ViewListener> view_listener_;
   input::InputConnectionPtr input_connection_;


### PR DESCRIPTION
In case any of the connections in the platform view constructor are closed, additional calls in on the view ptr wont manifest as channel error.