### PR TITLE
Fix failing test on Cirrus

### DIFF
--- a/testing/dart/paragraph_builder_test.dart
+++ b/testing/dart/paragraph_builder_test.dart
@@ -7,7 +7,6 @@ import 'dart:ui';
 import 'package:test/test.dart';
 
 void main() {
-  // TODO(flutter/flutter#22682): Re-enable this test.
   test('Should be able to build and layout a paragraph', () {
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle());
     builder.addText('Hello');
@@ -17,5 +16,5 @@ void main() {
     paragraph.layout(ParagraphConstraints(width: 800.0));
     expect(paragraph.width, isNonZero);
     expect(paragraph.height, isNonZero);
-  }, skip: 'Fails on cirrus.');
+  });
 }

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -11,7 +11,7 @@ popd
 
 run_test () {
   out/host_debug_unopt/dart out/host_debug_unopt/gen/frontend_server.dart.snapshot --sdk-root out/host_debug_unopt/flutter_patched_sdk --incremental --strong --target=flutter --packages flutter/testing/dart/.packages --output-dill out/host_debug_unopt/engine_test.dill $1
-  out/host_debug_unopt/flutter_tester --disable-observatory out/host_debug_unopt/engine_test.dill
+  out/host_debug_unopt/flutter_tester --disable-observatory --use-test-fonts out/host_debug_unopt/engine_test.dill
 }
 
 # Verify that a failing test returns a failure code.


### PR DESCRIPTION
Updates the tests to use the `--use-test-fonts` argument.

Fixes flutter/flutter#22682