### PR TITLE
Roll Dart to b04def964c428ada007cca7ef6b4936001db965d

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '8bad5c7b299ac081cdd30f244268478ee59aef63',
+  'dart_revision': 'b04def964c428ada007cca7ef6b4936001db965d',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/DEPS
+++ b/DEPS
@@ -89,7 +89,7 @@ vars = {
   'dart_stream_channel_tag': '1.6.8',
   'dart_string_scanner_tag': '1.0.3',
   'dart_term_glyph_tag': '1.0.1',
-  'dart_test_reflective_loader_tag': '0.1.4',
+  'dart_test_reflective_loader_tag': '0.1.8',
   'dart_test_tag': '1.0.0',
   'dart_tuple_tag': 'v1.0.1',
   'dart_typed_data_tag': '1.1.6',

--- a/travis/licenses_golden/licenses_third_party
+++ b/travis/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 542be6ee1bab90645d70fda3a0f28f6c
+Signature: ab4c5089f585043ee692012eaf5c8670
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
92ae73b6d8 Fork the remaining subclasses of AbstractAnalysisClass
884536dfaa [vm/kernel/bytecode] Fix bytecode generation for async closures
ae001707b7 [vm/kernel/bytecode] Do not call getter for a static field initialized with double literal
87f753dbd3 Replace some declarations of element with declaredElement
2be2cf2061 Bump analyzer_cli protobuf dep
206f955c43 [vm/compiler] Non-speculative ARM64 long division/remainder.
4bb3fb6cae Don't rewrite error Severity for special cases of front-end testing.
d6189709b8 Issue 33506. Rewrite MethodInvocation into InstanceCreationExpression.
26e087e66b Don't save Tokens in Judgments
4c75b49b3f Clear Token in field builder after use
ea0468dff4 Fork more server tests to run under CFE
841f62715a Clean up some hints from the analyzer code base
c5f933fdf7 [vm/lib] String._identityHashCode should be the same as String.get:hashCode
4fa139b4b8 [vm/compiler] Rework how logical expressions are compiled to IL.
9bb39ccabc [infra] Update checked in SDKs to 2.0.0-dev.69.5
2580bf87ae Fix invalid assert that slipped by in ac8fdb5a
1c2043e3a6 Update service test more to not be different in sync async mode
ac8fdb5a58 Add :controller_stream and call _asyncStarListenHelper
2e98da68f9 Call _asyncStarMoveNextHelper in kernel
cb5513fbc9 Make a single clear CHANGELOG entry for all 2.0.0 changes.
d3df394870 Add -O flag and documentation.
3f1bb85f17 [vm/kernel/bytecode] Do not generate InstantiateType for instantiated generic function types
c5ac5c0a2c [vm/kernel/bytecode] Fix serialization of closures with type arguments
ff0327be67 [vm] Streamline passing of ICData through compilation pipeline
012766901e Status file two flaky pkg bot tests.
6a6e7abfc6 Clean up some warnings in the server code base
e578b60899 Bump the analysis driver cache seed.
f169ebf418 Fork several server tests to run under CFE
b1c9b67b68 Add initial content for the analyzer --use-cfe builders.
373ed6b47f Create a LineInfo when resynthesizing a CompilationUnitElement
2a23bc2e0b Update named configurations on builders, turn off checking temporarily.
32851e157f Add support for running some non-integration tests in server using the CFE
0fd93a5c6e Test.dart exits with non-zero exit code if named configuration disagrees with flags.
804fc2add3 [VM runtime] Consider partial instantiation when printing closures (fixes #34034). Add regression test.
c3b7f29d46 Change a pair of negative tests to multitests
f10b4005cd Code to load a named configuration and check it against the existing options.
695476f115 Status file after 03df8b1
7413644de8 Change builder names from -ff- to -firefox-
0c187585c5 Added return-void-2-dynamic to whitelist of generalized-void.md
6920d6b11e Added specification of generated nSM forwarders for private methods
03df8b1eb8 Change a few language_2 tests to comply with reality
cf77a3b00f [Test.dart] Use Compiler, Runtime, etc. classes from pkg:smith.
55880dfeed Add support in the new API for CFE
4b07df24dd Store invalid deferred types used in bodies.
89cfa2edd7 Update package:test_reflective_loader.