### PR TITLE
Fix wrong conversion of MotionEvent to Flutter's PointerEvent kind.

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -429,7 +429,7 @@ public class FlutterView
             return;
         }
 
-        int pointerKind = event.getToolType(pointerIndex);
+        int pointerKind = getPointerDeviceTypeForToolType(event.getToolType(pointerIndex));
         if (pointerKind == -1) {
             return;
         }
@@ -438,7 +438,7 @@ public class FlutterView
 
         packet.putLong(timeStamp); // time_stamp
         packet.putLong(pointerChange); // change
-        packet.putLong(toolTypeToKind(pointerKind)); // kind
+        packet.putLong(pointerKind); // kind
         packet.putLong(event.getPointerId(pointerIndex)); // device
         packet.putDouble(event.getX(pointerIndex)); // physical_x
         packet.putDouble(event.getY(pointerIndex)); // physical_y
@@ -482,21 +482,6 @@ public class FlutterView
         } else {
             packet.putDouble(0.0); // tilt
         }
-    }
-
-    // Converts a MotionEvent.getToolType value to Flutter's PointerEvent.kind.
-    private int toolTypeToKind(int toolType) {
-        switch(toolType) {
-            case MotionEvent.TOOL_TYPE_FINGER:
-                return 0;
-            case MotionEvent.TOOL_TYPE_MOUSE:
-                return 1;
-            case MotionEvent.TOOL_TYPE_STYLUS:
-                return 2;
-            case MotionEvent.TOOL_TYPE_ERASER:
-                return 3;
-        }
-        return 0;
     }
 
     @Override

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -438,7 +438,7 @@ public class FlutterView
 
         packet.putLong(timeStamp); // time_stamp
         packet.putLong(pointerChange); // change
-        packet.putLong(pointerKind); // kind
+        packet.putLong(toolTypeToKind(pointerKind)); // kind
         packet.putLong(event.getPointerId(pointerIndex)); // device
         packet.putDouble(event.getX(pointerIndex)); // physical_x
         packet.putDouble(event.getY(pointerIndex)); // physical_y
@@ -482,6 +482,21 @@ public class FlutterView
         } else {
             packet.putDouble(0.0); // tilt
         }
+    }
+
+    // Converts a MotionEvent.getToolType value to Flutter's PointerEvent.kind.
+    private int toolTypeToKind(int toolType) {
+        switch(toolType) {
+            case MotionEvent.TOOL_TYPE_FINGER:
+                return 0;
+            case MotionEvent.TOOL_TYPE_MOUSE:
+                return 1;
+            case MotionEvent.TOOL_TYPE_STYLUS:
+                return 2;
+            case MotionEvent.TOOL_TYPE_ERASER:
+                return 3;
+        }
+        return 0;
     }
 
     @Override


### PR DESCRIPTION
We were sending the toolType values as-is which is wrong, e.g touch
events showed in Flutter as mouse events.