### PR TITLE
Add fml::FileExists implementation for Windows

### DIFF
--- a/fml/platform/win/file_win.cc
+++ b/fml/platform/win/file_win.cc
@@ -316,6 +316,10 @@ bool TruncateFile(const fml::UniqueFD& file, size_t size) {
   return true;
 }
 
+bool FileExists(const fml::UniqueFD& base_directory, const char* path) {
+  return IsFile(GetAbsolutePath(base_directory, path).c_str());
+}
+
 bool WriteAtomically(const fml::UniqueFD& base_directory,
                      const char* file_name,
                      const Mapping& mapping) {


### PR DESCRIPTION
This should unbreak the build.