### PR TITLE
fix setInitialRoute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tags
 Thumbs.db
 .idea
 pubspec.lock
+.vscode/

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -78,7 +78,7 @@ FLUTTER_EXPORT
  *   tree-shaken by the Dart compiler.
  * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
-- (bool)runWithEntrypoint:(NSString*)entrypoint;
+- (BOOL)runWithEntrypoint:(NSString*)entrypoint;
 
 /**
  * Runs a Dart program on an Isolate using the specified entrypoint and Dart library,
@@ -95,7 +95,7 @@ FLUTTER_EXPORT
  *   this will default to the same library as the `main()` function in the Dart program.
  * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
-- (bool)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)uri;
+- (BOOL)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)uri;
 
 /**
  * Sets the `FlutterViewController` for this instance.  The FlutterEngine must be

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -264,7 +264,7 @@
       }));
 }
 
-- (bool)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
+- (bool)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
   if (_shell != nullptr) {
     FML_LOG(WARNING) << "This FlutterEngine was already invoked.";
     return false;
@@ -351,6 +351,13 @@
                    << entrypoint.UTF8String;
   } else {
     [self maybeSetupPlatformViewChannels];
+  }
+
+  return _shell != nullptr;
+}
+
+- (bool)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
+  if ([self createShell:entrypoint libraryURI:libraryURI]) {
     [self launchEngine:entrypoint libraryURI:libraryURI];
   }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -264,10 +264,10 @@
       }));
 }
 
-- (bool)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
+- (BOOL)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
   if (_shell != nullptr) {
     FML_LOG(WARNING) << "This FlutterEngine was already invoked.";
-    return false;
+    return NO;
   }
 
   static size_t shellCount = 1;
@@ -356,7 +356,7 @@
   return _shell != nullptr;
 }
 
-- (bool)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
+- (BOOL)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)libraryURI {
   if ([self createShell:entrypoint libraryURI:libraryURI]) {
     [self launchEngine:entrypoint libraryURI:libraryURI];
   }
@@ -364,7 +364,7 @@
   return _shell != nullptr;
 }
 
-- (bool)runWithEntrypoint:(NSString*)entrypoint {
+- (BOOL)runWithEntrypoint:(NSString*)entrypoint {
   return [self runWithEntrypoint:entrypoint libraryURI:nil];
 }
 
@@ -379,7 +379,7 @@
   NSString* actionString;
   switch (action) {
     case FlutterTextInputActionUnspecified:
-      // Where did the term "unspecified" come from? iOS has a "default" and Android
+      // Where did the term "unspecified" come from? iOS has a "defasult" and Android
       // has "unspecified." These 2 terms seem to mean the same thing but we need
       // to pick just one. "unspecified" was chosen because "default" is often a
       // reserved word in languages with switch statements (dart, java, etc).

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -379,7 +379,7 @@
   NSString* actionString;
   switch (action) {
     case FlutterTextInputActionUnspecified:
-      // Where did the term "unspecified" come from? iOS has a "defasult" and Android
+      // Where did the term "unspecified" come from? iOS has a "default" and Android
       // has "unspecified." These 2 terms seem to mean the same thing but we need
       // to pick just one. "unspecified" was chosen because "default" is often a
       // reserved word in languages with switch statements (dart, java, etc).

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -44,7 +44,6 @@
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 - (BOOL)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 
-
 @end
 
 #endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_FRAMEWORK_SOURCE_FLUTTERENGINE_INTERNAL_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -42,6 +42,8 @@
 - (shell::FlutterPlatformViewsController*)platformViewsController;
 - (FlutterTextInputPlugin*)textInputPlugin;
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
+- (bool)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
+
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -42,7 +42,7 @@
 - (shell::FlutterPlatformViewsController*)platformViewsController;
 - (FlutterTextInputPlugin*)textInputPlugin;
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
-- (bool)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
+- (BOOL)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -37,6 +37,7 @@
   blink::ViewportMetrics _viewportMetrics;
   BOOL _initialized;
   BOOL _viewOpaque;
+  BOOL _engineNeedsLaunch;
 }
 
 #pragma mark - Manage and override all designated initializers
@@ -49,6 +50,7 @@
   if (self) {
     _viewOpaque = YES;
     _engine.reset([engine retain]);
+    _engineNeedsLaunch = false;
     _flutterView.reset([[FlutterView alloc] initWithDelegate:_engine opaque:self.isViewOpaque]);
     _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
 
@@ -68,8 +70,8 @@
     _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
     _engine.reset([[FlutterEngine alloc] initWithName:@"io.flutter" project:projectOrNil]);
     _flutterView.reset([[FlutterView alloc] initWithDelegate:_engine opaque:self.isViewOpaque]);
-    [_engine.get() runWithEntrypoint:nil];
-    [_engine.get() setViewController:self];
+    [_engine.get() createShell:nil libraryURI:nil];
+    _engineNeedsLaunch = true;
 
     [self performCommonViewControllerInitialization];
   }
@@ -370,6 +372,12 @@
 
 - (void)viewWillAppear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewWillAppear");
+
+  if (_engineNeedsLaunch) {
+    [_engine.get() launchEngine:nil libraryURI:nil];
+    [_engine.get() setViewController:self];
+    _engineNeedsLaunch = false;
+  }
 
   // Only recreate surface on subsequent appearances when viewport metrics are known.
   // First time surface creation is done on viewDidLayoutSubviews.

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -50,7 +50,7 @@
   if (self) {
     _viewOpaque = YES;
     _engine.reset([engine retain]);
-    _engineNeedsLaunch = false;
+    _engineNeedsLaunch = NO;
     _flutterView.reset([[FlutterView alloc] initWithDelegate:_engine opaque:self.isViewOpaque]);
     _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
 
@@ -71,7 +71,7 @@
     _engine.reset([[FlutterEngine alloc] initWithName:@"io.flutter" project:projectOrNil]);
     _flutterView.reset([[FlutterView alloc] initWithDelegate:_engine opaque:self.isViewOpaque]);
     [_engine.get() createShell:nil libraryURI:nil];
-    _engineNeedsLaunch = true;
+    _engineNeedsLaunch = YES;
 
     [self performCommonViewControllerInitialization];
   }
@@ -376,7 +376,7 @@
   if (_engineNeedsLaunch) {
     [_engine.get() launchEngine:nil libraryURI:nil];
     [_engine.get() setViewController:self];
-    _engineNeedsLaunch = false;
+    _engineNeedsLaunch = NO;
   }
 
   // Only recreate surface on subsequent appearances when viewport metrics are known.


### PR DESCRIPTION
`setInitialRoute` was broken by the iOS embedding refactor for cases where you directly createa  `FlutterViewController`.

fixes flutter/flutter#23736