### PR TITLE
Reland 'Pass null instead of 'none' locale'

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -150,7 +150,7 @@ class Locale {
   /// Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
   /// Typically this means the primary language subtag should be lowercase and
   /// the region subtag should be uppercase.
-  const Locale(this._languageCode, [ this._countryCode ]) : assert(_languageCode != null), assert(_languageCode != "");
+  const Locale(this._languageCode, [ this._countryCode ]) : assert(_languageCode != null), assert(_languageCode != '');
 
   /// The primary language subtag for the locale.
   ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -150,7 +150,7 @@ class Locale {
   /// Registry](https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry).
   /// Typically this means the primary language subtag should be lowercase and
   /// the region subtag should be uppercase.
-  const Locale(this._languageCode, [ this._countryCode ]) : assert(_languageCode != null);
+  const Locale(this._languageCode, [ this._countryCode ]) : assert(_languageCode != null), assert(_languageCode != "");
 
   /// The primary language subtag for the locale.
   ///

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -152,9 +152,6 @@ class Locale {
   /// the region subtag should be uppercase.
   const Locale(this._languageCode, [ this._countryCode ]) : assert(_languageCode != null);
 
-  /// Empty locale constant. This is an invalid locale.
-  static const Locale none = const Locale('', '');
-
   /// The primary language subtag for the locale.
   ///
   /// This must not be null.
@@ -443,7 +440,7 @@ class Window {
     if (_locales != null && _locales.isNotEmpty) {
       return _locales.first;
     }
-    return Locale.none;
+    return null;
   }
 
   /// The full system-reported supported locales of the device.


### PR DESCRIPTION
Engine-side fix, this time with https://github.com/flutter/flutter/pull/23375 that updates tests which assumed "_" as default locale.