### PR TITLE
Remove vmservice_io.main from entry points.

### DIFF
--- a/runtime/dart_vm_entry_points.txt
+++ b/runtime/dart_vm_entry_points.txt
@@ -43,4 +43,3 @@ dart:ui,SemanticsUpdate,SemanticsUpdate._
 dart:ui,SemanticsUpdateBuilder,SemanticsUpdateBuilder.
 dart:ui,Shader,Shader._
 dart:ui,TextBox,TextBox._
-dart:vmservice_io,::,main


### PR DESCRIPTION
The `@pragma` annotation on `vmservice_io.main` will ensure that it is included when necessary. The entry in `dart_vm_entry_points.txt` is superfluous.