### PR TITLE
Remove unnecessary saveLayer

### DIFF
--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -48,7 +48,7 @@ void ClipPathLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipPathLayer::Paint");
   FXL_DCHECK(needs_painting());
 
-  Layer::AutoSaveLayer save(context, paint_bounds(), nullptr);
+  SkAutoCanvasRestore save(&context.canvas, true);
   context.canvas.clipPath(clip_path_, true);
   PaintChildren(context);
 }

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -46,7 +46,7 @@ void ClipRRectLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipRRectLayer::Paint");
   FXL_DCHECK(needs_painting());
 
-  Layer::AutoSaveLayer save(context, paint_bounds(), nullptr);
+  SkAutoCanvasRestore save(&context.canvas, true);
   context.canvas.clipRRect(clip_rrect_, true);
   PaintChildren(context);
 }

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -91,11 +91,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
   context.canvas.drawPath(path_, paint);
 
   SkAutoCanvasRestore save(&context.canvas, false);
-  if (isRect_) {
-    context.canvas.save();
-  } else {
-    context.canvas.saveLayer(path_.getBounds(), nullptr);
-  }
+  context.canvas.save();
   context.canvas.clipPath(path_, true);
   PaintChildren(context);
   if (context.checkerboard_offscreen_layers && !isRect_)


### PR DESCRIPTION
saveLayer is slow so we should avoid it as much as possible. If
there are artifacts without saveLayer, then we should report that
to Skia for the fix instead of slowing the performance with
saveLayer.

This PQ makes average rasterizer time drop from 25ms to 18ms in
flutter_gallery transitions perf test on a Nexus 5X.

This partially fixes https://github.com/flutter/flutter/issues/13736 .
We probably still need some work in the opacity layer to squize
all the performance improvements.