### PR TITLE
support customize platformView theme

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewFactory.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewFactory.java
@@ -5,6 +5,8 @@
 package io.flutter.plugin.platform;
 
 import android.content.Context;
+import android.support.annotation.StyleRes;
+
 import io.flutter.plugin.common.MessageCodec;
 
 public abstract class PlatformViewFactory {
@@ -28,6 +30,16 @@ public abstract class PlatformViewFactory {
      *             sent from the Flutter app.
      */
     public abstract PlatformView create(Context context, int viewId, Object args);
+
+    /**
+     * Used to customize the Theme of Presentation. This is useful when need a translucent AndroidView.
+     * Return 0 by default, will use the theme defined by com.android.internal.R.attr.presentationTheme attribute.
+     * @return A style resource describing the theme to use for the window.
+     */
+    @StyleRes
+    protected int getPresentationTheme() {
+        return 0;
+    }
 
     /**
      * Returns the codec to be used for decoding the args parameter of {@link #create}.

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -96,7 +96,7 @@ class SingleViewPresentation extends Presentation {
             Object createParams,
             OnFocusChangeListener focusChangeListener
     ) {
-        super(outerContext, display);
+        super(outerContext, display, viewFactory.getPresentationTheme());
         this.viewFactory = viewFactory;
         this.accessibilityEventsDelegate = accessibilityEventsDelegate;
         this.viewId = viewId;
@@ -122,9 +122,10 @@ class SingleViewPresentation extends Presentation {
             AccessibilityEventsDelegate accessibilityEventsDelegate,
             PresentationState state,
             OnFocusChangeListener focusChangeListener,
-            boolean startFocused
+            boolean startFocused,
+            int themeId
     ) {
-        super(outerContext, display);
+        super(outerContext, display, themeId);
         this.accessibilityEventsDelegate = accessibilityEventsDelegate;
         viewFactory = null;
         this.state = state;

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -61,6 +61,7 @@ class VirtualDisplayController {
     private VirtualDisplay virtualDisplay;
     private SingleViewPresentation presentation;
     private Surface surface;
+    private int presentationThemeId;
 
 
     private VirtualDisplayController(
@@ -81,6 +82,7 @@ class VirtualDisplayController {
         this.surface = surface;
         this.virtualDisplay = virtualDisplay;
         densityDpi = context.getResources().getDisplayMetrics().densityDpi;
+        presentationThemeId = viewFactory.getPresentationTheme();
         presentation = new SingleViewPresentation(
                 context,
                 this.virtualDisplay.getDisplay(),
@@ -145,7 +147,8 @@ class VirtualDisplayController {
                 accessibilityEventsDelegate,
                 presentationState,
                 focusChangeListener,
-                isFocused);
+                isFocused,
+                presentationThemeId);
         presentation.show();
     }
 


### PR DESCRIPTION
This is necessary when need a translucent AndroidView to make the Flutter UI visible below an AndroidView.