### PR TITLE
libtxt: truncate paragraph width to an integer in order to match Blink's behavior

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -417,7 +417,7 @@ void Paragraph::Layout(double width, bool force) {
   }
   needs_layout_ = false;
 
-  width_ = width;
+  width_ = floor(width);
 
   if (!ComputeLineBreaks())
     return;


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/18665