### PR TITLE
Explicitly package vm and isolate snapshots on desktop and embedder targets.

### DIFF
--- a/shell/platform/darwin/desktop/BUILD.gn
+++ b/shell/platform/darwin/desktop/BUILD.gn
@@ -22,6 +22,7 @@ source_set("mac_desktop_platform") {
   deps = [
     "$flutter_root/common",
     "$flutter_root/fml",
+    "$flutter_root/lib/snapshot",
     "$flutter_root/shell/common",
     "$flutter_root/shell/gpu",
     "$flutter_root/shell/platform/darwin/common",

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -19,6 +19,7 @@ source_set("embedder") {
     "$flutter_root/assets",
     "$flutter_root/common",
     "$flutter_root/fml",
+    "$flutter_root/lib/snapshot",
     "$flutter_root/shell/common",
     "$flutter_root/shell/gpu",
     "//garnet/public/lib/fxl",
@@ -48,7 +49,6 @@ executable("embedder_unittests") {
   deps = [
     ":embedder",
     ":fixtures",
-    "$flutter_root/lib/snapshot",
     "$flutter_root/testing",
   ]
 


### PR DESCRIPTION
These snapshots used to be included (from the runtime target) in the executable if AOT mode was disabled. The mobile shells now include this snapshot in the kernel snapshot generated on the host. However the targets that run on the host still need this. The tester target was already patched but the desktop embedder targets were overlooked. The unit tests passed on the embedder target because the unit tester exectuable was including the snapshot in addition to the dylib. Now the dylib itself depends on the snapshot directly.