### PR TITLE
Fix crash in text layout when GetMinikinFontCollectionForStyle returns null.

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -871,6 +871,9 @@ Paragraph::GetMinikinFontCollectionForStyle(const TextStyle& style) {
 sk_sp<SkTypeface> Paragraph::GetDefaultSkiaTypeface(const TextStyle& style) {
   std::shared_ptr<minikin::FontCollection> collection =
       GetMinikinFontCollectionForStyle(style);
+  if (!collection) {
+    return nullptr;
+  }
   minikin::FakedFont faked_font =
       collection->baseFontFaked(GetMinikinFontStyle(style));
   return static_cast<FontSkia*>(faked_font.font)->GetSkTypeface();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/21324. I suspect there is a better fix. I am going to investigate the same. In the meantime, this prevents certain layout jobs from taking down the engine.