### PR TITLE
Simplify the fallback waiter and add traces for vsync scheduling overhead.

### DIFF
--- a/fml/trace_event.cc
+++ b/fml/trace_event.cc
@@ -124,6 +124,36 @@ void TraceEventEnd(TraceArg name) {
   );
 }
 
+void TraceEventAsyncComplete(TraceArg category_group,
+                             TraceArg name,
+                             TimePoint begin,
+                             TimePoint end) {
+  auto identifier = TraceNonce();
+
+  if (begin > end) {
+    auto temp = end;
+    end = begin;
+    begin = temp;
+  }
+
+  Dart_TimelineEvent(DCHECK_LITERAL(name),                   // label
+                     begin.ToEpochDelta().ToMicroseconds(),  // timestamp0
+                     identifier,                       // timestamp1_or_async_id
+                     Dart_Timeline_Event_Async_Begin,  // event type
+                     0,                                // argument_count
+                     nullptr,                          // argument_names
+                     nullptr                           // argument_values
+  );
+  Dart_TimelineEvent(DCHECK_LITERAL(name),                 // label
+                     end.ToEpochDelta().ToMicroseconds(),  // timestamp0
+                     identifier,                     // timestamp1_or_async_id
+                     Dart_Timeline_Event_Async_End,  // event type
+                     0,                              // argument_count
+                     nullptr,                        // argument_names
+                     nullptr                         // argument_values
+  );
+}
+
 void TraceEventAsyncBegin0(TraceArg category_group,
                            TraceArg name,
                            TraceIDArg id) {

--- a/fml/trace_event.cc
+++ b/fml/trace_event.cc
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <utility>
 
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/logging.h"
@@ -131,9 +132,7 @@ void TraceEventAsyncComplete(TraceArg category_group,
   auto identifier = TraceNonce();
 
   if (begin > end) {
-    auto temp = end;
-    end = begin;
-    begin = temp;
+    std::swap(begin, end);
   }
 
   Dart_TimelineEvent(DCHECK_LITERAL(name),                   // label

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -193,6 +193,11 @@ void TraceEvent2(TraceArg category_group,
 
 void TraceEventEnd(TraceArg name);
 
+void TraceEventAsyncComplete(TraceArg category_group,
+                             TraceArg name,
+                             TimePoint begin,
+                             TimePoint end);
+
 void TraceEventAsyncBegin0(TraceArg category_group,
                            TraceArg name,
                            TraceIDArg id);

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -10,6 +10,7 @@
 #include <mutex>
 
 #include "flutter/common/task_runners.h"
+#include "flutter/fml/synchronization/thread_annotations.h"
 #include "flutter/fml/time/time_point.h"
 
 namespace shell {
@@ -50,7 +51,7 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
 
  private:
   std::mutex callback_mutex_;
-  Callback callback_;
+  Callback callback_ FML_GUARDED_BY(callback_mutex_);
 
   FML_DISALLOW_COPY_AND_ASSIGN(VsyncWaiter);
 };

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -9,9 +9,9 @@
 namespace shell {
 namespace {
 
-fml::TimePoint SnapToNextTick(fml::TimePoint value,
-                              fml::TimePoint tick_phase,
-                              fml::TimeDelta tick_interval) {
+static fml::TimePoint SnapToNextTick(fml::TimePoint value,
+                                     fml::TimePoint tick_phase,
+                                     fml::TimeDelta tick_interval) {
   fml::TimeDelta offset = (tick_phase - value) % tick_interval;
   if (offset != fml::TimeDelta::Zero())
     offset = offset + tick_interval;
@@ -21,27 +21,19 @@ fml::TimePoint SnapToNextTick(fml::TimePoint value,
 }  // namespace
 
 VsyncWaiterFallback::VsyncWaiterFallback(blink::TaskRunners task_runners)
-    : VsyncWaiter(std::move(task_runners)),
-      phase_(fml::TimePoint::Now()),
-      weak_factory_(this) {}
+    : VsyncWaiter(std::move(task_runners)), phase_(fml::TimePoint::Now()) {}
 
 VsyncWaiterFallback::~VsyncWaiterFallback() = default;
 
-constexpr fml::TimeDelta interval = fml::TimeDelta::FromSecondsF(1.0 / 60.0);
-
 // |shell::VsyncWaiter|
 void VsyncWaiterFallback::AwaitVSync() {
-  fml::TimePoint now = fml::TimePoint::Now();
-  fml::TimePoint next = SnapToNextTick(now, phase_, interval);
+  constexpr fml::TimeDelta kSingleFrameInterval =
+      fml::TimeDelta::FromSecondsF(1.0 / 60.0);
 
-  task_runners_.GetUITaskRunner()->PostDelayedTask(
-      [self = weak_factory_.GetWeakPtr()] {
-        if (self) {
-          const auto frame_time = fml::TimePoint::Now();
-          self->FireCallback(frame_time, frame_time + interval);
-        }
-      },
-      next - now);
+  auto next =
+      SnapToNextTick(fml::TimePoint::Now(), phase_, kSingleFrameInterval);
+
+  FireCallback(next, next + kSingleFrameInterval);
 }
 
 }  // namespace shell

--- a/shell/common/vsync_waiter_fallback.h
+++ b/shell/common/vsync_waiter_fallback.h
@@ -20,7 +20,6 @@ class VsyncWaiterFallback final : public VsyncWaiter {
 
  private:
   fml::TimePoint phase_;
-  fml::WeakPtrFactory<VsyncWaiterFallback> weak_factory_;
 
   // |shell::VsyncWaiter|
   void AwaitVSync() override;


### PR DESCRIPTION
If platform vsync implementations consistently give the engine a frame start time far into the past, the engine will begin work frame workloads as soon as possible and generate frames at a high rate. Such cases are hard to diagnose. Now, the "VsyncSchedulingOverhead" async event will highlight this overhead. This async event is added over the duration that begins when the platform told the engine to begin its workload and ends when the engine actually began to do its work on the UI thread in response to this event.

Also, to take advantage of the [wait added by the base vsync waiter](https://github.com/flutter/engine/commit/b5f59ed89dbcea6db7492b9e22f841cc785262b9), the fallback waiter subclass has been simplified to remove the redundant delay.