### PR TITLE
Roll buildroot to 7aadfaf196f9cd8a299f9ad78fab63362800466d

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -115,7 +115,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '35959f6255c341eee550884ed69afd6b2891bd53',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7aadfaf196f9cd8a299f9ad78fab63362800466d',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Switches Android linker from gold to lld, preparation for LTO on Android.