### PR TITLE
Revert "Support overriding font leading in TextStyle and LibTxt (#6927)"

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -256,7 +256,6 @@ Int32List _encodeTextStyle(
   double letterSpacing,
   double wordSpacing,
   double height,
-  double leading,
   Locale locale,
   Paint background,
   Paint foreground,
@@ -311,24 +310,20 @@ Int32List _encodeTextStyle(
     result[0] |= 1 << 12;
     // Passed separately to native.
   }
-  if (leading != null) {
+  if (locale != null) {
     result[0] |= 1 << 13;
     // Passed separately to native.
   }
-  if (locale != null) {
+  if (background != null) {
     result[0] |= 1 << 14;
     // Passed separately to native.
   }
-  if (background != null) {
+  if (foreground != null) {
     result[0] |= 1 << 15;
     // Passed separately to native.
   }
-  if (foreground != null) {
-    result[0] |= 1 << 16;
-    // Passed separately to native.
-  }
   if (shadows != null) {
-    result[0] |= 1 << 17;
+    result[0] |= 1 << 16;
     // Passed separately to native.
   }
   return result;
@@ -349,8 +344,7 @@ class TextStyle {
   /// * `letterSpacing`: The amount of space (in logical pixels) to add between each letter.
   /// * `wordSpacing`: The amount of space (in logical pixels) to add at each sequence of white-space (i.e. between each word).
   /// * `textBaseline`: The common baseline that should be aligned between this text span and its parent text span, or, for the root text spans, with the line box.
-  /// * `height`: The height of this text span, as a multiple of the sum of font size and leading.
-  /// * `leading`: Custom leading to use instead of the font-provided leading as a multiple of font size. When null, default font leading will be used. Leading is the additional spacing between lines.
+  /// * `height`: The height of this text span, as a multiple of the font size.
   /// * `locale`: The locale used to select region-specific glyphs.
   /// * `background`: The paint drawn as a background for the text.
   /// * `foreground`: The paint used to draw the text. If this is specified, `color` must be null.
@@ -367,7 +361,6 @@ class TextStyle {
     double letterSpacing,
     double wordSpacing,
     double height,
-    double leading,
     Locale locale,
     Paint background,
     Paint foreground,
@@ -389,7 +382,6 @@ class TextStyle {
          letterSpacing,
          wordSpacing,
          height,
-         leading,
          locale,
          background,
          foreground,
@@ -400,7 +392,6 @@ class TextStyle {
        _letterSpacing = letterSpacing,
        _wordSpacing = wordSpacing,
        _height = height,
-       _leading = leading,
        _locale = locale,
        _background = background,
        _foreground = foreground,
@@ -412,7 +403,6 @@ class TextStyle {
   final double _letterSpacing;
   final double _wordSpacing;
   final double _height;
-  final double _leading;
   final Locale _locale;
   final Paint _background;
   final Paint _foreground;
@@ -430,7 +420,6 @@ class TextStyle {
         _letterSpacing != typedOther._letterSpacing ||
         _wordSpacing != typedOther._wordSpacing ||
         _height != typedOther._height ||
-        _leading != typedOther._leading ||
         _locale != typedOther._locale ||
         _background != typedOther._background ||
         _foreground != typedOther._foreground)
@@ -445,7 +434,7 @@ class TextStyle {
   }
 
   @override
-  int get hashCode => hashValues(hashList(_encoded), _fontFamily, _fontSize, _letterSpacing, _wordSpacing, _height, _leading, _locale, _background, _foreground);
+  int get hashCode => hashValues(hashList(_encoded), _fontFamily, _fontSize, _letterSpacing, _wordSpacing, _height, _locale, _background, _foreground);
 
   @override
   String toString() {
@@ -462,11 +451,10 @@ class TextStyle {
              'letterSpacing: ${  _encoded[0] & 0x00400 == 0x00400 ? "${_letterSpacing}x"                    : "unspecified"}, '
              'wordSpacing: ${    _encoded[0] & 0x00800 == 0x00800 ? "${_wordSpacing}x"                      : "unspecified"}, '
              'height: ${         _encoded[0] & 0x01000 == 0x01000 ? "${_height}x"                           : "unspecified"}, '
-             'leading: ${        _encoded[0] & 0x02000 == 0x02000 ? "${_leading}x"                           : "unspecified"}, '
-             'locale: ${         _encoded[0] & 0x04000 == 0x04000 ? _locale                                 : "unspecified"}, '
-             'background: ${     _encoded[0] & 0x08000 == 0x08000 ? _background                             : "unspecified"}, '
-             'foreground: ${     _encoded[0] & 0x10000 == 0x10000 ? _foreground                             : "unspecified"}, '
-             'shadows: ${        _encoded[0] & 0x20000 == 0x20000 ? _shadows                                : "unspecified"}'
+             'locale: ${         _encoded[0] & 0x02000 == 0x02000 ? _locale                                 : "unspecified"}, '
+             'background: ${     _encoded[0] & 0x04000 == 0x04000 ? _background                             : "unspecified"}, '
+             'foreground: ${     _encoded[0] & 0x08000 == 0x08000 ? _foreground                             : "unspecified"}, '
+             'shadows: ${        _encoded[0] & 0x10000 == 0x10000 ? _shadows                                : "unspecified"}'
            ')';
   }
 }
@@ -1147,8 +1135,8 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
   /// Applies the given style to the added text until [pop] is called.
   ///
   /// See [pop] for details.
-  void pushStyle(TextStyle style) => _pushStyle(style._encoded, style._fontFamily, style._fontSize, style._letterSpacing, style._wordSpacing, style._height, style._leading, _encodeLocale(style._locale), style._background?._objects, style._background?._data, style._foreground?._objects, style._foreground?._data, Shadow._encodeShadows(style._shadows));
-  void _pushStyle(Int32List encoded, String fontFamily, double fontSize, double letterSpacing, double wordSpacing, double height, double leading, String locale, List<dynamic> backgroundObjects, ByteData backgroundData, List<dynamic> foregroundObjects, ByteData foregroundData, ByteData shadowsData) native 'ParagraphBuilder_pushStyle';
+  void pushStyle(TextStyle style) => _pushStyle(style._encoded, style._fontFamily, style._fontSize, style._letterSpacing, style._wordSpacing, style._height, _encodeLocale(style._locale), style._background?._objects, style._background?._data, style._foreground?._objects, style._foreground?._data, Shadow._encodeShadows(style._shadows));
+  void _pushStyle(Int32List encoded, String fontFamily, double fontSize, double letterSpacing, double wordSpacing, double height, String locale, List<dynamic> backgroundObjects, ByteData backgroundData, List<dynamic> foregroundObjects, ByteData foregroundData, ByteData shadowsData) native 'ParagraphBuilder_pushStyle';
 
   static String _encodeLocale(Locale locale) => locale?.toString() ?? '';
 

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -41,11 +41,10 @@ const int tsFontSizeIndex = 9;
 const int tsLetterSpacingIndex = 10;
 const int tsWordSpacingIndex = 11;
 const int tsHeightIndex = 12;
-const int tsLeadingIndex = 13;
-const int tsLocaleIndex = 14;
-const int tsBackgroundIndex = 15;
-const int tsForegroundIndex = 16;
-const int tsTextShadowsIndex = 17;
+const int tsLocaleIndex = 13;
+const int tsBackgroundIndex = 14;
+const int tsForegroundIndex = 15;
+const int tsTextShadowsIndex = 16;
 
 const int tsColorMask = 1 << tsColorIndex;
 const int tsTextDecorationMask = 1 << tsTextDecorationIndex;
@@ -59,7 +58,6 @@ const int tsFontSizeMask = 1 << tsFontSizeIndex;
 const int tsLetterSpacingMask = 1 << tsLetterSpacingIndex;
 const int tsWordSpacingMask = 1 << tsWordSpacingIndex;
 const int tsHeightMask = 1 << tsHeightIndex;
-const int tsLeadingMask = 1 << tsLeadingIndex;
 const int tsLocaleMask = 1 << tsLocaleIndex;
 const int tsBackgroundMask = 1 << tsBackgroundIndex;
 const int tsForegroundMask = 1 << tsForegroundIndex;
@@ -209,7 +207,6 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
                                  double letterSpacing,
                                  double wordSpacing,
                                  double height,
-                                 double leading,
                                  const std::string& locale,
                                  Dart_Handle background_objects,
                                  Dart_Handle background_data,
@@ -270,11 +267,6 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
 
   if (mask & tsHeightMask) {
     style.height = height;
-  }
-
-  if (mask & tsLeadingMask) {
-    style.use_custom_leading = true;
-    style.leading = leading;
   }
 
   if (mask & tsLocaleMask) {

--- a/lib/ui/text/paragraph_builder.h
+++ b/lib/ui/text/paragraph_builder.h
@@ -40,7 +40,6 @@ class ParagraphBuilder : public RefCountedDartWrappable<ParagraphBuilder> {
                  double letterSpacing,
                  double wordSpacing,
                  double height,
-                 double leading,
                  const std::string& locale,
                  Dart_Handle background_objects,
                  Dart_Handle background_data,

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -761,13 +761,10 @@ void Paragraph::Layout(double width, bool force) {
       // TODO(garyq): Multipling in the style.height on the first line is
       // probably wrong. Figure out how paragraph and line heights are supposed
       // to work and fix it.
-      double leading =
-          style.use_custom_leading
-              ? (metrics.fDescent - metrics.fAscent) * style.leading
-              : metrics.fLeading;
-      double line_spacing = (line_number == 0)
-                                ? -metrics.fAscent * style.height
-                                : (-metrics.fAscent + leading) * style.height;
+      double line_spacing =
+          (line_number == 0)
+              ? -metrics.fAscent * style.height
+              : (-metrics.fAscent + metrics.fLeading) * style.height;
       if (line_spacing > max_line_spacing) {
         max_line_spacing = line_spacing;
         if (line_number == 0) {

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -214,10 +214,7 @@ class Paragraph {
   FRIEND_TEST(ParagraphTest, DecorationsParagraph);
   FRIEND_TEST(ParagraphTest, ItalicsParagraph);
   FRIEND_TEST(ParagraphTest, ChineseParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicLeadingOverrideParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicLeadingOverrideTallParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicLeadingOverrideNegativeParagraph);
+  FRIEND_TEST(ParagraphTest, DISABLED_ArabicParagraph);
   FRIEND_TEST(ParagraphTest, SpacingParagraph);
   FRIEND_TEST(ParagraphTest, LongWordParagraph);
   FRIEND_TEST(ParagraphTest, KernScaleParagraph);

--- a/third_party/txt/src/txt/styled_runs.h
+++ b/third_party/txt/src/txt/styled_runs.h
@@ -73,10 +73,7 @@ class StyledRuns {
   FRIEND_TEST(ParagraphTest, DecorationsParagraph);
   FRIEND_TEST(ParagraphTest, ItalicsParagraph);
   FRIEND_TEST(ParagraphTest, ChineseParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicLeadingOverrideParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicLeadingOverrideTallParagraph);
-  FRIEND_TEST(ParagraphTest, ArabicLeadingOverrideNegativeParagraph);
+  FRIEND_TEST(ParagraphTest, DISABLED_ArabicParagraph);
   FRIEND_TEST(ParagraphTest, LongWordParagraph);
   FRIEND_TEST(ParagraphTest, KernParagraph);
   FRIEND_TEST(ParagraphTest, HyphenBreakParagraph);

--- a/third_party/txt/src/txt/text_style.cc
+++ b/third_party/txt/src/txt/text_style.cc
@@ -47,10 +47,6 @@ bool TextStyle::equals(const TextStyle& other) const {
     return false;
   if (height != other.height)
     return false;
-  if (use_custom_leading != other.use_custom_leading)
-    return false;
-  if (use_custom_leading && leading != other.leading)
-    return false;
   if (locale != other.locale)
     return false;
   if (foreground != other.foreground)

--- a/third_party/txt/src/txt/text_style.h
+++ b/third_party/txt/src/txt/text_style.h
@@ -48,8 +48,6 @@ class TextStyle {
   double letter_spacing = 0.0;
   double word_spacing = 0.0;
   double height = 1.0;
-  double leading = 0;
-  bool use_custom_leading = false;
   std::string locale;
   bool has_background = false;
   SkPaint background;

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -821,15 +821,11 @@ TEST_F(ParagraphTest, ChineseParagraph) {
   ASSERT_TRUE(Snapshot());
 }
 
-TEST_F(ParagraphTest, ArabicParagraph) {
+// TODO(garyq): Support RTL languages.
+TEST_F(ParagraphTest, DISABLED_ArabicParagraph) {
   const char* text =
       "من أسر وإعلان الخاصّة وهولندا،, عل قائمة الضغوط بالمطالبة تلك. الصفحة "
-      "بمباركة التقليدية قام عن. تصفحبمباركة التقل. يدية فح قام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية تصفحب قام عن. فح "
-      "تصفحبمقباركة التقلفحيدية قام عن. تصفحبمباركة التقليدية ققام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تص  تصفحب "
-      "فحبمباركة التقققليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفحبمباركة "
-      "التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفح";
+      "بمباركة التقليدية قام عن. تصفح";
   auto icu_text = icu::UnicodeString::fromUTF8(text);
   std::u16string u16_text(icu_text.getBuffer(),
                           icu_text.getBuffer() + icu_text.length());
@@ -842,9 +838,12 @@ TEST_F(ParagraphTest, ArabicParagraph) {
 
   txt::TextStyle text_style;
   text_style.color = SK_ColorBLACK;
-  text_style.font_size = 45;
+  text_style.font_size = 35;
   text_style.letter_spacing = 2;
   text_style.font_family = "Katibeh";
+  text_style.decoration = TextDecoration::kUnderline |
+                          TextDecoration::kOverline |
+                          TextDecoration::kLineThrough;
   text_style.decoration_style = txt::TextDecorationStyle::kSolid;
   text_style.decoration_color = SK_ColorBLACK;
   builder.PushStyle(text_style);
@@ -857,190 +856,21 @@ TEST_F(ParagraphTest, ArabicParagraph) {
   paragraph->Layout(GetTestCanvasWidth() - 100);
 
   paragraph->Paint(GetCanvas(), 0, 0);
-  ASSERT_TRUE(Snapshot());
 
-  ASSERT_EQ(paragraph->text_.size(), 458ull);  // Arabic script uses ligatures
-
-  ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
-  ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
-  ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
-  ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
-  ASSERT_EQ(paragraph->records_.size(),
-            8ull);  // 8 lines, breaks into 8 records.
-  ASSERT_EQ(paragraph->paragraph_style_.text_direction, TextDirection::rtl);
-
-  ASSERT_EQ(paragraph->line_heights_[0], 45);
-  ASSERT_EQ(paragraph->line_heights_[1], 99);
-  ASSERT_EQ(paragraph->line_heights_[2], 153);
-  ASSERT_EQ(paragraph->line_heights_[3], 207);
-}
-
-TEST_F(ParagraphTest, ArabicLeadingOverrideParagraph) {
-  const char* text =
-      "من أسر وإعلان الخاصّة وهولندا،, عل قائمة الضغوط بالمطالبة تلك. الصفحة "
-      "بمباركة التقليدية قام عن. تصفحبمباركة التقل. يدية فح قام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية تصفحب قام عن. فح "
-      "تصفحبمقباركة التقلفحيدية قام عن. تصفحبمباركة التقليدية ققام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تص  تصفحب "
-      "فحبمباركة التقققليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفحبمباركة "
-      "التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفح";
-  auto icu_text = icu::UnicodeString::fromUTF8(text);
-  std::u16string u16_text(icu_text.getBuffer(),
-                          icu_text.getBuffer() + icu_text.length());
-
-  txt::ParagraphStyle paragraph_style;
-  paragraph_style.max_lines = 14;
-  paragraph_style.text_align = TextAlign::right;
-  paragraph_style.text_direction = TextDirection::rtl;
-  txt::ParagraphBuilder builder(paragraph_style, GetTestFontCollection());
-
-  txt::TextStyle text_style;
-  text_style.color = SK_ColorBLACK;
-  text_style.font_size = 45;
-  text_style.letter_spacing = 2;
-  text_style.font_family = "Katibeh";
-  text_style.decoration_style = txt::TextDecorationStyle::kSolid;
-  text_style.decoration_color = SK_ColorBLACK;
-  text_style.use_custom_leading = true;
-  text_style.leading = 0;
-  builder.PushStyle(text_style);
-
-  builder.AddText(u16_text);
-
-  builder.Pop();
-
-  auto paragraph = builder.Build();
-  paragraph->Layout(GetTestCanvasWidth() - 100);
-
-  paragraph->Paint(GetCanvas(), 0, 0);
-  ASSERT_TRUE(Snapshot());
-
-  ASSERT_EQ(paragraph->text_.size(), 458ull);  // Arabic script uses ligatures
+  ASSERT_EQ(paragraph->text_.size(), std::string{text}.length());
 
   ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
   ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
   ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
   ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
-  ASSERT_EQ(paragraph->records_.size(),
-            8ull);  // 8 lines, breaks into 8 records.
+  ASSERT_EQ(paragraph->records_.size(), 2ull);
   ASSERT_EQ(paragraph->paragraph_style_.text_direction, TextDirection::rtl);
 
-  ASSERT_EQ(paragraph->line_heights_[0], 45);
-  ASSERT_EQ(paragraph->line_heights_[1], 90);
-  ASSERT_EQ(paragraph->line_heights_[2], 135);
-  ASSERT_EQ(paragraph->line_heights_[3], 180);
-}
+  for (size_t i = 0; i < u16_text.length(); i++) {
+    ASSERT_EQ(paragraph->text_[i], u16_text[u16_text.length() - i]);
+  }
 
-TEST_F(ParagraphTest, ArabicLeadingOverrideTallParagraph) {
-  const char* text =
-      "من أسر وإعلان الخاصّة وهولندا،, عل قائمة الضغوط بالمطالبة تلك. الصفحة "
-      "بمباركة التقليدية قام عن. تصفحبمباركة التقل. يدية فح قام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية تصفحب قام عن. فح "
-      "تصفحبمقباركة التقلفحيدية قام عن. تصفحبمباركة التقليدية ققام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تص  تصفحب "
-      "فحبمباركة التقققليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفحبمباركة "
-      "التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفح";
-  auto icu_text = icu::UnicodeString::fromUTF8(text);
-  std::u16string u16_text(icu_text.getBuffer(),
-                          icu_text.getBuffer() + icu_text.length());
-
-  txt::ParagraphStyle paragraph_style;
-  paragraph_style.max_lines = 14;
-  paragraph_style.text_align = TextAlign::right;
-  paragraph_style.text_direction = TextDirection::rtl;
-  txt::ParagraphBuilder builder(paragraph_style, GetTestFontCollection());
-
-  txt::TextStyle text_style;
-  text_style.color = SK_ColorBLACK;
-  text_style.font_size = 45;
-  text_style.letter_spacing = 2;
-  text_style.font_family = "Katibeh";
-  text_style.decoration_style = txt::TextDecorationStyle::kSolid;
-  text_style.decoration_color = SK_ColorBLACK;
-  text_style.use_custom_leading = true;
-  text_style.leading = 0.65;
-  builder.PushStyle(text_style);
-
-  builder.AddText(u16_text);
-
-  builder.Pop();
-
-  auto paragraph = builder.Build();
-  paragraph->Layout(GetTestCanvasWidth() - 100);
-
-  paragraph->Paint(GetCanvas(), 0, 0);
   ASSERT_TRUE(Snapshot());
-
-  ASSERT_EQ(paragraph->text_.size(), 458ull);  // Arabic script uses ligatures
-
-  ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
-  ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
-  ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
-  ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
-  ASSERT_EQ(paragraph->records_.size(),
-            8ull);  // 8 lines, breaks into 8 records.
-  ASSERT_EQ(paragraph->paragraph_style_.text_direction, TextDirection::rtl);
-
-  ASSERT_EQ(paragraph->line_heights_[0], 45);
-  ASSERT_EQ(paragraph->line_heights_[1], 119);
-  ASSERT_EQ(paragraph->line_heights_[2], 193);
-  ASSERT_EQ(paragraph->line_heights_[3], 267);
-}
-
-TEST_F(ParagraphTest, ArabicLeadingOverrideNegativeParagraph) {
-  const char* text =
-      "من أسر وإعلان الخاصّة وهولندا،, عل قائمة الضغوط بالمطالبة تلك. الصفحة "
-      "بمباركة التقليدية قام عن. تصفحبمباركة التقل. يدية فح قام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية تصفحب قام عن. فح "
-      "تصفحبمقباركة التقلفحيدية قام عن. تصفحبمباركة التقليدية ققام عن. "
-      "تصفحبمباركة التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تص  تصفحب "
-      "فحبمباركة التقققليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفحبمباركة "
-      "التقليدية قام عن. تصفحبمباركة التقليدية قام عن. تصفح";
-  auto icu_text = icu::UnicodeString::fromUTF8(text);
-  std::u16string u16_text(icu_text.getBuffer(),
-                          icu_text.getBuffer() + icu_text.length());
-
-  txt::ParagraphStyle paragraph_style;
-  paragraph_style.max_lines = 14;
-  paragraph_style.text_align = TextAlign::right;
-  paragraph_style.text_direction = TextDirection::rtl;
-  txt::ParagraphBuilder builder(paragraph_style, GetTestFontCollection());
-
-  txt::TextStyle text_style;
-  text_style.color = SK_ColorBLACK;
-  text_style.font_size = 45;
-  text_style.letter_spacing = 2;
-  text_style.font_family = "Katibeh";
-  text_style.decoration_style = txt::TextDecorationStyle::kSolid;
-  text_style.decoration_color = SK_ColorBLACK;
-  text_style.use_custom_leading = true;
-  text_style.leading = -0.2;
-  builder.PushStyle(text_style);
-
-  builder.AddText(u16_text);
-
-  builder.Pop();
-
-  auto paragraph = builder.Build();
-  paragraph->Layout(GetTestCanvasWidth() - 100);
-
-  paragraph->Paint(GetCanvas(), 0, 0);
-  ASSERT_TRUE(Snapshot());
-
-  ASSERT_EQ(paragraph->text_.size(), 458ull);  // Arabic script uses ligatures
-
-  ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
-  ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
-  ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
-  ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
-  ASSERT_EQ(paragraph->records_.size(),
-            8ull);  // 8 lines, breaks into 8 records.
-  ASSERT_EQ(paragraph->paragraph_style_.text_direction, TextDirection::rtl);
-
-  ASSERT_EQ(paragraph->line_heights_[0], 45);
-  ASSERT_EQ(paragraph->line_heights_[1], 81);
-  ASSERT_EQ(paragraph->line_heights_[2], 117);
-  ASSERT_EQ(paragraph->line_heights_[3], 153);
 }
 
 TEST_F(ParagraphTest, GetGlyphPositionAtCoordinateParagraph) {
@@ -1332,6 +1162,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeTight)) {
 
 TEST_F(ParagraphTest,
        DISABLE_ON_WINDOWS(GetRectsForRangeIncludeLineSpacingMiddle)) {
+  // const char* text =
+  //     "12345,  \"67890\" 12345 67890 12345 67890 12345 67890 12345 67890
+  //     12345 " "67890 12345";
   const char* text =
       "(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("
       "　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("


### PR DESCRIPTION
This reverts commit 4b233f033b8ba7b7e5e84f1607dbdf2e4dcdc5d8.