### PR TITLE
Roll Dart to version 1be785ae2ddb1754a184cd638ab719e94d86b4e9

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'eab492385c3f345cb2f44f3b702b0e30e4a9c107',
+  'dart_revision': '1be785ae2ddb1754a184cd638ab719e94d86b4e9',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',
@@ -73,7 +73,7 @@ vars = {
   'dart_plugin_tag': 'f5b4b0e32d1406d62daccea030ba6457d14b1c47',
   'dart_pool_tag': '1.3.6',
   'dart_protobuf_tag': '0.9.0',
-  'dart_pub_rev': '58fe996eab8d54f28f5109c407ff0ab62fbd835d',
+  'dart_pub_rev': '5962908a66e814dd78f6856a4e5f792c6db65fbc',
   'dart_pub_semver_tag': '1.4.2',
   'dart_quiver_tag': '0.29.0+2',
   'dart_resource_rev': '2.1.5',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: e451900a1345f7d287e1032e5a26dac9
+Signature: 350887638dbf5cdb4d0e1879ddb0cf33
 
 UNUSED LICENSES:
 
@@ -5827,6 +5827,7 @@ FILE: ../../../third_party/dart/runtime/lib/stacktrace.dart
 FILE: ../../../third_party/dart/runtime/lib/symbol_patch.dart
 FILE: ../../../third_party/dart/runtime/lib/timer_impl.dart
 FILE: ../../../third_party/dart/runtime/lib/typed_data.cc
+FILE: ../../../third_party/dart/runtime/lib/typed_data_patch.dart
 FILE: ../../../third_party/dart/runtime/lib/uri.cc
 FILE: ../../../third_party/dart/runtime/lib/uri_patch.dart
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/app/application.dart

--- a/lib/ui/plugins/callback_cache.cc
+++ b/lib/ui/plugins/callback_cache.cc
@@ -169,7 +169,7 @@ Dart_Handle DartCallbackCache::LookupDartClosure(
 
   Dart_Handle closure;
   if (Dart_IsNull(cls_name)) {
-    closure = Dart_GetClosure(library, closure_name);
+    closure = Dart_GetField(library, closure_name);
   } else {
     Dart_Handle cls = Dart_GetClass(library, cls_name);
     DART_CHECK_VALID(cls);

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -463,7 +463,7 @@ bool DartIsolate::Run(const std::string& entrypoint_name) {
 
   tonic::DartState::Scope scope(this);
 
-  Dart_Handle entrypoint = Dart_GetClosure(
+  Dart_Handle entrypoint = Dart_GetField(
       Dart_RootLibrary(), tonic::ToDart(entrypoint_name.c_str()));
   if (tonic::LogIfError(entrypoint)) {
     return false;
@@ -506,7 +506,7 @@ bool DartIsolate::RunFromLibrary(const std::string& library_name,
   }
 
   Dart_Handle entrypoint =
-      Dart_GetClosure(library, tonic::ToDart(entrypoint_name.c_str()));
+      Dart_GetField(library, tonic::ToDart(entrypoint_name.c_str()));
   if (tonic::LogIfError(entrypoint)) {
     return false;
   }


### PR DESCRIPTION
This rolls includes the following changes :

1be785ae2d Clean up some dead code
7b9fb893d2 [vm] Add a service method for 'invoke' as the dual to 'eval'.
099f1504fa Mention -O flag in CHANGELOG
79f69abace [vm/compiler] breakage fix: add missing break
96a1e9985f Fix the pkg bot
7818db20a7 Add analysis hint for invalid use of @visibleForTemplate code.
71d96019d1 [vm/compiler] Introduce 64-bit NEGATE - all archs.
5013a2ccc4 Remove spurious line.
ef2f777625 Mark some analyzer tests as being flaky
cf560fe17b Fix a couple of the tests failing on the analyzer with fasta parser bot
63c11693e6 [gardening] Fix language_2/type_variable_promotion_test.
d0f28884ff [VM] Fix expression evaluation implementation: Never register temporary/unused classes with the system.
e2a1807fc2 [gardening] Update status for io/compile_all_test in PRODUCT AOT mode
f7ff739448 Insert date of 2.0.0 release in Changelog
bcabad6014 [vm] Fix SIMARM64 build on Windows.
af02ccae83 [infra] Fix filesets for new vm-kernel-precomp builders
8e2f28e264 Update homebrew to drop the @2 tab and fix for 2.0
ba119d7292 [VM] Remove "$compiler == precompiler" sections from language_2_precompiler.status
f3a2c0e28f [release] Prepare changelog for 2.1.0-dev.0.0
88cba7d860 [vm/kernel/bytecode] Fix arguments descriptor for List._fromLiteral call in bytecode
bd45ec0c4b [vm, gc] Refactor PageSpace::CollectGarbage to ensure the safepoint and task count remain well-scoped even with early exits.
8195fd8c64 Repair dart2js/string_interpolation_test
a0b335ac6c Try no implicit casts in pkg/analyzer_cli.
3d25d3761b Update pub - leave packages directories alone
327db5e9ab [vm] Fix kernel_isolate use_field_guard flag for kbc
a1ca88f554 Resolve invocation arguments to parameters.