### PR TITLE
Avoid a never-disappearing splash screen if the engine came from somewhere else on iOS

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -763,8 +763,12 @@ class AccessibilityBridge
                 sendAccessibilityEvent(event);
             }
             if (mInputFocusedObject != null && mInputFocusedObject.id == object.id
-                    && (mA11yFocusedObject == null || (mA11yFocusedObject.id == mInputFocusedObject.id))
-                    && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)) {
+                    && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)
+                    // If we have a TextField that has InputFocus, we should avoid announcing it if something
+                    // else we track has a11y focus. This needs to still work when, e.g., IME has a11y focus
+                    // or the "PASTE" popup is used though.
+                    // See more discussion at https://github.com/flutter/flutter/issues/23180
+                    && (mA11yFocusedObject == null || (mA11yFocusedObject.id == mInputFocusedObject.id))) {
                 String oldValue = object.previousValue != null ? object.previousValue : "";
                 String newValue = object.value != null ? object.value : "";
                 AccessibilityEvent event = createTextChangedEvent(object.id, oldValue, newValue);

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -763,6 +763,7 @@ class AccessibilityBridge
                 sendAccessibilityEvent(event);
             }
             if (mInputFocusedObject != null && mInputFocusedObject.id == object.id
+                    && (mA11yFocusedObject == null || (mA11yFocusedObject.id == mInputFocusedObject.id))
                     && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)) {
                 String oldValue = object.previousValue != null ? object.previousValue : "";
                 String newValue = object.value != null ? object.value : "";

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -237,11 +237,6 @@
 #pragma mark - Managing launch views
 
 - (void)installSplashScreenViewIfNecessary {
-  // If the engine wasn't created by this FlutterViewController, we should avoid installing
-  // a splash screen - otherwise we may never get rid of it.
-  if (!_engineNeedsLaunch) {
-    return;
-  }
   // Show the launch screen view again on top of the FlutterView if available.
   // This launch screen view will be removed once the first Flutter frame is rendered.
   if (self.isBeingPresented || self.isMovingToParentViewController) {
@@ -349,6 +344,19 @@
 }
 
 - (void)setSplashScreenView:(UIView*)view {
+  if (!view) {
+    // Special case: user wants to remove the splash screen view.
+    [self removeSplashScreenViewIfPresent];
+  } else if (_splashScreenView) {
+    FML_LOG(ERROR) << "Attempt to set the FlutterViewController's splash screen multiple times was "
+                      "ignored. The FlutterViewController's splash screen can only be set once. "
+                      "This condition can occur if a running FlutterEngine instance has been "
+                      "passed into the FlutterViewController and a consumer later called "
+                      "[FlutterViewController setSplashScreen:]. Setting the splash screen on a "
+                      "FlutterViewController with an already running engine is not supported, as "
+                      "the rasterizer will already be running by the time the view is shown.";
+    return;
+  }
   _splashScreenView.reset([view retain]);
   _splashScreenView.get().autoresizingMask =
       UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -237,6 +237,11 @@
 #pragma mark - Managing launch views
 
 - (void)installSplashScreenViewIfNecessary {
+  // If the engine wasn't created by this FlutterViewController, we should avoid installing
+  // a splash screen - otherwise we may never get rid of it.
+  if (_engineNeedsLaunch == NO) {
+    return;
+  }
   // Show the launch screen view again on top of the FlutterView if available.
   // This launch screen view will be removed once the first Flutter frame is rendered.
   if (self.isBeingPresented || self.isMovingToParentViewController) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -239,7 +239,7 @@
 - (void)installSplashScreenViewIfNecessary {
   // If the engine wasn't created by this FlutterViewController, we should avoid installing
   // a splash screen - otherwise we may never get rid of it.
-  if (_engineNeedsLaunch == NO) {
+  if (!_engineNeedsLaunch) {
     return;
   }
   // Show the launch screen view again on top of the FlutterView if available.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/24260

Today, if a user does the following sequence, they'll end up with a blank screen:

```
FlutterViewController* flutterViewController =
      [[FlutterViewController alloc] initWithEngine:_engine
                                            nibName:nil
                                             bundle:nil];
  flutterViewController.splashScreenView = [[UIView alloc] init];
  [self presentViewController:flutterViewController
                     animated:false
                   completion:nil];
```

Where `_engine` is a prewarmed `FlutterEngine` from somewhere else.

This prevents that.