### PR TITLE
Revert 'Dart SDK roll for 2018/09/20' 8471862c

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '46ec62909684e2944b7599b3d268b5ad351f628a',
+  'dart_revision': 'c688d0c0c3ad3dece3a79ce0e115d787a94707ea',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 2bc2dadbb340855517114ebd927ca790
+Signature: dfbc023ceeca15d70ea76e125a481c0f
 
 UNUSED LICENSES:
 
@@ -5455,7 +5455,6 @@ FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.cc
 FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.h
 FILE: ../../../third_party/dart/runtime/include/dart_embedder_api.h
 FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz.dart
-FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_test.dart
 FILE: ../../../third_party/dart/runtime/vm/base64.cc
 FILE: ../../../third_party/dart/runtime/vm/base64.h
 FILE: ../../../third_party/dart/runtime/vm/base64_test.cc


### PR DESCRIPTION
Dartdocs is breaking Flutter build. Revert until we resolve the breakage.