### PR TITLE
Refactor ios play input sound logic.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -13,6 +13,7 @@
 namespace {
 
 constexpr char kTextPlainFormat[] = "text/plain";
+const UInt32 kKeyPressClickSoundId = 1306;
 
 }  // namespaces
 
@@ -94,7 +95,7 @@ using namespace shell;
   if ([soundType isEqualToString:@"SystemSoundType.click"]) {
     // All feedback types are specific to Android and are treated as equal on
     // iOS.
-    AudioServicesPlaySystemSound(1306);
+    AudioServicesPlaySystemSound(kKeyPressClickSoundId);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -93,9 +93,8 @@ using namespace shell;
 - (void)playSystemSound:(NSString*)soundType {
   if ([soundType isEqualToString:@"SystemSoundType.click"]) {
     // All feedback types are specific to Android and are treated as equal on
-    // iOS. The surface must (and does) adopt the UIInputViewAudioFeedback
-    // protocol
-    [[UIDevice currentDevice] playInputClick];
+    // iOS.
+    AudioServicesPlaySystemSound(1306);
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -17,10 +17,6 @@
 #include "flutter/shell/platform/darwin/ios/ios_surface_software.h"
 #include "third_party/skia/include/utils/mac/SkCGUtils.h"
 
-@interface FlutterView () <UIInputViewAudioFeedback>
-
-@end
-
 @implementation FlutterView
 
 id<FlutterViewEngineDelegate> _delegate;
@@ -95,10 +91,6 @@ id<FlutterViewEngineDelegate> _delegate;
     return std::make_unique<shell::IOSSurfaceSoftware>(std::move(layer),
                                                        [_delegate platformViewsController]);
   }
-}
-
-- (BOOL)enableInputClicksWhenVisible {
-  return YES;
 }
 
 - (void)drawLayer:(CALayer*)layer inContext:(CGContextRef)context {


### PR DESCRIPTION
As there are extra requirement to use playInputClick in iOS, use AudioServicesPlaySystemSound instead to play input sound.
This will also fix https://github.com/flutter/flutter/issues/27768 .
See http://iphonedevwiki.net/index.php/AudioServices for the sound codes.