### PR TITLE
Use container and GKE to accelerate build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,27 +1,45 @@
-gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
+container:
+  image: liyuqian79/flutter_engine:base
 
-gce_instance:
-  image_project: flutter-cirrus
-  image_name: flutter-engine-ubuntu1604
-  zone: us-central1-a
-  cpu: 24
-  memory: 32Gb
-  disk: 60
-
-build_android_task:
+build_host_task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/github_repo"
-    ENGINE_PATH: "/var/tmp/flutter/engine"
-    PATH: $PATH:/var/tmp/depot_tools
 
   replace_engine_script: |
     cd $ENGINE_PATH/src
     rm -r flutter
-    cp $CIRRUS_WORKING_DIR -r ./flutter
+    mv $CIRRUS_WORKING_DIR flutter
     gclient sync
 
-  compile_android_script: |
+  compile_host_script: |
     cd $ENGINE_PATH/src
-    ./flutter/tools/gn --android --unoptimized
-    ninja -C out/android_debug_unopt
+    ./flutter/tools/gn --unoptimized
+    ninja -C out/host_debug_unopt
+
+#gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
+#
+#gce_instance:
+#  image_project: flutter-cirrus
+#  image_name: flutter-engine-ubuntu1604
+#  zone: us-central1-a
+#  cpu: 24
+#  memory: 32Gb
+#  disk: 60
+#
+#build_android_task:
+#  env:
+#    CIRRUS_WORKING_DIR: "/tmp/github_repo"
+#    ENGINE_PATH: "/var/tmp/flutter/engine"
+#    PATH: $PATH:/var/tmp/depot_tools
+#
+#  replace_engine_script: |
+#    cd $ENGINE_PATH/src
+#    rm -r flutter
+#    cp $CIRRUS_WORKING_DIR -r ./flutter
+#    gclient sync
+#
+#  compile_android_script: |
+#    cd $ENGINE_PATH/src
+#    ./flutter/tools/gn --android --unoptimized
+#    ninja -C out/android_debug_unopt
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 container:
-  image: liyuqian79/flutter_engine:base
+  image: gcr.io/flutter-cirrus/build-engine-image:0.1
 
-build_host_task:
+task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/github_repo"
 
@@ -11,35 +11,15 @@ build_host_task:
     mv $CIRRUS_WORKING_DIR flutter
     gclient sync
 
-  compile_host_script: |
-    cd $ENGINE_PATH/src
-    ./flutter/tools/gn --unoptimized
-    ninja -C out/host_debug_unopt
-
-#gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
-#
-#gce_instance:
-#  image_project: flutter-cirrus
-#  image_name: flutter-engine-ubuntu1604
-#  zone: us-central1-a
-#  cpu: 24
-#  memory: 32Gb
-#  disk: 60
-#
-#build_android_task:
-#  env:
-#    CIRRUS_WORKING_DIR: "/tmp/github_repo"
-#    ENGINE_PATH: "/var/tmp/flutter/engine"
-#    PATH: $PATH:/var/tmp/depot_tools
-#
-#  replace_engine_script: |
-#    cd $ENGINE_PATH/src
-#    rm -r flutter
-#    cp $CIRRUS_WORKING_DIR -r ./flutter
-#    gclient sync
-#
-#  compile_android_script: |
-#    cd $ENGINE_PATH/src
-#    ./flutter/tools/gn --android --unoptimized
-#    ninja -C out/android_debug_unopt
+  matrix:
+    - name: build_host
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized
+        ninja -C out/host_debug_unopt
+    - name: build_android
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --android --unoptimized
+        ninja -C out/android_debug_unopt
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,12 @@
-container:
-  image: gcr.io/flutter-cirrus/build-engine-image:0.1
+gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
+
+gke_container:
+ image: gcr.io/flutter-cirrus/build-engine-image:latest
+ cluster_name: build-32-cluster
+ zone: us-central1-a
+ namespace: default
+ cpu: 30 # can't use all 30-cores; system pods needs cores too
+ memory: 100Gb # similarly, can't use all 100Gb memory
 
 task:
   env:


### PR DESCRIPTION
This reduces the build time from 5 minutes to 3 minutes as we no longer need to cold start a GCE instance.

Moreover, we can now compile the host engine using this container.