### PR TITLE
Allow embedders to specify a custom GL proc address resolver.

### DIFF
--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -5,6 +5,7 @@
 #ifndef SHELL_GPU_GPU_SURFACE_GL_H_
 #define SHELL_GPU_GPU_SURFACE_GL_H_
 
+#include <functional>
 #include <memory>
 
 #include "flutter/fml/macros.h"
@@ -33,6 +34,10 @@ class GPUSurfaceGLDelegate {
     matrix.setIdentity();
     return matrix;
   }
+
+  using GLProcResolver =
+      std::function<void* /* proc name */ (const char* /* proc address */)>;
+  virtual GLProcResolver GetGLProcResolver() const { return nullptr; }
 };
 
 class GPUSurfaceGL : public Surface {
@@ -55,6 +60,7 @@ class GPUSurfaceGL : public Surface {
 
  private:
   GPUSurfaceGLDelegate* delegate_;
+  GPUSurfaceGLDelegate::GLProcResolver proc_resolver_;
   sk_sp<GrContext> context_;
   sk_sp<SkSurface> onscreen_surface_;
   sk_sp<SkSurface> offscreen_surface_;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -138,16 +138,25 @@ InferOpenGLPlatformViewCreationCallback(
         };
   }
 
+  shell::GPUSurfaceGLDelegate::GLProcResolver gl_proc_resolver = nullptr;
+  if (SAFE_ACCESS(open_gl_config, gl_proc_resolver, nullptr) != nullptr) {
+    gl_proc_resolver = [ptr = config->open_gl.gl_proc_resolver,
+                        user_data](const char* gl_proc_name) {
+      return ptr(user_data, gl_proc_name);
+    };
+  }
+
   bool fbo_reset_after_present =
       SAFE_ACCESS(open_gl_config, fbo_reset_after_present, false);
 
   shell::EmbedderSurfaceGL::GLDispatchTable gl_dispatch_table = {
-      gl_make_current,                    // gl_make_current_callback
-      gl_clear_current,                   // gl_clear_current_callback
-      gl_present,                         // gl_present_callback
-      gl_fbo_callback,                    // gl_fbo_callback
-      gl_make_resource_current_callback,  // gl_make_resource_current_callback
-      gl_surface_transformation_callback  // gl_surface_transformation_callback
+      gl_make_current,                     // gl_make_current_callback
+      gl_clear_current,                    // gl_clear_current_callback
+      gl_present,                          // gl_present_callback
+      gl_fbo_callback,                     // gl_fbo_callback
+      gl_make_resource_current_callback,   // gl_make_resource_current_callback
+      gl_surface_transformation_callback,  // gl_surface_transformation_callback
+      gl_proc_resolver,                    // gl_proc_resolver
   };
 
   return [gl_dispatch_table, fbo_reset_after_present,

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -60,6 +60,7 @@ typedef bool (*SoftwareSurfacePresentCallback)(void* /* user data */,
                                                const void* /* allocation */,
                                                size_t /* row bytes */,
                                                size_t /* height */);
+typedef void* (*ProcResolver)(void* /* user data */, const char* /* name */);
 
 typedef struct {
   // The size of this struct. Must be sizeof(FlutterOpenGLRendererConfig).
@@ -77,6 +78,7 @@ typedef struct {
   // The transformation to apply to the render target before any rendering
   // operations. This callback is optional.
   TransformationCallback surface_transformation;
+  ProcResolver gl_proc_resolver;
 } FlutterOpenGLRendererConfig;
 
 typedef struct {

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -70,6 +70,11 @@ SkMatrix EmbedderSurfaceGL::GLContextSurfaceTransformation() const {
   return callback();
 }
 
+// |shell::GPUSurfaceGLDelegate|
+EmbedderSurfaceGL::GLProcResolver EmbedderSurfaceGL::GetGLProcResolver() const {
+  return gl_dispatch_table_.gl_proc_resolver;
+}
+
 // |shell::EmbedderSurface|
 std::unique_ptr<Surface> EmbedderSurfaceGL::CreateGPUSurface() {
   return std::make_unique<GPUSurfaceGL>(this);

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -21,7 +21,8 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
     std::function<intptr_t(void)> gl_fbo_callback;                // required
     std::function<bool(void)> gl_make_resource_current_callback;  // optional
     std::function<SkMatrix(void)>
-        gl_surface_transformation_callback;  // optional
+        gl_surface_transformation_callback;              // optional
+    std::function<void*(const char*)> gl_proc_resolver;  // optional
   };
 
   EmbedderSurfaceGL(GLDispatchTable gl_dispatch_table,
@@ -60,6 +61,9 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
 
   // |shell::GPUSurfaceGLDelegate|
   SkMatrix GLContextSurfaceTransformation() const override;
+
+  // |shell::GPUSurfaceGLDelegate|
+  GLProcResolver GetGLProcResolver() const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSurfaceGL);
 };


### PR DESCRIPTION
This updates the embedder API but introduces no breaking ABI/API
changes.