### PR TITLE
Allow embedders to post tasks onto the render thread.

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -902,3 +902,18 @@ void FlutterEngineTraceEventDurationEnd(const char* name) {
 void FlutterEngineTraceEventInstant(const char* name) {
   fml::tracing::TraceEventInstant0("flutter", name);
 }
+
+FlutterEngineResult FlutterEnginePostRenderThreadTask(FlutterEngine engine,
+                                                      VoidCallback callback,
+                                                      void* baton) {
+  if (engine == nullptr || callback == nullptr) {
+    return kInvalidArguments;
+  }
+
+  auto task = [callback, baton]() { callback(baton); };
+
+  return reinterpret_cast<shell::EmbedderEngine*>(engine)->PostRenderThreadTask(
+             task)
+             ? kSuccess
+             : kInternalInconsistency;
+}

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -688,6 +688,14 @@ void FlutterEngineTraceEventDurationEnd(const char* name);
 FLUTTER_EXPORT
 void FlutterEngineTraceEventInstant(const char* name);
 
+// Posts a task onto the Flutter render thread. Typically, this may be called
+// from any thread as long as a |FlutterEngineShutdown| on the specific engine
+// has not already been initiated.
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEnginePostRenderThreadTask(FlutterEngine engine,
+                                                      VoidCallback callback,
+                                                      void* callback_data);
+
 #if defined(__cplusplus)
 }  // extern "C"
 #endif

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -203,4 +203,13 @@ bool EmbedderEngine::OnVsyncEvent(intptr_t baton,
                                               frame_target_time);
 }
 
+bool EmbedderEngine::PostRenderThreadTask(fml::closure task) {
+  if (!IsValid()) {
+    return false;
+  }
+
+  shell_->GetTaskRunners().GetGPUTaskRunner()->PostTask(task);
+  return true;
+}
+
 }  // namespace shell

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -63,6 +63,8 @@ class EmbedderEngine {
                     fml::TimePoint frame_start_time,
                     fml::TimePoint frame_target_time);
 
+  bool PostRenderThreadTask(fml::closure task);
+
  private:
   const ThreadHost thread_host_;
   std::unique_ptr<Shell> shell_;


### PR DESCRIPTION
Some embedders may have to wait on fences asynchronously before committing
contents. This allows them to post a task onto the engine managed thread used
for rendering.