### PR TITLE
When [self surfaceUpdated:YES] was called second time FlutterView was…

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -18,7 +18,7 @@
 namespace shell {
 
 void FlutterPlatformViewsController::SetFlutterView(UIView* flutter_view) {
-  flutter_view_.reset(flutter_view);
+  flutter_view_.reset([flutter_view retain]);
 }
 
 void FlutterPlatformViewsController::OnMethodCall(FlutterMethodCall* call, FlutterResult& result) {


### PR DESCRIPTION
When [self surfaceUpdated:YES] was called second time FlutterView was released; it cause crash
Using fml::scoped_nsobject:reset must retain object first