### PR TITLE
Allow explicit specification of the isolate snapshot.

### DIFF
--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -21,11 +21,13 @@ namespace blink {
 RuntimeController::RuntimeController(
     RuntimeDelegate& p_client,
     const DartVM* p_vm,
+    fxl::RefPtr<DartSnapshot> p_isolate_snapshot,
     TaskRunners p_task_runners,
     fml::WeakPtr<GrContext> p_resource_context,
     fxl::RefPtr<flow::SkiaUnrefQueue> p_unref_queue)
     : RuntimeController(p_client,
                         p_vm,
+                        std::move(p_isolate_snapshot),
                         std::move(p_task_runners),
                         std::move(p_resource_context),
                         std::move(p_unref_queue),
@@ -34,19 +36,21 @@ RuntimeController::RuntimeController(
 RuntimeController::RuntimeController(
     RuntimeDelegate& p_client,
     const DartVM* p_vm,
+    fxl::RefPtr<DartSnapshot> p_isolate_snapshot,
     TaskRunners p_task_runners,
     fml::WeakPtr<GrContext> p_resource_context,
     fxl::RefPtr<flow::SkiaUnrefQueue> p_unref_queue,
     WindowData p_window_data)
     : client_(p_client),
       vm_(p_vm),
+      isolate_snapshot_(std::move(p_isolate_snapshot)),
       task_runners_(p_task_runners),
       resource_context_(p_resource_context),
       unref_queue_(p_unref_queue),
       window_data_(std::move(p_window_data)),
       root_isolate_(
           DartIsolate::CreateRootIsolate(vm_,
-                                         vm_->GetIsolateSnapshot(),
+                                         isolate_snapshot_,
                                          task_runners_,
                                          std::make_unique<Window>(this),
                                          resource_context_,
@@ -89,6 +93,7 @@ std::unique_ptr<RuntimeController> RuntimeController::Clone() const {
   return std::unique_ptr<RuntimeController>(new RuntimeController(
       client_,            //
       vm_,                //
+      isolate_snapshot_,  //
       task_runners_,      //
       resource_context_,  //
       unref_queue_,       //

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -25,6 +25,7 @@ class RuntimeController final : public WindowClient {
  public:
   RuntimeController(RuntimeDelegate& client,
                     const DartVM* vm,
+                    fxl::RefPtr<DartSnapshot> isolate_snapshot,
                     TaskRunners task_runners,
                     fml::WeakPtr<GrContext> resource_context,
                     fxl::RefPtr<flow::SkiaUnrefQueue> unref_queue);
@@ -79,6 +80,7 @@ class RuntimeController final : public WindowClient {
 
   RuntimeDelegate& client_;
   const DartVM* vm_;
+  fxl::RefPtr<DartSnapshot> isolate_snapshot_;
   TaskRunners task_runners_;
   fml::WeakPtr<GrContext> resource_context_;
   fxl::RefPtr<flow::SkiaUnrefQueue> unref_queue_;
@@ -88,6 +90,7 @@ class RuntimeController final : public WindowClient {
 
   RuntimeController(RuntimeDelegate& client,
                     const DartVM* vm,
+                    fxl::RefPtr<DartSnapshot> isolate_snapshot,
                     TaskRunners task_runners,
                     fml::WeakPtr<GrContext> resource_context,
                     fxl::RefPtr<flow::SkiaUnrefQueue> unref_queue,

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -42,6 +42,7 @@ static constexpr char kSettingsChannel[] = "flutter/settings";
 
 Engine::Engine(Delegate& delegate,
                const blink::DartVM& vm,
+               fxl::RefPtr<blink::DartSnapshot> isolate_snapshot,
                blink::TaskRunners task_runners,
                blink::Settings settings,
                std::unique_ptr<Animator> animator,
@@ -69,6 +70,7 @@ Engine::Engine(Delegate& delegate,
   runtime_controller_ = std::make_unique<blink::RuntimeController>(
       *this,                        // runtime delegate
       &vm,                          // VM
+      std::move(isolate_snapshot),  // isolate snapshot
       std::move(task_runners),      // task runners
       std::move(resource_context),  // resource context
       std::move(unref_queue)        // skia unref queue

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -41,6 +41,7 @@ class Engine final : public blink::RuntimeDelegate {
 
   Engine(Delegate& delegate,
          const blink::DartVM& vm,
+         fxl::RefPtr<blink::DartSnapshot> isolate_snapshot,
          blink::TaskRunners task_runners,
          blink::Settings settings,
          std::unique_ptr<Animator> animator,

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -41,9 +41,21 @@ class Shell final : public PlatformView::Delegate,
  public:
   template <class T>
   using CreateCallback = std::function<std::unique_ptr<T>(Shell&)>;
+
+  // Create a shell with the given task runners and settings. The isolate
+  // snapshot will be shared with the snapshot of the service isolate.
   static std::unique_ptr<Shell> Create(
       blink::TaskRunners task_runners,
       blink::Settings settings,
+      CreateCallback<PlatformView> on_create_platform_view,
+      CreateCallback<Rasterizer> on_create_rasterizer);
+
+  // Creates a shell with the given task runners and settings. The isolate
+  // snapshot is specified upfront.
+  static std::unique_ptr<Shell> Create(
+      blink::TaskRunners task_runners,
+      blink::Settings settings,
+      fxl::RefPtr<blink::DartSnapshot> isolate_snapshot,
       CreateCallback<PlatformView> on_create_platform_view,
       CreateCallback<Rasterizer> on_create_rasterizer);
 
@@ -92,6 +104,7 @@ class Shell final : public PlatformView::Delegate,
   static std::unique_ptr<Shell> CreateShellOnPlatformThread(
       blink::TaskRunners task_runners,
       blink::Settings settings,
+      fxl::RefPtr<blink::DartSnapshot> isolate_snapshot,
       Shell::CreateCallback<PlatformView> on_create_platform_view,
       Shell::CreateCallback<Rasterizer> on_create_rasterizer);
 


### PR DESCRIPTION
The mobile shells all use the same isolate snapshot. This is also the snapshot used by the service isolate. This works towards a world where the isolate snapshot is no longer a member variable of the DartVM instance. Instead, all snapshots must be specified in the run configuration. For now, the new `Shell::Create` overload will only be used by Fuchsia till I refactor `dart_vm.cc`.

There are no API updates to the mobile shells.