### PR TITLE
Expose more pointer phases in embedder.h

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -540,6 +540,7 @@ FlutterEngineResult FlutterEngineSendWindowMetricsEvent(
              : kInvalidArguments;
 }
 
+// Returns the blink::PointerData::Change for the given FlutterPointerPhase.
 inline blink::PointerData::Change ToPointerDataChange(
     FlutterPointerPhase phase) {
   switch (phase) {
@@ -551,6 +552,12 @@ inline blink::PointerData::Change ToPointerDataChange(
       return blink::PointerData::Change::kDown;
     case kMove:
       return blink::PointerData::Change::kMove;
+    case kAdd:
+      return blink::PointerData::Change::kAdd;
+    case kRemove:
+      return blink::PointerData::Change::kRemove;
+    case kHover:
+      return blink::PointerData::Change::kHover;
   }
   return blink::PointerData::Change::kCancel;
 }

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -148,6 +148,9 @@ typedef enum {
   kUp,
   kDown,
   kMove,
+  kAdd,
+  kRemove,
+  kHover,
 } FlutterPointerPhase;
 
 typedef struct {


### PR DESCRIPTION
Adds 'add', 'remove', and 'hover' to the set of pointer phases that are
available to embedders. This is necessary for them to send hover events
to the engine.