### PR TITLE
Ensure Simulator publishes mDNS records

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -4,6 +4,9 @@
 
 #define FML_USED_ON_EMBEDDER
 
+#include <dns_sd.h>
+#include <net/if.h>
+
 #import "FlutterObservatoryPublisher.h"
 
 #include "flutter/fml/logging.h"
@@ -22,11 +25,9 @@
 
 #else
 
-@interface FlutterObservatoryPublisher () <NSNetServiceDelegate>
-@end
-
 @implementation FlutterObservatoryPublisher {
-  fml::scoped_nsobject<NSNetService> _netService;
+  DNSServiceRef _dnsServiceRef;
+  bool _dnsServiceRefInitialized;
 
   blink::DartServiceIsolate::CallbackHandle _callbackHandle;
   std::unique_ptr<fml::WeakPtrFactory<FlutterObservatoryPublisher>> _weakFactory;
@@ -36,6 +37,7 @@
   self = [super init];
   NSAssert(self, @"Super must not return null on init.");
 
+  _dnsServiceRefInitialized = false;
   _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterObservatoryPublisher>>(self);
 
   fml::MessageLoop::EnsureInitializedForCurrentThread();
@@ -54,14 +56,28 @@
 }
 
 - (void)dealloc {
-  [_netService.get() stop];
+  if (_dnsServiceRefInitialized) {
+    DNSServiceRefDeallocate(_dnsServiceRef);
+  }
   blink::DartServiceIsolate::RemoveServerStatusCallback(std::move(_callbackHandle));
   [super dealloc];
 }
 
+- (uint32_t)resolveInterface {
+  // We want to use the loopback interface on the simulator, to force it to be available via
+  // standard mDNS queries.
+#if TARGET_IPHONE_SIMULATOR
+  return if_nametoindex("lo0");
+#else   // TARGET_IPHONE_SIMULATOR
+  return 0;
+#endif  // TARGET_IPHONE_SIMULATOR
+}
+
 - (void)publishServiceProtocolPort:(std::string)uri {
+  if (_dnsServiceRefInitialized) {
+    DNSServiceRefDeallocate(_dnsServiceRef);
+  }
   if (uri.empty()) {
-    [_netService.get() stop];
     return;
   }
   // uri comes in as something like 'http://127.0.0.1:XXXXX/' where XXXXX is the port
@@ -69,33 +85,41 @@
   NSURL* url =
       [[[NSURL alloc] initWithString:[NSString stringWithUTF8String:uri.c_str()]] autorelease];
 
-  // DNS name has to be a max of 63 bytes.  Prefer to cut off the app name rather than
-  // the device hostName. e.g. 'io.flutter.example@someones-iphone', or
-  // 'ongAppNameBecauseThisCouldHappenAtSomePoint@somelongname-iphone'
-  NSString* serviceName = [NSString
-      stringWithFormat:@"%@@%@",
-                       [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"],
-                       [NSProcessInfo processInfo].hostName];
-  if ([serviceName length] > 63) {
-    serviceName = [serviceName substringFromIndex:[serviceName length] - 63];
+  NSString* serviceName =
+      [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleIdentifier"];
+
+  DNSServiceFlags flags = kDNSServiceFlagsDefault;
+  uint32_t interfaceIndex = [self resolveInterface];
+  const char* registrationType = "_dartobservatory._tcp";
+  const char* domain = "local.";  // default domain
+  uint16_t port = [[url port] intValue];
+
+  int err = DNSServiceRegister(&_dnsServiceRef, flags, interfaceIndex, [serviceName UTF8String],
+                               registrationType, domain, NULL, htons(port), 0, NULL,
+                               registrationCallback, NULL);
+
+  if (err != 0) {
+    FML_LOG(ERROR) << "Failed to register observatory port with mDNS.";
+  } else {
+    DNSServiceProcessResult(_dnsServiceRef);
   }
 
-  _netService.reset([[NSNetService alloc] initWithDomain:@"local."
-                                                    type:@"_dartobservatory._tcp."
-                                                    name:serviceName
-                                                    port:[[url port] intValue]]);
-
-  [_netService.get() setDelegate:self];
-  [_netService.get() publish];
+  _dnsServiceRefInitialized = err == 0;
 }
 
-- (void)netServiceDidPublish:(NSNetService*)sender {
-  FML_DLOG(INFO) << "FlutterObservatoryPublisher is ready!";
-}
-
-- (void)netService:(NSNetService*)sender didNotPublish:(NSDictionary*)errorDict {
-  FML_LOG(ERROR) << "Could not register as server for FlutterObservatoryPublisher. Check your "
-                    "network settings and relaunch the application.";
+static void DNSSD_API registrationCallback(DNSServiceRef sdRef,
+                                           DNSServiceFlags flags,
+                                           DNSServiceErrorType errorCode,
+                                           const char* name,
+                                           const char* regType,
+                                           const char* domain,
+                                           void* context) {
+  if (errorCode == kDNSServiceErr_NoError) {
+    FML_LOG(ERROR) << "FlutterObservatoryPublisher is ready!";
+  } else {
+    FML_LOG(ERROR) << "Could not register as server for FlutterObservatoryPublisher. Check your "
+                      "network settings and relaunch the application.";
+  }
 }
 
 #endif  // FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE && FLUTTER_RUNTIME_MODE !=

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -4,11 +4,15 @@
 
 #define FML_USED_ON_EMBEDDER
 
+#import <TargetConditionals.h>
+
 // NSNetService works fine on physical devices, but doesn't expose the services to regular mDNS
 // queries on the Simulator.  We can work around this by using the lower level C API, but that's
 // only available from iOS 9.3+/macOS 10.11.4+.
-#include <dns_sd.h>
-#include <net/if.h>
+#if TARGET_IPHONE_SIMULATOR
+#include <dns_sd.h>  // nogncheck
+#include <net/if.h>  // nogncheck
+#endif               // TARGET_IPHONE_SIMLUATOR
 
 #import "FlutterObservatoryPublisher.h"
 


### PR DESCRIPTION
`NSNetService` will not make published services visible through regular mDNS queries when run from the Simulator - you have to run system calls into the mDNSResponder service directly.  This prevents a regular mDNS client from discovering the dart observatory port

This change ensures that publish calls on the simulator are run on the local loopback interface, which can still be discovered by regular mDNS clients. 

Full support in the Dart client will require the fix for https://github.com/dart-lang/sdk/issues/17057 to land.