### PR TITLE
Shared layers again

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -470,7 +470,71 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: engine
-ORIGIN: ../../../flutter/benchmarking/benchmarking.cc + ../../../LICENSE
+ORIGIN: ../../../flutter/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart + ../../../LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../flutter/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
+FILE: ../../../flutter/fml/paths_unittests.cc
+FILE: ../../../flutter/lib/ui/isolate_name_server.dart
+FILE: ../../../flutter/lib/ui/painting/engine_layer.cc
+FILE: ../../../flutter/lib/ui/painting/engine_layer.h
+FILE: ../../../flutter/lib/ui/painting/image_encoding.cc
+FILE: ../../../flutter/lib/ui/painting/image_encoding.h
+FILE: ../../../flutter/lib/ui/plugins.dart
+FILE: ../../../flutter/lib/ui/semantics/custom_accessibility_action.cc
+FILE: ../../../flutter/lib/ui/semantics/custom_accessibility_action.h
+FILE: ../../../flutter/lib/ui/text/asset_manager_font_provider.cc
+FILE: ../../../flutter/lib/ui/text/asset_manager_font_provider.h
+FILE: ../../../flutter/shell/platform/android/apk_asset_provider.h
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewFactory.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistry.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistryImpl.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterCallbackInformation.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterRunArguments.java
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterCallbackCache.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache_Internal.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.h
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/headless_platform_view_ios.h
+----------------------------------------------------------------------------------------------------
+Copyright 2018 The Chromium Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: engine
+ORIGIN: ../../../flutter/fml/platform/android/paths_android.h + ../../../LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../flutter/benchmarking/benchmarking.cc
 FILE: ../../../flutter/benchmarking/benchmarking.h

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -10,7 +10,7 @@ ContainerLayer::ContainerLayer() {}
 
 ContainerLayer::~ContainerLayer() = default;
 
