### PR TITLE
Ensure that bridge is not destroyed when semantics is still enabled

### DIFF
--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -65,7 +65,7 @@ sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
 void PlatformViewIOS::SetSemanticsEnabled(bool enabled) {
   if (enabled && !accessibility_bridge_) {
     accessibility_bridge_ = std::make_unique<AccessibilityBridge>(owner_view_, this);
-  } else {
+  } else if (!enabled && accessibility_bridge_) {
     accessibility_bridge_.reset();
   }
   PlatformView::SetSemanticsEnabled(enabled);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/16904.

Currently calling `SetSemanticsEnabled` multiple times will result in the platform view prematurely releasing the accessibility bridge.  The listener `FlutterViewController:onAccessibilityStatusChanged` is triggered twice when enabling a11y via the shortcut, resulting in the accessibility bridge being initialized, and then immediately destroyed.  The underlying reason why this status listener is invoked multiple times is not clear.