### PR TITLE
Add a method to clear cached animated image frames

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1577,6 +1577,11 @@ class Codec extends NativeFieldWrapperClass2 {
   /// * -1 for infinity repetitions.
   int get repetitionCount native 'Codec_repetitionCount';
 
+  /// Clears the in-memory decoded frame cache and disables future caching of
+  /// decoded frames. This negatively impacts CPU usage, but reduces memory
+  /// consumption.
+  void clearAndDisableFrameCache() native 'Codec_clearAndDisableFrameCache';
+
   /// Fetches the next animation frame.
   ///
   /// Wraps back to the first frame after returning the last frame.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1582,6 +1582,10 @@ class Codec extends NativeFieldWrapperClass2 {
   /// consumption.
   void clearAndDisableFrameCache() native 'Codec_clearAndDisableFrameCache';
 
+  /// Re-enables caching of in-memory frames if caching has previously been
+  /// disabled. See [clearAndDisableFrameCache].
+  void enableFrameCache() native 'Codec_enableFrameCache';
+
   /// Fetches the next animation frame.
   ///
   /// Wraps back to the first frame after returning the last frame.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1580,11 +1580,11 @@ class Codec extends NativeFieldWrapperClass2 {
   /// Clears the in-memory decoded frame cache and disables future caching of
   /// decoded frames. This negatively impacts CPU usage, but reduces memory
   /// consumption.
-  void clearAndDisableFrameCache() native 'Codec_clearAndDisableFrameCache';
+  Future<bool> clearAndDisableFrameCache() => _futurize(_clearAndDisableFrameCache);
 
   /// Re-enables caching of in-memory frames if caching has previously been
   /// disabled. See [clearAndDisableFrameCache].
-  void enableFrameCache() native 'Codec_enableFrameCache';
+  Future<bool> enableFrameCache() => _futurize(_enableFrameCache);
 
   /// Fetches the next animation frame.
   ///
@@ -1601,6 +1601,11 @@ class Codec extends NativeFieldWrapperClass2 {
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.
   void dispose() native 'Codec_dispose';
+
+  String _clearAndDisableFrameCache(_Callback<bool> callback) native 'Codec_clearAndDisableFrameCache';
+
+  String _enableFrameCache(_Callback<bool> callback) native 'Codec_enableFrameCache';
+
 }
 
 /// Instantiates an image codec [Codec] object.

--- a/lib/ui/painting/codec.h
+++ b/lib/ui/painting/codec.h
@@ -30,8 +30,12 @@ class Codec : public RefCountedDartWrappable<Codec> {
   virtual int repetitionCount() = 0;
   virtual Dart_Handle getNextFrame(Dart_Handle callback_handle) = 0;
   void dispose();
-  virtual void enableFrameCache() {}
-  virtual void clearAndDisableFrameCache() {}
+  virtual Dart_Handle enableFrameCache(Dart_Handle callback_handle) {
+    return Dart_NewStringFromCString("Unsupported");
+  }
+  virtual Dart_Handle clearAndDisableFrameCache(Dart_Handle callback_handle) {
+    return Dart_NewStringFromCString("Unsupported");
+  }
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 };
@@ -43,11 +47,11 @@ class MultiFrameCodec : public Codec {
   Dart_Handle getNextFrame(Dart_Handle args);
   // Called to enable caching decoded frames in memory. Caching defaults to on,
   // so only has an effect if [clearAndDisableFrameCache] was previously called.
-  void enableFrameCache();
+  Dart_Handle enableFrameCache(Dart_Handle callback_handle);
   // Should be called to evict previously decoded frames in cases of memory
   // pressure. Multi frame codecs use much more CPU to render without frame
   // caching enabled.
-  void clearAndDisableFrameCache();
+  Dart_Handle clearAndDisableFrameCache(Dart_Handle callback_handle);
 
  private:
   MultiFrameCodec(std::unique_ptr<SkCodec> codec);

--- a/testing/dart/codec_test.dart
+++ b/testing/dart/codec_test.dart
@@ -72,6 +72,21 @@ void main() {
       [0, 240, 246],
     ]));
   });
+
+  test('frameCache methods smoke test', () async {
+    final Uint8List data = await _getSkiaResource('test640x479.gif').readAsBytes();
+    final ui.Codec codec = await ui.instantiateImageCodec(data);
+
+    // These methods should be disabling and enabling an in-memory cache of
+    // decoded frames in the native layer. No way to fully test the
+    // functionality from dart, but should at least verify that the calls run
+    // without errors.
+    await codec.getNextFrame();
+    expect(await codec.clearAndDisableFrameCache(), equals(true));
+    await codec.getNextFrame();
+    expect(await codec.enableFrameCache(), equals(true));
+    await codec.getNextFrame();
+  });
 }
 
 /// Returns a File handle to a file in the skia/resources directory.


### PR DESCRIPTION
Changes `Codec` to pre-emptively check what frames are actually required
to be stored and later blended by Skia, and then only cache those
specific frames. Previously it was always caching every single frame in
memory regardless of whether or not it was going to be actively reused.

Improves FPS and prevents crash with test gif on an iPhone 4S. See [#20998](https://github.com/flutter/flutter/issues/20998).