### PR TITLE
Keep overlays_gr_context_ in sync with the overlay surface

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -21,7 +21,7 @@ class EmbeddedViewParams {
 };
 
 // This is only used on iOS when running in a non headless mode,
-// in this case ViewEmbedded is a reference to the
+// in this case ExternalViewEmbedder is a reference to the
 // FlutterPlatformViewsController which is owned by FlutterViewController.
 class ExternalViewEmbedder {
  public:

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -210,8 +210,7 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int64_t view_id = composition_order_[i];
     if (gl_rendering) {
-      EnsureGLOverlayInitialized(view_id, gl_context, gr_context,
-                                 gr_context != overlays_gr_context_);
+      EnsureGLOverlayInitialized(view_id, gl_context, gr_context);
     } else {
       EnsureOverlayInitialized(view_id);
     }
@@ -221,7 +220,6 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
     canvas->flush();
     did_submit &= frame->Submit();
   }
-  overlays_gr_context_ = gr_context;
   picture_recorders_.clear();
   if (composition_order_ == active_composition_order_) {
     composition_order_.clear();
@@ -267,10 +265,10 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(int64_t overlay_id
 void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
     int64_t overlay_id,
     std::shared_ptr<IOSGLContext> gl_context,
-    GrContext* gr_context,
-    bool update_gr_context) {
+    GrContext* gr_context) {
   if (overlays_.count(overlay_id) != 0) {
-    if (update_gr_context) {
+    if (gr_context != overlays_gr_context_) {
+      overlays_gr_context_ = gr_context;
       // The overlay already exists, but the GrContext was changed so we need to recreate
       // the rendering surface with the new GrContext.
       IOSSurfaceGL* ios_surface_gl = (IOSSurfaceGL*)overlays_[overlay_id]->ios_surface.get();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -101,8 +101,7 @@ class FlutterPlatformViewsController {
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,
                                   std::shared_ptr<IOSGLContext> gl_context,
-                                  GrContext* gr_context,
-                                  bool update_gr_context);
+                                  GrContext* gr_context);
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterPlatformViewsController);
 };


### PR DESCRIPTION
When we come back from the background, and have no platform view in the layer tree, `composition_order_` will be empty. This would result in `EnsureGLOverlayInitialized` getting called, but `overlays_gr_context_` is falsely updated to the current `gr_context`, which puts us in a state where we will not update `overlays_gr_context_` the next time we call `EnsureGLOverlayInitialized` with non empty `composition_order_`.

This manifests as https://github.com/flutter/flutter/issues/28920