### PR TITLE
Don't map iOS reduce motion to disabled animations

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -763,6 +763,7 @@ class AccessibilityFeatures {
   static const int _kInvertColorsIndex = 1 << 1;
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
+  static const int _kReduceMotionIndex = 1 << 4;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -784,6 +785,12 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get boldText => _kBoldTextIndex & _index != 0;
 
+  /// The platform is requesting that certain animations be simplified and
+  /// parallax effects removed.
+  ///
+  /// Only supported on iOS.
+  bool get reduceMotion => _kReduceMotionIndex & _index != 0;
+
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -795,6 +802,8 @@ class AccessibilityFeatures {
       features.add('disableAnimations');
     if (boldText)
       features.add('boldText');
+    if (reduceMotion)
+      features.add('reduceMotion');
     return 'AccessibilityFeatures$features';
   }
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -31,6 +31,7 @@ enum class AccessibilityFeatureFlag : int32_t {
   kInvertColors = 1 << 1,
   kDisableAnimations = 1 << 2,
   kBoldText = 1 << 3,
+  kReduceMotion = 1 << 4,
 };
 
 class WindowClient {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -835,8 +835,9 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   int32_t flags = 0;
   if (UIAccessibilityIsInvertColorsEnabled())
     flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
-  if (UIAccessibilityIsReduceMotionEnabled())
-    flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kDisableAnimations);
+  // TODO(jonahwilliams): add a different flag for reduce motion since it is so different.
+  // if (UIAccessibilityIsReduceMotionEnabled())
+  //   flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kDisableAnimations);
   if (UIAccessibilityIsBoldTextEnabled())
     flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
 #if TARGET_OS_SIMULATOR

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -835,9 +835,8 @@ static inline blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* to
   int32_t flags = 0;
   if (UIAccessibilityIsInvertColorsEnabled())
     flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
-  // TODO(jonahwilliams): add a different flag for reduce motion since it is so different.
-  // if (UIAccessibilityIsReduceMotionEnabled())
-  //   flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kDisableAnimations);
+  if (UIAccessibilityIsReduceMotionEnabled())
+    flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kReduceMotion);
   if (UIAccessibilityIsBoldTextEnabled())
     flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
 #if TARGET_OS_SIMULATOR


### PR DESCRIPTION
This was an oversight on my part on the extent of reduce motion (seems to do very little actually).