### PR TITLE
Add unittest that runs Dart code synchronously.

### DIFF
--- a/runtime/fixtures/simple_main.dart
+++ b/runtime/fixtures/simple_main.dart
@@ -3,5 +3,12 @@
 // found in the LICENSE file.
 
 void main() {
-  print('Hello');
+}
+
+void sayHi() {
+  print("Hi");
+}
+
+void throwExceptionNow() {
+  throw("Hello");
 }


### PR DESCRIPTION
The usual method of invoking the "main" routine posts a task onto the runloop for later execution. This makes it hard to test. This variant just calls the specified routine directly.