### PR TITLE
Ensure the ResourceContext is not ripped out from under dart

### DIFF
--- a/runtime/fixtures/simple_main.dart
+++ b/runtime/fixtures/simple_main.dart
@@ -6,9 +6,9 @@ void main() {
 }
 
 void sayHi() {
-  print("Hi");
+  print('Hi');
 }
 
 void throwExceptionNow() {
-  throw("Hello");
+  throw 'Hello';
 }

--- a/runtime/fixtures/simple_main.dart
+++ b/runtime/fixtures/simple_main.dart
@@ -6,9 +6,9 @@ void main() {
 }
 
 void sayHi() {
-  print('Hi');
+  print("Hi");
 }
 
 void throwExceptionNow() {
-  throw 'Hello';
+  throw("Hello");
 }

--- a/shell/common/io_manager.cc
+++ b/shell/common/io_manager.cc
@@ -71,6 +71,16 @@ fml::WeakPtr<GrContext> IOManager::GetResourceContext() const {
              : fml::WeakPtr<GrContext>();
 }
 
+void IOManager::NotifyResourceContextAvailable(
+    sk_sp<GrContext> resource_context) {
+  // The resource context needs to survive as long as we have Dart objects
+  // referencing. We shouldn't ever need to replace it if we have one - unless
+  // we've somehow shut down the Dart VM and started a new one fresh.
+  if (!resource_context_) {
+    UpdateResourceContext(std::move(resource_context));
+  }
+}
+
 void IOManager::UpdateResourceContext(sk_sp<GrContext> resource_context) {
   resource_context_ = std::move(resource_context);
   resource_context_weak_factory_ =

--- a/shell/common/io_manager.h
+++ b/shell/common/io_manager.h
@@ -30,6 +30,15 @@ class IOManager : public blink::IOManager {
 
   fml::WeakPtr<GrContext> GetResourceContext() const override;
 
+  // This method should be called when a resource_context first becomes
+  // available. It is safe to call multiple times, and will only update
+  // the held resource context if it has not already been set.
+  void NotifyResourceContextAvailable(sk_sp<GrContext> resource_context);
+
+  // This method should be called if you want to force the IOManager to
+  // update its resource context reference. It should not be called
+  // if there are any Dart objects that have a reference to the old
+  // resource context, but may be called if the Dart VM is restarted.
   void UpdateResourceContext(sk_sp<GrContext> resource_context);
 
   fml::RefPtr<flow::SkiaUnrefQueue> GetSkiaUnrefQueue() const override;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -454,9 +454,14 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     fml::TaskRunner::RunNowOrPostTask(ui_task_runner, ui_task);
   };
 
-  // Step 0: Tell the IO thread that the PlatformView has a GLContext that can
-  // be used to create a resource context.
-  fml::TaskRunner::RunNowOrPostTask(task_runners_.GetIOTaskRunner(), io_task);
+  // Step 0: If the IOManager doesn't already have a ResourceContext, tell the
+  // IO thread that the PlatformView can make one for it now.
+  // Otherwise, jump right to step 1 on the UI thread.
+  if (!io_manager_->GetResourceContext()) {
+    fml::TaskRunner::RunNowOrPostTask(task_runners_.GetIOTaskRunner(), io_task);
+  } else {
+    fml::TaskRunner::RunNowOrPostTask(task_runners_.GetUITaskRunner(), ui_task);
+  }
   latch.Wait();
 }
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -446,7 +446,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
                   platform_view = platform_view_->GetWeakPtr(),
                   ui_task_runner = task_runners_.GetUITaskRunner(), ui_task] {
     if (io_manager) {
-      io_manager->UpdateResourceContext(
+      io_manager->NotifyResourceContextAvailable(
           platform_view ? platform_view->CreateResourceContext() : nullptr);
     }
     // Step 1: Next, post a task on the UI thread to tell the engine that it has


### PR DESCRIPTION
Will fix https://github.com/flutter/flutter/issues/26654

We need to make sure we don't rip the resource context out from under the Dart VM.  I was mistakenly thinking that the resource context depended on a GLContext, which is not correct.

Nevertheless, the resource context can get created late in the engine's lifecycle and we need a way to let objects know it's around when it becomes available.

I've left `UpdateResourceContext` to potentially support restarting the Dart VM.

/cc @jason-simmons @chinmaygarde 
