### PR TITLE
Build Android engine in presubmit using Cirrus and GCE

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,42 @@
+container:
+  image: cirrusci/flutter:base
+
+build_task:
+  env:
+    CIRRUS_WORKING_DIR: "/tmp/engine"
+
+  depot_tools_script: |
+    echo "Download depot_tools"
+    cd /tmp
+    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+    export PATH=$PATH:$(pwd)/depot_tools
+
+    echo "Fetching engine and dependencies with gclient sync"
+    mkdir engine && cd engine
+    cat <<EOF > .gclient
+    solutions = [
+      {
+        "managed": False,
+        "name": "src/flutter",
+        "url": "https://github.com/flutter/engine.git",
+        "custom_deps": {},
+        "deps_file": "DEPS",
+        "safesync_url": "",
+      },
+    ]
+    EOF
+    gclient sync
+    ls # test
+
+    echo "Replace the origin/master engine with the pull request's engine"
+    cd src
+    ls # test
+    rm -r engine
+    mv /tmp/engine ./
+    cd ..
+    gclient sync
+
+    echo "Compile host"
+    ./flutter/tools/gn --unoptimized
+    ninja -C out/android_debug_unopt
+

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,23 +1,18 @@
-container:
-  image: cirrusci/flutter:base
+gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
+
+gce_instance:
+  image_project: flutter-cirrus
+  image_name: flutter-engine-ubuntu1604
+  zone: us-central1-a
+  cpu: 24
+  memory: 32Gb
+  disk: 60
 
 build_task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/github_repo"
-    ENGINE_PATH: "/tmp/engine"
-    PATH: $PATH:/tmp/depot_tools
-
-  download_depot_tools_script: |
-    cd /tmp
-    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-
-  engine_cache:
-    folder: $ENGINE_PATH
-    fingerprint_script: cd $CIRRUS_WORKING_DIR && git fetch origin master && git rev-parse FETCH_HEAD
-    populate_script: |
-      mkdir --parents $ENGINE_PATH && cd $ENGINE_PATH
-      cp $CIRRUS_WORKING_DIR/travis/gclient .gclient
-      gclient sync
+    ENGINE_PATH: "/var/tmp/flutter/engine"
+    PATH: $PATH:/var/tmp/depot_tools
 
   replace_engine_script: |
     cd $ENGINE_PATH/src
@@ -25,13 +20,8 @@ build_task:
     cp $CIRRUS_WORKING_DIR -r ./flutter
     gclient sync
 
-  install_script: |
+  compile_android_script: |
     cd $ENGINE_PATH/src
-    sudo ./build/install-build-deps-android.sh
-    sudo ./build/install-build-deps.sh
-
-  compile_host_script: |
-    cd $ENGINE_PATH/src
-    ./flutter/tools/gn --unoptimized
+    ./flutter/tools/gn --android --unoptimized
     ninja -C out/android_debug_unopt
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,8 +25,13 @@ build_task:
     cp $CIRRUS_WORKING_DIR -r ./flutter
     gclient sync
 
-  # compile_host_script: |
-  #   cd /tmp/src
-  #   ./flutter/tools/gn --unoptimized
-  #   ninja -C out/android_debug_unopt
+  install_script: |
+    cd $ENGINE_PATH/src
+    sudo ./build/install-build-deps-android.sh
+    sudo ./build/install-build-deps.sh
+
+  compile_host_script: |
+    cd $ENGINE_PATH/src
+    ./flutter/tools/gn --unoptimized
+    ninja -C out/android_debug_unopt
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,15 +4,15 @@ container:
 build_task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/engine"
+    PATH: $PATH:/tmp/depot_tools
 
-  depot_tools_script: |
-    echo "Download depot_tools"
+  download_depot_tools_script: |
     cd /tmp
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
     export PATH=$PATH:$(pwd)/depot_tools
 
-    echo "Fetching engine and dependencies with gclient sync"
-    mkdir engine && cd engine
+  gclient_sync_engine_script: |
+    cd /tmp
     cat <<EOF > .gclient
     solutions = [
       {
@@ -26,17 +26,15 @@ build_task:
     ]
     EOF
     gclient sync
-    ls # test
 
-    echo "Replace the origin/master engine with the pull request's engine"
-    cd src
-    ls # test
-    rm -r engine
-    mv /tmp/engine ./
+  replace_engine_script: |
+    cd /tmp/src
+    rm -r flutter
+    mv /tmp/engine ./flutter
     cd ..
     gclient sync
 
-    echo "Compile host"
+  compile_host_script: |
     ./flutter/tools/gn --unoptimized
     ninja -C out/android_debug_unopt
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,38 +3,30 @@ container:
 
 build_task:
   env:
-    CIRRUS_WORKING_DIR: "/tmp/engine"
+    CIRRUS_WORKING_DIR: "/tmp/github_repo"
+    ENGINE_PATH: "/tmp/engine"
     PATH: $PATH:/tmp/depot_tools
 
   download_depot_tools_script: |
     cd /tmp
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 
-  gclient_sync_engine_script: |
-    cd /tmp
-    cat <<EOF > .gclient
-    solutions = [
-      {
-        "managed": False,
-        "name": "src/flutter",
-        "url": "https://github.com/flutter/engine.git",
-        "custom_deps": {},
-        "deps_file": "DEPS",
-        "safesync_url": "",
-      },
-    ]
-    EOF
-    gclient sync
+  engine_cache:
+    folder: $ENGINE_PATH
+    fingerprint_script: cd $CIRRUS_WORKING_DIR && git fetch origin master && git rev-parse FETCH_HEAD
+    populate_script: |
+      mkdir --parents $ENGINE_PATH && cd $ENGINE_PATH
+      cp $CIRRUS_WORKING_DIR/travis/gclient .gclient
+      gclient sync
 
   replace_engine_script: |
-    cd /tmp/src
+    cd $ENGINE_PATH/src
     rm -r flutter
-    mv /tmp/engine ./flutter
-    cd ..
+    cp $CIRRUS_WORKING_DIR -r ./flutter
     gclient sync
 
-  compile_host_script: |
-    cd /tmp/src
-    ./flutter/tools/gn --unoptimized
-    ninja -C out/android_debug_unopt
+  # compile_host_script: |
+  #   cd /tmp/src
+  #   ./flutter/tools/gn --unoptimized
+  #   ninja -C out/android_debug_unopt
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -8,7 +8,7 @@ gce_instance:
   memory: 32Gb
   disk: 60
 
-build_task:
+build_android_task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/github_repo"
     ENGINE_PATH: "/var/tmp/flutter/engine"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,6 +34,7 @@ build_task:
     gclient sync
 
   compile_host_script: |
+    cd /tmp/src
     ./flutter/tools/gn --unoptimized
     ninja -C out/android_debug_unopt
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,6 @@ build_task:
   download_depot_tools_script: |
     cd /tmp
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-    export PATH=$PATH:$(pwd)/depot_tools
 
   gclient_sync_engine_script: |
     cd /tmp

--- a/travis/licenses_golden/licenses_flutter
+++ b/travis/licenses_golden/licenses_flutter
@@ -187,6 +187,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: engine
 ORIGIN: ../../../LICENSE
 TYPE: LicenseType.bsd
+FILE: ../../../flutter/.cirrus.yml
 FILE: ../../../flutter/DEPS
 FILE: ../../../flutter/lib/io/dart_io.cc
 FILE: ../../../flutter/lib/io/dart_io.h


### PR DESCRIPTION
The whole process is less than 5 minutes using a 24-CPU GCE instance.

I may further improve it by using containers and more CPUs in the following PRs.