### PR TITLE
only succeed a11y hit testing of focusable targets in Android AccessibilityBridge

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -930,7 +930,7 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
                     child.ensureInverseTransform();
                     Matrix.multiplyMV(transformedPoint, 0, child.inverseTransform, 0, point, 0);
                     final SemanticsObject result = child.hitTest(transformedPoint);
-                    if (result != null) {
+                    if (result != null && result.isFocusable()) {
                         return result;
                     }
                 }


### PR DESCRIPTION
Fixes (1) of https://github.com/flutter/flutter/issues/18421

Without this change hit testing will succeed on an empty semantics object.  This change makes the semantics hit testing more predictable.

<img src="https://user-images.githubusercontent.com/8975114/41318442-2bc8d14e-6e4d-11e8-9005-e2d9c23e3ad3.png" width="300">