### PR TITLE
Support a model where the application creates a FlutterNativeView that is never destroyed

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -61,6 +61,11 @@ public class FlutterActivity extends Activity implements FlutterView.Provider, P
     }
 
     @Override
+    public boolean retainFlutterNativeView() {
+        return false;
+    }
+
+    @Override
     public final boolean hasPlugin(String key) {
         return pluginRegistry.hasPlugin(key);
     }

--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -65,6 +65,11 @@ public class FlutterFragmentActivity
     }
 
     @Override
+    public boolean retainFlutterNativeView() {
+        return false;
+    }
+
+    @Override
     public final boolean hasPlugin(String key) {
         return pluginRegistry.hasPlugin(key);
     }

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -26,6 +26,7 @@ public class FlutterNativeView implements BinaryMessenger {
     private long mNativePlatformView;
     private FlutterView mFlutterView;
     private final Context mContext;
+    private boolean applicationIsRunning;
 
     public FlutterNativeView(Context context) {
         mContext = context;
@@ -45,6 +46,7 @@ public class FlutterNativeView implements BinaryMessenger {
         mFlutterView = null;
         nativeDestroy(mNativePlatformView);
         mNativePlatformView = 0;
+        applicationIsRunning = false;
     }
 
     public FlutterPluginRegistry getPluginRegistry() {
@@ -71,12 +73,26 @@ public class FlutterNativeView implements BinaryMessenger {
 
     public void runFromBundle(String bundlePath, String snapshotOverride, String entrypoint, boolean reuseRuntimeController) {
         assertAttached();
+        if (applicationIsRunning)
+            throw new AssertionError("This Flutter engine instance is already running an application");
+
         nativeRunBundleAndSnapshot(mNativePlatformView, bundlePath, snapshotOverride, entrypoint, reuseRuntimeController, mContext.getResources().getAssets());
+
+        applicationIsRunning = true;
     }
 
     public void runFromSource(final String assetsDirectory, final String main, final String packages) {
         assertAttached();
+        if (applicationIsRunning)
+            throw new AssertionError("This Flutter engine instance is already running an application");
+
         nativeRunBundleAndSource(mNativePlatformView, assetsDirectory, main, packages);
+
+        applicationIsRunning = true;
+    }
+
+    public boolean isApplicationRunning() {
+      return applicationIsRunning;
     }
 
     public void setAssetBundlePathOnUI(final String assetsDirectory) {


### PR DESCRIPTION
This allows applications to start a Flutter engine instance during app startup
and keep it running throughout the app process' lifetime.

FlutterActivity subclasses can override createFlutterNativeView to provide a
preinitialized FlutterNativeView instance and override retainFlutterNativeView
to signal that the FlutterNativeView should be kept alive when the activity
is destroyed.