### PR TITLE
Add clang static analysis support to gn wrapper

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -116,7 +116,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7f64ff4928e7106cd8d81c6397fba4b7c1cdbb96',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '4a12b0dfad16723b2190b697a669e3ae17b50b35',
 
    # Fuchsia compatibility
    #

--- a/tools/gn
+++ b/tools/gn
@@ -91,6 +91,11 @@ def to_gn_args(args):
     gn_args['android_full_debug'] = args.target_os == 'android' and args.unoptimized
     gn_args['is_clang'] = not sys.platform.startswith(('cygwin', 'win'))
 
+    if not sys.platform.startswith(('cygwin', 'win')):
+      gn_args['use_clang_static_analyzer'] = args.clang_static_analyzer
+    else:
+      gn_args['use_clang_static_analyzer'] = False
+
     gn_args['embedder_for_target'] = args.embedder_for_target
 
     gn_args['enable_coverage'] = args.coverage
@@ -260,6 +265,9 @@ def parse_args(args):
 
   parser.add_argument('--clang', default=True, action='store_true')
   parser.add_argument('--no-clang', dest='clang', action='store_false')
+
+  parser.add_argument('--clang-static-analyzer', default=False, action='store_true')
+  parser.add_argument('--no-clang-static-analyzer', dest='clang_static_analyzer', action='store_false')
 
   parser.add_argument('--target-sysroot', type=str)
   parser.add_argument('--target-toolchain', type=str)


### PR DESCRIPTION
Adds --clang-static-analysis option to GN to enable/disable compiling
with clang static analysis enabled.