### PR TITLE
Convert synthesized Android motion events to long and not to int.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -254,8 +254,8 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
         }
 
         MotionEvent event = MotionEvent.obtain(
-                downTime.intValue(),
-                eventTime.intValue(),
+                downTime.longValue(),
+                eventTime.longValue(),
                 action,
                 pointerCount,
                 pointerProperties,


### PR DESCRIPTION
(this was a bug, the values would overflow sometimes)