### PR TITLE
Provide public api to allow FlutterEngine related context to be destoryed

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -50,7 +50,9 @@ FLUTTER_EXPORT
  * A newly initialized engine will not run the `FlutterDartProject` until either
  * `-runWithEntrypoint:` or `-runWithEntrypoint:libraryURI:` is called.
  *
- * FlutterEngine created with this method will have allowHeadlessExecution set to YES.
+ * FlutterEngine created with this method will have allowHeadlessExecution set to `YES`.
+ * This means that the engine will continue to run regardless of whether a `FlutterViewController`
+ * is attached to it or not.
  *
  * @param labelPrefix The label prefix used to identify threads for this instance. Should
  *   be unique across FlutterEngine instances, and is used in instrumentation to label

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -50,6 +50,8 @@ FLUTTER_EXPORT
  * A newly initialized engine will not run the `FlutterDartProject` until either
  * `-runWithEntrypoint:` or `-runWithEntrypoint:libraryURI:` is called.
  *
+ * FlutterEngine created with this method will have allowHeadlessExecution set to YES.
+ *
  * @param labelPrefix The label prefix used to identify threads for this instance. Should
  *   be unique across FlutterEngine instances, and is used in instrumentation to label
  *   the threads used by this FlutterEngine.
@@ -118,6 +120,15 @@ FLUTTER_EXPORT
  * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint libraryURI:(NSString*)uri;
+
+/**
+ * Destroy running context for an engine.
+ *
+ * If you create a FlutterEngine with allowHeadlessExecution set to YES,
+ * call destroyContext explicitly when you want to release the engine.
+ *
+ */
+- (void)destroyContext;
 
 /**
  * Sets the `FlutterViewController` for this instance.  The FlutterEngine must be

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -128,7 +128,8 @@ FLUTTER_EXPORT
  *
  * This method can be used to force the FlutterEngine object to release all resources.
  * After sending this message, the object will be in an unusable state until it is deallocated.
- * Accessing properties or sending messages to it will result in undefined behavior or runtime errors.
+ * Accessing properties or sending messages to it will result in undefined behavior or runtime
+ * errors.
  */
 - (void)destroyContext;
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -52,7 +52,7 @@ FLUTTER_EXPORT
  *
  * FlutterEngine created with this method will have allowHeadlessExecution set to `YES`.
  * This means that the engine will continue to run regardless of whether a `FlutterViewController`
- * is attached to it or not.
+ * is attached to it or not, until `-destroyContext:` is called or the process finishes.
  *
  * @param labelPrefix The label prefix used to identify threads for this instance. Should
  *   be unique across FlutterEngine instances, and is used in instrumentation to label
@@ -126,9 +126,9 @@ FLUTTER_EXPORT
 /**
  * Destroy running context for an engine.
  *
- * If you create a FlutterEngine with allowHeadlessExecution set to YES,
- * call destroyContext explicitly when you want to release the engine.
- *
+ * This method can be used to force the FlutterEngine object to release all resources.
+ * After sending this message, the object will be in an unusable state until it is deallocated.
+ * Accessing properties or sending messages to it will result in undefined behavior or runtime errors.
  */
 - (void)destroyContext;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -149,11 +149,14 @@
 
 - (void)notifyViewControllerDeallocated {
   if (!_allowHeadlessExecution) {
-    [self resetChannels];
-
-    _shell.reset();
-    _threadHost.Reset();
+    [self destroyContext];
   }
+}
+
+- (void)destroyContext {
+  [self resetChannels];
+  _shell.reset();
+  _threadHost.Reset();
 }
 
 - (FlutterViewController*)viewController {


### PR DESCRIPTION
Provide public api to allow FlutterEngine related context to be destoryed so that FlutterEngine can be released when needed.

I've noticed that many developers are using 
`FlutterEngine *flutterEngine = [[FlutterEngine alloc] initWithName:@"io.flutter" project:nil];`
and they may find that the engine can't be released. (See: https://github.com/flutter/flutter/issues/27149)
In this case, allowHeadlessExecution is set YES and they can't release the engine manually.
This PR will clearly make the `allowHeadlessExecution:YES` logic available to all developers and allow them to destory the context for the engine so that they can release the engine.
It(destoryContext)'s also safe even called multiple times.