### PR TITLE
Revert "Use all font managers to discover fonts for strut. (#7734)"

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -178,6 +178,26 @@ FontCollection::GetMinikinFontCollectionForFamilies(
   return font_collection;
 }
 
+minikin::MinikinFont* FontCollection::GetMinikinFontForFamilies(
+    const std::vector<std::string>& font_families,
+    minikin::FontStyle style) {
+  std::shared_ptr<minikin::FontFamily> font_family = nullptr;
+  for (std::string family_name : font_families) {
+    font_family = FindFontFamilyInManagers(family_name);
+    if (font_family != nullptr) {
+      break;
+    }
+  }
+  if (font_family == nullptr) {
+    const auto default_font_family = GetDefaultFontFamily();
+    font_family = FindFontFamilyInManagers(default_font_family);
+  }
+  if (font_family == nullptr) {
+    return nullptr;
+  }
+  return font_family.get()->getClosestMatch(style).font;
+}
+
 std::shared_ptr<minikin::FontFamily> FontCollection::FindFontFamilyInManagers(
     const std::string& family_name) {
   // Search for the font family in each font manager.

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -49,6 +49,10 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
       const std::vector<std::string>& font_families,
       const std::string& locale);
 
+  minikin::MinikinFont* GetMinikinFontForFamilies(
+      const std::vector<std::string>& font_families,
+      minikin::FontStyle style);
+
   // Provides a FontFamily that contains glyphs for ch. This caches previously
   // matched fonts. Also see FontCollection::DoMatchFallbackFont.
   const std::shared_ptr<minikin::FontFamily>& MatchFallbackFont(

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -441,20 +441,18 @@ void Paragraph::ComputeStrut(StrutMetrics* strut, SkFont& font) {
   // force_strut makes all lines have exactly the strut metrics, and ignores all
   // actual metrics. We only force the strut if the strut is non-zero and valid.
   strut->force_strut = paragraph_style_.force_strut_height && valid_strut;
-  minikin::FontStyle minikin_font_style(
-      0, GetWeight(paragraph_style_.strut_font_weight),
-      paragraph_style_.strut_font_style == FontStyle::italic);
+  const FontSkia* font_skia =
+      static_cast<const FontSkia*>(font_collection_->GetMinikinFontForFamilies(
+          paragraph_style_.strut_font_families,
+          // TODO(garyq): The variant is currently set to 0 (default) as we do
+          // not have a property to set it with. We should eventually support
+          // default, compact, and elegant variants.
+          minikin::FontStyle(
+              0, GetWeight(paragraph_style_.strut_font_weight),
+              paragraph_style_.strut_font_style == FontStyle::italic)));
 
-  std::shared_ptr<minikin::FontCollection> collection =
-      font_collection_->GetMinikinFontCollectionForFamilies(
-          paragraph_style_.strut_font_families, "");
-  if (!collection) {
-    return;
-  }
-  minikin::FakedFont faked_font = collection->baseFontFaked(minikin_font_style);
-
-  if (faked_font.font != nullptr) {
-    font.setTypeface(static_cast<FontSkia*>(faked_font.font)->GetSkTypeface());
+  if (font_skia != nullptr) {
+    font.setTypeface(font_skia->GetSkTypeface());
     font.setSize(paragraph_style_.strut_font_size);
     SkFontMetrics strut_metrics;
     font.getMetrics(&strut_metrics);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -2755,7 +2755,7 @@ TEST_F(ParagraphTest, FontFallbackParagraph) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph1)) {
   // The chinese extra height should be absorbed by the strut.
   const char* text = "01234満毎冠p来É本可\nabcd\n満毎É行p昼本可";
   auto icu_text = icu::UnicodeString::fromUTF8(text);
@@ -2767,7 +2767,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   paragraph_style.strut_font_families = std::vector<std::string>(1, "BlahFake");
   paragraph_style.strut_font_families.push_back("ahem");
   paragraph_style.strut_font_size = 50;
-  paragraph_style.strut_height = 1.8;
+  paragraph_style.strut_height = 1.5;
   paragraph_style.strut_leading = 0.1;
   paragraph_style.strut_enabled = true;
 
@@ -2781,7 +2781,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   text_style.font_weight = FontWeight::w500;
   text_style.word_spacing = 0;
   text_style.color = SK_ColorBLACK;
-  text_style.height = .5;
+  text_style.height = 1;
   builder.PushStyle(text_style);
 
   builder.AddText(u16_text);
@@ -2820,9 +2820,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 84.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -2831,9 +2831,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 95);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -2842,9 +2842,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 84.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -2853,9 +2853,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 34.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 95);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -2864,9 +2864,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 224.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 208.31348);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 285);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 267);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -2875,9 +2875,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 319.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 297.31348);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 380);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 356);
 
   ASSERT_TRUE(Snapshot());
 }
