### PR TITLE
Reduce log spam: failing to find an instructions buffer isn't an erro…

### DIFF
--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -60,7 +60,7 @@ fxl::RefPtr<NativeLibrary> NativeLibrary::CreateForCurrentProcess() {
 const uint8_t* NativeLibrary::ResolveSymbol(const char* symbol) {
   auto resolved_symbol = static_cast<const uint8_t*>(::dlsym(handle_, symbol));
   if (resolved_symbol == nullptr) {
-    FXL_DLOG(ERROR) << "Could not resolve symbol in library: " << symbol;
+    FXL_DLOG(INFO) << "Could not resolve symbol in library: " << symbol;
   }
   return resolved_symbol;
 }


### PR DESCRIPTION
…r for ordinary core snapshots.