### PR TITLE
Enforce clang-format on all files in commit 

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -83,13 +83,14 @@ using namespace shell;
   }
 
   if (@available(iOS 10, *)) {
-    if ([@"HapticFeedbackType.lightImpact" isEqualToString: feedbackType]) {
+    if ([@"HapticFeedbackType.lightImpact" isEqualToString:feedbackType]) {
       [[[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight] impactOccurred];
-    } else if ([@"HapticFeedbackType.mediumImpact" isEqualToString: feedbackType]) {
-      [[[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium] impactOccurred];
-    } else if ([@"HapticFeedbackType.heavyImpact" isEqualToString: feedbackType]) {
+    } else if ([@"HapticFeedbackType.mediumImpact" isEqualToString:feedbackType]) {
+      [[[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleMedium]
+          impactOccurred];
+    } else if ([@"HapticFeedbackType.heavyImpact" isEqualToString:feedbackType]) {
       [[[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleHeavy] impactOccurred];
-    } else if ([@"HapticFeedbackType.selectionClick" isEqualToString: feedbackType]) {
+    } else if ([@"HapticFeedbackType.selectionClick" isEqualToString:feedbackType]) {
       [[[UISelectionFeedbackGenerator alloc] init] selectionChanged];
     }
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -95,7 +95,7 @@ static UITextAutocapitalizationType ToUITextAutocapitalizationType(NSString* inp
 
 @end
 
-@interface FlutterTextInputView : UIView<UITextInput>
+@interface FlutterTextInputView : UIView <UITextInput>
 
 // UITextInput
 @property(nonatomic, readonly) NSMutableString* text;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -159,7 +159,8 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   //  We enforce in the framework that no other useful semantics are merged with these nodes.
   if ([self node].HasFlag(blink::SemanticsFlags::kScopesRoute))
     return false;
-  return ([self node].flags != 0 && [self node].flags != static_cast<int32_t>(blink::SemanticsFlags::kIsHidden)) ||
+  return ([self node].flags != 0 &&
+          [self node].flags != static_cast<int32_t>(blink::SemanticsFlags::kIsHidden)) ||
          ![self node].label.empty() || ![self node].value.empty() || ![self node].hint.empty() ||
          ([self node].actions & ~blink::kScrollableSemanticsActions) != 0;
 }
@@ -219,7 +220,7 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   return [self globalRect];
 }
 
-- (CGRect) globalRect {
+- (CGRect)globalRect {
   SkMatrix44 globalTransform = [self node].transform;
   for (SemanticsObject* parent = [self parent]; parent; parent = parent.parent) {
     globalTransform = parent.node.transform * globalTransform;
@@ -513,7 +514,8 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes) {
     NSMutableArray<SemanticsObject*>* newRoutes = [[[NSMutableArray alloc] init] autorelease];
     [root collectRoutes:newRoutes];
     for (SemanticsObject* route in newRoutes) {
-      if (std::find(previous_routes_.begin(), previous_routes_.end(), [route uid]) != previous_routes_.end()) {
+      if (std::find(previous_routes_.begin(), previous_routes_.end(), [route uid]) !=
+          previous_routes_.end()) {
         lastAdded = route;
       }
     }
@@ -522,8 +524,8 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes) {
       lastAdded = [newRoutes objectAtIndex:index];
     }
     if (lastAdded != nil && [lastAdded uid] != previous_route_id_) {
-        previous_route_id_ = [lastAdded uid];
-        routeChanged = true;
+      previous_route_id_ = [lastAdded uid];
+      routeChanged = true;
     }
     previous_routes_.clear();
     for (SemanticsObject* route in newRoutes) {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -261,7 +261,8 @@
   // Adding UIAccessibilityTraitKeyboardKey to the trait list so that iOS treats it like
   // a keyboard entry control, thus adding support for text editing features, such as
   // pinch to select text, and up/down fling to move cursor.
-  return [super accessibilityTraits] | [self textInputSurrogate].accessibilityTraits | UIAccessibilityTraitKeyboardKey;
+  return [super accessibilityTraits] | [self textInputSurrogate].accessibilityTraits |
+         UIAccessibilityTraitKeyboardKey;
 }
 
 #pragma mark - UITextInput overrides


### PR DESCRIPTION
This re-enforces clang-format across all files changed in the commit.

In c10c417, we enabled checking only for the lines changed in the diff
in order to reduce the change of merge conflicts with the shell refactor
landed in 58e84c8.

This also reformats all code to match the latest toolchain.
