### PR TITLE
Add frame and target time metadata to vsync events and connect platform vsync events using flows.

### DIFF
--- a/fml/trace_event.cc
+++ b/fml/trace_event.cc
@@ -5,6 +5,7 @@
 #include "flutter/fml/trace_event.h"
 
 #include <algorithm>
+#include <atomic>
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
@@ -30,6 +31,11 @@
 
 namespace fml {
 namespace tracing {
+
+size_t TraceNonce() {
+  static std::atomic_size_t gLastItem;
+  return ++gLastItem;
+}
 
 void TraceTimelineEvent(TraceArg category_group,
                         TraceArg name,

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -9,6 +9,20 @@
 
 namespace shell {
 
+#if defined(OS_FUCHSIA)
+// In general, traces on Fuchsia are recorded across the whole system.
+// Because of this, emitting a "VSYNC" event per flutter process is
+// undesirable, as the events will collide with each other.  We
+// instead let another area of the system emit them.
+static const char* kVsyncTraceName = "vsync callback";
+#else   // defined(OS_FUCHSIA)
+// Note: The tag name must be "VSYNC" (it is special) so that the
+// "Highlight Vsync" checkbox in the timeline can be enabled.
+static const char* kVsyncTraceName = "VSYNC";
+#endif  // defined(OS_FUCHSIA)
+
+static const char* kVsyncFlowName = "VsyncFlow";
+
 VsyncWaiter::VsyncWaiter(blink::TaskRunners task_runners)
     : task_runners_(std::move(task_runners)) {}
 
@@ -35,19 +49,20 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
     return;
   }
 
+  auto flow_identifier = fml::tracing::TraceNonce();
+
+  // The base trace ensures that flows have a root to begin from if one does not
+  // exist. The trace viewer will ignore traces that have no base event trace.
+  // While all our message loops insert a base trace trace
+  // (MessageLoop::RunExpiredTasks), embedders may not.
+  TRACE_EVENT0("flutter", "VsyncFireCallback");
+  TRACE_FLOW_BEGIN("flutter", kVsyncFlowName, flow_identifier);
+
   task_runners_.GetUITaskRunner()->PostTaskForTime(
-      [callback, frame_start_time, frame_target_time]() {
-#if defined(OS_FUCHSIA)
-        // In general, traces on Fuchsia are recorded across the whole system.
-        // Because of this, emitting a "VSYNC" event per flutter process is
-        // undesirable, as the events will collide with each other.  We
-        // instead let another area of the system emit them.
-        TRACE_EVENT0("flutter", "vsync callback");
-#else
-        // Note: The tag name must be "VSYNC" (it is special) so that the
-        // "Highlight Vsync" checkbox in the timeline can be enabled.
-        TRACE_EVENT0("flutter", "VSYNC");
-#endif
+      [callback, flow_identifier, frame_start_time, frame_target_time]() {
+        FML_TRACE_EVENT("flutter", kVsyncTraceName, "StartTime",
+                        frame_start_time, "TargetTime", frame_target_time);
+        TRACE_FLOW_END("flutter", kVsyncFlowName, flow_identifier);
         callback(frame_start_time, frame_target_time);
       },
       frame_start_time);

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -14,14 +14,14 @@ namespace shell {
 // Because of this, emitting a "VSYNC" event per flutter process is
 // undesirable, as the events will collide with each other.  We
 // instead let another area of the system emit them.
-static const char* kVsyncTraceName = "vsync callback";
+static constexpr const char* kVsyncTraceName = "vsync callback";
 #else   // defined(OS_FUCHSIA)
 // Note: The tag name must be "VSYNC" (it is special) so that the
 // "Highlight Vsync" checkbox in the timeline can be enabled.
-static const char* kVsyncTraceName = "VSYNC";
+static constexpr const char* kVsyncTraceName = "VSYNC";
 #endif  // defined(OS_FUCHSIA)
 
-static const char* kVsyncFlowName = "VsyncFlow";
+static constexpr const char* kVsyncFlowName = "VsyncFlow";
 
 VsyncWaiter::VsyncWaiter(blink::TaskRunners task_runners)
     : task_runners_(std::move(task_runners)) {}

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -888,6 +888,8 @@ FlutterEngineResult FlutterEngineOnVsync(FlutterEngine engine,
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
 
+  TRACE_EVENT0("flutter", "FlutterEngineOnVsync");
+
   auto start_time = fml::TimePoint::FromEpochDelta(
       fml::TimeDelta::FromNanoseconds(frame_start_time_nanos));
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -664,6 +664,8 @@ FlutterEngineResult FlutterEngineDispatchSemanticsAction(
 // garbage collection in periods in which the various threads are most likely to
 // be idle. For example, for a 60Hz display, embedders should add 16.6 * 1e6 to
 // the frame time field. The system monotonic clock is used as the timebase.
+//
+// That frame timepoints are in nanoseconds.
 FLUTTER_EXPORT
 FlutterEngineResult FlutterEngineOnVsync(FlutterEngine engine,
                                          intptr_t baton,


### PR DESCRIPTION
This will allow us to easily visualize the time the platform informed the engine of a vsync event, its arguments, and when the engine began its UI thread workload using this information.