### PR TITLE
Re-land "Buffer lifecycle in WindowData"

### DIFF
--- a/lib/stub_ui/hooks.dart
+++ b/lib/stub_ui/hooks.dart
@@ -84,6 +84,10 @@ void _updateUserSettingsData(String jsonData) {
   _updateAlwaysUse24HourFormat(data['alwaysUse24HourFormat']);
 }
 
+void _updateLifecycleState(String state) {
+  window._initialLifecycleState ??= state;
+}
+
 void _updateTextScaleFactor(double textScaleFactor) {
   window._textScaleFactor = textScaleFactor;
   _invoke(window.onTextScaleFactorChanged, window._onTextScaleFactorChangedZone);

--- a/lib/stub_ui/window.dart
+++ b/lib/stub_ui/window.dart
@@ -551,6 +551,15 @@ class Window {
     _onLocaleChangedZone = Zone.current;
   }
 
+  /// The lifecycle state immediately after dart isolate initialization.
+  ///
+  /// This property will not be updated as the lifecycle changes.
+  ///
+  /// It is used to initialize [SchedulerBinding.lifecycleState] at startup
+  /// with any buffered lifecycle state events.
+  String get initialLifecycleState => _initialLifecycleState;
+  String _initialLifecycleState;
+
   /// The setting indicating the current brightness mode of the host platform.
   /// If the platform has no preference, [platformBrightness] defaults to [Brightness.light].
   Brightness get platformBrightness => _platformBrightness;

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -89,6 +89,13 @@ void _updateUserSettingsData(String jsonData) {
   _updatePlatformBrightness(data['platformBrightness']);
 }
 
+@pragma('vm:entry-point')
+// ignore: unused_element
+void _updateLifecycleState(String state) {
+  window._initialLifecycleState ??= state;
+}
+
+
 void _updateTextScaleFactor(double textScaleFactor) {
   window._textScaleFactor = textScaleFactor;
   _invoke(window.onTextScaleFactorChanged, window._onTextScaleFactorChangedZone);

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -556,6 +556,15 @@ class Window {
     _onLocaleChangedZone = Zone.current;
   }
 
+  /// The lifecycle state immediately after dart isolate initialization.
+  ///
+  /// This property will not be updated as the lifecycle changes.
+  ///
+  /// It is used to initialize [SchedulerBinding.lifecycleState] at startup
+  /// with any buffered lifecycle state events.
+  String get initialLifecycleState => _initialLifecycleState;
+  String _initialLifecycleState;
+
   /// The system-reported text scale.
   ///
   /// This establishes the text scaling factor to use when rendering text,

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -217,6 +217,18 @@ void Window::UpdateUserSettingsData(const std::string& data) {
                                            }));
 }
 
+void Window::UpdateLifecycleState(const std::string& data) {
+  std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
+  if (!dart_state)
+    return;
+  tonic::DartState::Scope scope(dart_state);
+  tonic::LogIfError(tonic::DartInvokeField(library_.value(),
+                                           "_updateLifecycleState",
+                                           {
+                                               tonic::StdStringToDart(data),
+                                           }));
+}
+
 void Window::UpdateSemanticsEnabled(bool enabled) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
   if (!dart_state)

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -65,6 +65,7 @@ class Window final {
   void UpdateWindowMetrics(const ViewportMetrics& metrics);
   void UpdateLocales(const std::vector<std::string>& locales);
   void UpdateUserSettingsData(const std::string& data);
+  void UpdateLifecycleState(const std::string& data);
   void UpdateSemanticsEnabled(bool enabled);
   void UpdateAccessibilityFeatures(int32_t flags);
   void DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message);

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -128,7 +128,8 @@ bool RuntimeController::FlushRuntimeStateToIsolate() {
          SetLocales(window_data_.locale_data) &&
          SetSemanticsEnabled(window_data_.semantics_enabled) &&
          SetAccessibilityFeatures(window_data_.accessibility_feature_flags_) &&
-         SetUserSettingsData(window_data_.user_settings_data);
+         SetUserSettingsData(window_data_.user_settings_data) &&
+         SetLifecycleState(window_data_.lifecycle_state);
 }
 
 bool RuntimeController::SetViewportMetrics(const ViewportMetrics& metrics) {
@@ -158,6 +159,17 @@ bool RuntimeController::SetUserSettingsData(const std::string& data) {
 
   if (auto* window = GetWindowIfAvailable()) {
     window->UpdateUserSettingsData(window_data_.user_settings_data);
+    return true;
+  }
+
+  return false;
+}
+
+bool RuntimeController::SetLifecycleState(const std::string& data) {
+  window_data_.lifecycle_state = data;
+
+  if (auto* window = GetWindowIfAvailable()) {
+    window->UpdateLifecycleState(window_data_.lifecycle_state);
     return true;
   }
 

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -49,6 +49,8 @@ class RuntimeController final : public WindowClient {
 
   bool SetUserSettingsData(const std::string& data);
 
+  bool SetLifecycleState(const std::string& data);
+
   bool SetSemanticsEnabled(bool enabled);
 
   bool SetAccessibilityFeatures(int32_t flags);
@@ -111,6 +113,7 @@ class RuntimeController final : public WindowClient {
     std::string variant_code;
     std::vector<std::string> locale_data;
     std::string user_settings_data = "{}";
+    std::string lifecycle_state;
     bool semantics_enabled = false;
     bool assistive_technology_enabled = false;
     int32_t accessibility_feature_flags_ = 0;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -291,6 +291,8 @@ bool Engine::HandleLifecyclePlatformMessage(blink::PlatformMessage* message) {
   if (state == "AppLifecycleState.resumed" && have_surface_) {
     ScheduleFrame();
   }
+  runtime_controller_->SetLifecycleState(state);
+  // We always want pass the message forwards directly into the framework.
   return false;
 }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -292,7 +292,7 @@ bool Engine::HandleLifecyclePlatformMessage(blink::PlatformMessage* message) {
     ScheduleFrame();
   }
   runtime_controller_->SetLifecycleState(state);
-  // We always want pass the message forwards directly into the framework.
+  // Always forward these messages to the framework by returning false.
   return false;
 }
 


### PR DESCRIPTION
Relands flutter/engine#8010

Will require some framework-side testing updates (TestWindow class) to support this.

Adds mirrored API in stub_ui.

Fixes https://github.com/flutter/flutter/issues/2716