### PR TITLE
Integrated AndroidTouchProcessor within the old FlutterView

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/AndroidTouchProcessor.java
@@ -66,7 +66,6 @@ public class AndroidTouchProcessor {
   }
 
   // Must match the unpacking code in hooks.dart.
-  // TODO(mattcarroll): Update with additional fields for scroll wheel support
   private static final int POINTER_DATA_FIELD_COUNT = 24;
   private static final int BYTES_PER_FIELD = 8;
 

--- a/shell/platform/android/io/flutter/embedding/engine/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/AndroidTouchProcessor.java
@@ -1,5 +1,6 @@
 package io.flutter.embedding.engine.android;
 
+import android.os.Build;
 import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 import android.view.InputDevice;
@@ -36,7 +37,6 @@ public class AndroidTouchProcessor {
     int UP = 6;
   }
 
-
   // Must match the PointerDeviceKind enum in pointer.dart.
   @IntDef({
       PointerDeviceKind.TOUCH,
@@ -53,10 +53,25 @@ public class AndroidTouchProcessor {
     int UNKNOWN = 4;
   }
 
+  // Must match the PointerSignalKind enum in pointer.dart.
+  @IntDef({
+      PointerSignalKind.NONE,
+      PointerSignalKind.SCROLL,
+      PointerSignalKind.UNKNOWN
+  })
+  private @interface PointerSignalKind {
+    int NONE = 0;
+    int SCROLL = 1;
+    int UNKNOWN = 2;
+  }
+
   // Must match the unpacking code in hooks.dart.
   // TODO(mattcarroll): Update with additional fields for scroll wheel support
-  private static final int POINTER_DATA_FIELD_COUNT = 21;
+  private static final int POINTER_DATA_FIELD_COUNT = 24;
   private static final int BYTES_PER_FIELD = 8;
+
+  // This value must match the value in framework's platform_view.dart.
+  // This flag indicates whether the original Android pointer events were batched together.
   private static final int POINTER_DATA_FLAG_BATCHED = 1;
 
   @NonNull
@@ -114,11 +129,40 @@ public class AndroidTouchProcessor {
     }
 
     // Verify that the packet is the expected size.
-    assert packet.position() % (POINTER_DATA_FIELD_COUNT * BYTES_PER_FIELD) == 0;
+    assert(packet.position() % (POINTER_DATA_FIELD_COUNT * BYTES_PER_FIELD) != 0);
 
     // Send the packet to Flutter.
     renderer.dispatchPointerDataPacket(packet, packet.position());
 
+    return true;
+  }
+
+  /**
+   * Sends the given generic {@link MotionEvent} data to Flutter in a format that Flutter
+   * understands.
+   *
+   * Generic motion events include joystick movement, mouse hover, track pad touches, scroll wheel
+   * movements, etc.
+   */
+  public boolean onGenericMotionEvent(MotionEvent event) {
+    // Method isFromSource is only available in API 18+ (Jelly Bean MR2)
+    // Mouse hover support is not implemented for API < 18.
+    boolean isPointerEvent = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
+        && event.isFromSource(InputDevice.SOURCE_CLASS_POINTER);
+    if (!isPointerEvent || event.getActionMasked() != MotionEvent.ACTION_HOVER_MOVE) {
+      return false;
+    }
+
+    int pointerChange = getPointerChangeForAction(event.getActionMasked());
+    ByteBuffer packet = ByteBuffer.allocateDirect(
+        event.getPointerCount() * POINTER_DATA_FIELD_COUNT * BYTES_PER_FIELD
+    );
+    packet.order(ByteOrder.LITTLE_ENDIAN);
+
+    // ACTION_HOVER_MOVE always applies to a single pointer only.
+    addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, packet);
+    assert(packet.position() % (POINTER_DATA_FIELD_COUNT * BYTES_PER_FIELD) != 0);
+    renderer.dispatchPointerDataPacket(packet, packet.position());
     return true;
   }
 
