### PR TITLE
Remove runtime/dart_vm_entry_points.txt

### DIFF
--- a/runtime/dart_vm_entry_points.txt
+++ b/runtime/dart_vm_entry_points.txt
@@ -1,2 +1,0 @@
-# Please don't add entries to this file.
-# Use the @pragma('vm:entry-point') annotation instead.


### PR DESCRIPTION
Entry points files are deprecated and replaced with @pragma("vm:entry-point") annotations.
This file should not be used by now.