### PR TITLE
Roll the Dart VM.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'c95617b19c1bfd67bce35c8737429f4e26975ac2',
+  'dart_revision': '31e3441816c023fec5c34eefe33862f03a5d16ba',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.7',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 245264e071bbc5718149880a56087206
+Signature: 7e37ea7cfaf09234ddf8a8d80067ddb8
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
With this roll the VM defaults to sync-async.

31e3441816 Fix bad status lines (wrong tests...)
18828ac77a Mark some co19 tests as crashing.
36e73371fb Switch analyzer_cli to using AnalysisDriver only.
2b36f923d9 Fix status file.
398ba13e4a Reapply "Make --sync-async the default for the VM."
