### PR TITLE
DCHECK that clip layer's behavior isn't none

### DIFF
--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -13,7 +13,9 @@
 namespace flow {
 
 ClipPathLayer::ClipPathLayer(Clip clip_behavior)
-    : clip_behavior_(clip_behavior) {}
+    : clip_behavior_(clip_behavior) {
+  FML_DCHECK(clip_behavior != Clip::none);
+}
 
 ClipPathLayer::~ClipPathLayer() = default;
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -7,7 +7,9 @@
 namespace flow {
 
 ClipRectLayer::ClipRectLayer(Clip clip_behavior)
-    : clip_behavior_(clip_behavior) {}
+    : clip_behavior_(clip_behavior) {
+  FML_DCHECK(clip_behavior != Clip::none);
+}
 
 ClipRectLayer::~ClipRectLayer() = default;
 

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -7,7 +7,9 @@
 namespace flow {
 
 ClipRRectLayer::ClipRRectLayer(Clip clip_behavior)
-    : clip_behavior_(clip_behavior) {}
+    : clip_behavior_(clip_behavior) {
+  FML_DCHECK(clip_behavior != Clip::none);
+}
 
 ClipRRectLayer::~ClipRRectLayer() = default;
 


### PR DESCRIPTION
This will further guard that the framework won't forget to set the
clip behavior.

This has been tested with the flutter/flutter framework using
`flutter test --local-engine=host_debug_unopt`
to ensure a successful engine roll.