### PR TITLE
Use single_root_scheme when compiling platform

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -169,7 +169,9 @@ source_set("snapshot") {
 }
 
 compile_platform("non_strong_platform") {
-  libraries_specification_uri = "libraries.json"
+  single_root_scheme = "org-dartlang-sdk"
+  single_root_base = rebase_path("../../../")
+  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform.dill",
@@ -183,7 +185,9 @@ compile_platform("non_strong_platform") {
 }
 
 compile_platform("strong_platform") {
-  libraries_specification_uri = "libraries.json"
+  single_root_scheme = "org-dartlang-sdk"
+  single_root_base = rebase_path("../../../")
+  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform_strong.dill",


### PR DESCRIPTION
This should fix the first part of https://github.com/flutter/flutter/issues/22497 where the file uris doesn't match up. More will have to be done to fix the file endings on windows thing.