### PR TITLE
[License] Eliminate duplicate case in switch

### DIFF
--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 589881cc85de13ab88e7d283493fe1be
+Signature: a55f4ce9207b1a1dff62891b1c203f5e
 

--- a/tools/licenses/analysis_options.yaml
+++ b/tools/licenses/analysis_options.yaml
@@ -39,6 +39,7 @@ linter:
     - implementation_imports
     - library_names
     - library_prefixes
+    - no_duplicate_case_values
     - non_constant_identifier_names
     - one_member_abstracts
     - overridden_fields

--- a/tools/licenses/lib/filesystem.dart
+++ b/tools/licenses/lib/filesystem.dart
@@ -180,7 +180,6 @@ FileType identifyFile(String name, Reader reader) {
     // Documentation
     case '.md': return FileType.text;
     case '.txt': return FileType.text;
-    case '.diff': return FileType.text;
     case '.html': return FileType.text;
     // Fonts
     case '.ttf': return FileType.binary; // TrueType Font


### PR DESCRIPTION
Eliminates a duplicate switch case for .diff files. This changes behaviour to now
treat diffs as binary for the reasons outlined in the comment on the remaining .diff
case.