### PR TITLE
iOS generation of accessibility scroll notification and small bugfix in Android

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -719,14 +719,11 @@ class AccessibilityBridge
                 }
                 if (object.scrollChildren > 0) {
                     event.setItemCount(object.scrollChildren);
-                    event.setFromIndex(object.scrollIndex);
-                    int visibleChildren = object.childrenInHitTestOrder.size() - 1;
-                    // We assume that only children at the end of the list can be hidden.
-                    assert(!object.childrenInHitTestOrder.get(object.scrollIndex).hasFlag(Flag.IS_HIDDEN));
-                    for (; visibleChildren >= 0; visibleChildren--) {
-                        SemanticsObject child = object.childrenInHitTestOrder.get(visibleChildren);
+                    event.setFromIndex(object.scrollIndex + 1);
+                    int visibleChildren = 0;
+                    for (SemanticsObject child :  object.childrenInHitTestOrder) {
                         if (!child.hasFlag(Flag.IS_HIDDEN)) {
-                            break;
+                            visibleChildren += 1;
                         }
                     }
                     event.setToIndex(object.scrollIndex + visibleChildren);

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -719,13 +719,16 @@ class AccessibilityBridge
                 }
                 if (object.scrollChildren > 0) {
                     event.setItemCount(object.scrollChildren);
-                    event.setFromIndex(object.scrollIndex + 1);
+                    // We don't need to add 1 to the scroll index because TalkBack does this automagically.
+                    event.setFromIndex(object.scrollIndex);
                     int visibleChildren = 0;
-                    for (SemanticsObject child :  object.childrenInHitTestOrder) {
+                    for (SemanticsObject child : object.childrenInHitTestOrder) {
                         if (!child.hasFlag(Flag.IS_HIDDEN)) {
                             visibleChildren += 1;
                         }
                     }
+                    assert(object.scrollIndex + visibleChildren <= object.scrollChildren);
+                    assert(!object.childrenInHitTestOrder.get(object.scrollIndex).hasFlag(Flag.IS_HIDDEN));
                     event.setToIndex(object.scrollIndex + visibleChildren);
                 }
                 sendAccessibilityEvent(event);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -144,7 +144,7 @@ class AccessibilityBridge final {
   int32_t previous_route_id_;
   std::unordered_map<int32_t, blink::CustomAccessibilityAction> actions_;
   std::vector<int32_t> previous_routes_;
-  NSString* last_scroll_announcement;
+  fml::scoped_nsobject<NSString> last_scroll_announcement_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridge);
 };

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -144,6 +144,7 @@ class AccessibilityBridge final {
   int32_t previous_route_id_;
   std::unordered_map<int32_t, blink::CustomAccessibilityAction> actions_;
   std::vector<int32_t> previous_routes_;
+  NSString* last_scroll_announcement;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridge);
 };

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -179,6 +179,22 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   }
 }
 
