### PR TITLE
Warn users about incorrect use of setInitialRoute

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -213,6 +213,12 @@
 }
 
 - (void)setInitialRoute:(NSString*)route {
+  if (!_engineNeedsLaunch) {
+    FML_LOG(WARNING) << "Calling -[FlutterViewController setInitialRoute:] has no effect once the "
+                      "engine has started running. You should consider using either "
+                      "-[FlutterViewController pushRoute] or creating a custom method channel to "
+                      "communicate about initial route state after the engine has started.";
+  }
   [[_engine.get() navigationChannel] invokeMethod:@"setInitialRoute" arguments:route];
 }
 


### PR DESCRIPTION
Calling `setInitialRoute` after the engine has started running has no effect.  Even if we were to make it push the setting down to the window, there's nothing in the framework to inform users that it has changed.

Right now, the best bet is to call either `pushRoute` (which does something pretty diffferent), or have a user implement a custom channel for this.  It might be nice to create a callback for this in the framework at some point.

/cc @matthew-carroll - I know we've discussed this limitation on the Android side.