### PR TITLE
Synchronize Flutter's rendering with CA.

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -27,7 +27,7 @@ class ExternalViewEmbedder {
  public:
   ExternalViewEmbedder() = default;
 
-  virtual void SetFrameSize(SkISize frame_size) = 0;
+  virtual void BeginFrame(SkISize frame_size) = 0;
 
   virtual void PrerollCompositeEmbeddedView(int view_id) = 0;
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -165,7 +165,7 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
   auto external_view_embedder = surface_->GetExternalViewEmbedder();
 
   if (external_view_embedder != nullptr) {
-    external_view_embedder->SetFrameSize(layer_tree.frame_size());
+    external_view_embedder->BeginFrame(layer_tree.frame_size());
   }
 
   auto compositor_frame = compositor_context_->AcquireFrame(

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -71,6 +71,11 @@
 - (std::unique_ptr<shell::IOSSurfaceGL>)createGLSurfaceWithContext:
     (std::shared_ptr<shell::IOSGLContext>)gl_context {
   fml::scoped_nsobject<CAEAGLLayer> eagl_layer(reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
+  // TODO(amirh): We can lower this to iOS 8.0 once we have a Metal rendering backend.
+  // https://github.com/flutter/flutter/issues/24132
+  if (@available(iOS 9.0, *)) {
+    eagl_layer.get().presentsWithTransaction = YES;
+  }
   return std::make_unique<shell::IOSSurfaceGL>(eagl_layer, std::move(gl_context));
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -79,8 +79,7 @@ id<FlutterViewEngineDelegate> _delegate;
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
-    if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@(shell::kEmbeddedViewsPreview)]
-            boolValue]) {
+    if (shell::IsIosEmbeddedViewsPreviewEnabled()) {
       // TODO(amirh): We can lower this to iOS 8.0 once we have a Metal rendering backend.
       // https://github.com/flutter/flutter/issues/24132
       if (@available(iOS 9.0, *)) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -79,6 +79,16 @@ id<FlutterViewEngineDelegate> _delegate;
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
+    if ([[[NSBundle mainBundle] objectForInfoDictionaryKey:@(shell::kEmbeddedViewsPreview)]
+            boolValue]) {
+      // TODO(amirh): We can lower this to iOS 8.0 once we have a Metal rendering backend.
+      // https://github.com/flutter/flutter/issues/24132
+      if (@available(iOS 9.0, *)) {
+        // TODO(amirh): only do this if there's an embedded view.
+        // https://github.com/flutter/flutter/issues/24133
+        eagl_layer.get().presentsWithTransaction = YES;
+      }
+    }
     return std::make_unique<shell::IOSSurfaceGL>(std::move(eagl_layer),
                                                  [_delegate platformViewsController]);
   } else {

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -51,7 +51,7 @@ class IOSSurfaceGL : public IOSSurface,
   flow::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |flow::ExternalViewEmbedder|
-  void SetFrameSize(SkISize frame_size) override;
+  void BeginFrame(SkISize frame_size) override;
 
   // |flow::ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(int view_id) override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -82,10 +82,11 @@ flow::ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
   }
 }
 
-void IOSSurfaceGL::SetFrameSize(SkISize frame_size) {
+void IOSSurfaceGL::BeginFrame(SkISize frame_size) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);
   platform_views_controller->SetFrameSize(frame_size);
+  [CATransaction begin];
 }
 
 void IOSSurfaceGL::PrerollCompositeEmbeddedView(int view_id) {
@@ -111,7 +112,10 @@ bool IOSSurfaceGL::SubmitFrame(GrContext* context) {
   if (platform_views_controller == nullptr) {
     return true;
   }
-  return platform_views_controller->SubmitFrame(true, std::move(context), context_);
+
+  bool submitted = platform_views_controller->SubmitFrame(true, std::move(context), context_);
+  [CATransaction commit];
+  return submitted;
 }
 
 }  // namespace shell

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -46,7 +46,7 @@ class IOSSurfaceSoftware final : public IOSSurface,
   flow::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |flow::ExternalViewEmbedder|
-  void SetFrameSize(SkISize frame_size) override;
+  void BeginFrame(SkISize frame_size) override;
 
   // |flow::ExternalViewEmbedder|
   void PrerollCompositeEmbeddedView(int view_id) override;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -134,7 +134,7 @@ flow::ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
   }
 }
 
-void IOSSurfaceSoftware::SetFrameSize(SkISize frame_size) {
+void IOSSurfaceSoftware::BeginFrame(SkISize frame_size) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);
   platform_views_controller->SetFrameSize(frame_size);


### PR DESCRIPTION
Right now we do it whenever the platform views preview flag is on.
This is less efficient, filed
https://github.com/flutter/flutter/issues/24133 to only do this when
there's a platform view in the tree.

flutter/flutter#19030