### PR TITLE
Add support for new Scenic clip planes.

### DIFF
--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -32,7 +32,7 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 void ClipRRectLayer::UpdateScene(SceneUpdateContext& context) {
   FML_DCHECK(needs_system_composite());
 
-  // TODO(MZ-137): Need to be able to express the radii as vectors.
+  // TODO(SCN-137): Need to be able to express the radii as vectors.
   scenic::RoundedRectangle shape(
       context.session(),                                   // session
       clip_rrect_.width(),                                 //  width


### PR DESCRIPTION
Uses SetClipPlanesCmd in addition to the old clipping approach.
Flutter will use both clipping methods during a transition period
(Scenic will select internally which one to use).