### PR TITLE
use full git hash for version

### DIFF
--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -31,7 +31,6 @@ def main():
     '-C',
     repository,
     'rev-parse',
-    '--short',
     'HEAD',
   ])
 


### PR DESCRIPTION
This will enable us to more reliably compare engine.version with the version here.