### PR TITLE
Use drawImage for picture layer cache

### DIFF
--- a/flow/debug_print.cc
+++ b/flow/debug_print.cc
@@ -71,13 +71,9 @@ std::ostream& operator<<(std::ostream& os, const SkPoint& r) {
 }
 
 std::ostream& operator<<(std::ostream& os, const flow::RasterCacheKey& k) {
-  os << "Picture: " << k.picture_id() << " Scale: " << k.scale_key().width()
-     << ", " << k.scale_key().height()
-#if defined(OS_FUCHSIA)
-     << " Metrics scale: (" << k.metrics_scale_x() << ", "
-     << k.metrics_scale_y() << ")"
-#endif
-      ;
+  SkString matrix_string;
+  k.matrix().toString(&matrix_string);
+  os << "Picture: " << k.picture_id() << " matrix: " << matrix_string.c_str();
   return os;
 }
 

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -16,8 +16,10 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkPicture* sk_picture = picture();
 
   if (auto cache = context->raster_cache) {
+    SkMatrix ctm = matrix;
+    ctm.postTranslate(offset_.x(), offset_.y());
     raster_cache_result_ = cache->GetPrerolledImage(
-        context->gr_context, sk_picture, matrix, context->dst_color_space,
+        context->gr_context, sk_picture, ctm, context->dst_color_space,
         is_complex_, will_change_);
   } else {
     raster_cache_result_ = RasterCacheResult();

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -37,7 +37,9 @@ void PictureLayer::Paint(PaintContext& context) const {
 
   if (raster_cache_result_.is_valid()) {
     SkPaint paint;
-    paint.setFilterQuality(kLow_SkFilterQuality);
+    // nearest neighbor(kNone_SkFilterQuality) is enough as the cache resolution
+    // should approximately match the final device resolution.
+    paint.setFilterQuality(kNone_SkFilterQuality);
     context.canvas.drawImageRect(
         raster_cache_result_.image(),             // image
         raster_cache_result_.source_rect(),       // source

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -18,6 +18,9 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   if (auto cache = context->raster_cache) {
     SkMatrix ctm = matrix;
     ctm.postTranslate(offset_.x(), offset_.y());
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+    ctm = RasterCache::GetIntegralTransCTM(ctm);
+#endif
     raster_cache_result_ = cache->GetPrerolledImage(
         context->gr_context, sk_picture, ctm, context->dst_color_space,
         is_complex_, will_change_);
@@ -36,6 +39,10 @@ void PictureLayer::Paint(PaintContext& context) const {
 
   SkAutoCanvasRestore save(&context.canvas, true);
   context.canvas.translate(offset_.x(), offset_.y());
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  context.canvas.setMatrix(
+      RasterCache::GetIntegralTransCTM(context.canvas.getTotalMatrix()));
+#endif
 
   if (raster_cache_result_.is_valid()) {
     raster_cache_result_.draw(context.canvas);

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -36,17 +36,17 @@ void PictureLayer::Paint(PaintContext& context) const {
   context.canvas.translate(offset_.x(), offset_.y());
 
   if (raster_cache_result_.is_valid()) {
-    SkPaint paint;
-    // nearest neighbor(kNone_SkFilterQuality) is enough as the cache resolution
-    // should approximately match the final device resolution.
-    paint.setFilterQuality(kNone_SkFilterQuality);
-    context.canvas.drawImageRect(
-        raster_cache_result_.image(),             // image
-        raster_cache_result_.source_rect(),       // source
-        raster_cache_result_.destination_rect(),  // destination
-        &paint,                                   // paint
-        SkCanvas::kStrict_SrcRectConstraint       // source constraint
-    );
+    context.canvas.save();
+
+    context.canvas.translate(raster_cache_result_.destination_rect().fLeft,
+                             raster_cache_result_.destination_rect().fTop);
+    context.canvas.scale(
+        raster_cache_result_.destination_rect().width() / raster_cache_result_.source_rect().width(),
+        raster_cache_result_.destination_rect().height() / raster_cache_result_.source_rect().height());
+
+    context.canvas.drawImage(raster_cache_result_.image(), 0, 0);
+
+    context.canvas.restore();
   } else {
     context.canvas.drawPicture(picture());
   }

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -36,17 +36,7 @@ void PictureLayer::Paint(PaintContext& context) const {
   context.canvas.translate(offset_.x(), offset_.y());
 
   if (raster_cache_result_.is_valid()) {
-    context.canvas.save();
-
-    context.canvas.translate(raster_cache_result_.destination_rect().fLeft,
-                             raster_cache_result_.destination_rect().fTop);
-    context.canvas.scale(
-        raster_cache_result_.destination_rect().width() / raster_cache_result_.source_rect().width(),
-        raster_cache_result_.destination_rect().height() / raster_cache_result_.source_rect().height());
-
-    context.canvas.drawImage(raster_cache_result_.image(), 0, 0);
-
-    context.canvas.restore();
+    raster_cache_result_.draw(context.canvas);
   } else {
     context.canvas.drawPicture(picture());
   }

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -81,14 +81,13 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
   // Otherwise the decomposition would have failed already.
   FXL_DCHECK(scale.x() != 0 && scale.y() != 0);
 
+  // Compute cache rect which is after scale and have integral corners
+  SkMatrix scale_matrix = SkMatrix::MakeScale(scale.x(), scale.y());
   const SkRect logical_rect = picture->cullRect();
-
-  const SkRect physical_rect =
-      SkRect::MakeWH(std::fabs(logical_rect.width() * scale.x()),
-                     std::fabs(logical_rect.height() * scale.y()));
-
+  SkRect scaled_rect;
+  scale_matrix.mapRect(&scaled_rect, logical_rect);
   SkIRect cache_rect;
-  physical_rect.roundOut(&cache_rect);
+  scaled_rect.roundOut(&cache_rect);
 
   const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
       cache_rect.width(),
@@ -115,8 +114,8 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
   }
 
   canvas->clear(SK_ColorTRANSPARENT);
-  canvas->scale(std::abs(scale.x()), std::abs(scale.y()));
   canvas->translate(-cache_rect.left(), -cache_rect.top());
+  canvas->scale(scale.x(), scale.y());
   canvas->drawPicture(picture);
 
   if (checkerboard) {
@@ -127,8 +126,8 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
       surface->makeImageSnapshot(),  // image
       // compensate canvas->translate(-cache_rect.left(), -cache_rect.top())
       cache_rect.left(), cache_rect.top(),
-      // compensate scale(std::abs(scale.x()), std::abs(scale.y()))
-      1 / std::abs(scale.x()), 1 / std::abs(scale.y())};
+      // compensate scale(scale.x(), scale.y())
+      1 / scale.x(), 1 / scale.y()};
 }
 
 static inline size_t ClampSize(size_t value, size_t min, size_t max) {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -77,10 +77,9 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
 
   const SkVector3& scale = matrix.scale();
 
-  if (scale.x() == 0 || scale.y() == 0) {
-    // the whole canvas is empty and we can't inverse scale.x or scale.y
-    return {};
-  }
+  // Scale must be nonzero so we can invert them.
+  // Otherwise the decomposition would have failed already.
+  FXL_DCHECK(scale.x() != 0 && scale.y() != 0);
 
   const SkRect logical_rect = picture->cullRect();
 
@@ -126,8 +125,7 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
       // compensate canvas->translate(-logical_rect.left(), -logical_rect.top())
       logical_rect.left(), logical_rect.top(),
       // compensate scale(std::abs(scale.x()), std::abs(scale.y()))
-      1 / std::abs(scale.x()), 1 / std::abs(scale.y())
-  };
+      1 / std::abs(scale.x()), 1 / std::abs(scale.y())};
 }
 
 static inline size_t ClampSize(size_t value, size_t min, size_t max) {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -87,9 +87,12 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
       SkRect::MakeWH(std::fabs(logical_rect.width() * scale.x()),
                      std::fabs(logical_rect.height() * scale.y()));
 
+  SkIRect cache_rect;
+  physical_rect.roundOut(&cache_rect);
+
   const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
-      std::ceil(physical_rect.width()),  // physical width
-      std::ceil(physical_rect.height())  // physical height
+      cache_rect.width(),
+      cache_rect.height()
   );
 
   sk_sp<SkSurface> surface =
@@ -113,7 +116,7 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
 
   canvas->clear(SK_ColorTRANSPARENT);
   canvas->scale(std::abs(scale.x()), std::abs(scale.y()));
-  canvas->translate(-logical_rect.left(), -logical_rect.top());
+  canvas->translate(-cache_rect.left(), -cache_rect.top());
   canvas->drawPicture(picture);
 
   if (checkerboard) {
@@ -122,8 +125,8 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
 
   return {
       surface->makeImageSnapshot(),  // image
-      // compensate canvas->translate(-logical_rect.left(), -logical_rect.top())
-      logical_rect.left(), logical_rect.top(),
+      // compensate canvas->translate(-cache_rect.left(), -cache_rect.top())
+      cache_rect.left(), cache_rect.top(),
       // compensate scale(std::abs(scale.x()), std::abs(scale.y()))
       1 / std::abs(scale.x()), 1 / std::abs(scale.y())};
 }

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -19,8 +19,8 @@ namespace flow {
 
 void RasterCacheResult::draw(SkCanvas& canvas) const {
   SkAutoCanvasRestore auto_restore(&canvas, false);
-  SkIRect bounds = RasterCache::GetDeviceBounds(logical_rect_,
-                                                canvas.getTotalMatrix());
+  SkIRect bounds =
+      RasterCache::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
   FXL_DCHECK(bounds.size() == image_->dimensions());
   canvas.resetMatrix();
   canvas.drawImage(image_, bounds.fLeft, bounds.fTop);
@@ -87,10 +87,8 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
   const SkRect logical_rect = picture->cullRect();
   SkIRect cache_rect = RasterCache::GetDeviceBounds(logical_rect, ctm);
 
-  const SkImageInfo image_info = SkImageInfo::MakeN32Premul(
-      cache_rect.width(),
-      cache_rect.height()
-  );
+  const SkImageInfo image_info =
+      SkImageInfo::MakeN32Premul(cache_rect.width(), cache_rect.height());
 
   sk_sp<SkSurface> surface =
       context
@@ -120,7 +118,7 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
     DrawCheckerboard(canvas, logical_rect);
   }
 
-  return { surface->makeImageSnapshot(), logical_rect };
+  return {surface->makeImageSnapshot(), logical_rect};
 }
 
 static inline size_t ClampSize(size_t value, size_t min, size_t max) {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -77,6 +77,11 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
 
   const SkVector3& scale = matrix.scale();
 
+  if (scale.x() == 0 || scale.y() == 0) {
+    // the whole canvas is empty and we can't inverse scale.x or scale.y
+    return {};
+  }
+
   const SkRect logical_rect = picture->cullRect();
 
   const SkRect physical_rect =
@@ -118,8 +123,10 @@ RasterCacheResult RasterizePicture(SkPicture* picture,
 
   return {
       surface->makeImageSnapshot(),  // image
-      physical_rect,                 // source rect
-      logical_rect                   // destination rect
+      // compensate canvas->translate(-logical_rect.left(), -logical_rect.top())
+      logical_rect.left(), logical_rect.top(),
+      // compensate scale(std::abs(scale.x()), std::abs(scale.y()))
+      1 / std::abs(scale.x()), 1 / std::abs(scale.y())
   };
 }
 

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -156,7 +156,7 @@ RasterCacheResult RasterCache::GetPrerolledImage(
     return {};
   }
 
-  RasterCacheKey cache_key(*picture, matrix);
+  RasterCacheKey cache_key(*picture, transformation_matrix);
 
   Entry& entry = cache_[cache_key];
   entry.access_count = ClampSize(entry.access_count + 1, 0, threshold_);

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -22,7 +22,10 @@ class RasterCacheResult {
   RasterCacheResult() {}
 
   RasterCacheResult(sk_sp<SkImage> image,
-                    SkScalar tx, SkScalar ty, SkScalar sx, SkScalar sy)
+                    SkScalar tx,
+                    SkScalar ty,
+                    SkScalar sx,
+                    SkScalar sy)
       : image_(std::move(image)), tx_(tx), ty_(ty), sx_(sx), sy_(sy) {}
 
   operator bool() const { return static_cast<bool>(image_); }

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -49,6 +49,13 @@ class RasterCache {
     return bounds;
   }
 
+  static SkMatrix GetIntegralTransCTM(const SkMatrix& ctm) {
+    SkMatrix result = ctm;
+    result[SkMatrix::kMTransX] = SkScalarRoundToScalar(ctm.getTranslateX());
+    result[SkMatrix::kMTransY] = SkScalarRoundToScalar(ctm.getTranslateY());
+    return result;
+  }
+
   RasterCacheResult GetPrerolledImage(GrContext* context,
                                       SkPicture* picture,
                                       const SkMatrix& transformation_matrix,

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -19,29 +19,29 @@ namespace flow {
 
 class RasterCacheResult {
  public:
-  RasterCacheResult()
-      : source_rect_(SkRect::MakeEmpty()),
-        destination_rect_(SkRect::MakeEmpty()) {}
+  RasterCacheResult() {}
 
-  RasterCacheResult(sk_sp<SkImage> image, SkRect source, SkRect destination)
-      : image_(std::move(image)),
-        source_rect_(source),
-        destination_rect_(destination) {}
+  RasterCacheResult(sk_sp<SkImage> image,
+                    SkScalar tx, SkScalar ty, SkScalar sx, SkScalar sy)
+      : image_(std::move(image)), tx_(tx), ty_(ty), sx_(sx), sy_(sy) {}
 
   operator bool() const { return static_cast<bool>(image_); }
 
   bool is_valid() const { return static_cast<bool>(image_); };
 
-  sk_sp<SkImage> image() const { return image_; }
-
-  const SkRect& source_rect() const { return source_rect_; }
-
-  const SkRect& destination_rect() const { return destination_rect_; }
+  void draw(SkCanvas& canvas) const {
+    canvas.save();
+    canvas.translate(tx_, ty_);
+    canvas.scale(sx_, sy_);
+    canvas.drawImage(image_, 0, 0);
+    canvas.restore();
+  }
 
  private:
   sk_sp<SkImage> image_;
-  SkRect source_rect_;
-  SkRect destination_rect_;
+
+  // translation and scale to be applied before drawImage
+  SkScalar tx_, ty_, sx_, sy_;
 };
 
 class RasterCache {

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -34,8 +34,8 @@ class RasterCacheResult {
 
   void draw(SkCanvas& canvas) const {
     canvas.save();
-    canvas.translate(tx_, ty_);
     canvas.scale(sx_, sy_);
+    canvas.translate(tx_, ty_);
     canvas.drawImage(image_, 0, 0);
     canvas.restore();
   }

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -22,8 +22,8 @@ class RasterCacheResult {
   RasterCacheResult() {}
 
   RasterCacheResult(sk_sp<SkImage> image,
-                    SkScalar tx,
-                    SkScalar ty,
+                    int32_t tx,
+                    int32_t ty,
                     SkScalar sx,
                     SkScalar sy)
       : image_(std::move(image)), tx_(tx), ty_(ty), sx_(sx), sy_(sy) {}
@@ -44,7 +44,8 @@ class RasterCacheResult {
   sk_sp<SkImage> image_;
 
   // translation and scale to be applied before drawImage
-  SkScalar tx_, ty_, sx_, sy_;
+  int32_t  tx_, ty_;
+  SkScalar sx_, sy_;
 };
 
 class RasterCache {

--- a/flow/raster_cache_key.h
+++ b/flow/raster_cache_key.h
@@ -15,14 +15,14 @@ namespace flow {
 
 class RasterCacheKey {
  public:
-  RasterCacheKey(const SkPicture& picture, const MatrixDecomposition& matrix)
-      : picture_id_(picture.uniqueID()),
-        scale_key_(SkISize::Make(matrix.scale().x() * 1e3,
-                                 matrix.scale().y() * 1e3)) {}
+  RasterCacheKey(const SkPicture& picture, const SkMatrix& ctm)
+      : picture_id_(picture.uniqueID()), matrix_(ctm) {
+    matrix_[SkMatrix::kMTransX] = SkScalarFraction(ctm.getTranslateX());
+    matrix_[SkMatrix::kMTransY] = SkScalarFraction(ctm.getTranslateY());
+  }
 
   uint32_t picture_id() const { return picture_id_; }
-
-  const SkISize& scale_key() const { return scale_key_; }
+  const SkMatrix& matrix() const { return matrix_; }
 
   struct Hash {
     std::size_t operator()(RasterCacheKey const& key) const {
@@ -33,8 +33,7 @@ class RasterCacheKey {
   struct Equal {
     constexpr bool operator()(const RasterCacheKey& lhs,
                               const RasterCacheKey& rhs) const {
-      return lhs.picture_id_ == rhs.picture_id_ &&
-             lhs.scale_key_ == rhs.scale_key_;
+      return lhs.picture_id_ == rhs.picture_id_ && lhs.matrix_ == rhs.matrix_;
     }
   };
 
@@ -43,7 +42,12 @@ class RasterCacheKey {
 
  private:
   uint32_t picture_id_;
-  SkISize scale_key_;
+
+  // ctm where only fractional (0-1) translations are preserved:
+  //   matrix_ = ctm;
+  //   matrix_[SkMatrix::kMTransX] = SkScalarFraction(ctm.getTranslateX());
+  //   matrix_[SkMatrix::kMTransY] = SkScalarFraction(ctm.getTranslateY());
+  SkMatrix matrix_;
 };
 
 }  // namespace flow

--- a/flow/raster_cache_key.h
+++ b/flow/raster_cache_key.h
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 #include "flutter/flow/matrix_decomposition.h"
+#include "lib/fxl/logging.h"
 #include "lib/fxl/macros.h"
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPicture.h"
@@ -19,6 +20,9 @@ class RasterCacheKey {
       : picture_id_(picture.uniqueID()), matrix_(ctm) {
     matrix_[SkMatrix::kMTransX] = SkScalarFraction(ctm.getTranslateX());
     matrix_[SkMatrix::kMTransY] = SkScalarFraction(ctm.getTranslateY());
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+    FXL_DCHECK(matrix_.getTranslateX() == 0 && matrix_.getTranslateY() == 0);
+#endif
   }
 
   uint32_t picture_id() const { return picture_id_; }


### PR DESCRIPTION
The previous implementation uses drawImageRect with kLow_FilterQuality which will trigger bilerp inside Skia. That seems unnecessarily costly because the cache's resolution should be approximately equal to the device's resolution.

Also, the different src rect and dst rect in the previous implementation makes it a little harder to reason about the raster's behavior. (See, e.g., https://github.com/flutter/flutter/issues/17731)

This PR drops src/dst rects and simply uses translation/scale that intuitively matches (and compensates) the translation/scale of creating the cache. It also allows us to directly use drawImage so we no longer needs bilerp.

I haven't found a test that can tell the performance difference. Theoretically it can only go faster.