### PR TITLE
Allow the GrContext to be created after IOManager etc.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -280,6 +280,7 @@ FILE: ../../../flutter/lib/ui/plugins.dart
 FILE: ../../../flutter/lib/ui/plugins/callback_cache.cc
 FILE: ../../../flutter/lib/ui/plugins/callback_cache.h
 FILE: ../../../flutter/lib/ui/pointer.dart
+FILE: ../../../flutter/lib/ui/resource_context_manager.h
 FILE: ../../../flutter/lib/ui/semantics.dart
 FILE: ../../../flutter/lib/ui/semantics/custom_accessibility_action.cc
 FILE: ../../../flutter/lib/ui/semantics/custom_accessibility_action.h

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -57,6 +57,7 @@ source_set("ui") {
     "painting/vertices.h",
     "plugins/callback_cache.cc",
     "plugins/callback_cache.h",
+    "resource_context_manager.h",
     "semantics/custom_accessibility_action.cc",
     "semantics/custom_accessibility_action.h",
     "semantics/semantics_node.cc",

--- a/lib/ui/resource_context_manager.h
+++ b/lib/ui/resource_context_manager.h
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_RESOURCE_CONTEXT_MANAGER_H_
+#define FLUTTER_LIB_UI_RESOURCE_CONTEXT_MANAGER_H_
+
+#include "flutter/fml/memory/weak_ptr.h"
+#include "third_party/skia/include/gpu/GrContext.h"
+
+namespace blink {
+// Interface for methods that manage the GrContext creation, access, and
+// release. Meant to be implemented by the owner of the GLContext, e.g. the
+// PlatformView. These methods may be called from a non-platform task runner.
+class ResourceContextManager {
+ public:
+  virtual sk_sp<GrContext> CreateResourceContext() = 0;
+
+  // In almost all situations, this should be prefered to
+  // `CreateResourceContext`. This will get the currently applicable GrContext
+  // on the calling thread for the current GrContext, if one is available.
+  // Calling this will ensure that, in the event the GLContext has changed, the
+  // correct GrContext for the current GLContext will be used. Unlike all other
+  // methods on the platform view, this one may be called on a non-platform task
+  // runner.
+  virtual sk_sp<GrContext> GetOrCreateResourceContext() = 0;
+
+  virtual fml::WeakPtr<GrContext> GetOrCreateWeakResourceContext() = 0;
+
+  virtual void ReleaseResourceContext() const = 0;
+};
+
+}  // namespace blink
+
+#endif // FLUTTER_LIB_UI_RESOURCE_CONTEXT_MANAGER_H_

--- a/lib/ui/resource_context_manager.h
+++ b/lib/ui/resource_context_manager.h
@@ -32,4 +32,4 @@ class ResourceContextManager {
 
 }  // namespace blink
 
-#endif // FLUTTER_LIB_UI_RESOURCE_CONTEXT_MANAGER_H_
+#endif  // FLUTTER_LIB_UI_RESOURCE_CONTEXT_MANAGER_H_

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -17,7 +17,7 @@ UIDartState::UIDartState(TaskRunners task_runners,
                          TaskObserverAdd add_callback,
                          TaskObserverRemove remove_callback,
                          fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                         fml::WeakPtr<GrContext> resource_context,
+                         fml::WeakPtr<ResourceContextManager> resource_context_manager,
                          fml::RefPtr<flow::SkiaUnrefQueue> skia_unref_queue,
                          std::string advisory_script_uri,
                          std::string advisory_script_entrypoint,
@@ -27,7 +27,7 @@ UIDartState::UIDartState(TaskRunners task_runners,
       add_callback_(std::move(add_callback)),
       remove_callback_(std::move(remove_callback)),
       snapshot_delegate_(std::move(snapshot_delegate)),
-      resource_context_(std::move(resource_context)),
+      resource_context_manager_(std::move(resource_context_manager)),
       advisory_script_uri_(std::move(advisory_script_uri)),
       advisory_script_entrypoint_(std::move(advisory_script_entrypoint)),
       logger_prefix_(std::move(logger_prefix)),
@@ -114,7 +114,7 @@ fml::WeakPtr<SnapshotDelegate> UIDartState::GetSnapshotDelegate() const {
 }
 
 fml::WeakPtr<GrContext> UIDartState::GetResourceContext() const {
-  return resource_context_;
+  return resource_context_manager_->GetOrCreateWeakResourceContext();
 }
 
 IsolateNameServer* UIDartState::GetIsolateNameServer() {

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -13,16 +13,17 @@ using tonic::ToDart;
 
 namespace blink {
 
-UIDartState::UIDartState(TaskRunners task_runners,
-                         TaskObserverAdd add_callback,
-                         TaskObserverRemove remove_callback,
-                         fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                         fml::WeakPtr<ResourceContextManager> resource_context_manager,
-                         fml::RefPtr<flow::SkiaUnrefQueue> skia_unref_queue,
-                         std::string advisory_script_uri,
-                         std::string advisory_script_entrypoint,
-                         std::string logger_prefix,
-                         IsolateNameServer* isolate_name_server)
+UIDartState::UIDartState(
+    TaskRunners task_runners,
+    TaskObserverAdd add_callback,
+    TaskObserverRemove remove_callback,
+    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::WeakPtr<ResourceContextManager> resource_context_manager,
+    fml::RefPtr<flow::SkiaUnrefQueue> skia_unref_queue,
+    std::string advisory_script_uri,
+    std::string advisory_script_entrypoint,
+    std::string logger_prefix,
+    IsolateNameServer* isolate_name_server)
     : task_runners_(std::move(task_runners)),
       add_callback_(std::move(add_callback)),
       remove_callback_(std::move(remove_callback)),

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -15,6 +15,7 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/lib/ui/isolate_name_server/isolate_name_server.h"
+#include "flutter/lib/ui/resource_context_manager.h"
 #include "flutter/lib/ui/snapshot_delegate.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/skia/include/gpu/GrContext.h"
@@ -72,7 +73,7 @@ class UIDartState : public tonic::DartState {
               TaskObserverAdd add_callback,
               TaskObserverRemove remove_callback,
               fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-              fml::WeakPtr<GrContext> resource_context,
+              fml::WeakPtr<ResourceContextManager> resource_context_manager,
               fml::RefPtr<flow::SkiaUnrefQueue> skia_unref_queue,
               std::string advisory_script_uri,
               std::string advisory_script_entrypoint,
@@ -94,7 +95,7 @@ class UIDartState : public tonic::DartState {
   const TaskObserverAdd add_callback_;
   const TaskObserverRemove remove_callback_;
   fml::WeakPtr<SnapshotDelegate> snapshot_delegate_;
-  fml::WeakPtr<GrContext> resource_context_;
+  fml::WeakPtr<ResourceContextManager> resource_context_manager_;
   const std::string advisory_script_uri_;
   const std::string advisory_script_entrypoint_;
   const std::string logger_prefix_;

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -35,7 +35,7 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
     TaskRunners task_runners,
     std::unique_ptr<Window> window,
     fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-    fml::WeakPtr<GrContext> resource_context,
+    fml::WeakPtr<ResourceContextManager> resource_context_manager,
     fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
     std::string advisory_script_uri,
     std::string advisory_script_entrypoint,
@@ -56,7 +56,7 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
           std::move(shared_snapshot),    // shared snapshot
           task_runners,                  // task runners
           std::move(snapshot_delegate),  // snapshot delegate
-          std::move(resource_context),   // resource context
+          std::move(resource_context_manager),   // resource context_manager
           std::move(unref_queue),        // skia unref queue
           advisory_script_uri,           // advisory URI
           advisory_script_entrypoint,    // advisory entrypoint
@@ -100,7 +100,7 @@ DartIsolate::DartIsolate(DartVM* vm,
                          fml::RefPtr<DartSnapshot> shared_snapshot,
                          TaskRunners task_runners,
                          fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                         fml::WeakPtr<GrContext> resource_context,
+                         fml::WeakPtr<ResourceContextManager> resource_context_manager,
                          fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
                          std::string advisory_script_uri,
                          std::string advisory_script_entrypoint,
@@ -109,7 +109,7 @@ DartIsolate::DartIsolate(DartVM* vm,
                   vm->GetSettings().task_observer_add,
                   vm->GetSettings().task_observer_remove,
                   std::move(snapshot_delegate),
-                  std::move(resource_context),
+                  std::move(resource_context_manager),
                   std::move(unref_queue),
                   advisory_script_uri,
                   advisory_script_entrypoint,
@@ -645,7 +645,7 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
             (*raw_embedder_isolate)->GetSharedSnapshot(),   // shared_snapshot
             null_task_runners,                              // task_runners
             fml::WeakPtr<SnapshotDelegate>{},               // snapshot_delegate
-            fml::WeakPtr<GrContext>{},                      // resource_context
+            fml::WeakPtr<ResourceContextManager>{}, // resource_context_manager
             nullptr,                                        // unref_queue
             advisory_script_uri,         // advisory_script_uri
             advisory_script_entrypoint,  // advisory_script_entrypoint

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -51,15 +51,15 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
   // isolate lifecycle is entirely managed by the VM).
   auto root_embedder_data = std::make_unique<std::shared_ptr<DartIsolate>>(
       std::make_shared<DartIsolate>(
-          vm,                            // VM
-          std::move(isolate_snapshot),   // isolate snapshot
-          std::move(shared_snapshot),    // shared snapshot
-          task_runners,                  // task runners
-          std::move(snapshot_delegate),  // snapshot delegate
-          std::move(resource_context_manager),   // resource context_manager
-          std::move(unref_queue),        // skia unref queue
-          advisory_script_uri,           // advisory URI
-          advisory_script_entrypoint,    // advisory entrypoint
+          vm,                                   // VM
+          std::move(isolate_snapshot),          // isolate snapshot
+          std::move(shared_snapshot),           // shared snapshot
+          task_runners,                         // task runners
+          std::move(snapshot_delegate),         // snapshot delegate
+          std::move(resource_context_manager),  // resource context_manager
+          std::move(unref_queue),               // skia unref queue
+          advisory_script_uri,                  // advisory URI
+          advisory_script_entrypoint,           // advisory entrypoint
           nullptr  // child isolate preparer will be set when this isolate is
                    // prepared to run
           ));
@@ -95,16 +95,17 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
   return embedder_isolate;
 }
 
-DartIsolate::DartIsolate(DartVM* vm,
-                         fml::RefPtr<DartSnapshot> isolate_snapshot,
-                         fml::RefPtr<DartSnapshot> shared_snapshot,
-                         TaskRunners task_runners,
-                         fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                         fml::WeakPtr<ResourceContextManager> resource_context_manager,
-                         fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
-                         std::string advisory_script_uri,
-                         std::string advisory_script_entrypoint,
-                         ChildIsolatePreparer child_isolate_preparer)
+DartIsolate::DartIsolate(
+    DartVM* vm,
+    fml::RefPtr<DartSnapshot> isolate_snapshot,
+    fml::RefPtr<DartSnapshot> shared_snapshot,
+    TaskRunners task_runners,
+    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::WeakPtr<ResourceContextManager> resource_context_manager,
+    fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
+    std::string advisory_script_uri,
+    std::string advisory_script_entrypoint,
+    ChildIsolatePreparer child_isolate_preparer)
     : UIDartState(std::move(task_runners),
                   vm->GetSettings().task_observer_add,
                   vm->GetSettings().task_observer_remove,
@@ -645,9 +646,9 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
             (*raw_embedder_isolate)->GetSharedSnapshot(),   // shared_snapshot
             null_task_runners,                              // task_runners
             fml::WeakPtr<SnapshotDelegate>{},               // snapshot_delegate
-            fml::WeakPtr<ResourceContextManager>{}, // resource_context_manager
-            nullptr,                                        // unref_queue
-            advisory_script_uri,         // advisory_script_uri
+            fml::WeakPtr<ResourceContextManager>{},  // resource_context_manager
+            nullptr,                                 // unref_queue
+            advisory_script_uri,                     // advisory_script_uri
             advisory_script_entrypoint,  // advisory_script_entrypoint
             (*raw_embedder_isolate)->child_isolate_preparer_));
   }

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -12,6 +12,7 @@
 #include "flutter/fml/compiler_specific.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
+#include "flutter/lib/ui/resource_context_manager.h"
 #include "flutter/lib/ui/snapshot_delegate.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/window.h"
@@ -46,7 +47,7 @@ class DartIsolate : public UIDartState {
       TaskRunners task_runners,
       std::unique_ptr<Window> window,
       fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-      fml::WeakPtr<GrContext> resource_context,
+      fml::WeakPtr<ResourceContextManager> resource_context_manager,
       fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
       std::string advisory_script_uri,
       std::string advisory_script_entrypoint,
@@ -57,7 +58,7 @@ class DartIsolate : public UIDartState {
               fml::RefPtr<DartSnapshot> shared_snapshot,
               TaskRunners task_runners,
               fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-              fml::WeakPtr<GrContext> resource_context,
+              fml::WeakPtr<ResourceContextManager> resource_context_manager,
               fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
               std::string advisory_script_uri,
               std::string advisory_script_entrypoint,

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -116,7 +116,7 @@ std::unique_ptr<RuntimeController> RuntimeController::Clone() const {
       shared_snapshot_,             //
       task_runners_,                //
       snapshot_delegate_,           //
-      resource_context_manager_,            //
+      resource_context_manager_,    //
       unref_queue_,                 //
       advisory_script_uri_,         //
       advisory_script_entrypoint_,  //

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -21,7 +21,7 @@ RuntimeController::RuntimeController(
     fml::RefPtr<DartSnapshot> p_shared_snapshot,
     TaskRunners p_task_runners,
     fml::WeakPtr<SnapshotDelegate> p_snapshot_delegate,
-    fml::WeakPtr<GrContext> p_resource_context,
+    fml::WeakPtr<ResourceContextManager> p_resource_context_manager,
     fml::RefPtr<flow::SkiaUnrefQueue> p_unref_queue,
     std::string p_advisory_script_uri,
     std::string p_advisory_script_entrypoint)
@@ -31,7 +31,7 @@ RuntimeController::RuntimeController(
                         std::move(p_shared_snapshot),
                         std::move(p_task_runners),
                         std::move(p_snapshot_delegate),
-                        std::move(p_resource_context),
+                        std::move(p_resource_context_manager),
                         std::move(p_unref_queue),
                         std::move(p_advisory_script_uri),
                         std::move(p_advisory_script_entrypoint),
@@ -44,7 +44,7 @@ RuntimeController::RuntimeController(
     fml::RefPtr<DartSnapshot> p_shared_snapshot,
     TaskRunners p_task_runners,
     fml::WeakPtr<SnapshotDelegate> p_snapshot_delegate,
-    fml::WeakPtr<GrContext> p_resource_context,
+    fml::WeakPtr<ResourceContextManager> p_resource_context_manager,
     fml::RefPtr<flow::SkiaUnrefQueue> p_unref_queue,
     std::string p_advisory_script_uri,
     std::string p_advisory_script_entrypoint,
@@ -55,7 +55,7 @@ RuntimeController::RuntimeController(
       shared_snapshot_(std::move(p_shared_snapshot)),
       task_runners_(p_task_runners),
       snapshot_delegate_(p_snapshot_delegate),
-      resource_context_(p_resource_context),
+      resource_context_manager_(p_resource_context_manager),
       unref_queue_(p_unref_queue),
       advisory_script_uri_(p_advisory_script_uri),
       advisory_script_entrypoint_(p_advisory_script_entrypoint),
@@ -67,7 +67,7 @@ RuntimeController::RuntimeController(
                                          task_runners_,
                                          std::make_unique<Window>(this),
                                          snapshot_delegate_,
-                                         resource_context_,
+                                         resource_context_manager_,
                                          unref_queue_,
                                          p_advisory_script_uri,
                                          p_advisory_script_entrypoint)) {
@@ -116,7 +116,7 @@ std::unique_ptr<RuntimeController> RuntimeController::Clone() const {
       shared_snapshot_,             //
       task_runners_,                //
       snapshot_delegate_,           //
-      resource_context_,            //
+      resource_context_manager_,            //
       unref_queue_,                 //
       advisory_script_uri_,         //
       advisory_script_entrypoint_,  //

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -11,8 +11,8 @@
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/fml/macros.h"
-#include "flutter/lib/ui/text/font_collection.h"
 #include "flutter/lib/ui/resource_context_manager.h"
+#include "flutter/lib/ui/text/font_collection.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/window.h"
@@ -28,16 +28,17 @@ class Window;
 
 class RuntimeController final : public WindowClient {
  public:
-  RuntimeController(RuntimeDelegate& client,
-                    DartVM* vm,
-                    fml::RefPtr<DartSnapshot> isolate_snapshot,
-                    fml::RefPtr<DartSnapshot> shared_snapshot,
-                    TaskRunners task_runners,
-                    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                    fml::WeakPtr<ResourceContextManager> resource_context_manager,
-                    fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
-                    std::string advisory_script_uri,
-                    std::string advisory_script_entrypoint);
+  RuntimeController(
+      RuntimeDelegate& client,
+      DartVM* vm,
+      fml::RefPtr<DartSnapshot> isolate_snapshot,
+      fml::RefPtr<DartSnapshot> shared_snapshot,
+      TaskRunners task_runners,
+      fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+      fml::WeakPtr<ResourceContextManager> resource_context_manager,
+      fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
+      std::string advisory_script_uri,
+      std::string advisory_script_entrypoint);
 
   ~RuntimeController() override;
 
@@ -130,17 +131,18 @@ class RuntimeController final : public WindowClient {
   std::weak_ptr<DartIsolate> root_isolate_;
   std::pair<bool, uint32_t> root_isolate_return_code_ = {false, 0};
 
-  RuntimeController(RuntimeDelegate& client,
-                    DartVM* vm,
-                    fml::RefPtr<DartSnapshot> isolate_snapshot,
-                    fml::RefPtr<DartSnapshot> shared_snapshot,
-                    TaskRunners task_runners,
-                    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                    fml::WeakPtr<ResourceContextManager> resource_context_manager,
-                    fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
-                    std::string advisory_script_uri,
-                    std::string advisory_script_entrypoint,
-                    WindowData data);
+  RuntimeController(
+      RuntimeDelegate& client,
+      DartVM* vm,
+      fml::RefPtr<DartSnapshot> isolate_snapshot,
+      fml::RefPtr<DartSnapshot> shared_snapshot,
+      TaskRunners task_runners,
+      fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+      fml::WeakPtr<ResourceContextManager> resource_context_manager,
+      fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
+      std::string advisory_script_uri,
+      std::string advisory_script_entrypoint,
+      WindowData data);
 
   Window* GetWindowIfAvailable();
 

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -12,6 +12,7 @@
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/fml/macros.h"
 #include "flutter/lib/ui/text/font_collection.h"
+#include "flutter/lib/ui/resource_context_manager.h"
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "flutter/lib/ui/window/pointer_data_packet.h"
 #include "flutter/lib/ui/window/window.h"
@@ -33,7 +34,7 @@ class RuntimeController final : public WindowClient {
                     fml::RefPtr<DartSnapshot> shared_snapshot,
                     TaskRunners task_runners,
                     fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                    fml::WeakPtr<GrContext> resource_context,
+                    fml::WeakPtr<ResourceContextManager> resource_context_manager,
                     fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
                     std::string advisory_script_uri,
                     std::string advisory_script_entrypoint);
@@ -121,7 +122,7 @@ class RuntimeController final : public WindowClient {
   fml::RefPtr<DartSnapshot> shared_snapshot_;
   TaskRunners task_runners_;
   fml::WeakPtr<SnapshotDelegate> snapshot_delegate_;
-  fml::WeakPtr<GrContext> resource_context_;
+  fml::WeakPtr<ResourceContextManager> resource_context_manager_;
   fml::RefPtr<flow::SkiaUnrefQueue> unref_queue_;
   std::string advisory_script_uri_;
   std::string advisory_script_entrypoint_;
@@ -135,7 +136,7 @@ class RuntimeController final : public WindowClient {
                     fml::RefPtr<DartSnapshot> shared_snapshot,
                     TaskRunners task_runners,
                     fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                    fml::WeakPtr<GrContext> resource_context,
+                    fml::WeakPtr<ResourceContextManager> resource_context_manager,
                     fml::RefPtr<flow::SkiaUnrefQueue> unref_queue,
                     std::string advisory_script_uri,
                     std::string advisory_script_entrypoint,

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -42,7 +42,7 @@ Engine::Engine(Delegate& delegate,
                blink::Settings settings,
                std::unique_ptr<Animator> animator,
                fml::WeakPtr<blink::SnapshotDelegate> snapshot_delegate,
-               fml::WeakPtr<GrContext> resource_context,
+               fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
                fml::RefPtr<flow::SkiaUnrefQueue> unref_queue)
     : delegate_(delegate),
       settings_(std::move(settings)),
@@ -60,7 +60,7 @@ Engine::Engine(Delegate& delegate,
       std::move(shared_snapshot),           // shared snapshot
       std::move(task_runners),              // task runners
       std::move(snapshot_delegate),         // snapshot delegate
-      std::move(resource_context),          // resource context
+      std::move(resource_context_manager),  // resource context
       std::move(unref_queue),               // skia unref queue
       settings_.advisory_script_uri,        // advisory script uri
       settings_.advisory_script_entrypoint  // advisory script entrypoint

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -34,16 +34,17 @@ static constexpr char kNavigationChannel[] = "flutter/navigation";
 static constexpr char kLocalizationChannel[] = "flutter/localization";
 static constexpr char kSettingsChannel[] = "flutter/settings";
 
-Engine::Engine(Delegate& delegate,
-               blink::DartVM& vm,
-               fml::RefPtr<blink::DartSnapshot> isolate_snapshot,
-               fml::RefPtr<blink::DartSnapshot> shared_snapshot,
-               blink::TaskRunners task_runners,
-               blink::Settings settings,
-               std::unique_ptr<Animator> animator,
-               fml::WeakPtr<blink::SnapshotDelegate> snapshot_delegate,
-               fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
-               fml::RefPtr<flow::SkiaUnrefQueue> unref_queue)
+Engine::Engine(
+    Delegate& delegate,
+    blink::DartVM& vm,
+    fml::RefPtr<blink::DartSnapshot> isolate_snapshot,
+    fml::RefPtr<blink::DartSnapshot> shared_snapshot,
+    blink::TaskRunners task_runners,
+    blink::Settings settings,
+    std::unique_ptr<Animator> animator,
+    fml::WeakPtr<blink::SnapshotDelegate> snapshot_delegate,
+    fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
+    fml::RefPtr<flow::SkiaUnrefQueue> unref_queue)
     : delegate_(delegate),
       settings_(std::move(settings)),
       animator_(std::move(animator)),

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -12,6 +12,7 @@
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/lib/ui/resource_context_manager.h"
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/lib/ui/snapshot_delegate.h"
@@ -61,7 +62,7 @@ class Engine final : public blink::RuntimeDelegate {
          blink::Settings settings,
          std::unique_ptr<Animator> animator,
          fml::WeakPtr<blink::SnapshotDelegate> snapshot_delegate,
-         fml::WeakPtr<GrContext> resource_context,
+         fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
          fml::RefPtr<flow::SkiaUnrefQueue> unref_queue);
 
   ~Engine() override;

--- a/shell/common/io_manager.cc
+++ b/shell/common/io_manager.cc
@@ -13,7 +13,7 @@ namespace shell {
 
 sk_sp<GrContext> IOManager::CreateCompatibleResourceLoadingContext(
     GrBackend backend) {
-      FML_DLOG(ERROR) << "Creating resource context for iomanager";
+  FML_DLOG(ERROR) << "Creating resource context for iomanager";
   if (backend != GrBackend::kOpenGL_GrBackend) {
     return nullptr;
   }
@@ -43,8 +43,9 @@ sk_sp<GrContext> IOManager::CreateCompatibleResourceLoadingContext(
   return nullptr;
 }
 
-IOManager::IOManager(fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
-                     fml::RefPtr<fml::TaskRunner> unref_queue_task_runner)
+IOManager::IOManager(
+    fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
+    fml::RefPtr<fml::TaskRunner> unref_queue_task_runner)
     : resource_context_manager_(std::move(resource_context_manager)),
       unref_queue_(fml::MakeRefCounted<flow::SkiaUnrefQueue>(
           std::move(unref_queue_task_runner),
@@ -58,7 +59,8 @@ IOManager::~IOManager() {
 }
 
 fml::WeakPtr<GrContext> IOManager::GetResourceContext() const {
-  auto resource_context = resource_context_manager_->GetOrCreateWeakResourceContext();
+  auto resource_context =
+      resource_context_manager_->GetOrCreateWeakResourceContext();
   if (!resource_context) {
     FML_DLOG(WARNING) << "The IO manager was unable to get a resource "
                          "context. Async texture uploads will be disabled. "

--- a/shell/common/io_manager.h
+++ b/shell/common/io_manager.h
@@ -23,8 +23,9 @@ class IOManager {
   static sk_sp<GrContext> CreateCompatibleResourceLoadingContext(
       GrBackend backend);
 
-  IOManager(fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
-            fml::RefPtr<fml::TaskRunner> unref_queue_task_runner);
+  IOManager(
+      fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
+      fml::RefPtr<fml::TaskRunner> unref_queue_task_runner);
 
   ~IOManager();
 

--- a/shell/common/io_manager.h
+++ b/shell/common/io_manager.h
@@ -10,6 +10,7 @@
 #include "flutter/flow/skia_gpu_object.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/lib/ui/resource_context_manager.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 
 namespace shell {
@@ -22,7 +23,7 @@ class IOManager {
   static sk_sp<GrContext> CreateCompatibleResourceLoadingContext(
       GrBackend backend);
 
-  IOManager(sk_sp<GrContext> resource_context,
+  IOManager(fml::WeakPtr<blink::ResourceContextManager> resource_context_manager,
             fml::RefPtr<fml::TaskRunner> unref_queue_task_runner);
 
   ~IOManager();
@@ -33,9 +34,7 @@ class IOManager {
 
  private:
   // Resource context management.
-  sk_sp<GrContext> resource_context_;
-  std::unique_ptr<fml::WeakPtrFactory<GrContext>>
-      resource_context_weak_factory_;
+  fml::WeakPtr<blink::ResourceContextManager> resource_context_manager_;
 
   // Unref queue management.
   fml::RefPtr<flow::SkiaUnrefQueue> unref_queue_;

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -67,10 +67,24 @@ void PlatformView::NotifyDestroyed() {
   delegate_.OnPlatformViewDestroyed();
 }
 
-sk_sp<GrContext> PlatformView::CreateResourceContext() const {
+sk_sp<GrContext> PlatformView::CreateResourceContext() {
   FML_DLOG(WARNING) << "This platform does not setup the resource "
                        "context on the IO thread for async texture uploads.";
   return nullptr;
+}
+
+sk_sp<GrContext> PlatformView::GetOrCreateResourceContext() {
+  FML_DLOG(WARNING) << "This platform does not setup the resource "
+                       "context on the IO thread for async texture uploads.";
+  return nullptr;
+}
+
+fml::WeakPtr<GrContext> PlatformView::GetOrCreateWeakResourceContext() {
+  auto context = GetOrCreateResourceContext();
+  if (context) {
+    return fml::WeakPtrFactory<GrContext>(context.get()).GetWeakPtr();
+  }
+  return fml::WeakPtr<GrContext>();
 }
 
 void PlatformView::ReleaseResourceContext() const {}

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -11,6 +11,7 @@
 #include "flutter/flow/texture.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/weak_ptr.h"
+#include "flutter/lib/ui/resource_context_manager.h"
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/lib/ui/window/platform_message.h"
@@ -25,7 +26,7 @@ namespace shell {
 
 class Shell;
 
-class PlatformView {
+class PlatformView : public blink::ResourceContextManager {
  public:
   class Delegate {
    public:
@@ -84,14 +85,6 @@ class PlatformView {
 
   virtual void NotifyDestroyed();
 
-  // Unlike all other methods on the platform view, this one may be called on a
-  // non-platform task runner.
-  virtual sk_sp<GrContext> CreateResourceContext() const;
-
-  // Unlike all other methods on the platform view, this one may be called on a
-  // non-platform task runner.
-  virtual void ReleaseResourceContext() const;
-
   fml::WeakPtr<PlatformView> GetWeakPtr() const;
 
   virtual void UpdateSemantics(blink::SemanticsNodeUpdates updates,
@@ -115,6 +108,14 @@ class PlatformView {
 
   // Called once per texture update (e.g. video frame), on the platform thread.
   void MarkTextureFrameAvailable(int64_t texture_id);
+
+  virtual sk_sp<GrContext> CreateResourceContext() override;
+
+  virtual sk_sp<GrContext> GetOrCreateResourceContext() override;
+
+  virtual fml::WeakPtr<GrContext> GetOrCreateWeakResourceContext() override;
+
+  virtual void ReleaseResourceContext() const override;
 
  protected:
   PlatformView::Delegate& delegate_;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -69,13 +69,14 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
   auto io_task_runner = shell->GetTaskRunners().GetIOTaskRunner();
   fml::TaskRunner::RunNowOrPostTask(
       io_task_runner,
-      [&io_latch,          //
-       &io_manager,        //
-       &unref_queue,       //
-       &platform_view,     //
-       io_task_runner      //
+      [&io_latch,       //
+       &io_manager,     //
+       &unref_queue,    //
+       &platform_view,  //
+       io_task_runner   //
   ]() {
-        io_manager = std::make_unique<IOManager>(platform_view->GetWeakPtr(), io_task_runner);
+        io_manager = std::make_unique<IOManager>(platform_view->GetWeakPtr(),
+                                                 io_task_runner);
         unref_queue = io_manager->GetSkiaUnrefQueue();
         io_latch.Signal();
       });

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -387,7 +387,7 @@ sk_sp<GrContext> PlatformViewAndroid::CreateResourceContext() {
 }
 
 // |shell::PlatformView|
-sk_sp<GrContext> PlatformViewIOS::GetOrCreateResourceContext() {
+sk_sp<GrContext> PlatformViewAndroid::GetOrCreateResourceContext() {
   if (!resource_context_ || resource_context_->abandoned()) {
     return CreateResourceContext();
   }

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -369,22 +369,30 @@ std::unique_ptr<Surface> PlatformViewAndroid::CreateRenderingSurface() {
 }
 
 // |shell::PlatformView|
-sk_sp<GrContext> PlatformViewAndroid::CreateResourceContext() const {
+sk_sp<GrContext> PlatformViewAndroid::CreateResourceContext() {
   if (!android_surface_) {
     return nullptr;
   }
-  sk_sp<GrContext> resource_context;
   if (android_surface_->ResourceContextMakeCurrent()) {
     // TODO(chinmaygarde): Currently, this code depends on the fact that only
     // the OpenGL surface will be able to make a resource context current. If
     // this changes, this assumption breaks. Handle the same.
-    resource_context = IOManager::CreateCompatibleResourceLoadingContext(
+    resource_context_ = IOManager::CreateCompatibleResourceLoadingContext(
         GrBackend::kOpenGL_GrBackend);
   } else {
     FML_DLOG(ERROR) << "Could not make the resource context current.";
   }
 
-  return resource_context;
+  return resource_context_;
+}
+
+// |shell::PlatformView|
+sk_sp<GrContext> PlatformViewIOS::GetOrCreateResourceContext() {
+  if (!resource_context_ || resource_context_->abandoned()) {
+    return CreateResourceContext();
+  }
+
+  return resource_context_;
 }
 
 // |shell::PlatformView|

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -80,6 +80,7 @@ class PlatformViewAndroid final : public PlatformView {
   int next_response_id_ = 1;
   std::unordered_map<int, fml::RefPtr<blink::PlatformMessageResponse>>
       pending_responses_;
+  sk_sp<GrContext> resource_context_;
 
   // |shell::PlatformView|
   void UpdateSemantics(
@@ -100,7 +101,10 @@ class PlatformViewAndroid final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |shell::PlatformView|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrContext> CreateResourceContext() override;
+
+  // |shell::PlatformView|
+  sk_sp<GrContext> GetOrCreateResourceContext() override;
 
   // |shell::PlatformView|
   void ReleaseResourceContext() const override;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -47,6 +47,7 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;
   fml::closure firstFrameCallback_;
+  sk_sp<GrContext> resource_context_;
 
   // |shell::PlatformView|
   void HandlePlatformMessage(fml::RefPtr<blink::PlatformMessage> message) override;
@@ -55,7 +56,10 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |shell::PlatformView|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrContext> CreateResourceContext() override;
+
+  // |shell::PlatformView|
+  sk_sp<GrContext> GetOrCreateResourceContext() override;
 
   // |shell::PlatformView|
   void SetSemanticsEnabled(bool enabled) override;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -83,7 +83,8 @@ sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() {
     return nullptr;
   }
 
-  resource_context_ = IOManager::CreateCompatibleResourceLoadingContext(GrBackend::kOpenGL_GrBackend);
+  resource_context_ =
+      IOManager::CreateCompatibleResourceLoadingContext(GrBackend::kOpenGL_GrBackend);
   return resource_context_;
 }
 

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -59,12 +59,21 @@ std::unique_ptr<Surface> PlatformViewEmbedder::CreateRenderingSurface() {
 }
 
 // |shell::PlatformView|
-sk_sp<GrContext> PlatformViewEmbedder::CreateResourceContext() const {
+sk_sp<GrContext> PlatformViewEmbedder::CreateResourceContext() {
   if (embedder_surface_ == nullptr) {
     FML_LOG(ERROR) << "Embedder surface was null.";
     return nullptr;
   }
-  return embedder_surface_->CreateResourceContext();
+  resource_context_ = embedder_surface_->CreateResourceContext();
+  return resource_context_;
+}
+
+sk_sp<GrContext> PlatformViewEmbedder::GetOrCreateResourceContext() {
+  if (!resource_context_ || resource_context_->abandoned()) {
+    return CreateResourceContext();
+  }
+
+  return resource_context_;
 }
 
 }  // namespace shell

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -49,12 +49,16 @@ class PlatformViewEmbedder final : public PlatformView {
  private:
   std::unique_ptr<EmbedderSurface> embedder_surface_;
   PlatformDispatchTable platform_dispatch_table_;
+  sk_sp<GrContext> resource_context_;
 
   // |shell::PlatformView|
   std::unique_ptr<Surface> CreateRenderingSurface() override;
 
   // |shell::PlatformView|
-  sk_sp<GrContext> CreateResourceContext() const override;
+  sk_sp<GrContext> CreateResourceContext() override;
+
+  // |shell::PlatformView|
+  sk_sp<GrContext> GetOrCreateResourceContext() override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewEmbedder);
 };


### PR DESCRIPTION
Fixes flutter/flutter#24798

The PlatformView can be created before the GLContext is available/current.  This means that whatever GrContext (if any) that is fed to IOManager, UIDartState, and DartIsolate can be incorrect.

This patch changes constructor parameters expecting a `GrContext` in some shape or form to take a `ResourceContextManager` instead, which is implemented by `PlatformView` to ensure that callers get the correct `GrContext` associated with the current `GLContext`.

/cc @matthew-carroll  - this required a change to the Android embedding.
/cc @zanderso - this will require changes in Fuchsia.