### PR TITLE
Fix incorrect transformation matrix

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -412,12 +412,18 @@ FlutterEngineResult FlutterEngineRun(size_t version,
          user_data](blink::SemanticsNodeUpdates update) {
           for (const auto& value : update) {
             const auto& node = value.second;
-            const auto& transform = node.transform;
-            auto flutter_transform = FlutterTransformation{
-                transform.get(0, 0), transform.get(0, 1), transform.get(0, 2),
-                transform.get(1, 0), transform.get(1, 1), transform.get(1, 2),
-                transform.get(2, 0), transform.get(2, 1), transform.get(2, 2)};
-            const FlutterSemanticsNode embedder_node = {
+            SkMatrix transform = static_cast<SkMatrix>(node.transform);
+            FlutterTransformation flutter_transform{
+                transform.get(SkMatrix::kMScaleX),
+                transform.get(SkMatrix::kMSkewX),
+                transform.get(SkMatrix::kMTransX),
+                transform.get(SkMatrix::kMSkewY),
+                transform.get(SkMatrix::kMScaleY),
+                transform.get(SkMatrix::kMTransY),
+                transform.get(SkMatrix::kMPersp0),
+                transform.get(SkMatrix::kMPersp1),
+                transform.get(SkMatrix::kMPersp2)};
+            const FlutterSemanticsNode embedder_node{
                 sizeof(FlutterSemanticsNode),
                 node.id,
                 static_cast<FlutterSemanticsFlag>(node.flags),

--- a/shell/platform/embedder/fixtures/a11y_main.dart
+++ b/shell/platform/embedder/fixtures/a11y_main.dart
@@ -2,12 +2,17 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui';
 
-Float64List kIdentityTransform = () {
+Float64List kTestTransform = () {
   final Float64List values = Float64List(16);
-  values[0] = 1.0;
-  values[5] = 1.0;
-  values[10] = 1.0;
-  values[15] = 1.0;
+  values[0] = 1.0;  // scaleX
+  values[4] = 2.0;  // skewX
+  values[12] = 3.0; // transX
+  values[1] = 4.0;  // skewY
+  values[5] = 5.0;  // scaleY
+  values[13] = 6.0; // transY
+  values[3] = 7.0;  // pers0
+  values[7] = 8.0;  // pers1
+  values[15] = 9.0; // pers2
   return values;
 }();
 
@@ -68,7 +73,7 @@ main() async {
       id: 42,
       label: 'A: root',
       rect: Rect.fromLTRB(0.0, 0.0, 10.0, 10.0),
-      transform: kIdentityTransform,
+      transform: kTestTransform,
       childrenInTraversalOrder: Int32List.fromList(<int>[84, 96]),
       childrenInHitTestOrder: Int32List.fromList(<int>[96, 84]),
     )
@@ -76,13 +81,13 @@ main() async {
       id: 84,
       label: 'B: leaf',
       rect: Rect.fromLTRB(40.0, 40.0, 80.0, 80.0),
-      transform: kIdentityTransform,
+      transform: kTestTransform,
     )
     ..updateNode(
       id: 96,
       label: 'C: branch',
       rect: Rect.fromLTRB(40.0, 40.0, 80.0, 80.0),
-      transform: kIdentityTransform,
+      transform: kTestTransform,
       childrenInTraversalOrder: Int32List.fromList(<int>[128]),
       childrenInHitTestOrder: Int32List.fromList(<int>[128]),
     )
@@ -90,7 +95,7 @@ main() async {
       id: 128,
       label: 'D: leaf',
       rect: Rect.fromLTRB(40.0, 40.0, 80.0, 80.0),
-      transform: kIdentityTransform,
+      transform: kTestTransform,
       additionalActions: Int32List.fromList(<int>[21]),
     )
     ..updateCustomAction(

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -158,6 +158,15 @@ TEST(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
           ++node_batch_end_count;
         } else {
           ++node_count;
+          ASSERT_EQ(1.0, node->transform.scaleX);
+          ASSERT_EQ(2.0, node->transform.skewX);
+          ASSERT_EQ(3.0, node->transform.transX);
+          ASSERT_EQ(4.0, node->transform.skewY);
+          ASSERT_EQ(5.0, node->transform.scaleY);
+          ASSERT_EQ(6.0, node->transform.transY);
+          ASSERT_EQ(7.0, node->transform.pers0);
+          ASSERT_EQ(8.0, node->transform.pers1);
+          ASSERT_EQ(9.0, node->transform.pers2);
         }
       };
   int action_count = 0;


### PR DESCRIPTION
Previously the transformation matrix returned on semantics nodes was
fetched by matrix col,row (incorrectly). This uses the SkMatrix
constants instead and adds a test.