### PR TITLE
Reapply "Fix Dart 2 reload when running from a snapshot instead of pl…

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -715,6 +715,20 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
     );
   }
 
+  // TODO(rmacnak): This flag setting business preserves a side effect of using
+  // Dart_CreateIsolateFromKernel. It should be removed when some of the
+  // internal logic in reload no longer uses this flag.
+  Dart_IsolateFlags nonnull_flags;
+  if (flags == nullptr) {
+    Dart_IsolateFlagsInitialize(&nonnull_flags);
+    flags = &nonnull_flags;
+  }
+  bool dart2 = (vm->GetPlatformKernel().GetSize() > 0) ||
+               Dart_IsDart2Snapshot(embedder_isolate->GetIsolateSnapshot()
+                                        ->GetData()
+                                        ->GetSnapshotPointer());
+  flags->use_dart_frontend = dart2;
+
   // Create the Dart VM isolate and give it the embedder object as the baton.
   Dart_Isolate isolate =
       (vm->GetPlatformKernel().GetSize() > 0)


### PR DESCRIPTION
…atform.dill."

Without this flag, the VM will attempt to interpret a kernel file as source code.

Affects Fuchsia (FL-71) and code-push.