### PR TITLE
Removed sync_async flag from engine which was causing snapshot compatibility errors.

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -91,7 +91,8 @@ static const char* kDartStrongModeArgs[] = {
     "--strong",
     "--reify_generic_functions",
     "--limit_ints_to_64_bits",
-    "--sync_async",
+    // TODO(bkonyi): uncomment when sync-async is enabled in flutter/flutter.
+    // "--sync_async",
     // clang-format on
 };
 


### PR DESCRIPTION
Will be reenabled when sync-async is on by default in flutter/flutter.