### PR TITLE
Roll ICU to c56c671998902fcc4fc9ace88c83daa99f980793

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -150,7 +150,7 @@ deps = {
    Var('chromium_git') + '/chromium/src/ios.git' + '@' + Var('ios_tools_revision'),
 
   'src/third_party/icu':
-   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + '6cf2ab2580888e520683c2d993133018c91e612c',
+   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'c56c671998902fcc4fc9ace88c83daa99f980793',
 
   'src/third_party/dart':
    Var('dart_git') + '/sdk.git' + '@' + Var('dart_revision'),

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: e0ba0c8d1c77d42c4ec33b647ecc9b37
+Signature: 39110f8cc5232d6526d93cfcefe87975
 
 UNUSED LICENSES:
 
@@ -9798,6 +9798,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -9924,6 +9925,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10055,6 +10057,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10185,6 +10188,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10321,6 +10325,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10456,6 +10461,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10587,6 +10593,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10717,6 +10724,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10820,6 +10828,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -10990,6 +10999,7 @@ FILE: ../../../third_party/icu/android/icudtl.dat
 FILE: ../../../third_party/icu/cast/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
+FILE: ../../../third_party/icu/flutter/brkitr.patch
 FILE: ../../../third_party/icu/flutter/icudtl.dat
 FILE: ../../../third_party/icu/fuzzers/fuzzer_utils.h
 FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_fuzzer.cc
@@ -16690,50 +16700,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: tonic
-ORIGIN: ../../../garnet/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/dart_list.cc
-FILE: ../../../third_party/tonic/dart_list.h
-FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
-FILE: ../../../third_party/tonic/platform/platform_utils.h
-FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
-FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
 ORIGIN: ../../../third_party/tonic/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/tonic/common/build_config.h
@@ -16803,6 +16769,50 @@ FILE: ../../../third_party/tonic/common/log.h
 FILE: ../../../third_party/tonic/common/macros.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2018 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: tonic
+ORIGIN: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc + ../../../third_party/tonic/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/tonic/dart_list.cc
+FILE: ../../../third_party/tonic/dart_list.h
+FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
+FILE: ../../../third_party/tonic/platform/platform_utils.h
+FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
+FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2017 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
The reduces the ICU data file even more:

Uncompressed size: 883,280B (862.6 KB), minus 363.2KB
Compressed size: 460,972B (450.2KB), minus 83.9KB

The following unused resources are removed compared to the previous version:
 * uts46.nrm
 * nfkc_cf.nrm
 * cnvalias.icu
 * Break Iterators for:
   * Sentence breaks
   * Title breaks
   * CSS-specific line breaks ("regular" line breaks are still supported)