### PR TITLE
Revert: Remove uses of ReleaseOwnership from vulkan backend

### DIFF
--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -129,6 +129,10 @@ const VulkanHandle<VkInstance>& VulkanApplication::GetInstance() const {
   return instance_;
 }
 
+void VulkanApplication::ReleaseInstanceOwnership() {
+  instance_.ReleaseOwnership();
+}
+
 std::vector<VkPhysicalDevice> VulkanApplication::GetPhysicalDevices() const {
   if (!IsValid()) {
     return {};

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -38,6 +38,8 @@ class VulkanApplication {
 
   const VulkanHandle<VkInstance>& GetInstance() const;
 
+  void ReleaseInstanceOwnership();
+
   std::unique_ptr<VulkanDevice> AcquireFirstCompatibleLogicalDevice() const;
 
  private:

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -153,6 +153,10 @@ const VulkanHandle<VkDevice>& VulkanDevice::GetHandle() const {
   return device_;
 }
 
+void VulkanDevice::ReleaseDeviceOwnership() {
+  device_.ReleaseOwnership();
+}
+
 const VulkanHandle<VkPhysicalDevice>& VulkanDevice::GetPhysicalDeviceHandle()
     const {
   return physical_device_;

--- a/vulkan/vulkan_device.h
+++ b/vulkan/vulkan_device.h
@@ -35,6 +35,8 @@ class VulkanDevice {
 
   uint32_t GetGraphicsQueueIndex() const;
 
+  void ReleaseDeviceOwnership();
+
   FXL_WARN_UNUSED_RESULT
   bool GetSurfaceCapabilities(const VulkanSurface& surface,
                               VkSurfaceCapabilitiesKHR* capabilities) const;

--- a/vulkan/vulkan_handle.h
+++ b/vulkan/vulkan_handle.h
@@ -50,6 +50,11 @@ class VulkanHandle {
 
   operator Handle() const { return handle_; }
 
+  /// Relinquish responsibility of collecting the underlying handle when this
+  /// object is collected. It is the responsibility of the caller to ensure that
+  /// the lifetime of the handle extends past the lifetime of this object.
+  void ReleaseOwnership() { disposer_ = nullptr; }
+
   void Reset() { DisposeIfNecessary(); }
 
  private:


### PR DESCRIPTION
These are used by Fuchsia's flutter_runner.