### PR TITLE
Propagate pointer size from Android MotionEvent

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -196,7 +196,7 @@ void _invoke3<A1, A2, A3>(void callback(A1 a1, A2 a2, A3 a3), Zone zone, A1 arg1
 //
 //  * pointer_data.cc
 //  * FlutterView.java
-const int _kPointerDataFieldCount = 19;
+const int _kPointerDataFieldCount = 20;
 
 PointerDataPacket _unpackPointerDataPacket(ByteData packet) {
   const int kStride = Int64List.bytesPerElement;
@@ -220,6 +220,7 @@ PointerDataPacket _unpackPointerDataPacket(ByteData packet) {
       pressureMax: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
       distance: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
       distanceMax: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
+      size: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
       radiusMajor: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
       radiusMinor: packet.getFloat64(kStride * offset++, _kFakeHostEndian),
       radiusMin: packet.getFloat64(kStride * offset++, _kFakeHostEndian),

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -140,9 +140,10 @@ class PointerData {
 
   /// The area of the screen being pressed, scaled to a value between 0 and 1.
   /// The value of size can be used to determine fat touch events. This value
-  /// is a device specific approximation within the range of detectable values.
-  /// So, for example, the value of 0.1 could mean a touch with the tip of the
-  /// finger, 0.2 a touch with the full finger, and 0.3 the full palm.
+  /// is only set on Android, and is a device specific approximation within
+  /// the range of detectable values. So, for example, the value of 0.1 could
+  /// mean a touch with the tip of the finger, 0.2 a touch with full finger,
+  /// and 0.3 the full palm.
   final double size;
 
   /// The radius of the contact ellipse along the major axis, in logical pixels.

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -71,6 +71,7 @@ class PointerData {
     this.pressureMax: 0.0,
     this.distance: 0.0,
     this.distanceMax: 0.0,
+    this.size: 0.0,
     this.radiusMajor: 0.0,
     this.radiusMinor: 0.0,
     this.radiusMin: 0.0,
@@ -136,6 +137,13 @@ class PointerData {
   /// input device cannot detect "hover touch" input events, then this will be
   /// 0.0.
   final double distanceMax;
+
+  /// The area of the screen being pressed, scaled to a value between 0 and 1.
+  /// The value of size can be used to determine fat touch events. This value
+  /// is a device specific approximation within the range of detectable values.
+  /// So, for example, the value of 0.1 could mean a touch with the tip of the
+  /// finger, 0.2 a touch with the full finger, and 0.3 the full palm.
+  final double size;
 
   /// The radius of the contact ellipse along the major axis, in logical pixels.
   final double radiusMajor;
@@ -208,6 +216,7 @@ class PointerData {
              'pressureMax: $pressureMax, '
              'distance: $distance, '
              'distanceMax: $distanceMax, '
+             'size: $size, '
              'radiusMajor: $radiusMajor, '
              'radiusMinor: $radiusMinor, '
              'radiusMin: $radiusMin, '

--- a/lib/ui/window/pointer_data.cc
+++ b/lib/ui/window/pointer_data.cc
@@ -9,7 +9,7 @@
 namespace blink {
 
 // If this value changes, update the pointer data unpacking code in hooks.dart.
-static constexpr int kPointerDataFieldCount = 19;
+static constexpr int kPointerDataFieldCount = 20;
 
 static_assert(sizeof(PointerData) == sizeof(int64_t) * kPointerDataFieldCount,
               "PointerData has the wrong size");

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -43,6 +43,7 @@ struct alignas(8) PointerData {
   double pressure_max;
   double distance;
   double distance_max;
+  double size;
   double radius_major;
   double radius_minor;
   double radius_min;

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -488,6 +488,8 @@ public class FlutterView extends SurfaceView
             packet.putDouble(0.0); // distance_max
         }
 
+        packet.putDouble(event.getSize(pointerIndex)); // size
+
         packet.putDouble(event.getToolMajor(pointerIndex)); // radius_major
         packet.putDouble(event.getToolMinor(pointerIndex)); // radius_minor
 
@@ -519,7 +521,7 @@ public class FlutterView extends SurfaceView
         }
 
         // These values must match the unpacking code in hooks.dart.
-        final int kPointerDataFieldCount = 19;
+        final int kPointerDataFieldCount = 20;
         final int kBytePerField = 8;
 
         int pointerCount = event.getPointerCount();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/20300.
Requires https://github.com/flutter/flutter/pull/23536.