### PR TITLE
Look up ICU symbols based on the path to libflutter.so as a fallback

### DIFF
--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -52,6 +52,9 @@ DEF_SWITCH(ICUSymbolPrefix,
            "icu-symbol-prefix",
            "Prefix for the symbols representing ICU data linked into the "
            "Flutter library.")
+DEF_SWITCH(ICUNativeLibPath,
+           "icu-native-lib-path",
+           "Path to the library file that exports the ICU data.")
 DEF_SWITCH(DartFlags,
            "dart-flags",
            "Flags passed directly to the Dart VM without being interpreted "

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -6,6 +6,7 @@ package io.flutter.view;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.app.AlarmManager;
@@ -195,7 +196,12 @@ public class FlutterMain {
             sResourceExtractor.waitForCompletion();
 
             List<String> shellArgs = new ArrayList<>();
+
             shellArgs.add("--icu-symbol-prefix=_binary_icudtl_dat");
+            ApplicationInfo applicationInfo = applicationContext.getPackageManager().getApplicationInfo(
+                applicationContext.getPackageName(), PackageManager.GET_META_DATA);
+            shellArgs.add("--icu-native-lib-path=" + applicationInfo.nativeLibraryDir + File.separator + DEFAULT_LIBRARY);
+
             if (args != null) {
                 Collections.addAll(shellArgs, args);
             }


### PR DESCRIPTION
The ICU data is packaged within libflutter.so, and the engine uses
dlsym(RTLD_DEFAULT) to look up the ICU data symbols in the libraries
loaded by the process.

This approach apparently fails on some Xiaomi devices.  If RTLD_DEFAULT
can not find the symbols, then the platform will pass the path to the
libflutter.so library so the engine can use that to resolve the symbols.

Fixes https://github.com/flutter/flutter/issues/28208