### PR TITLE
Correct onAccessibilityFeaturesChanged docs

### DIFF
--- a/lib/stub_ui/window.dart
+++ b/lib/stub_ui/window.dart
@@ -791,7 +791,7 @@ class Window {
   AccessibilityFeatures get accessibilityFeatures => _accessibilityFeatures;
   AccessibilityFeatures _accessibilityFeatures;
 
-  /// A callback that is invoked when the value of [accessibilityFlags] changes.
+  /// A callback that is invoked when the value of [accessibilityFeatures] changes.
   ///
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -786,7 +786,7 @@ class Window {
   AccessibilityFeatures get accessibilityFeatures => _accessibilityFeatures;
   AccessibilityFeatures _accessibilityFeatures;
 
-  /// A callback that is invoked when the value of [accessibilityFlags] changes.
+  /// A callback that is invoked when the value of [accessibilityFeatures] changes.
   ///
   /// The framework invokes this callback in the same zone in which the
   /// callback was set.


### PR DESCRIPTION
Reference to `accessibilityFlags` corrected to `accessibilityFeatures`.