### PR TITLE
Allow dynamic patches without a patch number.

### DIFF
--- a/shell/platform/android/io/flutter/view/ResourceExtractor.java
+++ b/shell/platform/android/io/flutter/view/ResourceExtractor.java
@@ -218,19 +218,17 @@ class ResourceExtractor {
                 String buildNumber = updateManifest.optString("buildNumber", null);
                 if (buildNumber == null) {
                     Log.w(TAG, "Invalid update manifest: buildNumber");
-                }
-
-                String patchNumber = updateManifest.optString("patchNumber", null);
-                if (patchNumber == null) {
-                    Log.w(TAG, "Invalid update manifest: patchNumber");
-                }
-
-                if (buildNumber != null && patchNumber != null) {
-                  if (!buildNumber.equals(Long.toString(getVersionCode(packageInfo)))) {
+                } else {
+                    String patchNumber = updateManifest.optString("patchNumber", null);
+                    if (!buildNumber.equals(Long.toString(getVersionCode(packageInfo)))) {
                         Log.w(TAG, "Outdated update file for " + getVersionCode(packageInfo));
                     } else {
                         final File updateFile = new File(FlutterMain.getUpdateInstallationPath());
-                        expectedTimestamp += "-" + patchNumber + "-" + updateFile.lastModified();
+                        if (patchNumber != null) {
+                            expectedTimestamp += "-" + patchNumber + "-" + updateFile.lastModified();
+                        } else {
+                            expectedTimestamp += "-" + updateFile.lastModified();
+                        }
                     }
                 }
             }

--- a/shell/platform/android/io/flutter/view/ResourceUpdater.java
+++ b/shell/platform/android/io/flutter/view/ResourceUpdater.java
@@ -126,7 +126,7 @@ public final class ResourceUpdater {
 
         URI uri;
         try {
-            uri = new URI(metaData.getString("UpdateServerURL") + "/" + getAPKVersion());
+            uri = new URI(metaData.getString("UpdateServerURL") + "/" + getAPKVersion() + ".zip");
 
         } catch (URISyntaxException e) {
             Log.w(TAG, "Invalid AndroidManifest.xml UpdateServerURL: " + e.getMessage());


### PR DESCRIPTION
Unique patch numbers are mainly useful for canary and A-B testing, but
otherwise complicate things and can now be omitted.

Also, always append .zip to patch download URL. This obviates the need to
configure redirects on the server when not using patch numbers.

Also see https://github.com/flutter/flutter/pull/25796.