### PR TITLE
Fix windows build.

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -13,6 +13,10 @@
 #include "third_party/skia/include/core/SkSurfaceCharacterization.h"
 #include "third_party/skia/include/utils/SkBase64.h"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 namespace shell {
 
 Rasterizer::Rasterizer(blink::TaskRunners task_runners)


### PR DESCRIPTION
This is because a window system header defines ERROR to 0. This is used in FML logging. I couldn't just rename the same earlier because we also used FXL. But, I can attempt a rename now. Till that lands, this is a workaround to unbreak the bots.