### PR TITLE
Revert "Add antiAlias and saveCount to clipPath and restore (#5638)"

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2886,15 +2886,6 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// cause the new layer to be composited into the previous layer.
   void restore() native 'Canvas_restore';
 
-  /// Restore the current save stack to the state where [saveCount] is gotten.
-  ///
-  /// Use [save] and [saveLayer] to push state onto the stack, and use
-  /// [getSaveCount] to get the [saveCount].
-  ///
-  /// If a state was pushed with with [saveLayer], then this call will also
-  /// cause the new layer to be composited into the previous layer.
-  void restoreToCount(int saveCount) native 'Canvas_restoreToCount';
-
   /// Returns the number of items on the save stack, including the
   /// initial state. This means it returns 1 for a clean canvas, and
   /// that each call to [save] and [saveLayer] increments it, and that
@@ -2965,11 +2956,11 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// multiple draw commands intersect with the clip boundary, this can result
   /// in incorrect blending at the clip boundary. See [saveLayer] for a
   /// discussion of how to address that and some examples of using [clipRRect].
-  void clipRRect(RRect rrect, [bool doAntiAlias = true]) {
+  void clipRRect(RRect rrect) {
     assert(_rrectIsValid(rrect));
-    _clipRRect(rrect._value, doAntiAlias);
+    _clipRRect(rrect._value);
   }
-  void _clipRRect(Float32List rrect, bool doAntiAlias) native 'Canvas_clipRRect';
+  void _clipRRect(Float32List rrect) native 'Canvas_clipRRect';
 
   /// Reduces the clip region to the intersection of the current clip and the
   /// given [Path].
@@ -2978,11 +2969,11 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// multiple draw commands intersect with the clip boundary, this can result
   /// in incorrect blending at the clip boundary. See [saveLayer] for a
   /// discussion of how to address that.
-  void clipPath(Path path, [bool doAntiAlias = true]) {
+  void clipPath(Path path) {
     assert(path != null); // path is checked on the engine side
-    _clipPath(path, doAntiAlias);
+    _clipPath(path);
   }
-  void _clipPath(Path path, bool doAntiAlias) native 'Canvas_clipPath';
+  void _clipPath(Path path) native 'Canvas_clipPath';
 
   /// Paints the given [Color] onto the canvas, applying the given
   /// [BlendMode], with the given color being the source and the background

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -35,7 +35,6 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
   V(Canvas, saveLayerWithoutBounds) \
   V(Canvas, saveLayer)              \
   V(Canvas, restore)                \
-  V(Canvas, restoreToCount)         \
   V(Canvas, getSaveCount)           \
   V(Canvas, translate)              \
   V(Canvas, scale)                  \
@@ -121,12 +120,6 @@ void Canvas::restore() {
   canvas_->restore();
 }
 
-void Canvas::restoreToCount(int saveCount) {
-  if (!canvas_)
-    return;
-  canvas_->restoreToCount(saveCount);
-}
-
 int Canvas::getSaveCount() {
   if (!canvas_)
     return 0;
@@ -173,19 +166,19 @@ void Canvas::clipRect(double left,
   canvas_->clipRect(SkRect::MakeLTRB(left, top, right, bottom), clipOp, true);
 }
 
-void Canvas::clipRRect(const RRect& rrect, bool doAntiAlias) {
+void Canvas::clipRRect(const RRect& rrect) {
   if (!canvas_)
     return;
-  canvas_->clipRRect(rrect.sk_rrect, doAntiAlias);
+  canvas_->clipRRect(rrect.sk_rrect, true);
 }
 
-void Canvas::clipPath(const CanvasPath* path, bool doAntiAlias) {
+void Canvas::clipPath(const CanvasPath* path) {
   if (!canvas_)
     return;
   if (!path)
     Dart_ThrowException(
         ToDart("Canvas.clipPath called with non-genuine Path."));
-  canvas_->clipPath(path->path(), doAntiAlias);
+  canvas_->clipPath(path->path(), true);
 }
 
 void Canvas::drawColor(SkColor color, SkBlendMode blend_mode) {

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -48,7 +48,6 @@ class Canvas : public fxl::RefCountedThreadSafe<Canvas>,
                  const Paint& paint,
                  const PaintData& paint_data);
   void restore();
-  void restoreToCount(int saveCount);
   int getSaveCount();
 
   void translate(double dx, double dy);
@@ -62,8 +61,8 @@ class Canvas : public fxl::RefCountedThreadSafe<Canvas>,
                 double right,
                 double bottom,
                 SkClipOp clipOp);
-  void clipRRect(const RRect& rrect, bool doAntiAlias = true);
-  void clipPath(const CanvasPath* path, bool doAntiAlias = true);
+  void clipRRect(const RRect& rrect);
+  void clipPath(const CanvasPath* path);
 
   void drawColor(SkColor color, SkBlendMode blend_mode);
   void drawLine(double x1,


### PR DESCRIPTION
This reverts commit a2bf80590b80a797659193a2d7b320fda0f21ea2.

Reason for revert: need to fix several things including the framework test in order to unblock the engine roll.