### PR TITLE
Fix UIButton selector doesn't work in iOS platformview

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -416,7 +416,7 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
   [_flutterView touchesEnded:touches withEvent:event];
-  self.state = UIGestureRecognizerStateEnded;
+  self.state = UIGestureRecognizerStateFailed;
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {


### PR DESCRIPTION
1.Problem
When displaying a platform view in iOS without any 'GestureDetector' in flutter, the UIButton on that platform view doesn't get response.But the method 'releaseGesture'  in 'FlutterTouchInterceptingView'  has been executed.
2.Solution
I think the reason is that the 'ForwardingGestureRecognizer' recognize the UITouch.
In 'DelayingGestureRecognizer', it just set 'delaysTouchesBegan = YES'，so the UIButton's '- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(nullable UIEvent *)event' and the following method will not be executed.

@amirh Hi，I wish you can take some time for this.