### PR TITLE
Export FlutterSemanticsUpdateNotification and improve docs

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -149,7 +149,7 @@ FLUTTER_EXPORT
  * Although this method returns synchronously, it does not guarantee that a
  * semantics tree is actually available when the method returns. It
  * synchronously ensures that the next frame the Flutter framework creates will
- * have a semantics tree
+ * have a semantics tree.
  *
  * You can subscribe to semantics updates via `NSNotificationCenter` by adding
  * an observer for the name `FlutterSemanticsUpdateNotification`.  The `object`

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -146,10 +146,16 @@ FLUTTER_EXPORT
  * This method must only be called after launching the engine via
  * `-runWithEntrypoint:` or `-runWithEntryPoint:libraryURI`.
  *
+ * Although this method returns synchronously, it does not guarantee that a
+ * semantics tree is actually available; it only tells the Flutter framework to
+ * build a semantics tree the next it has a good reason to, such as when a frame
+ * is pumped.
+ *
  * You can subscribe to semantics updates via `NSNotificationCenter` by adding
  * an observer for the name `FlutterSemanticsUpdateNotification`.  The `object`
  * parameter will be the `FlutterViewController` associated with the semantics
- * update.
+ * update.  This will asynchronously fire after a semantics tree has actually
+ * built (which may be some time after the frame has been rendered).
  */
 - (void)ensureSemanticsEnabled;
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -147,9 +147,9 @@ FLUTTER_EXPORT
  * `-runWithEntrypoint:` or `-runWithEntryPoint:libraryURI`.
  *
  * Although this method returns synchronously, it does not guarantee that a
- * semantics tree is actually available; it only tells the Flutter framework to
- * build a semantics tree the next it has a good reason to, such as when a frame
- * is pumped.
+ * semantics tree is actually available when the method returns. It
+ * synchronously ensures that the next frame the Flutter framework creates will
+ * have a semantics tree
  *
  * You can subscribe to semantics updates via `NSNotificationCenter` by adding
  * an observer for the name `FlutterSemanticsUpdateNotification`.  The `object`

--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -23,6 +23,7 @@
  * The object passed as the sender is the `FlutterViewController` associated
  * with the update.
  */
+FLUTTER_EXPORT
 extern NSNotificationName const FlutterSemanticsUpdateNotification;
 
 /**


### PR DESCRIPTION
- Updates the docs on ensureSemantics to better indicate what's synchronous and what isn't
- Adds `FLUTTER_EXPORT` to the notification name so that it doesn't get stripped by the linker

/cc @albertwang0116 @xster 