### PR TITLE
Reset ParagraphBuilder after build()

### DIFF
--- a/testing/dart/paragraph_builder_test.dart
+++ b/testing/dart/paragraph_builder_test.dart
@@ -18,7 +18,7 @@ void main() {
     expect(paragraph.height, isNonZero);
   });
 
-  test('PushStyle should not segfault', () {
+  test('PushStyle should not segfault after build()', () {
     final ParagraphBuilder paragraphBuilder =
         ParagraphBuilder(ParagraphStyle());
     paragraphBuilder.build();

--- a/testing/dart/paragraph_builder_test.dart
+++ b/testing/dart/paragraph_builder_test.dart
@@ -17,4 +17,11 @@ void main() {
     expect(paragraph.width, isNonZero);
     expect(paragraph.height, isNonZero);
   });
+
+  test('PushStyle should not segfault', () {
+    final ParagraphBuilder paragraphBuilder =
+        ParagraphBuilder(ParagraphStyle());
+    paragraphBuilder.build();
+    paragraphBuilder.pushStyle(TextStyle());
+  });
 }

--- a/third_party/txt/src/txt/paragraph_builder.cc
+++ b/third_party/txt/src/txt/paragraph_builder.cc
@@ -84,6 +84,7 @@ std::unique_ptr<Paragraph> ParagraphBuilder::Build() {
   paragraph->SetText(std::move(text_), std::move(runs_));
   paragraph->SetParagraphStyle(paragraph_style_);
   paragraph->SetFontCollection(font_collection_);
+  SetParagraphStyle(paragraph_style_);
   return paragraph;
 }
 


### PR DESCRIPTION
Fixes flutter/flutter#26061

Crash was caused because `runs_` gets moved after build is called.  PushStyle codepaths attempt to use it again after the move, causing a NPE.

This makes `build()` reset the paragraph builder to its initial state, making it safe to call these methods on the builder after build. 

This is technically a change in behavior - ParagraphBuilders will be reusable after `build` to create new paragraphs, although I don't think we want to document that or commit to it being the case.