### PR TITLE
Shut down and restart the Dart VM as needed.

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -94,6 +94,7 @@ executable("runtime_unittests") {
     ":runtime",
     ":runtime_fixtures",
     "$flutter_root/fml",
+    "$flutter_root/shell/common",
     "$flutter_root/lib/snapshot",
     "$flutter_root/testing",
     "//third_party/dart/runtime:libdart_jit",

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -36,6 +36,8 @@ source_set("runtime") {
     "dart_snapshot_buffer.h",
     "dart_vm.cc",
     "dart_vm.h",
+    "dart_vm_lifecycle.cc",
+    "dart_vm_lifecycle.h",
     "embedder_resources.cc",
     "embedder_resources.h",
     "runtime_controller.cc",
@@ -73,7 +75,9 @@ source_set("runtime") {
       flutter_runtime_mode != "dynamic_release" && !is_fuchsia) {
     # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
     # instead puts Observatory into the runner's package.
-    deps += [ "//third_party/dart/runtime/observatory:embedded_observatory_archive" ]
+    deps += [
+      "//third_party/dart/runtime/observatory:embedded_observatory_archive",
+    ]
   }
 }
 
@@ -94,8 +98,8 @@ executable("runtime_unittests") {
     ":runtime",
     ":runtime_fixtures",
     "$flutter_root/fml",
-    "$flutter_root/shell/common",
     "$flutter_root/lib/snapshot",
+    "$flutter_root/shell/common",
     "$flutter_root/testing",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/skia",

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -131,11 +131,11 @@ std::unique_ptr<AutoIsolateShutdown> RunDartCodeInIsolate(
   if (!vm) {
     return {};
   }
-  TaskRunners task_runners(CURRENT_TEST_NAME,  //
-                           task_runner,        //
-                           task_runner,        //
-                           task_runner,        //
-                           task_runner         //
+  TaskRunners task_runners(testing::GetCurrentTestName(),  //
+                           task_runner,                    //
+                           task_runner,                    //
+                           task_runner,                    //
+                           task_runner                     //
   );
 
   auto weak_isolate = DartIsolate::CreateRootIsolate(

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -11,11 +11,6 @@
 #include "flutter/testing/thread_test.h"
 #include "third_party/tonic/scopes/dart_isolate_scope.h"
 
-#define CURRENT_TEST_NAME                                           \
-  std::string {                                                     \
-    ::testing::UnitTest::GetInstance()->current_test_info()->name() \
-  }
-
 namespace blink {
 
 using DartIsolateTest = ::testing::ThreadTest;
@@ -26,11 +21,11 @@ TEST_F(DartIsolateTest, RootIsolateCreationAndShutdown) {
   settings.task_observer_remove = [](intptr_t) {};
   auto vm = DartVM::ForProcess(settings);
   ASSERT_TRUE(vm);
-  TaskRunners task_runners(CURRENT_TEST_NAME,       //
-                           GetCurrentTaskRunner(),  //
-                           GetCurrentTaskRunner(),  //
-                           GetCurrentTaskRunner(),  //
-                           GetCurrentTaskRunner()   //
+  TaskRunners task_runners(testing::GetCurrentTestName(),  //
+                           GetCurrentTaskRunner(),         //
+                           GetCurrentTaskRunner(),         //
+                           GetCurrentTaskRunner(),         //
+                           GetCurrentTaskRunner()          //
   );
   auto weak_isolate = DartIsolate::CreateRootIsolate(
       vm.get(),                  // vm
@@ -55,11 +50,11 @@ TEST_F(DartIsolateTest, IsolateShutdownCallbackIsInIsolateScope) {
   settings.task_observer_remove = [](intptr_t) {};
   auto vm = DartVM::ForProcess(settings);
   ASSERT_TRUE(vm);
-  TaskRunners task_runners(CURRENT_TEST_NAME,       //
-                           GetCurrentTaskRunner(),  //
-                           GetCurrentTaskRunner(),  //
-                           GetCurrentTaskRunner(),  //
-                           GetCurrentTaskRunner()   //
+  TaskRunners task_runners(testing::GetCurrentTestName(),  //
+                           GetCurrentTaskRunner(),         //
+                           GetCurrentTaskRunner(),         //
+                           GetCurrentTaskRunner(),         //
+                           GetCurrentTaskRunner()          //
   );
   auto weak_isolate = DartIsolate::CreateRootIsolate(
       vm.get(),                  // vm

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -127,6 +127,7 @@ std::unique_ptr<AutoIsolateShutdown> RunDartCodeInIsolate(
     fml::RefPtr<fml::TaskRunner> task_runner,
     std::string entrypoint) {
   Settings settings = {};
+  settings.enable_observatory = true;
   settings.task_observer_add = [](intptr_t, fml::closure) {};
   settings.task_observer_remove = [](intptr_t) {};
 

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -81,8 +81,11 @@ TEST_F(DartIsolateTest, IsolateShutdownCallbackIsInIsolateScope) {
 
 class AutoIsolateShutdown {
  public:
-  AutoIsolateShutdown(std::shared_ptr<blink::DartIsolate> isolate)
-      : isolate_(std::move(isolate)) {}
+  AutoIsolateShutdown(std::shared_ptr<blink::DartVM> vm,
+                      std::shared_ptr<blink::DartIsolate> isolate)
+      : vm_(std::move(vm)), isolate_(std::move(isolate)) {
+    FML_CHECK(vm_);
+  }
 
   ~AutoIsolateShutdown() {
     if (isolate_) {
@@ -114,6 +117,7 @@ class AutoIsolateShutdown {
   }
 
  private:
+  std::shared_ptr<blink::DartVM> vm_;
   std::shared_ptr<blink::DartIsolate> isolate_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AutoIsolateShutdown);
@@ -151,7 +155,7 @@ std::unique_ptr<AutoIsolateShutdown> RunDartCodeInIsolate(
   );
 
   auto root_isolate =
-      std::make_unique<AutoIsolateShutdown>(weak_isolate.lock());
+      std::make_unique<AutoIsolateShutdown>(vm, weak_isolate.lock());
 
   if (!root_isolate->IsValid()) {
     FML_LOG(ERROR) << "Could not create isolate.";

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -459,11 +459,10 @@ DartVM::~DartVM() {
 
   dart::bin::CleanupDartIo();
 
-  if (result != nullptr) {
-    FML_LOG(ERROR) << "Could not cleanly shut down the Dart VM. Message: \""
-                   << result << "\".";
-    free(result);
-  }
+  FML_CHECK(result == nullptr)
+      << "Could not cleanly shut down the Dart VM. Error: \"" << result
+      << "\".";
+  free(result);
 }
 
 const Settings& DartVM::GetSettings() const {

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -430,6 +430,9 @@ DartVM::DartVM(const Settings& settings,
                                  &ServiceStreamCancelCallback);
 
   Dart_SetEmbedderInformationCallback(&EmbedderInformationCallback);
+
+  FML_DLOG(INFO) << "New Dart VM instance created. Instance count: "
+                 << gVMLaunchCount;
 }
 
 DartVM::~DartVM() {
@@ -445,6 +448,9 @@ DartVM::~DartVM() {
       << "Could not cleanly shut down the Dart VM. Error: \"" << result
       << "\".";
   free(result);
+
+  FML_DLOG(INFO) << "Dart VM instance destroyed. Instance count: "
+                 << gVMLaunchCount;
 }
 
 const Settings& DartVM::GetSettings() const {

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -299,6 +299,12 @@ std::shared_ptr<DartVM> DartVM::ForProcessIfInitialized() {
   return gVM.lock();
 }
 
+static std::atomic_size_t gVMLaunchCount;
+
+size_t DartVM::GetVMLaunchCount() {
+  return gVMLaunchCount;
+}
+
 DartVM::DartVM(const Settings& settings,
                fml::RefPtr<DartSnapshot> vm_snapshot,
                fml::RefPtr<DartSnapshot> isolate_snapshot,
@@ -308,6 +314,7 @@ DartVM::DartVM(const Settings& settings,
       isolate_snapshot_(std::move(isolate_snapshot)),
       shared_snapshot_(std::move(shared_snapshot)) {
   TRACE_EVENT0("flutter", "DartVMInitializer");
+  gVMLaunchCount++;
   FML_DLOG(INFO) << "Attempting Dart VM launch for mode: "
                  << (IsRunningPrecompiledCode() ? "AOT" : "Interpreter");
 

--- a/runtime/dart_vm.h
+++ b/runtime/dart_vm.h
@@ -6,6 +6,7 @@
 #define FLUTTER_RUNTIME_DART_VM_H_
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -24,17 +25,19 @@
 
 namespace blink {
 
-class DartVM : public fml::RefCountedThreadSafe<DartVM> {
+class DartVM {
  public:
-  static fml::RefPtr<DartVM> ForProcess(Settings settings);
+  ~DartVM();
 
-  static fml::RefPtr<DartVM> ForProcess(
+  static std::shared_ptr<DartVM> ForProcess(Settings settings);
+
+  static std::shared_ptr<DartVM> ForProcess(
       Settings settings,
       fml::RefPtr<DartSnapshot> vm_snapshot,
       fml::RefPtr<DartSnapshot> isolate_snapshot,
       fml::RefPtr<DartSnapshot> shared_snapshot);
 
-  static fml::RefPtr<DartVM> ForProcessIfInitialized();
+  static std::shared_ptr<DartVM> ForProcessIfInitialized();
 
   static bool IsRunningPrecompiledCode();
 
@@ -50,8 +53,6 @@ class DartVM : public fml::RefCountedThreadSafe<DartVM> {
 
   fml::RefPtr<DartSnapshot> GetSharedSnapshot() const;
 
-  fml::WeakPtr<DartVM> GetWeakPtr();
-
   ServiceProtocol& GetServiceProtocol();
 
  private:
@@ -61,17 +62,12 @@ class DartVM : public fml::RefCountedThreadSafe<DartVM> {
   const fml::RefPtr<DartSnapshot> isolate_snapshot_;
   const fml::RefPtr<DartSnapshot> shared_snapshot_;
   ServiceProtocol service_protocol_;
-  fml::WeakPtrFactory<DartVM> weak_factory_;
 
   DartVM(const Settings& settings,
          fml::RefPtr<DartSnapshot> vm_snapshot,
          fml::RefPtr<DartSnapshot> isolate_snapshot,
          fml::RefPtr<DartSnapshot> shared_snapshot);
 
-  ~DartVM();
-
-  FML_FRIEND_REF_COUNTED_THREAD_SAFE(DartVM);
-  FML_FRIEND_MAKE_REF_COUNTED(DartVM);
   FML_DISALLOW_COPY_AND_ASSIGN(DartVM);
 };
 

--- a/runtime/dart_vm.h
+++ b/runtime/dart_vm.h
@@ -29,16 +29,6 @@ class DartVM {
  public:
   ~DartVM();
 
-  static std::shared_ptr<DartVM> ForProcess(Settings settings);
-
-  static std::shared_ptr<DartVM> ForProcess(
-      Settings settings,
-      fml::RefPtr<DartSnapshot> vm_snapshot,
-      fml::RefPtr<DartSnapshot> isolate_snapshot,
-      fml::RefPtr<DartSnapshot> shared_snapshot);
-
-  static std::shared_ptr<DartVM> ForProcessIfInitialized();
-
   static bool IsRunningPrecompiledCode();
 
   static bool IsKernelMapping(const fml::FileMapping* mapping);
@@ -64,7 +54,14 @@ class DartVM {
   const fml::RefPtr<DartSnapshot> isolate_snapshot_;
   const fml::RefPtr<DartSnapshot> shared_snapshot_;
   ServiceProtocol service_protocol_;
-  std::mutex vm_thread_mutex_;
+
+  friend class DartVMLifecycleReference;
+
+  static std::shared_ptr<DartVM> Create(
+      Settings settings,
+      fml::RefPtr<DartSnapshot> vm_snapshot,
+      fml::RefPtr<DartSnapshot> isolate_snapshot,
+      fml::RefPtr<DartSnapshot> shared_snapshot);
 
   DartVM(const Settings& settings,
          fml::RefPtr<DartSnapshot> vm_snapshot,

--- a/runtime/dart_vm.h
+++ b/runtime/dart_vm.h
@@ -43,6 +43,8 @@ class DartVM {
 
   static bool IsKernelMapping(const fml::FileMapping* mapping);
 
+  static size_t GetVMLaunchCount();
+
   const Settings& GetSettings() const;
 
   const DartSnapshot& GetVMSnapshot() const;
@@ -62,6 +64,7 @@ class DartVM {
   const fml::RefPtr<DartSnapshot> isolate_snapshot_;
   const fml::RefPtr<DartSnapshot> shared_snapshot_;
   ServiceProtocol service_protocol_;
+  std::mutex vm_thread_mutex_;
 
   DartVM(const Settings& settings,
          fml::RefPtr<DartSnapshot> vm_snapshot,

--- a/runtime/dart_vm_lifecycle.cc
+++ b/runtime/dart_vm_lifecycle.cc
@@ -14,10 +14,9 @@
 namespace blink {
 
 static std::mutex gLifecycleMutex;
-// TODO: This needs to be a shared exclusive lock.
+// TODO: Make this a shared exclusive lock.
 static std::recursive_mutex gAccessMutex;
 std::weak_ptr<DartVM> gVM;
-// TODO: Move the VM launch count global here.
 
 DartVMLifecycleReference::DartVMLifecycleReference(std::shared_ptr<DartVM> vm)
     : vm_(vm) {}

--- a/runtime/dart_vm_lifecycle.cc
+++ b/runtime/dart_vm_lifecycle.cc
@@ -1,0 +1,92 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/runtime/dart_vm_lifecycle.h"
+
+#include <mutex>
+
+// The use of std::lock causes a false warning because that method has not been
+// decorated with thread safety annotations.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wthread-safety-analysis"
+
+namespace blink {
+
+static std::mutex gLifecycleMutex;
+// TODO: This needs to be a shared exclusive lock.
+static std::recursive_mutex gAccessMutex;
+std::weak_ptr<DartVM> gVM;
+// TODO: Move the VM launch count global here.
+
+DartVMLifecycleReference::DartVMLifecycleReference(std::shared_ptr<DartVM> vm)
+    : vm_(vm) {}
+
+DartVMLifecycleReference::DartVMLifecycleReference(
+    DartVMLifecycleReference&& other) {
+  other.abandoned_ = true;
+  vm_ = std::move(other.vm_);
+}
+
+DartVMLifecycleReference::~DartVMLifecycleReference() {
+  if (abandoned_) {
+    return;
+  }
+  std::lock(gLifecycleMutex, gAccessMutex);
+  std::lock_guard<std::mutex> lifecycle_lock(gLifecycleMutex, std::adopt_lock);
+  std::lock_guard<std::recursive_mutex> access_lock(gAccessMutex,
+                                                    std::adopt_lock);
+  vm_.reset();
+}
+
+DartVMLifecycleReference DartVMLifecycleReference::Create(
+    Settings settings,
+    fml::RefPtr<DartSnapshot> vm_snapshot,
+    fml::RefPtr<DartSnapshot> isolate_snapshot,
+    fml::RefPtr<DartSnapshot> shared_snapshot) {
+  std::lock(gLifecycleMutex, gAccessMutex);
+
+  std::lock_guard<std::mutex> lifecycle_lock(gLifecycleMutex, std::adopt_lock);
+  std::lock_guard<std::recursive_mutex> access_lock(gAccessMutex,
+                                                    std::adopt_lock);
+
+  // If there is already a running VM in the process. Grab a strong reference to
+  // it.
+  if (auto vm = gVM.lock()) {
+    FML_LOG(INFO) << "Attempted to create a VM in a process where one was "
+                     "already running. Ignoring arguments for current VM "
+                     "create call and reusing the old VM.";
+    // There was already a running VM in the process,
+    return DartVMLifecycleReference{std::move(vm)};
+  }
+
+  // If there is no VM in the process. Initialize one, hold the weak reference
+  // and pass a strong reference to the caller.
+  auto vm =
+      DartVM::Create(std::move(settings), std::move(vm_snapshot),
+                     std::move(isolate_snapshot), std::move(shared_snapshot));
+  gVM = vm;
+  return DartVMLifecycleReference{std::move(vm)};
+}
+
+DartVMAccessReference::DartVMAccessReference(std::shared_ptr<DartVM> vm)
+    : vm_(std::move(vm)) {}
+
+DartVMAccessReference::DartVMAccessReference(DartVMAccessReference&& other) {
+  other.abandoned_ = true;
+  vm_ = std::move(other.vm_);
+}
+
+DartVMAccessReference::~DartVMAccessReference() {
+  if (abandoned_) {
+    return;
+  }
+  gAccessMutex.unlock();  // Locked in the |DartVMAccessReference::Create|.
+}
+
+DartVMAccessReference DartVMAccessReference::Create() {
+  gAccessMutex.lock();  // Unlocked in the |~DartVMAccessReference|.
+  return DartVMAccessReference{gVM.lock()};
+}
+
+}  // namespace blink

--- a/runtime/dart_vm_lifecycle.h
+++ b/runtime/dart_vm_lifecycle.h
@@ -1,0 +1,81 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_RUNTIME_DART_VM_LIFECYCLE_H_
+#define FLUTTER_RUNTIME_DART_VM_LIFECYCLE_H_
+
+#include <memory>
+
+#include "flutter/fml/macros.h"
+#include "flutter/runtime/dart_vm.h"
+
+namespace blink {
+
+class DartVMLifecycleReference {
+ public:
+  FML_WARN_UNUSED_RESULT
+  static DartVMLifecycleReference Create(
+      Settings settings,
+      fml::RefPtr<DartSnapshot> vm_snapshot = nullptr,
+      fml::RefPtr<DartSnapshot> isolate_snapshot = nullptr,
+      fml::RefPtr<DartSnapshot> shared_snapshot = nullptr);
+
+  DartVMLifecycleReference(DartVMLifecycleReference&&);
+
+  ~DartVMLifecycleReference();
+
+  operator bool() const { return static_cast<bool>(vm_); }
+
+  DartVM* operator->() {
+    FML_DCHECK(vm_);
+    return vm_.get();
+  }
+
+  DartVM* operator&() {
+    FML_DCHECK(vm_);
+    return vm_.get();
+  }
+
+ private:
+  bool abandoned_ = false;
+  std::shared_ptr<DartVM> vm_;
+
+  DartVMLifecycleReference(std::shared_ptr<DartVM> vm);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DartVMLifecycleReference);
+};
+
+class DartVMAccessReference {
+ public:
+  DartVMAccessReference(DartVMAccessReference&&);
+
+  ~DartVMAccessReference();
+
+  FML_WARN_UNUSED_RESULT
+  static DartVMAccessReference Create();
+
+  operator bool() const { return static_cast<bool>(vm_); }
+
+  DartVM* operator->() {
+    FML_DCHECK(vm_);
+    return vm_.get();
+  }
+
+  DartVM* operator&() {
+    FML_DCHECK(vm_);
+    return vm_.get();
+  }
+
+ private:
+  bool abandoned_ = false;
+  std::shared_ptr<DartVM> vm_;
+
+  DartVMAccessReference(std::shared_ptr<DartVM> vm);
+
+  FML_DISALLOW_COPY_AND_ASSIGN(DartVMAccessReference);
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_RUNTIME_DART_VM_LIFECYCLE_H_

--- a/runtime/dart_vm_unittests.cc
+++ b/runtime/dart_vm_unittests.cc
@@ -3,25 +3,29 @@
 // found in the LICENSE file.
 
 #include "flutter/runtime/dart_vm.h"
+#include "flutter/shell/common/thread_host.h"
+#include "flutter/testing/testing.h"
+#include "flutter/testing/thread_test.h"
 #include "gtest/gtest.h"
 
 namespace blink {
 
-TEST(DartVM, SimpleInitialization) {
-  Settings settings = {};
+static Settings GetTestSettings() {
+  Settings settings;
   settings.task_observer_add = [](intptr_t, fml::closure) {};
   settings.task_observer_remove = [](intptr_t) {};
-  auto vm = DartVM::ForProcess(settings);
+  return settings;
+}
+
+TEST(DartVM, SimpleInitialization) {
+  auto vm = DartVM::ForProcess(GetTestSettings());
   ASSERT_TRUE(vm);
-  ASSERT_EQ(vm, DartVM::ForProcess(settings));
+  ASSERT_EQ(vm, DartVM::ForProcess(GetTestSettings()));
   ASSERT_FALSE(DartVM::IsRunningPrecompiledCode());
 }
 
 TEST(DartVM, SimpleIsolateNameServer) {
-  Settings settings = {};
-  settings.task_observer_add = [](intptr_t, fml::closure) {};
-  settings.task_observer_remove = [](intptr_t) {};
-  auto vm = DartVM::ForProcess(settings);
+  auto vm = DartVM::ForProcess(GetTestSettings());
   auto ns = vm->GetIsolateNameServer();
   ASSERT_EQ(ns->LookupIsolatePortByName("foobar"), ILLEGAL_PORT);
   ASSERT_FALSE(ns->RemoveIsolateNameMapping("foobar"));
@@ -29,6 +33,66 @@ TEST(DartVM, SimpleIsolateNameServer) {
   ASSERT_FALSE(ns->RegisterIsolatePortWithName(123, "foobar"));
   ASSERT_EQ(ns->LookupIsolatePortByName("foobar"), 123);
   ASSERT_TRUE(ns->RemoveIsolateNameMapping("foobar"));
+}
+
+TEST(DartVM, CanReinitializeVMOverAndOver) {
+  for (size_t i = 0; i < 1000; ++i) {
+    FML_LOG(INFO) << "Run " << i + 1;
+    // VM should not already be running.
+    ASSERT_FALSE(DartVM::ForProcessIfInitialized());
+    auto vm = DartVM::ForProcess(GetTestSettings());
+    ASSERT_TRUE(vm);
+    ASSERT_TRUE(DartVM::ForProcessIfInitialized());
+  }
+}
+
+using DartVMThreadTest = ::testing::ThreadTest;
+
+TEST_F(DartVMThreadTest, CanRunIsolatesInANewVM) {
+  for (size_t i = 0; i < 1000; ++i) {
+    FML_LOG(INFO) << "Run " << i + 1;
+    // VM should not already be running.
+    ASSERT_FALSE(DartVM::ForProcessIfInitialized());
+    auto vm = DartVM::ForProcess(GetTestSettings());
+    ASSERT_TRUE(vm);
+    ASSERT_TRUE(DartVM::ForProcessIfInitialized());
+
+    Settings settings = {};
+
+    settings.task_observer_add = [](intptr_t, fml::closure) {};
+    settings.task_observer_remove = [](intptr_t) {};
+
+    auto labels = testing::GetCurrentTestName() + std::to_string(i);
+    shell::ThreadHost host(labels, shell::ThreadHost::Type::UI |
+                                       shell::ThreadHost::Type::GPU |
+                                       shell::ThreadHost::Type::IO);
+
+    TaskRunners task_runners(
+        labels,                            // task runner labels
+        GetCurrentTaskRunner(),            // platform task runner
+        host.gpu_thread->GetTaskRunner(),  // GPU task runner
+        host.ui_thread->GetTaskRunner(),   // UI task runner
+        host.io_thread->GetTaskRunner()    // IO task runner
+    );
+
+    auto weak_isolate = DartIsolate::CreateRootIsolate(
+        vm.get(),                  // vm
+        vm->GetIsolateSnapshot(),  // isolate snapshot
+        vm->GetSharedSnapshot(),   // shared snapshot
+        std::move(task_runners),   // task runners
+        nullptr,                   // window
+        {},                        // snapshot delegate
+        {},                        // resource context
+        nullptr,                   // unref qeueue
+        "main.dart",               // advisory uri
+        "main"                     // advisory entrypoint
+    );
+
+    auto root_isolate = weak_isolate.lock();
+    ASSERT_TRUE(root_isolate);
+    ASSERT_EQ(root_isolate->GetPhase(), DartIsolate::Phase::LibrariesSetup);
+    ASSERT_TRUE(root_isolate->Shutdown());
+  }
 }
 
 }  // namespace blink

--- a/runtime/dart_vm_unittests.cc
+++ b/runtime/dart_vm_unittests.cc
@@ -82,8 +82,7 @@ TEST_F(DartVMThreadTest, CanRunIsolatesInANewVM) {
         std::move(task_runners),   // task runners
         nullptr,                   // window
         {},                        // snapshot delegate
-        {},                        // resource context
-        nullptr,                   // unref qeueue
+        {},                        // io manager
         "main.dart",               // advisory uri
         "main"                     // advisory entrypoint
     );

--- a/runtime/dart_vm_unittests.cc
+++ b/runtime/dart_vm_unittests.cc
@@ -36,12 +36,16 @@ TEST(DartVM, SimpleIsolateNameServer) {
 }
 
 TEST(DartVM, CanReinitializeVMOverAndOver) {
+  size_t vm_launch_count = DartVM::GetVMLaunchCount();
   for (size_t i = 0; i < 1000; ++i) {
     FML_LOG(INFO) << "Run " << i + 1;
     // VM should not already be running.
     ASSERT_FALSE(DartVM::ForProcessIfInitialized());
     auto vm = DartVM::ForProcess(GetTestSettings());
     ASSERT_TRUE(vm);
+    size_t new_vm_launch_count = DartVM::GetVMLaunchCount();
+    ASSERT_EQ(vm_launch_count + 1, new_vm_launch_count);
+    vm_launch_count = new_vm_launch_count;
     ASSERT_TRUE(DartVM::ForProcessIfInitialized());
   }
 }

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -85,7 +85,7 @@ class Shell final : public PlatformView::Delegate,
 
   const blink::TaskRunners task_runners_;
   const blink::Settings settings_;
-  fml::RefPtr<blink::DartVM> vm_;
+  std::shared_ptr<blink::DartVM> vm_;
   std::unique_ptr<PlatformView> platform_view_;  // on platform task runner
   std::unique_ptr<Engine> engine_;               // on UI task runner
   std::unique_ptr<Rasterizer> rasterizer_;       // on GPU task runner

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -23,6 +23,7 @@
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/lib/ui/window/platform_message.h"
+#include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/runtime/service_protocol.h"
 #include "flutter/shell/common/animator.h"
 #include "flutter/shell/common/engine.h"
@@ -57,7 +58,8 @@ class Shell final : public PlatformView::Delegate,
       fml::RefPtr<blink::DartSnapshot> isolate_snapshot,
       fml::RefPtr<blink::DartSnapshot> shared_snapshot,
       CreateCallback<PlatformView> on_create_platform_view,
-      CreateCallback<Rasterizer> on_create_rasterizer);
+      CreateCallback<Rasterizer> on_create_rasterizer,
+      blink::DartVMLifecycleReference vm);
 
   ~Shell();
 
@@ -71,7 +73,7 @@ class Shell final : public PlatformView::Delegate,
 
   fml::WeakPtr<PlatformView> GetPlatformView();
 
-  blink::DartVM& GetDartVM() const;
+  blink::DartVM* GetDartVM();
 
   bool IsSetup() const;
 
@@ -85,7 +87,7 @@ class Shell final : public PlatformView::Delegate,
 
   const blink::TaskRunners task_runners_;
   const blink::Settings settings_;
-  std::shared_ptr<blink::DartVM> vm_;
+  blink::DartVMLifecycleReference vm_;
   std::unique_ptr<PlatformView> platform_view_;  // on platform task runner
   std::unique_ptr<Engine> engine_;               // on UI task runner
   std::unique_ptr<Rasterizer> rasterizer_;       // on GPU task runner
@@ -99,9 +101,12 @@ class Shell final : public PlatformView::Delegate,
       service_protocol_handlers_;
   bool is_setup_ = false;
 
-  Shell(blink::TaskRunners task_runners, blink::Settings settings);
+  Shell(blink::DartVMLifecycleReference vm,
+        blink::TaskRunners task_runners,
+        blink::Settings settings);
 
   static std::unique_ptr<Shell> CreateShellOnPlatformThread(
+      blink::DartVMLifecycleReference vm,
       blink::TaskRunners task_runners,
       blink::Settings settings,
       fml::RefPtr<blink::DartSnapshot> isolate_snapshot,

--- a/testing/testing.cc
+++ b/testing/testing.cc
@@ -6,6 +6,8 @@
 
 namespace testing {
 
-//
+std::string GetCurrentTestName() {
+  return UnitTest::GetInstance()->current_test_info()->name();
+}
 
 }  // namespace testing

--- a/testing/testing.h
+++ b/testing/testing.h
@@ -5,6 +5,8 @@
 #ifndef TESTING_TESTING_H_
 #define TESTING_TESTING_H_
 
+#include <string>
+
 #include "gtest/gtest.h"
 
 namespace testing {
@@ -13,6 +15,8 @@ namespace testing {
 // target has fixtures configured. If there are no fixtures, this is a link
 // error.
 const char* GetFixturesPath();
+
+std::string GetCurrentTestName();
 
 }  // namespace testing
 


### PR DESCRIPTION
The shell was already designed to cleanly shut down the VM but it couldn't
earlier as `Dart_Initialize` could never be called again after a `Dart_Cleanup`. This
meant that shutting down an engine instance could not shut down the VM to save
memory because newly created engines in the process after that point couldn't
restart the VM. There can only be one VM running in a process at a time.

This limitation was lifted in https://dart-review.googlesource.com/c/sdk/+/76561.
