### PR TITLE
Fix code smells reported by chrome's clang plugin

### DIFF
--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -19,7 +19,7 @@ class AssetManager final : public AssetResolver {
  public:
   AssetManager();
 
-  ~AssetManager();
+  ~AssetManager() override;
 
   void PushFront(std::unique_ptr<AssetResolver> resolver);
 

--- a/common/settings.cc
+++ b/common/settings.cc
@@ -8,6 +8,9 @@
 
 namespace blink {
 
+Settings::Settings() = default;
+Settings::~Settings() = default;
+
 std::string Settings::ToString() const {
   std::stringstream stream;
   stream << "Settings: " << std::endl;

--- a/common/settings.cc
+++ b/common/settings.cc
@@ -9,6 +9,7 @@
 namespace blink {
 
 Settings::Settings() = default;
+Settings::Settings(const Settings& other) = default;
 Settings::~Settings() = default;
 
 std::string Settings::ToString() const {

--- a/common/settings.h
+++ b/common/settings.h
@@ -23,6 +23,7 @@ using TaskObserverRemove = std::function<void(intptr_t /* key */)>;
 
 struct Settings {
   Settings();
+  Settings(const Settings& other);
   ~Settings();
 
   // VM settings

--- a/common/settings.h
+++ b/common/settings.h
@@ -22,6 +22,9 @@ using TaskObserverAdd =
 using TaskObserverRemove = std::function<void(intptr_t /* key */)>;
 
 struct Settings {
+  Settings();
+  ~Settings();
+
   // VM settings
   std::string vm_snapshot_data_path;
   std::string vm_snapshot_instr_path;

--- a/common/task_runners.cc
+++ b/common/task_runners.cc
@@ -19,6 +19,8 @@ TaskRunners::TaskRunners(std::string label,
       ui_(std::move(ui)),
       io_(std::move(io)) {}
 
+TaskRunners::TaskRunners(const TaskRunners& other) = default;
+
 TaskRunners::~TaskRunners() = default;
 
 const std::string& TaskRunners::GetLabel() const {

--- a/common/task_runners.h
+++ b/common/task_runners.h
@@ -20,6 +20,8 @@ class TaskRunners {
               fml::RefPtr<fml::TaskRunner> ui,
               fml::RefPtr<fml::TaskRunner> io);
 
+  TaskRunners(const TaskRunners& other);
+
   ~TaskRunners();
 
   const std::string& GetLabel() const;

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -8,6 +8,7 @@ source_set("flow") {
     "compositor_context.h",
     "debug_print.cc",
     "debug_print.h",
+    "embedded_views.cc",
     "embedded_views.h",
     "instrumentation.cc",
     "instrumentation.h",

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -1,5 +1,8 @@
-#include "flutter/flow/embedded_views.h"
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
+#include "flutter/flow/embedded_views.h"
 
 namespace flow {
 

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -6,5 +6,7 @@
 
 namespace flow {
 
-  bool ExternalViewEmbedder::SubmitFrame(GrContext* context) { return false; };
+bool ExternalViewEmbedder::SubmitFrame(GrContext* context) {
+  return false;
+};
 }  // namespace flow

--- a/flow/embedded_views.cc
+++ b/flow/embedded_views.cc
@@ -1,0 +1,7 @@
+#include "flutter/flow/embedded_views.h"
+
+
+namespace flow {
+
+  bool ExternalViewEmbedder::SubmitFrame(GrContext* context) { return false; };
+}  // namespace flow

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -37,7 +37,7 @@ class ExternalViewEmbedder {
   virtual SkCanvas* CompositeEmbeddedView(int view_id,
                                           const EmbeddedViewParams& params) = 0;
 
-  virtual bool SubmitFrame(GrContext* context) { return false; };
+  virtual bool SubmitFrame(GrContext* context) = 0;
 
   virtual ~ExternalViewEmbedder() = default;
 

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -37,7 +37,7 @@ class ExternalViewEmbedder {
   virtual SkCanvas* CompositeEmbeddedView(int view_id,
                                           const EmbeddedViewParams& params) = 0;
 
-  virtual bool SubmitFrame(GrContext* context) = 0;
+  virtual bool SubmitFrame(GrContext* context);
 
   virtual ~ExternalViewEmbedder() = default;
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -96,7 +96,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
   TRACE_EVENT0("flutter", "LayerTree::Flatten");
 
   SkPictureRecorder recorder;
-  auto canvas = recorder.beginRecording(bounds);
+  auto* canvas = recorder.beginRecording(bounds);
 
   if (!canvas) {
     return nullptr;

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -15,7 +15,7 @@ PictureLayer::~PictureLayer() = default;
 void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkPicture* sk_picture = picture();
 
-  if (auto cache = context->raster_cache) {
+  if (auto* cache = context->raster_cache) {
     SkMatrix ctm = matrix;
     ctm.postTranslate(offset_.x(), offset_.y());
 #ifndef SUPPORT_FRACTIONAL_TRANSLATION

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -24,7 +24,8 @@ RasterCacheResult::RasterCacheResult(const RasterCacheResult& other) = default;
 
 RasterCacheResult::~RasterCacheResult() = default;
 
-RasterCacheResult::RasterCacheResult(sk_sp<SkImage> image, const SkRect& logical_rect)
+RasterCacheResult::RasterCacheResult(sk_sp<SkImage> image,
+                                     const SkRect& logical_rect)
     : image_(std::move(image)), logical_rect_(logical_rect) {}
 
 void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -18,6 +18,15 @@
 
 namespace flow {
 
+RasterCacheResult::RasterCacheResult() {}
+
+RasterCacheResult::RasterCacheResult(const RasterCacheResult& other) = default;
+
+RasterCacheResult::~RasterCacheResult() = default;
+
+RasterCacheResult::RasterCacheResult(sk_sp<SkImage> image, const SkRect& logical_rect)
+    : image_(std::move(image)), logical_rect_(logical_rect) {}
+
 void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   SkAutoCanvasRestore auto_restore(&canvas, true);
   SkIRect bounds =

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -19,10 +19,11 @@ namespace flow {
 
 class RasterCacheResult {
  public:
-  RasterCacheResult() {}
+  RasterCacheResult();
+  RasterCacheResult(const RasterCacheResult& other);
+  ~RasterCacheResult();
 
-  RasterCacheResult(sk_sp<SkImage> image, const SkRect& logical_rect)
-      : image_(std::move(image)), logical_rect_(logical_rect) {}
+  RasterCacheResult(sk_sp<SkImage> image, const SkRect& logical_rect);
 
   operator bool() const { return static_cast<bool>(image_); }
 

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -56,6 +56,7 @@ source_set("fml") {
     "task_runner.h",
     "thread.cc",
     "thread.h",
+    "thread_local.cc",
     "thread_local.h",
     "time/time_delta.h",
     "time/time_point.cc",

--- a/fml/file.cc
+++ b/fml/file.cc
@@ -43,4 +43,19 @@ fml::UniqueFD CreateDirectory(const fml::UniqueFD& base_directory,
   return CreateDirectory(base_directory, components, permission, 0);
 }
 
+ScopedTemporaryDirectory::ScopedTemporaryDirectory() {
+  path_ = CreateTemporaryDirectory();
+  if (path_ != "") {
+    dir_fd_ = OpenDirectory(path_.c_str(), false, FilePermission::kRead);
+  }
+}
+
+ScopedTemporaryDirectory::~ScopedTemporaryDirectory() {
+  if (path_ != "") {
+    if (!UnlinkDirectory(path_.c_str())) {
+      FML_LOG(ERROR) << "Could not remove directory: " << path_;
+    }
+  }
+}
+
 }  // namespace fml

--- a/fml/file.h
+++ b/fml/file.h
@@ -75,20 +75,9 @@ bool WriteAtomically(const fml::UniqueFD& base_directory,
 
 class ScopedTemporaryDirectory {
  public:
-  ScopedTemporaryDirectory() {
-    path_ = CreateTemporaryDirectory();
-    if (path_ != "") {
-      dir_fd_ = OpenDirectory(path_.c_str(), false, FilePermission::kRead);
-    }
-  }
+  ScopedTemporaryDirectory();
 
-  ~ScopedTemporaryDirectory() {
-    if (path_ != "") {
-      if (!UnlinkDirectory(path_.c_str())) {
-        FML_LOG(ERROR) << "Could not remove directory: " << path_;
-      }
-    }
-  }
+  ~ScopedTemporaryDirectory();
 
   const UniqueFD& fd() { return dir_fd_; }
 

--- a/fml/logging.cc
+++ b/fml/logging.cc
@@ -34,7 +34,7 @@ const char* StripDots(const char* path) {
 }
 
 const char* StripPath(const char* path) {
-  auto p = strrchr(path, '/');
+  auto* p = strrchr(path, '/');
   if (p)
     return p + 1;
   else

--- a/fml/mapping.cc
+++ b/fml/mapping.cc
@@ -22,4 +22,12 @@ const uint8_t* DataMapping::GetMapping() const {
   return data_.data();
 }
 
+size_t NonOwnedMapping::GetSize() const {
+  return size_;
+}
+
+const uint8_t* NonOwnedMapping::GetMapping() const {
+  return data_;
+}
+
 }  // namespace fml

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -84,9 +84,9 @@ class NonOwnedMapping : public Mapping {
   NonOwnedMapping(const uint8_t* data, size_t size)
       : data_(data), size_(size) {}
 
-  size_t GetSize() const override { return size_; }
+  size_t GetSize() const override;
 
-  const uint8_t* GetMapping() const override { return data_; }
+  const uint8_t* GetMapping() const override;
 
  private:
   const uint8_t* const data_;

--- a/fml/message.cc
+++ b/fml/message.cc
@@ -8,7 +8,9 @@
 
 namespace fml {
 
-size_t MessageSerializable::GetSerializableTag() const { return 0; };
+size_t MessageSerializable::GetSerializableTag() const {
+  return 0;
+};
 
 Message::Message() = default;
 

--- a/fml/message.cc
+++ b/fml/message.cc
@@ -8,6 +8,8 @@
 
 namespace fml {
 
+size_t MessageSerializable::GetSerializableTag() const { return 0; };
+
 Message::Message() = default;
 
 Message::~Message() = default;
@@ -96,7 +98,7 @@ uint8_t* Message::PrepareDecode(size_t size) {
   if ((size + size_read_) > buffer_length_) {
     return nullptr;
   }
-  auto buffer = buffer_ + size_read_;
+  auto* buffer = buffer_ + size_read_;
   size_read_ += size;
   return buffer;
 }

--- a/fml/message.h
+++ b/fml/message.h
@@ -47,7 +47,7 @@ class MessageSerializable {
 
   virtual bool Deserialize(Message& message) = 0;
 
-  virtual size_t GetSerializableTag() const { return 0; };
+  virtual size_t GetSerializableTag() const = 0;
 };
 
 // The traits passed to the encode/decode calls that accept traits should be
@@ -88,7 +88,7 @@ class Message {
   template <typename T,
             typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
   FML_WARN_UNUSED_RESULT bool Encode(const T& value) {
-    if (auto buffer = PrepareEncode(sizeof(T))) {
+    if (auto* buffer = PrepareEncode(sizeof(T))) {
       ::memcpy(buffer, &value, sizeof(T));
       return true;
     }
@@ -131,7 +131,7 @@ class Message {
   template <typename T,
             typename = std::enable_if_t<std::is_trivially_copyable<T>::value>>
   FML_WARN_UNUSED_RESULT bool Decode(T& value) {
-    if (auto buffer = PrepareDecode(sizeof(T))) {
+    if (auto* buffer = PrepareDecode(sizeof(T))) {
       ::memcpy(&value, buffer, sizeof(T));
       return true;
     }

--- a/fml/message.h
+++ b/fml/message.h
@@ -47,7 +47,7 @@ class MessageSerializable {
 
   virtual bool Deserialize(Message& message) = 0;
 
-  virtual size_t GetSerializableTag() const = 0;
+  virtual size_t GetSerializableTag() const;
 };
 
 // The traits passed to the encode/decode calls that accept traits should be

--- a/fml/message_loop.cc
+++ b/fml/message_loop.cc
@@ -19,7 +19,7 @@ FML_THREAD_LOCAL ThreadLocal tls_message_loop([](intptr_t value) {
 });
 
 MessageLoop& MessageLoop::GetCurrent() {
-  auto loop = reinterpret_cast<MessageLoop*>(tls_message_loop.Get());
+  auto* loop = reinterpret_cast<MessageLoop*>(tls_message_loop.Get());
   FML_CHECK(loop != nullptr)
       << "MessageLoop::EnsureInitializedForCurrentThread was not called on "
          "this thread prior to message loop use.";

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -145,4 +145,13 @@ void MessageLoopImpl::RunExpiredTasks() {
   }
 }
 
+MessageLoopImpl::DelayedTask::DelayedTask(size_t p_order,
+            fml::closure p_task,
+            fml::TimePoint p_target_time)
+    : order(p_order), task(std::move(p_task)), target_time(p_target_time) {}
+
+MessageLoopImpl::DelayedTask::DelayedTask(const DelayedTask& other) = default;
+
+MessageLoopImpl::DelayedTask::~DelayedTask() = default;
+
 }  // namespace fml

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -146,8 +146,8 @@ void MessageLoopImpl::RunExpiredTasks() {
 }
 
 MessageLoopImpl::DelayedTask::DelayedTask(size_t p_order,
-            fml::closure p_task,
-            fml::TimePoint p_target_time)
+                                          fml::closure p_task,
+                                          fml::TimePoint p_target_time)
     : order(p_order), task(std::move(p_task)), target_time(p_target_time) {}
 
 MessageLoopImpl::DelayedTask::DelayedTask(const DelayedTask& other) = default;

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -57,8 +57,9 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
 
     DelayedTask(size_t p_order,
                 fml::closure p_task,
-                fml::TimePoint p_target_time)
-        : order(p_order), task(std::move(p_task)), target_time(p_target_time) {}
+                fml::TimePoint p_target_time);
+    DelayedTask(const DelayedTask& other);
+    ~DelayedTask();
   };
 
   struct DelayedTaskCompare {

--- a/fml/platform/posix/file_posix.cc
+++ b/fml/platform/posix/file_posix.cc
@@ -19,7 +19,7 @@ namespace fml {
 
 std::string CreateTemporaryDirectory() {
   char directory_name[] = "/tmp/flutter_XXXXXXXX";
-  auto result = ::mkdtemp(directory_name);
+  auto* result = ::mkdtemp(directory_name);
   if (result == nullptr) {
     return "";
   }

--- a/fml/platform/posix/mapping_posix.cc
+++ b/fml/platform/posix/mapping_posix.cc
@@ -69,7 +69,7 @@ FileMapping::FileMapping(const fml::UniqueFD& handle,
 
   const auto is_writable = IsWritable(protection);
 
-  auto mapping =
+  auto* mapping =
       ::mmap(nullptr, stat_buffer.st_size, ToPosixProtectionFlags(protection),
              is_writable ? MAP_SHARED : MAP_PRIVATE, handle.get(), 0);
 

--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -58,7 +58,7 @@ fml::RefPtr<NativeLibrary> NativeLibrary::CreateForCurrentProcess() {
 }
 
 const uint8_t* NativeLibrary::ResolveSymbol(const char* symbol) {
-  auto resolved_symbol = static_cast<const uint8_t*>(::dlsym(handle_, symbol));
+  auto* resolved_symbol = static_cast<const uint8_t*>(::dlsym(handle_, symbol));
   if (resolved_symbol == nullptr) {
     FML_DLOG(INFO) << "Could not resolve symbol in library: " << symbol;
   }

--- a/fml/string_view.cc
+++ b/fml/string_view.cc
@@ -84,7 +84,7 @@ size_t StringView::find(StringView s, size_t pos) const {
   if (s.empty())
     return pos;
 
-  auto result = std::search(begin() + pos, end(), s.begin(), s.end());
+  auto* result = std::search(begin() + pos, end(), s.begin(), s.end());
   if (result == end())
     return npos;
   return result - begin();
@@ -94,7 +94,7 @@ size_t StringView::find(char c, size_t pos) const {
   if (pos > size_)
     return npos;
 
-  auto result = std::find(begin() + pos, end(), c);
+  auto* result = std::find(begin() + pos, end(), c);
   if (result == end())
     return npos;
   return result - begin();
@@ -106,8 +106,8 @@ size_t StringView::rfind(StringView s, size_t pos) const {
   if (s.empty())
     return std::min(pos, size_);
 
-  auto last = begin() + std::min(size_ - s.size(), pos) + s.size();
-  auto result = std::find_end(begin(), last, s.begin(), s.end());
+  auto* last = begin() + std::min(size_ - s.size(), pos) + s.size();
+  auto* result = std::find_end(begin(), last, s.begin(), s.end());
   if (result == last)
     return npos;
   return result - begin();

--- a/fml/thread_local.cc
+++ b/fml/thread_local.cc
@@ -8,7 +8,8 @@ namespace fml {
 
 ThreadLocal::ThreadLocal() : ThreadLocal(nullptr) {}
 
-ThreadLocal::ThreadLocal(ThreadLocalDestroyCallback destroy) : destroy_(destroy) {
+ThreadLocal::ThreadLocal(ThreadLocalDestroyCallback destroy)
+    : destroy_(destroy) {
   auto callback =
       reinterpret_cast<void (*)(void*)>(&ThreadLocal::ThreadLocalDestroy);
   FML_CHECK(pthread_key_create(&_key, callback) == 0);
@@ -32,4 +33,4 @@ ThreadLocal::Box::Box(ThreadLocalDestroyCallback destroy, intptr_t value)
 
 ThreadLocal::Box::~Box() = default;
 
-}
+}  // namespace fml

--- a/fml/thread_local.cc
+++ b/fml/thread_local.cc
@@ -1,0 +1,31 @@
+#include "flutter/fml/thread_local.h"
+
+namespace fml {
+
+ThreadLocal::ThreadLocal() : ThreadLocal(nullptr) {}
+
+ThreadLocal::ThreadLocal(ThreadLocalDestroyCallback destroy) : destroy_(destroy) {
+  auto callback =
+      reinterpret_cast<void (*)(void*)>(&ThreadLocal::ThreadLocalDestroy);
+  FML_CHECK(pthread_key_create(&_key, callback) == 0);
+}
+
+ThreadLocal::~ThreadLocal() {
+  // This will NOT call the destroy callbacks on thread local values still
+  // active in other threads. Those must be cleared manually. The usage
+  // of this class should be similar to the thread_local keyword but with
+  // with a static storage specifier
+
+  // Collect the container
+  delete reinterpret_cast<Box*>(pthread_getspecific(_key));
+
+  // Finally, collect the key
+  FML_CHECK(pthread_key_delete(_key) == 0);
+}
+
+ThreadLocal::Box::Box(ThreadLocalDestroyCallback destroy, intptr_t value)
+    : destroy_(destroy), value_(value) {}
+
+ThreadLocal::Box::~Box() = default;
+
+}

--- a/fml/thread_local.cc
+++ b/fml/thread_local.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "flutter/fml/thread_local.h"
 
 namespace fml {

--- a/fml/thread_local.h
+++ b/fml/thread_local.h
@@ -31,8 +31,8 @@ class ThreadLocal {
  private:
   class Box {
    public:
-    Box(ThreadLocalDestroyCallback destroy, intptr_t value)
-        : destroy_(destroy), value_(value) {}
+    Box(ThreadLocalDestroyCallback destroy, intptr_t value);
+    ~Box();
 
     intptr_t Value() const { return value_; }
 
@@ -60,22 +60,18 @@ class ThreadLocal {
 
   static inline void ThreadLocalDestroy(void* value) {
     FML_CHECK(value != nullptr);
-    auto box = reinterpret_cast<Box*>(value);
+    auto* box = reinterpret_cast<Box*>(value);
     box->DestroyValue();
     delete box;
   }
 
  public:
-  ThreadLocal() : ThreadLocal(nullptr) {}
+  ThreadLocal();
 
-  ThreadLocal(ThreadLocalDestroyCallback destroy) : destroy_(destroy) {
-    auto callback =
-        reinterpret_cast<void (*)(void*)>(&ThreadLocal::ThreadLocalDestroy);
-    FML_CHECK(pthread_key_create(&_key, callback) == 0);
-  }
+  ThreadLocal(ThreadLocalDestroyCallback destroy);
 
   void Set(intptr_t value) {
-    auto box = reinterpret_cast<Box*>(pthread_getspecific(_key));
+    auto* box = reinterpret_cast<Box*>(pthread_getspecific(_key));
     if (box == nullptr) {
       box = new Box(destroy_, value);
       FML_CHECK(pthread_setspecific(_key, box) == 0);
@@ -85,22 +81,11 @@ class ThreadLocal {
   }
 
   intptr_t Get() {
-    auto box = reinterpret_cast<Box*>(pthread_getspecific(_key));
+    auto* box = reinterpret_cast<Box*>(pthread_getspecific(_key));
     return box != nullptr ? box->Value() : 0;
   }
 
-  ~ThreadLocal() {
-    // This will NOT call the destroy callbacks on thread local values still
-    // active in other threads. Those must be cleared manually. The usage
-    // of this class should be similar to the thread_local keyword but with
-    // with a static storage specifier
-
-    // Collect the container
-    delete reinterpret_cast<Box*>(pthread_getspecific(_key));
-
-    // Finally, collect the key
-    FML_CHECK(pthread_key_delete(_key) == 0);
-  }
+  ~ThreadLocal();
 
  private:
   pthread_key_t _key;

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -92,6 +92,7 @@ source_set("ui") {
     "window/pointer_data.h",
     "window/pointer_data_packet.cc",
     "window/pointer_data_packet.h",
+    "window/viewport_metrics.cc",
     "window/viewport_metrics.h",
     "window/window.cc",
     "window/window.h",

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -69,7 +69,7 @@ Dart_Handle Scene::toImage(uint32_t width,
     return tonic::ToDart("Image dimensions for scene were invalid.");
   }
 
-  auto dart_state = UIDartState::Current();
+  auto* dart_state = UIDartState::Current();
   auto image_callback = std::make_unique<tonic::DartPersistentValue>(
       dart_state, raw_image_callback);
   auto unref_queue = dart_state->GetSkiaUnrefQueue();
@@ -114,7 +114,7 @@ Dart_Handle Scene::toImage(uint32_t width,
 
       auto dart_image = CanvasImage::Create();
       dart_image->set_image({std::move(raster_image), std::move(unref_queue)});
-      auto raw_dart_image = tonic::ToDart(std::move(dart_image));
+      auto* raw_dart_image = tonic::ToDart(std::move(dart_image));
 
       // All done!
       tonic::DartInvoke(image_callback->Get(), {raw_dart_image});

--- a/lib/ui/isolate_name_server/isolate_name_server.cc
+++ b/lib/ui/isolate_name_server/isolate_name_server.cc
@@ -6,6 +6,8 @@
 
 namespace blink {
 
+IsolateNameServer::IsolateNameServer() {}
+
 Dart_Port IsolateNameServer::LookupIsolatePortByName(const std::string& name) {
   std::lock_guard<std::mutex> lock(mutex_);
   return LookupIsolatePortByNameUnprotected(name);

--- a/lib/ui/isolate_name_server/isolate_name_server.cc
+++ b/lib/ui/isolate_name_server/isolate_name_server.cc
@@ -8,6 +8,8 @@ namespace blink {
 
 IsolateNameServer::IsolateNameServer() {}
 
+IsolateNameServer::~IsolateNameServer() = default;
+
 Dart_Port IsolateNameServer::LookupIsolatePortByName(const std::string& name) {
   std::lock_guard<std::mutex> lock(mutex_);
   return LookupIsolatePortByNameUnprotected(name);

--- a/lib/ui/isolate_name_server/isolate_name_server.h
+++ b/lib/ui/isolate_name_server/isolate_name_server.h
@@ -18,6 +18,7 @@ namespace blink {
 class IsolateNameServer {
  public:
   IsolateNameServer();
+  ~IsolateNameServer();
 
   // Looks up the Dart_Port associated with a given name. Returns ILLEGAL_PORT
   // if the name does not exist.

--- a/lib/ui/isolate_name_server/isolate_name_server.h
+++ b/lib/ui/isolate_name_server/isolate_name_server.h
@@ -17,7 +17,7 @@ namespace blink {
 
 class IsolateNameServer {
  public:
-  IsolateNameServer() {}
+  IsolateNameServer();
 
   // Looks up the Dart_Port associated with a given name. Returns ILLEGAL_PORT
   // if the name does not exist.

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -389,8 +389,12 @@ MultiFrameCodec::MultiFrameCodec(std::unique_ptr<SkCodec> codec,
 
 MultiFrameCodec::~MultiFrameCodec() {}
 
-int MultiFrameCodec::frameCount() { return frameInfos_.size(); }
-int MultiFrameCodec::repetitionCount() { return repetitionCount_; }
+int MultiFrameCodec::frameCount() {
+  return frameInfos_.size();
+}
+int MultiFrameCodec::repetitionCount() {
+  return repetitionCount_;
+}
 
 sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage(
     fml::WeakPtr<GrContext> resourceContext) {
@@ -504,14 +508,20 @@ Dart_Handle MultiFrameCodec::getNextFrame(Dart_Handle callback_handle) {
   return Dart_Null();
 }
 
-MultiFrameCodec::DecodedFrame::DecodedFrame(bool required) : required_(required) {}
+MultiFrameCodec::DecodedFrame::DecodedFrame(bool required)
+    : required_(required) {}
 MultiFrameCodec::DecodedFrame::~DecodedFrame() = default;
 
-SingleFrameCodec::SingleFrameCodec(fml::RefPtr<FrameInfo> frame) : frame_(std::move(frame)) {}
+SingleFrameCodec::SingleFrameCodec(fml::RefPtr<FrameInfo> frame)
+    : frame_(std::move(frame)) {}
 SingleFrameCodec::~SingleFrameCodec() {}
 
-int SingleFrameCodec::frameCount() { return 1; }
-int SingleFrameCodec::repetitionCount() { return 0; }
+int SingleFrameCodec::frameCount() {
+  return 1;
+}
+int SingleFrameCodec::repetitionCount() {
+  return 0;
+}
 
 Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
   if (!Dart_IsClosure(callback_handle)) {

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -283,7 +283,7 @@ void InstantiateImageCodec(Dart_NativeArguments args) {
 
   auto buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
 
-  auto dart_state = UIDartState::Current();
+  auto* dart_state = UIDartState::Current();
 
   const auto& task_runners = dart_state->GetTaskRunners();
   task_runners.GetIOTaskRunner()->PostTask(fml::MakeCopyable(
@@ -387,6 +387,11 @@ MultiFrameCodec::MultiFrameCodec(std::unique_ptr<SkCodec> codec,
   nextFrameIndex_ = 0;
 }
 
+MultiFrameCodec::~MultiFrameCodec() {}
+
+int MultiFrameCodec::frameCount() { return frameInfos_.size(); }
+int MultiFrameCodec::repetitionCount() { return repetitionCount_; }
+
 sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage(
     fml::WeakPtr<GrContext> resourceContext) {
   // Populate this bitmap from the cache if it exists
@@ -481,7 +486,7 @@ Dart_Handle MultiFrameCodec::getNextFrame(Dart_Handle callback_handle) {
     return ToDart("Callback must be a function");
   }
 
-  auto dart_state = UIDartState::Current();
+  auto* dart_state = UIDartState::Current();
 
   const auto& task_runners = dart_state->GetTaskRunners();
 
@@ -498,6 +503,15 @@ Dart_Handle MultiFrameCodec::getNextFrame(Dart_Handle callback_handle) {
 
   return Dart_Null();
 }
+
+MultiFrameCodec::DecodedFrame::DecodedFrame(bool required) : required_(required) {}
+MultiFrameCodec::DecodedFrame::~DecodedFrame() = default;
+
+SingleFrameCodec::SingleFrameCodec(fml::RefPtr<FrameInfo> frame) : frame_(std::move(frame)) {}
+SingleFrameCodec::~SingleFrameCodec() {}
+
+int SingleFrameCodec::frameCount() { return 1; }
+int SingleFrameCodec::repetitionCount() { return 0; }
 
 Dart_Handle SingleFrameCodec::getNextFrame(Dart_Handle callback_handle) {
   if (!Dart_IsClosure(callback_handle)) {

--- a/lib/ui/painting/codec.h
+++ b/lib/ui/painting/codec.h
@@ -36,15 +36,15 @@ class Codec : public RefCountedDartWrappable<Codec> {
 
 class MultiFrameCodec : public Codec {
  public:
-  int frameCount() { return frameInfos_.size(); }
-  int repetitionCount() { return repetitionCount_; }
-  Dart_Handle getNextFrame(Dart_Handle args);
+  int frameCount() override;
+  int repetitionCount() override;
+  Dart_Handle getNextFrame(Dart_Handle args) override;
 
  private:
   MultiFrameCodec(std::unique_ptr<SkCodec> codec,
                   const float decodedCacheRatioCap);
 
-  ~MultiFrameCodec() {}
+  ~MultiFrameCodec() override;
 
   sk_sp<SkImage> GetNextFrameImage(fml::WeakPtr<GrContext> resourceContext);
 
@@ -71,7 +71,8 @@ class MultiFrameCodec : public Codec {
     std::unique_ptr<SkBitmap> bitmap_ = nullptr;
     const bool required_;
 
-    DecodedFrame(bool required) : required_(required) {}
+    DecodedFrame(bool required);
+    ~DecodedFrame();
   };
 
   // A cache of previously loaded bitmaps, indexed by the frame they belong to.
@@ -86,13 +87,13 @@ class MultiFrameCodec : public Codec {
 
 class SingleFrameCodec : public Codec {
  public:
-  int frameCount() { return 1; }
-  int repetitionCount() { return 0; }
-  Dart_Handle getNextFrame(Dart_Handle args);
+  int frameCount() override;
+  int repetitionCount() override;
+  Dart_Handle getNextFrame(Dart_Handle args) override;
 
  private:
-  SingleFrameCodec(fml::RefPtr<FrameInfo> frame) : frame_(std::move(frame)) {}
-  ~SingleFrameCodec() {}
+  SingleFrameCodec(fml::RefPtr<FrameInfo> frame);
+  ~SingleFrameCodec() override;
 
   fml::RefPtr<FrameInfo> frame_;
 

--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -16,7 +16,7 @@ using tonic::ToDart;
 namespace blink {
 
 EngineLayer::EngineLayer(std::shared_ptr<flow::ContainerLayer> layer)
-      : layer_(layer) {}
+    : layer_(layer) {}
 
 EngineLayer::~EngineLayer() = default;
 

--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -15,6 +15,9 @@ using tonic::ToDart;
 
 namespace blink {
 
+EngineLayer::EngineLayer(std::shared_ptr<flow::ContainerLayer> layer)
+      : layer_(layer) {}
+
 EngineLayer::~EngineLayer() = default;
 
 size_t EngineLayer::GetAllocationSize() {

--- a/lib/ui/painting/engine_layer.h
+++ b/lib/ui/painting/engine_layer.h
@@ -35,8 +35,7 @@ class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
   std::shared_ptr<flow::ContainerLayer> Layer() const { return layer_; }
 
  private:
-  explicit EngineLayer(std::shared_ptr<flow::ContainerLayer> layer)
-      : layer_(layer) {}
+  explicit EngineLayer(std::shared_ptr<flow::ContainerLayer> layer);
   std::shared_ptr<flow::ContainerLayer> layer_;
 
   FML_FRIEND_MAKE_REF_COUNTED(EngineLayer);

--- a/lib/ui/painting/frame_info.cc
+++ b/lib/ui/painting/frame_info.cc
@@ -20,7 +20,7 @@ FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
 
 FrameInfo::FrameInfo(fml::RefPtr<CanvasImage> image, int durationMillis)
     : image_(std::move(image)), durationMillis_(durationMillis) {}
-FrameInfo::~FrameInfo() {};
+FrameInfo::~FrameInfo(){};
 
 void FrameInfo::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({FOR_EACH_BINDING(DART_REGISTER_NATIVE)});

--- a/lib/ui/painting/frame_info.cc
+++ b/lib/ui/painting/frame_info.cc
@@ -18,6 +18,10 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, FrameInfo);
 
 FOR_EACH_BINDING(DART_NATIVE_CALLBACK)
 
+FrameInfo::FrameInfo(fml::RefPtr<CanvasImage> image, int durationMillis)
+    : image_(std::move(image)), durationMillis_(durationMillis) {}
+FrameInfo::~FrameInfo() {};
+
 void FrameInfo::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({FOR_EACH_BINDING(DART_REGISTER_NATIVE)});
 }

--- a/lib/ui/painting/frame_info.h
+++ b/lib/ui/painting/frame_info.h
@@ -25,9 +25,8 @@ class FrameInfo final : public RefCountedDartWrappable<FrameInfo> {
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
  private:
-  FrameInfo(fml::RefPtr<CanvasImage> image, int durationMillis)
-      : image_(std::move(image)), durationMillis_(durationMillis) {}
-  ~FrameInfo(){};
+  FrameInfo(fml::RefPtr<CanvasImage> image, int durationMillis);
+  ~FrameInfo() override;
 
   const fml::RefPtr<CanvasImage> image_;
   const int durationMillis_;

--- a/lib/ui/painting/image.h
+++ b/lib/ui/painting/image.h
@@ -39,7 +39,7 @@ class CanvasImage final : public RefCountedDartWrappable<CanvasImage> {
     image_ = std::move(image);
   }
 
-  virtual size_t GetAllocationSize() override;
+  size_t GetAllocationSize() override;
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -31,7 +31,7 @@ class Picture : public RefCountedDartWrappable<Picture> {
 
   void dispose();
 
-  virtual size_t GetAllocationSize() override;
+  size_t GetAllocationSize() override;
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 

--- a/lib/ui/painting/picture_recorder.h
+++ b/lib/ui/painting/picture_recorder.h
@@ -23,7 +23,7 @@ class PictureRecorder : public RefCountedDartWrappable<PictureRecorder> {
  public:
   static fml::RefPtr<PictureRecorder> Create();
 
-  ~PictureRecorder();
+  ~PictureRecorder() override;
 
   SkCanvas* BeginRecording(SkRect bounds);
   fml::RefPtr<Picture> endRecording();

--- a/lib/ui/plugins/callback_cache.cc
+++ b/lib/ui/plugins/callback_cache.cc
@@ -134,7 +134,7 @@ void DartCallbackCache::LoadCacheFromDisk() {
     return;
   }
   const auto entries = d.GetArray();
-  for (auto it = entries.begin(); it != entries.end(); ++it) {
+  for (auto* it = entries.begin(); it != entries.end(); ++it) {
     const auto root_obj = it->GetObject();
     const auto representation = root_obj[kRepresentationKey].GetObject();
 

--- a/lib/ui/semantics/semantics_node.cc
+++ b/lib/ui/semantics/semantics_node.cc
@@ -10,6 +10,8 @@ namespace blink {
 
 SemanticsNode::SemanticsNode() = default;
 
+SemanticsNode::SemanticsNode(const SemanticsNode& other) = default;
+
 SemanticsNode::~SemanticsNode() = default;
 
 bool SemanticsNode::HasAction(SemanticsAction action) {

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -69,6 +69,7 @@ enum class SemanticsFlags : int32_t {
 
 struct SemanticsNode {
   SemanticsNode();
+  SemanticsNode(const SemanticsNode& other);
   ~SemanticsNode();
 
   bool HasAction(SemanticsAction action);

--- a/lib/ui/text/asset_manager_font_provider.cc
+++ b/lib/ui/text/asset_manager_font_provider.cc
@@ -123,4 +123,9 @@ SkTypeface* AssetManagerFontStyleSet::matchStyle(const SkFontStyle& pattern) {
   return SkRef(assets_[0].typeface.get());
 }
 
+    AssetManagerFontStyleSet::TypefaceAsset::TypefaceAsset(std::string a) : asset(std::move(a)) {}
+    AssetManagerFontStyleSet::TypefaceAsset::TypefaceAsset(const AssetManagerFontStyleSet::TypefaceAsset& other) = default;
+
+    AssetManagerFontStyleSet::TypefaceAsset::~TypefaceAsset() = default;
+
 }  // namespace blink

--- a/lib/ui/text/asset_manager_font_provider.cc
+++ b/lib/ui/text/asset_manager_font_provider.cc
@@ -123,9 +123,11 @@ SkTypeface* AssetManagerFontStyleSet::matchStyle(const SkFontStyle& pattern) {
   return SkRef(assets_[0].typeface.get());
 }
 
-    AssetManagerFontStyleSet::TypefaceAsset::TypefaceAsset(std::string a) : asset(std::move(a)) {}
-    AssetManagerFontStyleSet::TypefaceAsset::TypefaceAsset(const AssetManagerFontStyleSet::TypefaceAsset& other) = default;
+AssetManagerFontStyleSet::TypefaceAsset::TypefaceAsset(std::string a)
+    : asset(std::move(a)) {}
+AssetManagerFontStyleSet::TypefaceAsset::TypefaceAsset(
+    const AssetManagerFontStyleSet::TypefaceAsset& other) = default;
 
-    AssetManagerFontStyleSet::TypefaceAsset::~TypefaceAsset() = default;
+AssetManagerFontStyleSet::TypefaceAsset::~TypefaceAsset() = default;
 
 }  // namespace blink

--- a/lib/ui/text/asset_manager_font_provider.h
+++ b/lib/ui/text/asset_manager_font_provider.h
@@ -42,7 +42,9 @@ class AssetManagerFontStyleSet : public SkFontStyleSet {
   std::shared_ptr<blink::AssetManager> asset_manager_;
 
   struct TypefaceAsset {
-    TypefaceAsset(std::string a) : asset(std::move(a)) {}
+    TypefaceAsset(std::string a);
+    TypefaceAsset(const TypefaceAsset& other);
+    ~TypefaceAsset();
     std::string asset;
     sk_sp<SkTypeface> typeface;
   };

--- a/lib/ui/text/paragraph.h
+++ b/lib/ui/text/paragraph.h
@@ -49,7 +49,7 @@ class Paragraph : public RefCountedDartWrappable<Paragraph> {
   Dart_Handle getPositionForOffset(double dx, double dy);
   Dart_Handle getWordBoundary(unsigned offset);
 
-  virtual size_t GetAllocationSize() override;
+  size_t GetAllocationSize() override;
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -61,7 +61,7 @@ class UIDartState : public tonic::DartState {
     if (!object) {
       return {};
     }
-    auto state = UIDartState::Current();
+    auto* state = UIDartState::Current();
     FML_DCHECK(state);
     auto queue = state->GetSkiaUnrefQueue();
     return {std::move(object), std::move(queue)};

--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "flutter/lib/ui/window/viewport_metrics.h"
 
 

--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -2,8 +2,31 @@
 
 
 namespace blink {
-
 ViewportMetrics::ViewportMetrics() = default;
+ViewportMetrics::ViewportMetrics(
+  double p_device_pixel_ratio,
+  double p_physical_width,
+  double p_physical_height,
+  double p_physical_padding_top,
+  double p_physical_padding_right,
+  double p_physical_padding_bottom,
+  double p_physical_padding_left,
+  double p_physical_view_inset_top,
+  double p_physical_view_inset_right,
+  double p_physical_view_inset_bottom,
+  double p_physical_view_inset_left) :
+    device_pixel_ratio(p_device_pixel_ratio),
+    physical_width(p_physical_width),
+    physical_height(p_physical_height),
+    physical_padding_top(p_physical_padding_top),
+    physical_padding_right(p_physical_padding_right),
+    physical_padding_bottom(p_physical_padding_bottom),
+    physical_padding_left(p_physical_padding_left),
+    physical_view_inset_top(p_physical_view_inset_top),
+    physical_view_inset_right(p_physical_view_inset_right),
+    physical_view_inset_bottom(p_physical_view_inset_bottom),
+    physical_view_inset_left(p_physical_view_inset_left)
+{}
 
 ViewportMetrics::ViewportMetrics(const ViewportMetrics& other) = default;
 

--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -4,35 +4,31 @@
 
 #include "flutter/lib/ui/window/viewport_metrics.h"
 
-
 namespace blink {
 ViewportMetrics::ViewportMetrics() = default;
-ViewportMetrics::ViewportMetrics(
-  double p_device_pixel_ratio,
-  double p_physical_width,
-  double p_physical_height,
-  double p_physical_padding_top,
-  double p_physical_padding_right,
-  double p_physical_padding_bottom,
-  double p_physical_padding_left,
-  double p_physical_view_inset_top,
-  double p_physical_view_inset_right,
-  double p_physical_view_inset_bottom,
-  double p_physical_view_inset_left) :
-    device_pixel_ratio(p_device_pixel_ratio),
-    physical_width(p_physical_width),
-    physical_height(p_physical_height),
-    physical_padding_top(p_physical_padding_top),
-    physical_padding_right(p_physical_padding_right),
-    physical_padding_bottom(p_physical_padding_bottom),
-    physical_padding_left(p_physical_padding_left),
-    physical_view_inset_top(p_physical_view_inset_top),
-    physical_view_inset_right(p_physical_view_inset_right),
-    physical_view_inset_bottom(p_physical_view_inset_bottom),
-    physical_view_inset_left(p_physical_view_inset_left)
-{}
+ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
+                                 double p_physical_width,
+                                 double p_physical_height,
+                                 double p_physical_padding_top,
+                                 double p_physical_padding_right,
+                                 double p_physical_padding_bottom,
+                                 double p_physical_padding_left,
+                                 double p_physical_view_inset_top,
+                                 double p_physical_view_inset_right,
+                                 double p_physical_view_inset_bottom,
+                                 double p_physical_view_inset_left)
+    : device_pixel_ratio(p_device_pixel_ratio),
+      physical_width(p_physical_width),
+      physical_height(p_physical_height),
+      physical_padding_top(p_physical_padding_top),
+      physical_padding_right(p_physical_padding_right),
+      physical_padding_bottom(p_physical_padding_bottom),
+      physical_padding_left(p_physical_padding_left),
+      physical_view_inset_top(p_physical_view_inset_top),
+      physical_view_inset_right(p_physical_view_inset_right),
+      physical_view_inset_bottom(p_physical_view_inset_bottom),
+      physical_view_inset_left(p_physical_view_inset_left) {}
 
 ViewportMetrics::ViewportMetrics(const ViewportMetrics& other) = default;
-
 
 }  // namespace blink

--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -1,0 +1,11 @@
+#include "flutter/lib/ui/window/viewport_metrics.h"
+
+
+namespace blink {
+
+ViewportMetrics::ViewportMetrics() = default;
+
+ViewportMetrics::ViewportMetrics(const ViewportMetrics& other) = default;
+
+
+}  // namespace blink

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -11,6 +11,7 @@ namespace blink {
 
 struct ViewportMetrics {
   ViewportMetrics();
+  ViewportMetrics(double p_device_pixel_ratio, double p_physical_width, double p_physical_height, double p_physical_padding_top, double p_physical_padding_right, double p_physical_padding_bottom, double p_physical_padding_left, double p_physical_view_inset_top, double p_physical_view_inset_right, double p_physical_view_inset_bottom, double p_physical_view_inset_left);
   ViewportMetrics(const ViewportMetrics& other);
 
   double device_pixel_ratio = 1.0;

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -10,6 +10,9 @@
 namespace blink {
 
 struct ViewportMetrics {
+  ViewportMetrics();
+  ViewportMetrics(const ViewportMetrics& other);
+
   double device_pixel_ratio = 1.0;
   double physical_width = 0;
   double physical_height = 0;

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -11,7 +11,17 @@ namespace blink {
 
 struct ViewportMetrics {
   ViewportMetrics();
-  ViewportMetrics(double p_device_pixel_ratio, double p_physical_width, double p_physical_height, double p_physical_padding_top, double p_physical_padding_right, double p_physical_padding_bottom, double p_physical_padding_left, double p_physical_view_inset_top, double p_physical_view_inset_right, double p_physical_view_inset_bottom, double p_physical_view_inset_left);
+  ViewportMetrics(double p_device_pixel_ratio,
+                  double p_physical_width,
+                  double p_physical_height,
+                  double p_physical_padding_top,
+                  double p_physical_padding_right,
+                  double p_physical_padding_bottom,
+                  double p_physical_padding_left,
+                  double p_physical_view_inset_top,
+                  double p_physical_view_inset_right,
+                  double p_physical_view_inset_bottom,
+                  double p_physical_view_inset_left);
   ViewportMetrics(const ViewportMetrics& other);
 
   double device_pixel_ratio = 1.0;

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -152,7 +152,7 @@ bool DartIsolate::Initialize(Dart_Isolate dart_isolate, bool is_root_isolate) {
     return false;
   }
 
-  auto isolate_data = static_cast<std::shared_ptr<DartIsolate>*>(
+  auto* isolate_data = static_cast<std::shared_ptr<DartIsolate>*>(
       Dart_IsolateData(dart_isolate));
   if (isolate_data->get() != this) {
     return false;
@@ -620,7 +620,7 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
   DartVM* const vm = (*embedder_isolate)->GetDartVM();
 
   if (!is_root_isolate) {
-    auto raw_embedder_isolate = embedder_isolate.release();
+    auto* raw_embedder_isolate = embedder_isolate.release();
 
     blink::TaskRunners null_task_runners(advisory_script_uri, nullptr, nullptr,
                                          nullptr, nullptr);
@@ -728,6 +728,13 @@ std::weak_ptr<DartIsolate> DartIsolate::GetWeakIsolatePtr() {
 void DartIsolate::AddIsolateShutdownCallback(fml::closure closure) {
   shutdown_callbacks_.emplace_back(
       std::make_unique<AutoFireClosure>(std::move(closure)));
+}
+
+DartIsolate::AutoFireClosure::AutoFireClosure(fml::closure closure) : closure_(std::move(closure)) {}
+DartIsolate::AutoFireClosure::~AutoFireClosure() {
+  if (closure_) {
+    closure_();
+  }
 }
 
 }  // namespace blink

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -730,7 +730,8 @@ void DartIsolate::AddIsolateShutdownCallback(fml::closure closure) {
       std::make_unique<AutoFireClosure>(std::move(closure)));
 }
 
-DartIsolate::AutoFireClosure::AutoFireClosure(fml::closure closure) : closure_(std::move(closure)) {}
+DartIsolate::AutoFireClosure::AutoFireClosure(fml::closure closure)
+    : closure_(std::move(closure)) {}
 DartIsolate::AutoFireClosure::~AutoFireClosure() {
   if (closure_) {
     closure_();

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -98,12 +98,8 @@ class DartIsolate : public UIDartState {
 
   class AutoFireClosure {
    public:
-    AutoFireClosure(fml::closure closure) : closure_(std::move(closure)) {}
-    ~AutoFireClosure() {
-      if (closure_) {
-        closure_();
-      }
-    }
+    AutoFireClosure(fml::closure closure);
+    ~AutoFireClosure();
 
    private:
     fml::closure closure_;

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -313,7 +313,7 @@ DartVM::DartVM(const Settings& settings,
   // it does not recognize, it exits immediately.
   args.push_back("--ignore-unrecognized-flags");
 
-  for (const auto& profiler_flag :
+  for (auto* const profiler_flag :
        ProfilingFlags(settings.enable_dart_profiling)) {
     args.push_back(profiler_flag);
   }

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -311,9 +311,9 @@ std::pair<bool, uint32_t> RuntimeController::GetRootIsolateReturnCode() {
 }
 
 RuntimeController::Locale::Locale(std::string language_code_,
-       std::string country_code_,
-       std::string script_code_,
-       std::string variant_code_)
+                                  std::string country_code_,
+                                  std::string script_code_,
+                                  std::string variant_code_)
     : language_code(language_code_),
       country_code(country_code_),
       script_code(script_code_),

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -75,7 +75,7 @@ RuntimeController::RuntimeController(
   root_isolate->SetReturnCodeCallback([this](uint32_t code) {
     root_isolate_return_code_ = {true, code};
   });
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     tonic::DartState::Scope scope(root_isolate);
     window->DidCreateIsolate();
     if (!FlushRuntimeStateToIsolate()) {
@@ -134,7 +134,7 @@ bool RuntimeController::FlushRuntimeStateToIsolate() {
 bool RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {
   window_data_.viewport_metrics = metrics;
 
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     window->UpdateWindowMetrics(metrics);
     return true;
   }
@@ -145,7 +145,7 @@ bool RuntimeController::SetLocales(
     const std::vector<std::string>& locale_data) {
   window_data_.locale_data = locale_data;
 
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     window->UpdateLocales(locale_data);
     return true;
   }
@@ -155,7 +155,7 @@ bool RuntimeController::SetLocales(
 bool RuntimeController::SetUserSettingsData(const std::string& data) {
   window_data_.user_settings_data = data;
 
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     window->UpdateUserSettingsData(window_data_.user_settings_data);
     return true;
   }
@@ -166,7 +166,7 @@ bool RuntimeController::SetUserSettingsData(const std::string& data) {
 bool RuntimeController::SetSemanticsEnabled(bool enabled) {
   window_data_.semantics_enabled = enabled;
 
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     window->UpdateSemanticsEnabled(window_data_.semantics_enabled);
     return true;
   }
@@ -176,7 +176,7 @@ bool RuntimeController::SetSemanticsEnabled(bool enabled) {
 
 bool RuntimeController::SetAccessibilityFeatures(int32_t flags) {
   window_data_.accessibility_feature_flags_ = flags;
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     window->UpdateAccessibilityFeatures(
         window_data_.accessibility_feature_flags_);
     return true;
@@ -186,7 +186,7 @@ bool RuntimeController::SetAccessibilityFeatures(int32_t flags) {
 }
 
 bool RuntimeController::BeginFrame(fml::TimePoint frame_time) {
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     window->BeginFrame(frame_time);
     return true;
   }
@@ -206,7 +206,7 @@ bool RuntimeController::NotifyIdle(int64_t deadline) {
 
 bool RuntimeController::DispatchPlatformMessage(
     fml::RefPtr<PlatformMessage> message) {
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     TRACE_EVENT1("flutter", "RuntimeController::DispatchPlatformMessage",
                  "mode", "basic");
     window->DispatchPlatformMessage(std::move(message));
@@ -217,7 +217,7 @@ bool RuntimeController::DispatchPlatformMessage(
 
 bool RuntimeController::DispatchPointerDataPacket(
     const PointerDataPacket& packet) {
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     TRACE_EVENT1("flutter", "RuntimeController::DispatchPointerDataPacket",
                  "mode", "basic");
     window->DispatchPointerDataPacket(packet);
@@ -231,7 +231,7 @@ bool RuntimeController::DispatchSemanticsAction(int32_t id,
                                                 std::vector<uint8_t> args) {
   TRACE_EVENT1("flutter", "RuntimeController::DispatchSemanticsAction", "mode",
                "basic");
-  if (auto window = GetWindowIfAvailable()) {
+  if (auto* window = GetWindowIfAvailable()) {
     window->DispatchSemanticsAction(id, action, std::move(args));
     return true;
   }
@@ -309,5 +309,19 @@ std::weak_ptr<DartIsolate> RuntimeController::GetRootIsolate() {
 std::pair<bool, uint32_t> RuntimeController::GetRootIsolateReturnCode() {
   return root_isolate_return_code_;
 }
+
+RuntimeController::Locale::Locale(std::string language_code_,
+       std::string country_code_,
+       std::string script_code_,
+       std::string variant_code_)
+    : language_code(language_code_),
+      country_code(country_code_),
+      script_code(script_code_),
+      variant_code(variant_code_) {}
+RuntimeController::Locale::~Locale() = default;
+
+RuntimeController::WindowData::WindowData() = default;
+RuntimeController::WindowData::WindowData(const WindowData& other) = default;
+RuntimeController::WindowData::~WindowData() = default;
 
 }  // namespace blink

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -38,7 +38,7 @@ class RuntimeController final : public WindowClient {
                     std::string advisory_script_uri,
                     std::string advisory_script_entrypoint);
 
-  ~RuntimeController();
+  ~RuntimeController() override;
 
   std::unique_ptr<RuntimeController> Clone() const;
 
@@ -83,11 +83,8 @@ class RuntimeController final : public WindowClient {
     Locale(std::string language_code_,
            std::string country_code_,
            std::string script_code_,
-           std::string variant_code_)
-        : language_code(language_code_),
-          country_code(country_code_),
-          script_code(script_code_),
-          variant_code(variant_code_) {}
+           std::string variant_code_);
+    ~Locale();
 
     std::string language_code;
     std::string country_code;
@@ -96,6 +93,10 @@ class RuntimeController final : public WindowClient {
   };
 
   struct WindowData {
+    WindowData();
+    WindowData(const WindowData& other);
+    ~WindowData();
+
     ViewportMetrics viewport_metrics;
     std::string language_code;
     std::string country_code;

--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -177,7 +177,7 @@ bool ServiceProtocol::HandleMessage(fml::StringView method,
   // Find the handler by its "viewId" in the params.
   auto view_id_param_found = params.find(fml::StringView{"viewId"});
   if (view_id_param_found != params.end()) {
-    auto handler = reinterpret_cast<Handler*>(std::stoull(
+    auto* handler = reinterpret_cast<Handler*>(std::stoull(
         view_id_param_found->second.data() + kViewIdPrefx.size(), nullptr, 16));
     auto handler_found = handlers_.find(handler);
     if (handler_found != handlers_.end()) {
@@ -239,7 +239,7 @@ bool ServiceProtocol::HandleListViewsMethod(
   // Collect handler descriptions on their respective task runners.
   std::lock_guard<std::mutex> lock(handlers_mutex_);
   std::vector<std::pair<intptr_t, Handler::Description>> descriptions;
-  for (const auto& handler : handlers_) {
+  for (auto* const handler : handlers_) {
     fml::AutoResetWaitableEvent latch;
     Handler::Description description;
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -164,9 +164,9 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
   // for instrumentation.
   compositor_context_->engine_time().SetLapTime(layer_tree.construction_time());
 
-  auto canvas = frame->SkiaCanvas();
+  auto* canvas = frame->SkiaCanvas();
 
-  auto external_view_embedder = surface_->GetExternalViewEmbedder();
+  auto* external_view_embedder = surface_->GetExternalViewEmbedder();
 
   if (external_view_embedder != nullptr) {
     external_view_embedder->BeginFrame(layer_tree.frame_size());
@@ -253,7 +253,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsImage(
   }
 
   // Draw the current layer tree into the snapshot surface.
-  auto canvas = snapshot_surface->getCanvas();
+  auto* canvas = snapshot_surface->getCanvas();
 
   // There is no root surface transformation for the screenshot layer. Reset the
   // matrix to identity.
@@ -299,7 +299,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsImage(
 Rasterizer::Screenshot Rasterizer::ScreenshotLastLayerTree(
     Rasterizer::ScreenshotType type,
     bool base64_encode) {
-  auto layer_tree = GetLastLayerTree();
+  auto* layer_tree = GetLastLayerTree();
   if (layer_tree == nullptr) {
     FML_LOG(ERROR) << "Last layer tree was null when screenshotting.";
     return {};
@@ -351,5 +351,14 @@ void Rasterizer::FireNextFrameCallbackIfPresent() {
   next_frame_callback_ = nullptr;
   callback();
 }
+
+Rasterizer::Screenshot::Screenshot() {}
+
+Rasterizer::Screenshot::Screenshot(sk_sp<SkData> p_data, SkISize p_size)
+    : data(std::move(p_data)), frame_size(p_size) {}
+
+Rasterizer::Screenshot::Screenshot(const Screenshot& other) = default;
+
+Rasterizer::Screenshot::~Screenshot() = default;
 
 }  // namespace shell

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -54,10 +54,13 @@ class Rasterizer final : public blink::SnapshotDelegate {
     sk_sp<SkData> data;
     SkISize frame_size = SkISize::MakeEmpty();
 
-    Screenshot() {}
+    Screenshot();
 
-    Screenshot(sk_sp<SkData> p_data, SkISize p_size)
-        : data(std::move(p_data)), frame_size(p_size) {}
+    Screenshot(sk_sp<SkData> p_data, SkISize p_size);
+
+    Screenshot(const Screenshot& other);
+
+    ~Screenshot();
   };
 
   Screenshot ScreenshotLastLayerTree(ScreenshotType type, bool base64_encode);

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -588,7 +588,7 @@ void Shell::OnPlatformViewRegisterTexture(
   task_runners_.GetGPUTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(), texture] {
         if (rasterizer) {
-          if (auto registry = rasterizer->GetTextureRegistry()) {
+          if (auto* registry = rasterizer->GetTextureRegistry()) {
             registry->RegisterTexture(texture);
           }
         }
@@ -603,7 +603,7 @@ void Shell::OnPlatformViewUnregisterTexture(int64_t texture_id) {
   task_runners_.GetGPUTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(), texture_id]() {
         if (rasterizer) {
-          if (auto registry = rasterizer->GetTextureRegistry()) {
+          if (auto* registry = rasterizer->GetTextureRegistry()) {
             registry->UnregisterTexture(texture_id);
           }
         }
@@ -618,7 +618,7 @@ void Shell::OnPlatformViewMarkTextureFrameAvailable(int64_t texture_id) {
   // Tell the rasterizer that one of its textures has a new frame available.
   task_runners_.GetGPUTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(), texture_id]() {
-        auto registry = rasterizer->GetTextureRegistry();
+        auto* registry = rasterizer->GetTextureRegistry();
 
         if (!registry) {
           return;

--- a/shell/common/thread_host.cc
+++ b/shell/common/thread_host.cc
@@ -7,6 +7,7 @@
 namespace shell {
 
 ThreadHost::ThreadHost() = default;
+ThreadHost::ThreadHost(ThreadHost&&) = default;
 
 ThreadHost::ThreadHost(std::string name_prefix, uint64_t mask) {
   if (mask & ThreadHost::Type::Platform) {

--- a/shell/common/thread_host.h
+++ b/shell/common/thread_host.h
@@ -27,7 +27,7 @@ struct ThreadHost {
 
   ThreadHost();
 
-  ThreadHost(ThreadHost&&) = default;
+  ThreadHost(ThreadHost&&);
 
   ThreadHost& operator=(ThreadHost&&) = default;
 

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -368,9 +368,13 @@ bool GPUSurfaceGL::MakeRenderContextCurrent() {
   return delegate_->GLContextMakeCurrent();
 }
 
-bool GPUSurfaceGLDelegate::GLContextFBOResetAfterPresent() const { return false; }
+bool GPUSurfaceGLDelegate::GLContextFBOResetAfterPresent() const {
+  return false;
+}
 
-bool GPUSurfaceGLDelegate::UseOffscreenSurface() const { return false; }
+bool GPUSurfaceGLDelegate::UseOffscreenSurface() const {
+  return false;
+}
 
 SkMatrix GPUSurfaceGLDelegate::GLContextSurfaceTransformation() const {
   SkMatrix matrix;
@@ -382,6 +386,9 @@ flow::ExternalViewEmbedder* GPUSurfaceGLDelegate::GetExternalViewEmbedder() {
   return nullptr;
 }
 
-GPUSurfaceGLDelegate::GLProcResolver GPUSurfaceGLDelegate::GetGLProcResolver() const { return nullptr; }
+GPUSurfaceGLDelegate::GLProcResolver GPUSurfaceGLDelegate::GetGLProcResolver()
+    const {
+  return nullptr;
+}
 
 }  // namespace shell

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -368,4 +368,20 @@ bool GPUSurfaceGL::MakeRenderContextCurrent() {
   return delegate_->GLContextMakeCurrent();
 }
 
+bool GPUSurfaceGLDelegate::GLContextFBOResetAfterPresent() const { return false; }
+
+bool GPUSurfaceGLDelegate::UseOffscreenSurface() const { return false; }
+
+SkMatrix GPUSurfaceGLDelegate::GLContextSurfaceTransformation() const {
+  SkMatrix matrix;
+  matrix.setIdentity();
+  return matrix;
+}
+
+flow::ExternalViewEmbedder* GPUSurfaceGLDelegate::GetExternalViewEmbedder() {
+  return nullptr;
+}
+
+GPUSurfaceGLDelegate::GLProcResolver GPUSurfaceGLDelegate::GetGLProcResolver() const { return nullptr; }
+
 }  // namespace shell

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -26,23 +26,17 @@ class GPUSurfaceGLDelegate {
 
   virtual intptr_t GLContextFBO() const = 0;
 
-  virtual bool GLContextFBOResetAfterPresent() const { return false; }
+  virtual bool GLContextFBOResetAfterPresent() const;
 
-  virtual bool UseOffscreenSurface() const { return false; }
+  virtual bool UseOffscreenSurface() const;
 
-  virtual SkMatrix GLContextSurfaceTransformation() const {
-    SkMatrix matrix;
-    matrix.setIdentity();
-    return matrix;
-  }
+  virtual SkMatrix GLContextSurfaceTransformation() const;
 
-  virtual flow::ExternalViewEmbedder* GetExternalViewEmbedder() {
-    return nullptr;
-  }
+  virtual flow::ExternalViewEmbedder* GetExternalViewEmbedder();
 
   using GLProcResolver =
       std::function<void* /* proc name */ (const char* /* proc address */)>;
-  virtual GLProcResolver GetGLProcResolver() const { return nullptr; }
+  virtual GLProcResolver GetGLProcResolver() const;
 };
 
 class GPUSurfaceGL : public Surface {

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -19,13 +19,13 @@ class AndroidExternalTextureGL : public flow::Texture {
 
   ~AndroidExternalTextureGL() override;
 
-  virtual void Paint(SkCanvas& canvas,
+  void Paint(SkCanvas& canvas,
                      const SkRect& bounds,
                      bool freeze) override;
 
-  virtual void OnGrContextCreated() override;
+  void OnGrContextCreated() override;
 
-  virtual void OnGrContextDestroyed() override;
+  void OnGrContextDestroyed() override;
 
   void MarkNewFrameAvailable() override;
 

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -19,9 +19,7 @@ class AndroidExternalTextureGL : public flow::Texture {
 
   ~AndroidExternalTextureGL() override;
 
-  void Paint(SkCanvas& canvas,
-                     const SkRect& bounds,
-                     bool freeze) override;
+  void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) override;
 
   void OnGrContextCreated() override;
 

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -19,7 +19,7 @@ class APKAssetProvider final : public AssetResolver {
   explicit APKAssetProvider(JNIEnv* env,
                             jobject assetManager,
                             std::string directory);
-  virtual ~APKAssetProvider();
+  ~APKAssetProvider() override;
 
  private:
   fml::jni::ScopedJavaGlobalRef<jobject> java_asset_manager_;

--- a/shell/platform/android/platform_message_response_android.cc
+++ b/shell/platform/android/platform_message_response_android.cc
@@ -17,6 +17,8 @@ PlatformMessageResponseAndroid::PlatformMessageResponseAndroid(
       weak_java_object_(weak_java_object),
       platform_task_runner_(std::move(platform_task_runner)) {}
 
+PlatformMessageResponseAndroid::~PlatformMessageResponseAndroid() = default;
+
 // |blink::PlatformMessageResponse|
 void PlatformMessageResponseAndroid::Complete(
     std::unique_ptr<fml::Mapping> data) {
@@ -27,7 +29,7 @@ void PlatformMessageResponseAndroid::Complete(
   ]() {
         // We are on the platform thread. Attempt to get the strong reference to
         // the Java object.
-        auto env = fml::jni::AttachCurrentThread();
+        auto* env = fml::jni::AttachCurrentThread();
         auto java_object = weak_java_object.get(env);
 
         if (java_object.is_null()) {
@@ -57,7 +59,7 @@ void PlatformMessageResponseAndroid::CompleteEmpty() {
   ]() {
         // We are on the platform thread. Attempt to get the strong reference to
         // the Java object.
-        auto env = fml::jni::AttachCurrentThread();
+        auto* env = fml::jni::AttachCurrentThread();
         auto java_object = weak_java_object.get(env);
 
         if (java_object.is_null()) {

--- a/shell/platform/android/platform_message_response_android.h
+++ b/shell/platform/android/platform_message_response_android.h
@@ -25,6 +25,7 @@ class PlatformMessageResponseAndroid : public blink::PlatformMessageResponse {
       int response_id,
       fml::jni::JavaObjectWeakGlobalRef weak_java_object,
       fml::RefPtr<fml::TaskRunner> platform_task_runner);
+  ~PlatformMessageResponseAndroid() override;
 
   int response_id_;
   fml::jni::JavaObjectWeakGlobalRef weak_java_object_;

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -329,19 +329,18 @@ static void SetViewportMetrics(JNIEnv* env,
                                jint physicalViewInsetRight,
                                jint physicalViewInsetBottom,
                                jint physicalViewInsetLeft) {
-  const blink::ViewportMetrics metrics = {
-      .device_pixel_ratio = static_cast<double>(devicePixelRatio),
-      .physical_width = static_cast<double>(physicalWidth),
-      .physical_height = static_cast<double>(physicalHeight),
-      .physical_padding_top = static_cast<double>(physicalPaddingTop),
-      .physical_padding_right = static_cast<double>(physicalPaddingRight),
-      .physical_padding_bottom = static_cast<double>(physicalPaddingBottom),
-      .physical_padding_left = static_cast<double>(physicalPaddingLeft),
-      .physical_view_inset_top = static_cast<double>(physicalViewInsetTop),
-      .physical_view_inset_right = static_cast<double>(physicalViewInsetRight),
-      .physical_view_inset_bottom =
-          static_cast<double>(physicalViewInsetBottom),
-      .physical_view_inset_left = static_cast<double>(physicalViewInsetLeft),
+  const blink::ViewportMetrics metrics{
+      static_cast<double>(devicePixelRatio),
+      static_cast<double>(physicalWidth),
+      static_cast<double>(physicalHeight),
+      static_cast<double>(physicalPaddingTop),
+      static_cast<double>(physicalPaddingRight),
+      static_cast<double>(physicalPaddingBottom),
+      static_cast<double>(physicalPaddingLeft),
+      static_cast<double>(physicalViewInsetTop),
+      static_cast<double>(physicalViewInsetRight),
+      static_cast<double>(physicalViewInsetBottom),
+      static_cast<double>(physicalViewInsetLeft),
   };
 
   ANDROID_SHELL_HOLDER->SetViewportMetrics(metrics);

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -365,7 +365,7 @@ static jobject GetBitmap(JNIEnv* env, jobject jcaller, jlong shell_holder) {
     return nullptr;
   }
 
-  auto pixels_src = static_cast<const int32_t*>(screenshot.data->data());
+  auto* pixels_src = static_cast<const int32_t*>(screenshot.data->data());
 
   // Our configuration of Skia does not support rendering to the
   // BitmapConfig.ARGB_8888 format expected by android.graphics.Bitmap.

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -84,7 +84,7 @@ bool VsyncWaiterAndroid::Register(JNIEnv* env) {
 static void ConsumePendingCallback(jlong java_baton,
                                    fml::TimePoint frame_start_time,
                                    fml::TimePoint frame_target_time) {
-  auto weak_this = reinterpret_cast<std::weak_ptr<VsyncWaiter>*>(java_baton);
+  auto* weak_this = reinterpret_cast<std::weak_ptr<VsyncWaiter>*>(java_baton);
   auto shared_this = weak_this->lock();
   delete weak_this;
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -62,6 +62,7 @@ shared_library("create_flutter_framework_dylib") {
     "framework/Source/FlutterPlatformPlugin.h",
     "framework/Source/FlutterPlatformPlugin.mm",
     "framework/Source/FlutterPlatformViews_Internal.h",
+    "framework/Source/FlutterPlatformViews_Internal.mm",
     "framework/Source/FlutterPlatformViews.mm",
     "framework/Source/FlutterPluginAppLifeCycleDelegate.mm",
     "framework/Source/FlutterStandardCodec.mm",

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -32,10 +32,9 @@ class IOSSurface;
 struct FlutterPlatformViewLayer {
   FlutterPlatformViewLayer(fml::scoped_nsobject<UIView> overlay_view,
                            std::unique_ptr<IOSSurface> ios_surface,
-                           std::unique_ptr<Surface> surface)
-      : overlay_view(std::move(overlay_view)),
-        ios_surface(std::move(ios_surface)),
-        surface(std::move(surface)){};
+                           std::unique_ptr<Surface> surface);
+
+  ~FlutterPlatformViewLayer();
 
   fml::scoped_nsobject<UIView> overlay_view;
   std::unique_ptr<IOSSurface> ios_surface;
@@ -44,7 +43,8 @@ struct FlutterPlatformViewLayer {
 
 class FlutterPlatformViewsController {
  public:
-  FlutterPlatformViewsController() = default;
+  FlutterPlatformViewsController();
+  ~FlutterPlatformViewsController();
 
   void SetFlutterView(UIView* flutter_view);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -1,5 +1,6 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 
+#include "flutter/shell/platform/darwin/ios/ios_surface.h"
 
 namespace shell {
 FlutterPlatformViewLayer::FlutterPlatformViewLayer(fml::scoped_nsobject<UIView> overlay_view,

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -1,0 +1,19 @@
+#include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
+
+
+namespace shell {
+FlutterPlatformViewLayer::FlutterPlatformViewLayer(fml::scoped_nsobject<UIView> overlay_view,
+                         std::unique_ptr<IOSSurface> ios_surface,
+                         std::unique_ptr<Surface> surface)
+    : overlay_view(std::move(overlay_view)),
+      ios_surface(std::move(ios_surface)),
+      surface(std::move(surface)){};
+
+FlutterPlatformViewLayer::~FlutterPlatformViewLayer() = default;
+
+
+FlutterPlatformViewsController::FlutterPlatformViewsController() = default;
+FlutterPlatformViewsController::~FlutterPlatformViewsController() = default;
+
+
+}  // namespace shell

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -4,17 +4,15 @@
 
 namespace shell {
 FlutterPlatformViewLayer::FlutterPlatformViewLayer(fml::scoped_nsobject<UIView> overlay_view,
-                         std::unique_ptr<IOSSurface> ios_surface,
-                         std::unique_ptr<Surface> surface)
+                                                   std::unique_ptr<IOSSurface> ios_surface,
+                                                   std::unique_ptr<Surface> surface)
     : overlay_view(std::move(overlay_view)),
       ios_surface(std::move(ios_surface)),
       surface(std::move(surface)){};
 
 FlutterPlatformViewLayer::~FlutterPlatformViewLayer() = default;
 
-
 FlutterPlatformViewsController::FlutterPlatformViewsController() = default;
 FlutterPlatformViewsController::~FlutterPlatformViewsController() = default;
-
 
 }  // namespace shell

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"

--- a/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h
@@ -20,24 +20,15 @@ namespace shell {
 
 class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
  public:
-  void Complete(std::unique_ptr<fml::Mapping> data) override {
-    fml::RefPtr<PlatformMessageResponseDarwin> self(this);
-    platform_task_runner_->PostTask(fml::MakeCopyable([self, data = std::move(data)]() mutable {
-      self->callback_.get()(shell::GetNSDataFromMapping(std::move(data)));
-    }));
-  }
+  void Complete(std::unique_ptr<fml::Mapping> data) override;
 
-  void CompleteEmpty() override {
-    fml::RefPtr<PlatformMessageResponseDarwin> self(this);
-    platform_task_runner_->PostTask(
-        fml::MakeCopyable([self]() mutable { self->callback_.get()(nil); }));
-  }
+  void CompleteEmpty() override;
 
  private:
   explicit PlatformMessageResponseDarwin(PlatformMessageResponseCallback callback,
-                                         fml::RefPtr<fml::TaskRunner> platform_task_runner)
-      : callback_(callback, fml::OwnershipPolicy::Retain),
-        platform_task_runner_(std::move(platform_task_runner)) {}
+                                         fml::RefPtr<fml::TaskRunner> platform_task_runner);
+
+  ~PlatformMessageResponseDarwin() override;
 
   fml::ScopedBlock<PlatformMessageResponseCallback> callback_;
   fml::RefPtr<fml::TaskRunner> platform_task_runner_;

--- a/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
@@ -6,13 +6,13 @@
 
 namespace shell {
 
-PlatformMessageResponseDarwin::PlatformMessageResponseDarwin(PlatformMessageResponseCallback callback,
-                                         fml::RefPtr<fml::TaskRunner> platform_task_runner)
-      : callback_(callback, fml::OwnershipPolicy::Retain),
-        platform_task_runner_(std::move(platform_task_runner)) {}
+PlatformMessageResponseDarwin::PlatformMessageResponseDarwin(
+    PlatformMessageResponseCallback callback,
+    fml::RefPtr<fml::TaskRunner> platform_task_runner)
+    : callback_(callback, fml::OwnershipPolicy::Retain),
+      platform_task_runner_(std::move(platform_task_runner)) {}
 
 PlatformMessageResponseDarwin::~PlatformMessageResponseDarwin() = default;
-
 
 void PlatformMessageResponseDarwin::Complete(std::unique_ptr<fml::Mapping> data) {
   fml::RefPtr<PlatformMessageResponseDarwin> self(this);

--- a/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.mm
@@ -6,6 +6,25 @@
 
 namespace shell {
 
-//
+PlatformMessageResponseDarwin::PlatformMessageResponseDarwin(PlatformMessageResponseCallback callback,
+                                         fml::RefPtr<fml::TaskRunner> platform_task_runner)
+      : callback_(callback, fml::OwnershipPolicy::Retain),
+        platform_task_runner_(std::move(platform_task_runner)) {}
+
+PlatformMessageResponseDarwin::~PlatformMessageResponseDarwin() = default;
+
+
+void PlatformMessageResponseDarwin::Complete(std::unique_ptr<fml::Mapping> data) {
+  fml::RefPtr<PlatformMessageResponseDarwin> self(this);
+  platform_task_runner_->PostTask(fml::MakeCopyable([self, data = std::move(data)]() mutable {
+    self->callback_.get()(shell::GetNSDataFromMapping(std::move(data)));
+  }));
+}
+
+void PlatformMessageResponseDarwin::CompleteEmpty() {
+  fml::RefPtr<PlatformMessageResponseDarwin> self(this);
+  platform_task_runner_->PostTask(
+      fml::MakeCopyable([self]() mutable { self->callback_.get()(nil); }));
+}
 
 }  // namespace shell

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -18,13 +18,13 @@ class IOSExternalTextureGL : public flow::Texture {
   ~IOSExternalTextureGL() override;
 
   // Called from GPU thread.
-  virtual void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) override;
+  void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) override;
 
-  virtual void OnGrContextCreated() override;
+  void OnGrContextCreated() override;
 
-  virtual void OnGrContextDestroyed() override;
+  void OnGrContextDestroyed() override;
 
-  virtual void MarkNewFrameAvailable() override;
+  void MarkNewFrameAvailable() override;
 
  private:
   NSObject<FlutterTexture>* external_texture_;

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -63,7 +63,7 @@ class IOSSurfaceGL : public IOSSurface,
   SkCanvas* CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) override;
 
   // |flow::ExternalViewEmbedder|
-  virtual bool SubmitFrame(GrContext* context) override;
+  bool SubmitFrame(GrContext* context) override;
 
  private:
   std::shared_ptr<IOSGLContext> context_;

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -58,7 +58,7 @@ class IOSSurfaceSoftware final : public IOSSurface,
   SkCanvas* CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params) override;
 
   // |flow::ExternalViewEmbedder|
-  virtual bool SubmitFrame(GrContext* context) override;
+  bool SubmitFrame(GrContext* context) override;
 
  private:
   fml::scoped_nsobject<CALayer> layer_;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -27,7 +27,7 @@ class PlatformViewIOS final : public PlatformView {
  public:
   explicit PlatformViewIOS(PlatformView::Delegate& delegate, blink::TaskRunners task_runners);
 
-  ~PlatformViewIOS();
+  ~PlatformViewIOS() override;
 
   PlatformMessageRouter& GetPlatformMessageRouter();
 


### PR DESCRIPTION
Fixes the issues listed in https://www.chromium.org/developers/coding-style/chromium-style-checker-errors for the android and ios release targets. The issues were identified by compiling the engine with the [chrome-style clang plugin](https://chromium.googlesource.com/chromium/src/tools/+/master/clang/plugins/).

Fixing these issues is supposed to prevent code size bloat. For our code base I am only seeing a rather disappointing reduction of 317 Bytes for `libflutter.so` (uncompressed). 