### PR TITLE
[License] Sync analysis_options.yaml from framework

### DIFF
--- a/tools/licenses/analysis_options.yaml
+++ b/tools/licenses/analysis_options.yaml
@@ -1,78 +1,162 @@
 # Specify analysis options.
+#
+# Until there are meta linter rules, each desired lint must be explicitly enabled.
+# See: https://github.com/dart-lang/linter/issues/288
+#
+# For a list of lints, see: http://dart-lang.github.io/linter/lints/
+# See the configuration guide for more
+# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
+#
+# There are other similar analysis options files in the flutter repos,
+# which should be kept in sync with this file:
+#
+#   - analysis_options.yaml
+#   - tools/licenses/analysis_options.yaml (this file)
+#   - https://github.com/flutter/flutter/blob/master/analysis_options_user.yaml
+#   - https://github.com/flutter/flutter/blob/master/packages/flutter/lib/analysis_options_user.yaml
+#   - https://github.com/flutter/plugins/blob/master/analysis_options.yaml
+#
+# This file contains the analysis options used by Flutter tools, such as IntelliJ,
+# Android Studio, and the `flutter analyze` command.
 
 analyzer:
   strong-mode:
     implicit-dynamic: false
   errors:
-    strong_mode_invalid_field_override: ignore
-    strong_mode_down_cast_composite: ignore
+    # allow having TODOs in the code
     todo: ignore
 
 linter:
   rules:
-    - always_require_non_null_named_parameters
-    - avoid_empty_else
-    - avoid_function_literals_in_foreach_calls
-    - comment_references
-    - cancel_subscriptions
-    - close_sinks
-    - control_flow_in_finally
-    - directives_ordering
-    - empty_statements
-    - empty_catches
-    - hash_and_equals
-    # - invariant_booleans  # Produces false positives, see https://github.com/flutter/flutter/issues/5790
-    - iterable_contains_unrelated_type
-    - list_remove_unrelated_type
-    - literal_only_boolean_expressions
-    - test_types_in_equals
-    - throw_in_finally
-    - unrelated_type_equality_checks
-    - valid_regexps
+    # these rules are documented on and in the same order as
+    # the Dart Lint rules page to make maintenance easier
+    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
     - always_declare_return_types
+    - always_put_control_body_on_new_line
+    # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
+    - always_require_non_null_named_parameters
     - always_specify_types
     - annotate_overrides
+    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
     - avoid_as
+    # - avoid_bool_literals_in_conditional_expressions # not yet tested
+    # - avoid_catches_without_on_clauses # we do this commonly
+    # - avoid_catching_errors # we do this commonly
+    - avoid_classes_with_only_static_members
+    # - avoid_double_and_int_checks # only useful when targeting JS runtime
+    - avoid_empty_else
+    - avoid_field_initializers_in_const_classes
+    - avoid_function_literals_in_foreach_calls
+    # - avoid_implementing_value_types # not yet tested
     - avoid_init_to_null
+    # - avoid_js_rounded_ints # only useful when targeting JS runtime
+    - avoid_null_checks_in_equality_operators
+    # - avoid_positional_boolean_parameters # not yet tested
+    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
+    # - avoid_returning_null # there are plenty of valid reasons to return null
+    - avoid_returning_null_for_void
+    # - avoid_returning_this # there are plenty of valid reasons to return this
+    # - avoid_setters_without_getters # not yet tested
+    # - avoid_single_cascade_in_expression_statements # not yet tested
+    - avoid_slow_async_io
+    - avoid_types_as_parameter_names
+    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    - avoid_unused_constructor_parameters
+    - avoid_void_async
     - await_only_futures
     - camel_case_types
-    - constant_identifier_names
+    - cancel_subscriptions
+    # - cascade_invocations # not yet tested
+    # - close_sinks # not reliable enough
+    # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
+    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
+    # - curly_braces_in_flow_control_structures # not yet tested
+    - directives_ordering
+    - empty_catches
     - empty_constructor_bodies
+    - empty_statements
+    # - file_names # not yet tested
     - flutter_style_todos
+    - hash_and_equals
     - implementation_imports
+    # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
+    - iterable_contains_unrelated_type
+    # - join_return_with_assignment # not yet tested
     - library_names
     - library_prefixes
+    # - lines_longer_than_80_chars # not yet tested
+    - list_remove_unrelated_type
+    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
+    - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
-    - one_member_abstracts
+    # - null_closures  # not yet tested
+    # - omit_local_variable_types # opposite of always_specify_types
+    # - one_member_abstracts # too many false positives
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
     - overridden_fields
