### PR TITLE
add support for FlutterView reusing in multiple Activities

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -4,7 +4,6 @@
 
 package io.flutter.view;
 
-import android.app.Activity;
 import android.graphics.Rect;
 import android.opengl.Matrix;
 import android.os.Build;
@@ -42,7 +41,6 @@ class AccessibilityBridge
     private SemanticsObject mHoveredObject;
     private int previousRouteId = ROOT_NODE_ID;
     private List<Integer> previousRoutes;
-    private final View mDecorView;
     private Integer mLastLeftFrameInset = 0;
 
     private final BasicMessageChannel<Object> mFlutterAccessibilityChannel;
@@ -113,7 +111,6 @@ class AccessibilityBridge
         previousRoutes = new ArrayList<>();
         mFlutterAccessibilityChannel = new BasicMessageChannel<>(
                 owner, "flutter/accessibility", StandardMessageCodec.INSTANCE);
-        mDecorView = ((Activity) owner.getContext()).getWindow().getDecorView();
     }
 
     void setAccessibilityEnabled(boolean accessibilityEnabled) {
@@ -638,7 +635,7 @@ class AccessibilityBridge
             // a11y nodes.
             if (Build.VERSION.SDK_INT >= 23) {
                 Rect visibleFrame = new Rect();
-                mDecorView.getWindowVisibleDisplayFrame(visibleFrame);
+                mOwner.getRootView().getWindowVisibleDisplayFrame(visibleFrame);
                 if (!mLastLeftFrameInset.equals(visibleFrame.left)) {
                     rootObject.globalGeometryDirty = true;
                     rootObject.inverseTransformDirty = true;

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -5,11 +5,7 @@
 package io.flutter.view;
 
 import android.app.Activity;
-import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
-import android.content.pm.ApplicationInfo;
 import android.content.res.Configuration;
 import android.database.ContentObserver;
 import android.graphics.PixelFormat;
@@ -23,7 +19,6 @@ import android.os.Build;
 import android.text.format.DateFormat;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.*;
 import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeProvider;
@@ -35,10 +30,8 @@ import io.flutter.plugin.common.*;
 import io.flutter.plugin.editing.TextInputPlugin;
 import io.flutter.plugin.platform.PlatformPlugin;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.lang.reflect.Method;
-import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.*;
@@ -104,6 +97,9 @@ public class FlutterView extends SurfaceView
     private boolean mIsSoftwareRenderingEnabled = false; // using the software renderer or not
     private InputConnection mLastInputConnection;
 
+    private MethodChannel mFlutterPlatformChannel;
+    private PlatformPlugin mPlatformPlugin;
+
     public FlutterView(Context context) {
         this(context, null);
     }
@@ -113,7 +109,7 @@ public class FlutterView extends SurfaceView
     }
 
     public FlutterView(Context context, AttributeSet attrs, FlutterNativeView nativeView) {
-        super(context, attrs);
+        super(context.getApplicationContext(), attrs);
 
         mIsSoftwareRenderingEnabled = nativeGetIsSoftwareRenderingEnabled();
         mAnimationScaleObserver = new AnimationScaleObserver(new Handler());
@@ -122,13 +118,11 @@ public class FlutterView extends SurfaceView
         setFocusable(true);
         setFocusableInTouchMode(true);
 
-        Activity activity = (Activity) getContext();
         if (nativeView == null) {
-            mNativeView = new FlutterNativeView(activity.getApplicationContext());
+            mNativeView = new FlutterNativeView(context.getApplicationContext());
         } else {
             mNativeView = nativeView;
         }
-        mNativeView.attachViewAndActivity(this, activity);
 
         mSurfaceCallback = new SurfaceHolder.Callback() {
             @Override
@@ -163,17 +157,41 @@ public class FlutterView extends SurfaceView
         mFlutterLifecycleChannel = new BasicMessageChannel<>(this, "flutter/lifecycle", StringCodec.INSTANCE);
         mFlutterSystemChannel = new BasicMessageChannel<>(this, "flutter/system", JSONMessageCodec.INSTANCE);
         mFlutterSettingsChannel = new BasicMessageChannel<>(this, "flutter/settings", JSONMessageCodec.INSTANCE);
+        mFlutterPlatformChannel = new MethodChannel(this, "flutter/platform", JSONMethodCodec.INSTANCE);
 
-        PlatformPlugin platformPlugin = new PlatformPlugin(activity);
-        MethodChannel flutterPlatformChannel = new MethodChannel(this, "flutter/platform", JSONMethodCodec.INSTANCE);
-        flutterPlatformChannel.setMethodCallHandler(platformPlugin);
-        addActivityLifecycleListener(platformPlugin);
         mImm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         mTextInputPlugin = new TextInputPlugin(this);
 
 
         setLocales(getResources().getConfiguration());
         setUserSettings();
+
+        attachActivity((Activity) context);
+    }
+
+    /**
+     * Call this method when reuse this FlutterView on another Activity.
+     */
+    public void attachActivity(Activity activity) {
+        detachActivity();
+        mNativeView.attachViewAndActivity(this, activity);
+        mPlatformPlugin = new PlatformPlugin(activity);
+        mFlutterPlatformChannel.setMethodCallHandler(mPlatformPlugin);
+        addActivityLifecycleListener(mPlatformPlugin);
+    }
+
+    /**
+     * Call this method on Activity onDestroy in case of memory leak on Activity.
+     */
+    public void detachActivity() {
+        // mPlatformPlugin hold the strong reference of Activity, need to release.
+        if (mPlatformPlugin != null) {
+            removeActivityLifecycleListener(mPlatformPlugin);
+            mPlatformPlugin = null;
+            if (mNativeView != null && mNativeView.isAttached()) {
+                mNativeView.detach();
+            }
+        }
     }
 
     private void encodeKeyEvent(KeyEvent event, Map<String, Object> message) {
@@ -236,6 +254,10 @@ public class FlutterView extends SurfaceView
 
     public void addActivityLifecycleListener(ActivityLifecycleListener listener) {
         mActivityLifecycleListeners.add(listener);
+    }
+
+    public void removeActivityLifecycleListener(ActivityLifecycleListener listener) {
+        mActivityLifecycleListeners.remove(listener);
     }
 
     public void onStart() {


### PR DESCRIPTION
When add flutter in existing apps, we need to use FlutterView in multiple Activities. Creating multiple FlutterViews for each Activity will cause memory problem and low performance. My solution is let FlutterView use application's context, provide attachActivity and detachActivity Methods to support reusing one FlutterView in multiple Activities. Of course, the original usage won't be affected.