### PR TITLE
Use software renderer in embedder unittests

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -16,19 +16,18 @@ TEST(EmbedderTest, MustNotRunWithInvalidArgs) {
 }
 
 TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
-  FlutterOpenGLRendererConfig renderer = {};
-  renderer.struct_size = sizeof(FlutterOpenGLRendererConfig);
-  renderer.make_current = [](void*) { return false; };
-  renderer.clear_current = [](void*) { return false; };
-  renderer.present = [](void*) { return false; };
-  renderer.fbo_callback = [](void*) -> uint32_t { return 0; };
+  FlutterSoftwareRendererConfig renderer;
+  renderer.struct_size = sizeof(FlutterSoftwareRendererConfig);
+  renderer.surface_present_callback = [](void*, const void*, size_t, size_t) {
+    return false;
+  };
 
   std::string main =
       std::string(testing::GetFixturesPath()) + "/simple_main.dart";
 
   FlutterRendererConfig config = {};
-  config.type = FlutterRendererType::kOpenGL;
-  config.open_gl = renderer;
+  config.type = FlutterRendererType::kSoftware;
+  config.software = renderer;
 
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);


### PR DESCRIPTION
Reduces spurious error log messages in GLContextMakeCurrent() attempting
set up the GR context:

  [ERROR:flutter/shell/gpu/gpu_surface_gl.cc(42)] Could not make the context current to setup the gr context.