### PR TITLE
libtxt: update the unit tests and benchmarks

### DIFF
--- a/third_party/txt/benchmarks/paragraph_benchmarks.cc
+++ b/third_party/txt/benchmarks/paragraph_benchmarks.cc
@@ -373,7 +373,7 @@ static void BM_ParagraphMinikinDoLayout(benchmark::State& state) {
   paint.wordSpacing = text_style.word_spacing;
 
   auto collection = GetTestFontCollection()->GetMinikinFontCollectionForFamily(
-      text_style.font_family);
+      text_style.font_family, "en-US");
 
   while (state.KeepRunning()) {
     minikin::Layout layout;
@@ -413,7 +413,8 @@ static void BM_ParagraphMinikinAddStyleRun(benchmark::State& state) {
   while (state.KeepRunning()) {
     for (int i = 0; i < 20; ++i) {
       breaker.addStyleRun(
-          &paint, font_collection->GetMinikinFontCollectionForFamily("Roboto"),
+          &paint,
+          font_collection->GetMinikinFontCollectionForFamily("Roboto", "en-US"),
           font, state.range(0) / 20 * i, state.range(0) / 20 * (i + 1), false);
     }
   }

--- a/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
+++ b/third_party/txt/benchmarks/txt_run_all_benchmarks.cc
@@ -35,7 +35,7 @@ int main(int argc, char** argv) {
   }
   FXL_DCHECK(txt::GetFontDir().length() > 0);
 
-  fml::icu::InitializeICU();
+  fml::icu::InitializeICU("icudtl.dat");
 
   ::benchmark::RunSpecifiedBenchmarks();
 }

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -419,41 +419,46 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
   ASSERT_TRUE(paragraph->records_[0].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[0].offset().y(), expected_y);
   expected_y += 30;
-  ASSERT_DOUBLE_EQ(
+  ASSERT_NEAR(
       paragraph->records_[0].offset().x(),
       paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[0].line()]);
+          paragraph->breaker_.getWidths()[paragraph->records_[0].line()],
+      2.0);
 
   ASSERT_TRUE(paragraph->records_[1].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[1].offset().y(), expected_y);
   expected_y += 30;
-  ASSERT_DOUBLE_EQ(
+  ASSERT_NEAR(
       paragraph->records_[1].offset().x(),
       paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[1].line()]);
+          paragraph->breaker_.getWidths()[paragraph->records_[1].line()],
+      2.0);
 
   ASSERT_TRUE(paragraph->records_[2].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[2].offset().y(), expected_y);
   expected_y += 30;
-  ASSERT_DOUBLE_EQ(
+  ASSERT_NEAR(
       paragraph->records_[2].offset().x(),
       paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[2].line()]);
+          paragraph->breaker_.getWidths()[paragraph->records_[2].line()],
+      2.0);
 
   ASSERT_TRUE(paragraph->records_[3].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[3].offset().y(), expected_y);
   expected_y += 30 * 10;
-  ASSERT_DOUBLE_EQ(
+  ASSERT_NEAR(
       paragraph->records_[3].offset().x(),
       paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[3].line()]);
+          paragraph->breaker_.getWidths()[paragraph->records_[3].line()],
+      2.0);
 
   ASSERT_TRUE(paragraph->records_[13].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[13].offset().y(), expected_y);
-  ASSERT_DOUBLE_EQ(
+  ASSERT_NEAR(
       paragraph->records_[13].offset().x(),
       paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[13].line()]);
+          paragraph->breaker_.getWidths()[paragraph->records_[13].line()],
+      2.0);
 
   ASSERT_EQ(paragraph_style.text_align,
             paragraph->GetParagraphStyle().text_align);
@@ -523,45 +528,47 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(CenterAlignParagraph)) {
   ASSERT_TRUE(paragraph->records_[0].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[0].offset().y(), expected_y);
   expected_y += 30;
-  ASSERT_DOUBLE_EQ(
-      paragraph->records_[0].offset().x(),
-      (paragraph->width_ -
-       paragraph->breaker_.getWidths()[paragraph->records_[0].line()]) /
-          2);
+  ASSERT_NEAR(paragraph->records_[0].offset().x(),
+              (paragraph->width_ -
+               paragraph->breaker_.getWidths()[paragraph->records_[0].line()]) /
+                  2,
+              2.0);
 
   ASSERT_TRUE(paragraph->records_[1].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[1].offset().y(), expected_y);
   expected_y += 30;
-  ASSERT_DOUBLE_EQ(
-      paragraph->records_[1].offset().x(),
-      (paragraph->width_ -
-       paragraph->breaker_.getWidths()[paragraph->records_[1].line()]) /
-          2);
+  ASSERT_NEAR(paragraph->records_[1].offset().x(),
+              (paragraph->width_ -
+               paragraph->breaker_.getWidths()[paragraph->records_[1].line()]) /
+                  2,
+              2.0);
 
   ASSERT_TRUE(paragraph->records_[2].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[2].offset().y(), expected_y);
   expected_y += 30;
-  ASSERT_EQ(paragraph->records_[2].offset().x(),
-            (paragraph->width_ -
-             paragraph->breaker_.getWidths()[paragraph->records_[2].line()]) /
-                2);
+  ASSERT_NEAR(paragraph->records_[2].offset().x(),
+              (paragraph->width_ -
+               paragraph->breaker_.getWidths()[paragraph->records_[2].line()]) /
+                  2,
+              2.0);
 
   ASSERT_TRUE(paragraph->records_[3].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[3].offset().y(), expected_y);
   expected_y += 30 * 10;
-  ASSERT_DOUBLE_EQ(
-      paragraph->records_[3].offset().x(),
-      (paragraph->width_ -
-       paragraph->breaker_.getWidths()[paragraph->records_[3].line()]) /
-          2);
+  ASSERT_NEAR(paragraph->records_[3].offset().x(),
+              (paragraph->width_ -
+               paragraph->breaker_.getWidths()[paragraph->records_[3].line()]) /
+                  2,
+              2.0);
 
   ASSERT_TRUE(paragraph->records_[13].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[13].offset().y(), expected_y);
-  ASSERT_DOUBLE_EQ(
+  ASSERT_NEAR(
       paragraph->records_[13].offset().x(),
       (paragraph->width_ -
        paragraph->breaker_.getWidths()[paragraph->records_[13].line()]) /
-          2);
+          2,
+      2.0);
 
   ASSERT_EQ(paragraph_style.text_align,
             paragraph->GetParagraphStyle().text_align);

--- a/third_party/txt/tests/txt_run_all_unittests.cc
+++ b/third_party/txt/tests/txt_run_all_unittests.cc
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
   }
   FXL_DCHECK(txt::GetFontDir().length() > 0);
 
-  fml::icu::InitializeICU();
+  fml::icu::InitializeICU("icudtl.dat");
   SkGraphics::Init();
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
* pass a locale to GetMinikinFontCollectionForFamily
* provide the ICU data file path
* loosen checks based on the Minikin LineBreaker's line widths
  (LineBreaker widths do not exactly match the advances calculated during layout)