### PR TITLE
Restore functionality to run from .so file on Android

### DIFF
--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -22,9 +22,11 @@ const char* DartSnapshot::kIsolateInstructionsSymbol =
     "kDartIsolateSnapshotInstructions";
 
 #if defined(OS_ANDROID)
-// When assembling the .S file of the application the Android toolchain's gcc
-// will, due to ABI reasons, put a leading underscore in front of the symbols
-// (this is different on MacOS).
+// When assembling the .S file of the application, dart_bootstrap will prefix
+// symbols via an `_` to ensure Mac's `dlsym()` can find it (Mac ABI prefixes C
+// symbols with underscores).
+// But Linux ABI does not prefix C symbols with underscores, so we have to
+// explicitly look up the prefixed version.
 #define SYMBOL_PREFIX "_"
 #else
 #define SYMBOL_PREFIX ""

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -25,17 +25,15 @@ const char* DartSnapshot::kIsolateInstructionsSymbol =
 // When assembling the .S file of the application the Android toolchain's gcc
 // will, due to ABI reasons, put a leading underscore in front of the symbols
 // (this is different on MacOS).
-static const char* kVMDataSymbolSo = "_kDartVmSnapshotData";
-static const char* kVMInstructionsSymbolSo = "_kDartVmSnapshotInstructions";
-static const char* kIsolateDataSymbolSo = "_kDartIsolateSnapshotData";
-static const char* kIsolateInstructionsSymbolSo =
-    "_kDartIsolateSnapshotInstructions";
+#define SYMBOL_PREFIX "_"
 #else
-static const char* kVMDataSymbolSo = DartSnapshot::kVMDataSymbol;
-static const char* kVMInstructionsSymbolSo = DartSnapshot::kVMInstructionsSymbol;
-static const char* kIsolateDataSymbolSo = DartSnapshot::kIsolateDataSymbol;
-static const char* kIsolateInstructionsSymbolSo = DartSnapshot::kIsolateInstructionsSymbol;
+#define SYMBOL_PREFIX ""
 #endif
+
+static const char* kVMDataSymbolSo = SYMBOL_PREFIX "kDartVmSnapshotData";
+static const char* kVMInstructionsSymbolSo = SYMBOL_PREFIX "kDartVmSnapshotInstructions";
+static const char* kIsolateDataSymbolSo = SYMBOL_PREFIX "kDartIsolateSnapshotData";
+static const char* kIsolateInstructionsSymbolSo = SYMBOL_PREFIX "kDartIsolateSnapshotInstructions";
 
 std::unique_ptr<DartSnapshotBuffer> ResolveVMData(const Settings& settings) {
   if (settings.vm_snapshot_data_path.size() > 0) {

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -170,6 +170,10 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
   command_line.GetOptionValue(FlagForSwitch(Switch::Packages),
                               &settings.packages_file_path);
 
+  std::string aot_shared_library_path;
+  command_line.GetOptionValue(FlagForSwitch(Switch::AotSharedLibraryPath),
+                              &aot_shared_library_path);
+
   std::string aot_snapshot_path;
   command_line.GetOptionValue(FlagForSwitch(Switch::AotSnapshotPath),
                               &aot_snapshot_path);
@@ -191,7 +195,9 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
       FlagForSwitch(Switch::AotIsolateSnapshotInstructions),
       &aot_isolate_snapshot_instr_filename);
 
-  if (aot_snapshot_path.size() > 0) {
+  if (aot_shared_library_path.size() > 0) {
+    settings.application_library_path = aot_shared_library_path;
+  } else if (aot_snapshot_path.size() > 0) {
     settings.vm_snapshot_data_path = fml::paths::JoinPaths(
         {aot_snapshot_path, aot_vm_snapshot_data_filename});
     settings.vm_snapshot_instr_path = fml::paths::JoinPaths(


### PR DESCRIPTION
Flutter AOT builds can be done on Android using .so files (instead of
separate instruction/data snapshots) using the `--build-shared-library`
flag.

Running from .so files stopped working after the engine refactoring in
58e84c8bf0, which this CL restores.

Issue https://github.com/flutter/flutter/issues/17236