### PR TITLE
Create a job hierarchy with each Flutter application instance getting a child job.

### DIFF
--- a/content_handler/application.h
+++ b/content_handler/application.h
@@ -11,6 +11,7 @@
 #include <fuchsia/cpp/component.h>
 #include <fuchsia/cpp/views_v1.h>
 #include <fuchsia/cpp/views_v1_token.h>
+#include <zx/job.h>
 
 #include "engine.h"
 #include "flutter/common/settings.h"
@@ -41,6 +42,7 @@ class Application final : public Engine::Delegate,
   // This is a synchronous operation.
   static std::pair<std::unique_ptr<fsl::Thread>, std::unique_ptr<Application>>
   Create(Application::Delegate& delegate,
+         const zx::job& parent_job,
          component::ApplicationPackage package,
          component::ApplicationStartupInfo startup_info,
          fidl::InterfaceRequest<component::ApplicationController> controller);
@@ -49,12 +51,17 @@ class Application final : public Engine::Delegate,
   // may be collected after.
   ~Application();
 
+  static zx::job CreateDebugJobWithLabel(
+      const std::string& debug_label,
+      const zx::job& parent_job = zx::job::default_job());
+
   const std::string& GetDebugLabel() const;
 
  private:
   blink::Settings settings_;
   Delegate& delegate_;
   const std::string debug_label_;
+  zx::job debug_job_;
   UniqueFDIONS fdio_ns_ = UniqueFDIONSCreate();
   fxl::UniqueFD application_directory_;
   fxl::UniqueFD application_assets_directory_;
@@ -69,6 +76,7 @@ class Application final : public Engine::Delegate,
 
   Application(
       Application::Delegate& delegate,
+      const zx::job& parent_job,
       component::ApplicationPackage package,
       component::ApplicationStartupInfo startup_info,
       fidl::InterfaceRequest<component::ApplicationController> controller);

--- a/content_handler/application_runner.cc
+++ b/content_handler/application_runner.cc
@@ -4,6 +4,7 @@
 
 #include "application_runner.h"
 
+#include <unistd.h>
 #include <zircon/types.h>
 
 #include <sstream>
@@ -12,49 +13,44 @@
 #include "flutter/lib/ui/text/font_collection.h"
 #include "fuchsia_font_manager.h"
 #include "lib/icu_data/cpp/icu_data.h"
+#include "third_party/flutter/runtime/dart_vm.h"
 #include "third_party/skia/include/core/SkGraphics.h"
 
 namespace flutter {
-
-static void SetProcessName(const std::string& process_name) {
-  zx::process::self().set_property(ZX_PROP_NAME, process_name.c_str(),
-                                   process_name.size());
-}
 
 static void SetThreadName(const std::string& thread_name) {
   zx::thread::self().set_property(ZX_PROP_NAME, thread_name.c_str(),
                                   thread_name.size());
 }
 
-static void SetProcessName(const std::string& label, size_t app_count) {
-  // Format: "flutter.<label_truncated_to_fit>+<app_count>"
-  //         "flutter" in case of error.
+static void SetProcessName(const std::string& process_name) {
+  zx::process::self().set_property(ZX_PROP_NAME, process_name.c_str(),
+                                   process_name.size());
+}
 
-  const std::string prefix = "flutter.";
-  const std::string suffix =
-      app_count == 0 ? "" : "+" + std::to_string(app_count);
-
-  if ((prefix.size() + suffix.size()) > ZX_MAX_NAME_LEN) {
-    SetProcessName("flutter");
-    return;
+static std::string CreateProcessName() {
+  std::stringstream stream;
+  stream << "flutter.runner.";
+  if (blink::DartVM::IsRunningPrecompiledCode()) {
+    stream << "aot";
+  } else {
+    stream << "jit";
   }
-
-  auto truncated_label =
-      label.substr(0, ZX_MAX_NAME_LEN - 1 - (prefix.size() + suffix.size()));
-
-  SetProcessName(prefix + truncated_label + suffix);
+  stream << "." << getpid();
+  return stream.str();
 }
 
 ApplicationRunner::ApplicationRunner(fxl::Closure on_termination_callback)
-    : on_termination_callback_(std::move(on_termination_callback)),
+    : debug_job_(Application::CreateDebugJobWithLabel(CreateProcessName())),
+      on_termination_callback_(std::move(on_termination_callback)),
       host_context_(component::ApplicationContext::CreateFromStartupInfo()) {
+  SetProcessName(CreateProcessName());
+
   SkGraphics::Init();
 
   SetupICU();
 
   SetupGlobalFonts();
-
-  SetProcessName("application_runner", 0);
 
   SetThreadName("io.flutter.application_runner");
 
@@ -82,15 +78,11 @@ void ApplicationRunner::StartApplication(
     fidl::InterfaceRequest<component::ApplicationController> controller) {
   auto thread_application_pair =
       Application::Create(*this,                    // delegate
+                          debug_job_,               // debug job
                           std::move(package),       // application pacakge
                           std::move(startup_info),  // startup info
                           std::move(controller)     // controller request
       );
-
-  // Update the process label so that "ps" will will list the last appication
-  // started by the runner plus the count of applications hosted by this runner.
-  SetProcessName(thread_application_pair.second->GetDebugLabel(),
-                 active_applications_.size());
 
   active_applications_[thread_application_pair.second.get()] =
       std::move(thread_application_pair);

--- a/content_handler/application_runner.h
+++ b/content_handler/application_runner.h
@@ -48,6 +48,7 @@ class ApplicationRunner final : public Application::Delegate,
     }
   };
 
+  zx::job debug_job_;
   fxl::Closure on_termination_callback_;
   std::unique_ptr<component::ApplicationContext> host_context_;
   fidl::BindingSet<component::ApplicationRunner> active_applications_bindings_;


### PR DESCRIPTION
The Flutter application runner creates a root job named “flutter.runner.<aot|jit>”. Each application instance launched by the runner create a child job whose name is the URL of the application launched. The name of the process is also the name of the root job. Now, instead of the non-descriptive flutter.<name>+<application_count>, the job hierarchy in `ps` will show a tree of all running Flutter applications.