### PR TITLE
add signal to pointer kinds

### DIFF
--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -50,6 +50,9 @@ enum PointerDeviceKind {
   /// A pointer device with a stylus that has been inverted.
   invertedStylus,
 
+  /// A pointer device that uses a pointer signal.
+  signal,
+
   /// An unknown pointer device.
   unknown
 }


### PR DESCRIPTION
Fix the build for flutter:

```
ecuting: /Volumes/DevicelabAndroid/sdk/platform-tools/adb -s ZY22465W9K shell input tap 100 100
2019-03-06T16:19:46.016310: run:stdout: [+1392 ms] E/flutter (15708): [ERROR:flutter/shell/common/shell.cc(178)] Dart Error: Unhandled exception:
2019-03-06T16:19:46.016516: run:stdout: [        ] E/flutter (15708): RangeError (index): Invalid value: Not in range 0..4, inclusive: 5
run:stdout: [        ] E/flutter (15708): #0      List.[] (dart:core/runtime/lib/array.dart:161:52)
2019-03-06T16:19:46.016660: run:stdout: [        ] E/flutter (15708): #1      _unpackPointerDataPacket (dart:ui/hooks.dart:275:37)
2019-03-06T16:19:46.016943: run:stdout: [        ] E/flutter (15708): #2      _dispatchPointerDataPacket (dart:ui/hooks.dart:144:94)
2019-03-06T16:19:46.017514: run:stdout: [        ] E/flutter (15708): [ERROR:flutter/shell/common/shell.cc(178)] Dart Error: Unhandled exception:
2019-03-06T16:19:46.017718: run:stdout: [        ] E/flutter (15708): RangeError (index): Invalid value: Not in range 0..4, inclusive: 5
2019-03-06T16:19:46.017968: run:stdout: [        ] E/flutter (15708): #0      List.[] (dart:core/runtime/lib/array.dart:161:52)
2019-03-06T16:19:46.018177: run:stdout: [        ] E/flutter (15708): #1      _unpackPointerDataPacket (dart:ui/hooks.dart:275:37)
2019-03-06T16:19:46.018393: run:stdout: [        ] E/flutter (15708): #2      _dispatchPointerDataPacket (dart:ui/hooks.dart:144:94)
2019-03-06T16:19:46.034025: "/Volumes/DevicelabAndroid/sdk/platform-tools/adb" exit code: 0
```