### PR TITLE
Move Brightness definition to dart:ui (#27479)

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -924,6 +924,21 @@ class AccessibilityFeatures {
   int get hashCode => _index.hashCode;
 }
 
+/// Describes the contrast of a theme or color palette.
+enum Brightness {
+  /// The color is dark and will require a light text color to achieve readable
+  /// contrast.
+  ///
+  /// For example, the color might be dark grey, requiring white text.
+  dark,
+
+  /// The color is light and will require a dark text color to achieve readable
+  /// contrast.
+  ///
+  /// For example, the color might be bright white, requiring black text.
+  light,
+}
+
 /// The [Window] singleton. This object exposes the size of the display, the
 /// core scheduler API, the input event callback, the graphics drawing API, and
 /// other such core services.


### PR DESCRIPTION
Moves the definition of Brightness to dart:ui in the engine.