### PR TITLE
Pass operator_new_alignment value through gn script into GN args.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -116,7 +116,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'c98b19b722ba9c044b7fde55a98a8a1eb8bf3439',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '4a37279db248051cd25bbc93526c3001bdb8d785',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -116,7 +116,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '67befc4acace09d636db2f1f23e47719fa7e8795',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'c98b19b722ba9c044b7fde55a98a8a1eb8bf3439',
 
    # Fuchsia compatibility
    #

--- a/tools/gn
+++ b/tools/gn
@@ -93,6 +93,9 @@ def to_gn_args(args):
 
     gn_args['embedder_for_target'] = args.embedder_for_target
 
+    if args.operator_new_alignment is not None:
+      gn_args['operator_new_alignment'] = args.operator_new_alignment
+
     enable_lto = args.lto
     if args.unoptimized:
       # There is no point in enabling LTO in unoptimized builds.
@@ -252,6 +255,7 @@ def parse_args(args):
   parser.add_argument('--target-toolchain', type=str)
   parser.add_argument('--target-triple', type=str)
   parser.add_argument('--toolchain-prefix', type=str)
+  parser.add_argument('--operator-new-alignment', dest='operator_new_alignment', type=str, default=None)
 
   parser.add_argument('--enable-vulkan', action='store_true', default=False)
 


### PR DESCRIPTION
Background:

Some allocators (tcmalloc) don't provide alignment guarantees that
match clang's default expectations, which causes crashes when using
clang compiled binary with such allocators.

For example clang can produce movaps instructions to initialize newly
allocated object - which would crash if result of ::operator new() is
not 16 bytes aligned.