### PR TITLE
Replace hb_face_reference_table with hb_ot_color_has_png in isColorBitmapFont

### DIFF
--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -286,8 +286,7 @@ hb_font_funcs_t* getHbFontFuncs(bool forColorBitmapFont) {
 
 static bool isColorBitmapFont(hb_font_t* font) {
   hb_face_t* face = hb_font_get_face(font);
-  HbBlob cbdt(hb_face_reference_table(face, HB_TAG('C', 'B', 'D', 'T')));
-  return cbdt.size() > 0;
+  return hb_ot_color_has_png(face);
 }
 
 static float HBFixedToFloat(hb_position_t v) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/27328.

This results in a significant performance improvement when rendering emojis, as no copying is done when calling hb_ot_color_has_png. 

This changes behavior somewhat - it checks for the existence of a sbix table as well as a CBDT table: https://github.com/harfbuzz/harfbuzz/blob/29db2a44a6b7a28ade5e288779dbf5a200b43acd/src/hb-ot-color.cc#L268

However, Skia supports sbix fonts so this should be supported.