### PR TITLE
Respect the custom GL proc table when creating the resource context on the IO thread.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -403,6 +403,7 @@ FILE: ../../../flutter/shell/common/vsync_waiter_fallback.cc
 FILE: ../../../flutter/shell/common/vsync_waiter_fallback.h
 FILE: ../../../flutter/shell/gpu/gpu_surface_gl.cc
 FILE: ../../../flutter/shell/gpu/gpu_surface_gl.h
+FILE: ../../../flutter/shell/gpu/gpu_surface_gl_delegate.cc
 FILE: ../../../flutter/shell/gpu/gpu_surface_gl_delegate.h
 FILE: ../../../flutter/shell/gpu/gpu_surface_software.cc
 FILE: ../../../flutter/shell/gpu/gpu_surface_software.h

--- a/shell/common/io_manager.cc
+++ b/shell/common/io_manager.cc
@@ -32,7 +32,7 @@ sk_sp<GrContext> IOManager::CreateCompatibleResourceLoadingContext(
   // ES2 shading language when the ES3 external image extension is missing.
   options.fPreferExternalImagesOverES3 = true;
 
-  if (auto context = GrContext::MakeGL(GrGLMakeNativeInterface(), options)) {
+  if (auto context = GrContext::MakeGL(gl_interface, options)) {
     // Do not cache textures created by the image decoder.  These textures
     // should be deleted when they are no longer referenced by an SkImage.
     context->setResourceCacheLimits(0, 0);

--- a/shell/common/io_manager.cc
+++ b/shell/common/io_manager.cc
@@ -11,7 +11,8 @@
 namespace shell {
 
 sk_sp<GrContext> IOManager::CreateCompatibleResourceLoadingContext(
-    GrBackend backend) {
+    GrBackend backend,
+    sk_sp<const GrGLInterface> gl_interface) {
   if (backend != GrBackend::kOpenGL_GrBackend) {
     return nullptr;
   }

--- a/shell/common/io_manager.h
+++ b/shell/common/io_manager.h
@@ -21,7 +21,8 @@ class IOManager : public blink::IOManager {
   // the IOManager. The platforms may create the context themselves if they so
   // desire.
   static sk_sp<GrContext> CreateCompatibleResourceLoadingContext(
-      GrBackend backend);
+      GrBackend backend,
+      sk_sp<const GrGLInterface> gl_interface);
 
   IOManager(sk_sp<GrContext> resource_context,
             fml::RefPtr<fml::TaskRunner> unref_queue_task_runner);

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -28,6 +28,7 @@ source_set("gpu_surface_gl") {
   sources = [
     "$gpu_dir/gpu_surface_gl.cc",
     "$gpu_dir/gpu_surface_gl.h",
+    "$gpu_dir/gpu_surface_gl_delegate.cc",
     "$gpu_dir/gpu_surface_gl_delegate.h",
   ]
 

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -12,8 +12,6 @@
 #include "third_party/skia/include/core/SkSurface.h"
 #include "third_party/skia/include/gpu/GrBackendSurface.h"
 #include "third_party/skia/include/gpu/GrContextOptions.h"
-#include "third_party/skia/include/gpu/gl/GrGLAssembleInterface.h"
-#include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
 // These are common defines present on all OpenGL headers. However, we don't
 // want to perform GL header reasolution on each platform we support. So just
@@ -22,7 +20,6 @@
 #define GPU_GL_RGBA8 0x8058
 #define GPU_GL_RGBA4 0x8056
 #define GPU_GL_RGB565 0x8D62
-#define GPU_GL_VERSION 0x1F02
 
 namespace shell {
 
@@ -33,9 +30,6 @@ static const int kGrCacheMaxCount = 8192;
 // cache.
 static const size_t kGrCacheMaxByteSize = 512 * (1 << 20);
 
-// Version string prefix that identifies an OpenGL ES implementation.
-static const char kGLESVersionPrefix[] = "OpenGL ES";
-
 GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
     : delegate_(delegate), weak_factory_(this) {
   if (!delegate_->GLContextMakeCurrent()) {
@@ -43,8 +37,6 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
         << "Could not make the context current to setup the gr context.";
     return;
   }
-
-  proc_resolver_ = delegate_->GetGLProcResolver();
 
   GrContextOptions options;
 
@@ -60,26 +52,7 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
   // A similar work-around is also used in shell/common/io_manager.cc.
   options.fDisableGpuYUVConversion = true;
 
-  sk_sp<const GrGLInterface> interface;
-
-  if (proc_resolver_ == nullptr) {
-    interface = GrGLMakeNativeInterface();
-  } else {
-    auto gl_get_proc = [](void* context,
-                          const char gl_proc_name[]) -> GrGLFuncPtr {
-      return reinterpret_cast<GrGLFuncPtr>(
-          reinterpret_cast<GPUSurfaceGL*>(context)->proc_resolver_(
-              gl_proc_name));
-    };
-
-    if (IsProcResolverOpenGLES()) {
-      interface = GrGLMakeAssembledGLESInterface(this, gl_get_proc);
-    } else {
-      interface = GrGLMakeAssembledGLInterface(this, gl_get_proc);
-    }
-  }
-
-  auto context = GrContext::MakeGL(interface, options);
+  auto context = GrContext::MakeGL(delegate_->GetGLInterface(), options);
 
   if (context == nullptr) {
     FML_LOG(ERROR) << "Failed to setup Skia Gr context.";
@@ -105,8 +78,6 @@ GPUSurfaceGL::GPUSurfaceGL(sk_sp<GrContext> gr_context,
     return;
   }
 
-  proc_resolver_ = delegate_->GetGLProcResolver();
-
   delegate_->GLContextClearCurrent();
 
   valid_ = true;
@@ -131,20 +102,6 @@ GPUSurfaceGL::~GPUSurfaceGL() {
   context_ = nullptr;
 
   delegate_->GLContextClearCurrent();
-}
-
-bool GPUSurfaceGL::IsProcResolverOpenGLES() {
-  using GLGetStringProc = const char* (*)(uint32_t);
-  GLGetStringProc gl_get_string =
-      reinterpret_cast<GLGetStringProc>(proc_resolver_("glGetString"));
-  FML_CHECK(gl_get_string)
-      << "The GL proc resolver could not resolve glGetString";
-  const char* gl_version_string = gl_get_string(GPU_GL_VERSION);
-  FML_CHECK(gl_version_string)
-      << "The GL proc resolver's glGetString(GL_VERSION) failed";
-
-  return strncmp(gl_version_string, kGLESVersionPrefix,
-                 strlen(kGLESVersionPrefix)) == 0;
 }
 
 // |shell::Surface|
@@ -370,29 +327,6 @@ flow::ExternalViewEmbedder* GPUSurfaceGL::GetExternalViewEmbedder() {
 // |shell::Surface|
 bool GPUSurfaceGL::MakeRenderContextCurrent() {
   return delegate_->GLContextMakeCurrent();
-}
-
-bool GPUSurfaceGLDelegate::GLContextFBOResetAfterPresent() const {
-  return false;
-}
-
-bool GPUSurfaceGLDelegate::UseOffscreenSurface() const {
-  return false;
-}
-
-SkMatrix GPUSurfaceGLDelegate::GLContextSurfaceTransformation() const {
-  SkMatrix matrix;
-  matrix.setIdentity();
-  return matrix;
-}
-
-flow::ExternalViewEmbedder* GPUSurfaceGLDelegate::GetExternalViewEmbedder() {
-  return nullptr;
-}
-
-GPUSurfaceGLDelegate::GLProcResolver GPUSurfaceGLDelegate::GetGLProcResolver()
-    const {
-  return nullptr;
 }
 
 }  // namespace shell

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -46,7 +46,6 @@ class GPUSurfaceGL : public Surface {
 
  private:
   GPUSurfaceGLDelegate* delegate_;
-  GPUSurfaceGLDelegate::GLProcResolver proc_resolver_;
   sk_sp<GrContext> context_;
   sk_sp<SkSurface> onscreen_surface_;
   sk_sp<SkSurface> offscreen_surface_;
@@ -61,8 +60,6 @@ class GPUSurfaceGL : public Surface {
       const SkMatrix& root_surface_transformation);
 
   bool PresentSurface(SkCanvas* canvas);
-
-  bool IsProcResolverOpenGLES();
 
   FML_DISALLOW_COPY_AND_ASSIGN(GPUSurfaceGL);
 };

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -1,0 +1,104 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
+
+#include "third_party/skia/include/gpu/gl/GrGLAssembleInterface.h"
+
+namespace shell {
+
+bool GPUSurfaceGLDelegate::GLContextFBOResetAfterPresent() const {
+  return false;
+}
+
+bool GPUSurfaceGLDelegate::UseOffscreenSurface() const {
+  return false;
+}
+
+SkMatrix GPUSurfaceGLDelegate::GLContextSurfaceTransformation() const {
+  SkMatrix matrix;
+  matrix.setIdentity();
+  return matrix;
+}
+
+flow::ExternalViewEmbedder* GPUSurfaceGLDelegate::GetExternalViewEmbedder() {
+  return nullptr;
+}
+
+GPUSurfaceGLDelegate::GLProcResolver GPUSurfaceGLDelegate::GetGLProcResolver()
+    const {
+  return nullptr;
+}
+
+static bool IsProcResolverOpenGLES(
+    GPUSurfaceGLDelegate::GLProcResolver proc_resolver) {
+  // Version string prefix that identifies an OpenGL ES implementation.
+#define GPU_GL_VERSION 0x1F02
+  constexpr char kGLESVersionPrefix[] = "OpenGL ES";
+
+  using GLGetStringProc = const char* (*)(uint32_t);
+
+  GLGetStringProc gl_get_string =
+      reinterpret_cast<GLGetStringProc>(proc_resolver("glGetString"));
+
+  FML_CHECK(gl_get_string)
+      << "The GL proc resolver could not resolve glGetString";
+
+  const char* gl_version_string = gl_get_string(GPU_GL_VERSION);
+
+  FML_CHECK(gl_version_string)
+      << "The GL proc resolver's glGetString(GL_VERSION) failed";
+
+  return strncmp(gl_version_string, kGLESVersionPrefix,
+                 strlen(kGLESVersionPrefix)) == 0;
+}
+
+static sk_sp<const GrGLInterface> CreateGLInterface(
+    GPUSurfaceGLDelegate::GLProcResolver proc_resolver) {
+  if (proc_resolver == nullptr) {
+    // If there is no custom proc resolver, ask Skia to guess the native
+    // interface. This often leads to interesting results on most platforms.
+    return GrGLMakeNativeInterface();
+  }
+
+  struct ProcResolverContext {
+    GPUSurfaceGLDelegate::GLProcResolver resolver;
+  };
+
+  ProcResolverContext context = {
+      .resolver = proc_resolver,
+  };
+
+  GrGLGetProc gl_get_proc = [](void* context,
+                               const char gl_proc_name[]) -> GrGLFuncPtr {
+    auto proc_resolver_context =
+        reinterpret_cast<ProcResolverContext*>(context);
+    return reinterpret_cast<GrGLFuncPtr>(
+        proc_resolver_context->resolver(gl_proc_name));
+  };
+
+  // glGetString indicates an OpenGL ES interface.
+  if (IsProcResolverOpenGLES(proc_resolver)) {
+    return GrGLMakeAssembledGLESInterface(&context, gl_get_proc);
+  }
+
+  // Fallback to OpenGL.
+  if (auto interface = GrGLMakeAssembledGLInterface(&context, gl_get_proc)) {
+    return interface;
+  }
+
+  FML_LOG(ERROR) << "Could not create a valid GL interface.";
+  return nullptr;
+}
+
+sk_sp<const GrGLInterface> GPUSurfaceGLDelegate::GetGLInterface() const {
+  return CreateGLInterface(GetGLProcResolver());
+}
+
+sk_sp<const GrGLInterface>
+GPUSurfaceGLDelegate::GetDefaultPlatformGLInterface() {
+  return CreateGLInterface(nullptr);
+}
+
+}  // namespace shell

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -8,6 +8,7 @@
 #include "flutter/flow/embedded_views.h"
 #include "flutter/fml/macros.h"
 #include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
 namespace shell {
 
@@ -44,6 +45,14 @@ class GPUSurfaceGLDelegate {
   // Get a reference to the external views embedder. This happens on the same
   // thread that the renderer is operating on.
   virtual flow::ExternalViewEmbedder* GetExternalViewEmbedder();
+
+  sk_sp<const GrGLInterface> GetGLInterface() const;
+
+  // TODO(chinmaygarde): The presence of this method is to work around the fact
+  // that not all platforms can accept a custom GL proc table. Migrate all
+  // platforms to move GL proc resolution to the embedder and remove this
+  // method.
+  static sk_sp<const GrGLInterface> GetDefaultPlatformGLInterface();
 
   using GLProcResolver =
       std::function<void* /* proc name */ (const char* /* proc address */)>;

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -9,6 +9,7 @@
 
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/shell/common/io_manager.h"
+#include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 #include "flutter/shell/platform/android/android_external_texture_gl.h"
 #include "flutter/shell/platform/android/android_surface_gl.h"
 #include "flutter/shell/platform/android/platform_message_response_android.h"
@@ -379,7 +380,8 @@ sk_sp<GrContext> PlatformViewAndroid::CreateResourceContext() const {
     // the OpenGL surface will be able to make a resource context current. If
     // this changes, this assumption breaks. Handle the same.
     resource_context = IOManager::CreateCompatibleResourceLoadingContext(
-        GrBackend::kOpenGL_GrBackend);
+        GrBackend::kOpenGL_GrBackend,
+        GPUSurfaceGLDelegate::GetDefaultPlatformGLInterface());
   } else {
     FML_DLOG(ERROR) << "Could not make the resource context current.";
   }

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -12,6 +12,7 @@
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/io_manager.h"
+#include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
 #include "flutter/shell/platform/darwin/ios/ios_external_texture_gl.h"
@@ -82,7 +83,8 @@ sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
     return nullptr;
   }
 
-  return IOManager::CreateCompatibleResourceLoadingContext(GrBackend::kOpenGL_GrBackend);
+  return IOManager::CreateCompatibleResourceLoadingContext(
+      GrBackend::kOpenGL_GrBackend, GPUSurfaceGLDelegate::GetDefaultPlatformGLInterface());
 }
 
 // |shell::PlatformView|

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -81,11 +81,17 @@ sk_sp<GrContext> EmbedderSurfaceGL::CreateResourceContext() const {
   auto callback = gl_dispatch_table_.gl_make_resource_current_callback;
   if (callback && callback()) {
     if (auto context = IOManager::CreateCompatibleResourceLoadingContext(
-            GrBackend::kOpenGL_GrBackend)) {
+            GrBackend::kOpenGL_GrBackend, GetGLInterface())) {
       return context;
+    } else {
+      FML_LOG(ERROR)
+          << "Internal error: Resource context available but could not create "
+             "a compatible Skia context.";
+      return nullptr;
     }
   }
 
+  // The callback was not available or failed.
   FML_LOG(ERROR)
       << "Could not create a resource context for async texture uploads. "
          "Expect degraded performance. Set a valid make_resource_current "


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/28229