### PR TITLE
Use all font managers to discover fonts for strut.

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -178,26 +178,6 @@ FontCollection::GetMinikinFontCollectionForFamilies(
   return font_collection;
 }
 
-minikin::MinikinFont* FontCollection::GetMinikinFontForFamilies(
-    const std::vector<std::string>& font_families,
-    minikin::FontStyle style) {
-  std::shared_ptr<minikin::FontFamily> font_family = nullptr;
-  for (std::string family_name : font_families) {
-    font_family = FindFontFamilyInManagers(family_name);
-    if (font_family != nullptr) {
-      break;
-    }
-  }
-  if (font_family == nullptr) {
-    const auto default_font_family = GetDefaultFontFamily();
-    font_family = FindFontFamilyInManagers(default_font_family);
-  }
-  if (font_family == nullptr) {
-    return nullptr;
-  }
-  return font_family.get()->getClosestMatch(style).font;
-}
-
 std::shared_ptr<minikin::FontFamily> FontCollection::FindFontFamilyInManagers(
     const std::string& family_name) {
   // Search for the font family in each font manager.

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -49,10 +49,6 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
       const std::vector<std::string>& font_families,
       const std::string& locale);
 
-  minikin::MinikinFont* GetMinikinFontForFamilies(
-      const std::vector<std::string>& font_families,
-      minikin::FontStyle style);
-
   // Provides a FontFamily that contains glyphs for ch. This caches previously
   // matched fonts. Also see FontCollection::DoMatchFallbackFont.
   const std::shared_ptr<minikin::FontFamily>& MatchFallbackFont(

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -441,32 +441,24 @@ void Paragraph::ComputeStrut(StrutMetrics* strut, SkFont& font) {
   // force_strut makes all lines have exactly the strut metrics, and ignores all
   // actual metrics. We only force the strut if the strut is non-zero and valid.
   strut->force_strut = paragraph_style_.force_strut_height && valid_strut;
-  const FontSkia* font_skia =
-      static_cast<const FontSkia*>(font_collection_->GetMinikinFontForFamilies(
-          paragraph_style_.strut_font_families,
-          // TODO(garyq): The variant is currently set to 0 (default) as we do
-          // not have a property to set it with. We should eventually support
-          // default, compact, and elegant variants.
-          minikin::FontStyle(
-              0, GetWeight(paragraph_style_.strut_font_weight),
-              paragraph_style_.strut_font_style == FontStyle::italic)));
+  minikin::FontStyle minikin_font_style(
+      0, GetWeight(paragraph_style_.strut_font_weight),
+      paragraph_style_.strut_font_style == FontStyle::italic);
 
-  if (font_skia != nullptr) {
-    font.setTypeface(font_skia->GetSkTypeface());
+  std::shared_ptr<minikin::FontCollection> collection =
+      font_collection_->GetMinikinFontCollectionForFamilies(
+          paragraph_style_.strut_font_families, "");
+  if (!collection) {
+    return;
+  }
+  minikin::FakedFont faked_font = collection->baseFontFaked(minikin_font_style);
+
+  if (faked_font.font != nullptr) {
+    font.setTypeface(static_cast<FontSkia*>(faked_font.font)->GetSkTypeface());
     font.setSize(paragraph_style_.strut_font_size);
     SkFontMetrics strut_metrics;
     font.getMetrics(&strut_metrics);
-    SkString name;
-    // if (font_skia->GetSkTypeface() != nullptr) {
-    if (font.getTypefaceOrDefault() != nullptr) {
-      FML_DLOG(ERROR) << "Has typeface";
-      font.getTypefaceOrDefault()->getFamilyName(&name);
-    } else {
-      name.append("Null typeface");
-    }
-    std::string str(name.c_str());
-    str.append("HELLO");
-    FML_DLOG(ERROR) << strut_metrics.fAscent << " " << str;
+
     strut->ascent = paragraph_style_.strut_height * -strut_metrics.fAscent;
     strut->descent = paragraph_style_.strut_height * strut_metrics.fDescent;
     strut->leading =

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -456,7 +456,17 @@ void Paragraph::ComputeStrut(StrutMetrics* strut, SkFont& font) {
     font.setSize(paragraph_style_.strut_font_size);
     SkFontMetrics strut_metrics;
     font.getMetrics(&strut_metrics);
-
+    SkString name;
+    // if (font_skia->GetSkTypeface() != nullptr) {
+    if (font.getTypefaceOrDefault() != nullptr) {
+      FML_DLOG(ERROR) << "Has typeface";
+      font.getTypefaceOrDefault()->getFamilyName(&name);
+    } else {
+      name.append("Null typeface");
+    }
+    std::string str(name.c_str());
+    str.append("HELLO");
+    FML_DLOG(ERROR) << strut_metrics.fAscent << " " << str;
     strut->ascent = paragraph_style_.strut_height * -strut_metrics.fAscent;
     strut->descent = paragraph_style_.strut_height * strut_metrics.fDescent;
     strut->leading =

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -2708,7 +2708,7 @@ TEST_F(ParagraphTest, FontFallbackParagraph) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   // The chinese extra height should be absorbed by the strut.
   const char* text = "01234満毎冠p来É本可\nabcd\n満毎É行p昼本可";
   auto icu_text = icu::UnicodeString::fromUTF8(text);
@@ -2720,7 +2720,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   paragraph_style.strut_font_families = std::vector<std::string>(1, "BlahFake");
   paragraph_style.strut_font_families.push_back("ahem");
   paragraph_style.strut_font_size = 50;
-  paragraph_style.strut_height = 1.5;
+  paragraph_style.strut_height = 1.8;
   paragraph_style.strut_leading = 0.1;
   paragraph_style.strut_enabled = true;
 
@@ -2734,7 +2734,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   text_style.font_weight = FontWeight::w500;
   text_style.word_spacing = 0;
   text_style.color = SK_ColorBLACK;
-  text_style.height = 1;
+  text_style.height = .5;
   builder.PushStyle(text_style);
 
   builder.AddText(u16_text);
@@ -2773,9 +2773,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 84.5);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -2784,9 +2784,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 95);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -2795,9 +2795,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 84.5);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -2806,9 +2806,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 95);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -2817,9 +2817,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 208.31348);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 224.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 267);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 285);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -2828,9 +2828,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 297.31348);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 319.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 356);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 380);
 
   ASSERT_TRUE(Snapshot());
 }
