### PR TITLE
Revert "Log Tonic errors with FML_LOG"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -123,7 +123,7 @@ deps = {
    # and not have to specific specific hashes.
 
   'src/third_party/tonic':
-   Var('fuchsia_git') + '/tonic' + '@' + '2de0ba78507e764f908b195885f53592048b7c45',
+   Var('fuchsia_git') + '/tonic' + '@' + '57d508b12462db686573edcbc97891d90cf92f90',
 
   'src/third_party/benchmark':
    Var('fuchsia_git') + '/third_party/benchmark' + '@' + '296537bc48d380adf21567c5d736ab79f5363d22',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 09731565df309a8750981693eccc220b
+Signature: ec72b49802f64feb7fa74573a404abc5
 
 UNUSED LICENSES:
 
@@ -16752,10 +16752,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/common/log.cc + ../../../third_party/tonic/LICENSE
+ORIGIN: ../../../third_party/tonic/common/macros.h + ../../../third_party/tonic/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/common/log.cc
-FILE: ../../../third_party/tonic/common/log.h
 FILE: ../../../third_party/tonic/common/macros.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2018 The Fuchsia Authors. All rights reserved.

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -28,7 +28,6 @@
 #include "flutter/shell/common/vsync_waiter.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "third_party/skia/include/core/SkGraphics.h"
-#include "third_party/tonic/common/log.h"
 
 #ifdef ERROR
 #undef ERROR
@@ -176,9 +175,6 @@ static void PerformInitializationTasks(const blink::Settings& settings) {
           settings.verbose_logging ? fml::LOG_INFO : fml::LOG_ERROR;
       fml::SetLogSettings(log_settings);
     }
-
-    tonic::SetLogHandler(
-        [](const char* message) { FML_LOG(ERROR) << message; });
 
     if (settings.trace_skia) {
       InitSkiaEventTracer(settings.trace_skia);


### PR DESCRIPTION
Reverts flutter/engine#6015

This is causing the [Windows bots](https://uberchromegw.corp.google.com/i/client.flutter/builders/Windows%20Engine/builds/2394/steps/build%20host_debug_unopt/logs/stdio) to fail.