### PR TITLE
Dart SDK roll for 2018-09-21

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': 'c688d0c0c3ad3dece3a79ce0e115d787a94707ea',
+  'dart_revision': '654c4babc8355dbc53d5575327c60d95ed6ff8ed',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',
@@ -47,7 +47,7 @@ vars = {
   'dart_csslib_tag': '0.14.4+1',
   'dart_dart2js_info_tag': '0.5.6+4',
   'dart_dart_style_tag': '1.2.0',
-  'dart_dartdoc_tag': 'v0.20.4',
+  'dart_dartdoc_tag': 'v0.21.1',
   'dart_fixnum_tag': '0.10.8',
   'dart_glob_tag': '1.1.7',
   'dart_html_tag': '0.13.3+2',
@@ -58,7 +58,7 @@ vars = {
   'dart_http_throttle_tag': '1.0.2',
   'dart_intl_tag': '0.15.6',
   'dart_json_rpc_2_tag': '2.0.9',
-  'dart_linter_tag': '0.1.62',
+  'dart_linter_tag': '0.1.63',
   'dart_logging_tag': '0.11.3+2',
   'dart_markdown_tag': '2.0.2',
   'dart_matcher_tag': '0.12.3',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: dfbc023ceeca15d70ea76e125a481c0f
+Signature: 560e6d4446f2dc19f142baa51148b61a
 
 UNUSED LICENSES:
 
@@ -5455,6 +5455,7 @@ FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.cc
 FILE: ../../../third_party/dart/runtime/bin/typed_data_utils.h
 FILE: ../../../third_party/dart/runtime/include/dart_embedder_api.h
 FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz.dart
+FILE: ../../../third_party/dart/runtime/tools/dartfuzz/dartfuzz_test.dart
 FILE: ../../../third_party/dart/runtime/vm/base64.cc
 FILE: ../../../third_party/dart/runtime/vm/base64.h
 FILE: ../../../third_party/dart/runtime/vm/base64_test.cc


### PR DESCRIPTION
654c4babc8 [vm/bytecode] Fix a couple of assertions when running with bytecode
b540626589 Change DeclarationResolver to extend RecursiveAstVisitor<void>.
52bec5e34b Update parser to find token on which to report the error
93dcfaa289 [vm, gc] Concurrent marking.
e06ef81efa [vm] Unconditionally generate interpreter stubs
6a04b3079f Fix test_mixinInference_noMatchingClass_namedMixinApplication_new_syntax
484405b1c8 Fix missing_return hint in _getInferredMixinType
1357778286 Issue 34546. Get ClassElementImpl a way that support element handles.
012b7050e5 [VM interpreter] Use a helper to test entry frame pc marker.
e22dd19b13 Create a base class for compile-time error code test cases.
491db89917 Upgrade dartdoc to v0.21.1
7cd25705ab Fix parsing label between 2 switch cases
33f6c8ef35 More super mixin tests.
e9ff597673 Optimize gatherMixinSupertypeConstraints for new mixin syntax.
5cf0d9e844 Replicate existing analyzer supermixin tests using new "mixin" syntax.
20342cea27 [vm/compiler] added compilation trace tracer
c92406f57c bump to linter 0.1.63
19e2040f35 [vm] Cleanup the ability to specify entry points via JSON and text files
ead158ab5d Fix gatherMixinSupertypeConstraints to handle named mixin applications.
51f2dac483 Reland: [vm] Adds a benchmark for Dart_LoadLibraryFromKernel
82c784a60f Revert "[vm] Adds a benchmark for Dart_LoadLibraryFromKernel"
762a14e139 Update dart2js_dynamic_test to exclude CFE code.
0c60a52bb2 [VM bytecode] Triage failures in interpreted mode.
e75a48b7fe Add status entries for dartdevk on new super invocation tests
46e5954b0a Turn on and fix mixin type inference checks when not in "supermixin" mode.
b7f762923e Add tests for more super invocation edge cases
64b6d713e3 [dartdevc] enable super mixin support in Kernel backend
0ec9945885 Fix #33629 boolean negation of void
0b5a7c847d Add support for intermittent filesystems to the analysis server, this PR is a synced version of Devons PR https://dart-review.googlesource.com/c/sdk/+/72980, without the DAS protocol change.
fee8efa3d6 [vm] Adds a benchmark for Dart_LoadLibraryFromKernel
46ec629096 [vm/bytecode] Trigger JIT-compilation from interpreter
9f5aecb22b Introduce a new flag to the Dart Analysis Server: --ux-experiment-1 which changes analysis roots to the be the current set of priority files.
9f72b09f0f Convert resolver.dart to triple-slash comment style.
ee0a6033bf Fix checks for absence of concrete implementations of super-invoked members.
3a5b748521 Optimize index data structure for search by supertype id.
af2fd419fb Update more analyzer error codes to be generated from messages.yaml
0bbdd8f7d9 [build] Correctly rebase kernel-service output for depfile
cbf60679eb [vm/fuzzer] Migrated driver from Python to Dart.
e95d944f5f [VM interpreter] Propagate error from invoked compiled function to interpreter caller.
05ba85399f Cleanup fasta parser rewriter insert token methods
07a1f233f8 Improve parser recover to fix more code completion tests
ffa99b9cde Update analyzer error code generation
fa0b38b45d Fix some constructor initializer code completion situations
2455141018 Remove ClassElement.isSuperConstructorAccessible().
3263550e86 [vm] Decouple bytecode reading from compilation
e3dbea9523 Convert declaration_resolver.dart to triple-slash comment style.
d32e93db46 Remove unused import.
4baa3ec951 Create a base class for non-error resolver test cases.
2e43557274 Mark Kernel classes that were Dart mixin declarations