### PR TITLE
Update test .gitignore

### DIFF
--- a/testing/dart/.gitignore
+++ b/testing/dart/.gitignore
@@ -1,2 +1,4 @@
 .packages
 pubspec.lock
+ios/**
+android/**


### PR DESCRIPTION
`testing/dart/android/` and `testing/dart/ios` both look like generated
directories created after each `run_tests` execution. Also updates that
script to use `flutter pub get`.