### PR TITLE
Always save canvas to prevent ClipRects from drawing on top of higher layers.

### DIFF
--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -41,8 +41,8 @@ void ClipRectLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipRectLayer::Paint");
   FML_DCHECK(needs_painting());
 
-  SkAutoCanvasRestore save(&context.canvas, clip_behavior_ != Clip::hardEdge);
-  context.canvas.clipRect(paint_bounds());
+  SkAutoCanvasRestore save(&context.canvas, true);
+  context.canvas.clipRect(paint_bounds(), clip_behavior_ != Clip::hardEdge);
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
     context.canvas.saveLayer(paint_bounds(), nullptr);
   }


### PR DESCRIPTION
When ClipRects have hardEdge clipBehavior, the cliprect will draw on top of the performance overlay. This prevents that by always saving when doing SkAutoCanvasRestore.

Fixes https://github.com/flutter/flutter/issues/21095