### PR TITLE
[platform_view] iOSP platformView composition optimize.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -226,21 +226,38 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
     return did_submit;
   }
   UIView* flutter_view = flutter_view_.get();
+    
+   NSLog(@"-------");
+  std::unordered_set<int64_t> composition_order_set;
+    for (size_t i: composition_order_) {
+      composition_order_set.insert(composition_order_[i]);
+    }
 
-  // This can be more efficient, instead of removing all views and then re-attaching them,
-  // we should only remove the views that has been completly removed from the layer tree, and
-  // reorder the views using UIView's bringSubviewToFront.
-  // TODO(amirh): make this more efficient.
-  // https://github.com/flutter/flutter/issues/23793
-  for (UIView* sub_view in [flutter_view subviews]) {
-    [sub_view removeFromSuperview];
+  for (size_t i: active_composition_order_) {
+    int64_t view_id = active_composition_order_[i];
+    if (composition_order_set.find(view_id) == composition_order_set.end()) {
+      [touch_interceptors_[view_id].get() removeFromSuperview];
+      [overlays_[view_id]->overlay_view.get() removeFromSuperview];
+    }
   }
-
+    
+  composition_order_set.clear();
   active_composition_order_.clear();
+    
+  NSLog(@"=======");
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int view_id = composition_order_[i];
-    [flutter_view addSubview:touch_interceptors_[view_id].get()];
-    [flutter_view addSubview:overlays_[view_id]->overlay_view.get()];
+    if (touch_interceptors_[view_id].get().superview == flutter_view) {
+        [flutter_view bringSubviewToFront:touch_interceptors_[view_id].get()];
+    } else {
+        [flutter_view addSubview:touch_interceptors_[view_id].get()];
+    }
+    if (overlays_[view_id]->overlay_view.get().superview == flutter_view) {
+        [flutter_view bringSubviewToFront:overlays_[view_id]->overlay_view.get()];
+    } else {
+        [flutter_view addSubview:overlays_[view_id]->overlay_view.get()];
+    }
+      
     active_composition_order_.push_back(view_id);
   }
 
@@ -429,6 +446,7 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
   [_flutterView touchesMoved:touches withEvent:event];
+    self.state = UIGestureRecognizerStateChanged;
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -11,7 +11,6 @@
 #include <map>
 #include <memory>
 #include <string>
-#include <assert.h>
 
 #include "FlutterPlatformViews_Internal.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
