### PR TITLE
[WIP] Allow nested message loop activations.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -182,6 +182,7 @@ executable("fml_unittests") {
     "synchronization/thread_annotations_unittest.cc",
     "synchronization/thread_checker_unittest.cc",
     "synchronization/waitable_event_unittest.cc",
+    "task_runner_unittests.cc",
     "thread_local_unittests.cc",
     "thread_unittests.cc",
     "time/time_delta_unittest.cc",

--- a/fml/message_loop.cc
+++ b/fml/message_loop.cc
@@ -15,15 +15,15 @@
 namespace fml {
 
 FML_THREAD_LOCAL ThreadLocal tls_message_loop([](intptr_t value) {
-  delete reinterpret_cast<MessageLoop*>(value);
+  delete reinterpret_cast<RefPtr<MessageLoop>*>(value);
 });
 
 MessageLoop& MessageLoop::GetCurrent() {
-  auto loop = reinterpret_cast<MessageLoop*>(tls_message_loop.Get());
+  auto loop = reinterpret_cast<RefPtr<MessageLoop>*>(tls_message_loop.Get());
   FML_CHECK(loop != nullptr)
       << "MessageLoop::EnsureInitializedForCurrentThread was not called on "
          "this thread prior to message loop use.";
-  return *loop;
+  return *loop->get();
 }
 
 void MessageLoop::EnsureInitializedForCurrentThread() {
@@ -31,48 +31,80 @@ void MessageLoop::EnsureInitializedForCurrentThread() {
     // Already initialized.
     return;
   }
-  tls_message_loop.Set(reinterpret_cast<intptr_t>(new MessageLoop()));
+  auto message_loop_ptr = new RefPtr<MessageLoop>(nullptr);
+  *message_loop_ptr = MakeRefCounted<MessageLoop>();
+  tls_message_loop.Set(reinterpret_cast<intptr_t>(message_loop_ptr));
 }
 
 bool MessageLoop::IsInitializedForCurrentThread() {
   return tls_message_loop.Get() != 0;
 }
 
-MessageLoop::MessageLoop()
-    : loop_(MessageLoopImpl::Create()),
-      task_runner_(fml::MakeRefCounted<fml::TaskRunner>(loop_)) {
-  FML_CHECK(loop_);
-  FML_CHECK(task_runner_);
+MessageLoop::MessageLoop() {
+  PushMessageLoop();
 }
 
 MessageLoop::~MessageLoop() = default;
 
-void MessageLoop::Run() {
-  loop_->DoRun();
+void MessageLoop::Run(fml::closure on_done) {
+  FML_DCHECK(impls_.size() != 0);
+  if (impls_.top()->DidRun()) {
+    PushMessageLoop();
+  }
+  auto impl_to_run = impls_.top();
+  if (on_done) {
+    impl_to_run->PostTask(on_done, TimePoint::Now());
+  }
+  impl_to_run->DoRun();
+}
+
+size_t MessageLoop::GetActivationCount() const {
+  return impls_.size();
 }
 
 void MessageLoop::Terminate() {
-  loop_->DoTerminate();
+  FML_DCHECK(impls_.size() != 0);
+
+  // Pop the message loop on top of the activation stack.
+  auto loop_to_terminate = impls_.top();
+  impls_.pop();
+  loop_to_terminate->DoTerminate();
+
+  // If there is another activation, flush its tasks and rearm timers.
+  // If there are no more loops, push an inactive loop so that tasks may be
+  // posted onto it.
+  if (impls_.size() != 0) {
+    impls_.top()->RunExpiredTasksNow();
+  } else {
+    PushMessageLoop();
+  }
 }
 
-fml::RefPtr<fml::TaskRunner> MessageLoop::GetTaskRunner() const {
-  return task_runner_;
+fml::RefPtr<fml::TaskRunner> MessageLoop::GetTaskRunner() {
+  return fml::MakeRefCounted<fml::TaskRunner>(Ref(this));
 }
 
 fml::RefPtr<MessageLoopImpl> MessageLoop::GetLoopImpl() const {
-  return loop_;
+  FML_CHECK(impls_.size() > 0);
+  return impls_.top();
 }
 
 void MessageLoop::AddTaskObserver(intptr_t key, fml::closure callback) {
-  loop_->AddTaskObserver(key, callback);
+  GetLoopImpl()->AddTaskObserver(key, callback);
 }
 
 void MessageLoop::RemoveTaskObserver(intptr_t key) {
-  loop_->RemoveTaskObserver(key);
+  GetLoopImpl()->RemoveTaskObserver(key);
 }
 
 void MessageLoop::RunExpiredTasksNow() {
-  loop_->RunExpiredTasksNow();
+  GetLoopImpl()->RunExpiredTasksNow();
+}
+
+void MessageLoop::PushMessageLoop() {
+  auto loop_impl = MessageLoopImpl::Create();
+  FML_CHECK(loop_impl);
+  impls_.push(std::move(loop_impl));
 }
 
 }  // namespace fml

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -46,6 +46,8 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
   // instead of dedicating a thread to the message loop.
   void RunExpiredTasksNow();
 
+  bool DidRun() const;
+
  protected:
   MessageLoopImpl();
 
@@ -76,6 +78,7 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
   DelayedTaskQueue delayed_tasks_;
   size_t order_;
   std::atomic_bool terminated_;
+  std::atomic_bool did_run_;
 
   void RegisterTask(fml::closure task, fml::TimePoint target_time);
 

--- a/fml/task_runner.cc
+++ b/fml/task_runner.cc
@@ -11,42 +11,67 @@
 #include "flutter/fml/logging.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/message_loop_impl.h"
+#include "flutter/fml/synchronization/waitable_event.h"
 
 namespace fml {
 
-TaskRunner::TaskRunner(fml::RefPtr<MessageLoopImpl> loop)
+TaskRunner::TaskRunner(fml::RefPtr<MessageLoop> loop)
     : loop_(std::move(loop)) {}
 
 TaskRunner::~TaskRunner() = default;
 
 void TaskRunner::PostTask(fml::closure task) {
-  loop_->PostTask(std::move(task), fml::TimePoint::Now());
+  loop_->GetLoopImpl()->PostTask(std::move(task), fml::TimePoint::Now());
 }
 
 void TaskRunner::PostTaskForTime(fml::closure task,
                                  fml::TimePoint target_time) {
-  loop_->PostTask(std::move(task), target_time);
+  loop_->GetLoopImpl()->PostTask(std::move(task), target_time);
 }
 
 void TaskRunner::PostDelayedTask(fml::closure task, fml::TimeDelta delay) {
-  loop_->PostTask(std::move(task), fml::TimePoint::Now() + delay);
+  loop_->GetLoopImpl()->PostTask(std::move(task),
+                                 fml::TimePoint::Now() + delay);
 }
 
 bool TaskRunner::RunsTasksOnCurrentThread() {
   if (!fml::MessageLoop::IsInitializedForCurrentThread()) {
     return false;
   }
-  return MessageLoop::GetCurrent().GetLoopImpl() == loop_;
+  return &MessageLoop::GetCurrent() == loop_.get();
 }
 
-void TaskRunner::RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
-                                  fml::closure task) {
-  FML_DCHECK(runner);
-  if (runner->RunsTasksOnCurrentThread()) {
+void TaskRunner::RunNowOrPostTask(fml::closure task) {
+  FML_DCHECK(task);
+
+  if (RunsTasksOnCurrentThread()) {
     task();
-  } else {
-    runner->PostTask(std::move(task));
+    return;
   }
+
+  AutoResetWaitableEvent latch;
+
+  // Legacy path for platforms on which we do not have access to the message
+  // loop implementation (Fuchsia and Desktop Linux).
+  if (!loop_) {
+    PostTask([task, &latch]() {
+      task();
+      latch.Signal();
+    });
+    latch.Wait();
+    return;
+  }
+
+  auto task_in_loop_activation = [loop = loop_, task, &latch]() {
+    loop->Run([loop, task, &latch]() {
+      task();
+      loop->Terminate();
+      latch.Signal();
+    });
+  };
+
+  PostTask(task_in_loop_activation);
+  latch.Wait();
 }
 
 }  // namespace fml

--- a/fml/task_runner.h
+++ b/fml/task_runner.h
@@ -13,7 +13,7 @@
 
 namespace fml {
 
-class MessageLoopImpl;
+class MessageLoop;
 
 class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner> {
  public:
@@ -27,14 +27,13 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner> {
 
   virtual ~TaskRunner();
 
-  static void RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
-                               fml::closure task);
+  void RunNowOrPostTask(fml::closure task);
 
  protected:
-  TaskRunner(fml::RefPtr<MessageLoopImpl> loop);
+  TaskRunner(fml::RefPtr<MessageLoop> loop);
 
  private:
-  fml::RefPtr<MessageLoopImpl> loop_;
+  fml::RefPtr<MessageLoop> loop_;
 
   FML_FRIEND_MAKE_REF_COUNTED(TaskRunner);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(TaskRunner);

--- a/fml/task_runner_unittests.cc
+++ b/fml/task_runner_unittests.cc
@@ -1,0 +1,74 @@
+// Copyright 2018 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#define FML_USED_ON_EMBEDDER
+
+#include <thread>
+
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/synchronization/count_down_latch.h"
+#include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/fml/thread.h"
+#include "flutter/fml/thread_local.h"
+#include "flutter/testing/testing.h"
+
+namespace fml {
+
+TEST(TaskRunnerTest, RunNowOrPostTaskOnDifferentThread) {
+  FML_THREAD_LOCAL ThreadLocal count;
+  Thread thread;
+
+  thread.GetTaskRunner()->PostTask([]() { count.Set(999); });
+
+  ASSERT_NE(count.Get(), 999);
+
+  bool did_assert = false;
+
+  AutoResetWaitableEvent latch;
+  thread.GetTaskRunner()->RunNowOrPostTask([&did_assert, &latch]() {
+    // Make sure the utility method created its own activation.
+    ASSERT_EQ(MessageLoop::GetCurrent().GetActivationCount(), 2u);
+    ASSERT_EQ(count.Get(), 999);
+    did_assert = true;
+    latch.Signal();
+  });
+
+  latch.Wait();
+  ASSERT_TRUE(did_assert);
+}
+
+TEST(TaskRunnerTest, RunNowOrPostTaskOnSameThread) {
+  FML_THREAD_LOCAL ThreadLocal count;
+  Thread thread;
+
+  thread.GetTaskRunner()->PostTask([]() { count.Set(999); });
+
+  ASSERT_NE(count.Get(), 999);
+
+  size_t assertions_checked = 0;
+
+  AutoResetWaitableEvent latch;
+  thread.GetTaskRunner()->PostTask([&assertions_checked, &latch]() {
+    // No new activation is pused because it is not a RunNow variant.
+    ASSERT_EQ(MessageLoop::GetCurrent().GetActivationCount(), 1u);
+    ASSERT_EQ(count.Get(), 999);
+    assertions_checked++;
+    latch.Signal();
+
+    MessageLoop::GetCurrent().GetTaskRunner()->RunNowOrPostTask(
+        [&assertions_checked]() {
+          // No new activation is pushed because we are already on the right
+          // thread.
+          ASSERT_EQ(MessageLoop::GetCurrent().GetActivationCount(), 1u);
+          ASSERT_EQ(count.Get(), 999);
+          assertions_checked++;
+        });
+  });
+
+  latch.Wait();
+  ASSERT_EQ(assertions_checked, 2u);
+}
+
+}  // namespace fml

--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -140,8 +140,7 @@ static bool HandleMessageOnHandler(
   FML_DCHECK(handler);
   fml::AutoResetWaitableEvent latch;
   bool result = false;
-  fml::TaskRunner::RunNowOrPostTask(
-      handler->GetServiceProtocolHandlerTaskRunner(method),
+  handler->GetServiceProtocolHandlerTaskRunner(method)->RunNowOrPostTask(
       [&latch,    //
        &result,   //
        &handler,  //
@@ -242,17 +241,15 @@ bool ServiceProtocol::HandleListViewsMethod(
   for (const auto& handler : handlers_) {
     fml::AutoResetWaitableEvent latch;
     Handler::Description description;
-
-    fml::TaskRunner::RunNowOrPostTask(
-        handler->GetServiceProtocolHandlerTaskRunner(
-            kListViewsExtensionName),  // task runner
-        [&latch,                       //
-         &description,                 //
-         &handler                      //
+    handler->GetServiceProtocolHandlerTaskRunner(kListViewsExtensionName)
+        ->RunNowOrPostTask([&latch,        //
+                            &description,  //
+                            &handler       //
     ]() {
           description = handler->GetServiceProtocolDescription();
           latch.Signal();
         });
+
     latch.Wait();
     descriptions.emplace_back(std::make_pair<intptr_t, Handler::Description>(
         reinterpret_cast<intptr_t>(handler), std::move(description)));

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -61,8 +61,9 @@ static bool ValidateShell(Shell* shell) {
 
   {
     fml::AutoResetWaitableEvent latch;
-    fml::TaskRunner::RunNowOrPostTask(
-        shell->GetTaskRunners().GetPlatformTaskRunner(), [shell, &latch]() {
+
+    shell->GetTaskRunners().GetPlatformTaskRunner()->RunNowOrPostTask(
+        [shell, &latch]() {
           shell->GetPlatformView()->NotifyCreated();
           latch.Signal();
         });
@@ -71,8 +72,8 @@ static bool ValidateShell(Shell* shell) {
 
   {
     fml::AutoResetWaitableEvent latch;
-    fml::TaskRunner::RunNowOrPostTask(
-        shell->GetTaskRunners().GetPlatformTaskRunner(), [shell, &latch]() {
+    shell->GetTaskRunners().GetPlatformTaskRunner()->RunNowOrPostTask(
+        [shell, &latch]() {
           shell->GetPlatformView()->NotifyDestroyed();
           latch.Signal();
         });


### PR DESCRIPTION
Message loops can now be run multiple times on the same thread. Each run of the
message loop pushes a new activation on the thread local activation stack.
All tasks posted to the previous loop activation are suspended and the tasks posted
in the new activation serviced till that activation is terminated. The message loop can
never have zero activations on its activation stack. Terminating the last
activation pushes an activation that is not running. This allows callers to
freely post tasks onto the message loop and only have them serviced when the
loop is run next.

This allows the RunNowOrPostTaskAPI (now an instance method on the task runner)
to be reimplemented in a manner such that the tasks posted in a synchronous
fashion can post tasks back onto the sync locked task runner (because they end
up on a new activation).

flutter/flutter#23974
flutter/flutter#23975