### PR TITLE
Revert "Use single_root_scheme when compiling platform (#6402)"

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -169,9 +169,7 @@ source_set("snapshot") {
 }
 
 compile_platform("non_strong_platform") {
-  single_root_scheme = "org-dartlang-sdk"
-  single_root_base = rebase_path("../../../")
-  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
+  libraries_specification_uri = "libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform.dill",
@@ -185,9 +183,7 @@ compile_platform("non_strong_platform") {
 }
 
 compile_platform("strong_platform") {
-  single_root_scheme = "org-dartlang-sdk"
-  single_root_base = rebase_path("../../../")
-  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
+  libraries_specification_uri = "libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform_strong.dill",


### PR DESCRIPTION
This reverts commit 360d446684024d3b8c80790c4098ae109a5d531f.

Causing problems currently when trying to build for a physical device in the device lab - may work after rolling https://dart-review.googlesource.com/c/77985

/cc @jensjoha @aam @a-siva @GaryQian 