### PR TITLE
Re-land "libtxt: exclude trailing whitespace from right-justified lines"

### DIFF
--- a/third_party/txt/src/minikin/LineBreaker.cpp
+++ b/third_party/txt/src/minikin/LineBreaker.cpp
@@ -107,7 +107,7 @@ void LineBreaker::setIndents(const std::vector<float>& indents) {
 // end of line. It is the Unicode set:
 // [[:General_Category=Space_Separator:]-[:Line_Break=Glue:]], plus '\n'. Note:
 // all such characters are in the BMP, so it's ok to use code units for this.
-static bool isLineEndSpace(uint16_t c) {
+bool isLineEndSpace(uint16_t c) {
   return c == '\n' || c == ' ' || c == 0x1680 ||
          (0x2000 <= c && c <= 0x200A && c != 0x2007) || c == 0x205F ||
          c == 0x3000;

--- a/third_party/txt/src/minikin/LineBreaker.h
+++ b/third_party/txt/src/minikin/LineBreaker.h
@@ -49,6 +49,8 @@ enum HyphenationFrequency {
   kHyphenationFrequency_Full = 2
 };
 
+bool isLineEndSpace(uint16_t c);
+
 // TODO: want to generalize to be able to handle array of line widths
 class LineWidths {
  public:

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -187,9 +187,14 @@ class Paragraph {
   mutable std::unique_ptr<icu::BreakIterator> word_breaker_;
 
   struct LineRange {
-    LineRange(size_t s, size_t e, size_t ewn, bool h)
-        : start(s), end(e), end_including_newline(ewn), hard_break(h) {}
+    LineRange(size_t s, size_t e, size_t eew, size_t ein, bool h)
+        : start(s),
+          end(e),
+          end_excluding_whitespace(eew),
+          end_including_newline(ein),
+          hard_break(h) {}
     size_t start, end;
+    size_t end_excluding_whitespace;
     size_t end_including_newline;
     bool hard_break;
   };
@@ -300,7 +305,7 @@ class Paragraph {
 
   // Calculate the starting X offset of a line based on the line's width and
   // alignment.
-  double GetLineXOffset(size_t line_number, double line_total_advance);
+  double GetLineXOffset(double line_total_advance);
 
   // Creates and draws the decorations onto the canvas.
   void PaintDecorations(SkCanvas* canvas, const PaintRecord& record);

--- a/third_party/txt/src/txt/paragraph_style.cc
+++ b/third_party/txt/src/txt/paragraph_style.cc
@@ -37,4 +37,16 @@ bool ParagraphStyle::ellipsized() const {
   return !ellipsis.empty();
 }
 
+TextAlign ParagraphStyle::effective_align() const {
+  if (text_align == TextAlign::start) {
+    return (text_direction == TextDirection::ltr) ? TextAlign::left
+                                                  : TextAlign::right;
+  } else if (text_align == TextAlign::end) {
+    return (text_direction == TextDirection::ltr) ? TextAlign::right
+                                                  : TextAlign::left;
+  } else {
+    return text_align;
+  }
+}
+
 }  // namespace txt

--- a/third_party/txt/src/txt/paragraph_style.h
+++ b/third_party/txt/src/txt/paragraph_style.h
@@ -66,6 +66,9 @@ class ParagraphStyle {
 
   bool unlimited_lines() const;
   bool ellipsized() const;
+
+  // Return a text alignment value that is not dependent on the text direction.
+  TextAlign effective_align() const;
 };
 
 }  // namespace txt


### PR DESCRIPTION
If a line is right justified, then remove any trailing whitespace from the
text range given to Minikin.  Right justification shifts the line's glyphs
by the layout advance computed by Minikin, and this advance should exclude
whitespace so that the last visible character will be flush with the right
margin.

Also exclude trailing whitespace from center justified lines.

Fixes https://github.com/flutter/flutter/issues/17502
Fixes https://github.com/flutter/flutter/issues/16333