### PR TITLE
Pass on the new unsafe-package-serialization option

### DIFF
--- a/frontend_server/lib/server.dart
+++ b/frontend_server/lib/server.dart
@@ -20,9 +20,11 @@ import 'package:vm/frontend_server.dart' as frontend show FrontendCompiler,
 class _FlutterFrontendCompiler implements frontend.CompilerInterface{
   final frontend.CompilerInterface _compiler;
 
-  _FlutterFrontendCompiler(StringSink output, {bool trackWidgetCreation: false}):
-      _compiler = new frontend.FrontendCompiler(output,
-          transformer: trackWidgetCreation ? new WidgetCreatorTracker() : null);
+  _FlutterFrontendCompiler(StringSink output,
+      {bool trackWidgetCreation: false, bool unsafePackageSerialization}) :
+          _compiler = new frontend.FrontendCompiler(output,
+          transformer: trackWidgetCreation ? new WidgetCreatorTracker() : null,
+          unsafePackageSerialization: unsafePackageSerialization);
 
   @override
   Future<bool> compile(String filename, ArgResults options, {IncrementalCompiler generator}) async {
@@ -123,7 +125,9 @@ Future<int> starter(
     }
   }
 
-  compiler ??= new _FlutterFrontendCompiler(output, trackWidgetCreation: options['track-widget-creation']);
+  compiler ??= new _FlutterFrontendCompiler(output,
+      trackWidgetCreation: options['track-widget-creation'],
+      unsafePackageSerialization: options['unsafe-package-serialization']);
 
   if (options.rest.isNotEmpty) {
     return await compiler.compile(options.rest[0], options) ? 0 : 254;


### PR DESCRIPTION
Together with an upcoming PR in flutter/flutter it takes test of flutter/packages/flutter (on my machine, today) from ~2:40 to ~1:20...

Edit: Updated description ---- before `02:40 +3101 ~25: All tests passed!`; after (with flutter/flutter) change too: `01:18 +3101 ~25: All tests passed!`.