### PR TITLE
Revert "Roll Dart to 17b54c76ce9b945c6f013ad08c19268409c0694a"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '17b54c76ce9b945c6f013ad08c19268409c0694a',
+  'dart_revision': 'b04def964c428ada007cca7ef6b4936001db965d',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 900a294928de496c68d8b2df730a14a2
+Signature: ab4c5089f585043ee692012eaf5c8670
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Reverts flutter/engine#5955

Dart roll is reverted as the engine is not in a buildable state (Linux bot fails due to previous change).
While the problem is not related to this change, it prevents us from rolling engine before and after the Dart roll and get clear benchmarking results.