### PR TITLE
libtxt: fix a bug that used incorrect buffer size depending on conditions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Dan Field <dfield@gmail.com>
 Victor Choueiri <victor@ctrlanddev.com>
 Simon Lightfoot <simon@devangels.london>
 Dwayne Slater <ds84182@gmail.com>
+Tetsuhiro Ueda <najeira@gmail.com>

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -552,9 +552,8 @@ void Paragraph::Layout(double width, bool force) {
         }
       }
 
-      layout.doLayout(text_ptr, text_start, text_count, text_size,
-                      run.is_rtl(), font, minikin_paint,
-                      minikin_font_collection);
+      layout.doLayout(text_ptr, text_start, text_count, text_size, run.is_rtl(),
+                      font, minikin_paint, minikin_font_collection);
 
       if (layout.nGlyphs() == 0)
         continue;

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -504,6 +504,7 @@ void Paragraph::Layout(double width, bool force) {
       uint16_t* text_ptr = text_.data();
       size_t text_start = run.start();
       size_t text_count = run.end() - run.start();
+      size_t text_size = text_.size();
 
       // Apply ellipsizing if the run was not completely laid out and this
       // is the last line (or lines are unlimited).
@@ -541,6 +542,7 @@ void Paragraph::Layout(double width, bool force) {
         text_ptr = ellipsized_text.data();
         text_start = 0;
         text_count = ellipsized_text.size();
+        text_size = text_count;
 
         // If there is no line limit, then skip all lines after the ellipsized
         // line.
@@ -550,7 +552,7 @@ void Paragraph::Layout(double width, bool force) {
         }
       }
 
-      layout.doLayout(text_ptr, text_start, text_count, text_.size(),
+      layout.doLayout(text_ptr, text_start, text_count, text_size,
                       run.is_rtl(), font, minikin_paint,
                       minikin_font_collection);
 


### PR DESCRIPTION
When laying out ellipsized text, incorrect buffer size is passed to layout.doLayout. This causes access to outside of the buffer. This fix make sure to use correct buffer size.

Fixes https://github.com/flutter/flutter/issues/17495