### PR TITLE
Make FlutterStandardCodec handle writing NSData

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
@@ -217,7 +217,8 @@ FLUTTER_EXPORT
 
 /**
  Invokes the specified Flutter method with the specified arguments, expecting
- no results.  See [MethodChannel.setMethodCallHandler](https://docs.flutter.io/flutter/services/MethodChannel/setMethodCallHandler.html).
+ no results.  See
+ [MethodChannel.setMethodCallHandler](https://docs.flutter.io/flutter/services/MethodChannel/setMethodCallHandler.html).
 
  - Parameters:
    - method: The name of the method to invoke.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h
@@ -217,7 +217,7 @@ FLUTTER_EXPORT
 
 /**
  Invokes the specified Flutter method with the specified arguments, expecting
- no results.
+ no results.  See [MethodChannel.setMethodCallHandler](https://docs.flutter.io/flutter/services/MethodChannel/setMethodCallHandler.html).
 
  - Parameters:
    - method: The name of the method to invoke.

--- a/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
@@ -307,6 +307,8 @@ using namespace shell;
     [self writeSize:typedData.elementCount];
     [self writeAlignment:typedData.elementSize];
     [self writeData:typedData.data];
+  } else if ([value isKindOfClass:[NSData class]]) {
+    [self writeValue:[FlutterStandardTypedData typedDataWithBytes:value]];
   } else if ([value isKindOfClass:[NSArray class]]) {
     NSArray* array = value;
     [self writeByte:FlutterStandardFieldList];

--- a/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
@@ -125,16 +125,16 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeStringWithNonBMPCodePoint) {
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeArray) {
-  NSArray* value = @[ [NSNull null], @"hello", @3.14, @47, @{ @42 : @"nested" } ];
+  NSArray* value = @[ [NSNull null], @"hello", @3.14, @47, @{@42 : @"nested"} ];
   checkEncodeDecode(value);
 }
 
 TEST(FlutterStandardCodec, CanEncodeAndDecodeDictionary) {
   NSDictionary* value =
-      @{ @"a" : @3.14,
-         @"b" : @47,
-         [NSNull null] : [NSNull null],
-         @3.14 : @[ @"nested" ] };
+      @{@"a" : @3.14,
+        @"b" : @47,
+        [NSNull null] : [NSNull null],
+        @3.14 : @[ @"nested" ]};
   checkEncodeDecode(value);
 }
 
@@ -196,8 +196,8 @@ TEST(FlutterStandardCodec, HandlesMethodCallsWithSingleArgument) {
 TEST(FlutterStandardCodec, HandlesMethodCallsWithArgumentList) {
   FlutterStandardMethodCodec* codec = [FlutterStandardMethodCodec sharedInstance];
   NSArray* arguments = @[ @42, @"world" ];
-  FlutterMethodCall* call =
-      [FlutterMethodCall methodCallWithMethodName:@"hello" arguments:arguments];
+  FlutterMethodCall* call = [FlutterMethodCall methodCallWithMethodName:@"hello"
+                                                              arguments:arguments];
   NSData* encoded = [codec encodeMethodCall:call];
   FlutterMethodCall* decoded = [codec decodeMethodCall:encoded];
   ASSERT_TRUE([decoded isEqual:call]);
@@ -219,7 +219,7 @@ TEST(FlutterStandardCodec, HandlesSuccessEnvelopesWithSingleResult) {
 
 TEST(FlutterStandardCodec, HandlesSuccessEnvelopesWithResultMap) {
   FlutterStandardMethodCodec* codec = [FlutterStandardMethodCodec sharedInstance];
-  NSDictionary* result = @{ @"a" : @42, @42 : @"a" };
+  NSDictionary* result = @{@"a" : @42, @42 : @"a"};
   NSData* encoded = [codec encodeSuccessEnvelope:result];
   id decoded = [codec decodeEnvelope:encoded];
   ASSERT_TRUE([decoded isEqual:result]);
@@ -227,9 +227,10 @@ TEST(FlutterStandardCodec, HandlesSuccessEnvelopesWithResultMap) {
 
 TEST(FlutterStandardCodec, HandlesErrorEnvelopes) {
   FlutterStandardMethodCodec* codec = [FlutterStandardMethodCodec sharedInstance];
-  NSDictionary* details = @{ @"a" : @42, @42 : @"a" };
-  FlutterError* error =
-      [FlutterError errorWithCode:@"errorCode" message:@"something failed" details:details];
+  NSDictionary* details = @{@"a" : @42, @42 : @"a"};
+  FlutterError* error = [FlutterError errorWithCode:@"errorCode"
+                                            message:@"something failed"
+                                            details:details];
   NSData* encoded = [codec encodeErrorEnvelope:error];
   id decoded = [codec decodeEnvelope:encoded];
   ASSERT_TRUE([decoded isEqual:error]);

--- a/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
+++ b/shell/platform/darwin/ios/framework/Source/flutter_standard_codec_unittest.mm
@@ -145,6 +145,16 @@ TEST(FlutterStandardCodec, CanEncodeAndDecodeByteArray) {
   checkEncodeDecode(value);
 }
 
+TEST(FlutterStandardCodec, CanEncodeAndDecodeNSData) {
+  FlutterStandardMessageCodec* codec = [FlutterStandardMessageCodec sharedInstance];
+  uint8_t bytes[4] = {0xBA, 0x5E, 0xBA, 0x11};
+  NSData* data = [NSData dataWithBytes:bytes length:4];
+  FlutterStandardTypedData* standardData = [FlutterStandardTypedData typedDataWithBytes:data];
+
+  NSData* encoded = [codec encode:data];
+  ASSERT_TRUE([encoded isEqual:[codec encode:standardData]]);
+}
+
 TEST(FlutterStandardCodec, CanEncodeAndDecodeInt32Array) {
   uint8_t bytes[8] = {0xBA, 0x5E, 0xBA, 0x11, 0xff, 0xff, 0xff, 0xff};
   NSData* data = [NSData dataWithBytes:bytes length:8];


### PR DESCRIPTION
iOS developers can accidentally pass an `NSData` object directly to
`FlutterStandardCodec` and forget to wrap it in
`FlutterStandardTypedData`.  This failure won't be caught until
runtime.

Let's make `FlutterStandardCodec` more tolerant by making it assume
that `NSData` should be treated as a binary blob and by wrapping it
automatically.

Fixes https://github.com/flutter/flutter/issues/17449

Testing Done:
* Made a sample Flutter iOS application that created a
  `FlutterMethodChannel` and invoked a method using an `NSData*`
  argument.  Verified that the Flutter method handler received the
  message and that the `MethodCall.arguments` was a `UInt8Array` that
  preserved the original byte order.
* Verified that without this change, the same sample application
  crashed when run in debug mode.