### PR TITLE
Fix potential null pointer dereference in FlutterDartProject

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -73,8 +73,10 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
       NSString* libraryName = [mainBundle objectForInfoDictionaryKey:@"FLTLibraryPath"];
       NSString* libraryPath = [mainBundle pathForResource:libraryName ofType:@""];
       if (libraryPath.length > 0) {
-        settings.application_library_path =
-            [NSBundle bundleWithPath:libraryPath].executablePath.UTF8String;
+        NSString* executablePath = [NSBundle bundleWithPath:libraryPath].executablePath;
+        if (executablePath.length > 0) {
+          settings.application_library_path = executablePath.UTF8String;
+        }
       }
     }
 
@@ -84,8 +86,11 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
       NSString* applicationFrameworkPath =
           [mainBundle pathForResource:@"Frameworks/App.framework" ofType:@""];
       if (applicationFrameworkPath.length > 0) {
-        settings.application_library_path =
-            [NSBundle bundleWithPath:applicationFrameworkPath].executablePath.UTF8String;
+        NSString* executablePath =
+            [NSBundle bundleWithPath:applicationFrameworkPath].executablePath;
+        if (executablePath.length > 0) {
+          settings.application_library_path = executablePath.UTF8String;
+        }
       }
     }
   }


### PR DESCRIPTION
If `FlutterDartProject` found an `FLTLibraryPath` entry in an iOS
application's `Info.plist`, it assumed that values that were valid
filesystem paths were paths to bundles.  After the attempt to
retrieve the `NSBundle` fails, `FlutterDartProject` then assigns
`nil` to a C++ `std::string`, resulting in a null pointer
dereference.

Add some failure checks to prevent this.
