### PR TITLE
Revert spelling correction in licence matcher

### DIFF
--- a/tools/licenses/lib/patterns.dart
+++ b/tools/licenses/lib/patterns.dart
@@ -1209,7 +1209,7 @@ final List<RegExp> csLicenses = <RegExp>[
     r'^\1\2OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF *\n'
     r'^\1\2SUCH DAMAGE\. *\n'
     r'^(?:(?:\1\2?g? *)? *\n)*'
-    r'^\1\2The licence and distribution terms for any publicly available version or *\n'
+    r'^\1\2The licence and distribution terms for any publically available version or *\n'
     r'^\1\2derivative of this code cannot be changed\. +i\.e\. +this code cannot simply be *\n'
     r'^\1\2copied and put under another distribution licence *\n'
     r'^\1\2\[including the GNU Public Licence\.\]',


### PR DESCRIPTION
In f986a12e20b874317c690f7efe71a452c7a66a61 (#7179), the word
'publically' was altered to 'publicly', causing the licence aggregator
to fail to match the licence text included in many BoringSSL source
files.

The original licence includes several misspellings (e.g. 'rouines'
rather than 'routines') which we need to faithfully reproduce in our
match regex.

The failure this triggered went unnoticed during pre-/post-submit
due to the fact that the contents of the third_party directory didn't
change, so hash of the list of files used as a signature matched the
signature in the golden file, causing the run to be skipped.