### PR TITLE
Copy embedder header to the out directory.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -33,10 +33,8 @@ group("flutter") {
   # If on the host, compile all unittests targets.
   if (current_toolchain == host_toolchain) {
     if (is_mac) {
-      public_deps += [
-        "$flutter_root/shell/platform/darwin:flutter_channels_unittests",
-        "$flutter_root/shell/platform/embedder:flutter_embedder_framework",
-      ]
+      public_deps +=
+          [ "$flutter_root/shell/platform/darwin:flutter_channels_unittests" ]
     }
 
     public_deps += [

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -57,12 +57,26 @@ executable("embedder_unittests") {
   }
 }
 
-shared_library("flutter_engine") {
+shared_library("flutter_engine_library") {
+  visibility = [ ":*" ]
+
+  output_name = "flutter_engine"
+
   deps = [
     ":embedder",
   ]
 
   public_configs = [ "$flutter_root:config" ]
+}
+
+copy("copy_headers") {
+  visibility = [ ":*" ]
+  sources = [
+    "embedder.h",
+  ]
+  outputs = [
+    "$root_out_dir/flutter_embedder.h",
+  ]
 }
 
 if (is_mac) {
@@ -77,11 +91,11 @@ if (is_mac) {
       "$_flutter_embedder_framework_dir/Versions/A/FlutterEmbedder",
     ]
     deps = [
-      ":flutter_engine",
+      ":flutter_engine_library",
     ]
   }
 
-  copy("copy_headers") {
+  copy("copy_framework_headers") {
     visibility = [ ":*" ]
     sources = [
       "embedder.h",
@@ -149,6 +163,7 @@ if (is_mac) {
   }
 
   action("generate_symlinks") {
+    visibility = [ ":*" ]
     script = "//build/config/mac/package_framework.py"
     outputs = [
       "$root_build_dir/FlutterEmbedder.stamp",
@@ -167,7 +182,7 @@ if (is_mac) {
       "FlutterEmbedder.stamp",
     ]
     deps = [
-      ":copy_headers",
+      ":copy_framework_headers",
       ":copy_icu",
       ":copy_info_plist",
       ":copy_module_map",
@@ -176,8 +191,22 @@ if (is_mac) {
   }
 
   group("flutter_embedder_framework") {
+    visibility = [ ":*" ]
     deps = [
       ":generate_symlinks",
     ]
+  }
+}
+
+group("flutter_engine") {
+  # All platforms require the embedder dylib and headers.
+  deps = [
+    ":copy_headers",
+    ":flutter_engine_library",
+  ]
+
+  # For the Mac, the dylib is packaged in a framework with the appropriate headers.
+  if (is_mac) {
+    deps += [ ":flutter_embedder_framework" ]
   }
 }


### PR DESCRIPTION
This allows the stable header to be referenced from a known location. Also reduces the visibility of the framework target so that it is automatically built on the mac.