### PR TITLE
Give more control over when dynamic patches get downloaded and installed.

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -220,6 +220,7 @@ public final class FlutterActivityDelegate
     @Override
     public void onResume() {
         Application app = (Application) activity.getApplicationContext();
+        FlutterMain.onResume(app);
         if (app instanceof FlutterApplication) {
             FlutterApplication flutterApp = (FlutterApplication) app;
             flutterApp.setCurrentActivity(activity);

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -295,9 +295,11 @@ public class FlutterMain {
             .addResource(fromFlutterAssets(sAotIsolateSnapshotData))
             .addResource(fromFlutterAssets(sAotIsolateSnapshotInstr))
             .addResource(fromFlutterAssets(DEFAULT_KERNEL_BLOB));
+
         if (sIsPrecompiledAsSharedLibrary) {
           sResourceExtractor
             .addResource(sAotSharedLibraryPath);
+
         } else {
           sResourceExtractor
             .addResource(sAotVmSnapshotData)
@@ -319,7 +321,7 @@ public class FlutterMain {
             }
             if (sResourceUpdater.getDownloadMode() == ResourceUpdater.DownloadMode.ON_RESUME) {
                 // If patch installation is already in progress, it's important to wait for it to
-                // finish before checking for a new download in order to avoid multiple downloads.
+                // finish before checking for new download, in order to avoid multiple downloads.
                 sResourceExtractor.waitForCompletion();
                 sResourceUpdater.startUpdateDownloadOnce();
                 if (sResourceUpdater.getInstallMode() == ResourceUpdater.InstallMode.IMMEDIATE) {

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -313,23 +313,8 @@ public class FlutterMain {
 
     public static void onResume(Context context) {
         if (sResourceUpdater != null) {
-            if (sResourceUpdater.getInstallMode() == ResourceUpdater.InstallMode.ON_NEXT_RESUME) {
-                sResourceExtractor.waitForCompletion();
-                if (!sResourceExtractor.filesMatch()) {
-                    restartApplication(context);
-                }
-            }
             if (sResourceUpdater.getDownloadMode() == ResourceUpdater.DownloadMode.ON_RESUME) {
-                // If patch installation is already in progress, it's important to wait for it to
-                // finish before checking for new download, in order to avoid multiple downloads.
-                sResourceExtractor.waitForCompletion();
                 sResourceUpdater.startUpdateDownloadOnce();
-                if (sResourceUpdater.getInstallMode() == ResourceUpdater.InstallMode.IMMEDIATE) {
-                    sResourceUpdater.waitForDownloadCompletion();
-                    if (!sResourceExtractor.filesMatch()) {
-                        restartApplication(context);
-                    }
-                }
             }
         }
     }
@@ -377,17 +362,6 @@ public class FlutterMain {
 
     public static String getUpdateInstallationPath() {
         return sResourceUpdater == null ? null : sResourceUpdater.getUpdateInstallationPath();
-    }
-
-    private static void restartApplication(Context context) {
-        Log.i(TAG, "Restarting application...");
-        Intent restartIntent = context.getPackageManager()
-                .getLaunchIntentForPackage(context.getPackageName());
-        PendingIntent pendingIntent = PendingIntent.getActivity(
-                context, 0, restartIntent, Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        alarmManager.set(AlarmManager.RTC, System.currentTimeMillis() + 100, pendingIntent);
-        System.exit(0);
     }
 
     /**

--- a/shell/platform/android/io/flutter/view/ResourceExtractor.java
+++ b/shell/platform/android/io/flutter/view/ResourceExtractor.java
@@ -112,7 +112,9 @@ class ResourceExtractor {
     }
 
     void waitForCompletion() {
-        assert mExtractTask != null;
+        if (mExtractTask == null) {
+            return;
+        }
 
         try {
             mExtractTask.get();
@@ -123,6 +125,17 @@ class ResourceExtractor {
         } catch (InterruptedException e3) {
             deleteFiles();
         }
+    }
+
+    boolean filesMatch() {
+        JSONObject updateManifest = readUpdateManifest();
+        if (!validateUpdateManifest(updateManifest)) {
+            updateManifest = null;
+        }
+
+        final File dataDir = new File(PathUtils.getDataDirectory(mContext));
+        final String timestamp = checkTimestamp(dataDir, updateManifest);
+        return (timestamp == null);
     }
 
     private String[] getExistingTimestamps(File dataDir) {

--- a/shell/platform/android/io/flutter/view/ResourceUpdater.java
+++ b/shell/platform/android/io/flutter/view/ResourceUpdater.java
@@ -26,17 +26,17 @@ import java.util.concurrent.ExecutionException;
 public final class ResourceUpdater {
     private static final String TAG = "ResourceUpdater";
 
-    // Controls when to check if a new patch is available for download, and to start download.
+    // Controls when to check if a new patch is available for download, and start downloading.
     // Note that by default the application will not block to wait for the download to finish.
-    // Patches get downloaded in the background, but the developer can also use [InstallMode]
-    // to control whether to block on download completion in order to install patches sooner.
+    // Patches are downloaded in the background, but the developer can also use [InstallMode]
+    // to control whether to block on download completion, in order to install patches sooner.
     enum DownloadMode {
         // Check for and download patch on application restart (but not necessarily apply it).
         // This is the default setting which will also check for new patches least frequently.
         ON_RESTART,
 
         // Check for and download patch on application resume (but not necessarily apply it).
-        // By definition, this setting will also check for new patches on application restart.
+        // By definition, this setting will check for new patches both on restart and resume.
         ON_RESUME
     }
 
@@ -44,15 +44,17 @@ public final class ResourceUpdater {
     enum InstallMode {
         // Wait for next application restart before applying downloaded patch. With this
         // setting, the application will not block to wait for patch download to finish.
-        // Application can be restarted either by the user, or the system, for any reason.
+        // The application can be restarted later either by the user, or by the system,
+        // for any reason, at which point the newly downloaded patch will get applied.
         // This is the default setting, and is the least urgent way to install patches.
         ON_NEXT_RESTART,
 
         // Apply patch as soon as it's downloaded. This will block to wait for new patch
-        // download to finish, and will immediately apply it. For now this setting is only
-        // effective when download happens during application restart. For now, patches
-        // downloaded during resume will not get installed immediately as that requires
-        // forcibly restarting the app (which might be implemented in the future).
+        // download to finish, and will immediately apply it. This setting increases the
+        // urgency with which patches are installed, but may also affect startup latency.
+        // For now, this setting is only effective when download happens during restart.
+        // Patches downloaded during resume will not get installed immediately as that
+        // requires force restarting the app (which might be implemented in the future).
         IMMEDIATE
     }
 

--- a/shell/platform/android/io/flutter/view/ResourceUpdater.java
+++ b/shell/platform/android/io/flutter/view/ResourceUpdater.java
@@ -48,14 +48,11 @@ public final class ResourceUpdater {
         // This is the default setting, and is the least urgent way to install patches.
         ON_NEXT_RESTART,
 
-        // Wait for next application resume before applying downloaded patch. With this
-        // setting, the application will force restart on next resume if there was new
-        // patch downloaded. This is a more urgent way to install patches, but can be
-        // more disruptive to the end user.
-        ON_NEXT_RESUME,
-
         // Apply patch as soon as it's downloaded. This will block to wait for new patch
-        // download to finish, and will immediately apply it.
+        // download to finish, and will immediately apply it. For now this setting is only
+        // effective when download happens during application restart. For now, patches
+        // downloaded during resume will not get installed immediately as that requires
+        // forcibly restarting the app (which might be implemented in the future).
         IMMEDIATE
     }
 

--- a/shell/platform/android/io/flutter/view/ResourceUpdater.java
+++ b/shell/platform/android/io/flutter/view/ResourceUpdater.java
@@ -46,7 +46,7 @@ public final class ResourceUpdater {
         // setting, the application will not block to wait for patch download to finish.
         // The application can be restarted later either by the user, or by the system,
         // for any reason, at which point the newly downloaded patch will get applied.
-        // This is the default setting, and is the least urgent way to install patches.
+        // This is the default setting, and is the least disruptive way to apply patches.
         ON_NEXT_RESTART,
 
         // Apply patch as soon as it's downloaded. This will block to wait for new patch


### PR DESCRIPTION
This change introduces manifest properties that control when dynamic patches are downloaded and installed in the application lifecycle.

Application developer can choose whether between install on restart, install on resume, or immediate forced install of dynamic patches.