@@ -232,9 +231,9 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
 
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int view_id = composition_order_[i];
-      UIView *intercepter = touch_interceptors_[view_id].get();
-      UIView *overlay = overlays_[view_id]->overlay_view;
-      assert(intercepter.superview  == overlay.superview);
+    UIView* intercepter = touch_interceptors_[view_id].get();
+    UIView* overlay = overlays_[view_id]->overlay_view;
+    FML_CHECK(intercepter.superview == overlay.superview);
 
     if (intercepter.superview == flutter_view) {
       [flutter_view bringSubviewToFront:intercepter];

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -232,10 +232,13 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
     for (size_t i: composition_order_) {
       composition_order_set.insert(composition_order_[i]);
     }
+    NSLog(@"%@", @(active_composition_order_.size()));
+    NSLog(@"%@", @(composition_order_set.size()));
 
   for (size_t i: active_composition_order_) {
     int64_t view_id = active_composition_order_[i];
     if (composition_order_set.find(view_id) == composition_order_set.end()) {
+        NSLog(@"not find");
       [touch_interceptors_[view_id].get() removeFromSuperview];
       [overlays_[view_id]->overlay_view.get() removeFromSuperview];
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -227,18 +227,13 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
   }
   UIView* flutter_view = flutter_view_.get();
     
-   NSLog(@"-------");
   std::unordered_set<int64_t> composition_order_set;
-    for (size_t i: composition_order_) {
-      composition_order_set.insert(composition_order_[i]);
+    for (int64_t view_id : composition_order_) {
+      composition_order_set.insert(view_id);
     }
-    NSLog(@"%@", @(active_composition_order_.size()));
-    NSLog(@"%@", @(composition_order_set.size()));
 
-  for (size_t i: active_composition_order_) {
-    int64_t view_id = active_composition_order_[i];
+  for (int64_t view_id: active_composition_order_) {
     if (composition_order_set.find(view_id) == composition_order_set.end()) {
-        NSLog(@"not find");
       [touch_interceptors_[view_id].get() removeFromSuperview];
       [overlays_[view_id]->overlay_view.get() removeFromSuperview];
     }
@@ -247,7 +242,6 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
   composition_order_set.clear();
   active_composition_order_.clear();
     
-  NSLog(@"=======");
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int view_id = composition_order_[i];
     if (touch_interceptors_[view_id].get().superview == flutter_view) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -226,35 +226,35 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
     return did_submit;
   }
   UIView* flutter_view = flutter_view_.get();
-    
-  std::unordered_set<int64_t> composition_order_set;
-    for (int64_t view_id : composition_order_) {
-      composition_order_set.insert(view_id);
-    }
 
-  for (int64_t view_id: active_composition_order_) {
+  std::unordered_set<int64_t> composition_order_set;
+  for (int64_t view_id : composition_order_) {
+    composition_order_set.insert(view_id);
+  }
+
+  for (int64_t view_id : active_composition_order_) {
     if (composition_order_set.find(view_id) == composition_order_set.end()) {
       [touch_interceptors_[view_id].get() removeFromSuperview];
       [overlays_[view_id]->overlay_view.get() removeFromSuperview];
     }
   }
-    
+
   composition_order_set.clear();
   active_composition_order_.clear();
-    
+
   for (size_t i = 0; i < composition_order_.size(); i++) {
     int view_id = composition_order_[i];
     if (touch_interceptors_[view_id].get().superview == flutter_view) {
-        [flutter_view bringSubviewToFront:touch_interceptors_[view_id].get()];
+      [flutter_view bringSubviewToFront:touch_interceptors_[view_id].get()];
     } else {
-        [flutter_view addSubview:touch_interceptors_[view_id].get()];
+      [flutter_view addSubview:touch_interceptors_[view_id].get()];
     }
     if (overlays_[view_id]->overlay_view.get().superview == flutter_view) {
-        [flutter_view bringSubviewToFront:overlays_[view_id]->overlay_view.get()];
+      [flutter_view bringSubviewToFront:overlays_[view_id]->overlay_view.get()];
     } else {
-        [flutter_view addSubview:overlays_[view_id]->overlay_view.get()];
+      [flutter_view addSubview:overlays_[view_id]->overlay_view.get()];
     }
-      
+
     active_composition_order_.push_back(view_id);
   }
 
@@ -443,7 +443,7 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
   [_flutterView touchesMoved:touches withEvent:event];
-    self.state = UIGestureRecognizerStateChanged;
+  self.state = UIGestureRecognizerStateChanged;
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -65,7 +65,9 @@ class FlutterPlatformViewsController {
   // Discards all platform views instances and auxiliary resources.
   void Reset();
 
-  bool SubmitFrame(bool gl_rendering,
+    void extracted();
+    
+    bool SubmitFrame(bool gl_rendering,
                    GrContext* gr_context,
                    std::shared_ptr<IOSGLContext> gl_context);
 
@@ -97,7 +99,8 @@ class FlutterPlatformViewsController {
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);
   void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
-
+    
+    void DetachUnusedLayers();
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,
                                   std::shared_ptr<IOSGLContext> gl_context,

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -64,7 +64,7 @@ class FlutterPlatformViewsController {
 
   // Discards all platform views instances and auxiliary resources.
   void Reset();
-    
+
   bool SubmitFrame(bool gl_rendering,
                    GrContext* gr_context,
                    std::shared_ptr<IOSGLContext> gl_context);
@@ -97,7 +97,7 @@ class FlutterPlatformViewsController {
   void OnDispose(FlutterMethodCall* call, FlutterResult& result);
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);
   void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
-    
+
   void DetachUnusedLayers();
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -64,10 +64,8 @@ class FlutterPlatformViewsController {
 
   // Discards all platform views instances and auxiliary resources.
   void Reset();
-
-    void extracted();
     
-    bool SubmitFrame(bool gl_rendering,
+  bool SubmitFrame(bool gl_rendering,
                    GrContext* gr_context,
                    std::shared_ptr<IOSGLContext> gl_context);
 
@@ -100,7 +98,7 @@ class FlutterPlatformViewsController {
   void OnAcceptGesture(FlutterMethodCall* call, FlutterResult& result);
   void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
     
-    void DetachUnusedLayers();
+  void DetachUnusedLayers();
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,
                                   std::shared_ptr<IOSGLContext> gl_context,


### PR DESCRIPTION
Optimize the performance of the platform view composition.
When recomposition is required, we previously remove all the platform view related views (intercepting view, platform view) and re-add them for each frame. This is mentioned in https://github.com/flutter/flutter/issues/23793.
This PR enhanced the performance by re-arrange the existing UIViews and only add the newly created Views.

As a result, it would also fix https://github.com/flutter/flutter/issues/29427
