### PR TITLE
Provide a default pressure range if a MotionEvent does not have a device

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -472,10 +472,15 @@ public class FlutterView extends SurfaceView
 
         packet.putLong(0); // obscured
 
-        InputDevice.MotionRange pressureRange = event.getDevice().getMotionRange(MotionEvent.AXIS_PRESSURE);
         packet.putDouble(event.getPressure(pointerIndex)); // pressure
-        packet.putDouble(pressureRange.getMin()); // pressure_min
-        packet.putDouble(pressureRange.getMax()); // pressure_max
+        if (event.getDevice() != null) {
+            InputDevice.MotionRange pressureRange = event.getDevice().getMotionRange(MotionEvent.AXIS_PRESSURE);
+            packet.putDouble(pressureRange.getMin()); // pressure_min
+            packet.putDouble(pressureRange.getMax()); // pressure_max
+        } else {
+            packet.putDouble(0.0); // pressure_min
+            packet.putDouble(1.0); // pressure_max
+        }
 
         if (pointerKind == kPointerDeviceKindStylus) {
             packet.putDouble(event.getAxisValue(MotionEvent.AXIS_DISTANCE, pointerIndex)); // distance


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/27641