### PR TITLE
Add an explicit `-[FlutterViewController init]` implementation

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -84,7 +84,7 @@
   return [self initWithProject:nil nibName:nil bundle:nil];
 }
 
-- (instancetype) init {
+- (instancetype)init {
   return [self initWithProject:nil nibName:nil bundle: nil];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -84,6 +84,10 @@
   return [self initWithProject:nil nibName:nil bundle:nil];
 }
 
+- (instancetype) init {
+  return [self initWithProject:nil nibName:nil bundle: nil];
+}
+
 #pragma mark - Common view controller initialization tasks
 
 - (void)performCommonViewControllerInitialization {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -85,7 +85,7 @@
 }
 
 - (instancetype)init {
-  return [self initWithProject:nil nibName:nil bundle: nil];
+  return [self initWithProject:nil nibName:nil bundle:nil];
 }
 
 #pragma mark - Common view controller initialization tasks


### PR DESCRIPTION
`-[FlutterViewController init]` currently works because it inherits
the `-[UIViewController init]` convenience initializer that invokes
the `-[UIViewController initWithNibName:bundle:]` designated
initializer that `FlutterViewController` overrides.

However, this doesn't seem to be explicitly documented, so it's a bit
confusing (or at least non-obvious), and it seems potentially
brittle.  Add an explicit implementation of `-[FlutterViewController
init]` instead.