### PR TITLE
Enable transparent FlutterViews

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -114,7 +114,7 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
       surface_->GetContext(), canvas, surface_->GetRootTransformation(), true);
 
   if (canvas) {
-    canvas->clear(SK_ColorBLACK);
+    canvas->clear(SK_ColorTRANSPARENT);
   }
 
   if (compositor_frame && compositor_frame->Raster(layer_tree, false)) {
@@ -186,7 +186,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsImage(
 
   auto frame = compositor_context.AcquireFrame(
       surface_context, canvas, root_surface_transformation, false);
-  canvas->clear(SK_ColorBLACK);
+  canvas->clear(SK_ColorTRANSPARENT);
   frame->Raster(*tree, true);
   canvas->flush();
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -131,20 +131,11 @@ public class FlutterView extends SurfaceView
         }
         mNativeView.attachViewAndActivity(this, activity);
 
-        int color = 0xFF000000;
-        TypedValue typedValue = new TypedValue();
-        context.getTheme().resolveAttribute(android.R.attr.colorBackground, typedValue, true);
-        if (typedValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && typedValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
-            color = typedValue.data;
-        }
-        // TODO(abarth): Consider letting the developer override this color.
-        final int backgroundColor = color;
-
         mSurfaceCallback = new SurfaceHolder.Callback() {
             @Override
             public void surfaceCreated(SurfaceHolder holder) {
                 assertAttached();
-                nativeSurfaceCreated(mNativeView.get(), holder.getSurface(), backgroundColor);
+                nativeSurfaceCreated(mNativeView.get(), holder.getSurface());
             }
 
             @Override
@@ -651,8 +642,7 @@ public class FlutterView extends SurfaceView
         return nativeGetBitmap(mNativeView.get());
     }
 
-    private static native void nativeSurfaceCreated(long nativePlatformViewAndroid, Surface surface,
-            int backgroundColor);
+    private static native void nativeSurfaceCreated(long nativePlatformViewAndroid, Surface surface);
 
     private static native void nativeSurfaceChanged(long nativePlatformViewAndroid, int width, int height);
 

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -176,8 +176,7 @@ static jstring GetObservatoryUri(JNIEnv* env, jclass clazz) {
 static void SurfaceCreated(JNIEnv* env,
                            jobject jcaller,
                            jlong shell_holder,
-                           jobject jsurface,
-                           jint backgroundColor) {
+                           jobject jsurface) {
   // Note: This frame ensures that any local references used by
   // ANativeWindow_fromSurface are released immediately. This is needed as a
   // workaround for https://code.google.com/p/android/issues/detail?id=68174
@@ -638,7 +637,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
   static const JNINativeMethod view_methods[] = {
       {
           .name = "nativeSurfaceCreated",
-          .signature = "(JLandroid/view/Surface;I)V",
+          .signature = "(JLandroid/view/Surface;)V",
           .fnPtr = reinterpret_cast<void*>(&shell::SurfaceCreated),
       },
       {


### PR DESCRIPTION
- Changes rasterizer to clear the canvas with `SkColor_TRANSPARENT`
- Removes the unused `backgroundColor` param from `FlutterView.java`

Partially addresses [#9627](https://github.com/flutter/flutter/issues/9627)