@@ -136,11 +180,14 @@ public class AndroidTouchProcessor {
 
     int pointerKind = getPointerDeviceTypeForToolType(event.getToolType(pointerIndex));
 
+    int signalKind = PointerSignalKind.NONE;
+
     long timeStamp = event.getEventTime() * 1000; // Convert from milliseconds to microseconds.
 
     packet.putLong(timeStamp); // time_stamp
     packet.putLong(pointerChange); // change
     packet.putLong(pointerKind); // kind
+    packet.putLong(signalKind); // signal_kind
     packet.putLong(event.getPointerId(pointerIndex)); // device
     packet.putDouble(event.getX(pointerIndex)); // physical_x
     packet.putDouble(event.getY(pointerIndex)); // physical_y
@@ -192,7 +239,10 @@ public class AndroidTouchProcessor {
       packet.putDouble(0.0); // tilt
     }
 
-    packet.putLong(pointerData);
+    packet.putLong(pointerData); // platformData
+
+    packet.putDouble(0.0); // scroll_delta_x
+    packet.putDouble(0.0); // scroll_delta_y
   }
 
   @PointerChange

--- a/shell/platform/android/io/flutter/embedding/engine/android/AndroidTouchProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/AndroidTouchProcessor.java
@@ -129,7 +129,9 @@ public class AndroidTouchProcessor {
     }
 
     // Verify that the packet is the expected size.
-    assert(packet.position() % (POINTER_DATA_FIELD_COUNT * BYTES_PER_FIELD) != 0);
+    if (packet.position() % (POINTER_DATA_FIELD_COUNT * BYTES_PER_FIELD) != 0) {
+      throw new AssertionError("Packet position is not on field boundary");
+    }
 
     // Send the packet to Flutter.
     renderer.dispatchPointerDataPacket(packet, packet.position());

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
@@ -315,7 +315,34 @@ public class FlutterView extends FrameLayout {
       return false;
     }
 
+    // TODO(abarth): This version check might not be effective in some
+    // versions of Android that statically compile code and will be upset
+    // at the lack of |requestUnbufferedDispatch|. Instead, we should factor
+    // version-dependent code into separate classes for each supported
+    // version and dispatch dynamically.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      requestUnbufferedDispatch(event);
+    }
+
     return androidTouchProcessor.onTouchEvent(event);
