### PR TITLE
Set fPreferExternalImagesOverES3 option in Skia

### DIFF
--- a/shell/common/io_manager.cc
+++ b/shell/common/io_manager.cc
@@ -23,6 +23,10 @@ sk_sp<GrContext> IOManager::CreateCompatibleResourceLoadingContext(
   // that feature, which will cause texture uploads to do CPU YUV conversion.
   options.fDisableGpuYUVConversion = true;
 
+  // To get video playback on the widest range of devices, we limit Skia to
+  // ES2 shading language when the ES3 external image extension is missing.
+  options.fPreferExternalImagesOverES3 = true;
+
   if (auto context = GrContext::MakeGL(GrGLMakeNativeInterface(), options)) {
     // Do not cache textures created by the image decoder.  These textures
     // should be deleted when they are no longer referenced by an SkImage.

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -45,6 +45,10 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
   GrContextOptions options;
   options.fAvoidStencilBuffers = true;
 
+  // To get video playback on the widest range of devices, we limit Skia to
+  // ES2 shading language when the ES3 external image extension is missing.
+  options.fPreferExternalImagesOverES3 = true;
+
   auto context = GrContext::MakeGL(GrGLMakeNativeInterface(), options);
 
   if (context == nullptr) {


### PR DESCRIPTION
This causes Skia to fall back to the ES2 shading language when the GL
driver doesn't clearly communicate that it supports the ES3 external
image extension. Doing so ensures that video playback (which relies on
external images) works on many more devices.

Fixes https://github.com/flutter/flutter/issues/16178