### PR TITLE
Fix sundry Fuchsia build issues after the tonic/fxl migration.

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -60,6 +60,8 @@ source_set("flow") {
 
   public_configs = [ "$flutter_root:config" ]
 
+  public_deps = []
+
   deps = [
     "$flutter_root/common",
     "$flutter_root/fml",

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -11,6 +11,7 @@
 
 #include "flutter/flow/compositor_context.h"
 #include "flutter/fml/build_config.h"
+#include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/macros.h"
 #include "lib/ui/scenic/cpp/resources.h"

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -60,6 +60,8 @@ source_set("fml") {
     "unique_object.h",
   ]
 
+  public_deps = []
+
   deps = [
     "//third_party/dart/runtime:dart_api",
 
@@ -129,6 +131,8 @@ source_set("fml") {
 
   if (is_fuchsia) {
     sources += [ "platform/fuchsia/paths_fuchsia.cc" ]
+
+    public_deps += [ "//zircon/public/lib/trace-provider" ]
   }
 
   if (is_win) {

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -5,7 +5,9 @@
 #ifndef FLUTTER_FML_TRACE_EVENT_H_
 #define FLUTTER_FML_TRACE_EVENT_H_
 
-#if defined(__Fuchsia__)
+#include "flutter/fml/build_config.h"
+
+#if defined(OS_FUCHSIA)
 
 // Forward to the system tracing mechanism on Fuchsia.
 
@@ -19,13 +21,15 @@
 #define TRACE_EVENT_ASYNC_BEGIN1(a, b, c, d, e) TRACE_ASYNC_BEGIN(a, b, c, d, e)
 #define TRACE_EVENT_ASYNC_END1(a, b, c, d, e) TRACE_ASYNC_END(a, b, c, d, e)
 
-#else  // defined(__Fuchsia__)
+#endif  // defined(OS_FUCHSIA)
 
 #include <cstddef>
 #include <cstdint>
 #include <string>
 
 #include "flutter/fml/macros.h"
+
+#if !defined(OS_FUCHSIA)
 
 #ifndef TRACE_EVENT_HIDE_MACROS
 
@@ -71,6 +75,8 @@
   ::fml::tracing::TraceEventFlowEnd0(category, name, id);
 
 #endif  // TRACE_EVENT_HIDE_MACROS
+
+#endif  // !defined(OS_FUCHSIA)
 
 namespace fml {
 namespace tracing {
@@ -136,7 +142,5 @@ class ScopedInstantEnd {
 
 }  // namespace tracing
 }  // namespace fml
-
-#endif  // defined(__Fuchsia__)
 
 #endif  // FLUTTER_FML_TRACE_EVENT_H_

--- a/lib/ui/compositing/scene_host.h
+++ b/lib/ui/compositing/scene_host.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 
 #if defined(OS_FUCHSIA)

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -14,6 +14,7 @@
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/logging.h"
+#include "flutter/fml/mapping.h"
 #include "flutter/fml/time/time_delta.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/lib/io/dart_io.h"
@@ -155,14 +156,13 @@ Dart_Handle GetVMServiceAssetsArchiveCallback() {
     (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE)
   return nullptr;
 #elif OS_FUCHSIA
-  std::vector<uint8_t> observatory_assets_archive;
-  if (!files::ReadFileToVector("pkg/data/observatory.tar",
-                               &observatory_assets_archive)) {
+  fml::FileMapping mapping("pkg/data/observatory.tar", false /* executable */);
+  if (mapping.GetSize() == 0 || mapping.GetMapping() == nullptr) {
     FML_LOG(ERROR) << "Fail to load Observatory archive";
     return nullptr;
   }
-  return tonic::DartConverter<tonic::Uint8List>::ToDart(
-      observatory_assets_archive.data(), observatory_assets_archive.size());
+  return tonic::DartConverter<tonic::Uint8List>::ToDart(mapping.GetMapping(),
+                                                        mapping.GetSize());
 #else
   return tonic::DartConverter<tonic::Uint8List>::ToDart(
       ::dart::observatory::observatory_assets_archive,


### PR DESCRIPTION
I used `fml::FileMapping` instead of `ReadFilesToVector` as there is no need to port that extra method from FXL for just this one use. Also prevents an unnecessary copy.