### PR TITLE
Revert "Eliminate support for Dart 1 (#5504)"

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -11,6 +11,7 @@ namespace blink {
 std::string Settings::ToString() const {
   std::stringstream stream;
   stream << "Settings: " << std::endl;
+  stream << "script_snapshot_path: " << script_snapshot_path << std::endl;
   stream << "vm_snapshot_data_path: " << vm_snapshot_data_path << std::endl;
   stream << "vm_snapshot_instr_path: " << vm_snapshot_instr_path << std::endl;
   stream << "isolate_snapshot_data_path: " << isolate_snapshot_data_path
@@ -31,6 +32,7 @@ std::string Settings::ToString() const {
   stream << "trace_startup: " << trace_startup << std::endl;
   stream << "endless_trace_buffer: " << endless_trace_buffer << std::endl;
   stream << "enable_dart_profiling: " << enable_dart_profiling << std::endl;
+  stream << "dart_non_checked_mode: " << dart_non_checked_mode << std::endl;
   stream << "enable_observatory: " << enable_observatory << std::endl;
   stream << "observatory_port: " << observatory_port << std::endl;
   stream << "ipv6: " << ipv6 << std::endl;

--- a/common/settings.h
+++ b/common/settings.h
@@ -23,6 +23,7 @@ using TaskObserverRemove = std::function<void(intptr_t /* key */)>;
 
 struct Settings {
   // VM settings
+  std::string script_snapshot_path;
   std::string platform_kernel_path;
 
   std::string vm_snapshot_data_path;
@@ -46,6 +47,7 @@ struct Settings {
   bool trace_startup = false;
   bool endless_trace_buffer = false;
   bool enable_dart_profiling = false;
+  bool dart_non_checked_mode = false;
   // Used as the script URI in debug messages. Does not affect how the Dart code
   // is executed.
   std::string advisory_script_uri = "main.dart";

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -277,9 +277,18 @@ bool DartIsolate::PrepareForRunningFromPrecompiledCode() {
   return true;
 }
 
+static bool LoadScriptSnapshot(std::shared_ptr<const fml::Mapping> mapping,
+                               bool last_piece) {
+  FXL_CHECK(last_piece) << "Script snapshots cannot be divided";
+  if (tonic::LogIfError(Dart_LoadScriptFromSnapshot(mapping->GetMapping(),
+                                                    mapping->GetSize()))) {
+    return false;
+  }
+  return true;
+}
+
 static bool LoadKernelSnapshot(std::shared_ptr<const fml::Mapping> mapping,
                                bool last_piece) {
-  FXL_DCHECK(Dart_IsKernel(mapping->GetMapping(), mapping->GetSize())) << "Only kernel snapshots are supported";
   Dart_Handle library =
       Dart_LoadLibraryFromKernel(mapping->GetMapping(), mapping->GetSize());
   if (tonic::LogIfError(library)) {
@@ -296,6 +305,16 @@ static bool LoadKernelSnapshot(std::shared_ptr<const fml::Mapping> mapping,
     return false;
   }
   return true;
+}
+
+static bool LoadSnapshot(std::shared_ptr<const fml::Mapping> mapping,
+                         bool last_piece) {
+  if (Dart_IsKernel(mapping->GetMapping(), mapping->GetSize())) {
+    return LoadKernelSnapshot(std::move(mapping), last_piece);
+  } else {
+    return LoadScriptSnapshot(std::move(mapping), last_piece);
+  }
+  return false;
 }
 
 FXL_WARN_UNUSED_RESULT
@@ -321,7 +340,7 @@ bool DartIsolate::PrepareForRunningFromSnapshot(
     return false;
   }
 
-  if (!LoadKernelSnapshot(mapping, last_piece)) {
+  if (!LoadSnapshot(mapping, last_piece)) {
     return false;
   }
 
@@ -547,12 +566,20 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
   // thread.
   service_isolate->ResetWeakPtrFactory();
 
+  const bool isolate_snapshot_is_dart_2 = Dart_IsDart2Snapshot(
+      vm->GetIsolateSnapshot()->GetData()->GetSnapshotPointer());
+  const bool is_preview_dart2 =
+      (vm->GetPlatformKernel().GetSize() > 0) || isolate_snapshot_is_dart_2;
+  const bool running_from_sources =
+      !DartVM::IsRunningPrecompiledCode() && !is_preview_dart2;
+
   tonic::DartState::Scope scope(service_isolate);
   if (!DartServiceIsolate::Startup(
           settings.ipv6 ? "::1" : "127.0.0.1",  // server IP address
           settings.observatory_port,            // server observatory port
           tonic::DartState::HandleLibraryTag,   // embedder library tag handler
-          false,  // disable websocket origin check
+          running_from_sources,                 // running from source code
+          false,  //  disable websocket origin check
           error   // error (out)
           )) {
     // Error is populated by call to startup.

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -27,6 +27,7 @@
   }
 
 #define kLibrarySourceNamePrefix "/vmservice"
+static const char* kServiceIsolateScript = "vmservice_io.dart";
 
 namespace flutter {
 namespace runtime {
@@ -83,6 +84,7 @@ void DartServiceIsolate::Shutdown(Dart_NativeArguments args) {
 bool DartServiceIsolate::Startup(std::string server_ip,
                                  intptr_t server_port,
                                  Dart_LibraryTagHandler embedder_tag_handler,
+                                 bool running_from_sources,
                                  bool disable_origin_check,
                                  char** error) {
   Dart_Isolate isolate = Dart_CurrentIsolate();
@@ -106,14 +108,31 @@ bool DartServiceIsolate::Startup(std::string server_ip,
         &flutter::runtime::__flutter_embedded_service_isolate_resources_[0]);
   }
 
-  // Set the root library for the isolate.
-  Dart_Handle uri = Dart_NewStringFromCString("dart:vmservice_io");
-  Dart_Handle library = Dart_LookupLibrary(uri);
-  SHUTDOWN_ON_ERROR(library);
-  Dart_Handle result = Dart_SetRootLibrary(library);
-  SHUTDOWN_ON_ERROR(result);
-  result = Dart_SetNativeResolver(library, GetNativeFunction, GetSymbol);
-  SHUTDOWN_ON_ERROR(result);
+  Dart_Handle result;
+
+  if (running_from_sources) {
+    // Use our own library tag handler when loading service isolate sources.
+    Dart_SetLibraryTagHandler(DartServiceIsolate::LibraryTagHandler);
+    // Load main script.
+    Dart_Handle library = LoadScript(kServiceIsolateScript);
+    FXL_DCHECK(library != Dart_Null());
+    SHUTDOWN_ON_ERROR(library);
+    // Setup native entry resolution.
+    result = Dart_SetNativeResolver(library, GetNativeFunction, GetSymbol);
+
+    SHUTDOWN_ON_ERROR(result);
+    // Finalize loading.
+    result = Dart_FinalizeLoading(false);
+    SHUTDOWN_ON_ERROR(result);
+  } else {
+    Dart_Handle uri = Dart_NewStringFromCString("dart:vmservice_io");
+    Dart_Handle library = Dart_LookupLibrary(uri);
+    SHUTDOWN_ON_ERROR(library);
+    result = Dart_SetRootLibrary(library);
+    SHUTDOWN_ON_ERROR(result);
+    result = Dart_SetNativeResolver(library, GetNativeFunction, GetSymbol);
+    SHUTDOWN_ON_ERROR(result);
+  }
 
   // Make runnable.
   Dart_ExitScope();
@@ -127,7 +146,7 @@ bool DartServiceIsolate::Startup(std::string server_ip,
   Dart_EnterIsolate(isolate);
   Dart_EnterScope();
 
-  library = Dart_RootLibrary();
+  Dart_Handle library = Dart_RootLibrary();
   SHUTDOWN_ON_ERROR(library);
 
   // Set the HTTP server's ip.
@@ -153,6 +172,30 @@ bool DartServiceIsolate::Startup(std::string server_ip,
                     Dart_NewBoolean(disable_origin_check));
   SHUTDOWN_ON_ERROR(result);
   return true;
+}
+
+Dart_Handle DartServiceIsolate::GetSource(const char* name) {
+  const intptr_t kBufferSize = 512;
+  char buffer[kBufferSize];
+  snprintf(&buffer[0], kBufferSize - 1, "%s/%s", kLibrarySourceNamePrefix,
+           name);
+  const char* vmservice_source = NULL;
+  int r = g_resources->ResourceLookup(buffer, &vmservice_source);
+  FXL_DCHECK(r != EmbedderResources::kNoSuchInstance);
+  return Dart_NewStringFromCString(vmservice_source);
+}
+
+Dart_Handle DartServiceIsolate::LoadScript(const char* name) {
+  Dart_Handle url = Dart_NewStringFromCString("dart:vmservice_io");
+  Dart_Handle source = GetSource(name);
+  return Dart_LoadScript(url, Dart_Null(), source, 0, 0);
+}
+
+Dart_Handle DartServiceIsolate::LoadSource(Dart_Handle library,
+                                           const char* name) {
+  Dart_Handle url = Dart_NewStringFromCString(name);
+  Dart_Handle source = GetSource(name);
+  return Dart_LoadSource(library, url, Dart_Null(), source, 0, 0);
 }
 
 Dart_Handle DartServiceIsolate::LoadResource(Dart_Handle library,
@@ -203,6 +246,43 @@ Dart_Handle DartServiceIsolate::LoadResources(Dart_Handle library) {
     }
   }
   return result;
+}
+
+Dart_Handle DartServiceIsolate::LibraryTagHandler(Dart_LibraryTag tag,
+                                                  Dart_Handle library,
+                                                  Dart_Handle url) {
+  if (!Dart_IsLibrary(library)) {
+    return Dart_NewApiError("not a library");
+  }
+  if (!Dart_IsString(url)) {
+    return Dart_NewApiError("url is not a string");
+  }
+  const char* url_string = NULL;
+  Dart_Handle result = Dart_StringToCString(url, &url_string);
+  if (Dart_IsError(result)) {
+    return result;
+  }
+  Dart_Handle library_url = Dart_LibraryUrl(library);
+  const char* library_url_string = NULL;
+  result = Dart_StringToCString(library_url, &library_url_string);
+  if (Dart_IsError(result)) {
+    return result;
+  }
+  if (tag == Dart_kImportTag) {
+    // Embedder handles all requests for external libraries.
+    return g_embedder_tag_handler(tag, library, url);
+  }
+  FXL_DCHECK((tag == Dart_kSourceTag) || (tag == Dart_kCanonicalizeUrl));
+  if (tag == Dart_kCanonicalizeUrl) {
+    // url is already canonicalized.
+    return url;
+  }
+  // Get source from builtin resources.
+  Dart_Handle source = GetSource(url_string);
+  if (Dart_IsError(source)) {
+    return source;
+  }
+  return Dart_LoadSource(library, url, Dart_Null(), source, 0, 0);
 }
 
 }  // namespace blink

--- a/runtime/dart_service_isolate.h
+++ b/runtime/dart_service_isolate.h
@@ -16,6 +16,7 @@ class DartServiceIsolate {
   static bool Startup(std::string server_ip,
                       intptr_t server_port,
                       Dart_LibraryTagHandler embedder_tag_handler,
+                      bool running_from_sources,
                       bool disable_origin_check,
                       char** error);
 
@@ -26,6 +27,14 @@ class DartServiceIsolate {
   static void TriggerResourceLoad(Dart_NativeArguments args);
   static void NotifyServerState(Dart_NativeArguments args);
   static void Shutdown(Dart_NativeArguments args);
+
+  // Script loading.
+  static Dart_Handle GetSource(const char* name);
+  static Dart_Handle LoadScript(const char* name);
+  static Dart_Handle LoadSource(Dart_Handle library, const char* name);
+  static Dart_Handle LibraryTagHandler(Dart_LibraryTag tag,
+                                       Dart_Handle library,
+                                       Dart_Handle url);
 
   // Observatory resource loading.
   static Dart_Handle LoadResources(Dart_Handle library);

--- a/shell/common/isolate_configuration.cc
+++ b/shell/common/isolate_configuration.cc
@@ -145,6 +145,17 @@ std::unique_ptr<IsolateConfiguration> IsolateConfiguration::InferFromSettings(
     }
   }
 
+  // Running from script snapshot.
+  {
+    // TODO(engine): Add AssetManager::GetAsMapping or such to avoid the copy.
+    std::vector<uint8_t> script_snapshot;
+    if (asset_manager && asset_manager->GetAsBuffer(
+                             settings.script_snapshot_path, &script_snapshot)) {
+      return CreateForSnapshot(
+          std::make_unique<fml::DataMapping>(std::move(script_snapshot)));
+    }
+  }
+
   // Running from kernel divided into several pieces (for sharing).
   {
     // TODO(fuchsia): Add AssetManager::GetAsMapping or such to avoid the copy.

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -129,6 +129,10 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
     }
   }
 
+  // Checked mode overrides.
+  settings.dart_non_checked_mode =
+      command_line.HasOption(FlagForSwitch(Switch::DartNonCheckedMode));
+
   settings.ipv6 = command_line.HasOption(FlagForSwitch(Switch::IPv6));
 
   settings.start_paused =
@@ -156,6 +160,9 @@ blink::Settings SettingsFromCommandLine(const fxl::CommandLine& command_line) {
 
   command_line.GetOptionValue(FlagForSwitch(Switch::FlutterAssetsDir),
                               &settings.assets_path);
+
+  command_line.GetOptionValue(FlagForSwitch(Switch::Snapshot),
+                              &settings.script_snapshot_path);
 
   command_line.GetOptionValue(FlagForSwitch(Switch::MainDartFile),
                               &settings.main_dart_file_path);

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -93,6 +93,7 @@ DEF_SWITCH(Help, "help", "Display this help text.")
 DEF_SWITCH(LogTag, "log-tag", "Tag associated with log messages.")
 DEF_SWITCH(MainDartFile, "dart-main", "The path to the main Dart file.")
 DEF_SWITCH(Packages, "packages", "Specify the path to the packages.")
+DEF_SWITCH(Snapshot, "snapshot-blob", "Specify the path to the snapshot blob")
 DEF_SWITCH(StartPaused,
            "start-paused",
            "Start the application paused in the Dart debugger.")
@@ -121,6 +122,13 @@ DEF_SWITCH(RunForever,
            "run-forever",
            "In non-interactive mode, keep the shell running after the Dart "
            "script has completed.")
+DEF_SWITCH(DartNonCheckedMode,
+           "dart-non-checked-mode",
+           "Dart code runs in checked mode when the runtime mode is debug. In "
+           "profile and release product modes, the application code is "
+           "precompiled and checked mode is unsupported. However, this flag "
+           "may be specified if the user wishes to run in the debug product "
+           "mode (i.e. with JIT or DBC) with checked mode off.")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -8,30 +8,30 @@
 /**
  BREAKING CHANGES:
 
- February 28, 2018: Removed "initWithFLXArchive" and "initWithFLXArchiveWithScriptSnapshot".
+ February 28, 2018: Removed "initWithFLXArchive" and
+ "initWithFLXArchiveWithScriptSnapshot".
 
- January 15, 2018: Marked "initWithFLXArchive" and "initWithFLXArchiveWithScriptSnapshot" as
- unavailable following the deprecation from December 11, 2017. Scheduled to be removed on February
+ January 15, 2018: Marked "initWithFLXArchive" and
+ "initWithFLXArchiveWithScriptSnapshot" as unavailable following the
+ deprecation from December 11, 2017. Scheduled to be removed on February
  19, 2018.
 
  January 09, 2018: Deprecated "FlutterStandardBigInteger" and its use in
- "FlutterStandardMessageCodec" and "FlutterStandardMethodCodec". Scheduled to be marked as
- unavailable once the deprecation has been available on the flutter/flutter alpha branch for four
- weeks. "FlutterStandardBigInteger" was needed because the Dart 1.0 int type had no size limit. With
- Dart 2.0, the int type is a fixed-size, 64-bit signed integer. If you need to communicate larger
- integers, use NSString encoding instead.
+ "FlutterStandardMessageCodec" and "FlutterStandardMethodCodec". Scheduled to
+ be marked as unavailable once the deprecation has been available on the
+ flutter/flutter alpha branch for four weeks. "FlutterStandardBigInteger" was
+ needed because the Dart 1.0 int type had no size limit. With Dart 2.0, the
+ int type is a fixed-size, 64-bit signed integer. If you need to communicate
+ larger integers, use NSString encoding instead.
 
- December 11, 2017: Deprecated "initWithFLXArchive" and "initWithFLXArchiveWithScriptSnapshot" and
- scheculed the same to be marked as unavailable on January 15, 2018. Instead,
- "initWithFlutterAssets" and "initWithFlutterAssetsWithScriptSnapshot" should be used. The reason
- for this change is that the FLX archive will be deprecated and replaced with a flutter assets
- directory containing the same files as the FLX did.
+ December 11, 2017: Deprecated "initWithFLXArchive" and
+ "initWithFLXArchiveWithScriptSnapshot" and scheculed the same to be marked as
+ unavailable on January 15, 2018. Instead, "initWithFlutterAssets" and
+ "initWithFlutterAssetsWithScriptSnapshot" should be used. The reason for this
+ change is that the FLX archive will be deprecated and replaced with a flutter
+ assets directory containing the same files as the FLX did.
 
  November 29, 2017: Added a BREAKING CHANGES section.
-
- June 11, 2018: Eliminated "initWithFlutterAssetsWithScriptSnapshot" which was only used for Dart 1
- code. Flutter is now Dart 2 only. In Dart 2, application code is loaded from a kernel snapshot in
- debug mode, or AOT-compiled and linked in profile and release modes.
  */
 
 #include "FlutterAppDelegate.h"

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -18,6 +18,9 @@ FLUTTER_EXPORT
                              dartMain:(NSURL*)dartMainURL
                              packages:(NSURL*)dartPackages NS_DESIGNATED_INITIALIZER;
 
+- (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL
+    NS_DESIGNATED_INITIALIZER;
+
 - (instancetype)initFromDefaultSourceForConfiguration;
 
 /**

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -15,6 +15,7 @@
 #include "flutter/shell/platform/darwin/common/command_line.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 
+static const char* kScriptSnapshotFileName = "snapshot_blob.bin";
 static const char* kVMKernelSnapshotFileName = "platform.dill";
 static const char* kApplicationKernelSnapshotFileName = "kernel_blob.bin";
 
@@ -79,6 +80,17 @@ static blink::Settings DefaultSettingsForProcess() {
       settings.assets_path = assetsPath.UTF8String;
 
       if (!blink::DartVM::IsRunningPrecompiledCode()) {
+        // Looking for the various script and kernel snapshot buffers only makes sense if we have a
+        // VM that can use these buffers.
+        {
+          // Check if there is a script snapshot in the assets directory we could potentially use.
+          NSURL* scriptSnapshotURL = [NSURL URLWithString:@(kScriptSnapshotFileName)
+                                            relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+          if ([[NSFileManager defaultManager] fileExistsAtPath:scriptSnapshotURL.path]) {
+            settings.script_snapshot_path = scriptSnapshotURL.path.UTF8String;
+          }
+        }
+
         {
           // Check if there is a VM kernel snapshot in the assets directory we could potentially
           // use.
@@ -152,6 +164,26 @@ static blink::Settings DefaultSettingsForProcess() {
 
     if ([[NSFileManager defaultManager] fileExistsAtPath:dartPackages.path]) {
       _settings.packages_file_path = dartPackages.path.UTF8String;
+    }
+  }
+
+  return self;
+}
+
+- (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL {
+  self = [super init];
+
+  if (self) {
+    _settings = DefaultSettingsForProcess();
+
+    if ([[NSFileManager defaultManager] fileExistsAtPath:flutterAssetsURL.path]) {
+      _settings.assets_path = flutterAssetsURL.path.UTF8String;
+
+      NSURL* scriptSnapshotPath =
+          [NSURL URLWithString:@(kScriptSnapshotFileName) relativeToURL:flutterAssetsURL];
+      if ([[NSFileManager defaultManager] fileExistsAtPath:scriptSnapshotPath.path]) {
+        _settings.script_snapshot_path = scriptSnapshotPath.path.UTF8String;
+      }
     }
   }
 


### PR DESCRIPTION
Broke runtime_unittests, which are still running directly from source.

This reverts commit 0ea93c3a3e40426fd222ba22c2f60756c8a32097.