### PR TITLE
[Fuchsia] Depend on libtrace when that is what's really meant

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -149,7 +149,7 @@ source_set("fml") {
   if (is_fuchsia) {
     sources += [ "platform/fuchsia/paths_fuchsia.cc" ]
 
-    public_deps += [ "//zircon/public/lib/trace-provider" ]
+    public_deps += [ "//zircon/public/lib/trace" ]
   }
 
   if (is_win) {

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -28,6 +28,7 @@ executable("testing") {
   if (is_fuchsia) {
     deps += [
       "//garnet/public/lib/ui/scenic:client",
+      "//zircon/public/lib/trace",
       "//zircon/public/lib/trace-provider",
     ]
   }


### PR DESCRIPTION
libtrace-provider has libtrace listed as a dependency when really it
does not have any such dependency. This lets trace clients use
libtrace-provider as a dependency when what they really mean is libtrace.

This errant dependency in trace-provider is being fixed, which
means we need to fix these clients.