### PR TITLE
[platform_views] Fix duplicated touch event pass down to flutter view from platform view. 

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -410,6 +410,7 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
   // So this is safe as when FlutterView is deallocated the reference to ForwardingGestureRecognizer
   // will go away.
   UIView* _flutterView;
+  // Counting the touches that has started in one touch sequence.
   NSInteger _currentEventTouchCount;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -410,8 +410,8 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
   // So this is safe as when FlutterView is deallocated the reference to ForwardingGestureRecognizer
   // will go away.
   UIView* _flutterView;
-  // Counting the touches that has started in one touch sequence.
-  NSInteger _currentEventTouchCount;
+  // Counting the pointers that has started in one touch sequence.
+  NSInteger _currentTouchPointersCount;
 }
 
 - (instancetype)initWithTarget:(id)target flutterView:(UIView*)flutterView {
@@ -419,14 +419,14 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
   if (self) {
     self.delegate = self;
     _flutterView = flutterView;
-    _currentEventTouchCount = 0;
+    _currentTouchPointersCount = 0;
   }
   return self;
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
   [_flutterView touchesBegan:touches withEvent:event];
-  _currentEventTouchCount += touches.count;
+  _currentTouchPointersCount += touches.count;
   [_flutterView touchesBegan:touches withEvent:event];
 }
 
@@ -436,19 +436,19 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
   [_flutterView touchesEnded:touches withEvent:event];
-  _currentEventTouchCount -= touches.count;
+  _currentTouchPointersCount -= touches.count;
   // Touches in one touch sequence are sent to the touchesEnded method separately if different
   // fingers stop touching the screen at different time. So one touchesEnded method triggering does
   // not necessarially mean the touch sequence has ended. We Only set the state to
   // UIGestureRecognizerStateFailed when all the touches in the current touch sequence is ended.
-  if (_currentEventTouchCount == 0) {
+  if (_currentTouchPointersCount == 0) {
     self.state = UIGestureRecognizerStateFailed;
   }
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
   [_flutterView touchesCancelled:touches withEvent:event];
-  _currentEventTouchCount = 0;
+  _currentTouchPointersCount = 0;
   self.state = UIGestureRecognizerStateFailed;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -417,8 +417,8 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
   self = [super initWithTarget:target action:nil];
   if (self) {
     self.delegate = self;
-    _flutterView = flutterView;ng how many touches have begun for one touch sequence.
-      _currentEventTouchCount = 0;
+    _flutterView = flutterView;
+    _currentEventTouchCount = 0;
   }
   return self;
 }


### PR DESCRIPTION
Fix for https://github.com/flutter/flutter/issues/27700 and https://github.com/flutter/flutter/issues/24207

There are 2 fixes included in this PR. 
1. The intercepting views sometime pass up the touches events to flutter view,  even after the forward gesture recognizer pass the event to the flutter view. We only want the event to be passed to the flutter view once. So we let the intercepting view 'consumes' the event in this PR to fix the problem. 

2. When a touch sequence has multiple touch points participated(e.g. Pinch gesture), the touchesBegan and touchesEnded can be triggered multiple times if the touches do not happen simultaneously. One example would be: when performing a pinch gesture with 2 fingers, I put down one finger, keep the finger on the screen, then put down another finger, perform pinch, lift up both finger at the same time. In this sequence, touchesBegan is called twice with each touch in one of the calls and touchesEnded is called once and has 2 touches in the callback. To handle this issue, we added a count to count the touches in one touch sequence. We only set the state to fail when the count reaches 0(That is all the touches has began in the current sequence is ended).