### PR TITLE
Fix Top, Left, and Right padding for fullscreen android apps.

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -632,7 +632,7 @@ class AccessibilityBridge
         if (rootObject != null) {
             final float[] identity = new float[16];
             Matrix.setIdentityM(identity, 0);
-            // in android devices above AP 23, the system nav bar can be placed on the left side
+            // in android devices API 23 and above, the system nav bar can be placed on the left side
             // of the screen in landscape mode. We must handle the translation ourselves for the
             // a11y nodes.
             if (Build.VERSION.SDK_INT >= 23) {


### PR DESCRIPTION
The android WindowInsets does not take into account status and nav bars that are hidden. This change ensures that the top, left, and right edges have properly zeroed padding when it is necessary to correct for the hidden bars.

Top is zeroed when the status bar is hidden (called "Fullscreen" in android)

Left or Right or Both are zeroed when the navigation bar would appear on the respective sides when the device is in landscape mode.

This patch does not handle bottom padding when in portrait mode or landscape mode yet due to the issues with providing proper insets for on-screen keyboards.