### PR TITLE
Use a [NSLocale currentLocale] for first locale on iOS to ensure countryCode exists. Allow language-only locales.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -749,17 +749,24 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
 - (void)onLocaleUpdated:(NSNotification*)notification {
   NSArray<NSString*>* preferredLocales = [NSLocale preferredLanguages];
   NSMutableArray<NSString*>* data = [NSMutableArray new];
+  bool first = true;
   for (NSString* localeID in preferredLocales) {
-    NSLocale* currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:localeID];
+    NSLocale* currentLocale;
+    if (first) {
+      currentLocale = [NSLocale currentLocale];
+      first = false;
+    } else {
+      currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:localeID];
+    }
     NSString* languageCode = [currentLocale objectForKey:NSLocaleLanguageCode];
     NSString* countryCode = [currentLocale objectForKey:NSLocaleCountryCode];
     NSString* scriptCode = [currentLocale objectForKey:NSLocaleScriptCode];
     NSString* variantCode = [currentLocale objectForKey:NSLocaleVariantCode];
-    if (!languageCode || !countryCode) {
+    if (!languageCode) {
       continue;
     }
     [data addObject:languageCode];
-    [data addObject:countryCode];
+    [data addObject:(countryCode ? countryCode : @"")];
     [data addObject:(scriptCode ? scriptCode : @"")];
     [data addObject:(variantCode ? variantCode : @"")];
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -753,6 +753,8 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
   for (NSString* localeID in preferredLocales) {
     NSLocale* currentLocale;
     if (first) {
+      // Use a different API for first/default locale as preferredLanguages
+      // may strip the region/country code from the locales.
       currentLocale = [NSLocale currentLocale];
       first = false;
     } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -748,7 +748,7 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
 
 - (void)onLocaleUpdated:(NSNotification*)notification {
   NSArray<NSString*>* preferredLocales = [NSLocale preferredLanguages];
-  NSMutableArray<NSString*>* data = [NSMutableArray new];
+  NSMutableArray<NSString*>* data = [[NSMutableArray new] autorelease];
 
   // Force prepend the [NSLocale currentLocale] to the front of the list
   // to ensure we are including the full default locale. preferredLocales
@@ -767,7 +767,7 @@ static blink::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) {
 
   // Add any secondary locales/languages to the list.
   for (NSString* localeID in preferredLocales) {
-    NSLocale* currentLocale = [[NSLocale alloc] initWithLocaleIdentifier:localeID];
+    NSLocale* currentLocale = [[[NSLocale alloc] initWithLocaleIdentifier:localeID] autorelease];
     NSString* languageCode = [currentLocale objectForKey:NSLocaleLanguageCode];
     NSString* countryCode = [currentLocale objectForKey:NSLocaleCountryCode];
     NSString* scriptCode = [currentLocale objectForKey:NSLocaleScriptCode];


### PR DESCRIPTION
iOS's preferredLanguages may not always include the region/country code. To ensure the default locale is always complete, we use the [NSLocale currentLocale] only for the default locale which does not strip countryCode.

Also, we are able to handle language-only locales, so it should be safe to not enforce countryCode being non-null.