### PR TITLE
Roll Dart SDK to 1a185867a996a91be5fdd1535d89e7d3750d0050

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '3b6caa3517bcc7150030f240deedb010f5e3bc60',
+  'dart_revision': '1a185867a996a91be5fdd1535d89e7d3750d0050',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.7',
@@ -47,7 +47,7 @@ vars = {
   'dart_csslib_tag': '0.14.1',
   'dart_dart2js_info_tag': '0.5.6+2',
   'dart_dart_style_tag': '1.0.14',
-  'dart_dartdoc_tag': 'v0.19.1',
+  'dart_dartdoc_tag': 'v0.20.0',
   'dart_fixnum_tag': '0.10.5',
   'dart_glob_tag': '1.1.5',
   'dart_html_tag': '0.13.3',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 4f70d46ccf69a2097702f43b31412881
+Signature: b4c0719b4d85013e853632a2a5cfcd91
 
 UNUSED LICENSES:
 
@@ -4624,6 +4624,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: dart
 ORIGIN: ../../../third_party/dart/LICENSE
 TYPE: LicenseType.bsd
+FILE: ../../../third_party/dart/.gitconfig
 FILE: ../../../third_party/dart/.mailmap
 FILE: ../../../third_party/dart/client/idea/.idea/.name
 FILE: ../../../third_party/dart/client/idea/.idea/inspectionProfiles/Project_Default.xml


### PR DESCRIPTION
dart-lang/sdk@1a18586 Search for element declarations in discovered available files.
dart-lang/sdk@7e899d0 Add fix-all in file fixes for the 2 additional dart analysis server fix types: USE_NOT_EQ_NULL and USE_EQ_EQ_NULL
dart-lang/sdk@eb82559 Reapply "[vm] Add tests for determinism of script and AppJIT snapshots."
dart-lang/sdk@f66769c Add duplicate shown/hidden name analyzer note to changelog
dart-lang/sdk@95afe41 Add an implementation of the UnresolvedNameGenerator for analyzer
dart-lang/sdk@fcb41fb Replace more calls to parseTypeVariablesOpt with computeTypeParamOrArg
dart-lang/sdk@8e00451 Add fix-all in file fixes for the 3 additional dart analysis server fix types: ADD_NE_NULL, REMOVE_UNNECESSARY_CAST, REPLACE_BOOLEAN_WITH_BOOL
dart-lang/sdk@b75da96 Move all type mask code to inferrer/typemasks and use it via an AbstractValueStrategy
dart-lang/sdk@7ce2432 Add UnlinkedScope
dart-lang/sdk@8e92598 [infra] Add config for custom hunk text when using git diff on status files
dart-lang/sdk@14b9d7f [infra] Prepare test.py for the --preview-dart-2 VM flag flip
dart-lang/sdk@00f75ad Emit a compile-time error on incorrect types of initializing formals
dart-lang/sdk@b62b438 Infer Object members for dynamic receivers
dart-lang/sdk@b3bae42 Fix a batch of long lines
dart-lang/sdk@796f530 Report FieldInitializerOutsideConstructor error in BodyBuilder
dart-lang/sdk@e1ffb22 Remove Declaration.prepareTopLevelInference
dart-lang/sdk@ff8100d [infra] Add dartk reload/rollback configurations to test matrix
dart-lang/sdk@b851714 Remove Declaration.computeLibraryUri
dart-lang/sdk@5ecd782 [kernel] Add an option to the cloner for cloning annotations
dart-lang/sdk@bb0808d Replace Builder by Declaration
dart-lang/sdk@39b0efd Handle generic jsinterop classes as type arguments.
dart-lang/sdk@c6129f7 Use AbstractValue in the rest of type inference
dart-lang/sdk@947760f Use AbstractValue in much of inference
dart-lang/sdk@3dd70ce Usa AbstractValue in the rest of ssa
dart-lang/sdk@bbef9ae Use AbstractValue in most of ssa
dart-lang/sdk@aecf8e8 Use AbstractValue in KernelToTypeInferenceMap and KernelTypeGraphBuilder
dart-lang/sdk@032925c Remove obsolete features
dart-lang/sdk@715c14c Added changelog entry for member conflict updates
dart-lang/sdk@08c893d Simplify class member conflict rules.
dart-lang/sdk@377eb52 [vm/kernel/bytecode] Add library reference and invocation kind to ConstantICData
dart-lang/sdk@a53b585 Fix more Analyzer tests
dart-lang/sdk@fa9ff9a Fix regression in deferred loading.
dart-lang/sdk@2911f1f More dart2js strong mode cleanup.
dart-lang/sdk@b6d20fa Enable the fix-all feature for the DartFixKind.ADD_EXPLICIT_CAST fix, tests been added as well.
dart-lang/sdk@a1f6aa8 improve speed of dartdevk SDK and ddc test package summary build
dart-lang/sdk@9e3842d Observatory strong mode fix: fix type errors with onDisconnect.
dart-lang/sdk@3027302 [VM] Fix for issue 33277 (skip HasAttemptedReload check for kernel      isolate too).
dart-lang/sdk@0e3ca9a Fix strong mode runtime error in dart2js.
dart-lang/sdk@3d2b660 Reland "[vm] Support definition of entry-points via @pragma('vm.extern') annotations.""
dart-lang/sdk@fb4f887 [vm/kernel/aot] Fix recognition of native methods after annotations are constant evaluated
dart-lang/sdk@753d954 Move to dartdoc 0.20.0 and enable preview-dart-2.
dart-lang/sdk@39d902b Update pubspec to indicate that analyzer_plugin supports the latest analyzer.
dart-lang/sdk@bfeb80a Observatory strong mode fixes: fix some int/double mismatches.
dart-lang/sdk@7fc88c4 Observatory strong mode fix: add required calls to .toList().
dart-lang/sdk@fe3bba8 Switch integration tests to use a snapshot for the analysis server.
dart-lang/sdk@cc9c8f9 Add HintCode for duplicate shown/hidden names
dart-lang/sdk@e7bad54 Make dart2js only run with 64 bit ints, not the larger ints from the vm.
