### PR TITLE
[wip] Add optional shader parameter to Paragraph::paint

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3316,7 +3316,7 @@ class Canvas extends NativeFieldWrapperClass2 {
   void _drawPicture(Picture picture) native 'Canvas_drawPicture';
 
   /// Draws the text in the given [Paragraph] into this canvas at the given
-  /// [Offset].
+  /// [Offset] with an optional [Shader] applied to the text.
   ///
   /// The [Paragraph] object must have had [Paragraph.layout] called on it
   /// first.
@@ -3335,10 +3335,10 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// If the text is centered, the centering axis will be at the position
   /// described by adding half of the [ParagraphConstraints.width] given to
   /// [Paragraph.layout], to the `offset` argument's [Offset.dx] coordinate.
-  void drawParagraph(Paragraph paragraph, Offset offset) {
+  void drawParagraph(Paragraph paragraph, Offset offset, {Shader shader = null}) {
     assert(paragraph != null);
     assert(_offsetIsValid(offset));
-    paragraph._paint(this, offset.dx, offset.dy);
+    paragraph._paint(this, offset.dx, offset.dy, shader);
   }
 
   /// Draws a sequence of points according to the given [PointMode].

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1015,7 +1015,7 @@ class Paragraph extends NativeFieldWrapperClass2 {
   // Redirecting the paint function in this way solves some dependency problems
   // in the C++ code. If we straighten out the C++ dependencies, we can remove
   // this indirection.
-  void _paint(Canvas canvas, double x, double y) native 'Paragraph_paint';
+  void _paint(Canvas canvas, double x, double y, Shader shader) native 'Paragraph_paint';
 }
 
 /// Builds a [Paragraph] containing text with the given styling information.

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -80,8 +80,8 @@ void Paragraph::layout(double width) {
   m_paragraphImpl->layout(width);
 }
 
-void Paragraph::paint(Canvas* canvas, double x, double y) {
-  m_paragraphImpl->paint(canvas, x, y);
+void Paragraph::paint(Canvas* canvas, double x, double y, Shader* shader) {
+  m_paragraphImpl->paint(canvas, x, y, shader);
 }
 
 std::vector<TextBox> Paragraph::getRectsForRange(unsigned start, unsigned end) {

--- a/lib/ui/text/paragraph.h
+++ b/lib/ui/text/paragraph.h
@@ -41,7 +41,7 @@ class Paragraph : public fxl::RefCountedThreadSafe<Paragraph>,
   bool didExceedMaxLines();
 
   void layout(double width);
-  void paint(Canvas* canvas, double x, double y);
+  void paint(Canvas* canvas, double x, double y, Shader* shader = nullptr);
 
   std::vector<TextBox> getRectsForRange(unsigned start, unsigned end);
   Dart_Handle getPositionForOffset(double dx, double dy);

--- a/lib/ui/text/paragraph_impl.h
+++ b/lib/ui/text/paragraph_impl.h
@@ -6,6 +6,7 @@
 #define FLUTTER_LIB_UI_TEXT_PARAGRAPH_IMPL_H_
 
 #include "flutter/lib/ui/painting/canvas.h"
+#include "flutter/lib/ui/painting/shader.h"
 #include "flutter/lib/ui/text/text_box.h"
 
 namespace blink {
@@ -30,7 +31,7 @@ class ParagraphImpl {
 
   virtual void layout(double width) = 0;
 
-  virtual void paint(Canvas* canvas, double x, double y) = 0;
+  virtual void paint(Canvas* canvas, double x, double y, Shader* shader = nullptr) = 0;
 
   virtual std::vector<TextBox> getRectsForRange(unsigned start,
                                                 unsigned end) = 0;

--- a/lib/ui/text/paragraph_impl.h
+++ b/lib/ui/text/paragraph_impl.h
@@ -31,7 +31,10 @@ class ParagraphImpl {
 
   virtual void layout(double width) = 0;
 
-  virtual void paint(Canvas* canvas, double x, double y, Shader* shader = nullptr) = 0;
+  virtual void paint(Canvas* canvas,
+                     double x,
+                     double y,
+                     Shader* shader = nullptr) = 0;
 
   virtual std::vector<TextBox> getRectsForRange(unsigned start,
                                                 unsigned end) = 0;

--- a/lib/ui/text/paragraph_impl_txt.cc
+++ b/lib/ui/text/paragraph_impl_txt.cc
@@ -54,7 +54,10 @@ void ParagraphImplTxt::layout(double width) {
   m_paragraph->Layout(width);
 }
 
-void ParagraphImplTxt::paint(Canvas* canvas, double x, double y, Shader* shader) {
+void ParagraphImplTxt::paint(Canvas* canvas,
+                             double x,
+                             double y,
+                             Shader* shader) {
   SkCanvas* sk_canvas = canvas->canvas();
   sk_sp<SkShader> sk_shader = shader == nullptr ? nullptr : shader->shader();
   if (!sk_canvas)

--- a/lib/ui/text/paragraph_impl_txt.cc
+++ b/lib/ui/text/paragraph_impl_txt.cc
@@ -54,11 +54,12 @@ void ParagraphImplTxt::layout(double width) {
   m_paragraph->Layout(width);
 }
 
-void ParagraphImplTxt::paint(Canvas* canvas, double x, double y) {
+void ParagraphImplTxt::paint(Canvas* canvas, double x, double y, Shader* shader) {
   SkCanvas* sk_canvas = canvas->canvas();
+  sk_sp<SkShader> sk_shader = shader == nullptr ? nullptr : shader->shader();
   if (!sk_canvas)
     return;
-  m_paragraph->Paint(sk_canvas, x, y);
+  m_paragraph->Paint(sk_canvas, x, y, sk_shader);
 }
 
 std::vector<TextBox> ParagraphImplTxt::getRectsForRange(unsigned start,

--- a/lib/ui/text/paragraph_impl_txt.h
+++ b/lib/ui/text/paragraph_impl_txt.h
@@ -27,7 +27,7 @@ class ParagraphImplTxt : public ParagraphImpl {
   bool didExceedMaxLines() override;
 
   void layout(double width) override;
-  void paint(Canvas* canvas, double x, double y) override;
+  void paint(Canvas* canvas, double x, double y, Shader* shader = nullptr) override;
 
   std::vector<TextBox> getRectsForRange(unsigned start, unsigned end) override;
   Dart_Handle getPositionForOffset(double dx, double dy) override;

--- a/lib/ui/text/paragraph_impl_txt.h
+++ b/lib/ui/text/paragraph_impl_txt.h
@@ -27,7 +27,10 @@ class ParagraphImplTxt : public ParagraphImpl {
   bool didExceedMaxLines() override;
 
   void layout(double width) override;
-  void paint(Canvas* canvas, double x, double y, Shader* shader = nullptr) override;
+  void paint(Canvas* canvas,
+             double x,
+             double y,
+             Shader* shader = nullptr) override;
 
   std::vector<TextBox> getRectsForRange(unsigned start, unsigned end) override;
   Dart_Handle getPositionForOffset(double dx, double dy) override;

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -877,7 +877,10 @@ sk_sp<SkTypeface> Paragraph::GetDefaultSkiaTypeface(const TextStyle& style) {
 
 // The x,y coordinates will be the very top left corner of the rendered
 // paragraph.
-void Paragraph::Paint(SkCanvas* canvas, double x, double y, sk_sp<SkShader> shader) {
+void Paragraph::Paint(SkCanvas* canvas,
+                      double x,
+                      double y,
+                      sk_sp<SkShader> shader) {
   SkPoint base_offset = SkPoint::Make(x, y);
   SkPaint paint;
   for (const PaintRecord& record : records_) {

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -37,6 +37,7 @@
 #include "third_party/icu/source/common/unicode/ubidi.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkPaint.h"
+#include "third_party/skia/include/core/SkShader.h"
 #include "third_party/skia/include/core/SkTextBlob.h"
 #include "third_party/skia/include/core/SkTypeface.h"
 #include "third_party/skia/include/effects/SkDashPathEffect.h"
@@ -876,7 +877,7 @@ sk_sp<SkTypeface> Paragraph::GetDefaultSkiaTypeface(const TextStyle& style) {
 
 // The x,y coordinates will be the very top left corner of the rendered
 // paragraph.
-void Paragraph::Paint(SkCanvas* canvas, double x, double y) {
+void Paragraph::Paint(SkCanvas* canvas, double x, double y, sk_sp<SkShader> shader) {
   SkPoint base_offset = SkPoint::Make(x, y);
   SkPaint paint;
   for (const PaintRecord& record : records_) {
@@ -885,6 +886,9 @@ void Paragraph::Paint(SkCanvas* canvas, double x, double y) {
     } else {
       paint.reset();
       paint.setColor(record.style().color);
+    }
+    if (shader) {
+      paint.setShader(shader);
     }
     SkPoint offset = base_offset + record.offset();
     PaintBackground(canvas, record, base_offset);

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -100,7 +100,7 @@ class Paragraph {
 
   // Paints the Laid out text onto the supplied SkCanvas at (x, y) offset from
   // the origin. Only valid after Layout() is called.
-  void Paint(SkCanvas* canvas, double x, double y);
+  void Paint(SkCanvas* canvas, double x, double y, sk_sp<SkShader> shader = nullptr);
 
   // Getter for paragraph_style_.
   const ParagraphStyle& GetParagraphStyle() const;

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -100,7 +100,10 @@ class Paragraph {
 
   // Paints the Laid out text onto the supplied SkCanvas at (x, y) offset from
   // the origin. Only valid after Layout() is called.
-  void Paint(SkCanvas* canvas, double x, double y, sk_sp<SkShader> shader = nullptr);
+  void Paint(SkCanvas* canvas,
+             double x,
+             double y,
+             sk_sp<SkShader> shader = nullptr);
 
   // Getter for paragraph_style_.
   const ParagraphStyle& GetParagraphStyle() const;

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -18,6 +18,7 @@
 #include "render_test.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkColor.h"
+#include "third_party/skia/include/core/SkShader.h"
 #include "txt/font_style.h"
 #include "txt/font_weight.h"
 #include "txt/paragraph.h"


### PR DESCRIPTION
This allows us to remove saveLayer from painting text with shaders.
That's the last place in our Dart framework where we automatically
inserts a saveLayer.