### PR TITLE
Support custom kernel blob path in test fixtures

### DIFF
--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -7,11 +7,24 @@ import("//third_party/dart/build/dart/dart_action.gni")
 # Builds test fixtures for a unit test.
 #
 # Generates a directory structure containing an assets directory and the Dart
-# code to execute compiled to kernel, emitted to assets/kernel_blob.bin.
+# code to execute compiled to kernel. Generates:
+#   * an asserts directory at `$target_name/assets`.
+#   * a C++ implementation for `flutter/testing/testing.h`, defining
+#     `testing::GetFixturesPath()`, which returns the assets path.
+#   * a kernel snapshot at `$target_name/assets/$kernel_out`.
+#
+# Rule attributes:
+#   * fixtures: list of Dart files, including a main entrypoint.
+#   * kernel_out: the output path, relative to the assets directory, of the
+#     generated kernel snapshot. By default, `kernel_blob.bin`.
 template("test_fixtures") {
   testonly = true
 
   assert(defined(invoker.fixtures), "Test fixtures must be specified.")
+  kernel_out = "kernel_blob.bin"
+  if (defined(invoker.kernel_out)) {
+    kernel_out = invoker.kernel_out
+  }
 
   fixtures_location = "$target_gen_dir/$target_name/assets"
   fixtures_location_file = "$target_gen_dir/$target_name/test_fixtures_location.cc"
@@ -54,12 +67,12 @@ template("test_fixtures") {
       fixture_paths += [ rebase_path(fixture) ]
     }
     inputs = fixture_paths
-    outputs = ["$fixtures_location/kernel_blob.bin"]
+    outputs = ["$fixtures_location/$kernel_out"]
 
     args = [
       "--sdk-root", rebase_path("$root_out_dir/flutter_patched_sdk"),
       "--target", "flutter",
-      "--output-dill", rebase_path("$fixtures_location/kernel_blob.bin"),
+      "--output-dill", rebase_path("$fixtures_location/$kernel_out"),
     ] + fixture_paths
     deps = [
       "//third_party/dart/utils/kernel-service:frontend_server"


### PR DESCRIPTION
Updates the test_fixtures rule to support a custom kernel output file
name. Improves rule documentation.