### PR TITLE
Fix Colors.fromARGB docs to mention the fromRGBO constructor

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -114,7 +114,7 @@ class Color {
   ///
   /// Out of range values are brought into range using modulo 255.
   ///
-  /// See also [fromARGB], which takes the alpha value as a floating point
+  /// See also [fromRGBO], which takes the alpha value as a floating point
   /// value.
   const Color.fromARGB(int a, int r, int g, int b) :
     value = (((a & 0xff) << 24) |


### PR DESCRIPTION
In the `Colors` class the `fromRGBO` ctor takes the alpha value as a `double` while `fromARGB`:

1) Is the ctor that this doc belongs to, and
2) Takes alpha as an integer