### PR TITLE
update docs for Path.getBounds

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1799,7 +1799,8 @@ class Path extends NativeFieldWrapperClass2 {
   /// a width the approximate length of the path (if drawn with a stroke width
   /// of 1.0).  Because of this, you should not rely on `Rect.isEmpty` to test
   /// whether the bounds of this path contains any points, but instead test that 
-  /// `Rect.width + Rect.height > 0.0` (.
+  /// `Rect.width + Rect.height > 0.0` or use the `computeMetrics` API to check
+  /// the path length.
   // see https://skia.org/user/api/SkPath_Reference#SkPath_getBounds
   Rect getBounds() {
     final Float32List rect = _getBounds();

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1793,14 +1793,18 @@ class Path extends NativeFieldWrapperClass2 {
 
   /// Computes the bounding rectangle for this path.
   /// 
-  /// The returned bounds width and height may be larger or smaller than area
-  /// affected when Path is drawn.  For example, a path containing a straight
-  /// line on the horizontal axis may result in a [Rect] with a height of 0 and
-  /// a width the approximate length of the path (if drawn with a stroke width
-  /// of 1.0).  Because of this, you should not rely on `Rect.isEmpty` to test
-  /// whether the bounds of this path contains any points, but instead test that 
-  /// `Rect.width + Rect.height > 0.0` or use the `computeMetrics` API to check
-  /// the path length.
+  /// A path containing only axis-aligned points on the same straight line will
+  /// have no area, and therefore `Rect.isEmpty` will return true for such a
+  /// path. Consider checking `rect.width + rect.height > 0.0` instead, or
+  /// using the [computeMetrics] API to check the path length.
+  /// 
+  /// For many more elaborate paths, the bounds may be inaccurate.  For example,
+  /// when a path contains a circle, the points used to compute the bounds are
+  /// the circle's implied control points, which form a square around the circle;
+  /// if the circle has a transformation applied using [transform] then that 
+  /// square is rotated, and the (axis-aligned, non-rotated) bounding box
+  /// therefore ends up grossly overestimating the actual area covered by the
+  /// circle.
   // see https://skia.org/user/api/SkPath_Reference#SkPath_getBounds
   Rect getBounds() {
     final Float32List rect = _getBounds();

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1792,6 +1792,15 @@ class Path extends NativeFieldWrapperClass2 {
   Path _transform(Float64List matrix4) native 'Path_transform';
 
   /// Computes the bounding rectangle for this path.
+  /// 
+  /// The returned bounds width and height may be larger or smaller than area
+  /// affected when Path is drawn.  For example, a path containing a straight
+  /// line on the horizontal axis may result in a [Rect] with a height of 0 and
+  /// a width the approximate length of the path (if drawn with a stroke width
+  /// of 1.0).  Because of this, you should not rely on `Rect.isEmpty` to test
+  /// whether the bounds of this path contains any points, but instead test that 
+  /// `Rect.width + Rect.height > 0.0` (.
+  // see https://skia.org/user/api/SkPath_Reference#SkPath_getBounds
   Rect getBounds() {
     final Float32List rect = _getBounds();
     return new Rect.fromLTRB(rect[0], rect[1], rect[2], rect[3]);


### PR DESCRIPTION
Path.getBounds can return a rectangle that returns true for `isEmpty` even though the path has content.  This is a limitation in the underlying Skia API: https://skia.org/user/api/SkPath_Reference#SkPath_getBounds

This means that code like this:

```
Path path = new Path()..lineTo(10.0, 0.0);
... // other code that doesn't extend/modify/transform the path
if (path.getBounds().isEmpty) {
  throw new StateError('Expected a non-empty path!'); 
         // will throw here, even though path 
         // is not empty and bounds does have a valid dimension
}
```

I intuitively expected `getBounds` to work differently here than it does, and I suspect other users will too. 

I suppose it would be possible to make our API force the width or height to be at least 1.0 as an alternative, but I'm not sure about how correct that would be and if it would end up causing other problems.  Obviously using `PathMetrics` to get the length will be very reliable, but it's also more expensive than `getBounds` (and you may be interested in getting the bounds for other reason).  @brianosman maybe could offer some input as to whether that's a good idea or not.  If it is, I'll amend this PR to do something like that and update the docs accordingly, but assuming Skia's API was designed with reason here we should document it.