### PR TITLE
Revert "Dart SDK roll for 2018/09/04 (#6161)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '2b995b2654ba162c48cdd187ce0b2f1d24c6838f',
+  'dart_revision': '760a9690c22ec3f3d163173737f9949f97e6e02a',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -5461,7 +5461,6 @@ FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/backend/code_statistics.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h
-FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_state.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_reader.cc

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 5ff2cabdf3ef0c70254ec22bc9e767c6
+Signature: da77c336d1e2756b2cca2e2d00f2d741
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
This reverts commit b22badf1d473d2fc88e8db60d2616028bfbc5226.
FlutterTesterDevice (in packages/flutter_tools/test/integration/flutter_tester_test.dart) is failing:

```
../../bin/cache/dart-sdk/bin/dart test/integration/flutter_tester_test.dart
00:00 +0: FlutterTesterDevice start
00:00 +0 -1: FlutterTesterDevice start [E]
  Bad state: Invalid script: file:///tmp/flutter_tester_device_test.EAPFMQ/test/integration/flutter_tester_test.dart
```
