### PR TITLE
Use newer Skia API for PathMeasure

### DIFF
--- a/lib/ui/painting/path_measure.h
+++ b/lib/ui/painting/path_measure.h
@@ -5,10 +5,12 @@
 #ifndef FLUTTER_LIB_UI_PAINTING_PATH_MEASURE_H_
 #define FLUTTER_LIB_UI_PAINTING_PATH_MEASURE_H_
 
+#include <vector>
+
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/path.h"
+#include "third_party/skia/include/core/SkContourMeasure.h"
 #include "third_party/skia/include/core/SkPath.h"
-#include "third_party/skia/include/core/SkPathMeasure.h"
 #include "third_party/tonic/typed_data/float64_list.h"
 
 namespace tonic {
@@ -30,22 +32,24 @@ class CanvasPathMeasure : public RefCountedDartWrappable<CanvasPathMeasure> {
                                                bool forceClosed);
 
   void setPath(const CanvasPath* path, bool isClosed);
-  float getLength();
-  tonic::Float32List getPosTan(float distance);
-  fml::RefPtr<CanvasPath> getSegment(float startD,
+  float getLength(int contourIndex);
+  tonic::Float32List getPosTan(int contourIndex, float distance);
+  fml::RefPtr<CanvasPath> getSegment(int contourIndex,
+                                     float startD,
                                      float stopD,
                                      bool startWithMoveTo);
-  bool isClosed();
+  bool isClosed(int contourIndex);
   bool nextContour();
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
-  const SkPathMeasure& pathMeasure() const { return *path_measure_; }
+  const SkContourMeasureIter& pathMeasure() const { return *path_measure_; }
 
  private:
   CanvasPathMeasure();
 
-  std::unique_ptr<SkPathMeasure> path_measure_;
+  std::unique_ptr<SkContourMeasureIter> path_measure_;
+  std::vector<sk_sp<SkContourMeasure>> measures_;
 };
 
 }  // namespace blink

--- a/testing/dart/path_test.dart
+++ b/testing/dart/path_test.dart
@@ -210,9 +210,11 @@ void main() {
     print(metrics);
     expect(metrics[0].length, 20);
     expect(metrics[0].isClosed, true);
-    expect(() => metrics[0].getTangentForOffset(4.0), throwsStateError);
-    expect(() => metrics[0].getTangentForOffset(4.0), throwsStateError);
+    expect(() => metrics[0].getTangentForOffset(4.0), isNotNull);
+    expect(() => metrics[0].extractPath(4.0, 10.0), isNotNull);
     expect(metrics[1].length, 10);
     expect(metrics[1].isClosed, false);
+    expect(() => metrics[1].getTangentForOffset(4.0), isNotNull);
+    expect(() => metrics[1].extractPath(4.0, 10.0), isNotNull);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/27139

Skia refactored the API for this as of https://skia-review.googlesource.com/c/skia/+/187922 - we can now support the methods exposed here even if the iterator has advanced beyond the current contour.

This allows us to avoid throwing if someone tries to access some members of the `PathMetric` class when the iterator isn't on the expected contour.

@jonahwilliams - do I have to update anything in the ui_stub folder for this?