### PR TITLE
Roll Dart to a2eb050044eec93f0844667b8b6132e858467e4e.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -31,7 +31,7 @@ vars = {
   # Dart is: https://github.com/dart-lang/sdk/blob/master/DEPS.
   # You can use //tools/dart/create_updated_flutter_deps.py to produce
   # updated revision list of existing dependencies.
-  'dart_revision': '654c4babc8355dbc53d5575327c60d95ed6ff8ed',
+  'dart_revision': 'a2eb050044eec93f0844667b8b6132e858467e4e',
 
   'dart_args_tag': '1.4.4',
   'dart_async_tag': '2.0.8',


### PR DESCRIPTION
a2eb050044 [VM interpreter] Update bash script to run a Dart program in interpreted mode.
699282b5d3 Rename State class when StatefulWidget is renamed.
2d53894e3f Check that selection offset/length is valid in Extract Local refactoring.
7ad1e5da99 Perform substitution on type argument/parameter bounds.
309d38f300 Consistency in messages about duplication
8385c36d97 Move all int literal parsing and checking code together.
f4dfb6176f Corrected the "reusing part" error to take exports into account.
baa13a2e6d Introduce option to serialize less in frontend_server
fe39691269 Don't use --no-preview-dart-2
0d588bf50c Add --omit-as-casts option
1e5b80918a [dart2js] hashCode stability to improve repeatability
