### PR TITLE
swap brightness definition on iOS to match android

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -140,9 +140,9 @@ using namespace shell;
 - (void)setSystemChromeSystemUIOverlayStyle:(NSDictionary*)message {
   NSString* style = message[@"statusBarBrightness"];
   UIStatusBarStyle statusBarStyle;
-  if ([style isEqualToString:@"Brightness.light"])
+  if ([style isEqualToString:@"Brightness.dark"])
     statusBarStyle = UIStatusBarStyleLightContent;
-  else if ([style isEqualToString:@"Brightness.dark"])
+  else if ([style isEqualToString:@"Brightness.light"])
     statusBarStyle = UIStatusBarStyleDefault;
   else
     return;


### PR DESCRIPTION
The status bar having a brightness of dark implies it is the style for light content.  Fixes https://github.com/flutter/flutter/issues/17523