### PR TITLE
Guard the service protocol's global handlers list with a reader/writer lock.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -164,6 +164,8 @@ FILE: ../../../flutter/fml/platform/posix/file_posix.cc
 FILE: ../../../flutter/fml/platform/posix/mapping_posix.cc
 FILE: ../../../flutter/fml/platform/posix/native_library_posix.cc
 FILE: ../../../flutter/fml/platform/posix/paths_posix.cc
+FILE: ../../../flutter/fml/platform/posix/shared_mutex_posix.cc
+FILE: ../../../flutter/fml/platform/posix/shared_mutex_posix.h
 FILE: ../../../flutter/fml/platform/win/errors_win.cc
 FILE: ../../../flutter/fml/platform/win/errors_win.h
 FILE: ../../../flutter/fml/platform/win/file_win.cc
@@ -176,9 +178,13 @@ FILE: ../../../flutter/fml/platform/win/wstring_conversion.h
 FILE: ../../../flutter/fml/string_view.cc
 FILE: ../../../flutter/fml/string_view.h
 FILE: ../../../flutter/fml/string_view_unittest.cc
+FILE: ../../../flutter/fml/synchronization/atomic_object.h
 FILE: ../../../flutter/fml/synchronization/count_down_latch.cc
 FILE: ../../../flutter/fml/synchronization/count_down_latch.h
 FILE: ../../../flutter/fml/synchronization/count_down_latch_unittests.cc
