### PR TITLE
Re-add ACTION_LONG_CLICK for Android a11y

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -278,7 +278,17 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
         }
         switch (action) {
             case AccessibilityNodeInfo.ACTION_CLICK: {
+                // Note: TalkBack prior to Oreo doesn't use this handler and instead simulates a
+                //     click event at the center of the SemanticsNode. Other a11y services might go
+                //     through this handler though.
                 mOwner.dispatchSemanticsAction(virtualViewId, Action.TAP);
+                return true;
+            }
+            case AccessibilityNodeInfo.ACTION_LONG_CLICK: {
+                // Note: TalkBack doesn't use this handler and instead simulates a long click event
+                //     at the center of the SemanticsNode. Other a11y services might go through this
+                //     handler though.
+                mOwner.dispatchSemanticsAction(virtualViewId, Action.LONG_PRESS);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_SCROLL_FORWARD: {


### PR DESCRIPTION
This was accidentally removed in https://github.com/flutter/engine/pull/5081. Re-added with a comment explaining why this should stay even though its not used by Talkback (other a11y services might use it, though).

/cc @jonahwilliams 