### PR TITLE
Wait for Dart VM initialization before the letting the service isolate constructor access the VM object.

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -257,6 +257,7 @@ fml::RefPtr<DartVM> DartVM::ForProcess(Settings settings) {
 }
 
 static std::once_flag gVMInitialization;
+static std::mutex gVMMutex;
 static fml::RefPtr<DartVM> gVM;
 
 fml::RefPtr<DartVM> DartVM::ForProcess(
@@ -264,6 +265,7 @@ fml::RefPtr<DartVM> DartVM::ForProcess(
     fml::RefPtr<DartSnapshot> vm_snapshot,
     fml::RefPtr<DartSnapshot> isolate_snapshot,
     fml::RefPtr<DartSnapshot> shared_snapshot) {
+  std::lock_guard<std::mutex> lock(gVMMutex);
   std::call_once(gVMInitialization, [settings,          //
                                      vm_snapshot,       //
                                      isolate_snapshot,  //
@@ -296,6 +298,7 @@ fml::RefPtr<DartVM> DartVM::ForProcess(
 }
 
 fml::RefPtr<DartVM> DartVM::ForProcessIfInitialized() {
+  std::lock_guard<std::mutex> lock(gVMMutex);
   return gVM;
 }
 


### PR DESCRIPTION
The service isolate creation callback may occur on a background thread before
the call the Dart_Initialize within the DartVM construtor can finish. We store
pointers to various snapshots within the DartVM object. These snapshots are
necessary for to successfully create the service isolate. The isolate creation
callback access the global object within the ForProcessIfInitialized method.
This method can return null if the VM object has not been initialized. This
leads to the service protocol failing to start in a non-deterministic manner.
This patch moves the creation and access of the DartVM object within a critical
section.