### PR TITLE
Support querying refresh rate fps in engine

### DIFF
--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -30,8 +30,8 @@ const fml::StringView ServiceProtocol::kFlushUIThreadTasksExtensionName =
     "_flutter.flushUIThreadTasks";
 const fml::StringView ServiceProtocol::kSetAssetBundlePathExtensionName =
     "_flutter.setAssetBundlePath";
-const fml::StringView ServiceProtocol::kGetRefreshRateFPSExtensionName =
-    "_flutter.getRefreshRateFPS";
+const fml::StringView ServiceProtocol::kQueryRefreshRateFPSExtensionName =
+    "_flutter.queryRefreshRateFPS";
 
 static constexpr fml::StringView kViewIdPrefx = "_flutterView/";
 static constexpr fml::StringView kListViewsExtensionName = "_flutter.listViews";
@@ -47,7 +47,7 @@ ServiceProtocol::ServiceProtocol()
           kRunInViewExtensionName,
           kFlushUIThreadTasksExtensionName,
           kSetAssetBundlePathExtensionName,
-          kGetRefreshRateExtensionName,
+          kQueryRefreshRateFPSExtensionName,
       }),
       handlers_mutex_(fml::SharedMutex::Create()) {}
 
@@ -204,7 +204,7 @@ bool ServiceProtocol::HandleMessage(fml::StringView method,
   if (method == kScreenshotExtensionName ||
       method == kScreenshotSkpExtensionName ||
       method == kFlushUIThreadTasksExtensionName ||
-      method == kGetRefreshRateFPSExtensionName) {
+      method == kQueryRefreshRateFPSExtensionName) {
     return HandleMessageOnHandler(handlers_.begin()->first, method, params,
                                   response);
   }

--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -30,6 +30,8 @@ const fml::StringView ServiceProtocol::kFlushUIThreadTasksExtensionName =
     "_flutter.flushUIThreadTasks";
 const fml::StringView ServiceProtocol::kSetAssetBundlePathExtensionName =
     "_flutter.setAssetBundlePath";
+const fml::StringView ServiceProtocol::kGetRefreshRateExtensionName =
+    "_flutter.getRefreshRate";
 
 static constexpr fml::StringView kViewIdPrefx = "_flutterView/";
 static constexpr fml::StringView kListViewsExtensionName = "_flutter.listViews";
@@ -45,6 +47,7 @@ ServiceProtocol::ServiceProtocol()
           kRunInViewExtensionName,
           kFlushUIThreadTasksExtensionName,
           kSetAssetBundlePathExtensionName,
+          kGetRefreshRateExtensionName,
       }),
       handlers_mutex_(fml::SharedMutex::Create()) {}
 
@@ -270,6 +273,13 @@ bool ServiceProtocol::HandleListViewsMethod(
 
   response.AddMember("views", viewsList, allocator);
 
+  return true;
+}
+
+bool ServiceProtocol::HandleGetRefreshRateMethod(
+    rapidjson::Document& response) const {
+  response.SetObject();
+  response.AddMember("rate", "60.0", response.GetAllocator());
   return true;
 }
 

--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -30,8 +30,8 @@ const fml::StringView ServiceProtocol::kFlushUIThreadTasksExtensionName =
     "_flutter.flushUIThreadTasks";
 const fml::StringView ServiceProtocol::kSetAssetBundlePathExtensionName =
     "_flutter.setAssetBundlePath";
-const fml::StringView ServiceProtocol::kGetRefreshRateExtensionName =
-    "_flutter.getRefreshRate";
+const fml::StringView ServiceProtocol::kGetRefreshRateFPSExtensionName =
+    "_flutter.getRefreshRateFPS";
 
 static constexpr fml::StringView kViewIdPrefx = "_flutterView/";
 static constexpr fml::StringView kListViewsExtensionName = "_flutter.listViews";