-void ContainerLayer::Add(std::unique_ptr<Layer> layer) {
+void ContainerLayer::Add(std::shared_ptr<Layer> layer) {
   layer->set_parent(this);
   layers_.push_back(std::move(layer));
 }

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -15,7 +15,7 @@ class ContainerLayer : public Layer {
   ContainerLayer();
   ~ContainerLayer() override;
 
-  void Add(std::unique_ptr<Layer> layer);
+  void Add(std::shared_ptr<Layer> layer);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
@@ -23,7 +23,7 @@ class ContainerLayer : public Layer {
   void UpdateScene(SceneUpdateContext& context) override;
 #endif  // defined(OS_FUCHSIA)
 
-  const std::vector<std::unique_ptr<Layer>>& layers() const { return layers_; }
+  const std::vector<std::shared_ptr<Layer>>& layers() const { return layers_; }
 
  protected:
   void PrerollChildren(PrerollContext* context,
@@ -36,7 +36,7 @@ class ContainerLayer : public Layer {
 #endif  // defined(OS_FUCHSIA)
 
  private:
-  std::vector<std::unique_ptr<Layer>> layers_;
+  std::vector<std::shared_ptr<Layer>> layers_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);
 };

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -38,7 +38,7 @@ class LayerTree {
 
   Layer* root_layer() const { return root_layer_.get(); }
 
-  void set_root_layer(std::unique_ptr<Layer> root_layer) {
+  void set_root_layer(std::shared_ptr<Layer> root_layer) {
     root_layer_ = std::move(root_layer);
   }
 
@@ -73,7 +73,7 @@ class LayerTree {
 
  private:
   SkISize frame_size_;  // Physical pixels.
-  std::unique_ptr<Layer> root_layer_;
+  std::shared_ptr<Layer> root_layer_;
   fml::TimeDelta construction_time_;
   uint32_t rasterizer_tracing_threshold_;
   bool checkerboard_raster_cache_images_;

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -46,6 +46,14 @@ void PictureLayer::Paint(PaintContext& context) const {
 
   if (raster_cache_result_.is_valid()) {
     raster_cache_result_.draw(context.canvas);
+
+    // We cannot share the RasterCacheResult with the framework (UI thread)
+    // because it includes an SkImage and its associated GrContext doesn't
+    // seem to be thread safe when we construct SkImage in one thread and
+    // destruct it in another thread. Hence set it to empty right after use
+    // so the retained engine layer that's sent to the framework doesn't hold
+    // an SkImage reference.
+    raster_cache_result_ = {};
   } else {
     context.canvas.drawPicture(picture());
   }

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -23,6 +23,8 @@ source_set("ui") {
     "painting/canvas.h",
     "painting/codec.cc",
     "painting/codec.h",
+    "painting/engine_layer.h",
+    "painting/engine_layer.cc",
     "painting/frame_info.cc",
     "painting/frame_info.h",
     "painting/gradient.cc",

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -69,7 +69,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// This is equivalent to [pushTransform] with a matrix with only translation.
   ///
   /// See [pop] for details about the operation stack.
-  void pushOffset(double dx, double dy) native 'SceneBuilder_pushOffset';
+  EngineLayer pushOffset(double dx, double dy) native 'SceneBuilder_pushOffset';
 
   /// Pushes a rectangular clip operation onto the operation stack.
   ///
@@ -177,10 +177,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   // ignore: deprecated_member_use
-  void pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = defaultClipBehavior}) {
-    _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index);
+  EngineLayer pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = defaultClipBehavior}) {
+    return _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index);
   }
-  void _pushPhysicalShape(Path path, double elevation, int color, int shadowColor, int clipBehavior) native
+  EngineLayer _pushPhysicalShape(Path path, double elevation, int color, int shadowColor, int clipBehavior) native
     'SceneBuilder_pushPhysicalShape';
 
   /// Ends the effect of the most recently pushed operation.
@@ -190,6 +190,14 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// Calling this function removes the most recently added operation from the
   /// stack.
   void pop() native 'SceneBuilder_pop';
+
+  /// Add a retained engine layer subtree from previous frames.
+  ///
+  /// All the engine layers that are in the subtree of the retained layer will
+  /// be automatically appended to the current engine layer tree. Therefore,
+  /// once this is called, there's no need to call [addToScene] for its children
+  /// layers.
+  EngineLayer addRetained(EngineLayer retainedLayer) native 'SceneBuilder_addRetained';
 
   /// Adds an object to the scene that displays performance statistics.
   ///

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -26,7 +26,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Scene);
 
 DART_BIND_ALL(Scene, FOR_EACH_BINDING)
 
-fml::RefPtr<Scene> Scene::create(std::unique_ptr<flow::Layer> rootLayer,
+fml::RefPtr<Scene> Scene::create(std::shared_ptr<flow::Layer> rootLayer,
                                  uint32_t rasterizerTracingThreshold,
                                  bool checkerboardRasterCacheImages,
                                  bool checkerboardOffscreenLayers) {
@@ -35,7 +35,7 @@ fml::RefPtr<Scene> Scene::create(std::unique_ptr<flow::Layer> rootLayer,
       checkerboardRasterCacheImages, checkerboardOffscreenLayers);
 }
 
-Scene::Scene(std::unique_ptr<flow::Layer> rootLayer,
+Scene::Scene(std::shared_ptr<flow::Layer> rootLayer,
              uint32_t rasterizerTracingThreshold,
              bool checkerboardRasterCacheImages,
              bool checkerboardOffscreenLayers)

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -24,7 +24,7 @@ class Scene : public RefCountedDartWrappable<Scene> {
 
  public:
   ~Scene() override;
-  static fml::RefPtr<Scene> create(std::unique_ptr<flow::Layer> rootLayer,
+  static fml::RefPtr<Scene> create(std::shared_ptr<flow::Layer> rootLayer,
                                    uint32_t rasterizerTracingThreshold,
                                    bool checkerboardRasterCacheImages,
                                    bool checkerboardOffscreenLayers);
@@ -40,7 +40,7 @@ class Scene : public RefCountedDartWrappable<Scene> {
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  explicit Scene(std::unique_ptr<flow::Layer> rootLayer,
+  explicit Scene(std::shared_ptr<flow::Layer> rootLayer,
                  uint32_t rasterizerTracingThreshold,
                  bool checkerboardRasterCacheImages,
                  bool checkerboardOffscreenLayers);

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -12,6 +12,7 @@
 #include "flutter/lib/ui/compositing/scene.h"
 #include "flutter/lib/ui/compositing/scene_host.h"
 #include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/painting/engine_layer.h"
 #include "flutter/lib/ui/painting/image_filter.h"
 #include "flutter/lib/ui/painting/path.h"
 #include "flutter/lib/ui/painting/picture.h"
@@ -33,7 +34,7 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   ~SceneBuilder() override;
 
   void pushTransform(const tonic::Float64List& matrix4);
-  void pushOffset(double dx, double dy);
+  fml::RefPtr<EngineLayer> pushOffset(double dx, double dy);
   void pushClipRect(double left,
                     double right,
                     double top,
@@ -50,11 +51,13 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                       double maskRectTop,
                       double maskRectBottom,
                       int blendMode);
-  void pushPhysicalShape(const CanvasPath* path,
-                         double elevation,
-                         int color,
-                         int shadowColor,
-                         int clipBehavior);
+  fml::RefPtr<EngineLayer> pushPhysicalShape(const CanvasPath* path,
+                                             double elevation,
+                                             int color,
+                                             int shadowColor,
+                                             int clipBehavior);
+
+  void addRetained(fml::RefPtr<EngineLayer> retainedLayer);
 
   void pop();
 
@@ -92,14 +95,14 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
  private:
   SceneBuilder();
 
-  std::unique_ptr<flow::ContainerLayer> root_layer_;
+  std::shared_ptr<flow::ContainerLayer> root_layer_;
   flow::ContainerLayer* current_layer_ = nullptr;
 
   int rasterizer_tracing_threshold_ = 0;
   bool checkerboard_raster_cache_images_ = false;
   bool checkerboard_offscreen_layers_ = false;
 
-  void PushLayer(std::unique_ptr<flow::ContainerLayer> layer);
+  void PushLayer(std::shared_ptr<flow::ContainerLayer> layer);
 
   FML_DISALLOW_COPY_AND_ASSIGN(SceneBuilder);
 };

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -11,6 +11,7 @@
 #include "flutter/lib/ui/isolate_name_server/isolate_name_server_natives.h"
 #include "flutter/lib/ui/painting/canvas.h"
 #include "flutter/lib/ui/painting/codec.h"
+#include "flutter/lib/ui/painting/engine_layer.h"
 #include "flutter/lib/ui/painting/frame_info.h"
 #include "flutter/lib/ui/painting/gradient.h"
 #include "flutter/lib/ui/painting/image.h"
@@ -70,6 +71,7 @@ void DartUI::InitForGlobal() {
     CanvasPathMeasure::RegisterNatives(g_natives);
     Codec::RegisterNatives(g_natives);
     DartRuntimeHooks::RegisterNatives(g_natives);
+    EngineLayer::RegisterNatives(g_natives);
     FrameInfo::RegisterNatives(g_natives);
     ImageFilter::RegisterNatives(g_natives);
     ImageShader::RegisterNatives(g_natives);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1742,6 +1742,13 @@ enum PathOperation {
   reverseDifference,
 }
 
+/// A handle for the framework to hold and retain an engine layer across frames.
+class EngineLayer extends NativeFieldWrapperClass2 {
+  /// This class is created by the engine, and should not be instantiated
+  /// or extended directly.
+  EngineLayer._();
+}
+
 /// A complex, one-dimensional subset of a plane.
 ///
 /// A path consists of a number of subpaths, and a _current point_.

--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -1,0 +1,26 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/painting/engine_layer.h"
+
+#include "flutter/flow/layers/container_layer.h"
+
+#include "third_party/tonic/converter/dart_converter.h"
+#include "third_party/tonic/dart_args.h"
+#include "third_party/tonic/dart_binding_macros.h"
+#include "third_party/tonic/dart_library_natives.h"
+
+using tonic::ToDart;
+
+namespace blink {
+
+EngineLayer::~EngineLayer() = default;
+
+IMPLEMENT_WRAPPERTYPEINFO(ui, EngineLayer);
+
+#define FOR_EACH_BINDING(V)  // nothing to bind
+
+DART_BIND_ALL(EngineLayer, FOR_EACH_BINDING)
+
+}  // namespace blink

--- a/lib/ui/painting/engine_layer.h
+++ b/lib/ui/painting/engine_layer.h
@@ -1,0 +1,44 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_
+#define FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_
+
+#include "flutter/lib/ui/dart_wrapper.h"
+
+#include "flutter/flow/layers/layer.h"
+
+namespace tonic {
+class DartLibraryNatives;
+}  // namespace tonic
+
+namespace blink {
+
+class EngineLayer;
+
+class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
+  DEFINE_WRAPPERTYPEINFO();
+
+ public:
+  ~EngineLayer() override;
+  static fml::RefPtr<EngineLayer> MakeRetained(
+      std::shared_ptr<flow::ContainerLayer> layer) {
+    return fml::MakeRefCounted<EngineLayer>(layer);
+  }
+
+  static void RegisterNatives(tonic::DartLibraryNatives* natives);
+
+  std::shared_ptr<flow::ContainerLayer> Layer() const { return layer_; }
+
+ private:
+  explicit EngineLayer(std::shared_ptr<flow::ContainerLayer> layer)
+      : layer_(layer) {}
+  std::shared_ptr<flow::ContainerLayer> layer_;
+
+  FML_FRIEND_MAKE_REF_COUNTED(EngineLayer);
+};
+
+}  // namespace blink
+
+#endif  // FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_


### PR DESCRIPTION
This relands "Share engine layers with the framework" (#6412)

We make it thread safe by not sharing the SkImage inside the RasterCacheResult.

In the future, we'll do the same for the raster cache of the whole layer subtree: save the SkImage inside RasterCache and don't share it with the framework.