### PR TITLE
Ensure that the EGL rendering context is bound to the GPU thread in Rasterizer::MakeRasterSnapshot

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -93,6 +93,10 @@ sk_sp<SkImage> Rasterizer::MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                               SkISize picture_size) {
   TRACE_EVENT0("flutter", __FUNCTION__);
 
+  if (!surface_->MakeRenderContextCurrent()) {
+    return nullptr;
+  }
+
   sk_sp<SkSurface> surface;
   if (surface_ == nullptr || surface_->GetContext() == nullptr) {
     // Raster surface is fine if there is no on screen surface. This might

--- a/shell/common/surface.cc
+++ b/shell/common/surface.cc
@@ -68,4 +68,8 @@ flow::ExternalViewEmbedder* Surface::GetExternalViewEmbedder() {
   return nullptr;
 }
 
+bool Surface::MakeRenderContextCurrent() {
+  return true;
+}
+
 }  // namespace shell

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -58,6 +58,8 @@ class Surface {
 
   virtual flow::ExternalViewEmbedder* GetExternalViewEmbedder();
 
+  virtual bool MakeRenderContextCurrent();
+
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(Surface);
 };

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -363,4 +363,9 @@ flow::ExternalViewEmbedder* GPUSurfaceGL::GetExternalViewEmbedder() {
   return delegate_->GetExternalViewEmbedder();
 }
 
+// |shell::Surface|
+bool GPUSurfaceGL::MakeRenderContextCurrent() {
+  return delegate_->GLContextMakeCurrent();
+}
+
 }  // namespace shell

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -69,6 +69,9 @@ class GPUSurfaceGL : public Surface {
   // |shell::Surface|
   flow::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |shell::Surface|
+  bool MakeRenderContextCurrent() override;
+
  private:
   GPUSurfaceGLDelegate* delegate_;
   GPUSurfaceGLDelegate::GLProcResolver proc_resolver_;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/24083