### PR TITLE
Roll Dart to dart-lang/sdk@760a9690c2

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '3e0631761c84d9fb86c237cc57dca7b878f5800f',
+  'dart_revision': '760a9690c22ec3f3d163173737f9949f97e6e02a',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -643,13 +643,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
-ORIGIN: ../../../flutter/fml/time/time_delta_unittest.cc + ../../../third_party/tonic/LICENSE
+ORIGIN: ../../../flutter/lib/ui/painting/image.cc + ../../../LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../flutter/fml/export.h
-FILE: ../../../flutter/fml/time/time_delta_unittest.cc
-FILE: ../../../flutter/fml/time/time_point_unittest.cc
+FILE: ../../../flutter/lib/ui/painting/image.cc
+FILE: ../../../flutter/lib/ui/painting/image.h
+FILE: ../../../flutter/shell/common/switches.cc
+FILE: ../../../flutter/shell/common/switches.h
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
 ----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
+Copyright 2013 The Chromium Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -680,17 +684,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
-ORIGIN: ../../../flutter/lib/ui/painting/image.cc + ../../../LICENSE
+ORIGIN: ../../../garnet/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../flutter/lib/ui/painting/image.cc
-FILE: ../../../flutter/lib/ui/painting/image.h
-FILE: ../../../flutter/shell/common/switches.cc
-FILE: ../../../flutter/shell/common/switches.h
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
+FILE: ../../../flutter/fml/export.h
+FILE: ../../../flutter/fml/time/time_delta_unittest.cc
+FILE: ../../../flutter/fml/time/time_point_unittest.cc
 ----------------------------------------------------------------------------------------------------
-Copyright 2013 The Chromium Authors. All rights reserved.
+Copyright 2017 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -643,17 +643,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
-ORIGIN: ../../../flutter/lib/ui/painting/image.cc + ../../../LICENSE
+ORIGIN: ../../../flutter/fml/time/time_delta_unittest.cc + ../../../third_party/tonic/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../flutter/lib/ui/painting/image.cc
-FILE: ../../../flutter/lib/ui/painting/image.h
-FILE: ../../../flutter/shell/common/switches.cc
-FILE: ../../../flutter/shell/common/switches.h
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
+FILE: ../../../flutter/fml/export.h
+FILE: ../../../flutter/fml/time/time_delta_unittest.cc
+FILE: ../../../flutter/fml/time/time_point_unittest.cc
 ----------------------------------------------------------------------------------------------------
-Copyright 2013 The Chromium Authors. All rights reserved.
+Copyright 2017 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -684,13 +680,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
-ORIGIN: ../../../garnet/LICENSE
+ORIGIN: ../../../flutter/lib/ui/painting/image.cc + ../../../LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../flutter/fml/export.h
-FILE: ../../../flutter/fml/time/time_delta_unittest.cc
-FILE: ../../../flutter/fml/time/time_point_unittest.cc
+FILE: ../../../flutter/lib/ui/painting/image.cc
+FILE: ../../../flutter/lib/ui/painting/image.h
+FILE: ../../../flutter/shell/common/switches.cc
+FILE: ../../../flutter/shell/common/switches.h
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
 ----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
+Copyright 2013 The Chromium Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: ff60dd095e2456af074915ace0492342
+Signature: 018879b823c0d21625f109959a471893
 
 UNUSED LICENSES:
 
@@ -16700,6 +16700,50 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: tonic
+ORIGIN: ../../../garnet/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/tonic/dart_list.cc
+FILE: ../../../third_party/tonic/dart_list.h
+FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
+FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
+FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
+FILE: ../../../third_party/tonic/platform/platform_utils.h
+FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
+FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2017 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: tonic
 ORIGIN: ../../../third_party/tonic/LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../third_party/tonic/common/build_config.h
@@ -16769,50 +16813,6 @@ FILE: ../../../third_party/tonic/common/log.h
 FILE: ../../../third_party/tonic/common/macros.h
 ----------------------------------------------------------------------------------------------------
 Copyright 2018 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc + ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/dart_list.cc
-FILE: ../../../third_party/tonic/dart_list.h
-FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
-FILE: ../../../third_party/tonic/platform/platform_utils.h
-FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
-FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
dart-lang/sdk@760a9690c2 Remove tests irrelevant for Dart 2
dart-lang/sdk@185eec12a6 Avoid crash on falsely enqueued .call methods.
dart-lang/sdk@3ea3b21e3c Deprecate summary field PackageBundle.unlinkedUnitHashes.
dart-lang/sdk@1b8f3026bf Remove most of isStrongModeError: false, update language_2 tests.
dart-lang/sdk@c6d786a3e7 [vm/bytecode] Take environment defines into account when generating bytecode
dart-lang/sdk@cc62869910 [Status files] Update status for passing corelib_2 tests in bytecode mode
dart-lang/sdk@0789ab8b0e Add clarification for broadcast stream.first
dart-lang/sdk@68e66d4ef5 Parser test cleanup
dart-lang/sdk@34963476ed Clarify behavior of sublist with end == start
dart-lang/sdk@bb382f3c81 Drop _CastQueueMixin
dart-lang/sdk@38b9a544df Call our error events in StreamTransform.bind doc
dart-lang/sdk@1b13583ba8 [vm/bytecode] Keep original declaration order of named parameters in native wrappers