### PR TITLE
Synchronizes analysis_options.yaml files, and turns on Function typedef lint.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,13 +1,13 @@
 # Specify analysis options.
 #
 # This file is a copy of analysis_options_repo.yaml from flutter repo
-# as of 2018-01-07, but with "sort_constructors_first" disabled
-# (because we have private fake constructors), with
-# "always_require_non_null_named_parameters" disabled (because we
-# can't import the meta package from the SDK), and with
-# "prefer_final_fields" disabled (because we do weird things with
-# private fields, especially on the Window object):
-# https://github.com/lfutter/flutter/blob/master/analysis_options_repo.yaml
+# as of 2018-01-07, but with:
+#  - "always_require_non_null_named_parameters" disabled (because we
+#    can't import the meta package from the SDK), and
+#  - "sort_constructors_first" disabled (because we have private fake
+#     constructors),
+#  - "prefer_final_fields" disabled (because we do weird things with
+#    private fields, especially on the Window object):
 
 analyzer:
   language:
@@ -22,6 +22,9 @@ analyzer:
     missing_return: warning
     # allow having TODOs in the code
     todo: ignore
+  # `flutter analyze` (without `--watch`) just ignores directories
+  # that contain a .dartignore file, and this file does not have any
+  # effect on what files are actually analyzed.
 
 linter:
   rules:
@@ -31,11 +34,12 @@ linter:
     - always_declare_return_types
     - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    # always_require_non_null_named_parameters
+    # always_require_non_null_named_parameters # DIFFERENT FROM FLUTTER/FLUTTER
     - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
     - avoid_as
+    # - avoid_bool_literals_in_conditional_expressions # not yet tested
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly
     - avoid_classes_with_only_static_members
@@ -44,11 +48,16 @@ linter:
     - avoid_init_to_null
     - avoid_null_checks_in_equality_operators
     # - avoid_positional_boolean_parameters # not yet tested
+    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     # - avoid_returning_null # we do this commonly
     # - avoid_returning_this # https://github.com/dart-lang/linter/issues/842
     # - avoid_setters_without_getters # not yet tested
+    # - avoid_single_cascade_in_expression_statements # not yet tested
     - avoid_slow_async_io
+    # - avoid_types_as_parameter_names # https://github.com/dart-lang/linter/pull/954/files
     # - avoid_types_on_closure_parameters # conflicts with always_specify_types
     # - avoid_unused_constructor_parameters # https://github.com/dart-lang/linter/pull/847
     - await_only_futures
@@ -85,15 +94,18 @@ linter:
     # - parameter_assignments # we do this commonly
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    # - prefer_bool_in_asserts # not yet tested
+    - prefer_bool_in_asserts
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
     - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
     # - prefer_constructors_over_static_methods # not yet tested
     - prefer_contains
+    # - prefer_equal_for_default_values # not yet tested
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
-    # - prefer_final_fields
+    # - prefer_final_fields # DIFFERENT FROM FLUTTER/FLUTTER
     - prefer_final_locals
     - prefer_foreach
     # - prefer_function_declarations_over_variables # not yet tested
@@ -106,7 +118,7 @@ linter:
     - public_member_api_docs # this is the only difference from analysis_options.yaml
     - recursive_getters
     - slash_for_doc_comments
-    # - sort_constructors_first
+    # - sort_constructors_first # DIFFERENT FROM FLUTTER/FLUTTER
     - sort_unnamed_constructors_first
     - super_goes_last
     - test_types_in_equals
@@ -120,6 +132,7 @@ linter:
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
     - unnecessary_overrides
+    - unnecessary_parenthesis
     # - unnecessary_statements # not yet tested
     - unnecessary_this
     - unrelated_type_equality_checks

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Specify analysis options.
 #
 # This file is a copy of analysis_options_repo.yaml from flutter repo
-# as of 2018-01-07, but with:
+# as of 2018-05-30, but with:
 #  - "always_require_non_null_named_parameters" disabled (because we
 #    can't import the meta package from the SDK), and
 #  - "sort_constructors_first" disabled (because we have private fake
@@ -109,6 +109,7 @@ linter:
     - prefer_final_locals
     - prefer_foreach
     # - prefer_function_declarations_over_variables # not yet tested
+    - prefer_generic_function_type_aliases
     - prefer_initializing_formals
     # - prefer_interpolation_to_compose_strings # not yet tested
     - prefer_is_empty