@@ -2887,7 +2887,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph1)) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph2)) {
   // This string is all one size and smaller than the strut metrics.
   const char* text = "01234ABCDEFGH\nabcd\nABCDEFGH";
   auto icu_text = icu::UnicodeString::fromUTF8(text);
@@ -2949,9 +2949,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 74);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 83.229004);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -2960,9 +2960,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 91);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -2971,9 +2971,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 74);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 83.229004);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -2982,9 +2982,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 33.229004);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 91);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -2993,9 +2993,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 184);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 215.229);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 240);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 273);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -3004,9 +3004,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 264);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 306.229);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 320);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 364);
 
   ASSERT_TRUE(Snapshot());
 }
@@ -3016,7 +3016,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph2)) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutParagraph3)) {
   // The strut is too small to absorb the extra chinese height, but the english
   // second line height is increased due to strut.
   const char* text = "01234満毎p行来昼本可\nabcd\n満毎冠行来昼本可";
@@ -3028,7 +3028,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   paragraph_style.max_lines = 10;
   paragraph_style.strut_font_families = std::vector<std::string>(1, "ahem");
   paragraph_style.strut_font_size = 50;
-  paragraph_style.strut_height = 1.2;
+  paragraph_style.strut_height = 1.1;
   paragraph_style.strut_enabled = true;
   txt::ParagraphBuilder builder(paragraph_style, GetTestFontCollection());
 
@@ -3079,9 +3079,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 58);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60.526855);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -3090,9 +3090,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 63);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -3101,9 +3101,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 58);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60.526855);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -3112,9 +3112,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 8);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 10.526855);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 60);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 63);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -3123,9 +3123,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 128);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 136.52686);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 180);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 189);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -3134,9 +3134,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 199.52686);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 240);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 252);
 
   ASSERT_TRUE(Snapshot());
 }
@@ -3146,7 +3146,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutParagraph3)) {
 //
 // TODO(garyq): Re-enable strut tests, allow font metric fakery, or
 // consolidate skia font metric behavior.
-TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
+TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(DISABLED_StrutForceParagraph)) {
   // The strut is too small to absorb the extra chinese height, but the english
   // second line height is increased due to strut.
   const char* text = "01234満毎冠行来昼本可\nabcd\n満毎冠行来昼本可";
@@ -3210,9 +3210,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 72.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
 
   boxes = paragraph->GetRectsForRange(0, 1, rect_height_max_style,
                                       rect_width_style);
@@ -3221,9 +3221,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
 
   boxes =
       paragraph->GetRectsForRange(6, 10, rect_height_style, rect_width_style);
@@ -3232,9 +3232,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 72.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80.313477);
 
   boxes = paragraph->GetRectsForRange(6, 10, rect_height_max_style,
                                       rect_width_style);
@@ -3243,9 +3243,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 22.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 30.313477);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 500);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89);
 
   boxes = paragraph->GetRectsForRange(14, 16, rect_height_max_style,
                                       rect_width_style);
@@ -3254,9 +3254,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 182.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 208.31348);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 100);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 240);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 267);
 
   boxes = paragraph->GetRectsForRange(20, 25, rect_height_max_style,
                                       rect_width_style);
@@ -3265,9 +3265,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(StrutForceParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 50);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 262.5);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 297.31348);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 300);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 320);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 356);
 
   ASSERT_TRUE(Snapshot());
 }


### PR DESCRIPTION
This reverts commit c4a55552b5f07fdb0bb1db73df08a1843dd7e5a8.

This change blocks the roll and has further font-consistency problems to resolve first.