### PR TITLE
Implement UniqueFDTraits::Free on non-win systems

### DIFF
--- a/fml/unique_fd.cc
+++ b/fml/unique_fd.cc
@@ -24,7 +24,7 @@ void UniqueFDTraits::Free(HANDLE fd) {
 namespace unix {
 
 void UniqueFDTraits::Free(int fd) {
-  FML_IGNORE_EINTR(fd);
+  close(fd);
 }
 
 }  // namespace unix

--- a/fml/unique_fd.h
+++ b/fml/unique_fd.h
@@ -12,6 +12,10 @@
 
 #include <windows.h>
 
+#else  // OS_WIN
+
+#include <unistd.h>
+
 #endif  // OS_WIN
 
 namespace fml {


### PR DESCRIPTION
As https://github.com/flutter/flutter/issues/19069 explained, timerfd was not closed properly. After long run, Android app will show error logs like:
```
                 Parcel  E  dup() failed in Parcel::read, i is 1, fds[i] is -1, fd_count is 2, error: Too many open files
```
and crashed soon:
```
             JavaBinder  E  !!! FAILED BINDER TRANSACTION !!!  (parcel size = 576)
         AndroidRuntime  E  FATAL EXCEPTION: main
         AndroidRuntime  E  Process: com.example.flutterlooprunner, PID: 25534
         AndroidRuntime  E  java.lang.RuntimeException: Adding window failed
         AndroidRuntime  E      at android.view.ViewRootImpl.setView(ViewRootImpl.java:888)
         AndroidRuntime  E      at android.view.WindowManagerGlobal.addView(WindowManagerGlobal.java:516)
         AndroidRuntime  E      at android.view.WindowManagerImpl.addView(WindowManagerImpl.java:95)
         AndroidRuntime  E      at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:3721)
         AndroidRuntime  E      at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2933)
         AndroidRuntime  E      at android.app.ActivityThread.-wrap12(ActivityThread.java)
         AndroidRuntime  E      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1650)
         AndroidRuntime  E      at android.os.Handler.dispatchMessage(Handler.java:102)
         AndroidRuntime  E      at android.os.Looper.loop(Looper.java:159)
         AndroidRuntime  E      at android.app.ActivityThread.main(ActivityThread.java:6364)
         AndroidRuntime  E      at java.lang.reflect.Method.invoke(Native Method)
         AndroidRuntime  E      at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1096)
         AndroidRuntime  E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:883)
         AndroidRuntime  E  Caused by: android.os.DeadObjectException: Transaction failed on small parcel; remote process probably died
         AndroidRuntime  E      at android.os.BinderProxy.transactNative(Native Method)
         AndroidRuntime  E      at android.os.BinderProxy.transact(Binder.java:827)
         AndroidRuntime  E      at android.view.IWindowSession$Stub$Proxy.addToDisplay(IWindowSession.java:922)
         AndroidRuntime  E      at android.view.ViewRootImpl.setView(ViewRootImpl.java:868)
         AndroidRuntime  E      ... 12 more
```