### PR TITLE
Move FlutterPlatformViewsController into FlutterEngine.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -7,6 +7,8 @@
 
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 
+#import "FlutterPlatformViews_Internal.h"
+
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/task_runner.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
@@ -22,7 +24,7 @@
 
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 
-@interface FlutterEngine () <FlutterScreenshotDelegate>
+@interface FlutterEngine () <FlutterViewEngineDelegate>
 
 - (shell::Shell&)shell;
 
@@ -37,6 +39,7 @@
                                base64Encode:(bool)base64Encode;
 
 - (FlutterPlatformPlugin*)platformPlugin;
+- (shell::FlutterPlatformViewsController*)platformViewsController;
 - (FlutterTextInputPlugin*)textInputPlugin;
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -5,7 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERPLATFORMVIEWS_INTERNAL_H_
 
-#include "FlutterView.h"
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/common/shell.h"
@@ -29,20 +28,22 @@ namespace shell {
 
 class FlutterPlatformViewsController : public flow::ExternalViewEmbedder {
  public:
-  FlutterPlatformViewsController(NSObject<FlutterBinaryMessenger>* messenger,
-                                 FlutterView* flutter_view);
+  FlutterPlatformViewsController() = default;
+
+  void SetFlutterView(UIView* flutter_view);
 
   void RegisterViewFactory(NSObject<FlutterPlatformViewFactory>* factory, NSString* factoryId);
 
   void CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params);
 
+  void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
+
  private:
   fml::scoped_nsobject<FlutterMethodChannel> channel_;
-  fml::scoped_nsobject<FlutterView> flutter_view_;
+  fml::scoped_nsobject<UIView> flutter_view_;
   std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>> factories_;
   std::map<int64_t, fml::scoped_nsobject<FlutterTouchInterceptingView>> views_;
 
-  void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
   void OnCreate(FlutterMethodCall* call, FlutterResult& result);
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -9,15 +9,19 @@
 
 #include <memory>
 
+#import "FlutterPlatformViews_Internal.h"
+
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
 
-@protocol FlutterScreenshotDelegate <NSObject>
+@protocol FlutterViewEngineDelegate <NSObject>
 
 - (shell::Rasterizer::Screenshot)takeScreenshot:(shell::Rasterizer::ScreenshotType)type
                                 asBase64Encoded:(BOOL)base64Encode;
+
+- (flow::ExternalViewEmbedder*)externalViewEmbedder;
 
 @end
 
@@ -27,7 +31,7 @@
 - (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder*)aDecoder NS_UNAVAILABLE;
 
-- (instancetype)initWithDelegate:(id<FlutterScreenshotDelegate>)delegate
+- (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
 - (std::unique_ptr<shell::IOSSurface>)createSurface;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -113,8 +113,6 @@
   _statusBarStyle = UIStatusBarStyleDefault;
 
   [self setupNotificationCenterObservers];
-  _platformViewsController.reset(
-      new shell::FlutterPlatformViewsController(_engine.get(), _flutterView.get()));
 }
 
 - (fml::scoped_nsobject<FlutterEngine>)engine {
@@ -123,10 +121,6 @@
 
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr {
   return _weakFactory->GetWeakPtr();
-}
-
-- (flow::ExternalViewEmbedder*)viewEmbedder {
-  return _platformViewsController.get();
 }
 
 - (void)setupNotificationCenterObservers {
@@ -364,10 +358,11 @@
   // NotifyCreated/NotifyDestroyed are synchronous and require hops between the UI and GPU thread.
   if (appeared) {
     [self installSplashScreenViewCallback];
+    [_engine.get() platformViewsController] -> SetFlutterView(_flutterView.get());
     [_engine.get() platformView] -> NotifyCreated();
-
   } else {
     [_engine.get() platformView] -> NotifyDestroyed();
+    [_engine.get() platformViewsController] -> SetFlutterView(nullptr);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -19,8 +19,6 @@
 
 @property(readonly) fml::scoped_nsobject<FlutterEngine> engine;
 
-- (flow::ExternalViewEmbedder*)viewEmbedder;
-
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERVIEWCONTROLLER_INTERNAL_H_

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -13,8 +13,6 @@
 
 namespace shell {
 
-typedef flow::ExternalViewEmbedder* (^GetExternalViewEmbedder)(void);
-
 class IOSSurface {
  public:
   IOSSurface();

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -18,7 +18,7 @@ namespace shell {
 class IOSSurfaceGL : public IOSSurface, public GPUSurfaceGLDelegate {
  public:
   IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-               ::shell::GetExternalViewEmbedder get_view_embedder);
+               flow::ExternalViewEmbedder& external_view_embedder);
 
   ~IOSSurfaceGL() override;
 
@@ -46,7 +46,7 @@ class IOSSurfaceGL : public IOSSurface, public GPUSurfaceGLDelegate {
  private:
   IOSGLContext context_;
 
-  fml::scoped_nsprotocol<::shell::GetExternalViewEmbedder> get_view_embedder_;
+  flow::ExternalViewEmbedder& external_view_embedder_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceGL);
 };

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -10,8 +10,8 @@
 namespace shell {
 
 IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-                           ::shell::GetExternalViewEmbedder get_view_embedder)
-    : context_(std::move(layer)), get_view_embedder_([get_view_embedder retain]) {}
+                           flow::ExternalViewEmbedder& view_embedder)
+    : context_(std::move(layer)), external_view_embedder_(view_embedder) {}
 
 IOSSurfaceGL::~IOSSurfaceGL() = default;
 
@@ -59,7 +59,7 @@ bool IOSSurfaceGL::GLContextPresent() {
 }
 
 flow::ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
-  return get_view_embedder_.get()();
+  return &external_view_embedder_;
 }
 
 }  // namespace shell

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -17,7 +17,7 @@ namespace shell {
 class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDelegate {
  public:
   IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
-                     ::shell::GetExternalViewEmbedder get_view_embedder);
+                     flow::ExternalViewEmbedder& view_embedder);
 
   ~IOSSurfaceSoftware() override;
 
@@ -44,7 +44,7 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
 
  private:
   fml::scoped_nsobject<CALayer> layer_;
-  fml::scoped_nsprotocol<::shell::GetExternalViewEmbedder> get_view_embedder_;
+  flow::ExternalViewEmbedder& external_view_embedder_;
   sk_sp<SkSurface> sk_surface_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceSoftware);

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -16,8 +16,8 @@
 namespace shell {
 
 IOSSurfaceSoftware::IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
-                                       ::shell::GetExternalViewEmbedder get_view_embedder)
-    : layer_(std::move(layer)), get_view_embedder_([get_view_embedder retain]) {
+                                       flow::ExternalViewEmbedder& view_embedder)
+    : layer_(std::move(layer)), external_view_embedder_(view_embedder) {
   UpdateStorageSizeIfNecessary();
 }
 
@@ -127,7 +127,7 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
 }
 
 flow::ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
-  return get_view_embedder_.get()();
+  return &external_view_embedder_;
 }
 
 }  // namespace shell


### PR DESCRIPTION
This PR breaks PlatformViewsController's construction dependency on FlutterView,
which allows making FlutterEngine its owner instead of
FlutterViewController.

Additionally moved the `platform_views` channel ownership to FlutterEngine to conform with all other system channels.

Also renamed the FlutterScreenshotDelegate to FlutterViewEngineDelegate
which is FlutterView's delegate to the engine, and expanded it to
provide a view embedder.