### PR TITLE
Remove unused argument on Animator, Engine and PlatformView delegates.

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -103,7 +103,7 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
   {
     TRACE_EVENT2("flutter", "Framework Workload", "mode", "basic", "frame",
                  FrameParity());
-    delegate_.OnAnimatorBeginFrame(*this, last_begin_frame_time_);
+    delegate_.OnAnimatorBeginFrame(last_begin_frame_time_);
   }
 
   if (!frame_scheduled_) {
@@ -124,8 +124,8 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
           // no further frames were produced, and it is safe (w.r.t. jank) to
           // notify the engine we are idle.
           if (notify_idle_task_id == self->notify_idle_task_id_) {
-            self->delegate_.OnAnimatorNotifyIdle(
-                *self.get(), Dart_TimelineGetMicros() + 100000);
+            self->delegate_.OnAnimatorNotifyIdle(Dart_TimelineGetMicros() +
+                                                 100000);
           }
         },
         kNotifyIdleTaskWaitTime);
@@ -148,7 +148,7 @@ void Animator::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   // Commit the pending continuation.
   producer_continuation_.Complete(std::move(layer_tree));
 
-  delegate_.OnAnimatorDraw(*this, layer_tree_pipeline_);
+  delegate_.OnAnimatorDraw(layer_tree_pipeline_);
 }
 
 bool Animator::CanReuseLastLayerTree() {
@@ -157,7 +157,7 @@ bool Animator::CanReuseLastLayerTree() {
 
 void Animator::DrawLastLayerTree() {
   pending_frame_semaphore_.Signal();
-  delegate_.OnAnimatorDrawLastLayerTree(*this);
+  delegate_.OnAnimatorDrawLastLayerTree();
 }
 
 void Animator::RequestFrame(bool regenerate_layer_tree) {
@@ -205,7 +205,7 @@ void Animator::AwaitVSync() {
         }
       });
 
-  delegate_.OnAnimatorNotifyIdle(*this, dart_frame_deadline_);
+  delegate_.OnAnimatorNotifyIdle(dart_frame_deadline_);
 }
 
 }  // namespace shell

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -20,17 +20,14 @@ class Animator final {
  public:
   class Delegate {
    public:
-    virtual void OnAnimatorBeginFrame(const Animator& animator,
-                                      fml::TimePoint frame_time) = 0;
+    virtual void OnAnimatorBeginFrame(fml::TimePoint frame_time) = 0;
 
-    virtual void OnAnimatorNotifyIdle(const Animator& animator,
-                                      int64_t deadline) = 0;
+    virtual void OnAnimatorNotifyIdle(int64_t deadline) = 0;
 
     virtual void OnAnimatorDraw(
-        const Animator& animator,
         fml::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) = 0;
 
-    virtual void OnAnimatorDrawLastLayerTree(const Animator& animator) = 0;
+    virtual void OnAnimatorDrawLastLayerTree() = 0;
   };
 
   Animator(Delegate& delegate,

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -385,8 +385,7 @@ void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
 
 void Engine::UpdateSemantics(blink::SemanticsNodeUpdates update,
                              blink::CustomAccessibilityActionUpdates actions) {
-  delegate_.OnEngineUpdateSemantics(*this, std::move(update),
-                                    std::move(actions));
+  delegate_.OnEngineUpdateSemantics(std::move(update), std::move(actions));
 }
 
 void Engine::HandlePlatformMessage(
@@ -394,7 +393,7 @@ void Engine::HandlePlatformMessage(
   if (message->channel() == kAssetChannel) {
     HandleAssetPlatformMessage(std::move(message));
   } else {
-    delegate_.OnEngineHandlePlatformMessage(*this, std::move(message));
+    delegate_.OnEngineHandlePlatformMessage(std::move(message));
   }
 }
 

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -32,12 +32,10 @@ class Engine final : public blink::RuntimeDelegate {
   class Delegate {
    public:
     virtual void OnEngineUpdateSemantics(
-        const Engine& engine,
         blink::SemanticsNodeUpdates update,
         blink::CustomAccessibilityActionUpdates actions) = 0;
 
     virtual void OnEngineHandlePlatformMessage(
-        const Engine& engine,
         fml::RefPtr<blink::PlatformMessage> message) = 0;
 
     virtual void OnPreEngineRestart() = 0;

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -33,39 +33,38 @@ std::unique_ptr<VsyncWaiter> PlatformView::CreateVSyncWaiter() {
 
 void PlatformView::DispatchPlatformMessage(
     fml::RefPtr<blink::PlatformMessage> message) {
-  delegate_.OnPlatformViewDispatchPlatformMessage(*this, std::move(message));
+  delegate_.OnPlatformViewDispatchPlatformMessage(std::move(message));
 }
 
 void PlatformView::DispatchPointerDataPacket(
     std::unique_ptr<blink::PointerDataPacket> packet) {
-  delegate_.OnPlatformViewDispatchPointerDataPacket(*this, std::move(packet));
+  delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
 void PlatformView::DispatchSemanticsAction(int32_t id,
                                            blink::SemanticsAction action,
                                            std::vector<uint8_t> args) {
-  delegate_.OnPlatformViewDispatchSemanticsAction(*this, id, action,
-                                                  std::move(args));
+  delegate_.OnPlatformViewDispatchSemanticsAction(id, action, std::move(args));
 }
 
 void PlatformView::SetSemanticsEnabled(bool enabled) {
-  delegate_.OnPlatformViewSetSemanticsEnabled(*this, enabled);
+  delegate_.OnPlatformViewSetSemanticsEnabled(enabled);
 }
 
 void PlatformView::SetAccessibilityFeatures(int32_t flags) {
-  delegate_.OnPlatformViewSetAccessibilityFeatures(*this, flags);
+  delegate_.OnPlatformViewSetAccessibilityFeatures(flags);
 }
 
 void PlatformView::SetViewportMetrics(const blink::ViewportMetrics& metrics) {
-  delegate_.OnPlatformViewSetViewportMetrics(*this, metrics);
+  delegate_.OnPlatformViewSetViewportMetrics(metrics);
 }
 
 void PlatformView::NotifyCreated() {
-  delegate_.OnPlatformViewCreated(*this, CreateRenderingSurface());
+  delegate_.OnPlatformViewCreated(CreateRenderingSurface());
 }
 
 void PlatformView::NotifyDestroyed() {
-  delegate_.OnPlatformViewDestroyed(*this);
+  delegate_.OnPlatformViewDestroyed();
 }
 
 sk_sp<GrContext> PlatformView::CreateResourceContext() const {
@@ -91,15 +90,15 @@ void PlatformView::HandlePlatformMessage(
 void PlatformView::OnPreEngineRestart() const {}
 
 void PlatformView::RegisterTexture(std::shared_ptr<flow::Texture> texture) {
-  delegate_.OnPlatformViewRegisterTexture(*this, std::move(texture));
+  delegate_.OnPlatformViewRegisterTexture(std::move(texture));
 }
 
 void PlatformView::UnregisterTexture(int64_t texture_id) {
-  delegate_.OnPlatformViewUnregisterTexture(*this, texture_id);
+  delegate_.OnPlatformViewUnregisterTexture(texture_id);
 }
 
 void PlatformView::MarkTextureFrameAvailable(int64_t texture_id) {
-  delegate_.OnPlatformViewMarkTextureFrameAvailable(*this, texture_id);
+  delegate_.OnPlatformViewMarkTextureFrameAvailable(texture_id);
 }
 
 std::unique_ptr<Surface> PlatformView::CreateRenderingSurface() {
@@ -115,7 +114,7 @@ void PlatformView::SetNextFrameCallback(fml::closure closure) {
     return;
   }
 
-  delegate_.OnPlatformViewSetNextFrameCallback(*this, std::move(closure));
+  delegate_.OnPlatformViewSetNextFrameCallback(std::move(closure));
 }
 
 }  // namespace shell

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -29,48 +29,36 @@ class PlatformView {
  public:
   class Delegate {
    public:
-    virtual void OnPlatformViewCreated(const PlatformView& view,
-                                       std::unique_ptr<Surface> surface) = 0;
+    virtual void OnPlatformViewCreated(std::unique_ptr<Surface> surface) = 0;
 
-    virtual void OnPlatformViewDestroyed(const PlatformView& view) = 0;
+    virtual void OnPlatformViewDestroyed() = 0;
 
-    virtual void OnPlatformViewSetNextFrameCallback(const PlatformView& view,
-                                                    fml::closure closure) = 0;
+    virtual void OnPlatformViewSetNextFrameCallback(fml::closure closure) = 0;
 
     virtual void OnPlatformViewSetViewportMetrics(
-        const PlatformView& view,
         const blink::ViewportMetrics& metrics) = 0;
 
     virtual void OnPlatformViewDispatchPlatformMessage(
-        const PlatformView& view,
         fml::RefPtr<blink::PlatformMessage> message) = 0;
 
     virtual void OnPlatformViewDispatchPointerDataPacket(
-        const PlatformView& view,
         std::unique_ptr<blink::PointerDataPacket> packet) = 0;
 
     virtual void OnPlatformViewDispatchSemanticsAction(
-        const PlatformView& view,
         int32_t id,
         blink::SemanticsAction action,
         std::vector<uint8_t> args) = 0;
 
-    virtual void OnPlatformViewSetSemanticsEnabled(const PlatformView& view,
-                                                   bool enabled) = 0;
+    virtual void OnPlatformViewSetSemanticsEnabled(bool enabled) = 0;
 
-    virtual void OnPlatformViewSetAccessibilityFeatures(
-        const PlatformView& view,
-        int32_t flags) = 0;
+    virtual void OnPlatformViewSetAccessibilityFeatures(int32_t flags) = 0;
 
     virtual void OnPlatformViewRegisterTexture(
-        const PlatformView& view,
         std::shared_ptr<flow::Texture> texture) = 0;
 
-    virtual void OnPlatformViewUnregisterTexture(const PlatformView& view,
-                                                 int64_t texture_id) = 0;
+    virtual void OnPlatformViewUnregisterTexture(int64_t texture_id) = 0;
 
     virtual void OnPlatformViewMarkTextureFrameAvailable(
-        const PlatformView& view,
         int64_t texture_id) = 0;
   };
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -393,10 +393,8 @@ blink::DartVM& Shell::GetDartVM() const {
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewCreated(const PlatformView& view,
-                                  std::unique_ptr<Surface> surface) {
+void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   // Note:
@@ -435,9 +433,8 @@ void Shell::OnPlatformViewCreated(const PlatformView& view,
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewDestroyed(const PlatformView& view) {
+void Shell::OnPlatformViewDestroyed() {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   // Note:
@@ -485,10 +482,8 @@ void Shell::OnPlatformViewDestroyed(const PlatformView& view) {
 
 // |shell::PlatformView::Delegate|
 void Shell::OnPlatformViewSetViewportMetrics(
-    const PlatformView& view,
     const blink::ViewportMetrics& metrics) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -501,10 +496,8 @@ void Shell::OnPlatformViewSetViewportMetrics(
 
 // |shell::PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchPlatformMessage(
-    const PlatformView& view,
     fml::RefPtr<blink::PlatformMessage> message) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -517,10 +510,8 @@ void Shell::OnPlatformViewDispatchPlatformMessage(
 
 // |shell::PlatformView::Delegate|
 void Shell::OnPlatformViewDispatchPointerDataPacket(
-    const PlatformView& view,
     std::unique_ptr<blink::PointerDataPacket> packet) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
   task_runners_.GetUITaskRunner()->PostTask(fml::MakeCopyable(
       [engine = engine_->GetWeakPtr(), packet = std::move(packet)] {
@@ -531,12 +522,10 @@ void Shell::OnPlatformViewDispatchPointerDataPacket(
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewDispatchSemanticsAction(const PlatformView& view,
-                                                  int32_t id,
+void Shell::OnPlatformViewDispatchSemanticsAction(int32_t id,
                                                   blink::SemanticsAction action,
                                                   std::vector<uint8_t> args) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -548,10 +537,8 @@ void Shell::OnPlatformViewDispatchSemanticsAction(const PlatformView& view,
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewSetSemanticsEnabled(const PlatformView& view,
-                                              bool enabled) {
+void Shell::OnPlatformViewSetSemanticsEnabled(bool enabled) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -563,10 +550,8 @@ void Shell::OnPlatformViewSetSemanticsEnabled(const PlatformView& view,
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewSetAccessibilityFeatures(const PlatformView& view,
-                                                   int32_t flags) {
+void Shell::OnPlatformViewSetAccessibilityFeatures(int32_t flags) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetUITaskRunner()->PostTask(
@@ -579,10 +564,8 @@ void Shell::OnPlatformViewSetAccessibilityFeatures(const PlatformView& view,
 
 // |shell::PlatformView::Delegate|
 void Shell::OnPlatformViewRegisterTexture(
-    const PlatformView& view,
     std::shared_ptr<flow::Texture> texture) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetGPUTaskRunner()->PostTask(
@@ -596,10 +579,8 @@ void Shell::OnPlatformViewRegisterTexture(
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewUnregisterTexture(const PlatformView& view,
-                                            int64_t texture_id) {
+void Shell::OnPlatformViewUnregisterTexture(int64_t texture_id) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetGPUTaskRunner()->PostTask(
@@ -613,10 +594,8 @@ void Shell::OnPlatformViewUnregisterTexture(const PlatformView& view,
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewMarkTextureFrameAvailable(const PlatformView& view,
-                                                    int64_t texture_id) {
+void Shell::OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   // Tell the rasterizer that one of its textures has a new frame available.
@@ -646,10 +625,8 @@ void Shell::OnPlatformViewMarkTextureFrameAvailable(const PlatformView& view,
 }
 
 // |shell::PlatformView::Delegate|
-void Shell::OnPlatformViewSetNextFrameCallback(const PlatformView& view,
-                                               fml::closure closure) {
+void Shell::OnPlatformViewSetNextFrameCallback(fml::closure closure) {
   FML_DCHECK(is_setup_);
-  FML_DCHECK(&view == platform_view_.get());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetGPUTaskRunner()->PostTask(
@@ -661,8 +638,7 @@ void Shell::OnPlatformViewSetNextFrameCallback(const PlatformView& view,
 }
 
 // |shell::Animator::Delegate|
-void Shell::OnAnimatorBeginFrame(const Animator& animator,
-                                 fml::TimePoint frame_time) {
+void Shell::OnAnimatorBeginFrame(fml::TimePoint frame_time) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
@@ -672,7 +648,7 @@ void Shell::OnAnimatorBeginFrame(const Animator& animator,
 }
 
 // |shell::Animator::Delegate|
-void Shell::OnAnimatorNotifyIdle(const Animator& animator, int64_t deadline) {
+void Shell::OnAnimatorNotifyIdle(int64_t deadline) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
@@ -683,7 +659,6 @@ void Shell::OnAnimatorNotifyIdle(const Animator& animator, int64_t deadline) {
 
 // |shell::Animator::Delegate|
 void Shell::OnAnimatorDraw(
-    const Animator& animator,
     fml::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) {
   FML_DCHECK(is_setup_);
 
@@ -697,7 +672,7 @@ void Shell::OnAnimatorDraw(
 }
 
 // |shell::Animator::Delegate|
-void Shell::OnAnimatorDrawLastLayerTree(const Animator& animator) {
+void Shell::OnAnimatorDrawLastLayerTree() {
   FML_DCHECK(is_setup_);
 
   task_runners_.GetGPUTaskRunner()->PostTask(
@@ -710,7 +685,6 @@ void Shell::OnAnimatorDrawLastLayerTree(const Animator& animator) {
 
 // |shell::Engine::Delegate|
 void Shell::OnEngineUpdateSemantics(
-    const Engine& engine,
     blink::SemanticsNodeUpdates update,
     blink::CustomAccessibilityActionUpdates actions) {
   FML_DCHECK(is_setup_);
@@ -727,7 +701,6 @@ void Shell::OnEngineUpdateSemantics(
 
 // |shell::Engine::Delegate|
 void Shell::OnEngineHandlePlatformMessage(
-    const Engine& engine,
     fml::RefPtr<blink::PlatformMessage> message) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -115,84 +115,68 @@ class Shell final : public PlatformView::Delegate,
              std::unique_ptr<IOManager> io_manager);
 
   // |shell::PlatformView::Delegate|
-  void OnPlatformViewCreated(const PlatformView& view,
-                             std::unique_ptr<Surface> surface) override;
+  void OnPlatformViewCreated(std::unique_ptr<Surface> surface) override;
 
   // |shell::PlatformView::Delegate|
-  void OnPlatformViewDestroyed(const PlatformView& view) override;
+  void OnPlatformViewDestroyed() override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewSetViewportMetrics(
-      const PlatformView& view,
       const blink::ViewportMetrics& metrics) override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewDispatchPlatformMessage(
-      const PlatformView& view,
       fml::RefPtr<blink::PlatformMessage> message) override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewDispatchPointerDataPacket(
-      const PlatformView& view,
       std::unique_ptr<blink::PointerDataPacket> packet) override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(
-      const PlatformView& view,
       int32_t id,
       blink::SemanticsAction action,
       std::vector<uint8_t> args) override;
 
   // |shell::PlatformView::Delegate|
-  void OnPlatformViewSetSemanticsEnabled(const PlatformView& view,
-                                         bool enabled) override;
+  void OnPlatformViewSetSemanticsEnabled(bool enabled) override;
 
   // |shell:PlatformView::Delegate|
-  void OnPlatformViewSetAccessibilityFeatures(const PlatformView& view,
-                                              int32_t flags) override;
+  void OnPlatformViewSetAccessibilityFeatures(int32_t flags) override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewRegisterTexture(
-      const PlatformView& view,
       std::shared_ptr<flow::Texture> texture) override;
 
   // |shell::PlatformView::Delegate|
-  void OnPlatformViewUnregisterTexture(const PlatformView& view,
-                                       int64_t texture_id) override;
+  void OnPlatformViewUnregisterTexture(int64_t texture_id) override;
 
   // |shell::PlatformView::Delegate|
-  void OnPlatformViewMarkTextureFrameAvailable(const PlatformView& view,
-                                               int64_t texture_id) override;
+  void OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) override;
 
   // |shell::PlatformView::Delegate|
-  void OnPlatformViewSetNextFrameCallback(const PlatformView& view,
-                                          fml::closure closure) override;
+  void OnPlatformViewSetNextFrameCallback(fml::closure closure) override;
 
   // |shell::Animator::Delegate|
-  void OnAnimatorBeginFrame(const Animator& animator,
-                            fml::TimePoint frame_time) override;
+  void OnAnimatorBeginFrame(fml::TimePoint frame_time) override;
 
   // |shell::Animator::Delegate|
-  void OnAnimatorNotifyIdle(const Animator& animator,
-                            int64_t deadline) override;
+  void OnAnimatorNotifyIdle(int64_t deadline) override;
 
   // |shell::Animator::Delegate|
   void OnAnimatorDraw(
-      const Animator& animator,
       fml::RefPtr<flutter::Pipeline<flow::LayerTree>> pipeline) override;
 
   // |shell::Animator::Delegate|
-  void OnAnimatorDrawLastLayerTree(const Animator& animator) override;
+  void OnAnimatorDrawLastLayerTree() override;
 
   // |shell::Engine::Delegate|
   void OnEngineUpdateSemantics(
-      const Engine& engine,
       blink::SemanticsNodeUpdates update,
       blink::CustomAccessibilityActionUpdates actions) override;
 
   // |shell::Engine::Delegate|
   void OnEngineHandlePlatformMessage(
-      const Engine& engine,
       fml::RefPtr<blink::PlatformMessage> message) override;
 
   // |shell::Engine::Delegate|


### PR DESCRIPTION
When these delegate methods were initially added, it was expected that a single
shell would be able to own mutliple platform views, engines and animators. This
plan was abandoned in favor of creating multiple shells with their own platform
views, engines, etc.. The arguments were meant to ease the disambiguate the
instances of the variaous objects managed by the shell. This is no longer
necessary.