### PR TITLE
Deprecate -[FlutterDartProject initFromDefaultSourceForConfiguration] (#18886)

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -8,8 +8,8 @@
 /**
  BREAKING CHANGES:
 
- July 23, 2018: Marked -[FlutterDartProject initFromDefaultSourceForConfiguration]
- deprecated.
+ July 26, 2018: Marked -[FlutterDartProject
+ initFromDefaultSourceForConfiguration] deprecated.
 
  February 28, 2018: Removed "initWithFLXArchive" and
  "initWithFLXArchiveWithScriptSnapshot".

--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -8,6 +8,9 @@
 /**
  BREAKING CHANGES:
 
+ July 23, 2018: Marked -[FlutterDartProject initFromDefaultSourceForConfiguration]
+ deprecated.
+
  February 28, 2018: Removed "initWithFLXArchive" and
  "initWithFLXArchiveWithScriptSnapshot".
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -21,7 +21,7 @@ FLUTTER_EXPORT
 - (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL
     NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initFromDefaultSourceForConfiguration;
+- (instancetype)initFromDefaultSourceForConfiguration FLUTTER_DEPRECATED("Use -init instead.");
 
 /**
  Returns the file name for the given asset.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -15,9 +15,10 @@
 #include "FlutterTexture.h"
 
 FLUTTER_EXPORT
-@interface FlutterViewController : UIViewController<FlutterBinaryMessenger, FlutterTextureRegistry, FlutterPluginRegistry>
+@interface FlutterViewController
+    : UIViewController <FlutterBinaryMessenger, FlutterTextureRegistry, FlutterPluginRegistry>
 
-- (instancetype)initWithProject:(FlutterDartProject*)project
+- (instancetype)initWithProject:(FlutterDartProject*)projectOrNil
                         nibName:(NSString*)nibNameOrNil
                          bundle:(NSBundle*)nibBundleOrNil NS_DESIGNATED_INITIALIZER;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -158,11 +158,12 @@ static blink::Settings DefaultSettingsForProcess() {
   if (self) {
     _settings = DefaultSettingsForProcess();
 
-    if ([[NSFileManager defaultManager] fileExistsAtPath:dartMainURL.path]) {
+    if (dartMainURL != nil && [[NSFileManager defaultManager] fileExistsAtPath:dartMainURL.path]) {
       _settings.main_dart_file_path = dartMainURL.path.UTF8String;
     }
 
-    if ([[NSFileManager defaultManager] fileExistsAtPath:dartPackages.path]) {
+    if (dartPackages.path != nil &&
+        [[NSFileManager defaultManager] fileExistsAtPath:dartPackages.path]) {
       _settings.packages_file_path = dartPackages.path.UTF8String;
     }
   }
@@ -176,7 +177,8 @@ static blink::Settings DefaultSettingsForProcess() {
   if (self) {
     _settings = DefaultSettingsForProcess();
 
-    if ([[NSFileManager defaultManager] fileExistsAtPath:flutterAssetsURL.path]) {
+    if (flutterAssetsURL != nil &&
+        [[NSFileManager defaultManager] fileExistsAtPath:flutterAssetsURL.path]) {
       _settings.assets_path = flutterAssetsURL.path.UTF8String;
 
       NSURL* scriptSnapshotPath =
@@ -192,12 +194,9 @@ static blink::Settings DefaultSettingsForProcess() {
 
 #pragma mark - Convenience initializers
 
+// Exists for backward-compatibility.  Expect this to be removed.
 - (instancetype)initFromDefaultSourceForConfiguration {
-  if (blink::DartVM::IsRunningPrecompiledCode()) {
-    return [self initWithPrecompiledDartBundle:nil];
-  } else {
-    return [self initWithFlutterAssets:nil dartMain:nil packages:nil];
-  }
+  return [self init];
 }
 
 - (const blink::Settings&)settings {

--- a/shell/platform/darwin/ios/framework/Source/FlutterHeadlessDartRunner.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterHeadlessDartRunner.mm
@@ -93,8 +93,7 @@ static std::string CreateShellLabel() {
     return;
   }
 
-  FlutterDartProject* project =
-      [[[FlutterDartProject alloc] initFromDefaultSourceForConfiguration] autorelease];
+  FlutterDartProject* project = [[[FlutterDartProject alloc] init] autorelease];
 
   auto config = project.runConfiguration;
   config.SetEntrypointAndLibrary(entrypoint.UTF8String, uri.UTF8String);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -60,16 +60,16 @@
 
 #pragma mark - Manage and override all designated initializers
 
-- (instancetype)initWithProject:(FlutterDartProject*)project
+- (instancetype)initWithProject:(FlutterDartProject*)projectOrNil
                         nibName:(NSString*)nibNameOrNil
                          bundle:(NSBundle*)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
 
   if (self) {
-    if (project == nil)
-      _dartProject.reset([[FlutterDartProject alloc] initFromDefaultSourceForConfiguration]);
+    if (projectOrNil == nil)
+      _dartProject.reset([[FlutterDartProject alloc] init]);
     else
-      _dartProject.reset([project retain]);
+      _dartProject.reset([projectOrNil retain]);
 
     [self performCommonViewControllerInitialization];
   }


### PR DESCRIPTION
`-[FlutterDartProject initFromDefaultSourceForConfiguration]` no
longer seems very useful.  It calls `-initWithPrecompiledDartBundle:`
or `-initWithFlutterAssets:dartMain:packages:`, but since it now
passes `nil` for all arguments, both paths end up doing the same
thing.

Additionally, `-initFromDefaultSourceForConfiguration` is awkward to
use in Swift.  The automatically generated Swift interface is:

    public convenience init!(fromDefaultSourceForConfiguration: ())

and it's not obvious how to call that.

Let's deprecate `-initFromDefaultSourceForConfiguration` and instead
expect callers to use the existing `-init` method. (We can make
`-init` do different things for different build configurations later
if necessary.)

Bonus: Rename some parameters to make it more obvious when they may
be `nil`.