### PR TITLE
Wrap the user entrypoint function in a zone with native exception callback.

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -83,6 +83,10 @@ struct Settings {
   // as fast as possible in returning from this callback. Long running
   // operations in this callback do have the capability of introducing jank.
   std::function<void(int64_t)> idle_notification_callback;
+  // A callback given to the embedder to react to unhandled exceptions in the
+  // running Flutter application. This callback is made on an internal engine
+  // managed thread and embedders must thread as necessary. Performing blocking
+  // calls in this callback will cause applications to jank.
   UnhandledExceptionCallback unhandled_exception_callback;
   bool enable_software_rendering = false;
   bool skia_deterministic_rendering_on_cpu = false;

--- a/common/settings.h
+++ b/common/settings.h
@@ -20,6 +20,9 @@ namespace blink {
 using TaskObserverAdd =
     std::function<void(intptr_t /* key */, fml::closure /* callback */)>;
 using TaskObserverRemove = std::function<void(intptr_t /* key */)>;
+using UnhandledExceptionCallback =
+    std::function<bool(const std::string& /* error */,
+                       const std::string& /* stack trace */)>;
 
 struct Settings {
   Settings();
@@ -80,6 +83,7 @@ struct Settings {
   // as fast as possible in returning from this callback. Long running
   // operations in this callback do have the capability of introducing jank.
   std::function<void(int64_t)> idle_notification_callback;
+  UnhandledExceptionCallback unhandled_exception_callback;
   bool enable_software_rendering = false;
   bool skia_deterministic_rendering_on_cpu = false;
   bool verbose_logging = false;

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -166,7 +166,7 @@ void _drawFrame() {
 // ignore: unused_element
 void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction) {
   startMainIsolateFunction((){
-    runZoned<Future<void>>(() async {
+    runZoned<Future<void>>(() {
       userMainFunction();
     }, onError: (Object error, StackTrace stackTrace) {
       _reportUnhandledException(error.toString(), stackTrace.toString());

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -174,7 +174,7 @@ void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction)
   }, null);
 }
 
-void _reportUnhandledException(String error, String stackTrace) native "Window_reportUnhandledException";
+void _reportUnhandledException(String error, String stackTrace) native 'Window_reportUnhandledException';
 
 /// Invokes [callback] inside the given [zone].
 void _invoke(void callback(), Zone zone) {

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -162,6 +162,20 @@ void _drawFrame() {
   _invoke(window.onDrawFrame, window._onDrawFrameZone);
 }
 
+@pragma('vm:entry-point')
+// ignore: unused_element
+void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction) {
+  startMainIsolateFunction((){
+    runZoned<Future<void>>(() async {
+      userMainFunction();
+    }, onError: (Object error, StackTrace stackTrace) {
+      _reportUnhandledException(error.toString(), stackTrace.toString());
+    });
+  }, null);
+}
+
+void _reportUnhandledException(String error, String stackTrace) native "Window_reportUnhandledException";
+
 /// Invokes [callback] inside the given [zone].
 void _invoke(void callback(), Zone zone) {
   if (callback == null)

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -13,15 +13,17 @@ using tonic::ToDart;
 
 namespace blink {
 
-UIDartState::UIDartState(TaskRunners task_runners,
-                         TaskObserverAdd add_callback,
-                         TaskObserverRemove remove_callback,
-                         fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
-                         fml::WeakPtr<IOManager> io_manager,
-                         std::string advisory_script_uri,
-                         std::string advisory_script_entrypoint,
-                         std::string logger_prefix,
-                         IsolateNameServer* isolate_name_server)
+UIDartState::UIDartState(
+    TaskRunners task_runners,
+    TaskObserverAdd add_callback,
+    TaskObserverRemove remove_callback,
+    fml::WeakPtr<SnapshotDelegate> snapshot_delegate,
+    fml::WeakPtr<IOManager> io_manager,
+    std::string advisory_script_uri,
+    std::string advisory_script_entrypoint,
+    std::string logger_prefix,
+    UnhandledExceptionCallback unhandled_exception_callback,
+    IsolateNameServer* isolate_name_server)
     : task_runners_(std::move(task_runners)),
       add_callback_(std::move(add_callback)),
       remove_callback_(std::move(remove_callback)),
@@ -30,6 +32,7 @@ UIDartState::UIDartState(TaskRunners task_runners,
       advisory_script_uri_(std::move(advisory_script_uri)),
       advisory_script_entrypoint_(std::move(advisory_script_entrypoint)),
       logger_prefix_(std::move(logger_prefix)),
+      unhandled_exception_callback_(unhandled_exception_callback),
       isolate_name_server_(isolate_name_server) {
   AddOrRemoveTaskObserver(true /* add */);
 }
@@ -131,6 +134,19 @@ tonic::DartErrorHandleType UIDartState::GetLastError() {
     error = microtask_queue_.GetLastError();
   }
   return error;
+}
+
+void UIDartState::ReportUnhandledException(const std::string& error,
+                                           const std::string& stack_trace) {
+  if (unhandled_exception_callback_ &&
+      unhandled_exception_callback_(error, stack_trace)) {
+    return;
+  }
+
+  // Either the exception handler was not set or it could not handle the error,
+  // just log the exception.
+  FML_LOG(ERROR) << "Unhandled Exception: " << error << std::endl
+                 << stack_trace;
 }
 
 }  // namespace blink

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -57,6 +57,9 @@ class UIDartState : public tonic::DartState {
 
   tonic::DartErrorHandleType GetLastError();
 
+  void ReportUnhandledException(const std::string& error,
+                                const std::string& stack_trace);
+
   template <class T>
   static flow::SkiaGPUObject<T> CreateGPUObject(sk_sp<T> object) {
     if (!object) {
@@ -77,6 +80,7 @@ class UIDartState : public tonic::DartState {
               std::string advisory_script_uri,
               std::string advisory_script_entrypoint,
               std::string logger_prefix,
+              UnhandledExceptionCallback unhandled_exception_callback,
               IsolateNameServer* isolate_name_server);
 
   ~UIDartState() override;
@@ -102,6 +106,7 @@ class UIDartState : public tonic::DartState {
   std::string debug_name_;
   std::unique_ptr<Window> window_;
   tonic::DartMicrotaskQueue microtask_queue_;
+  UnhandledExceptionCallback unhandled_exception_callback_;
   IsolateNameServer* isolate_name_server_;
 
   void AddOrRemoveTaskObserver(bool add);

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -65,6 +65,27 @@ void SetIsolateDebugName(Dart_NativeArguments args) {
   UIDartState::Current()->SetDebugName(name);
 }
 
+void ReportUnhandledException(Dart_NativeArguments args) {
+  Dart_Handle exception = nullptr;
+
+  auto error_name =
+      tonic::DartConverter<std::string>::FromArguments(args, 0, exception);
+  if (exception) {
+    Dart_ThrowException(exception);
+    return;
+  }
+
+  auto stack_trace =
+      tonic::DartConverter<std::string>::FromArguments(args, 1, exception);
+  if (exception) {
+    Dart_ThrowException(exception);
+    return;
+  }
+
+  UIDartState::Current()->ReportUnhandledException(std::move(error_name),
+                                                   std::move(stack_trace));
+}
+
 Dart_Handle SendPlatformMessage(Dart_Handle window,
                                 const std::string& name,
                                 Dart_Handle callback,
@@ -318,6 +339,7 @@ void Window::RegisterNatives(tonic::DartLibraryNatives* natives) {
       {"Window_render", Render, 2, true},
       {"Window_updateSemantics", UpdateSemantics, 2, true},
       {"Window_setIsolateDebugName", SetIsolateDebugName, 2, true},
+      {"Window_reportUnhandledException", ReportUnhandledException, 2, true},
   });
 }
 

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -88,6 +88,7 @@ class DartIsolate : public UIDartState {
   DartVM* GetDartVM() const;
 
   fml::RefPtr<DartSnapshot> GetIsolateSnapshot() const;
+
   fml::RefPtr<DartSnapshot> GetSharedSnapshot() const;
 
   std::weak_ptr<DartIsolate> GetWeakIsolatePtr();


### PR DESCRIPTION
This is similar to how [we recommend](https://flutter.io/docs/cookbook/maintenance/error-reporting) users attach uncaught exception handlers in their code for reporting purposes. The same limitations as that approach apply here as well.