### PR TITLE
Fix typo in painting.dart

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2317,7 +2317,7 @@ class PathMetric {
 
 class _PathMeasure extends NativeFieldWrapperClass2 {
   _PathMeasure(Path path, bool forceClosed) {
-    currentContourIndex = -1; // nextContour will incremenet this to the zero based index.
+    currentContourIndex = -1; // nextContour will increment this to the zero based index.
     _constructor(path, forceClosed);
   }
   void _constructor(Path path, bool forceClosed) native 'PathMeasure_constructor';


### PR DESCRIPTION
I missed this in #7809 - thought I had pushed up the change and realized I hadn't saved in my local editor.