### PR TITLE
Fix NullPointerException in ResourceCleaner

### DIFF
--- a/shell/platform/android/io/flutter/view/ResourceCleaner.java
+++ b/shell/platform/android/io/flutter/view/ResourceCleaner.java
@@ -27,7 +27,7 @@ class ResourceCleaner {
         }
 
         boolean hasFilesToDelete() {
-            return mFilesToDelete.length > 0;
+            return mFilesToDelete != null && mFilesToDelete.length > 0;
         }
 
         @Override


### PR DESCRIPTION
In rare cases, the following crash is recorded in our Google Play Store Console.

```
java.lang.RuntimeException: 
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:5908)
  at android.app.ActivityThread.access$1100 (ActivityThread.java:205)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1656)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loop (Looper.java:280)
  at android.app.ActivityThread.main (ActivityThread.java:6710)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:858)
Caused by: java.lang.NullPointerException: 
  at io.flutter.view.ResourceCleaner$CleanTask.hasFilesToDelete (ResourceCleaner.java:30)
  at io.flutter.view.ResourceCleaner.start (ResourceCleaner.java:74)
  at io.flutter.view.FlutterMain.initResources (FlutterMain.java:259)
  at io.flutter.view.FlutterMain.startInitialization (FlutterMain.java:160)
  at io.flutter.view.FlutterMain.startInitialization (FlutterMain.java:138)
  at io.flutter.app.FlutterApplication.onCreate (FlutterApplication.java:22)
  at me.cartune.android.MyApplication.onCreate (MyApplication.java:50)
  at android.app.Instrumentation.callApplicationOnCreate (Instrumentation.java:1155)
  at android.app.ActivityThread.handleBindApplication (ActivityThread.java:5903)
```

Flutter 1.1.8

File#listFiles may return null.

>  Returns null if this abstract pathname does not denote a directory, or if an I/O error occurs.

https://developer.android.com/reference/java/io/File#listFiles()
