### PR TITLE
Do not short-circuit font resolution too early

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -152,10 +152,6 @@ FontCollection::GetMinikinFontCollectionForFamilies(
       minikin_families.push_back(minikin_family);
     }
   }
-  // Default font family also not found. We fail to get a FontCollection.
-  if (minikin_families.empty()) {
-    return nullptr;
-  }
   if (enable_font_fallback_) {
     for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
       auto it = fallback_fonts_.find(fallback_family);
@@ -163,6 +159,10 @@ FontCollection::GetMinikinFontCollectionForFamilies(
         minikin_families.push_back(it->second);
       }
     }
+  }
+  // Default font family also not found. We fail to get a FontCollection.
+  if (minikin_families.empty()) {
+    return nullptr;
   }
   // Create the minikin font collection.
   auto font_collection =


### PR DESCRIPTION
When no user-specified or default fonts were found, we were completely skipping the system fallback font logic.