### PR TITLE
Add space metrics tracking for trailing whitespace "ghost" runs.

### DIFF
--- a/third_party/txt/src/txt/paint_record.cc
+++ b/third_party/txt/src/txt/paint_record.cc
@@ -26,24 +26,28 @@ PaintRecord::PaintRecord(TextStyle style,
                          sk_sp<SkTextBlob> text,
                          SkFontMetrics metrics,
                          size_t line,
-                         double run_width)
+                         double run_width,
+                         bool is_ghost)
     : style_(style),
       offset_(offset),
       text_(std::move(text)),
       metrics_(metrics),
       line_(line),
-      run_width_(run_width) {}
+      run_width_(run_width),
+      is_ghost_(is_ghost) {}
 
 PaintRecord::PaintRecord(TextStyle style,
                          sk_sp<SkTextBlob> text,
                          SkFontMetrics metrics,
                          size_t line,
-                         double run_width)
+                         double run_width,
+                         bool is_ghost)
     : style_(style),
       text_(std::move(text)),
       metrics_(metrics),
       line_(line),
-      run_width_(run_width) {}
+      run_width_(run_width),
+      is_ghost_(is_ghost) {}
 
 PaintRecord::PaintRecord(PaintRecord&& other) {
   style_ = other.style_;
@@ -51,7 +55,7 @@ PaintRecord::PaintRecord(PaintRecord&& other) {
   text_ = std::move(other.text_);
   metrics_ = other.metrics_;
   line_ = other.line_;
-  run_width_ = other.run_width_;
+  run_width_ = other.run_width_, is_ghost_ = other.is_ghost_;
 }
 
 PaintRecord& PaintRecord::operator=(PaintRecord&& other) {
@@ -61,6 +65,7 @@ PaintRecord& PaintRecord::operator=(PaintRecord&& other) {
   metrics_ = other.metrics_;
   line_ = other.line_;
   run_width_ = other.run_width_;
+  is_ghost_ = other.is_ghost_;
   return *this;
 }
 

--- a/third_party/txt/src/txt/paint_record.h
+++ b/third_party/txt/src/txt/paint_record.h
@@ -39,13 +39,15 @@ class PaintRecord {
               sk_sp<SkTextBlob> text,
               SkFontMetrics metrics,
               size_t line,
-              double run_width);
+              double run_width,
+              bool is_ghost);
 
   PaintRecord(TextStyle style,
               sk_sp<SkTextBlob> text,
               SkFontMetrics metrics,
               size_t line,
-              double run_width);
+              double run_width,
+              bool is_ghost);
 
   PaintRecord(PaintRecord&& other);
 
