### PR TITLE
Support custom kernel blob path in embedder API

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -50,6 +50,7 @@ source_set("embedder") {
 
 test_fixtures("fixtures") {
   fixtures = [ "fixtures/simple_main.dart" ]
+  kernel_out = "kernel_out.bin"
 }
 
 executable("embedder_unittests") {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -302,13 +302,15 @@ FlutterResult FlutterEngineRun(size_t version,
   settings.assets_path = args->assets_path;
 
   // Verify the assets path contains Dart 2 kernel assets.
-  const std::string kApplicationKernelSnapshotFileName = "kernel_blob.bin";
-  std::string application_kernel_path = fml::paths::JoinPaths(
-      {settings.assets_path, kApplicationKernelSnapshotFileName});
+  std::string snapshotPath = "kernel_blob.bin";
+  if (SAFE_ACCESS(args, kernel_snapshot_path, nullptr) != nullptr)
+    snapshotPath = SAFE_ACCESS(args, kernel_snapshot_path, nullptr);
+  std::string application_kernel_path =
+      fml::paths::JoinPaths({settings.assets_path, snapshotPath});
   if (!fml::IsFile(application_kernel_path)) {
     return kInvalidArguments;
   }
-  settings.application_kernel_asset = kApplicationKernelSnapshotFileName;
+  settings.application_kernel_asset = snapshotPath;
 
   settings.task_observer_add = [](intptr_t key, fml::closure callback) {
     fml::MessageLoop::GetCurrent().AddTaskObserver(key, std::move(callback));

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -191,8 +191,8 @@ typedef struct {
   //
   // \deprecated As of Dart 2, running from Dart source is no longer supported.
   // Dart code should now be compiled to kernel form and will be loaded by from
-  // |kernel_blob.bin| in the assets directory. This struct member is retained
-  // for ABI stability.
+  // |kernel_snapshot_path| in the assets directory. This struct member is
+  // retained for ABI stability.
   const char* main_path__unused__;
   // The path to the |.packages| for the project. The string can be collected
   // after the call to |FlutterEngineRun| returns. The string must be NULL
@@ -200,8 +200,8 @@ typedef struct {
   //
   // \deprecated As of Dart 2, running from Dart source is no longer supported.
   // Dart code should now be compiled to kernel form and will be loaded by from
-  // |kernel_blob.bin| in the assets directory. This struct member is retained
-  // for ABI stability.
+  // |kernel_snapshot_path| in the assets directory. This struct member is
+  // retained for ABI stability.
   const char* packages_path__unused__;
   // The path to the icudtl.dat file for the project. The string can be
   // collected after the call to |FlutterEngineRun| returns. The string must
@@ -217,6 +217,11 @@ typedef struct {
   // to respond to platform messages from the Dart application. The callback
   // will be invoked on the thread on which the |FlutterEngineRun| call is made.
   FlutterPlatformMessageCallback platform_message_callback;
+  // The path within |assets_path| at which the compiled Dart kernel file
+  // containing the |main| entry point can be found. The string can be
+  // collected after the call to |FlutterEngineRun| returns. The string must be
+  // NULL terminated. Defaults to |kernel_blob.bin| if null.
+  const char* kernel_snapshot_path;
 } FlutterProjectArgs;
 
 FLUTTER_EXPORT

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -29,6 +29,7 @@ TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = testing::GetFixturesPath();
+  args.kernel_snapshot_path = "kernel_out.bin";
 
   FlutterEngine engine = nullptr;
   FlutterResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config,
@@ -37,4 +38,26 @@ TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
 
   result = FlutterEngineShutdown(engine);
   ASSERT_EQ(result, FlutterResult::kSuccess);
+}
+
+TEST(EmbedderTest, FailsRunWithInvalidKernelBlob) {
+  FlutterSoftwareRendererConfig renderer;
+  renderer.struct_size = sizeof(FlutterSoftwareRendererConfig);
+  renderer.surface_present_callback = [](void*, const void*, size_t, size_t) {
+    return false;
+  };
+
+  FlutterRendererConfig config = {};
+  config.type = FlutterRendererType::kSoftware;
+  config.software = renderer;
+
+  FlutterProjectArgs args = {};
+  args.struct_size = sizeof(FlutterProjectArgs);
+  args.assets_path = testing::GetFixturesPath();
+  args.kernel_snapshot_path = "no_such_file";
+
+  FlutterEngine engine = nullptr;
+  FlutterResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config,
+                                          &args, nullptr, &engine);
+  ASSERT_NE(result, FlutterResult::kSuccess);
 }

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -12,6 +12,10 @@ template("test_fixtures") {
   testonly = true
 
   assert(defined(invoker.fixtures), "Test fixtures must be specified.")
+  kernel_out = "kernel_blob.bin"
+  if (defined(invoker.kernel_out)) {
+    kernel_out = invoker.kernel_out
+  }
 
   fixtures_location = "$target_gen_dir/$target_name/assets"
   fixtures_location_file = "$target_gen_dir/$target_name/test_fixtures_location.cc"
@@ -54,12 +58,12 @@ template("test_fixtures") {
       fixture_paths += [ rebase_path(fixture) ]
     }
     inputs = fixture_paths
-    outputs = ["$fixtures_location/kernel_blob.bin"]
+    outputs = ["$fixtures_location/$kernel_out"]
 
     args = [
       "--sdk-root", rebase_path("$root_out_dir/flutter_patched_sdk"),
       "--target", "flutter",
-      "--output-dill", rebase_path("$fixtures_location/kernel_blob.bin"),
+      "--output-dill", rebase_path("$fixtures_location/$kernel_out"),
     ] + fixture_paths
     deps = [
       "//third_party/dart/utils/kernel-service:frontend_server"


### PR DESCRIPTION
Adds support to the embedder API for the user to specify an
arbitrarily-named kernel blob path within the asset path.

Updates the test_fixtures rule to support a custom kernel output file
name.