### PR TITLE
Extracted PlatformViewsChannel from PlatformViewsController.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -556,6 +556,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/system
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/SettingsChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/SystemChannel.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -160,6 +160,7 @@ action("flutter_shell_java") {
     "io/flutter/embedding/engine/systemchannels/LocalizationChannel.java",
     "io/flutter/embedding/engine/systemchannels/NavigationChannel.java",
     "io/flutter/embedding/engine/systemchannels/PlatformChannel.java",
+    "io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java",
     "io/flutter/embedding/engine/systemchannels/SettingsChannel.java",
     "io/flutter/embedding/engine/systemchannels/SystemChannel.java",
     "io/flutter/embedding/engine/systemchannels/TextInputChannel.java",

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -80,7 +80,7 @@ public class FlutterPluginRegistry
     public void attach(FlutterView flutterView, Activity activity) {
         mFlutterView = flutterView;
         mActivity = activity;
-        mPlatformViewsController.attach(activity, flutterView, flutterView);
+        mPlatformViewsController.attach(activity, flutterView, flutterView.getDartExecutor());
     }
 
     public void detach() {

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -37,145 +37,139 @@ public class PlatformViewsChannel {
 
       switch (call.method) {
         case "create":
-          Map<String, Object> createArgs = call.arguments();
-          PlatformViewCreationRequest request = new PlatformViewCreationRequest(
-              (int) createArgs.get("id"),
-              (String) createArgs.get("viewType"),
-              (double) createArgs.get("width"),
-              (double) createArgs.get("height"),
-              (int) createArgs.get("direction"),
-              createArgs.containsKey("params")
-                  ? ByteBuffer.wrap((byte[]) createArgs.get("params"))
-                  : null
-          );
-
-          try {
-            long textureId = handler.createPlatformView(request);
-            result.success(textureId);
-          } catch (InvalidDirectionException exception) {
-            result.error(
-                "error",
-                "Trying to create a view with unknown direction value: " + request.direction + "(view id: " + request.viewId + ")",
-                null
-            );
-            return;
-          } catch (DuplicatePlatformViewException exception) {
-            result.error(
-                "error",
-                "Trying to create an already created platform view, view id: " + request.viewId,
-                null
-            );
-            return;
-          } catch (UnregisteredPlatformViewTypeException exception) {
-            result.error(
-                "error",
-                "Trying to create a platform view of unregistered type: " + request.viewType,
-                null
-            );
-          } catch (FailedToCreateVirtualDisplayException exception) {
-            result.error(
-                "error",
-                "Failed creating virtual display for a " + request.viewType + " with id: " + request.viewId,
-                null
-            );
-          }
+          create(call, result);
           break;
         case "dispose":
-          int viewId = call.arguments();
-          try {
-            handler.disposePlatformView(viewId);
-            result.success(null);
-          } catch (NoSuchPlatformViewException exception) {
-            result.error(
-                "error",
-                "Trying to dispose a platform view with unknown id: " + viewId,
-                null
-            );
-          }
+          dispose(call, result);
           break;
         case "resize":
-          Map<String, Object> resizeArgs = call.arguments();
-          PlatformViewResizeRequest resizeRequest = new PlatformViewResizeRequest(
-              (int) resizeArgs.get("id"),
-              (double) resizeArgs.get("width"),
-              (double) resizeArgs.get("height")
-          );
-          try {
-            handler.resizePlatformView(
-                resizeRequest,
-                new Runnable() {
-                  @Override
-                  public void run() {
-                    result.success(null);
-                  }
-                }
-              );
-          } catch (NoSuchPlatformViewException exception) {
-            result.error(
-                "error",
-                "Trying to resize a platform view with unknown id: " + resizeRequest.viewId,
-                null
-            );
-          }
+          resize(call, result);
           break;
         case "touch":
-          List<Object> args = call.arguments();
-          PlatformViewTouch touch = new PlatformViewTouch(
-              (int) args.get(0),
-              (Number) args.get(1),
-              (Number) args.get(2),
-              (int) args.get(3),
-              (int) args.get(4),
-              args.get(5),
-              args.get(6),
-              (int) args.get(7),
-              (int) args.get(8),
-              (float) (double) args.get(9),
-              (float) (double) args.get(10),
-              (int) args.get(11),
-              (int) args.get(12),
-              (int) args.get(13),
-              (int) args.get(14)
-          );
-
-          try {
-            handler.onTouch(touch);
-            result.success(null);
-          } catch (NoSuchPlatformViewException exception) {
-            result.error(
-                "error",
-                "Sending touch to an unknown view with id: " + touch.viewId,
-                null
-            );
-          }
-          return;
+          touch(call, result);
+          break;
         case "setDirection":
-          Map<String, Object> setDirectionArgs = call.arguments();
-          int newDirectionViewId = (int) setDirectionArgs.get("id");
-          int direction = (int) setDirectionArgs.get("direction");
-
-          try {
-            handler.setDirection(
-                newDirectionViewId,
-                direction
-            );
-            result.success(null);
-          } catch (InvalidDirectionException exception) {
-            result.error(
-                "error",
-                "Trying to set unknown direction value: " + direction + "(view id: " + newDirectionViewId + ")",
-                null
-            );
-          } catch (NoSuchPlatformViewException exception) {
-            result.error(
-                "error",
-                "Sending touch to an unknown view with id: " + newDirectionViewId,
-                null
-            );
-          }
+          setDirection(call, result);
           break;
       }
       result.notImplemented();
+    }
+
+    private void create(MethodCall call, MethodChannel.Result result) {
+      Map<String, Object> createArgs = call.arguments();
+      PlatformViewCreationRequest request = new PlatformViewCreationRequest(
+          (int) createArgs.get("id"),
+          (String) createArgs.get("viewType"),
+          (double) createArgs.get("width"),
+          (double) createArgs.get("height"),
+          (int) createArgs.get("direction"),
+          createArgs.containsKey("params")
+              ? ByteBuffer.wrap((byte[]) createArgs.get("params"))
+              : null
+      );
+
+      try {
+        long textureId = handler.createPlatformView(request);
+        result.success(textureId);
+      } catch (IllegalStateException exception) {
+        result.error(
+            "error",
+            exception.getMessage(),
+            null
+        );
+      }
+    }
+
+    private void dispose(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+      int viewId = call.arguments();
+      try {
+        handler.disposePlatformView(viewId);
+        result.success(null);
+      } catch (IllegalStateException exception) {
+        result.error(
+            "error",
+            exception.getMessage(),
+            null
+        );
+      }
+    }
+
+    private void resize(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+      Map<String, Object> resizeArgs = call.arguments();
+      PlatformViewResizeRequest resizeRequest = new PlatformViewResizeRequest(
+          (int) resizeArgs.get("id"),
+          (double) resizeArgs.get("width"),
+          (double) resizeArgs.get("height")
+      );
+      try {
+        handler.resizePlatformView(
+            resizeRequest,
+            new Runnable() {
+              @Override
+              public void run() {
+                result.success(null);
+              }
+            }
+        );
+      } catch (IllegalStateException exception) {
+        result.error(
+            "error",
+            exception.getMessage(),
+            null
+        );
+      }
+    }
+
+    private void touch(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+      List<Object> args = call.arguments();
+      PlatformViewTouch touch = new PlatformViewTouch(
+          (int) args.get(0),
+          (Number) args.get(1),
+          (Number) args.get(2),
+          (int) args.get(3),
+          (int) args.get(4),
+          args.get(5),
+          args.get(6),
+          (int) args.get(7),
+          (int) args.get(8),
+          (float) (double) args.get(9),
+          (float) (double) args.get(10),
+          (int) args.get(11),
+          (int) args.get(12),
+          (int) args.get(13),
+          (int) args.get(14)
+      );
+
+      try {
+        handler.onTouch(touch);
+        result.success(null);
+      } catch (IllegalStateException exception) {
+        result.error(
+            "error",
+            exception.getMessage(),
+            null
+        );
+      }
+    }
+
+    private void setDirection(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+      Map<String, Object> setDirectionArgs = call.arguments();
+      int newDirectionViewId = (int) setDirectionArgs.get("id");
+      int direction = (int) setDirectionArgs.get("direction");
+
+      try {
+        handler.setDirection(
+            newDirectionViewId,
+            direction
+        );
+        result.success(null);
+      } catch (IllegalStateException exception) {
+        result.error(
+            "error",
+            exception.getMessage(),
+            null
+        );
+      }
     }
   };
 
@@ -217,18 +211,13 @@ public class PlatformViewsChannel {
      * given Flutter execution context, and then return the new texture's ID.
      */
     // TODO(mattcarroll): Introduce an annotation for @TextureId
-    long createPlatformView(@NonNull PlatformViewCreationRequest request) throws
-        InvalidDirectionException,
-        DuplicatePlatformViewException,
-        UnregisteredPlatformViewTypeException,
-        FailedToCreateVirtualDisplayException;
+    long createPlatformView(@NonNull PlatformViewCreationRequest request);
 
     /**
      * The Flutter application could like dispose of an existing Android {@code View},
      * i.e., platform view.
      */
-    void disposePlatformView(int viewId) throws
-        NoSuchPlatformViewException;
+    void disposePlatformView(int viewId);
 
     /**
      * The Flutter application would like to resize an existing Android {@code View},
@@ -236,25 +225,21 @@ public class PlatformViewsChannel {
      */
     void resizePlatformView(
         @NonNull PlatformViewResizeRequest request,
-        @NonNull Runnable onComplete) throws
-        NoSuchPlatformViewException;
+        @NonNull Runnable onComplete);
 
     /**
      * The user touched a platform view within Flutter.
      *
      * Touch data is reported in {@code touch}.
      */
-    void onTouch(@NonNull PlatformViewTouch touch) throws
-        NoSuchPlatformViewException;
+    void onTouch(@NonNull PlatformViewTouch touch);
 
     /**
      * The Flutter application would like to change the layout direction of
      * an existing Android {@code View}, i.e., platform view.
      */
     // TODO(mattcarroll): Introduce an annotation for @TextureId
-    void setDirection(int viewId, int direction) throws
-        InvalidDirectionException,
-        NoSuchPlatformViewException;
+    void setDirection(int viewId, int direction);
   }
 
   /**
@@ -444,33 +429,6 @@ public class PlatformViewsChannel {
       this.flags = flags;
     }
   }
-
-  /**
-   * An attempt was made to use platform views on a version of Android that platform
-   * views does not support.
-   */
-  public static class InvalidPlatformVersionException extends IllegalStateException {}
-
-  /**
-   * An invalid value for a layout direction was sent.
-   */
-  public static class InvalidDirectionException extends IllegalArgumentException {}
-
-  /**
-   * An attempt was made to create a platform view with an ID that already exists.
-   */
-  public static class DuplicatePlatformViewException extends IllegalStateException {}
-
-  /**
-   * A request was sent to create a platform view of a View type that isn't registered
-   * with the platform view system.
-   */
-  public static class UnregisteredPlatformViewTypeException extends IllegalStateException {}
-
-  /**
-   * Something went wrong when creating the virtual display for a new platform view.
-   */
-  public static class FailedToCreateVirtualDisplayException extends IllegalStateException {}
 
   /**
    * The provided platform view ID does not correspond to any existing platform view.

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -18,7 +18,7 @@ import io.flutter.plugin.common.StandardMethodCodec;
 
 /**
  * System channel that sends 2-way communication between Flutter and Android to
- * display Android Views within Flutter.
+ * facilitate embedding of Android Views within a Flutter application.
  *
  * Register a {@link PlatformViewsHandler} to implement the Android side of this channel.
  */

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.embedding.engine.systemchannels;
 
 import android.support.annotation.NonNull;

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -1,0 +1,475 @@
+package io.flutter.embedding.engine.systemchannels;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import io.flutter.plugin.common.StandardMethodCodec;
+
+/**
+ * System channel that sends 2-way communication between Flutter and Android to
+ * display Android Views within Flutter.
+ *
+ * Register a {@link PlatformViewsHandler} to implement the Android side of this channel.
+ */
+public class PlatformViewsChannel {
+  private final MethodChannel channel;
+  private PlatformViewsHandler handler;
+
+  private final MethodChannel.MethodCallHandler parsingHandler = new MethodChannel.MethodCallHandler() {
+    @Override
+    public void onMethodCall(MethodCall call, MethodChannel.Result result) {
+      // If there is no handler to respond to this message then we don't need to
+      // parse it. Return.
+      if (handler == null) {
+        return;
+      }
+
+      switch (call.method) {
+        case "create":
+          Map<String, Object> createArgs = call.arguments();
+          PlatformViewCreationRequest request = new PlatformViewCreationRequest(
+              (int) createArgs.get("id"),
+              (String) createArgs.get("viewType"),
+              (double) createArgs.get("width"),
+              (double) createArgs.get("height"),
+              (int) createArgs.get("direction"),
+              createArgs.containsKey("params")
+                  ? ByteBuffer.wrap((byte[]) createArgs.get("params"))
+                  : null
+          );
+
+          try {
+            long textureId = handler.createPlatformView(request);
+            result.success(textureId);
+          } catch (InvalidDirectionException exception) {
+            result.error(
+                "error",
+                "Trying to create a view with unknown direction value: " + request.direction + "(view id: " + request.viewId + ")",
+                null
+            );
+            return;
+          } catch (DuplicatePlatformViewException exception) {
+            result.error(
+                "error",
+                "Trying to create an already created platform view, view id: " + request.viewId,
+                null
+            );
+            return;
+          } catch (UnregisteredPlatformViewTypeException exception) {
+            result.error(
+                "error",
+                "Trying to create a platform view of unregistered type: " + request.viewType,
+                null
+            );
+          } catch (FailedToCreateVirtualDisplayException exception) {
+            result.error(
+                "error",
+                "Failed creating virtual display for a " + request.viewType + " with id: " + request.viewId,
+                null
+            );
+          }
+          break;
+        case "dispose":
+          int viewId = call.arguments();
+          try {
+            handler.disposePlatformView(viewId);
+            result.success(null);
+          } catch (NoSuchPlatformViewException exception) {
+            result.error(
+                "error",
+                "Trying to dispose a platform view with unknown id: " + viewId,
+                null
+            );
+          }
+          break;
+        case "resize":
+          Map<String, Object> resizeArgs = call.arguments();
+          PlatformViewResizeRequest resizeRequest = new PlatformViewResizeRequest(
+              (int) resizeArgs.get("id"),
+              (double) resizeArgs.get("width"),
+              (double) resizeArgs.get("height")
+          );
+          try {
+            handler.resizePlatformView(
+                resizeRequest,
+                new Runnable() {
+                  @Override
+                  public void run() {
+                    result.success(null);
+                  }
+                }
+              );
+          } catch (NoSuchPlatformViewException exception) {
+            result.error(
+                "error",
+                "Trying to resize a platform view with unknown id: " + resizeRequest.viewId,
+                null
+            );
+          }
+          break;
+        case "touch":
+          List<Object> args = call.arguments();
+          PlatformViewTouch touch = new PlatformViewTouch(
+              (int) args.get(0),
+              (Number) args.get(1),
+              (Number) args.get(2),
+              (int) args.get(3),
+              (int) args.get(4),
+              args.get(5),
+              args.get(6),
+              (int) args.get(7),
+              (int) args.get(8),
+              (float) (double) args.get(9),
+              (float) (double) args.get(10),
+              (int) args.get(11),
+              (int) args.get(12),
+              (int) args.get(13),
+              (int) args.get(14)
+          );
+
+          try {
+            handler.onTouch(touch);
+            result.success(null);
+          } catch (NoSuchPlatformViewException exception) {
+            result.error(
+                "error",
+                "Sending touch to an unknown view with id: " + touch.viewId,
+                null
+            );
+          }
+          return;
+        case "setDirection":
+          Map<String, Object> setDirectionArgs = call.arguments();
+          int newDirectionViewId = (int) setDirectionArgs.get("id");
+          int direction = (int) setDirectionArgs.get("direction");
+
+          try {
+            handler.setDirection(
+                newDirectionViewId,
+                direction
+            );
+            result.success(null);
+          } catch (InvalidDirectionException exception) {
+            result.error(
+                "error",
+                "Trying to set unknown direction value: " + direction + "(view id: " + newDirectionViewId + ")",
+                null
+            );
+          } catch (NoSuchPlatformViewException exception) {
+            result.error(
+                "error",
+                "Sending touch to an unknown view with id: " + newDirectionViewId,
+                null
+            );
+          }
+          break;
+      }
+      result.notImplemented();
+    }
+  };
+
+  /**
+   * Constructs a {@code PlatformViewsChannel} that connects Android to the Dart code
+   * running in {@code dartExecutor}.
+   *
+   * The given {@code dartExecutor} is permitted to be idle or executing code.
+   *
+   * See {@link DartExecutor}.
+   */
+  public PlatformViewsChannel(@NonNull DartExecutor dartExecutor) {
+    channel = new MethodChannel(dartExecutor, "flutter/platform_views", StandardMethodCodec.INSTANCE);
+    channel.setMethodCallHandler(parsingHandler);
+  }
+
+  /**
+   * Sets the {@link PlatformViewsHandler} which receives all events and requests
+   * that are parsed from the underlying platform views channel.
+   */
+  public void setPlatformViewsHandler(@Nullable PlatformViewsHandler handler) {
+    this.handler = handler;
+  }
+
+  /**
+   * Handler that receives platform view messages sent from Flutter to Android
+   * through a given {@link PlatformViewsChannel}.
+   *
+   * To register a {@code PlatformViewsHandler} with a {@link PlatformViewsChannel},
+   * see {@link PlatformViewsChannel#setPlatformViewsHandler(PlatformViewsHandler)}.
+   */
+  public interface PlatformViewsHandler {
+    /**
+     * The Flutter application would like to display a new Android {@code View}, i.e.,
+     * platform view.
+     *
+     * The handler should instantiate the desired Android {@code View}, create a new
+     * {@link io.flutter.view.FlutterView.SurfaceTextureRegistryEntry} within the
+     * given Flutter execution context, and then return the new texture's ID.
+     */
+    // TODO(mattcarroll): Introduce an annotation for @TextureId
+    long createPlatformView(@NonNull PlatformViewCreationRequest request) throws
+        InvalidDirectionException,
+        DuplicatePlatformViewException,
+        UnregisteredPlatformViewTypeException,
+        FailedToCreateVirtualDisplayException;
+
+    /**
+     * The Flutter application could like dispose of an existing Android {@code View},
+     * i.e., platform view.
+     */
+    void disposePlatformView(int viewId) throws
+        NoSuchPlatformViewException;
+
+    /**
+     * The Flutter application would like to resize an existing Android {@code View},
+     * i.e., platform view.
+     */
+    void resizePlatformView(
+        @NonNull PlatformViewResizeRequest request,
+        @NonNull Runnable onComplete) throws
+        NoSuchPlatformViewException;
+
+    /**
+     * The user touched a platform view within Flutter.
+     *
+     * Touch data is reported in {@code touch}.
+     */
+    void onTouch(@NonNull PlatformViewTouch touch) throws
+        NoSuchPlatformViewException;
+
+    /**
+     * The Flutter application would like to change the layout direction of
+     * an existing Android {@code View}, i.e., platform view.
+     */
+    // TODO(mattcarroll): Introduce an annotation for @TextureId
+    void setDirection(int viewId, int direction) throws
+        InvalidDirectionException,
+        NoSuchPlatformViewException;
+  }
+
+  /**
+   * Request sent from Flutter to create a new platform view.
+   */
+  public static class PlatformViewCreationRequest {
+    /**
+     * The ID of the platform view as seen by the Flutter side.
+     */
+    public final int viewId;
+
+    /**
+     * The type of Android {@code View} to create for this platform view.
+     */
+    @NonNull
+    public final String viewType;
+
+    /**
+     * The density independent width to display the platform view.
+     */
+    public final double logicalWidth;
+
+    /**
+     * The density independent height to display the platform view.
+     */
+    public final double logicalHeight;
+
+    /**
+     * The layout direction of the new platform view.
+     *
+     * See {@link android.view.View.LAYOUT_DIRECTION_LTR} and
+     * {@link android.view.View.LAYOUT_DIRECTION_RTL}
+     */
+    public final int direction;
+
+    /**
+     * Custom parameters that are unique to the desired platform view.
+     */
+    @Nullable
+    public final ByteBuffer params;
+
+    public PlatformViewCreationRequest(
+        int viewId,
+        @NonNull String viewType,
+        double logicalWidth,
+        double logicalHeight,
+        int direction,
+        @Nullable ByteBuffer params
+    ) {
+      this.viewId = viewId;
+      this.viewType = viewType;
+      this.logicalWidth = logicalWidth;
+      this.logicalHeight = logicalHeight;
+      this.direction = direction;
+      this.params = params;
+    }
+  }
+
+  /**
+   * Request sent from Flutter to resize a platform view.
+   */
+  public static class PlatformViewResizeRequest {
+    /**
+     * The ID of the platform view as seen by the Flutter side.
+     */
+    public final int viewId;
+
+    /**
+     * The new density independent width to display the platform view.
+     */
+    public final double newLogicalWidth;
+
+    /**
+     * The new density independent height to display the platform view.
+     */
+    public final double newLogicalHeight;
+
+    public PlatformViewResizeRequest(
+        int viewId,
+        double newLogicalWidth,
+        double newLogicalHeight
+    ) {
+      this.viewId = viewId;
+      this.newLogicalWidth = newLogicalWidth;
+      this.newLogicalHeight = newLogicalHeight;
+    }
+  }
+
+  /**
+   * The state of a touch event in Flutter within a platform view.
+   */
+  public static class PlatformViewTouch {
+    /**
+     * The ID of the platform view as seen by the Flutter side.
+     */
+    public final int viewId;
+
+    /**
+     * The amount of time that the touch has been pressed.
+     */
+    @NonNull
+    public final Number downTime;
+    /**
+     * TODO(mattcarroll): javadoc
+     */
+    @NonNull
+    public final Number eventTime;
+    public final int action;
+    /**
+     * The number of pointers (e.g, fingers) involved in the touch event.
+     */
+    public final int pointerCount;
+    /**
+     * Properties for each pointer, encoded in a raw format.
+     */
+    @NonNull
+    public final Object rawPointerPropertiesList;
+    /**
+     * Coordinates for each pointer, encoded in a raw format.
+     */
+    @NonNull
+    public final Object rawPointerCoords;
+    /**
+     * TODO(mattcarroll): javadoc
+     */
+    public final int metaState;
+    /**
+     * TODO(mattcarroll): javadoc
+     */
+    public final int buttonState;
+    /**
+     * Coordinate precision along the x-axis.
+     */
+    public final float xPrecision;
+    /**
+     * Coordinate precision along the y-axis.
+     */
+    public final float yPrecision;
+    /**
+     * TODO(mattcarroll): javadoc
+     */
+    public final int deviceId;
+    /**
+     * TODO(mattcarroll): javadoc
+     */
+    public final int edgeFlags;
+    /**
+     * TODO(mattcarroll): javadoc
+     */
+    public final int source;
+    /**
+     * TODO(mattcarroll): javadoc
+     */
+    public final int flags;
+
+    PlatformViewTouch(
+        int viewId,
+        @NonNull Number downTime,
+        @NonNull Number eventTime,
+        int action,
+        int pointerCount,
+        @NonNull Object rawPointerPropertiesList,
+        @NonNull Object rawPointerCoords,
+        int metaState,
+        int buttonState,
+        float xPrecision,
+        float yPrecision,
+        int deviceId,
+        int edgeFlags,
+        int source,
+        int flags
+    ) {
+      this.viewId = viewId;
+      this.downTime = downTime;
+      this.eventTime = eventTime;
+      this.action = action;
+      this.pointerCount = pointerCount;
+      this.rawPointerPropertiesList = rawPointerPropertiesList;
+      this.rawPointerCoords = rawPointerCoords;
+      this.metaState = metaState;
+      this.buttonState = buttonState;
+      this.xPrecision = xPrecision;
+      this.yPrecision = yPrecision;
+      this.deviceId = deviceId;
+      this.edgeFlags = edgeFlags;
+      this.source = source;
+      this.flags = flags;
+    }
+  }
+
+  /**
+   * An attempt was made to use platform views on a version of Android that platform
+   * views does not support.
+   */
+  public static class InvalidPlatformVersionException extends IllegalStateException {}
+
+  /**
+   * An invalid value for a layout direction was sent.
+   */
+  public static class InvalidDirectionException extends IllegalArgumentException {}
+
+  /**
+   * An attempt was made to create a platform view with an ID that already exists.
+   */
+  public static class DuplicatePlatformViewException extends IllegalStateException {}
+
+  /**
+   * A request was sent to create a platform view of a View type that isn't registered
+   * with the platform view system.
+   */
+  public static class UnregisteredPlatformViewTypeException extends IllegalStateException {}
+
+  /**
+   * Something went wrong when creating the virtual display for a new platform view.
+   */
+  public static class FailedToCreateVirtualDisplayException extends IllegalStateException {}
+
+  /**
+   * The provided platform view ID does not correspond to any existing platform view.
+   */
+  public static class NoSuchPlatformViewException extends IllegalStateException {}
+}

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -60,6 +60,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     private final HashMap<Integer, VirtualDisplayController> vdControllers;
 
     private final PlatformViewsChannel.PlatformViewsHandler channelHandler = new PlatformViewsChannel.PlatformViewsHandler() {
+        @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
         @Override
         public long createPlatformView(@NonNull PlatformViewsChannel.PlatformViewCreationRequest request) {
             ensureValidAndroidVersion();
@@ -187,6 +188,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             view.dispatchTouchEvent(event);
         }
 
+        @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
         @Override
         public void setDirection(int viewId, int direction) {
             ensureValidAndroidVersion();

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -12,20 +12,24 @@ import android.content.Context;
 import android.os.Build;
 import android.support.annotation.UiThread;
 import android.util.DisplayMetrics;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
+
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.systemchannels.PlatformViewsChannel;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMethodCodec;
 import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.TextureRegistry;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Manages platform views.
@@ -33,10 +37,8 @@ import java.util.Map;
  * Each {@link io.flutter.app.FlutterPluginRegistry} has a single platform views controller.
  * A platform views controller can be attached to at most one Flutter view.
  */
-public class PlatformViewsController implements MethodChannel.MethodCallHandler, PlatformViewsAccessibilityDelegate {
+public class PlatformViewsController {
     private static final String TAG = "PlatformViewsController";
-
-    private static final String CHANNEL_NAME = "flutter/platform_views";
 
     // API level 20 is required for VirtualDisplay#setSurface which we use when resizing a platform view.
     private static final int MINIMAL_SDK = Build.VERSION_CODES.KITKAT_WATCH;
@@ -49,13 +51,53 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
     // The texture registry maintaining the textures into which the embedded views will be rendered.
     private TextureRegistry textureRegistry;
 
-    // The messenger used to communicate with the framework over the platform views channel.
-    private BinaryMessenger messenger;
+    // The system channel used to communicate with Flutter about platform views.
+    private PlatformViewsChannel platformViewsChannel;
 
     // The accessibility bridge to which accessibility events form the platform views will be dispatched.
     private final AccessibilityEventsDelegate accessibilityEventsDelegate;
 
     private final HashMap<Integer, VirtualDisplayController> vdControllers;
+
+    private final PlatformViewsChannel.PlatformViewsHandler channelHandler = new PlatformViewsChannel.PlatformViewsHandler() {
+        @Override
+        public long createPlatformView(@NonNull PlatformViewsChannel.PlatformViewCreationRequest request) throws PlatformViewsChannel.InvalidDirectionException, PlatformViewsChannel.DuplicatePlatformViewException, PlatformViewsChannel.UnregisteredPlatformViewTypeException, PlatformViewsChannel.FailedToCreateVirtualDisplayException {
+            ensureValidAndroidVersion();
+            return PlatformViewsController.this.createPlatformView(request);
+        }
+
+        @Override
+        public void disposePlatformView(int viewId) throws PlatformViewsChannel.NoSuchPlatformViewException {
+            ensureValidAndroidVersion();
+            PlatformViewsController.this.disposePlatformView(viewId);
+        }
+
+        @Override
+        public void resizePlatformView(@NonNull PlatformViewsChannel.PlatformViewResizeRequest request, @NonNull Runnable onComplete) throws PlatformViewsChannel.NoSuchPlatformViewException {
+            ensureValidAndroidVersion();
+            PlatformViewsController.this.resizePlatformView(request, onComplete);
+        }
+
+        @Override
+        public void onTouch(@NonNull PlatformViewsChannel.PlatformViewTouch touch) throws PlatformViewsChannel.NoSuchPlatformViewException {
+            ensureValidAndroidVersion();
+            PlatformViewsController.this.onTouch(touch);
+        }
+
+        @Override
+        public void setDirection(int viewId, int direction) throws PlatformViewsChannel.InvalidDirectionException, PlatformViewsChannel.NoSuchPlatformViewException {
+            ensureValidAndroidVersion();
+            PlatformViewsController.this.setDirection(viewId, direction);
+        }
+
+        private void ensureValidAndroidVersion() {
+            if (Build.VERSION.SDK_INT < MINIMAL_SDK) {
+                Log.e(TAG, "Trying to use platform views with API " + Build.VERSION.SDK_INT
+                    + ", required API level is: " + MINIMAL_SDK);
+                throw new PlatformViewsChannel.InvalidPlatformVersionException();
+            }
+        }
+    };
 
     public PlatformViewsController() {
         registry = new PlatformViewRegistryImpl();
@@ -70,9 +112,9 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
      *                This should be the context of the Activity hosting the Flutter application.
      * @param textureRegistry The texture registry which provides the output textures into which the embedded views
      *                        will be rendered.
-     * @param messenger The Flutter application on the other side of this messenger drives this platform views controller.
+     * @param dartExecutor The dart execution context, which is used to setup a system channel.
      */
-    public void attach(Context context, TextureRegistry textureRegistry, BinaryMessenger messenger) {
+    public void attach(Context context, TextureRegistry textureRegistry, @NonNull DartExecutor dartExecutor) {
         if (this.context != null) {
             throw new AssertionError(
                     "A PlatformViewsController can only be attached to a single output target.\n" +
@@ -81,9 +123,8 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
         }
         this.context = context;
         this.textureRegistry = textureRegistry;
-        this.messenger = messenger;
-        MethodChannel channel = new MethodChannel(messenger, CHANNEL_NAME, StandardMethodCodec.INSTANCE);
-        channel.setMethodCallHandler(this);
+        platformViewsChannel = new PlatformViewsChannel(dartExecutor);
+        platformViewsChannel.setPlatformViewsHandler(channelHandler);
     }
 
     /**
@@ -95,8 +136,8 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
      */
     @UiThread
     public void detach() {
-        messenger.setMessageHandler(CHANNEL_NAME, null);
-        messenger = null;
+        platformViewsChannel.setPlatformViewsHandler(null);
+        platformViewsChannel = null;
         context = null;
         textureRegistry = null;
     }
@@ -123,86 +164,28 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
         flushAllViews();
     }
 
-    @Override
-    public View getPlatformViewById(Integer id) {
-        VirtualDisplayController controller = vdControllers.get(id);
-        if (controller == null) {
-            return null;
-        }
-        return controller.getView();
-    }
-
-    @Override
-    public void onMethodCall(final MethodCall call, final MethodChannel.Result result) {
-        if (Build.VERSION.SDK_INT < MINIMAL_SDK) {
-            Log.e(TAG, "Trying to use platform views with API " + Build.VERSION.SDK_INT
-                    + ", required API level is: " + MINIMAL_SDK);
-            return;
-        }
-        switch (call.method) {
-            case "create":
-                createPlatformView(call, result);
-                return;
-            case "dispose":
-                disposePlatformView(call, result);
-                return;
-            case "resize":
-                resizePlatformView(call, result);
-                return;
-            case "touch":
-                onTouch(call, result);
-                return;
-            case "setDirection":
-                setDirection(call, result);
-                return;
-        }
-        result.notImplemented();
-    }
-
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
-    private void createPlatformView(MethodCall call, MethodChannel.Result result) {
-        Map<String, Object> args = call.arguments();
-        int id = (int) args.get("id");
-        String viewType = (String) args.get("viewType");
-        double logicalWidth = (double) args.get("width");
-        double logicalHeight = (double) args.get("height");
-        int direction = (int) args.get("direction");
-
-        if (!validateDirection(direction)) {
-            result.error(
-                    "error",
-                    "Trying to create a view with unknown direction value: " + direction + "(view id: " + id + ")",
-                    null
-            );
-            return;
+    private long createPlatformView(PlatformViewsChannel.PlatformViewCreationRequest request) {
+        if (!validateDirection(request.direction)) {
+            throw new PlatformViewsChannel.InvalidDirectionException();
         }
 
-        if (vdControllers.containsKey(id)) {
-            result.error(
-                    "error",
-                    "Trying to create an already created platform view, view id: " + id,
-                    null
-            );
-            return;
+        if (vdControllers.containsKey(request.viewId)) {
+            throw new PlatformViewsChannel.DuplicatePlatformViewException();
         }
 
-        PlatformViewFactory viewFactory = registry.getFactory(viewType);
+        PlatformViewFactory viewFactory = registry.getFactory(request.viewType);
         if (viewFactory == null) {
-            result.error(
-                    "error",
-                    "Trying to create a platform view of unregistered type: " + viewType,
-                    null
-            );
-            return;
+            throw new PlatformViewsChannel.NoSuchPlatformViewException();
         }
 
         Object createParams = null;
-        if (args.containsKey("params")) {
-            createParams = viewFactory.getCreateArgsCodec().decodeMessage(ByteBuffer.wrap((byte[]) args.get("params")));
+        if (request.params != null) {
+            createParams = viewFactory.getCreateArgsCodec().decodeMessage(request.params);
         }
 
-        int physicalWidth = toPhysicalPixels(logicalWidth);
-        int physicalHeight = toPhysicalPixels(logicalHeight);
+        int physicalWidth = toPhysicalPixels(request.logicalWidth);
+        int physicalHeight = toPhysicalPixels(request.logicalHeight);
         validateVirtualDisplayDimensions(physicalWidth, physicalHeight);
 
         TextureRegistry.SurfaceTextureEntry textureEntry = textureRegistry.createSurfaceTexture();
@@ -211,161 +194,100 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
                 accessibilityEventsDelegate,
                 viewFactory,
                 textureEntry,
-                physicalWidth,
-                physicalHeight,
-                id,
+                toPhysicalPixels(request.logicalWidth),
+                toPhysicalPixels(request.logicalHeight),
+                request.viewId,
                 createParams
         );
 
         if (vdController == null) {
-            result.error(
-                    "error",
-                    "Failed creating virtual display for a " + viewType + " with id: " + id,
-                    null
-            );
-            return;
+            throw new PlatformViewsChannel.FailedToCreateVirtualDisplayException();
         }
 
-        vdControllers.put(id, vdController);
-        vdController.getView().setLayoutDirection(direction);
+        vdControllers.put(request.viewId, vdController);
+        vdController.getView().setLayoutDirection(request.direction);
 
         // TODO(amirh): copy accessibility nodes to the FlutterView's accessibility tree.
 
-        result.success(textureEntry.id());
+        return textureEntry.id();
     }
 
-    private void disposePlatformView(MethodCall call, MethodChannel.Result result) {
-        int id = call.arguments();
-
-        VirtualDisplayController vdController = vdControllers.get(id);
+    private void disposePlatformView(int viewId) {
+        VirtualDisplayController vdController = vdControllers.get(viewId);
         if (vdController == null) {
-            result.error(
-                    "error",
-                    "Trying to dispose a platform view with unknown id: " + id,
-                    null
-            );
-            return;
+            throw new PlatformViewsChannel.NoSuchPlatformViewException();
         }
 
         vdController.dispose();
-        vdControllers.remove(id);
-        result.success(null);
+        vdControllers.remove(viewId);
     }
 
-    private void resizePlatformView(MethodCall call, final MethodChannel.Result result) {
-        Map<String, Object> args = call.arguments();
-        int id = (int) args.get("id");
-        double width = (double) args.get("width");
-        double height = (double) args.get("height");
-
-        VirtualDisplayController vdController = vdControllers.get(id);
+    private void resizePlatformView(
+        PlatformViewsChannel.PlatformViewResizeRequest request,
+        Runnable onComplete
+    ) {
+        VirtualDisplayController vdController = vdControllers.get(request.viewId);
         if (vdController == null) {
-            result.error(
-                    "error",
-                    "Trying to resize a platform view with unknown id: " + id,
-                    null
-            );
-            return;
+            throw new PlatformViewsChannel.NoSuchPlatformViewException();
         }
 
-        int physicalWidth = toPhysicalPixels(width);
-        int physicalHeight = toPhysicalPixels(height);
+        int physicalWidth = toPhysicalPixels(request.newLogicalWidth);
+        int physicalHeight = toPhysicalPixels(request.newLogicalHeight);
         validateVirtualDisplayDimensions(physicalWidth, physicalHeight);
 
         vdController.resize(
-                physicalWidth,
-                physicalHeight,
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        result.success(null);
-                    }
-                }
+            toPhysicalPixels(request.newLogicalWidth),
+            toPhysicalPixels(request.newLogicalHeight),
+            onComplete
         );
     }
 
-    private void onTouch(MethodCall call, MethodChannel.Result result) {
-        List<Object> args = call.arguments();
-
+    private void onTouch(PlatformViewsChannel.PlatformViewTouch touch) {
         float density = context.getResources().getDisplayMetrics().density;
-
-        int id = (int) args.get(0);
-        Number downTime = (Number) args.get(1);
-        Number eventTime = (Number) args.get(2);
-        int action = (int) args.get(3);
-        int pointerCount = (int) args.get(4);
         PointerProperties[] pointerProperties =
-                parsePointerPropertiesList(args.get(5)).toArray(new PointerProperties[pointerCount]);
+                parsePointerPropertiesList(touch.rawPointerPropertiesList)
+                    .toArray(new PointerProperties[touch.pointerCount]);
         PointerCoords[] pointerCoords =
-                parsePointerCoordsList(args.get(6), density).toArray(new PointerCoords[pointerCount]);
+                parsePointerCoordsList(touch.rawPointerCoords, density)
+                    .toArray(new PointerCoords[touch.pointerCount]);
 
-        int metaState = (int) args.get(7);
-        int buttonState = (int) args.get(8);
-        float xPrecision = (float) (double) args.get(9);
-        float yPrecision = (float) (double) args.get(10);
-        int deviceId = (int) args.get(11);
-        int edgeFlags = (int) args.get(12);
-        int source = (int) args.get(13);
-        int flags = (int) args.get(14);
-
-        View view = vdControllers.get(id).getView();
+        View view = vdControllers.get(touch.viewId).getView();
         if (view == null) {
-            result.error(
-                    "error",
-                    "Sending touch to an unknown view with id: " + id,
-                    null
-            );
-            return;
+            throw new PlatformViewsChannel.NoSuchPlatformViewException();
         }
 
         MotionEvent event = MotionEvent.obtain(
-                downTime.longValue(),
-                eventTime.longValue(),
-                action,
-                pointerCount,
-                pointerProperties,
-                pointerCoords,
-                metaState,
-                buttonState,
-                xPrecision,
-                yPrecision,
-                deviceId,
-                edgeFlags,
-                source,
-                flags
+            touch.downTime.longValue(),
+            touch.eventTime.longValue(),
+            touch.action,
+            touch.pointerCount,
+            pointerProperties,
+            pointerCoords,
+            touch.metaState,
+            touch.buttonState,
+            touch.xPrecision,
+            touch.yPrecision,
+            touch.deviceId,
+            touch.edgeFlags,
+            touch.source,
+            touch.flags
         );
 
         view.dispatchTouchEvent(event);
-        result.success(null);
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
-    private void setDirection(MethodCall call, MethodChannel.Result result) {
-        Map<String, Object> args = call.arguments();
-        int id = (int) args.get("id");
-        int direction = (int) args.get("direction");
-
+    private void setDirection(int viewId, int direction) {
         if (!validateDirection(direction)) {
-            result.error(
-                    "error",
-                    "Trying to set unknown direction value: " + direction + "(view id: " + id + ")",
-                    null
-            );
-            return;
+            throw new PlatformViewsChannel.InvalidDirectionException();
         }
 
-        View view = vdControllers.get(id).getView();
+        View view = vdControllers.get(viewId).getView();
         if (view == null) {
-            result.error(
-                    "error",
-                    "Sending touch to an unknown view with id: " + id,
-                    null
-            );
-            return;
+            throw new PlatformViewsChannel.NoSuchPlatformViewException();
         }
 
         view.setLayoutDirection(direction);
-        result.success(null);
     }
 
     private static boolean validateDirection(int direction) {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -15,6 +15,8 @@ import android.graphics.Rect;
 import android.graphics.SurfaceTexture;
 import android.os.Build;
 import android.os.Handler;
+import android.provider.Settings;
+import android.support.annotation.NonNull;
 import android.os.LocaleList;
 import android.support.annotation.RequiresApi;
 import android.support.annotation.UiThread;
@@ -197,7 +199,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
         sendLocalesToDart(getResources().getConfiguration());
         sendUserPlatformSettingsToDart();
     }
-    
+
     private static Activity getActivity(Context context) {
         if (context == null) {
             return null;
@@ -210,6 +212,11 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
             return getActivity(((ContextWrapper) context).getBaseContext());
         }
         return null;
+    }
+
+    @NonNull
+    public DartExecutor getDartExecutor() {
+        return dartExecutor;
     }
 
     @Override


### PR DESCRIPTION
This PR extracts all platform view system channel communication into `PlatformViewsChannel`.

The relationship between `PlatformViewsController` and `PlatformViewsChannel` is analogous to multiple other relationships including: `TextInputPlugin` and `TextInputChannel`, `AndroidKeyProcessor` and `KeyEventChannel`, and `AccessibilityBridge` and `AccessibilityChannel`.

The idea behind these relationships is that the channels codify the Android/Flutter communication API, while the other associated class handles any state and handler behavior.

At a technical level, this PR handles communication issues with `Exception`s so that the inner workings of method channels are completely hidden from down stream consumers.