### PR TITLE
Track clip in preroll and quick reject with clipped paint bounds

### DIFF
--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -10,7 +10,9 @@ ChildSceneLayer::ChildSceneLayer() = default;
 
 ChildSceneLayer::~ChildSceneLayer() = default;
 
-void ChildSceneLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void ChildSceneLayer::Preroll(PrerollContext* context,
+                              const SkMatrix& matrix,
+                              const SkIRect& device_clip) {
   set_needs_system_composite(true);
 }
 

--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -6,15 +6,11 @@
 
 namespace flow {
 
-ChildSceneLayer::ChildSceneLayer() = default;
-
-ChildSceneLayer::~ChildSceneLayer() = default;
-
-void ChildSceneLayer::Preroll(PrerollContext* context,
-                              const SkMatrix& matrix,
-                              const SkIRect& device_clip) {
+ChildSceneLayer::ChildSceneLayer() {
   set_needs_system_composite(true);
 }
+
+ChildSceneLayer::~ChildSceneLayer() = default;
 
 void ChildSceneLayer::Paint(PaintContext& context) const {
   FXL_NOTREACHED() << "This layer never needs painting.";

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -27,7 +27,9 @@ class ChildSceneLayer : public Layer {
 
   void set_hit_testable(bool hit_testable) { hit_testable_ = hit_testable; }
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/child_scene_layer.h
+++ b/flow/layers/child_scene_layer.h
@@ -27,10 +27,6 @@ class ChildSceneLayer : public Layer {
 
   void set_hit_testable(bool hit_testable) { hit_testable_ = hit_testable; }
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
-
   void Paint(PaintContext& context) const override;
 
   void UpdateScene(SceneUpdateContext& context) override;

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -12,29 +12,25 @@
 
 namespace flow {
 
-ClipPathLayer::ClipPathLayer() = default;
+ClipPathLayer::ClipPathLayer() {
+  set_needs_system_composite(true);
+}
 
 ClipPathLayer::~ClipPathLayer() = default;
 
-void ClipPathLayer::Preroll(PrerollContext* context,
-                            const SkMatrix& matrix,
-                            const SkIRect& device_clip) {
+SkIRect ClipPathLayer::OnPreroll(PrerollContext* context,
+                                 const SkMatrix& matrix,
+                                 const SkIRect& device_clip) {
   SkIRect new_device_clip = ComputeDeviceIRect(matrix, clip_path_.getBounds());
-  if (!new_device_clip.intersect(device_clip)) {
-    new_device_clip.setEmpty();
-  }
+  IntersectOrSetEmpty(new_device_clip, device_clip);
 
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds, new_device_clip);
-
   if (child_paint_bounds.intersect(clip_path_.getBounds())) {
     set_paint_bounds(child_paint_bounds);
   }
 
-  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
-  if (!device_paint_bounds_.intersect(device_clip)) {
-    device_paint_bounds_.setEmpty();
-  }
+  return new_device_clip;
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -16,12 +16,24 @@ ClipPathLayer::ClipPathLayer() = default;
 
 ClipPathLayer::~ClipPathLayer() = default;
 
-void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void ClipPathLayer::Preroll(PrerollContext* context,
+                            const SkMatrix& matrix,
+                            const SkIRect& device_clip) {
+  SkIRect new_device_clip = ComputeDeviceIRect(matrix, clip_path_.getBounds());
+  if (!new_device_clip.intersect(device_clip)) {
+    new_device_clip.setEmpty();
+  }
+
   SkRect child_paint_bounds = SkRect::MakeEmpty();
-  PrerollChildren(context, matrix, &child_paint_bounds);
+  PrerollChildren(context, matrix, &child_paint_bounds, new_device_clip);
 
   if (child_paint_bounds.intersect(clip_path_.getBounds())) {
     set_paint_bounds(child_paint_bounds);
+  }
+
+  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
+  if (!device_paint_bounds_.intersect(device_clip)) {
+    device_paint_bounds_.setEmpty();
   }
 }
 

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -12,10 +12,7 @@
 
 namespace flow {
 
-ClipPathLayer::ClipPathLayer() {
-  set_needs_system_composite(true);
-}
-
+ClipPathLayer::ClipPathLayer() = default;
 ClipPathLayer::~ClipPathLayer() = default;
 
 SkIRect ClipPathLayer::OnPreroll(PrerollContext* context,

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -16,10 +16,6 @@ class ClipPathLayer : public ContainerLayer {
 
   void set_clip_path(const SkPath& clip_path) { clip_path_ = clip_path; }
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
-
   void Paint(PaintContext& context) const override;
 
 #if defined(OS_FUCHSIA)
@@ -28,6 +24,10 @@ class ClipPathLayer : public ContainerLayer {
 
  private:
   SkPath clip_path_;
+
+  SkIRect OnPreroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(ClipPathLayer);
 };

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -16,7 +16,9 @@ class ClipPathLayer : public ContainerLayer {
 
   void set_clip_path(const SkPath& clip_path) { clip_path_ = clip_path; }
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -6,29 +6,25 @@
 
 namespace flow {
 
-ClipRectLayer::ClipRectLayer() = default;
+ClipRectLayer::ClipRectLayer() {
+  set_needs_system_composite(true);
+}
 
 ClipRectLayer::~ClipRectLayer() = default;
 
-void ClipRectLayer::Preroll(PrerollContext* context,
-                            const SkMatrix& matrix,
-                            const SkIRect& device_clip) {
+SkIRect ClipRectLayer::OnPreroll(PrerollContext* context,
+                                 const SkMatrix& matrix,
+                                 const SkIRect& device_clip) {
   SkIRect new_device_clip = ComputeDeviceIRect(matrix, clip_rect_);
-  if (!new_device_clip.intersect(device_clip)) {
-    new_device_clip.setEmpty();
-  }
+  IntersectOrSetEmpty(new_device_clip, device_clip);
 
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds, new_device_clip);
-
   if (child_paint_bounds.intersect(clip_rect_)) {
     set_paint_bounds(child_paint_bounds);
   }
 
-  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
-  if (!device_paint_bounds_.intersect(device_clip)) {
-    device_paint_bounds_.setEmpty();
-  }
+  return new_device_clip;
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -10,12 +10,24 @@ ClipRectLayer::ClipRectLayer() = default;
 
 ClipRectLayer::~ClipRectLayer() = default;
 
-void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void ClipRectLayer::Preroll(PrerollContext* context,
+                            const SkMatrix& matrix,
+                            const SkIRect& device_clip) {
+  SkIRect new_device_clip = ComputeDeviceIRect(matrix, clip_rect_);
+  if (!new_device_clip.intersect(device_clip)) {
+    new_device_clip.setEmpty();
+  }
+
   SkRect child_paint_bounds = SkRect::MakeEmpty();
-  PrerollChildren(context, matrix, &child_paint_bounds);
+  PrerollChildren(context, matrix, &child_paint_bounds, new_device_clip);
 
   if (child_paint_bounds.intersect(clip_rect_)) {
     set_paint_bounds(child_paint_bounds);
+  }
+
+  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
+  if (!device_paint_bounds_.intersect(device_clip)) {
+    device_paint_bounds_.setEmpty();
   }
 }
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -6,10 +6,7 @@
 
 namespace flow {
 
-ClipRectLayer::ClipRectLayer() {
-  set_needs_system_composite(true);
-}
-
+ClipRectLayer::ClipRectLayer() = default;
 ClipRectLayer::~ClipRectLayer() = default;
 
 SkIRect ClipRectLayer::OnPreroll(PrerollContext* context,

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -16,7 +16,9 @@ class ClipRectLayer : public ContainerLayer {
 
   void set_clip_rect(const SkRect& clip_rect) { clip_rect_ = clip_rect; }
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
   void Paint(PaintContext& context) const override;
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -16,9 +16,6 @@ class ClipRectLayer : public ContainerLayer {
 
   void set_clip_rect(const SkRect& clip_rect) { clip_rect_ = clip_rect; }
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
   void Paint(PaintContext& context) const override;
 
 #if defined(OS_FUCHSIA)
@@ -27,6 +24,10 @@ class ClipRectLayer : public ContainerLayer {
 
  private:
   SkRect clip_rect_;
+
+  SkIRect OnPreroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(ClipRectLayer);
 };

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -10,12 +10,24 @@ ClipRRectLayer::ClipRRectLayer() = default;
 
 ClipRRectLayer::~ClipRRectLayer() = default;
 
-void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void ClipRRectLayer::Preroll(PrerollContext* context,
+                             const SkMatrix& matrix,
+                             const SkIRect& device_clip) {
+  SkIRect new_device_clip = ComputeDeviceIRect(matrix, clip_rrect_.getBounds());
+  if (!new_device_clip.intersect(device_clip)) {
+    new_device_clip.setEmpty();
+  }
+
   SkRect child_paint_bounds = SkRect::MakeEmpty();
-  PrerollChildren(context, matrix, &child_paint_bounds);
+  PrerollChildren(context, matrix, &child_paint_bounds, new_device_clip);
 
   if (child_paint_bounds.intersect(clip_rrect_.getBounds())) {
     set_paint_bounds(child_paint_bounds);
+  }
+
+  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
+  if (!device_paint_bounds_.intersect(device_clip)) {
+    device_paint_bounds_.setEmpty();
   }
 }
 

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -6,10 +6,7 @@
 
 namespace flow {
 
-ClipRRectLayer::ClipRRectLayer() {
-  set_needs_system_composite(true);
-}
-
+ClipRRectLayer::ClipRRectLayer() = default;
 ClipRRectLayer::~ClipRRectLayer() = default;
 
 SkIRect ClipRRectLayer::OnPreroll(PrerollContext* context,

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -6,29 +6,25 @@
 
 namespace flow {
 
-ClipRRectLayer::ClipRRectLayer() = default;
+ClipRRectLayer::ClipRRectLayer() {
+  set_needs_system_composite(true);
+}
 
 ClipRRectLayer::~ClipRRectLayer() = default;
 
-void ClipRRectLayer::Preroll(PrerollContext* context,
-                             const SkMatrix& matrix,
-                             const SkIRect& device_clip) {
+SkIRect ClipRRectLayer::OnPreroll(PrerollContext* context,
+                                  const SkMatrix& matrix,
+                                  const SkIRect& device_clip) {
   SkIRect new_device_clip = ComputeDeviceIRect(matrix, clip_rrect_.getBounds());
-  if (!new_device_clip.intersect(device_clip)) {
-    new_device_clip.setEmpty();
-  }
+  IntersectOrSetEmpty(new_device_clip, device_clip);
 
   SkRect child_paint_bounds = SkRect::MakeEmpty();
   PrerollChildren(context, matrix, &child_paint_bounds, new_device_clip);
-
   if (child_paint_bounds.intersect(clip_rrect_.getBounds())) {
     set_paint_bounds(child_paint_bounds);
   }
 
-  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
-  if (!device_paint_bounds_.intersect(device_clip)) {
-    device_paint_bounds_.setEmpty();
-  }
+  return new_device_clip;
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -16,10 +16,6 @@ class ClipRRectLayer : public ContainerLayer {
 
   void set_clip_rrect(const SkRRect& clip_rrect) { clip_rrect_ = clip_rrect; }
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
-
   void Paint(PaintContext& context) const override;
 
 #if defined(OS_FUCHSIA)
@@ -28,6 +24,10 @@ class ClipRRectLayer : public ContainerLayer {
 
  private:
   SkRRect clip_rrect_;
+
+  SkIRect OnPreroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(ClipRRectLayer);
 };

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -16,7 +16,9 @@ class ClipRRectLayer : public ContainerLayer {
 
   void set_clip_rrect(const SkRRect& clip_rrect) { clip_rrect_ = clip_rrect; }
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -6,7 +6,8 @@
 
 namespace flow {
 
-ContainerLayer::ContainerLayer() = default;
+ContainerLayer::ContainerLayer() {};
+
 ContainerLayer::~ContainerLayer() = default;
 
 void ContainerLayer::Add(std::unique_ptr<Layer> layer) {

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -17,10 +17,6 @@ class ContainerLayer : public Layer {
 
   void Add(std::unique_ptr<Layer> layer);
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
-
 #if defined(OS_FUCHSIA)
   void UpdateScene(SceneUpdateContext& context) override;
 #endif  // defined(OS_FUCHSIA)
@@ -37,6 +33,11 @@ class ContainerLayer : public Layer {
 #if defined(OS_FUCHSIA)
   void UpdateSceneChildren(SceneUpdateContext& context);
 #endif  // defined(OS_FUCHSIA)
+
+ protected:
+  SkIRect OnPreroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 
  private:
   std::vector<std::unique_ptr<Layer>> layers_;

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -17,7 +17,9 @@ class ContainerLayer : public Layer {
 
   void Add(std::unique_ptr<Layer> layer);
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
 
 #if defined(OS_FUCHSIA)
   void UpdateScene(SceneUpdateContext& context) override;
@@ -28,7 +30,8 @@ class ContainerLayer : public Layer {
  protected:
   void PrerollChildren(PrerollContext* context,
                        const SkMatrix& child_matrix,
-                       SkRect* child_paint_bounds);
+                       SkRect* child_paint_bounds,
+                       const SkIRect& device_clip);
   void PaintChildren(PaintContext& context) const;
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -11,6 +11,7 @@ namespace flow {
 
 Layer::Layer()
     : parent_(nullptr),
+      needs_system_composite_(false),
       paint_bounds_(SkRect::MakeEmpty()) {}
 
 Layer::~Layer() = default;

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -11,14 +11,17 @@ namespace flow {
 
 Layer::Layer()
     : parent_(nullptr),
-      needs_system_composite_(false),
       paint_bounds_(SkRect::MakeEmpty()) {}
 
 Layer::~Layer() = default;
 
 void Layer::Preroll(PrerollContext* context,
                     const SkMatrix& matrix,
-                    const SkIRect& device_clip) {}
+                    const SkIRect& device_clip) {
+  SkIRect new_device_clip = OnPreroll(context, matrix, device_clip);
+  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
+  IntersectOrSetEmpty(device_paint_bounds_, new_device_clip);
+}
 
 #if defined(OS_FUCHSIA)
 void Layer::UpdateScene(SceneUpdateContext& context) {}
@@ -50,6 +53,12 @@ SkIRect Layer::ComputeDeviceIRect(const SkMatrix& ctm, const SkRect& rect) {
   SkIRect device_irect;
   device_rect.roundOut(&device_irect);
   return device_irect;
+}
+
+void Layer::IntersectOrSetEmpty(SkIRect& rect, const SkIRect& clip) {
+  if (!rect.intersect(clip)) {
+    rect.setEmpty();
+  }
 }
 
 }  // namespace flow

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -16,7 +16,9 @@ Layer::Layer()
 
 Layer::~Layer() = default;
 
-void Layer::Preroll(PrerollContext* context, const SkMatrix& matrix) {}
+void Layer::Preroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) {}
 
 #if defined(OS_FUCHSIA)
 void Layer::UpdateScene(SceneUpdateContext& context) {}
@@ -40,6 +42,14 @@ Layer::AutoSaveLayer::~AutoSaveLayer() {
     DrawCheckerboard(&paint_context_.canvas, bounds_);
   }
   paint_context_.canvas.restore();
+}
+
+SkIRect Layer::ComputeDeviceIRect(const SkMatrix& ctm, const SkRect& rect) {
+  SkRect device_rect;
+  ctm.mapRect(&device_rect, rect);
+  SkIRect device_irect;
+  device_rect.roundOut(&device_irect);
+  return device_irect;
 }
 
 }  // namespace flow

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -50,9 +50,9 @@ class Layer {
     SkRect child_paint_bounds;
   };
 
-  virtual void Preroll(PrerollContext* context,
-                       const SkMatrix& matrix,
-                       const SkIRect& device_clip);
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip);
 
   struct PaintContext {
     SkCanvas& canvas;
@@ -110,7 +110,15 @@ class Layer {
   SkIRect device_paint_bounds_;  // any pixel outside of this rect (in device
                                  // coordinate) will never be drawn
 
+  // Returns the new device_clip that takes this layer into consideration
+  virtual SkIRect OnPreroll(PrerollContext* context,
+                            const SkMatrix& matrix,
+                            const SkIRect& device_clip) { return device_clip; }
+
   static SkIRect ComputeDeviceIRect(const SkMatrix& ctm, const SkRect& rect);
+
+  // Intersect rect with clip; if there's no intersection, set rect to empty.
+  static void IntersectOrSetEmpty(SkIRect& rect, const SkIRect& clip);
 
  private:
   ContainerLayer* parent_;

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -104,7 +104,7 @@ class Layer {
     paint_bounds_ = paint_bounds;
   }
 
-  bool needs_painting() const { return !paint_bounds_.isEmpty(); }
+  bool needs_painting() const { return !device_paint_bounds_.isEmpty(); }
 
  protected:
   SkIRect device_paint_bounds_;  // any pixel outside of this rect (in device

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -50,7 +50,9 @@ class Layer {
     SkRect child_paint_bounds;
   };
 
-  virtual void Preroll(PrerollContext* context, const SkMatrix& matrix);
+  virtual void Preroll(PrerollContext* context,
+                       const SkMatrix& matrix,
+                       const SkIRect& device_clip);
 
   struct PaintContext {
     SkCanvas& canvas;
@@ -103,6 +105,12 @@ class Layer {
   }
 
   bool needs_painting() const { return !paint_bounds_.isEmpty(); }
+
+ protected:
+  SkIRect device_paint_bounds_;  // any pixel outside of this rect (in device
+                                 // coordinate) will never be drawn
+
+  static SkIRect ComputeDeviceIRect(const SkMatrix& ctm, const SkRect& rect);
 
  private:
   ContainerLayer* parent_;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -32,7 +32,7 @@ void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       SkRect::MakeEmpty(),
   };
 
-  root_layer_->Preroll(&context, SkMatrix::I());
+  root_layer_->Preroll(&context, SkMatrix::I(), SkIRect::MakeSize(frame_size_));
 }
 
 #if defined(OS_FUCHSIA)
@@ -105,7 +105,8 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
   // Even if we don't have a root layer, we still need to create an empty
   // picture.
   if (root_layer_) {
-    root_layer_->Preroll(&preroll_context, SkMatrix::I());
+    root_layer_->Preroll(&preroll_context, SkMatrix::I(),
+                         SkIRect::MakeSize(frame_size_));
     // The needs painting flag may be set after the preroll. So check it after.
     if (root_layer_->needs_painting()) {
       root_layer_->Paint(paint_context);

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -9,9 +9,7 @@
 
 namespace flow {
 
-PhysicalShapeLayer::PhysicalShapeLayer() : isRect_(false) {
-  set_needs_system_composite(true);
-}
+PhysicalShapeLayer::PhysicalShapeLayer() : isRect_(false) {}
 
 PhysicalShapeLayer::~PhysicalShapeLayer() = default;
 
@@ -53,6 +51,7 @@ SkIRect PhysicalShapeLayer::OnPreroll(PrerollContext* context,
   } else {
 #if defined(OS_FUCHSIA)
     // Let the system compositor draw all shadows for us.
+    set_needs_system_composite(true);
     set_paint_bounds(path_.getBounds());
 #else
     // Add some margin to the paint bounds to leave space for the shadow.

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -93,10 +93,6 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "PhysicalShapeLayer::Paint");
   FXL_DCHECK(needs_painting());
 
-  if (device_paint_bounds_.isEmpty()) {
-    return;
-  }
-
   if (elevation_ != 0) {
     DrawShadow(&context.canvas, path_, shadow_color_, elevation_,
                SkColorGetA(color_) != 0xff, device_pixel_ratio_);

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -28,10 +28,6 @@ class PhysicalShapeLayer : public ContainerLayer {
                          bool transparentOccluder,
                          SkScalar dpr);
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
-
   void Paint(PaintContext& context) const override;
 
 #if defined(OS_FUCHSIA)
@@ -46,6 +42,10 @@ class PhysicalShapeLayer : public ContainerLayer {
   SkPath path_;
   bool isRect_;
   SkRRect frameRRect_;
+
+  SkIRect OnPreroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 };
 
 }  // namespace flow

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -28,7 +28,9 @@ class PhysicalShapeLayer : public ContainerLayer {
                          bool transparentOccluder,
                          SkScalar dpr);
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -12,9 +12,9 @@ PictureLayer::PictureLayer() = default;
 
 PictureLayer::~PictureLayer() = default;
 
-void PictureLayer::Preroll(PrerollContext* context,
-                           const SkMatrix& matrix,
-                           const SkIRect& device_clip) {
+SkIRect PictureLayer::OnPreroll(PrerollContext* context,
+                                const SkMatrix& matrix,
+                                const SkIRect& device_clip) {
   SkPicture* sk_picture = picture();
 
   if (auto cache = context->raster_cache) {
@@ -33,10 +33,7 @@ void PictureLayer::Preroll(PrerollContext* context,
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());
   set_paint_bounds(bounds);
 
-  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
-  if (!device_paint_bounds_.intersect(device_clip)) {
-    device_paint_bounds_.setEmpty();
-  }
+  return device_clip;
 }
 
 void PictureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -12,7 +12,9 @@ PictureLayer::PictureLayer() = default;
 
 PictureLayer::~PictureLayer() = default;
 
-void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void PictureLayer::Preroll(PrerollContext* context,
+                           const SkMatrix& matrix,
+                           const SkIRect& device_clip) {
   SkPicture* sk_picture = picture();
 
   if (auto cache = context->raster_cache) {
@@ -30,6 +32,11 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   SkRect bounds = sk_picture->cullRect().makeOffset(offset_.x(), offset_.y());
   set_paint_bounds(bounds);
+
+  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
+  if (!device_paint_bounds_.intersect(device_clip)) {
+    device_paint_bounds_.setEmpty();
+  }
 }
 
 void PictureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/picture_layer.h
+++ b/flow/layers/picture_layer.h
@@ -28,10 +28,6 @@ class PictureLayer : public Layer {
 
   SkPicture* picture() const { return picture_.get().get(); }
 
-  void Preroll(PrerollContext* frame,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
-
   void Paint(PaintContext& context) const override;
 
  private:
@@ -42,6 +38,10 @@ class PictureLayer : public Layer {
   bool is_complex_ = false;
   bool will_change_ = false;
   RasterCacheResult raster_cache_result_;
+
+  SkIRect OnPreroll(PrerollContext* frame,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(PictureLayer);
 };

--- a/flow/layers/picture_layer.h
+++ b/flow/layers/picture_layer.h
@@ -28,7 +28,9 @@ class PictureLayer : public Layer {
 
   SkPicture* picture() const { return picture_.get().get(); }
 
-  void Preroll(PrerollContext* frame, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* frame,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -12,9 +12,16 @@ TextureLayer::TextureLayer() = default;
 
 TextureLayer::~TextureLayer() = default;
 
-void TextureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void TextureLayer::Preroll(PrerollContext* context,
+                           const SkMatrix& matrix,
+                           const SkIRect& device_clip) {
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
+
+  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
+  if (!device_paint_bounds_.intersect(device_clip)) {
+    device_paint_bounds_.setEmpty();
+  }
 }
 
 void TextureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -12,16 +12,12 @@ TextureLayer::TextureLayer() = default;
 
 TextureLayer::~TextureLayer() = default;
 
-void TextureLayer::Preroll(PrerollContext* context,
-                           const SkMatrix& matrix,
-                           const SkIRect& device_clip) {
+SkIRect TextureLayer::OnPreroll(PrerollContext* context,
+                                const SkMatrix& matrix,
+                                const SkIRect& device_clip) {
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
-
-  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
-  if (!device_paint_bounds_.intersect(device_clip)) {
-    device_paint_bounds_.setEmpty();
-  }
+  return device_clip;
 }
 
 void TextureLayer::Paint(PaintContext& context) const {

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -23,7 +23,9 @@ class TextureLayer : public Layer {
   void set_size(const SkSize& size) { size_ = size; }
   void set_texture_id(int64_t texture_id) { texture_id_ = texture_id; }
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
   void Paint(PaintContext& context) const override;
 
  private:

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -23,15 +23,16 @@ class TextureLayer : public Layer {
   void set_size(const SkSize& size) { size_ = size; }
   void set_texture_id(int64_t texture_id) { texture_id_ = texture_id; }
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
   void Paint(PaintContext& context) const override;
 
  private:
   SkPoint offset_;
   SkSize size_;
   int64_t texture_id_;
+
+  SkIRect OnPreroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(TextureLayer);
 };

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -10,15 +10,22 @@ TransformLayer::TransformLayer() = default;
 
 TransformLayer::~TransformLayer() = default;
 
-void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void TransformLayer::Preroll(PrerollContext* context,
+                             const SkMatrix& matrix,
+                             const SkIRect& device_clip) {
   SkMatrix child_matrix;
   child_matrix.setConcat(matrix, transform_);
 
   SkRect child_paint_bounds = SkRect::MakeEmpty();
-  PrerollChildren(context, child_matrix, &child_paint_bounds);
+  PrerollChildren(context, child_matrix, &child_paint_bounds, device_clip);
 
   transform_.mapRect(&child_paint_bounds);
   set_paint_bounds(child_paint_bounds);
+
+  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
+  if (!device_paint_bounds_.intersect(device_clip)) {
+    device_paint_bounds_.setEmpty();
+  }
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -10,9 +10,9 @@ TransformLayer::TransformLayer() = default;
 
 TransformLayer::~TransformLayer() = default;
 
-void TransformLayer::Preroll(PrerollContext* context,
-                             const SkMatrix& matrix,
-                             const SkIRect& device_clip) {
+SkIRect TransformLayer::OnPreroll(PrerollContext* context,
+                                  const SkMatrix& matrix,
+                                  const SkIRect& device_clip) {
   SkMatrix child_matrix;
   child_matrix.setConcat(matrix, transform_);
 
@@ -22,10 +22,7 @@ void TransformLayer::Preroll(PrerollContext* context,
   transform_.mapRect(&child_paint_bounds);
   set_paint_bounds(child_paint_bounds);
 
-  device_paint_bounds_ = ComputeDeviceIRect(matrix, paint_bounds());
-  if (!device_paint_bounds_.intersect(device_clip)) {
-    device_paint_bounds_.setEmpty();
-  }
+  return device_clip;
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -16,10 +16,6 @@ class TransformLayer : public ContainerLayer {
 
   void set_transform(const SkMatrix& transform) { transform_ = transform; }
 
-  void Preroll(PrerollContext* context,
-               const SkMatrix& matrix,
-               const SkIRect& device_clip) override;
-
   void Paint(PaintContext& context) const override;
 
 #if defined(OS_FUCHSIA)
@@ -28,6 +24,10 @@ class TransformLayer : public ContainerLayer {
 
  private:
   SkMatrix transform_;
+
+  SkIRect OnPreroll(PrerollContext* context,
+                    const SkMatrix& matrix,
+                    const SkIRect& device_clip) override;
 
   FXL_DISALLOW_COPY_AND_ASSIGN(TransformLayer);
 };

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -16,7 +16,9 @@ class TransformLayer : public ContainerLayer {
 
   void set_transform(const SkMatrix& transform) { transform_ = transform; }
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+  void Preroll(PrerollContext* context,
+               const SkMatrix& matrix,
+               const SkIRect& device_clip) override;
 
   void Paint(PaintContext& context) const override;
 


### PR DESCRIPTION
This should improve the performance of https://fuchsia.atlassian.net/browse/FL-53 by ~40% because there are 20 small physical layers but only 12 are within the device clip. Without this change, we create 20 Vulkan surfaces and render into all of them. With this change, we only created 12.

By having this for all layers, we get a ~20% speedup for complex_layout_scroll_perf test. 