### PR TITLE
Add missing values to semantics action enums

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -7,8 +7,9 @@ part of dart.ui;
 /// The possible actions that can be conveyed from the operating system
 /// accessibility APIs to a semantics node.
 //
-// When changes are made to this class, the equivalent APIs in each of the
-// embedders *must* be updated.
+// When changes are made to this class, the equivalent APIs in
+// `lib/ui/semantics/semantics_node.h` and in each of the embedders *must* be
+// updated.
 class SemanticsAction {
   const SemanticsAction._(this.index);
 

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -16,7 +16,8 @@
 
 namespace blink {
 
-// Must match the SemanticsAction enum in semantics.dart.
+// Must match the SemanticsAction enum in semantics.dart and in each of the
+// embedders.
 enum class SemanticsAction : int32_t {
   kTap = 1 << 0,
   kLongPress = 1 << 1,
@@ -37,6 +38,8 @@ enum class SemanticsAction : int32_t {
   kDidLoseAccessibilityFocus = 1 << 16,
   kCustomAction = 1 << 17,
   kDismiss = 1 << 18,
+  kMoveCursorForwardByWordIndex = 1 << 19,
+  kMoveCursorBackwardByWordIndex = 1 << 20,
 };
 
 const int kScrollableSemanticsActions =

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -97,6 +97,10 @@ typedef enum {
   kFlutterSemanticsActionCustomAction = 1 << 17,
   // A request that the node should be dismissed.
   kFlutterSemanticsActionDismiss = 1 << 18,
+  // Move the cursor forward by one word.
+  kFlutterSemanticsActionMoveCursorForwardByWordIndex = 1 << 19,
+  // Move the cursor backward by one word.
+  kFlutterSemanticsActionMoveCursorBackwardByWordIndex = 1 << 20,
 } FlutterSemanticsAction;
 
 // The set of properties that may be associated with a semantics node.


### PR DESCRIPTION
This brings the Dart and C++ semantics flag enums back in sync.

In #5902, the ability to move the cursor forward and backward one word
were added to dart:ui, and to the Android embedder, but not to the
SemanticsAction enum on the C++ side.