### PR TITLE
Roll buildroot to 7b5fd64b26afe194fa49463bad204b2cfba47fb6

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -114,7 +114,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'fc7d5af92fe6f12b0622e4c3082d9bed8ad01c4b',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7b5fd64b26afe194fa49463bad204b2cfba47fb6',
 
    # Fuchsia compatibility
    #

--- a/shell/platform/darwin/desktop/flutter_application_delegate.mm
+++ b/shell/platform/darwin/desktop/flutter_application_delegate.mm
@@ -26,20 +26,20 @@
                                                           action:@selector(onNewFlutterWindow:)
                                                    keyEquivalent:@""] autorelease];
   newEngineItem.keyEquivalent = @"n";
-  newEngineItem.keyEquivalentModifierMask = NSCommandKeyMask;
+  newEngineItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
 
   NSMenuItem* shutdownEngineItem =
       [[[NSMenuItem alloc] initWithTitle:@"Shutdown Engine"
                                   action:@selector(onShutdownFlutterWindow:)
                            keyEquivalent:@""] autorelease];
   shutdownEngineItem.keyEquivalent = @"w";
-  shutdownEngineItem.keyEquivalentModifierMask = NSCommandKeyMask;
+  shutdownEngineItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
 
   NSMenuItem* quitItem = [[[NSMenuItem alloc] initWithTitle:@"Quit"
                                                      action:@selector(onQuitFlutterApplication:)
                                               keyEquivalent:@""] autorelease];
   quitItem.keyEquivalent = @"q";
-  quitItem.keyEquivalentModifierMask = NSCommandKeyMask;
+  quitItem.keyEquivalentModifierMask = NSEventModifierFlagCommand;
 
   [mainMenu addItem:engineItem];
   [engineItem setSubmenu:engineMenu];

--- a/shell/platform/darwin/desktop/flutter_window.mm
+++ b/shell/platform/darwin/desktop/flutter_window.mm
@@ -54,7 +54,7 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(NSEventPh
 - (instancetype)init {
   self =
       [super initWithContentRect:NSMakeRect(10.0, 10.0, 800.0, 600.0)
-                       styleMask:NSTitledWindowMask | NSClosableWindowMask | NSResizableWindowMask
+                       styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable
                          backing:NSBackingStoreBuffered
                            defer:YES];
   if (self) {

--- a/shell/platform/darwin/desktop/flutter_window.mm
+++ b/shell/platform/darwin/desktop/flutter_window.mm
@@ -52,11 +52,11 @@ static inline blink::PointerData::Change PointerChangeFromNSEventPhase(NSEventPh
 }
 
 - (instancetype)init {
-  self =
-      [super initWithContentRect:NSMakeRect(10.0, 10.0, 800.0, 600.0)
-                       styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable
-                         backing:NSBackingStoreBuffered
-                           defer:YES];
+  self = [super initWithContentRect:NSMakeRect(10.0, 10.0, 800.0, 600.0)
+                          styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
+                                    NSWindowStyleMaskResizable
+                            backing:NSBackingStoreBuffered
+                              defer:YES];
   if (self) {
     self.delegate = self;
     [self setupRenderSurface];


### PR DESCRIPTION
The buildroot bumped the Mac min SDK version to 10.12, which deprecates some constants and caused the bots to fail when https://github.com/flutter/engine/pull/5744 was submitted.