### PR TITLE
Don’t terminate the runner when it has no more applications.

### DIFF
--- a/content_handler/application_runner.h
+++ b/content_handler/application_runner.h
@@ -23,7 +23,7 @@ namespace flutter {
 class ApplicationRunner final : public Application::Delegate,
                                 public component::ApplicationRunner {
  public:
-  ApplicationRunner(fxl::Closure on_termination_callback);
+  ApplicationRunner();
 
   ~ApplicationRunner();
 
@@ -48,7 +48,6 @@ class ApplicationRunner final : public Application::Delegate,
     }
   };
 
-  fxl::Closure on_termination_callback_;
   std::unique_ptr<component::ApplicationContext> host_context_;
   fidl::BindingSet<component::ApplicationRunner> active_applications_bindings_;
   std::unordered_map<const Application*, ActiveApplication>
@@ -71,8 +70,6 @@ class ApplicationRunner final : public Application::Delegate,
   void SetupICU();
 
   void SetupGlobalFonts();
-
-  void FireTerminationCallbackIfNecessary();
 
   FXL_DISALLOW_COPY_AND_ASSIGN(ApplicationRunner);
 };

--- a/content_handler/main.cc
+++ b/content_handler/main.cc
@@ -15,12 +15,12 @@ int main(int argc, char const* argv[]) {
   FXL_DCHECK(provider.is_valid()) << "Trace provider must be valid.";
 
   FXL_DLOG(INFO) << "Flutter application services initialized.";
-  flutter::ApplicationRunner runner([&loop]() {
-    loop.PostQuitTask();
-    FXL_DLOG(INFO) << "Flutter application services terminated. Good bye...";
-  });
+
+  flutter::ApplicationRunner runner;
 
   loop.Run();
+
+  FXL_DLOG(INFO) << "Flutter application services terminated.";
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Instead, keep it around to service more requests. There may be a race between runner shutdown and request for new applications.