### PR TITLE
Remove assert for unsupported SemanticsEvents

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -691,8 +691,6 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
                 e.getText().add((String) data.get("message"));
                 sendAccessibilityEvent(e);
             }
-            default:
-                assert false;
         }
     }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -614,8 +614,6 @@ void AccessibilityBridge::HandleEvent(NSDictionary<NSString*, id>* annotatedEven
   if ([type isEqualToString:@"announce"]) {
     NSString* message = annotatedEvent[@"data"][@"message"];
     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, message);
-  } else {
-    NSCAssert(NO, @"Invalid event type %@", type);
   }
 }
 


### PR DESCRIPTION
Not all platforms are expected to handle all SemanticsEvents. Therefore, it is ok to just drop unsupported events on the floor.

Fixes https://github.com/flutter/flutter/issues/17853.

/cc @jonahwilliams 