### PR TITLE
Support loading flutter assets from dynamic patch

### DIFF
--- a/assets/zip_asset_store.cc
+++ b/assets/zip_asset_store.cc
@@ -23,8 +23,7 @@ void UniqueUnzipperTraits::Free(void* file) {
 }
 
 ZipAssetStore::ZipAssetStore(std::string file_path, std::string directory)
-    : file_path_(std::move(file_path)),
-      directory_(std::move(directory)) {
+    : file_path_(std::move(file_path)), directory_(std::move(directory)) {
   BuildStatCache();
 }
 

--- a/assets/zip_asset_store.cc
+++ b/assets/zip_asset_store.cc
@@ -22,8 +22,9 @@ void UniqueUnzipperTraits::Free(void* file) {
   unzClose(file);
 }
 
-ZipAssetStore::ZipAssetStore(std::string file_path)
-    : file_path_(std::move(file_path)) {
+ZipAssetStore::ZipAssetStore(std::string file_path, std::string directory)
+    : file_path_(std::move(file_path)),
+      directory_(std::move(directory)) {
   BuildStatCache();
 }
 
@@ -43,8 +44,10 @@ std::unique_ptr<fml::Mapping> ZipAssetStore::GetAsMapping(
     const std::string& asset_name) const {
   TRACE_EVENT1("flutter", "ZipAssetStore::GetAsMapping", "name",
                asset_name.c_str());
-  auto found = stat_cache_.find(asset_name);
 
+  std::stringstream file_name;
+  file_name << directory_.c_str() << "/" << asset_name;
+  auto found = stat_cache_.find(file_name.str());
   if (found == stat_cache_.end()) {
     return nullptr;
   }

--- a/assets/zip_asset_store.cc
+++ b/assets/zip_asset_store.cc
@@ -44,9 +44,7 @@ std::unique_ptr<fml::Mapping> ZipAssetStore::GetAsMapping(
   TRACE_EVENT1("flutter", "ZipAssetStore::GetAsMapping", "name",
                asset_name.c_str());
 
-  std::stringstream file_name;
-  file_name << directory_.c_str() << "/" << asset_name;
-  auto found = stat_cache_.find(file_name.str());
+  auto found = stat_cache_.find(directory_ + "/" + asset_name);
   if (found == stat_cache_.end()) {
     return nullptr;
   }

--- a/assets/zip_asset_store.h
+++ b/assets/zip_asset_store.h
@@ -23,7 +23,7 @@ using UniqueUnzipper = fml::UniqueObject<void*, UniqueUnzipperTraits>;
 
 class ZipAssetStore final : public AssetResolver {
  public:
-  ZipAssetStore(std::string file_path);
+  ZipAssetStore(std::string file_path, std::string directory);
 
   ~ZipAssetStore() override;
 
@@ -35,7 +35,9 @@ class ZipAssetStore final : public AssetResolver {
         : file_pos(p_file_pos), uncompressed_size(p_uncompressed_size) {}
   };
 
-  std::string file_path_;
+  const std::string file_path_;
+  const std::string directory_;
+
   mutable std::map<std::string, CacheEntry> stat_cache_;
 
   // |blink::AssetResolver|

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -253,7 +253,7 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
     const auto file_ext_index = bundlepath.rfind(".");
     if (bundlepath.substr(file_ext_index) == ".zip") {
       asset_manager->PushBack(
-          std::make_unique<blink::ZipAssetStore>(bundlepath));
+          std::make_unique<blink::ZipAssetStore>(bundlepath, "flutter_assets"));
     } else {
       asset_manager->PushBack(
           std::make_unique<blink::DirectoryAssetBundle>(fml::OpenDirectory(


### PR DESCRIPTION
This replicates similar logic found in ApkAssetProvider that locates assets by their short name in a sudbirectory inside of an archive file, instead of only at the root of archive.