### PR TITLE
Add NSNull check in setSystemChromeSystemUIOverlayStyle

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -140,6 +140,9 @@ using namespace shell;
 
 - (void)setSystemChromeSystemUIOverlayStyle:(NSDictionary*)message {
   NSString* style = message[@"statusBarBrightness"];
+  if (style == (id)[NSNull null])
+    return;
+
   UIStatusBarStyle statusBarStyle;
   if ([style isEqualToString:@"Brightness.dark"])
     statusBarStyle = UIStatusBarStyleLightContent;


### PR DESCRIPTION
Based on report from [#20215](https://github.com/flutter/flutter/issues/20215), there will be an Exception raised by `[NSObject(NSObject) doesNotRecognizeSelector:] ` when calling SystemChrome.setSystemUIOverlayStyle without specifying any value for statusBarBrightness.

After investigation, I found out this is caused because we don't have any NSNull check when getting statusBarBrightness value from dictionary (null from dart world will be converted to NSNull when nested). This can cause calling `[NSNull isEqualToString]` which will cause `doesNotRecognizeSelector` being called.

Since I think this is platform specific, it's better to add the check here rather than in the framework side.