### PR TITLE
Re-land removal of vmservice_io from release builds.

### DIFF
--- a/runtime/dart_vm_entry_points.txt
+++ b/runtime/dart_vm_entry_points.txt
@@ -44,4 +44,3 @@ dart:ui,SemanticsUpdate,SemanticsUpdate._
 dart:ui,SemanticsUpdateBuilder,SemanticsUpdateBuilder.
 dart:ui,Shader,Shader._
 dart:ui,TextBox,TextBox._
-dart:vmservice_io,::,main


### PR DESCRIPTION
The issues with Flutter microbenchmarks have been addressed in https://github.com/flutter/flutter/pull/19430.
@mraleph 