### PR TITLE
Anti-Aliasing for shape layers

### DIFF
--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -142,6 +142,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
   // Call drawPath without clip if possible for better performance.
   SkPaint paint;
   paint.setColor(color_);
+  paint.setAntiAlias(true);
   if (clip_behavior_ != Clip::antiAliasWithSaveLayer) {
     context.leaf_nodes_canvas->drawPath(path_, paint);
   }


### PR DESCRIPTION
We're missing setting anti-aliasing on the paint used to draw the path for a physical layer, which caused physical shapes with round edges to look jagged.

This will allow relanding physical shape compositing in the framework.