### PR TITLE
Update GetCallbackHandle to use Dart_IsTearOff instead of a string comparison

### DIFF
--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -318,14 +318,12 @@ static std::string GetFunctionName(Dart_Handle func) {
 }
 
 void GetCallbackHandle(Dart_NativeArguments args) {
-  const char* kAnonymousClosureName = "<anonymous closure>";
   Dart_Handle func = Dart_GetNativeArgument(args, 0);
   std::string name = GetFunctionName(func);
   std::string class_name = GetFunctionClassName(func);
   std::string library_path = GetFunctionLibraryUrl(func);
 
-  // TODO(24394): check !Dart_IsTearOff(func) instead of string comparison.
-  if (name.empty() || (name == kAnonymousClosureName)) {
+  if (!Dart_IsTearOff(func)) {
     Dart_SetReturnValue(args, Dart_Null());
     return;
   }

--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -323,7 +323,11 @@ void GetCallbackHandle(Dart_NativeArguments args) {
   std::string class_name = GetFunctionClassName(func);
   std::string library_path = GetFunctionLibraryUrl(func);
 
-  if (!Dart_IsTearOff(func)) {
+  // `name` is empty if `func` can't be used as a callback. This is the case
+  // when `func` is not a function object or is not a static function. Anonymous
+  // closures (e.g. `(int a, int b) => a + b;`) also cannot be used as
+  // callbacks, so `func` must be a tear-off of a named static function.
+  if (!Dart_IsTearOff(func) || name.empty()) {
     Dart_SetReturnValue(args, Dart_Null());
     return;
   }

--- a/testing/dart/plugin_utilities_test.dart
+++ b/testing/dart/plugin_utilities_test.dart
@@ -27,7 +27,7 @@ void main() {
     expect(topClosure, isNotNull);
     expect(topClosure(), "top");
 
-    // Static method callback
+    // Static method callback.
     final hGetInt = PluginUtilities.getCallbackHandle(Foo.getInt);
     expect(hGetInt, isNotNull);
     expect(hGetInt, isNot(0));
@@ -39,5 +39,9 @@ void main() {
     // Instance method callbacks cannot be looked up.
     final foo = new Foo();
     expect(PluginUtilities.getCallbackHandle(foo.getDouble), isNull);
+
+    // Anonymous closures cannot be looked up.
+    final anon = (int a, int b) => a + b;
+    expect(PluginUtilities.getCallbackHandle(anon), isNull);
   });
 }


### PR DESCRIPTION
Update GetCallbackHandle to use Dart_IsTearOff instead of a string comparison to determine whether or not a closure was provided as an argument to PluginUtilities.GetCallbackHandle.

Fixes flutter/flutter#24394