### PR TITLE
Reset a11y bridge state on hot restart

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -205,7 +205,8 @@ public class FlutterNativeView implements BinaryMessenger {
 
     // Called by native to update the semantics/accessibility tree.
     private void updateSemantics(ByteBuffer buffer, String[] strings) {
-        if (mFlutterView == null) return;
+        if (mFlutterView == null)
+            return;
         mFlutterView.updateSemantics(buffer, strings);
     }
 
@@ -218,13 +219,17 @@ public class FlutterNativeView implements BinaryMessenger {
 
     // Called by native to notify first Flutter frame rendered.
     private void onFirstFrame() {
-        if (mFlutterView == null) return;
+        if (mFlutterView == null)
+            return;
         mFlutterView.onFirstFrame();
     }
 
-    // Called by native to notify when the engine is restarted (cold reload).
+    // Called by native to notify when the engine is restarted (hot restart).
     @SuppressWarnings("unused")
     private void onPreEngineRestart() {
+        if (mFlutterView != null) {
+            mFlutterView.resetAccessibilityTree();
+        }
         if (mPluginRegistry == null)
             return;
         mPluginRegistry.onPreEngineRestart();

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -129,11 +129,12 @@ class AccessibilityBridge final {
 
   fml::WeakPtr<AccessibilityBridge> GetWeakPtr();
 
+  void clearState();
+
  private:
   SemanticsObject* GetOrCreateObject(int32_t id, blink::SemanticsNodeUpdates& updates);
   void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
                                         NSMutableArray<NSNumber*>* doomed_uids);
-  void ReleaseObjects(std::unordered_map<int, SemanticsObject*>& objects);
   void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
 
   UIView* view_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -687,4 +687,10 @@ fml::WeakPtr<AccessibilityBridge> AccessibilityBridge::GetWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }
 
+void AccessibilityBridge::clearState() {
+  [objects_ removeAllObjects];
+  previous_route_id_ = 0;
+  previous_routes_.clear();
+}
+
 }  // namespace shell

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -120,6 +120,9 @@ std::unique_ptr<VsyncWaiter> PlatformViewIOS::CreateVSyncWaiter() {
 }
 
 void PlatformViewIOS::OnPreEngineRestart() const {
+  if (accessibility_bridge_) {
+    accessibility_bridge_->clearState();
+  }
   if (!owner_controller_) {
     return;
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/20388

Previous PRs fixed an issue where the native side wasn't flushing access down to Dart land.  This PR makes sure that any internal state the engine has gotten from Dart gets flushed when a hot restart happens, to make sure we don't end up with stale a11y information across hot restarts (I ran into this while manually testing things for the progress indicator semantics work).

I also did a tiny bit of cleanup in the vicinity: moved some returns to newlines in Java, and removed an unused declaration in the C++ iOS header.

/cc @matthew-carroll  - I'm touching FlutterNativeView.java here, I assume this will have some impact on your embedding refactor work but I hope it's minimal.  We would definitely want to make sure that this call to reset doesn't get lost in that refactor though.