### PR TITLE
 Synthesize Android MotionEvents with the long form obtain method.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -243,7 +243,7 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
                 flags
         );
 
-        view.onTouchEvent(event);
+        view.dispatchTouchEvent(event);
         result.success(null);
     }
 


### PR DESCRIPTION
The simple form MotionEvent.obtain method I used before does not allow
to synthesize multi pointer events.

Another change in this PR: Pass the touch events to the embedded view with dispatchTouchEvent instead of directly invoking onTouchEvent (the later is just part of the pipeline, dispatchTouchEvent also invokes methods like onInterceptTouchEvent).