### PR TITLE
Assert in place of ArgumentError for null checks

### DIFF
--- a/lib/ui/isolate_name_server.dart
+++ b/lib/ui/isolate_name_server.dart
@@ -7,31 +7,29 @@ part of dart.ui;
 abstract class IsolateNameServer {
   // Looks up the [SendPort] associated with a given name. Returns null
   // if the name does not exist.
+  //
+  // `name` must not be null.
   static SendPort lookupPortByName(String name) {
-    if (name == null) {
-      throw new ArgumentError("'name' cannot be null.");
-    }
+    assert(name != null, "'name' cannot be null.");
     return _lookupPortByName(name);
   }
 
   // Registers a SendPort with a given name. Returns true if registration is
   // successful, false if the name entry already exists.
+  //
+  // `port` and `name` must not be null.
   static bool registerPortWithName(SendPort port, String name) {
-    if (name == null) {
-      throw new ArgumentError("'name' cannot be null.");
-    }
-    if (port == null) {
-      throw new ArgumentError("'port' cannot be null.");
-    }
+    assert(port != null, "'port' cannot be null.");
+    assert(name != null, "'name' cannot be null.");
     return _registerPortWithName(port, name);
   }
 
   // Removes a name to SendPort mapping given a name. Returns true if the
   // mapping was successfully removed, false if the mapping does not exist.
+  //
+  // `name` must not be null.
   static bool removePortNameMapping(String name) {
-    if (name == null) {
-      throw new ArgumentError("'name' cannot be null.");
-    }
+    assert(name != null, "'name' cannot be null.");
     return _removePortNameMapping(name);
   }
 

--- a/testing/dart/isolate_name_server_test.dart
+++ b/testing/dart/isolate_name_server_test.dart
@@ -81,20 +81,6 @@ void main() {
     receivePort2.close();
   });
 
-  test('isolate name server null args', () {
-    // None of our IsolateNameServer methods should accept null.
-    expect(() => IsolateNameServer.lookupPortByName(null), throwsArgumentError);
-    expect(() => IsolateNameServer.registerPortWithName(null, 'abc'),
-        throwsArgumentError);
-    final receivePort = new ReceivePort();
-    final sendPort = receivePort.sendPort;
-    expect(() => IsolateNameServer.registerPortWithName(sendPort, null),
-        throwsArgumentError);
-    expect(() => IsolateNameServer.removePortNameMapping(null),
-        throwsArgumentError);
-    receivePort.close();
-  });
-
   test('isolate name server multi-isolate', () async {
     // Register our send port with the name server.
     final receivePort = new ReceivePort();


### PR DESCRIPTION
For consistency with the rest of dart:ui, check required parameters with
assert(param != null) rather than throwing ArgumentError. ArgumentError
is typically reserved for checking the validity of non-null args -- e.g.
that a list has the required number of elements.