### PR TITLE
Add missing pragma directive.

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -752,6 +752,7 @@ enum TextDirection {
 /// A rectangle enclosing a run of text.
 ///
 /// This is similar to [Rect] but includes an inherent [TextDirection].
+@pragma('vm:entry-point')
 class TextBox {
   /// Creates an object that describes a box containing text.
   const TextBox.fromLTRBD(


### PR DESCRIPTION
This should fix the failing tests flutter_gallery_ios32__transition_perf, flutter_gallery_ios__transition_perf,
flutter_gallery__transition_perf and flutter_gallery__transition_perf which are hitting an assertion due to missing pragmas.