### PR TITLE
Fix 404 handling when downloading dynamic patches.

### DIFF
--- a/shell/platform/android/io/flutter/view/ResourceUpdater.java
+++ b/shell/platform/android/io/flutter/view/ResourceUpdater.java
@@ -104,26 +104,23 @@ public final class ResourceUpdater {
                     connection.setIfModifiedSince(lastDownloadTime);
                 }
 
+                URL resolvedURL = connection.getURL();
+                Log.i(TAG, "Resolved update URL " + resolvedURL);
+
+                int responseCode = connection.getResponseCode();
+                Log.i(TAG, "HTTP response code " + responseCode);
+
+                if (responseCode == HttpURLConnection.HTTP_NOT_FOUND) {
+                    Log.i(TAG, "Latest update not found");
+                    return null;
+                }
+
+                if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+                    Log.i(TAG, "Already have latest update");
+                    return null;
+                }
+
                 try (InputStream input = connection.getInputStream()) {
-                    URL resolvedURL = connection.getURL();
-                    Log.i(TAG, "Resolved update URL " + resolvedURL);
-
-                    if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) {
-                        if (resolvedURL.equals(unresolvedURL)) {
-                            Log.i(TAG, "Rolled back all updates");
-                            localFile.delete();
-                            return null;
-                        } else {
-                            Log.i(TAG, "Latest update not found");
-                            return null;
-                        }
-                    }
-
-                    if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
-                        Log.i(TAG, "Already have latest update");
-                        return null;
-                    }
-
                     Log.i(TAG, "Downloading update " + unresolvedURL);
                     try (OutputStream output = new FileOutputStream(localFile)) {
                         int count;


### PR DESCRIPTION
Before this change, the 404 check would never trigger because
try statement would get unrolled first before we reach the check.
This change makes sure that we check for 404 before that happens.

Also, this change will no longer delete the patch file when 404
happens, so patch rollback now must happen by pushing an actual
rollback zip file.