### PR TITLE
Eliminate arm64 restriction in iOS framework plist

### DIFF
--- a/shell/platform/darwin/ios/framework/Info.plist
+++ b/shell/platform/darwin/ios/framework/Info.plist
@@ -20,10 +20,6 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>UIRequiredDeviceCapabilities</key>
-  <array>
-    <string>arm64</string>
-  </array>
   <key>MinimumOSVersion</key>
   <string>8.0</string>
 </dict>


### PR DESCRIPTION
Eliminates the declaration that only arm64 is supported in
Flutter.framework's Info.plist. This causes Xcode's app thinning tools
to remove Flutter.framework in thinned archives for armv7 devices.