### PR TITLE
Don't require `FLTLibraryPath` and `FLTAssetsPath` from the main `NSBundle`

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -43,6 +43,12 @@ FLUTTER_EXPORT
  */
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package;
 
+/**
+ Returns the default identifier for the bundle where we expect to find the Flutter Dart
+ application.
+ */
++ (NSString*)defaultBundleIdentifier;
+
 @end
 
 #endif  // FLUTTER_FLUTTERDARTPROJECT_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -19,10 +19,21 @@ static const char* kScriptSnapshotFileName = "snapshot_blob.bin";
 static const char* kVMKernelSnapshotFileName = "platform.dill";
 static const char* kApplicationKernelSnapshotFileName = "kernel_blob.bin";
 
-static blink::Settings DefaultSettingsForProcess() {
+static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   auto command_line = shell::CommandLineFromNSProcessInfo();
 
-  // Settings passed in explicitly via command line arguments take priority.
+  // Precedence:
+  // 1. Settings from the specified NSBundle.
+  // 2. Settings passed explicitly via command-line arguments.
+  // 3. Default values.
+
+  NSBundle* mainBundle = [NSBundle mainBundle];
+  NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterViewController class]];
+  bool hasExplicitBundle = bundle != nil;
+  if (bundle == nil) {
+    bundle = mainBundle;
+  }
+
   auto settings = shell::SettingsFromCommandLine(command_line);
 
   settings.task_observer_add = [](intptr_t key, fml::closure callback) {
@@ -38,18 +49,24 @@ static blink::Settings DefaultSettingsForProcess() {
 
   // Flutter ships the ICU data file in the the bundle of the engine. Look for it there.
   if (settings.icu_data_path.size() == 0) {
-    NSBundle* bundle = [NSBundle bundleForClass:[FlutterViewController class]];
-    NSString* icuDataPath = [bundle pathForResource:@"icudtl" ofType:@"dat"];
+    NSString* icuDataPath = [engineBundle pathForResource:@"icudtl" ofType:@"dat"];
     if (icuDataPath.length > 0) {
       settings.icu_data_path = icuDataPath.UTF8String;
     }
   }
 
   if (blink::DartVM::IsRunningPrecompiledCode()) {
-    // The application bundle could be specified in the Info.plist.
+    if (hasExplicitBundle) {
+      NSString* executablePath = bundle.executablePath;
+      if ([[NSFileManager defaultManager] fileExistsAtPath:executablePath]) {
+        settings.application_library_path = executablePath.UTF8String;
+      }
+    }
+
+    // No application bundle specified.  Try a known location from the main bundle's Info.plist.
     if (settings.application_library_path.size() == 0) {
-      NSString* libraryName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"FLTLibraryPath"];
-      NSString* libraryPath = [[NSBundle mainBundle] pathForResource:libraryName ofType:nil];
+      NSString* libraryName = [mainBundle objectForInfoDictionaryKey:@"FLTLibraryPath"];
+      NSString* libraryPath = [mainBundle pathForResource:libraryName ofType:@""];
       if (libraryPath.length > 0) {
         settings.application_library_path =
             [NSBundle bundleWithPath:libraryPath].executablePath.UTF8String;
@@ -60,7 +77,7 @@ static blink::Settings DefaultSettingsForProcess() {
     // Frameworks directory.
     if (settings.application_library_path.size() == 0) {
       NSString* applicationFrameworkPath =
-          [[NSBundle mainBundle] pathForResource:@"Frameworks/App.framework" ofType:@""];
+          [mainBundle pathForResource:@"Frameworks/App.framework" ofType:@""];
       if (applicationFrameworkPath.length > 0) {
         settings.application_library_path =
             [NSBundle bundleWithPath:applicationFrameworkPath].executablePath.UTF8String;
@@ -70,11 +87,8 @@ static blink::Settings DefaultSettingsForProcess() {
 
   // Checks to see if the flutter assets directory is already present.
   if (settings.assets_path.size() == 0) {
-    // The kernel assets will not be present in the Flutter frameworks bundle since it is not user
-    // editable. Instead, look inside the main bundle.
-    NSBundle* bundle = [NSBundle mainBundle];
-    NSString* assets_directory_name = [FlutterDartProject flutterAssetsName:bundle];
-    NSString* assetsPath = [bundle pathForResource:assets_directory_name ofType:@""];
+    NSString* assetsName = [FlutterDartProject flutterAssetsName:bundle];
+    NSString* assetsPath = [mainBundle pathForResource:assetsName ofType:@""];
 
     if (assetsPath.length > 0) {
       settings.assets_path = assetsPath.UTF8String;
@@ -136,15 +150,7 @@ static blink::Settings DefaultSettingsForProcess() {
 
   if (self) {
     _precompiledDartBundle.reset([bundle retain]);
-
-    _settings = DefaultSettingsForProcess();
-
-    if (bundle != nil) {
-      NSString* executablePath = _precompiledDartBundle.get().executablePath;
-      if ([[NSFileManager defaultManager] fileExistsAtPath:executablePath]) {
-        _settings.application_library_path = executablePath.UTF8String;
-      }
-    }
+    _settings = DefaultSettingsForProcess(bundle);
   }
 
   return self;
@@ -216,11 +222,6 @@ static blink::Settings DefaultSettingsForProcess() {
     flutterAssetsName = @"flutter_assets";
   }
   return flutterAssetsName;
-}
-
-+ (NSString*)pathForFlutterAssetsFromBundle:(NSBundle*)bundle {
-  NSString* flutterAssetsName = [FlutterDartProject flutterAssetsName:bundle];
-  return [bundle pathForResource:flutterAssetsName ofType:nil];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -25,11 +25,16 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   // Precedence:
   // 1. Settings from the specified NSBundle.
   // 2. Settings passed explicitly via command-line arguments.
-  // 3. Default values.
+  // 3. Settings from the NSBundle with the default bundle ID.
+  // 4. Settings from the main NSBundle and default values.
 
   NSBundle* mainBundle = [NSBundle mainBundle];
   NSBundle* engineBundle = [NSBundle bundleForClass:[FlutterViewController class]];
+
   bool hasExplicitBundle = bundle != nil;
+  if (bundle == nil) {
+    bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
+  }
   if (bundle == nil) {
     bundle = mainBundle;
   }
@@ -231,6 +236,10 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package {
   return [self lookupKeyForAsset:[NSString stringWithFormat:@"packages/%@/%@", package, asset]];
+}
+
++ (NSString*)defaultBundleIdentifier {
+  return @"io.flutter.flutter.app";
 }
 
 @end


### PR DESCRIPTION
We'd like the ability to add Flutter to existing iOS applications
without requiring that they set `FLTLibraryPath` and `FLTAssetsPath`
in the main bundle's `Info.plist`.

1. Modify `-[FlutterDartProject initWithPrecompiledDartBundle:]` to
   support setting the library and assets path from the specified
   `NSBundle` instead.

2. If no `NSBundle` is explicitly specified, look for one with a
   default bundle identifier ("io.flutter.flutter.app") before
   falling back to the main NSBundle.

Also remove `+[FlutterDartProject pathForFlutterAssetsFromBundle:]`
because we don't use it internally, and it isn't exposed in the
header file.
