### PR TITLE
Temporarily use expat on Android because the Android font manager depends on the same.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -71,7 +71,7 @@ def to_gn_args(args):
     gn_args['skia_use_dng_sdk'] = False    # RAW image handling.
     gn_args['skia_use_sfntly'] = False     # PDF handling depedency.
     gn_args['skia_enable_pdf'] = False     # PDF handling.
-    gn_args['skia_use_expat'] = False      # XML handling (for SVG and friends).
+    gn_args['skia_use_expat'] = args.target_os == 'android'
     gn_args['skia_use_fontconfig'] = False # Use the custom font manager instead.
     gn_args['is_official_build'] = True    # Disable Skia test utilities.
 


### PR DESCRIPTION
There is currently no way to configure Skia to include xml just for Android font manifest file parsing. Adding in expat also enables all the SVG canvas stuff. I am going to patch the Skia GN files to support that configuration but this patch unblocks the bots.