### PR TITLE
 Eliminate support for Dart 1

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -11,7 +11,6 @@ namespace blink {
 std::string Settings::ToString() const {
   std::stringstream stream;
   stream << "Settings: " << std::endl;
-  stream << "script_snapshot_path: " << script_snapshot_path << std::endl;
   stream << "vm_snapshot_data_path: " << vm_snapshot_data_path << std::endl;
   stream << "vm_snapshot_instr_path: " << vm_snapshot_instr_path << std::endl;
   stream << "isolate_snapshot_data_path: " << isolate_snapshot_data_path

--- a/common/settings.cc
+++ b/common/settings.cc
@@ -32,7 +32,7 @@ std::string Settings::ToString() const {
   stream << "trace_startup: " << trace_startup << std::endl;
   stream << "endless_trace_buffer: " << endless_trace_buffer << std::endl;
   stream << "enable_dart_profiling: " << enable_dart_profiling << std::endl;
-  stream << "dart_non_checked_mode: " << dart_non_checked_mode << std::endl;
+  stream << "enable_dart_asserts:" << enable_dart_asserts << std::endl;
   stream << "enable_observatory: " << enable_observatory << std::endl;
   stream << "observatory_port: " << observatory_port << std::endl;
   stream << "ipv6: " << ipv6 << std::endl;

--- a/common/settings.cc
+++ b/common/settings.cc
@@ -31,7 +31,6 @@ std::string Settings::ToString() const {
   stream << "trace_startup: " << trace_startup << std::endl;
   stream << "endless_trace_buffer: " << endless_trace_buffer << std::endl;
   stream << "enable_dart_profiling: " << enable_dart_profiling << std::endl;
-  stream << "enable_dart_asserts:" << enable_dart_asserts << std::endl;
   stream << "enable_observatory: " << enable_observatory << std::endl;
   stream << "observatory_port: " << observatory_port << std::endl;
   stream << "ipv6: " << ipv6 << std::endl;

--- a/common/settings.h
+++ b/common/settings.h
@@ -23,7 +23,6 @@ using TaskObserverRemove = std::function<void(intptr_t /* key */)>;
 
 struct Settings {
   // VM settings
-  std::string script_snapshot_path;
   std::string platform_kernel_path;
 
   std::string vm_snapshot_data_path;

--- a/common/settings.h
+++ b/common/settings.h
@@ -46,7 +46,6 @@ struct Settings {
   bool trace_startup = false;
   bool endless_trace_buffer = false;
   bool enable_dart_profiling = false;
-  bool enable_dart_asserts = true;
   // Used as the script URI in debug messages. Does not affect how the Dart code
   // is executed.
   std::string advisory_script_uri = "main.dart";

--- a/common/settings.h
+++ b/common/settings.h
@@ -47,7 +47,7 @@ struct Settings {
   bool trace_startup = false;
   bool endless_trace_buffer = false;
   bool enable_dart_profiling = false;
-  bool dart_non_checked_mode = false;
+  bool enable_dart_asserts = true;
   // Used as the script URI in debug messages. Does not affect how the Dart code
   // is executed.
   std::string advisory_script_uri = "main.dart";

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -566,20 +566,12 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
   // thread.
   service_isolate->ResetWeakPtrFactory();
 
-  const bool isolate_snapshot_is_dart_2 = Dart_IsDart2Snapshot(
-      vm->GetIsolateSnapshot()->GetData()->GetSnapshotPointer());
-  const bool is_preview_dart2 =
-      (vm->GetPlatformKernel().GetSize() > 0) || isolate_snapshot_is_dart_2;
-  const bool running_from_sources =
-      !DartVM::IsRunningPrecompiledCode() && !is_preview_dart2;
-
   tonic::DartState::Scope scope(service_isolate);
   if (!DartServiceIsolate::Startup(
           settings.ipv6 ? "::1" : "127.0.0.1",  // server IP address
           settings.observatory_port,            // server observatory port
           tonic::DartState::HandleLibraryTag,   // embedder library tag handler
-          running_from_sources,                 // running from source code
-          false,  //  disable websocket origin check
+          false,  // disable websocket origin check
           error   // error (out)
           )) {
     // Error is populated by call to startup.

--- a/runtime/dart_service_isolate.h
+++ b/runtime/dart_service_isolate.h
@@ -16,7 +16,6 @@ class DartServiceIsolate {
   static bool Startup(std::string server_ip,
                       intptr_t server_port,
                       Dart_LibraryTagHandler embedder_tag_handler,
-                      bool running_from_sources,
                       bool disable_origin_check,
                       char** error);
 
@@ -27,14 +26,6 @@ class DartServiceIsolate {
   static void TriggerResourceLoad(Dart_NativeArguments args);
   static void NotifyServerState(Dart_NativeArguments args);
   static void Shutdown(Dart_NativeArguments args);
-
-  // Script loading.
-  static Dart_Handle GetSource(const char* name);
-  static Dart_Handle LoadScript(const char* name);
-  static Dart_Handle LoadSource(Dart_Handle library, const char* name);
-  static Dart_Handle LibraryTagHandler(Dart_LibraryTag tag,
-                                       Dart_Handle library,
-                                       Dart_Handle url);
 
   // Observatory resource loading.
   static Dart_Handle LoadResources(Dart_Handle library);

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -83,14 +83,6 @@ static const char* kDartAssertArgs[] = {
     // clang-format on
 };
 
-static const char* kDartCheckedModeArgs[] = {
-    // clang-format off
-    "--enable_type_checks",
-    "--error_on_bad_type",
-    "--error_on_bad_override",
-    // clang-format on
-};
-
 static const char* kDartStrongModeArgs[] = {
     // clang-format off
     "--strong",
@@ -324,18 +316,18 @@ DartVM::DartVM(const Settings& settings,
                 arraysize(kDartPrecompilationArgs));
   }
 
-  // Enable checked mode if we are not running precompiled code. We run non-
+  // Enable asserts if we are not running precompiled code. We run non-
   // precompiled code only in the debug product mode.
-  bool use_checked_mode = !settings.dart_non_checked_mode;
+  bool enable_asserts = settings.enable_dart_asserts;
 
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_PROFILE || \
     FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE
-  use_checked_mode = false;
+  enable_asserts = false;
 #endif
 
 #if !OS_FUCHSIA
   if (IsRunningPrecompiledCode()) {
-    use_checked_mode = false;
+    enable_asserts = false;
   }
 #endif  // !OS_FUCHSIA
 
@@ -346,29 +338,12 @@ DartVM::DartVM(const Settings& settings,
               arraysize(kDartWriteProtectCodeArgs));
 #endif
 
-  const bool isolate_snapshot_is_dart_2 =
-      Dart_IsDart2Snapshot(isolate_snapshot_->GetData()->GetSnapshotPointer());
+  // Require Dart 2.
+  FML_DCHECK(platform_kernel_mapping_->GetSize() > 0);
 
-  const bool is_preview_dart2 =
-      (platform_kernel_mapping_->GetSize() > 0) || isolate_snapshot_is_dart_2;
-
-  FXL_DLOG(INFO) << "Dart 2 " << (is_preview_dart2 ? "is" : "is NOT")
-                 << " enabled. Platform kernel: "
-                 << static_cast<bool>(platform_kernel_mapping_->GetSize() > 0)
-                 << " Isolate Snapshot is Dart 2: "
-                 << isolate_snapshot_is_dart_2;
-
-  if (is_preview_dart2) {
-    PushBackAll(&args, kDartStrongModeArgs, arraysize(kDartStrongModeArgs));
-    if (use_checked_mode) {
-      PushBackAll(&args, kDartAssertArgs, arraysize(kDartAssertArgs));
-    }
-  } else if (use_checked_mode) {
-    FXL_DLOG(INFO) << "Checked mode is ON";
+  PushBackAll(&args, kDartStrongModeArgs, arraysize(kDartStrongModeArgs));
+  if (enable_asserts) {
     PushBackAll(&args, kDartAssertArgs, arraysize(kDartAssertArgs));
-    PushBackAll(&args, kDartCheckedModeArgs, arraysize(kDartCheckedModeArgs));
-  } else {
-    FXL_DLOG(INFO) << "Is not Dart 2 and Checked mode is OFF";
   }
 
   if (settings.start_paused) {

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -318,7 +318,7 @@ DartVM::DartVM(const Settings& settings,
 
   // Enable asserts if we are not running precompiled code. We run non-
   // precompiled code only in the debug product mode.
-  bool enable_asserts = settings.enable_dart_asserts;
+  bool enable_asserts = true;
 
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_PROFILE || \
     FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE
@@ -365,6 +365,7 @@ DartVM::DartVM(const Settings& settings,
   PushBackAll(&args, kDartFuchsiaTraceArgs, arraysize(kDartFuchsiaTraceArgs));
 #endif
 
+  // Add VM dart_flags last to allow user overrides.
   for (size_t i = 0; i < settings.dart_flags.size(); i++)
     args.push_back(settings.dart_flags[i].c_str());
 

--- a/shell/common/isolate_configuration.cc
+++ b/shell/common/isolate_configuration.cc
@@ -145,17 +145,6 @@ std::unique_ptr<IsolateConfiguration> IsolateConfiguration::InferFromSettings(
     }
   }
 
-  // Running from script snapshot.
-  {
-    // TODO(engine): Add AssetManager::GetAsMapping or such to avoid the copy.
-    std::vector<uint8_t> script_snapshot;
-    if (asset_manager && asset_manager->GetAsBuffer(
-                             settings.script_snapshot_path, &script_snapshot)) {
-      return CreateForSnapshot(
-          std::make_unique<fml::DataMapping>(std::move(script_snapshot)));
-    }
-  }
-
   // Running from kernel divided into several pieces (for sharing).
   {
     // TODO(fuchsia): Add AssetManager::GetAsMapping or such to avoid the copy.

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -161,9 +161,6 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
   command_line.GetOptionValue(FlagForSwitch(Switch::FlutterAssetsDir),
                               &settings.assets_path);
 
-  command_line.GetOptionValue(FlagForSwitch(Switch::Snapshot),
-                              &settings.script_snapshot_path);
-
   command_line.GetOptionValue(FlagForSwitch(Switch::MainDartFile),
                               &settings.main_dart_file_path);
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -129,10 +129,6 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
     }
   }
 
-  // Override default assertions mode.
-  settings.enable_dart_asserts =
-      !command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));
-
   settings.ipv6 = command_line.HasOption(FlagForSwitch(Switch::IPv6));
 
   settings.start_paused =

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -129,9 +129,9 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
     }
   }
 
-  // Checked mode overrides.
-  settings.dart_non_checked_mode =
-      command_line.HasOption(FlagForSwitch(Switch::DartNonCheckedMode));
+  // Override default assertions mode.
+  settings.enable_dart_asserts =
+      !command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));
 
   settings.ipv6 = command_line.HasOption(FlagForSwitch(Switch::IPv6));
 

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -93,7 +93,6 @@ DEF_SWITCH(Help, "help", "Display this help text.")
 DEF_SWITCH(LogTag, "log-tag", "Tag associated with log messages.")
 DEF_SWITCH(MainDartFile, "dart-main", "The path to the main Dart file.")
 DEF_SWITCH(Packages, "packages", "Specify the path to the packages.")
-DEF_SWITCH(Snapshot, "snapshot-blob", "Specify the path to the snapshot blob")
 DEF_SWITCH(StartPaused,
            "start-paused",
            "Start the application paused in the Dart debugger.")

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -122,13 +122,12 @@ DEF_SWITCH(RunForever,
            "run-forever",
            "In non-interactive mode, keep the shell running after the Dart "
            "script has completed.")
-DEF_SWITCH(DartNonCheckedMode,
-           "dart-non-checked-mode",
-           "Dart code runs in checked mode when the runtime mode is debug. In "
-           "profile and release product modes, the application code is "
-           "precompiled and checked mode is unsupported. However, this flag "
-           "may be specified if the user wishes to run in the debug product "
-           "mode (i.e. with JIT or DBC) with checked mode off.")
+DEF_SWITCH(DisableDartAsserts,
+           "disable-dart-asserts",
+           "In debug mode, disable assertions. In profile and release product "
+           "modes, the application code is precompiled and assertions are "
+           "unsupported. This flag may be specified if the user wishes to run "
+           "with assertions disabled in in the debug product mode.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -121,12 +121,6 @@ DEF_SWITCH(RunForever,
            "run-forever",
            "In non-interactive mode, keep the shell running after the Dart "
            "script has completed.")
-DEF_SWITCH(DisableDartAsserts,
-           "disable-dart-asserts",
-           "In debug mode, disable assertions. In profile and release product "
-           "modes, the application code is precompiled and assertions are "
-           "unsupported. This flag may be specified if the user wishes to run "
-           "with assertions disabled in in the debug product mode.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -8,30 +8,30 @@
 /**
  BREAKING CHANGES:
 
- February 28, 2018: Removed "initWithFLXArchive" and
- "initWithFLXArchiveWithScriptSnapshot".
+ February 28, 2018: Removed "initWithFLXArchive" and "initWithFLXArchiveWithScriptSnapshot".
 
- January 15, 2018: Marked "initWithFLXArchive" and
- "initWithFLXArchiveWithScriptSnapshot" as unavailable following the
- deprecation from December 11, 2017. Scheduled to be removed on February
+ January 15, 2018: Marked "initWithFLXArchive" and "initWithFLXArchiveWithScriptSnapshot" as
+ unavailable following the deprecation from December 11, 2017. Scheduled to be removed on February
  19, 2018.
 
  January 09, 2018: Deprecated "FlutterStandardBigInteger" and its use in
- "FlutterStandardMessageCodec" and "FlutterStandardMethodCodec". Scheduled to
- be marked as unavailable once the deprecation has been available on the
- flutter/flutter alpha branch for four weeks. "FlutterStandardBigInteger" was
- needed because the Dart 1.0 int type had no size limit. With Dart 2.0, the
- int type is a fixed-size, 64-bit signed integer. If you need to communicate
- larger integers, use NSString encoding instead.
+ "FlutterStandardMessageCodec" and "FlutterStandardMethodCodec". Scheduled to be marked as
+ unavailable once the deprecation has been available on the flutter/flutter alpha branch for four
+ weeks. "FlutterStandardBigInteger" was needed because the Dart 1.0 int type had no size limit. With
+ Dart 2.0, the int type is a fixed-size, 64-bit signed integer. If you need to communicate larger
+ integers, use NSString encoding instead.
 
- December 11, 2017: Deprecated "initWithFLXArchive" and
- "initWithFLXArchiveWithScriptSnapshot" and scheculed the same to be marked as
- unavailable on January 15, 2018. Instead, "initWithFlutterAssets" and
- "initWithFlutterAssetsWithScriptSnapshot" should be used. The reason for this
- change is that the FLX archive will be deprecated and replaced with a flutter
- assets directory containing the same files as the FLX did.
+ December 11, 2017: Deprecated "initWithFLXArchive" and "initWithFLXArchiveWithScriptSnapshot" and
+ scheculed the same to be marked as unavailable on January 15, 2018. Instead,
+ "initWithFlutterAssets" and "initWithFlutterAssetsWithScriptSnapshot" should be used. The reason
+ for this change is that the FLX archive will be deprecated and replaced with a flutter assets
+ directory containing the same files as the FLX did.
 
  November 29, 2017: Added a BREAKING CHANGES section.
+
+ June 11, 2018: Eliminated "initWithFlutterAssetsWithScriptSnapshot" which was only used for Dart 1
+ code. Flutter is now Dart 2 only. In Dart 2, application code is loaded from a kernel snapshot in
+ debug mode, or AOT-compiled and linked in profile and release modes.
  */
 
 #include "FlutterAppDelegate.h"

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -18,9 +18,6 @@ FLUTTER_EXPORT
                              dartMain:(NSURL*)dartMainURL
                              packages:(NSURL*)dartPackages NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL
-    NS_DESIGNATED_INITIALIZER;
-
 - (instancetype)initFromDefaultSourceForConfiguration;
 
 /**

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -15,7 +15,6 @@
 #include "flutter/shell/platform/darwin/common/command_line.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 
-static const char* kScriptSnapshotFileName = "snapshot_blob.bin";
 static const char* kVMKernelSnapshotFileName = "platform.dill";
 static const char* kApplicationKernelSnapshotFileName = "kernel_blob.bin";
 
@@ -80,17 +79,6 @@ static blink::Settings DefaultSettingsForProcess() {
       settings.assets_path = assetsPath.UTF8String;
 
       if (!blink::DartVM::IsRunningPrecompiledCode()) {
-        // Looking for the various script and kernel snapshot buffers only makes sense if we have a
-        // VM that can use these buffers.
-        {
-          // Check if there is a script snapshot in the assets directory we could potentially use.
-          NSURL* scriptSnapshotURL = [NSURL URLWithString:@(kScriptSnapshotFileName)
-                                            relativeToURL:[NSURL fileURLWithPath:assetsPath]];
-          if ([[NSFileManager defaultManager] fileExistsAtPath:scriptSnapshotURL.path]) {
-            settings.script_snapshot_path = scriptSnapshotURL.path.UTF8String;
-          }
-        }
-
         {
           // Check if there is a VM kernel snapshot in the assets directory we could potentially
           // use.
@@ -164,26 +152,6 @@ static blink::Settings DefaultSettingsForProcess() {
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:dartPackages.path]) {
       _settings.packages_file_path = dartPackages.path.UTF8String;
-    }
-  }
-
-  return self;
-}
-
-- (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL {
-  self = [super init];
-
-  if (self) {
-    _settings = DefaultSettingsForProcess();
-
-    if ([[NSFileManager defaultManager] fileExistsAtPath:flutterAssetsURL.path]) {
-      _settings.assets_path = flutterAssetsURL.path.UTF8String;
-
-      NSURL* scriptSnapshotPath =
-          [NSURL URLWithString:@(kScriptSnapshotFileName) relativeToURL:flutterAssetsURL];
-      if ([[NSFileManager defaultManager] fileExistsAtPath:scriptSnapshotPath.path]) {
-        _settings.script_snapshot_path = scriptSnapshotPath.path.UTF8String;
-      }
     }
   }
 


### PR DESCRIPTION
Eliminates support for running directly from sources or script snapshots. In
debug mode, we run from a kernel snapshot; in profile and release modes, we
link in AOT-compiled code.

Renames --dart-non-checked-mode to --disable-dart-asserts since checked mode
does not make sense in Dart 2.