### PR TITLE
Only overflow the cache for one required frame

### DIFF
--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -374,11 +374,11 @@ MultiFrameCodec::MultiFrameCodec(std::unique_ptr<SkCodec> codec,
   nextFrameIndex_ = 0;
   // Go through our frame information and mark which frames are required in
   // order to decode subsequent ones.
-  requiredFrameInfos_.clear();
+  requiredFrames_.clear();
   for (size_t frameIndex = 0; frameIndex < frameInfos_.size(); frameIndex++) {
     const int requiredFrame = frameInfos_[frameIndex].fRequiredFrame;
     if (requiredFrame != SkCodec::kNoFrame) {
-      requiredFrameInfos_[requiredFrame] = true;
+      requiredFrames_[requiredFrame] = true;
     }
   }
 }
@@ -438,7 +438,7 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage(
   }
 
   // Hold onto this if we need it to decode future frames.
-  if (requiredFrameInfos_[nextFrameIndex_]) {
+  if (requiredFrames_[nextFrameIndex_]) {
     lastRequiredFrame_ = frameAlreadyCached
                              ? frameBitmaps_[nextFrameIndex_]
                              : std::make_shared<SkBitmap>(bitmap);

--- a/lib/ui/painting/codec.h
+++ b/lib/ui/painting/codec.h
@@ -80,6 +80,7 @@ class MultiFrameCodec : public Codec {
   // [SkCodec::getFrameInfo()]. Will cache other non-essential frames until
   // [decodedCacheSize_] : [compressedSize_] exceeds [decodedCacheRatioCap_].
   std::map<int, std::unique_ptr<DecodedFrame>> frameBitmaps_;
+  int lastDecodedRequiredFrame_ = -1;
 
   FML_FRIEND_MAKE_REF_COUNTED(MultiFrameCodec);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(MultiFrameCodec);

--- a/lib/ui/painting/codec.h
+++ b/lib/ui/painting/codec.h
@@ -65,7 +65,7 @@ class MultiFrameCodec : public Codec {
   size_t decodedCacheSize_;
 
   std::vector<SkCodec::FrameInfo> frameInfos_;
-  std::map<int, bool> requiredFrameInfos_;
+  std::map<int, bool> requiredFrames_;
 
   // A cache of previously loaded bitmaps, indexed by the frame they belong to.
   // Caches all frames until [decodedCacheSize_] : [compressedSize_] exceeds

--- a/lib/ui/painting/codec.h
+++ b/lib/ui/painting/codec.h
@@ -65,22 +65,16 @@ class MultiFrameCodec : public Codec {
   size_t decodedCacheSize_;
 
   std::vector<SkCodec::FrameInfo> frameInfos_;
-  // A struct linking the bitmap of a frame to whether it's required to render
-  // other dependent frames.
-  struct DecodedFrame {
-    std::unique_ptr<SkBitmap> bitmap_ = nullptr;
-    const bool required_;
-
-    DecodedFrame(bool required);
-    ~DecodedFrame();
-  };
+  std::map<int, bool> requiredFrameInfos_;
 
   // A cache of previously loaded bitmaps, indexed by the frame they belong to.
-  // Always holds at least the frames marked as required for reuse by
-  // [SkCodec::getFrameInfo()]. Will cache other non-essential frames until
-  // [decodedCacheSize_] : [compressedSize_] exceeds [decodedCacheRatioCap_].
-  std::map<int, std::unique_ptr<DecodedFrame>> frameBitmaps_;
-  int lastDecodedRequiredFrame_ = -1;
+  // Caches all frames until [decodedCacheSize_] : [compressedSize_] exceeds
+  // [decodedCacheRatioCap_].
+  std::map<int, std::shared_ptr<SkBitmap>> frameBitmaps_;
+  // The last decoded frame that's required to decode any subsequent frames.
+  std::shared_ptr<SkBitmap> lastRequiredFrame_;
+  // The index of the last decoded required frame.
+  int lastRequiredFrameIndex_ = -1;
 
   FML_FRIEND_MAKE_REF_COUNTED(MultiFrameCodec);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(MultiFrameCodec);


### PR DESCRIPTION
Previously codec.cc needed all required frames to already be decoded
before it could decode any of their dependent frames. To accomplish this
it would always cache required frames, regardless of cache limit.

However both GIF and WEBP (the only currently supported animated image
formats) only allow the image to depend on one decoded frame at a time.
This means that there's no reason to cache all the required frames since
it's only valid for the image formats to require one previously decoded
frame at a time. (For example, frame 10 and frame 11 in a hypothetical
animated image could all depend on frame 9. But no subsequent frame
after frame 9 could depend on frames 0-8.)

Warning: this logic will break if we decide to support more animated
formats in the future.

Fixes flutter/flutter#24835.