### PR TITLE
Call SkAutoCanvasRestore with doSave = true

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -18,7 +18,7 @@
 namespace flow {
 
 void RasterCacheResult::draw(SkCanvas& canvas) const {
-  SkAutoCanvasRestore auto_restore(&canvas, false);
+  SkAutoCanvasRestore auto_restore(&canvas, true);
   SkIRect bounds =
       RasterCache::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
   FXL_DCHECK(bounds.size() == image_->dimensions());


### PR DESCRIPTION
Although we do have a save before this SkAutoCanvasRestore so we
can theoretically send in doSave = false, it's safer to set doSave
to true to prevent future breakage.

As discussed with mtklein@google.com and reed@google.com, saving
canvas is very cheap in Skia so this should have no performance
impact. Skia is also considering remove doSave argument from
SkAutoCanvasRestore and always save the canvas.