### PR TITLE
Make sure that 'setInitialRoute' works fine for a developer create engine.

### DIFF
--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -260,13 +260,19 @@ void Engine::DispatchPlatformMessage(
     HandleSettingsPlatformMessage(message.get());
     return;
   } else if (message->channel() == kNavigationChannel) {
-    HandleNavigationPlatformMessage(std::move(message));
-    return;
+    if (HandleInitialRoutePlatformMessage(std::move(message))) {
+      return;
+    }
   }
 
   if (runtime_controller_->IsRootIsolateRunning() &&
       runtime_controller_->DispatchPlatformMessage(std::move(message))) {
     return;
+  }
+
+  // TODO(kangwang1988): Do the job below when we need to deliver `platform to
+  // dart` navigation messages.
+  if (message->channel() == kNavigationChannel) {
   }
 }
 
@@ -292,7 +298,7 @@ bool Engine::HandleLifecyclePlatformMessage(blink::PlatformMessage* message) {
   return false;
 }
 
-bool Engine::HandleNavigationPlatformMessage(
+bool Engine::HandleInitialRoutePlatformMessage(
     fml::RefPtr<blink::PlatformMessage> message) {
   const auto& data = message->data();
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -259,16 +259,15 @@ void Engine::DispatchPlatformMessage(
   } else if (message->channel() == kSettingsChannel) {
     HandleSettingsPlatformMessage(message.get());
     return;
+  } else if (message->channel() == kNavigationChannel) {
+    HandleNavigationPlatformMessage(std::move(message));
+    return;
   }
 
   if (runtime_controller_->IsRootIsolateRunning() &&
       runtime_controller_->DispatchPlatformMessage(std::move(message))) {
     return;
   }
-
-  // If there's no runtime_, we may still need to set the initial route.
-  if (message->channel() == kNavigationChannel)
-    HandleNavigationPlatformMessage(std::move(message));
 }
 
 bool Engine::HandleLifecyclePlatformMessage(blink::PlatformMessage* message) {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -157,7 +157,7 @@ class Engine final : public blink::RuntimeDelegate {
 
   bool HandleLifecyclePlatformMessage(blink::PlatformMessage* message);
 
-  bool HandleNavigationPlatformMessage(
+  bool HandleInitialRoutePlatformMessage(
       fml::RefPtr<blink::PlatformMessage> message);
 
   bool HandleLocalizationPlatformMessage(blink::PlatformMessage* message);


### PR DESCRIPTION
Make sure that 'setInitialRoute' works fine when a developer creates their own engine and call runWithEntryPoint before pushing a FlutterVC.

This will fix: https://github.com/flutter/flutter/issues/27216