### PR TITLE
Adds dynamic, interpreter configs to tools/gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -17,7 +17,9 @@ group("flutter") {
     public_deps += [ "$flutter_root/shell/testing" ]
   }
 
-  if (flutter_runtime_mode != "debug") {
+  if (flutter_runtime_mode != "debug" &&
+      flutter_runtime_mode != "dynamic_profile" &&
+      flutter_runtime_mode != "dynamic_release") {
     public_deps += [ "$flutter_root/lib/snapshot:entry_points_json_files" ]
   }
 

--- a/common/config.gni
+++ b/common/config.gni
@@ -14,7 +14,7 @@ declare_args() {
   # Enable ahead-of-time compilation on platforms where AOT is optional.
   flutter_aot = false
 
-  # The runtime mode ("debug", "profile", or "release")
+  # The runtime mode ("debug", "profile", "release", "dynamic_profile", or "dynamic_release")
   flutter_runtime_mode = "debug"
 }
 
@@ -24,6 +24,8 @@ feature_defines_list = [
   "FLUTTER_RUNTIME_MODE_DEBUG=1",
   "FLUTTER_RUNTIME_MODE_PROFILE=2",
   "FLUTTER_RUNTIME_MODE_RELEASE=3",
+  "FLUTTER_RUNTIME_MODE_DYNAMIC_PROFILE=4",
+  "FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE=5",
 ]
 
 if (flutter_runtime_mode == "debug") {
@@ -32,6 +34,10 @@ if (flutter_runtime_mode == "debug") {
   feature_defines_list += [ "FLUTTER_RUNTIME_MODE=2" ]
 } else if (flutter_runtime_mode == "release") {
   feature_defines_list += [ "FLUTTER_RUNTIME_MODE=3" ]
+} else if (flutter_runtime_mode == "dynamic_profile") {
+  feature_defines_list += [ "FLUTTER_RUNTIME_MODE=4" ]
+} else if (flutter_runtime_mode == "dynamic_release") {
+  feature_defines_list += [ "FLUTTER_RUNTIME_MODE=5" ]
 } else {
   feature_defines_list += [ "FLUTTER_RUNTIME_MODE=0" ]
 }

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -104,7 +104,9 @@ source_set("runtime") {
 
   public_configs = [ "$flutter_root:config" ]
 
-  if (flutter_runtime_mode != "release" && !is_fuchsia) {
+  if (flutter_runtime_mode != "release" &&
+      flutter_runtime_mode != "dynamic_release" &&
+      !is_fuchsia) {
     # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
     # instead puts Observatory into the runner's package.
     deps += [ "//third_party/dart/runtime/observatory:embedded_observatory_archive" ]

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -39,7 +39,8 @@
 namespace dart {
 namespace observatory {
 
-#if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE)
+#if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE) && \
+    (FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE)
 
 // These two symbols are defined in |observatory_archive.cc| which is generated
 // by the |//third_party/dart/runtime/observatory:archive_observatory| rule.
@@ -49,7 +50,8 @@ extern unsigned int observatory_assets_archive_len;
 extern const uint8_t* observatory_assets_archive;
 
 #endif  // !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE !=
-        // FLUTTER_RUNTIME_MODE_RELEASE)
+        // FLUTTER_RUNTIME_MODE_RELEASE) && (FLUTTER_RUNTIME_MODE !=
+        // FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE)
 
 }  // namespace observatory
 }  // namespace dart
@@ -151,7 +153,8 @@ bool DartFileModifiedCallback(const char* source_url, int64_t since_ms) {
 void ThreadExitCallback() {}
 
 Dart_Handle GetVMServiceAssetsArchiveCallback() {
-#if (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE)
+#if (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE) || \
+    (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE)
   return nullptr;
 #elif OS_FUCHSIA
   std::vector<uint8_t> observatory_assets_archive;
@@ -325,6 +328,11 @@ DartVM::DartVM(const Settings& settings,
   // Enable checked mode if we are not running precompiled code. We run non-
   // precompiled code only in the debug product mode.
   bool use_checked_mode = !settings.dart_non_checked_mode;
+
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_PROFILE || \
+    FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE
+  use_checked_mode = false;
+#endif
 
 #if !OS_FUCHSIA
   if (IsRunningPrecompiledCode()) {

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -227,7 +227,8 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
       settings.dart_flags.push_back(*it);
   }
 
-#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
+#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE && \
+    FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE
   settings.trace_skia =
       command_line.HasOption(FlagForSwitch(Switch::TraceSkia));
 #endif

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -64,7 +64,9 @@ shared_library("flutter_shell_native") {
     "//third_party/skia",
     "//third_party/skia:gpu",
   ]
-  if (flutter_runtime_mode == "debug") {
+  if (flutter_runtime_mode == "debug" ||
+      flutter_runtime_mode == "dynamic_profile" ||
+      flutter_runtime_mode == "dynamic_release") {
     deps += [ "//third_party/dart/runtime:libdart_jit" ]
   } else {
     deps += [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -101,7 +101,9 @@ shared_library("create_flutter_framework_dylib") {
     "//third_party/skia",
     "//third_party/skia:gpu",
   ]
-  if (flutter_runtime_mode == "debug") {
+  if (flutter_runtime_mode == "debug" ||
+      flutter_runtime_mode == "dynamic_profile" ||
+      flutter_runtime_mode == "dynamic_release") {
     deps += [
       "$flutter_root/lib/snapshot",
       "//third_party/dart/runtime:libdart_jit",

--- a/tools/gn
+++ b/tools/gn
@@ -16,6 +16,9 @@ def get_out_dir(args):
     else:
         target_dir = ['host']
 
+    if args.dynamic:
+        target_dir.append('dynamic')
+
     target_dir.append(args.runtime_mode)
 
     if args.simulator:
@@ -23,6 +26,9 @@ def get_out_dir(args):
 
     if args.unoptimized:
         target_dir.append('unopt')
+
+    if args.target_os != 'ios' and args.interpreter:
+        target_dir.append('interpreter')
 
     if args.android_cpu != 'arm':
         target_dir.append(args.android_cpu)
@@ -64,6 +70,10 @@ def to_gn_args(args):
     if args.target_os != 'android' and args.enable_vulkan:
       raise Exception('--enable-vulkan is only supported on Android')
 
+    runtime_mode = args.runtime_mode
+    if args.dynamic and runtime_mode in ['profile', 'release']:
+      runtime_mode = 'dynamic_' + runtime_mode
+
     gn_args = {}
 
     # Skia GN args.
@@ -88,7 +98,7 @@ def to_gn_args(args):
       # The GN arg is not available in the windows toolchain.
       gn_args['enable_lto'] = enable_lto
 
-    aot = args.runtime_mode != 'debug'
+    aot = not runtime_mode in ['debug', 'dynamic_profile', 'dynamic_release']
     if args.target_os == 'android':
         gn_args['target_os'] = 'android'
     elif args.target_os == 'ios':
@@ -99,10 +109,14 @@ def to_gn_args(args):
     else:
       aot = False
 
-    if args.runtime_mode == 'debug':
+    if runtime_mode == 'debug':
         gn_args['dart_runtime_mode'] = 'develop'
+    elif runtime_mode == 'dynamic_profile':
+        gn_args['dart_runtime_mode'] = 'profile'
+    elif runtime_mode == 'dynamic_release':
+        gn_args['dart_runtime_mode'] = 'release'
     else:
-        gn_args['dart_runtime_mode'] = args.runtime_mode
+        gn_args['dart_runtime_mode'] = runtime_mode
 
     if args.target_os == 'android':
         gn_args['target_cpu'] = args.android_cpu
@@ -120,7 +134,13 @@ def to_gn_args(args):
     # On iOS Devices, use the Dart bytecode interpreter so we don't incur
     # snapshotting and linking costs of the precompiler during development.
     # We can still use the JIT on the simulator though.
-    use_dbc = args.target_os == 'ios' and not args.simulator and args.runtime_mode == 'debug'
+    can_use_dbc = runtime_mode in ['debug', 'dynamic_profile', 'dynamic_release']
+    use_dbc = args.target_os == 'ios' and not args.simulator and can_use_dbc
+    # Use dbc if it is requested on the command line and supported by the
+    # requested runtime mode.
+    if args.interpreter and not can_use_dbc:
+      raise Exception('--interpreter not supported with --runtime-mode=' + runtime_mode)
+    use_dbc = use_dbc or (args.interpreter and can_use_dbc)
     if use_dbc:
       gn_args['dart_target_arch'] = 'dbc'
     else:
@@ -145,7 +165,7 @@ def to_gn_args(args):
     if target_is_32_bit:
       gn_args["host_cpu"] = "x86"
 
-    gn_args['flutter_runtime_mode'] = args.runtime_mode
+    gn_args['flutter_runtime_mode'] = runtime_mode
     gn_args['flutter_aot'] = aot
 
     if args.target_sysroot:
@@ -186,6 +206,8 @@ def parse_args(args):
   parser.add_argument('--unoptimized', default=False, action='store_true')
 
   parser.add_argument('--runtime-mode', type=str, choices=['debug', 'profile', 'release'], default='debug')
+  parser.add_argument('--dynamic', default=False, action='store_true')
+  parser.add_argument('--interpreter', default=False, action='store_true')
 
   parser.add_argument('--target-os', type=str, choices=['android', 'ios', 'linux'])
   parser.add_argument('--android', dest='target_os', action='store_const', const='android')


### PR DESCRIPTION
Adds --dynamic and --interpreter flags to tools/gn. These flags result in engines with properties as follows:

--dynamic:
- JIT targeting native code on Android and
  DBC on iOS

--interpreter
- Target DBC even if running on Android.

For example:

gn --android --dynamic --interpreter --runtime-mode release

Will generate an engine:
- Without Dart asserts
- Without Observatory
- With JIT compililation to DBC

into out/android_dynamic_release_dbc

/cc @sbaranov @Hixie @a-siva @mraleph 