### PR TITLE
Remove use of GrVkInterface in vulkan.

### DIFF
--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -227,4 +227,21 @@ sk_sp<GrVkInterface> VulkanProcTable::CreateSkiaInterface() const {
                                    0 /* extensions */);
 }
 
+GrVkGetProc VulkanProcTable::CreateSkiaGetProc() const {
+  if (!IsValid()) {
+    return nullptr;
+  }
+
+  return [this](const char* proc_name, VkInstance instance, VkDevice device) {
+    if (device != VK_NULL_HANDLE) {
+      auto result = AcquireProc(proc_name, {device, nullptr});
+      if (result != nullptr) {
+        return result;
+      }
+    }
+
+    return AcquireProc(proc_name, {instance, nullptr});
+  };
+}
+
 }  // namespace vulkan

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -11,6 +11,7 @@
 #include "lib/fxl/memory/ref_counted.h"
 #include "lib/fxl/memory/ref_ptr.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
+#include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
 #include "third_party/skia/include/gpu/vk/GrVkInterface.h"
 
 namespace vulkan {
@@ -59,7 +60,9 @@ class VulkanProcTable : public fxl::RefCountedThreadSafe<VulkanProcTable> {
 
   bool SetupDeviceProcAddresses(const VulkanHandle<VkDevice>& device);
 
+  // CreateSkiaInterface is deprecated.
   sk_sp<GrVkInterface> CreateSkiaInterface() const;
+  GrVkGetProc CreateSkiaGetProc() const;
 
 #define DEFINE_PROC(name) Proc<PFN_vk##name> name;
 

--- a/vulkan/vulkan_window.cc
+++ b/vulkan/vulkan_window.cc
@@ -13,7 +13,6 @@
 #include "flutter/vulkan/vulkan_surface.h"
 #include "flutter/vulkan/vulkan_swapchain.h"
 #include "third_party/skia/include/gpu/GrContext.h"
-#include "third_party/skia/include/gpu/vk/GrVkInterface.h"
 
 namespace vulkan {
 
@@ -117,9 +116,9 @@ bool VulkanWindow::CreateSkiaGrContext() {
 }
 
 bool VulkanWindow::CreateSkiaBackendContext(GrVkBackendContext* context) {
-  auto interface = vk->CreateSkiaInterface();
+  auto getProc = vk->CreateSkiaGetProc();
 
-  if (interface == nullptr || !interface->validate(0)) {
+  if (getProc == nullptr) {
     return false;
   }
 
@@ -138,7 +137,7 @@ bool VulkanWindow::CreateSkiaBackendContext(GrVkBackendContext* context) {
                          kKHR_swapchain_GrVkExtensionFlag |
                          surface_->GetNativeSurface().GetSkiaExtensionName();
   context->fFeatures = skia_features;
-  context->fInterface.reset(interface.release());
+  context->fGetProc = std::move(getProc);
   context->fOwnsInstanceAndDevice = false;
   return true;
 }


### PR DESCRIPTION
We are working on removing GrVkInterface from the public API in Skia. CreateSkiaInterface is currently used in fuchsia so we will need to roll this change into fuchsia before we can remove that function.

@chinmaygarde @brianosman 