### PR TITLE
Fixing image encoding format conversion.

### DIFF
--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -86,9 +86,10 @@ sk_sp<SkData> EncodeImage(sk_sp<SkImage> image, ImageByteFormat format) {
   if (pixmap.colorType() != kRGBA_8888_SkColorType) {
     TRACE_EVENT0("flutter", "ConvertToRGBA");
 
-    // Convert the pixel data to N32 to adhere to our API contract.
-    const auto image_info = SkImageInfo::MakeN32Premul(image->width(),
-                                                       image->height());
+    // Convert the pixel data to N32 and RGBA to adhere to our API contract.
+    const auto image_info = SkImageInfo::MakeN32Premul(
+        image->width(), image->height()).makeColorType(kRGBA_8888_SkColorType);
+
     auto surface = SkSurface::MakeRaster(image_info);
     surface->writePixels(pixmap, 0, 0);
     if (!surface->peekPixels(&pixmap)) {


### PR DESCRIPTION
On a Linux host, we were having to convert the type of the bitmap to N32, but we weren't also fixing the channel order to RGBA, so consequently we were getting BGRA when the API was asking for RGBA.  This forces the color format to be RGBA when that is what is asked for.

We weren't needing to do conversion on macOS, so macOS was always getting RGBA.