### PR TITLE
Don't attempt to build any platform target on Fuchsia.

### DIFF
--- a/shell/platform/BUILD.gn
+++ b/shell/platform/BUILD.gn
@@ -15,8 +15,9 @@ group("platform") {
     deps = [
       "embedder",
     ]
-  } else if (is_win) {
-    # There is no platform target on windows. Instead, only a tester is used.
+  } else if (is_win || is_fuchsia) {
+    # There is no platform target on Windows. Fuchsia has its own runner
+    # implementation.
     deps = []
   } else {
     assert(false, "Unknown/Unsupported platform.")


### PR DESCRIPTION
Fuchsia should not requesting to build this meta target at all. But it is possible that one of the newer unit tests started including the shell target unconditionally. Just do what we do on Windows and not assert.