### PR TITLE
Revert "Roll buildroot to eba79bb6db1b50a98ab8ce39def287f7d332a5b8 (#6215)"

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -115,7 +115,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'eba79bb6db1b50a98ab8ce39def287f7d332a5b8',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'be483cb1cd3a9c4313b2e534034d23a05c3d849e',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
This reverts commit 35ddf873aeed64f17f9bd4e3002fc1df75ff4495.

Buildbots are hanging while generating treemaps with LTO enabled.