### PR TITLE
Make `FlutterAppDelegate` respond to life cycle events dynamically

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -22,6 +22,8 @@ FLUTTER_EXPORT
 */
 - (void)addDelegate:(NSObject<FlutterPlugin>*)delegate;
 
+- (BOOL)hasPluginThatRespondsToSelector:(SEL)selector;
+
 /**
  Calls all plugins registered for `UIApplicationDelegate` callbacks.
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -22,9 +22,16 @@
   [super dealloc];
 }
 
-- (BOOL)application:(UIApplication*)application
-    willFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-  return [_lifeCycleDelegate application:application willFinishLaunchingWithOptions:launchOptions];
+- (BOOL)respondsToSelector:(SEL)selector {
+  return [super respondsToSelector:selector] ||
+         [_lifeCycleDelegate hasPluginThatRespondsToSelector:selector];
+}
+
+- (id)forwardingTargetForSelector:(SEL)selector {
+  if ([_lifeCycleDelegate hasPluginThatRespondsToSelector:selector]) {
+    return _lifeCycleDelegate;
+  }
+  return [super forwardingTargetForSelector:selector];
 }
 
 - (BOOL)application:(UIApplication*)application
@@ -49,95 +56,6 @@
   if (self.rootFlutterViewController != nil) {
     [self.rootFlutterViewController handleStatusBarTouches:event];
   }
-}
-
-- (void)applicationDidEnterBackground:(UIApplication*)application {
-  [_lifeCycleDelegate applicationDidEnterBackground:application];
-}
-
-- (void)applicationWillEnterForeground:(UIApplication*)application {
-  [_lifeCycleDelegate applicationWillEnterForeground:application];
-}
-
-- (void)applicationWillResignActive:(UIApplication*)application {
-  [_lifeCycleDelegate applicationWillResignActive:application];
-}
-
-- (void)applicationDidBecomeActive:(UIApplication*)application {
-  [_lifeCycleDelegate applicationDidBecomeActive:application];
-}
-
-- (void)applicationWillTerminate:(UIApplication*)application {
-  [_lifeCycleDelegate applicationWillTerminate:application];
-}
-
-- (void)application:(UIApplication*)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
-  [_lifeCycleDelegate application:application
-      didRegisterUserNotificationSettings:notificationSettings];
-}
-
-- (void)application:(UIApplication*)application
-    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-  [_lifeCycleDelegate application:application
-      didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-}
-
-- (void)application:(UIApplication*)application
-    didReceiveRemoteNotification:(NSDictionary*)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  [_lifeCycleDelegate application:application
-      didReceiveRemoteNotification:userInfo
-            fetchCompletionHandler:completionHandler];
-}
-
-- (BOOL)application:(UIApplication*)application
-            openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
-  return [_lifeCycleDelegate application:application openURL:url options:options];
-}
-
-- (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
-  return [_lifeCycleDelegate application:application handleOpenURL:url];
-}
-
-- (BOOL)application:(UIApplication*)application
-              openURL:(NSURL*)url
-    sourceApplication:(NSString*)sourceApplication
-           annotation:(id)annotation {
-  return [_lifeCycleDelegate application:application
-                                 openURL:url
-                       sourceApplication:sourceApplication
-                              annotation:annotation];
-}
-
-- (void)application:(UIApplication*)application
-    performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
-               completionHandler:(void (^)(BOOL succeeded))completionHandler NS_AVAILABLE_IOS(9_0) {
-  [_lifeCycleDelegate application:application
-      performActionForShortcutItem:shortcutItem
-                 completionHandler:completionHandler];
-}
-
-- (void)application:(UIApplication*)application
-    handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
-                      completionHandler:(nonnull void (^)())completionHandler {
-  [_lifeCycleDelegate application:application
-      handleEventsForBackgroundURLSession:identifier
-                        completionHandler:completionHandler];
-}
-
-- (void)application:(UIApplication*)application
-    performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  [_lifeCycleDelegate application:application performFetchWithCompletionHandler:completionHandler];
-}
-
-- (BOOL)application:(UIApplication*)application
-    continueUserActivity:(NSUserActivity*)userActivity
-      restorationHandler:(void (^)(NSArray*))restorationHandler {
-  return [_lifeCycleDelegate application:application
-                    continueUserActivity:userActivity
-                      restorationHandler:restorationHandler];
 }
 
 #pragma mark - FlutterPluginRegistry methods. All delegating to the rootViewController

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -5,17 +5,41 @@
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h"
 #include "flutter/fml/logging.h"
 #include "flutter/fml/paths.h"
+#include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h"
 
 static const char* kCallbackCacheSubDir = "Library/Caches/";
 
+static const SEL lifeCycleSelectors[] = {
+    @selector(application:didFinishLaunchingWithOptions:),
+    @selector(application:willFinishLaunchingWithOptions:),
+    @selector(applicationDidBecomeActive:),
+    @selector(applicationWillResignActive:),
+    @selector(applicationDidEnterBackground:),
+    @selector(applicationWillEnterForeground:),
+    @selector(applicationWillTerminate:),
+    @selector(application:didRegisterUserNotificationSettings:),
+    @selector(application:didRegisterForRemoteNotificationsWithDeviceToken:),
+    @selector(application:didReceiveRemoteNotification:fetchCompletionHandler:),
+    @selector(application:openURL:options:),
+    @selector(application:handleOpenURL:),
+    @selector(application:openURL:sourceApplication:annotation:),
+    @selector(application:performActionForShortcutItem:completionHandler:),
+    @selector(application:handleEventsForBackgroundURLSession:completionHandler:),
+    @selector(application:performFetchWithCompletionHandler:),
+    @selector(application:continueUserActivity:restorationHandler:),
+};
+
 @implementation FlutterPluginAppLifeCycleDelegate {
   UIBackgroundTaskIdentifier _debugBackgroundTask;
 
   // Weak references to registered plugins.
   NSPointerArray* _pluginDelegates;
+
+  // Maps selectors to an array of weak references to plugins that respond to those selectors.
+  std::map<SEL, fml::scoped_nsobject<NSPointerArray>> _selectorTable;
 }
 
 - (instancetype)init {
@@ -41,18 +65,37 @@ static BOOL isPowerOfTwo(NSUInteger x) {
   if (isPowerOfTwo([_pluginDelegates count])) {
     [_pluginDelegates compact];
   }
+
+  for (const auto& selector : lifeCycleSelectors) {
+    if ([delegate respondsToSelector:selector]) {
+      auto& p = _selectorTable[selector];
+      if (p.get() == nil) {
+        p.reset([[NSPointerArray weakObjectsPointerArray] retain]);
+      }
+
+      [p.get() addPointer:(__bridge void*)delegate];
+    }
+  }
+}
+
+- (BOOL)hasPluginThatRespondsToSelector:(SEL)selector {
+  return _selectorTable.find(selector) != _selectorTable.end();
 }
 
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-  for (id<FlutterPlugin> plugin in [_pluginDelegates allObjects]) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return YES;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if (![plugin application:application didFinishLaunchingWithOptions:launchOptions]) {
-        return NO;
-      }
+
+    if (![plugin application:application didFinishLaunchingWithOptions:launchOptions]) {
+      return NO;
     }
   }
   return YES;
@@ -61,14 +104,18 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     willFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   blink::DartCallbackCache::LoadCacheFromDisk();
-  for (id<FlutterPlugin> plugin in [_pluginDelegates allObjects]) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return YES;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if (![plugin application:application willFinishLaunchingWithOptions:launchOptions]) {
-        return NO;
-      }
+
+    if (![plugin application:application willFinishLaunchingWithOptions:launchOptions]) {
+      return NO;
     }
   }
   return YES;
@@ -101,13 +148,16 @@ static BOOL isPowerOfTwo(NSUInteger x) {
                          "To reconnect, launch your application again via 'flutter run'";
                 }];
 #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationDidEnterBackground:application];
-    }
+    [plugin applicationDidEnterBackground:application];
   }
 }
 
@@ -115,86 +165,108 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   [application endBackgroundTask:_debugBackgroundTask];
 #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationWillEnterForeground:application];
-    }
+    [plugin applicationWillEnterForeground:application];
   }
 }
 
 - (void)applicationWillResignActive:(UIApplication*)application {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationWillResignActive:application];
-    }
+    [plugin applicationWillResignActive:application];
   }
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationDidBecomeActive:application];
-    }
+    [plugin applicationDidBecomeActive:application];
   }
 }
 
 - (void)applicationWillTerminate:(UIApplication*)application {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationWillTerminate:application];
-    }
+    [plugin applicationWillTerminate:application];
   }
 }
 
 - (void)application:(UIApplication*)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin application:application didRegisterUserNotificationSettings:notificationSettings];
-    }
+    [plugin application:application didRegisterUserNotificationSettings:notificationSettings];
   }
 }
 
 - (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-    }
+    [plugin application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
   }
 }
 
 - (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
-              didReceiveRemoteNotification:userInfo
-                    fetchCompletionHandler:completionHandler]) {
-        return;
-      }
+
+    if ([plugin application:application
+            didReceiveRemoteNotification:userInfo
+                  fetchCompletionHandler:completionHandler]) {
+      return;
     }
   }
 }
@@ -202,28 +274,36 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return NO;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application openURL:url options:options]) {
-        return YES;
-      }
+
+    if ([plugin application:application openURL:url options:options]) {
+      return YES;
     }
   }
   return NO;
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return NO;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application handleOpenURL:url]) {
-        return YES;
-      }
+
+    if ([plugin application:application handleOpenURL:url]) {
+      return YES;
     }
   }
   return NO;
@@ -233,17 +313,21 @@ static BOOL isPowerOfTwo(NSUInteger x) {
               openURL:(NSURL*)url
     sourceApplication:(NSString*)sourceApplication
            annotation:(id)annotation {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return NO;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
-                        openURL:url
-              sourceApplication:sourceApplication
-                     annotation:annotation]) {
-        return YES;
-      }
+
+    if ([plugin application:application
+                      openURL:url
+            sourceApplication:sourceApplication
+                   annotation:annotation]) {
+      return YES;
     }
   }
   return NO;
@@ -252,16 +336,20 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (void)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler NS_AVAILABLE_IOS(9_0) {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
-              performActionForShortcutItem:shortcutItem
-                         completionHandler:completionHandler]) {
-        return;
-      }
+
+    if ([plugin application:application
+            performActionForShortcutItem:shortcutItem
+                       completionHandler:completionHandler]) {
+      return;
     }
   }
 }
@@ -269,16 +357,20 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
                       completionHandler:(nonnull void (^)())completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return NO;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
-              handleEventsForBackgroundURLSession:identifier
-                                completionHandler:completionHandler]) {
-        return YES;
-      }
+
+    if ([plugin application:application
+            handleEventsForBackgroundURLSession:identifier
+                              completionHandler:completionHandler]) {
+      return YES;
     }
   }
   return NO;
@@ -286,14 +378,18 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (BOOL)application:(UIApplication*)application
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return NO;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application performFetchWithCompletionHandler:completionHandler]) {
-        return YES;
-      }
+
+    if ([plugin application:application performFetchWithCompletionHandler:completionHandler]) {
+      return YES;
     }
   }
   return NO;
@@ -302,16 +398,20 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
       restorationHandler:(void (^)(NSArray*))restorationHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
+  auto it = _selectorTable.find(_cmd);
+  if (it == _selectorTable.end()) {
+    return NO;
+  }
+
+  for (id<FlutterPlugin> plugin in [it->second.get() allObjects]) {
+    if (plugin == nil) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
-              continueUserActivity:userActivity
-                restorationHandler:restorationHandler]) {
-        return YES;
-      }
+
+    if ([plugin application:application
+            continueUserActivity:userActivity
+              restorationHandler:restorationHandler]) {
+      return YES;
     }
   }
   return NO;


### PR DESCRIPTION
Make `FlutterAppDelegate` respond to various application life cycle
events (e.g. `applicationDidEnterBackground:`,
`applicationWillEnterForeground:`, etc.) dynamically by forwarding
them to the `FlutterPluginAppLifeCycleDelegate` only if a registered
plugin wants it.  This avoids unnecessary runtime warnings (e.g.
issue #9984).

`FlutterPluginAppLifeCycleDelegate` now maintains an internal table
mapping selectors to corresponding plugins, and it no longer iterates
over all plugins for each event (at the cost of using additional
space).

Note that empirical testing seems to indicate that iOS caches which
parts of the `UIApplicationDelegate` protocol the application
implements.  This means that client applications now must call
`-[FlutterAppDelegate addApplicationLifeCycleDelegate]` early in
application initialization (e.g. in the `-init` method) for plugins
to receive life cycle events.

This change also greatly reduces the amount of code that should be
copied and pasted from `FlutterAppDelegate` if client applications
cannot directly inherit from it.  Alternatively, it provides an
example for how client applications can use `FlutterAppDelegate` via
composition rather than inheritance (issue #20709).