### PR TITLE
SystemNavigator.pop can pop w/o UINavigationController

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -5,10 +5,14 @@
 #ifndef SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMPLUGIN_H_
 #define SHELL_PLATFORM_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMPLUGIN_H_
 
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterChannels.h"
+
+#include <UIKit/UIKit.h>
 
 @interface FlutterPlatformPlugin : NSObject
 
+- (instancetype)initWithViewController:(fml::WeakPtr<UIViewController>)vc;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "flutter/fml/logging.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h"
 
 #include <AudioToolbox/AudioToolbox.h>
@@ -31,7 +32,20 @@ const char* const kOverlayStyleUpdateNotificationKey =
 
 using namespace shell;
 
-@implementation FlutterPlatformPlugin
+@implementation FlutterPlatformPlugin {
+  fml::WeakPtr<UIViewController> _vc;
+}
+
+- (instancetype)initWithViewController:(fml::WeakPtr<UIViewController>)vc {
+  FML_DCHECK(vc) << "vc must be set";
+  self = [super init];
+
+  if (self) {
+    _vc = vc;
+  }
+
+  return self;
+}
 
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
   NSString* method = call.method;
@@ -178,9 +192,13 @@ using namespace shell;
   // Apple's human user guidelines say not to terminate iOS applications. However, if the
   // root view of the app is a navigation controller, it is instructed to back up a level
   // in the navigation hierarchy.
+  // It's also possible in an Add2App scenario that the FlutterViewController was presented
+  // outside the context of a UINavigationController, and still wants to be popped.
   UIViewController* viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
   if ([viewController isKindOfClass:[UINavigationController class]]) {
     [((UINavigationController*)viewController) popViewControllerAnimated:NO];
+  } else if (_vc && viewController != _vc.get()) {
+    [_vc.get() dismissViewControllerAnimated:NO completion:nil];
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/platform/darwin/platform_version.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
@@ -34,6 +35,7 @@
   fml::scoped_nsobject<FlutterDartProject> _dartProject;
   shell::ThreadHost _threadHost;
   std::unique_ptr<shell::Shell> _shell;
+  fml::WeakPtrFactory<FlutterViewController>* _weakFactory;
 
   // Channels
   fml::scoped_nsobject<FlutterPlatformPlugin> _platformPlugin;
@@ -65,6 +67,7 @@
                          bundle:(NSBundle*)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
+    _weakFactory = new fml::WeakPtrFactory<FlutterViewController>(self);
     if (projectOrNil == nil)
       _dartProject.reset([[FlutterDartProject alloc] init]);
     else
@@ -209,7 +212,7 @@
       binaryMessenger:self
                 codec:[FlutterJSONMessageCodec sharedInstance]]);
 
-  _platformPlugin.reset([[FlutterPlatformPlugin alloc] init]);
+  _platformPlugin.reset([[FlutterPlatformPlugin alloc] initWithViewController:_weakFactory->GetWeakPtr()]);
   [_platformChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
     [_platformPlugin.get() handleMethodCall:call result:result];
   }];
@@ -501,6 +504,7 @@
 - (void)dealloc {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [_pluginPublications release];
+  delete _weakFactory;
   [super dealloc];
 }
 


### PR DESCRIPTION
Today, iOS apps in Flutter ignore System.pop unless they find that the `rootViewController` is a `UINavigationViewController`.  

For Add2App, it's entirely possible someone will show the view using something like `showDetailViewController` from `UIViewController`.  This patch updates the logic to handle that scenario, but to do so the `FlutterPlatformPlugin` needs to get access to the `FlutterViewController`, and to do that I added functionality there for `FlutterViewController` to create `WeakPtr`s.

I'd be very happy if it turns out there's a way to stack allocate the `WeakPtrFactory` (or equivalent functionality) in Objective C++.