### PR TITLE
Android Embedding PR 19: Add accessibility to new FlutterView.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -110,7 +110,7 @@ public class FlutterEngine {
     // TODO(mattcarroll): FlutterRenderer is temporally coupled to attach(). Remove that coupling if possible.
     this.renderer = new FlutterRenderer(flutterJNI);
 
-    accessibilityChannel = new AccessibilityChannel(dartExecutor);
+    accessibilityChannel = new AccessibilityChannel(dartExecutor, flutterJNI);
     keyEventChannel = new KeyEventChannel(dartExecutor);
     lifecycleChannel = new LifecycleChannel(dartExecutor);
     localizationChannel = new LocalizationChannel(dartExecutor);

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -97,6 +97,7 @@ public class FlutterJNI {
   
   private Long nativePlatformViewId;
   private FlutterRenderer.RenderSurface renderSurface;
+  private AccessibilityDelegate accessibilityDelegate;
   private PlatformMessageHandler platformMessageHandler;
   private final Set<EngineLifecycleListener> engineLifecycleListeners = new HashSet<>();
   private final Set<OnFirstFrameRenderedListener> firstFrameListeners = new HashSet<>();
@@ -106,9 +107,7 @@ public class FlutterJNI {
    *
    * Flutter expects a user interface to exist on the platform side (Android), and that interface
    * is expected to offer some capabilities that Flutter depends upon. The {@link FlutterRenderer.RenderSurface}
-   * interface represents those expectations. For example, Flutter expects to be able to request
-   * that its user interface "update custom accessibility actions" and therefore the delegate interface
-   * declares a corresponding method, {@link FlutterRenderer.RenderSurface#updateCustomAccessibilityActions(ByteBuffer, String[])}.
+   * interface represents those expectations.
    *
    * If an app includes a user interface that renders a Flutter UI then a {@link FlutterRenderer.RenderSurface}
    * should be set (this is the typical Flutter scenario). If no UI is being rendered, such as a
@@ -123,7 +122,22 @@ public class FlutterJNI {
   }
 
   /**
-   * Call invoked by native to be forwarded to an {@link io.flutter.view.AccessibilityBridge}.
+   * Sets the {@link AccessibilityDelegate} for the attached Flutter context.
+   *
+   * The {@link AccessibilityDelegate} is responsible for maintaining an Android-side cache of
+   * Flutter's semantics tree and custom accessibility actions. This cache should be hooked up
+   * to Android's accessibility system.
+   *
+   * See {@link AccessibilityBridge} for an example of an {@link AccessibilityDelegate} and the
+   * surrounding responsibilities.
+   */
+  @UiThread
+  public void setAccessibilityDelegate(@Nullable AccessibilityDelegate accessibilityDelegate) {
+    this.accessibilityDelegate = accessibilityDelegate;
+  }
+
+  /**
+   * Invoked by native to send semantics tree updates from Flutter to Android.
    *
    * The {@code buffer} and {@code strings} form a communication protocol that is implemented here:
    * https://github.com/flutter/engine/blob/master/shell/platform/android/platform_view_android.cc#L207
@@ -131,14 +145,14 @@ public class FlutterJNI {
   @SuppressWarnings("unused")
   @UiThread
   private void updateSemantics(ByteBuffer buffer, String[] strings) {
-    if (renderSurface != null) {
-      renderSurface.updateSemantics(buffer, strings);
+    if (accessibilityDelegate != null) {
+      accessibilityDelegate.updateSemantics(buffer, strings);
     }
     // TODO(mattcarroll): log dropped messages when in debug mode (https://github.com/flutter/flutter/issues/25391)
   }
 
   /**
-   * Call invoked by native to be forwarded to an {@link io.flutter.view.AccessibilityBridge}.
+   * Invoked by native to send new custom accessibility events from Flutter to Android.
    *
    * The {@code buffer} and {@code strings} form a communication protocol that is implemented here:
    * https://github.com/flutter/engine/blob/master/shell/platform/android/platform_view_android.cc#L207
@@ -148,8 +162,8 @@ public class FlutterJNI {
   @SuppressWarnings("unused")
   @UiThread
   private void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
-    if (renderSurface != null) {
-      renderSurface.updateCustomAccessibilityActions(buffer, strings);
+    if (accessibilityDelegate != null) {
+      accessibilityDelegate.updateCustomAccessibilityActions(buffer, strings);
     }
     // TODO(mattcarroll): log dropped messages when in debug mode (https://github.com/flutter/flutter/issues/25391)
   }
@@ -531,5 +545,29 @@ public class FlutterJNI {
     if (nativePlatformViewId == null) {
       throw new RuntimeException("Cannot execute operation because FlutterJNI is not attached to native.");
     }
+  }
+
+  /**
+   * Delegate responsible for creating and updating Android-side caches of Flutter's semantics
+   * tree and custom accessibility actions.
+   *
+   * {@link AccessibilityBridge} is an example of an {@code AccessibilityDelegate}.
+   */
+  public interface AccessibilityDelegate {
+    /**
+     * Sends new custom accessibility actions from Flutter to Android.
+     *
+     * Implementers are expected to maintain an Android-side cache of custom accessibility actions.
+     * This method provides new actions to add to that cache.
+     */
+    void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings);
+
+    /**
+     * Sends new {@code SemanticsNode} information from Flutter to Android.
+     *
+     * Implementers are expected to maintain an Android-side cache of Flutter's semantics tree.
+     * This method provides updates from Flutter for the Android-side semantics tree cache.
+     */
+    void updateSemantics(ByteBuffer buffer, String[] strings);
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterFragment.java
@@ -336,11 +336,6 @@ public class FlutterFragment extends Fragment {
       //                    to platformPlugin. We're implicitly entangling the Window, Activity, Fragment,
       //                    and engine all with this one call.
       platformPlugin.onPostResume();
-
-      // TODO(mattcarroll): consider a more abstract way to invoke this behavior. It is very strange for
-      //                    a Fragment to have a seemingly random View responsibility, but this is what
-      //                    existed in the original embedding and I don't have a good alternative yet.
-      flutterView.updateAccessibilityFeatures();
     } else {
       Log.w(TAG, "onPostResume() invoked before FlutterFragment was attached to an Activity.");
     }

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterSurfaceView.java
@@ -173,16 +173,6 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
   }
 
   @Override
-  public void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
-    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
-  }
-
-  @Override
-  public void updateSemantics(ByteBuffer buffer, String[] strings) {
-    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
-  }
-
-  @Override
   public void onFirstFrameRendered() {
     // TODO(mattcarroll): decide where this method should live and what it needs to do.
     Log.d(TAG, "onFirstFrameRendered()");

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterTextureView.java
@@ -184,16 +184,6 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
   }
 
   @Override
-  public void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
-    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
-  }
-
-  @Override
-  public void updateSemantics(ByteBuffer buffer, String[] strings) {
-    // TODO(mattcarroll): refactor RenderSurface to move this method somewhere else.
-  }
-
-  @Override
   public void onFirstFrameRendered() {
     // TODO(mattcarroll): decide where this method should live and what it needs to do.
     Log.d(TAG, "onFirstFrameRendered()");

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
@@ -21,6 +21,8 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.WindowInsets;
 import android.view.WindowManager;
+import android.view.accessibility.AccessibilityManager;
+import android.view.accessibility.AccessibilityNodeProvider;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.widget.FrameLayout;
@@ -31,7 +33,9 @@ import java.util.Locale;
 
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.editing.TextInputPlugin;
+import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.VsyncWaiter;
 
 /**
@@ -81,9 +85,18 @@ public class FlutterView extends FrameLayout {
   private AndroidKeyProcessor androidKeyProcessor;
   @Nullable
   private AndroidTouchProcessor androidTouchProcessor;
+  @Nullable
+  private AccessibilityBridge accessibilityBridge;
 
   // Directly implemented View behavior that communicates with Flutter.
   private final FlutterRenderer.ViewportMetrics viewportMetrics = new FlutterRenderer.ViewportMetrics();
+
+  private final AccessibilityBridge.OnAccessibilityChangeListener onAccessibilityChangeListener = new AccessibilityBridge.OnAccessibilityChangeListener() {
+    @Override
+    public void onAccessibilityChanged(boolean isAccessibilityEnabled, boolean isTouchExplorationEnabled) {
+      resetWillNotDraw(isAccessibilityEnabled, isTouchExplorationEnabled);
+    }
+  };
 
   /**
    * Constructs a {@code FlutterSurfaceView} programmatically, without any XML attributes.
@@ -335,17 +348,35 @@ public class FlutterView extends FrameLayout {
       return false;
     }
 
-    // TODO(mattcarroll): hook up to accessibility.
-    return false;
+    boolean handled = accessibilityBridge.onAccessibilityHoverEvent(event);
+    if (!handled) {
+      // TODO(ianh): Expose hover events to the platform,
+      // implementing ADD, REMOVE, etc.
+    }
+    return handled;
   }
   //-------- End: Process UI I/O that Flutter cares about. ---------
 
   //-------- Start: Accessibility -------
-  /**
-   * No-op. Placeholder so that the containing Fragment can call through, but not yet implemented.
-   */
-  public void updateAccessibilityFeatures() {
-    // TODO(mattcarroll): bring in accessibility code from old FlutterView.
+  @Override
+  public AccessibilityNodeProvider getAccessibilityNodeProvider() {
+    if (accessibilityBridge != null && accessibilityBridge.isAccessibilityEnabled()) {
+      return accessibilityBridge;
+    } else {
+      // TODO(goderbauer): when a11y is off this should return a one-off snapshot of
+      // the a11y
+      // tree.
+      return null;
+    }
+  }
+
+  // TODO(mattcarroll): Confer with Ian as to why we need this method. Delete if possible, otherwise add comments.
+  private void resetWillNotDraw(boolean isAccessibilityEnabled, boolean isTouchExplorationEnabled) {
+    if (!flutterEngine.getRenderer().isSoftwareRenderingEnabled()) {
+      setWillNotDraw(!(isAccessibilityEnabled || isTouchExplorationEnabled));
+    } else {
+      setWillNotDraw(false);
+    }
   }
   //-------- End: Accessibility ---------
 
@@ -390,6 +421,17 @@ public class FlutterView extends FrameLayout {
         textInputPlugin
     );
     androidTouchProcessor = new AndroidTouchProcessor(this.flutterEngine.getRenderer());
+    accessibilityBridge = new AccessibilityBridge(
+        this,
+        flutterEngine.getAccessibilityChannel(),
+        (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE),
+        getContext().getContentResolver()
+    );
+    accessibilityBridge.setOnAccessibilityChangeListener(onAccessibilityChangeListener);
+    resetWillNotDraw(
+        accessibilityBridge.isAccessibilityEnabled(),
+        accessibilityBridge.isTouchExplorationEnabled()
+    );
 
     // Inform the Android framework that it should retrieve a new InputConnection
     // now that an engine is attached.

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -233,7 +233,7 @@ public class FlutterRenderer implements TextureRegistry {
    * UI.
    *
    * A {@code RenderSurface} is responsible for carrying out behaviors that are needed by a
-   * corresponding {@link FlutterRenderer}, e.g., {@link #updateSemantics(ByteBuffer, String[])}.
+   * corresponding {@link FlutterRenderer}.
    *
    * A {@code RenderSurface} also receives callbacks for important events, e.g.,
    * {@link #onFirstFrameRendered()}.
@@ -254,12 +254,6 @@ public class FlutterRenderer implements TextureRegistry {
      * This method will cease any on-going rendering from Flutter to this {@code RenderSurface}.
      */
     void detachFromRenderer();
-
-    // TODO(mattcarroll): describe what this callback is intended to do
-    void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings);
-
-    // TODO(mattcarroll): describe what this callback is intended to do
-    void updateSemantics(ByteBuffer buffer, String[] strings);
 
     /**
      * The {@link FlutterRenderer} corresponding to this {@code RenderSurface} has painted its

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -4,10 +4,13 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.HashMap;
+import java.util.Map;
 
+import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.StandardMessageCodec;
+import io.flutter.view.AccessibilityBridge;
 
 /**
  * System channel that sends accessibility requests and events from Flutter to Android.
@@ -17,7 +20,9 @@ import io.flutter.plugin.common.StandardMessageCodec;
  */
 public class AccessibilityChannel {
   @NonNull
-  public BasicMessageChannel<Object> channel;
+  public final BasicMessageChannel<Object> channel;
+  @NonNull
+  public final FlutterJNI flutterJNI;
   @Nullable
   private AccessibilityMessageHandler handler;
 
@@ -76,9 +81,62 @@ public class AccessibilityChannel {
    *
    * See {@link DartExecutor}.
    */
-  public AccessibilityChannel(@NonNull DartExecutor dartExecutor) {
+  public AccessibilityChannel(@NonNull DartExecutor dartExecutor, @NonNull FlutterJNI flutterJNI) {
     channel = new BasicMessageChannel<>(dartExecutor, "flutter/accessibility", StandardMessageCodec.INSTANCE);
     channel.setMessageHandler(parsingMessageHandler);
+    this.flutterJNI = flutterJNI;
+  }
+
+  /**
+   * Informs Flutter that the Android OS currently has accessibility enabled.
+   *
+   * To accommodate enabled accessibility, this method instructs Flutter to activate
+   * its semantics tree, which forms the basis of Flutter's accessibility support.
+   */
+  public void onAndroidAccessibilityEnabled() {
+    flutterJNI.setSemanticsEnabled(true);
+  }
+
+  /**
+   * Informs Flutter that the Android OS currently has accessibility disabled.
+   *
+   * Given that accessibility is not required at this time, this method instructs Flutter
+   * to deactivate its semantics tree.
+   */
+  public void onAndroidAccessibilityDisabled() {
+    flutterJNI.setSemanticsEnabled(false);
+  }
+
+  /**
+   * Instructs Flutter to activate/deactivate accessibility features corresponding to the
+   * flags provided by {@code accessibilityFeatureFlags}.
+   */
+  public void setAccessibilityFeatures(int accessibilityFeatureFlags) {
+    flutterJNI.setAccessibilityFeatures(accessibilityFeatureFlags);
+  }
+
+  /**
+   * Instructs Flutter to perform the given {@code action} on the {@code SemanticsNode}
+   * referenced by the given {@code virtualViewId}.
+   *
+   * One might wonder why Flutter would need to be instructed that the user wants to perform
+   * an action. When the user is touching the screen in accessibility mode, Android takes over the
+   * touch input, categorizing input as one of a many accessibility gestures. Therefore, Flutter
+   * does not have an opportunity to react to said touch input. Instead, Flutter must be notified
+   * by Android of the desired action. Additionally, some accessibility systems use other input
+   * methods, such as speech, to take virtual actions. Android interprets those requests and then
+   * instructs the app to take the appropriate action.
+   */
+  public void dispatchSemanticsAction(int virtualViewId, @NonNull AccessibilityBridge.Action action) {
+    flutterJNI.dispatchSemanticsAction(virtualViewId, action);
+  }
+
+  /**
+   * Instructs Flutter to perform the given {@code action} on the {@code SemanticsNode}
+   * referenced by the given {@code virtualViewId}, passing the given {@code args}.
+   */
+  public void dispatchSemanticsAction(int virtualViewId, @NonNull AccessibilityBridge.Action action, @Nullable Object args) {
+    flutterJNI.dispatchSemanticsAction(virtualViewId, action, args);
   }
 
   /**
@@ -87,6 +145,7 @@ public class AccessibilityChannel {
    */
   public void setAccessibilityMessageHandler(@Nullable AccessibilityMessageHandler handler) {
     this.handler = handler;
+    flutterJNI.setAccessibilityDelegate(handler);
   }
 
   /**
@@ -96,7 +155,7 @@ public class AccessibilityChannel {
    * To register an {@code AccessibilityMessageHandler} with a {@link AccessibilityChannel},
    * see {@link AccessibilityChannel#setAccessibilityMessageHandler(AccessibilityMessageHandler)}.
    */
-  public interface AccessibilityMessageHandler {
+  public interface AccessibilityMessageHandler extends FlutterJNI.AccessibilityDelegate {
     /**
      * The Dart application would like the given {@code message} to be announced.
      */

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -32,6 +32,7 @@ import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.util.Predicate;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.*;
 
 /**
@@ -48,7 +49,6 @@ import java.util.*;
  *   {@link #rootAccessibilityView} is expected to notify the {@code AccessibilityBridge} of
  *   relevant interactions: {@link #onAccessibilityHoverEvent(MotionEvent)}, {@link #reset()},
  *   {@link #updateSemantics(ByteBuffer, String[])}, and {@link #updateCustomAccessibilityActions(ByteBuffer, String[])}</li>
- *   <li>A {@link FlutterJNI} instance, corresponding to the running Flutter app.</li>
  *   <li>An {@link AccessibilityChannel} that is connected to the running Flutter app.</li>
  *   <li>Android's {@link AccessibilityManager} to query and listen for accessibility settings.</li>
  *   <li>Android's {@link ContentResolver} to listen for changes to system animation settings.</li>
@@ -60,12 +60,6 @@ import java.util.*;
  * accessibility events may be consumed by a Flutter widget, as if it were an Android
  * {@link View}. {@code AccessibilityBridge} refers to Flutter's accessible widgets as
  * "virtual views" and identifies them with "virtual view IDs".
- *
- * Most communication between the Android OS accessibility system and Flutter's accessibility
- * system is achieved via the {@link AccessibilityChannel} system channel. However, some
- * information is exchanged directly between the Android embedding and Flutter framework
- * via {@link FlutterJNI}.
- * TODO(mattcarroll): consider moving FlutterJNI calls over to AccessibilityChannel
  */
 public class AccessibilityBridge extends AccessibilityNodeProvider {
     private static final String TAG = "AccessibilityBridge";
@@ -85,10 +79,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     // Real Android View, which internally holds a Flutter UI.
     @NonNull
     private final View rootAccessibilityView;
-
-    // Direct interface between Flutter's Android embedding and the Flutter framework.
-    @NonNull
-    private final FlutterJNI flutterJNI;
 
     // The accessibility communication API between Flutter's Android embedding and
     // the Flutter framework.
@@ -239,6 +229,24 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             e.getText().add(message);
             sendAccessibilityEvent(e);
         }
+
+        /**
+         * New custom accessibility actions exist in Flutter. Update our Android-side cache.
+         */
+        @Override
+        public void updateCustomAccessibilityActions(ByteBuffer buffer, String[] strings) {
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+            AccessibilityBridge.this.updateCustomAccessibilityActions(buffer, strings);
+        }
+
+        /**
+         * Flutter's semantics tree has changed. Update our Android-side cache.
+         */
+        @Override
+        public void updateSemantics(ByteBuffer buffer, String[] strings) {
+            buffer.order(ByteOrder.LITTLE_ENDIAN);
+            AccessibilityBridge.this.updateSemantics(buffer, strings);
+        }
     };
 
     // Listener that is notified when accessibility is turned on/off.
@@ -247,10 +255,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         public void onAccessibilityStateChanged(boolean accessibilityEnabled) {
             if (accessibilityEnabled) {
                 accessibilityChannel.setAccessibilityMessageHandler(accessibilityMessageHandler);
-                flutterJNI.setSemanticsEnabled(true);
+                accessibilityChannel.onAndroidAccessibilityEnabled();
             } else {
                 accessibilityChannel.setAccessibilityMessageHandler(null);
-                flutterJNI.setSemanticsEnabled(false);
+                accessibilityChannel.onAndroidAccessibilityDisabled();
             }
 
             if (onAccessibilityChangeListener != null) {
@@ -313,15 +321,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         }
     };
 
-    AccessibilityBridge(
+    public AccessibilityBridge(
         @NonNull View rootAccessibilityView,
-        @NonNull FlutterJNI flutterJNI,
         @NonNull AccessibilityChannel accessibilityChannel,
         @NonNull AccessibilityManager accessibilityManager,
         @NonNull ContentResolver contentResolver
     ) {
         this.rootAccessibilityView = rootAccessibilityView;
-        this.flutterJNI = flutterJNI;
         this.accessibilityChannel = accessibilityChannel;
         this.accessibilityManager = accessibilityManager;
         this.contentResolver = contentResolver;
@@ -388,10 +394,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     }
 
     /**
-     * Sends the current value of {@link #accessibilityFeatureFlags} to Flutter via {@link FlutterJNI}.
+     * Sends the current value of {@link #accessibilityFeatureFlags} to Flutter.
      */
     private void sendLatestAccessibilityFlagsToFlutter() {
-        flutterJNI.setAccessibilityFeatures(accessibilityFeatureFlags);
+        accessibilityChannel.setAccessibilityFeatures(accessibilityFeatureFlags);
     }
 
     private boolean shouldSetCollectionInfo(final SemanticsNode semanticsNode) {
@@ -709,8 +715,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
      * In a traditional Android app, the given view ID refers to a {@link View} within an Android
      * {@link View} hierarchy. Flutter does not have an Android {@link View} hierarchy, therefore
      * the given view ID is a {@code virtualViewId} that refers to a {@code SemanticsNode} within
-     * a Flutter app. The given arguments of this method are forwarded from Android to Flutter
-     * via {@link FlutterJNI}.
+     * a Flutter app. The given arguments of this method are forwarded from Android to Flutter.
      */
     @Override
     public boolean performAction(int virtualViewId, int accessibilityAction, @Nullable Bundle arguments) {
@@ -723,27 +728,27 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 // Note: TalkBack prior to Oreo doesn't use this handler and instead simulates a
                 //     click event at the center of the SemanticsNode. Other a11y services might go
                 //     through this handler though.
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.TAP);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.TAP);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_LONG_CLICK: {
                 // Note: TalkBack doesn't use this handler and instead simulates a long click event
                 //     at the center of the SemanticsNode. Other a11y services might go through this
                 //     handler though.
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.LONG_PRESS);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.LONG_PRESS);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_SCROLL_FORWARD: {
                 if (semanticsNode.hasAction(Action.SCROLL_UP)) {
-                    flutterJNI.dispatchSemanticsAction(virtualViewId, Action.SCROLL_UP);
+                    accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.SCROLL_UP);
                 } else if (semanticsNode.hasAction(Action.SCROLL_LEFT)) {
                     // TODO(ianh): bidi support using textDirection
-                    flutterJNI.dispatchSemanticsAction(virtualViewId, Action.SCROLL_LEFT);
+                    accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.SCROLL_LEFT);
                 } else if (semanticsNode.hasAction(Action.INCREASE)) {
                     semanticsNode.value = semanticsNode.increasedValue;
                     // Event causes Android to read out the updated value.
                     sendAccessibilityEvent(virtualViewId, AccessibilityEvent.TYPE_VIEW_SELECTED);
-                    flutterJNI.dispatchSemanticsAction(virtualViewId, Action.INCREASE);
+                    accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.INCREASE);
                 } else {
                     return false;
                 }
@@ -751,15 +756,15 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             }
             case AccessibilityNodeInfo.ACTION_SCROLL_BACKWARD: {
                 if (semanticsNode.hasAction(Action.SCROLL_DOWN)) {
-                    flutterJNI.dispatchSemanticsAction(virtualViewId, Action.SCROLL_DOWN);
+                    accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.SCROLL_DOWN);
                 } else if (semanticsNode.hasAction(Action.SCROLL_RIGHT)) {
                     // TODO(ianh): bidi support using textDirection
-                    flutterJNI.dispatchSemanticsAction(virtualViewId, Action.SCROLL_RIGHT);
+                    accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.SCROLL_RIGHT);
                 } else if (semanticsNode.hasAction(Action.DECREASE)) {
                     semanticsNode.value = semanticsNode.decreasedValue;
                     // Event causes Android to read out the updated value.
                     sendAccessibilityEvent(virtualViewId, AccessibilityEvent.TYPE_VIEW_SELECTED);
-                    flutterJNI.dispatchSemanticsAction(virtualViewId, Action.DECREASE);
+                    accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.DECREASE);
                 } else {
                     return false;
                 }
@@ -784,7 +789,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 return performCursorMoveAction(semanticsNode, virtualViewId, arguments, true);
             }
             case AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS: {
-                flutterJNI.dispatchSemanticsAction(
+                accessibilityChannel.dispatchSemanticsAction(
                     virtualViewId,
                     Action.DID_LOSE_ACCESSIBILITY_FOCUS
                 );
@@ -796,7 +801,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS: {
-                flutterJNI.dispatchSemanticsAction(
+                accessibilityChannel.dispatchSemanticsAction(
                     virtualViewId,
                     Action.DID_GAIN_ACCESSIBILITY_FOCUS
                 );
@@ -821,7 +826,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 return true;
             }
             case ACTION_SHOW_ON_SCREEN: {
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.SHOW_ON_SCREEN);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.SHOW_ON_SCREEN);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_SET_SELECTION: {
@@ -849,23 +854,23 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                     selection.put("base", semanticsNode.textSelectionExtent);
                     selection.put("extent", semanticsNode.textSelectionExtent);
                 }
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.SET_SELECTION, selection);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.SET_SELECTION, selection);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_COPY: {
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.COPY);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.COPY);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_CUT: {
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.CUT);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.CUT);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_PASTE: {
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.PASTE);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.PASTE);
                 return true;
             }
             case AccessibilityNodeInfo.ACTION_DISMISS: {
-                flutterJNI.dispatchSemanticsAction(virtualViewId, Action.DISMISS);
+                accessibilityChannel.dispatchSemanticsAction(virtualViewId, Action.DISMISS);
                 return true;
             }
             default:
@@ -873,7 +878,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 final int flutterId = accessibilityAction - FIRST_RESOURCE_ID;
                 CustomAccessibilityAction contextAction = customAccessibilityActions.get(flutterId);
                 if (contextAction != null) {
-                    flutterJNI.dispatchSemanticsAction(
+                    accessibilityChannel.dispatchSemanticsAction(
                         virtualViewId,
                         Action.CUSTOM_ACTION,
                         contextAction.id
@@ -905,7 +910,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         switch (granularity) {
             case AccessibilityNodeInfo.MOVEMENT_GRANULARITY_CHARACTER: {
                 if (forward && semanticsNode.hasAction(Action.MOVE_CURSOR_FORWARD_BY_CHARACTER)) {
-                    flutterJNI.dispatchSemanticsAction(
+                    accessibilityChannel.dispatchSemanticsAction(
                         virtualViewId,
                         Action.MOVE_CURSOR_FORWARD_BY_CHARACTER,
                         extendSelection
@@ -913,7 +918,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                     return true;
                 }
                 if (!forward && semanticsNode.hasAction(Action.MOVE_CURSOR_BACKWARD_BY_CHARACTER)) {
-                    flutterJNI.dispatchSemanticsAction(
+                    accessibilityChannel.dispatchSemanticsAction(
                         virtualViewId,
                         Action.MOVE_CURSOR_BACKWARD_BY_CHARACTER,
                         extendSelection
@@ -924,7 +929,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             }
             case AccessibilityNodeInfo.MOVEMENT_GRANULARITY_WORD:
                 if (forward && semanticsNode.hasAction(Action.MOVE_CURSOR_FORWARD_BY_WORD)) {
-                    flutterJNI.dispatchSemanticsAction(
+                    accessibilityChannel.dispatchSemanticsAction(
                         virtualViewId,
                         Action.MOVE_CURSOR_FORWARD_BY_WORD,
                         extendSelection
@@ -932,7 +937,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                     return true;
                 }
                 if (!forward && semanticsNode.hasAction(Action.MOVE_CURSOR_BACKWARD_BY_WORD)) {
-                    flutterJNI.dispatchSemanticsAction(
+                    accessibilityChannel.dispatchSemanticsAction(
                         virtualViewId,
                         Action.MOVE_CURSOR_BACKWARD_BY_WORD,
                         extendSelection

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -852,8 +852,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
 
         mAccessibilityNodeProvider = new AccessibilityBridge(
             this,
-            getFlutterNativeView().getFlutterJNI(),
-            new AccessibilityChannel(dartExecutor),
+            new AccessibilityChannel(dartExecutor, getFlutterNativeView().getFlutterJNI()),
             (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE),
             getContext().getContentResolver()
         );


### PR DESCRIPTION
Android Embedding PR 19: Add accessibility to new FlutterView.

Accessibility previously separated its communication between the accessibility channel and FlutterJNI.  This PR now unifies that communication, at least at the API level.  No the `AccessibilityChannel` class can be used for all accessibility communication.  Behind the scenes it still utilizes `FlutterJNI`, but hopefully we can eventually migrate those calls for real.

This PR also moves 2 accessibility methods out of `RenderSurface` into a new interface called `AccessibilityDelegate`.  When I created `RenderSurface` I didn't really know what those methods were supposed to do.  Now that I do, they really belong elsewhere. 

Based on manual spot checks of the gallery app using the old FlutterView, accessibility interaction appears to still be working as expected.

Also, accessibility in a simple test app with the new FlutterView/FlutterEngine appears to be working now, too.