+- (NSString*)scrollNotification {
+  int32_t scrollIndex = [self node].scrollIndex;
+  int32_t scrollChildren = [self node].scrollChildren;
+  if (scrollChildren == 0 || ![self hasChildren]) {
+    return @"";
+  }
+  int visibleChildren = 0;
+  for (SemanticsObject* child in self.children) {
+    if (![child node].HasFlag(blink::SemanticsFlags::kIsHidden)) {
+      visibleChildren += 1;
+    }
+  }
+  // TODO: add translations.
+  return [NSString stringWithFormat:@"Showing items %d to %d of %d", scrollIndex + 1, scrollIndex + visibleChildren, scrollChildren];
+}
+
 - (BOOL)onCustomAccessibilityAction:(FlutterCustomAccessibilityAction*)action {
   if (![self node].HasAction(blink::SemanticsAction::kCustomAction))
     return NO;
@@ -495,7 +511,8 @@ AccessibilityBridge::AccessibilityBridge(UIView* view, PlatformViewIOS* platform
       objects_([[NSMutableDictionary alloc] init]),
       weak_factory_(this),
       previous_route_id_(0),
-      previous_routes_({}) {
+      previous_routes_({}),
+      last_scroll_announcement(@"") {
   accessibility_channel_.reset([[FlutterBasicMessageChannel alloc]
          initWithName:@"flutter/accessibility"
       binaryMessenger:platform_view->GetOwnerViewController()
@@ -518,6 +535,7 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes,
                                           blink::CustomAccessibilityActionUpdates actions) {
   BOOL layoutChanged = NO;
   BOOL scrollOccured = NO;
+  SemanticsObject* scrolledNode = nil;
   for (const auto& entry : actions) {
     const blink::CustomAccessibilityAction& action = entry.second;
     actions_[action.id] = action;
@@ -526,7 +544,10 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes,
     const blink::SemanticsNode& node = entry.second;
     SemanticsObject* object = GetOrCreateObject(node.id, nodes);
     layoutChanged = layoutChanged || [object nodeWillCauseLayoutChange:&node];
-    scrollOccured = scrollOccured || [object nodeWillCauseScroll:&node];
+    if ([object nodeWillCauseScroll:&node]) {
+      scrollOccured = true;
+      scrolledNode = object;
+    }
     [object setSemanticsNode:&node];
     const NSUInteger newChildCount = node.childrenInTraversalOrder.size();
     NSMutableArray* newChildren =
@@ -608,8 +629,13 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes,
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);
   }
   if (scrollOccured) {
-    // TODO(tvolkert): provide meaningful string (e.g. "page 2 of 5")
-    UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification, @"");
+    NSString* scrollNotification = scrolledNode.scrollNotification;
+    if ([scrollNotification isEqualToString:@""] || ![scrollNotification isEqualToString:last_scroll_announcement]) {
+      [last_scroll_announcement release];
+      last_scroll_announcement = scrollNotification;
+      [scrollNotification retain];
+      UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification, scrollNotification);
+    }
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -512,7 +512,7 @@ AccessibilityBridge::AccessibilityBridge(UIView* view, PlatformViewIOS* platform
       weak_factory_(this),
       previous_route_id_(0),
       previous_routes_({}),
-      last_scroll_announcement(@"") {
+      last_scroll_announcement_(@"") {
   accessibility_channel_.reset([[FlutterBasicMessageChannel alloc]
          initWithName:@"flutter/accessibility"
       binaryMessenger:platform_view->GetOwnerViewController()
@@ -630,10 +630,8 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes,
   }
   if (scrollOccured) {
     NSString* scrollNotification = scrolledNode.scrollNotification;
-    if ([scrollNotification isEqualToString:@""] || ![scrollNotification isEqualToString:last_scroll_announcement]) {
-      [last_scroll_announcement release];
-      last_scroll_announcement = scrollNotification;
-      [scrollNotification retain];
+    if ([scrollNotification isEqualToString:@""] || ![scrollNotification isEqualToString:last_scroll_announcement_.get()]) {
+      last_scroll_announcement_.reset(scrollNotification);
       UIAccessibilityPostNotification(UIAccessibilityPageScrolledNotification, scrollNotification);
     }
   }


### PR DESCRIPTION
This does not address the issue of _how_ to get a localized value. TalkBack on Android can generate the correct notification just from the indexes/child count.

Some options:
- (Preferred) Add support for some trivial localizations to the engine. Since the accessibility announcements will be required by any/all flutter on iOS platforms it doesn't make sense to opt-in.

- Generate a message on the framework side and use platform channels to call it out. This doesn't solve the localization problem, it just moves it somewhere else. It also works differently from the Android versions. Unlike Material/Cupertino localizations, if this localization isn't provided then only a11y modes break, which might go unnoticed. 

_Note: I'm not sure if it makes sense to leave an un-localized value as a placeholder for now._