### PR TITLE
Cherry-revert android locale getter

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -31,13 +31,6 @@ public class LocalizationChannel {
    * Send the given {@code locales} to Dart.
    */
   public void sendLocales(List<String> data) {
-    // List<String> data = new ArrayList<>();
-    // for (Locale locale : locales) {
-    //   data.add(locale.getLanguage());
-    //   data.add(locale.getCountry());
-    //   data.add(locale.getScript());
-    //   data.add(locale.getVariant());
-    // }
     channel.invokeMethod("setLocale", data);
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -30,14 +30,14 @@ public class LocalizationChannel {
   /**
    * Send the given {@code locales} to Dart.
    */
-  public void sendLocales(List<Locale> locales) {
-    List<String> data = new ArrayList<>();
-    for (Locale locale : locales) {
-      data.add(locale.getLanguage());
-      data.add(locale.getCountry());
-      data.add(locale.getScript());
-      data.add(locale.getVariant());
-    }
+  public void sendLocales(List<String> data) {
+    // List<String> data = new ArrayList<>();
+    // for (Locale locale : locales) {
+    //   data.add(locale.getLanguage());
+    //   data.add(locale.getCountry());
+    //   data.add(locale.getScript());
+    //   data.add(locale.getVariant());
+    // }
     channel.invokeMethod("setLocale", data);
   }
 


### PR DESCRIPTION
The new version of this is crashing on startup for old devices < API 21.

This partially reverts the localization channel refactor and integrates the old known working version into the refactored version.

Fixes https://github.com/flutter/flutter/issues/28495