### PR TITLE
Tear down the shell before terminating message loops on host threads.

### DIFF
--- a/content_handler/engine.cc
+++ b/content_handler/engine.cc
@@ -215,6 +215,7 @@ Engine::Engine(Delegate& delegate,
 }
 
 Engine::~Engine() {
+  shell_.reset();
   for (const auto& thread : host_threads_) {
     thread.TaskRunner()->PostTask(
         []() { fsl::MessageLoop::GetCurrent()->PostQuitTask(); });


### PR DESCRIPTION
Shell teardown is synchronous. The shell was attempting to destroy components on a quitting message loop. The message loop implementation was executing such tasks on the calling thread which the shell does not consider thread safe.