### PR TITLE
Eliminate main_dart_file_path, package_file_path

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -25,8 +25,6 @@ std::string Settings::ToString() const {
          << std::endl;
   stream << "application_library_path: " << application_library_path
          << std::endl;
-  stream << "main_dart_file_path: " << main_dart_file_path << std::endl;
-  stream << "packages_file_path: " << packages_file_path << std::endl;
   stream << "temp_directory_path: " << temp_directory_path << std::endl;
   stream << "dart_flags:" << std::endl;
   for (const auto& dart_flag : dart_flags) {

--- a/common/settings.h
+++ b/common/settings.h
@@ -38,9 +38,6 @@ struct Settings {
   std::string application_kernel_asset;
   std::string application_kernel_list_asset;
 
-  std::string main_dart_file_path;
-  std::string packages_file_path;
-
   std::string temp_directory_path;
   std::vector<std::string> dart_flags;
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -170,12 +170,6 @@ blink::Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   command_line.GetOptionValue(FlagForSwitch(Switch::FlutterAssetsDir),
                               &settings.assets_path);
 
-  command_line.GetOptionValue(FlagForSwitch(Switch::MainDartFile),
-                              &settings.main_dart_file_path);
-
-  command_line.GetOptionValue(FlagForSwitch(Switch::Packages),
-                              &settings.packages_file_path);
-
   std::string aot_shared_library_path;
   command_line.GetOptionValue(FlagForSwitch(Switch::AotSharedLibraryPath),
                               &aot_shared_library_path);

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -92,8 +92,6 @@ DEF_SWITCH(FlutterAssetsDir,
            "Path to the Flutter assets directory.")
 DEF_SWITCH(Help, "help", "Display this help text.")
 DEF_SWITCH(LogTag, "log-tag", "Tag associated with log messages.")
-DEF_SWITCH(MainDartFile, "dart-main", "The path to the main Dart file.")
-DEF_SWITCH(Packages, "packages", "Specify the path to the packages.")
 DEF_SWITCH(StartPaused,
            "start-paused",
            "Start the application paused in the Dart debugger.")

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -157,15 +157,6 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 
   if (self) {
     _settings = DefaultSettingsForProcess();
-
-    if (dartMainURL != nil && [[NSFileManager defaultManager] fileExistsAtPath:dartMainURL.path]) {
-      _settings.main_dart_file_path = dartMainURL.path.UTF8String;
-    }
-
-    if (dartPackages.path != nil &&
-        [[NSFileManager defaultManager] fileExistsAtPath:dartPackages.path]) {
-      _settings.packages_file_path = dartPackages.path.UTF8String;
-    }
   }
 
   return self;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -266,9 +266,7 @@ FlutterResult FlutterEngineRun(size_t version,
     return kInvalidArguments;
   }
 
-  if (SAFE_ACCESS(args, assets_path, nullptr) == nullptr ||
-      SAFE_ACCESS(args, main_path, nullptr) == nullptr ||
-      SAFE_ACCESS(args, packages_path, nullptr) == nullptr) {
+  if (SAFE_ACCESS(args, assets_path, nullptr) == nullptr) {
     return kInvalidArguments;
   }
 
@@ -293,18 +291,14 @@ FlutterResult FlutterEngineRun(size_t version,
   settings.icu_data_path = icu_data_path;
   settings.assets_path = args->assets_path;
 
-  // Check whether the assets path contains Dart 2 kernel assets.
+  // Verify the assets path contains Dart 2 kernel assets.
   const std::string kApplicationKernelSnapshotFileName = "kernel_blob.bin";
   std::string application_kernel_path = fml::paths::JoinPaths(
       {settings.assets_path, kApplicationKernelSnapshotFileName});
-  if (fml::IsFile(application_kernel_path)) {
-    // Run from a kernel snapshot.
-    settings.application_kernel_asset = kApplicationKernelSnapshotFileName;
-  } else {
-    // Run from a main Dart file.
-    settings.main_dart_file_path = args->main_path;
-    settings.packages_file_path = args->packages_path;
+  if (!fml::IsFile(application_kernel_path)) {
+    return kInvalidArguments;
   }
+  settings.application_kernel_asset = kApplicationKernelSnapshotFileName;
 
   settings.task_observer_add = [](intptr_t key, fml::closure callback) {
     fml::MessageLoop::GetCurrent().AddTaskObserver(key, std::move(callback));


### PR DESCRIPTION
These settings were specific to Dart 1 and are no longer used in the
engine. This eliminates them from the Settings class.