### PR TITLE
Fallback font match caching to fix emoji lag.

### DIFF
--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -20,7 +20,6 @@
 #include <unicode/ubidi.h>
 #include <unicode/utf16.h>
 #include <algorithm>
-#include <chrono>
 #include <fstream>
 #include <iostream>  // for debugging
 #include <string>
@@ -41,7 +40,6 @@
 #include "HbFontCache.h"
 #include "LayoutUtils.h"
 #include "MinikinInternal.h"
-#include "flutter/fml/logging.h"
 
 using std::string;
 using std::vector;
@@ -664,17 +662,10 @@ float Layout::doLayoutRunCached(
       }
       ctx->paint.hyphenEdit = hyphen;
       size_t wordcount = std::min(start + count, wordend) - iter;
-      std::chrono::milliseconds startTime =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::system_clock::now().time_since_epoch());
       advance += doLayoutWord(buf + wordstart, iter - wordstart, wordcount,
                               wordend - wordstart, isRtl, ctx, iter - dstStart,
                               collection, layout,
                               advances ? advances + (iter - start) : advances);
-      std::chrono::milliseconds endTime =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::system_clock::now().time_since_epoch());
-      FML_DLOG(ERROR) << endTime.count() - startTime.count() << " " << count;
       wordstart = wordend;
     }
   } else {

--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -20,6 +20,7 @@
 #include <unicode/ubidi.h>
 #include <unicode/utf16.h>
 #include <algorithm>
+#include <chrono>
 #include <fstream>
 #include <iostream>  // for debugging
 #include <string>
@@ -40,6 +41,7 @@
 #include "HbFontCache.h"
 #include "LayoutUtils.h"
 #include "MinikinInternal.h"
+#include "flutter/fml/logging.h"
 
 using std::string;
 using std::vector;
@@ -662,10 +664,17 @@ float Layout::doLayoutRunCached(
       }
       ctx->paint.hyphenEdit = hyphen;
       size_t wordcount = std::min(start + count, wordend) - iter;
+      std::chrono::milliseconds startTime =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::system_clock::now().time_since_epoch());
       advance += doLayoutWord(buf + wordstart, iter - wordstart, wordcount,
                               wordend - wordstart, isRtl, ctx, iter - dstStart,
                               collection, layout,
                               advances ? advances + (iter - start) : advances);
+      std::chrono::milliseconds endTime =
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::system_clock::now().time_since_epoch());
+      FML_DLOG(ERROR) << endTime.count() - startTime.count() << " " << count;
       wordstart = wordend;
     }
   } else {

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -205,8 +205,7 @@ const std::shared_ptr<minikin::FontFamily>& FontCollection::MatchFallbackFont(
   // Check if the ch's matched font has been cached. We cache the results of
   // this method as repeated matchFamilyStyleCharacter calls can become
   // extremely laggy when typing a large number of complex emojis.
-  std::unordered_map<uint32_t, const std::shared_ptr<minikin::FontFamily>*>::
-      const_iterator lookup = fallback_match_cache_.find(ch);
+  auto lookup = fallback_match_cache_.find(ch);
   if (lookup != fallback_match_cache_.end()) {
     return *lookup->second;
   }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -202,6 +202,9 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
 const std::shared_ptr<minikin::FontFamily>& FontCollection::MatchFallbackFont(
     uint32_t ch,
     std::string locale) {
+  // Check if the ch's matched font has been cached. We cache the results of
+  // this method as repeated matchFamilyStyleCharacter calls can become
+  // extremely laggy when typing a large number of complex emojis.
   if (fallback_match_cache_.count(ch) > 0) {
     return *fallback_match_cache_[ch];
   }

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -80,6 +80,8 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
                      std::shared_ptr<minikin::FontCollection>,
                      FamilyKey::Hasher>
       font_collections_cache_;
+  // Cache that stores the results of MatchFallbackFont to ensure lag-free emoji
+  // font fallback matching.
   std::unordered_map<uint32_t, const std::shared_ptr<minikin::FontFamily>*>
       fallback_match_cache_;
   std::unordered_map<std::string, std::shared_ptr<minikin::FontFamily>>

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -80,6 +80,8 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
                      std::shared_ptr<minikin::FontCollection>,
                      FamilyKey::Hasher>
       font_collections_cache_;
+  std::unordered_map<uint32_t, const std::shared_ptr<minikin::FontFamily>*>
+      fallback_match_cache_;
   std::unordered_map<std::string, std::shared_ptr<minikin::FontFamily>>
       fallback_fonts_;
   std::unordered_map<std::string, std::set<std::string>>

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -49,6 +49,8 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
       const std::string& family,
       const std::string& locale);
 
+  // Provides a FontFamily that contains glyphs for ch. This caches previously
+  // matched fonts. Also see FontCollection::DoMatchFallbackFont.
   const std::shared_ptr<minikin::FontFamily>& MatchFallbackFont(
       uint32_t ch,
       std::string locale);
@@ -89,6 +91,12 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
   std::unordered_map<std::string, std::set<std::string>>
       fallback_fonts_for_locale_;
   bool enable_font_fallback_;
+
+  // Performs the actual work of MatchFallbackFont. The result is cached in
+  // fallback_match_cache_.
+  const std::shared_ptr<minikin::FontFamily>& DoMatchFallbackFont(
+      uint32_t ch,
+      std::string locale);
 
   std::vector<sk_sp<SkFontMgr>> GetFontManagerOrder() const;
 


### PR DESCRIPTION
Large emoji string cause lag due to repeated font fallback matching. Here we naively cache the results of MatchFallbackFont.