### PR TITLE
Fix a gesture failure problem on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -25,8 +25,8 @@ static double kTouchTrackerCheckInterval = 1.f;
 
 @interface FlutterViewController () <FlutterTextInputDelegate>
 @property(nonatomic, readonly) NSMutableDictionary* pluginPublications;
-@property(nonatomic,retain) NSMutableSet *touchTrackerSet;
-@property(nonatomic,retain) NSMutableDictionary<NSValue *,NSNumber *> *touchTrackerDict;
+@property(nonatomic, retain) NSMutableSet* touchTrackerSet;
+@property(nonatomic, retain) NSMutableDictionary<NSValue*, NSNumber*>* touchTrackerDict;
 
 @end
 
@@ -74,7 +74,7 @@ static double kTouchTrackerCheckInterval = 1.f;
       _dartProject.reset([[FlutterDartProject alloc] init]);
     else
       _dartProject.reset([projectOrNil retain]);
-    
+
     _touchTrackerSet = [[NSMutableSet set] retain];
     _touchTrackerDict = [[NSMutableDictionary dictionary] retain];
 
@@ -558,7 +558,7 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   return blink::PointerData::DeviceKind::kTouch;
 }
 
-- (void)dispatchTouches:(NSSet*)touches phase:(UITouchPhase)phase trackTouches:(BOOL)bTrack{
+- (void)dispatchTouches:(NSSet*)touches phase:(UITouchPhase)phase trackTouches:(BOOL)bTrack {
   // Note: we cannot rely on touch.phase, since in some cases, e.g.,
   // handleStatusBarTouches, we synthesize touches from existing events.
   //
@@ -572,37 +572,37 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   int i = 0;
   for (UITouch* touch in touches) {
     int device_id = 0;
-    NSValue *key = [NSValue valueWithPointer:(void*)touch];
-      
+    NSValue* key = [NSValue valueWithPointer:(void*)touch];
+
     switch (eventTypePhase.second) {
-      case Accessed:{
+      case Accessed: {
         device_id = _touchMapper.identifierOf(touch);
-        if(bTrack){
-            [self.touchTrackerSet addObject:touch];
-            self.touchTrackerDict[key]=@(tsNow+kTouchTrackerCheckInterval);
+        if (bTrack) {
+          [self.touchTrackerSet addObject:touch];
+          self.touchTrackerDict[key] = @(tsNow + kTouchTrackerCheckInterval);
         }
         break;
       }
-      case Added:{
+      case Added: {
         device_id = _touchMapper.registerTouch(touch);
-        if(bTrack){
-            [self.touchTrackerSet addObject:touch];
-            self.touchTrackerDict[key]=@(tsNow+kTouchTrackerCheckInterval);
+        if (bTrack) {
+          [self.touchTrackerSet addObject:touch];
+          self.touchTrackerDict[key] = @(tsNow + kTouchTrackerCheckInterval);
         }
         break;
       }
-      case Removed:{
+      case Removed: {
         device_id = _touchMapper.unregisterTouch(touch);
-        if(bTrack){
-            [self.touchTrackerDict removeObjectForKey:key];
-            [self.touchTrackerSet removeObject:touch];
+        if (bTrack) {
+          [self.touchTrackerDict removeObjectForKey:key];
+          [self.touchTrackerSet removeObject:touch];
         }
         break;
       }
     }
-    
-    if(device_id == 0){
-        continue;
+
+    if (device_id == 0) {
+      continue;
     }
 
     FML_DCHECK(device_id != 0);
@@ -704,28 +704,28 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   [self dispatchTouches:touches phase:UITouchPhaseCancelled trackTouches:TRUE];
 }
 
-- (BOOL)checkIfCompleteTouches{
-    NSInteger cnt = self.touchTrackerSet.count;
-    if(cnt<=0)
-        return FALSE;
-    NSTimeInterval tsNow = [[NSDate date] timeIntervalSinceReferenceDate];
-    NSSet *tmpTrackingTouches = [self.touchTrackerSet copy];
-    NSMutableSet *set = [NSMutableSet set];
-    for(UITouch *touch in tmpTrackingTouches){
-        NSValue *key = [NSValue valueWithPointer:(void*)touch];
-        NSNumber *expiredTime = [self.touchTrackerDict objectForKey:key];
-        if(expiredTime.doubleValue<=tsNow){
-            [set addObject:touch];
-            [self.touchTrackerDict removeObjectForKey:key];
-            [self.touchTrackerSet removeObject:touch];
-        }
-    }
-    if(set.count>0){
-        [self dispatchTouches:set phase:UITouchPhaseBegan trackTouches:FALSE];
-        [self dispatchTouches:set phase:UITouchPhaseCancelled trackTouches:FALSE];
-        return TRUE;
-    }
+- (BOOL)checkIfCompleteTouches {
+  NSInteger cnt = self.touchTrackerSet.count;
+  if (cnt <= 0)
     return FALSE;
+  NSTimeInterval tsNow = [[NSDate date] timeIntervalSinceReferenceDate];
+  NSSet* tmpTrackingTouches = [self.touchTrackerSet copy];
+  NSMutableSet* set = [NSMutableSet set];
+  for (UITouch* touch in tmpTrackingTouches) {
+    NSValue* key = [NSValue valueWithPointer:(void*)touch];
+    NSNumber* expiredTime = [self.touchTrackerDict objectForKey:key];
+    if (expiredTime.doubleValue <= tsNow) {
+      [set addObject:touch];
+      [self.touchTrackerDict removeObjectForKey:key];
+      [self.touchTrackerSet removeObject:touch];
+    }
+  }
+  if (set.count > 0) {
+    [self dispatchTouches:set phase:UITouchPhaseBegan trackTouches:FALSE];
+    [self dispatchTouches:set phase:UITouchPhaseCancelled trackTouches:FALSE];
+    return TRUE;
+  }
+  return FALSE;
 }
 
 #pragma mark - Handle view resizing

--- a/shell/platform/darwin/ios/framework/Source/flutter_touch_mapper.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_touch_mapper.mm
@@ -11,8 +11,8 @@ TouchMapper::TouchMapper() : free_spots_(~0) {}
 TouchMapper::~TouchMapper() = default;
 
 int TouchMapper::registerTouch(UITouch* touch) {
-  if(touch_map_.find(touch) != touch_map_.end()){
-      return 0;
+  if (touch_map_.find(touch) != touch_map_.end()) {
+    return 0;
   }
   int freeSpot = ffsll(free_spots_);
   touch_map_[touch] = freeSpot;
@@ -21,8 +21,8 @@ int TouchMapper::registerTouch(UITouch* touch) {
 }
 
 int TouchMapper::unregisterTouch(UITouch* touch) {
-  if(touch_map_.find(touch) == touch_map_.end()){
-      return 0;
+  if (touch_map_.find(touch) == touch_map_.end()) {
+    return 0;
   }
   auto index = touch_map_[touch];
   free_spots_ |= 1 << (index - 1);
@@ -31,8 +31,8 @@ int TouchMapper::unregisterTouch(UITouch* touch) {
 }
 
 int TouchMapper::identifierOf(UITouch* touch) const {
-  if(touch_map_.find(touch) == touch_map_.end()){
-      return 0;
+  if (touch_map_.find(touch) == touch_map_.end()) {
+    return 0;
   }
   return touch_map_.at(touch);
 }

--- a/shell/platform/darwin/ios/framework/Source/flutter_touch_mapper.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_touch_mapper.mm
@@ -11,6 +11,9 @@ TouchMapper::TouchMapper() : free_spots_(~0) {}
 TouchMapper::~TouchMapper() = default;
 
 int TouchMapper::registerTouch(UITouch* touch) {
+  if(touch_map_.find(touch) != touch_map_.end()){
+      return 0;
+  }
   int freeSpot = ffsll(free_spots_);
   touch_map_[touch] = freeSpot;
   free_spots_ &= ~(1 << (freeSpot - 1));
@@ -18,6 +21,9 @@ int TouchMapper::registerTouch(UITouch* touch) {
 }
 
 int TouchMapper::unregisterTouch(UITouch* touch) {
+  if(touch_map_.find(touch) == touch_map_.end()){
+      return 0;
+  }
   auto index = touch_map_[touch];
   free_spots_ |= 1 << (index - 1);
   touch_map_.erase(touch);
@@ -25,6 +31,9 @@ int TouchMapper::unregisterTouch(UITouch* touch) {
 }
 
 int TouchMapper::identifierOf(UITouch* touch) const {
+  if(touch_map_.find(touch) == touch_map_.end()){
+      return 0;
+  }
   return touch_map_.at(touch);
 }
 


### PR DESCRIPTION
Previously, our team met a gesture failure problem in our ItemDetail page. The scenario is like below:
![img_4754](https://user-images.githubusercontent.com/817851/44980397-59be3300-afa2-11e8-8d8d-8efdca418884.JPG)

i.e., we have a scrollable listview(VerticalDragGestureRecognizer actully) which contains a lot of items. Some items are pure text for display, some items are images which is wrapped in a GestureDetector(TapGestureRecognizer actully) so that a single tap could allow the app open a full-screen image.

However, in some abnormal operations,especially when user touch the screen with multiple fingers. For example, when I touch the screen with two fingers, if I touch one image with two fingers in the same image multiple times, the image will not be clickable.
I reproduced the problem and found that that's because that TapGestureRecognizer's state is "GestureRecognizerState.possible" when a new touchevent comes after some idle time, as below:
![screen shot 2018-09-03 at 6 13 21 pm](https://user-images.githubusercontent.com/817851/44981426-131e0800-afa5-11e8-9941-bbebf127d1ff.png)
So this event will be ignored and the tap will not work.

In some operations with two fingers, like one on the listview(text section) while another one on the Image multiple times, the list will not scroll smoothly.

I also reproduces the problem and found that that's because the VerticalDragGestureRecognizer's  trackedPointers will be never be empty again, so the didStopTrackingLastPointer will be not called and it's state will be always _DragState.accepted.
![screen shot 2018-09-03 at 6 21 15 pm](https://user-images.githubusercontent.com/817851/44981878-79eff100-afa6-11e8-95ba-f9f2f8574906.png)

The list stuck like below(no bounce-back effect):
![img_0006](https://user-images.githubusercontent.com/817851/44986180-6ac46f80-afb5-11e8-8d46-9d584034d7e4.PNG)

When this happens, the image will also be not clickable because of the corresponding RenderIgnorePointer has a true value for ignoring, as below:
![screen shot 2018-09-03 at 8 08 49 pm](https://user-images.githubusercontent.com/817851/44986112-318bff80-afb5-11e8-8d36-555c5883443c.png)

I dug more and found this is a platform-specific problem, i.e., it happens only for iOS.
Currently, gestures in flutter track every UITouch in iOS side. For certain flutter gesture, named FG, it tracks any UITouche (UT) in FG's area. Normally, for UT, there are several states, BEGIN(touchesBegan), UPDATE(touchesMoved), FINISH(touchesEnded/touchesCancelled). When the BEGIN and FINISH are called in pair for UT, the flutter gesture works fine. However, when faced with some unusual operations as mentioned above, I found several typical cases as shown below(for one UITouch object, or UT):
A. touchesBegan called -> touchesBegan called -> touchesEnded called
B. touchesBegan called -> touchesEnded called -> touchesBegan called 
C. touchesBegan called

That's to say, in some unusual operations, the logic behind flutter gesture in iOS will not work properly.
I add some track and check code based on a timeout logic in my patch to fix this problem, it works fine for us and those problems mentioned above disappear.







