### PR TITLE
Make the virtual display's presentation window non focusable.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.view.Display;
 import android.view.View;
+import android.view.WindowManager;
 import android.widget.FrameLayout;
 
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
@@ -32,6 +33,10 @@ class SingleViewPresentation extends Presentation {
         super(outerContext, display);
         mViewFactory = viewFactory;
         mViewId = viewId;
+        getWindow().setFlags(
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+        );
     }
 
     /**
@@ -45,6 +50,10 @@ class SingleViewPresentation extends Presentation {
         super(outerContext, display);
         mViewFactory = null;
         mView = view;
+        getWindow().setFlags(
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+        );
     }
 
     @Override


### PR DESCRIPTION
When the FlutterView's window loses focus Flutter cannot bring up the
keyboard (so e.g tapping on text fields doesn't work).

This workaround makes sure that Flutter text fields are working but
unfortunately now the embedded Android view cannot bring up the keyboard
as it's window is not focused.

Submitting this until as a stop gap while we're trying to figure out if
it's possible to allow both windows to bring up the keyboard.

Filed flutter/flutter/issues/19718 for enabling embedded views to bring up keyboard.