### PR TITLE
Disables all GPU work on applicationWillResignActive according the Ap…

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -419,12 +419,12 @@
 
 - (void)applicationWillResignActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillResignActive");
+  [self surfaceUpdated:NO];
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
 }
 
 - (void)applicationDidEnterBackground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationDidEnterBackground");
-  [self surfaceUpdated:NO];
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
 }
 


### PR DESCRIPTION
As @cbracken mentions:
Related flutter/engine#4002, which disables all GPU work on applicationDidEnterBackground but doesn't apply the Apple's guidance on applicationWillResignActive/applicationBecameActive.
