### PR TITLE
Fix allocation of JNI byte buffer on API level 22 and below

### DIFF
--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -289,20 +289,23 @@ void PlatformViewAndroid::UpdateSemantics(blink::SemanticsNodeUpdates update,
       }
     }
 
-    // TODO(jonahwilliams): determine cause of JNI failure in API level 22
-    // fml::jni::ScopedJavaLocalRef<jobject> direct_actions_buffer(
-    //   env, env->NewDirectByteBuffer(actions_buffer.data(), actions_buffer.size()));
+    // Calling NewDirectByteBuffer in API level 22 and below with a size of zero
+    // will cause a JNI crash.
+    if (actions_buffer.size() > 0) {
+      fml::jni::ScopedJavaLocalRef<jobject> direct_actions_buffer(
+        env, env->NewDirectByteBuffer(actions_buffer.data(), actions_buffer.size()));
+      FlutterViewUpdateCustomAccessibilityActions(
+        env, view.obj(), direct_actions_buffer.obj(),
+        fml::jni::VectorToStringArray(env, action_strings).obj());
+    }
 
-    fml::jni::ScopedJavaLocalRef<jobject> direct_buffer(
-        env, env->NewDirectByteBuffer(buffer.data(), buffer.size()));
-
-    // TODO(jonahwilliams): determine cause of JNI failure in API level 22
-    // FlutterViewUpdateCustomAccessibilityActions(
-    //   env, view.obj(), direct_actions_buffer.obj(),
-    //   fml::jni::VectorToStringArray(env, action_strings).obj());
-    FlutterViewUpdateSemantics(
-      env, view.obj(), direct_buffer.obj(),
-      fml::jni::VectorToStringArray(env, strings).obj());
+    if (buffer.size() > 0) {
+      fml::jni::ScopedJavaLocalRef<jobject> direct_buffer(
+          env, env->NewDirectByteBuffer(buffer.data(), buffer.size()));
+      FlutterViewUpdateSemantics(
+        env, view.obj(), direct_buffer.obj(),
+        fml::jni::VectorToStringArray(env, strings).obj());
+    }
   }
 }
 

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -289,15 +289,17 @@ void PlatformViewAndroid::UpdateSemantics(blink::SemanticsNodeUpdates update,
       }
     }
 
-    fml::jni::ScopedJavaLocalRef<jobject> direct_actions_buffer(
-      env, env->NewDirectByteBuffer(actions_buffer.data(), actions_buffer.size()));
+    // TODO(jonahwilliams): determine cause of JNI failure in API level 22
+    // fml::jni::ScopedJavaLocalRef<jobject> direct_actions_buffer(
+    //   env, env->NewDirectByteBuffer(actions_buffer.data(), actions_buffer.size()));
 
     fml::jni::ScopedJavaLocalRef<jobject> direct_buffer(
         env, env->NewDirectByteBuffer(buffer.data(), buffer.size()));
 
-    FlutterViewUpdateCustomAccessibilityActions(
-      env, view.obj(), direct_actions_buffer.obj(),
-      fml::jni::VectorToStringArray(env, action_strings).obj());
+    // TODO(jonahwilliams): determine cause of JNI failure in API level 22
+    // FlutterViewUpdateCustomAccessibilityActions(
+    //   env, view.obj(), direct_actions_buffer.obj(),
+    //   fml::jni::VectorToStringArray(env, action_strings).obj());
     FlutterViewUpdateSemantics(
       env, view.obj(), direct_buffer.obj(),
       fml::jni::VectorToStringArray(env, strings).obj());

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -178,8 +178,9 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
 }
 
 // |shell::PlatformView|
-void PlatformViewAndroid::UpdateSemantics(blink::SemanticsNodeUpdates update,
-                                          blink::CustomAccessibilityActionUpdates actions) {
+void PlatformViewAndroid::UpdateSemantics(
+    blink::SemanticsNodeUpdates update,
+    blink::CustomAccessibilityActionUpdates actions) {
   constexpr size_t kBytesPerNode = 36 * sizeof(int32_t);
   constexpr size_t kBytesPerChild = sizeof(int32_t);
   constexpr size_t kBytesPerAction = 2 * sizeof(int32_t);
@@ -196,7 +197,8 @@ void PlatformViewAndroid::UpdateSemantics(blink::SemanticsNodeUpdates update,
       num_bytes +=
           value.second.childrenInTraversalOrder.size() * kBytesPerChild;
       num_bytes += value.second.childrenInHitTestOrder.size() * kBytesPerChild;
-      num_bytes += value.second.customAccessibilityActions.size() * kBytesPerChild;
+      num_bytes +=
+          value.second.customAccessibilityActions.size() * kBytesPerChild;
     }
 
     std::vector<uint8_t> buffer(num_bytes);
@@ -271,7 +273,8 @@ void PlatformViewAndroid::UpdateSemantics(blink::SemanticsNodeUpdates update,
     // custom accessibility actions.
     size_t num_action_bytes = actions.size() * kBytesPerAction;
     std::vector<uint8_t> actions_buffer(num_action_bytes);
-    int32_t* actions_buffer_int32 = reinterpret_cast<int32_t*>(&actions_buffer[0]);
+    int32_t* actions_buffer_int32 =
+        reinterpret_cast<int32_t*>(&actions_buffer[0]);
 
     std::vector<std::string> action_strings;
     size_t actions_position = 0;
@@ -293,18 +296,19 @@ void PlatformViewAndroid::UpdateSemantics(blink::SemanticsNodeUpdates update,
     // will cause a JNI crash.
     if (actions_buffer.size() > 0) {
       fml::jni::ScopedJavaLocalRef<jobject> direct_actions_buffer(
-        env, env->NewDirectByteBuffer(actions_buffer.data(), actions_buffer.size()));
+          env, env->NewDirectByteBuffer(actions_buffer.data(),
+                                        actions_buffer.size()));
       FlutterViewUpdateCustomAccessibilityActions(
-        env, view.obj(), direct_actions_buffer.obj(),
-        fml::jni::VectorToStringArray(env, action_strings).obj());
+          env, view.obj(), direct_actions_buffer.obj(),
+          fml::jni::VectorToStringArray(env, action_strings).obj());
     }
 
     if (buffer.size() > 0) {
       fml::jni::ScopedJavaLocalRef<jobject> direct_buffer(
           env, env->NewDirectByteBuffer(buffer.data(), buffer.size()));
       FlutterViewUpdateSemantics(
-        env, view.obj(), direct_buffer.obj(),
-        fml::jni::VectorToStringArray(env, strings).obj());
+          env, view.obj(), direct_buffer.obj(),
+          fml::jni::VectorToStringArray(env, strings).obj());
     }
   }
 }


### PR DESCRIPTION
The first commented out line is failing as described here: https://github.com/flutter/flutter/issues/19475

The check that is failing is here: https://android.googlesource.com/platform/art/+/a92853e/src/check_jni.cc#1789

The PR itself is too old for an automatic rollback, and it's not broken on iOS anyway.