### PR TITLE
Force lf-line endings in .dart-files so that source offsets match across platforms.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,3 @@
-## This page intentionally left blank. ##
-#
-# Workaround for VS2013 automatically creating .gitattributes files with
-# default settings that we don't want.
-# See also:
-# http://connect.microsoft.com/VisualStudio/feedback/details/804948/inappropriately-creates-gitattributes-file
-# http://crbug.com/342064
+# Dart sources have to be normalized so that source offsets in kernel files
+# with source embedded in them match across all platforms.
+*.dart text eol=lf


### PR DESCRIPTION
Goes toward fixing https://github.com/flutter/flutter/issues/22497