### PR TITLE
Fix a crash on some android device with the error message "EGL Error: EGL_BAD_MATCH"

### DIFF
--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -65,6 +65,12 @@ static EGLResult<EGLSurface> CreateContext(EGLDisplay display,
   EGLint attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
 
   EGLContext context = eglCreateContext(display, config, share, attributes);
+  if (context == EGL_NO_CONTEXT) {
+    EGLint last_error = eglGetError();
+    if (last_error == EGL_BAD_MATCH && share != EGL_NO_CONTEXT) {
+      context = eglCreateContext(display, config, EGL_NO_CONTEXT, attributes);
+    }
+  }
 
   return {context != EGL_NO_CONTEXT, context};
 }


### PR DESCRIPTION
We met a crash on one android device with the error message below:
```
E/flutter (29807): [ERROR:flutter/shell/platform/android/android_context_gl.cc(187)] Could not create an EGL context
E/flutter (29807): [ERROR:flutter/shell/platform/android/android_context_gl.cc(53)] EGL Error: EGL_BAD_MATCH (12297)
I/DEBUG   (29807): begin to generate native report
```

This pr handles the certain case and enable flutter work normally in those devices.

Environment:
```
KyleWongdeMacBook-Pro:src kylewong$ flutter doctor -v
[✓] Flutter (Channel alf_beta_v0.8.2_snapshot, v0.8.3-pre.5, on Mac OS X 10.14 18A389, locale en-CN)
    • Flutter version 0.8.3-pre.5 at /Users/kylewong/Codes/fwn_idlefish/flutter
    • Framework revision db697e6120 (25 hours ago), 2018-09-26 19:32:39 +0800
    • Engine revision 58a1894a1c
    • Dart version 2.1.0-dev.3.1.flutter-760a9690c2

[✓] Android toolchain - develop for Android devices (Android SDK 28.0.2)
    • Android SDK at /Users/kylewong/Library/Android/sdk
    • Android NDK at /Users/kylewong/Library/Android/sdk/ndk-bundle
    • Platform android-28, build-tools 28.0.2
    • Java binary at: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1024-b01)
    • All Android licenses accepted.

[!] iOS toolchain - develop for iOS devices (Xcode 10.0)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 10.0, Build version 10A254a
    • ios-deploy 1.9.2
    ! CocoaPods out of date (1.5.0 is recommended).
        CocoaPods is used to retrieve the iOS platform side's plugin code that responds to your plugin usage on the Dart side.
        Without resolving iOS dependencies with CocoaPods, plugins will not work on iOS.
        For more info, see https://flutter.io/platform-plugins
      To upgrade:
        brew upgrade cocoapods
        pod setup

[✓] Android Studio (version 3.1)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin version 27.1.1
    • Dart plugin version 173.4700
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1024-b01)

[✓] Connected devices (1 available)
    • HUAWEI P6 T00 • 022BTF7N44035887 • android-arm • Android 4.2.2 (API 17)

! Doctor found issues in 1 category.
```

The HUAWEI P6 T00  is the one that crashes and fixed using this commit.
It has informations below:
![2](https://user-images.githubusercontent.com/817851/46146348-21560000-c295-11e8-88eb-6cc043598515.png)
![1](https://user-images.githubusercontent.com/817851/46146354-2450f080-c295-11e8-9a66-e81441b5e8e1.png)

