### PR TITLE
Roll Dart to ef720983530e04819b6fda0659ed7a3fdb190060.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'cd9a42239f76e110dd73aeaac4c69a057a76ddf1',
+  'dart_revision': 'ef720983530e04819b6fda0659ed7a3fdb190060',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: fbcaf0eca04aa4bfacf6dcc71a919be3
+Signature: 7e3e1daeb388f5b96234b99e29bf6711
 
 UNUSED LICENSES:
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -86,6 +86,12 @@ action("generate_snapshot_bin") {
     "--await_is_keyword",
     "--vm_flag",
     "--enable_mirrors=false",
+    "--vm_flag",
+    "--no-strong",
+    "--vm_flag",
+    "--no-sync-async",
+    "--vm_flag",
+    "--no-reify-generic-functions",
     "--vm_output_bin",
     rebase_path(vm_snapshot_data, root_build_dir),
     "--vm_instructions_output_bin",
@@ -289,6 +295,9 @@ template("generate_entry_points_json_with_gen_snapshot") {
       output,
     ]
     args = [
+      "--no-strong",
+      "--no-sync-async",
+      "--no-reify-generic-functions",
       "--print-precompiler-entry-points=" + rebase_path(output),
       "--snapshot-kind=app-aot-blobs",
       "--vm_snapshot_data=" + rebase_path("$target_gen_dir/dummy.vm_data.snapshot"),

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -92,7 +92,15 @@ static const char* kDartCheckedModeArgs[] = {
     // clang-format on
 };
 
-static const char* kDartStrongModeArgs[] = {
+static const char* kDartModeArgs[] = {
+    // clang-format off
+    "--no-strong",
+    "--no-reify_generic_functions",
+    "--no-sync_async",
+    // clang-format on
+};
+
+static const char* kDart2ModeArgs[] = {
     // clang-format off
     "--strong",
     "--reify_generic_functions",
@@ -381,16 +389,19 @@ DartVM::DartVM(const Settings& settings,
                  << isolate_snapshot_is_dart_2;
 
   if (is_preview_dart2) {
-    PushBackAll(&args, kDartStrongModeArgs, arraysize(kDartStrongModeArgs));
+    PushBackAll(&args, kDart2ModeArgs, arraysize(kDart2ModeArgs));
     if (use_checked_mode) {
       PushBackAll(&args, kDartAssertArgs, arraysize(kDartAssertArgs));
     }
-  } else if (use_checked_mode) {
-    FML_DLOG(INFO) << "Checked mode is ON";
-    PushBackAll(&args, kDartAssertArgs, arraysize(kDartAssertArgs));
-    PushBackAll(&args, kDartCheckedModeArgs, arraysize(kDartCheckedModeArgs));
   } else {
-    FML_DLOG(INFO) << "Is not Dart 2 and Checked mode is OFF";
+    PushBackAll(&args, kDartModeArgs, arraysize(kDartModeArgs));
+    if (use_checked_mode) {
+      FML_DLOG(INFO) << "Checked mode is ON";
+      PushBackAll(&args, kDartAssertArgs, arraysize(kDartAssertArgs));
+      PushBackAll(&args, kDartCheckedModeArgs, arraysize(kDartCheckedModeArgs));
+    } else {
+      FML_DLOG(INFO) << "Is not Dart 2 and Checked mode is OFF";
+    }
   }
 
   if (settings.start_paused) {


### PR DESCRIPTION
ef72098353 [VM] Add new SymbolConstant to package:kernel/ast.dart
44679beac8 Add script to add commit hash and metadata to the json record of a test.py run.
14cf3717f2 [VM] Do not generate fall-through code if the intrinsic is exhaustive (handles all cases)
f8633aeae7 Move KernelToElementMapForBuilding and friends to js_model/element_map*
88bff737f9 Inline element map mixins that are only applied once
8c03bff4bb Step towards splitting element maps in K/J versions
c4bfa601d1 Add first step of an in-memory serialization test
e311e12bc4 Move all data for collection for testing behind one flag
1cd9cae45e [gardening] Mark vm/cc/CustomIsolates as Crashing
e0f0f4b6a9 [gardening] Mark service/regexp_function_test as flaky
b72b00631b [infra] Fix typo in test matrix (#32229)
bdfa1b75c2 [VM] Fix memory leak in run_vm_tests
a6c76475a9 [gardening] Mark service/regexp_test as Crashing on windows
dd2cf0e74e Fix unittest path
5cba87a500 Test that the run_vm_tests benchmarks continue to work.
e1fe4d48a5 Remove type inferrer from generators
c42bde5eac Remove type-inference listener
6616ddeb88 Move dart2js unittests to subfolders
f3036f4e17 Support supermixins in dart2js
5e263044e8 Enable StrongModeWorldStrategy
9e3bcc4cec Report MIXIN_INSTANTIATE when a mixin is instantiated.
e20af737a2 Triage Analyzer language_2 failures for mixin declarations.
c925fa6b00 Lay the groundwork for comparing language_2 compilation results between analyzer and CFE.
4ef1ad0644 Update the language spec to allow `with` clause without an `extends` clause
e62a2084c1 Fix benchmark runs.
9795cd9613 Remove uses of DartType from const expression serialization.
13efc4f8d8 Convert test_strategies.dart to triple-slash comment style.
eb8350aaf7 Adjust status settings for service/rewind_test.dart
c4d35070af [vm] Don't build the kernel service snapshot if the platform dill has bytecode
134bb884de Handle generic types in native behavior
d66572d09b [vm, arm64] Eliminate some no-ops already filtered from the other architectures.
be5cd6307f fix #34296, generic function instantiation should be checked eagerly
cd3ddede99 Move flags strong/sync-async/reify-generic-functions back to global vm flags (they are not set as isolate specific flags).
3903b5b2d8 [vm] Fix passing --enable_interpreter in tests.