### PR TITLE
Match iOS text affinity to Android

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -589,7 +589,7 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 }
 
 - (void)insertText:(NSString*)text {
-  _selectionAffinity = _kTextAffinityUpstream;
+  _selectionAffinity = _kTextAffinityDownstream;
   [self replaceRange:_selectedTextRange withText:text];
 }
 


### PR DESCRIPTION
Currently, Android always responds to text editing by setting the text affinity to downstream. Flutter can change the affinity to upstream if it needs to. 

The iOS text input sets editing text to an upstream affinity, so newlines don't move the cursor initially. Fixed by setting to always return downstream.

Fixes https://github.com/flutter/flutter/issues/20293