### PR TITLE
Reapply "Don't link the core snapshot in the Android engine."

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -104,14 +104,6 @@ source_set("runtime") {
 
   public_configs = [ "$flutter_root:config" ]
 
-  # In AOT mode, precompiled snapshots contain the instruction buffer.
-  # Generation of the same requires all application specific script code to be
-  # specified up front. In such cases, there can be no generic snapshot.
-  # In Fuchsia, we load from a file instead of linking.
-  if (!flutter_aot && !is_fuchsia) {
-    deps += [ "$flutter_root/lib/snapshot" ]
-  }
-
   if (flutter_runtime_mode != "release" && !is_fuchsia) {
     # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
     # instead puts Observatory into the runner's package.

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -48,6 +48,7 @@ executable("embedder_unittests") {
   deps = [
     ":embedder",
     ":fixtures",
+    "$flutter_root/lib/snapshot",
     "$flutter_root/testing",
   ]
 

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -17,6 +17,7 @@ executable("testing") {
     "$flutter_root/assets",
     "$flutter_root/common",
     "$flutter_root/fml",
+    "$flutter_root/lib/snapshot",
     "$flutter_root/shell/common",
     "//garnet/public/lib/fxl",
     "//third_party/dart/runtime:libdart_jit",


### PR DESCRIPTION
Add back the core snapshot to runtime_unittests and embedder_unittests.