### PR TITLE
Call drawPaint instead of drawPath if there's clip

### DIFF
--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -87,10 +87,6 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
                SkColorGetA(color_) != 0xff, device_pixel_ratio_);
   }
 
-  SkPaint paint;
-  paint.setColor(color_);
-  context.canvas.drawPath(path_, paint);
-
   int saveCount = context.canvas.save();
   switch (clip_behavior_) {
     case Clip::hardEdge:
@@ -105,6 +101,18 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
       break;
     case Clip::none:
       break;
+  }
+
+  SkPaint paint;
+  paint.setColor(color_);
+  if (clip_behavior_ == Clip::none) {
+    context.canvas.drawPath(path_, paint);
+  } else {
+    // If we want to avoid the bleeding edge artifact
+    // (https://github.com/flutter/flutter/issues/18057#issue-328003931)
+    // using saveLayer, we have to call drawPaint instead of drawPath as
+    // anti-aliased drawPath will always have such artifacts.
+    context.canvas.drawPaint(paint);
   }
 
   PaintChildren(context);


### PR DESCRIPTION
If we want to avoid the bleeding edge artifact (https://github.com/flutter/flutter/issues/18057#issue-328003931) using saveLayer, we have to call drawPaint instead of drawPath as anti-aliased drawPath will always have such artifacts.

This is discovered when I try to add golden tests for such bleeding artifacts using our new Clip enum.