### PR TITLE
Deprecate FlutterProjectArgs.main_path, packages_path

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -270,6 +270,11 @@ FlutterResult FlutterEngineRun(size_t version,
     return kInvalidArguments;
   }
 
+  if (SAFE_ACCESS(args, main_path__unused__, nullptr) != nullptr) {
+    FML_LOG(WARNING)
+        << "FlutterProjectArgs.main_path is deprecated and should be set null.";
+  }
+
   if (!IsRendererValid(config)) {
     return kInvalidArguments;
   }

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -275,6 +275,11 @@ FlutterResult FlutterEngineRun(size_t version,
         << "FlutterProjectArgs.main_path is deprecated and should be set null.";
   }
 
+  if (SAFE_ACCESS(args, packages_path__unused__, nullptr) != nullptr) {
+    FML_LOG(WARNING) << "FlutterProjectArgs.packages_path is deprecated and "
+                        "should be set null.";
+  }
+
   if (!IsRendererValid(config)) {
     return kInvalidArguments;
   }

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -185,10 +185,15 @@ typedef struct {
   // string can be collected after the call to |FlutterEngineRun| returns. The
   // string must be NULL terminated.
   const char* assets_path;
-  // The path to the Dart file containing the |main| entry point. The string can
-  // be collected after the call to |FlutterEngineRun| returns. The string must
-  // be NULL terminated.
-  const char* main_path;
+  // The path to the Dart file containing the |main| entry point.
+  // The string can be collected after the call to |FlutterEngineRun| returns.
+  // The string must be NULL terminated.
+  //
+  // \deprecated As of Dart 2, running from Dart source is no longer supported.
+  // Dart code should now be compiled to kernel form and will be loaded by from
+  // |kernel_blob.bin| in the assets directory. This struct member is retained
+  // for ABI stability.
+  const char* main_path__unused__;
   // The path to the |.packages| for the project. The string can be collected
   // after the call to |FlutterEngineRun| returns. The string must be NULL
   // terminated.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -197,7 +197,12 @@ typedef struct {
   // The path to the |.packages| for the project. The string can be collected
   // after the call to |FlutterEngineRun| returns. The string must be NULL
   // terminated.
-  const char* packages_path;
+  //
+  // \deprecated As of Dart 2, running from Dart source is no longer supported.
+  // Dart code should now be compiled to kernel form and will be loaded by from
+  // |kernel_blob.bin| in the assets directory. This struct member is retained
+  // for ABI stability.
+  const char* packages_path__unused__;
   // The path to the icudtl.dat file for the project. The string can be
   // collected after the call to |FlutterEngineRun| returns. The string must
   // be NULL terminated.

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -29,7 +29,6 @@ TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = testing::GetFixturesPath();
-  args.main_path = "";
   args.packages_path = "";
 
   FlutterEngine engine = nullptr;

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -29,7 +29,6 @@ TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = testing::GetFixturesPath();
-  args.packages_path = "";
 
   FlutterEngine engine = nullptr;
   FlutterResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config,


### PR DESCRIPTION
As of Dart 2, running from Dart source is no longer supported.  Dart
code should now be compiled to kernel form and will be loaded by from
kernel.blob in the assets directory. We retain the struct member for ABI
stability.