### PR TITLE
Keep engine alive if VC is not deallocated

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -144,13 +144,15 @@
   FML_DCHECK(self.iosPlatformView);
   _viewController = [viewController getWeakPtr];
   self.iosPlatformView->SetOwnerViewController(_viewController);
-  if (!viewController && !_allowHeadlessExecution) {
+  [self maybeSetupPlatformViewChannels];
+}
+
+- (void)notifyViewControllerDeallocated {
+  if (!_allowHeadlessExecution) {
     [self resetChannels];
 
     _shell.reset();
     _threadHost.Reset();
-  } else {
-    [self maybeSetupPlatformViewChannels];
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -43,6 +43,7 @@
 - (FlutterTextInputPlugin*)textInputPlugin;
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 - (BOOL)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
+- (void)notifyViewControllerDeallocated;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -430,6 +430,7 @@
 }
 
 - (void)dealloc {
+  [_engine.get() notifyViewControllerDeallocated];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [super dealloc];
 }


### PR DESCRIPTION
See #7531 

Fixes https://github.com/flutter/flutter/issues/26660
Fixes https://github.com/flutter/flutter/issues/26848

The FlutterViewController can end up having a child view controller that makes it `viewDidDisappear`, but we don't want to get rid of the engine in that case.  We could try to track some state around that in FlutterViewController and override the presenting methods, but that seems overly complicated and likely to miss some scenario.

A solution similar to this was considered as part of #6879 but rejected at the time as feeling cumbersome.  The workflow where a FlutterViewController disappears but still needs to maintain an engine (even though it's not a "fully" headless engine) wasn't considered at the time.