### PR TITLE
Fix a compilation problem when using iPhoneOS12.0sdk(Xcode10) && clang version 7.0.0.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -134,7 +134,8 @@
 
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
-      restorationHandler:(void(^)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler {
+      restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>>* __nullable
+                                       restorableObjects))restorationHandler {
   return [_lifeCycleDelegate application:application
                     continueUserActivity:userActivity
                       restorationHandler:restorationHandler];

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -134,7 +134,7 @@
 
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
-      restorationHandler:(void (^)(NSArray*))restorationHandler {
+      restorationHandler:(void(^)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler {
   return [_lifeCycleDelegate application:application
                     continueUserActivity:userActivity
                       restorationHandler:restorationHandler];


### PR DESCRIPTION
When compiling Flutter engine corresponding to Flutter version0.8.2, using commands below:
```
./flutter/tools/gn --runtime-mode=debug --target-os=ios --ios --ios-cpu=arm
ninja -C out/ios_debug_arm/
```
I met up with an error:
```
KyleWongdeMacBook-Pro:src kylewong$ ninja -C out/ios_debug_arm/
ninja: Entering directory `out/ios_debug_arm/'
[1/31] OBJCXX obj/flutter/shell/platform/darwin/ios/framework/Source/libFlutter.FlutterAppDelegate.o
FAILED: obj/flutter/shell/platform/darwin/ios/framework/Source/libFlutter.FlutterAppDelegate.o 
../../buildtools/mac-x64/clang/bin/clang++ -MMD -MF obj/flutter/shell/platform/darwin/ios/framework/Source/libFlutter.FlutterAppDelegate.o.d -DFLUTTER_FRAMEWORK -DNO_TCMALLOC -DMEMORY_TOOL_REPLACES_ALLOCATOR -DMEMORY_SANITIZER_INITIAL_SIZE -DTOOLCHAIN_VERSION=c1408453246f0475547b6fe634c2f3dad71c6457 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DSK_HAS_JPEG_LIBRARY -DSK_HAS_PNG_LIBRARY -DSK_HAS_WEBP_LIBRARY -DFLUTTER_RUNTIME_MODE_DEBUG=1 -DFLUTTER_RUNTIME_MODE_PROFILE=2 -DFLUTTER_RUNTIME_MODE_RELEASE=3 -DFLUTTER_RUNTIME_MODE_DYNAMIC_PROFILE=4 -DFLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE=5 -DFLUTTER_RUNTIME_MODE=1 -DFLUTTER_AOT=1 -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DUCHAR_TYPE=uint16_t -DSK_DISABLE_EXPLICIT_GPU_RESOURCE_ALLOCATION -DSK_DISABLE_RENDER_TARGET_SORTING -DSK_SUPPORT_LEGACY_VULKAN_INTERFACE -DSK_LEGACY_SKCODEC_NONE_ENUM -I../.. -Igen -I../.. -I../../flutter/third_party/txt/src -I../../third_party/harfbuzz/src -I../../third_party/icu/source/common -I../../third_party/icu/source/i18n -I../../third_party/skia/include/android -I../../third_party/skia/include/c -I../../third_party/skia/include/codec -I../../third_party/skia/include/config -I../../third_party/skia/include/core -I../../third_party/skia/include/effects -I../../third_party/skia/include/encode -I../../third_party/skia/include/gpu -I../../third_party/skia/include/atlastext -I../../third_party/skia/include/pathops -I../../third_party/skia/include/ports -I../../third_party/skia/include/svg -I../../third_party/skia/include/utils -I../../third_party/skia/include/utils/mac -I../../third_party -I../../third_party/dart/runtime -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk -miphoneos-version-min=8.0  -flto -fno-strict-aliasing -arch armv7 -fcolor-diagnostics -Wall -Wextra -Wendif-labels -Werror -Wno-missing-field-initializers -Wno-unused-parameter -Wunguarded-availability -fvisibility=hidden -stdlib=libc++ -Wheader-hygiene -Wstring-conversion -Wthread-safety -Os -fno-ident -fdata-sections -ffunction-sections -g2  -fvisibility-inlines-hidden -fobjc-call-cxx-cdtors -std=c++14 -fno-rtti -fno-exceptions -c ../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm -o obj/flutter/shell/platform/darwin/ios/framework/Source/libFlutter.FlutterAppDelegate.o
../../flutter/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm:137:46: error: conflicting parameter types in implementation of 'application:continueUserActivity:restorationHandler:': 'void (^ _Nonnull)(NSArray<id<UIUserActivityRestoring>> * _Nullable)' vs 'void (^ _Nonnull)(NSArray *)' [-Werror,-Wmismatched-parameter-types]
      restorationHandler:(void (^)(NSArray*))restorationHandler {
                          ~~~~~~~~~~~~~~~~~~ ^
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS12.0.sdk/System/Library/Frameworks/UIKit.framework/Headers/UIApplication.h:433:199: note: previous definition is here
- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void(^)(NSArray<id<UIUserActivityRestoring>> * __nullable restorableObjects))restorationHandler NS_AVAILABLE_IOS(8_0);
                                                                                                                         ~~~~~~                                                                       ^
1 error generated.
[10/31] OBJCXX obj/flutter/shell/platform/darwin/ios/framework/Source/libFlutter.FlutterViewController.o
ninja: build stopped: subcommand failed.
```

This pr fix the mismatched-parameter-types problem.

Flutter Environment:
```
[✓] Flutter (Channel unknown, v0.8.2, on Mac OS X 10.14 18A389, locale en-CN)
    • Flutter version 0.8.2 at /Users/kylewong/Codes/fwn_idlefish/flutter
    • Framework revision 5ab9e70727 (11 days ago), 2018-09-07 12:33:05 -0700
    • Engine revision 58a1894a1c
    • Dart version 2.1.0-dev.3.1.flutter-760a9690c2

[✓] Android toolchain - develop for Android devices (Android SDK 28.0.2)
    • Android SDK at /Users/kylewong/Library/Android/sdk
    • Android NDK at /Users/kylewong/Library/Android/sdk/ndk-bundle
    • Platform android-28, build-tools 28.0.2
    • Java binary at: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1024-b01)
    • All Android licenses accepted.

[!] iOS toolchain - develop for iOS devices (Xcode 10.0)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 10.0, Build version 10A254a
    • ios-deploy 1.9.2
    ! CocoaPods out of date (1.5.0 is recommended).
        CocoaPods is used to retrieve the iOS platform side's plugin code that responds to your plugin usage on the Dart side.
        Without resolving iOS dependencies with CocoaPods, plugins will not work on iOS.
        For more info, see https://flutter.io/platform-plugins
      To upgrade:
        brew upgrade cocoapods
        pod setup

[✓] Android Studio (version 3.1)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin version 27.1.1
    • Dart plugin version 173.4700
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1024-b01)

[!] Connected devices
    ! No devices available
```