### PR TITLE
Mark deprecated Flutter iOS APIs as unavailable

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/Flutter.h
+++ b/shell/platform/darwin/ios/framework/Headers/Flutter.h
@@ -8,6 +8,10 @@
 /**
  BREAKING CHANGES:
 
+ August 31, 2018: Marked -[FlutterDartProject
+ initFromDefaultSourceForConfiguration] and FlutterStandardBigInteger as
+ unavailable.
+
  July 26, 2018: Marked -[FlutterDartProject
  initFromDefaultSourceForConfiguration] deprecated.
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
@@ -154,13 +154,6 @@ FLUTTER_EXPORT
  - `FlutterStandardTypedData`: `Uint8List`, `Int32List`, `Int64List`, or `Float64List`
  - `NSArray`: `List`
  - `NSDictionary`: `Map`
-
- Support for `FlutterStandardBigInteger` has been deprecated on 2018-01-09 to be
- made unavailable four weeks after this change is available on the Flutter alpha
- branch. `FlutterStandardBigInteger` were needed because the Dart 1.0 `int` type
- had no size limit. With Dart 2.0, the `int` type is a fixed-size, 64-bit signed
- integer. If you need to communicate larger integers, use `NSString` encoding
- instead.
  */
 FLUTTER_EXPORT
 @interface FlutterStandardMessageCodec : NSObject <FlutterMessageCodec>
@@ -309,25 +302,13 @@ FLUTTER_EXPORT
  and `FlutterStandardMethodCodec`.
  */
 FLUTTER_EXPORT
