### PR TITLE
Fix a minikin crash (nullptr& EXC_BAD_ACCESS) on iOS8.

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -133,10 +133,9 @@ FontCollection::GetMinikinFontCollectionForFamily(
     };
     if (enable_font_fallback_) {
       for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
-        std::shared_ptr<minikin::FontFamily> fallback_font_ =
-            fallback_fonts_[fallback_family];
-        if (fallback_font_.get() != nullptr) {
-          minikin_families.push_back(fallback_font_);
+        auto it = fallback_fonts_.find(fallback_family);
+        if (it != fallback_fonts_.end()) {
+          minikin_families.push_back(it->second);
         }
       }
     }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -132,8 +132,13 @@ FontCollection::GetMinikinFontCollectionForFamily(
         minikin_family,
     };
     if (enable_font_fallback_) {
-      for (std::string fallback_family : fallback_fonts_for_locale_[locale])
-        minikin_families.push_back(fallback_fonts_[fallback_family]);
+      for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
+        std::shared_ptr<minikin::FontFamily> fallback_font_ =
+            fallback_fonts_[fallback_family];
+        if (fallback_font_.get() != nullptr) {
+          minikin_families.push_back(fallback_font_);
+        }
+      }
     }
 
     // Create the minikin font collection.


### PR DESCRIPTION
## Reproduce procedure
Using 'flutter doctor -v' as below:
```
[✓] Flutter (Channel unknown, v0.8.2, on Mac OS X 10.14.2 18C31g, locale en-CN)
    • Flutter version 0.8.2 at /Users/kylewong/Codes/Flutter/beta/flutter
    • Framework revision 5ab9e70727 (9 weeks ago), 2018-09-07 12:33:05 -0700
    • Engine revision 58a1894a1c
    • Dart version 2.1.0-dev.3.1.flutter-760a9690c2

[✓] Android toolchain - develop for Android devices (Android SDK 28.0.3)
    • Android SDK at /Users/kylewong/Library/Android/sdk
    • Android NDK at /Users/kylewong/Library/Android/sdk/ndk-bundle
    • Platform android-28, build-tools 28.0.3
    • Java binary at: /Applications/Android Studio.app/Contents/jre/jdk/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1136-b06)
    • All Android licenses accepted.

[!] iOS toolchain - develop for iOS devices (Xcode 10.0)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Xcode 10.0, Build version 10A254a
    • ios-deploy 1.9.2
    ! CocoaPods out of date (1.5.0 is recommended).
        CocoaPods is used to retrieve the iOS platform side's plugin code that responds to your plugin usage on the Dart side.
        Without resolving iOS dependencies with CocoaPods, plugins will not work on iOS.
        For more info, see https://flutter.io/platform-plugins
      To upgrade:
        brew upgrade cocoapods
        pod setup

[✓] Android Studio (version 3.2)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin version 30.0.1
    • Dart plugin version 181.5656
    • Java version OpenJDK Runtime Environment (build 1.8.0_152-release-1136-b06)

[✓] Connected devices (1 available)
    • iPhone • 70d6*****a7b4b806a7bc • ios • iOS 8.4

! Doctor found issues in 1 category.
```
And using the patch to flutter framework as below:
```
From 0d4e163bab5a355e0b75e9deecd0fd8410f94edd Mon Sep 17 00:00:00 2001
From: KyleWong <kang.wang1988@gmail.com>
Date: Thu, 8 Nov 2018 20:33:45 +0800
Subject: [PATCH] =?UTF-8?q?IntroText=20change=20to=20famous=20Song=20poems?=
 =?UTF-8?q?=20"=E3=80=8A=E5=BF=B5=E5=A5=B4=E5=A8=87=E2=80=A2=E8=B5=A4?=
 =?UTF-8?q?=E5=A3=81=E6=80=80=E5=8F=A4=E3=80=8B".?=
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit

---
 .../flutter_gallery/lib/demo/material/tooltip_demo.dart     | 6 +++---
 1 file changed, 3 insertions(+), 3 deletions(-)

diff --git a/examples/flutter_gallery/lib/demo/material/tooltip_demo.dart b/examples/flutter_gallery/lib/demo/material/tooltip_demo.dart
index 448ef950c..419eb9f54 100644
--- a/examples/flutter_gallery/lib/demo/material/tooltip_demo.dart
+++ b/examples/flutter_gallery/lib/demo/material/tooltip_demo.dart
@@ -5,9 +5,9 @@
 import 'package:flutter/material.dart';
 
 const String _introText =
-  'Tooltips are short identifying messages that briefly appear in response to '
-  'a long press. Tooltip messages are also used by services that make Flutter '
-  'apps accessible, like screen readers.';
+  '''念奴娇·赤壁怀古
+大江东去，浪淘尽，千古风流人物。故垒西边，人道是：三国周郎赤壁。乱石穿空，惊涛拍岸，卷起千堆雪。江山如画，一时多少豪杰。
+遥想公瑾当年，小乔初嫁了，雄姿英发。羽扇纶巾，谈笑间、樯橹灰飞烟灭。故国神游，多情应笑我，早生华发。人生如梦，一樽还酹江月。''';
 
 class TooltipDemo extends StatelessWidget {
 
-- 
2.17.1 (Apple Git-112)
```
It's easy to reproduce this problem.

## flutter gallery crash on iOS8 because of nullptr
![screen shot 2018-11-08 at 8 20 52 pm](https://user-images.githubusercontent.com/817851/48199211-7148dc00-e396-11e8-90b3-3b0e0931e207.png)

## As the fallback_font_ could be null, I think it's better to add the null check for related logic:
![screen shot 2018-11-08 at 8 07 28 pm](https://user-images.githubusercontent.com/817851/48199576-6e022000-e397-11e8-9486-91fa75f3fed2.png)
