### PR TITLE
Roll Dart to ff815d05a52c03a318bff51ba4529ff5210b7bd6

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'f981f097602ca434ce0a36b1f704723cad105fb6',
+  'dart_revision': 'ff815d05a52c03a318bff51ba4529ff5210b7bd6',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.7',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 7800acf839e69a9c38375b073b436ef4
+Signature: 31d089189c09b6be4e8cd538f4aac979
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
```
ff815d05a5 [release] Prepare changelog for 2.0.0-dev.59.0
17afa8ef56 Give private parameters public names for constructor.
7b33203f8e Fixes to make hackernews run strong mode clean
718e1578a0 Update Analyzer AstBuilder to optionally parse function bodies
1ca17b6d03 [vm/kernel] Recognize desugared mixin applications in dart:mirrors
8b0c1f8044 Fix AstRewriteVisitor to set elements/types for instance creation nodes.
84fcf42c25 Bump analyzer version in preparation for publishing.
96dd9d49db Update Analyzer tests to pass NonExistingSource rather than null
736ddd9b0e [Observatory] Refactor observatory build to prepare for Fuchsia prebuilt
b7336ab443 Improve field type argument recovery
6bc7288e70 Fix fused UTF-8/JSON decoding.
2a3d1dc9ed [vm] Prepare status for app_jitk builders (#33126)
40f61d6b0b Handle Windows line ending in generate_messages_test
7dc4fbf5a2 [fasta] Add support for annotations on enum values
2514a67614 Import link.dart directly
990c85276b Avoid allocation and bottom-type on Link
58dc4e476d Revert "[vm] Support definition of entry-points via @pragma('vm.extern') annotations."
e20189ecf5 Adjusted the instantiate-to-bound algorithm to break cycles at every member, not just one.
3e50ea32b5 [vm] Support definition of entry-points via @pragma('vm.extern') annotations.
e2597dfba7 Revert "Mark normal classes that were originally mixin applications"
d28c5499fc [infra] Add support for app_jitk compiler to test.py (#33126)
640791c922 Add example to docs/language/informal/super-bounded-types.md.
53cd0b4af1 Mark normal classes that were originally mixin applications
6b7f3d5f54 Share non-generic signatures through init.types
b79e06630c Add a recovery test
```