### PR TITLE
Remove unnecessary includes of Skia headers.

### DIFF
--- a/flow/layers/platform_view_layer.h
+++ b/flow/layers/platform_view_layer.h
@@ -6,11 +6,8 @@
 #define FLUTTER_FLOW_LAYERS_PLATFORM_VIEW_LAYER_H_
 
 #include "flutter/flow/layers/layer.h"
-#include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
-#include "third_party/skia/include/gpu/GrTexture.h"
-#include "third_party/skia/include/gpu/GrTypes.h"
+#include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkSize.h"
 
 namespace flow {
 

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -6,11 +6,8 @@
 #define FLUTTER_FLOW_LAYERS_TEXTURE_LAYER_H_
 
 #include "flutter/flow/layers/layer.h"
-#include "third_party/skia/include/core/SkSurface.h"
-#include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrContext.h"
-#include "third_party/skia/include/gpu/GrTexture.h"
-#include "third_party/skia/include/gpu/GrTypes.h"
+#include "third_party/skia/include/core/SkPoint.h"
+#include "third_party/skia/include/core/SkSize.h"
 
 namespace flow {
 

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -7,7 +7,7 @@
 #include <GLES/glext.h>
 
 #include "flutter/shell/platform/android/platform_view_android_jni.h"
-#include "third_party/skia/include/gpu/GrTexture.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
 
 namespace shell {
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -11,8 +11,6 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
-#include "third_party/skia/include/gpu/GrTexture.h"
-#include "third_party/skia/include/gpu/GrTypes.h"
 
 namespace shell {
 


### PR DESCRIPTION
@chinmaygarde, Eventually Skia wants to hide GrTexture.h. There were a few unneeded includes of this filein Flutter engine, along with some other unnecessary includes.