@@ -2840,7 +2840,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
   // This string is all one size and smaller than the strut metrics.
   const char* text = "01234ABCDEFGH\nabcd\nABCDEFGH";
   auto icu_text = icu::UnicodeString::fromUTF8(text);
@@ -2902,9 +2902,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 83.229004);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 74);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -2913,9 +2913,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 91);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -2924,9 +2924,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 83.229004);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 74);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -2935,9 +2935,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 91);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -2946,9 +2946,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 215.229);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 184);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 273);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 240);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -2957,9 +2957,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 306.229);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 264);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 364);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 320);
 
   ASSERT_TRUE(Snapshot());
 }
@@ -2969,7 +2969,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   // The strut is too small to absorb the extra chinese height, but the english
   // second line height is increased due to strut.
   const char* text = "01234満毎p行来昼本可\nabcd\n満毎冠行来昼本可";
@@ -2981,7 +2981,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   paragraph_style.max_lines = 10;
   paragraph_style.strut_font_families = std::vector<std::string>(1, "ahem");
   paragraph_style.strut_font_size = 50;
-  paragraph_style.strut_height = 1.1;
+  paragraph_style.strut_height = 1.2;
   paragraph_style.strut_enabled = true;
   txt::ParagraphBuilder builder(paragraph_style, GetTestFontCollection());
 
@@ -3032,9 +3032,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60.526855);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 58);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -3043,9 +3043,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 63);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -3054,9 +3054,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60.526855);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 58);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -3065,9 +3065,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 63);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -3076,9 +3076,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 136.52686);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 128);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 189);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 180);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -3087,9 +3087,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 199.52686);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 188);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 252);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 240);
 
   ASSERT_TRUE(Snapshot());
 }
@@ -3099,7 +3099,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
   // The strut is too small to absorb the extra chinese height, but the english
   // second line height is increased due to strut.
   const char* text = "01234満毎冠行来昼本可\nabcd\n満毎冠行来昼本可";
@@ -3163,9 +3163,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 72.5);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -3174,9 +3174,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -3185,9 +3185,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 72.5);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -3196,9 +3196,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -3207,9 +3207,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 208.31348);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 182.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 267);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 240);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -3218,9 +3218,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 297.31348);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 262.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 356);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 320);
 
   ASSERT_TRUE(Snapshot());
 }


### PR DESCRIPTION
This is a much better and more correct way to obtain direct font metrics using the existing API.

This rolls back FontCollection::GetMinikinFontForFamilies as it is no longer necessary or correct.

Will require a manual engine roll as this changes tests that were written against the old version.