### PR TITLE
Fix weak pointer use violations in shell and platform view.

### DIFF
--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -123,6 +123,8 @@ class PlatformView {
   SkISize size_;
   fml::WeakPtrFactory<PlatformView> weak_factory_;
 
+  // Unlike all other methods on the platform view, this is called on the GPU
+  // task runner.
   virtual std::unique_ptr<Surface> CreateRenderingSurface();
 
  private:

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -15,7 +15,7 @@
 namespace shell {
 
 /// Represents a Frame that has been fully configured for the underlying client
-/// rendering API. A frame may only be sumitted once.
+/// rendering API. A frame may only be submitted once.
 class SurfaceFrame {
  public:
   using SubmitCallback =


### PR DESCRIPTION
This are a few of the violations caught by enabling the check [here](https://github.com/flutter/engine/blob/f4951df193a7966f9ed4da43d555eee0913d84d1/fml/memory/thread_checker.h#L60). Still auditing all use cases. Those these uses were not actual threading violations (because of latches), some of our uses of the vsync latches are dodgy. Fixing those next.