### PR TITLE
Bugfix: Prevent crash when responding to a platform message after FlutterJNI detaches from native.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -10,6 +10,7 @@ import android.graphics.SurfaceTexture;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+import android.util.Log;
 import android.view.Surface;
 
 import java.nio.ByteBuffer;
@@ -480,8 +481,11 @@ public class FlutterJNI {
 
   @UiThread
   public void invokePlatformMessageEmptyResponseCallback(int responseId) {
-    ensureAttachedToNative();
-    nativeInvokePlatformMessageEmptyResponseCallback(nativePlatformViewId, responseId);
+    if (isAttached()) {
+      nativeInvokePlatformMessageEmptyResponseCallback(nativePlatformViewId, responseId);
+    } else {
+      Log.w(TAG, "Tried to send a platform message response, but FlutterJNI was detached from native C++. Could not send. Response ID: " + responseId);
+    }
   }
 
   // Send an empty response to a platform message received from Dart.
@@ -492,13 +496,16 @@ public class FlutterJNI {
 
   @UiThread
   public void invokePlatformMessageResponseCallback(int responseId, ByteBuffer message, int position) {
-    ensureAttachedToNative();
-    nativeInvokePlatformMessageResponseCallback(
-        nativePlatformViewId,
-        responseId,
-        message,
-        position
-    );
+    if (isAttached()) {
+      nativeInvokePlatformMessageResponseCallback(
+          nativePlatformViewId,
+          responseId,
+          message,
+          position
+      );
+    } else {
+      Log.w(TAG, "Tried to send a platform message response, but FlutterJNI was detached from native C++. Could not send. Response ID: " + responseId);
+    }
   }
 
   // Send a data-carrying response to a platform message received from Dart.


### PR DESCRIPTION
Bugfix: Prevent crash when responding to a platform message after FlutterJNI detaches from native (#28651).