### PR TITLE
Revert "Remove vmservice_io.main from entry points. (#5625)"

### DIFF
--- a/runtime/dart_vm_entry_points.txt
+++ b/runtime/dart_vm_entry_points.txt
@@ -43,3 +43,4 @@ dart:ui,SemanticsUpdate,SemanticsUpdate._
 dart:ui,SemanticsUpdateBuilder,SemanticsUpdateBuilder.
 dart:ui,Shader,Shader._
 dart:ui,TextBox,TextBox._
+dart:vmservice_io,::,main


### PR DESCRIPTION
This caused failures in Flutter microbenchmarks.

See: flutter/flutter#19096 and flutter/flutter#19210

This reverts commit 4466d61a993fdbde2cb092b4da9bbef33d1962fe.