### PR TITLE
reverse hit test order for android

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -922,7 +922,8 @@ class AccessibilityBridge extends AccessibilityNodeProvider implements BasicMess
                 return null;
             if (childrenInHitTestOrder != null) {
                 final float[] transformedPoint = new float[4];
-                for (int i = 0; i < childrenInHitTestOrder.size(); i += 1) {
+                int size = childrenInHitTestOrder.size();
+                for (int i = size - 1; i >= 0; i -= 1) {
                     final SemanticsObject child = childrenInHitTestOrder.get(i);
                     if (child.hasFlag(Flag.IS_HIDDEN)) {
                         continue;


### PR DESCRIPTION
Hit test in reverse order on Android.  Allows a11y focus of snackbar and bottom sheets which appear over list items.

Fixes https://github.com/flutter/flutter/issues/18421