### PR TITLE
Android Embedding PR 8: Add FlutterEngine attachment/detachment to FlutterView

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterSurfaceView.java
@@ -20,10 +20,10 @@ import io.flutter.embedding.engine.renderer.FlutterRenderer;
  * Paints a Flutter UI on a {@link android.view.Surface}.
  *
  * To begin rendering a Flutter UI, the owner of this {@code FlutterSurfaceView} must invoke
- * {@link #onAttachedToRenderer(FlutterRenderer)} with the desired {@link FlutterRenderer}.
+ * {@link #attachToRenderer(FlutterRenderer)} with the desired {@link FlutterRenderer}.
  *
  * To stop rendering a Flutter UI, the owner of this {@code FlutterSurfaceView} must invoke
- * {@link #onDetachedFromRenderer()}.
+ * {@link #detachFromRenderer()}.
  *
  * A {@code FlutterSurfaceView} is intended for situations where a developer needs to render
  * a Flutter UI, but does not require any keyboard input, gesture input, accessibility
@@ -31,7 +31,7 @@ import io.flutter.embedding.engine.renderer.FlutterRenderer;
  * desired, consider using a {@link FlutterView} which provides all of these behaviors and
  * utilizes a {@code FlutterSurfaceView} internally.
  */
-public class FlutterSurfaceView extends SurfaceView {
+public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.RenderSurface {
   private static final String TAG = "FlutterSurfaceView";
 
   private boolean isSurfaceAvailableForRendering = false;
@@ -103,7 +103,7 @@ public class FlutterSurfaceView extends SurfaceView {
    * If no Android {@link android.view.Surface} is available yet, this {@code FlutterSurfaceView}
    * will wait until a {@link android.view.Surface} becomes available and then begin rendering.
    */
-  public void onAttachedToRenderer(@NonNull FlutterRenderer flutterRenderer) {
+  public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
     if (this.flutterRenderer != null) {
       this.flutterRenderer.detachFromRenderSurface();
     }
@@ -124,7 +124,7 @@ public class FlutterSurfaceView extends SurfaceView {
    *
    * This method will cease any on-going rendering from Flutter to this {@code FlutterSurfaceView}.
    */
-  public void onDetachedFromRenderer() {
+  public void detachFromRenderer() {
     if (flutterRenderer != null) {
       // If we're attached to an Android window then we were rendering a Flutter UI. Now that
       // this FlutterSurfaceView is detached from the FlutterRenderer, we need to stop rendering.
@@ -164,5 +164,20 @@ public class FlutterSurfaceView extends SurfaceView {
     }
 
     flutterRenderer.surfaceDestroyed();
+  }
+
+  @Override
+  public void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
+    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
+  }
+
+  @Override
+  public void updateSemantics(ByteBuffer buffer, String[] strings) {
+    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
+  }
+
+  @Override
+  public void onFirstFrameRendered() {
+    // TODO(mattcarroll): decide where this method should live and what it needs to do.
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterTextureView.java
@@ -13,16 +13,18 @@ import android.util.Log;
 import android.view.Surface;
 import android.view.TextureView;
 
+import java.nio.ByteBuffer;
+
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 
 /**
  * Paints a Flutter UI on a {@link SurfaceTexture}.
  *
  * To begin rendering a Flutter UI, the owner of this {@code FlutterTextureView} must invoke
- * {@link #onAttachedToRenderer(FlutterRenderer)} with the desired {@link FlutterRenderer}.
+ * {@link #attachToRenderer(FlutterRenderer)} with the desired {@link FlutterRenderer}.
  *
  * To stop rendering a Flutter UI, the owner of this {@code FlutterTextureView} must invoke
- * {@link #onDetachedFromRenderer()}.
+ * {@link #detachFromRenderer()}.
  *
  * A {@code FlutterTextureView} is intended for situations where a developer needs to render
  * a Flutter UI, but does not require any keyboard input, gesture input, accessibility
@@ -30,7 +32,7 @@ import io.flutter.embedding.engine.renderer.FlutterRenderer;
  * desired, consider using a {@link FlutterView} which provides all of these behaviors and
  * utilizes a {@code FlutterTextureView} internally.
  */
-public class FlutterTextureView extends TextureView {
+public class FlutterTextureView extends TextureView implements FlutterRenderer.RenderSurface {
   private static final String TAG = "FlutterTextureView";
 
   private boolean isSurfaceAvailableForRendering = false;
@@ -115,7 +117,7 @@ public class FlutterTextureView extends TextureView {
    * If no Android {@link SurfaceTexture} is available yet, this {@code FlutterSurfaceView}
    * will wait until a {@link SurfaceTexture} becomes available and then begin rendering.
    */
-  public void onAttachedToRenderer(@NonNull FlutterRenderer flutterRenderer) {
+  public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
     if (this.flutterRenderer != null) {
       this.flutterRenderer.detachFromRenderSurface();
     }
@@ -136,7 +138,7 @@ public class FlutterTextureView extends TextureView {
    *
    * This method will cease any on-going rendering from Flutter to this {@code FlutterTextureView}.
    */
-  public void onDetachedFromRenderer() {
+  public void detachFromRenderer() {
     if (flutterRenderer != null) {
       // If we're attached to an Android window then we were rendering a Flutter UI. Now that
       // this FlutterTextureView is detached from the FlutterRenderer, we need to stop rendering.
@@ -176,5 +178,20 @@ public class FlutterTextureView extends TextureView {
     }
 
     flutterRenderer.surfaceDestroyed();
+  }
+
+  @Override
+  public void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
+    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
+  }
+
+  @Override
+  public void updateSemantics(ByteBuffer buffer, String[] strings) {
+    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
+  }
+
+  @Override
+  public void onFirstFrameRendered() {
+    // TODO(mattcarroll): decide where this method should live and what it needs to do.
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
@@ -49,7 +49,6 @@ public class FlutterView extends FrameLayout {
   // Flutter engine
   @Nullable
   private FlutterEngine flutterEngine;
-  private boolean isAttachedToFlutterEngine = false;
 
   /**
    * Constructs a {@code FlutterSurfaceView} programmatically, without any XML attributes.
@@ -116,7 +115,7 @@ public class FlutterView extends FrameLayout {
    * {@link FlutterEngine}.
    */
   public void attachToFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    if (isAttachedToFlutterEngine) {
+    if (isAttachedToFlutterEngine()) {
       if (flutterEngine == this.flutterEngine) {
         // We are already attached to this FlutterEngine
         return;
@@ -127,7 +126,6 @@ public class FlutterView extends FrameLayout {
     }
 
     this.flutterEngine = flutterEngine;
-    isAttachedToFlutterEngine = true;
 
     // Instruct our FlutterRenderer that we are now its designated RenderSurface.
     this.flutterEngine.getRenderer().attachToRenderSurface(renderSurface);
@@ -144,7 +142,7 @@ public class FlutterView extends FrameLayout {
    * {@link FlutterEngine}.
    */
   public void detachFromFlutterEngine() {
-    if (!isAttachedToFlutterEngine) {
+    if (!isAttachedToFlutterEngine()) {
       return;
     }
     Log.d(TAG, "Detaching from Flutter Engine");
@@ -153,14 +151,16 @@ public class FlutterView extends FrameLayout {
     flutterEngine.getRenderer().detachFromRenderSurface();
     flutterEngine = null;
 
-    isAttachedToFlutterEngine = false;
-
     // TODO(mattcarroll): clear the surface when JNI doesn't blow up
 //    if (isSurfaceAvailableForRendering) {
 //      Canvas canvas = surfaceHolder.lockCanvas();
 //      canvas.drawColor(Color.RED);
 //      surfaceHolder.unlockCanvasAndPost(canvas);
 //    }
+  }
+
+  private boolean isAttachedToFlutterEngine() {
+    return flutterEngine != null;
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
@@ -38,15 +38,15 @@ import io.flutter.embedding.engine.renderer.FlutterRenderer;
 public class FlutterView extends FrameLayout {
   private static final String TAG = "FlutterView";
 
-  // View configuration
+  // Behavior configuration of this FlutterView.
   @NonNull
   private RenderMode renderMode;
 
-  // View structure
+  // Internal view hierarchy references.
   @Nullable
   private FlutterRenderer.RenderSurface renderSurface;
 
-  // Flutter engine
+  // Connections to a Flutter execution context.
   @Nullable
   private FlutterEngine flutterEngine;
 
@@ -106,10 +106,10 @@ public class FlutterView extends FrameLayout {
   /**
    * Connects this {@code FlutterView} to the given {@link FlutterEngine}.
    *
-   * Once invoked, the Flutter UI painted by the given {@link FlutterEngine} will be
-   * displayed by this {@code FlutterView}. Additionally, user touch events, accessibility
-   * events, keyboard events, and more will be forwarded from this {@code FlutterView}
-   * to the attached {@link FlutterEngine}.
+   * This {@code FlutterView} will begin rendering the UI painted by the given {@link FlutterEngine}.
+   * This {@code FlutterView} will also begin forwarding interaction events from this
+   * {@code FlutterView} to the given {@link FlutterEngine}, e.g., user touch events, accessibility
+   * events, keyboard events, and others.
    *
    * See {@link #detachFromFlutterEngine()} for information on how to detach from a
    * {@link FlutterEngine}.
@@ -134,9 +134,9 @@ public class FlutterView extends FrameLayout {
   /**
    * Disconnects this {@code FlutterView} from a previously attached {@link FlutterEngine}.
    *
-   * Once invoked, the UI of this {@code FlutterView} will be cleared, and all touch events,
-   * accessibility events, keyboard events, etc. will no longer be forwarded to the previously
-   * attached {@link FlutterEngine}.
+   * This {@code FlutterView} will clear its UI and stop forwarding all events to the previously-attached
+   * {@link FlutterEngine}. This includes touch events, accessibility events, keyboard events,
+   * and others.
    *
    * See {@link #attachToFlutterEngine(FlutterEngine)} for information on how to attach a
    * {@link FlutterEngine}.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -247,6 +247,22 @@ public class FlutterRenderer implements TextureRegistry {
    * {@link #onFirstFrameRendered()}.
    */
   public interface RenderSurface {
+    /**
+     * Invoked by the owner of this {@code RenderSurface} when it wants to begin rendering
+     * a Flutter UI to this {@code RenderSurface}.
+     *
+     * The details of how rendering is handled is an implementation detail.
+     */
+    void attachToRenderer(@NonNull FlutterRenderer renderer);
+
+    /**
+     * Invoked by the owner of this {@code RenderSurface} when it no longer wants to render
+     * a Flutter UI to this {@code RenderSurface}.
+     *
+     * This method will cease any on-going rendering from Flutter to this {@code RenderSurface}.
+     */
+    void detachFromRenderer();
+
     // TODO(mattcarroll): describe what this callback is intended to do
     void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings);
 

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -12,6 +12,7 @@ import io.flutter.app.FlutterPluginRegistry;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.FlutterEngine.EngineLifecycleListener;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.FlutterRenderer.RenderSurface;
 import io.flutter.plugin.common.*;
 import java.nio.ByteBuffer;
@@ -167,6 +168,16 @@ public class FlutterNativeView implements BinaryMessenger {
     }
 
     private final class RenderSurfaceImpl implements RenderSurface {
+        @Override
+        public void attachToRenderer(@NonNull FlutterRenderer renderer) {
+            // Not relevant for v1 embedding.
+        }
+
+        @Override
+        public void detachFromRenderer() {
+            // Not relevant for v1 embedding.
+        }
+
         // Called by native to update the semantics/accessibility tree.
         public void updateSemantics(ByteBuffer buffer, String[] strings) {
             if (mFlutterView == null) {


### PR DESCRIPTION
This PR introduces methods to attach and detach a `FlutterEngine` to a `FlutterView`.  That connection is forwarded to a `FlutterSurfaceView` or `FlutterTextureView`, each of which is now abstracted as a `RenderSurface`.

This PR also renames some methods of the form onXXXX to just xxxx because the verbiage makes more sense for their behavior.