### PR TITLE
Use final state passed to dart before initialization as the initial lifecycleState.

### DIFF
--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -94,7 +94,7 @@ void _updateUserSettingsData(String jsonData) {
 void _updateLifecycleState(String state) {
   // We do not update the state if the state has already been used to initialize
   // the lifecycleState.
-  if (window._initialLifecycleStateAccessed)
+  if (!window._initialLifecycleStateAccessed)
     window._initialLifecycleState = state;
 }
 

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -92,7 +92,10 @@ void _updateUserSettingsData(String jsonData) {
 @pragma('vm:entry-point')
 // ignore: unused_element
 void _updateLifecycleState(String state) {
-  window._initialLifecycleState ??= state;
+  // We do not update the state if the state has already been used to initialize
+  // the lifecycleState.
+  if (window._initialLifecycleStateAccessed)
+    window._initialLifecycleState = state;
 }
 
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -562,8 +562,15 @@ class Window {
   ///
   /// It is used to initialize [SchedulerBinding.lifecycleState] at startup
   /// with any buffered lifecycle state events.
-  String get initialLifecycleState => _initialLifecycleState;
+  String get initialLifecycleState {
+    _initialLifecycleStateAccessed = true;
+    return _initialLifecycleState;
+  }
   String _initialLifecycleState;
+  /// Tracks if the initial state has been accessed. Once accessed, we
+  /// will stop updating the [initialLifecycleState], as it is not the
+  /// preferred way to access the state.
+  bool _initialLifecycleStateAccessed = false;
 
   /// The system-reported text scale.
   ///

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -167,6 +167,7 @@ bool RuntimeController::SetUserSettingsData(const std::string& data) {
 
 bool RuntimeController::SetLifecycleState(const std::string& data) {
   window_data_.lifecycle_state = data;
+  // FML_DLOG(ERROR) << data;
 
   if (auto* window = GetWindowIfAvailable()) {
     window->UpdateLifecycleState(window_data_.lifecycle_state);

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -167,7 +167,6 @@ bool RuntimeController::SetUserSettingsData(const std::string& data) {
 
 bool RuntimeController::SetLifecycleState(const std::string& data) {
   window_data_.lifecycle_state = data;
-  // FML_DLOG(ERROR) << data;
 
   if (auto* window = GetWindowIfAvailable()) {
     window->UpdateLifecycleState(window_data_.lifecycle_state);


### PR DESCRIPTION
We were previously incorrectly caching the very first state even if the state had changed before the value was used to initialize Flutter.

Now, we track the initial state before flutter uses it to initialize, at which point we stop updating it.