+FILE: ../../../flutter/fml/synchronization/shared_mutex.h
+FILE: ../../../flutter/fml/synchronization/shared_mutex_std.cc
+FILE: ../../../flutter/fml/synchronization/shared_mutex_std.h
 FILE: ../../../flutter/fml/synchronization/thread_annotations.h
 FILE: ../../../flutter/fml/synchronization/thread_annotations_unittest.cc
 FILE: ../../../flutter/fml/synchronization/thread_checker.h

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -46,8 +46,10 @@ source_set("fml") {
     "paths.h",
     "string_view.cc",
     "string_view.h",
+    "synchronization/atomic_object.h",
     "synchronization/count_down_latch.cc",
     "synchronization/count_down_latch.h",
+    "synchronization/shared_mutex.h",
     "synchronization/thread_annotations.h",
     "synchronization/thread_checker.h",
     "synchronization/waitable_event.cc",
@@ -82,6 +84,12 @@ source_set("fml") {
   public_configs = [ "$flutter_root:config" ]
 
   libs = []
+
+  if (is_ios || is_mac) {
+    sources += [ "platform/posix/shared_mutex_posix.cc" ]
+  } else {
+    sources += [ "synchronization/shared_mutex_std.cc" ]
+  }
 
   if (is_ios || is_mac) {
     sources += [

--- a/fml/platform/posix/shared_mutex_posix.cc
+++ b/fml/platform/posix/shared_mutex_posix.cc
@@ -27,4 +27,8 @@ void SharedMutexPosix::Unlock() {
   pthread_rwlock_unlock(&rwlock_);
 }
 
+void SharedMutexPosix::UnlockShared() {
+  pthread_rwlock_unlock(&rwlock_);
+}
+
 }  // namespace fml

--- a/fml/platform/posix/shared_mutex_posix.cc
+++ b/fml/platform/posix/shared_mutex_posix.cc
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/platform/posix/shared_mutex_posix.h"
+#include "flutter/fml/logging.h"
+
+namespace fml {
+
+SharedMutex* SharedMutex::Create() {
+  return new SharedMutexPosix();
+}
+
+SharedMutexPosix::SharedMutexPosix() {
+  FML_CHECK(pthread_rwlock_init(&rwlock_, nullptr) == 0);
+}
+
+void SharedMutexPosix::Lock() {
+  pthread_rwlock_wrlock(&rwlock_);
+}
+
+void SharedMutexPosix::LockShared() {
+  pthread_rwlock_rdlock(&rwlock_);
+}
+
+void SharedMutexPosix::Unlock() {
+  pthread_rwlock_unlock(&rwlock_);
+}
+
+}  // namespace fml

--- a/fml/platform/posix/shared_mutex_posix.h
+++ b/fml/platform/posix/shared_mutex_posix.h
@@ -15,6 +15,7 @@ class SharedMutexPosix : public SharedMutex {
   virtual void Lock();
   virtual void LockShared();
   virtual void Unlock();
+  virtual void UnlockShared();
 
  private:
   friend SharedMutex* SharedMutex::Create();

--- a/fml/platform/posix/shared_mutex_posix.h
+++ b/fml/platform/posix/shared_mutex_posix.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_POSIX_H_
+#define FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_POSIX_H_
+
+#include <shared_mutex>
+#include "flutter/fml/synchronization/shared_mutex.h"
+
+namespace fml {
+
+class SharedMutexPosix : public SharedMutex {
+ public:
+  virtual void Lock();
+  virtual void LockShared();
+  virtual void Unlock();
+
+ private:
+  friend SharedMutex* SharedMutex::Create();
+  SharedMutexPosix();
+
+  pthread_rwlock_t rwlock_;
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_POSIX_H_

--- a/fml/synchronization/atomic_object.h
+++ b/fml/synchronization/atomic_object.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_SYNCHRONIZATION_ATOMIC_OBJECT_H_
+#define FLUTTER_FML_SYNCHRONIZATION_ATOMIC_OBJECT_H_
+
+#include <mutex>
+
+namespace fml {
+
+// A wrapper for an object instance that can be read or written atomically.
+template <typename T>
+class AtomicObject {
+ public:
+  AtomicObject() = default;
+  AtomicObject(T object) : object_(object) {}
+
+  T Load() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return object_;
+  }
+
+  void Store(const T& object) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    object_ = object;
+  }
+
+ private:
+  mutable std::mutex mutex_;
+  T object_;
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_SYNCHRONIZATION_ATOMIC_OBJECT_H_

--- a/fml/synchronization/shared_mutex.h
+++ b/fml/synchronization/shared_mutex.h
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_H_
+#define FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_H_
+
+namespace fml {
+
+// Interface for a reader/writer lock.
+class SharedMutex {
+ public:
+  static SharedMutex* Create();
+  virtual ~SharedMutex() = default;
+
+  virtual void Lock() = 0;
+  virtual void LockShared() = 0;
+  virtual void Unlock() = 0;
+};
+
+// RAII wrapper that does a shared acquire of a SharedMutex.
+class SharedLock {
+ public:
+  explicit SharedLock(SharedMutex& shared_mutex) : shared_mutex_(shared_mutex) {
+    shared_mutex_.LockShared();
+  }
+
+  ~SharedLock() { shared_mutex_.Unlock(); }
+
+ private:
+  SharedMutex& shared_mutex_;
+};
+
+// RAII wrapper that does an exclusive acquire of a SharedMutex.
+class UniqueLock {
+ public:
+  explicit UniqueLock(SharedMutex& shared_mutex) : shared_mutex_(shared_mutex) {
+    shared_mutex_.Lock();
+  }
+
+  ~UniqueLock() { shared_mutex_.Unlock(); }
+
+ private:
+  SharedMutex& shared_mutex_;
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_H_

--- a/fml/synchronization/shared_mutex.h
+++ b/fml/synchronization/shared_mutex.h
@@ -16,6 +16,7 @@ class SharedMutex {
   virtual void Lock() = 0;
   virtual void LockShared() = 0;
   virtual void Unlock() = 0;
+  virtual void UnlockShared() = 0;
 };
 
 // RAII wrapper that does a shared acquire of a SharedMutex.
@@ -25,7 +26,7 @@ class SharedLock {
     shared_mutex_.LockShared();
   }
 
-  ~SharedLock() { shared_mutex_.Unlock(); }
+  ~SharedLock() { shared_mutex_.UnlockShared(); }
 
  private:
   SharedMutex& shared_mutex_;

--- a/fml/synchronization/shared_mutex_std.cc
+++ b/fml/synchronization/shared_mutex_std.cc
@@ -1,0 +1,25 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/synchronization/shared_mutex_std.h"
+
+namespace fml {
+
+SharedMutex* SharedMutex::Create() {
+  return new SharedMutexStd();
+}
+
+void SharedMutexStd::Lock() {
+  mutex_.lock();
+}
+
+void SharedMutexStd::LockShared() {
+  mutex_.lock_shared();
+}
+
+void SharedMutexStd::Unlock() {
+  mutex_.unlock();
+}
+
+}  // namespace fml

--- a/fml/synchronization/shared_mutex_std.cc
+++ b/fml/synchronization/shared_mutex_std.cc
@@ -22,7 +22,6 @@ void SharedMutexStd::Unlock() {
   mutex_.unlock();
 }
 
-
 void SharedMutexStd::UnlockShared() {
   mutex_.unlock_shared();
 }

--- a/fml/synchronization/shared_mutex_std.cc
+++ b/fml/synchronization/shared_mutex_std.cc
@@ -22,4 +22,9 @@ void SharedMutexStd::Unlock() {
   mutex_.unlock();
 }
 
+
+void SharedMutexStd::UnlockShared() {
+  mutex_.unlock_shared();
+}
+
 }  // namespace fml

--- a/fml/synchronization/shared_mutex_std.h
+++ b/fml/synchronization/shared_mutex_std.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_STD_H_
+#define FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_STD_H_
+
+#include <shared_mutex>
+#include "flutter/fml/synchronization/shared_mutex.h"
+
+namespace fml {
+
+class SharedMutexStd : public SharedMutex {
+ public:
+  virtual void Lock();
+  virtual void LockShared();
+  virtual void Unlock();
+
+ private:
+  friend SharedMutex* SharedMutex::Create();
+  SharedMutexStd() = default;
+
+  std::shared_timed_mutex mutex_;
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_SYNCHRONIZATION_SHARED_MUTEX_STD_H_

--- a/fml/synchronization/shared_mutex_std.h
+++ b/fml/synchronization/shared_mutex_std.h
@@ -15,6 +15,7 @@ class SharedMutexStd : public SharedMutex {
   virtual void Lock();
   virtual void LockShared();
   virtual void Unlock();
+  virtual void UnlockShared();
 
  private:
   friend SharedMutex* SharedMutex::Create();

--- a/runtime/service_protocol.h
+++ b/runtime/service_protocol.h
@@ -6,13 +6,14 @@
 #define FLUTTER_RUNTIME_SERVICE_PROTOCOL_H_
 
 #include <map>
-#include <mutex>
 #include <set>
 #include <string>
 
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/string_view.h"
+#include "flutter/fml/synchronization/atomic_object.h"
+#include "flutter/fml/synchronization/shared_mutex.h"
 #include "flutter/fml/synchronization/thread_annotations.h"
 #include "flutter/fml/task_runner.h"
 #include "rapidjson/document.h"
@@ -72,8 +73,8 @@ class ServiceProtocol {
 
  private:
   const std::set<fml::StringView> endpoints_;
-  mutable std::mutex handlers_mutex_;
-  std::map<Handler*, Handler::Description> handlers_;
+  std::unique_ptr<fml::SharedMutex> handlers_mutex_;
+  std::map<Handler*, fml::AtomicObject<Handler::Description>> handlers_;
 
   FML_WARN_UNUSED_RESULT
   static bool HandleMessage(const char* method,


### PR DESCRIPTION
Relands original https://github.com/flutter/engine/pull/6895 with fix for Windows test failure.

Original description:
The service protocol holds the lock while waiting for completion of service
RPC tasks. These tasks (specifically hot restart/RunInView) may need to
modify a handler's description data.

Task execution and ServiceProtocol::SetHandlerDescription will obtain a shared
lock to make this possible. AddHandler and RemoveHandler will obtain an
exclusive lock in order to guard against a handler being deleted while a
service task is running.

Fix for Windows test is to use unlock_shared when lock_shared is used.