### PR TITLE
fix sendLocales on old android versions

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -321,7 +321,7 @@ public class FlutterView extends SurfaceView
 
     private void sendLocalesToDart(Configuration config) {
         List<Locale> locales = new ArrayList<>();
-        if (Build.VERSION.SDK_INT >= 24) {
+        if (Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
             LocaleList localeList = config.getLocales();
             int localeCount = localeList.size();
             for (int index = 0; index < localeCount; ++index) {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -320,12 +320,16 @@ public class FlutterView extends SurfaceView
     }
 
     private void sendLocalesToDart(Configuration config) {
-        LocaleList localeList = config.getLocales();
-        int localeCount = localeList.size();
         List<Locale> locales = new ArrayList<>();
-        for (int index = 0; index < localeCount; ++index) {
-            Locale locale = localeList.get(index);
-            locales.add(locale);
+        if (Build.VERSION.SDK_INT >= 24) {
+            LocaleList localeList = config.getLocales();
+            int localeCount = localeList.size();
+            for (int index = 0; index < localeCount; ++index) {
+                Locale locale = localeList.get(index);
+                locales.add(locale);
+            }
+        } else {
+            locales.add(config.locale);
         }
         localizationChannel.sendLocales(locales);
     }


### PR DESCRIPTION
[Configuration.getLocales()][1] was added in API level 24. 
For earlier versions, we instead return only the current locale.

Fixes https://github.com/flutter/flutter/issues/28321

[1]: https://developer.android.com/reference/android/content/res/Configuration#getLocales()