### PR TITLE
Apply changes to the embedded UIView tree when presenting a frame

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -396,10 +396,6 @@
   return _shell->Screenshot(type, base64Encode);
 }
 
-- (flow::ExternalViewEmbedder*)externalViewEmbedder {
-  return _platformViewsController.get();
-}
-
 #pragma mark - FlutterBinaryMessenger
 
 - (void)sendOnChannel:(NSString*)channel message:(NSData*)message {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -135,6 +135,11 @@ void FlutterPlatformViewsController::Present() {
   }
   UIView* flutter_view = flutter_view_.get();
 
+  // This can be more efficient, instead of removing all views and then re-attaching them,
+  // we should only remove the views that has been completly removed from the layer tree, and
+  // reorder the views using UIView's bringSubviewToFront.
+  // TODO(amirh): make this more efficient.
+  // https://github.com/flutter/flutter/issues/23793
   for (UIView* sub_view in [flutter_view subviews]) {
     [sub_view removeFromSuperview];
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -36,6 +36,8 @@ class FlutterPlatformViewsController {
 
   void CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params);
 
+  void Present();
+
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
  private:
@@ -43,6 +45,13 @@ class FlutterPlatformViewsController {
   fml::scoped_nsobject<UIView> flutter_view_;
   std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>> factories_;
   std::map<int64_t, fml::scoped_nsobject<FlutterTouchInterceptingView>> views_;
+
+  // A vector of embedded view IDs according to their composition order.
+  // The last ID in this vector belond to the that is composited on top of all others.
+  std::vector<int64_t> composition_order_;
+
+  // The latest composition order that was presented in Present().
+  std::vector<int64_t> active_composition_order_;
 
   void OnCreate(FlutterMethodCall* call, FlutterResult& result);
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -26,7 +26,7 @@
 
 namespace shell {
 
-class FlutterPlatformViewsController : public flow::ExternalViewEmbedder {
+class FlutterPlatformViewsController {
  public:
   FlutterPlatformViewsController() = default;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -11,7 +11,6 @@
 
 #import "FlutterPlatformViews_Internal.h"
 
-#include "flutter/flow/embedded_views.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
@@ -21,7 +20,7 @@
 - (shell::Rasterizer::Screenshot)takeScreenshot:(shell::Rasterizer::ScreenshotType)type
                                 asBase64Encoded:(BOOL)base64Encode;
 
-- (flow::ExternalViewEmbedder*)externalViewEmbedder;
+- (shell::FlutterPlatformViewsController*)platformViewsController;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -80,11 +80,11 @@ id<FlutterViewEngineDelegate> _delegate;
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
     return std::make_unique<shell::IOSSurfaceGL>(std::move(eagl_layer),
-                                                 *[_delegate externalViewEmbedder]);
+                                                 *[_delegate platformViewsController]);
   } else {
     fml::scoped_nsobject<CALayer> layer(reinterpret_cast<CALayer*>([self.layer retain]));
     return std::make_unique<shell::IOSSurfaceSoftware>(std::move(layer),
-                                                       *[_delegate externalViewEmbedder]);
+                                                       *[_delegate platformViewsController]);
   }
 }
 

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -5,6 +5,8 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SURFACE_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SURFACE_H_
 
+#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
+
 #include <memory>
 
 #include "flutter/fml/macros.h"
@@ -15,7 +17,7 @@ namespace shell {
 
 class IOSSurface {
  public:
-  IOSSurface();
+  IOSSurface(FlutterPlatformViewsController& platform_views_controller);
 
   virtual ~IOSSurface();
 
@@ -26,6 +28,12 @@ class IOSSurface {
   virtual void UpdateStorageSizeIfNecessary() = 0;
 
   virtual std::unique_ptr<Surface> CreateGPUSurface() = 0;
+
+ protected:
+  FlutterPlatformViewsController& GetPlatformViewsController();
+
+ private:
+  FlutterPlatformViewsController& platform_views_controller_;
 
  public:
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurface);

--- a/shell/platform/darwin/ios/ios_surface.mm
+++ b/shell/platform/darwin/ios/ios_surface.mm
@@ -11,8 +11,12 @@
 
 namespace shell {
 
-IOSSurface::IOSSurface() = default;
+IOSSurface::IOSSurface(FlutterPlatformViewsController& platform_views_controller)
+    : platform_views_controller_(platform_views_controller) {}
 
 IOSSurface::~IOSSurface() = default;
 
+FlutterPlatformViewsController& IOSSurface::GetPlatformViewsController() {
+  return platform_views_controller_;
+}
 }  // namespace shell

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -15,10 +15,12 @@
 
 namespace shell {
 
-class IOSSurfaceGL : public IOSSurface, public GPUSurfaceGLDelegate {
+class IOSSurfaceGL : public IOSSurface,
+                     public GPUSurfaceGLDelegate,
+                     public flow::ExternalViewEmbedder {
  public:
   IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-               flow::ExternalViewEmbedder& external_view_embedder);
+               FlutterPlatformViewsController& platform_views_controller);
 
   ~IOSSurfaceGL() override;
 
@@ -43,10 +45,11 @@ class IOSSurfaceGL : public IOSSurface, public GPUSurfaceGLDelegate {
   // |shell::GPUSurfaceGLDelegate|
   flow::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |flow::ExternalViewEmbedder|
+  void CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) override;
+
  private:
   IOSGLContext context_;
-
-  flow::ExternalViewEmbedder& external_view_embedder_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceGL);
 };

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -10,8 +10,8 @@
 namespace shell {
 
 IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-                           flow::ExternalViewEmbedder& view_embedder)
-    : context_(std::move(layer)), external_view_embedder_(view_embedder) {}
+                           FlutterPlatformViewsController& platform_views_controller)
+    : IOSSurface(platform_views_controller), context_(std::move(layer)) {}
 
 IOSSurfaceGL::~IOSSurfaceGL() = default;
 
@@ -59,7 +59,11 @@ bool IOSSurfaceGL::GLContextPresent() {
 }
 
 flow::ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
-  return &external_view_embedder_;
+  return this;
+}
+
+void IOSSurfaceGL::CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) {
+  GetPlatformViewsController().CompositeEmbeddedView(view_id, params);
 }
 
 }  // namespace shell

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -55,7 +55,12 @@ bool IOSSurfaceGL::GLContextClearCurrent() {
 
 bool IOSSurfaceGL::GLContextPresent() {
   TRACE_EVENT0("flutter", "IOSSurfaceGL::GLContextPresent");
-  return IsValid() ? context_.PresentRenderBuffer() : false;
+  if (!IsValid() || !context_.PresentRenderBuffer()) {
+    return false;
+  }
+
+  GetPlatformViewsController().Present();
+  return true;
 }
 
 flow::ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SURFACE_SOFTWARE_H_
 #define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SURFACE_SOFTWARE_H_
 
+#include "flutter/flow/embedded_views.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/gpu/gpu_surface_software.h"
@@ -14,10 +15,12 @@
 
 namespace shell {
 
-class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDelegate {
+class IOSSurfaceSoftware final : public IOSSurface,
+                                 public GPUSurfaceSoftwareDelegate,
+                                 public flow::ExternalViewEmbedder {
  public:
   IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
-                     flow::ExternalViewEmbedder& view_embedder);
+                     FlutterPlatformViewsController& platform_views_controller);
 
   ~IOSSurfaceSoftware() override;
 
@@ -42,9 +45,11 @@ class IOSSurfaceSoftware final : public IOSSurface, public GPUSurfaceSoftwareDel
   // |shell::GPUSurfaceSoftwareDelegate|
   flow::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |flow::ExternalViewEmbedder|
+  void CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) override;
+
  private:
   fml::scoped_nsobject<CALayer> layer_;
-  flow::ExternalViewEmbedder& external_view_embedder_;
   sk_sp<SkSurface> sk_surface_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceSoftware);

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -123,6 +123,8 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
 
   layer_.get().contents = reinterpret_cast<id>(static_cast<CGImageRef>(pixmap_image));
 
