### PR TITLE
libtxt: support per-locale fallback font collections

### DIFF
--- a/third_party/txt/src/minikin/FontCollection.cpp
+++ b/third_party/txt/src/minikin/FontCollection.cpp
@@ -44,6 +44,12 @@ const uint32_t TEXT_STYLE_VS = 0xFE0E;
 
 uint32_t FontCollection::sNextId = 0;
 
+// libtxt: return a locale string for a language list ID
+std::string GetFontLocale(uint32_t langListId) {
+  const FontLanguages& langs = FontLanguageListCache::getById(langListId);
+  return langs.size() ? langs[0].getString() : "";
+}
+
 FontCollection::FontCollection(std::shared_ptr<FontFamily>&& typeface)
     : mMaxChar(0) {
   std::vector<std::shared_ptr<FontFamily>> typefaces;
@@ -295,7 +301,8 @@ const std::shared_ptr<FontFamily>& FontCollection::getFamilyForChar(
     // libtxt: check if the fallback font provider can match this character
     if (mFallbackFontProvider) {
       const std::shared_ptr<FontFamily>& fallback =
-          mFallbackFontProvider->matchFallbackFont(ch);
+          mFallbackFontProvider->matchFallbackFont(ch,
+                                                   GetFontLocale(langListId));
       if (fallback) {
         return fallback;
       }
@@ -332,7 +339,8 @@ const std::shared_ptr<FontFamily>& FontCollection::getFamilyForChar(
     // libtxt: check if the fallback font provider can match this character
     if (mFallbackFontProvider) {
       const std::shared_ptr<FontFamily>& fallback =
-          mFallbackFontProvider->matchFallbackFont(ch);
+          mFallbackFontProvider->matchFallbackFont(ch,
+                                                   GetFontLocale(langListId));
       if (fallback) {
         return fallback;
       }

--- a/third_party/txt/src/minikin/FontCollection.h
+++ b/third_party/txt/src/minikin/FontCollection.h
@@ -38,7 +38,8 @@ class FontCollection {
    public:
     virtual ~FallbackFontProvider() = default;
     virtual const std::shared_ptr<FontFamily>& matchFallbackFont(
-        uint32_t ch) = 0;
+        uint32_t ch,
+        std::string locale) = 0;
   };
 
   struct Run {

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -30,15 +30,16 @@
 
 namespace txt {
 
-namespace {
+bool FontCollection::FamilyKey::operator==(
+    const FontCollection::FamilyKey& other) const {
+  return font_family == other.font_family && locale == other.locale;
+}
 
-// Font families that will be used as a last resort if no font manager provides
-// a font matching a particular character.
-const std::vector<std::string> last_resort_fonts{
-    "Arial",
-};
-
-}  // anonymous namespace
+size_t FontCollection::FamilyKey::Hasher::operator()(
+    const FontCollection::FamilyKey& key) const {
+  return std::hash<std::string>()(key.font_family) ^
+         std::hash<std::string>()(key.locale);
+}
 
 class TxtFallbackFontProvider
     : public minikin::FontCollection::FallbackFontProvider {
@@ -47,8 +48,9 @@ class TxtFallbackFontProvider
       : font_collection_(font_collection) {}
 
   virtual const std::shared_ptr<minikin::FontFamily>& matchFallbackFont(
-      uint32_t ch) {
-    return font_collection_->MatchFallbackFont(ch);
+      uint32_t ch,
+      std::string locale) {
+    return font_collection_->MatchFallbackFont(ch, locale);
   }
 
  private:
@@ -92,15 +94,19 @@ void FontCollection::DisableFontFallback() {
 }
 
 std::shared_ptr<minikin::FontCollection>
-FontCollection::GetMinikinFontCollectionForFamily(const std::string& family) {
+FontCollection::GetMinikinFontCollectionForFamily(
+    const std::string& font_family,
+    const std::string& locale) {
   // Look inside the font collections cache first.
-  auto cached = font_collections_cache_.find(family);
+  FamilyKey family_key(font_family, locale);
+  auto cached = font_collections_cache_.find(family_key);
   if (cached != font_collections_cache_.end()) {
     return cached->second;
   }
 
   for (sk_sp<SkFontMgr>& manager : GetFontManagerOrder()) {
-    sk_sp<SkFontStyleSet> font_style_set(manager->matchFamily(family.c_str()));
+    sk_sp<SkFontStyleSet> font_style_set(
+        manager->matchFamily(font_family.c_str()));
     if (font_style_set == nullptr || font_style_set->count() == 0) {
       continue;
     }
@@ -136,8 +142,8 @@ FontCollection::GetMinikinFontCollectionForFamily(const std::string& family) {
         minikin_family,
     };
     if (enable_font_fallback_) {
-      for (const auto& fallback : fallback_fonts_)
-        minikin_families.push_back(fallback.second);
+      for (SkFontID font_id : fallback_fonts_for_locale_[locale])
+        minikin_families.push_back(fallback_fonts_[font_id]);
     }
 
     // Create the minikin font collection.
@@ -149,16 +155,16 @@ FontCollection::GetMinikinFontCollectionForFamily(const std::string& family) {
     }
 
     // Cache the font collection for future queries.
-    font_collections_cache_[family] = font_collection;
+    font_collections_cache_[family_key] = font_collection;
 
     return font_collection;
   }
 
   const auto default_font_family = GetDefaultFontFamily();
-  if (family != default_font_family) {
+  if (font_family != default_font_family) {
     std::shared_ptr<minikin::FontCollection> default_collection =
-        GetMinikinFontCollectionForFamily(default_font_family);
-    font_collections_cache_[family] = default_collection;
+        GetMinikinFontCollectionForFamily(default_font_family, "");
+    font_collections_cache_[family_key] = default_collection;
     return default_collection;
   }
 
@@ -167,21 +173,27 @@ FontCollection::GetMinikinFontCollectionForFamily(const std::string& family) {
 }
 
 const std::shared_ptr<minikin::FontFamily>& FontCollection::MatchFallbackFont(
-    uint32_t ch) {
+    uint32_t ch,
+    std::string locale) {
   for (const sk_sp<SkFontMgr>& manager : GetFontManagerOrder()) {
-    sk_sp<SkTypeface> typeface(
-        manager->matchFamilyStyleCharacter(0, SkFontStyle(), nullptr, 0, ch));
+    std::vector<const char*> bcp47;
+    if (!locale.empty())
+      bcp47.push_back(locale.c_str());
+    sk_sp<SkTypeface> typeface(manager->matchFamilyStyleCharacter(
+        0, SkFontStyle(), bcp47.data(), bcp47.size(), ch));
     if (!typeface)
       continue;
 
-    return GetFontFamilyForTypeface(typeface);
+    fallback_fonts_for_locale_[locale].insert(typeface->uniqueID());
+
+    return GetFallbackFont(typeface);
   }
 
   return null_family_;
 }
 
 const std::shared_ptr<minikin::FontFamily>&
-FontCollection::GetFontFamilyForTypeface(const sk_sp<SkTypeface>& typeface) {
+FontCollection::GetFallbackFont(const sk_sp<SkTypeface>& typeface) {
   SkFontID typeface_id = typeface->uniqueID();
   auto fallback_it = fallback_fonts_.find(typeface_id);
   if (fallback_it != fallback_fonts_.end()) {
@@ -200,16 +212,6 @@ FontCollection::GetFontFamilyForTypeface(const sk_sp<SkTypeface>& typeface) {
   font_collections_cache_.clear();
 
   return insert_it.first->second;
-}
-
-void FontCollection::UpdateFallbackFonts(sk_sp<SkFontMgr> manager) {
-  for (const std::string& family : last_resort_fonts) {
-    sk_sp<SkTypeface> typeface(
-        manager->matchFamilyStyle(family.c_str(), SkFontStyle()));
-    if (typeface) {
-      GetFontFamilyForTypeface(typeface);
-    }
-  }
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -313,6 +313,13 @@ class Paragraph {
   // Draws the background onto the canvas.
   void PaintBackground(SkCanvas* canvas, const PaintRecord& record);
 
+  // Obtain a Minikin font collection matching this text style.
+  std::shared_ptr<minikin::FontCollection> GetMinikinFontCollectionForStyle(
+      const TextStyle& style);
+
+  // Get a default SkTypeface for a text style.
+  sk_sp<SkTypeface> GetDefaultSkiaTypeface(const TextStyle& style);
+
   FXL_DISALLOW_COPY_AND_ASSIGN(Paragraph);
 };
 


### PR DESCRIPTION
A given character may render differently in various locales, and fonts on the
host system may be tagged with locale metadata in order to support this.
If the text renderer needs to find a fallback font for a character, it should
pass the preferred locale to Skia's font manager which can use it to find the
best matching font.

The font collection also needs to maintain different caches of fallback fonts
for each locale.

See https://github.com/flutter/flutter/pull/17879