### PR TITLE
Avoid announcing text field when it lacks a11y focus

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -763,8 +763,12 @@ class AccessibilityBridge
                 sendAccessibilityEvent(event);
             }
             if (mInputFocusedObject != null && mInputFocusedObject.id == object.id
-                    && (mA11yFocusedObject == null || (mA11yFocusedObject.id == mInputFocusedObject.id))
-                    && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)) {
+                    && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)
+                    // If we have a TextField that has InputFocus, we should avoid announcing it if something
+                    // else we track has a11y focus. This needs to still work when, e.g., IME has a11y focus
+                    // or the "PASTE" popup is used though.
+                    // See more discussion at https://github.com/flutter/flutter/issues/23180
+                    && (mA11yFocusedObject == null || (mA11yFocusedObject.id == mInputFocusedObject.id))) {
                 String oldValue = object.previousValue != null ? object.previousValue : "";
                 String newValue = object.value != null ? object.value : "";
                 AccessibilityEvent event = createTextChangedEvent(object.id, oldValue, newValue);

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -763,6 +763,7 @@ class AccessibilityBridge
                 sendAccessibilityEvent(event);
             }
             if (mInputFocusedObject != null && mInputFocusedObject.id == object.id
+                    && (mA11yFocusedObject == null || (mA11yFocusedObject.id == mInputFocusedObject.id))
                     && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)) {
                 String oldValue = object.previousValue != null ? object.previousValue : "";
                 String newValue = object.value != null ? object.value : "";


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/23180

Applys similar fix to what @jonahwilliams did, but specifically to the area where we send the announcement for the textfield.