--- a/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
+++ b/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
@@ -18,7 +18,7 @@ import 'package:vm/frontend_server.dart' show ProgramTransformer;
 //
 // The parameter name contains a randomly generate hex string to avoid collision
 // with user generated parameters.
-final String _creationLocationParameterName =
+const String _creationLocationParameterName =
     r'$creationLocationd_0dea112b090073317d4';
 
 /// Name of private field added to the Widget class and any other classes that
@@ -27,7 +27,7 @@ final String _creationLocationParameterName =
 /// Regardless of what library a class implementing Widget is defined in, the
 /// private field will always be defined in the context of the widget_inspector
 /// library ensuring no name conflicts with regular fields.
-final String _locationFieldName = r'_location';
+const String _locationFieldName = r'_location';
 
 bool _hasNamedParameter(FunctionNode function, String name) {
   return function.namedParameters

--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -22,7 +22,7 @@ class _FlutterFrontendCompiler implements frontend.CompilerInterface{
 
   _FlutterFrontendCompiler(StringSink output, {bool trackWidgetCreation: false}):
       _compiler = new frontend.FrontendCompiler(output,
-          transformer: (trackWidgetCreation ? new WidgetCreatorTracker() : null));
+          transformer: trackWidgetCreation ? new WidgetCreatorTracker() : null);
 
   @override
   Future<Null> compile(String filename, ArgResults options, {IncrementalCompiler generator}) async {

--- a/frontend_server/test/server_test.dart
+++ b/frontend_server/test/server_test.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
+import 'package:frontend_server/server.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:vm/frontend_server.dart' as frontend show CompilerInterface;
-
-import '../lib/server.dart';
 
 class _MockedCompiler extends Mock implements frontend.CompilerInterface {}
 

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -1329,18 +1329,19 @@ class RRect {
 
   /// Whether this rounded rectangle has a side with no straight section.
   bool get isStadium {
-    return (
-      tlRadius == trRadius && trRadius == brRadius && brRadius == blRadius &&
-      (width <= 2.0 * tlRadiusX || height <= 2.0 * tlRadiusY)
-    );
+    return tlRadius == trRadius
+        && trRadius == brRadius
+        && brRadius == blRadius
+        && (width <= 2.0 * tlRadiusX || height <= 2.0 * tlRadiusY);
   }
 
   /// Whether this rounded rectangle has no side with a straight section.
   bool get isEllipse {
-    return (
-      tlRadius == trRadius && trRadius == brRadius && brRadius == blRadius &&
-      width <= 2.0 * tlRadiusX && height <= 2.0 * tlRadiusY
-    );
+    return tlRadius == trRadius
+        && trRadius == brRadius
+        && brRadius == blRadius
+        && width <= 2.0 * tlRadiusX
+        && height <= 2.0 * tlRadiusY;
   }
 
   /// Whether this rounded rectangle would draw as a circle.

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -39,7 +39,7 @@ void _updateWindowMetrics(double devicePixelRatio,
   _invoke(window.onMetricsChanged, window._onMetricsChangedZone);
 }
 
-typedef String _LocaleClosure();
+typedef _LocaleClosure = String Function();
 
 String _localeClosure() => window._locale.toString();
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1315,7 +1315,7 @@ class Image extends NativeFieldWrapperClass2 {
 }
 
 /// Callback signature for [decodeImageFromList].
-typedef void ImageDecoderCallback(Image result);
+typedef ImageDecoderCallback = void Function(Image result);
 
 /// Information for a single frame of an animation.
 ///
@@ -3339,13 +3339,13 @@ class PictureRecorder extends NativeFieldWrapperClass2 {
 }
 
 /// Generic callback signature, used by [_futurize].
-typedef void _Callback<T>(T result);
+typedef _Callback<T> = void Function(T result);
 
 /// Signature for a method that receives a [_Callback].
 ///
 /// Return value should be null on success, and a string error message on
 /// failure.
-typedef String _Callbacker<T>(_Callback<T> callback);
+typedef _Callbacker<T> = String Function(_Callback<T> callback);
 
 /// Converts a method that receives a value-returning callback to a method that
 /// returns a Future.
@@ -3358,7 +3358,7 @@ typedef String _Callbacker<T>(_Callback<T> callback);
 /// Example usage:
 ///
 /// ```dart
-/// typedef void IntCallback(int result);
+/// typedef IntCallback = void Function(int result);
 ///
 /// String _doSomethingAndCallback(IntCallback callback) {
 ///   new Timer(new Duration(seconds: 1), () { callback(1); });

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1067,7 +1067,7 @@ class Paint {
   }
 
   // Must be kept in sync with the default in paint.cc.
-  static final double _kStrokeMiterLimitDefault = 4.0;
+  static const double _kStrokeMiterLimitDefault = 4.0;
 
   /// The limit for miters to be drawn on segments when the join is set to
   /// [StrokeJoin.miter] and the [style] is set to [PaintingStyle.stroke]. If

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -150,7 +150,7 @@ class SemanticsAction {
   ///
   /// The map's key is the [index] of the action and the value is the action
   /// itself.
-  static final Map<int, SemanticsAction> values = const <int, SemanticsAction>{
+  static const Map<int, SemanticsAction> values = const <int, SemanticsAction>{
     _kTapIndex: tap,
     _kLongPressIndex: longPress,
     _kScrollLeftIndex: scrollLeft,
@@ -369,7 +369,7 @@ class SemanticsFlag {
   /// The possible semantics flags.
   ///
   /// The map's key is the [index] of the flag and the value is the flag itself.
-  static final Map<int, SemanticsFlag> values = const <int, SemanticsFlag>{
+  static const Map<int, SemanticsFlag> values = const <int, SemanticsFlag>{
     _kHasCheckedStateIndex: hasCheckedState,
     _kIsCheckedIndex: isChecked,
     _kIsSelectedIndex: isSelected,

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -5,25 +5,25 @@
 part of dart.ui;
 
 /// Signature of callbacks that have no arguments and return no data.
-typedef void VoidCallback();
+typedef VoidCallback = void Function();
 
 /// Signature for [Window.onBeginFrame].
-typedef void FrameCallback(Duration duration);
+typedef FrameCallback = void Function(Duration duration);
 
 /// Signature for [Window.onPointerDataPacket].
-typedef void PointerDataPacketCallback(PointerDataPacket packet);
+typedef PointerDataPacketCallback = void Function(PointerDataPacket packet);
 
 /// Signature for [Window.onSemanticsAction].
-typedef void SemanticsActionCallback(int id, SemanticsAction action, ByteData args);
+typedef SemanticsActionCallback = void Function(int id, SemanticsAction action, ByteData args);
 
 /// Signature for responses to platform messages.
 ///
 /// Used as a parameter to [Window.sendPlatformMessage] and
 /// [Window.onPlatformMessage].
-typedef void PlatformMessageResponseCallback(ByteData data);
+typedef PlatformMessageResponseCallback = void Function(ByteData data);
 
 /// Signature for [Window.onPlatformMessage].
-typedef void PlatformMessageCallback(String name, ByteData data, PlatformMessageResponseCallback callback);
+typedef PlatformMessageCallback = void Function(String name, ByteData data, PlatformMessageResponseCallback callback);
 
 /// States that an application can be in.
 ///

--- a/shell/testing/observatory/test.dart
+++ b/shell/testing/observatory/test.dart
@@ -147,7 +147,7 @@ Future<Null> testStartPaused(Uri uri) async {
   Expect.equals(resumedResponse['pauseEvent']['kind'], 'Resume');
 }
 
-typedef Future<Null> TestFunction(Uri uri);
+typedef TestFunction = Future<Null> Function(Uri uri);
 
 final List<TestFunction> basicTests = <TestFunction>[
   testHttpProtocolRequest,

--- a/tools/licenses/lib/filesystem.dart
+++ b/tools/licenses/lib/filesystem.dart
@@ -23,7 +23,7 @@ enum FileType {
   metadata, // can be skipped entirely (e.g. Mac OS X ._foo files)
 }
 
-typedef List<int> Reader();
+typedef Reader = List<int> Function();
 
 class BytesOf extends Key { BytesOf(dynamic value) : super(value); }
 class UTF8Of extends Key { UTF8Of(dynamic value) : super(value); }


### PR DESCRIPTION
This a companion to https://github.com/flutter/flutter/pull/18035.

Addresses https://github.com/flutter/flutter/issues/18028 for the engine repo, and synchronizes the analysis_options.yaml files between the engine and the flutter/flutter repo.