### PR TITLE
Flutter tester default locales.

### DIFF
--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -125,6 +125,19 @@ int RunTester(const blink::Settings& settings, bool run_forever) {
     return EXIT_FAILURE;
   }
 
+  // Initialize default testing locales. There is no platform to
+  // pass locales on the tester, so to retain expected locale behavior,
+  // we emulate it in here by passing in 'en_US' and 'zh_CN' as test locales.
+  const char* locale_json =
+      "{\"method\":\"setLocale\",\"args\":[\"en\",\"US\",\"\",\"\",\"zh\","
+      "\"CN\",\"\",\"\"]}";
+  std::vector<uint8_t> locale_bytes(locale_json,
+                                    locale_json + std::strlen(locale_json));
+  fml::RefPtr<blink::PlatformMessageResponse> response;
+  shell->GetPlatformView()->DispatchPlatformMessage(
+      fml::MakeRefCounted<blink::PlatformMessage>("flutter/localization",
+                                                  locale_bytes, response));
+
   std::initializer_list<fml::FileMapping::Protection> protection = {
       fml::FileMapping::Protection::kRead};
   auto main_dart_file_mapping = std::make_unique<fml::FileMapping>(


### PR DESCRIPTION
Provide `en_US` and `zh_CN` to locales in Flutter tester so that the behavior of the tester remains consistent with platforms that always supply locales.

Framework-side tests: https://github.com/flutter/flutter/pull/23596