### PR TITLE
Remove legacy and deprecated defaultClipBehavior

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -181,7 +181,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   // ignore: deprecated_member_use
-  EngineLayer pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = defaultClipBehavior}) {
+  EngineLayer pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = Clip.none}) {
     return _pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index);
   }
   EngineLayer _pushPhysicalShape(Path path, double elevation, int color, int shadowColor, int clipBehavior) native

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1018,14 +1018,6 @@ enum Clip {
   antiAliasWithSaveLayer,
 }
 
-/// The global default value of whether and how to clip a widget. This is only for
-/// temporary migration from default-to-clip to default-to-NOT-clip.
-///
-// TODO(liyuqian): Set it to Clip.none. (https://github.com/flutter/flutter/issues/18057)
-// We currently have Clip.antiAlias to preserve our old behaviors.
-@Deprecated("Do not use this as it'll soon be removed after we set the default behavior to Clip.none.")
-const Clip defaultClipBehavior = Clip.antiAlias;
-
 // If we actually run on big endian machines, we'll need to do something smarter
 // here. We don't use [Endian.Host] because it's not a compile-time
 // constant and can't propagate into the set/get calls.


### PR DESCRIPTION
The defaultClipBehavior is no longer used anywhere in the Flutter framework.