### PR TITLE
Verify RunConfiguration is valid before running

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -390,6 +390,9 @@ FlutterResult FlutterEngineRun(size_t version,
   run_configuration.AddAssetResolver(
       std::make_unique<blink::DirectoryAssetBundle>(fml::OpenDirectory(
           settings.assets_path.c_str(), false, fml::FilePermission::kRead)));
+  if (!run_configuration.IsValid()) {
+    return kInvalidArguments;
+  }
 
   if (!embedder_engine->Run(std::move(run_configuration))) {
     return kInvalidArguments;

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -47,7 +47,7 @@ bool EmbedderEngine::NotifyDestroyed() {
 }
 
 bool EmbedderEngine::Run(RunConfiguration run_configuration) {
-  if (!IsValid()) {
+  if (!IsValid() || !run_configuration.IsValid()) {
     return false;
   }
 


### PR DESCRIPTION
In cases where a valid IsolateConfiguration cannot be inferred, (e.g.,
settings.kernel_list_asset is missing) RunConfiguration can be created
with a null IsolateConfiguration. In such cases, bail out early with
kInvalidSettings.

Also adds a redundant paranoid check to EmbedderEngine::Run.