### PR TITLE
Support in/out of list announcements on Android

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -445,6 +445,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/SingleV
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/PathUtils.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/util/Preconditions.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/util/Predicate.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/AccessibilityBridge.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterCallbackInformation.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -131,6 +131,7 @@ java_library("flutter_shell_java") {
     "io/flutter/plugin/platform/VirtualDisplayController.java",
     "io/flutter/util/PathUtils.java",
     "io/flutter/util/Preconditions.java",
+    "io/flutter/util/Predicate.java",
     "io/flutter/view/AccessibilityBridge.java",
     "io/flutter/view/FlutterCallbackInformation.java",
     "io/flutter/view/FlutterMain.java",

--- a/shell/platform/android/io/flutter/util/Predicate.java
+++ b/shell/platform/android/io/flutter/util/Predicate.java
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.util;
+
+// TODO(dnfield): remove this if/when we can use appcompat to support it.
+// java.util.function.Predicate isn't available until API24
+public interface Predicate<T> {
+    public abstract boolean test(T t);
+}

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -104,74 +104,6 @@ class AccessibilityBridge
         }
 
         final int value;
-
-        static String flagsToString(int value) {
-            if (value == 0) {
-                return "(no flags)";
-            }
-            StringBuilder builder = new StringBuilder();
-            if ((value & HAS_CHECKED_STATE.value) != 0) {
-                builder.append("HAS_CHECKED_STATE | ");
-            }
-            if ((value & IS_CHECKED.value) != 0) {
-                builder.append("IS_CHECKED | ");
-            }
-            if ((value & IS_SELECTED.value) != 0) {
-                builder.append("IS_SELECTED | ");
-            }
-            if ((value & IS_BUTTON.value) != 0) {
-                builder.append("IS_BUTTON | ");
-            }
-            if ((value & IS_TEXT_FIELD.value) != 0) {
-                builder.append("IS_TEXT_FIELD | ");
-            }
-            if ((value & IS_FOCUSED.value) != 0) {
-                builder.append("IS_FOCUSED | ");
-            }
-            if ((value & HAS_ENABLED_STATE.value) != 0) {
-                builder.append("HAS_ENABLED_STATE | ");
-            }
-            if ((value & IS_ENABLED.value) != 0) {
-                builder.append("IS_ENABLED | ");
-            }
-            if ((value & IS_IN_MUTUALLY_EXCLUSIVE_GROUP.value) != 0) {
-                builder.append("IS_IN_MUTUALLY_EXCLUSIVE_GROUP | ");
-            }
-            if ((value & IS_HEADER.value) != 0) {
-                builder.append("IS_HEADER | ");
-            }
-            if ((value & IS_OBSCURED.value) != 0) {
-                builder.append("IS_OBSCURED | ");
-            }
-            if ((value & SCOPES_ROUTE.value) != 0) {
-                builder.append("SCOPES_ROUTE | ");
-            }
-            if ((value & NAMES_ROUTE.value) != 0) {
-                builder.append("NAMES_ROUTE | ");
-            }
-            if ((value & IS_HIDDEN.value) != 0) {
-                builder.append("IS_HIDDEN | ");
-            }
-            if ((value & IS_IMAGE.value) != 0) {
-                builder.append("IS_IMAGE | ");
-            }
-            if ((value & IS_LIVE_REGION.value) != 0) {
-                builder.append("IS_LIVE_REGION | ");
-            }
-            if ((value & HAS_TOGGLED_STATE.value) != 0) {
-                builder.append("HAS_TOGGLED_STATE | ");
-            }
-            if ((value & IS_TOGGLED.value) != 0) {
-                builder.append("IS_TOGGLED | ");
-            }
-            if ((value & HAS_IMPLICIT_SCROLLING.value) != 0) {
-                builder.append("HAS_IMPLICIT_SCROLLING | ");
-            }
-            if (builder.length() > 3) {
-                builder.setLength(builder.length() - 3);
-            }
-            return builder.toString();
-        }
     }
 
     AccessibilityBridge(FlutterView owner) {
@@ -1142,22 +1074,6 @@ class AccessibilityBridge
             return null;
         }
 
-        // boolean hasAncestor(SemanticsObject ancestor) {
-        //     SemanticsObject nextAncestor = parent;
-        //     while (nextAncestor != null && nextAncestor != ancestor) {
-        //         nextAncestor = nextAncestor.parent;
-        //     }
-        //     return nextAncestor == ancestor;
-        // }
-
-        // boolean hasAncestorWithFlag(Flag flag) {
-        //     SemanticsObject nextAncestor = parent;
-        //     while (nextAncestor != null && !nextAncestor.hasFlag(flag)) {
-        //         nextAncestor = nextAncestor.parent;
-        //     }
-        //     return nextAncestor != null && nextAncestor.hasFlag(flag);
-        // }
-
         boolean hasAction(Action action) {
             return (actions & action.value) != 0;
         }
@@ -1190,7 +1106,7 @@ class AccessibilityBridge
         void log(String indent, boolean recursive) {
             Log.i(TAG,
                     indent + "SemanticsObject id=" + id + " label=" + label + " actions=" + actions
-                            + " flags=" + Flag.flagsToString(flags) + "\n" + indent + "  +-- textDirection="
+                            + " flags=" + flags + "\n" + indent + "  +-- textDirection="
                             + textDirection + "\n" + indent + "  +-- rect.ltrb=(" + left + ", "
                             + top + ", " + right + ", " + bottom + ")\n" + indent
                             + "  +-- transform=" + Arrays.toString(transform) + "\n");


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/22876

This makes it so that TalkBack will announce in/out of list under the following conditions:

1. The List has a specified number of children for semantics purposes.  Without this, we don't know how many columns or rows to tell TalkBack to announce, and without that, TalkBack won't announce in or out of list.
2. The currently focused A11y node is a child of the list __or__ the currently focused A11y node does not have a parent that has implicit scrolling.  This is needed because TalkBack only tracks one list at a time, and so if we have multiple or nested lists it would only announce one.  The second part of the check is needed because we want to announce out of list if you move focus to a non-list node.

We really should expose semantics properties for row and column counts, to better support multi-dimensional list-like widgets (like GridView, or third party widgets that want to have better scrolling semantics).

I've added a Predicate utility class because even with Lambda support in Java 1.8, we won't be able to use `java.util.function.Predicate` (only available in API 24+).