### PR TITLE
Roll Dart to 050561fd82be5e775316223c9d2d9e7e5e596c8e

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'bb56d4592f7cde38cdf0a04ad7f40d105af99d11',
+  'dart_revision': '050561fd82be5e775316223c9d2d9e7e5e596c8e',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: d2753c18f5888758e87aa10c270fa760
+Signature: 23f7e8d39ec24c9954fd6a342b83e480
 
 UNUSED LICENSES:
 
@@ -4436,6 +4436,8 @@ FILE: ../../../third_party/dart/client/idea/.idea/.name
 FILE: ../../../third_party/dart/client/idea/.idea/inspectionProfiles/Project_Default.xml
 FILE: ../../../third_party/dart/client/idea/.idea/vcs.xml
 FILE: ../../../third_party/dart/runtime/CPPLINT.cfg
+FILE: ../../../third_party/dart/runtime/docs/compiler/images/catch-block-entry-0.png
+FILE: ../../../third_party/dart/runtime/docs/compiler/images/catch-block-entry-1.png
 FILE: ../../../third_party/dart/runtime/observatory/lib/elements.dart
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/img/chromium_icon.png
 FILE: ../../../third_party/dart/runtime/observatory/lib/src/elements/img/dart_icon.png
@@ -5466,6 +5468,8 @@ FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_pass.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/compiler_state.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/base_flow_graph_builder.h
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_flow_graph_builder.cc
+FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_flow_graph_builder.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_reader.cc
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/bytecode_reader.h
 FILE: ../../../third_party/dart/runtime/vm/compiler/frontend/constant_evaluator.cc


### PR DESCRIPTION
dart-lang/sdk@050561f [vm] Relax recently added assertion in Dart 1 mode
dart-lang/sdk@6c712f1 Add a fix to create a mixin
dart-lang/sdk@cc08d0e Add operators `&`, `|` and `^` to `bool`.
dart-lang/sdk@5af9844 Language specification reorganization.
dart-lang/sdk@2cb2ac4 Optimize `ClassHierarchyBuilder.isInheritedInSubtypeOf`.
dart-lang/sdk@e8880fd Fix handling of unary- in the analyzer/FE comparison tool.
dart-lang/sdk@bd103eb Store unlinked data with unlinked salt.
dart-lang/sdk@c5d77d1 Support mixins in more places in index and search.
dart-lang/sdk@c3bdb6c Refactor summary resynthesis tests in preparation for using the one-phase summary API.
dart-lang/sdk@ddcb8b7 Remove unused SubtypeManager.
dart-lang/sdk@76091c1 [vm/bytecode] Add PushNull, PushTrue, PushFalse and PushInt bytecodes
dart-lang/sdk@a80b13e Add an assist to convert from a class to a mixin
dart-lang/sdk@0f45b2e Fix spelling hexidecimal -> hexadecimal
dart-lang/sdk@348ed30 [vm/kernel] In async transformation check if strongMode is on.
dart-lang/sdk@c6c4748 [vm/bytecode] Bytecode compilation
dart-lang/sdk@78d9a28 [vm, arm] Globally block LR for register allocation.
dart-lang/sdk@078be2c [vm] Add library private key to the Class hash function for reload.
dart-lang/sdk@4fab565 Several minor fixes to the analyzer/FE comparison tool.
dart-lang/sdk@eb96871 Compute unlinked API signatures without unlinked summaries.
dart-lang/sdk@98d25ed fix #34450, implement boolean bitwise operators in dartdevc
dart-lang/sdk@229d793 [vm/compiler] Support materializing unboxed variables when entering catch.
dart-lang/sdk@eec96f9 [vm/kernel] Preserve strong mode types in async transformation
dart-lang/sdk@bf4facd Handle errors when comparing analyzer and front end behaviors.
dart-lang/sdk@3e9f4e6 dart2js: generate simple '==' in more cases
