### PR TITLE
Use right stream for Java, on mac try to autoselect Java 1.8

### DIFF
--- a/tools/android_lint/bin/main.dart
+++ b/tools/android_lint/bin/main.dart
@@ -202,7 +202,7 @@ Future<void> checkJava1_8() async {
   }
   // `java -version` writes to stderr.
   final String javaVersionStdout = javaResult.stderr;
-  if (javaVersionStdout.contains('"1.8')) {
+  if (!javaVersionStdout.contains('"1.8')) {
     print('The Android SDK tools may not work properly with your Java version. '
         'If this process fails, please retry using Java 1.8.');
   }


### PR DESCRIPTION
`java -version` writes to stderr, not stdout (?!), and `java --version` isn't supported on 1.8 (the version we actually hope to find).

This PR also uses the macOS `java_home` utility to try to find Java 1.8 for the user if it's installed.