### PR TITLE
Don't instantiate FlutterPlatformViewsController if the flag is off.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -77,7 +77,11 @@
 
   _pluginPublications = [NSMutableDictionary new];
   _publisher.reset([[FlutterObservatoryPublisher alloc] init]);
-  _platformViewsController.reset(new shell::FlutterPlatformViewsController());
+
+  if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@(shell::kEmbeddedViewsPreview)]
+          boolValue]) {
+    _platformViewsController.reset(new shell::FlutterPlatformViewsController());
+  }
 
   [self setupChannels];
 
@@ -192,11 +196,13 @@
       binaryMessenger:self
                 codec:[FlutterJSONMethodCodec sharedInstance]]);
 
-  _platformViewsChannel.reset([[FlutterMethodChannel alloc]
-         initWithName:@"flutter/platform_views"
-      binaryMessenger:self
-                codec:[FlutterStandardMethodCodec sharedInstance]]);
-
+  if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@(shell::kEmbeddedViewsPreview)]
+          boolValue]) {
+    _platformViewsChannel.reset([[FlutterMethodChannel alloc]
+           initWithName:@"flutter/platform_views"
+        binaryMessenger:self
+                  codec:[FlutterStandardMethodCodec sharedInstance]]);
+  }
   _textInputChannel.reset([[FlutterMethodChannel alloc]
          initWithName:@"flutter/textinput"
       binaryMessenger:self
@@ -231,10 +237,13 @@
       [_platformPlugin.get() handleMethodCall:call result:result];
     }];
 
-    [_platformViewsChannel.get()
-        setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
-          _platformViewsController->OnMethodCall(call, result);
-        }];
+    if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@(shell::kEmbeddedViewsPreview)]
+            boolValue]) {
+      [_platformViewsChannel.get()
+          setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
+            _platformViewsController->OnMethodCall(call, result);
+          }];
+    }
 
     [_textInputChannel.get() setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
       [_textInputPlugin.get() handleMethodCall:call result:result];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -359,7 +359,10 @@
   // NotifyCreated/NotifyDestroyed are synchronous and require hops between the UI and GPU thread.
   if (appeared) {
     [self installSplashScreenViewCallback];
-    [_engine.get() platformViewsController] -> SetFlutterView(_flutterView.get());
+    if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@(shell::kEmbeddedViewsPreview)]
+            boolValue]) {
+      [_engine.get() platformViewsController] -> SetFlutterView(_flutterView.get());
+    }
     [_engine.get() platformView] -> NotifyCreated();
   } else {
     [_engine.get() platformView] -> NotifyDestroyed();

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -123,7 +123,10 @@ void PlatformViewIOS::OnPreEngineRestart() const {
   if (!owner_controller_) {
     return;
   }
-  [owner_controller_.get() platformViewsController] -> Reset();
+  if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@(shell::kEmbeddedViewsPreview)]
+          boolValue]) {
+    [owner_controller_.get() platformViewsController] -> Reset();
+  }
 }
 
 fml::scoped_nsprotocol<FlutterTextInputPlugin*> PlatformViewIOS::GetTextInputPlugin() const {


### PR DESCRIPTION
This should make it less likely for bugs in the platform views embedding
preview to affect the engine when the flag is off.