+  }
+
+  /**
+   * Invoked by Android when a generic motion event occurs, e.g., joystick movement, mouse hover,
+   * track pad touches, scroll wheel movements, etc.
+   *
+   * Flutter handles all of its own gesture detection and processing, therefore this
+   * method forwards all {@link MotionEvent} data from Android to Flutter.
+   */
+  @Override
+  public boolean onGenericMotionEvent(MotionEvent event) {
+    boolean handled = isAttachedToFlutterEngine() && androidTouchProcessor.onGenericMotionEvent(event);
+    if (handled) {
+      return true;
+    } else {
+      // TODO(mattcarroll): why are we returning the super value here but not in onTouchEvent and onHoverEvent?
+      return super.onGenericMotionEvent(event);
+    }
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
@@ -312,7 +312,7 @@ public class FlutterView extends FrameLayout {
   @Override
   public boolean onTouchEvent(MotionEvent event) {
     if (!isAttachedToFlutterEngine()) {
-      return false;
+      return super.onTouchEvent(event);
     }
 
     // TODO(abarth): This version check might not be effective in some
@@ -337,12 +337,7 @@ public class FlutterView extends FrameLayout {
   @Override
   public boolean onGenericMotionEvent(MotionEvent event) {
     boolean handled = isAttachedToFlutterEngine() && androidTouchProcessor.onGenericMotionEvent(event);
-    if (handled) {
-      return true;
-    } else {
-      // TODO(mattcarroll): why are we returning the super value here but not in onTouchEvent and onHoverEvent?
-      return super.onGenericMotionEvent(event);
-    }
+    return handled ? true : super.onGenericMotionEvent(event);
   }
 
   /**
@@ -359,7 +354,7 @@ public class FlutterView extends FrameLayout {
   @Override
   public boolean onHoverEvent(MotionEvent event) {
     if (!isAttachedToFlutterEngine()) {
-      return false;
+      return super.onHoverEvent(event);
     }
 
     // TODO(mattcarroll): hook up to accessibility.

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -371,7 +371,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         if (!isAttached()) {
-            return false;
+            return super.onTouchEvent(event);
         }
 
         // TODO(abarth): This version check might not be effective in some
@@ -389,7 +389,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     @Override
     public boolean onHoverEvent(MotionEvent event) {
         if (!isAttached()) {
-            return false;
+            return super.onHoverEvent(event);
         }
 
         boolean handled = mAccessibilityNodeProvider.onAccessibilityHoverEvent(event);
@@ -410,11 +410,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     @Override
     public boolean onGenericMotionEvent(MotionEvent event) {
         boolean handled = isAttached() && androidTouchProcessor.onGenericMotionEvent(event);
-        if (handled) {
-            return true;
-        } else {
-            return super.onGenericMotionEvent(event);
-        }
+        return handled ? true : super.onGenericMotionEvent(event);
     }
 
     @Override

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -29,7 +29,9 @@ import android.view.inputmethod.InputMethodManager;
 import io.flutter.app.FlutterPluginRegistry;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.android.AndroidKeyProcessor;
+import io.flutter.embedding.engine.android.AndroidTouchProcessor;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.embedding.engine.systemchannels.KeyEventChannel;
 import io.flutter.embedding.engine.systemchannels.LifecycleChannel;
@@ -88,6 +90,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     }
 
     private final DartExecutor dartExecutor;
+    private final FlutterRenderer flutterRenderer;
     private final NavigationChannel navigationChannel;
     private final KeyEventChannel keyEventChannel;
     private final LifecycleChannel lifecycleChannel;
@@ -98,6 +101,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     private final InputMethodManager mImm;
     private final TextInputPlugin mTextInputPlugin;
     private final AndroidKeyProcessor androidKeyProcessor;
+    private final AndroidTouchProcessor androidTouchProcessor;
     private AccessibilityBridge mAccessibilityNodeProvider;
     private final SurfaceHolder.Callback mSurfaceCallback;
     private final ViewportMetrics mMetrics;
@@ -133,6 +137,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
         }
 
         dartExecutor = mNativeView.getDartExecutor();
+        flutterRenderer = new FlutterRenderer(mNativeView.getFlutterJNI());
         mIsSoftwareRenderingEnabled = FlutterJNI.nativeGetIsSoftwareRenderingEnabled();
         mMetrics = new ViewportMetrics();
         mMetrics.devicePixelRatio = context.getResources().getDisplayMetrics().density;
@@ -180,6 +185,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
         mImm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
         mTextInputPlugin = new TextInputPlugin(this, dartExecutor);
         androidKeyProcessor = new AndroidKeyProcessor(keyEventChannel, mTextInputPlugin);
+        androidTouchProcessor = new AndroidTouchProcessor(flutterRenderer);
 
         // Send initial platform information to Dart
         sendLocalesToDart(getResources().getConfiguration());
@@ -362,147 +368,6 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
         return mTextInputPlugin.createInputConnection(this, outAttrs);
     }
 
-    // Must match the PointerChange enum in pointer.dart.
-    private static final int kPointerChangeCancel = 0;
-    private static final int kPointerChangeAdd = 1;
-    private static final int kPointerChangeRemove = 2;
-    private static final int kPointerChangeHover = 3;
-    private static final int kPointerChangeDown = 4;
-    private static final int kPointerChangeMove = 5;
-    private static final int kPointerChangeUp = 6;
-
-    // Must match the PointerDeviceKind enum in pointer.dart.
-    private static final int kPointerDeviceKindTouch = 0;
-    private static final int kPointerDeviceKindMouse = 1;
-    private static final int kPointerDeviceKindStylus = 2;
-    private static final int kPointerDeviceKindInvertedStylus = 3;
-    private static final int kPointerDeviceKindUnknown = 4;
-
-    // Must match the PointerSignalKind enum in pointer.dart.
-    private static final int kPointerSignalKindNone = 0;
-    private static final int kPointerSignalKindScroll = 1;
-    private static final int kPointerSignalKindUnknown = 2;
-
-    // These values must match the unpacking code in hooks.dart.
-    private static final int kPointerDataFieldCount = 24;
-    private static final int kPointerBytesPerField = 8;
-
-    private int getPointerChangeForAction(int maskedAction) {
-        // Primary pointer:
-        if (maskedAction == MotionEvent.ACTION_DOWN) {
-            return kPointerChangeDown;
-        }
-        if (maskedAction == MotionEvent.ACTION_UP) {
-            return kPointerChangeUp;
-        }
-        // Secondary pointer:
-        if (maskedAction == MotionEvent.ACTION_POINTER_DOWN) {
-            return kPointerChangeDown;
-        }
-        if (maskedAction == MotionEvent.ACTION_POINTER_UP) {
-            return kPointerChangeUp;
-        }
-        // All pointers:
-        if (maskedAction == MotionEvent.ACTION_MOVE) {
-            return kPointerChangeMove;
-        }
-        if (maskedAction == MotionEvent.ACTION_HOVER_MOVE) {
-            return kPointerChangeHover;
-        }
-        if (maskedAction == MotionEvent.ACTION_CANCEL) {
-            return kPointerChangeCancel;
-        }
-        return -1;
-    }
-
-    private int getPointerDeviceTypeForToolType(int toolType) {
-        switch (toolType) {
-        case MotionEvent.TOOL_TYPE_FINGER:
-            return kPointerDeviceKindTouch;
-        case MotionEvent.TOOL_TYPE_STYLUS:
-            return kPointerDeviceKindStylus;
-        case MotionEvent.TOOL_TYPE_MOUSE:
-            return kPointerDeviceKindMouse;
-        case MotionEvent.TOOL_TYPE_ERASER:
-            return kPointerDeviceKindInvertedStylus;
-        default:
-            // MotionEvent.TOOL_TYPE_UNKNOWN will reach here.
-            return kPointerDeviceKindUnknown;
-        }
-    }
-
-    private void addPointerForIndex(MotionEvent event, int pointerIndex, int pointerChange,
-                                    int pointerData, ByteBuffer packet) {
-        if (pointerChange == -1) {
-            return;
-        }
-
-        int pointerKind = getPointerDeviceTypeForToolType(event.getToolType(pointerIndex));
-
-        int signalKind = kPointerSignalKindNone;
-
-        long timeStamp = event.getEventTime() * 1000; // Convert from milliseconds to microseconds.
-
-        packet.putLong(timeStamp); // time_stamp
-        packet.putLong(pointerChange); // change
-        packet.putLong(pointerKind); // kind
-        packet.putLong(signalKind); // signal_kind
-        packet.putLong(event.getPointerId(pointerIndex)); // device
-        packet.putDouble(event.getX(pointerIndex)); // physical_x
-        packet.putDouble(event.getY(pointerIndex)); // physical_y
-
-        if (pointerKind == kPointerDeviceKindMouse) {
-            packet.putLong(event.getButtonState() & 0x1F); // buttons
-        } else if (pointerKind == kPointerDeviceKindStylus) {
-            packet.putLong((event.getButtonState() >> 4) & 0xF); // buttons
-        } else {
-            packet.putLong(0); // buttons
-        }
-
-        packet.putLong(0); // obscured
-
-        packet.putDouble(event.getPressure(pointerIndex)); // pressure
-        double pressureMin = 0.0, pressureMax = 1.0;
-        if (event.getDevice() != null) {
-            InputDevice.MotionRange pressureRange = event.getDevice().getMotionRange(MotionEvent.AXIS_PRESSURE);
-            if (pressureRange != null) {
-                pressureMin = pressureRange.getMin();
-                pressureMax = pressureRange.getMax();
-            }
-        }
-        packet.putDouble(pressureMin); // pressure_min
-        packet.putDouble(pressureMax); // pressure_max
-
-        if (pointerKind == kPointerDeviceKindStylus) {
-            packet.putDouble(event.getAxisValue(MotionEvent.AXIS_DISTANCE, pointerIndex)); // distance
-            packet.putDouble(0.0); // distance_max
-        } else {
-            packet.putDouble(0.0); // distance
-            packet.putDouble(0.0); // distance_max
-        }
-
-        packet.putDouble(event.getSize(pointerIndex)); // size
-
-        packet.putDouble(event.getToolMajor(pointerIndex)); // radius_major
-        packet.putDouble(event.getToolMinor(pointerIndex)); // radius_minor
-
-        packet.putDouble(0.0); // radius_min
-        packet.putDouble(0.0); // radius_max
-
-        packet.putDouble(event.getAxisValue(MotionEvent.AXIS_ORIENTATION, pointerIndex)); // orientation
-
-        if (pointerKind == kPointerDeviceKindStylus) {
-            packet.putDouble(event.getAxisValue(MotionEvent.AXIS_TILT, pointerIndex)); // tilt
-        } else {
-            packet.putDouble(0.0); // tilt
-        }
-
-        packet.putLong(pointerData); // platformData
-
-        packet.putDouble(0.0); // scroll_delta_x
-        packet.putDouble(0.0); // scroll_delta_y
-    }
-
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         if (!isAttached()) {
@@ -518,49 +383,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
             requestUnbufferedDispatch(event);
         }
 
-        // This value must match the value in framework's platform_view.dart.
-        // This flag indicates whether the original Android pointer events were batched together.
-        final int kPointerDataFlagBatched = 1;
-
-        int pointerCount = event.getPointerCount();
-
-        ByteBuffer packet = ByteBuffer.allocateDirect(pointerCount * kPointerDataFieldCount * kPointerBytesPerField);
-        packet.order(ByteOrder.LITTLE_ENDIAN);
-
-        int maskedAction = event.getActionMasked();
-        int pointerChange = getPointerChangeForAction(event.getActionMasked());
-        if (maskedAction == MotionEvent.ACTION_DOWN || maskedAction == MotionEvent.ACTION_POINTER_DOWN) {
-            // ACTION_DOWN and ACTION_POINTER_DOWN always apply to a single pointer only.
-            addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, packet);
-        } else if (maskedAction == MotionEvent.ACTION_UP || maskedAction == MotionEvent.ACTION_POINTER_UP) {
-            // ACTION_UP and ACTION_POINTER_UP may contain position updates for other pointers.
-            // We are converting these updates to move events here in order to preserve this data.
-            // We also mark these events with a flag in order to help the framework reassemble
-            // the original Android event later, should it need to forward it to a PlatformView.
-            for (int p = 0; p < pointerCount; p++) {
-                if (p != event.getActionIndex()) {
-                    if (event.getToolType(p) == MotionEvent.TOOL_TYPE_FINGER) {
-                        addPointerForIndex(event, p, kPointerChangeMove, kPointerDataFlagBatched, packet);
-                    }
-                }
-            }
-            // It's important that we're sending the UP event last. This allows PlatformView
-            // to correctly batch everything back into the original Android event if needed.
-            addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, packet);
-        } else {
-            // ACTION_MOVE may not actually mean all pointers have moved
-            // but it's the responsibility of a later part of the system to
-            // ignore 0-deltas if desired.
-            for (int p = 0; p < pointerCount; p++) {
-                addPointerForIndex(event, p, pointerChange, 0, packet);
-            }
-        }
-
-        if (packet.position() % (kPointerDataFieldCount * kPointerBytesPerField) != 0) {
-          throw new AssertionError("Packet position is not on field boundary");
-        }
-        mNativeView.getFlutterJNI().dispatchPointerDataPacket(packet, packet.position());
-        return true;
+        return androidTouchProcessor.onTouchEvent(event);
     }
 
     @Override
@@ -577,30 +400,21 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
         return handled;
     }
 
+    /**
+     * Invoked by Android when a generic motion event occurs, e.g., joystick movement, mouse hover,
+     * track pad touches, scroll wheel movements, etc.
+     *
+     * Flutter handles all of its own gesture detection and processing, therefore this
+     * method forwards all {@link MotionEvent} data from Android to Flutter.
+     */
     @Override
     public boolean onGenericMotionEvent(MotionEvent event) {
-        // Method isFromSource is only available in API 18+ (Jelly Bean MR2)
-        // Mouse hover support is not implemented for API < 18.
-        boolean isPointerEvent = Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2
-            && event.isFromSource(InputDevice.SOURCE_CLASS_POINTER);
-        if (!isPointerEvent ||
-            event.getActionMasked() != MotionEvent.ACTION_HOVER_MOVE ||
-            !isAttached()) {
+        boolean handled = isAttached() && androidTouchProcessor.onGenericMotionEvent(event);
+        if (handled) {
+            return true;
+        } else {
             return super.onGenericMotionEvent(event);
         }
-
-        int pointerChange = getPointerChangeForAction(event.getActionMasked());
-        ByteBuffer packet = ByteBuffer.allocateDirect(
-            event.getPointerCount() * kPointerDataFieldCount * kPointerBytesPerField);
-        packet.order(ByteOrder.LITTLE_ENDIAN);
-
-        // ACTION_HOVER_MOVE always applies to a single pointer only.
-        addPointerForIndex(event, event.getActionIndex(), pointerChange, 0, packet);
-        if (packet.position() % (kPointerDataFieldCount * kPointerBytesPerField) != 0) {
-          throw new AssertionError("Packet position is not on field boundary");
-        }
-        mNativeView.getFlutterJNI().dispatchPointerDataPacket(packet, packet.position());
-        return true;
     }
 
     @Override


### PR DESCRIPTION
Integrated `AndroidTouchProcessor` within the old `FlutterView` to prevent duplicated code for the same logic, this change also required some behavior updates in `AndroidTouchProcessor` due to recent changes in `FlutterView`.