### PR TITLE
Fix LibTxt/minikin text shifiting when breaking into multiple runs

### DIFF
--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -1132,7 +1132,9 @@ void Layout::appendLayout(Layout* src, size_t start, float extraAdvance) {
     int font_ix = findFace(src->mFaces[i], NULL);
     fontMap[i] = font_ix;
   }
-  int x0 = mAdvance;
+  // LibTxt: Changed x0 from int to float to prevent rounding that causes text
+  // jitter.
+  float x0 = mAdvance;
   for (size_t i = 0; i < src->mGlyphs.size(); i++) {
     LayoutGlyph& srcGlyph = src->mGlyphs[i];
     int font_ix = fontMap[srcGlyph.font_ix];

--- a/third_party/txt/src/txt/paint_record.h
+++ b/third_party/txt/src/txt/paint_record.h
@@ -63,7 +63,7 @@ class PaintRecord {
 
   size_t line() const { return line_; }
 
-  size_t GetRunWidth() const { return run_width_; }
+  double GetRunWidth() const { return run_width_; }
 
  private:
   TextStyle style_;

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -184,6 +184,7 @@ class Paragraph {
   FRIEND_TEST(ParagraphTest, HyphenBreakParagraph);
   FRIEND_TEST(ParagraphTest, RepeatLayoutParagraph);
   FRIEND_TEST(ParagraphTest, Ellipsize);
+  FRIEND_TEST(ParagraphTest, UnderlineShiftParagraph);
 
   // Starting data to layout.
   std::vector<uint16_t> text_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/21442

Patched minikin to not round advances for no clear reason.

Added test to test for this in the future.