### PR TITLE
Mark const extern

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ gke_container:
 task:
   env:
     CIRRUS_WORKING_DIR: "/tmp/github_repo"
-
+    DEPOT_TOOLS_UPDATE: 0
   replace_engine_script: |
     cd $ENGINE_PATH/src
     rm -r flutter
@@ -88,7 +88,7 @@ format_and_dart_test_task:
 
   env:
     CIRRUS_WORKING_DIR: "/tmp/github_repo"
-
+    DEPOT_TOOLS_UPDATE: 0
   replace_engine_script: |
     cd $ENGINE_PATH/src
     rm -r flutter

--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -23,7 +23,7 @@
  * The object passed as the sender is the `FlutterViewController` associated
  * with the update.
  */
-const NSNotificationName FlutterSemanticsUpdateNotification = @"FlutterSemanticsUpdate";
+extern NSNotificationName const FlutterSemanticsUpdateNotification;
 
 /**
  * A `UIViewController` implementation for Flutter views.

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -22,6 +22,8 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h"
 #include "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
+NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemanticsUpdate";
+
 @implementation FlutterViewController {
   std::unique_ptr<fml::WeakPtrFactory<FlutterViewController>> _weakFactory;
   fml::scoped_nsobject<FlutterEngine> _engine;


### PR DESCRIPTION
This was added as part of #8005 

Without being marked as `extern`, it'll get picked up as a duplicate symbol downstream.