### PR TITLE
Avoid unnecessarily creating/destroying the PlatformView

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -391,9 +391,9 @@
 
   if (_engineNeedsLaunch) {
     [_engine.get() launchEngine:nil libraryURI:nil];
+    [_engine.get() setViewController:self];
     _engineNeedsLaunch = NO;
   }
-  [_engine.get() setViewController:self];
 
   // Only recreate surface on subsequent appearances when viewport metrics are known.
   // First time surface creation is done on viewDidLayoutSubviews.
@@ -425,7 +425,6 @@
   TRACE_EVENT0("flutter", "viewDidDisappear");
   [self surfaceUpdated:NO];
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
-  [_engine.get() setViewController:nil];
   [super viewDidDisappear:animated];
 }
 


### PR DESCRIPTION
This is a fix for flutter/flutter#26966 (which could be closed once this rolls into the framework).

It still allows the ViewController to be released per the tests in ios_add2app

These changes were introduced in the release ViewController patch, but aren't necessary now since we have the ViewController notify the Engine when it's deallocated so the engine can then free up the relevant resources.

/cc @KevinTheGray @chinmaygarde