### PR TITLE
Remove unused function CreateSkiaInterface

### DIFF
--- a/vulkan/vulkan_proc_table.cc
+++ b/vulkan/vulkan_proc_table.cc
@@ -206,27 +206,6 @@ PFN_vkVoidFunction VulkanProcTable::AcquireProc(
   return GetDeviceProcAddr(device, proc_name);
 }
 
-sk_sp<GrVkInterface> VulkanProcTable::CreateSkiaInterface() const {
-  if (!IsValid()) {
-    return nullptr;
-  }
-
-  GrVkInterface::GetProc proc = [this](const char* proc_name,
-                                       VkInstance instance, VkDevice device) {
-    if (device != VK_NULL_HANDLE) {
-      auto result = AcquireProc(proc_name, {device, nullptr});
-      if (result != nullptr) {
-        return result;
-      }
-    }
-
-    return AcquireProc(proc_name, {instance, nullptr});
-  };
-
-  return sk_make_sp<GrVkInterface>(proc, instance_, device_,
-                                   0 /* extensions */);
-}
-
 GrVkGetProc VulkanProcTable::CreateSkiaGetProc() const {
   if (!IsValid()) {
     return nullptr;

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -12,7 +12,6 @@
 #include "lib/fxl/memory/ref_ptr.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
 #include "third_party/skia/include/gpu/vk/GrVkBackendContext.h"
-#include "third_party/skia/include/gpu/vk/GrVkInterface.h"
 
 namespace vulkan {
 

--- a/vulkan/vulkan_proc_table.h
+++ b/vulkan/vulkan_proc_table.h
@@ -60,8 +60,6 @@ class VulkanProcTable : public fxl::RefCountedThreadSafe<VulkanProcTable> {
 
   bool SetupDeviceProcAddresses(const VulkanHandle<VkDevice>& device);
 
-  // CreateSkiaInterface is deprecated.
-  sk_sp<GrVkInterface> CreateSkiaInterface() const;
   GrVkGetProc CreateSkiaGetProc() const;
 
 #define DEFINE_PROC(name) Proc<PFN_vk##name> name;


### PR DESCRIPTION
The change requires the fuchsia change, https://fuchsia-review.googlesource.com/c/topaz/+/176455 to land first. After that their are no more uses of CreateSkiaInterface or GrVkInterface in flutter.

@chinmaygarde @brianosman 