### PR TITLE
Link dart:* sources into engine for debugger source support

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -48,6 +48,8 @@ struct Settings {
   std::string isolate_snapshot_instr_path;  // deprecated
   MappingCallback isolate_snapshot_instr;
 
+  MappingCallback platform_strong_dill;
+
   std::string application_library_path;
   std::string application_kernel_asset;
   std::string application_kernel_list_asset;

--- a/common/settings.h
+++ b/common/settings.h
@@ -48,7 +48,9 @@ struct Settings {
   std::string isolate_snapshot_instr_path;  // deprecated
   MappingCallback isolate_snapshot_instr;
 
-  MappingCallback platform_strong_dill;
+  // Returns the Mapping to a kernel buffer which contains sources for dart:*
+  // libraries.
+  MappingCallback dart_library_sources_kernel;
 
   std::string application_library_path;
   std::string application_kernel_asset;

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -94,6 +94,14 @@ template("bin_to_assembly") {
       "--target_os",
       current_os,
     ]
+    if (defined(invoker.size_symbol)) {
+      args += [
+        "--size_symbol_name",
+        invoker.size_symbol,
+        "--target_arch",
+        current_cpu,
+      ]
+    }
     if (invoker.executable) {
       args += [ "--executable" ]
     }
@@ -201,17 +209,29 @@ bin_to_linkable("isolate_snapshot_instructions_linkable") {
   executable = true
 }
 
+bin_to_linkable("platform_strong_dill_linkable") {
+  deps = [
+    ":strong_platform",
+  ]
+  input = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
+  symbol = "kPlatformStrongDill"
+  size_symbol = "kPlatformStrongDillSize"
+  executable = false
+}
+
 source_set("snapshot") {
   deps = [
     ":isolate_snapshot_data_linkable",
     ":isolate_snapshot_instructions_linkable",
     ":vm_snapshot_data_linkable",
     ":vm_snapshot_instructions_linkable",
+    ":platform_strong_dill_linkable",
   ]
   sources = get_target_outputs(":isolate_snapshot_data_linkable") +
     get_target_outputs(":isolate_snapshot_instructions_linkable") +
     get_target_outputs(":vm_snapshot_data_linkable") +
-    get_target_outputs(":vm_snapshot_instructions_linkable")
+    get_target_outputs(":vm_snapshot_instructions_linkable") +
+    get_target_outputs(":platform_strong_dill_linkable")
 }
 
 compile_platform("non_strong_platform") {

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -32,6 +32,13 @@
 #include "third_party/tonic/scopes/dart_api_scope.h"
 #include "third_party/tonic/typed_data/uint8_list.h"
 
+extern "C" {
+#if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
+extern const uint8_t kPlatformStrongDill[];
+extern const intptr_t kPlatformStrongDillSize;
+#endif
+}
+
 namespace dart {
 namespace observatory {
 
@@ -438,6 +445,12 @@ DartVM::DartVM(const Settings& settings,
                                  &ServiceStreamCancelCallback);
 
   Dart_SetEmbedderInformationCallback(&EmbedderInformationCallback);
+
+#if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
+  // Set sources for dart:* libraries for debugging.
+  Dart_SetDartLibrarySourcesKernel(kPlatformStrongDill,
+                                   kPlatformStrongDillSize);
+#endif
 }
 
 DartVM::~DartVM() {

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -439,12 +439,12 @@ DartVM::DartVM(const Settings& settings,
 
   Dart_SetEmbedderInformationCallback(&EmbedderInformationCallback);
 
-  if (settings.platform_strong_dill != nullptr) {
-    std::unique_ptr<fml::Mapping> platform_strong_dill =
-        settings.platform_strong_dill();
+  if (settings.dart_library_sources_kernel != nullptr) {
+    std::unique_ptr<fml::Mapping> dart_library_sources =
+        settings.dart_library_sources_kernel();
     // Set sources for dart:* libraries for debugging.
-    Dart_SetDartLibrarySourcesKernel(platform_strong_dill->GetMapping(),
-                                     platform_strong_dill->GetSize());
+    Dart_SetDartLibrarySourcesKernel(dart_library_sources->GetMapping(),
+                                     dart_library_sources->GetSize());
   }
 }
 

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -71,6 +71,9 @@ shared_library("flutter_shell_native") {
   } else {
     deps += [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
   }
+  if (flutter_runtime_mode == "debug") {
+    deps += [ "$flutter_root/lib/snapshot" ]
+  }
 
   public_configs = [ "$flutter_root:config" ]
 

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -107,7 +107,7 @@ void FlutterMain::Init(JNIEnv* env,
     };
   };
 
-  settings.platform_strong_dill =
+  settings.dart_library_sources_kernel =
       make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
 #endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -25,6 +25,14 @@
 
 namespace shell {
 
+extern "C" {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  // Used for debugging dart:* sources.
+  extern const uint8_t kPlatformStrongDill[];
+  extern const intptr_t kPlatformStrongDillSize;
+#endif
+}
+
 FlutterMain::FlutterMain(blink::Settings settings)
     : settings_(std::move(settings)) {}
 
@@ -89,6 +97,20 @@ void FlutterMain::Init(JNIEnv* env,
   settings.task_observer_remove = [](intptr_t key) {
     fml::MessageLoop::GetCurrent().RemoveTaskObserver(key);
   };
+
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  // There are no ownership concerns here as all mappings are owned by the
+  // embedder and not the engine.
+  auto make_mapping_callback = [](const uint8_t* mapping, size_t size) {
+    return [mapping, size]() {
+      return std::make_unique<fml::NonOwnedMapping>(mapping, size);
+    };
+  };
+
+  settings.platform_strong_dill =
+      make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
+#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+
   // Not thread safe. Will be removed when FlutterMain is refactored to no
   // longer be a singleton.
   g_flutter_main.reset(new FlutterMain(std::move(settings)));

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -27,9 +27,9 @@ namespace shell {
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  // Used for debugging dart:* sources.
-  extern const uint8_t kPlatformStrongDill[];
-  extern const intptr_t kPlatformStrongDillSize;
+// Used for debugging dart:* sources.
+extern const uint8_t kPlatformStrongDill[];
+extern const intptr_t kPlatformStrongDillSize;
 #endif
 }
 
@@ -109,7 +109,7 @@ void FlutterMain::Init(JNIEnv* env,
 
   settings.dart_library_sources_kernel =
       make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
-#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 
   // Not thread safe. Will be removed when FlutterMain is refactored to no
   // longer be a singleton.

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -15,6 +15,14 @@
 #include "flutter/shell/platform/darwin/common/command_line.h"
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 
+extern "C" {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  // Used for debugging dart:* sources.
+  extern const uint8_t kPlatformStrongDill[];
+  extern const intptr_t kPlatformStrongDillSize;
+#endif
+}
+
 static const char* kApplicationKernelSnapshotFileName = "kernel_blob.bin";
 
 static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
@@ -122,6 +130,19 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
       }
     }
   }
+
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  // There are no ownership concerns here as all mappings are owned by the
+  // embedder and not the engine.
+  auto make_mapping_callback = [](const uint8_t* mapping, size_t size) {
+    return [mapping, size]() {
+      return std::make_unique<fml::NonOwnedMapping>(mapping, size);
+    };
+  };
+
+  settings.platform_strong_dill =
+      make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
+#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 
   return settings;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -17,9 +17,9 @@
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  // Used for debugging dart:* sources.
-  extern const uint8_t kPlatformStrongDill[];
-  extern const intptr_t kPlatformStrongDillSize;
+// Used for debugging dart:* sources.
+extern const uint8_t kPlatformStrongDill[];
+extern const intptr_t kPlatformStrongDillSize;
 #endif
 }
 
@@ -135,14 +135,12 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   // There are no ownership concerns here as all mappings are owned by the
   // embedder and not the engine.
   auto make_mapping_callback = [](const uint8_t* mapping, size_t size) {
-    return [mapping, size]() {
-      return std::make_unique<fml::NonOwnedMapping>(mapping, size);
-    };
+    return [mapping, size]() { return std::make_unique<fml::NonOwnedMapping>(mapping, size); };
   };
 
   settings.dart_library_sources_kernel =
       make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
-#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 
   return settings;
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -140,7 +140,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
     };
   };
 
-  settings.platform_strong_dill =
+  settings.dart_library_sources_kernel =
       make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
 #endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -13,6 +13,14 @@
 #define FLUTTER_EXPORT __attribute__((visibility("default")))
 #endif  // OS_WIN
 
+extern "C" {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  // Used for debugging dart:* sources.
+  extern const uint8_t kPlatformStrongDill[];
+  extern const intptr_t kPlatformStrongDillSize;
+#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+}
+
 #include "flutter/shell/platform/embedder/embedder.h"
 
 #include <type_traits>
@@ -286,6 +294,12 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
                                 args->isolate_snapshot_instructions_size);
     }
   }
+
+#if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
+  settings.platform_strong_dill =
+      make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
+#endif // !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
+
 }
 
 FlutterEngineResult FlutterEngineRun(size_t version,

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -15,10 +15,10 @@
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  // Used for debugging dart:* sources.
-  extern const uint8_t kPlatformStrongDill[];
-  extern const intptr_t kPlatformStrongDillSize;
-#endif // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+// Used for debugging dart:* sources.
+extern const uint8_t kPlatformStrongDill[];
+extern const intptr_t kPlatformStrongDillSize;
+#endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
 }
 
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -298,8 +298,7 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
 #if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
   settings.dart_library_sources_kernel =
       make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
-#endif // !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
-
+#endif  // !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
 }
 
 FlutterEngineResult FlutterEngineRun(size_t version,

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -296,7 +296,7 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
   }
 
 #if !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
-  settings.platform_strong_dill =
+  settings.dart_library_sources_kernel =
       make_mapping_callback(kPlatformStrongDill, kPlatformStrongDillSize);
 #endif // !OS_FUCHSIA && (FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG)
 


### PR DESCRIPTION
Currently, dart:* libraries appear to have no source in debuggers like Observatory. With this change, these sources will be available in debug mode applications. Sources for dart:* libraries are lazily loaded on a script-by-script basis.

Refer to https://dart-review.googlesource.com/c/sdk/+/93375 for the Dart SDK change.