### PR TITLE
Clear the font collection's cache when a font is dynamically loaded

### DIFF
--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -158,6 +158,7 @@ void FontCollection::LoadFontFromList(const uint8_t* font_data,
   } else {
     font_provider.RegisterTypeface(typeface, family_name);
   }
+  collection_->ClearFontFamilyCache();
 }
 
 }  // namespace blink

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -286,4 +286,8 @@ FontCollection::GetFallbackFontFamily(const sk_sp<SkFontMgr>& manager,
   return insert_it.first->second;
 }
 
+void FontCollection::ClearFontFamilyCache() {
+  font_collections_cache_.clear();
+}
+
 }  // namespace txt

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -59,6 +59,9 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
   // missing from the requested font family.
   void DisableFontFallback();
 
+  // Remove all entries in the font family cache.
+  void ClearFontFamilyCache();
+
  private:
   struct FamilyKey {
     FamilyKey(const std::vector<std::string>& families, const std::string& loc);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/26293