@@ -65,6 +67,8 @@ class PaintRecord {
 
   double GetRunWidth() const { return run_width_; }
 
+  bool isGhost() const { return is_ghost_; }
+
  private:
   TextStyle style_;
   // offset_ is the overall offset of the origin of the SkTextBlob.
@@ -75,6 +79,9 @@ class PaintRecord {
   SkFontMetrics metrics_;
   size_t line_;
   double run_width_ = 0.0f;
+  // 'Ghost' runs represent trailing whitespace. 'Ghost' runs should not have
+  // decorations painted on them and do not impact layout of visible glyphs.
+  bool is_ghost_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PaintRecord);
 };

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -271,9 +271,11 @@ class Paragraph {
 
   class BidiRun {
    public:
+    // Constructs a BidiRun with is_ghost defaulted to false.
     BidiRun(size_t s, size_t e, TextDirection d, const TextStyle& st)
         : start_(s), end_(e), direction_(d), style_(&st), is_ghost_(false) {}
 
+    // Constructs a BidiRun with a custom is_ghost flag.
     BidiRun(size_t s,
             size_t e,
             TextDirection d,
@@ -286,6 +288,7 @@ class Paragraph {
     TextDirection direction() const { return direction_; }
     const TextStyle& style() const { return *style_; }
     bool is_rtl() const { return direction_ == TextDirection::rtl; }
+    // Tracks if the run represents trailing whitespace.
     bool is_ghost() const { return is_ghost_; }
 
    private:

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -272,18 +272,27 @@ class Paragraph {
   class BidiRun {
    public:
     BidiRun(size_t s, size_t e, TextDirection d, const TextStyle& st)
-        : start_(s), end_(e), direction_(d), style_(&st) {}
+        : start_(s), end_(e), direction_(d), style_(&st), is_ghost_(false) {}
+
+    BidiRun(size_t s,
+            size_t e,
+            TextDirection d,
+            const TextStyle& st,
+            bool is_ghost)
+        : start_(s), end_(e), direction_(d), style_(&st), is_ghost_(is_ghost) {}
 
     size_t start() const { return start_; }
     size_t end() const { return end_; }
     TextDirection direction() const { return direction_; }
     const TextStyle& style() const { return *style_; }
     bool is_rtl() const { return direction_ == TextDirection::rtl; }
+    bool is_ghost() const { return is_ghost_; }
 
    private:
     size_t start_, end_;
     TextDirection direction_;
     const TextStyle* style_;
+    bool is_ghost_;
   };
 
   struct GlyphPosition {

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -419,7 +419,8 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
   ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
   ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
   ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
-  ASSERT_EQ(paragraph->records_.size(), paragraph_style.max_lines);
+  // Two records for each due to 'ghost' trailing whitespace run.
+  ASSERT_EQ(paragraph->records_.size(), paragraph_style.max_lines * 2);
   double expected_y = 24;
 
   ASSERT_TRUE(paragraph->records_[0].style().equals(text_style));
@@ -431,15 +432,6 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
           paragraph->breaker_.getWidths()[paragraph->records_[0].line()],
       2.0);
 
-  ASSERT_TRUE(paragraph->records_[1].style().equals(text_style));
-  ASSERT_DOUBLE_EQ(paragraph->records_[1].offset().y(), expected_y);
-  expected_y += 30;
-  ASSERT_NEAR(
-      paragraph->records_[1].offset().x(),
-      paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[1].line()],
-      2.0);
-
   ASSERT_TRUE(paragraph->records_[2].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[2].offset().y(), expected_y);
   expected_y += 30;
@@ -449,21 +441,30 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
           paragraph->breaker_.getWidths()[paragraph->records_[2].line()],
       2.0);
 
-  ASSERT_TRUE(paragraph->records_[3].style().equals(text_style));
-  ASSERT_DOUBLE_EQ(paragraph->records_[3].offset().y(), expected_y);
-  expected_y += 30 * 10;
+  ASSERT_TRUE(paragraph->records_[4].style().equals(text_style));
+  ASSERT_DOUBLE_EQ(paragraph->records_[4].offset().y(), expected_y);
+  expected_y += 30;
   ASSERT_NEAR(
-      paragraph->records_[3].offset().x(),
+      paragraph->records_[4].offset().x(),
       paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[3].line()],
+          paragraph->breaker_.getWidths()[paragraph->records_[4].line()],
       2.0);
 
-  ASSERT_TRUE(paragraph->records_[13].style().equals(text_style));
-  ASSERT_DOUBLE_EQ(paragraph->records_[13].offset().y(), expected_y);
+  ASSERT_TRUE(paragraph->records_[6].style().equals(text_style));
+  ASSERT_DOUBLE_EQ(paragraph->records_[6].offset().y(), expected_y);
+  expected_y += 30 * 10;
   ASSERT_NEAR(
-      paragraph->records_[13].offset().x(),
+      paragraph->records_[6].offset().x(),
       paragraph->width_ -
-          paragraph->breaker_.getWidths()[paragraph->records_[13].line()],
+          paragraph->breaker_.getWidths()[paragraph->records_[6].line()],
+      2.0);
+
+  ASSERT_TRUE(paragraph->records_[26].style().equals(text_style));
+  ASSERT_DOUBLE_EQ(paragraph->records_[26].offset().y(), expected_y);
+  ASSERT_NEAR(
+      paragraph->records_[26].offset().x(),
+      paragraph->width_ -
+          paragraph->breaker_.getWidths()[paragraph->records_[26].line()],
       2.0);
 
   ASSERT_EQ(paragraph_style.text_align,
@@ -528,7 +529,8 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(CenterAlignParagraph)) {
   ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
   ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
   ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
-  ASSERT_EQ(paragraph->records_.size(), paragraph_style.max_lines);
+  // Two records for each due to 'ghost' trailing whitespace run.
+  ASSERT_EQ(paragraph->records_.size(), paragraph_style.max_lines * 2);
   double expected_y = 24;
 
   ASSERT_TRUE(paragraph->records_[0].style().equals(text_style));
@@ -537,15 +539,6 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(CenterAlignParagraph)) {
   ASSERT_NEAR(paragraph->records_[0].offset().x(),
               (paragraph->width_ -
                paragraph->breaker_.getWidths()[paragraph->records_[0].line()]) /
-                  2,
-              2.0);
-
-  ASSERT_TRUE(paragraph->records_[1].style().equals(text_style));
-  ASSERT_DOUBLE_EQ(paragraph->records_[1].offset().y(), expected_y);
-  expected_y += 30;
-  ASSERT_NEAR(paragraph->records_[1].offset().x(),
-              (paragraph->width_ -
-               paragraph->breaker_.getWidths()[paragraph->records_[1].line()]) /
                   2,
               2.0);
 
@@ -558,21 +551,30 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(CenterAlignParagraph)) {
                   2,
               2.0);
 
-  ASSERT_TRUE(paragraph->records_[3].style().equals(text_style));
-  ASSERT_DOUBLE_EQ(paragraph->records_[3].offset().y(), expected_y);
-  expected_y += 30 * 10;
-  ASSERT_NEAR(paragraph->records_[3].offset().x(),
+  ASSERT_TRUE(paragraph->records_[4].style().equals(text_style));
+  ASSERT_DOUBLE_EQ(paragraph->records_[4].offset().y(), expected_y);
+  expected_y += 30;
+  ASSERT_NEAR(paragraph->records_[4].offset().x(),
               (paragraph->width_ -
-               paragraph->breaker_.getWidths()[paragraph->records_[3].line()]) /
+               paragraph->breaker_.getWidths()[paragraph->records_[4].line()]) /
                   2,
               2.0);
 
-  ASSERT_TRUE(paragraph->records_[13].style().equals(text_style));
-  ASSERT_DOUBLE_EQ(paragraph->records_[13].offset().y(), expected_y);
+  ASSERT_TRUE(paragraph->records_[6].style().equals(text_style));
+  ASSERT_DOUBLE_EQ(paragraph->records_[6].offset().y(), expected_y);
+  expected_y += 30 * 10;
+  ASSERT_NEAR(paragraph->records_[6].offset().x(),
+              (paragraph->width_ -
+               paragraph->breaker_.getWidths()[paragraph->records_[6].line()]) /
+                  2,
+              2.0);
+
+  ASSERT_TRUE(paragraph->records_[26].style().equals(text_style));
+  ASSERT_DOUBLE_EQ(paragraph->records_[26].offset().y(), expected_y);
   ASSERT_NEAR(
-      paragraph->records_[13].offset().x(),
+      paragraph->records_[26].offset().x(),
       (paragraph->width_ -
-       paragraph->breaker_.getWidths()[paragraph->records_[13].line()]) /
+       paragraph->breaker_.getWidths()[paragraph->records_[26].line()]) /
           2,
       2.0);
 
@@ -1713,7 +1715,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeCenterParagraph)) {
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 346.04492);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 346.04492);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 358.49414);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 59);
 
   paint.setColor(SK_ColorRED);
@@ -1821,7 +1823,7 @@ TEST_F(ParagraphTest,
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 346.04492);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 346.04492);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 358.49414);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 59);
 
   paint.setColor(SK_ColorBLACK);
@@ -1845,7 +1847,7 @@ TEST_F(ParagraphTest,
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 331.83594);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 59.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 331.83594);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 419.18359);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 118);
 
   paint.setColor(SK_ColorRED);
@@ -2366,7 +2368,7 @@ TEST_F(ParagraphTest, Ellipsize) {
 
   // Check that the ellipsizer limited the text to one line and did not wrap
   // to a second line.
-  ASSERT_EQ(paragraph->records_.size(), 1ull);
+  ASSERT_EQ(paragraph->records_.size(), 2ull);
 }
 
 // Test for shifting when identical runs of text are built as multiple runs.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/26658.

This adds the concept of a "ghost" run representing trailing whitespace where it does not impact the layout of visible glyphs, but does have metrics as if it existed in GetRectsForRange().

Previously, these space metrics were discarded.

This allows trailing spaces to appear at the end of center and right aligned text without changing the alignment.

Will require a manual engine roll as it breaks one test in the framework specifically testing for this (https://github.com/flutter/flutter/pull/27808)