+    - package_api_docs
+    - package_names
     - package_prefixed_library_names
+    # - parameter_assignments # we do this commonly
+    - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
     - prefer_collection_literals
+    - prefer_conditional_assignment
     - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
     - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    # - prefer_constructors_over_static_methods # not yet tested
+    - prefer_contains
     - prefer_equal_for_default_values
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_locals
+    - prefer_foreach
+    # - prefer_function_declarations_over_variables # not yet tested
+    - prefer_generic_function_type_aliases
     - prefer_initializing_formals
+    # - prefer_int_literals # not yet tested
+    # - prefer_interpolation_to_compose_strings # not yet tested
     - prefer_is_empty
     - prefer_is_not_empty
+    - prefer_iterable_whereType
+    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
     - prefer_single_quotes
+    - prefer_typing_uninitialized_variables
     - prefer_void_to_null
+    # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
+    - recursive_getters
     - slash_for_doc_comments
     - sort_constructors_first
+    - sort_pub_dependencies
     - sort_unnamed_constructors_first
     - super_goes_last
-    - type_annotate_public_apis
+    - test_types_in_equals
+    - throw_in_finally
+    # - type_annotate_public_apis # subset of always_specify_types
     - type_init_formals
-    - unawaited_futures
+    # - unawaited_futures # too many false positives
     - unnecessary_brace_in_string_interps
+    - unnecessary_const
     - unnecessary_getters_setters
+    # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
     - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_statements
     - unnecessary_this
-    - package_names
+    - unrelated_type_equality_checks
+    - use_rethrow_when_possible
+    # - use_setters_to_change_properties # not yet tested
+    # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
+    # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
+    - valid_regexps
+    # - void_checks # not yet tested

--- a/tools/licenses/analysis_options.yaml
+++ b/tools/licenses/analysis_options.yaml
@@ -33,13 +33,13 @@ linter:
     # https://github.com/dart-lang/linter/blob/master/example/all.yaml
     - always_declare_return_types
     - always_put_control_body_on_new_line
-    # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
+    - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
     - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
     - avoid_as
-    # - avoid_bool_literals_in_conditional_expressions # not yet tested
+    - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly
     - avoid_classes_with_only_static_members
@@ -47,7 +47,7 @@ linter:
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
-    # - avoid_implementing_value_types # not yet tested
+    - avoid_implementing_value_types
     - avoid_init_to_null
     # - avoid_js_rounded_ints # only useful when targeting JS runtime
     - avoid_null_checks_in_equality_operators
@@ -59,8 +59,8 @@ linter:
     # - avoid_returning_null # there are plenty of valid reasons to return null
     - avoid_returning_null_for_void
     # - avoid_returning_this # there are plenty of valid reasons to return this
-    # - avoid_setters_without_getters # not yet tested
-    # - avoid_single_cascade_in_expression_statements # not yet tested
+    - avoid_setters_without_getters
+    - avoid_single_cascade_in_expression_statements
     - avoid_slow_async_io
     - avoid_types_as_parameter_names
     # - avoid_types_on_closure_parameters # conflicts with always_specify_types
@@ -79,7 +79,7 @@ linter:
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    # - file_names # not yet tested
+    - file_names
     - flutter_style_todos
     - hash_and_equals
     - implementation_imports
@@ -94,7 +94,7 @@ linter:
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - non_constant_identifier_names
-    # - null_closures  # not yet tested
+    - null_closures
     # - omit_local_variable_types # opposite of always_specify_types
     # - one_member_abstracts # too many false positives
     # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
@@ -118,10 +118,10 @@ linter:
     - prefer_final_fields
     - prefer_final_locals
     - prefer_foreach
-    # - prefer_function_declarations_over_variables # not yet tested
+    - prefer_function_declarations_over_variables # not yet tested
     - prefer_generic_function_type_aliases
     - prefer_initializing_formals
-    # - prefer_int_literals # not yet tested
+    - prefer_int_literals
     # - prefer_interpolation_to_compose_strings # not yet tested
     - prefer_is_empty
     - prefer_is_not_empty
@@ -155,8 +155,8 @@ linter:
     - unnecessary_this
     - unrelated_type_equality_checks
     - use_rethrow_when_possible
-    # - use_setters_to_change_properties # not yet tested
+    - use_setters_to_change_properties
     # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
     # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
     - valid_regexps
-    # - void_checks # not yet tested
+    - void_checks


### PR DESCRIPTION
This syncs in the analysis_options.yaml from the framework but re-enables any lints the framework disables that were enabled in the license tool, or that seem reasonable to add.