### PR TITLE
Removed callback for HeadlessDartRunner

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterHeadlessDartRunner.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterHeadlessDartRunner.h
@@ -45,12 +45,8 @@ FLUTTER_EXPORT
 
  - Parameter entrypoint: The name of a top-level function from a Dart library.
  - Parameter uri: The URI of the Dart library which contains entrypoint.
- - Parameter callback: The callback to be invoked when the new Isolate is
-   invoked.
 */
-- (void)runWithEntrypointAndCallback:(NSString*)entrypoint
-                          libraryUri:(NSString*)uri
-                          completion:(FlutterHeadlessDartRunnerCallback)callback;
+- (void)runWithEntrypointAndLibraryUri:(NSString*)entrypoint libraryUri:(NSString*)uri;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterHeadlessDartRunner.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterHeadlessDartRunner.mm
@@ -47,9 +47,7 @@ static std::string CreateShellLabel() {
   std::unique_ptr<shell::Shell> _shell;
 }
 
-- (void)runWithEntrypointAndCallback:(NSString*)entrypoint
-                          libraryUri:(NSString*)uri
-                          completion:(FlutterHeadlessDartRunnerCallback)callback {
+- (void)runWithEntrypointAndLibraryUri:(NSString*)entrypoint libraryUri:(NSString*)uri {
   if (_shell != nullptr || entrypoint.length == 0) {
     FML_LOG(ERROR) << "This headless dart runner was already used to run some code.";
     return;
@@ -100,8 +98,7 @@ static std::string CreateShellLabel() {
 
   // Override the default run configuration with the specified entrypoint.
   _shell->GetTaskRunners().GetUITaskRunner()->PostTask(
-      fml::MakeCopyable([engine = _shell->GetEngine(), config = std::move(config),
-                         callback = Block_copy(callback)]() mutable {
+      fml::MakeCopyable([engine = _shell->GetEngine(), config = std::move(config)]() mutable {
         BOOL success = NO;
         FML_LOG(INFO) << "Attempting to launch background engine configuration...";
         if (!engine || !engine->Run(std::move(config))) {
@@ -109,10 +106,6 @@ static std::string CreateShellLabel() {
         } else {
           FML_LOG(INFO) << "Background Isolate successfully started and run.";
           success = YES;
-        }
-        if (callback != nil) {
-          callback(success);
-          Block_release(callback);
         }
       }));
 }


### PR DESCRIPTION
This is to be somewhat consistent with the Android interface where we decided against having a callback for when the created by a background shell is entered.