### PR TITLE
Make PictureRecorder optionally devicePixelRatio aware

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2582,17 +2582,25 @@ class Canvas extends NativeFieldWrapperClass2 {
   ///
   /// To end the recording, call [PictureRecorder.endRecording] on the
   /// given recorder.
-  Canvas(PictureRecorder recorder, [ Rect cullRect ]) : assert(recorder != null) {
+  Canvas(PictureRecorder recorder, [ Rect cullRect ]) : 
+    wasScaledToDevicePixelRatio = recorder?.scaledToDevicePixelRatio, 
+    assert(recorder != null) {
     if (recorder.isRecording)
       throw new ArgumentError('"recorder" must not already be associated with another Canvas.');
     cullRect ??= Rect.largest;
     _constructor(recorder, cullRect.left, cullRect.top, cullRect.right, cullRect.bottom);
+    
+    if (recorder.scaledToDevicePixelRatio == true) {
+      scale(window.devicePixelRatio, window.devicePixelRatio);
+    }
   }
   void _constructor(PictureRecorder recorder,
                     double left,
                     double top,
                     double right,
                     double bottom) native 'Canvas_constructor';
+
+  final bool wasScaledToDevicePixelRatio;
 
   /// Saves a copy of the current transform and clip on the save stack.
   ///
@@ -3311,8 +3319,23 @@ class PictureRecorder extends NativeFieldWrapperClass2 {
   /// Creates a new idle PictureRecorder. To associate it with a
   /// [Canvas] and begin recording, pass this [PictureRecorder] to the
   /// [Canvas] constructor.
-  PictureRecorder() { _constructor(); }
-  void _constructor() native 'PictureRecorder_constructor';
+  /// 
+  /// Setting `scaledToDevicePixelRatio` will cause any [Canvas], [Picture],
+  /// or [Image] created from this recording to be scaled by the
+  /// [Window.devicePixelRatio].  This flag is helpful if you intend to create
+  /// and [Image] from this recording, especially if the recording is done at
+  /// lower resolutions and will be displayed on the device.  Note that it will
+  /// result in a larger [Image].
+  PictureRecorder({this.scaledToDevicePixelRatio = false}) { _constructor(scaledToDevicePixelRatio); }
+  void _constructor(bool scaledToDevicePixelRatio) native 'PictureRecorder_constructor';
+
+  /// Whether this recorder should scale its drawings and images to the
+  /// [Window.devicePixelRatio].
+  /// 
+  /// This is desirable if the recorder is intended to produce a [Picture]
+  /// that will be made into an [Image] (via [Picture.toImage]). Note that
+  /// this will result in a larger image.
+  final bool scaledToDevicePixelRatio;
 
   /// Whether this object is currently recording commands.
   ///

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -24,7 +24,8 @@ class Picture : public fxl::RefCountedThreadSafe<Picture>,
 
  public:
   ~Picture() override;
-  static fxl::RefPtr<Picture> Create(flow::SkiaGPUObject<SkPicture> picture);
+  static fxl::RefPtr<Picture> Create(flow::SkiaGPUObject<SkPicture> picture,
+                                     bool scaled_to_device = false);
 
   sk_sp<SkPicture> picture() const { return picture_.get(); }
 
@@ -37,9 +38,10 @@ class Picture : public fxl::RefCountedThreadSafe<Picture>,
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  explicit Picture(flow::SkiaGPUObject<SkPicture> picture);
+  explicit Picture(flow::SkiaGPUObject<SkPicture> picture, bool scaled_to_device = false);
 
   flow::SkiaGPUObject<SkPicture> picture_;
+  bool scaled_to_device_;
 };
 
 }  // namespace blink

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -27,15 +27,16 @@ FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
 
 void PictureRecorder::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register(
-      {{"PictureRecorder_constructor", PictureRecorder_constructor, 1, true},
+      {{"PictureRecorder_constructor", PictureRecorder_constructor, 2, true},
        FOR_EACH_BINDING(DART_REGISTER_NATIVE)});
 }
 
-fxl::RefPtr<PictureRecorder> PictureRecorder::Create() {
-  return fxl::MakeRefCounted<PictureRecorder>();
+fxl::RefPtr<PictureRecorder> PictureRecorder::Create(bool scaled_to_device) {
+  return fxl::MakeRefCounted<PictureRecorder>(scaled_to_device);
 }
 
-PictureRecorder::PictureRecorder() {}
+PictureRecorder::PictureRecorder(bool scaled_to_device)
+    : scaled_to_device_(scaled_to_device) {}
 
 PictureRecorder::~PictureRecorder() {}
 
@@ -51,8 +52,10 @@ fxl::RefPtr<Picture> PictureRecorder::endRecording() {
   if (!isRecording())
     return nullptr;
 
-  fxl::RefPtr<Picture> picture = Picture::Create(UIDartState::CreateGPUObject(
-      picture_recorder_.finishRecordingAsPicture()));
+  fxl::RefPtr<Picture> picture =
+      Picture::Create(UIDartState::CreateGPUObject(
+                          picture_recorder_.finishRecordingAsPicture()),
+                      scaled_to_device_);
   canvas_->Clear();
   canvas_->ClearDartWrapper();
   canvas_ = nullptr;

--- a/lib/ui/painting/picture_recorder.h
+++ b/lib/ui/painting/picture_recorder.h
@@ -22,7 +22,7 @@ class PictureRecorder : public fxl::RefCountedThreadSafe<PictureRecorder>,
   FRIEND_MAKE_REF_COUNTED(PictureRecorder);
 
  public:
-  static fxl::RefPtr<PictureRecorder> Create();
+  static fxl::RefPtr<PictureRecorder> Create(bool scaled_to_device = false);
 
   ~PictureRecorder();
 
@@ -35,11 +35,12 @@ class PictureRecorder : public fxl::RefCountedThreadSafe<PictureRecorder>,
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  PictureRecorder();
+  PictureRecorder(bool scaled_to_device = false);
 
   SkRTreeFactory rtree_factory_;
   SkPictureRecorder picture_recorder_;
   fxl::RefPtr<Canvas> canvas_;
+  bool scaled_to_device_;
 };
 
 }  // namespace blink

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -6,13 +6,13 @@ import 'dart:ui';
 
 import 'package:test/test.dart';
 
-class FakeEverything implements Canvas, PictureRecorder, Color {
+class FakeEverything implements PictureRecorder, Color {
   dynamic noSuchMethod(Invocation invocation) {
     return new FakeEverything();
   }
 }
 
-class NegativeSpace implements Canvas, PictureRecorder, Color {
+class NegativeSpace implements PictureRecorder, Color {
   dynamic noSuchMethod(Invocation invocation) {
     return false;
   }
@@ -33,6 +33,7 @@ void main() {
     List<dynamic> list = <dynamic>[fake, fake];
     Offset offset = new Offset(double.NAN, double.NAN);
     Path path = new Path();
+    Color color = new Color(0x0);
 
     try { new Canvas(null, null); } catch (error) { }
     try { new Canvas(null, rect); } catch (error) { }

--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -2,3 +2,6 @@ name: engine_tests
 dependencies:
   test: any
   path: any
+dev_dependencies:
+  flutter_test:
+    sdk: flutter


### PR DESCRIPTION
See discussion in https://github.com/flutter/flutter/issues/17782

Today, if you use a `PictureRecorder` to ultimately create an image, the resolution will come out lower than expected/reflected if rendered on the device.  A work around looks like this:

```
    var rec = new ui.PictureRecorder();
    var canvas = new Canvas(rec);
    var dpr = ui.window.devicePixelRatio;
    canvas.scale(dpr, dpr);
    canvas.drawPath(sendPath, blackPaint);
    var picture = rec.endRecording();
    return picture.toImage((24 * dpr).ceil(), (24 * dpr).ceil());
```

Which has already led to confusion for users (myself and @sneerath both raised issues/comments around this).
This patch enables the code to look more like this:

```
  var rec = new ui.PictureRecorder(scaledToDevicePixelRatio: true);
  var canvas = new Canvas(rec);
  canvas.drawPath(sendPath, blackPaint);
  var picture = rec.endRecording();
  return picture.toImage(24, 24);
```

This will actually create a picture that's 24 * window.devicePixelRatio square.  

I started out hoping all the code could be in `painting.dart`, but at least some of it needs to be in engine because of how `Image` works today.

cc @tvolkert @Hixie  @nsreenath