### PR TITLE
Move canvas clear after preroll

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -63,6 +63,8 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 bool CompositorContext::ScopedFrame::Raster(flow::LayerTree& layer_tree,
                                             bool ignore_raster_cache) {
   layer_tree.Preroll(*this, ignore_raster_cache);
+  // Clearing canvas after preroll reduces one render target switch when preroll
+  // paints some raster cache.
   if (canvas()) {
     canvas()->clear(SK_ColorTRANSPARENT);
   }

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -63,6 +63,9 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 bool CompositorContext::ScopedFrame::Raster(flow::LayerTree& layer_tree,
                                             bool ignore_raster_cache) {
   layer_tree.Preroll(*this, ignore_raster_cache);
+  if (canvas()) {
+    canvas()->clear(SK_ColorTRANSPARENT);
+  }
   layer_tree.Paint(*this, ignore_raster_cache);
   return true;
 }

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -181,10 +181,6 @@ bool Rasterizer::DrawToSurface(flow::LayerTree& layer_tree) {
       surface_->GetContext(), canvas, external_view_embedder,
       surface_->GetRootTransformation(), true);
 
-  if (canvas) {
-    canvas->clear(SK_ColorTRANSPARENT);
-  }
-
   if (compositor_frame && compositor_frame->Raster(layer_tree, false)) {
     frame->Submit();
     if (external_view_embedder != nullptr) {


### PR DESCRIPTION
This will reduce 1 render target switch when preroll paints some raster cache.