### PR TITLE
Postpone engine initialization to -viewWillAppear on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -167,18 +167,6 @@
     return false;
   }
 
-  // Launch the Dart application with the inferred run configuration.
-  _shell->GetTaskRunners().GetUITaskRunner()->PostTask(
-      fxl::MakeCopyable([engine = _shell->GetEngine(),                   //
-                         config = [_dartProject.get() runConfiguration]  //
-  ]() mutable {
-        if (engine) {
-          auto result = engine->Run(std::move(config));
-          if (!result) {
-            FXL_LOG(ERROR) << "Could not launch engine with configuration.";
-          }
-        }
-      }));
   return true;
 }
 
@@ -398,6 +386,20 @@
 
 - (void)viewWillAppear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewWillAppear");
+
+  // Launch the Dart application with the inferred run configuration.
+  _shell->GetTaskRunners().GetUITaskRunner()->PostTask(
+      fxl::MakeCopyable([engine = _shell->GetEngine(),                   //
+                         config = [_dartProject.get() runConfiguration]  //
+  ]() mutable {
+        if (engine) {
+          auto result = engine->Run(std::move(config));
+          if (!result) {
+            FXL_LOG(ERROR) << "Could not launch engine with configuration.";
+          }
+        }
+      }));
+
   // Only recreate surface on subsequent appearances when viewport metrics are known.
   // First time surface creation is done on viewDidLayoutSubviews.
   if (_viewportMetrics.physical_width)


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/18500 by allowing `-setInitialRoute:` to be called before starting the dart isolate.