### PR TITLE
Don't enable LTO on Windows hosts as the toolchain does not read the value.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -84,7 +84,7 @@ def to_gn_args(args):
       # There is no point in enabling LTO in unoptimized builds.
       enable_lto = False
 
-    if args.target_os != 'win':
+    if not sys.platform.startswith('win'):
       # The GN arg is not available in the windows toolchain.
       gn_args['enable_lto'] = enable_lto
 


### PR DESCRIPTION
This causes a non-fatal warning on the gn step on Windows.