### PR TITLE
Add a11y support for embedded iOS platform view

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -605,7 +605,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// nodes will be added as children to this node. If a platform view is
   /// specified, `childrenInHitTestOrder` and `childrenInTraversalOrder` must be
   /// empty, and other semantic configurations will be ignored. The ignored configurations
-  /// include:[flags], [actions], [textSelectionBase], [textSelectionExtent], [scrollChildren],
+  /// include: [flags], [actions], [textSelectionBase], [textSelectionExtent], [scrollChildren],
   /// [scrollIndex], [scrollPosition], [scrollExtentMax], [scrollExtentMin], [elevation],
   /// [thickness], [label], [hint], [value], [increasedValue], [decreasedValue], [textDirection],
   /// [transform], [childrenInTraversalOrder], [childrenInHitTestOrder], [additionalActions]

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -604,7 +604,11 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// The field `platformViewId` references the platform view, whose semantics
   /// nodes will be added as children to this node. If a platform view is
   /// specified, `childrenInHitTestOrder` and `childrenInTraversalOrder` must be
-  /// empty, and other semantic configurations will be ignored.
+  /// empty, and other semantic configurations will be ignored. The ignored configurations
+  /// include:[flags], [actions], [textSelectionBase], [textSelectionExtent], [scrollChildren],
+  /// [scrollIndex], [scrollPosition], [scrollExtentMax], [scrollExtentMin], [elevation],
+  /// [thickness], [label], [hint], [value], [increasedValue], [decreasedValue], [textDirection],
+  /// [transform], [childrenInTraversalOrder], [childrenInHitTestOrder], [additionalActions]
   ///
   /// For scrollable nodes `scrollPosition` describes the current scroll
   /// position in logical pixel. `scrollExtentMax` and `scrollExtentMin`

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -604,7 +604,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// The field `platformViewId` references the platform view, whose semantics
   /// nodes will be added as children to this node. If a platform view is
   /// specified, `childrenInHitTestOrder` and `childrenInTraversalOrder` must be
