### PR TITLE
Use correct flags on LUCI/legacy

### DIFF
--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -24,6 +24,15 @@ if [[ -n "${GEM_HOME}" ]]
     PATH="${GEM_HOME}/bin:$PATH"
 fi
 
+# Jazzy 0.8.x, used on chrome infra, expects --no-download-badge
+# Jazzy 0.9.x, used on LUCI, doesn't support that flag.
+noDownloadBadge=""
+if [[ -z "$LUCI_CONTEXT" ]]
+  then
+    noDownloadBadge="--no-download-badge"
+fi
+
+
 # Use iPhoneSimulator SDK
 # See: https://github.com/realm/jazzy/issues/791
 jazzy \
@@ -39,4 +48,4 @@ jazzy \
   --module Flutter\
   --root-url https://docs.flutter.io/objc/\
   --output "$1"\
-  --no-download-badge
+  $noDownloadBadge


### PR DESCRIPTION
Jazzy 0.8.x crashes on LUCI, but 0.9.x appears to work fine.

Jazzy 0.9.x doesn't support the --no-download-badge.

Eventually this can be reverted when we cut over to LUCI permanently