### PR TITLE
Roll Dart to 17b54c76ce9b945c6f013ad08c19268409c0694a

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'b04def964c428ada007cca7ef6b4936001db965d',
+  'dart_revision': '17b54c76ce9b945c6f013ad08c19268409c0694a',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: ab4c5089f585043ee692012eaf5c8670
+Signature: 900a294928de496c68d8b2df730a14a2
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
dart-lang/sdk@17b54c7 Improve error detection in search code
dart-lang/sdk@0ac1178 Initial stress test for code completion
dart-lang/sdk@e0f6fdf Refactor testing:TestConfiguration to use smith:Configuration by inclusion.
dart-lang/sdk@95d1ebd Fix one cause of timeouts in tests
dart-lang/sdk@72b2542 Mark tests with Dart 1 constants in const context failing in all configs.
dart-lang/sdk@42b02e0 Add more test steps to the analyzer --use-cfe bots.
dart-lang/sdk@8bec83b Add the analyzer-use-cfe-linux bot to the commit queue.
dart-lang/sdk@315216e [dart2js] Avoid collision with getInterceptor.
dart-lang/sdk@f02d4d4 Fix bad merge
dart-lang/sdk@1a83245 Triage language tests for void
dart-lang/sdk@35a982b [VM kernel] Add missing type parameter finalization in type reader.
dart-lang/sdk@09a8660 fix typo
dart-lang/sdk@8cbbd7a [VM interpreter] Use write barrier in implicit setter.
dart-lang/sdk@91caf82 Do self-interceptor optimization on a per-use basis
dart-lang/sdk@8df84c0 Store resolution for out of range integer literals.
dart-lang/sdk@bfa890d [vm/compiler] Various 64-bit operator improvements.
dart-lang/sdk@92a7094 Fix three missing return warnings.
dart-lang/sdk@1babc13 [vm/kernel/bytecode] Report compile-time errors from constant evaluation while generating bytecode
dart-lang/sdk@8114ecb Fix tests after fixing constant fields with CFE.
dart-lang/sdk@85edb76 Fix field constants verifying with CFE.
dart-lang/sdk@8692936 Verify constants using Analyzer.
dart-lang/sdk@b83072c Clean up use of callFailingTest
dart-lang/sdk@8d3d82a [vm/kernel] Untangle the spaghetti-code in BuildGraphOfFunction and fix bugs.
dart-lang/sdk@368bcc4 Add parse dartdoc tests for fasta parser
dart-lang/sdk@cda3659 [fasta] Handle annotations on formals of typedefs
dart-lang/sdk@46743f3 Remove $runtime == drt sections and uses of drt from status files.
dart-lang/sdk@637e55d [kernel] Add VariableDeclarations to represent formals of Typedefs
dart-lang/sdk@4c455e7 [VM] During hot-reload check if .packages was modified, tell IKG to re-load it if so
dart-lang/sdk@5a259ac De-flake the analysis server integration tests.
dart-lang/sdk@380696f Set element/type for some resynthesized expressions.
dart-lang/sdk@4ab8408 [vm/kernel/bytecode] Support partial tear-off instantiation constants in bytecode generator and bytecode reader
dart-lang/sdk@62a2752 Translate ConstructorElement(s) of parameterized InterfaceType(s) to ConstructorMember(s).
dart-lang/sdk@a19a468 Revise CHANGELOG.
dart-lang/sdk@91c6130 CHANGELOG copyedits
dart-lang/sdk@5f4c617 Fix typo in CHANGELOG.md
dart-lang/sdk@5313553 Run the analysis server 'analysis-server-cold' with --use-cfe.
dart-lang/sdk@758e5ea Use '=' for default values of named parameters.
dart-lang/sdk@f625490 Attempt to fix failures on the windows bot
dart-lang/sdk@bbfc465 Cleaned up a few entries in the CHANGELOG
dart-lang/sdk@e402732 Improve documentation of the -O flag
