### PR TITLE
Refactor dynamic patching to use clearer naming and structure.

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -33,6 +33,7 @@ import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterRunArguments;
 import io.flutter.view.FlutterView;
 
+import java.io.File;
 import java.util.ArrayList;
 
 /**
@@ -343,8 +344,9 @@ public final class FlutterActivityDelegate
         if (!flutterView.getFlutterNativeView().isApplicationRunning()) {
             FlutterRunArguments args = new FlutterRunArguments();
             ArrayList<String> bundlePaths = new ArrayList<>();
-            if (FlutterMain.getUpdateInstallationPath() != null) {
-                bundlePaths.add(FlutterMain.getUpdateInstallationPath());
+            if (FlutterMain.getResourceUpdater() != null) {
+                File patchFile = FlutterMain.getResourceUpdater().getPatch();
+                bundlePaths.add(patchFile.getPath());
             }
             bundlePaths.add(appBundlePath);
             args.bundlePaths = bundlePaths.toArray(new String[0]);

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -360,8 +360,13 @@ public class FlutterMain {
         return appBundle.exists() ? appBundle.getPath() : null;
     }
 
-    public static String getUpdateInstallationPath() {
-        return sResourceUpdater == null ? null : sResourceUpdater.getUpdateInstallationPath();
+    /**
+     * Returns the main internal interface for the dynamic patching subsystem.
+     *
+     * If this is null, it means that dynamic patching is disabled in this app.
+     */
+    public static ResourceUpdater getResourceUpdater() {
+        return sResourceUpdater;
     }
 
     /**


### PR DESCRIPTION
This is a no-op change, except for fixing a bug where download task
reference wasn't cleared after download was completed.

This change also removes call to output stream flush(), which is not
necessary according to Java spec.

The rest of the change deals with requiring the code to work directly
with ResourceUpdater object instead of having FlutterMain be a facade
that forwards some of ResourceUpdater's methods. This simplifies the
other (more essential) upcoming changes that will be landing in the
followings few PRs.