### PR TITLE
Rename dart-non-checked-mode: disable-dart-asserts

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -37,7 +37,7 @@ std::string Settings::ToString() const {
   stream << "trace_startup: " << trace_startup << std::endl;
   stream << "endless_trace_buffer: " << endless_trace_buffer << std::endl;
   stream << "enable_dart_profiling: " << enable_dart_profiling << std::endl;
-  stream << "dart_non_checked_mode: " << dart_non_checked_mode << std::endl;
+  stream << "disable_dart_asserts: " << disable_dart_asserts << std::endl;
   stream << "enable_observatory: " << enable_observatory << std::endl;
   stream << "observatory_port: " << observatory_port << std::endl;
   stream << "ipv6: " << ipv6 << std::endl;

--- a/common/settings.h
+++ b/common/settings.h
@@ -50,7 +50,7 @@ struct Settings {
   bool trace_startup = false;
   bool endless_trace_buffer = false;
   bool enable_dart_profiling = false;
-  bool dart_non_checked_mode = false;
+  bool disable_dart_asserts = false;
   // Used as the script URI in debug messages. Does not affect how the Dart code
   // is executed.
   std::string advisory_script_uri = "main.dart";

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -325,18 +325,18 @@ DartVM::DartVM(const Settings& settings,
                 arraysize(kDartPrecompilationArgs));
   }
 
-  // Enable checked mode if we are not running precompiled code. We run non-
+  // Enable Dart assertions if we are not running precompiled code. We run non-
   // precompiled code only in the debug product mode.
-  bool use_checked_mode = !settings.dart_non_checked_mode;
+  bool enable_asserts = !settings.disable_dart_asserts;
 
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_PROFILE || \
     FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DYNAMIC_RELEASE
-  use_checked_mode = false;
+  enable_asserts = false;
 #endif
 
 #if !OS_FUCHSIA
   if (IsRunningPrecompiledCode()) {
-    use_checked_mode = false;
+    enable_asserts = false;
   }
 #endif  // !OS_FUCHSIA
 
@@ -347,7 +347,7 @@ DartVM::DartVM(const Settings& settings,
               arraysize(kDartWriteProtectCodeArgs));
 #endif
 
-  if (use_checked_mode) {
+  if (enable_asserts) {
     PushBackAll(&args, kDartAssertArgs, arraysize(kDartAssertArgs));
   }
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -139,8 +139,8 @@ blink::Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   }
 
   // Checked mode overrides.
-  settings.dart_non_checked_mode =
-      command_line.HasOption(FlagForSwitch(Switch::DartNonCheckedMode));
+  settings.disable_dart_asserts =
+      command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));
 
   settings.ipv6 = command_line.HasOption(FlagForSwitch(Switch::IPv6));
 

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -122,13 +122,13 @@ DEF_SWITCH(RunForever,
            "run-forever",
            "In non-interactive mode, keep the shell running after the Dart "
            "script has completed.")
-DEF_SWITCH(DartNonCheckedMode,
-           "dart-non-checked-mode",
-           "Dart code runs in checked mode when the runtime mode is debug. In "
-           "profile and release product modes, the application code is "
-           "precompiled and checked mode is unsupported. However, this flag "
-           "may be specified if the user wishes to run in the debug product "
-           "mode (i.e. with JIT or DBC) with checked mode off.")
+DEF_SWITCH(DisableDartAsserts,
+           "disable-dart-asserts",
+           "Dart code runs with assertions enabled when the runtime mode is "
+           "debug. In profile and release product modes, assertions are "
+           "disabled. This flag may be specified if the user wishes to run "
+           "with assertions disabled in the debug product mode (i.e. with JIT "
+           "or DBC).")
 DEF_SWITCHES_END
 
 void PrintUsage(const std::string& executable_name);


### PR DESCRIPTION
In Dart 2, runtime checked mode has been eliminated. Many of these type
checks have been moved to static compile-time checks, the remainder are
enforced at runtime, and are no longer optional.

CHANGELOG: flutter_tester: --dart-non-checked-mode has been renamed to --disable-dart-asserts.