### PR TITLE
Avg ms/frame instead of FPS in performance overlay

### DIFF
--- a/flow/instrumentation.cc
+++ b/flow/instrumentation.cc
@@ -64,7 +64,7 @@ fml::TimeDelta Stopwatch::MaxDelta() const {
 }
 
 fml::TimeDelta Stopwatch::AverageDelta() const {
-  fml::TimeDelta sum; // default to 0
+  fml::TimeDelta sum;  // default to 0
   for (size_t i = 0; i < kMaxSamples; i++) {
     sum = sum + laps_[i];
   }

--- a/flow/instrumentation.cc
+++ b/flow/instrumentation.cc
@@ -63,6 +63,14 @@ fml::TimeDelta Stopwatch::MaxDelta() const {
   return max_delta;
 }
 
+fml::TimeDelta Stopwatch::AverageDelta() const {
+  fml::TimeDelta sum; // default to 0
+  for (size_t i = 0; i < kMaxSamples; i++) {
+    sum = sum + laps_[i];
+  }
+  return sum / kMaxSamples;
+}
+
 // Initialize the SkSurface for drawing into. Draws the base background and any
 // timing data from before the initial Visualize() call.
 void Stopwatch::InitVisualizeSurface(const SkRect& rect) const {

--- a/flow/instrumentation.h
+++ b/flow/instrumentation.h
@@ -14,6 +14,8 @@
 
 namespace flow {
 
+// DEPRECATED
+// The frame per second FPS could be different than 60 (e.g., 120).
 static const double kOneFrameMS = 1e3 / 60.0;
 
 class Stopwatch {
@@ -27,6 +29,8 @@ class Stopwatch {
   fml::TimeDelta CurrentLap() const { return fml::TimePoint::Now() - start_; }
 
   fml::TimeDelta MaxDelta() const;
+
+  fml::TimeDelta AverageDelta() const;
 
   void InitVisualizeSurface(const SkRect& rect) const;
 

--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -40,19 +40,14 @@ void VisualizeStopWatch(SkCanvas& canvas,
   }
 
   if (show_labels) {
-    double ms_per_frame = stopwatch.MaxDelta().ToMillisecondsF();
-    double fps;
-    if (ms_per_frame < kOneFrameMS) {
-      fps = 1e3 / kOneFrameMS;
-    } else {
-      fps = 1e3 / ms_per_frame;
-    }
-
+    double max_ms_per_frame = stopwatch.MaxDelta().ToMillisecondsF();
+    double average_ms_per_frame = stopwatch.AverageDelta().ToMillisecondsF();
     std::stringstream stream;
     stream.setf(std::ios::fixed | std::ios::showpoint);
     stream << std::setprecision(1);
-    stream << label_prefix << "  " << fps << " fps  " << ms_per_frame
-           << "ms/frame";
+    stream << label_prefix << "  "
+           << "max " << max_ms_per_frame << " ms/frame, "
+           << "avg " << average_ms_per_frame << " ms/frame";
     DrawStatisticsText(canvas, stream.str(), x + label_x, y + height + label_y);
   }
 }


### PR DESCRIPTION
This change follows our trend to move all our performance metrics to frame time instead of FPS. Computing FPS from max ms/frame is misleading and we're no longer just using 60 FPS displays.

Tested on iOS devices. Android devices currently don't show any text because of https://github.com/flutter/flutter/issues/26387

We will add a gold test to the framework for performance overlay to both test this change and prevent regressions like https://github.com/flutter/flutter/issues/26387

Here's a screenshot of the new performance overlay:
![image](https://user-images.githubusercontent.com/22987568/51003190-a8e51900-14ea-11e9-8e3d-62dfdee4d795.png)
