### PR TITLE
Flutterview improvements

### DIFF
--- a/shell/platform/android/io/flutter/embedding/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/FlutterFragment.java
@@ -153,7 +153,7 @@ public class FlutterFragment extends Fragment {
     if (detach || retainFlutterIsolateAfterFragmentDestruction()) {
       // Detach, but do not destroy the FlutterView if a plugin expressed interest in its
       // FlutterNativeView.
-      flutterEngine.detach();
+      flutterEngine.detachFromJni();
     } else {
       flutterEngine.destroy();
     }

--- a/shell/platform/android/io/flutter/embedding/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/FlutterRenderer.java
@@ -50,6 +50,7 @@ public class FlutterRenderer implements TextureRegistry {
   public void detachFromRenderSurface() {
     // TODO(mattcarroll): do we care if we're asked to detach without first being attached?
     if (this.renderSurface != null) {
+      surfaceDestroyed();
       this.renderSurface = null;
     }
   }

--- a/shell/platform/android/io/flutter/embedding/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/FlutterView.java
@@ -18,7 +18,6 @@ import android.support.annotation.NonNull;
 import android.text.format.DateFormat;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -131,7 +130,6 @@ public class FlutterView extends SurfaceView implements
 
   private boolean isAttachedToRenderer = false;
   private boolean mIsSoftwareRenderingEnabled = false; // using the software renderer or not
-  private int backgroundColor;
 
   // Accessibility
   private boolean mAccessibilityEnabled = false;
@@ -178,24 +176,12 @@ public class FlutterView extends SurfaceView implements
     mAccessibilityManager = (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
     mAnimationScaleObserver = new AnimationScaleObserver(new Handler());
 
-    // Process any theme and attribute preferences.
-    readBackgroundColorFromThemeAndAttributes();
+    // Apply a splash background color if desired.
+    // TODO(mattcarroll): support attr and programmatic control
 
     // Initialize this View as needed.
     setFocusable(true);
     setFocusableInTouchMode(true);
-  }
-
-  // TODO(mattcarroll): add XML attribute support for background color
-  private void readBackgroundColorFromThemeAndAttributes() {
-    int color = 0xFF000000;
-    TypedValue typedValue = new TypedValue();
-    getContext().getTheme().resolveAttribute(android.R.attr.colorBackground, typedValue, true);
-    if (typedValue.type >= TypedValue.TYPE_FIRST_COLOR_INT && typedValue.type <= TypedValue.TYPE_LAST_COLOR_INT) {
-      color = typedValue.data;
-    }
-    // TODO(abarth): Consider letting the developer override this color.
-    backgroundColor = color;
   }
 
   @Override


### PR DESCRIPTION
**Capabilities introduced in this PR:**

- Splash color for FlutterView controlled programmatically (XML is blocked on AAR production)
- Splash Drawable for FlutterView controlled programmatically (XML is blocked on AAR production)
- FlutterView can now be inflated from XML
- FlutterView can be made transparent (I copied @mklim's code from other PR)
- FlutterView can be added to/removed from the Android View hierarchy without blowing up or losing the Flutter UI
- FlutterView can have a FlutterRenderer attached and detached without blowing up, corrupting the Flutter content, or losing Flutter content

Each of the above capabilities has been verified in a sample app.


**Expected next steps:**

- Begin introducing a stable package structure to clearly breakdown responsibilities
- Ensure that FlutterActivity, FlutterFragment, and FlutterView facilitate common customization use-cases without major code duplication (right now it takes major duplication to really take advantage of FlutterView)
- Begin refactoring the plugin API to reflect important Android restrictions that are currently mishandled