### PR TITLE
Add a delay to Animator::BeginFrame's NotifyIdle call

### DIFF
--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -75,6 +75,7 @@ class Animator final {
   bool paused_;
   bool regenerate_layer_tree_;
   bool frame_scheduled_;
+  int notify_idle_task_id_;
   bool dimension_change_pending_;
   SkISize last_layer_tree_size_;
 


### PR DESCRIPTION
This change adds a delay before Animator::BeginFrame calls its
delegate's OnAnimatorNotifyIdle.  This is because under certain
workloads, such as our parent view resizing us, which is communicated
via viewport change events, we won't have a frame scheduled yet in the
animator, despite the fact that we will go on to schedule a frame once
the viewport event arrives.

In Fuchsia's resizing performance test, on our reference high end x86-64
hardware, the previous logic was resulting in a ~45ms garbage collection
right after the first frame of an animation.