### PR TITLE
Roll dart to c688d0c0c3ad3dece3a79ce0e115d787a94707ea.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -18,12 +18,6 @@ group("flutter") {
     public_deps += [ "$flutter_root/shell/testing" ]
   }
 
-  if (flutter_runtime_mode != "debug" &&
-      flutter_runtime_mode != "dynamic_profile" &&
-      flutter_runtime_mode != "dynamic_release") {
-    public_deps += [ "$flutter_root/lib/snapshot:entry_points_json_files" ]
-  }
-
   if (!is_fuchsia && !is_fuchsia_host) {
     if (current_toolchain == host_toolchain) {
       public_deps += [

--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '4eb879133a06c86869dc54cecf904f4b1d46c47b',
+  'dart_revision': 'c688d0c0c3ad3dece3a79ce0e115d787a94707ea',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',
@@ -46,7 +46,7 @@ vars = {
   'dart_crypto_tag': '2.0.6',
   'dart_csslib_tag': '0.14.4+1',
   'dart_dart2js_info_tag': '0.5.6+4',
-  'dart_dart_style_tag': '6f3efd209ff1828835936397b64be79265cc0c19',
+  'dart_dart_style_tag': '1.2.0',
   'dart_dartdoc_tag': 'v0.20.4',
   'dart_fixnum_tag': '0.10.8',
   'dart_glob_tag': '1.1.7',
@@ -115,7 +115,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7141218c62890635ce966e2530b465ea4c55c3e2',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e191609670284e0d62ef2309d073b5586ac7d4a9',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 5b5ec302d3f100a7ca4552f231d9f8b7
+Signature: dfbc023ceeca15d70ea76e125a481c0f
 
 UNUSED LICENSES:
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -5,7 +5,6 @@
 import("$flutter_root/lib/ui/dart_ui.gni")
 import("//build/compiled_action.gni")
 import("//third_party/dart/utils/compile_platform.gni")
-import("//third_party/dart/utils/generate_entry_points_json.gni")
 
 if (is_fuchsia) {
   import("//build/dart/dart_library.gni")
@@ -212,96 +211,4 @@ if (is_fuchsia || is_fuchsia_host) {
       ":strong_platform",
     ]
   }
-}
-
-# Template to generate entry points JSON file using gen_snapshot tool.
-# List of entry points is generated as a by-product while doing precompilation.
-#
-# This template expects the following arguments:
-#  - input: Name of the input dart script for precompilation.
-#  - output: Name of the output entry points JSON file.
-#  - extra_args: Extra arguments to pass to dart_bootstrap (optional).
-#  - extra_inputs: Extra input dependencies (optional).
-#
-template("generate_entry_points_json_with_gen_snapshot") {
-  assert(defined(invoker.input), "Must define input dart script")
-  assert(defined(invoker.output), "Must define output json file")
-  extra_args = []
-  if (defined(invoker.extra_args)) {
-    extra_args += invoker.extra_args
-  }
-  extra_inputs = []
-  if (defined(invoker.extra_inputs)) {
-    extra_inputs += invoker.extra_inputs
-  }
-  compiled_action(target_name) {
-    # Printing precompiler entry points is folded into precompilation, so gen_snapshot is invoked
-    # with correct arguments to generate app-aot snapshot.
-
-    input = invoker.input
-    output = invoker.output
-
-    tool = "//third_party/dart/runtime/bin:gen_snapshot"
-    inputs = [ input ] + extra_inputs
-    outputs = [
-      output,
-
-      # Though they are not consumed, GN needs to know to create the output directory.
-      "$target_gen_dir/dummy.vm_data.snapshot",
-      "$target_gen_dir/dummy.vm_instr.snapshot",
-      "$target_gen_dir/dummy.isolate_data.snapshot",
-      "$target_gen_dir/dummy.isolate_instr.snapshot",
-    ]
-    args = [
-             "--no-strong",
-             "--no-sync-async",
-             "--no-reify-generic-functions",
-             "--print-precompiler-entry-points=" + rebase_path(output),
-             "--snapshot-kind=app-aot-blobs",
-             "--vm_snapshot_data=" +
-                 rebase_path("$target_gen_dir/dummy.vm_data.snapshot"),
-             "--vm_snapshot_instructions=" +
-                 rebase_path("$target_gen_dir/dummy.vm_instr.snapshot"),
-             "--isolate_snapshot_data=" +
-                 rebase_path("$target_gen_dir/dummy.isolate_data.snapshot"),
-             "--isolate_snapshot_instructions=" +
-                 rebase_path("$target_gen_dir/dummy.isolate_instr.snapshot"),
-           ] + extra_args + [ rebase_path(input) ]
-  }
-}
-
-generate_entry_points_json_with_gen_snapshot("entry_points_json") {
-  input = "$flutter_root/lib/snapshot/snapshot.dart"
-  output = "$root_out_dir/dart_entry_points/entry_points.json"
-  dart_ui = "$flutter_root/lib/ui/ui.dart"
-  vmservice_io = "//third_party/dart/runtime/bin/vmservice/vmservice_io.dart"
-  dart_vm_entry_points_txt = "$flutter_root/runtime/dart_vm_entry_points.txt"
-  dart_io_entries_txt = "//third_party/dart/runtime/bin/dart_io_entries.txt"
-
-  extra_inputs = [
-    dart_ui,
-    vmservice_io,
-    dart_vm_entry_points_txt,
-    dart_io_entries_txt,
-  ]
-
-  extra_args = [
-    "--await_is_keyword",
-    "--url_mapping=dart:ui," + rebase_path(dart_ui),
-    "--url_mapping=dart:vmservice_io," + rebase_path(vmservice_io),
-    "--causal_async_stacks",
-    "--embedder_entry_points_manifest=" + rebase_path(dart_vm_entry_points_txt),
-    "--embedder_entry_points_manifest=" + rebase_path(dart_io_entries_txt),
-  ]
-}
-
-copy_entry_points_extra_json("entry_points_extra_json") {
-  output = "$root_out_dir/dart_entry_points/entry_points_extra.json"
-}
-
-group("entry_points_json_files") {
-  public_deps = [
-    ":entry_points_extra_json",
-    ":entry_points_json",
-  ]
 }


### PR DESCRIPTION
Changes since last roll:
```
c688d0c0c3 [frontend] When serializing compiled expression proc, clone type params first.
346895eb35 Choose the right platform in the command-line fasta tool in strong mode
51d530475a [frontend] Honor embedSourceText option in incremental compiler.
06792cb91f Remove StackListener.popList
69cd7cb43f [infra] Add compare_results.dart and update_flakiness.dart.
c3c4e63ce4 Adjusted spec to use package syntax, thus eliminating bnf.sty
0315707dec Add 'set' case to type_variable_conflict_test
00f2054242 Add --repeat flag to test.py, so tests can be run multiple times
cf5cdea808 Add J/K versions CommonElements and ElementEnvironment
1681241062 Remove _ClassEnsurer
a5b71813ab Use json expectation files in dynamic tests
d560887ae5 Fix TypeError in Observatory
867c5271be Debugging dart in methods with dynamic type arguments
2e3f17fa2b Add support for the new mixin syntax to supertype constraint checking and resynthesis.
929b2fbc55 Adjust status file to account for CustomIsolates test passing now.
f0974aee20 Remove entry_points option from the test harness (should fix the precompiler bot failure).
296e4aa7e6 Split mixin_declaration_inference_valid_classes_test.dart into multiple tests.
2c427d33fc Train the dartanalyzer on less source.
41273507b2 Detect references to instance variables without declared type.
a0776096b9 Cleanup some of the build rules to not use Dart 1 mode.
3463f94ed9 Delete any existing version of a DevFS file before overwriting the file
7763ec3cd1 Surface analyzer toplevel inference limitations as DDC errors.
a386c07281 [vm/aot] Add extra call specialization pass
878017481f Roll dart_style to 1.2.0.
a890d95a26 [vm/compiler] Avoid !(x>y) -> x<=y on fp operands.
bc79674bc1 [vm/aot] Fix inferred type of implicitly initialized final fields
7df4900a94 Train the dartanalyzer tool on generating summaries.
80c1b88626 Add copyright comments in resolution tests.
bbe49524be Cache mapping from subtypes names to files where they are subtyped.
cf67e402bd Add test case reproducing issues #34498 and #34500.
81ce969060 Enable implicit constructors with optional parameters in mixin applications.
cb331064e0 Compare AnalysisOptions signatures in analyzer_cli.
eb059a76f3 Keep analyzer-specific status entries together in language_2_analyzer.status
62ce86e20c Add --test-list and --repeat options to test.py, for deflaking
9e86c1a395 Normalize strong.status
3831da8743 Include all problems in expectations
a1bd50168e Make input validation optional
6fe272314d Tweak parameters of ProcessedOptions
0a5d7b866d Update status files after de984e58.
de984e58cb Type checking for redirecting factories.
4134b95a3d [vm/tfa] Streamline handling of tear-offs in TFA
d44ffba254 [vm/tfa] Stop accepting non-empty entry points json files
30f0026022 [VM runtime] Fix type test: C is a subtype of C<FutureOr> (fixes #34482).
bbe83465ea Test that type of the ListLiteral with two different enums is inferred.
37b41bd317 Update status files after d4148159cc39d3f38d8295cf79ed736c6337d7ac
d9fcaa33b1 Implement StreamTransformer.fromBind
abb392fc0d add Pubspec.dependencyOverrides
c733ed7fd7 firefix status for LayoutTests/fast/dom/Range/getClientRects-character_t01
d4148159cc Initial valid inference checks
dcabf2cb0e Test for mixin declaration isObject and tweaks for error verifier.
```