### PR TITLE
Add missing kHasImplicitScrolling enum value

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -264,8 +264,9 @@ class SemanticsAction {
 
 /// A Boolean value that can be associated with a semantics node.
 //
-// When changes are made to this class, the equivalent APIs in each of the
-// embedders *must* be updated.
+// When changes are made to this class, the equivalent APIs in
+// `lib/ui/semantics/semantics_node.h` and in each of the embedders *must* be
+// updated.
 class SemanticsFlag {
   static const int _kHasCheckedStateIndex = 1 << 0;
   static const int _kIsCheckedIndex = 1 << 1;
@@ -476,9 +477,9 @@ class SemanticsFlag {
   /// to move focus to an offscreen child.
   ///
   /// For example, a [ListView] widget has implicit scrolling so that users can
-  /// easily move to the next visible set of children. A [TabBar] widget does
-  /// not have implicit scrolling, so that users can navigate into the tab
-  /// body when reaching the end of the tab bar.
+  /// easily move the accessibility focus to the next set of children. A
+  /// [PageView] widget does not have implicit scrolling, so that users don't
+  /// navigate to the next page when reaching the end of the current one.
   static const SemanticsFlag hasImplicitScrolling = const SemanticsFlag._(_kHasImplicitScrollingIndex);
 
   /// The possible semantics flags.

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -65,6 +65,7 @@ enum class SemanticsFlags : int32_t {
   kIsLiveRegion = 1 << 15,
   kHasToggledState = 1 << 16,
   kIsToggled = 1 << 17,
+  kHasImplicitScrolling = 1 << 18,
 };
 
 struct SemanticsNode {

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -141,6 +141,14 @@ typedef enum {
   kFlutterSemanticsFlagHasToggledState = 1 << 16,
   // If true, the semantics node is "on". If false, the semantics node is "off".
   kFlutterSemanticsFlagIsToggled = 1 << 17,
+  // Whether the platform can scroll the semantics node when the user attempts
+  // to move the accessibility focus to an offscreen child.
+  //
+  // For example, a |ListView| widget has implicit scrolling so that users can
+  // easily move the accessibility focus to the next set of children. A
+  // |PageView| widget does not have implicit scrolling, so that users don't
+  // navigate to the next page when reaching the end of the current one.
+  kFlutterSemanticsFlagHasImplicitScrolling = 1 << 18,
 } FlutterSemanticsFlag;
 
 typedef enum {


### PR DESCRIPTION
This brings the Dart and C++ semantics flag enums back in sync.

In #5941, implicit scrolling support was added to SemanticsFlag in
dart:ui, and to the Android embedder, but not to the SemanticsFlags enum
on the C++ side.

This also adds this flag to the embedder API.