### PR TITLE
Add deadline_now_delta argument to Engine::NotifyIdle's trace

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/common/engine.h"
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "flutter/common/settings.h"
@@ -19,6 +20,7 @@
 #include "flutter/shell/common/animator.h"
 #include "flutter/shell/common/platform_view.h"
 #include "flutter/shell/common/shell.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "third_party/rapidjson/rapidjson/document.h"
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
@@ -194,7 +196,8 @@ void Engine::BeginFrame(fml::TimePoint frame_time) {
 }
 
 void Engine::NotifyIdle(int64_t deadline) {
-  TRACE_EVENT0("flutter", "Engine::NotifyIdle");
+  TRACE_EVENT1("flutter", "Engine::NotifyIdle", "deadline_now_delta",
+               std::to_string(deadline - Dart_TimelineGetMicros()).c_str());
   runtime_controller_->NotifyIdle(deadline);
 }
 


### PR DESCRIPTION
This allows us to figure out from looking at a trace if an
|Engine::NotifyIdle| call went beyond its deadline