### PR TITLE
Fix suspicious typo "painted" to "paint"

### DIFF
--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -306,7 +306,7 @@ SceneUpdateContext::Frame::~Frame() {
                         std::move(paint_layers_));
 }
 
-void SceneUpdateContext::Frame::AddPaintedLayer(Layer* layer) {
+void SceneUpdateContext::Frame::AddPaintLayer(Layer* layer) {
   FML_DCHECK(layer->needs_painting());
   paint_layers_.push_back(layer);
   paint_bounds_.join(layer->paint_bounds());

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -102,7 +102,7 @@ class SceneUpdateContext {
           float elevation);
     ~Frame();
 
-    void AddPaintedLayer(Layer* layer);
+    void AddPaintLayer(Layer* layer);
 
    private:
     const SkRRect& rrect_;


### PR DESCRIPTION
Since it's adding to paint_layers_, I think the "painted" is a typo of
"paint". It's also a misleading typo which mistakenly let people believe
that the layer has already been painted.