### PR TITLE
Only build full sdk on release to speed up bots

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -283,7 +283,7 @@ def parse_args(args):
 
   parser.add_argument('--out-dir', default='', type=str)
 
-  parser.add_argument('--full-dart-sdk', default=False, action='store_true', 
+  parser.add_argument('--full-dart-sdk', default=True, action='store_true', 
                       help='include trained dart2js and dartdevc snapshots. Enable only on steps that create an sdk')
 
   return parser.parse_args(args)

--- a/tools/gn
+++ b/tools/gn
@@ -283,7 +283,8 @@ def parse_args(args):
 
   parser.add_argument('--out-dir', default='', type=str)
 
-  parser.add_argument('--full-dart-sdk', default=False, action='store_true')
+  parser.add_argument('--full-dart-sdk', default=False, action='store_true', 
+                      help='include trained dart2js and dartdevc snapshots. Enable only on steps that create an sdk')
 
   return parser.parse_args(args)
 

--- a/tools/gn
+++ b/tools/gn
@@ -232,8 +232,8 @@ def to_gn_args(args):
     if args.arm_float_abi:
       gn_args['arm_float_abi'] = args.arm_float_abi
 
-    # Switch flutter to full Dart SDK when building for the host system.
-    if args.target_os is None:
+    # Switch flutter to full Dart SDK when building for the release host system.
+    if args.target_os is None and runtime_mode == 'release':
       gn_args['dart_platform_sdk'] = False
 
     return gn_args

--- a/tools/gn
+++ b/tools/gn
@@ -233,7 +233,8 @@ def to_gn_args(args):
       gn_args['arm_float_abi'] = args.arm_float_abi
 
     # Whether to build all dart snapshots.
-    gn_args['dart_platform_sdk'] = !args.full_dart_sdk;
+    if args.full_dart_sdk:
+        gn_args['dart_platform_sdk'] = False
 
     return gn_args
 

--- a/tools/gn
+++ b/tools/gn
@@ -233,7 +233,7 @@ def to_gn_args(args):
       gn_args['arm_float_abi'] = args.arm_float_abi
 
     # Whether to build all dart snapshots.
-    gn_args['dart_platform_sdk'] = args.full_dart_sdk;
+    gn_args['dart_platform_sdk'] = !args.full_dart_sdk;
 
     return gn_args
 

--- a/tools/gn
+++ b/tools/gn
@@ -232,9 +232,8 @@ def to_gn_args(args):
     if args.arm_float_abi:
       gn_args['arm_float_abi'] = args.arm_float_abi
 
-    # Switch flutter to full Dart SDK when building for the release host system.
-    if args.target_os is None and runtime_mode == 'release':
-      gn_args['dart_platform_sdk'] = False
+    # Whether to build all dart snapshots.
+    gn_args['dart_platform_sdk'] = args.full_dart_sdk;
 
     return gn_args
 
@@ -283,6 +282,8 @@ def parse_args(args):
   parser.add_argument('--coverage', default=False, action='store_true')
 
   parser.add_argument('--out-dir', default='', type=str)
+
+  parser.add_argument('--full-dart-sdk', default=False, action='store_true')
 
   return parser.parse_args(args)
 


### PR DESCRIPTION
We don't need the dart2js or dartdevc snapshots in the engine, and we only ship the release sdk variants. 