### PR TITLE
Mark new unavailable for those init marked unavailable

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -84,6 +84,8 @@ FLUTTER_EXPORT
  */
 - (instancetype)init NS_UNAVAILABLE;
 
++ (instancetype)new NS_UNAVAILABLE;
+
 /**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
  * contains `main()`).

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.h
@@ -11,6 +11,7 @@
 
 @interface FlutterPlatformPlugin : NSObject
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 - (instancetype)initWithEngine:(fml::WeakPtr<FlutterEngine>)engine NS_DESIGNATED_INITIALIZER;
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -27,6 +27,7 @@
 @interface FlutterView : UIView
 
 - (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 - (instancetype)initWithFrame:(CGRect)frame NS_UNAVAILABLE;
 - (instancetype)initWithCoder:(NSCoder*)aDecoder NS_UNAVAILABLE;
 


### PR DESCRIPTION
When the instance method:init is unavailable, mark the class method:new unavailable.