### PR TITLE
Roll Dart to version eab492385c3f345cb2f44f3b702b0e30e4a9c107

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '1ac34f151363958a11bb2997611acc2a1d54ed01',
+  'dart_revision': 'eab492385c3f345cb2f44f3b702b0e30e4a9c107',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 7cd085644530226184f2303275192384
+Signature: e451900a1345f7d287e1032e5a26dac9
 
 UNUSED LICENSES:
 
@@ -4748,9 +4748,9 @@ FILE: ../../../third_party/dart/runtime/vm/heap/heap.h
 FILE: ../../../third_party/dart/runtime/vm/heap/heap_test.cc
 FILE: ../../../third_party/dart/runtime/vm/heap/pages.cc
 FILE: ../../../third_party/dart/runtime/vm/heap/pages_test.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/pointer_block.cc
+FILE: ../../../third_party/dart/runtime/vm/heap/pointer_block.h
 FILE: ../../../third_party/dart/runtime/vm/heap/scavenger.h
-FILE: ../../../third_party/dart/runtime/vm/heap/store_buffer.cc
-FILE: ../../../third_party/dart/runtime/vm/heap/store_buffer.h
 FILE: ../../../third_party/dart/runtime/vm/heap/verifier.cc
 FILE: ../../../third_party/dart/runtime/vm/instructions_ia32.cc
 FILE: ../../../third_party/dart/runtime/vm/instructions_ia32.h
@@ -5827,7 +5827,6 @@ FILE: ../../../third_party/dart/runtime/lib/stacktrace.dart
 FILE: ../../../third_party/dart/runtime/lib/symbol_patch.dart
 FILE: ../../../third_party/dart/runtime/lib/timer_impl.dart
 FILE: ../../../third_party/dart/runtime/lib/typed_data.cc
-FILE: ../../../third_party/dart/runtime/lib/typed_data_patch.dart
 FILE: ../../../third_party/dart/runtime/lib/uri.cc
 FILE: ../../../third_party/dart/runtime/lib/uri_patch.dart
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/application.dart
@@ -16654,6 +16653,50 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: tonic
+ORIGIN: ../../../garnet/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/tonic/dart_list.cc
+FILE: ../../../third_party/tonic/dart_list.h
+FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
+FILE: ../../../third_party/tonic/platform/platform_utils.h
+FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
+FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2017 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: tonic
 ORIGIN: ../../../third_party/tonic/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/tonic/common/build_config.h
@@ -16721,50 +16764,6 @@ TYPE: LicenseType.bsd
 FILE: ../../../third_party/tonic/common/macros.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2018 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc + ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/dart_list.cc
-FILE: ../../../third_party/tonic/dart_list.h
-FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
-FILE: ../../../third_party/tonic/platform/platform_utils.h
-FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
-FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Includes the following changes:

eab492385c Updates for passing / failing analysis_server tests.
235ccc9374 Remove --checked from dart --help
77d6758afb Attempt to fix failing tests on the windows bots
a2b052939e [vm] Add timeline events for GC phases.
9e9adcef57 [observatory] Include observatory main.dart.js.map with debug build.
7eda513405 [infra] Add new vm-kernel-precomp builders to the test matrix
83aa463fac Enable a few more server tests under CFE
75f92ac8fe Point old super mixin informal spec to canonical copy
5dd2aca7fe [kernel] Fix non-deterministic output generation
85d85246ad [vm/kernel/bytecode] Revise access to instance fields in bytecode
af45552aa5 [gen_snapshot] Remove --print_dependencies and --dependencies_only.
34f17b2973 [VM] Add missing 6-type-test to subtypecache search in simdbc (it has it in 2 places)
19a90c2c8b More CFE tests for server
6879e4cedc Add completion contributor tests for CFE
6137511849 Add more CFE tests for server
1cd9175e3e Fix mixed dartdoc processing
575a8f8381 [VM] Extend subtype-test mechanism with support for generic methods
278d962a7f [vm/precomp] Update status files for Dart 1 AOT.
35d26c9b14 Always use relative paths to import from within the front end
84d8887d3f Fixes a minor typo in the documentation of the StreamTransformer class.
1b6992b915 [dart2js] Mark failing unit tests as RuntimeError to fix CQ (#34095)
9b5a4241de [vm, gc] Don't rebuild the remembered set during marking.
c712470bb9 dart2js status bingo
dac348c8c9 [observatory] Only run field guards test if it is enabled in the vm.
4d156f9fb0 [dart2js] Fix function_type GVN bug
4196c0e2f5 Fix dart2js/sourcemaps/minified_names_test
8c059e7a34 Update language_2 status file for kernel bytecode passing tests.
ac69a3041a [vm, gc] Rename store_buffer.h as pointer_block.h as it also defines the mark stack blocks.
9510738c62 dart2js status update
6bdf3b7ed6 [observatory] Fix _guardLength serialization to output a string, rather than an int.
1f4449658d Refactor dartdoc parsing
0fbe9d3a95 [dart2js] Dynamically generated tear-off constructors should have names
cb4f5b3a3a Resynthesize nameOffset for properties/parameters.
69f216d4f1 Fix mock SDK and Flutter to pass some Flutter tests.
c619413fef Fix for unawaited future in assists.
66693ea6e2 [VM runtime] For now, do not use field guards when using kernel bytecode.
31765bf56f Clean up some hints in server code
c30af508a4 Store import prefix offset into metadata and resynthesize.
c439ebead0 [vm, gc] Update old allocation stats when scanning instead of pushing.
d933d4aa39 Update tests for const constructors in subclasses of mixin applications
b570ea1ff1 status update to make dart2js run function_type/ tests
9767af2550 [vm/precomp] Support @pragma for fields and remove associated entry-point entries.
80e08e0913 Use 'useCFE' flag to turn on CFE in AnalysisDriver.
98cf15cf5b Remove unnecessary commentToken parameter
89fd468b89 remove unused DocumentationCommentToken.references field
49b18446c2 Refactor dartdoc parsing
bc8a8386af Fix tests that reference the flutter package
de408202a5 [vm/precomp] Take 4 for procedure- and class-entrypoints.