### PR TITLE
Reland "Use single_root_scheme when compiling platform (#6402)"

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -169,7 +169,9 @@ source_set("snapshot") {
 }
 
 compile_platform("non_strong_platform") {
-  libraries_specification_uri = "libraries.json"
+  single_root_scheme = "org-dartlang-sdk"
+  single_root_base = rebase_path("../../../")
+  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform.dill",
@@ -183,7 +185,9 @@ compile_platform("non_strong_platform") {
 }
 
 compile_platform("strong_platform") {
-  libraries_specification_uri = "libraries.json"
+  single_root_scheme = "org-dartlang-sdk"
+  single_root_base = rebase_path("../../../")
+  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform_strong.dill",


### PR DESCRIPTION
This reverts commit 5340f422481a69b4234b2a61f39c486f158b6eed (#6431), relands single root filesystem that is needed for reusable platform kernel files, that is safe to land now since dart roll c048bec5d23d0c1bfc0afb980d64940442aa93e1 has the fix for previously broken dependency file generation.