### PR TITLE
Dart SDK roll for 8/1/2018

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '08f59e5de360f53e370f4899144fe58f3bce5275',
+  'dart_revision': '8bad5c7b299ac081cdd30f244268478ee59aef63',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 9c2e8832352ffc7775c039012cb195af
+Signature: 7d1459d5f0304c3567e608822215c746
 
 UNUSED LICENSES:
 
@@ -5493,6 +5493,8 @@ FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_reader.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_reader.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_evaluator.cc


### PR DESCRIPTION
List of commits included in this roll:

8bad5c7b29 [vm/compiler] Non-speculative X64 long division/remainder.
918cda18c5 Add docs about sourcemap extensions
329e029bd6 Fixes https://github.com/dart-lang/sdk/issues/34035
12326c10e1 Store constructor field initializera when the target is not a field.
50da4b8d92 Skip ShadowInvalidFieldInitializer while resynthesizing constructor initializers.
8810b6ecc7 Translate kernel.Instantiation in constant expressions.
cb7341fceb Initial support for inlining-data in source-maps.
4206131030 Fix tracking of onStep position of arguments to new expression
384b0a9a73 Issue 34038. Fix resynthesizing imports when mixed with exports.
ba7dbcf412 Update the test output processor to produce more useful analysis
4b2ee8e9a5 Improve catch clause recovery
66500de4dc More fixes to the CFE integration tests
3f2251986d CC sra also in changes to compiler files and tests
4734c55882 Report error on unsupported operators
00e3109368 [VM] Adjust flags for creating depfiles
07c462b471 [vm] Refactoring: extract BaseFlowGraphBuilder to a separate file
ff9167ff7b Fix parseDirectives to recognize metadata
079bebb78b [ VM ] Added missing token position for `assert` statements
174649b9be [gardening] Update status of dissasemble_test on Windows
8c5aca7d4d Remove the Factory interface
3dc201e168 Update ChangeBuilder to not include empty edits (Take 2)
18047b2757 Refactor test.dart by changing class Configuration to TestConfiguration
7373d38a31 Update status for Dart2js minified CSP on Chrome with fast startup
61148eade8 Update mixin-declaration feature specification.
a98feb0f01 [VM interpreter] Fix exception handling. Convert bytecode indices to pc offsets when reading bytecode exception tables. Print pc descriptors and exception handlers in bytecode disassembly. Propagate unhandled exceptions after calling interpreter.
da2ed2fd59 Don't ignore runtime cast failures on Map<K,V>.
3d8ca8e566 [gardening] Increase debug app-jitk timeout
0313f7bd66 [gardening] Update status file for failing test
6c39bc38f3 Clear ShadowX references that are not required after compilation.
05b9bbd2b5 Remove the dart1 version of the analysis server snapshot.
9107399190 Add back in the analysis server training.
9fb6c09015 Store reference/type for invalid types.
21db860271 Remove non-strong dart2js builders from test_matrix.json
2e7b0a13f1 Add support for accessing all of the created contexts
73663ae7c6 Allow void on the RHS of null coalescing expressions
17cb6d95d1 Don't remember TypeEnvironment in resolution results.
72960de5f9 [VM] Fix one more place where bound error allocation happened on BG thread in new space
6ad79ff4bd Update status file for tests passing under CFE
23ba527735 [VM] Ensure to alloate bound errors in old space on BG compiler
fe8052428b Remove CONTENT_MODIFIED from spec/test for getSignature
c4c847a45c Revert "[CQ] Remove pkg-linux-release from the CQ trybots until it is fixed"
beaf05efa3 [vm] When generating JITDUMP also dump IR and attach it as source to code.
24158b773d [vm/compiler] Do not LICM LoadStaticField for uninitialized fields.
68bfaf3ac3 [vm/compiler] Avoid crashes when canonicalizing unreachable AssertAssignable.
5a45b2a62b [infra] Upgrade homebrew dependencies to work on Dart 2
8e287dc037 [VM] Only add direct implementor when reading script snapshots if the implemented class is from the full snapshot
6e81d74fcc [VM] Optimize generation of type testing stubs in JIT mode.
058510eeab fix #28233, add hint for missing returns to function expressions
4482d13ff7 [vm/compiler] Bug fix in 64-bit MOD (%) operator.