### PR TITLE
Allow all entrypoints support by the command line VM.

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -178,7 +178,7 @@ typedef _BinaryFunction(Null args, Null message);
 void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction) {
   startMainIsolateFunction((){
     runZoned<Future<void>>(() {
-      List<String> empty_args = [];
+      const List<String> empty_args = <String>[];
       if (userMainFunction is _BinaryFunction) {
         // This seems to be undocumented but supported by the command line VM.
         // Let's do the same in case old entry-points are ported to Flutter.

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -168,7 +168,9 @@ void _drawFrame() {
   _invoke(window.onDrawFrame, window._onDrawFrameZone);
 }
 
+// ignore: always_declare_return_types, prefer_generic_function_type_aliases
 typedef _UnaryFunction(Null args);
+// ignore: always_declare_return_types, prefer_generic_function_type_aliases
 typedef _BinaryFunction(Null args, Null message);
 
 @pragma('vm:entry-point')
@@ -180,7 +182,7 @@ void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction)
       if (userMainFunction is _BinaryFunction) {
         // This seems to be undocumented but supported by the command line VM.
         // Let's do the same in case old entry-points are ported to Flutter.
-        (userMainFunction as dynamic)(empty_args, "");
+        (userMainFunction as dynamic)(empty_args, '');
       } else if (userMainFunction is _UnaryFunction) {
         (userMainFunction as dynamic)(empty_args);
       } else {

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -168,12 +168,24 @@ void _drawFrame() {
   _invoke(window.onDrawFrame, window._onDrawFrameZone);
 }
 
+typedef _UnaryFunction(Null args);
+typedef _BinaryFunction(Null args, Null message);
+
 @pragma('vm:entry-point')
 // ignore: unused_element
 void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction) {
   startMainIsolateFunction((){
     runZoned<Future<void>>(() {
-      userMainFunction();
+      List<String> empty_args = [];
+      if (userMainFunction is _BinaryFunction) {
+        // This seems to be undocumented but supported by the command line VM.
+        // Let's do the same in case old entry-points are ported to Flutter.
+        (userMainFunction as dynamic)(empty_args, "");
+      } else if (userMainFunction is _UnaryFunction) {
+        (userMainFunction as dynamic)(empty_args);
+      } else {
+        userMainFunction();
+      }
     }, onError: (Object error, StackTrace stackTrace) {
       _reportUnhandledException(error.toString(), stackTrace.toString());
     });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/27617. Uses the same logic in `isolate_patch.dart`.