+  GetPlatformViewsController().Present();
+
   return true;
 }
 

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -16,8 +16,8 @@
 namespace shell {
 
 IOSSurfaceSoftware::IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
-                                       flow::ExternalViewEmbedder& view_embedder)
-    : layer_(std::move(layer)), external_view_embedder_(view_embedder) {
+                                       FlutterPlatformViewsController& platform_views_controller)
+    : IOSSurface(platform_views_controller), layer_(std::move(layer)) {
   UpdateStorageSizeIfNecessary();
 }
 
@@ -127,7 +127,11 @@ bool IOSSurfaceSoftware::PresentBackingStore(sk_sp<SkSurface> backing_store) {
 }
 
 flow::ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
-  return &external_view_embedder_;
+  return this;
+}
+void IOSSurfaceSoftware::CompositeEmbeddedView(int view_id,
+                                               const flow::EmbeddedViewParams& params) {
+  GetPlatformViewsController().CompositeEmbeddedView(view_id, params);
 }
 
 }  // namespace shell


### PR DESCRIPTION
This makes the CompositeEmbeddedView calls (which are invoked during the flow paint traversal) track the order of embedded UIViews.
After the paint traversal is complete, if we apply the required changes to the UIView subtree (if there are no changes we do nothing).

For review convenience I split this into 2 commits:
  * 33ed0d3 makes `IOSGLSurface` and `IOSSoftwareSurface` the `ViewEmbedder`s, and gives them a reference to `FlutterPlatformViewsController` which allows them to trigger `FlutterPlatformViewsController::Present` at the right time.
  * ae74020 adds the logic for tracking the order of embedded views and changing the `UIView` subtree.

flutter/flutter#19030