### PR TITLE
Lower the threshold to raster cache pictures

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -84,7 +84,7 @@ static bool IsPictureWorthRasterizing(SkPicture* picture,
 
   // TODO(abarth): We should find a better heuristic here that lets us avoid
   // wasting memory on trivial layers that are easy to re-rasterize every frame.
-  return picture->approximateOpCount() > 10;
+  return picture->approximateOpCount() > 5;
 }
 
 static RasterCacheResult Rasterize(


### PR DESCRIPTION
After removing clips by default, the OpCount of a picture drops
significantly. That makes our old threshold suboptimal. The new
threshold reflects the clip change and will improve our scroll
performance by ~10% for complex_layout and flutter_gallery scroll
benchmarks:

(flutter_gallery) home_scroll_perf frame raster time:
average		9.1ms	-> 7.4ms
90th_percentile	11.3ms	-> 9.2ms
99th_percentile	45ms	-> 38ms

complex_layout_scroll_perf frame raster time:
average		4.8	-> 4.4ms
90th_percentile	7.8ms	-> 5.4ms
99th_percentile	19ms	-> 17ms

This should help mitigate issues like
https://github.com/flutter/flutter/issues/24782