### PR TITLE
Add FlutterProjectArgs::root_isolate_create_callback

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -361,6 +361,10 @@ FlutterEngineResult FlutterEngineRun(size_t version,
   settings.task_observer_remove = [](intptr_t key) {
     fml::MessageLoop::GetCurrent().RemoveTaskObserver(key);
   };
+  if (SAFE_ACCESS(args, root_isolate_create_callback, nullptr) != nullptr) {
+    settings.root_isolate_create_callback =
+        SAFE_ACCESS(args, root_isolate_create_callback, nullptr);
+  }
 
   // Create a thread host with the current thread as the platform thread and all
   // other threads managed.

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -362,8 +362,11 @@ FlutterEngineResult FlutterEngineRun(size_t version,
     fml::MessageLoop::GetCurrent().RemoveTaskObserver(key);
   };
   if (SAFE_ACCESS(args, root_isolate_create_callback, nullptr) != nullptr) {
-    settings.root_isolate_create_callback =
+    VoidCallback callback =
         SAFE_ACCESS(args, root_isolate_create_callback, nullptr);
+    settings.root_isolate_create_callback = [callback, user_data]() {
+      callback(user_data);
+    };
   }
 
   // Create a thread host with the current thread as the platform thread and all

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -184,6 +184,8 @@ typedef void (*FlutterPlatformMessageCallback)(
     const FlutterPlatformMessage* /* message*/,
     void* /* user data */);
 
+typedef void (*FlutterRootIsolateCreateCallback)();
+
 typedef struct {
   // The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
@@ -251,6 +253,9 @@ typedef struct {
   const uint8_t* isolate_snapshot_instructions;
   // The size of the isolate snapshot instructions buffer.
   size_t isolate_snapshot_instructions_size;
+  // The callback invoked by the engine in root isolate scope. Called
+  // immediately after the root isolate has been created and marked runnable.
+  FlutterRootIsolateCreateCallback root_isolate_create_callback;
 } FlutterProjectArgs;
 
 FLUTTER_EXPORT

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -184,8 +184,6 @@ typedef void (*FlutterPlatformMessageCallback)(
     const FlutterPlatformMessage* /* message*/,
     void* /* user data */);
 
-typedef void (*FlutterRootIsolateCreateCallback)();
-
 typedef struct {
   // The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
@@ -255,7 +253,7 @@ typedef struct {
   size_t isolate_snapshot_instructions_size;
   // The callback invoked by the engine in root isolate scope. Called
   // immediately after the root isolate has been created and marked runnable.
-  FlutterRootIsolateCreateCallback root_isolate_create_callback;
+  VoidCallback root_isolate_create_callback;
 } FlutterProjectArgs;
 
 FLUTTER_EXPORT

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -29,10 +29,16 @@ TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
   FlutterProjectArgs args = {};
   args.struct_size = sizeof(FlutterProjectArgs);
   args.assets_path = testing::GetFixturesPath();
+  args.root_isolate_create_callback = [](void* data) {
+    std::string str_data = reinterpret_cast<char*>(data);
+    ASSERT_EQ(str_data, "Data");
+  };
 
+  std::string str_data = "Data";
+  void* user_data = const_cast<char*>(str_data.c_str());
   FlutterEngine engine = nullptr;
   FlutterEngineResult result = FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config,
-                                                &args, nullptr, &engine);
+                                                &args, user_data, &engine);
   ASSERT_EQ(result, FlutterEngineResult::kSuccess);
 
   result = FlutterEngineShutdown(engine);


### PR DESCRIPTION
Allows embedders to specify a callback to be invoked in isolate scope
once root isolate has been created and marked runnable.

As an example of where this is useful, embedder unit test fixtures may
want to include Dart functions backed by a native implementation. On
isolate creation, this patch allows the unit test author to call
Dart_SetNativeResolver in root isolate scope.