### PR TITLE
Revert "Disable the persistent cache (#6835)"

### DIFF
--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -40,8 +40,16 @@ PersistentCache* PersistentCache::GetCacheForProcess() {
   return gPersistentCache.get();
 }
 
-PersistentCache::PersistentCache() {
-  // TODO(chinmaygarde): Reenable caching, avoiding the windows crasher.
+PersistentCache::PersistentCache()
+    : cache_directory_(std::make_shared<fml::UniqueFD>(
+          CreateDirectory(fml::paths::GetCachesDirectory(),
+                          {
+                              "flutter_engine",           //
+                              GetFlutterEngineVersion(),  //
+                              "skia",                     //
+                              GetSkiaVersion()            //
+                          },
+                          fml::FilePermission::kReadWrite))) {
   if (!IsValid()) {
     FML_LOG(WARNING) << "Could not acquire the persistent cache directory. "
                         "Caching of GPU resources on disk is disabled.";

--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -44,10 +44,10 @@ PersistentCache::PersistentCache()
     : cache_directory_(std::make_shared<fml::UniqueFD>(
           CreateDirectory(fml::paths::GetCachesDirectory(),
                           {
-                              "flutter_engine",           //
-                              GetFlutterEngineVersion(),  //
-                              "skia",                     //
-                              GetSkiaVersion()            //
+                              "flutter_engine",                  //
+                              blink::GetFlutterEngineVersion(),  //
+                              "skia",                            //
+                              blink::GetSkiaVersion()            //
                           },
                           fml::FilePermission::kReadWrite))) {
   if (!IsValid()) {


### PR DESCRIPTION
This reverts commit 093b2fea8ac09fb1e9e0d712dbdecc0a09f2c1ad.

For https://github.com/flutter/flutter/issues/24058, we now only get a
"Program linking failed" error message on Windows Android simulators
without crahsing. Skia seems to have handled the linking failure in
https://skia-review.googlesource.com/c/skia/+/180372 by rebuilding the
program.

Moreover, Skia now has GLSL persistent cache
https://skia-review.googlesource.com/c/skia/+/181564 which would reduce
shader compilation janks (https://github.com/flutter/flutter/issues/813)
on devices without binary cache capability (e.g., all iOS devices).