### PR TITLE
Don't load a splash screen by default

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -88,7 +88,7 @@ FLUTTER_EXPORT
  *
  * @param asset The name of the asset. The name can be hierarchical.
  * @param package The name of the package from which the asset originates.
- * @returns: The file name to be used for lookup in the main bundle.
+ * @return The file name to be used for lookup in the main bundle.
  */
 - (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package;
 
@@ -129,14 +129,18 @@ FLUTTER_EXPORT
  * a replacement until the first frame is rendered.
  *
  * The view used should be appropriate for multiple sizes; an autoresizing mask to
- * have a flexible
- * width and height will be applied automatically.
- *
- * If not specified, uses a view generated from `UILaunchStoryboardName` from the
- * main bundle's
- * `Info.plist` file.
+ * have a flexible width and height will be applied automatically.
  */
 @property(strong, nonatomic) UIView* splashScreenView;
+
+/**
+ * Attempts to set the `splashScreenView` property from the `UILaunchStoryboardName` from the
+ * main bundle's `Info.plist` file.  This method will not change the value of `splashScreenView`
+ * if it cannot find a default one from a storyboard or nib.
+ *
+ * @return `YES` if successful, `NO` otherwise.
+ */
+- (BOOL)loadDefaultSplashScreenView;
 
 /**
  * Controls whether the created view will be opaque or not.


### PR DESCRIPTION
Fixes flutter/flutter#24420

This allows a consumer to decide whether they want to load the default storyboard/splash screen, and opt in by default. They could still get the previous behavior by calling [flutterViewController loadDefaultSplashScreen], but won't be forced into it in scenarios where they probably don't want it (as with a prewarmed engine for a child view/viewcontroller).