### PR TITLE
Skia Cleanup

### DIFF
--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -66,7 +66,6 @@ source_set("flow") {
     "$flutter_root/fml",
     "$flutter_root/synchronization",
     "//third_party/skia",
-    "//third_party/skia:gpu",
   ]
 
   if (is_fuchsia) {

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -108,8 +108,6 @@ source_set("ui") {
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/rapidjson",
     "//third_party/skia",
-    "//third_party/skia:effects",
-    "//third_party/skia:gpu",
     "//third_party/tonic",
   ]
   if (is_fuchsia) {

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -400,7 +400,7 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage(
     SkCodec::Options options;
     options.fFrameIndex = nextFrameIndex_;
     const int requiredFrame = frameInfos_[nextFrameIndex_].fRequiredFrame;
-    if (requiredFrame != SkCodec::kNone) {
+    if (requiredFrame != SkCodec::kNoFrame) {
       const SkBitmap* requiredBitmap =
           frameBitmaps_[requiredFrame]->bitmap_.get();
       if (requiredBitmap == nullptr) {

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -102,7 +102,6 @@ source_set("common") {
     "$flutter_root/synchronization",
     "//third_party/dart/runtime:dart_api",
     "//third_party/skia",
-    "//third_party/skia:gpu",
   ]
 
   public_deps = [

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -30,7 +30,7 @@ source_set("gpu_surface_gl") {
     "$gpu_dir/gpu_surface_gl.h",
   ]
 
-  deps = gpu_common_deps + [ "//third_party/skia:gpu" ]
+  deps = gpu_common_deps + [ "//third_party/skia" ]
 }
 
 source_set("gpu_surface_vulkan") {
@@ -40,7 +40,7 @@ source_set("gpu_surface_vulkan") {
   ]
 
   deps = gpu_common_deps + [
-           "//third_party/skia:gpu",
+           "//third_party/skia",
            "$flutter_root/vulkan",
          ]
 }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -61,7 +61,6 @@ shared_library("flutter_shell_native") {
     "$flutter_root/runtime",
     "$flutter_root/shell/common",
     "//third_party/skia",
-    "//third_party/skia:gpu",
   ]
   if (flutter_runtime_mode == "debug" ||
       flutter_runtime_mode == "dynamic_profile" ||

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -109,7 +109,6 @@ shared_library("create_flutter_framework_dylib") {
     "$flutter_root/shell/common",
     "$flutter_root/shell/platform/darwin/common",
     "//third_party/skia",
-    "//third_party/skia:gpu",
   ]
   if (flutter_runtime_mode == "debug" ||
       flutter_runtime_mode == "dynamic_profile" ||

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -39,7 +39,6 @@ source_set("embedder") {
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/skia",
-    "//third_party/skia:gpu",
     "//third_party/tonic",
   ]
 

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -113,7 +113,7 @@ source_set("txt") {
   ]
 
   deps = [
-    "//third_party/skia:effects",
+    "//third_party/skia",
   ]
 
   if (is_mac || is_ios) {

--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -60,12 +60,10 @@ source_set("vulkan") {
   deps = [
     "$flutter_root/fml",
     "//third_party/skia",
-    "//third_party/skia:gpu",
   ]
 
   public_configs = [
     ":vulkan_config",
     "$flutter_root:config",
-    "//third_party/skia:skia_private",
   ]
 }


### PR DESCRIPTION
- Do not depend on private targets of Skia (This depends on https://github.com/flutter/engine/pull/6785).
- Do not use the deprecated enum.