### PR TITLE
fix ios flutter engine  memory leak

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -32,14 +32,14 @@
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
   _name = [name retain];
-  _messenger = [messenger retain];
+  _messenger = messenger;
   _codec = [codec retain];
   return self;
 }
 
 - (void)dealloc {
   [_name release];
-  [_messenger release];
+  //[_messenger release];
   [_codec release];
   [super dealloc];
 }
@@ -172,14 +172,14 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
   _name = [name retain];
-  _messenger = [messenger retain];
+  _messenger = messenger;
   _codec = [codec retain];
   return self;
 }
 
 - (void)dealloc {
   [_name release];
-  [_messenger release];
+  //[_messenger release];
   [_codec release];
   [super dealloc];
 }
@@ -251,7 +251,7 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
   _name = [name retain];
-  _messenger = [messenger retain];
+  _messenger = messenger;
   _codec = [codec retain];
   return self;
 }
@@ -259,7 +259,7 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
 - (void)dealloc {
   [_name release];
   [_codec release];
-  [_messenger release];
+  //[_messenger release];
   [super dealloc];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterChannels.mm
@@ -39,7 +39,6 @@
 
 - (void)dealloc {
   [_name release];
-  //[_messenger release];
   [_codec release];
   [super dealloc];
 }
@@ -179,7 +178,6 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
 
 - (void)dealloc {
   [_name release];
-  //[_messenger release];
   [_codec release];
   [super dealloc];
 }
@@ -259,7 +257,6 @@ NSObject const* FlutterEndOfEventStream = [NSObject new];
 - (void)dealloc {
   [_name release];
   [_codec release];
-  //[_messenger release];
   [super dealloc];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -274,7 +274,6 @@
     }];
 
     __block __typeof(self)weakSelf = self;
-
     [_platformViewsChannel.get()
         setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
             [weakSelf platformCall:call result:result];
@@ -587,7 +586,7 @@
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
   _pluginKey = [pluginKey retain];
-  _flutterEngine = flutterEngine;//[flutterEngine retain];
+  _flutterEngine = flutterEngine;
   return self;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -521,7 +521,10 @@
                        : fml::MakeRefCounted<blink::PlatformMessage>(
                              channel.UTF8String, shell::GetVectorFromNSData(message), response);
 
-  _shell->GetPlatformView()->DispatchPlatformMessage(platformMessage);
+    //avoid access zombies object and crash ,_shell maybe not reset or engine may be release but not nil ,use lifecyclechannel check if engine is gone
+    if(_lifecycleChannel.get()){
+        _shell->GetPlatformView()->DispatchPlatformMessage(platformMessage);
+    }
 }
 
 - (void)setMessageHandlerOnChannel:(NSString*)channel

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -416,6 +416,8 @@
 
 - (void)viewWillDisappear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewWillDisappear");
+  [[[UIApplication sharedApplication] keyWindow] endEditing:YES];
+
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
 
   [super viewWillDisappear:animated];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -416,7 +416,6 @@
 
 - (void)viewWillDisappear:(BOOL)animated {
   TRACE_EVENT0("flutter", "viewWillDisappear");
-  [[[UIApplication sharedApplication] keyWindow] endEditing:YES];
 
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
 

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -22,6 +22,7 @@ IOSGLContext::IOSGLContext() {
     resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
                                                   sharegroup:context_.get().sharegroup]);
   }
+  [[NSNotificationCenter defaultCenter] postNotificationName:@"EAGLContextsharegroup" object:context_.get().sharegroup];
 
   // TODO:
   // iOS displays are more variable than just P3 or sRGB.  Reading the display

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -22,7 +22,6 @@ IOSGLContext::IOSGLContext() {
     resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
                                                   sharegroup:context_.get().sharegroup]);
   }
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"EAGLContextsharegroup" object:context_.get().sharegroup];
 
   // TODO:
   // iOS displays are more variable than just P3 or sRGB.  Reading the display

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -64,10 +64,7 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
 IOSGLRenderTarget::~IOSGLRenderTarget() {
   [EAGLContext setCurrentContext:context_];
   FML_DCHECK(glGetError() == GL_NO_ERROR);
-    
-    
-    
- //这里添加一句话--> 解决platform内存泄漏的问题
+ //fix platformview memory leak
   [EAGLContext setCurrentContext:context_.get()];
   // Deletes on GL_NONEs are ignored
   glDeleteFramebuffers(1, &framebuffer_);

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -64,7 +64,11 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
 IOSGLRenderTarget::~IOSGLRenderTarget() {
   [EAGLContext setCurrentContext:context_];
   FML_DCHECK(glGetError() == GL_NO_ERROR);
-
+    
+    
+    
+ //这里添加一句话--> 解决platform内存泄漏的问题
+  [EAGLContext setCurrentContext:context_.get()];
   // Deletes on GL_NONEs are ignored
   glDeleteFramebuffers(1, &framebuffer_);
   glDeleteRenderbuffers(1, &colorbuffer_);

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -64,8 +64,6 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
 IOSGLRenderTarget::~IOSGLRenderTarget() {
   [EAGLContext setCurrentContext:context_];
   FML_DCHECK(glGetError() == GL_NO_ERROR);
- //fix platformview memory leak https://github.com/flutter/flutter/issues/24714
-  [EAGLContext setCurrentContext:context_.get()];
   // Deletes on GL_NONEs are ignored
   glDeleteFramebuffers(1, &framebuffer_);
   glDeleteRenderbuffers(1, &colorbuffer_);

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -64,7 +64,7 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
 IOSGLRenderTarget::~IOSGLRenderTarget() {
   [EAGLContext setCurrentContext:context_];
   FML_DCHECK(glGetError() == GL_NO_ERROR);
- //fix platformview memory leak
+ //fix platformview memory leak https://github.com/flutter/flutter/issues/24714
   [EAGLContext setCurrentContext:context_.get()];
   // Deletes on GL_NONEs are ignored
   glDeleteFramebuffers(1, &framebuffer_);

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -64,6 +64,8 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
 IOSGLRenderTarget::~IOSGLRenderTarget() {
   [EAGLContext setCurrentContext:context_];
   FML_DCHECK(glGetError() == GL_NO_ERROR);
+ //fix platformview memory leak https://github.com/flutter/flutter/issues/24714
+  [EAGLContext setCurrentContext:context_.get()];
   // Deletes on GL_NONEs are ignored
   glDeleteFramebuffers(1, &framebuffer_);
   glDeleteRenderbuffers(1, &colorbuffer_);


### PR DESCRIPTION
solved the issue  FlutterMethodChannel may cause memory leak in iOS 

 https://github.com/flutter/flutter/issues/26007

the demo:
https://github.com/Natoto/flutterOnExistApp/tree/flutter1.2

 the docment:
https://juejin.im/post/5c24ad306fb9a049d2361cff 

there is a big circular reference between register enginer and messger of method channel