### PR TITLE
fix paused video player lose the last image  when the engine goes into inactive on iOS

### DIFF
--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -68,8 +68,9 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas, const SkRect& bounds, bool fr
 void IOSExternalTextureGL::OnGrContextCreated() {}
 
 void IOSExternalTextureGL::OnGrContextDestroyed() {
-//Avoid video_player showing a black background when the app goes into the background and becomes active.
-//  texture_ref_.Reset(nullptr);
+  // Avoid video_player showing a black background when the app goes into the background and becomes
+  // active.
+  //  texture_ref_.Reset(nullptr);
   cache_ref_.Reset(nullptr);
 }
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -68,7 +68,8 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas, const SkRect& bounds, bool fr
 void IOSExternalTextureGL::OnGrContextCreated() {}
 
 void IOSExternalTextureGL::OnGrContextDestroyed() {
-  texture_ref_.Reset(nullptr);
+//Avoid video_player showing a black background when the app goes into the background and becomes active.
+//  texture_ref_.Reset(nullptr);
   cache_ref_.Reset(nullptr);
 }
 


### PR DESCRIPTION
1.Problem
The video player in our application is paused when the application goes into background and will play when the app goes into foreground. In this time span the video player lose last image so it displays a white background
the issue is here https://github.com/flutter/flutter/issues/30491
2.Solution
I think the class IOSExternalTextureGL reset the member  cache_ref_  to nullptr cause the problem.  Remove that code fix the problem well and also will not cause memory leaks
@cbracken @zoechi  Hi, I wish you can take some time for this.