### PR TITLE
Create an empty group that the Fuchsia bots use to determine the root_out_dir.

### DIFF
--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -1,0 +1,6 @@
+# Copyright 2018 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+group("linux") {
+}


### PR DESCRIPTION
The Fuchsia bots seem to reference this target to figure out the root_out_directory https://fuchsia.googlesource.com/build/+/master/dart/dart_test.gni#67. Note that the presence of the flutter_tester binary location itself is not depended on. Instead, the target is used to infer the directory containing the flutter_tester after a build.

Patching the //build repository in Fuchsia would mean making the tree red till a //topaz patch lands. To avoid doing this, we add back the missing reference.