### PR TITLE
IWYU to get SkFontMetrics

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -39,6 +39,7 @@
 
 #include "third_party/skia/include/core/SkCanvas.h"
 #include "third_party/skia/include/core/SkFont.h"
+#include "third_party/skia/include/core/SkFontMetrics.h"
 #include "third_party/skia/include/core/SkMaskFilter.h"
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkTextBlob.h"


### PR DESCRIPTION
This pending change https://skia-review.googlesource.com/c/skia/+/185460 removes SkFontMetrics.h as a transitive include. Updating call sites to IWYU.