### PR TITLE
Only send a11y events if a11y is turned on (Android)

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -679,7 +679,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
             case "tooltip": {
                 AccessibilityEvent e = obtainAccessibilityEvent(ROOT_NODE_ID, AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
                 e.getText().add((String) data.get("message"));
-                mOwner.getParent().requestSendAccessibilityEvent(mOwner, e);
+                sendAccessibilityEvent(e);
             }
             default:
                 assert false;
@@ -690,7 +690,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         AccessibilityEvent e = obtainAccessibilityEvent(route.id, AccessibilityEvent.TYPE_WINDOW_STATE_CHANGED);
         String routeName = route.getRouteName();
         e.getText().add(routeName);
-        mOwner.getParent().requestSendAccessibilityEvent(mOwner, e);
+        sendAccessibilityEvent(e);
     }
 
     private void willRemoveSemanticsObject(SemanticsObject object) {


### PR DESCRIPTION
Otherwise Android will remind you in a friendly stack trace:

```
E/FlutterView( 9685): java.lang.IllegalStateException: Accessibility off. Did you forget to check that?
E/FlutterView( 9685): 	at android.view.accessibility.AccessibilityManager.sendAccessibilityEvent(AccessibilityManager.java:407)
E/FlutterView( 9685): 	at android.view.ViewRootImpl.requestSendAccessibilityEvent(ViewRootImpl.java:7113)
E/FlutterView( 9685): 	at android.view.ViewGroup.requestSendAccessibilityEvent(ViewGroup.java:980)
E/FlutterView( 9685): 	at android.view.ViewGroup.requestSendAccessibilityEvent(ViewGroup.java:980)
E/FlutterView( 9685): 	at android.view.ViewGroup.requestSendAccessibilityEvent(ViewGroup.java:980)
E/FlutterView( 9685): 	at io.flutter.view.AccessibilityBridge.createWindowChangeEvent(AccessibilityBridge.java:693)
E/FlutterView( 9685): 	at io.flutter.view.AccessibilityBridge.updateSemantics(AccessibilityBridge.java:505)
E/FlutterView( 9685): 	at io.flutter.view.FlutterView.updateSemantics(FlutterView.java:765)
E/FlutterView( 9685): 	at io.flutter.view.FlutterNativeView.updateSemantics(FlutterNativeView.java:182)
E/FlutterView( 9685): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/FlutterView( 9685): 	at android.os.MessageQueue.next(MessageQueue.java:325)
E/FlutterView( 9685): 	at android.os.Looper.loop(Looper.java:142)
E/FlutterView( 9685): 	at android.app.ActivityThread.main(ActivityThread.java:6541)
E/FlutterView( 9685): 	at java.lang.reflect.Method.invoke(Native Method)
E/FlutterView( 9685): 	at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
E/FlutterView( 9685): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:767)
```