### PR TITLE
Fix NullPointerException in SurfaceTextureRegistryEntry

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -1102,7 +1102,7 @@ public class FlutterView extends SurfaceView
         private SurfaceTexture.OnFrameAvailableListener onFrameListener = new SurfaceTexture.OnFrameAvailableListener() {
             @Override
             public void onFrameAvailable(SurfaceTexture texture) {
-                if (released) {
+                if (released || mNativeView == null) {
                     // Even though we make sure to unregister the callback before releasing, as of Android O
                     // SurfaceTexture has a data race when accessing the callback, so the callback may
                     // still be called by a stale reference after released==true and mNativeView==null.


### PR DESCRIPTION
In rare cases, the following crash is recorded in our Google Play Store Console.

```
java.lang.NullPointerException: 
  at io.flutter.view.FlutterView$SurfaceTextureRegistryEntry$1.onFrameAvailable (FlutterView.java:1081)
  at android.graphics.SurfaceTexture$1.handleMessage (SurfaceTexture.java:206)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:280)
  at android.app.ActivityThread.main (ActivityThread.java:6710)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:858)
```

Flutter 1.1.8
