### PR TITLE
Missing dealloc method in FlutterEventChannel

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -256,7 +256,7 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
   return self;
 }
 
-- (void)dealloc{
+- (void)dealloc {
   [_name release];
   [_codec release];
   [_messenger release];

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -256,8 +256,7 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
   return self;
 }
 
-- (void)dealloc
-{
+- (void)dealloc{
     [_name release];
     [_codec release];
     [_messenger release];

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -21,9 +21,9 @@
 + (instancetype)messageChannelWithName:(NSString*)name
                        binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
                                  codec:(NSObject<FlutterMessageCodec>*)codec {
-  return
-      [[[FlutterBasicMessageChannel alloc] initWithName:name binaryMessenger:messenger codec:codec]
-          autorelease];
+  return [[[FlutterBasicMessageChannel alloc] initWithName:name
+                                           binaryMessenger:messenger
+                                                     codec:codec] autorelease];
 }
 
 - (instancetype)initWithName:(NSString*)name
@@ -162,8 +162,8 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
 + (instancetype)methodChannelWithName:(NSString*)name
                       binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
                                 codec:(NSObject<FlutterMethodCodec>*)codec {
-  return [[[FlutterMethodChannel alloc] initWithName:name binaryMessenger:messenger codec:codec]
-      autorelease];
+  return [[[FlutterMethodChannel alloc] initWithName:name binaryMessenger:messenger
+                                               codec:codec] autorelease];
 }
 
 - (instancetype)initWithName:(NSString*)name
@@ -185,8 +185,8 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
 }
 
 - (void)invokeMethod:(NSString*)method arguments:(id)arguments {
-  FlutterMethodCall* methodCall =
-      [FlutterMethodCall methodCallWithMethodName:method arguments:arguments];
+  FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:method
+                                                                    arguments:arguments];
   NSData* message = [_codec encodeMethodCall:methodCall];
   [_messenger sendOnChannel:_name message:message];
 }
@@ -241,8 +241,8 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
 + (instancetype)eventChannelWithName:(NSString*)name
                      binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger
                                codec:(NSObject<FlutterMethodCodec>*)codec {
-  return [[[FlutterEventChannel alloc] initWithName:name binaryMessenger:messenger codec:codec]
-      autorelease];
+  return [[[FlutterEventChannel alloc] initWithName:name binaryMessenger:messenger
+                                              codec:codec] autorelease];
 }
 
 - (instancetype)initWithName:(NSString*)name

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -192,8 +192,8 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
 }
 
 - (void)invokeMethod:(NSString*)method arguments:(id)arguments result:(FlutterResult)callback {
-  FlutterMethodCall* methodCall =
-      [FlutterMethodCall methodCallWithMethodName:method arguments:arguments];
+  FlutterMethodCall* methodCall = [FlutterMethodCall methodCallWithMethodName:method
+                                                                    arguments:arguments];
   NSData* message = [_codec encodeMethodCall:methodCall];
   FlutterBinaryReply reply = ^(NSData* data) {
     if (callback) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -256,6 +256,14 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
   return self;
 }
 
+- (void)dealloc
+{
+    [_name release];
+    [_codec release];
+    [_messenger release];
+    [super dealloc];
+}
+
 - (void)setStreamHandler:(NSObject<FlutterStreamHandler>*)handler {
   if (!handler) {
     [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:nil];

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -257,10 +257,10 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
 }
 
 - (void)dealloc{
-    [_name release];
-    [_codec release];
-    [_messenger release];
-    [super dealloc];
+  [_name release];
+  [_codec release];
+  [_messenger release];
+  [super dealloc];
 }
 
 - (void)setStreamHandler:(NSObject<FlutterStreamHandler>*)handler {


### PR DESCRIPTION
I believe that the dealloc method for class FlutterEventChannel in iOS Flutter.framework is missing which leads to potential memory leaks.