### PR TITLE
avoid overreleasing FlutterView

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -18,7 +18,7 @@
 namespace shell {
 
 void FlutterPlatformViewsController::SetFlutterView(UIView* flutter_view) {
-  flutter_view_.reset(flutter_view);
+  flutter_view_.reset([flutter_view retain]);
 }
 
 void FlutterPlatformViewsController::OnMethodCall(FlutterMethodCall* call, FlutterResult& result) {


### PR DESCRIPTION
FlutterPlatformViewsController ends up releasing a FlutterView it's not the owner of, which then gets over-released later.  In an Add2App scenario, this leads to zombies/crashes/EXC_BAD_ACCESS.

/cc @jamesderlin - this may be contributing to the test failures we've been looking at, although I'm only seeing this reproduce on a physical device (not on a simulator).