### PR TITLE
Add kernel-worker and dart2js to BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -23,6 +23,7 @@ group("flutter") {
       public_deps += [
         "$flutter_root/frontend_server",
         "//third_party/dart:create_sdk",
+        "//third_party/dart:dart2js",
       ]
     }
   }

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -24,6 +24,7 @@ group("flutter") {
         "$flutter_root/frontend_server",
         "//third_party/dart:create_sdk",
         "//third_party/dart:dart2js",
+        "//third_party/dart/utils/bazel:kernel_worker",
       ]
     }
   }


### PR DESCRIPTION
The kernel-worker is utilized by build_runner for incremental compilation to kernel. As far as I know this should have no impact on the build.