### PR TITLE
Fix crash when removeViewImmediate invoked from platform view

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -306,6 +306,7 @@ class SingleViewPresentation extends Presentation {
                 return;
             }
             View view = (View) args[0];
+            view.clearAnimation();
             mFakeWindowRootView.removeView(view);
         }
 

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -232,7 +232,8 @@ class SingleViewPresentation extends Presentation {
      * (see: https://github.com/flutter/flutter/issues/20714). This was triggered when selecting text in an embedded
      * WebView (as the selection handles are implemented as popup windows).
      *
-     * This dynamic proxy overrides the addView, removeView, and updateViewLayout methods to prevent these crashes.
+     * This dynamic proxy overrides the addView, removeView, removeViewImmediate, and updateViewLayout methods
+     * to prevent these crashes.
      *
      * This will be more efficient as a static proxy that's not using reflection, but as the engine is currently
      * not being built against the latest Android SDK we cannot override all relevant method.
@@ -266,6 +267,9 @@ class SingleViewPresentation extends Presentation {
                 case "removeView":
                     removeView(args);
                     return null;
+                case "removeViewImmediate":
+                    removeViewImmediate(args);
+                    return null;
                 case "updateViewLayout":
                     updateViewLayout(args);
                     return null;
@@ -290,6 +294,15 @@ class SingleViewPresentation extends Presentation {
         private void removeView(Object[] args) {
             if (mFakeWindowRootView == null) {
                 Log.w(TAG, "Embedded view called removeView while detached from presentation");
+                return;
+            }
+            View view = (View) args[0];
+            mFakeWindowRootView.removeView(view);
+        }
+
+        private void removeViewImmediate(Object[] args) {
+            if (mFakeWindowRootView == null) {
+                Log.w(TAG, "Embedded view called removeViewImmediate while detached from presentation");
                 return;
             }
             View view = (View) args[0];


### PR DESCRIPTION
Since `removeViewImmediate` method isn't handled by `WindowManagerHandler`,
the real `WindowManager`'s `removeViewImmediate` will be invoked, which caused the crash.

Here is the crash stack trace:

```
09-15 19:08:21.513 32298-32298/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: xyz.wsxyeah.flutterplugindemoexample, PID: 32298
    java.lang.IllegalArgumentException: View=android.widget.PopupWindow$PopupDecorView{a54e7dd V.E...... R....... 288,528-393,633} not attached to window manager
        at android.view.WindowManagerGlobal.findViewLocked(WindowManagerGlobal.java:485)
        at android.view.WindowManagerGlobal.removeView(WindowManagerGlobal.java:394)
        at android.view.WindowManagerImpl.removeViewImmediate(WindowManagerImpl.java:124)
        at java.lang.reflect.Method.invoke(Native Method)
        at io.flutter.plugin.platform.SingleViewPresentation$WindowManagerHandler.invoke(SingleViewPresentation.java:274)
        at java.lang.reflect.Proxy.invoke(Proxy.java:1006)
        at $Proxy0.removeViewImmediate(Unknown Source)
        at android.widget.PopupWindow.dismissImmediate(PopupWindow.java:1987)
        at android.widget.PopupWindow.dismiss(PopupWindow.java:1930)
        at android.widget.Editor$HandleView.dismiss(Editor.java:4601)
        at android.widget.Editor$HandleView.hide(Editor.java:4606)
        at android.widget.Editor$InsertionPointCursorController.hide(Editor.java:5675)
        at android.widget.Editor.hideInsertionPointCursorController(Editor.java:743)
        at android.widget.Editor.refreshTextActionMode(Editor.java:2066)
        at android.widget.TextView.spanChange(TextView.java:9903)
        at android.widget.TextView$ChangeWatcher.onSpanChanged(TextView.java:12534)
        at android.text.SpannableStringBuilder.sendSpanChanged(SpannableStringBuilder.java:1303)
        at android.text.SpannableStringBuilder.setSpan(SpannableStringBuilder.java:750)
        at android.text.SpannableStringBuilder.setSpan(SpannableStringBuilder.java:674)
        at android.text.Selection.setSelection(Selection.java:95)
        at android.text.Selection.setSelection(Selection.java:77)
        at android.widget.Editor.selectCurrentWord(Editor.java:978)
        at android.widget.Editor.selectCurrentWordAndStartDrag(Editor.java:2182)
        at android.widget.Editor.performLongClick(Editor.java:1209)
        at android.widget.TextView.performLongClick(TextView.java:11346)
        at android.view.View.performLongClick(View.java:6653)
        at android.view.View$CheckForLongPress.run(View.java:25850)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```