### PR TITLE
Revert "Clean up stale cache entries in Skia's GrContext (#6859)"

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -16,10 +16,6 @@
 
 namespace shell {
 
-// The rasterizer will tell Skia to purge cached resources that have not been
-// used within this interval.
-static constexpr std::chrono::milliseconds kSkiaCleanupExpiration(15000);
-
 Rasterizer::Rasterizer(blink::TaskRunners task_runners)
     : Rasterizer(std::move(task_runners),
                  std::make_unique<flow::CompositorContext>()) {}
@@ -190,9 +186,6 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
       external_view_embedder->SubmitFrame(surface_->GetContext());
     }
     FireNextFrameCallbackIfPresent();
-
-    surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
-
     return true;
   }
 


### PR DESCRIPTION
This reverts commit 2c6be93fa98aeb0dd3c1efa2db201232eb8eefba.

Fixes https://github.com/flutter/flutter/issues/24397

This causes an access issue on iOS simulators - I believe this may be because the surface is getting created on the platform thread and the rasterizer is trying to access it on the GPU thread, but I'm not quite sure why this would only happen on the simulator.

Will land TBR @jason-simmons @chinmaygarde @cbracken 