### PR TITLE
expose bold text flag in accessibility features for iOS

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -762,6 +762,7 @@ class AccessibilityFeatures {
   static const int _kAccessibleNavigation = 1 << 0;
   static const int _kInvertColorsIndex = 1 << 1;
   static const int _kDisableAnimationsIndex = 1 << 2;
+  static const int _kBoldTextIndex = 1 << 3;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -778,6 +779,11 @@ class AccessibilityFeatures {
   /// The platform is requesting that animations be disabled or simplified.
   bool get disableAnimations => _kDisableAnimationsIndex & _index != 0;
 
+  /// The platform is requesting that text be rendered at a bold font weight.
+  ///
+  /// Only supported on iOS.
+  bool get boldText => _kBoldTextIndex & _index != 0;
+
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -787,6 +793,8 @@ class AccessibilityFeatures {
       features.add('invertColors');
     if (disableAnimations)
       features.add('disableAnimations');
+    if (boldText)
+      features.add('boldText');
     return 'AccessibilityFeatures$features';
   }
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -30,6 +30,7 @@ enum class AccessibilityFeatureFlag : int32_t {
   kAccessibleNavigation = 1 << 0,
   kInvertColors = 1 << 1,
   kDisableAnimations = 1 << 2,
+  kBoldText = 1 << 3,
 };
 
 class WindowClient {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -296,6 +296,11 @@
                object:nil];
 
   [center addObserver:self
+             selector:@selector(onAccessibilityStatusChanged:)
+                 name:UIAccessibilityBoldTextStatusDidChangeNotification
+               object:nil];
+
+  [center addObserver:self
              selector:@selector(onMemoryWarning:)
                  name:UIApplicationDidReceiveMemoryWarningNotification
                object:nil];
@@ -811,6 +816,8 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
     flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
   if (UIAccessibilityIsReduceMotionEnabled())
     flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kDisableAnimations);
+  if (UIAccessibilityIsBoldTextEnabled())
+    flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the


### PR DESCRIPTION
Work towards https://github.com/flutter/flutter/issues/4825, still needs framework to honor it.