### PR TITLE
Don't drop MotionEvents with unknown tool type.

### DIFF
--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -49,6 +49,9 @@ enum PointerDeviceKind {
 
   /// A pointer device with a stylus that has been inverted.
   invertedStylus,
+
+  /// An unknown pointer device.
+  unknown
 }
 
 /// Information about the state of a pointer.

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -382,6 +382,7 @@ public class FlutterView extends SurfaceView
     private static final int kPointerDeviceKindMouse = 1;
     private static final int kPointerDeviceKindStylus = 2;
     private static final int kPointerDeviceKindInvertedStylus = 3;
+    private static final int kPointerDeviceKindUnknown = 4;
 
     private int getPointerChangeForAction(int maskedAction) {
         // Primary pointer:
@@ -416,9 +417,11 @@ public class FlutterView extends SurfaceView
             return kPointerDeviceKindStylus;
         case MotionEvent.TOOL_TYPE_MOUSE:
             return kPointerDeviceKindMouse;
+        case MotionEvent.TOOL_TYPE_ERASER:
+            return kPointerDeviceKindInvertedStylus;
         default:
             // MotionEvent.TOOL_TYPE_UNKNOWN will reach here.
-            return -1;
+            return kPointerDeviceKindUnknown;
         }
     }
 
@@ -429,9 +432,6 @@ public class FlutterView extends SurfaceView
         }
 
         int pointerKind = getPointerDeviceTypeForToolType(event.getToolType(pointerIndex));
-        if (pointerKind == -1) {
-            return;
-        }
 
         long timeStamp = event.getEventTime() * 1000; // Convert from milliseconds to microseconds.
 


### PR DESCRIPTION
Instead, send them with the new unknown PointerDeviceKind.

We hit this when running `adb shell input tap` in tests which sends events with
an unknown tool type.

This also fills in a missing conversion for TOOL_TYPE_ERASER.