### PR TITLE
Eliminate .member = foo struct initialization

### DIFF
--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -67,7 +67,7 @@ static sk_sp<const GrGLInterface> CreateGLInterface(
   };
 
   ProcResolverContext context = {
-      .resolver = proc_resolver,
+      proc_resolver
   };
 
   GrGLGetProc gl_get_proc = [](void* context,


### PR DESCRIPTION
This broke the Windows MSVC build:
```
[3049/3506] CXX obj/flutter/shell/gpu/gpu_surface_gl.gpu_surface_gl_delegate.obj
FAILED: obj/flutter/shell/gpu/gpu_surface_gl.gpu_surface_gl_delegate.obj
ninja -t msvc -e environment.x64 -- E:\b\c\goma_cache\client/gomacc.exe "E:\b\depot_tools\win_toolchain\vs_files\3bc0ec615cf20ee342f3bc29bc991b5ad66d8d2c\VC\Tools\MSVC\14.14.26428\bin\HostX64\x64/cl.exe" /nologo /showIncludes /FC @obj/flutter/shell/gpu/gpu_surface_gl.gpu_surface_gl_delegate.obj.rsp /c ../../flutter/shell/gpu/gpu_surface_gl_delegate.cc /Foobj/flutter/shell/gpu/gpu_surface_gl.gpu_surface_gl_delegate.obj /Fdobj/flutter/shell/gpu/gpu_surface_gl_cc.pdb
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(70): error C2059: syntax error: '.'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(71): error C2143: syntax error: missing ';' before '}'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(76): error C2061: syntax error: identifier 'ProcResolverContext'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(78): error C3536: 'proc_resolver_context': cannot be used before it is initialized
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(78): error C2227: left of '->resolver' must point to class/struct/union/generic type
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(78): note: type is 'int'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(82): error C2059: syntax error: 'if'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(82): error C2143: syntax error: missing ';' before '{'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(82): error C2447: '{': missing function header (old-style formal list?)
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(87): error C2059: syntax error: 'if'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(87): error C2143: syntax error: missing ';' before '{'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(87): error C2447: '{': missing function header (old-style formal list?)
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(91): error C2059: syntax error: '('
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(91): error C2059: syntax error: ')'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(92): error C2059: syntax error: 'return'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(95): error C2653: 'GPUSurfaceGLDelegate': is not a class or namespace name
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(95): error C2270: 'GetGLInterface': modifiers not allowed on nonmember functions
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(96): error C3861: 'GetGLProcResolver': identifier not found
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(96): error C3861: 'CreateGLInterface': identifier not found
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(100): error C2653: 'GPUSurfaceGLDelegate': is not a class or namespace name
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(101): error C3861: 'CreateGLInterface': identifier not found
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(104): error C2059: syntax error: '}'
e:\b\rr\tmpahx5uo\w\src\flutter\shell\gpu\gpu_surface_gl_delegate.cc(104): error C2143: syntax error: missing ';' before '}'
```