### PR TITLE
Update default flutter_assets path for iOS embedding

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -182,8 +182,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 + (NSString*)flutterAssetsName:(NSBundle*)bundle {
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
   if (flutterAssetsName == nil) {
-    // Default to "flutter_assets"
-    flutterAssetsName = @"flutter_assets";
+    flutterAssetsName = @"Frameworks/App.framework/flutter_assets";
   }
   return flutterAssetsName;
 }


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/26630 failed because this still points plugins to the current location for `flutter_assets`, which was detected when a test tried to load the flutter_gallery video player page.

This updates the default location so that we expect to find `flutter_assets` inside `Frameworks/App.framework`.  I'm not thrilled with this - but overriding it with a plist value by default would be much harder to make non-breaking for clients.

This will require a manual roll with the changes from https://github.com/dnfield/flutter/tree/flutter_assets_ios