### PR TITLE
Clear the on-screen surface every frame.

### DIFF
--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -280,8 +280,10 @@ bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
   if (offscreen_surface_ != nullptr) {
     TRACE_EVENT0("flutter", "CopyTextureOnscreen");
     SkPaint paint;
-    onscreen_surface_->getCanvas()->drawImage(
-        offscreen_surface_->makeImageSnapshot(), 0, 0, &paint);
+    SkCanvas* onscreen_canvas = onscreen_surface_->getCanvas();
+    onscreen_canvas->clear(SK_ColorTRANSPARENT);
+    onscreen_canvas->drawImage(offscreen_surface_->makeImageSnapshot(), 0, 0,
+                               &paint);
   }
 
   {


### PR DESCRIPTION
We are currently clearing the offscreen surface before rasterizing, but
as we draw the image snapshot of the offscreen surface into the onscreen
surface transparent pixels are blended with the current contents of the onscreen surface instead of replacing them. This is
particularly noticeable when embedding platform views.