### PR TITLE
Flush UserSettings to window

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -68,6 +68,9 @@ void _updateLocales(List<String> locales) {
 @pragma('vm:entry-point')
 void _updateUserSettingsData(String jsonData) {
   final Map<String, dynamic> data = json.decode(jsonData);
+  if (data.isEmpty) {
+    return;
+  }
   _updateTextScaleFactor(data['textScaleFactor'].toDouble());
   _updateAlwaysUse24HourFormat(data['alwaysUse24HourFormat']);
 }

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -128,7 +128,8 @@ bool RuntimeController::FlushRuntimeStateToIsolate() {
   return SetViewportMetrics(window_data_.viewport_metrics) &&
          SetLocales(window_data_.locale_data) &&
          SetSemanticsEnabled(window_data_.semantics_enabled) &&
-         SetAccessibilityFeatures(window_data_.accessibility_feature_flags_);
+         SetAccessibilityFeatures(window_data_.accessibility_feature_flags_) &&
+         SetUserSettingsData(window_data_.user_settings_data);
 }
 
 bool RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -67,6 +67,12 @@ void main() {
       window.onTextScaleFactorChanged = originalOnTextScaleFactorChanged;
     });
 
+    test('updateUserSettings can handle an empty object', () {
+      // this should now throw.
+      _updateUserSettingsData('{}');
+      expect(true, equals(true));
+    });
+
     test('onMetricsChanged preserves callback zone', () {
       Zone innerZone;
       Zone runZone;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/19145

When the engine is hot restarted, we're not flushing the user settings down to the window again, which results in them getting defaulted to potentially incorrect values.

This should fix that on both Android and iOS (this bug was original reported for iOS targets).