### PR TITLE
Add overloads for lookup that lets you specify a bundle

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -35,6 +35,16 @@ FLUTTER_EXPORT
 + (NSString*)lookupKeyForAsset:(NSString*)asset;
 
 /**
+ * Returns the file name for the given asset.
+ * The returned file name can be used to access the asset in the supplied bundle.
+ *
+ * @param asset The name of the asset. The name can be hierarchical.
+ * @param bundle The `NSBundle` to use for looking up the asset.
+ * @return the file name to be used for lookup in the main bundle.
+ */
++ (NSString*)lookupKeyForAsset:(NSString*)asset fromBundle:(NSBundle*)bundle;
+
+/**
  * Returns the file name for the given asset which originates from the specified package.
  * The returned file name can be used to access the asset in the application's main bundle.
  *
@@ -43,6 +53,18 @@ FLUTTER_EXPORT
  * @return the file name to be used for lookup in the main bundle.
  */
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package;
+
+/**
+ * Returns the file name for the given asset which originates from the specified package.
+ * The returned file name can be used to access the asset in the specified bundle.
+ *
+ * @param asset The name of the asset. The name can be hierarchical.
+ * @param package The name of the package from which the asset originates.
+ * @param bundle The bundle to use when doing the lookup.
+ * @return the file name to be used for lookup in the main bundle.
+ */
++ (NSString*)lookupKeyForAsset:(NSString*)asset
+                   fromPackage:(NSString*)package fromBundle(NSBundle*)bundle;
 
 /**
  * Returns the default identifier for the bundle where we expect to find the Flutter Dart

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -66,7 +66,7 @@ FLUTTER_EXPORT
  * @return the file name to be used for lookup in the main bundle.
  */
 + (NSString*)lookupKeyForAsset:(NSString*)asset
-                   fromPackage:(NSString*)package fromBundle(NSBundle*)bundle;
+                   fromPackage:(NSString*)package fromBundle:(NSBundle*)bundle;
 
 /**
  * Returns the default identifier for the bundle where we expect to find the Flutter Dart

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -66,7 +66,8 @@ FLUTTER_EXPORT
  * @return the file name to be used for lookup in the main bundle.
  */
 + (NSString*)lookupKeyForAsset:(NSString*)asset
-                   fromPackage:(NSString*)package fromBundle:(NSBundle*)bundle;
+                   fromPackage:(NSString*)package
+                    fromBundle:(NSBundle*)bundle;
 
 /**
  * Returns the default identifier for the bundle where we expect to find the Flutter Dart

--- a/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterDartProject.h
@@ -26,8 +26,10 @@ FLUTTER_EXPORT
 - (instancetype)initFromDefaultSourceForConfiguration FLUTTER_UNAVAILABLE("Use -init instead.");
 
 /**
- * Returns the file name for the given asset.
- * The returned file name can be used to access the asset in the application's main bundle.
+ * Returns the file name for the given asset. If the bundle with the identifier
+ * "io.flutter.flutter.app" exists, it will try use that bundle; otherwise, it
+ * will use the main bundle.  To specify a different bundle, use
+ * `-lookupKeyForAsset:asset:fromBundle`.
  *
  * @param asset The name of the asset. The name can be hierarchical.
  * @return the file name to be used for lookup in the main bundle.

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -207,12 +207,23 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset {
-  NSString* flutterAssetsName = [FlutterDartProject flutterAssetsName:[NSBundle mainBundle]];
+  return [self lookupKeyForAsset fromBundle:[NSBundle mainBundle]];
+}
+
++ (NSString*)lookupKeyForAsset:(NSString*)asset fromBundle:(NSBundle*)bundle {
+  NSString* flutterAssetsName = [FlutterDartProject flutterAssetsName:bundle];
   return [NSString stringWithFormat:@"%@/%@", flutterAssetsName, asset];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package {
   return [self lookupKeyForAsset:[NSString stringWithFormat:@"packages/%@/%@", package, asset]];
+}
+
++ (NSString*)lookupKeyForAsset:(NSString*)asset
+                   fromPackage:(NSString*)package
+                    fromBundle:(NSBundle*)bundle {
+  return [self lookupKeyForAsset:[NSString stringWithFormat:@"packages/%@/%@", package, asset]
+                      fromBundle:bundle];
 }
 
 + (NSString*)defaultBundleIdentifier {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -207,7 +207,11 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset {
-  return [self lookupKeyForAsset fromBundle:[NSBundle mainBundle]];
+  NSBundle* bundle = [NSBundle bundleWithIdnetifier:[FlutterDartProject defaultBundleIdentifier]];
+  if (bundle == nil) {
+    bundle = [NSBundle mainBundle];
+  }
+  return [self lookupKeyForAsset fromBundle:bundle];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromBundle:(NSBundle*)bundle {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -200,7 +200,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 
 + (NSString*)flutterAssetsName:(NSBundle*)bundle {
   if (bundle == nil) {
-    bundle = [NSBundle bundleWithIdnetifier:[FlutterDartProject defaultBundleIdentifier]];
+    bundle = [NSBundle bundleWithIdentifier:[FlutterDartProject defaultBundleIdentifier]];
   }
   if (bundle == nil) {
     bundle = [NSBundle mainBundle];
@@ -213,7 +213,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset {
-  return [self lookupKeyForAsset fromBundle:nil];
+  return [self lookupKeyForAsset:asset fromBundle:nil];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromBundle:(NSBundle*)bundle {
@@ -222,7 +222,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package {
-  return [self lookupKeyForAsset:asset fromPackage:package fromBundle:nil]];
+  return [self lookupKeyForAsset:asset fromPackage:package fromBundle:nil];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -199,6 +199,12 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 #pragma mark - Assets-related utilities
 
 + (NSString*)flutterAssetsName:(NSBundle*)bundle {
+  if (bundle == nil) {
+    bundle = [NSBundle bundleWithIdnetifier:[FlutterDartProject defaultBundleIdentifier]];
+  }
+  if (bundle == nil) {
+    bundle = [NSBundle mainBundle];
+  }
   NSString* flutterAssetsName = [bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
   if (flutterAssetsName == nil) {
     flutterAssetsName = @"Frameworks/App.framework/flutter_assets";
@@ -207,11 +213,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset {
-  NSBundle* bundle = [NSBundle bundleWithIdnetifier:[FlutterDartProject defaultBundleIdentifier]];
-  if (bundle == nil) {
-    bundle = [NSBundle mainBundle];
-  }
-  return [self lookupKeyForAsset fromBundle:bundle];
+  return [self lookupKeyForAsset fromBundle:nil];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromBundle:(NSBundle*)bundle {
@@ -220,7 +222,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package {
-  return [self lookupKeyForAsset:[NSString stringWithFormat:@"packages/%@/%@", package, asset]];
+  return [self lookupKeyForAsset:asset fromPackage:package fromBundle:nil]];
 }
 
 + (NSString*)lookupKeyForAsset:(NSString*)asset


### PR DESCRIPTION
Some customers want to package up the App.framework into a separate bundle from the main one.  This lets them look up flutter asset keys in whatever bundle they desire.

fixes https://github.com/flutter/flutter/issues/28739

/cc @AlbertWang0116