### PR TITLE
Add flutter config to macOS targets

### DIFF
--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -61,6 +61,8 @@ source_set("framework_shared") {
   set_sources_assignment_filter(sources_assignment_filter)
 
   defines = [ "FLUTTER_FRAMEWORK" ]
+
+  public_configs = [ "$flutter_root:config" ]
 }
 
 executable("flutter_channels_unittests") {
@@ -78,4 +80,6 @@ executable("flutter_channels_unittests") {
     "$flutter_root/testing",
     "//third_party/dart/runtime:libdart_jit",
   ]
+
+  public_configs = [ "$flutter_root:config" ]
 }


### PR DESCRIPTION
In 9345274 (#7642), //shell/platform/darwin:framework_shared was added
without the root flutter config, causing a build breakage in Fuchsia,
where flutter sits under //third_party/flutter as opposed to at the
root. The flutter root config is required to set -I../../third_party as
an include path.