### PR TITLE
Add support for calling into other plugins from a background context on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -16,6 +16,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 @protocol FlutterPluginRegistrar;
+@protocol FlutterPluginRegistry;
+
+/**
+ * A plugin registration callback.
+ *
+ * Used for registering plugins with additional instances of
+ * `FlutterPluginRegistry`.
+ *
+ * @param registry The registry to register plugins with.
+ */
+typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>* registry);
 
 /**
  * Implemented by the iOS part of a Flutter plugin.
@@ -43,6 +54,19 @@ NS_ASSUME_NONNULL_BEGIN
  *     registering callbacks.
  */
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar;
+@optional
+/**
+ * Set a callback for registering plugins to an additional `FlutterPluginRegistry`,
+ * including headless `FlutterEngine` instances.
+ *
+ * This method is typically called from within an application's `AppDelegate` at
+ * startup to allow for plugins which create additional `FlutterEngine` instances
+ * to register the application's plugins.
+ *
+ * @param callback A callback for registering some set of plugins with a
+ *     `FlutterPluginRegistry`.
+ */
++ (void)setPluginRegistrantCallback:(FlutterPluginRegistrantCallback)callback;
 @optional
 /**
  * Called if this plugin has been registered to receive `FlutterMethodCall`s.


### PR DESCRIPTION
Added `FlutterPluginRegistrantCallback` typedef and optional `setPluginRegistrantCallback` static method in `FlutterPlugin`. `setPluginRegistrantCallback` is used to set a callback defined in AppDelegate.m which registers some subset of plugins with a `FlutterPluginRegistry` (for example, a headless FlutterEngine). This allows for plugins which utilize background execution functionality to enable the use of other plugins on the background isolate. This puts iOS on par with Android for background execution.

Along with updated examples and Medium posts, this fixes flutter/flutter#21925.