### PR TITLE
load default splash screen when not init with engine

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -71,7 +71,7 @@
     _flutterView.reset([[FlutterView alloc] initWithDelegate:_engine opaque:self.isViewOpaque]);
     [_engine.get() createShell:nil libraryURI:nil];
     _engineNeedsLaunch = YES;
-
+    [self loadDefaultSplashScreenView];
     [self performCommonViewControllerInitialization];
   }
 


### PR DESCRIPTION
This fixes a regression for regular flutter apps caused by #6883.

Fixes https://github.com/flutter/flutter/issues/24563