### PR TITLE
Allow specifying the out directory prefix

### DIFF
--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -2,7 +2,7 @@
 echo "Analyzing dart:ui library..."
 RESULTS=`dartanalyzer                                                          \
   --options flutter/analysis_options.yaml                                      \
-  out/host_debug_unopt/gen/sky/bindings/dart_ui/ui.dart                        \
+  "$1out/host_debug_unopt/gen/sky/bindings/dart_ui/ui.dart"                    \
   2>&1                                                                         \
   | grep -Ev "No issues found!"                                          \
   | grep -Ev "Analyzing.+out/host_debug_unopt/gen/sky/bindings/dart_ui/ui\.dart"`


### PR DESCRIPTION
This makes the first parameter to the script be the location of the out directory.  I'd like to make this configurable for LUCI.

If it's not specified, it should behave as previously.