### PR TITLE
Do not export libdart symbols

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -112,6 +112,8 @@ def to_gn_args(args):
     else:
       aot = False
 
+    gn_args['dart_lib_export_symbols'] = False
+
     if runtime_mode == 'debug':
         gn_args['dart_runtime_mode'] = 'develop'
     elif runtime_mode == 'dynamic_profile':


### PR DESCRIPTION
Requires https://dart-review.googlesource.com/c/sdk/+/76567.