### PR TITLE
libtxt: add all styles of a fallback font family to the cache

### DIFF
--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -78,17 +78,22 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
                      std::shared_ptr<minikin::FontCollection>,
                      FamilyKey::Hasher>
       font_collections_cache_;
-  std::unordered_map<SkFontID, std::shared_ptr<minikin::FontFamily>>
+  std::unordered_map<std::string, std::shared_ptr<minikin::FontFamily>>
       fallback_fonts_;
-  std::unordered_map<std::string, std::set<SkFontID>>
+  std::unordered_map<std::string, std::set<std::string>>
       fallback_fonts_for_locale_;
   std::shared_ptr<minikin::FontFamily> null_family_;
   bool enable_font_fallback_;
 
   std::vector<sk_sp<SkFontMgr>> GetFontManagerOrder() const;
 
-  const std::shared_ptr<minikin::FontFamily>& GetFallbackFont(
-      const sk_sp<SkTypeface>& typeface);
+  std::shared_ptr<minikin::FontFamily> CreateMinikinFontFamily(
+      const sk_sp<SkFontMgr>& manager,
+      const std::string& family_name);
+
+  const std::shared_ptr<minikin::FontFamily>& GetFallbackFontFamily(
+      const sk_sp<SkFontMgr>& manager,
+      const std::string& family_name);
 
   FXL_DISALLOW_COPY_AND_ASSIGN(FontCollection);
 };


### PR DESCRIPTION
libtxt will query Skia for a fallback typeface when it encounters a character
that is not found in the primary font.  The font collection should make all
the variants of the fallback typeface's font family available to Minikin for
use in future font lookups.

Fixes https://github.com/flutter/flutter/issues/17985