### PR TITLE
Reland #7777 with proper LICENSE

### DIFF
--- a/ci/licenses.sh
+++ b/ci/licenses.sh
@@ -42,7 +42,7 @@ fi
 
 echo "Checking license count in licenses_flutter..."
 actualLicenseCount=`tail -n 1 flutter/ci/licenses_golden/licenses_flutter | tr -dc '0-9'`
-expectedLicenseCount=2 # When changing this number: Update the error message below as well describing all expected license types.
+expectedLicenseCount=3 # When changing this number: Update the error message below as well describing all expected license types.
 
 if [ "$actualLicenseCount" -ne "$expectedLicenseCount" ]
 then

--- a/ci/licenses.sh
+++ b/ci/licenses.sh
@@ -53,6 +53,8 @@ then
     echo "double-check that all newly added files have a BSD-style license"
     echo "header with the following copyright:"
     echo "    Copyright 2013 The Flutter Authors. All rights reserved."
+    echo "Files in 'third_party/bsdiff' may have the following copyright instead:"
+    echo "    Copyright 2003-2005 Colin Percival. All rights reserved."
     echo "Files in 'third_party/txt' may have an Apache license header instead."
     echo "If you're absolutely sure that the change in license count is"
     echo "intentional, update 'flutter/ci/licenses.sh' with the new count."

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -5,6 +5,37 @@ UNUSED LICENSES:
 USED LICENSES:
 
 ====================================================================================================
+LIBRARY: bsdiff
+ORIGIN: ../../../flutter/third_party/bsdiff/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../flutter/third_party/bsdiff/io/flutter/util/BSDiff.java
+----------------------------------------------------------------------------------------------------
+Copyright 2003-2005 Colin Percival. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
 LIBRARY: engine
 LIBRARY: txt
 ORIGIN: ../../../flutter/LICENSE
@@ -977,4 +1008,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ====================================================================================================
-Total license count: 2
+Total license count: 3

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -166,6 +166,10 @@ java_library("flutter_shell_java") {
     "io/flutter/view/VsyncWaiter.java",
   ]
 
+  java_files += [
+    "$flutter_root/third_party/bsdiff/io/flutter/util/BSDiff.java",
+  ]
+
   deps = [
     ":android_support_v13",
     ":android_support_annotations",

--- a/sky/packages/sky_engine/LICENSE
+++ b/sky/packages/sky_engine/LICENSE
@@ -3492,6 +3492,32 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 --------------------------------------------------------------------------------
+bsdiff
+
+Copyright 2003-2005 Colin Percival. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+--------------------------------------------------------------------------------
 engine
 txt
 

--- a/third_party/bsdiff/LICENSE
+++ b/third_party/bsdiff/LICENSE
@@ -1,0 +1,23 @@
+Copyright 2003-2005 Colin Percival. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/third_party/bsdiff/README.md
+++ b/third_party/bsdiff/README.md
@@ -1,0 +1,12 @@
+# BSDiff
+
+Binary diff/patch algorithm based on
+[bsdiff 4.3](http://www.daemonology.net/bsdiff/) by Colin Percival.
+It's very effective at compressesing incremental changes in binaries.
+
+This implementation has the following differences from Colin's code,
+to make it easier to read and apply patches in Java and Objective C:
+
+* Using gzip instead of bzip2 because gzip is included in JDK by default
+* Using big- instead of little-endian serialization to simplify Java code
+* Using two's complement instead of high-bit coding for negatives numbers

--- a/third_party/bsdiff/io/flutter/util/BSDiff.java
+++ b/third_party/bsdiff/io/flutter/util/BSDiff.java
@@ -1,0 +1,91 @@
+// Copyright 2003-2005 Colin Percival. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.util;
+
+import java.io.*;
+import java.util.zip.GZIPInputStream;
+
+/**
+ * This is a Java port of algorithm from Flutter framework bsdiff.dart.
+ * Note that this port uses 32-bit ints, which limits data size to 2GB.
+ **/
+public abstract class BSDiff {
+    public static byte[] bspatch(byte[] olddata, byte[] diffdata) throws IOException {
+        InputStream in = new ByteArrayInputStream(diffdata, 0, diffdata.length);
+        DataInputStream header = new DataInputStream(in);
+
+        byte[] magic = new byte[8];
+        header.read(magic);
+        if (!new String(magic).equals("BZDIFF40")) {
+            throw new IOException("Invalid magic");
+        }
+
+        int ctrllen = (int) header.readLong();
+        int datalen = (int) header.readLong();
+        int newsize = (int) header.readLong();
+        header.close();
+
+        in = new ByteArrayInputStream(diffdata, 0, diffdata.length);
+        in.skip(32);
+        DataInputStream cpf = new DataInputStream(new GZIPInputStream(in));
+
+        in = new ByteArrayInputStream(diffdata, 0, diffdata.length);
+        in.skip(32 + ctrllen);
+        InputStream dpf = new GZIPInputStream(in);
+
+        in = new ByteArrayInputStream(diffdata, 0, diffdata.length);
+        in.skip(32 + ctrllen + datalen);
+        InputStream epf = new GZIPInputStream(in);
+
+        byte[] newdata = new byte[newsize];
+
+	int oldpos = 0;
+        int newpos = 0;
+
+        while (newpos < newsize) {
+            int[] ctrl = new int[3];
+            for (int i = 0; i <= 2; i++) {
+                ctrl[i] = (int) cpf.readLong();
+            }
+            if (newpos + ctrl[0] > newsize) {
+                throw new IOException("Invalid ctrl[0]");
+            }
+
+            read(dpf, newdata, newpos, ctrl[0]);
+
+            for (int i = 0; i < ctrl[0]; i++) {
+                if ((oldpos + i >= 0) && (oldpos + i < olddata.length)) {
+                    newdata[newpos + i] += olddata[oldpos + i];
+                }
+            }
+
+            newpos += ctrl[0];
+            oldpos += ctrl[0];
+
+            if (newpos + ctrl[1] > newsize) {
+                throw new IOException("Invalid ctrl[0]");
+            }
+
+            read(epf, newdata, newpos, ctrl[1]);
+
+            newpos += ctrl[1];
+            oldpos += ctrl[2];
+        }
+
+        cpf.close();
+        dpf.close();
+        epf.close();
+
+        return newdata;
+    }
+
+    private static void read(InputStream in, byte[] buf, int off, int len) throws IOException {
+        for (int i, n = 0; n < len; n += i) {
+            if ((i = in.read(buf, off + n, len - n)) < 0) {
+                throw new IOException("Unexpected EOF");
+            }
+        }
+    }
+}


### PR DESCRIPTION
This change is identical to https://github.com/flutter/engine/pull/7777, except it moves BSDiff.java to third_party with a separate LICENSE.