### PR TITLE
Share engine layers with the framework

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -475,6 +475,8 @@ TYPE: LicenseType.bsd
 FILE: ../../../flutter/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
 FILE: ../../../flutter/fml/paths_unittests.cc
 FILE: ../../../flutter/lib/ui/isolate_name_server.dart
+FILE: ../../../flutter/lib/ui/painting/engine_layer.cc
+FILE: ../../../flutter/lib/ui/painting/engine_layer.h
 FILE: ../../../flutter/lib/ui/painting/image_encoding.cc
 FILE: ../../../flutter/lib/ui/painting/image_encoding.h
 FILE: ../../../flutter/lib/ui/plugins.dart

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -10,7 +10,7 @@ ContainerLayer::ContainerLayer() {}
 
 ContainerLayer::~ContainerLayer() = default;
 
-void ContainerLayer::Add(std::unique_ptr<Layer> layer) {
+void ContainerLayer::Add(std::shared_ptr<Layer> layer) {
   layer->set_parent(this);
   layers_.push_back(std::move(layer));
 }

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -15,7 +15,7 @@ class ContainerLayer : public Layer {
   ContainerLayer();
   ~ContainerLayer() override;
 
-  void Add(std::unique_ptr<Layer> layer);
+  void Add(std::shared_ptr<Layer> layer);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
@@ -23,7 +23,7 @@ class ContainerLayer : public Layer {
   void UpdateScene(SceneUpdateContext& context) override;
 #endif  // defined(OS_FUCHSIA)
 
-  const std::vector<std::unique_ptr<Layer>>& layers() const { return layers_; }
+  const std::vector<std::shared_ptr<Layer>>& layers() const { return layers_; }
 
  protected:
   void PrerollChildren(PrerollContext* context,
@@ -36,7 +36,7 @@ class ContainerLayer : public Layer {
 #endif  // defined(OS_FUCHSIA)
 
  private:
-  std::vector<std::unique_ptr<Layer>> layers_;
+  std::vector<std::shared_ptr<Layer>> layers_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);
 };

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -38,7 +38,7 @@ class LayerTree {
 
   Layer* root_layer() const { return root_layer_.get(); }
 
-  void set_root_layer(std::unique_ptr<Layer> root_layer) {
+  void set_root_layer(std::shared_ptr<Layer> root_layer) {
     root_layer_ = std::move(root_layer);
   }
 
@@ -73,7 +73,7 @@ class LayerTree {
 
  private:
   SkISize frame_size_;  // Physical pixels.
-  std::unique_ptr<Layer> root_layer_;
+  std::shared_ptr<Layer> root_layer_;
   fml::TimeDelta construction_time_;
   uint32_t rasterizer_tracing_threshold_;
   bool checkerboard_raster_cache_images_;

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -23,6 +23,8 @@ source_set("ui") {
     "painting/canvas.h",
     "painting/codec.cc",
     "painting/codec.h",
+    "painting/engine_layer.h",
+    "painting/engine_layer.cc",
     "painting/frame_info.cc",
     "painting/frame_info.h",
     "painting/gradient.cc",

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -69,7 +69,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// This is equivalent to [pushTransform] with a matrix with only translation.
   ///
   /// See [pop] for details about the operation stack.
-  void pushOffset(double dx, double dy) native 'SceneBuilder_pushOffset';
+  EngineLayer pushOffset(double dx, double dy) native 'SceneBuilder_pushOffset';
 
   /// Pushes a rectangular clip operation onto the operation stack.
   ///
@@ -177,10 +177,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   // ignore: deprecated_member_use
-  void pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = defaultClipBehavior}) {
+  EngineLayer pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = defaultClipBehavior}) {
     _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index);
   }
-  void _pushPhysicalShape(Path path, double elevation, int color, int shadowColor, int clipBehavior) native
+  EngineLayer _pushPhysicalShape(Path path, double elevation, int color, int shadowColor, int clipBehavior) native
     'SceneBuilder_pushPhysicalShape';
 
   /// Ends the effect of the most recently pushed operation.
@@ -190,6 +190,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// Calling this function removes the most recently added operation from the
   /// stack.
   void pop() native 'SceneBuilder_pop';
+
+  /// Add a retained engine layer subtree from previous frames.
+  ///
+  /// All the engine layers that are in the subtree of the retained layer will
+  /// be automatically appended to the current engine layer tree. Therefore,
+  /// once this is called, there's no need to call [addToScene] for its children
+  /// layers.
+  EngineLayer addRetained(EngineLayer retainedLayer) native 'SceneBuilder_addRetained';
 
   /// Adds an object to the scene that displays performance statistics.
   ///

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -178,7 +178,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   // ignore: deprecated_member_use
   EngineLayer pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = defaultClipBehavior}) {
-    _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index);
+    return _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index);
   }
   EngineLayer _pushPhysicalShape(Path path, double elevation, int color, int shadowColor, int clipBehavior) native
     'SceneBuilder_pushPhysicalShape';

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -26,7 +26,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Scene);
 
 DART_BIND_ALL(Scene, FOR_EACH_BINDING)
 
