### PR TITLE
Delete GL textures when they are released from the texture registry.

### DIFF
--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -16,7 +16,11 @@ AndroidExternalTextureGL::AndroidExternalTextureGL(
     const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture)
     : Texture(id), surface_texture_(surfaceTexture), transform(SkMatrix::I()) {}
 
-AndroidExternalTextureGL::~AndroidExternalTextureGL() = default;
+AndroidExternalTextureGL::~AndroidExternalTextureGL() {
+  if (state_ == AttachmentState::attached) {
+    glDeleteTextures(1, &texture_name_);
+  }
+}
 
 void AndroidExternalTextureGL::OnGrContextCreated() {
   state_ = AttachmentState::uninitialized;

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -134,8 +134,8 @@ public class FlutterRenderer implements TextureRegistry {
       if (released) {
         return;
       }
-      unregisterTexture(id);
       surfaceTexture.release();
+      unregisterTexture(id);
       released = true;
     }
   }

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -1128,11 +1128,16 @@ public class FlutterView extends SurfaceView
                 return;
             }
             released = true;
-            mNativeView.getFlutterJNI().unregisterTexture(id);
+
+            // The ordering of the next 3 calls is important:
+            // First we remove the frame listener, then we release the SurfaceTexture, and only after we unregister
+            // the texture which actually deletes the GL texture.
+
             // Otherwise onFrameAvailableListener might be called after mNativeView==null
             // (https://github.com/flutter/flutter/issues/20951). See also the check in onFrameAvailable.
             surfaceTexture.setOnFrameAvailableListener(null);
             surfaceTexture.release();
+            mNativeView.getFlutterJNI().unregisterTexture(id);
         }
     }
 }


### PR DESCRIPTION
On Android we were never deleting the textures allocated for
the texture registry, which resulted in a memory leak, see:
https://github.com/flutter/flutter/issues/24145