### PR TITLE
Roll Dart to 937ee2e8ca4b76499e24cd463f07bfb736bccd74.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,11 +31,11 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '84ca27a09ebd6a65cd23ee52d835d89cbe06c574',
+  'dart_revision': '937ee2e8ca4b76499e24cd463f07bfb736bccd74',
 
   'dart_args_tag': '1.4.1',
   'dart_async_tag': '2.0.7',
-  'dart_bazel_worker_tag': 'v0.1.9',
+  'dart_bazel_worker_tag': '0.1.11',
   'dart_boolean_selector_tag': '1.0.3',
   'dart_boringssl_gen_rev': 'fc47eaa1a245d858bae462cd64d4155605b850ea',
   'dart_boringssl_rev': '189270cd190267f5bd60cfe8f8ce7a61d07ba6f4',
@@ -46,7 +46,7 @@ vars = {
   'dart_crypto_tag': '2.0.5',
   'dart_csslib_tag': '0.14.1',
   'dart_dart2js_info_tag': '0.5.6+4',
-  'dart_dart_style_tag': '1.1.1',
+  'dart_dart_style_tag': '1.1.2',
   'dart_dartdoc_tag': 'v0.20.1',
   'dart_fixnum_tag': '0.10.5',
   'dart_glob_tag': '1.1.5',
@@ -56,34 +56,33 @@ vars = {
   'dart_http_retry_tag': '0.1.1',
   'dart_http_tag': '0.11.3+17',
   'dart_http_throttle_tag': '1.0.2',
-  'dart_intl_tag': '0.15.2',
+  'dart_intl_tag': '0.15.6',
   'dart_json_rpc_2_tag': '2.0.6',
   'dart_linter_tag': '0.1.56',
   'dart_logging_tag': '0.11.3+1',
-  'dart_markdown_tag': '2.0.0',
+  'dart_markdown_tag': '2.0.1',
   'dart_matcher_tag': '0.12.3',
   'dart_mime_tag': '0.9.6',
   'dart_mockito_tag': 'd39ac507483b9891165e422ec98d9fb480037c8b',
   'dart_mustache4dart_tag': 'v2.1.2',
-  'dart_oauth2_tag': '1.1.0',
+  'dart_oauth2_tag': '1.2.1',
   'dart_observatory_pub_packages_rev': 'caf0aecfb15077fc7a34d48e9df13606c793fddf',
   'dart_package_config_tag': '1.0.3',
   'dart_package_resolver_tag': '1.0.2+1',
   'dart_path_tag': '1.5.1',
   'dart_plugin_tag': '0.2.0+2',
   'dart_pool_tag': '1.3.4',
-  'dart_protobuf_tag': '0.7.1',
+  'dart_protobuf_tag': '0.9.0',
   'dart_pub_rev': '58fe996eab8d54f28f5109c407ff0ab62fbd835d',
   'dart_pub_semver_tag': '1.4.1',
   'dart_quiver_tag': '0.29.0',
-  'dart_resource_rev': 'af5a5bf65511943398146cf146e466e5f0b95cb9',
   'dart_root_certificates_rev': '16ef64be64c7dfdff2b9f4b910726e635ccc519e',
   'dart_shelf_packages_handler_tag': '1.0.3',
   'dart_shelf_static_rev': 'v0.2.7',
-  'dart_shelf_tag': '0.7.2',
+  'dart_shelf_tag': '0.7.3+2',
   'dart_shelf_web_socket_tag': '0.2.2',
   'dart_source_map_stack_trace_tag': '1.1.4',
-  'dart_source_maps_tag': '0.10.4',
+  'dart_source_maps_tag': '0.10.6',
   'dart_source_span_tag': '1.4.0',
   'dart_stack_trace_tag': '1.9.2',
   'dart_stream_channel_tag': '1.6.4',
@@ -96,7 +95,7 @@ vars = {
   'dart_utf_tag': '0.9.0+4',
   'dart_watcher_tag': '0.9.7+8',
   'dart_web_socket_channel_tag': '1.0.7',
-  'dart_yaml_tag': '2.1.13',
+  'dart_yaml_tag': '2.1.14',
 
   # Build bot tooling for iOS
   'ios_tools_revision': '69b7c1b160e7107a6a98d948363772dc9caea46f',
@@ -282,9 +281,6 @@ deps = {
 
   'src/third_party/dart/third_party/pkg/quiver':
    Var('chromium_git') + '/external/github.com/google/quiver-dart' + '@' + Var('dart_quiver_tag'),
-
-  'src/third_party/dart/third_party/pkg/resource':
-   Var('dart_git') + '/resource.git' + '@' + Var('dart_resource_rev'),
 
   'src/third_party/dart/third_party/pkg/shelf':
    Var('dart_git') + '/shelf.git' + '@' + Var('dart_shelf_tag'),

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 9d07cf4ed9f6c4ece22105db33c2e6f4
+Signature: 8ab62fe95c1ef8d1c186d49def733f8e
 
 UNUSED LICENSES:
 
@@ -4480,7 +4480,6 @@ FILE: ../../../third_party/dart/client/idea/.idea/.name
 FILE: ../../../third_party/dart/client/idea/.idea/inspectionProfiles/Project_Default.xml
 FILE: ../../../third_party/dart/client/idea/.idea/vcs.xml
 FILE: ../../../third_party/dart/runtime/CPPLINT.cfg
-FILE: ../../../third_party/dart/runtime/observatory/.analysis_options
 FILE: ../../../third_party/dart/runtime/observatory/lib/elements.dart
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/img/chromium_icon.png
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/img/dart_icon.png
@@ -4490,8 +4489,6 @@ FILE: ../../../third_party/dart/runtime/observatory/web/index.html
 FILE: ../../../third_party/dart/runtime/observatory/web/third_party/trace_viewer_full.html
 FILE: ../../../third_party/dart/runtime/observatory/web/timeline.html
 FILE: ../../../third_party/dart/runtime/vm/snapshot_test_in.dat
-FILE: ../../../third_party/dart/samples/build_dart/test.foo
-FILE: ../../../third_party/dart/samples/build_dart_simple/test.foo
 FILE: ../../../third_party/dart/sdk/lib/html/html_common/conversions_dart2js.dart
 FILE: ../../../third_party/dart/sdk/lib/html/html_common/html_common.dart
 FILE: ../../../third_party/dart/sdk/lib/libraries.json
@@ -4884,10 +4881,6 @@ FILE: ../../../third_party/dart/runtime/vm/virtual_memory_win.cc
 FILE: ../../../third_party/dart/runtime/vm/zone.cc
 FILE: ../../../third_party/dart/runtime/vm/zone.h
 FILE: ../../../third_party/dart/runtime/vm/zone_test.cc
-FILE: ../../../third_party/dart/samples/build_dart/bin/test.dart
-FILE: ../../../third_party/dart/samples/build_dart/build.dart
-FILE: ../../../third_party/dart/samples/build_dart_simple/build.dart
-FILE: ../../../third_party/dart/samples/build_dart_simple/test.dart
 FILE: ../../../third_party/dart/samples/sample_extension/sample_asynchronous_extension.dart
 FILE: ../../../third_party/dart/samples/sample_extension/sample_extension.cc
 FILE: ../../../third_party/dart/samples/sample_extension/sample_extension_dllmain_win.cc
@@ -5642,6 +5635,10 @@ FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_reader.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_reader.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_evaluator.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_evaluator.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_fingerprints.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_fingerprints.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_translation_helper.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/kernel_translation_helper.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/scope_builder.cc


### PR DESCRIPTION
937ee2e8ca [vm] Propagate unwind errors received during reload stress testing.
d34c8b6650 Add some invalid tests as expected to fail.
ed99019d2d Check for InvalidExpression presence in resynthesized constant expressions.
51dd296cc5 Store unresolved variable prefix/postfix operator resolution.
54c7754beb [build] Use the right section type in bin_to_coff.py
b0600a2d4b Report inference err for C<<T>()> for some C and some function with params
afb283543f [VM interpreter] Fix bad ifdef.
8b1030cc7e Fix a runtime type issue in pkg/analysis_server/benchmark/benchmarks.dart.
f793a60790 [VM interpreter] Improve transition from jitted code to interpreted code. Arguments are not copied anymore into an array allocated for each transition.
b3c27213eb Translate errors for conflicting members.
6ec5801c4f Store resolution for 'throw' in constant.
5e17f099f0 Infer annotations only for the first VariableDeclarationJudgment of a variable declaration statement.
1c95390082 Store resolution for final fields that initialized multiple times.
93cad16e71 Update the move metadata file.
d80c0b25d7 MOVE_FILE refactor review tweaks
902b6db749 Mark analyzer_cli, analysis_server pubspecs as not-to-publish
188ef5e3d5 Analyze all the pkg/ code on the bots.
fcde5ca4c4 Remove old samples.
e8ecb3bc08 Support incompatible Dart SDK changes with patches to the Flutter Engine.
fad786769d [fasta] Reject generic function types in bounds of type variables
d3e241d14f [fasta] Clone missing default values of formals in forwarding stubs
52f359ca83 [Gardening] Update status files for target-arm64 builder
6b01ba7112 Update status for vm --checked (enable asserts) tests.
fb9225c90e [Gardening] Remove line for cc/Profiler_FunctionInline, test passes now
58f1819023 Update the checked-in sdk to version 2.0.0-dev.68.0
30d0785be2 Update Firefox status for Dart 2
e3e277f544 Merge remote-tracking branch 'github/master'
97319b838a Decouple library loader from the K-world
2aea197aa8 Fix write into top-level variables of deferred libraries.
73a446d5a1 Create move.yml
f601b9cd45 fix #33287, error in dartdevc if an int cannot be represented in JS
dbd1b2f533 [test] Reload harness now reloads from, e.g. the URI of a snapshot or kernel file instead of the URI of the source from which it was derived.
c2628192a2 [vm] Use C++11 thread_local instead of platform TLS for Thread::Current().
85e35a74cf [gardening] Update flaky test status
3ad109038e Fix a runtime type issue in the dartanalyzer cli.
7952cf0b8d [vm] In the reload stress test, reload from the script uri instead of the root library's uri, which are different when not running from source.
eb946bf26c Replace a use of templateUnspecified with templateExpectedFunctionBody
7f8db8d06f [vm] Refactoring: extract constant evaluator and fingerprints helper
23e3265476 Replace two uses of templateUnspecified with a more specific error
cd11ca1591 [gardening] Update status for flaky tests
fed9f5b179 Fix the way we check for synthetic forwarding semi stub.
96b840dcd2 Fix an npe in the analyzer cli when used with --no-hints.
6c55957851 Store data for loadLibrary() invocation and tear-off.
3e59362747 [vm] Shut down application isolates before the kernel isolate.
76d1a9b7d1 Fix a runtime types issue in the plugin channel with reported error messages.
370f2e8ff8 [ VM / Build ] Added bin_to_coff.py to generate object files from binaries. Speeds up Windows builds significantly since .dill files are no longer converted to assembly and run through asm.exe.
32522fe214 [observatory] Progress toward static mode compatibility.
fbd9c4e7a6 Fix a build mode test breakage from a recent DEPS update.
5993d0e6a2 [vm] Check for NULL finalizers in Dart_PostCObject.
6f648307b9 Address two flaky tests.
b42553ddaf Fix analyzer/FE integration of references to local function type parameters.
89d6f50465 Fix override completion suggestion when fasta parser enabled
0a80489ad5 Reuse the same DillLoader between compilations.
b8098e9683 Added new feature spec generic-function-instantiation.md.
aeb226b228 Index metadata and flush on a library invalidation.
647c72e0e5 Fix keyword completion with fasta parser enabled
166e3e12b3 Remove Scanner.useFasta
020a756c3b Fuse _ResolutionStorer and ResolutionStorer, and make types concrete.
cca35631f1 Remove unused import
ff98451995 Reorder members of Factory and related classes.
f55e23a6b8 Fixed obsolete reference about member conflicts
2efe3447ee Update DEPS to remove dependencies on upper-case constants
85350b0c53 [vm/fuzzer] Added configuration support in DartFuzz.
6f822ace89 Update bazel_worker, shelf, oauth2, markdown DEPS to latest versions to enable removing deprecated CONSTANTS.
403273a088 Deprecate options.declarationCasts.
6cc709e192 Avoid using deprecated apis and constants.
8eb51536ae [vm] Add more File::OpenUri tests.
b5fe750007 Strong mode fixes to kernel and dart2js
576f01045a [build] Copy Observatory assets with GN rather than observatory_tool.py
e26d3d5f9f Reenable the `Iterable.whereType` method.
876ce438e6 [fuchsia] Mark runtime_kernel testonly
24d281806a Don't create new CoreTypes and ClassHierarchy.
5500ce049f Disable two failing tests.
715d59779e Added specification that redirecting constructors must be checked.
c267586b65 [co19] co19 roll: Fix wrong patchset landed. [co19] co19 roll: DEPS and test_matrix update
54f66eebf2 [co19] co19 roll: DEPS and test_matrix update
8370393ab4 Change Chrome-linux trybot to Dart 2 mode
35589e03cc Don't create defensive copies in memory file system
4f1d6a33fc Remove --analyze-* flags
2dd33c2a6c Have the package:analyzer strong mode option hard coded to on. Delete several spec mode only tests.
94ca9b35af Mark four tests as slow.
63b0bf3478 Re-add accidentally removed status file entries during merge
e5d31282eb [vm] Support Dart metadata on libraries and library dependencies in Dart 2 mode
d4df9b9152 misc: update async_helper pubspec to make it clear it's not public
6f12cc3eb5 Fix FF and IE status to make bots green
7ffebea896 Failing test for annotation on formal parameters of redirecting factory constructors.
cf30a28ca1 Map UnexpectedDollarInString to an analyzer error code
b5e97a6537 Roll dart_style to version 1.1.2
21258299d7 Reland "Fix #32227 export dynamic from dart:core in analyzer."
0b4d8b45bb fasta parser tests for 33647
