### PR TITLE
make sure to release matrix4

### DIFF
--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -61,6 +61,7 @@ void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
   filter_ = SkImageFilter::MakeMatrixFilter(
       ToSkMatrix(matrix4), static_cast<SkFilterQuality>(filterQuality),
       nullptr);
+  matrix4.Release();
 }
 
 }  // namespace blink


### PR DESCRIPTION
Was poking around the ImageFilter code and noticed the matrix4 wasn't getting released in this call - fixes a potential memory leak.