### PR TITLE
Unconditionally set resource id to empty string

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -145,8 +145,8 @@ class AccessibilityBridge
 
         AccessibilityNodeInfo result = AccessibilityNodeInfo.obtain(mOwner, virtualViewId);
         // Work around for https://github.com/flutter/flutter/issues/2101 
-	result.setViewIdResourceName(""); 
-	result.setPackageName(mOwner.getContext().getPackageName());
+        result.setViewIdResourceName(""); 
+        result.setPackageName(mOwner.getContext().getPackageName());
         result.setClassName("android.view.View");
         result.setSource(mOwner, virtualViewId);
         result.setFocusable(object.isFocusable());
@@ -543,7 +543,6 @@ class AccessibilityBridge
                     return createAccessibilityNodeInfo(mA11yFocusedObject.id);
             }
         }
-	Log.i(TAG, "Did not find focus");
         return null;
     }
 
@@ -879,12 +878,12 @@ class AccessibilityBridge
         assert mObjects.containsKey(object.id);
         assert mObjects.get(object.id) == object;
         object.parent = null;
-        if (mA11yFocusedObject != null && mA11yFocusedObject.id == object.id) {
+        if (mA11yFocusedObject == object) {
             sendAccessibilityEvent(mA11yFocusedObject.id,
                     AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED);
             mA11yFocusedObject = null;
         }
-        if (mInputFocusedObject != null && mInputFocusedObject.id == object.id) {
+        if (mInputFocusedObject == object) {
             mInputFocusedObject = null;
         }
         if (mHoveredObject == object) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -144,7 +144,9 @@ class AccessibilityBridge
         }
 
         AccessibilityNodeInfo result = AccessibilityNodeInfo.obtain(mOwner, virtualViewId);
-        result.setPackageName(mOwner.getContext().getPackageName());
+        // Work around for https://github.com/flutter/flutter/issues/2101 
+	result.setViewIdResourceName(""); 
+	result.setPackageName(mOwner.getContext().getPackageName());
         result.setClassName("android.view.View");
         result.setSource(mOwner, virtualViewId);
         result.setFocusable(object.isFocusable());
@@ -529,6 +531,7 @@ class AccessibilityBridge
 
     @Override
     public AccessibilityNodeInfo findFocus(int focus) {
+	Log.i(TAG, "Focus on " + Integer.toString(focus));
         switch (focus) {
             case AccessibilityNodeInfo.FOCUS_INPUT: {
                 if (mInputFocusedObject != null)
@@ -540,6 +543,7 @@ class AccessibilityBridge
                     return createAccessibilityNodeInfo(mA11yFocusedObject.id);
             }
         }
+	Log.i(TAG, "Did not find focus");
         return null;
     }
 
@@ -875,12 +879,12 @@ class AccessibilityBridge
         assert mObjects.containsKey(object.id);
         assert mObjects.get(object.id) == object;
         object.parent = null;
-        if (mA11yFocusedObject == object) {
+        if (mA11yFocusedObject != null && mA11yFocusedObject.id == object.id) {
             sendAccessibilityEvent(mA11yFocusedObject.id,
                     AccessibilityEvent.TYPE_VIEW_ACCESSIBILITY_FOCUS_CLEARED);
             mA11yFocusedObject = null;
         }
-        if (mInputFocusedObject == object) {
+        if (mInputFocusedObject != null && mInputFocusedObject.id == object.id) {
             mInputFocusedObject = null;
         }
         if (mHoveredObject == object) {

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -531,7 +531,6 @@ class AccessibilityBridge
 
     @Override
     public AccessibilityNodeInfo findFocus(int focus) {
-	Log.i(TAG, "Focus on " + Integer.toString(focus));
         switch (focus) {
             case AccessibilityNodeInfo.FOCUS_INPUT: {
                 if (mInputFocusedObject != null)


### PR DESCRIPTION
Newer talkback versions attempt to check if the accessibility node comes from the PIN screen, resulting in an NPE when there is no resource Id set. This causes https://github.com/flutter/flutter/issues/21030

Fixes  flutter/flutter#21030