-FLUTTER_DEPRECATED(
-    "Deprecated on 2018-01-09 to be made unavailable four weeks after the "
-    "deprecation is available on the flutter/flutter alpha branch. "
+FLUTTER_UNAVAILABLE(
+    "Unavailable on 2018-08-31. Deprecated on 2018-01-09. "
     "FlutterStandardBigInteger was needed because the Dart 1.0 int type had no "
     "size limit. With Dart 2.0, the int type is a fixed-size, 64-bit signed "
     "integer. If you need to communicate larger integers, use NSString encoding "
     "instead.")
 @interface FlutterStandardBigInteger : NSObject
-/**
- Creates a `FlutterStandardBigInteger` from a hexadecimal representation.
-
- - Parameter hex: a hexadecimal string.
- */
-+ (instancetype)bigIntegerWithHex:(NSString*)hex;
-
-/**
- The hexadecimal string representation of this integer.
- */
-@property(readonly, nonatomic) NSString* hex;
 @end
 
 /**

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -21,7 +21,7 @@ FLUTTER_EXPORT
 - (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL
     NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initFromDefaultSourceForConfiguration FLUTTER_DEPRECATED("Use -init instead.");
+- (instancetype)initFromDefaultSourceForConfiguration FLUTTER_UNAVAILABLE("Use -init instead.");
 
 /**
  Returns the file name for the given asset.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterMacros.h
@@ -21,7 +21,7 @@
 #endif  // defined(NS_ASSUME_NONNULL_BEGIN)
 
 /**
- Indicates that the API has been deprecated for the specifed reason. Code that
+ Indicates that the API has been deprecated for the specified reason. Code that
  uses the deprecated API will continue to work as before. However, the API will
  soon become unavailable and users are encouraged to immediately take the
  appropriate action mentioned in the deprecation message and the BREAKING

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -208,12 +208,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   return self;
 }
 
-#pragma mark - Convenience initializers
-
-// Exists for backward-compatibility.  Expect this to be removed.
-- (instancetype)initFromDefaultSourceForConfiguration {
-  return [self init];
-}
+#pragma mark - Settings accessors
 
 - (const blink::Settings&)settings {
   return _settings;

--- a/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
@@ -203,41 +203,6 @@ using namespace shell;
 }
 @end
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-
-@implementation FlutterStandardBigInteger
-+ (instancetype)bigIntegerWithHex:(NSString*)hex {
-  return [[[FlutterStandardBigInteger alloc] initWithHex:hex] autorelease];
-}
-
-- (instancetype)initWithHex:(NSString*)hex {
-  NSAssert(hex, @"Hex cannot be nil");
-  self = [super init];
-  NSAssert(self, @"Super init cannot be nil");
-  _hex = [hex retain];
-  return self;
-}
-
-- (void)dealloc {
-  [_hex release];
-  [super dealloc];
-}
-
-- (BOOL)isEqual:(id)object {
-  if (self == object)
-    return YES;
-  if (![object isKindOfClass:[FlutterStandardBigInteger class]])
-    return NO;
-  FlutterStandardBigInteger* other = (FlutterStandardBigInteger*)object;
-  return [self.hex isEqual:other.hex];
-}
-
-- (NSUInteger)hash {
-  return [self.hex hash];
-}
-@end
-
 #pragma mark - Writer and reader of standard codec
 
 @implementation FlutterStandardWriter {
@@ -336,10 +301,6 @@ using namespace shell;
     NSString* string = value;
     [self writeByte:FlutterStandardFieldString];
     [self writeUTF8:string];
-  } else if ([value isKindOfClass:[FlutterStandardBigInteger class]]) {
-    FlutterStandardBigInteger* bigInt = value;
-    [self writeByte:FlutterStandardFieldIntHex];
-    [self writeUTF8:bigInt.hex];
   } else if ([value isKindOfClass:[FlutterStandardTypedData class]]) {
     FlutterStandardTypedData* typedData = value;
     [self writeByte:FlutterStandardFieldForDataType(typedData.type)];
@@ -479,7 +440,6 @@ using namespace shell;
       return [NSNumber numberWithDouble:value];
     }
     case FlutterStandardFieldIntHex:
-      return [FlutterStandardBigInteger bigIntegerWithHex:[self readUTF8]];
     case FlutterStandardFieldString:
       return [self readUTF8];
     case FlutterStandardFieldUInt8Data:
@@ -522,4 +482,3 @@ using namespace shell;
   return [[[FlutterStandardReader alloc] initWithData:data] autorelease];
 }
 @end
-#pragma clang diagnostic pop

--- a/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec_Internal.h
@@ -16,6 +16,7 @@ typedef NS_ENUM(NSInteger, FlutterStandardField) {
   FlutterStandardFieldIntHex,
   FlutterStandardFieldFloat64,
   FlutterStandardFieldString,
+  // The following must match the corresponding order from `FlutterStandardDataType`.
   FlutterStandardFieldUInt8Data,
   FlutterStandardFieldInt32Data,
   FlutterStandardFieldInt64Data,

--- a/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
@@ -66,16 +66,13 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt32) {
   checkEncodeDecode(@(value), [NSData dataWithBytes:bytes length:9]);
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 TEST(FlutterStandardCodec, CanEncodeAndDecodeUInt64AsHexString) {
   FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
   UInt64 u64 = 0xfffffffffffffffa;
   NSData* encoded = [codec encode:@(u64)];
-  FlutterStandardBigInteger* decoded = [codec decode:encoded];
-  ASSERT_TRUE([decoded.hex isEqual:@"fffffffffffffffa"]);
+  NSString* decoded = [codec decode:encoded];
+  ASSERT_TRUE([decoded isEqual:@"fffffffffffffffa"]);
 }
-#pragma clang diagnostic pop
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt8) {
   uint8_t bytes[5] = {0x03, 0xfe, 0xff, 0xff, 0xff};
@@ -98,15 +95,6 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeSInt64) {
   uint8_t bytes[9] = {0x04, 0xef, 0xcd, 0xab, 0x90, 0x78, 0x56, 0x34, 0x12};
   checkEncodeDecode(@(0x1234567890abcdef), [NSData dataWithBytes:bytes length:9]);
 }
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-TEST(FlutterStandardCodec, CanEncodeAndDecodeBigInteger) {
-  FlutterStandardBigInteger* value =
-      [FlutterStandardBigInteger bigIntegerWithHex:@"-abcdef0123456789abcdef01234567890"];
-  checkEncodeDecode(value);
-}
-#pragma clang diagnostic pop
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeFloat32) {
   uint8_t bytes[16] = {0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,


### PR DESCRIPTION
The following were previously marked as deprecated over a month ago:
* `FlutterStandardBigInteger`
* `-[FlutterDartProject initFromDefaultSourceForConfiguration]`

Remove their implementations and mark them as unavailable.