### PR TITLE
Expose push/popRoute on FlutterViewController

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -46,10 +46,28 @@ FLUTTER_EXPORT
 
 /**
  Sets the first route that the Flutter app shows. The default is "/".
+ This method will guarnatee that the initial route is delivered, even if the
+ Flutter window hasn't been created yet when called. It cannot be used to update
+ the current route being shown in a visible FlutterViewController (see pushRoute
+ and popRoute).
 
  - Parameter route: The name of the first route to show.
  */
 - (void)setInitialRoute:(NSString*)route;
+
+/**
+ Instructs the Flutter Navigator (if any) to go back.
+ */
+- (void)popRoute;
+
+/**
+ Instructs the Flutter Navigator (if any) to push a route on to the navigation
+ stack.  The setInitialRoute method should be prefered if this is called before the
+ FlutterViewController has come into view.
+
+ - Parameter route: The name of the route to push to the navigation stack.
+ */
+- (void)pushRoute:(NSString*)route;
 
 - (id<FlutterPluginRegistry>)pluginRegistry;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -315,6 +315,14 @@
   [_navigationChannel.get() invokeMethod:@"setInitialRoute" arguments:route];
 }
 
+- (void)popRoute {
+  [_navigationChannel.get() invokeMethod:@"popRoute" arguments:nil];
+}
+
+- (void)pushRoute:(NSString*)route {
+  [_navigationChannel.get() invokeMethod:@"pushRoute" arguments:route];
+}
+
 #pragma mark - Loading the view
 
 - (void)loadView {


### PR DESCRIPTION
This, along with #6341, will close out the rest of flutter/flutter#22054

Allows for the host app in an Add2App to perform runtime navigation (beyond just setting the initial route) on iOS.

/cc @matthew-carroll 