### PR TITLE
Fix wrong `flutter/platform_views` protocol implementation on iOS.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -88,8 +88,8 @@ void FlutterPlatformViewsController::OnCreate(FlutterMethodCall* call, FlutterRe
 }
 
 void FlutterPlatformViewsController::OnDispose(FlutterMethodCall* call, FlutterResult& result) {
-  NSDictionary<NSString*, id>* args = [call arguments];
-  int64_t viewId = [args[@"id"] longLongValue];
+  NSNumber* arg = [call arguments];
+  int64_t viewId = [arg longLongValue];
 
   if (views_.count(viewId) == 0) {
     result([FlutterError errorWithCode:@"unknown_view"


### PR DESCRIPTION
The `id` parameter of onDispose is passed as the method argument and not as
part of a map.