### PR TITLE
Rename FlutterResult in embedder.h

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -286,11 +286,11 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
   }
 }
 
-FlutterResult FlutterEngineRun(size_t version,
-                               const FlutterRendererConfig* config,
-                               const FlutterProjectArgs* args,
-                               void* user_data,
-                               FlutterEngine* engine_out) {
+FlutterEngineResult FlutterEngineRun(size_t version,
+                                     const FlutterRendererConfig* config,
+                                     const FlutterProjectArgs* args,
+                                     void* user_data,
+                                     FlutterEngine* engine_out) {
   // Step 0: Figure out arguments for shell creation.
   if (version != FLUTTER_ENGINE_VERSION) {
     return kInvalidLibraryVersion;
@@ -500,7 +500,7 @@ FlutterResult FlutterEngineRun(size_t version,
   return kSuccess;
 }
 
-FlutterResult FlutterEngineShutdown(FlutterEngine engine) {
+FlutterEngineResult FlutterEngineShutdown(FlutterEngine engine) {
   if (engine == nullptr) {
     return kInvalidArguments;
   }
@@ -510,7 +510,7 @@ FlutterResult FlutterEngineShutdown(FlutterEngine engine) {
   return kSuccess;
 }
 
-FlutterResult FlutterEngineSendWindowMetricsEvent(
+FlutterEngineResult FlutterEngineSendWindowMetricsEvent(
     FlutterEngine engine,
     const FlutterWindowMetricsEvent* flutter_metrics) {
   if (engine == nullptr || flutter_metrics == nullptr) {
@@ -544,9 +544,10 @@ inline blink::PointerData::Change ToPointerDataChange(
   return blink::PointerData::Change::kCancel;
 }
 
-FlutterResult FlutterEngineSendPointerEvent(FlutterEngine engine,
-                                            const FlutterPointerEvent* pointers,
-                                            size_t events_count) {
+FlutterEngineResult FlutterEngineSendPointerEvent(
+    FlutterEngine engine,
+    const FlutterPointerEvent* pointers,
+    size_t events_count) {
   if (engine == nullptr || pointers == nullptr || events_count == 0) {
     return kInvalidArguments;
   }
@@ -575,7 +576,7 @@ FlutterResult FlutterEngineSendPointerEvent(FlutterEngine engine,
              : kInvalidArguments;
 }
 
-FlutterResult FlutterEngineSendPlatformMessage(
+FlutterEngineResult FlutterEngineSendPlatformMessage(
     FlutterEngine engine,
     const FlutterPlatformMessage* flutter_message) {
   if (engine == nullptr || flutter_message == nullptr) {
@@ -600,7 +601,7 @@ FlutterResult FlutterEngineSendPlatformMessage(
              : kInvalidArguments;
 }
 
-FlutterResult FlutterEngineSendPlatformMessageResponse(
+FlutterEngineResult FlutterEngineSendPlatformMessageResponse(
     FlutterEngine engine,
     const FlutterPlatformMessageResponseHandle* handle,
     const uint8_t* data,
@@ -623,13 +624,14 @@ FlutterResult FlutterEngineSendPlatformMessageResponse(
   return kSuccess;
 }
 
-FlutterResult __FlutterEngineFlushPendingTasksNow() {
+FlutterEngineResult __FlutterEngineFlushPendingTasksNow() {
   fml::MessageLoop::GetCurrent().RunExpiredTasksNow();
   return kSuccess;
 }
 
-FlutterResult FlutterEngineRegisterExternalTexture(FlutterEngine engine,
-                                                   int64_t texture_identifier) {
+FlutterEngineResult FlutterEngineRegisterExternalTexture(
+    FlutterEngine engine,
+    int64_t texture_identifier) {
   if (engine == nullptr || texture_identifier == 0) {
     return kInvalidArguments;
   }
@@ -640,7 +642,7 @@ FlutterResult FlutterEngineRegisterExternalTexture(FlutterEngine engine,
   return kSuccess;
 }
 
-FlutterResult FlutterEngineUnregisterExternalTexture(
+FlutterEngineResult FlutterEngineUnregisterExternalTexture(
     FlutterEngine engine,
     int64_t texture_identifier) {
   if (engine == nullptr || texture_identifier == 0) {
@@ -655,7 +657,7 @@ FlutterResult FlutterEngineUnregisterExternalTexture(
   return kSuccess;
 }
 
-FlutterResult FlutterEngineMarkExternalTextureFrameAvailable(
+FlutterEngineResult FlutterEngineMarkExternalTextureFrameAvailable(
     FlutterEngine engine,
     int64_t texture_identifier) {
   if (engine == nullptr || texture_identifier == 0) {

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -24,7 +24,7 @@ typedef enum {
   kInvalidLibraryVersion,
   kInvalidArguments,
   kInternalInconsistency,
-} FlutterResult;
+} FlutterEngineResult;
 
 typedef enum {
   kOpenGL,
@@ -248,32 +248,33 @@ typedef struct {
 } FlutterProjectArgs;
 
 FLUTTER_EXPORT
-FlutterResult FlutterEngineRun(size_t version,
-                               const FlutterRendererConfig* config,
-                               const FlutterProjectArgs* args,
-                               void* user_data,
-                               FlutterEngine* engine_out);
+FlutterEngineResult FlutterEngineRun(size_t version,
+                                     const FlutterRendererConfig* config,
+                                     const FlutterProjectArgs* args,
+                                     void* user_data,
+                                     FlutterEngine* engine_out);
 
 FLUTTER_EXPORT
-FlutterResult FlutterEngineShutdown(FlutterEngine engine);
+FlutterEngineResult FlutterEngineShutdown(FlutterEngine engine);
 
 FLUTTER_EXPORT
-FlutterResult FlutterEngineSendWindowMetricsEvent(
+FlutterEngineResult FlutterEngineSendWindowMetricsEvent(
     FlutterEngine engine,
     const FlutterWindowMetricsEvent* event);
 
 FLUTTER_EXPORT
-FlutterResult FlutterEngineSendPointerEvent(FlutterEngine engine,
-                                            const FlutterPointerEvent* events,
-                                            size_t events_count);
+FlutterEngineResult FlutterEngineSendPointerEvent(
+    FlutterEngine engine,
+    const FlutterPointerEvent* events,
+    size_t events_count);
 
 FLUTTER_EXPORT
-FlutterResult FlutterEngineSendPlatformMessage(
+FlutterEngineResult FlutterEngineSendPlatformMessage(
     FlutterEngine engine,
     const FlutterPlatformMessage* message);
 
 FLUTTER_EXPORT
-FlutterResult FlutterEngineSendPlatformMessageResponse(
+FlutterEngineResult FlutterEngineSendPlatformMessageResponse(
     FlutterEngine engine,
     const FlutterPlatformMessageResponseHandle* handle,
     const uint8_t* data,
@@ -283,7 +284,7 @@ FlutterResult FlutterEngineSendPlatformMessageResponse(
 // message loop not controlled by the Flutter engine. This API will be
 // deprecated soon.
 FLUTTER_EXPORT
-FlutterResult __FlutterEngineFlushPendingTasksNow();
+FlutterEngineResult __FlutterEngineFlushPendingTasksNow();
 
 // Register an external texture with a unique (per engine) identifier. Only
 // rendering backends that support external textures accept external texture
@@ -291,18 +292,19 @@ FlutterResult __FlutterEngineFlushPendingTasksNow();
 // mark that a frame is available by calling
 // |FlutterEngineMarkExternalTextureFrameAvailable|.
 FLUTTER_EXPORT
-FlutterResult FlutterEngineRegisterExternalTexture(FlutterEngine engine,
-                                                   int64_t texture_identifier);
+FlutterEngineResult FlutterEngineRegisterExternalTexture(
+    FlutterEngine engine,
+    int64_t texture_identifier);
 
 // Unregister a previous texture registration.
 FLUTTER_EXPORT
-FlutterResult FlutterEngineUnregisterExternalTexture(
+FlutterEngineResult FlutterEngineUnregisterExternalTexture(
     FlutterEngine engine,
     int64_t texture_identifier);
 
 // Mark that a new texture frame is available for a given texture identifier.
 FLUTTER_EXPORT
-FlutterResult FlutterEngineMarkExternalTextureFrameAvailable(
+FlutterEngineResult FlutterEngineMarkExternalTextureFrameAvailable(
     FlutterEngine engine,
     int64_t texture_identifier);
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -10,9 +10,9 @@ TEST(EmbedderTest, MustNotRunWithInvalidArgs) {
   FlutterEngine engine = nullptr;
   FlutterRendererConfig config = {};
   FlutterProjectArgs args = {};
-  FlutterResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION + 1, &config,
-                                          &args, NULL, &engine);
-  ASSERT_NE(result, FlutterResult::kSuccess);
+  FlutterEngineResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION + 1,
+                                                &config, &args, NULL, &engine);
+  ASSERT_NE(result, FlutterEngineResult::kSuccess);
 }
 
 TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
@@ -31,10 +31,10 @@ TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
   args.assets_path = testing::GetFixturesPath();
 
   FlutterEngine engine = nullptr;
-  FlutterResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config,
-                                          &args, nullptr, &engine);
-  ASSERT_EQ(result, FlutterResult::kSuccess);
+  FlutterEngineResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config,
+                                                &args, nullptr, &engine);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
 
   result = FlutterEngineShutdown(engine);
-  ASSERT_EQ(result, FlutterResult::kSuccess);
+  ASSERT_EQ(result, FlutterEngineResult::kSuccess);
 }


### PR DESCRIPTION
FlutterResult is also the name of a class in the Objective-C API
surface, which is problematic when building a framework that contains
both (such as a macOS implementation of the Flutter framework).