### PR TITLE
Fix the Windows build

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -50,15 +50,16 @@ extern const intptr_t kPlatformStrongDillSize;
     return static_cast<decltype(pointer->member)>((default_value));      \
   })()
 
-#define LOG_EMBEDDER_ERROR(code)                                      \
-  ([=]() {                                                            \
-    do {                                                              \
-      FML_LOG(ERROR) << "Returning error '" << #code << "' (" << code \
-                     << ") from Flutter Embedder API call to '"       \
-                     << __FUNCTION__ << "'.";                         \
-    } while (0);                                                      \
-    return code;                                                      \
-  })()
+static FlutterEngineResult LogEmbedderError(FlutterEngineResult code,
+                                            const char* name,
+                                            const char* function) {
+  FML_LOG(ERROR) << "Returning error '" << name << "' (" << code
+                 << ") from Flutter Embedder API call to '" << __FUNCTION__
+                 << "'.";
+  return code;
+}
+
+#define LOG_EMBEDDER_ERROR(code) LogEmbedderError(code, #code, __FUNCTION__)
 
 static bool IsOpenGLRendererConfigValid(const FlutterRendererConfig* config) {
   if (config->type != kOpenGL) {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -51,14 +51,14 @@ extern const intptr_t kPlatformStrongDillSize;
   })()
 
 #define LOG_EMBEDDER_ERROR(code)                                      \
-  ({                                                                  \
+  ([=]() {                                                            \
     do {                                                              \
       FML_LOG(ERROR) << "Returning error '" << #code << "' (" << code \
                      << ") from Flutter Embedder API call to '"       \
                      << __FUNCTION__ << "'.";                         \
     } while (0);                                                      \
-    (code);                                                           \
-  })
+    return code;                                                      \
+  })()
 
 static bool IsOpenGLRendererConfigValid(const FlutterRendererConfig* config) {
   if (config->type != kOpenGL) {


### PR DESCRIPTION
Windows doesn't like the macro this way - making it a lambda works though.

This will have to be landed on red to fix the build.

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8919403792598141808/+/steps/build_host_debug_unopt/0/stdout is the failure