-fml::RefPtr<Scene> Scene::create(std::unique_ptr<flow::Layer> rootLayer,
+fml::RefPtr<Scene> Scene::create(std::shared_ptr<flow::Layer> rootLayer,
                                  uint32_t rasterizerTracingThreshold,
                                  bool checkerboardRasterCacheImages,
                                  bool checkerboardOffscreenLayers) {
@@ -35,7 +35,7 @@ fml::RefPtr<Scene> Scene::create(std::unique_ptr<flow::Layer> rootLayer,
       checkerboardRasterCacheImages, checkerboardOffscreenLayers);
 }
 
-Scene::Scene(std::unique_ptr<flow::Layer> rootLayer,
+Scene::Scene(std::shared_ptr<flow::Layer> rootLayer,
              uint32_t rasterizerTracingThreshold,
              bool checkerboardRasterCacheImages,
              bool checkerboardOffscreenLayers)

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -24,7 +24,7 @@ class Scene : public RefCountedDartWrappable<Scene> {
 
  public:
   ~Scene() override;
-  static fml::RefPtr<Scene> create(std::unique_ptr<flow::Layer> rootLayer,
+  static fml::RefPtr<Scene> create(std::shared_ptr<flow::Layer> rootLayer,
                                    uint32_t rasterizerTracingThreshold,
                                    bool checkerboardRasterCacheImages,
                                    bool checkerboardOffscreenLayers);
@@ -40,7 +40,7 @@ class Scene : public RefCountedDartWrappable<Scene> {
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  explicit Scene(std::unique_ptr<flow::Layer> rootLayer,
+  explicit Scene(std::shared_ptr<flow::Layer> rootLayer,
                  uint32_t rasterizerTracingThreshold,
                  bool checkerboardRasterCacheImages,
                  bool checkerboardOffscreenLayers);

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -82,7 +82,7 @@ void SceneBuilder::pushTransform(const tonic::Float64List& matrix4) {
 
 void SceneBuilder::pushOffset(double dx, double dy) {
   SkMatrix sk_matrix = SkMatrix::MakeTrans(dx, dy);
-  auto layer = std::make_unique<flow::TransformLayer>();
+  auto layer = std::make_shared<flow::TransformLayer>();
   layer->set_transform(sk_matrix);
   PushLayer(std::move(layer));
 }

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -81,7 +81,7 @@ void SceneBuilder::pushTransform(const tonic::Float64List& matrix4) {
   PushLayer(std::move(layer));
 }
 
-RetainedLayer SceneBuilder::pushOffset(double dx, double dy) {
+fml::RefPtr<EngineLayer> SceneBuilder::pushOffset(double dx, double dy) {
   SkMatrix sk_matrix = SkMatrix::MakeTrans(dx, dy);
   auto layer = std::make_shared<flow::TransformLayer>();
   layer->set_transform(sk_matrix);
@@ -150,11 +150,11 @@ void SceneBuilder::pushShaderMask(Shader* shader,
   PushLayer(std::move(layer));
 }
 
-RetainedLayer SceneBuilder::pushPhysicalShape(const CanvasPath* path,
-                                              double elevation,
-                                              int color,
-                                              int shadow_color,
-                                              int clipBehavior) {
+fml::RefPtr<EngineLayer> SceneBuilder::pushPhysicalShape(const CanvasPath* path,
+                                                         double elevation,
+                                                         int color,
+                                                         int shadow_color,
+                                                         int clipBehavior) {
   const SkPath& sk_path = path->path();
   flow::Clip clip_behavior = static_cast<flow::Clip>(clipBehavior);
   auto layer = std::make_shared<flow::PhysicalShapeLayer>(clip_behavior);
@@ -168,7 +168,7 @@ RetainedLayer SceneBuilder::pushPhysicalShape(const CanvasPath* path,
   return EngineLayer::MakeRetained(layer);
 }
 
-void SceneBuilder::addRetained(RetainedLayer retainedLayer) {
+void SceneBuilder::addRetained(fml::RefPtr<EngineLayer> retainedLayer) {
   if (!current_layer_) {
     return;
   }

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -53,6 +53,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, SceneBuilder);
   V(SceneBuilder, pushShaderMask)                   \
   V(SceneBuilder, pushPhysicalShape)                \
   V(SceneBuilder, pop)                              \
+  V(SceneBuilder, addRetained)                      \
   V(SceneBuilder, addPicture)                       \
   V(SceneBuilder, addTexture)                       \
   V(SceneBuilder, addChildScene)                    \
@@ -80,11 +81,12 @@ void SceneBuilder::pushTransform(const tonic::Float64List& matrix4) {
   PushLayer(std::move(layer));
 }
 
-void SceneBuilder::pushOffset(double dx, double dy) {
+RetainedLayer SceneBuilder::pushOffset(double dx, double dy) {
   SkMatrix sk_matrix = SkMatrix::MakeTrans(dx, dy);
   auto layer = std::make_shared<flow::TransformLayer>();
   layer->set_transform(sk_matrix);
-  PushLayer(std::move(layer));
+  PushLayer(layer);
+  return EngineLayer::MakeRetained(layer);
 }
 
 void SceneBuilder::pushClipRect(double left,
@@ -148,21 +150,29 @@ void SceneBuilder::pushShaderMask(Shader* shader,
   PushLayer(std::move(layer));
 }
 
-void SceneBuilder::pushPhysicalShape(const CanvasPath* path,
-                                     double elevation,
-                                     int color,
-                                     int shadow_color,
-                                     int clipBehavior) {
+RetainedLayer SceneBuilder::pushPhysicalShape(const CanvasPath* path,
+                                              double elevation,
+                                              int color,
+                                              int shadow_color,
+                                              int clipBehavior) {
   const SkPath& sk_path = path->path();
   flow::Clip clip_behavior = static_cast<flow::Clip>(clipBehavior);
-  auto layer = std::make_unique<flow::PhysicalShapeLayer>(clip_behavior);
+  auto layer = std::make_shared<flow::PhysicalShapeLayer>(clip_behavior);
   layer->set_path(sk_path);
   layer->set_elevation(elevation);
   layer->set_color(static_cast<SkColor>(color));
   layer->set_shadow_color(static_cast<SkColor>(shadow_color));
   layer->set_device_pixel_ratio(
       UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio);
-  PushLayer(std::move(layer));
+  PushLayer(layer);
+  return EngineLayer::MakeRetained(layer);
+}
+
+void SceneBuilder::addRetained(RetainedLayer retainedLayer) {
+  if (!current_layer_) {
+    return;
+  }
+  current_layer_->Add(retainedLayer->Layer());
 }
 
 void SceneBuilder::pop() {
@@ -260,7 +270,7 @@ fml::RefPtr<Scene> SceneBuilder::build() {
   return scene;
 }
 
-void SceneBuilder::PushLayer(std::unique_ptr<flow::ContainerLayer> layer) {
+void SceneBuilder::PushLayer(std::shared_ptr<flow::ContainerLayer> layer) {
   FML_DCHECK(layer);
 
   if (!root_layer_) {

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -34,7 +34,7 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   ~SceneBuilder() override;
 
   void pushTransform(const tonic::Float64List& matrix4);
-  RetainedLayer pushOffset(double dx, double dy);
+  fml::RefPtr<EngineLayer> pushOffset(double dx, double dy);
   void pushClipRect(double left,
                     double right,
                     double top,
@@ -51,13 +51,13 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                       double maskRectTop,
                       double maskRectBottom,
                       int blendMode);
-  RetainedLayer pushPhysicalShape(const CanvasPath* path,
-                                  double elevation,
-                                  int color,
-                                  int shadowColor,
-                                  int clipBehavior);
+  fml::RefPtr<EngineLayer> pushPhysicalShape(const CanvasPath* path,
+                                             double elevation,
+                                             int color,
+                                             int shadowColor,
+                                             int clipBehavior);
 
-  void addRetained(RetainedLayer retainedLayer);
+  void addRetained(fml::RefPtr<EngineLayer> retainedLayer);
 
   void pop();
 

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -12,6 +12,7 @@
 #include "flutter/lib/ui/compositing/scene.h"
 #include "flutter/lib/ui/compositing/scene_host.h"
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/painting/engine_layer.h"
 #include "flutter/lib/ui/painting/image_filter.h"
 #include "flutter/lib/ui/painting/path.h"
 #include "flutter/lib/ui/painting/picture.h"
@@ -33,7 +34,7 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   ~SceneBuilder() override;
 
   void pushTransform(const tonic::Float64List& matrix4);
-  void pushOffset(double dx, double dy);
+  RetainedLayer pushOffset(double dx, double dy);
   void pushClipRect(double left,
                     double right,
                     double top,
@@ -50,11 +51,13 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                       double maskRectTop,
                       double maskRectBottom,
                       int blendMode);
-  void pushPhysicalShape(const CanvasPath* path,
-                         double elevation,
-                         int color,
-                         int shadowColor,
-                         int clipBehavior);
+  RetainedLayer pushPhysicalShape(const CanvasPath* path,
+                                  double elevation,
+                                  int color,
+                                  int shadowColor,
+                                  int clipBehavior);
+
+  void addRetained(RetainedLayer retainedLayer);
 
   void pop();
 
@@ -92,14 +95,14 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
  private:
   SceneBuilder();
 
-  std::unique_ptr<flow::ContainerLayer> root_layer_;
+  std::shared_ptr<flow::ContainerLayer> root_layer_;
   flow::ContainerLayer* current_layer_ = nullptr;
 
   int rasterizer_tracing_threshold_ = 0;
   bool checkerboard_raster_cache_images_ = false;
   bool checkerboard_offscreen_layers_ = false;
 
-  void PushLayer(std::unique_ptr<flow::ContainerLayer> layer);
+  void PushLayer(std::shared_ptr<flow::ContainerLayer> layer);
 
   FML_DISALLOW_COPY_AND_ASSIGN(SceneBuilder);
 };

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -11,6 +11,7 @@
 #include "flutter/lib/ui/isolate_name_server/isolate_name_server_natives.h"
 #include "flutter/lib/ui/painting/canvas.h"
 #include "flutter/lib/ui/painting/codec.h"
+#include "flutter/lib/ui/painting/engine_layer.h"
 #include "flutter/lib/ui/painting/frame_info.h"
 #include "flutter/lib/ui/painting/gradient.h"
 #include "flutter/lib/ui/painting/image.h"
@@ -58,6 +59,7 @@ void DartUI::InitForGlobal() {
     CanvasPathMeasure::RegisterNatives(g_natives);
     Codec::RegisterNatives(g_natives);
     DartRuntimeHooks::RegisterNatives(g_natives);
+    EngineLayer::RegisterNatives(g_natives);
     FrameInfo::RegisterNatives(g_natives);
     ImageFilter::RegisterNatives(g_natives);
     ImageShader::RegisterNatives(g_natives);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1742,6 +1742,13 @@ enum PathOperation {
   reverseDifference,
 }
 
+/// A handle for the framework to hold and retain an engine layer across frames.
+class EngineLayer extends NativeFieldWrapperClass2 {
+  /// This class is created by the engine, and should not be instantiated
+  /// or extended directly.
+  EngineLayer._();
+}
+
 /// A complex, one-dimensional subset of a plane.
 ///
 /// A path consists of a number of subpaths, and a _current point_.

--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -1,0 +1,26 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/painting/engine_layer.h"
+
+#include "flutter/flow/layers/container_layer.h"
+
+#include "third_party/tonic/converter/dart_converter.h"
+#include "third_party/tonic/dart_args.h"
+#include "third_party/tonic/dart_binding_macros.h"
+#include "third_party/tonic/dart_library_natives.h"
+
+using tonic::ToDart;
+
+namespace blink {
+
+EngineLayer::~EngineLayer() = default;
+
+IMPLEMENT_WRAPPERTYPEINFO(ui, EngineLayer);
+
+#define FOR_EACH_BINDING(V) // nothing to bind
+
+DART_BIND_ALL(EngineLayer, FOR_EACH_BINDING)
+
+}  // namespace blink

--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -19,7 +19,7 @@ EngineLayer::~EngineLayer() = default;
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, EngineLayer);
 
-#define FOR_EACH_BINDING(V) // nothing to bind
+#define FOR_EACH_BINDING(V)  // nothing to bind
 
 DART_BIND_ALL(EngineLayer, FOR_EACH_BINDING)
 

--- a/lib/ui/painting/engine_layer.h
+++ b/lib/ui/painting/engine_layer.h
@@ -17,15 +17,13 @@ namespace blink {
 
 class EngineLayer;
 
-using RetainedLayer = fml::RefPtr<EngineLayer>;
-
 class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
   DEFINE_WRAPPERTYPEINFO();
-  FML_FRIEND_MAKE_REF_COUNTED(EngineLayer);
 
  public:
   ~EngineLayer() override;
-  static RetainedLayer MakeRetained(std::shared_ptr<flow::ContainerLayer> layer) {
+  static fml::RefPtr<EngineLayer> MakeRetained(
+      std::shared_ptr<flow::ContainerLayer> layer) {
     return fml::MakeRefCounted<EngineLayer>(layer);
   }
 
@@ -34,8 +32,11 @@ class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
   std::shared_ptr<flow::ContainerLayer> Layer() const { return layer_; }
 
  private:
-  explicit EngineLayer(std::shared_ptr<flow::ContainerLayer> layer) : layer_(layer) {}
+  explicit EngineLayer(std::shared_ptr<flow::ContainerLayer> layer)
+      : layer_(layer) {}
   std::shared_ptr<flow::ContainerLayer> layer_;
+
+  FML_FRIEND_MAKE_REF_COUNTED(EngineLayer);
 };
 
 }  // namespace blink

--- a/lib/ui/painting/engine_layer.h
+++ b/lib/ui/painting/engine_layer.h
@@ -1,0 +1,43 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_
+#define FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_
+
+#include "flutter/lib/ui/dart_wrapper.h"
+
+#include "flutter/flow/layers/layer.h"
+
+namespace tonic {
+class DartLibraryNatives;
+}  // namespace tonic
+
+namespace blink {
+
+class EngineLayer;
+
+using RetainedLayer = fml::RefPtr<EngineLayer>;
+
+class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
+  DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_MAKE_REF_COUNTED(EngineLayer);
+
+ public:
+  ~EngineLayer() override;
+  static RetainedLayer MakeRetained(std::shared_ptr<flow::ContainerLayer> layer) {
+    return fml::MakeRefCounted<EngineLayer>(layer);
+  }
+
+  static void RegisterNatives(tonic::DartLibraryNatives* natives);
+
+  std::shared_ptr<flow::ContainerLayer> Layer() const { return layer_; }
+
+ private:
+  explicit EngineLayer(std::shared_ptr<flow::ContainerLayer> layer) : layer_(layer) {}
+  std::shared_ptr<flow::ContainerLayer> layer_;
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_


### PR DESCRIPTION
To make the PR minimal, we currently only share the engine layer when `pushPhysicalShape` (for Fuchsia) or `pushOffset` (for `RepaintBoundary` and `Opacity`) are called. They should be sufficient for our short-term perf goal. In the future, we can incrementally share more engine layers with the framework.

https://github.com/flutter/flutter/issues/21756