### PR TITLE
Make `ParagraphConstraints` have const constructor

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -984,7 +984,7 @@ class ParagraphConstraints {
   /// Creates constraints for laying out a pargraph.
   ///
   /// The [width] argument must not be null.
-  ParagraphConstraints({
+  const ParagraphConstraints({
     this.width,
   }) : assert(width != null);
 


### PR DESCRIPTION
Looks like something that got overlooked.