### PR TITLE
Pass scriptCode into Locale on initialization.

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -53,8 +53,9 @@ void _updateLocales(List<String> locales) {
   final int numLocales = locales.length ~/ stringsPerLocale;
   window._locales = new List<Locale>(numLocales);
   for (int localeIndex = 0; localeIndex < numLocales; localeIndex++) {
-    window._locales[localeIndex] = new Locale(locales[localeIndex * stringsPerLocale],
-                                   locales[localeIndex * stringsPerLocale + 1]);
+    window._locales[localeIndex] = new Locale.fromSubtags( languageCode: locales[localeIndex * stringsPerLocale],
+                                   countryCode: locales[localeIndex * stringsPerLocale + 1],
+                                   scriptCode: locales[localeIndex * stringsPerLocale + 2]);
   }
   _invoke(window.onLocaleChanged, window._onLocaleChangedZone);
 }

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -54,8 +54,8 @@ void _updateLocales(List<String> locales) {
   window._locales = new List<Locale>(numLocales);
   for (int localeIndex = 0; localeIndex < numLocales; localeIndex++) {
     window._locales[localeIndex] = new Locale.fromSubtags( languageCode: locales[localeIndex * stringsPerLocale],
-                                   countryCode: locales[localeIndex * stringsPerLocale + 1],
-                                   scriptCode: locales[localeIndex * stringsPerLocale + 2]);
+                                   countryCode: locales[localeIndex * stringsPerLocale + 1] == '' ? null : locales[localeIndex * stringsPerLocale + 1],
+                                   scriptCode: locales[localeIndex * stringsPerLocale + 2] == '' ? null : locales[localeIndex * stringsPerLocale + 2]);
   }
   _invoke(window.onLocaleChanged, window._onLocaleChangedZone);
 }

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -53,9 +53,14 @@ void _updateLocales(List<String> locales) {
   final int numLocales = locales.length ~/ stringsPerLocale;
   window._locales = new List<Locale>(numLocales);
   for (int localeIndex = 0; localeIndex < numLocales; localeIndex++) {
-    window._locales[localeIndex] = new Locale.fromSubtags( languageCode: locales[localeIndex * stringsPerLocale],
-                                   countryCode: locales[localeIndex * stringsPerLocale + 1] == '' ? null : locales[localeIndex * stringsPerLocale + 1],
-                                   scriptCode: locales[localeIndex * stringsPerLocale + 2] == '' ? null : locales[localeIndex * stringsPerLocale + 2]);
+    final String countryCode = locales[localeIndex * stringsPerLocale + 1];
+    final String scriptCode = locales[localeIndex * stringsPerLocale + 2];
+
+    window._locales[localeIndex] = new Locale.fromSubtags(
+      languageCode: locales[localeIndex * stringsPerLocale],
+      countryCode: countryCode.isEmpty ? null : countryCode,
+      scriptCode: scriptCode.isEmpty ? null : scriptCode,
+    );
   }
   _invoke(window.onLocaleChanged, window._onLocaleChangedZone);
 }


### PR DESCRIPTION
Modifying the toString() to encode scriptCode as `_$scriptCode` makes Locale incompatible with dart:intl which expects locale strings to be `$languageCode_$countryCode`, so I have added a new `toCompleteString()` method to generate the fully encoded scriptCode.