### PR TITLE
[embedder] Document make_resource_current on FlutterOpenGLRendererConfig and warn if the callback is not set.

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -91,6 +91,12 @@ typedef struct {
   BoolCallback clear_current;
   BoolCallback present;
   UIntCallback fbo_callback;
+  // This is an optional callback. Flutter will ask the emebdder to create a GL
+  // context current on a background thread. If the embedder is able to do so,
+  // Flutter will assume that this context is in the same sharegroup as the main
+  // rendering context and use this context for asynchronous texture uploads.
+  // Though optional, it is recommended that all embedders set this callback as
+  // it will lead to better performance in texture handling.
   BoolCallback make_resource_current;
   // By default, the renderer config assumes that the FBO does not change for
   // the duration of the engine run. If this argument is true, the

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -80,9 +80,16 @@ std::unique_ptr<Surface> EmbedderSurfaceGL::CreateGPUSurface() {
 sk_sp<GrContext> EmbedderSurfaceGL::CreateResourceContext() const {
   auto callback = gl_dispatch_table_.gl_make_resource_current_callback;
   if (callback && callback()) {
-    return IOManager::CreateCompatibleResourceLoadingContext(
-        GrBackend::kOpenGL_GrBackend);
+    if (auto context = IOManager::CreateCompatibleResourceLoadingContext(
+            GrBackend::kOpenGL_GrBackend)) {
+      return context;
+    }
   }
+
+  FML_LOG(ERROR)
+      << "Could not create a resource context for async texture uploads. "
+         "Expect degraded performance. Set a valid make_resource_current "
+         "callback on FlutterOpenGLRendererConfig.";
   return nullptr;
 }
 


### PR DESCRIPTION
Based on feedback on  b/231668456