### PR TITLE
Fix keyboard not showing for targetSdk 28

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -36,6 +36,7 @@ public class TextInputPlugin implements MethodCallHandler {
 
     public TextInputPlugin(FlutterView view) {
         mView = view;
+        mView.requestFocus();
         mImm = (InputMethodManager) view.getContext().getSystemService(
                 Context.INPUT_METHOD_SERVICE);
         mFlutterChannel = new MethodChannel(view, "flutter/textinput", JSONMethodCodec.INSTANCE);

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -36,7 +36,6 @@ public class TextInputPlugin implements MethodCallHandler {
 
     public TextInputPlugin(FlutterView view) {
         mView = view;
-        mView.requestFocus();
         mImm = (InputMethodManager) view.getContext().getSystemService(
                 Context.INPUT_METHOD_SERVICE);
         mFlutterChannel = new MethodChannel(view, "flutter/textinput", JSONMethodCodec.INSTANCE);
@@ -168,6 +167,7 @@ public class TextInputPlugin implements MethodCallHandler {
     }
 
     private void showTextInput(FlutterView view) {
+        view.requestFocus();
         mImm.showSoftInput(view, 0);
     }
 


### PR DESCRIPTION
After bumping the targetSdk of Flutter apps to 28, the keyboard doesn't open anymore when inputting text on an Android Pie devices as described at https://github.com/flutter/flutter/issues/19644

The problem is caused by a change on the way the focus in handled: when the call `mImm.showSoftInput(view, 0);` is made, the currently focused view is the `DecorView` from the `Activity` hosting Flutter but the passed view reference (`view` argument) is the `FlutterView`. As the `InputMethodManager` checks if both views are the same before showing the keyboard, it never appears because the `FlutterView` never has focus.
As Flutter doesn't have any input views as far as the Android side is concerned, the focus should always stay on the `FlutterView` itself and thus, this PR changes the `TextInputPlugin` to focus on the `FlutterView` as soon as it's created, fixing the keyboard issue.

Co-authored-by: Igor Borges <igor@borges.me>