### PR TITLE
Return real null instead of null string when locale has not been set in locale closure.

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -42,7 +42,12 @@ void _updateWindowMetrics(double devicePixelRatio,
 
 typedef _LocaleClosure = String Function();
 
-String _localeClosure() => window.locale.toString();
+String _localeClosure() {
+  if (window.locale == null) {
+    return null;
+  }
+  return window.locale.toString();
+}
 
 @pragma('vm:entry-point')
 _LocaleClosure _getLocaleClosure() => _localeClosure;


### PR DESCRIPTION
This prevents the io.Platform from receiving `'null'` (the string 'null') as the locale.