### PR TITLE
Wire the old JNI bindings through the new API

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -44,6 +44,14 @@ public class FlutterEngine {
     this.isBackgroundView = isBackgroundView;
 
     this.flutterJNI = new FlutterJNI();
+    flutterJNI.setEngineHandler(new EngineHandler() {
+      @SuppressWarnings("unused")
+      public void onPreEngineRestart() {
+        if (pluginRegistry == null)
+          return;
+        pluginRegistry.onPreEngineRestart();
+      }
+    });
     attachToJni();
 
     // TODO(mattcarroll): FlutterRenderer is temporally coupled to attach(). Remove that coupling if possible.
@@ -99,12 +107,9 @@ public class FlutterEngine {
     return dartExecutor;
   }
 
-  // TODO(mattcarroll): what does this callback actually represent?
-  // Called by native to notify when the engine is restarted (cold reload).
-  @SuppressWarnings("unused")
-  private void onPreEngineRestart() {
-    if (pluginRegistry == null)
-      return;
-    pluginRegistry.onPreEngineRestart();
+  /** Callbacks triggered by the C++ layer in response to Engine lifecycle events. */
+  public interface EngineHandler {
+    /** Called when the engine is restarted. This happens during hot restart. */
+    void onPreEngineRestart();
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import io.flutter.embedding.engine.dart.PlatformMessageHandler;
+import io.flutter.embedding.engine.FlutterEngine.EngineHandler;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
 import io.flutter.plugin.common.BinaryMessenger;
@@ -22,6 +23,7 @@ public class FlutterJNI {
 
   private FlutterRenderer.RenderSurface renderSurface;
   private PlatformMessageHandler platformMessageHandler;
+  private @Nullable EngineHandler engineHandler;
   private final Set<OnFirstFrameRenderedListener> firstFrameListeners = new CopyOnWriteArraySet<>();
 
   public void setRenderSurface(@Nullable FlutterRenderer.RenderSurface renderSurface) {
@@ -30,6 +32,10 @@ public class FlutterJNI {
 
   public void setPlatformMessageHandler(@Nullable PlatformMessageHandler platformMessageHandler) {
     this.platformMessageHandler = platformMessageHandler;
+  }
+
+  public void setEngineHandler(@Nullable EngineHandler engineHandler) {
+    this.engineHandler = engineHandler;
   }
 
   public void addOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener) {
@@ -183,4 +189,14 @@ public class FlutterJNI {
       int position
   );
   //------ End from FlutterNativeView ----
+
+  //------ Start from Engine ---
+  @SuppressWarnings("unused")
+  private void onPreEngineRestart() {
+    if (engineHandler == null) {
+      return;
+    }
+    engineHandler.onPreEngineRestart();
+  }
+  //------ End from Engine ---
 }

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -8,12 +8,15 @@ import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import io.flutter.app.FlutterPluginRegistry;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.renderer.FlutterRenderer.RenderSurface;
 import io.flutter.plugin.common.*;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.HashMap;
 import java.util.Map;
 import android.content.res.AssetManager;
+import io.flutter.embedding.engine.dart.PlatformMessageHandler;
 
 public class FlutterNativeView implements BinaryMessenger {
     private static final String TAG = "FlutterNativeView";
@@ -25,6 +28,9 @@ public class FlutterNativeView implements BinaryMessenger {
     private final FlutterPluginRegistry mPluginRegistry;
     private long mNativePlatformView;
     private FlutterView mFlutterView;
+    private FlutterJNI mFlutterJNI;
+    private final PlatformMessageHandlerImpl mPlatformMessageHandler;
+    private final RenderSurfaceImpl mRenderSurface;
     private final Context mContext;
     private boolean applicationIsRunning;
 
@@ -35,6 +41,11 @@ public class FlutterNativeView implements BinaryMessenger {
     public FlutterNativeView(Context context, boolean isBackgroundView) {
         mContext = context;
         mPluginRegistry = new FlutterPluginRegistry(this, context);
+        mFlutterJNI = new FlutterJNI();
+        mRenderSurface = new RenderSurfaceImpl();
+        mFlutterJNI.setRenderSurface(mRenderSurface);
+        mPlatformMessageHandler = new PlatformMessageHandlerImpl();
+        mFlutterJNI.setPlatformMessageHandler(mPlatformMessageHandler);
         attach(this, isBackgroundView);
         assertAttached();
         mMessageHandlers = new HashMap<>();
@@ -43,13 +54,13 @@ public class FlutterNativeView implements BinaryMessenger {
     public void detach() {
         mPluginRegistry.detach();
         mFlutterView = null;
-        nativeDetach(mNativePlatformView);
+        mFlutterJNI.nativeDetach(mNativePlatformView);
     }
 
     public void destroy() {
         mPluginRegistry.destroy();
         mFlutterView = null;
-        nativeDestroy(mNativePlatformView);
+        mFlutterJNI.nativeDestroy(mNativePlatformView);
         mNativePlatformView = 0;
         applicationIsRunning = false;
     }
@@ -101,7 +112,7 @@ public class FlutterNativeView implements BinaryMessenger {
         if (applicationIsRunning)
             throw new AssertionError(
                     "This Flutter engine instance is already running an application");
-        nativeRunBundleAndSnapshotFromLibrary(mNativePlatformView, bundlePath,
+        mFlutterJNI.nativeRunBundleAndSnapshotFromLibrary(mNativePlatformView, bundlePath,
             defaultPath, entrypoint, libraryPath, mContext.getResources().getAssets());
 
         applicationIsRunning = true;
@@ -112,7 +123,8 @@ public class FlutterNativeView implements BinaryMessenger {
     }
 
     public static String getObservatoryUri() {
-        return nativeGetObservatoryUri();
+        FlutterJNI flutterJNI = new FlutterJNI();
+        return flutterJNI.nativeGetObservatoryUri();
     }
 
     @Override
@@ -133,9 +145,9 @@ public class FlutterNativeView implements BinaryMessenger {
             mPendingReplies.put(replyId, callback);
         }
         if (message == null) {
-            nativeDispatchEmptyPlatformMessage(mNativePlatformView, channel, replyId);
+            mFlutterJNI.nativeDispatchEmptyPlatformMessage(mNativePlatformView, channel, replyId);
         } else {
-            nativeDispatchPlatformMessage(
+            mFlutterJNI.nativeDispatchPlatformMessage(
                     mNativePlatformView, channel, message, message.position(), replyId);
         }
     }
@@ -149,77 +161,89 @@ public class FlutterNativeView implements BinaryMessenger {
         }
     }
 
+    /*package*/ FlutterJNI getFlutterJNI() {
+        return mFlutterJNI;
+    }
+
     private void attach(FlutterNativeView view, boolean isBackgroundView) {
-        mNativePlatformView = nativeAttach(view, isBackgroundView);
+        mNativePlatformView = mFlutterJNI.nativeAttach(mFlutterJNI, isBackgroundView);
     }
 
-    // Called by native to send us a platform message.
-    private void handlePlatformMessage(final String channel, byte[] message, final int replyId) {
-        assertAttached();
-        BinaryMessageHandler handler = mMessageHandlers.get(channel);
-        if (handler != null) {
-            try {
-                final ByteBuffer buffer = (message == null ? null : ByteBuffer.wrap(message));
-                handler.onMessage(buffer, new BinaryReply() {
-                    private final AtomicBoolean done = new AtomicBoolean(false);
-                    @Override
-                    public void reply(ByteBuffer reply) {
-                        if (!isAttached()) {
-                            Log.d(TAG,
-                                    "handlePlatformMessage replying to a detached view, channel="
-                                            + channel);
-                            return;
+    private final class PlatformMessageHandlerImpl implements PlatformMessageHandler {
+        // Called by native to send us a platform message.
+        public void handlePlatformMessage(final String channel, byte[] message, final int replyId) {
+            assertAttached();
+            BinaryMessageHandler handler = mMessageHandlers.get(channel);
+            if (handler != null) {
+                try {
+                    final ByteBuffer buffer = (message == null ? null : ByteBuffer.wrap(message));
+                    handler.onMessage(buffer, new BinaryReply() {
+                        private final AtomicBoolean done = new AtomicBoolean(false);
+                        @Override
+                        public void reply(ByteBuffer reply) {
+                            if (!isAttached()) {
+                                Log.d(TAG,
+                                        "handlePlatformMessage replying to a detached view, channel="
+                                                + channel);
+                                return;
+                            }
+                            if (done.getAndSet(true)) {
+                                throw new IllegalStateException("Reply already submitted");
+                            }
+                            if (reply == null) {
+                                mFlutterJNI.nativeInvokePlatformMessageEmptyResponseCallback(
+                                        mNativePlatformView, replyId);
+                            } else {
+                                mFlutterJNI.nativeInvokePlatformMessageResponseCallback(
+                                        mNativePlatformView, replyId, reply, reply.position());
+                            }
                         }
-                        if (done.getAndSet(true)) {
-                            throw new IllegalStateException("Reply already submitted");
-                        }
-                        if (reply == null) {
-                            nativeInvokePlatformMessageEmptyResponseCallback(
-                                    mNativePlatformView, replyId);
-                        } else {
-                            nativeInvokePlatformMessageResponseCallback(
-                                    mNativePlatformView, replyId, reply, reply.position());
-                        }
-                    }
-                });
-            } catch (Exception ex) {
-                Log.e(TAG, "Uncaught exception in binary message listener", ex);
-                nativeInvokePlatformMessageEmptyResponseCallback(mNativePlatformView, replyId);
+                    });
+                } catch (Exception ex) {
+                    Log.e(TAG, "Uncaught exception in binary message listener", ex);
+                    mFlutterJNI.nativeInvokePlatformMessageEmptyResponseCallback(mNativePlatformView, replyId);
+                }
+                return;
             }
-            return;
+            mFlutterJNI.nativeInvokePlatformMessageEmptyResponseCallback(mNativePlatformView, replyId);
         }
-        nativeInvokePlatformMessageEmptyResponseCallback(mNativePlatformView, replyId);
-    }
 
-    // Called by native to respond to a platform message that we sent.
-    private void handlePlatformMessageResponse(int replyId, byte[] reply) {
-        BinaryReply callback = mPendingReplies.remove(replyId);
-        if (callback != null) {
-            try {
-                callback.reply(reply == null ? null : ByteBuffer.wrap(reply));
-            } catch (Exception ex) {
-                Log.e(TAG, "Uncaught exception in binary message reply handler", ex);
+        // Called by native to respond to a platform message that we sent.
+        public void handlePlatformMessageResponse(int replyId, byte[] reply) {
+            BinaryReply callback = mPendingReplies.remove(replyId);
+            if (callback != null) {
+                try {
+                    callback.reply(reply == null ? null : ByteBuffer.wrap(reply));
+                } catch (Exception ex) {
+                    Log.e(TAG, "Uncaught exception in binary message reply handler", ex);
+                }
             }
         }
     }
 
-    // Called by native to update the semantics/accessibility tree.
-    private void updateSemantics(ByteBuffer buffer, String[] strings) {
-        if (mFlutterView == null) return;
-        mFlutterView.updateSemantics(buffer, strings);
-    }
+    private final class RenderSurfaceImpl implements RenderSurface {
+        // Called by native to update the semantics/accessibility tree.
+        public void updateSemantics(ByteBuffer buffer, String[] strings) {
+            if (mFlutterView == null) return;
+            mFlutterView.updateSemantics(buffer, strings);
+        }
 
-    // Called by native to update the custom accessibility actions.
-    private void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
-        if (mFlutterView == null)
-            return;
-        mFlutterView.updateCustomAccessibilityActions(buffer, strings);
-    }
+        // Called by native to update the custom accessibility actions.
+        public void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
+            if (mFlutterView == null)
+                return;
+            mFlutterView.updateCustomAccessibilityActions(buffer, strings);
+        }
 
-    // Called by native to notify first Flutter frame rendered.
-    private void onFirstFrame() {
-        if (mFlutterView == null) return;
-        mFlutterView.onFirstFrame();
+        // Called by native to notify first Flutter frame rendered.
+        public void onFirstFrameRendered() {
+            if (mFlutterView == null) return;
+            mFlutterView.onFirstFrame();
+        }
+
+        /*package*/ FlutterJNI getFlutterJNI() {
+            return mFlutterJNI;
+        }
     }
 
     // Called by native to notify when the engine is restarted (cold reload).
@@ -229,31 +253,4 @@ public class FlutterNativeView implements BinaryMessenger {
             return;
         mPluginRegistry.onPreEngineRestart();
     }
-
-    private static native long nativeAttach(FlutterNativeView view, boolean isBackgroundView);
-    private static native void nativeDestroy(long nativePlatformViewAndroid);
-    private static native void nativeDetach(long nativePlatformViewAndroid);
-
-    private static native void nativeRunBundleAndSnapshotFromLibrary(
-            long nativePlatformViewAndroid, String bundlePath,
-            String defaultPath, String entrypoint, String libraryUrl,
-            AssetManager manager);
-
-    private static native String nativeGetObservatoryUri();
-
-    // Send an empty platform message to Dart.
-    private static native void nativeDispatchEmptyPlatformMessage(
-            long nativePlatformViewAndroid, String channel, int responseId);
-
-    // Send a data-carrying platform message to Dart.
-    private static native void nativeDispatchPlatformMessage(long nativePlatformViewAndroid,
-            String channel, ByteBuffer message, int position, int responseId);
-
-    // Send an empty response to a platform message received from Dart.
-    private static native void nativeInvokePlatformMessageEmptyResponseCallback(
-            long nativePlatformViewAndroid, int responseId);
-
-    // Send a data-carrying response to a platform message received from Dart.
-    private static native void nativeInvokePlatformMessageResponseCallback(
-            long nativePlatformViewAndroid, int responseId, ByteBuffer message, int position);
 }

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -47,15 +47,6 @@ bool CheckException(JNIEnv* env) {
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_callback_info_class =
     nullptr;
 
-// FlutterView.java, from original embedding API. Not used in 2nd iteration of
-// embedding.
-static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_view_class = nullptr;
-
-// FlutterNativeView.java, from original embedding API. Not used in 2nd
-// iteration of embedding.
-static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_native_view_class =
-    nullptr;
-
 // FlutterJNI.java, used in 2nd iteration of embedding to centralize all JNI
 // calls.
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_jni_class = nullptr;
@@ -158,21 +149,6 @@ void SurfaceTextureDetachFromGLContext(JNIEnv* env, jobject obj) {
 
 // Called By Java
 
-static jlong Attach(JNIEnv* env,
-                    jclass clazz,
-                    jobject flutterView,
-                    jboolean is_background_view) {
-  FML_LOG(ERROR) << "This is a test!";
-  fml::jni::JavaObjectWeakGlobalRef java_object(env, flutterView);
-  auto shell_holder = std::make_unique<AndroidShellHolder>(
-      FlutterMain::Get().GetSettings(), java_object, is_background_view);
-  if (shell_holder->IsValid()) {
-    return reinterpret_cast<jlong>(shell_holder.release());
-  } else {
-    return 0;
-  }
-}
-
 static jlong AttachJNI(JNIEnv* env,
                        jclass clazz,
                        jobject flutterJNI,
@@ -188,16 +164,8 @@ static jlong AttachJNI(JNIEnv* env,
   }
 }
 
-static void Detach(JNIEnv* env, jobject jcaller, jlong shell_holder) {
-  // Nothing to do.
-}
-
 static void DetachJNI(JNIEnv* env, jobject jcaller, jlong shell_holder) {
   // Nothing to do.
-}
-
-static void Destroy(JNIEnv* env, jobject jcaller, jlong shell_holder) {
-  delete ANDROID_SHELL_HOLDER;
 }
 
 static void DestroyJNI(JNIEnv* env, jobject jcaller, jlong shell_holder) {
@@ -579,213 +547,7 @@ static void InvokePlatformMessageEmptyResponseCallback(JNIEnv* env,
       );
 }
 
-bool RegisterOldApi(JNIEnv* env) {
-  g_flutter_view_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
-      env, env->FindClass("io/flutter/view/FlutterView"));
-  if (g_flutter_view_class->is_null()) {
-    FML_LOG(ERROR) << "Could not locate FlutterView class";
-    return false;
-  }
-
-  g_flutter_native_view_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
-      env, env->FindClass("io/flutter/view/FlutterNativeView"));
-  if (g_flutter_native_view_class->is_null()) {
-    FML_LOG(ERROR) << "Could not locate FlutterNativeView class";
-    return false;
-  }
-
-  static const JNINativeMethod native_view_methods[] = {
-      {
-          .name = "nativeAttach",
-          .signature = "(Lio/flutter/view/FlutterNativeView;Z)J",
-          .fnPtr = reinterpret_cast<void*>(&shell::Attach),
-      },
-      {
-          .name = "nativeDestroy",
-          .signature = "(J)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::Destroy),
-      },
-      {
-          .name = "nativeRunBundleAndSnapshotFromLibrary",
-          .signature =
-              "(JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;"
-              "Ljava/lang/String;Landroid/content/res/AssetManager;)V",
-          .fnPtr =
-              reinterpret_cast<void*>(&shell::RunBundleAndSnapshotFromLibrary),
-      },
-      {
-          .name = "nativeDetach",
-          .signature = "(J)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::Detach),
-      },
-      {
-          .name = "nativeGetObservatoryUri",
-          .signature = "()Ljava/lang/String;",
-          .fnPtr = reinterpret_cast<void*>(&shell::GetObservatoryUri),
-      },
-      {
-          .name = "nativeDispatchEmptyPlatformMessage",
-          .signature = "(JLjava/lang/String;I)V",
-          .fnPtr =
-              reinterpret_cast<void*>(&shell::DispatchEmptyPlatformMessage),
-      },
-      {
-          .name = "nativeDispatchPlatformMessage",
-          .signature = "(JLjava/lang/String;Ljava/nio/ByteBuffer;II)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::DispatchPlatformMessage),
-      },
-      {
-          .name = "nativeInvokePlatformMessageResponseCallback",
-          .signature = "(JILjava/nio/ByteBuffer;I)V",
-          .fnPtr = reinterpret_cast<void*>(
-              &shell::InvokePlatformMessageResponseCallback),
-      },
-      {
-          .name = "nativeInvokePlatformMessageEmptyResponseCallback",
-          .signature = "(JI)V",
-          .fnPtr = reinterpret_cast<void*>(
-              &shell::InvokePlatformMessageEmptyResponseCallback),
-      },
-  };
-
-  static const JNINativeMethod view_methods[] = {
-      {
-          .name = "nativeSurfaceCreated",
-          .signature = "(JLandroid/view/Surface;)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::SurfaceCreated),
-      },
-      {
-          .name = "nativeSurfaceChanged",
-          .signature = "(JII)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::SurfaceChanged),
-      },
-      {
-          .name = "nativeSurfaceDestroyed",
-          .signature = "(J)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::SurfaceDestroyed),
-      },
-      {
-          .name = "nativeSetViewportMetrics",
-          .signature = "(JFIIIIIIIIII)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::SetViewportMetrics),
-      },
-      {
-          .name = "nativeGetBitmap",
-          .signature = "(J)Landroid/graphics/Bitmap;",
-          .fnPtr = reinterpret_cast<void*>(&shell::GetBitmap),
-      },
-      {
-          .name = "nativeDispatchPointerDataPacket",
-          .signature = "(JLjava/nio/ByteBuffer;I)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::DispatchPointerDataPacket),
-      },
-      {
-          .name = "nativeDispatchSemanticsAction",
-          .signature = "(JIILjava/nio/ByteBuffer;I)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::DispatchSemanticsAction),
-      },
-      {
-          .name = "nativeSetSemanticsEnabled",
-          .signature = "(JZ)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::SetSemanticsEnabled),
-      },
-      {
-          .name = "nativeSetAccessibilityFeatures",
-          .signature = "(JI)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::SetAccessibilityFeatures),
-      },
-      {
-          .name = "nativeGetIsSoftwareRenderingEnabled",
-          .signature = "()Z",
-          .fnPtr = reinterpret_cast<void*>(&shell::GetIsSoftwareRendering),
-      },
-      {
-          .name = "nativeRegisterTexture",
-          .signature = "(JJLandroid/graphics/SurfaceTexture;)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::RegisterTexture),
-      },
-      {
-          .name = "nativeMarkTextureFrameAvailable",
-          .signature = "(JJ)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::MarkTextureFrameAvailable),
-      },
-      {
-          .name = "nativeUnregisterTexture",
-          .signature = "(JJ)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::UnregisterTexture),
-      },
-  };
-
-  if (env->RegisterNatives(g_flutter_native_view_class->obj(),
-                           native_view_methods,
-                           arraysize(native_view_methods)) != 0) {
-    FML_LOG(ERROR) << "Failed to RegisterNatives with FlutterNativeView.";
-    return false;
-  }
-
-  if (env->RegisterNatives(g_flutter_view_class->obj(), view_methods,
-                           arraysize(view_methods)) != 0) {
-    FML_LOG(ERROR) << "Failed to RegisterNatives with FlutterView";
-    return false;
-  }
-
-  g_handle_platform_message_method =
-      env->GetMethodID(g_flutter_native_view_class->obj(),
-                       "handlePlatformMessage", "(Ljava/lang/String;[BI)V");
-
-  if (g_handle_platform_message_method == nullptr) {
-    FML_LOG(ERROR) << "Could not locate handlePlatformMessage method";
-    return false;
-  }
-
-  g_handle_platform_message_response_method =
-      env->GetMethodID(g_flutter_native_view_class->obj(),
-                       "handlePlatformMessageResponse", "(I[B)V");
-
-  if (g_handle_platform_message_response_method == nullptr) {
-    FML_LOG(ERROR) << "Could not locate handlePlatformMessageResponse method";
-    return false;
-  }
-
-  g_update_semantics_method =
-      env->GetMethodID(g_flutter_native_view_class->obj(), "updateSemantics",
-                       "(Ljava/nio/ByteBuffer;[Ljava/lang/String;)V");
-
-  if (g_update_semantics_method == nullptr) {
-    FML_LOG(ERROR) << "Could not locate updateSemantics method";
-    return false;
-  }
-
-  g_update_custom_accessibility_actions_method = env->GetMethodID(
-      g_flutter_native_view_class->obj(), "updateCustomAccessibilityActions",
-      "(Ljava/nio/ByteBuffer;[Ljava/lang/String;)V");
-
-  if (g_update_custom_accessibility_actions_method == nullptr) {
-    FML_LOG(ERROR)
-        << "Could not locate updateCustomAccessibilityActions method";
-    return false;
-  }
-
-  g_on_first_frame_method = env->GetMethodID(g_flutter_native_view_class->obj(),
-                                             "onFirstFrame", "()V");
-
-  if (g_on_first_frame_method == nullptr) {
-    FML_LOG(ERROR) << "Could not locate onFirstFrame method";
-    return false;
-  }
-
-  g_on_engine_restart_method = env->GetMethodID(
-      g_flutter_native_view_class->obj(), "onPreEngineRestart", "()V");
-
-  if (g_on_engine_restart_method == nullptr) {
-    FML_LOG(ERROR) << "Could not locate onEngineRestart method";
-    return false;
-  }
-
-  return true;
-}
-
-bool RegisterNewApi(JNIEnv* env) {
+bool RegisterApi(JNIEnv* env) {
   g_flutter_engine_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
       env, env->FindClass("io/flutter/embedding/engine/FlutterEngine"));
   if (g_flutter_engine_class->is_null()) {
@@ -998,16 +760,11 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
     return false;
   }
 
-  // TODO(mattcarroll): this assumes the use of the new API is based on what
-  // we're compiling against but that's not true. Need to support both
-  // simultaneously.
-  bool is_using_new_api = false;
   g_flutter_jni_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
       env, env->FindClass("io/flutter/embedding/engine/FlutterJNI"));
   if (g_flutter_jni_class->is_null()) {
-    FML_LOG(ERROR) << "Failed to find FlutterJNI Class. Assuming old API";
-  } else {
-    is_using_new_api = true;
+    FML_LOG(ERROR) << "Failed to find FlutterJNI Class.";
+    return false;
   }
 
   g_surface_texture_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
@@ -1064,11 +821,7 @@ bool PlatformViewAndroid::Register(JNIEnv* env) {
     return false;
   }
 
-  if (is_using_new_api) {
-    return RegisterNewApi(env);
-  } else {
-    return RegisterOldApi(env);
-  }
+  return RegisterApi(env);
 }
 
 }  // namespace shell

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -50,7 +50,6 @@ static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_callback_info_class =
 // FlutterJNI.java, used in 2nd iteration of embedding to centralize all JNI
 // calls.
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_jni_class = nullptr;
-static fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_engine_class = nullptr;
 
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_surface_texture_class = nullptr;
 
@@ -548,13 +547,6 @@ static void InvokePlatformMessageEmptyResponseCallback(JNIEnv* env,
 }
 
 bool RegisterApi(JNIEnv* env) {
-  g_flutter_engine_class = new fml::jni::ScopedJavaGlobalRef<jclass>(
-      env, env->FindClass("io/flutter/embedding/engine/FlutterEngine"));
-  if (g_flutter_engine_class->is_null()) {
-    FML_LOG(ERROR) << "Failed to find FlutterEngine Class.";
-    return false;
-  }
-
   static const JNINativeMethod flutter_jni_methods[] = {
       // Start of methods from FlutterNativeView
       {
@@ -727,8 +719,8 @@ bool RegisterApi(JNIEnv* env) {
     return false;
   }
 
-  g_on_engine_restart_method = env->GetMethodID(g_flutter_engine_class->obj(),
-                                                "onPreEngineRestart", "()V");
+  g_on_engine_restart_method =
+      env->GetMethodID(g_flutter_jni_class->obj(), "onPreEngineRestart", "()V");
 
   if (g_on_engine_restart_method == nullptr) {
     FML_LOG(ERROR) << "Could not locate onEngineRestart method";


### PR DESCRIPTION
Tested by going through a regular `flutter run` and by running
`flutter/flutter/examples/flutter_view`. `FlutterView` and
`FlutterNativeView` have been changed to wrap an instance of
`FlutterJNI` for all their internal native calls.

Fixes flutter/flutter#22580