### PR TITLE
fix setter for viewOpaque

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -187,7 +187,7 @@
   return _viewOpaque;
 }
 
-- (void)viewOpaque:(BOOL)value {
+- (void)setViewOpaque:(BOOL)value {
   _viewOpaque = value;
   if (_flutterView.get().layer.opaque != value) {
     _flutterView.get().layer.opaque = value;


### PR DESCRIPTION
I missed this in #6570 - the setter can't be accessed from Swift the way it is, and probably doesn't work quite right in Objective C either.

/cc @chinmaygarde @jamesderlin 