### PR TITLE
Add an internal_nodes_canvas to PaintContext.

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -16,7 +16,6 @@ class EmbeddedViewParams {
  public:
   SkPoint offsetPixels;
   SkSize sizePoints;
-  SkISize canvasBaseLayerSize;
 };
 
 // This is only used on iOS when running in a non headless mode,
@@ -25,6 +24,12 @@ class EmbeddedViewParams {
 class ExternalViewEmbedder {
  public:
   ExternalViewEmbedder() = default;
+
+  virtual void SetFrameSize(SkISize frame_size) = 0;
+
+  virtual void PrerollCompositeEmbeddedView(int view_id) = 0;
+
+  virtual std::vector<SkCanvas*> GetCurrentCanvases() = 0;
 
   // Must be called on the UI thread.
   virtual SkCanvas* CompositeEmbeddedView(int view_id,

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -14,6 +14,13 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
                                 const SkMatrix& matrix) {
   set_paint_bounds(SkRect::MakeXYWH(offset_.x(), offset_.y(), size_.width(),
                                     size_.height()));
+
+  if (context->view_embedder == nullptr) {
+    FML_LOG(ERROR) << "Trying to embed a platform view but the PrerollContext "
+                      "does not support embedding";
+    return;
+  }
+  context->view_embedder->PrerollCompositeEmbeddedView(view_id_);
 }
 
 void PlatformViewLayer::Paint(PaintContext& context) const {
@@ -27,12 +34,9 @@ void PlatformViewLayer::Paint(PaintContext& context) const {
   params.offsetPixels =
       SkPoint::Make(transform.getTranslateX(), transform.getTranslateY());
   params.sizePoints = size_;
-  params.canvasBaseLayerSize = context.canvas->getBaseLayerSize();
 
   SkCanvas* canvas =
       context.view_embedder->CompositeEmbeddedView(view_id_, params);
-  // TODO(amirh): copy the full canvas state here
-  canvas->concat(context.canvas->getTotalMatrix());
   context.canvas = canvas;
 }
 }  // namespace flow

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -36,8 +36,8 @@ void TransformLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "TransformLayer::Paint");
   FML_DCHECK(needs_painting());
 
-  SkAutoCanvasRestore save(context.canvas, true);
-  context.canvas->concat(transform_);
+  SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
+  context.internal_nodes_canvas->concat(transform_);
   PaintChildren(context);
 }
 

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -156,7 +156,12 @@ void RasterCache::Prepare(PrerollContext* context,
     entry.image = Rasterize(context->gr_context, ctm, context->dst_color_space,
                             checkerboard_images_, layer->paint_bounds(),
                             [layer, context](SkCanvas* canvas) {
+                              SkISize canvas_size = canvas->getBaseLayerSize();
+                              SkNWayCanvas internal_nodes_canvas(
+                                  canvas_size.width(), canvas_size.height());
+                              internal_nodes_canvas.addCanvas(canvas);
                               Layer::PaintContext paintContext = {
+                                  (SkCanvas*)&internal_nodes_canvas,
                                   canvas,
                                   nullptr,
                                   context->frame_time,

--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -188,6 +188,7 @@ SceneUpdateContext::ExecutePaintTasks(CompositorContext::ScopedFrame& frame) {
     FML_DCHECK(task.surface);
     SkCanvas* canvas = task.surface->GetSkiaSurface()->getCanvas();
     Layer::PaintContext context = {canvas,
+                                   canvas,
                                    nullptr,
                                    frame.context().frame_time(),
                                    frame.context().engine_time(),

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -164,6 +164,11 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
 
   auto external_view_embedder = surface_->GetExternalViewEmbedder();
 
+  // TODO(amirh): uncomment this once external_view_embedder is populated.
+  // if (external_view_embedder != nullptr) {
+  //   external_view_embedder->SetFrameSize(layer_tree.frame_size());
+  // }
+
   auto compositor_frame = compositor_context_->AcquireFrame(
       surface_->GetContext(), canvas, external_view_embedder,
       surface_->GetRootTransformation(), true);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -49,6 +49,12 @@ class FlutterPlatformViewsController {
 
   void RegisterViewFactory(NSObject<FlutterPlatformViewFactory>* factory, NSString* factoryId);
 
+  void SetFrameSize(SkISize frame_size);
+
+  void PrerollCompositeEmbeddedView(int view_id);
+
+  std::vector<SkCanvas*> GetCurrentCanvases();
+
   SkCanvas* CompositeEmbeddedView(int view_id,
                                   const flow::EmbeddedViewParams& params,
                                   IOSSurface& surface);
@@ -63,6 +69,7 @@ class FlutterPlatformViewsController {
   std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>> factories_;
   std::map<int64_t, fml::scoped_nsobject<FlutterTouchInterceptingView>> views_;
   std::map<int64_t, std::unique_ptr<FlutterPlatformViewLayer>> overlays_;
+  SkISize frame_size_;
 
   // A vector of embedded view IDs according to their composition order.
   // The last ID in this vector belond to the that is composited on top of all others.
@@ -71,7 +78,7 @@ class FlutterPlatformViewsController {
   // The latest composition order that was presented in Present().
   std::vector<int64_t> active_composition_order_;
 
-  std::vector<std::unique_ptr<SurfaceFrame>> composition_frames_;
+  std::map<int64_t, std::unique_ptr<SurfaceFrame>> composition_frames_;
 
   void OnCreate(FlutterMethodCall* call, FlutterResult& result);
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -46,6 +46,15 @@ class IOSSurfaceGL : public IOSSurface,
   flow::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |flow::ExternalViewEmbedder|
+  void SetFrameSize(SkISize frame_size) override;
+
+  // |flow::ExternalViewEmbedder|
+  void PrerollCompositeEmbeddedView(int view_id) override;
+
+  // |flow::ExternalViewEmbedder|
+  std::vector<SkCanvas*> GetCurrentCanvases() override;
+
+  // |flow::ExternalViewEmbedder|
   SkCanvas* CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) override;
 
  private:

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -74,6 +74,24 @@ flow::ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
   }
 }
 
+void IOSSurfaceGL::SetFrameSize(SkISize frame_size) {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  platform_views_controller->SetFrameSize(frame_size);
+}
+
+void IOSSurfaceGL::PrerollCompositeEmbeddedView(int view_id) {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  platform_views_controller->PrerollCompositeEmbeddedView(view_id);
+}
+
+std::vector<SkCanvas*> IOSSurfaceGL::GetCurrentCanvases() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  return platform_views_controller->GetCurrentCanvases();
+}
+
 SkCanvas* IOSSurfaceGL::CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -46,6 +46,15 @@ class IOSSurfaceSoftware final : public IOSSurface,
   flow::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |flow::ExternalViewEmbedder|
+  void SetFrameSize(SkISize frame_size) override;
+
+  // |flow::ExternalViewEmbedder|
+  void PrerollCompositeEmbeddedView(int view_id) override;
+
+  // |flow::ExternalViewEmbedder|
+  std::vector<SkCanvas*> GetCurrentCanvases() override;
+
+  // |flow::ExternalViewEmbedder|
   SkCanvas* CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) override;
 
  private:

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -138,6 +138,24 @@ flow::ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
   }
 }
 
+void IOSSurfaceSoftware::SetFrameSize(SkISize frame_size) {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  platform_views_controller->SetFrameSize(frame_size);
+}
+
+void IOSSurfaceSoftware::PrerollCompositeEmbeddedView(int view_id) {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  platform_views_controller->PrerollCompositeEmbeddedView(view_id);
+}
+
+std::vector<SkCanvas*> IOSSurfaceSoftware::GetCurrentCanvases() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  return platform_views_controller->GetCurrentCanvases();
+}
+
 SkCanvas* IOSSurfaceSoftware::CompositeEmbeddedView(int view_id,
                                                     const flow::EmbeddedViewParams& params) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();


### PR DESCRIPTION
When we visit a PlatformViewLayer during the paint traversal it replaces
the PaintContext's canvas with a new one that is painted ontop of the
embedded view.
We need to make sure that operations applied by parent layers are also
applied to the new canvas.

To achieve this we collect all the canvases in a SkNWayCanvas and use
this canvas by non leaf nodes. Leaf nodes still paint only to the "current"
canvas.

This PR moves the overlay canvas creation from the paint phase to the
preroll phase, collects them into a SkNWayCanvas and set it in
PaintContext.

To keep this PR focused, I only used the internal_nodes_canvas in the
tranform_layer.
Will followup with a PR that changes all internal layers to use the
internal_nodes_canvas.

flutter/flutter#19030