-  /// empty.
+  /// empty, and other semantic configurations will be ignored.
   ///
   /// For scrollable nodes `scrollPosition` describes the current scroll
   /// position in logical pixel. `scrollExtentMax` and `scrollExtentMin`

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -604,11 +604,7 @@ class SemanticsUpdateBuilder extends NativeFieldWrapperClass2 {
   /// The field `platformViewId` references the platform view, whose semantics
   /// nodes will be added as children to this node. If a platform view is
   /// specified, `childrenInHitTestOrder` and `childrenInTraversalOrder` must be
-  /// empty, and other semantic configurations will be ignored. The ignored configurations
-  /// include: [flags], [actions], [textSelectionBase], [textSelectionExtent], [scrollChildren],
-  /// [scrollIndex], [scrollPosition], [scrollExtentMax], [scrollExtentMin], [elevation],
-  /// [thickness], [label], [hint], [value], [increasedValue], [decreasedValue], [textDirection],
-  /// [transform], [childrenInTraversalOrder], [childrenInHitTestOrder], [additionalActions]
+  /// empty.
   ///
   /// For scrollable nodes `scrollPosition` describes the current scroll
   /// position in logical pixel. `scrollExtentMax` and `scrollExtentMin`

--- a/lib/ui/semantics/semantics_node.cc
+++ b/lib/ui/semantics/semantics_node.cc
@@ -24,7 +24,7 @@ bool SemanticsNode::HasFlag(SemanticsFlags flag) {
   return (flags & static_cast<int32_t>(flag)) != 0;
 }
 
-bool SemanticsNode::IsPlatformViewNode() {
+bool SemanticsNode::IsPlatformViewNode() const {
   return platformViewId > kMinPlatfromViewId;
 }
 

--- a/lib/ui/semantics/semantics_node.cc
+++ b/lib/ui/semantics/semantics_node.cc
@@ -7,6 +7,8 @@
 #include <string.h>
 
 namespace blink {
+    
+constexpr int32_t kMinPlatfromViewId = -1;
 
 SemanticsNode::SemanticsNode() = default;
 
@@ -21,5 +23,9 @@ bool SemanticsNode::HasAction(SemanticsAction action) {
 bool SemanticsNode::HasFlag(SemanticsFlags flag) {
   return (flags & static_cast<int32_t>(flag)) != 0;
 }
+    
+    bool SemanticsNode::IsPlatformViewNode() {
+        return platformViewId > kMinPlatfromViewId;
+    }
 
 }  // namespace blink

--- a/lib/ui/semantics/semantics_node.cc
+++ b/lib/ui/semantics/semantics_node.cc
@@ -7,7 +7,7 @@
 #include <string.h>
 
 namespace blink {
-    
+
 constexpr int32_t kMinPlatfromViewId = -1;
 
 SemanticsNode::SemanticsNode() = default;
@@ -23,9 +23,9 @@ bool SemanticsNode::HasAction(SemanticsAction action) {
 bool SemanticsNode::HasFlag(SemanticsFlags flag) {
   return (flags & static_cast<int32_t>(flag)) != 0;
 }
-    
-    bool SemanticsNode::IsPlatformViewNode() {
-        return platformViewId > kMinPlatfromViewId;
-    }
+
+bool SemanticsNode::IsPlatformViewNode() {
+  return platformViewId > kMinPlatfromViewId;
+}
 
 }  // namespace blink

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -80,7 +80,7 @@ struct SemanticsNode {
 
   bool HasAction(SemanticsAction action);
   bool HasFlag(SemanticsFlags flag);
-    
+
   // Weather this node is for embeded platform views.
   bool IsPlatformViewNode();
 

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -80,6 +80,9 @@ struct SemanticsNode {
 
   bool HasAction(SemanticsAction action);
   bool HasFlag(SemanticsFlags flag);
+    
+  // Weather this node is for embeded platform views.
+  bool IsPlatformViewNode();
 
   int32_t id = 0;
   int32_t flags = 0;

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -81,7 +81,7 @@ struct SemanticsNode {
   bool HasAction(SemanticsAction action);
   bool HasFlag(SemanticsFlags flag);
 
-  // Weather this node is for embeded platform views.
+  // Whether this node is for embeded platform views.
   bool IsPlatformViewNode() const;
 
   int32_t id = 0;

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -82,7 +82,7 @@ struct SemanticsNode {
   bool HasFlag(SemanticsFlags flag);
 
   // Weather this node is for embeded platform views.
-  bool IsPlatformViewNode();
+  bool IsPlatformViewNode() const;
 
   int32_t id = 0;
   int32_t flags = 0;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -165,6 +165,13 @@ void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(int view_id) {
   composition_order_.push_back(view_id);
 }
 
+NSObject<FlutterPlatformView>* FlutterPlatformViewsController::GetPlatformViewByID(int view_id) {
+  if (views_.empty()) {
+    return nil;
+  }
+  return views_[view_id].get();
+}
+
 std::vector<SkCanvas*> FlutterPlatformViewsController::GetCurrentCanvases() {
   std::vector<SkCanvas*> canvases;
   for (size_t i = 0; i < composition_order_.size(); i++) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -58,10 +58,10 @@ class FlutterPlatformViewsController {
 
   void PrerollCompositeEmbeddedView(int view_id);
 
-  // Returns the FlutterPlatformView object associated with the view_id.
+  // Returns the `FlutterPlatformView` object associated with the view_id.
   //
-  // If the FlutterPlatformViewsController does not contain any FlutterPlatformView object or
-  // a FlutterPlatformView object asscociated with the view_id cannot be found, the method returns
+  // If the `FlutterPlatformViewsController` does not contain any `FlutterPlatformView` object or
+  // a `FlutterPlatformView` object asscociated with the view_id cannot be found, the method returns
   // nil.
   NSObject<FlutterPlatformView>* GetPlatformViewByID(int view_id);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -58,6 +58,11 @@ class FlutterPlatformViewsController {
 
   void PrerollCompositeEmbeddedView(int view_id);
 
+  // Returns the FlutterPlatformView object associated with the view_id.
+  //
+  // If the FlutterPlatformViewsController does not contain any FlutterPlatformView object or
+  // a FlutterPlatformView object asscociated with the view_id cannot be found, the method returns
+  // nil.
   NSObject<FlutterPlatformView>* GetPlatformViewByID(int view_id);
 
   std::vector<SkCanvas*> GetCurrentCanvases();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -58,6 +58,8 @@ class FlutterPlatformViewsController {
 
   void PrerollCompositeEmbeddedView(int view_id);
 
+  NSObject<FlutterPlatformView>* GetPlatformViewByID(int view_id);
+
   std::vector<SkCanvas*> GetCurrentCanvases();
 
   SkCanvas* CompositeEmbeddedView(int view_id, const flow::EmbeddedViewParams& params);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -131,8 +131,8 @@ class AccessibilityBridge final {
 
   fml::WeakPtr<AccessibilityBridge> GetWeakPtr();
 
-  FlutterPlatformViewsController* flutter_platform_views_controller() const {
-    return flutter_platform_views_controller_;
+  FlutterPlatformViewsController* GetFlutterPlatformViewsController() const {
+    return platform_views_controller_;
   };
 
   void clearState();
@@ -145,7 +145,7 @@ class AccessibilityBridge final {
 
   UIView* view_;
   PlatformViewIOS* platform_view_;
-  FlutterPlatformViewsController* flutter_platform_views_controller_;
+  FlutterPlatformViewsController* platform_views_controller_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;
   fml::WeakPtrFactory<AccessibilityBridge> weak_factory_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -131,7 +131,7 @@ class AccessibilityBridge final {
 
   fml::WeakPtr<AccessibilityBridge> GetWeakPtr();
 
-  FlutterPlatformViewsController* GetFlutterPlatformViewsController() const {
+  FlutterPlatformViewsController* GetPlatformViewsController() const {
     return platform_views_controller_;
   };
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -27,6 +27,8 @@ namespace shell {
 class AccessibilityBridge;
 }  // namespace shell
 
+@class FlutterPlatformViewSemanticsContainer;
+
 /**
  * A node in the iOS semantics tree.
  */
@@ -70,6 +72,11 @@ class AccessibilityBridge;
  * be equal to this object.
  */
 @property(nonatomic, strong) NSMutableArray<SemanticsObject*>* children;
+
+/**
+ * Used if this SemanticsObject is for a platform view.
+ */
+@property(strong, nonatomic) FlutterPlatformViewSemanticsContainer* platformViewSemanticsContainer;
 
 - (BOOL)nodeWillCauseLayoutChange:(const blink::SemanticsNode*)node;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -71,6 +71,16 @@ class AccessibilityBridge;
  */
 @property(nonatomic, strong) NSMutableArray<SemanticsObject*>* children;
 
+/**
+ * Whether this object is a placeholder node for platform views.
+ *
+ * If set to YES, this object will not contain a SemanticsNode,
+ * instead the accessibilityElements of this object will be the
+ * platform view. And the platform view
+ * will handle the accessibility of itself.
+ */
+@property(nonatomic, assign) BOOL isPlatformViewSemanticPlaceholder;
+
 - (BOOL)nodeWillCauseLayoutChange:(const blink::SemanticsNode*)node;
 
 #pragma mark - Designated initializers

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -123,8 +123,8 @@ class AccessibilityBridge;
  * view.
  *
  * See also:
- * * SemanticsObject for the other type of semantics objects.
- * * FlutterSemanticsObject for default implementation of `SemanticsObject`.
+ * * `SemanticsObject` for the other type of semantics objects.
+ * * `FlutterSemanticsObject` for default implementation of `SemanticsObject`.
  */
 @interface FlutterPlatformViewSemanticsContainer : UIAccessibilityElement
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -71,16 +71,6 @@ class AccessibilityBridge;
  */
 @property(nonatomic, strong) NSMutableArray<SemanticsObject*>* children;
 
-/**
- * Whether this object is a placeholder node for platform views.
- *
- * If set to YES, this object will not contain a SemanticsNode,
- * instead the accessibilityElements of this object will be the
- * platform view. And the platform view
- * will handle the accessibility of itself.
- */
-@property(nonatomic, assign) BOOL isPlatformViewSemanticPlaceholder;
-
 - (BOOL)nodeWillCauseLayoutChange:(const blink::SemanticsNode*)node;
 
 #pragma mark - Designated initializers
@@ -116,6 +106,23 @@ class AccessibilityBridge;
  *    editable text widgets to a11y.
  */
 @interface FlutterSemanticsObject : SemanticsObject
+@end
+
+/**
+ * Designated to act as an accessibility container of a platform view.
+ *
+ * This object does not take any accessibility actions on its own, nor has any accessibility
+ * label/value/trait/hint... on its own. The accessibility data will be handled by the platform
+ * view.
+ *
+ * See also:
+ * * SemanticsObject for the other type of semantics objects.
+ * * FlutterSemanticsObject for default implementation of `SemanticsObject`.
+ */
+@interface FlutterPlatformViewSemanticsContainer : UIAccessibilityElement
+
+- (instancetype)init __attribute__((unavailable("Use initWithAccessibilityContainer: instead")));
+
 @end
 
 namespace shell {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -113,7 +113,9 @@ class PlatformViewIOS;
 
 class AccessibilityBridge final {
  public:
-  AccessibilityBridge(UIView* view, PlatformViewIOS* platform_view);
+  AccessibilityBridge(UIView* view,
+                      PlatformViewIOS* platform_view,
+                      FlutterPlatformViewsController* platform_views_controller);
   ~AccessibilityBridge();
 
   void UpdateSemantics(blink::SemanticsNodeUpdates nodes,
@@ -129,6 +131,10 @@ class AccessibilityBridge final {
 
   fml::WeakPtr<AccessibilityBridge> GetWeakPtr();
 
+  FlutterPlatformViewsController* flutter_platform_views_controller() const {
+    return flutter_platform_views_controller_;
+  };
+
   void clearState();
 
  private:
@@ -139,6 +145,7 @@ class AccessibilityBridge final {
 
   UIView* view_;
   PlatformViewIOS* platform_view_;
+  FlutterPlatformViewsController* flutter_platform_views_controller_;
   fml::scoped_nsobject<NSMutableDictionary<NSNumber*, SemanticsObject*>> objects_;
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;
   fml::WeakPtrFactory<AccessibilityBridge> weak_factory_;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -440,7 +440,7 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   }
   SemanticsObject* child = [_semanticsObject children][index - 1];
 
-  // If the child is a semantic place holder for a platform view,
+  // If the child is a semanticsObject that acts as a place holder for a platform view,
   // inject the platform view into the iOS accessibility tree.
   if (child.isPlatformViewSemanticPlaceholder) {
     shell::FlutterPlatformViewsController* controller = _bridge.get()->GetPlatformViewsController();

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -450,6 +450,9 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
     UIView* platformView = [platformViewProtocolObject view];
     child.accessibilityElements = @[ platformView ];
     return child;
+  } else if (child.accessibilityElements.count > 0 &&
+             [child.accessibilityElements.firstObject isKindOfClass:[UIView class]]) {
+    child.accessibilityElements = nil;
   }
 
   if ([child hasChildren])
@@ -678,6 +681,14 @@ SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid,
         }
         [object.parent.children replaceObjectAtIndex:positionInChildlist withObject:object];
         objects_.get()[@(node.id)] = object;
+      }
+
+      BOOL isPlatformViewNode = node.platformViewId > -1;
+      BOOL wasPlatformViewNode = object.node.platformViewId > -1;
+      if (wasPlatformViewNode && !isPlatformViewNode) {
+        // The node changed its type from platform view node to something else. In this
+        // case, we need to clean up the accessibility element that we previously.
+        object.accessibilityElements = nil;
       }
     }
   }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -684,7 +684,7 @@ SemanticsObject* AccessibilityBridge::GetOrCreateObject(int32_t uid,
       BOOL wasPlatformViewNode = object.node.platformViewId > -1;
       if (wasPlatformViewNode && !isPlatformViewNode) {
         // The node changed its type from platform view node to something else. In this
-        // case, we need to clean up the accessibility element that we previously.
+        // case, we need to clean up the accessibility elements that we previously added.
         object.accessibilityElements = nil;
       }
     }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -466,7 +466,8 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
     return _semanticsObject;
   }
 
-  // Create an addtional child to act as the accessibility container for the platform view.
+  // Return the additional child acts as a container of platform view. The
+  // platformViewSemanticsContainer was created and cached in the updateSemantics path.
   if (_semanticsObject.node.IsPlatformViewNode() && index == [self accessibilityElementCount] - 1) {
     FML_CHECK(_semanticsObject.platformViewSemanticsContainer != nil);
     return _semanticsObject.platformViewSemanticsContainer;
@@ -602,6 +603,7 @@ void AccessibilityBridge::UpdateSemantics(blink::SemanticsNodeUpdates nodes,
       }
       object.accessibilityCustomActions = accessibilityCustomActions;
     }
+
     if (object.node.IsPlatformViewNode()) {
       shell::FlutterPlatformViewsController* controller = GetPlatformViewsController();
       if (controller) {

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -441,8 +441,7 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
 
   // If the child is a semantic node for a platform view,
   // inject the platform view into the iOS accessibility tree.
-  shell::FlutterPlatformViewsController* controller =
-      _bridge.get()->GetPlatformViewsController();
+  shell::FlutterPlatformViewsController* controller = _bridge.get()->GetPlatformViewsController();
   if (child.node.IsPlatformViewNode() && controller) {
     NSObject<FlutterPlatformView>* platformViewContainer =
         controller->GetPlatformViewByID(child.node.platformViewId);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -166,7 +166,10 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   //  We enforce in the framework that no other useful semantics are merged with these nodes.
   if ([self node].HasFlag(blink::SemanticsFlags::kScopesRoute))
     return false;
-  NSLog(@"%@", @([self node].flags));
+  // If the node is the placeholder for a platform view. We know it should be a container.
+  if ([self node].platformViewId > -1) {
+    return false;
+  }
   return ([self node].flags != 0 &&
           [self node].flags != static_cast<int32_t>(blink::SemanticsFlags::kIsHidden)) ||
          ![self node].label.empty() || ![self node].value.empty() || ![self node].hint.empty() ||

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -164,12 +164,9 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   // entire element tree looking for such a hit.
 
   //  We enforce in the framework that no other useful semantics are merged with these nodes.
-  if ([self node].HasFlag(blink::SemanticsFlags::kScopesRoute))
+  if ([self node].HasFlag(blink::SemanticsFlags::kScopesRoute) || [self node].platformViewId > -1)
     return false;
-  // If the node is the placeholder for a platform view. We know it should be a container.
-  if ([self node].platformViewId > -1) {
-    return false;
-  }
+
   return ([self node].flags != 0 &&
           [self node].flags != static_cast<int32_t>(blink::SemanticsFlags::kIsHidden)) ||
          ![self node].label.empty() || ![self node].value.empty() || ![self node].hint.empty() ||

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -438,7 +438,7 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   }
   SemanticsObject* child = [_semanticsObject children][index - 1];
     
-    // This if block handles the embedded platform view accessibility.
+    // This 'if' block handles adding accessibility support for the embedded platform view.
     // We first check if the child is a semantic node for a platform view.
     // If so, we add the platform view as accessibilityElements of the child.
     shell::FlutterPlatformViewsController *flutterPlatformViewsController = _bridge.get()->flutter_platform_views_controller();

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -450,9 +450,6 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
     UIView* platformView = [platformViewProtocolObject view];
     child.accessibilityElements = @[ platformView ];
     return child;
-  } else if (child.accessibilityElements.count > 0 &&
-             [child.accessibilityElements.firstObject isKindOfClass:[UIView class]]) {
-    child.accessibilityElements = nil;
   }
 
   if ([child hasChildren])

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -442,7 +442,7 @@ blink::SemanticsAction GetSemanticsActionForScrollDirection(
   // If the child is a semantic node for a platform view,
   // inject the platform view into the iOS accessibility tree.
   shell::FlutterPlatformViewsController* controller =
-      _bridge.get()->GetFlutterPlatformViewsController();
+      _bridge.get()->GetPlatformViewsController();
   if (child.node.IsPlatformViewNode() && controller) {
     NSObject<FlutterPlatformView>* platformViewContainer =
         controller->GetPlatformViewByID(child.node.platformViewId);

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -50,7 +50,7 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
 
     if (accessibility_bridge_) {
       accessibility_bridge_.reset(
-          new AccessibilityBridge(static_cast<FlutterView*>(owner_controller_.get().view), this));
+          new AccessibilityBridge(static_cast<FlutterView*>(owner_controller_.get().view), this, [owner_controller.get() platformViewsController]));
     }
     // Do not call `NotifyCreated()` here - let FlutterViewController take care
     // of that when its Viewport is sized.  If `NotifyCreated()` is called here,
@@ -96,7 +96,7 @@ void PlatformViewIOS::SetSemanticsEnabled(bool enabled) {
   }
   if (enabled && !accessibility_bridge_) {
     accessibility_bridge_ = std::make_unique<AccessibilityBridge>(
-        static_cast<FlutterView*>(owner_controller_.get().view), this);
+        static_cast<FlutterView*>(owner_controller_.get().view), this, [owner_controller_.get() platformViewsController]);
   } else if (!enabled && accessibility_bridge_) {
     accessibility_bridge_.reset();
   }

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -50,7 +50,8 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
 
     if (accessibility_bridge_) {
       accessibility_bridge_.reset(
-          new AccessibilityBridge(static_cast<FlutterView*>(owner_controller_.get().view), this, [owner_controller.get() platformViewsController]));
+          new AccessibilityBridge(static_cast<FlutterView*>(owner_controller_.get().view), this,
+                                  [owner_controller.get() platformViewsController]));
     }
     // Do not call `NotifyCreated()` here - let FlutterViewController take care
     // of that when its Viewport is sized.  If `NotifyCreated()` is called here,
@@ -96,7 +97,8 @@ void PlatformViewIOS::SetSemanticsEnabled(bool enabled) {
   }
   if (enabled && !accessibility_bridge_) {
     accessibility_bridge_ = std::make_unique<AccessibilityBridge>(
-        static_cast<FlutterView*>(owner_controller_.get().view), this, [owner_controller_.get() platformViewsController]);
+        static_cast<FlutterView*>(owner_controller_.get().view), this,
+        [owner_controller_.get() platformViewsController]);
   } else if (!enabled && accessibility_bridge_) {
     accessibility_bridge_.reset();
   }


### PR DESCRIPTION
Follow up the framework change in https://github.com/flutter/flutter/pull/29304.
Inject the accessibility element tree in the semantic node if the node is for platform views.

https://github.com/flutter/flutter/issues/29302
