### PR TITLE
Revert "Add elevation and thickness to SemanticsNode"

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -607,14 +607,6 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   ///
   /// The `transform` is a matrix that maps this node's coordinate system into
   /// its parent's coordinate system.
-  ///
-  /// The `elevation` describes the distance in z-direction between this node
-  /// and the `elevation` of the parent.
-  ///
-  /// The `thickness` describes how much space this node occupies in the
-  /// z-direction starting at `elevation`. Basically, in the z-direction the
-  /// node starts at `elevation` above the parent and ends at `elevation` +
-  /// `thickness` above the parent.
   void updateNode({
     int id,
     int flags,
@@ -626,8 +618,6 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
     double scrollPosition,
     double scrollExtentMax,
     double scrollExtentMin,
-    double elevation,
-    double thickness,
     Rect rect,
     String label,
     String hint,
@@ -657,8 +647,6 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
       rect.top,
       rect.right,
       rect.bottom,
-      elevation,
-      thickness,
       label,
       hint,
       value,
@@ -686,8 +674,6 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
     double top,
     double right,
     double bottom,
-    double elevation,
-    double thickness,
     String label,
     String hint,
     String value,

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -87,8 +87,6 @@ struct SemanticsNode {
   double scrollPosition = std::nan("");
   double scrollExtentMax = std::nan("");
   double scrollExtentMin = std::nan("");
-  double elevation = 0.0;
-  double thickness = 0.0;
   std::string label;
   std::string hint;
   std::string value;

--- a/lib/ui/semantics/semantics_update_builder.cc
+++ b/lib/ui/semantics/semantics_update_builder.cc
@@ -50,8 +50,6 @@ void SemanticsUpdateBuilder::updateNode(
     double top,
     double right,
     double bottom,
-    double elevation,
-    double thickness,
     std::string label,
     std::string hint,
     std::string value,
@@ -74,8 +72,6 @@ void SemanticsUpdateBuilder::updateNode(
   node.scrollExtentMax = scrollExtentMax;
   node.scrollExtentMin = scrollExtentMin;
   node.rect = SkRect::MakeLTRB(left, top, right, bottom);
-  node.elevation = elevation;
-  node.thickness = thickness;
   node.label = label;
   node.hint = hint;
   node.value = value;

--- a/lib/ui/semantics/semantics_update_builder.h
+++ b/lib/ui/semantics/semantics_update_builder.h
@@ -38,8 +38,6 @@ class SemanticsUpdateBuilder
                   double top,
                   double right,
                   double bottom,
-                  double elevation,
-                  double thickness,
                   std::string label,
                   std::string hint,
                   std::string value,


### PR DESCRIPTION
Reverts flutter/engine#7282.

Engine is currently not in a state that can be rolled into flutter/flutter. Reverting this change for now because it requires a manual engine roll. 