### PR TITLE
Reland "Lower the threshold to raster cache pictures (#7687)"

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -87,7 +87,7 @@ static bool IsPictureWorthRasterizing(SkPicture* picture,
 
   // TODO(abarth): We should find a better heuristic here that lets us avoid
   // wasting memory on trivial layers that are easy to re-rasterize every frame.
-  return picture->approximateOpCount() > 10;
+  return picture->approximateOpCount() > 5;
 }
 
 static RasterCacheResult Rasterize(


### PR DESCRIPTION
This reverts commit 68d9ac44ec530a22beda85fcdf01871770a710d7.

https://github.com/flutter/engine/pull/7759 has landed without any
unexpected regressions. Hence we'll reland this as planned.