### PR TITLE
Dart SDK roll for 2018-05-30

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'github_git': 'https://github.com',
   'skia_git': 'https://skia.googlesource.com',
-  'skia_revision': '137b87485508e3882968a10559c2cb389dcc93c5',
+  'skia_revision': '588f879677d4f36e16a42dd96876534f104c2e2f',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'ff815d05a52c03a318bff51ba4529ff5210b7bd6',
+  'dart_revision': '3b6caa3517bcc7150030f240deedb010f5e3bc60',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.7',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 782592db06110d1380d491ec2cb2d99e
+Signature: 49e586d59520eaf4d90da8e9a6dab15e
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Commits:

3b6caa3517b Split UnresolvedNameGenerator
f50873d3451 [fuchsia] Renaming component FIDL to fuchsia.sys.
13987b073d6 Add Forest method to access the name of a variable declaration
3b86f823d0a [vm/corelib] Remove GrowableArrayMarker hack.
88127f10e4f Clean up num#toStringAsPrecision docs
1eb1885c62d tools/addlatexhash.dart: Remove unused import
03cb46a2290 [vm/perf] Fix JITDUMP integration.
9d9eff44c99 Support sharing function signatures in deferred parts for fast startup
ae9f5d2a1b1 Add Forest API for logical expressions
66c590d3ad3 Add json/utf8 BOM support in changelog.
d116e62d76d Improve catch parameter recovery
aa8e2ee178d Revert "[vm] Add tests for determinism of script and AppJIT snapshots."
ec47e524bc9 Switch to non-alpha versions for analyzer/front_end/kernel.
aac0478fada [vm] Add tests for determinism of script and AppJIT snapshots.
6cc7aa803a1 Change names/declarations tasks in AnalysisDriver sync.
c30af41b96c Reapply "[mirrors] Add IsolateMirror.loadUri."
a40993a6aff Observatory strong mode fix: Fix incorrect types in DebuggerStackElement.
0fdfc9aa3b6 Observatory strong mode fix: Add a needed implements clause.
209029ab8ee Observatory strong mode fix: Pass through a type parameter in the implements clause for GuardedMock.
1d323687b39 Use selection to decide whether EXTRACT_LOCAL_VARIABLE and EXTRACT_METHOD are available.