### PR TITLE
Use the internal_nodes_canvas for all leaf node operations.

### DIFF
--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -50,14 +50,15 @@ void ClipPathLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipPathLayer::Paint");
   FML_DCHECK(needs_painting());
 
-  SkAutoCanvasRestore save(context.canvas, true);
-  context.canvas->clipPath(clip_path_, clip_behavior_ != Clip::hardEdge);
+  SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
+  context.internal_nodes_canvas->clipPath(clip_path_,
+                                          clip_behavior_ != Clip::hardEdge);
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
-    context.canvas->saveLayer(paint_bounds(), nullptr);
+    context.internal_nodes_canvas->saveLayer(paint_bounds(), nullptr);
   }
   PaintChildren(context);
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
-    context.canvas->restore();
+    context.internal_nodes_canvas->restore();
   }
 }
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -41,14 +41,15 @@ void ClipRectLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipRectLayer::Paint");
   FML_DCHECK(needs_painting());
 
-  SkAutoCanvasRestore save(context.canvas, true);
-  context.canvas->clipRect(paint_bounds(), clip_behavior_ != Clip::hardEdge);
+  SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
+  context.internal_nodes_canvas->clipRect(paint_bounds(),
+                                          clip_behavior_ != Clip::hardEdge);
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
-    context.canvas->saveLayer(paint_bounds(), nullptr);
+    context.internal_nodes_canvas->saveLayer(paint_bounds(), nullptr);
   }
   PaintChildren(context);
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
-    context.canvas->restore();
+    context.internal_nodes_canvas->restore();
   }
 }
 

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -48,14 +48,15 @@ void ClipRRectLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ClipRRectLayer::Paint");
   FML_DCHECK(needs_painting());
 
