### PR TITLE
Set up secondary isolates with all kernel buffers rather than just one buffer.

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -348,14 +348,16 @@ bool DartIsolate::PrepareForRunningFromKernel(
     return false;
   }
 
-  if (child_isolate_preparer_  == nullptr) {
-    child_isolate_preparer_ = [buffers = kernel_buffers_](DartIsolate* isolate) {
-      for (unsigned long i = 0; i < buffers.size(); i++) {
-        bool last_piece = i + 1 == buffers.size();
-        const std::shared_ptr<const fml::Mapping> &buffer = buffers.at(i);
-        if (!isolate->PrepareForRunningFromKernel(buffer, last_piece)) {
-          return false;
-        }
+  // child isolate shares root isolate embedder_isolate (line 691 and 693 below)
+  if (child_isolate_preparer_ == nullptr) {
+    child_isolate_preparer_ = [buffers =
+                                   kernel_buffers_](DartIsolate* isolate) {
+       for (unsigned long i = 0; i < buffers.size(); i++) {
+         bool last_piece = i + 1 == buffers.size();
+         const std::shared_ptr<const fml::Mapping>& buffer = buffers.at(i);
+         if (!isolate->PrepareForRunningFromKernel(buffer, last_piece)) {
+           return false;
+         }
       }
       return true;
     };

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -348,11 +348,11 @@ bool DartIsolate::PrepareForRunningFromKernel(
     return false;
   }
 
-  child_isolate_preparer_ = [this](DartIsolate* isolate) {
-    for (unsigned long i = 0; i < kernel_buffers_.size(); i++) {
-      bool last_piece = i + 1 == kernel_buffers_.size();
-      auto kernel_buffer = kernel_buffers_.at(i);
-      if (!isolate->PrepareForRunningFromKernel(kernel_buffer, last_piece)) {
+  child_isolate_preparer_ = [buffers = kernel_buffers_](DartIsolate* isolate) {
+    for (unsigned long i = 0; i < buffers.size(); i++) {
+      bool last_piece = i + 1 == buffers.size();
+      auto buffer = buffers.at(i);
+      if (!isolate->PrepareForRunningFromKernel(buffer, last_piece)) {
         return false;
       }
     }

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -348,16 +348,18 @@ bool DartIsolate::PrepareForRunningFromKernel(
     return false;
   }
 
-  child_isolate_preparer_ = [buffers = kernel_buffers_](DartIsolate* isolate) {
-    for (unsigned long i = 0; i < buffers.size(); i++) {
-      bool last_piece = i + 1 == buffers.size();
-      auto buffer = buffers.at(i);
-      if (!isolate->PrepareForRunningFromKernel(buffer, last_piece)) {
-        return false;
+  if (child_isolate_preparer_  == nullptr) {
+    child_isolate_preparer_ = [buffers = kernel_buffers_](DartIsolate* isolate) {
+      for (unsigned long i = 0; i < buffers.size(); i++) {
+        bool last_piece = i + 1 == buffers.size();
+        const std::shared_ptr<const fml::Mapping> &buffer = buffers.at(i);
+        if (!isolate->PrepareForRunningFromKernel(buffer, last_piece)) {
+          return false;
+        }
       }
-    }
-    return true;
-  };
+      return true;
+    };
+  }
   phase_ = Phase::Ready;
   return true;
 }

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -348,8 +348,15 @@ bool DartIsolate::PrepareForRunningFromKernel(
     return false;
   }
 
-  child_isolate_preparer_ = [mapping](DartIsolate* isolate) {
-    return isolate->PrepareForRunningFromKernel(mapping);
+  child_isolate_preparer_ = [this](DartIsolate* isolate) {
+    for (unsigned long i = 0; i < kernel_buffers_.size(); i++) {
+      bool last_piece = i + 1 == kernel_buffers_.size();
+      auto kernel_buffer = kernel_buffers_.at(i);
+      if (!isolate->PrepareForRunningFromKernel(kernel_buffer, last_piece)) {
+        return false;
+      }
+    }
+    return true;
   };
   phase_ = Phase::Ready;
   return true;

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -348,7 +348,9 @@ bool DartIsolate::PrepareForRunningFromKernel(
     return false;
   }
 
-  // child isolate shares root isolate embedder_isolate (line 691 and 693 below)
+  // Child isolate shares root isolate embedder_isolate (lines 691 and 693
+  // below). Re-initializing child_isolate_preparer_ lambda while it is being
+  // executed leads to crashes.
   if (child_isolate_preparer_ == nullptr) {
     child_isolate_preparer_ = [buffers =
                                    kernel_buffers_](DartIsolate* isolate) {

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -354,12 +354,12 @@ bool DartIsolate::PrepareForRunningFromKernel(
   if (child_isolate_preparer_ == nullptr) {
     child_isolate_preparer_ = [buffers =
                                    kernel_buffers_](DartIsolate* isolate) {
-       for (unsigned long i = 0; i < buffers.size(); i++) {
-         bool last_piece = i + 1 == buffers.size();
-         const std::shared_ptr<const fml::Mapping>& buffer = buffers.at(i);
-         if (!isolate->PrepareForRunningFromKernel(buffer, last_piece)) {
-           return false;
-         }
+      for (unsigned long i = 0; i < buffers.size(); i++) {
+        bool last_piece = i + 1 == buffers.size();
+        const std::shared_ptr<const fml::Mapping>& buffer = buffers.at(i);
+        if (!isolate->PrepareForRunningFromKernel(buffer, last_piece)) {
+          return false;
+        }
       }
       return true;
     };

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -117,7 +117,7 @@ class DartIsolate : public UIDartState {
   const fml::RefPtr<DartSnapshot> shared_snapshot_;
   std::vector<std::shared_ptr<const fml::Mapping>> kernel_buffers_;
   std::vector<std::unique_ptr<AutoFireClosure>> shutdown_callbacks_;
-  ChildIsolatePreparer child_isolate_preparer_;
+  ChildIsolatePreparer child_isolate_preparer_ = nullptr;
 
   FML_WARN_UNUSED_RESULT
   bool Initialize(Dart_Isolate isolate, bool is_root_isolate);


### PR DESCRIPTION
This fixes issue with having secondary isolates not being able to use `package:flutter` classes.