### PR TITLE
Remove the only user of fxl::StringView in FML.

### DIFF
--- a/fml/paths.cc
+++ b/fml/paths.cc
@@ -4,12 +4,14 @@
 
 #include "flutter/fml/paths.h"
 
+#include <sstream>
+
 #include "flutter/fml/build_config.h"
 
 namespace fml {
 namespace paths {
 
-std::string JoinPaths(std::initializer_list<fxl::StringView> components) {
+std::string JoinPaths(std::initializer_list<std::string> components) {
   std::stringstream stream;
   size_t i = 0;
   const size_t size = components.size();

--- a/fml/paths.h
+++ b/fml/paths.h
@@ -8,14 +8,12 @@
 #include <string>
 #include <utility>
 
-#include "lib/fxl/strings/string_view.h"
-
 namespace fml {
 namespace paths {
 
 std::pair<bool, std::string> GetExecutableDirectoryPath();
 
-std::string JoinPaths(std::initializer_list<fxl::StringView> components);
+std::string JoinPaths(std::initializer_list<std::string> components);
 
 }  // namespace paths
 }  // namespace fml


### PR DESCRIPTION
This API is not used often and the string sizes are small enough to be covered by SSO anyway. Using std::string instead to avoid pulling in a large dependency.