### PR TITLE
Cleanup Dart sticky errors API and roll tonic to 4634b29a24ccfc0fcfafcc8196ef30131185ad88

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -125,7 +125,7 @@ deps = {
    # and not have to specific specific hashes.
 
   'src/third_party/tonic':
-   Var('fuchsia_git') + '/tonic' + '@' + '5c9c2b63091ffd6000d44a3b5ff86e4f349e6978',
+   Var('fuchsia_git') + '/tonic' + '@' + '4634b29a24ccfc0fcfafcc8196ef30131185ad88',
 
   'src/third_party/benchmark':
    Var('fuchsia_git') + '/third_party/benchmark' + '@' + '21f1eb3fe269ea43eba862bf6b699cde46587ade',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -17564,8 +17564,6 @@ FILE: ../../../third_party/tonic/dart_message_handler.cc
 FILE: ../../../third_party/tonic/dart_message_handler.h
 FILE: ../../../third_party/tonic/dart_microtask_queue.cc
 FILE: ../../../third_party/tonic/dart_microtask_queue.h
-FILE: ../../../third_party/tonic/dart_sticky_error.cc
-FILE: ../../../third_party/tonic/dart_sticky_error.h
 FILE: ../../../third_party/tonic/file_loader/file_loader.cc
 FILE: ../../../third_party/tonic/file_loader/file_loader.h
 FILE: ../../../third_party/tonic/filesystem/filesystem/eintr_wrapper.h

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -21,7 +21,6 @@
 #include "third_party/tonic/dart_class_provider.h"
 #include "third_party/tonic/dart_message_handler.h"
 #include "third_party/tonic/dart_state.h"
-#include "third_party/tonic/dart_sticky_error.h"
 #include "third_party/tonic/file_loader/file_loader.h"
 #include "third_party/tonic/scopes/dart_api_scope.h"
 #include "third_party/tonic/scopes/dart_isolate_scope.h"
@@ -701,17 +700,6 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
 // |Dart_IsolateShutdownCallback|
 void DartIsolate::DartIsolateShutdownCallback(
     std::shared_ptr<DartIsolate>* embedder_isolate) {
-  if (!tonic::DartStickyError::IsSet()) {
-    return;
-  }
-
-  tonic::DartApiScope api_scope;
-  Dart_Handle sticky_error = Dart_GetStickyError();
-  if (!Dart_IsFatalError(sticky_error)) {
-    FML_LOG(ERROR) << "Isolate " << tonic::StdStringFromDart(Dart_DebugName())
-                   << " exited with an error";
-    FML_CHECK(tonic::LogIfError(sticky_error));
-  }
 }
 
 // |Dart_IsolateCleanupCallback|

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -27,7 +27,6 @@
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/dart_class_library.h"
 #include "third_party/tonic/dart_class_provider.h"
-#include "third_party/tonic/dart_sticky_error.h"
 #include "third_party/tonic/file_loader/file_loader.h"
 #include "third_party/tonic/logging/dart_error.h"
 #include "third_party/tonic/scopes/dart_api_scope.h"


### PR DESCRIPTION
This PR prepares Flutter engine for the cleanup of Dart API Dart_GetStickyError/Dart_SetStickyError/Dart_HasStickyError.
