### PR TITLE
Expose approximateBytesUsed for Picture

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3306,6 +3306,12 @@ class Picture extends NativeFieldWrapperClass2 {
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.
   void dispose() native 'Picture_dispose';
+
+  /// Returns the approximate number of bytes allocated for this object.
+  /// 
+  /// The actual size of this picture may be larger, particularly if it contains
+  /// references to image or other large objects.
+  int get approximateBytesUsed native 'Picture_GetAllocationSize';
 }
 
 /// Records a [Picture] containing a sequence of graphical operations.

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -18,7 +18,8 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Picture);
 
 #define FOR_EACH_BINDING(V) \
   V(Picture, toImage)       \
-  V(Picture, dispose)
+  V(Picture, dispose)       \
+  V(Picture, GetAllocationSize)
 
 DART_BIND_ALL(Picture, FOR_EACH_BINDING)
 


### PR DESCRIPTION
I'd like to cache pictures, and want to be able to have it be memory-aware.

The comment(s) about refed objects would apply to things like `canvas.drawImage()` recorded into the picture.

The method already exists in the C++, just isn't exposed to the Dart side (yet).
