### PR TITLE
Support for trim path effects in Flutter

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2079,10 +2079,10 @@ class Path extends NativeFieldWrapperClass2 {
   }
   Path _transform(Float64List matrix4) native 'Path_transform';
 
-  /// Cuts the path into a subset of itself leaving only the region between 
-  /// `startT` and `stopT` fraction values. Set `isComplement` to true to 
+  /// Cuts the path into a subset of itself leaving only the region between
+  /// `startT` and `stopT` fraction values. Set `isComplement` to true to
   /// invert the result by cutting out the region from `startT` to `stopT`.
-  /// 
+  ///
   /// Returns true when the cut is succesfully made, false if not.
   bool trim(double startT, double stopT, bool isComplement) {
     return _trim(startT, stopT, isComplement);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2080,14 +2080,14 @@ class Path extends NativeFieldWrapperClass2 {
   Path _transform(Float64List matrix4) native 'Path_transform';
 
   /// Cuts the path into a subset of itself leaving only the region between
-  /// `startT` and `stopT` fraction values. Set `isComplement` to true to
-  /// invert the result by cutting out the region from `startT` to `stopT`.
+  /// `startT` and `stopT` fraction values in [0,1]. Set `isInverted` to true 
+  /// to invert the result by cutting out the region from `startT` to `stopT`.
   ///
   /// Returns true when the cut is succesfully made, false if not.
-  bool trim(double startT, double stopT, bool isComplement) {
-    return _trim(startT, stopT, isComplement);
+  bool trim(double startT, double stopT, bool isInverted) {
+    return _trim(startT.clamp(0.0, 1.0), stopT.clamp(0.0, 1.0), isInverted);
   }
-  bool _trim(double startT, double endT, bool isComplement) native 'Path_trim';
+  bool _trim(double startT, double endT, bool isInverted) native 'Path_trim';
 
   /// Computes the bounding rectangle for this path.
   ///

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2080,7 +2080,7 @@ class Path extends NativeFieldWrapperClass2 {
   Path _transform(Float64List matrix4) native 'Path_transform';
 
   /// Cuts the path into a subset of itself leaving only the region between
-  /// `startT` and `stopT` fraction values in [0,1]. Set `isInverted` to true 
+  /// `startT` and `stopT` fraction values in [0,1]. Set `isInverted` to true
   /// to invert the result by cutting out the region from `startT` to `stopT`.
   ///
   /// Returns true when the cut is succesfully made, false if not.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2079,6 +2079,16 @@ class Path extends NativeFieldWrapperClass2 {
   }
   Path _transform(Float64List matrix4) native 'Path_transform';
 
+  /// Cuts the path into a subset of itself leaving only the region between 
+  /// `startT` and `stopT` fraction values. Set `isComplement` to true to 
+  /// invert the result by cutting out the region from `startT` to `stopT`.
+  /// 
+  /// Returns true when the cut is succesfully made, false if not.
+  bool trim(double startT, double stopT, bool isComplement) {
+    return _trim(startT, stopT, isComplement);
+  }
+  bool _trim(double startT, double endT, bool isComplement) native 'Path_trim';
+
   /// Computes the bounding rectangle for this path.
   ///
   /// A path containing only axis-aligned points on the same straight line will

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -282,7 +282,7 @@ fml::RefPtr<CanvasPath> CanvasPath::transform(tonic::Float64List& matrix4) {
 
 bool CanvasPath::trim(double startT, double stopT, bool isInverted) {
   SkTrimPathEffect::Mode mode = isInverted ? SkTrimPathEffect::Mode::kInverted
-                                             : SkTrimPathEffect::Mode::kNormal;
+                                           : SkTrimPathEffect::Mode::kNormal;
   sk_sp<SkPathEffect> pathEffect = SkTrimPathEffect::Make(startT, stopT, mode);
   if (!pathEffect) {
     return false;

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -8,12 +8,12 @@
 #include <math.h>
 
 #include "flutter/lib/ui/painting/matrix.h"
+#include "third_party/skia/include/core/SkStrokeRec.h"
+#include "third_party/skia/include/effects/SkTrimPathEffect.h"
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_args.h"
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
-#include "third_party/skia/include/effects/SkTrimPathEffect.h"
-#include "third_party/skia/include/core/SkStrokeRec.h"
 
 using tonic::ToDart;
 
@@ -281,18 +281,16 @@ fml::RefPtr<CanvasPath> CanvasPath::transform(tonic::Float64List& matrix4) {
 }
 
 bool CanvasPath::trim(double startT, double stopT, bool isComplement) {
-  SkTrimPathEffect::Mode mode = isComplement ? 
-                                SkTrimPathEffect::Mode::kInverted : 
-                                SkTrimPathEffect::Mode::kNormal;
-  sk_sp<SkPathEffect> pathEffect = 
-      SkTrimPathEffect::Make(startT, stopT, mode);
-  if(!pathEffect) {
+  SkTrimPathEffect::Mode mode = isComplement ? SkTrimPathEffect::Mode::kInverted
+                                             : SkTrimPathEffect::Mode::kNormal;
+  sk_sp<SkPathEffect> pathEffect = SkTrimPathEffect::Make(startT, stopT, mode);
+  if (!pathEffect) {
     return false;
   }
   SkStrokeRec rec(SkStrokeRec::InitStyle::kHairline_InitStyle);
   if (pathEffect->filterPath(&path_, path_, &rec, nullptr)) {
-        return true;
-    }
+    return true;
+  }
   return false;
 }
 

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -280,8 +280,8 @@ fml::RefPtr<CanvasPath> CanvasPath::transform(tonic::Float64List& matrix4) {
   return path;
 }
 
-bool CanvasPath::trim(double startT, double stopT, bool isComplement) {
-  SkTrimPathEffect::Mode mode = isComplement ? SkTrimPathEffect::Mode::kInverted
+bool CanvasPath::trim(double startT, double stopT, bool isInverted) {
+  SkTrimPathEffect::Mode mode = isInverted ? SkTrimPathEffect::Mode::kInverted
                                              : SkTrimPathEffect::Mode::kNormal;
   sk_sp<SkPathEffect> pathEffect = SkTrimPathEffect::Make(startT, stopT, mode);
   if (!pathEffect) {

--- a/lib/ui/painting/path.h
+++ b/lib/ui/painting/path.h
@@ -101,7 +101,7 @@ class CanvasPath : public RefCountedDartWrappable<CanvasPath> {
   tonic::Float32List getBounds();
   bool op(CanvasPath* path1, CanvasPath* path2, int operation);
   fml::RefPtr<CanvasPath> clone();
-  bool trim(double startT, double stopT, bool isComplement);
+  bool trim(double startT, double stopT, bool isInverted);
 
   const SkPath& path() const { return path_; }
 

--- a/lib/ui/painting/path.h
+++ b/lib/ui/painting/path.h
@@ -101,6 +101,7 @@ class CanvasPath : public RefCountedDartWrappable<CanvasPath> {
   tonic::Float32List getBounds();
   bool op(CanvasPath* path1, CanvasPath* path2, int operation);
   fml::RefPtr<CanvasPath> clone();
+  bool trim(double startT, double stopT, bool isComplement);
 
   const SkPath& path() const { return path_; }
 


### PR DESCRIPTION
We're adding support for trimmed paths in Flare and Flutter. This allows for really interesting effects like rain drops, fireworks, and a lot of other cases where being able to animate the visible portion of the stroke is useful.

Here is an example of a square with a trimmed stroke in Flare:
![screen shot 2019-01-15 at 11 19 20 am](https://user-images.githubusercontent.com/454182/51205010-d1d62700-18b9-11e9-8c4b-319d0343c970.png)


Here's a terribly compressed gif  of it running in Flutter using an engine with the modifications in this pull request.
![trimpath](https://user-images.githubusercontent.com/454182/51204939-ac491d80-18b9-11e9-8309-77f4a963f00b.gif)



