### PR TITLE
Set and unset accessibility flags even when re-entrant

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -878,6 +878,8 @@ public class FlutterView extends SurfaceView
         }
         if (mTouchExplorationEnabled) {
             mAccessibilityFeatureFlags |= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
+        } else {
+            mAccessibilityFeatureFlags &= ~AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
         }
         // Apply additional accessibility settings
         updateAccessibilityFeatures();

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -877,7 +877,7 @@ public class FlutterView extends SurfaceView
             ensureAccessibilityEnabled();
         }
         if (mTouchExplorationEnabled) {
-            mAccessibilityFeatureFlags ^= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
+            mAccessibilityFeatureFlags |= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
         }
         // Apply additional accessibility settings
         updateAccessibilityFeatures();
@@ -896,7 +896,7 @@ public class FlutterView extends SurfaceView
             String transitionAnimationScale = Settings.Global.getString(getContext().getContentResolver(),
                 Settings.Global.TRANSITION_ANIMATION_SCALE);
             if (transitionAnimationScale != null && transitionAnimationScale.equals("0")) {
-                mAccessibilityFeatureFlags ^= AccessibilityFeature.DISABLE_ANIMATIONS.value;
+                mAccessibilityFeatureFlags |= AccessibilityFeature.DISABLE_ANIMATIONS.value;
             } else {
                 mAccessibilityFeatureFlags &= ~AccessibilityFeature.DISABLE_ANIMATIONS.value;
             }
@@ -966,7 +966,7 @@ public class FlutterView extends SurfaceView
             String value = Settings.Global.getString(getContext().getContentResolver(),
                     Settings.Global.TRANSITION_ANIMATION_SCALE);
             if (value != null && value.equals("0")) {
-                mAccessibilityFeatureFlags ^= AccessibilityFeature.DISABLE_ANIMATIONS.value;
+                mAccessibilityFeatureFlags |= AccessibilityFeature.DISABLE_ANIMATIONS.value;
             } else {
                 mAccessibilityFeatureFlags &= ~AccessibilityFeature.DISABLE_ANIMATIONS.value;
             }
@@ -980,7 +980,7 @@ public class FlutterView extends SurfaceView
             if (enabled) {
                 mTouchExplorationEnabled = true;
                 ensureAccessibilityEnabled();
-                mAccessibilityFeatureFlags ^= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
+                mAccessibilityFeatureFlags |= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
                 nativeSetAccessibilityFeatures(mNativeView.get(), mAccessibilityFeatureFlags);
             } else {
                 mTouchExplorationEnabled = false;

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -715,21 +715,12 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification {
   auto platformView = [_engine.get() platformView];
   int32_t flags = 0;
-  if (UIAccessibilityIsInvertColorsEnabled()) {
+  if (UIAccessibilityIsInvertColorsEnabled())
     flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
-  } else {
-    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
-  }
-  if (UIAccessibilityIsReduceMotionEnabled()) {
+  if (UIAccessibilityIsReduceMotionEnabled())
     flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kReduceMotion);
-  } else {
-    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kReduceMotion);
-  }
-  if (UIAccessibilityIsBoldTextEnabled()) {
+  if (UIAccessibilityIsBoldTextEnabled())
     flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
-  } else {
-    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
-  }
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the
@@ -738,11 +729,8 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
   platformView->SetAccessibilityFeatures(flags);
 #else
   bool enabled = UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning();
-  if (enabled) {
+  if (enabled)
     flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kAccessibleNavigation);
-  } else {
-    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kAccessibleNavigation);
-  }
   platformView->SetSemanticsEnabled(enabled || UIAccessibilityIsSpeakScreenEnabled());
   platformView->SetAccessibilityFeatures(flags);
 #endif

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -715,12 +715,21 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
 - (void)onAccessibilityStatusChanged:(NSNotification*)notification {
   auto platformView = [_engine.get() platformView];
   int32_t flags = 0;
-  if (UIAccessibilityIsInvertColorsEnabled())
-    flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
-  if (UIAccessibilityIsReduceMotionEnabled())
-    flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kReduceMotion);
-  if (UIAccessibilityIsBoldTextEnabled())
-    flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
+  if (UIAccessibilityIsInvertColorsEnabled()) {
+    flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
+  } else {
+    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kInvertColors);
+  }
+  if (UIAccessibilityIsReduceMotionEnabled()) {
+    flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kReduceMotion);
+  } else {
+    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kReduceMotion);
+  }
+  if (UIAccessibilityIsBoldTextEnabled()) {
+    flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
+  } else {
+    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kBoldText);
+  }
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the
@@ -729,8 +738,11 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
   platformView->SetAccessibilityFeatures(flags);
 #else
   bool enabled = UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning();
-  if (UIAccessibilityIsVoiceOverRunning() || UIAccessibilityIsSwitchControlRunning())
-    flags ^= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kAccessibleNavigation);
+  if (enabled) {
+    flags |= static_cast<int32_t>(blink::AccessibilityFeatureFlag::kAccessibleNavigation);
+  } else {
+    flags &= ~static_cast<int32_t>(blink::AccessibilityFeatureFlag::kAccessibleNavigation);
+  }
   platformView->SetSemanticsEnabled(enabled || UIAccessibilityIsSpeakScreenEnabled());
   platformView->SetAccessibilityFeatures(flags);
 #endif


### PR DESCRIPTION
Using `^=` was toggling these instead of setting them when they're enabled - this caused part of what is noted in https://github.com/flutter/flutter/issues/20388, but I'd like to leave that bug open even if this lands - I suspect that we should be resetting some internal state of the a11y bridges that we're not, but need to confirm.

/cc @matthew-carroll in case this impacts the embedding refactor