### PR TITLE
Delay the vsync callback till the frame start time specified by embedder.

### DIFF
--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -35,7 +35,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
     return;
   }
 
-  task_runners_.GetUITaskRunner()->PostTask(
+  task_runners_.GetUITaskRunner()->PostTaskForTime(
       [callback, frame_start_time, frame_target_time]() {
 #if defined(OS_FUCHSIA)
         // In general, traces on Fuchsia are recorded across the whole system.
@@ -49,7 +49,8 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
         TRACE_EVENT0("flutter", "VSYNC");
 #endif
         callback(frame_start_time, frame_target_time);
-      });
+      },
+      frame_start_time);
 }
 
 float VsyncWaiter::GetDisplayRefreshRate() const {


### PR DESCRIPTION
The current assumption is that the embedder will wait till the vsync event and
then fire the callback. However, some embedders have that information upfront.
Since the time point has already been specified by the embedder, there is no
reason to burden the embedder with having to setup a wait either.