### PR TITLE
Eliminate obsolete FlutterDartProject initializers

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -16,23 +16,9 @@ FLUTTER_EXPORT
 @interface FlutterDartProject : NSObject
 
 /**
- * Initializes with a specific
+ * Initializes a Flutter Dart project from a bundle.
  */
 - (instancetype)initWithPrecompiledDartBundle:(NSBundle*)bundle NS_DESIGNATED_INITIALIZER;
-
-/**
- * Initializes with a specific set of Flutter Assets, with a specified location of
- * main() and Dart packages.
- */
-- (instancetype)initWithFlutterAssets:(NSURL*)flutterAssetsURL
-                             dartMain:(NSURL*)dartMainURL
-                             packages:(NSURL*)dartPackages NS_DESIGNATED_INITIALIZER;
-
-/**
- * Initializes from a specific set of Flutter Assets.
- */
-- (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL
-    NS_DESIGNATED_INITIALIZER;
 
 /**
  * Unavailable - use `init` instead.

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -134,7 +134,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 #pragma mark - Override base class designated initializers
 
 - (instancetype)init {
-  return [self initWithFlutterAssets:nil dartMain:nil packages:nil];
+  return [self initWithPrecompiledDartBundle:nil];
 }
 
 #pragma mark - Designated initializers
@@ -145,33 +145,6 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   if (self) {
     _precompiledDartBundle.reset([bundle retain]);
     _settings = DefaultSettingsForProcess(bundle);
-  }
-
-  return self;
-}
-
-- (instancetype)initWithFlutterAssets:(NSURL*)flutterAssetsURL
-                             dartMain:(NSURL*)dartMainURL
-                             packages:(NSURL*)dartPackages {
-  self = [super init];
-
-  if (self) {
-    _settings = DefaultSettingsForProcess();
-  }
-
-  return self;
-}
-
-- (instancetype)initWithFlutterAssetsWithScriptSnapshot:(NSURL*)flutterAssetsURL {
-  self = [super init];
-
-  if (self) {
-    _settings = DefaultSettingsForProcess();
-
-    if (flutterAssetsURL != nil &&
-        [[NSFileManager defaultManager] fileExistsAtPath:flutterAssetsURL.path]) {
-      _settings.assets_path = flutterAssetsURL.path.UTF8String;
-    }
   }
 
   return self;


### PR DESCRIPTION
Technically both of these are part of the public API exposed in
Flutter.framework. Neither is used within Flutter itself, and both have
been broken since the removal of Dart 1 support, so eliminating rather
than marking unavailable.