### PR TITLE
[WIP] Migrate the engine to AndroidX

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -153,51 +153,51 @@ java_library("flutter_shell_java") {
   ]
 
   deps = [
-    ":android_support_v13",
-    ":android_support_annotations",
-    ":android_support_compat",
-    ":android_support_fragment",
-    ":android_arch_lifecycle_common",
-    ":android_arch_lifecycle_viewmodel",
+    ":androidx_legacy_support_v13",
+    ":androidx_annotation",
+    ":androidx_core",
+    ":androidx_fragment",
+    ":androidx_lifecycle_common",
+    ":androidx_lifecycle_viewmodel",
   ]
 
   jar_path = "$root_out_dir/flutter_java.jar"
 }
 
-java_prebuilt("android_support_v13") {
+java_prebuilt("androidx_legacy_support_v13") {
   supports_android = true
 
-  jar_path = "//third_party/android_support/android_support_v13.jar"
+  jar_path = "//third_party/androidx/androidx_legacy_support_v13.jar"
 }
 
-java_prebuilt("android_support_compat") {
+java_prebuilt("androidx_core") {
   supports_android = true
 
-  jar_path = "//third_party/android_support/android_support_compat.jar"
+  jar_path = "//third_party/androidx/androidx_core.jar"
 }
 
-java_prebuilt("android_support_annotations") {
+java_prebuilt("androidx_annotation") {
   supports_android = true
 
-  jar_path = "//third_party/android_support/android_support_annotations.jar"
+  jar_path = "//third_party/androidx/androidx_annotation.jar"
 }
 
-java_prebuilt("android_support_fragment") {
+java_prebuilt("androidx_fragment") {
   supports_android = true
 
-  jar_path = "//third_party/android_support/android_support_fragment.jar"
+  jar_path = "//third_party/androidx/androidx_fragment.jar"
 }
 
-java_prebuilt("android_arch_lifecycle_common") {
+java_prebuilt("androidx_lifecycle_common") {
   supports_android = true
 
-  jar_path = "//third_party/android_support/android_arch_lifecycle_common.jar"
+  jar_path = "//third_party/androidx/androidx_lifecycle_common.jar"
 }
 
-java_prebuilt("android_arch_lifecycle_viewmodel") {
+java_prebuilt("androidx_lifecycle_viewmodel") {
   supports_android = true
 
-  jar_path = "//third_party/android_support/android_arch_lifecycle_viewmodel.jar"
+  jar_path = "//third_party/androidx/androidx_lifecycle_viewmodel.jar"
 }
 
 copy("flutter_shell_assets") {

--- a/shell/platform/android/io/flutter/app/FlutterApplication.java
+++ b/shell/platform/android/io/flutter/app/FlutterApplication.java
@@ -6,7 +6,7 @@ package io.flutter.app;
 
 import android.app.Activity;
 import android.app.Application;
-import android.support.annotation.CallSuper;
+import androidx.annotation.CallSuper;
 
 import io.flutter.view.FlutterMain;
 

--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -8,7 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.support.v4.app.FragmentActivity;
+import androidx.fragment.app.FragmentActivity;
 import io.flutter.app.FlutterActivityDelegate.ViewFactory;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.view.FlutterNativeView;
@@ -101,7 +101,7 @@ public class FlutterFragmentActivity
             super.onBackPressed();
         }
     }
-        
+
     @Override
     protected void onStart() {
         super.onStart();

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -7,10 +7,10 @@ package io.flutter.embedding.engine;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.SurfaceTexture;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.UiThread;
 import android.view.Surface;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.UiThread;
 
 import java.nio.ByteBuffer;
 import java.util.HashSet;
@@ -92,7 +92,7 @@ public class FlutterJNI {
 
   @UiThread
   public static native String nativeGetObservatoryUri();
-  
+
   private Long nativePlatformViewId;
   private FlutterRenderer.RenderSurface renderSurface;
   private PlatformMessageHandler platformMessageHandler;

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -9,8 +9,8 @@ import android.graphics.Bitmap;
 import android.graphics.SurfaceTexture;
 import android.os.Build;
 import android.os.Handler;
-import android.support.annotation.NonNull;
 import android.view.Surface;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;

--- a/shell/platform/android/io/flutter/plugin/common/ErrorLogResult.java
+++ b/shell/platform/android/io/flutter/plugin/common/ErrorLogResult.java
@@ -4,8 +4,8 @@
 
 package io.flutter.plugin.common;
 
-import android.support.annotation.Nullable;
 import android.util.Log;
+import androidx.annotation.Nullable;
 
 /**
  * An implementation of {@link MethodChannel.Result} that writes error results

--- a/shell/platform/android/io/flutter/plugin/common/MethodCall.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodCall.java
@@ -4,7 +4,7 @@
 
 package io.flutter.plugin.common;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import java.util.Map;
 import org.json.JSONObject;
 

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -4,8 +4,8 @@
 
 package io.flutter.plugin.common;
 
-import android.support.annotation.Nullable;
 import android.util.Log;
+import androidx.annotation.Nullable;
 import io.flutter.plugin.common.BinaryMessenger.BinaryMessageHandler;
 import io.flutter.plugin.common.BinaryMessenger.BinaryReply;
 import java.nio.ByteBuffer;

--- a/tools/android_support/download_android_support.py
+++ b/tools/android_support/download_android_support.py
@@ -13,7 +13,7 @@ import json
 # Path constants. (All of these should be absolute paths.)
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 FLUTTER_DIR = os.path.abspath(os.path.join(THIS_DIR, '..', '..', '..'))
-INSTALL_DIR = os.path.join(FLUTTER_DIR, 'third_party', 'android_support')
+INSTALL_DIR = os.path.join(FLUTTER_DIR, 'third_party', 'androidx')
 
 def GetInstalledVersion(out_file_name):
   version_file = os.path.join(INSTALL_DIR, out_file_name + '.stamp')

--- a/tools/android_support/files.json
+++ b/tools/android_support/files.json
@@ -1,8 +1,8 @@
 {
-  "android_arch_lifecycle_common.jar": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/common/1.1.1/common-1.1.1.jar",
-  "android_arch_lifecycle_viewmodel.jar": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/viewmodel/1.1.1/viewmodel-1.1.1.aar",
-  "android_support_fragment.jar": "https://dl.google.com/dl/android/maven2/com/android/support/support-fragment/28.0.0/support-fragment-28.0.0.aar",
-  "android_support_v13.jar": "https://dl.google.com/dl/android/maven2/com/android/support/support-v13/28.0.0/support-v13-28.0.0.aar",
-  "android_support_annotations.jar": "https://dl.google.com/dl/android/maven2/com/android/support/support-annotations/28.0.0/support-annotations-28.0.0.jar",
-  "android_support_compat.jar": "https://dl.google.com/dl/android/maven2/com/android/support/support-compat/28.0.0/support-compat-28.0.0.aar"
+  "androidx_lifecycle_common.jar": "https://dl.google.com/dl/android/maven2/androidx/lifecycle/lifecycle-common/2.0.0-rc01/lifecycle-common-2.0.0-rc01.jar",
+  "androidx_lifecycle_viewmodel.jar": "https://dl.google.com/dl/android/maven2/androidx/lifecycle/lifecycle-viewmodel/2.0.0-rc01/lifecycle-viewmodel-2.0.0-rc01.aar",
+  "androidx_fragment.jar": "https://dl.google.com/dl/android/maven2/androidx/fragment/fragment/1.0.0/fragment-1.0.0.aar",
+  "androidx_legacy_support_v13.jar": "https://dl.google.com/dl/android/maven2/androidx/legacy/legacy-support-v13/1.0.0-alpha1/legacy-support-v13-1.0.0-alpha1.aar",
+  "androidx_annotation.jar": "https://dl.google.com/dl/android/maven2/androidx/annotation/annotation/1.0.0/annotation-1.0.0.jar",
+  "androidx_core.jar": "https://dl.google.com/dl/android/maven2/androidx/core/core/1.0.0/core-1.0.0.aar"
 }

--- a/tools/gen_javadoc.py
+++ b/tools/gen_javadoc.py
@@ -25,12 +25,12 @@ def main():
 
   classpath = [
     ANDROID_SRC_ROOT,
-    'third_party/android_support/android_arch_lifecycle_common.jar',
-    'third_party/android_support/android_arch_lifecycle_viewmodel.jar',
-    'third_party/android_support/android_support_annotations.jar',
-    'third_party/android_support/android_support_compat.jar',
-    'third_party/android_support/android_support_fragment.jar',
-    'third_party/android_support/android_support_v13.jar',
+    'third_party/androidx/androidx_lifecycle_common.jar',
+    'third_party/androidx/androidx_lifecycle_viewmodel.jar',
+    'third_party/androidx/androidx_annotation.jar',
+    'third_party/androidx/androidx_core.jar',
+    'third_party/androidx/androidx_fragment.jar',
+    'third_party/androidx/androidx_legacy_support_v13.jar',
     'third_party/android_tools/sdk/platforms/android-28/android.jar',
     'base/android/java/src',
     'third_party/jsr-305/src/ri/src/main/java',


### PR DESCRIPTION
Manually migrated dependencies following [the equivalency
table](https://developer.android.com/jetpack/androidx/migrate).

- android.arch.lifecycle:common -> androidx.lifecycle:lifecycle-common:2.0.0-rc01
- android.arch.lifecycle:viewmodel -> androidx.lifecycle:lifecycle-viewmodel:2.0.0-rc01
- com.android.support:support-fragment -> androidx.fragment:fragment:1.0.0
- com.android.support:support-v13 -> androidx.legacy:legacy-support-v13:1.0.0
- com.android.support:support-annotations -> androidx.annotation:annotation:1.0.0
- com.android.support:support-compat -> androidx.core:core:1.0.0