### PR TITLE
Only reject gestures to embedded UIViews when the framework says so.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -22,6 +22,9 @@
 
 // Stop delaying any active touch sequence (and let it arrive the embedded view).
 - (void)releaseGesture;
+
+// Prevent the touch sequence from ever arriving to the embedded view.
+- (void)blockGesture;
 @end
 
 namespace shell {
@@ -89,6 +92,7 @@ class FlutterPlatformViewsController {
   void OnCreate(FlutterMethodCall* call, FlutterResult& result);
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);
+  void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
 
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,


### PR DESCRIPTION
Previously the framework could only tell the engine to forward a touch
sequence to an embeded UIView between the time touches has started and
the time touches ended. This couldn't support gesture arena setups where
the gesture is recognized after the touch sequence is complete (e.g a
tap competing with a scroll).

This change makes it so that a touch gesture is only finally rejected by
a platform view when the framework invokes the `rejectGesture` method.
This allows the framework to resolve a gesture conflict after the touch
sequence was ended.

Will land this after https://github.com/flutter/flutter/pull/25792

fixes https://github.com/flutter/flutter/issues/24076
fixes https://github.com/flutter/flutter/issues/24207
