### PR TITLE
Remove deprecated libraries from snapshot

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -2,17 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/lib/ui/dart_ui.gni")
 import("//build/compiled_action.gni")
 import("//third_party/dart/utils/compile_platform.gni")
-
-if (is_fuchsia) {
-  import("//build/dart/dart_library.gni")
-  import("//build/dart/toolchain.gni")
-  import("//topaz/public/dart-pkg/fuchsia/sdk_ext.gni")
-  import("//topaz/public/dart-pkg/zircon/sdk_ext.gni")
-  import("//topaz/public/lib/ui/flutter/sdk_ext/sdk_ext.gni")
-}
+import("$flutter_root/lib/ui/dart_ui.gni")
 
 bindings_output_dir = "$root_gen_dir/sky/bindings"
 

--- a/lib/stub_ui/compositing.dart
+++ b/lib/stub_ui/compositing.dart
@@ -314,7 +314,7 @@ class SceneHost {
   ///
   /// The export token is a dart:zircon Handle, but that type isn't
   /// available here. This is called by ChildViewConnection in
-  /// //topaz/public/lib/ui/flutter/.
+  /// //topaz/public/dart/fuchsia_scenic_flutter/.
   ///
   /// The scene host takes ownership of the provided export token handle.
   SceneHost(dynamic exportTokenHandle);

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -370,7 +370,7 @@ class SceneHost extends NativeFieldWrapperClass2 {
   ///
   /// The export token is a dart:zircon Handle, but that type isn't
   /// available here. This is called by ChildViewConnection in
-  /// //topaz/public/lib/ui/flutter/.
+  /// //topaz/public/dart/fuchsia_scenic_flutter/.
   ///
   /// The scene host takes ownership of the provided export token handle.
   SceneHost(dynamic exportTokenHandle) {


### PR DESCRIPTION
Fuchsia is no longer using these Dart libraries, instead using their SDK versions.  Remove them from the snapshot so they can be deleted from Fuchsia's tree.