### PR TITLE
Ensure that typed data is released within SendPlatformMessage scope.

### DIFF
--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -85,12 +85,9 @@ Dart_Handle SendPlatformMessage(Dart_Handle window,
                                 const std::string& name,
                                 Dart_Handle callback,
                                 Dart_Handle data_handle) {
-  tonic::DartByteData data(data_handle);
   UIDartState* dart_state = UIDartState::Current();
 
   if (!dart_state->window()) {
-    // Must release the TypedData buffer before allocating other Dart objects.
-    data.Release();
     return tonic::ToDart(
         "Platform messages can only be sent from the main isolate");
   }
@@ -101,12 +98,12 @@ Dart_Handle SendPlatformMessage(Dart_Handle window,
         tonic::DartPersistentValue(dart_state, callback),
         dart_state->GetTaskRunners().GetUITaskRunner());
   }
-  if (Dart_IsNull(data.dart_handle())) {
+  if (Dart_IsNull(data_handle)) {
     dart_state->window()->client()->HandlePlatformMessage(
         fml::MakeRefCounted<PlatformMessage>(name, response));
   } else {
+    tonic::DartByteData data(data_handle);
     const uint8_t* buffer = static_cast<const uint8_t*>(data.data());
-
     dart_state->window()->client()->HandlePlatformMessage(
         fml::MakeRefCounted<PlatformMessage>(
             name, std::vector<uint8_t>(buffer, buffer + data.length_in_bytes()),

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -84,7 +84,8 @@ void ReportUnhandledException(Dart_NativeArguments args) {
 Dart_Handle SendPlatformMessage(Dart_Handle window,
                                 const std::string& name,
                                 Dart_Handle callback,
-                                const tonic::DartByteData& data) {
+                                Dart_Handle data_handle) {
+  tonic::DartByteData data(data_handle);
   UIDartState* dart_state = UIDartState::Current();
 
   if (!dart_state->window()) {


### PR DESCRIPTION
We used to make tonic make the wrapper before the SendPlatformMessage invocation. However, tonic would not collect the wrapper before make the Dart API call to return the value from the native method. This is illegal and would trip an assertion in the Dart VM. A more systematic fix required reworking tonic to handle this case. However, to fix our illegal use of the Dart API now, this patch creates the wrapper manually in function scope.

Fixes https://github.com/flutter/flutter/issues/29058