### PR TITLE
Macros to specify Dart exceptions that originate in native code.

### DIFF
--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -14,6 +14,8 @@ source_set("ui") {
     "dart_runtime_hooks.h",
     "dart_ui.cc",
     "dart_ui.h",
+    "flutter_dart_api.cc",
+    "flutter_dart_api.h",
     "isolate_name_server/isolate_name_server.cc",
     "isolate_name_server/isolate_name_server.h",
     "isolate_name_server/isolate_name_server_natives.cc",
@@ -109,5 +111,7 @@ source_set("ui") {
     deps += [ "//topaz/public/dart-pkg/zircon" ]
   }
 
-  public_deps = ["$flutter_root/third_party/txt"]
+  public_deps = [
+    "$flutter_root/third_party/txt",
+  ]
 }

--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -12,6 +12,7 @@
 #include <sstream>
 
 #include "flutter/common/settings.h"
+#include "flutter/lib/ui/flutter_dart_api.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "lib/fxl/build_config.h"
 #include "lib/fxl/logging.h"
@@ -203,17 +204,14 @@ void Logger_PrintString(Dart_NativeArguments args) {
 void SaveCompilationTrace(Dart_NativeArguments args) {
   uint8_t* buffer = nullptr;
   intptr_t length = 0;
+
   Dart_Handle result = Dart_SaveCompilationTrace(&buffer, &length);
-  if (Dart_IsError(result)) {
-    Dart_SetReturnValue(args, result);
-    return;
-  }
+  CHECK_AND_RETURN_DART_ENGINE_ERROR(args, result,
+                                     "Could not save compilation trace.");
 
   result = Dart_NewExternalTypedData(Dart_TypedData_kUint8, buffer, length);
-  if (Dart_IsError(result)) {
-    Dart_SetReturnValue(args, result);
-    return;
-  }
+  CHECK_AND_RETURN_DART_ENGINE_ERROR(
+      args, result, "Could not create typed data buffer for trace");
 
   Dart_SetReturnValue(args, result);
 }

--- a/lib/ui/flutter_dart_api.cc
+++ b/lib/ui/flutter_dart_api.cc
@@ -1,0 +1,53 @@
+// Copyright 2018 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/flutter_dart_api.h"
+
+#include <cstdio>
+
+#ifdef _DEBUG
+// Needed by dartutils.h below.
+#define DEBUG
+#endif  // _DEBUG
+
+#include "third_party/dart/runtime/bin/dartutils.h"
+#include "topaz/lib/tonic/converter/dart_converter.h"
+
+namespace blink {
+
+static Dart_Handle ExceptionValueForType(DartErrorType type,
+                                         const char* format,
+                                         va_list message_args) {
+  char message_buffer[256];
+  vsnprintf(message_buffer, sizeof(message_buffer), format, message_args);
+  switch (type) {
+    case DartErrorType::kArgumentError:
+      return ::dart::bin::DartUtils::NewDartArgumentError(message_buffer);
+    case DartErrorType::kEngineError:
+      // TODO(chinmaygarde): Placeholder till the engine gets its own error
+      // type.
+      return Dart_NewStringFromCString(message_buffer);
+  }
+
+  return Dart_Null();
+}
+
+void SetUnhandledExceptionAsReturnValue(Dart_NativeArguments args,
+                                        DartErrorType type,
+                                        const char* message,
+                                        ...) {
+  va_list message_args;
+  va_start(message_args, message);
+  auto exception_value = ExceptionValueForType(type, message, message_args);
+  va_end(message_args);
+
+  auto unhandled_exception = Dart_NewUnhandledExceptionError(exception_value);
+  Dart_SetReturnValue(args, unhandled_exception);
+}
+
+bool IsHandleValid(Dart_Handle arg) {
+  return arg != nullptr && !Dart_IsError(arg);
+}
+
+}  // namespace blink

--- a/lib/ui/flutter_dart_api.h
+++ b/lib/ui/flutter_dart_api.h
@@ -1,0 +1,66 @@
+// Copyright 2018 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_DART_API_H_
+#define FLUTTER_LIB_UI_DART_API_H_
+
+#include <cstdarg>
+
+#include "flutter/fml/compiler_specific.h"
+#include "third_party/dart/runtime/include/dart_api.h"
+
+#define RETURN_DART_ERROR(args, type, message, ...)                         \
+  {                                                                         \
+    SetUnhandledExceptionAsReturnValue(args, type, message, ##__VA_ARGS__); \
+    return;                                                                 \
+  }
+
+#define RETURN_DART_ARGUMENT_ERROR(args, message, ...)                     \
+  RETURN_DART_ERROR(args, ::blink::DartErrorType::kArgumentError, message, \
+                    ##__VA_ARGS__)
+
+#define RETURN_DART_ENGINE_ERROR(args, message, ...)                     \
+  RETURN_DART_ERROR(args, ::blink::DartErrorType::kEngineError, message, \
+                    ##__VA_ARGS__)
+
+#define CHECK_AND_RETURN_DART_ERROR(args, arg_to_validate, type, message, ...) \
+  {                                                                            \
+    if (!::blink::IsHandleValid(arg_to_validate)) {                            \
+      RETURN_DART_ERROR(args, type, message, ##__VA_ARGS__);                   \
+    }                                                                          \
+  };
+
+#define CHECK_AND_RETURN_DART_ARGUMENT_ERROR(args, arg_to_validate, message,   \
+                                             ...)                              \
+  CHECK_AND_RETURN_DART_ERROR(args, arg_to_validate,                           \
+                              ::blink::DartErrorType::kArgumentError, message, \
+                              ##__VA_ARGS__)
+
+#define CHECK_AND_RETURN_DART_ENGINE_ERROR(args, arg_to_validate, message,   \
+                                           ...)                              \
+  CHECK_AND_RETURN_DART_ERROR(args, arg_to_validate,                         \
+                              ::blink::DartErrorType::kEngineError, message, \
+                              ##__VA_ARGS__)
+
+namespace blink {
+
+enum class DartErrorType {
+  // An ArgumentError from dart:core.
+  kArgumentError,
+
+  // A string containing the error message.
+  // TODO(chinmaygarde): Add a dedicated error type for engine errors.
+  kEngineError,
+};
+
+bool IsHandleValid(Dart_Handle arg);
+
+void SetUnhandledExceptionAsReturnValue(Dart_NativeArguments args,
+                                        DartErrorType type,
+                                        const char* message,
+                                        ...) FML_PRINTF_FORMAT(3, 4);
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_DART_API_H_

--- a/lib/ui/natives.dart
+++ b/lib/ui/natives.dart
@@ -37,9 +37,6 @@ void _setupHooks() {
 
 void saveCompilationTrace(String filePath) {
   final dynamic result = _saveCompilationTrace();
-  if (result is Error)
-    throw result;
-
   final File file = new File(filePath);
   file.writeAsBytesSync(result);
 }

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -8,6 +8,7 @@
 #include <math.h>
 
 #include "flutter/flow/layers/physical_shape_layer.h"
+#include "flutter/lib/ui/flutter_dart_api.h"
 #include "flutter/lib/ui/painting/image.h"
 #include "flutter/lib/ui/painting/matrix.h"
 #include "flutter/lib/ui/ui_dart_state.h"

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -105,8 +105,7 @@ source_set("runtime") {
   public_configs = [ "$flutter_root:config" ]
 
   if (flutter_runtime_mode != "release" &&
-      flutter_runtime_mode != "dynamic_release" &&
-      !is_fuchsia) {
+      flutter_runtime_mode != "dynamic_release" && !is_fuchsia) {
     # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
     # instead puts Observatory into the runner's package.
     deps += [ "//third_party/dart/runtime/observatory:embedded_observatory_archive" ]


### PR DESCRIPTION
So far, the approach taken for the specification of Dart exceptions
thrown from native code invoked by Dart has been ad-hoc and
inconsistent. Various approaches have been devised.

In some cases, Dart_ThrowException has been used. We have actively
discouraged the use of this mechanism since the C++ objects on the stack
will not have their destructors called in exceptional circumstances. The
fear has been that even if this has not been an issue in existing code,
refactoring the same could leak to resource leaks or deadlocks (in case
the destructor of a lock guard is never called).

In other cases, we have resorted to returning null to Dart code in case
of errors or a string describing the error in case of exceptions. The
Dart code is then responsible for constructing and throwing an exception
on behalf of the engine.

In other circumstances, where there engine needs to return a non-void
value, a dynamic return type with type checks has been used (with a
string used to indicate error conditions). This scheme immediately
breaks down when the return value needs to be string.

This patch proposes a safe workaround for the specification of
exceptions originating in native code that also leads to the writing of
idiomatic Dart code after the native has been made.

The various macros in flutter_dart_api.h construct one of the well known
exception types (currently in dart:core but engine specific exception
types can be added later). The exception types are set as unhandled
return values on the current native function invocation in Dart. As soon
as the return value is set, the native function is immediately returned
from. This way, the C++ objects get their destructors and the error
(along with a descriptive message) is converted into an exception in
Dart code that the user or Flutter developer can optionally catch and
act on.

Note that this scheme needs access to the arguments object that is
hidden in the tonic Dart wrapper. These are used extensively in the ui
Dart bindings. Once this patch lands, we can go over existing code and
reconcile the various ways in which exceptional circumstances were
specified. In a separate patch, the tonic Dart wrappers can be retro-
fitted to give implementations access to the args handle.