### PR TITLE
Do not clear FlutterJNI state when a FlutterView is detached

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -109,8 +109,6 @@ public class FlutterEngine {
     pluginRegistry.detach();
     dartExecutor.onDetachedFromJNI();
     flutterJNI.removeEngineLifecycleListener(engineLifecycleListener);
-    // TODO(mattcarroll): investigate detach vs destroy. document user-cases. update code if needed.
-    flutterJNI.detachFromNativeButKeepNativeResources();
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -393,15 +393,6 @@ public class FlutterJNI {
   private native long nativeAttach(FlutterJNI flutterJNI, boolean isBackgroundView);
 
   @UiThread
-  public void detachFromNativeButKeepNativeResources() {
-    ensureAttachedToNative();
-    nativeDetach(nativePlatformViewId);
-    nativePlatformViewId = null;
-  }
-
-  private native void nativeDetach(long nativePlatformViewId);
-
-  @UiThread
   public void detachFromNativeAndReleaseResources() {
     ensureAttachedToNative();
     nativeDestroy(nativePlatformViewId);

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -50,7 +50,6 @@ public class FlutterNativeView implements BinaryMessenger {
         mPluginRegistry.detach();
         dartExecutor.onDetachedFromJNI();
         mFlutterView = null;
-        mFlutterJNI.detachFromNativeButKeepNativeResources();
     }
 
     public void destroy() {

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -160,11 +160,6 @@ static jlong AttachJNI(JNIEnv* env,
   }
 }
 
-// TODO(mattcarroll): delete this method here and in FlutterJNI.java
-static void DetachJNI(JNIEnv* env, jobject jcaller, jlong shell_holder) {
-  // Nothing to do.
-}
-
 static void DestroyJNI(JNIEnv* env, jobject jcaller, jlong shell_holder) {
   delete ANDROID_SHELL_HOLDER;
 }
@@ -546,11 +541,6 @@ bool RegisterApi(JNIEnv* env) {
           .name = "nativeAttach",
           .signature = "(Lio/flutter/embedding/engine/FlutterJNI;Z)J",
           .fnPtr = reinterpret_cast<void*>(&shell::AttachJNI),
-      },
-      {
-          .name = "nativeDetach",
-          .signature = "(J)V",
-          .fnPtr = reinterpret_cast<void*>(&shell::DetachJNI),
       },
       {
           .name = "nativeDestroy",


### PR DESCRIPTION
If an app is using retainFlutterNativeView or a plugin wants to keep the
FlutterNativeView active, then the FlutterNativeView should not drop its
handle to the corresponding native platform view.

Fixes https://github.com/flutter/flutter/issues/26931