### PR TITLE
Fix Windows embedding

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -89,16 +89,16 @@ static bool IsRendererValid(const FlutterRendererConfig* config) {
   return false;
 }
 
-#if OS_LINUX || OS_WIN
-
 static void* DefaultGLProcResolver(const char* name) {
   static fml::RefPtr<fml::NativeLibrary> proc_library =
+#if OS_LINUX
       fml::NativeLibrary::CreateForCurrentProcess();
+#elif OS_WIN  // OS_LINUX
+      fml::NativeLibrary::Create("opengl32.dll");
+#endif        // OS_WIN
   return static_cast<void*>(
       const_cast<uint8_t*>(proc_library->ResolveSymbol(name)));
 }
-
-#endif  // OS_LINUX || OS_WIN
 
 static shell::Shell::CreateCallback<shell::PlatformView>
 InferOpenGLPlatformViewCreationCallback(


### PR DESCRIPTION
Appears that #6523 or #6525 introduced a bug for embedder scenarios on Windows causing the native_library_win to be incorrectly initialized and thus incapable of correctly resolving GL functions.  This change fixes that.