### PR TITLE
Update DEPS to track Skia's flutter/1.0 branch

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'fuchsia_git': 'https://fuchsia.googlesource.com',
   'github_git': 'https://github.com',
   'skia_git': 'https://skia.googlesource.com',
-  'skia_revision': 'eb35650f9177d30e59cf6289a834ce1bb86cdfb7',
+  'skia_revision': 'refs/heads/flutter/1.0',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the


### PR DESCRIPTION
flutter/1.0 points at the same Git hash right now. That branch will be used to cherry-pick low-risk/high-priority fixes for the 1.0 release.