### PR TITLE
Undefine ERROR in platform_view_layer.cc

### DIFF
--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -4,6 +4,10 @@
 
 #include "flutter/flow/layers/platform_view_layer.h"
 
+#ifdef ERROR
+#undef ERROR
+#endif
+
 namespace flow {
 
 PlatformViewLayer::PlatformViewLayer() = default;


### PR DESCRIPTION
On Windows the ERROR macro is defined by some headers which breaks the
FML_LOG(ERROR).