### PR TITLE
expose setMatrix for Canvas

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3237,7 +3237,7 @@ class Canvas extends NativeFieldWrapperClass2 {
       throw new ArgumentError('"matrix4" must have 16 entries.');
     _setMatrix(matrix4);
   }
-  void _setMatrix(Float64List matrix4) native "Canvas_setMatrix";
+  void _setMatrix(Float64List matrix4) native 'Canvas_setMatrix';
 
   /// Reduces the clip region to the intersection of the current clip and the
   /// given rectangle.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3211,6 +3211,11 @@ class Canvas extends NativeFieldWrapperClass2 {
 
   /// Multiply the current transform by the specified 4⨉4 transformation matrix
   /// specified as a list of values in column-major order.
+  ///
+  /// See also:
+  ///
+  ///   * [setMatrix], which replaces the current matrix rather than multiplying
+  ///     it.
   void transform(Float64List matrix4) {
     assert(matrix4 != null);
     if (matrix4.length != 16)
@@ -3218,6 +3223,21 @@ class Canvas extends NativeFieldWrapperClass2 {
     _transform(matrix4);
   }
   void _transform(Float64List matrix4) native 'Canvas_transform';
+
+  /// Set the current transform to the specified 4x4 transformation matrix
+  /// specified as a list of values in column-major order.
+  ///
+  /// See also:
+  ///
+  ///   * [transform], which multiplies the current matrix rather than replacing
+  ///     it.
+  void setMatrix(Float64List matrix4) {
+    assert(matrix4 != null);
+    if (matrix4.length != 16)
+      throw new ArgumentError('"matrix4" must have 16 entries.');
+    _setMatrix(matrix4);
+  }
+  void _setMatrix(Float64List matrix4) native "Canvas_setMatrix";
 
   /// Reduces the clip region to the intersection of the current clip and the
   /// given rectangle.

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -41,6 +41,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
   V(Canvas, rotate)                 \
   V(Canvas, skew)                   \
   V(Canvas, transform)              \
+  V(Canvas, setMatrix)              \
   V(Canvas, clipRect)               \
   V(Canvas, clipRRect)              \
   V(Canvas, clipPath)               \
@@ -154,6 +155,12 @@ void Canvas::transform(const tonic::Float64List& matrix4) {
   if (!canvas_)
     return;
   canvas_->concat(ToSkMatrix(matrix4));
+}
+
+void Canvas::setMatrix(const tonic::Float64List& matrix4) {
+  if (!canvas_)
+    return;
+  canvas_->setMatrix(ToSkMatrix(matrix4));
 }
 
 void Canvas::clipRect(double left,

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -55,6 +55,7 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
   void skew(double sx, double sy);
   void transform(const tonic::Float64List& matrix4);
 
+  void setMatrix(const tonic::Float64List& matrix4);
   void clipRect(double left,
                 double top,
                 double right,

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -76,6 +76,7 @@ void main() {
     testCanvas((Canvas canvas) => canvas.saveLayer(rect, paint));
     testCanvas((Canvas canvas) => canvas.saveLayer(null, null));
     testCanvas((Canvas canvas) => canvas.scale(double.nan, double.nan));
+    testCanvas((Canvas canvas) => canvas.setMatrix(null));
     testCanvas((Canvas canvas) => canvas.skew(double.nan, double.nan));
     testCanvas((Canvas canvas) => canvas.transform(null));
     testCanvas((Canvas canvas) => canvas.translate(double.nan, double.nan));


### PR DESCRIPTION
Currently the canvas API only provides a method for multiplying the current matrix.  I have a use case in the framework where I want to do something like this:

```dart
context.canvas.save();
context.canvas.setMatrix(Matrix4.identity().storage);
context.canvas.drawPath( // my pre-transformed path
context.canvas.restore(); // get back to whatever transforms were applied to the canvas before this
```

Unfortunately, it looks like our only tests for canvas is that the methods don't blow up.  I think to really test this we'd need some kind of golden, as the canvas doesn't expose any information about its current matrix.