### PR TITLE
Fixed an Android keyboard entry bug that was introduced by the embedding refactor. (#28438)

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/AndroidKeyProcessor.java
@@ -10,13 +10,16 @@ import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 
 import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
+import io.flutter.plugin.editing.TextInputPlugin;
 
 public class AndroidKeyProcessor {
   private final KeyEventChannel keyEventChannel;
+  private final TextInputPlugin textInputPlugin;
   private int combiningCharacter;
 
-  public AndroidKeyProcessor(@NonNull KeyEventChannel keyEventChannel) {
+  public AndroidKeyProcessor(@NonNull KeyEventChannel keyEventChannel, @NonNull TextInputPlugin textInputPlugin) {
     this.keyEventChannel = keyEventChannel;
+    this.textInputPlugin = textInputPlugin;
   }
 
   public void onKeyUp(@NonNull KeyEvent keyEvent) {
@@ -27,6 +30,13 @@ public class AndroidKeyProcessor {
   }
 
   public void onKeyDown(@NonNull KeyEvent keyEvent) {
+    if (keyEvent.getDeviceId() != KeyCharacterMap.VIRTUAL_KEYBOARD) {
+      if (textInputPlugin.getLastInputConnection() != null
+          && textInputPlugin.getInputMethodManager().isAcceptingText()) {
+        textInputPlugin.getLastInputConnection().sendKeyEvent(keyEvent);
+      }
+    }
+
     Character complexCharacter = applyCombiningCharacterToBaseCharacter(keyEvent.getUnicodeChar());
     keyEventChannel.keyDown(
         new KeyEventChannel.FlutterKeyEvent(keyEvent, complexCharacter)

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -6,6 +6,7 @@ package io.flutter.plugin.editing;
 
 import android.content.Context;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.Selection;
@@ -22,13 +23,20 @@ import io.flutter.view.FlutterView;
  * Android implementation of the text input plugin.
  */
 public class TextInputPlugin {
+    @NonNull
     private final FlutterView mView;
+    @NonNull
     private final InputMethodManager mImm;
+    @NonNull
     private final TextInputChannel textInputChannel;
     private int mClient = 0;
+    @Nullable
     private TextInputChannel.Configuration configuration;
+    @Nullable
     private Editable mEditable;
     private boolean mRestartInputPending;
+    @Nullable
+    private InputConnection lastInputConnection;
 
     public TextInputPlugin(FlutterView view, @NonNull DartExecutor dartExecutor) {
         mView = view;
@@ -62,6 +70,11 @@ public class TextInputPlugin {
                 clearTextInputClient();
             }
         });
+    }
+
+    @NonNull
+    public InputMethodManager getInputMethodManager() {
+        return mImm;
     }
 
     private static int inputTypeFromTextInputType(
@@ -114,7 +127,10 @@ public class TextInputPlugin {
     }
 
     public InputConnection createInputConnection(FlutterView view, EditorInfo outAttrs) {
-        if (mClient == 0) return null;
+        if (mClient == 0) {
+            lastInputConnection = null;
+            return lastInputConnection;
+        }
 
         outAttrs.inputType = inputTypeFromTextInputType(
             configuration.inputType,
@@ -148,7 +164,13 @@ public class TextInputPlugin {
         outAttrs.initialSelStart = Selection.getSelectionStart(mEditable);
         outAttrs.initialSelEnd = Selection.getSelectionEnd(mEditable);
 
-        return connection;
+        lastInputConnection = connection;
+        return lastInputConnection;
+    }
+
+    @Nullable
+    public InputConnection getLastInputConnection() {
+        return lastInputConnection;
     }
 
     private void showTextInput(FlutterView view) {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -110,7 +110,6 @@ public class FlutterView extends SurfaceView
     private FlutterNativeView mNativeView;
     private final AnimationScaleObserver mAnimationScaleObserver;
     private boolean mIsSoftwareRenderingEnabled = false; // using the software renderer or not
-    private InputConnection mLastInputConnection;
 
     public FlutterView(Context context) {
         this(context, null);
@@ -181,7 +180,7 @@ public class FlutterView extends SurfaceView
         addActivityLifecycleListener(platformPlugin);
         mImm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         mTextInputPlugin = new TextInputPlugin(this, dartExecutor);
-        androidKeyProcessor = new AndroidKeyProcessor(keyEventChannel);
+        androidKeyProcessor = new AndroidKeyProcessor(keyEventChannel, mTextInputPlugin);
 
         // Send initial platform information to Dart
         sendLocalesToDart(getResources().getConfiguration());
@@ -202,13 +201,6 @@ public class FlutterView extends SurfaceView
         if (!isAttached()) {
             return super.onKeyDown(keyCode, event);
         }
-
-        if (event.getDeviceId() != KeyCharacterMap.VIRTUAL_KEYBOARD) {
-            if (mLastInputConnection != null && mImm.isAcceptingText()) {
-                mLastInputConnection.sendKeyEvent(event);
-            }
-        }
-
         androidKeyProcessor.onKeyDown(event);
         return super.onKeyDown(keyCode, event);
     }


### PR DESCRIPTION
The Android embedding refactor inadvertently stopped storing the `mLastInputConnection` in `FlutterView`.  That mistake broke certain types of text input.

The chosen solution in this PR is to make `TextInputPlugin` a dependency of `AndroidKeyProcessor` such that `AndroidKeyProcessor` can ask `TextInputPlugin` for the last `InputConnection` and resurrect the behavior that was lost from `FlutterView`.

I have verified that this change resolves the specific emulator issue logged in the ticket.  I have not verified with a physical keyboard.