### PR TITLE
Add a build dependencies script for Linux desktop

### DIFF
--- a/build/install-build-deps-linux-desktop.sh
+++ b/build/install-build-deps-linux-desktop.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Installs the dependencies necessary to build the Linux Flutter shell, beyond
+# those installed by install-build-deps.sh.
+
+set -e
+
+sudo apt-get -y install libglfw3-dev libepoxy-dev libjsoncpp-dev libgtk-3-dev \
+    libx11-dev


### PR DESCRIPTION
Installs the dependencies necessary to build the Linux desktop shell.
Similar to the existing install-build-deps.sh and
install-build-deps-android.sh but specifically for the desktop shell
requirements.

This would become part of the engine build setup instructions and bot
scripts.