### PR TITLE
Don't populate the external view embedder in PaintContext.

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -162,8 +162,19 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
 
   auto canvas = frame->SkiaCanvas();
 
+  // External view embedding required that the gpu and platform threads are the
+  // same. The dynamic merging of these threads is WIP so for now we don't
+  // populate the view embedder. Once we can merge the threads, we should
+  // populate the view embedded here with surface_->GetExternalViewEmbedder() if
+  // the scene contains an external view (and we can probably assert that the
+  // gpu and platform threads are the same).
+  //
+  // TODO(amirh): populate the view embedder once we dynamically merge the
+  // threads for embedded platform views.
+  auto external_view_embedder = nullptr;
+
   auto compositor_frame = compositor_context_->AcquireFrame(
-      surface_->GetContext(), canvas, surface_->GetExternalViewEmbedder(),
+      surface_->GetContext(), canvas, external_view_embedder,
       surface_->GetRootTransformation(), true);
 
   if (canvas) {


### PR DESCRIPTION
The platform views embedding is still WIP, and until we dynamically
merge the gpu and platform threads based on the presence of an embedded
view in the scene fetching the view embedder is not thread safe.

This PR essentially disables iOS platform views embedding, we will
re-enable once dynamic thread merging is supported.