@@ -203,7 +203,8 @@ bool ServiceProtocol::HandleMessage(fml::StringView method,
   // fallbacks.
   if (method == kScreenshotExtensionName ||
       method == kScreenshotSkpExtensionName ||
-      method == kFlushUIThreadTasksExtensionName) {
+      method == kFlushUIThreadTasksExtensionName ||
+      method == kGetRefreshRateFPSExtensionName) {
     return HandleMessageOnHandler(handlers_.begin()->first, method, params,
                                   response);
   }
@@ -273,13 +274,6 @@ bool ServiceProtocol::HandleListViewsMethod(
 
   response.AddMember("views", viewsList, allocator);
 
-  return true;
-}
-
-bool ServiceProtocol::HandleGetRefreshRateMethod(
-    rapidjson::Document& response) const {
-  response.SetObject();
-  response.AddMember("rate", "60.0", response.GetAllocator());
   return true;
 }
 

--- a/runtime/service_protocol.h
+++ b/runtime/service_protocol.h
@@ -27,6 +27,7 @@ class ServiceProtocol {
   static const fml::StringView kRunInViewExtensionName;
   static const fml::StringView kFlushUIThreadTasksExtensionName;
   static const fml::StringView kSetAssetBundlePathExtensionName;
+  static const fml::StringView kGetRefreshRateExtensionName;
 
   class Handler {
    public:
@@ -95,6 +96,9 @@ class ServiceProtocol {
 
   FML_WARN_UNUSED_RESULT
   bool HandleListViewsMethod(rapidjson::Document& response) const;
+
+  FML_WARN_UNUSED_RESULT
+  bool HandleGetRefreshRateMethod(rapidjson::Document& response) const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ServiceProtocol);
 };

--- a/runtime/service_protocol.h
+++ b/runtime/service_protocol.h
@@ -27,7 +27,7 @@ class ServiceProtocol {
   static const fml::StringView kRunInViewExtensionName;
   static const fml::StringView kFlushUIThreadTasksExtensionName;
   static const fml::StringView kSetAssetBundlePathExtensionName;
-  static const fml::StringView kGetRefreshRateFPSExtensionName;
+  static const fml::StringView kQueryRefreshRateFPSExtensionName;
 
   class Handler {
    public:

--- a/runtime/service_protocol.h
+++ b/runtime/service_protocol.h
@@ -27,7 +27,7 @@ class ServiceProtocol {
   static const fml::StringView kRunInViewExtensionName;
   static const fml::StringView kFlushUIThreadTasksExtensionName;
   static const fml::StringView kSetAssetBundlePathExtensionName;
-  static const fml::StringView kGetRefreshRateExtensionName;
+  static const fml::StringView kGetRefreshRateFPSExtensionName;
 
   class Handler {
    public:
@@ -96,9 +96,6 @@ class ServiceProtocol {
 
   FML_WARN_UNUSED_RESULT
   bool HandleListViewsMethod(rapidjson::Document& response) const;
-
-  FML_WARN_UNUSED_RESULT
-  bool HandleGetRefreshRateMethod(rapidjson::Document& response) const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ServiceProtocol);
 };

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -36,7 +36,7 @@ class Animator final {
 
   ~Animator();
 
-  float GetRefreshRateFPS() const { return waiter_->GetRefreshRateFPS(); }
+  float QueryRefreshRateFPS() const { return waiter_->QueryRefreshRateFPS(); }
 
   void RequestFrame(bool regenerate_layer_tree = true);
 

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -36,6 +36,8 @@ class Animator final {
 
   ~Animator();
 
+  float GetRefreshRateFPS() const { return waiter_->GetRefreshRateFPS(); }
+
   void RequestFrame(bool regenerate_layer_tree = true);
 
   void Render(std::unique_ptr<flow::LayerTree> layer_tree);

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -66,6 +66,8 @@ class Engine final : public blink::RuntimeDelegate {
 
   ~Engine() override;
 
+  float GetRefreshRateFPS() const { return animator_->GetRefreshRateFPS(); }
+
   fml::WeakPtr<Engine> GetWeakPtr() const;
 
   FML_WARN_UNUSED_RESULT

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -66,7 +66,7 @@ class Engine final : public blink::RuntimeDelegate {
 
   ~Engine() override;
 
-  float GetRefreshRateFPS() const { return animator_->GetRefreshRateFPS(); }
+  float QueryRefreshRateFPS() const { return animator_->QueryRefreshRateFPS(); }
 
   fml::WeakPtr<Engine> GetWeakPtr() const;
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -293,6 +293,11 @@ Shell::Shell(blink::TaskRunners task_runners, blink::Settings settings)
           task_runners_.GetUITaskRunner(),
           std::bind(&Shell::OnServiceProtocolSetAssetBundlePath, this,
                     std::placeholders::_1, std::placeholders::_2)};
+  service_protocol_handlers_
+      [blink::ServiceProtocol::kGetRefreshRateFPSExtensionName.ToString()] = {
+          task_runners_.GetPlatformTaskRunner(),
+          std::bind(&Shell::OnServiceProtocolGetRefreshRateFPS, this,
+                    std::placeholders::_1, std::placeholders::_2)};
 }
 
 Shell::~Shell() {
@@ -936,6 +941,15 @@ bool Shell::OnServiceProtocolFlushUIThreadTasks(
   // tasks are processed.
   response.SetObject();
   response.AddMember("type", "Success", response.GetAllocator());
+  return true;
+}
+
+bool Shell::OnServiceProtocolGetRefreshRateFPS(
+    const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+    rapidjson::Document& response) {
+  FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
+  response.SetObject();
+  response.AddMember("fps", engine_->GetRefreshRateFPS(), response.GetAllocator());
   return true;
 }
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -294,9 +294,9 @@ Shell::Shell(blink::TaskRunners task_runners, blink::Settings settings)
           std::bind(&Shell::OnServiceProtocolSetAssetBundlePath, this,
                     std::placeholders::_1, std::placeholders::_2)};
   service_protocol_handlers_
-      [blink::ServiceProtocol::kGetRefreshRateFPSExtensionName.ToString()] = {
+      [blink::ServiceProtocol::kQueryRefreshRateFPSExtensionName.ToString()] = {
           task_runners_.GetPlatformTaskRunner(),
-          std::bind(&Shell::OnServiceProtocolGetRefreshRateFPS, this,
+          std::bind(&Shell::OnServiceProtocolQueryRefreshRateFPS, this,
                     std::placeholders::_1, std::placeholders::_2)};
 }
 
@@ -944,12 +944,12 @@ bool Shell::OnServiceProtocolFlushUIThreadTasks(
   return true;
 }
 
-bool Shell::OnServiceProtocolGetRefreshRateFPS(
+bool Shell::OnServiceProtocolQueryRefreshRateFPS(
     const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
     rapidjson::Document& response) {
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
   response.SetObject();
-  response.AddMember("fps", engine_->GetRefreshRateFPS(), response.GetAllocator());
+  response.AddMember("fps", engine_->QueryRefreshRateFPS(), response.GetAllocator());
   return true;
 }
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -226,7 +226,7 @@ class Shell final : public PlatformView::Delegate,
       rapidjson::Document& response);
 
   // Service protocol handler
-  bool OnServiceProtocolGetRefreshRateFPS(
+  bool OnServiceProtocolQueryRefreshRateFPS(
       const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -225,6 +225,11 @@ class Shell final : public PlatformView::Delegate,
       const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 
+  // Service protocol handler
+  bool OnServiceProtocolGetRefreshRateFPS(
+      const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+      rapidjson::Document& response);
+
   FML_DISALLOW_COPY_AND_ASSIGN(Shell);
 };
 

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -28,7 +28,7 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
 
   // Get the display's maximum refresh rate in the unit of frame per second.
   // Return 0.0 if the refresh rate is unkonwn.
-  virtual float GetRefreshRateFPS() const { return 0.0; }
+  virtual float QueryRefreshRateFPS() const { return 0.0; }
 
  protected:
   const blink::TaskRunners task_runners_;

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -26,6 +26,10 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   void FireCallback(fml::TimePoint frame_start_time,
                     fml::TimePoint frame_target_time);
 
+  // Get the display's maximum refresh rate in the unit of frame per second.
+  // Return 0.0 if the refresh rate is unkonwn.
+  virtual float GetRefreshRateFPS() const { return 0.0; }
+
  protected:
   const blink::TaskRunners task_runners_;
   std::mutex callback_mutex_;

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -806,6 +806,7 @@ public class FlutterView extends SurfaceView
         WindowManager wm = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
         float fps = wm.getDefaultDisplay().getRefreshRate();
         VsyncWaiter.refreshPeriodNanos = (long) (1000000000.0 / fps);
+        VsyncWaiter.refreshRateFPS = fps;
     }
 
     // Called by native to update the semantics/accessibility tree.

--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -10,6 +10,10 @@ public class VsyncWaiter {
     // This estimate will be updated by FlutterView when it is attached to a Display.
     public static long refreshPeriodNanos = 1000000000 / 60;
 
+    // This should also be updated by FlutterView when it is attached to a Display.
+    // The initial value of 0.0 indicates unkonwn refresh rate.
+    public static float refreshRateFPS = 0.0f;
+
     public static void asyncWaitForVsync(final long cookie) {
         Choreographer.getInstance().postFrameCallback(new Choreographer.FrameCallback() {
             @Override

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -83,7 +83,7 @@ bool VsyncWaiterAndroid::Register(JNIEnv* env) {
   return env->RegisterNatives(clazz, methods, arraysize(methods)) == 0;
 }
 
-float VsyncWaiterAndroid::GetRefreshRateFPS() const {
+float VsyncWaiterAndroid::QueryRefreshRateFPS() const {
   JNIEnv* env = fml::jni::AttachCurrentThread();
   if (g_vsync_waiter_class == nullptr) {
     return kUnknownRefreshRateFPS;

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -21,7 +21,7 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
 
   ~VsyncWaiterAndroid() override;
 
-  float GetRefreshRateFPS() const override;
+  float QueryRefreshRateFPS() const override;
 
  private:
   // |shell::VsyncWaiter|

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -21,6 +21,8 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
 
   ~VsyncWaiterAndroid() override;
 
+  float GetRefreshRateFPS() const override;
+
  private:
   // |shell::VsyncWaiter|
   void AwaitVSync() override;


### PR DESCRIPTION
The current implementation only deals with Android devices and we'll add iOS devices support soon.

Currently, we assume that the query always happens on the platform thread so we're not handling any data race conditions.