### PR TITLE
Add support for sending generated character with key events.

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -173,7 +173,6 @@ public class FlutterView extends SurfaceView
         mImm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         mTextInputPlugin = new TextInputPlugin(this);
 
-
         setLocales(getResources().getConfiguration());
         sendUserPlatformSettingsToDart();
     }

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -173,6 +173,7 @@ public class FlutterView extends SurfaceView
         mImm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         mTextInputPlugin = new TextInputPlugin(this);
 
+
         setLocales(getResources().getConfiguration());
         sendUserPlatformSettingsToDart();
     }


### PR DESCRIPTION
This adds a "character" key in the key event message that gives the framework the character that was generated as a result of a keypress, including handling combining characters for composed characters.

Also, the "plainCodePoint" is added, which gives the generated Unicode code point as if no modifiers were pressed.

This is needed by the key handling changes for the framework in an upcoming PR.

Submitting this doesn't break anything for existing code (it just sends an extra key that is ignored).