### PR TITLE
Dart SDK roll for 2018/09/20

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'c688d0c0c3ad3dece3a79ce0e115d787a94707ea',
+  'dart_revision': '46ec62909684e2944b7599b3d268b5ad351f628a',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: dfbc023ceeca15d70ea76e125a481c0f
+Signature: 2bc2dadbb340855517114ebd927ca790
 
 UNUSED LICENSES:
 
@@ -5455,6 +5455,7 @@ FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.cc
 FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.h
 FILE: ../../../third_party/dart/runtime/include/dart_embedder_api.h
 FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_test.dart
 FILE: ../../../third_party/dart/runtime/vm/base64.cc
 FILE: ../../../third_party/dart/runtime/vm/base64.h
 FILE: ../../../third_party/dart/runtime/vm/base64_test.cc


### PR DESCRIPTION
46ec629096 [vm/bytecode] Trigger JIT-compilation from interpreter
9f5aecb22b Introduce a new flag to the Dart Analysis Server: --ux-experiment-1 which changes analysis roots to the be the current set of priority files.
9f72b09f0f Convert resolver.dart to triple-slash comment style.
ee0a6033bf Fix checks for absence of concrete implementations of super-invoked members.
3a5b748521 Optimize index data structure for search by supertype id.
af2fd419fb Update more analyzer error codes to be generated from messages.yaml
0bbdd8f7d9 [build] Correctly rebase kernel-service output for depfile
cbf60679eb [vm/fuzzer] Migrated driver from Python to Dart.
e95d944f5f [VM interpreter] Propagate error from invoked compiled function to interpreter caller.
05ba85399f Cleanup fasta parser rewriter insert token methods
07a1f233f8 Improve parser recover to fix more code completion tests
ffa99b9cde Update analyzer error code generation
fa0b38b45d Fix some constructor initializer code completion situations
2455141018 Remove ClassElement.isSuperConstructorAccessible().
3263550e86 [vm] Decouple bytecode reading from compilation
e3dbea9523 Convert declaration_resolver.dart to triple-slash comment style.
d32e93db46 Remove unused import.
4baa3ec951 Create a base class for non-error resolver test cases.
2e43557274 Mark Kernel classes that were Dart mixin declarations