### PR TITLE
Android embedding refactor pr5 add flutterengine impl

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -7,6 +7,8 @@ package io.flutter.app;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.platform.PlatformViewRegistry;
@@ -45,6 +47,12 @@ public class FlutterPluginRegistry
 
     public FlutterPluginRegistry(FlutterNativeView nativeView, Context context) {
         mNativeView = nativeView;
+        mAppContext = context;
+        mPlatformViewsController = new PlatformViewsController();
+    }
+
+    public FlutterPluginRegistry(FlutterEngine engine, Context context) {
+        // TODO(mattcarroll): implement use of engine instead of nativeView.
         mAppContext = context;
         mPlatformViewsController = new PlatformViewsController();
     }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -52,6 +52,22 @@ public class FlutterEngine {
     }
   };
 
+  /**
+   * Constructs a new {@code FlutterEngine}.
+   *
+   * A new {@code FlutterEngine} does not execute any Dart code automatically. See
+   * {@link #getDartExecutor()} and {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}
+   * to begin executing Dart code within this {@code FlutterEngine}.
+   *
+   * A new {@code FlutterEngine} will not display any UI until a
+   * {@link io.flutter.embedding.engine.renderer.FlutterRenderer.RenderSurface} is registered. See
+   * {@link #getRenderer()} and {@link FlutterRenderer#attachToRenderSurface(FlutterRenderer.RenderSurface)}.
+   *
+   * A new {@code FlutterEngine} does not come with any Flutter plugins attached. To attach plugins,
+   * see {@link #getPluginRegistry()}.
+   *
+   * A new {@code FlutterEngine} does come with all default system channels attached.
+   */
   public FlutterEngine(Context context) {
     this.flutterJNI = new FlutterJNI();
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
@@ -80,6 +96,12 @@ public class FlutterEngine {
     return flutterJNI.isAttached();
   }
 
+  /**
+   * Detaches this {@code FlutterEngine} from Flutter's native implementation, but allows
+   * reattachment later.
+   *
+   * // TODO(mattcarroll): document use-cases for this behavior.
+   */
   public void detachFromJni() {
     pluginRegistry.detach();
     dartExecutor.onDetachedFromJNI();
@@ -88,6 +110,12 @@ public class FlutterEngine {
     flutterJNI.detachFromNativeButKeepNativeResources();
   }
 
+  /**
+   * Cleans up all components within this {@code FlutterEngine} and then detaches from Flutter's
+   * native implementation.
+   *
+   * A {@code FlutterEngine} instance should be discarded after invoking this method.
+   */
   public void destroy() {
     pluginRegistry.destroy();
     dartExecutor.onDetachedFromJNI();
@@ -95,11 +123,27 @@ public class FlutterEngine {
     flutterJNI.detachFromNativeAndReleaseResources();
   }
 
+  /**
+   * The Dart execution context associated with this {@code FlutterEngine}.
+   *
+   * The {@link DartExecutor} can be used to start executing Dart code from a given entrypoint.
+   * See {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}.
+   *
+   * Use the {@link DartExecutor} to connect any desired message channels and method channels
+   * to facilitate communication between Android and Dart/Flutter.
+   */
   @NonNull
   public DartExecutor getDartExecutor() {
     return dartExecutor;
   }
 
+  /**
+   * The rendering system associated with this {@code FlutterEngine}.
+   *
+   * To render a Flutter UI that is produced by this {@code FlutterEngine}'s Dart code, attach
+   * a {@link io.flutter.embedding.engine.renderer.FlutterRenderer.RenderSurface} to this
+   * {@link FlutterRenderer}.
+   */
   @NonNull
   public FlutterRenderer getRenderer() {
     return renderer;

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -4,6 +4,13 @@
 
 package io.flutter.embedding.engine;
 
+import android.content.Context;
+import android.support.annotation.NonNull;
+
+import io.flutter.app.FlutterPluginRegistry;
+import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
+
 /**
  * A single Flutter execution environment.
  *
@@ -19,16 +26,90 @@ package io.flutter.embedding.engine;
  * Android app.
  *
  * To start running Flutter within this {@code FlutterEngine}, get a reference to this engine's
- * {@link DartExecutor} and then use {@link DartExecutor#runFromBundle(FlutterRunArguments)}.
- * The {@link DartExecutor#runFromBundle(FlutterRunArguments)} method must not be invoked twice on the same
- * {@code FlutterEngine}.
+ * {@link DartExecutor} and then use {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}.
+ * The {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)} method must not be
+ * invoked twice on the same {@code FlutterEngine}.
  *
  * To start rendering Flutter content to the screen, use {@link #getRenderer()} to obtain a
  * {@link FlutterRenderer} and then attach a {@link FlutterRenderer.RenderSurface}.  Consider using
  * a {@link io.flutter.embedding.android.FlutterView} as a {@link FlutterRenderer.RenderSurface}.
  */
 public class FlutterEngine {
-  // TODO(mattcarroll): bring in FlutterEngine implementation in future PR
+  private static final String TAG = "FlutterEngine";
+
+  private final FlutterJNI flutterJNI;
+  private final FlutterRenderer renderer;
+  private final DartExecutor dartExecutor;
+  // TODO(mattcarroll): integrate system channels with FlutterEngine
+  private final FlutterPluginRegistry pluginRegistry;
+
+  private final EngineLifecycleListener engineLifecycleListener = new EngineLifecycleListener() {
+    @SuppressWarnings("unused")
+    public void onPreEngineRestart() {
+      if (pluginRegistry == null)
+        return;
+      pluginRegistry.onPreEngineRestart();
+    }
+  };
+
+  public FlutterEngine(Context context) {
+    this.flutterJNI = new FlutterJNI();
+    flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
+    attachToJni();
+
+    this.dartExecutor = new DartExecutor(flutterJNI);
+    this.dartExecutor.onAttachedToJNI();
+
+    // TODO(mattcarroll): FlutterRenderer is temporally coupled to attach(). Remove that coupling if possible.
+    this.renderer = new FlutterRenderer(flutterJNI);
+
+    this.pluginRegistry = new FlutterPluginRegistry(this, context);
+  }
+
+  private void attachToJni() {
+    // TODO(mattcarroll): update native call to not take in "isBackgroundView"
+    flutterJNI.attachToNative(false);
+
+    if (!isAttachedToJni()) {
+      throw new RuntimeException("FlutterEngine failed to attach to its native Object reference.");
+    }
+  }
+
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+  private boolean isAttachedToJni() {
+    return flutterJNI.isAttached();
+  }
+
+  public void detachFromJni() {
+    pluginRegistry.detach();
+    dartExecutor.onDetachedFromJNI();
+    flutterJNI.removeEngineLifecycleListener(engineLifecycleListener);
+    // TODO(mattcarroll): investigate detach vs destroy. document user-cases. update code if needed.
+    flutterJNI.detachFromNativeButKeepNativeResources();
+  }
+
+  public void destroy() {
+    pluginRegistry.destroy();
+    dartExecutor.onDetachedFromJNI();
+    flutterJNI.removeEngineLifecycleListener(engineLifecycleListener);
+    flutterJNI.detachFromNativeAndReleaseResources();
+  }
+
+  @NonNull
+  public DartExecutor getDartExecutor() {
+    return dartExecutor;
+  }
+
+  @NonNull
+  public FlutterRenderer getRenderer() {
+    return renderer;
+  }
+
+  // TODO(mattcarroll): propose a robust story for plugin backward compability and future facing API.
+  @NonNull
+  public FlutterPluginRegistry getPluginRegistry() {
+    return pluginRegistry;
+  }
 
   /**
    * Lifecycle callbacks for Flutter engine lifecycle events.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -6,6 +6,7 @@ package io.flutter.embedding.engine;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import io.flutter.app.FlutterPluginRegistry;
 import io.flutter.embedding.engine.dart.DartExecutor;
@@ -37,17 +38,19 @@ import io.flutter.embedding.engine.renderer.FlutterRenderer;
 public class FlutterEngine {
   private static final String TAG = "FlutterEngine";
 
+  @NonNull
   private final FlutterJNI flutterJNI;
+  @NonNull
   private final FlutterRenderer renderer;
+  @NonNull
   private final DartExecutor dartExecutor;
   // TODO(mattcarroll): integrate system channels with FlutterEngine
+  @NonNull
   private final FlutterPluginRegistry pluginRegistry;
 
   private final EngineLifecycleListener engineLifecycleListener = new EngineLifecycleListener() {
     @SuppressWarnings("unused")
     public void onPreEngineRestart() {
-      if (pluginRegistry == null)
-        return;
       pluginRegistry.onPreEngineRestart();
     }
   };
@@ -68,7 +71,7 @@ public class FlutterEngine {
    *
    * A new {@code FlutterEngine} does come with all default system channels attached.
    */
-  public FlutterEngine(Context context) {
+  public FlutterEngine(@NonNull Context context) {
     this.flutterJNI = new FlutterJNI();
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
     attachToJni();
@@ -114,7 +117,7 @@ public class FlutterEngine {
    * Cleans up all components within this {@code FlutterEngine} and then detaches from Flutter's
    * native implementation.
    *
-   * A {@code FlutterEngine} instance should be discarded after invoking this method.
+   * This {@code FlutterEngine} instance should be discarded after invoking this method.
    */
   public void destroy() {
     pluginRegistry.destroy();


### PR DESCRIPTION
This PR pulls in the majority of the FlutterEngine implementation from staging.

A few notes:

 * System channels are not yet included because those PRs are outstanding and their inclusion is not necessary to making progress on `FlutterEngine`.
 * The connection between `FlutterEngine` and plugins has yet to be firmly established.  Only a beginning to that API is included here and it is likely to change.
 * This PR does not actually use a FlutterEngine because, as per request, I'm attempting to submit shorter PRs for this process.