### PR TITLE
Check needs_painting in RasterCache::Prepare

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -164,7 +164,9 @@ void RasterCache::Prepare(PrerollContext* context,
                                   context->texture_registry,
                                   context->raster_cache,
                                   context->checkerboard_offscreen_layers};
-                              layer->Paint(paintContext);
+                              if (layer->needs_painting()) {
+                                layer->Paint(paintContext);
+                              }
                             });
   }
 }


### PR DESCRIPTION
Otherwise, this may trigger `FML_DCHECK(needs_painting())`. We haven't caused crashes for our users because it probably requires a locally debug engine build to trigger the assert.