### PR TITLE
Make the FlutterPlatformViewFactory create FlutterPlatformViews.

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -164,10 +164,9 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
 
   auto external_view_embedder = surface_->GetExternalViewEmbedder();
 
-  // TODO(amirh): uncomment this once external_view_embedder is populated.
-  // if (external_view_embedder != nullptr) {
-  //   external_view_embedder->SetFrameSize(layer_tree.frame_size());
-  // }
+  if (external_view_embedder != nullptr) {
+    external_view_embedder->SetFrameSize(layer_tree.frame_size());
+  }
 
   auto compositor_frame = compositor_context_->AcquireFrame(
       surface_->GetContext(), canvas, external_view_embedder,

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlatformViews.h
@@ -12,6 +12,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Wraps a `UIView` for embedding in the Flutter hierarchy
+ */
+@protocol FlutterPlatformView <NSObject>
+/**
+ * Returns a reference to the `UIView` that is wrapped by this `FlutterPlatformView`.
+ */
+- (UIView*)view;
+@end
+
 FLUTTER_EXPORT
 @protocol FlutterPlatformViewFactory <NSObject>
 /**
@@ -28,9 +38,9 @@ FLUTTER_EXPORT
  *   code, this will be null. Otherwise this will be the value sent from the Dart code as decoded by
  *   `createArgsCodec`.
  */
-- (UIView*)createWithFrame:(CGRect)frame
-            viewIdentifier:(int64_t)viewId
-                 arguments:(id _Nullable)args;
+- (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
+                                   viewIdentifier:(int64_t)viewId
+                                        arguments:(id _Nullable)args;
 
 /**
  * Returns the `FlutterMessageCodec` for decoding the args parameter of `createWithFrame`.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -70,7 +70,8 @@ class FlutterPlatformViewsController {
   fml::scoped_nsobject<FlutterMethodChannel> channel_;
   fml::scoped_nsobject<UIView> flutter_view_;
   std::map<std::string, fml::scoped_nsobject<NSObject<FlutterPlatformViewFactory>>> factories_;
-  std::map<int64_t, fml::scoped_nsobject<FlutterTouchInterceptingView>> views_;
+  std::map<int64_t, fml::scoped_nsobject<NSObject<FlutterPlatformView>>> views_;
+  std::map<int64_t, fml::scoped_nsobject<FlutterTouchInterceptingView>> touch_interceptors_;
   std::map<int64_t, std::unique_ptr<FlutterPlatformViewLayer>> overlays_;
   SkISize frame_size_;
 


### PR DESCRIPTION
Handing a UIView reference directly to the engine makes it challenging
for plugin authors to retain a controller for that UIView (e.g the
controller that talks over the platform channel) for as long as the
embedded view is needed.

We instead make the factory return a FlutterPlatformView which is a
wrapper around the UIView that the engine retains as long as the
platform view instance is needed. This allows plugin authors to keep
their control logic in the FlutterPlatformView and know that the engine
is responsible for retaining the reference.