### PR TITLE
Fix versions implementation

### DIFF
--- a/lib/ui/versions.cc
+++ b/lib/ui/versions.cc
@@ -25,7 +25,7 @@ void GetVersions(Dart_NativeArguments args) {
 }
 
 void Versions::RegisterNatives(tonic::DartLibraryNatives* natives) {
-  natives->Register({{"Versions_getVersions", GetVersions, 1, true}});
+  natives->Register({{"Versions_getVersions", GetVersions, 0, true}});
 }
 
 }  // namespace blink

--- a/testing/dart/versions_test.dart
+++ b/testing/dart/versions_test.dart
@@ -2,12 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// HACK: pretend to be dart.ui in order to access its internals
-library dart.ui;
+import 'dart:ui';
 
 import 'package:test/test.dart';
-
-part '../../lib/ui/versions.dart';
 
 bool _isNotEmpty(String s) {
   if (s == null || s.isEmpty) {


### PR DESCRIPTION
As implemented currently, versions throws an error because of an off-by-one issue with the native registration:

```
 error: native function 'Versions_getVersions' (0 arguments) cannot be found
  dart:ui/versions.dart 13:35                    new Versions._internal
(etc.)
```

Unfortunately, the test wasn't actually testing the implementation.  It looks like the test file was modeled after window_hooks_integration_test.dart, which needs to fake being part of dart:ui to access internals.  We really should just rewrite that so we're not testing internal implementation details, or so that we're exposing relevant bits (see https://github.com/flutter/flutter/issues/27628)

I've updated the native registration and the test.