### PR TITLE
Remove cullRect calculation on TransformLayers with a perspective transform.

### DIFF
--- a/flow/layers/default_layer_builder.cc
+++ b/flow/layers/default_layer_builder.cc
@@ -39,7 +39,7 @@ void DefaultLayerBuilder::PushTransform(const SkMatrix& sk_matrix) {
   SkRect cullRect;
   // Perspective projections don't produce rectangles that are useful for
   // culling for some reason.
-  if (sk_matrix.invert(&inverse_sk_matrix) && !inverse_sk_matrix.hasPerspective()) {
+  if (!sk_matrix.hasPerspective() && sk_matrix.invert(&inverse_sk_matrix)) {
     inverse_sk_matrix.mapRect(&cullRect, cull_rects_.top());
   } else {
     cullRect = kGiantRect;

--- a/flow/layers/default_layer_builder.cc
+++ b/flow/layers/default_layer_builder.cc
@@ -37,12 +37,13 @@ DefaultLayerBuilder::~DefaultLayerBuilder() = default;
 void DefaultLayerBuilder::PushTransform(const SkMatrix& sk_matrix) {
   SkMatrix inverse_sk_matrix;
   SkRect cullRect;
-  if (sk_matrix.invert(&inverse_sk_matrix)) {
+  // Perspective projections don't produce rectangles that are useful for
+  // culling for some reason.
+  if (sk_matrix.invert(&inverse_sk_matrix) && !inverse_sk_matrix.hasPerspective()) {
     inverse_sk_matrix.mapRect(&cullRect, cull_rects_.top());
   } else {
     cullRect = kGiantRect;
   }
-
   auto layer = std::make_unique<flow::TransformLayer>();
   layer->set_transform(sk_matrix);
   PushLayer(std::move(layer), cullRect);

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -129,7 +129,7 @@
 
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
-      restorationHandler:(void (^)(NSArray*))restorationHandler {
+      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>>*))restorationHandler {
   return [_lifeCycleDelegate application:application
                     continueUserActivity:userActivity
                       restorationHandler:restorationHandler];


### PR DESCRIPTION
- do not produce a cullRect from a TransformLayer with perspective.
- Fix type error in Xcode-beta.

Fixes https://github.com/flutter/flutter/issues/19062

## The problem
Creating a transform layer with a perspective transform and a child layer that needs compositing causes said child to always be culled in the `DefaultLayerBuilder`.  This was not a bug that was introduced recently, and I've confirmed this occurs at least two months back in master, (and I believe it has existed since basically forever).  It can be reproduced trivially with the following snippet,  The result of which is an empty screen.  The red box will appear only when the perspective is commented out.

```dart

void main() {
  runApp(new Center(
    child: new Transform(
      transform: new Matrix4.identity()
        ..setEntry(3, 2, 0.001), // perspective transform
      child: new Ancestor( // new child layer
        child: new Container( // something to draw
          color: Colors.red,
            width: 200.0,
            height: 200.0,
          ),
       ),
   ));
}

class Ancestor extends SingleChildRenderObjectWidget {
  const Ancestor({Widget child, Key key}): super(child: child, key: key);
  
  @override
  RenderObject createRenderObject(BuildContext context) {
    return new RenderAncestor();
  }
}
class RenderAncestor extends RenderProxyBox {
  @override
  bool get alwaysNeedsCompositing => true; 

  @override
  void paint(PaintingContext context, Offset offset) {
    context.pushLayer(new OffsetLayer(), super.paint, offset);
  }
}

```

For reference, left with the perspective applied and right without.

<img src="https://user-images.githubusercontent.com/8975114/42416591-265188ac-8228-11e8-9e22-0a4b77dcd78c.png" width="250"><img src="https://user-images.githubusercontent.com/8975114/42416592-27a06930-8228-11e8-94a4-1432894b2ef4.png" width="250">

According to the Flutter tool, the layer tree looks like the following - but this is not what is displayed.
```
flutter: TransformLayer#34ae6
flutter:  │ owner: RenderView#e6b34
flutter:  │ creator: [root]
flutter:  │ offset: Offset(0.0, 0.0)
flutter:  │ transform:
flutter:  │   [0] 3.0,0.0,0.0,0.0
flutter:  │   [1] 0.0,3.0,0.0,0.0
flutter:  │   [2] 0.0,0.0,1.0,0.0
flutter:  │   [3] 0.0,0.0,0.0,1.0
flutter:  │
flutter:  └─child 1: TransformLayer#53916
flutter:    │ offset: Offset(0.0, 0.0)
flutter:    │ transform:
flutter:    │   [0] 1.1875,0.0,0.0,-35.156250000000014
flutter:    │   [1] 0.406,1.0,0.0,-76.12499999999994
flutter:    │   [2] 0.0,0.0,1.0,0.0
flutter:    │   [3] 0.001,0.0,0.0,0.8125
flutter:    │
flutter:    └─child 1: OffsetLayer#87f88
flutter:      │ offset: Offset(0.0, 0.0)
flutter:      │
flutter:      └─child 1: PictureLayer#28202
flutter:          paint bounds: Rect.fromLTRB(29.6, -6090.0, 15187.5, 32886.0)
flutter:
```

Instead, the `DefaultLayerBuilder` is always culling the PictureLayer when the perspective transform is applied.  The problematic culling rect in question is calculated in `DefaultLayerBuilder::pushTransfrom`. 

https://github.com/flutter/engine/blob/f52955c2558a8bc2539192f88d84fe7d339f5d4b/flow/layers/default_layer_builder.cc#L37-L49

With some assorted rotations applied and no perspective, a rect might be produced something like:
`Rect.LTRB{-3.33333e+08, -4.71228e+09, 3.33333e+08, 4.71227e+09}`.  However, as soon as there is any amount of perspective you start getting less reasonable values like `Rect.LTRB{-793.003, -13768.9, -792.997, 14504.9}`. A matrix with a perspective _does_ go through a separate code path in Skia [here](https://github.com/google/skia/blob/dd962a95c5f21cba18a8ef90f2a6f974e2968142/src/core/SkMatrix.cpp#L971-L997), but having checked it out nothing seems obviously wrong.   Now, at this point i've been debugging for a while so I haven't really sat down and thought about the math too much (shame!)

## The Solution (?)

The simplest solution to me seems to be just don't producing a cullingRect if the transform matrix has any perspective.  I'm not sure how much work this particular culling heuristic is buying us, but this change wouldn't effect other common transforms like translations/rotations. I'm also open to exploring other solutions or digging into the linear algebra some more...

(Also I fixed a type error that prevented me from building on the latest xcode beta)