### PR TITLE
Revert "Lower the threshold to raster cache pictures"

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -84,7 +84,7 @@ static bool IsPictureWorthRasterizing(SkPicture* picture,
 
   // TODO(abarth): We should find a better heuristic here that lets us avoid
   // wasting memory on trivial layers that are easy to re-rasterize every frame.
-  return picture->approximateOpCount() > 5;
+  return picture->approximateOpCount() > 10;
 }
 
 static RasterCacheResult Rasterize(


### PR DESCRIPTION
Reverts flutter/engine#7687

Reason for revert: unexpected regression suspected. revert to collect more data points.