### PR TITLE
Recommended implementation of combining characters implementation.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -439,6 +439,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterFragmentActi
 FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/dart/PlatformMessageHandler.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -108,6 +108,7 @@ java_library("flutter_shell_java") {
     "io/flutter/app/FlutterPluginRegistry.java",
     "io/flutter/embedding/engine/FlutterEngine.java",
     "io/flutter/embedding/engine/FlutterJNI.java",
+    "io/flutter/embedding/engine/android/AndroidKeyProcessor.java",
     "io/flutter/embedding/engine/dart/DartExecutor.java",
     "io/flutter/embedding/engine/dart/DartMessenger.java",
     "io/flutter/embedding/engine/dart/PlatformMessageHandler.java",

--- a/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
@@ -1,0 +1,70 @@
+package io.flutter.embedding.engine.android;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+
+import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
+
+public class AndroidKeyProcessor {
+  private final KeyEventChannel keyEventChannel;
+  private int baseCharacter;
+
+  public AndroidKeyProcessor(@NonNull KeyEventChannel keyEventChannel) {
+    this.keyEventChannel = keyEventChannel;
+  }
+
+  public void onKeyUp(@NonNull KeyEvent keyEvent) {
+    Character complexCharacter = applyKeyToBaseCharacter(keyEvent.getUnicodeChar());
+    keyEventChannel.keyUp(
+        new KeyEventChannel.FlutterKeyEvent(keyEvent, complexCharacter)
+    );
+  }
+
+  public void onKeyDown(@NonNull KeyEvent keyEvent) {
+    Character complexCharacter = applyKeyToBaseCharacter(keyEvent.getUnicodeChar());
+    keyEventChannel.keyDown(
+        new KeyEventChannel.FlutterKeyEvent(keyEvent, complexCharacter)
+    );
+  }
+
+  /**
+   * Applies the given unicode character in {@code codePoint} to a previously entered
+   * unicode character and returns the combination of these characters if a combination
+   * exists.
+   *
+   * If the given unicode character is the first to be pressed in a session, or if
+   * the new unicode character cannot be combined with the previous unicode character,
+   * null is returned.
+   *
+   * This method mutates {@link #baseCharacter} over time to combine characters.
+   */
+  @Nullable
+  private Character applyKeyToBaseCharacter(int codePoint) {
+    if (codePoint == 0) {
+      return null;
+    }
+
+    if ((codePoint & KeyCharacterMap.COMBINING_ACCENT) != 0) {
+      // If a combining character was entered before, combine this one with that one.
+      int plainCodePoint = codePoint & KeyCharacterMap.COMBINING_ACCENT_MASK;
+      if (baseCharacter != 0) {
+        baseCharacter = KeyCharacterMap.getDeadChar(baseCharacter, plainCodePoint);
+      } else {
+        baseCharacter = plainCodePoint;
+      }
+    } else {
+      if (baseCharacter != 0) {
+        int combinedChar = KeyCharacterMap.getDeadChar(baseCharacter, codePoint);
+        if (combinedChar > 0) {
+          codePoint = combinedChar;
+        }
+        baseCharacter = 0;
+      }
+      return (char) codePoint;
+    }
+
+    return null;
+  }
+}

--- a/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
@@ -39,7 +39,7 @@ public class AndroidKeyProcessor {
    * One of the following things happens in this method:
    * <ul>
    *   <li>If no previous {@link #combiningCharacter} exists and the {@code newCharacterCodePoint}
-   *   is not a combining character, then nothing happens and null is returned.</li>
+   *   is not a combining character, then nothing happens and {@code newCharacterCodePoint} is returned.</li>
    *   <li>If no previous {@link #combiningCharacter} exists and the {@code newCharacterCodePoint}
    *   is a combining character, then {@code newCharacterCodePoint} is saved as the
    *   {@link #combiningCharacter} and null is returned.</li>
@@ -61,7 +61,7 @@ public class AndroidKeyProcessor {
       return null;
     }
 
-    Character complexCharacter = null;
+    Character complexCharacter = (char) newCharacterCodePoint;
     boolean isNewCodePointACombiningCharacter = (newCharacterCodePoint & KeyCharacterMap.COMBINING_ACCENT) != 0;
     if (isNewCodePointACombiningCharacter) {
       // If a combining character was entered before, combine this one with that one.

--- a/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
@@ -39,7 +39,7 @@ public class AndroidKeyProcessor {
    * One of the following things happens in this method:
    * <ul>
    *   <li>If no previous {@link #combiningCharacter} exists and the {@code newCharacterCodePoint}
-   *   is not a combining character, then nothing happens and {@code newCharacterCodePoint} is returned.</li>
+   *   is not a combining character, then {@code newCharacterCodePoint} is returned.</li>
    *   <li>If no previous {@link #combiningCharacter} exists and the {@code newCharacterCodePoint}
    *   is a combining character, then {@code newCharacterCodePoint} is saved as the
    *   {@link #combiningCharacter} and null is returned.</li>

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
@@ -47,6 +47,7 @@ public class KeyEventChannel {
 
   private void encodeKeyEvent(@NonNull FlutterKeyEvent event, @NonNull Map<String, Object> message) {
     message.put("flags", event.flags);
+    message.put("plainCodePoint", event.plainCodePoint);
     message.put("codePoint", event.codePoint);
     message.put("keyCode", event.keyCode);
     message.put("scanCode", event.scanCode);
@@ -61,6 +62,7 @@ public class KeyEventChannel {
    */
   public static class FlutterKeyEvent {
     public final int flags;
+    public final int plainCodePoint;
     public final int codePoint;
     public final int keyCode;
     @Nullable
@@ -80,6 +82,7 @@ public class KeyEventChannel {
     ) {
       this(
           androidKeyEvent.getFlags(),
+          androidKeyEvent.getUnicodeChar(0x0),
           androidKeyEvent.getUnicodeChar(),
           androidKeyEvent.getKeyCode(),
           complexCharacter,
@@ -90,6 +93,7 @@ public class KeyEventChannel {
 
     public FlutterKeyEvent(
         int flags,
+        int plainCodePoint,
         int codePoint,
         int keyCode,
         @Nullable Character complexCharacter,
@@ -97,6 +101,7 @@ public class KeyEventChannel {
         int metaState
     ) {
       this.flags = flags;
+      this.plainCodePoint = plainCodePoint;
       this.codePoint = codePoint;
       this.keyCode = keyCode;
       this.complexCharacter = complexCharacter;

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.engine.systemchannels;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.KeyEvent;
 
 import java.util.HashMap;
@@ -26,7 +27,7 @@ public class KeyEventChannel {
     this.channel = new BasicMessageChannel<>(dartExecutor, "flutter/keyevent", JSONMessageCodec.INSTANCE);
   }
 
-  public void keyUp(@NonNull KeyEvent keyEvent) {
+  public void keyUp(@NonNull FlutterKeyEvent keyEvent) {
     Map<String, Object> message = new HashMap<>();
     message.put("type", "keyup");
     message.put("keymap", "android");
@@ -35,7 +36,7 @@ public class KeyEventChannel {
     channel.send(message);
   }
 
-  public void keyDown(@NonNull KeyEvent keyEvent) {
+  public void keyDown(@NonNull FlutterKeyEvent keyEvent) {
     Map<String, Object> message = new HashMap<>();
     message.put("type", "keydown");
     message.put("keymap", "android");
@@ -44,11 +45,63 @@ public class KeyEventChannel {
     channel.send(message);
   }
 
-  private void encodeKeyEvent(@NonNull KeyEvent event, @NonNull Map<String, Object> message) {
-    message.put("flags", event.getFlags());
-    message.put("codePoint", event.getUnicodeChar());
-    message.put("keyCode", event.getKeyCode());
-    message.put("scanCode", event.getScanCode());
-    message.put("metaState", event.getMetaState());
+  private void encodeKeyEvent(@NonNull FlutterKeyEvent event, @NonNull Map<String, Object> message) {
+    message.put("flags", event.flags);
+    message.put("codePoint", event.codePoint);
+    message.put("keyCode", event.keyCode);
+    message.put("scanCode", event.scanCode);
+    message.put("metaState", event.metaState);
+    if (event.complexCharacter != null) {
+      message.put("character", event.complexCharacter.toString());
+    }
+  }
+
+  /**
+   * Key event as defined by Flutter.
+   */
+  public static class FlutterKeyEvent {
+    public final int flags;
+    public final int codePoint;
+    public final int keyCode;
+    @Nullable
+    public final Character complexCharacter;
+    public final int scanCode;
+    public final int metaState;
+
+    public FlutterKeyEvent(
+        @NonNull KeyEvent androidKeyEvent
+    ) {
+      this(androidKeyEvent, null);
+    }
+
+    public FlutterKeyEvent(
+        @NonNull KeyEvent androidKeyEvent,
+        @Nullable Character complexCharacter
+    ) {
+      this(
+          androidKeyEvent.getFlags(),
+          androidKeyEvent.getUnicodeChar(),
+          androidKeyEvent.getKeyCode(),
+          complexCharacter,
+          androidKeyEvent.getScanCode(),
+          androidKeyEvent.getMetaState()
+      );
+    }
+
+    public FlutterKeyEvent(
+        int flags,
+        int codePoint,
+        int keyCode,
+        @Nullable Character complexCharacter,
+        int scanCode,
+        int metaState
+    ) {
+      this.flags = flags;
+      this.codePoint = codePoint;
+      this.keyCode = keyCode;
+      this.complexCharacter = complexCharacter;
+      this.scanCode = scanCode;
+      this.metaState = metaState;
+    }
   }
 }

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -26,6 +26,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import io.flutter.app.FlutterPluginRegistry;
+import io.flutter.embedding.engine.android.AndroidKeyProcessor;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
 import io.flutter.embedding.engine.systemchannels.LifecycleChannel;
@@ -93,6 +94,7 @@ public class FlutterView extends SurfaceView
     private final SystemChannel systemChannel;
     private final InputMethodManager mImm;
     private final TextInputPlugin mTextInputPlugin;
+    private final AndroidKeyProcessor androidKeyProcessor;
     private final SurfaceHolder.Callback mSurfaceCallback;
     private final ViewportMetrics mMetrics;
     private final AccessibilityManager mAccessibilityManager;
@@ -172,7 +174,7 @@ public class FlutterView extends SurfaceView
         addActivityLifecycleListener(platformPlugin);
         mImm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         mTextInputPlugin = new TextInputPlugin(this);
-
+        androidKeyProcessor = new AndroidKeyProcessor(keyEventChannel);
 
         setLocales(getResources().getConfiguration());
         sendUserPlatformSettingsToDart();
@@ -183,7 +185,7 @@ public class FlutterView extends SurfaceView
         if (!isAttached()) {
             return super.onKeyUp(keyCode, event);
         }
-        keyEventChannel.keyUp(event);
+        androidKeyProcessor.onKeyUp(event);
         return super.onKeyUp(keyCode, event);
     }
 
@@ -199,7 +201,7 @@ public class FlutterView extends SurfaceView
             }
         }
 
-        keyEventChannel.keyDown(event);
+        androidKeyProcessor.onKeyDown(event);
         return super.onKeyDown(keyCode, event);
     }
 


### PR DESCRIPTION
This is a recommended approach to achieve the behavior in https://github.com/flutter/engine/pull/7722 without introducing state into the KeyEventChannel.

The approach in this recommendation roughly follows the breakdown that can be seen between `TextInputPlugin` and `TextInputChannel` as well as `AccessibilityBridge` and `AccessibilityChannel`.  At the moment those examples are only visible, themselves, in another PR:
https://github.com/flutter/engine/pull/7738

Specific recommendations in this PR:

 * Utilize channels as stateless definitions of boundary APIs and message structures
 * Introduce a dedicated class responsible for mutating information over time that flows through a given channel
 * Define a `FlutterKeyEvent` which explicitly declares all of the information that Flutter might want for a key event, regardless of what Android reports in its standard `KeyEvent`
 * Don't use Hungarian notation (mSomething, sSomething)
 * I also renamed `combiningCharacters` to `baseCharacter` based on my reading of the javadocs.  That might be wrong.  The crux of the issue is that I'm not (and probably most people are not) familiar with this level of key encoding behavior.  Therefore, I would recommend excessively commenting this new code with links to relevant docs and/or explanations of these concepts that an average reader may have never heard of.