### PR TITLE
Do not pass short-lived buffers as labels to Dart_TimelineEvent

### DIFF
--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -147,12 +147,12 @@ void TraceEventFlowEnd0(TraceArg category_group, TraceArg name, TraceIDArg id);
 
 class ScopedInstantEnd {
  public:
-  ScopedInstantEnd(std::string str) : label_(std::move(str)) {}
+  ScopedInstantEnd(const char* str) : label_(str) {}
 
-  ~ScopedInstantEnd() { TraceEventEnd(label_.c_str()); }
+  ~ScopedInstantEnd() { TraceEventEnd(label_); }
 
  private:
-  const std::string label_;
+  const char* label_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ScopedInstantEnd);
 };


### PR DESCRIPTION
Dart no longer makes a copy of the label string when recording events.

See https://github.com/flutter/engine/pull/8152