### PR TITLE
[License] Assert license filename is non-null, non-empty

### DIFF
--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: a55f4ce9207b1a1dff62891b1c203f5e
+Signature: 0461a8d6fe3503cd19d8e0d3becfee87
 

--- a/tools/licenses/analysis_options.yaml
+++ b/tools/licenses/analysis_options.yaml
@@ -56,4 +56,5 @@ linter:
     - unnecessary_brace_in_string_interps
     - unnecessary_getters_setters
     - unnecessary_new
+    - unnecessary_statements
     - package_names

--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -357,9 +357,10 @@ abstract class License implements Comparable<License> {
   bool get isUsed => _licensees.isNotEmpty;
 
   void markUsed(String filename, String libraryName) {
+    assert(filename != null);
+    assert(filename != '');
     assert(libraryName != null);
     assert(libraryName != '');
-    filename != null;
     _licensees.add(filename);
     _libraries.add(libraryName);
   }


### PR DESCRIPTION
This appears to have been the original intent behind the dead statement.