-  SkAutoCanvasRestore save(context.canvas, true);
-  context.canvas->clipRRect(clip_rrect_, clip_behavior_ != Clip::hardEdge);
+  SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
+  context.internal_nodes_canvas->clipRRect(clip_rrect_,
+                                           clip_behavior_ != Clip::hardEdge);
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
-    context.canvas->saveLayer(paint_bounds(), nullptr);
+    context.internal_nodes_canvas->saveLayer(paint_bounds(), nullptr);
   }
   PaintChildren(context);
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
-    context.canvas->restore();
+    context.internal_nodes_canvas->restore();
   }
 }
 

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -26,13 +26,13 @@ Layer::AutoSaveLayer::AutoSaveLayer(const PaintContext& paint_context,
                                     const SkRect& bounds,
                                     const SkPaint* paint)
     : paint_context_(paint_context), bounds_(bounds) {
-  paint_context_.canvas->saveLayer(bounds_, paint);
+  paint_context_.internal_nodes_canvas->saveLayer(bounds_, paint);
 }
 
 Layer::AutoSaveLayer::AutoSaveLayer(const PaintContext& paint_context,
                                     const SkCanvas::SaveLayerRec& layer_rec)
     : paint_context_(paint_context), bounds_(*layer_rec.fBounds) {
-  paint_context_.canvas->saveLayer(layer_rec);
+  paint_context_.internal_nodes_canvas->saveLayer(layer_rec);
 }
 
 Layer::AutoSaveLayer Layer::AutoSaveLayer::Create(
@@ -50,9 +50,9 @@ Layer::AutoSaveLayer Layer::AutoSaveLayer::Create(
 
 Layer::AutoSaveLayer::~AutoSaveLayer() {
   if (paint_context_.checkerboard_offscreen_layers) {
-    DrawCheckerboard(paint_context_.canvas, bounds_);
+    DrawCheckerboard(paint_context_.internal_nodes_canvas, bounds_);
   }
-  paint_context_.canvas->restore();
+  paint_context_.internal_nodes_canvas->restore();
 }
 
 }  // namespace flow

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -77,11 +77,7 @@ class Layer {
     // The leaf_nodes_canvas is the "current" canvas and is used by leaf
     // layers.
     SkCanvas* internal_nodes_canvas;
-    // I'm temporarily leaving the name of this field to be canvas to reduce
-    // noise in the incremental change. A followup change will rename this
-    // and use the corrrect canvas in each callsite.
-    // TODO(amirh) rename canvas to leaf_nodes_canvas.
-    SkCanvas* canvas;
+    SkCanvas* leaf_nodes_canvas;
     ExternalViewEmbedder* view_embedder;
     const Stopwatch& frame_time;
     const Stopwatch& engine_time;

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -49,7 +49,7 @@ void OpacityLayer::Paint(PaintContext& context) const {
     RasterCacheResult child_cache =
         context.raster_cache->Get(layers()[0].get(), ctm);
     if (child_cache.is_valid()) {
-      child_cache.draw(*context.internal_nodes_canvas, &paint);
+      child_cache.draw(*context.leaf_nodes_canvas, &paint);
       return;
     }
   }

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -31,12 +31,12 @@ void OpacityLayer::Paint(PaintContext& context) const {
   SkPaint paint;
   paint.setAlpha(alpha_);
 
-  SkAutoCanvasRestore save(context.canvas, true);
-  context.canvas->translate(offset_.fX, offset_.fY);
+  SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
+  context.internal_nodes_canvas->translate(offset_.fX, offset_.fY);
 
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  context.canvas->setMatrix(
-      RasterCache::GetIntegralTransCTM(context.canvas->getTotalMatrix()));
+  context.internal_nodes_canvas->setMatrix(RasterCache::GetIntegralTransCTM(
+      context.leaf_nodes_canvas->getTotalMatrix()));
 #endif
 
   // Embedded platform views are changing the canvas in the middle of the paint
@@ -45,11 +45,11 @@ void OpacityLayer::Paint(PaintContext& context) const {
   // don't use the cache.
   if (context.view_embedder == nullptr && layers().size() == 1 &&
       context.raster_cache) {
-    const SkMatrix& ctm = context.canvas->getTotalMatrix();
+    const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();
     RasterCacheResult child_cache =
         context.raster_cache->Get(layers()[0].get(), ctm);
     if (child_cache.is_valid()) {
-      child_cache.draw(*context.canvas, &paint);
+      child_cache.draw(*context.internal_nodes_canvas, &paint);
       return;
     }
   }

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -73,15 +73,16 @@ void PerformanceOverlayLayer::Paint(PaintContext& context) const {
   SkScalar y = paint_bounds().y() + padding;
   SkScalar width = paint_bounds().width() - (padding * 2);
   SkScalar height = paint_bounds().height() / 2;
-  SkAutoCanvasRestore save(context.canvas, true);
+  SkAutoCanvasRestore save(context.leaf_nodes_canvas, true);
 
-  VisualizeStopWatch(*context.canvas, context.frame_time, x, y, width,
-                     height - padding,
+  VisualizeStopWatch(*context.leaf_nodes_canvas, context.frame_time, x, y,
+                     width, height - padding,
                      options_ & kVisualizeRasterizerStatistics,
                      options_ & kDisplayRasterizerStatistics, "GPU");
 
-  VisualizeStopWatch(*context.canvas, context.engine_time, x, y + height, width,
-                     height - padding, options_ & kVisualizeEngineStatistics,
+  VisualizeStopWatch(*context.leaf_nodes_canvas, context.engine_time, x,
+                     y + height, width, height - padding,
+                     options_ & kVisualizeEngineStatistics,
                      options_ & kDisplayEngineStatistics, "UI");
 }
 

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -83,7 +83,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
   FML_DCHECK(needs_painting());
 
   if (elevation_ != 0) {
-    DrawShadow(context.canvas, path_, shadow_color_, elevation_,
+    DrawShadow(context.leaf_nodes_canvas, path_, shadow_color_, elevation_,
                SkColorGetA(color_) != 0xff, device_pixel_ratio_);
   }
 
@@ -91,20 +91,20 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
   SkPaint paint;
   paint.setColor(color_);
   if (clip_behavior_ != Clip::antiAliasWithSaveLayer) {
-    context.canvas->drawPath(path_, paint);
+    context.leaf_nodes_canvas->drawPath(path_, paint);
   }
 
-  int saveCount = context.canvas->save();
+  int saveCount = context.internal_nodes_canvas->save();
   switch (clip_behavior_) {
     case Clip::hardEdge:
-      context.canvas->clipPath(path_, false);
+      context.internal_nodes_canvas->clipPath(path_, false);
       break;
     case Clip::antiAlias:
-      context.canvas->clipPath(path_, true);
+      context.internal_nodes_canvas->clipPath(path_, true);
       break;
     case Clip::antiAliasWithSaveLayer:
-      context.canvas->clipPath(path_, true);
-      context.canvas->saveLayer(paint_bounds(), nullptr);
+      context.internal_nodes_canvas->clipPath(path_, true);
+      context.internal_nodes_canvas->saveLayer(paint_bounds(), nullptr);
       break;
     case Clip::none:
       break;
@@ -115,12 +115,12 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
     // (https://github.com/flutter/flutter/issues/18057#issue-328003931)
     // using saveLayer, we have to call drawPaint instead of drawPath as
     // anti-aliased drawPath will always have such artifacts.
-    context.canvas->drawPaint(paint);
+    context.leaf_nodes_canvas->drawPaint(paint);
   }
 
   PaintChildren(context);
 
-  context.canvas->restoreToCount(saveCount);
+  context.internal_nodes_canvas->restoreToCount(saveCount);
 }
 
 void PhysicalShapeLayer::DrawShadow(SkCanvas* canvas,

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -34,22 +34,22 @@ void PictureLayer::Paint(PaintContext& context) const {
   FML_DCHECK(picture_.get());
   FML_DCHECK(needs_painting());
 
-  SkAutoCanvasRestore save(context.canvas, true);
-  context.canvas->translate(offset_.x(), offset_.y());
+  SkAutoCanvasRestore save(context.leaf_nodes_canvas, true);
+  context.leaf_nodes_canvas->translate(offset_.x(), offset_.y());
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  context.canvas->setMatrix(
-      RasterCache::GetIntegralTransCTM(context.canvas->getTotalMatrix()));
+  context.leaf_nodes_canvas->setMatrix(RasterCache::GetIntegralTransCTM(
+      context.leaf_nodes_canvas->getTotalMatrix()));
 #endif
 
   if (context.raster_cache) {
-    const SkMatrix& ctm = context.canvas->getTotalMatrix();
+    const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();
     RasterCacheResult result = context.raster_cache->Get(*picture(), ctm);
     if (result.is_valid()) {
-      result.draw(*context.canvas);
+      result.draw(*context.leaf_nodes_canvas);
       return;
     }
   }
-  context.canvas->drawPicture(picture());
+  context.leaf_nodes_canvas->drawPicture(picture());
 }
 
 }  // namespace flow

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -30,13 +30,13 @@ void PlatformViewLayer::Paint(PaintContext& context) const {
     return;
   }
   EmbeddedViewParams params;
-  SkMatrix transform = context.canvas->getTotalMatrix();
+  SkMatrix transform = context.leaf_nodes_canvas->getTotalMatrix();
   params.offsetPixels =
       SkPoint::Make(transform.getTranslateX(), transform.getTranslateY());
   params.sizePoints = size_;
 
   SkCanvas* canvas =
       context.view_embedder->CompositeEmbeddedView(view_id_, params);
-  context.canvas = canvas;
+  context.leaf_nodes_canvas = canvas;
 }
 }  // namespace flow

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -21,8 +21,8 @@ void ShaderMaskLayer::Paint(PaintContext& context) const {
   SkPaint paint;
   paint.setBlendMode(blend_mode_);
   paint.setShader(shader_);
-  context.canvas->translate(mask_rect_.left(), mask_rect_.top());
-  context.canvas->drawRect(
+  context.leaf_nodes_canvas->translate(mask_rect_.left(), mask_rect_.top());
+  context.leaf_nodes_canvas->drawRect(
       SkRect::MakeWH(mask_rect_.width(), mask_rect_.height()), paint);
 }
 

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -23,7 +23,7 @@ void TextureLayer::Paint(PaintContext& context) const {
   if (!texture) {
     return;
   }
-  texture->Paint(*context.canvas, paint_bounds(), freeze_);
+  texture->Paint(*context.leaf_nodes_canvas, paint_bounds(), freeze_);
 }
 
 }  // namespace flow


### PR DESCRIPTION
This is a followup to #6728 which introduced the `internal_nodes_canvas`, this PR changes all the PaintContext's canvas callsites to explicitly use either the `leaf_nodes_canvas` or the `internal_nodes canvas`.

Some more context on why we do this:
When embedding platform views we are painting to multiple canvases, e.g with a single platform view in the tree, there will be one canvas for the content that is below the platform view and one canvas for the content that is above it. 
To achieve this we change the target canvas during the paint traversal.
We need to make sure that any persistent operations that were done on the current canvas by parent nodes will be applied on the next canvas as well. We achieve this by adding all of the canvases to an `SkNWayCanvas` which we call the `internal_nodes_canvas`. All operations by internal nodes (e.g clips, translations, saves) are performed on all canvases (through the `internal_nodes_canvas`).
Drawing operations by leaf nodes are only performed on the "current" canvas (which is the `leaf_nodes_canvas`).

flutter/flutter#19030