### PR TITLE
Roll Dart SDK to 1fe279d859

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '1a185867a996a91be5fdd1535d89e7d3750d0050',
+  'dart_revision': '1fe279d8598693e8005b71d6db386a96f2e49ce3',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.7',
@@ -45,7 +45,7 @@ vars = {
   'dart_convert_tag': '2.0.1',
   'dart_crypto_tag': '2.0.2+1',
   'dart_csslib_tag': '0.14.1',
-  'dart_dart2js_info_tag': '0.5.6+2',
+  'dart_dart2js_info_tag': '0.5.6+4',
   'dart_dart_style_tag': '1.0.14',
   'dart_dartdoc_tag': 'v0.20.0',
   'dart_fixnum_tag': '0.10.5',
@@ -63,7 +63,7 @@ vars = {
   'dart_markdown_tag': '2.0.0',
   'dart_matcher_tag': '0.12.1+4',
   'dart_mime_tag': '0.9.6',
-  'dart_mockito_tag': 'a92db054fba18bc2d605be7670aee74b7cadc00a',
+  'dart_mockito_tag': 'd39ac507483b9891165e422ec98d9fb480037c8b',
   'dart_mustache4dart_tag': 'v2.1.2',
   'dart_oauth2_tag': '1.1.0',
   'dart_observatory_pub_packages_rev': 'd3a3aebefbd35aa30fe7bbc2889b772b398f7d7f',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: a5cb5aa06d214091f9be091211d2c8ae
+Signature: 204ca81d3ac31d08c9ca6943047dd457
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
This includes the following commits

  dart-lang/sdk@1fe279d859 (origin/master, origin/HEAD) Fix _FutureListener.handleError() to use explicit type for Zone.runBinary
  dart-lang/sdk@a9257d05fb [vm] Prepare status files for dartk reload/rollback builders (#33126)
  dart-lang/sdk@6ac6baae8e Record interfaceTargets for calls on dynamic receivers
  dart-lang/sdk@82755aa303 Rename ClosedWorld to JClosedWorld and merge it with ClosedWorldRefiner
  dart-lang/sdk@b58cc36ddc Extract KClosedWorld from ClosedWorld.
  dart-lang/sdk@9a193853d4 [VM] Mark a few tests as passing
  dart-lang/sdk@5c2cec0e19 Make _FilesReferencingNameTask faster by using maintained FileSystemState.knownFiles list.
  dart-lang/sdk@5269e21913 Fix for MockSdk on Windows.
  dart-lang/sdk@d0b28d2040 Fix analysis_server tests on Windows.
  dart-lang/sdk@9d83013040 Use known FileState from FileSystemState directly.
  dart-lang/sdk@b3b528648b Discover all SDK libraries.
  dart-lang/sdk@41e1d2cc28 [dart2js] Fix --csp
  dart-lang/sdk@56424f08a8 [js_runtime] Test for JavaScriptFunction type tests.
  dart-lang/sdk@5f9fcd0bbc [vm, x64] Remove embedded address from the implementation of math.min/max.
  dart-lang/sdk@025cee6f1f Skip tests of snapshot determinism on Windows.
  dart-lang/sdk@6ba8c711fa Observatory strong mode fix: expand the class hierarchy for debug events.
  dart-lang/sdk@f3502f9051 Fix bug in RTI optimization
  dart-lang/sdk@d319d3eda4 [vm/kernel/bytecode] Do not generate bytecode for external (native) members
  dart-lang/sdk@7246d2e759 Fix exception in fix processor (issue 33312)
  dart-lang/sdk@b19560e7ad Implement stubs for the remaining converted generators
  dart-lang/sdk@b7266fa3b3 [vm/kernel/bytecode] Support async/async*/sync* in bytecode generator
  dart-lang/sdk@c6cf61752e Update PluginWatcherTest to the fact that async functions start running synchronously.
  dart-lang/sdk@e1549df93f Fix regression introduced in 'Use AbstractValue in most of ssa'
  dart-lang/sdk@184df3aee0 Make AnalysisServer.getAnalysisResult() sync to avoid changing behavior between Dart1 and Dart2.
  dart-lang/sdk@99a5f149ac [vm] Enable type stubs based type checks in JIT mode for some types.
  dart-lang/sdk@90c4215af4 [vm] Adds full GC check on all external allocations
  dart-lang/sdk@bef7cd354f Observatory strong mode fix: Use .nodes= instead of .children= to accommodate text nodes.
  dart-lang/sdk@72aae537a2 Observatory strong mode fix: clean up port mocking.
  dart-lang/sdk@312f02532a [js_runtime] JavaScriptFunction matches any Dart function type
  dart-lang/sdk@c8860b4ca2 Remove all uses of --limit-ints-to-64-bits VM option
  dart-lang/sdk@5db95fbb61 Upgrade mockito to latest version.
  dart-lang/sdk@1bc9b8d00c Mark ContextRoot.pathContext constructor argument as required.
  dart-lang/sdk@b7bc0d06c4 Fix state machine in _DiscoverAvailableFilesTask.perform
  dart-lang/sdk@2c44dc11c7 Improve type variable recovery
  dart-lang/sdk@789ceee184 Update version number in DEPS for dart2js_info pkg
  dart-lang/sdk@0629e3afa5 [VM] Fix vm/cc/DartAPI_TypeGetParameterizedTypes test
  dart-lang/sdk@e18fd7c3e7 Remove the test for getNavigation() and removing the analysis context.
  dart-lang/sdk@2a545d7153 Initial implementations for some of the generator methods
  dart-lang/sdk@5f42fe5822 Simplify DartCompletionContributorTest.computeSuggestions() async behaviour.
  dart-lang/sdk@f6ece48aba Fix the test that want to run async code to be async.
  dart-lang/sdk@e9a60098bb [VM] Use UserVisibleName for types in error messages reported to users to make the error more clear. This fixes the case in issue 33303.
  dart-lang/sdk@cb07f74f4b Clean up some of analyzers generators based on feedback
  dart-lang/sdk@e9818eefd8 Update analyzer status about type parameters on constructors.
  dart-lang/sdk@6f68bec1bc TBR: Typos fixed
  dart-lang/sdk@545ad130a2 Fix a couple of bugs in the analyzer forest implementation
  dart-lang/sdk@85b4a799eb Search references to elements and subtypes in all known (and discovered) files.
  dart-lang/sdk@4fb6395058 Report error when a constructor has type parameters.
  dart-lang/sdk@315a186dc4 Better test error handler argument types.
  dart-lang/sdk@0aadba1189 Revert "[vm] Enable type stubs based type checks in JIT mode for some types."
  dart-lang/sdk@4be50d6fa1 [vm] Enable type stubs based type checks in JIT mode for some types.
  dart-lang/sdk@1d8bef0d89 Remove class TypeInferenceEngineImpl
  dart-lang/sdk@dd83e698d8 Add 64-bit integer semantics to the specification.
  dart-lang/sdk@a10eda4988 update dart2js status files
  dart-lang/sdk@6458b5da2f Always include added files into the list of files to discover.
  dart-lang/sdk@c984e63f61 Skip tests of snapshot determinism in checked mode.
  dart-lang/sdk@99dadf4d7f Remove unneeded (and incorrectly typed) mock step
  dart-lang/sdk@f87933d845 Introduce tests specific to behaviors of FunctionType.
  dart-lang/sdk@64cfdb4cc6 Remove _explicitTypeParameters and substitute4 from FunctionTypeImpl.
  dart-lang/sdk@b930ae19b1 Fix regression in deferred loading (part2)
  dart-lang/sdk@a0c4ac14c1 Omit redundant bounds check for Dart2 on typed setters/getters.
  dart-lang/sdk@2ad29cbd15 Remove unnecessary uses of toExpression
  dart-lang/sdk@7a76a40438 Add several other generators
  dart-lang/sdk@483c42b899 Switch dart2js to use dart 2 vm.
  dart-lang/sdk@f5d991e6a1 Support extracting selected statements into a new Flutter widget.
  dart-lang/sdk@89c2da2846 Add generator for unlinked names
  dart-lang/sdk@c911a1bef6 Clean up additional dart2js strong mode runtime error and don't add method type variable in dart 1 version.
  dart-lang/sdk@9a02f5bf4d [vm/kernel] Fix bugs with expression evaluation in debug mode.
  dart-lang/sdk@0aad13db00 Revert 'Copy @failingTest annotations to mixin applications.'
  dart-lang/sdk@41c5da8919 [vm] Fix non-reproducibility of VM builds.
  dart-lang/sdk@e8659b0f28 Remove skipTypeVariables

x