### PR TITLE
 Reland "Only reject gestures to embedded UIViews when the framework sa…

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -356,7 +356,7 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
   if (self) {
     self.delaysTouchesBegan = YES;
     self.delegate = self;
-    _forwardingRecognizer.reset(forwardingRecognizer);
+    _forwardingRecognizer.reset([forwardingRecognizer retain]);
   }
   return self;
 }
@@ -373,12 +373,8 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
   return otherGestureRecognizer == self;
 }
 
-- (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
-  self.state = UIGestureRecognizerStateBegan;
-}
-
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
-  self.state = UIGestureRecognizerStateCancelled;
+  self.state = UIGestureRecognizerStateFailed;
 }
 @end
 
@@ -415,7 +411,7 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
   [_flutterView touchesCancelled:touches withEvent:event];
-  self.state = UIGestureRecognizerStateCancelled;
+  self.state = UIGestureRecognizerStateFailed;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer*)gestureRecognizer

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -22,6 +22,9 @@
 
 // Stop delaying any active touch sequence (and let it arrive the embedded view).
 - (void)releaseGesture;
+
+// Prevent the touch sequence from ever arriving to the embedded view.
+- (void)blockGesture;
 @end
 
 namespace shell {
@@ -89,6 +92,7 @@ class FlutterPlatformViewsController {
   void OnCreate(FlutterMethodCall* call, FlutterResult& result);
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);
+  void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
 
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,


### PR DESCRIPTION
…ys so. (#7307)"

This reverts commit 20ee4e3.

The changes to the original commit are in ad4eedb:

- Keep the DelayingGestureRecognizer a discrete gesture recognizer, when it was set to a began state embedded WkWebViews wasn't receiving touch events.
- Fix a bug of not retaining the forwardRecognizer pointer when assigning it to a scoped_nsobject. 