### PR TITLE
Support for loading dynamic patches in AOT mode.

### DIFF
--- a/shell/platform/android/io/flutter/view/ResourceUpdater.java
+++ b/shell/platform/android/io/flutter/view/ResourceUpdater.java
@@ -319,12 +319,12 @@ public final class ResourceUpdater {
         }
 
         CRC32 checksum = new CRC32();
-        String[] files = {
+        String[] checksumFiles = {
             "isolate_snapshot_data",
             "isolate_snapshot_instr",
             "flutter_assets/isolate_snapshot_data",
         };
-        for (String fn : files) {
+        for (String fn : checksumFiles) {
             AssetManager manager = context.getResources().getAssets();
             try (InputStream is = manager.open(fn)) {
                 int count = 0;

--- a/shell/platform/android/io/flutter/view/ResourceUpdater.java
+++ b/shell/platform/android/io/flutter/view/ResourceUpdater.java
@@ -318,31 +318,35 @@ public final class ResourceUpdater {
             return false;
         }
 
-        final AssetManager manager = context.getResources().getAssets();
-        try (InputStream is = manager.open("flutter_assets/isolate_snapshot_data")) {
-            CRC32 checksum = new CRC32();
-
-            int count = 0;
-            byte[] buffer = new byte[BUFFER_SIZE];
-            while ((count = is.read(buffer, 0, BUFFER_SIZE)) != -1) {
-                checksum.update(buffer, 0, count);
+        CRC32 checksum = new CRC32();
+        String[] files = {
+            "isolate_snapshot_data",
+            "isolate_snapshot_instr",
+            "flutter_assets/isolate_snapshot_data",
+        };
+        for (String fn : files) {
+            AssetManager manager = context.getResources().getAssets();
+            try (InputStream is = manager.open(fn)) {
+                int count = 0;
+                byte[] buffer = new byte[BUFFER_SIZE];
+                while ((count = is.read(buffer, 0, BUFFER_SIZE)) != -1) {
+                    checksum.update(buffer, 0, count);
+                }
+            } catch (IOException e) {
+                // Skip missing files.
             }
+        }
 
-            if (!baselineChecksum.equals(String.valueOf(checksum.getValue()))) {
-                Log.w(TAG, "Mismatched update file for APK");
-                return false;
-            }
-
-            return true;
-
-        } catch (IOException e) {
-            Log.w(TAG, "Could not read APK: " + e);
+        if (!baselineChecksum.equals(String.valueOf(checksum.getValue()))) {
+            Log.w(TAG, "Mismatched update file for APK");
             return false;
         }
+
+        return true;
     }
 
     void startUpdateDownloadOnce() {
-        if (downloadTask != null ) {
+        if (downloadTask != null) {
             return;
         }
         downloadTask = new DownloadTask();


### PR DESCRIPTION
Before this change, when a dynamic patch was installed, it only validated the checksum of the original JIT snapshot. Now, the checksum will be validated for either AOT snapshot or JIT snapshot, whichever is found in the APK. This allows installing dynamic patches also in AOT mode.

Also see https://github.com/flutter/flutter/pull/27672 that implements building of AOT dynamic patches.