### PR TITLE
WIP: Add asserts to Locale constructor for parameter length

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -150,7 +150,15 @@ class Locale {
   /// Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
   /// Typically this means the primary language subtag should be lowercase and
   /// the region subtag should be uppercase.
-  const Locale(this._languageCode, [ this._countryCode ]) : assert(_languageCode != null);
+  const Locale(
+    this._languageCode, [
+    this._countryCode,
+  ]) : assert(_languageCode != null),
+       assert(_languageCode.length >= 2),
+       assert(_languageCode.length != 4),
+       assert(_languageCode.length <= 8),
+       assert((_countryCode ?? "XX").length >= 2),
+       assert((_countryCode ?? "XX").length <= 3);
 
   /// The primary language subtag for the locale.
   ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -157,8 +157,8 @@ class Locale {
        assert(_languageCode.length >= 2),
        assert(_languageCode.length != 4),
        assert(_languageCode.length <= 8),
-       assert((_countryCode ?? "XX").length >= 2),
-       assert((_countryCode ?? "XX").length <= 3);
+       assert((_countryCode ?? 'XX').length >= 2),
+       assert((_countryCode ?? 'XX').length <= 3);
 
   /// The primary language subtag for the locale.
   ///

--- a/testing/dart/locale_test.dart
+++ b/testing/dart/locale_test.dart
@@ -7,16 +7,18 @@ import 'dart:ui';
 import 'package:test/test.dart';
 
 void main() {
-  test('Locale', () {
-    final Null $null = null;
-    expect(const Locale('en').toString(), 'en');
-    expect(const Locale('en'), new Locale('en', $null));
-    expect(const Locale('en').hashCode, new Locale('en', $null).hashCode);
-    expect(const Locale('en'), isNot(new Locale('en', '')));
-    expect(const Locale('en').hashCode, isNot(new Locale('en', '').hashCode));
-    expect(const Locale('en', 'US').toString(), 'en_US');
-    expect(const Locale('iw').toString(), 'he');
-    expect(const Locale('iw', 'DD').toString(), 'he_DE');
-    expect(const Locale('iw', 'DD'), const Locale('he', 'DE'));
+  group('Locale', () {
+    test('Unnamed constructor', () {
+      final Null $null = null;
+      expect(const Locale('en').toString(), 'en');
+      expect(const Locale('en'), new Locale('en', $null));
+      expect(const Locale('en').hashCode, new Locale('en', $null).hashCode);
+      expect(const Locale('en'), isNot(new Locale('en', '')));
+      expect(const Locale('en').hashCode, isNot(new Locale('en', '').hashCode));
+      expect(const Locale('en', 'US').toString(), 'en_US');
+      expect(const Locale('iw').toString(), 'he');
+      expect(const Locale('iw', 'DD').toString(), 'he_DE');
+      expect(const Locale('iw', 'DD'), const Locale('he', 'DE'));
+    });
   });
 }

--- a/testing/dart/locale_test.dart
+++ b/testing/dart/locale_test.dart
@@ -13,8 +13,6 @@ void main() {
       expect(const Locale('en').toString(), 'en');
       expect(const Locale('en'), new Locale('en', $null));
       expect(const Locale('en').hashCode, new Locale('en', $null).hashCode);
-      expect(const Locale('en'), isNot(new Locale('en', '')));
-      expect(const Locale('en').hashCode, isNot(new Locale('en', '').hashCode));
       expect(const Locale('en', 'US').toString(), 'en_US');
       expect(const Locale('iw').toString(), 'he');
       expect(const Locale('iw', 'DD').toString(), 'he_DE');


### PR DESCRIPTION
Remove unit tests that deal with Locale('en', '').

This might break code, particularly if these unit tests were important.

Alternatively, Locale('en', '') should become equal to Locale('en'), there is no way to produce a syntactically correct Locale Identifier string which represents a zero-length region.