### PR TITLE
Roll Dart SDK to 009388516560a9bceeb0682c9c1244e046bfe34d.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '69fce633b72e158f5ac553cf3f0f4fcd0f7c735a',
+  'dart_revision': '009388516560a9bceeb0682c9c1244e046bfe34d',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -643,13 +643,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
-ORIGIN: ../../../flutter/fml/time/time_delta_unittest.cc + ../../../third_party/tonic/LICENSE
+ORIGIN: ../../../flutter/lib/ui/painting/image.cc + ../../../LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../flutter/fml/export.h
-FILE: ../../../flutter/fml/time/time_delta_unittest.cc
-FILE: ../../../flutter/fml/time/time_point_unittest.cc
+FILE: ../../../flutter/lib/ui/painting/image.cc
+FILE: ../../../flutter/lib/ui/painting/image.h
+FILE: ../../../flutter/shell/common/switches.cc
+FILE: ../../../flutter/shell/common/switches.h
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
 ----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
+Copyright 2013 The Chromium Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -680,17 +684,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
-ORIGIN: ../../../flutter/lib/ui/painting/image.cc + ../../../LICENSE
+ORIGIN: ../../../garnet/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../flutter/lib/ui/painting/image.cc
-FILE: ../../../flutter/lib/ui/painting/image.h
-FILE: ../../../flutter/shell/common/switches.cc
-FILE: ../../../flutter/shell/common/switches.h
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
+FILE: ../../../flutter/fml/export.h
+FILE: ../../../flutter/fml/time/time_delta_unittest.cc
+FILE: ../../../flutter/fml/time/time_point_unittest.cc
 ----------------------------------------------------------------------------------------------------
-Copyright 2013 The Chromium Authors. All rights reserved.
+Copyright 2017 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 2cf18ab3f78b7a31e743ed06f3db5660
+Signature: c20d05f54a1f7a6053857b8999c70ba6
 
 UNUSED LICENSES:
 
@@ -16690,6 +16690,50 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: tonic
+ORIGIN: ../../../garnet/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/tonic/dart_list.cc
+FILE: ../../../third_party/tonic/dart_list.h
+FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
+FILE: ../../../third_party/tonic/platform/platform_utils.h
+FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
+FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2017 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: tonic
 ORIGIN: ../../../third_party/tonic/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/tonic/common/build_config.h
@@ -16759,50 +16803,6 @@ FILE: ../../../third_party/tonic/common/log.h
 FILE: ../../../third_party/tonic/common/macros.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2018 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc + ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/dart_list.cc
-FILE: ../../../third_party/tonic/dart_list.h
-FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
-FILE: ../../../third_party/tonic/platform/platform_utils.h
-FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
-FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Included changes:

```
0093885165 Issues on co19_2 missing compile-time error failures
a95db177b8 Fix VM status after language_2 triage
fe939f9433 [vm] Update status file after entrypoints change (again).
ee6ef702ce Update issues for Fasta missing compile-time errors in language_2
b7790e3147 [VM] Make all of our compilation pipeline use a [FrameLayout] to generate code
2a36502b02 Squelch some false warnings for disallowed uses of void
244c9bebec Remove STRONG_MODE flag
814738b273 Remove CompilerOptions.strongMode/enableTypeAssertions/trustTypeAnnotations
d7c71862da Check setters in Dart 2
bedc1440d0 Analyzer: replaceComponent: Add small to big instead of the other way around
a814614cf4 Fix analyzer/FE integration of invalid assignments to classes.
701b13048b [vm/kernel/bytecode] Zap expression stack in try-catch handlers
7f88b64e0a [vm] buffer size based log flushing
dec1da2437 [VM interpreter] Bytecode reader should make const list immutable.
51bed8a0ed [test matrix] Add back --compiler=dartkb
1f5f197e90 [VM] Do not start the kernel isolate when doing an app JIT snapshot training run if a kernel file is specified as the application.
9bf9822bec Increase a timeout for a slow test.
5e0a28a384 [vm/kernel/bytecode] Support unsafeCast() intrinsic method in bytecode
2cca4415b1 Replace Deprecated.expires with message
844b7a9c40 [Test] Add test case for capturing variables in nested sync* closures
a37496d24d [VM interpreter] Fix native call to growable list factory.
47332ae3cb [vm] Update status file after entrypoints change.
b97f885d1d Revert "[vm] Deep clone context when cloning closure"
f88582e74f Improve wording in invalid return spec per comments.
fc24d41b47 Fix status file for super_call4_test/01
2e22f7b247 [vm] Fix a bug in the field exactness tracking state machine.
dea7de23bd [vm] Use multiple entrypoints to remove unnecessary checks on calls against "this".
c082761e09 [vm/compiler] improve type progagation
```