### PR TITLE
Pass scriptCode to engine and addd iOS Chinese locale hack to ameliorate Chinese l10n.

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -317,7 +317,7 @@ public class FlutterView extends SurfaceView
     }
 
     private void setLocale(Locale locale) {
-        mFlutterLocalizationChannel.invokeMethod("setLocale", Arrays.asList(locale.getLanguage(), locale.getCountry()));
+        mFlutterLocalizationChannel.invokeMethod("setLocale", Arrays.asList(locale.getLanguage(), locale.getCountry(), locale.getScript()));
     }
 
     @Override

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -894,8 +894,17 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
   NSLocale* currentLocale = [NSLocale currentLocale];
   NSString* languageCode = [currentLocale objectForKey:NSLocaleLanguageCode];
   NSString* countryCode = [currentLocale objectForKey:NSLocaleCountryCode];
-  if (languageCode && countryCode)
-    [_localizationChannel.get() invokeMethod:@"setLocale" arguments:@[ languageCode, countryCode ]];
+  NSString* scriptCode = [currentLocale objectForKey:NSLocaleScriptCode];
+  if (languageCode && countryCode) {
+    // Script code is not present when a language only has one script.
+    if (scriptCode) {
+      [_localizationChannel.get() invokeMethod:@"setLocale"
+                                     arguments:@[ languageCode, countryCode, scriptCode ]];
+    } else {
+      [_localizationChannel.get() invokeMethod:@"setLocale"
+                                     arguments:@[ languageCode, countryCode, @"" ]];
+    }
+  }
 }
 
 #pragma mark - Set user settings


### PR DESCRIPTION
We currently do not support the more detailed locales provided by iOS. The result is that without the Script Code data, we are incorrectly choosing simplified/traditional Chinese depending on whichever language is listed first as supported.

This is a hack that temporarily makes this problem better as I work on expanding the Localization APIs to fully support the more nuanced locales.