### PR TITLE
Flush all embedded Android views on hot restart.

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -103,6 +103,7 @@ bool Engine::Restart(RunConfiguration configuration) {
   }
   runtime_controller_ = runtime_controller_->Clone();
   UpdateAssetManager(nullptr);
+  delegate_.OnEngineRestart();
   return Run(std::move(configuration));
 }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -101,9 +101,9 @@ bool Engine::Restart(RunConfiguration configuration) {
     FML_LOG(ERROR) << "Engine run configuration was invalid.";
     return false;
   }
+  delegate_.OnPreEngineRestart();
   runtime_controller_ = runtime_controller_->Clone();
   UpdateAssetManager(nullptr);
-  delegate_.OnEngineRestart();
   return Run(std::move(configuration));
 }
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -40,7 +40,7 @@ class Engine final : public blink::RuntimeDelegate {
         const Engine& engine,
         fml::RefPtr<blink::PlatformMessage> message) = 0;
 
-    virtual void OnEngineRestart() = 0;
+    virtual void OnPreEngineRestart() = 0;
   };
 
   Engine(Delegate& delegate,

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -39,6 +39,8 @@ class Engine final : public blink::RuntimeDelegate {
     virtual void OnEngineHandlePlatformMessage(
         const Engine& engine,
         fml::RefPtr<blink::PlatformMessage> message) = 0;
+
+    virtual void OnEngineRestart() = 0;
   };
 
   Engine(Delegate& delegate,

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -88,6 +88,8 @@ void PlatformView::HandlePlatformMessage(
     response->CompleteEmpty();
 }
 
+void PlatformView::OnEngineRestart() const {}
+
 void PlatformView::RegisterTexture(std::shared_ptr<flow::Texture> texture) {
   delegate_.OnPlatformViewRegisterTexture(*this, std::move(texture));
 }

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -88,7 +88,7 @@ void PlatformView::HandlePlatformMessage(
     response->CompleteEmpty();
 }
 
-void PlatformView::OnEngineRestart() const {}
+void PlatformView::OnPreEngineRestart() const {}
 
 void PlatformView::RegisterTexture(std::shared_ptr<flow::Texture> texture) {
   delegate_.OnPlatformViewRegisterTexture(*this, std::move(texture));

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -108,7 +108,7 @@ class PlatformView {
   virtual void HandlePlatformMessage(
       fml::RefPtr<blink::PlatformMessage> message);
 
-  virtual void OnEngineRestart() const;
+  virtual void OnPreEngineRestart() const;
 
   void SetNextFrameCallback(fml::closure closure);
 

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -108,6 +108,8 @@ class PlatformView {
   virtual void HandlePlatformMessage(
       fml::RefPtr<blink::PlatformMessage> message);
 
+  virtual void OnEngineRestart() const;
+
   void SetNextFrameCallback(fml::closure closure);
 
   void DispatchPointerDataPacket(

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -741,7 +741,7 @@ void Shell::OnEngineHandlePlatformMessage(
 }
 
 // |shell::Engine::Delegate|
-void Shell::OnEngineRestart() {
+void Shell::OnPreEngineRestart() {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
@@ -750,7 +750,7 @@ void Shell::OnEngineRestart() {
       task_runners_.GetPlatformTaskRunner(),
       [view = platform_view_->GetWeakPtr(), &latch]() {
         if (view) {
-          view->OnEngineRestart();
+          view->OnPreEngineRestart();
         }
         latch.Signal();
       });

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -740,6 +740,21 @@ void Shell::OnEngineHandlePlatformMessage(
       });
 }
 
+// |shell::Engine::Delegate|
+void Shell::OnEngineRestart() {
+  fml::AutoResetWaitableEvent latch;
+  task_runners_.GetPlatformTaskRunner()->PostTask(
+      [view = platform_view_->GetWeakPtr(), &latch] {
+        if (view) {
+          view->OnEngineRestart();
+        }
+        latch.Signal();
+      });
+  // This is blocking as any embedded platform views has to be flushed before
+  // we re-run the Dart code.
+  latch.Wait();
+}
+
 // |blink::ServiceProtocol::Handler|
 fml::RefPtr<fml::TaskRunner> Shell::GetServiceProtocolHandlerTaskRunner(
     fml::StringView method) const {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -742,9 +742,13 @@ void Shell::OnEngineHandlePlatformMessage(
 
 // |shell::Engine::Delegate|
 void Shell::OnEngineRestart() {
+  FML_DCHECK(is_setup_);
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
+
   fml::AutoResetWaitableEvent latch;
-  task_runners_.GetPlatformTaskRunner()->PostTask(
-      [view = platform_view_->GetWeakPtr(), &latch] {
+  fml::TaskRunner::RunNowOrPostTask(
+      task_runners_.GetPlatformTaskRunner(),
+      [view = platform_view_->GetWeakPtr(), &latch]() {
         if (view) {
           view->OnEngineRestart();
         }

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -196,7 +196,7 @@ class Shell final : public PlatformView::Delegate,
       fml::RefPtr<blink::PlatformMessage> message) override;
 
   // |shell::Engine::Delegate|
-  void OnEngineRestart() override;
+  void OnPreEngineRestart() override;
 
   // |blink::ServiceProtocol::Handler|
   fml::RefPtr<fml::TaskRunner> GetServiceProtocolHandlerTaskRunner(

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -195,6 +195,9 @@ class Shell final : public PlatformView::Delegate,
       const Engine& engine,
       fml::RefPtr<blink::PlatformMessage> message) override;
 
+  // |shell::Engine::Delegate|
+  void OnEngineRestart() override;
+
   // |blink::ServiceProtocol::Handler|
   fml::RefPtr<fml::TaskRunner> GetServiceProtocolHandlerTaskRunner(
       fml::StringView method) const override;

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -82,6 +82,10 @@ public class FlutterPluginRegistry
         mActivity = null;
     }
 
+    public void onEngineRestart() {
+        mPlatformViewsController.onEngineRestart();
+    }
+
     private class FlutterRegistrar implements Registrar {
         private final String pluginKey;
 

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -82,8 +82,8 @@ public class FlutterPluginRegistry
         mActivity = null;
     }
 
-    public void onEngineRestart() {
-        mPlatformViewsController.onEngineRestart();
+    public void onPreEngineRestart() {
+        mPlatformViewsController.onPreEngineRestart();
     }
 
     private class FlutterRegistrar implements Registrar {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -69,10 +69,11 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
     }
 
     public void onFlutterViewDestroyed() {
-        for (VirtualDisplayController controller : vdControllers.values()) {
-            controller.dispose();
-        }
-        vdControllers.clear();
+        flushAllViews();
+    }
+
+    public void onEngineRestart() {
+        flushAllViews();
     }
 
     @Override
@@ -297,4 +298,10 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
         return (int) Math.round(logicalPixels * density);
     }
 
+    private void flushAllViews() {
+        for (VirtualDisplayController controller : vdControllers.values()) {
+            controller.dispose();
+        }
+        vdControllers.clear();
+    }
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -72,7 +72,7 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
         flushAllViews();
     }
 
-    public void onEngineRestart() {
+    public void onPreEngineRestart() {
         flushAllViews();
     }
 

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -198,6 +198,14 @@ public class FlutterNativeView implements BinaryMessenger {
         mFlutterView.onFirstFrame();
     }
 
+    // Called by native to notify when the engine is restarted (cold reload).
+    @SuppressWarnings("unused")
+    private void onEngineRestart() {
+        if (mPluginRegistry == null)
+            return;
+        mPluginRegistry.onEngineRestart();
+    }
+
     private static native long nativeAttach(FlutterNativeView view);
     private static native void nativeDestroy(long nativePlatformViewAndroid);
     private static native void nativeDetach(long nativePlatformViewAndroid);

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -200,10 +200,10 @@ public class FlutterNativeView implements BinaryMessenger {
 
     // Called by native to notify when the engine is restarted (cold reload).
     @SuppressWarnings("unused")
-    private void onEngineRestart() {
+    private void onPreEngineRestart() {
         if (mPluginRegistry == null)
             return;
-        mPluginRegistry.onEngineRestart();
+        mPluginRegistry.onPreEngineRestart();
     }
 
     private static native long nativeAttach(FlutterNativeView view);

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -158,14 +158,14 @@ void PlatformViewAndroid::HandlePlatformMessage(
 }
 
 // |shell::PlatformView|
-void PlatformViewAndroid::OnEngineRestart() const {
+void PlatformViewAndroid::OnPreEngineRestart() const {
   JNIEnv* env = fml::jni::AttachCurrentThread();
   fml::jni::ScopedJavaLocalRef<jobject> view = java_object_.get(env);
   if (view.is_null()) {
     // The Java object died.
     return;
   }
-  FlutterViewOnEngineRestart(fml::jni::AttachCurrentThread(), view.obj());
+  FlutterViewOnPreEngineRestart(fml::jni::AttachCurrentThread(), view.obj());
 }
 
 void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -157,6 +157,17 @@ void PlatformViewAndroid::HandlePlatformMessage(
   }
 }
 
+// |shell::PlatformView|
+void PlatformViewAndroid::OnEngineRestart() const {
+  JNIEnv* env = fml::jni::AttachCurrentThread();
+  fml::jni::ScopedJavaLocalRef<jobject> view = java_object_.get(env);
+  if (view.is_null()) {
+    // The Java object died.
+    return;
+  }
+  FlutterViewOnEngineRestart(fml::jni::AttachCurrentThread(), view.obj());
+}
+
 void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
                                                   jint id,
                                                   jint action,

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -84,7 +84,7 @@ class PlatformViewAndroid final : public PlatformView {
       fml::RefPtr<blink::PlatformMessage> message) override;
 
   // |shell::PlatformView|
-  void OnEngineRestart() const override;
+  void OnPreEngineRestart() const override;
 
   // |shell::PlatformView|
   std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -84,6 +84,9 @@ class PlatformViewAndroid final : public PlatformView {
       fml::RefPtr<blink::PlatformMessage> message) override;
 
   // |shell::PlatformView|
+  void OnEngineRestart() const override;
+
+  // |shell::PlatformView|
   std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
 
   // |shell::PlatformView|

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -96,6 +96,12 @@ void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj) {
   FML_CHECK(CheckException(env));
 }
 
+static jmethodID g_on_engine_restart_method = nullptr;
+void FlutterViewOnEngineRestart(JNIEnv* env, jobject obj) {
+  env->CallVoidMethod(obj, g_on_engine_restart_method);
+  FML_CHECK(CheckException(env));
+}
+
 static jmethodID g_attach_to_gl_context_method = nullptr;
 void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jint textureId) {
   env->CallVoidMethod(obj, g_attach_to_gl_context_method, textureId);
@@ -695,6 +701,13 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
                                              "onFirstFrame", "()V");
 
   if (g_on_first_frame_method == nullptr) {
+    return false;
+  }
+
+  g_on_engine_restart_method = env->GetMethodID(
+      g_flutter_native_view_class->obj(), "onEngineRestart", "()V");
+
+  if (g_on_engine_restart_method == nullptr) {
     return false;
   }
 

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -97,7 +97,7 @@ void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj) {
 }
 
 static jmethodID g_on_engine_restart_method = nullptr;
-void FlutterViewOnEngineRestart(JNIEnv* env, jobject obj) {
+void FlutterViewOnPreEngineRestart(JNIEnv* env, jobject obj) {
   env->CallVoidMethod(obj, g_on_engine_restart_method);
   FML_CHECK(CheckException(env));
 }
@@ -705,7 +705,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
   }
 
   g_on_engine_restart_method = env->GetMethodID(
-      g_flutter_native_view_class->obj(), "onEngineRestart", "()V");
+      g_flutter_native_view_class->obj(), "onPreEngineRestart", "()V");
 
   if (g_on_engine_restart_method == nullptr) {
     return false;

--- a/shell/platform/android/platform_view_android_jni.h
+++ b/shell/platform/android/platform_view_android_jni.h
@@ -34,7 +34,7 @@ void FlutterViewUpdateCustomAccessibilityActions(JNIEnv* env,
 
 void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj);
 
-void FlutterViewOnEngineRestart(JNIEnv* env, jobject obj);
+void FlutterViewOnPreEngineRestart(JNIEnv* env, jobject obj);
 
 void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jint textureId);
 

--- a/shell/platform/android/platform_view_android_jni.h
+++ b/shell/platform/android/platform_view_android_jni.h
@@ -34,6 +34,8 @@ void FlutterViewUpdateCustomAccessibilityActions(JNIEnv* env,
 
 void FlutterViewOnFirstFrame(JNIEnv* env, jobject obj);
 
+void FlutterViewOnEngineRestart(JNIEnv* env, jobject obj);
+
 void SurfaceTextureAttachToGLContext(JNIEnv* env, jobject obj, jint textureId);
 
 void SurfaceTextureUpdateTexImage(JNIEnv* env, jobject obj);


### PR DESCRIPTION
Adds an OnEngineRestarted method to PlatformView, this is currently only
implemented for Android where we need to use it for embedded views.

Fixes flutter/flutter#19576