### PR TITLE
Roll Dart to 779dc6eb85c1f2249803d017ffa785c85681ad1b

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'e6d7d67f4b35556805dd083fed15bf3ed41f7e33',
+  'dart_revision': '779dc6eb85c1f2249803d017ffa785c85681ad1b',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.6',
@@ -59,7 +59,7 @@ vars = {
   'dart_http_throttle_tag': '1.0.1',
   'dart_intl_tag': '0.15.2',
   'dart_json_rpc_2_tag': '2.0.6',
-  'dart_linter_tag': '0.1.49',
+  'dart_linter_tag': '0.1.50',
   'dart_logging_tag': '0.11.3+1',
   'dart_markdown_tag': '1.1.1',
   'dart_matcher_tag': '0.12.1+4',
@@ -74,8 +74,8 @@ vars = {
   'dart_plugin_tag': '0.2.0+2',
   'dart_pool_tag': '1.3.4',
   'dart_protobuf_tag': '0.7.1',
-  'dart_pub_rev': '4947e0b3cb3ec77e4e8fe0d3141ce4dc60f43256',
-  'dart_pub_semver_tag': '1.3.7',
+  'dart_pub_rev': 'c61b8a3a24a7b1f931bad24b1f663e2c9a4c4354',
+  'dart_pub_semver_tag': '1.4.1',
   'dart_quiver_tag': '5aaa3f58c48608af5b027444d561270b53f15dbf',
   'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',
   'dart_root_certificates_rev': '16ef64be64c7dfdff2b9f4b910726e635ccc519e',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: ee1af487941cb16b5491caf536dd0d96
+Signature: 5db29e66257aa1c8a2ac53d069aeb153
 
 UNUSED LICENSES:
 
@@ -6027,15 +6027,21 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: dart
-ORIGIN: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.cc + ../../../third_party/dart/LICENSE
+ORIGIN: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_kbc.cc + ../../../third_party/dart/LICENSE
 TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_kbc.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/assembler/disassembler_kbc.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h
+FILE: ../../../third_party/dart/runtime/vm/constants_kbc.h
 FILE: ../../../third_party/dart/runtime/vm/datastream.cc
 FILE: ../../../third_party/dart/runtime/vm/finalizable_data.h
 FILE: ../../../third_party/dart/runtime/vm/hash.h
+FILE: ../../../third_party/dart/runtime/vm/interpreter.cc
+FILE: ../../../third_party/dart/runtime/vm/interpreter.h
+FILE: ../../../third_party/dart/runtime/vm/stack_frame_kbc.h
 FILE: ../../../third_party/dart/runtime/vm/type_testing_stubs.cc
 FILE: ../../../third_party/dart/runtime/vm/type_testing_stubs.h
 FILE: ../../../third_party/dart/sdk/lib/js/_js.dart


### PR DESCRIPTION
This roll includes the following Dart SDK commits:

779dc6eb85 Stop leaking file descriptors for HTTP clients
b294e48bdf Hack to fix sort order
5951f1e4f1 Improve enum declaration identifier recovery
1860096702 Use correct type arguments for Forest.
6e15762556 Bump to linter 0.1.50
e5820f7e94 Place generator body in same unit as entry
41fcbd097c [VM runtime] Initial version of Kernel Bytecode interpreter in VM runtime. Not fully working yet, only x64, no gc, no frame walking, etc...
a4772ea629 Refer to Expression and Statement via prefix
310745ca8b Add support for adding missing named parameters to constructors.
e8c8557fcb Switch the fix for adding not named required/positional parameter to using _ExecutableParameters.
fa071e8ecb Update AstBuildingForest tests
bedf640eca Address review comments from previous CLs
2d95c54392 CHANGELOG for cast/retype changes
6efd3b3654 Refactor output code for generators
e67222a92b [vm/compiler] Do not use call->ArgumentAt(0) to access receiver.
5afa2dca51 [dart:io] Fix ProcessStartMode.values
a49fd95d59 [CHANGELOG] Update for dart:io constant rename
3ec1b929e3 Remove dependencies on isolates.
2ad715e706 [vm/hr] Directly compare type arguments count when validate hot reload.
8dbe716085 Remove the unused GenericCovariantInterface bit
f61e1c0fb3 Mark metadata_test as failing on dart_precompiled
24224ced5b [VM] Update status file, test became much slower after strong-mode changes to mirrors implementation
a8364e3412 Add missing method to FastaParserTestCase
b5154dd01e Revert "[vm/kernel] Expression execution through Kernel.
2daa5610ac Add more issue numbers to fasta status file
b25e12ddc6 [fasta] Remove BuiltTypeBuilder
afd0a52a5a [vm/kernel] Expression execution through Kernel.
41eb5ddfdc Add some issue numbers to fasta status file
df9af04061 Remove CompilerOptions.useKernel
972d4b0b1d Add frontendInternal key and external example to messages tests
ee0a2cd8bc Restore type arguments on Forest
a65dc90bd0 Improve error message for invalid characters
fe3f87f192 [fasta] Reland "Handle annotations on formals and variables"
4c7926107e Remove support for --use-old-frontend option
039e8a1755 [vm/kernel] Enable kernel2kernel "constants" transformation in AOT mode (after running TFA)
2f781e46b0 Introduced support for metadata on enum values
862a894de6 Make `cast` do the same things as `retype`.
b347839ee6 Remove impact_test
3adb731af3 Remove id equivalence test and ast id helpers
d0112f4431 Remove old frontend equivalence tests
17e22dfcd3 Remove unneeded kernel tests and sourcemap old-frontend tests
a0d3bef5fb [release] Prepare changelog for 2.0.0-dev.54.0
2f924e457e Revert "[infra] Temporarily remove windows builder from the CQ"
fd9823ae9e Issue 21965. Add Quick Fix for adding missing named parameter.
964dae472c Issue 30577. Use AST to find position for the first directive.
74d03e7a75 Add a test that reproduces hot reload issue when class type arguments change.
3beb7fe860 Fix how we pass the type-parameter to StreamIterator in for-in
cc034472bb Fix LineInfo.getOffsetOfLineAfter().
f2b137343c Do not run analyzer benchmarks in checked mode.
702aca4ab1 [vm] Address TODOs for warn on unused result.
ac6ea06fd2 [dart:io] Switch ProcessStartMode back to an enum
0bab7e6bfa Issue 32765. Improve guess for type name identifier.
b73541cffe Add a skeleton for Dart Folding
ebcf5bec30 Update Analyzer/CFE type resolution test to use AstBuildingForest
316b10216f Fix Analyzer warning
1d8620044a Call computeTypeVar rather than parseTypeArguments when parsing expressions
8f6c6c2a8e Implement some missing override checking
2296f9d637 Run transformations on expression compilation.
c9cd32fb58 Clean up Forest.literalList and Forest.literalMap
2ccafe7a54 [kernel] Change dill representation of doubles
51fa3f3b0c Decouple HNode from TypeMask
d3c7df35b4 Revive AbstractValueDomain
03abbc73d2 CFE support for expression evaluation, refactored.
054559c5f3 Revert "CFE support for compiling individual expressions in a context."
95fab34cdf [infra] Temporarily remove windows builder from the CQ
4f586e265e [fasta] Update expectation files after CL 50941
9c6c3dcd89 [fasta] Store calculated bounds of type variables as their defaults
831a6ba598 Remove useOldFrontend testing from various tests
9bac9ee596 Remove useOldFrontend from compiler_helper
4b53f7e0d2 Remove useOldFrontend testing from TypeEnvironment
8e885f4393 Remove CompileMode
27ae11e4d8 Filter instantiation stubs
2e1c17e5c1 Revert "dump-info: Use relative paths for library canonicalUri..."
e10f0717d2 fix test status for a few tests changed in 3002e47e
95c29e6fb0 First cut test for Analyzer/BodyBuilder integration test
b017db1e8c [corelib_2 tests] Bigint computations are slow on simulated architectures. An added regression test for modPow increased computation time.
446668e95c Add required information for three more cases
3002e47e36 cleanup language_2 and corelib_2 tests that import dart:mirrors
4da831fd3a Latest pub_semver
179b31c157 Allow built-in identifiers for non-type entities, with a warning.
603d832371 Test for sync* checks
d87642df9c fix #33036, dartdevk now uses CFE for patching its SDK
1b8a3b1045 Implement support for overridden elements that are declared in mixins.
6c301a4e32 Bring in the latest pub
e62dd0157e [VM bigint] Fix padding length in Montgomery Reduction (fixes #32626). Add regression test to existing bigint test.
8515d74332 Add ImportElement.namespace and use it in completion.
410db09743 Do not convert the worker object in jsinterop, just like we do for window
f62302b8ee Make extracted widgets follow Flutter style - const constructor and @required named parameters.
d624b8580a Add DartEditBuilder.writeReference().
2dd6aba0f4 Add the analyzer implementation of Forest
65d7bf8152 [vm] Align 64-bit atomic variables for 32-bit iOS.
de59cdf498 [VM] Fix for issue 33027 (Fixes strong mode runtime error in _FileSystemWatcher
3192d0052c Start adding parameters needed by analyzer
86ccd4f790 Fix poor error messages on null dereference
92f50475b8 Issue 32849. Use export namespace for import prefix and combinator completions.
66412a28f2 Use %systemroot% instead of hardcoded 'C:\Windows'
a06b1d96cb Revert "[VM] Reduce Smi size to 32 bit on 64 bit platforms"
89e43b4141 [fasta] Normalize type arguments as in Dart 1 when not in strong mode
dffbbad8a5 [gardening] Fix analyzer warning on regress_33040_instantiation_test
a6b6d6a608 [VM] Remove converted closure function code from the VM
56e47e6b2d Fix analyzer on #33040 regression test.
235b81d045 Remove MockCompiler
b74bb147ce Remove use of MockCompiler from type_test_helper
3cd0a1f5e4 Remove old_frontend and mirrors tests
add1e67295 Include generic type arguments in deferred load computation.
296ab86012 Revert "Add DartEditBuilder.writeTopLevelElementReference()."
e9e0166375 Add regression test for #33040
772c9bb5f3 [vm/kernel] Re-land partial instantiation of local functions.
5618373690 Copy timers to jsshell.js preamble
e5e83a29fb Revert "Add a fix for prefer_single_quotes"
eb2fbf501f Add a fix for prefer_single_quotes
f6a1f48450 Allow using pseudo keywords for names in refactorings.
332dc7f3e9 Issue 32935. Fix NPE in 'Make final' quick fix.
67d3e4e3a1 Use actual names of the @isTest of isTestGroup executable in outlines.
07ad1904f3 Sort declarations in type_system.dart and type_system_test.dart.
04e9f7da27 [vm/kernel/aot] Fix infinite looping in TFA (ensure convergence of analysis)
515a7acc0b [ VM / Dart 2 ] Updated status file entries for remaining DartAPI tests that are failing with issue numbers.
b7a63c8d52 Use @isTest and @isTestGroup to understand executable element as a test/group.
5904247715 Fix a typo in socket.dart.
23a1534432 Add DartEditBuilder.writeTopLevelElementReference().
a989bac685 [frontend-server] Re-enable depfile test on Windows.
543d8775e3 Clarify that global/local/static functions can also be closurized
64754764b1 Update computeType to call computeTypeParamOrArg
94be474fee Generate cross buildfiles for armsimdbc and armsimdbc64.
31597f1cd7 [fasta] Add more nodes to the Forest API
c8c994b26d Revert "Add some status entries for crashing tests related to issue"
f35bb0379d [vm/kernel] Initialize function type args even when resuming from yield.
19cf8d1768 [vm] Rewrite Intrinsifier::InitializeState to be data driven.
e434cb91e1 Mark some commonly failing flaky tests.
5a69552d34 [VM] Fix typo in 54d842a89c722b7c27762b96ba21fab55a2ad55a.
2f458c4c48 [vm] Reify more generics in the mirrors implementation to appease Dart 2.
54d842a89c [VM runtime] Explicitly specify length of parent type argument vector in native call Internal_prependTypeArguments to protect against vector reuse optimization. This is indirectly related to issue #33040.
50fbd1a3ed [GN] Fix dartanalyzer_aot target
e5e4871a04 Simplify 'this' caching in constructors.
8f52be2282 Don't infer types when there's an irreconcilable type mismatch.
dfa661d460 Add AnalysisSessionHelper.getTopLevelPropertyAccessor().
58f41fd1b5 update issue21159_test for Dart 2, fixes #30701