### PR TITLE
Roll buildroot to support Android SDK 28

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -117,7 +117,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '28e1832ab628495ad471936abd9d9e0b34b4056d',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5f54a3e98dea0a79589820527658b49fef7916ea',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -117,7 +117,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '03aad5103257255b57245e018e4cd701c728ead7',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '28e1832ab628495ad471936abd9d9e0b34b4056d',
 
    # Fuchsia compatibility
    #

--- a/DEPS
+++ b/DEPS
@@ -117,7 +117,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '8e538639660413490ea9261eee84864005e240f4',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '03aad5103257255b57245e018e4cd701c728ead7',
 
    # Fuchsia compatibility
    #

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 ENV DEPOT_TOOLS_PATH $HOME/depot_tools
 ENV ENGINE_PATH $HOME/engine

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 ENV DEPOT_TOOLS_PATH $HOME/depot_tools
 ENV ENGINE_PATH $HOME/engine

--- a/ci/docker/build/engine_gclient
+++ b/ci/docker/build/engine_gclient
@@ -1,6 +1,6 @@
 solutions = [{
   "name"        : "src/flutter",
-  "url"         : "https://github.com/flutter/engine.git",
+  "url"         : "https://github.com/dnfield/engine.git",
   "deps_file"   : "DEPS",
   "managed"     : False,
   "safesync_url": "",

--- a/ci/docker/build/engine_gclient
+++ b/ci/docker/build/engine_gclient
@@ -1,6 +1,6 @@
 solutions = [{
   "name"        : "src/flutter",
-  "url"         : "https://github.com/dnfield/engine.git",
+  "url"         : "https://github.com/flutter/engine.git",
   "deps_file"   : "DEPS",
   "managed"     : False,
   "safesync_url": "",

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -146,16 +146,16 @@ java_library("flutter_shell_java") {
   ]
 
   deps = [
-    ":android_support_v4",
+    ":android_support_v13",
   ]
 
   jar_path = "$root_out_dir/flutter_java.jar"
 }
 
-java_prebuilt("android_support_v4") {
+java_prebuilt("android_support_v13") {
   supports_android = true
 
-  jar_path = "//third_party/android_tools/sdk/extras/android/support/v4/android-support-v4.jar"
+  jar_path = "//third_party/android_tools/sdk/extras/android/support/v13/android-support-v13.jar"
 }
 
 copy("flutter_shell_assets") {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/20717

See https://github.com/flutter/buildroot/pull/194

Enables support of Java 8 language features in the engine, as well as rolling the Android SDK to 28

/cc @matthew-carroll - not sure if/how this impacts your embedding refactor