### PR TITLE
Revert "Pass null instead of 'none' locale"

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -152,6 +152,9 @@ class Locale {
   /// the region subtag should be uppercase.
   const Locale(this._languageCode, [ this._countryCode ]) : assert(_languageCode != null);
 
+  /// Empty locale constant. This is an invalid locale.
+  static const Locale none = const Locale('', '');
+
   /// The primary language subtag for the locale.
   ///
   /// This must not be null.
@@ -440,7 +443,7 @@ class Window {
     if (_locales != null && _locales.isNotEmpty) {
       return _locales.first;
     }
-    return null;
+    return Locale.none;
   }
 
   /// The full system-reported supported locales of the device.


### PR DESCRIPTION
Reverts flutter/engine#6613.

Passing null has further reaching repercussions and will take more time to properly fix.