### PR TITLE
TextInputType.number default fix

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -19,7 +19,9 @@ static UIKeyboardType ToUIKeyboardType(NSDictionary* type) {
   if ([inputType isEqualToString:@"TextInputType.number"]) {
     if ([type[@"signed"] boolValue])
       return UIKeyboardTypeNumbersAndPunctuation;
-    return UIKeyboardTypeDecimalPad;
+    if ([type[@"decimal"] boolValue])
+      return UIKeyboardTypeDecimalPad;
+    return UIKeyboardTypeNumberPad;
   }
   if ([inputType isEqualToString:@"TextInputType.phone"])
     return UIKeyboardTypePhonePad;


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/25454

The logic for converting the passed "inputType" to the native input type differed between Android and iOS.  The iOS code was differing from what the flutter docs say, so I have changed that code to match the docs and Android.

The equivalent Android code is at https://github.com/flutter/engine/blob/master/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java#L78.