### PR TITLE
Support real fonts in 'flutter test'

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -86,10 +86,10 @@ bool Engine::UpdateAssetManager(
   }
 
   // Using libTXT as the text engine.
+  font_collection_.RegisterFonts(asset_manager_);
+  
   if (settings_.use_test_fonts) {
     font_collection_.RegisterTestFonts();
-  } else {
-    font_collection_.RegisterFonts(asset_manager_);
   }
 
   return true;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -87,7 +87,7 @@ bool Engine::UpdateAssetManager(
 
   // Using libTXT as the text engine.
   font_collection_.RegisterFonts(asset_manager_);
-  
+
   if (settings_.use_test_fonts) {
     font_collection_.RegisterTestFonts();
   }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -95,12 +95,12 @@ void FontCollection::SetTestFontManager(sk_sp<SkFontMgr> font_manager) {
 // Return the available font managers in the order they should be queried.
 std::vector<sk_sp<SkFontMgr>> FontCollection::GetFontManagerOrder() const {
   std::vector<sk_sp<SkFontMgr>> order;
-  if (test_font_manager_)
-    order.push_back(test_font_manager_);
   if (dynamic_font_manager_)
     order.push_back(dynamic_font_manager_);
   if (asset_font_manager_)
     order.push_back(asset_font_manager_);
+  if (test_font_manager_)
+    order.push_back(test_font_manager_);
   if (default_font_manager_)
     order.push_back(default_font_manager_);
   return order;


### PR DESCRIPTION
Change the order of font_managers to query in font_collection
so that dynamic_font_manager fonts will be resolved.

Tested with test case in `flutter/flutter` repo:

`packages/flutter/test/rendering/localized_fonts_test.dart`

Ensured:
- A font loaded with FontLoader will be used
- The default 'Ahem' font is still loaded by default

The test above still cannot be fixed because FontLoader and the
underlying mechanisms don't cover Locale-specific font loading
and therefore a CJK font-family won't be able to be loaded as needed
for that test.

Fixes flutter/flutter#17700