### PR TITLE
Update a11y word forward/back enum names

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -98,9 +98,9 @@ typedef enum {
   // A request that the node should be dismissed.
   kFlutterSemanticsActionDismiss = 1 << 18,
   // Move the cursor forward by one word.
-  kFlutterSemanticsActionMoveCursorForwardByWordIndex = 1 << 19,
+  kFlutterSemanticsActionMoveCursorForwardByWord = 1 << 19,
   // Move the cursor backward by one word.
-  kFlutterSemanticsActionMoveCursorBackwardByWordIndex = 1 << 20,
+  kFlutterSemanticsActionMoveCursorBackwardByWord = 1 << 20,
 } FlutterSemanticsAction;
 
 // The set of properties that may be associated with a semantics node.


### PR DESCRIPTION
This updates the FlutterSemanticsAction enumerator identifiers for the'move cursor forward/back one word' actions (added in flutter/engine#8033) for consistency with the 'move cusor forward/back on character' identifiers.

ABI compatibility is unaffected, but this with require the following change in any embedder making use of these fields:

Rename:
    kFlutterSemanticsActionMoveCursorForwardByWordIndex
to:
    kFlutterSemanticsActionMoveCursorForwardByWord

Rename:
    kFlutterSemanticsActionMoveCursorBackwardByWordIndex
to:
    kFlutterSemanticsActionMoveCursorBackwardByWord