### PR TITLE
Plumb a reference of PlatformViewsController and AccessibilityBridge to each other

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -516,6 +516,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/Platfor
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewFactory.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistry.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewRegistryImpl.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -158,6 +158,7 @@ java_library("flutter_shell_java") {
     "io/flutter/plugin/platform/PlatformViewFactory.java",
     "io/flutter/plugin/platform/PlatformViewRegistry.java",
     "io/flutter/plugin/platform/PlatformViewRegistryImpl.java",
+    "io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java",
     "io/flutter/plugin/platform/PlatformViewsController.java",
     "io/flutter/plugin/platform/SingleViewPresentation.java",
     "io/flutter/plugin/platform/VirtualDisplayController.java",

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -94,6 +94,10 @@ public class FlutterPluginRegistry
         mPlatformViewsController.onPreEngineRestart();
     }
 
+    public PlatformViewsController getPlatformViewsController() {
+        return mPlatformViewsController;
+    }
+
     private class FlutterRegistrar implements Registrar {
         private final String pluginKey;
 

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
@@ -35,7 +35,6 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.editing.TextInputPlugin;
-import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.VsyncWaiter;
 
@@ -444,15 +443,15 @@ public class FlutterView extends FrameLayout {
         textInputPlugin
     );
     androidTouchProcessor = new AndroidTouchProcessor(this.flutterEngine.getRenderer());
-    PlatformViewsController platformViewsController = flutterEngine.getPluginRegistry().getPlatformViewsController();
     accessibilityBridge = new AccessibilityBridge(
         this,
         flutterEngine.getAccessibilityChannel(),
         (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE),
         getContext().getContentResolver(),
-        platformViewsController
+        // TODO(mattcaroll): plumb the platform views controller to the accessibility bridge.
+        // https://github.com/flutter/flutter/issues/29618
+        null
     );
-    platformViewsController.attachAccessibilityBridge(accessibilityBridge);
     accessibilityBridge.setOnAccessibilityChangeListener(onAccessibilityChangeListener);
     resetWillNotDraw(
         accessibilityBridge.isAccessibilityEnabled(),

--- a/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/engine/android/FlutterView.java
@@ -35,6 +35,7 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
 import io.flutter.plugin.editing.TextInputPlugin;
+import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.VsyncWaiter;
 
@@ -443,12 +444,15 @@ public class FlutterView extends FrameLayout {
         textInputPlugin
     );
     androidTouchProcessor = new AndroidTouchProcessor(this.flutterEngine.getRenderer());
+    PlatformViewsController platformViewsController = flutterEngine.getPluginRegistry().getPlatformViewsController();
     accessibilityBridge = new AccessibilityBridge(
         this,
         flutterEngine.getAccessibilityChannel(),
         (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE),
-        getContext().getContentResolver()
+        getContext().getContentResolver(),
+        platformViewsController
     );
+    platformViewsController.attachAccessibilityBridge(accessibilityBridge);
     accessibilityBridge.setOnAccessibilityChangeListener(onAccessibilityChangeListener);
     resetWillNotDraw(
         accessibilityBridge.isAccessibilityEnabled(),

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -1,0 +1,11 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.plugin.platform;
+
+/**
+ * Facilitates interaction between the accessibility bridge and embedded platform views.
+ */
+public interface PlatformViewsAccessibilityDelegate {
+}

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -8,4 +8,6 @@ package io.flutter.plugin.platform;
  * Facilitates interaction between the accessibility bridge and embedded platform views.
  */
 public interface PlatformViewsAccessibilityDelegate {
+    // TODO(amirh): add a View getViewById(int id) here.
+    // not filing a tracking issue as this is going to be done in the next PR.
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -14,6 +14,7 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.StandardMethodCodec;
+import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.TextureRegistry;
 
 import java.nio.ByteBuffer;
@@ -49,6 +50,9 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
 
     // The messenger used to communicate with the framework over the platform views channel.
     private BinaryMessenger mMessenger;
+
+    // The accessibility bridge to which accessibility events form the platform views will be dispatched.
+    private AccessibilityBridge accessibilityBridge;
 
     private final HashMap<Integer, VirtualDisplayController> vdControllers;
 
@@ -94,6 +98,25 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
         mTextureRegistry = null;
     }
 
+    /**
+     * Attaches an accessibility bridge for this platform views controller.
+     *
+     * Accessibility events sent by platform views that belonging to this controller will be
+     * dispatched to this accessibility bridge.
+     */
+    public void attachAccessibilityBridge(AccessibilityBridge accessibilityBridge) {
+        this.accessibilityBridge = accessibilityBridge;
+    }
+
+    /**
+     * Detaches the current accessibility bridge.
+     *
+     * Any accessibility events sent by platform views belonging to this controller will be ignored.
+     */
+    public void detachAccessibiltyBridge() {
+        this.accessibilityBridge = null;
+    }
+
     public PlatformViewRegistry getRegistry() {
         return mRegistry;
     }
@@ -104,6 +127,17 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler 
 
     public void onPreEngineRestart() {
         flushAllViews();
+    }
+
+    /**
+     * Returns the embedded view with id, or null if no view with this id is registered.
+     */
+    public View getPlatformViewById(Integer id) {
+        VirtualDisplayController controller = vdControllers.get(id);
+        if (controller == null) {
+            return null;
+        }
+        return controller.getView();
     }
 
     @Override

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -32,7 +32,7 @@ import static android.view.MotionEvent.PointerProperties;
  * Each {@link io.flutter.app.FlutterPluginRegistry} has a single platform views controller.
  * A platform views controller can be attached to at most one Flutter view.
  */
-public class PlatformViewsController implements MethodChannel.MethodCallHandler {
+public class PlatformViewsController implements MethodChannel.MethodCallHandler, PlatformViewsAccessibilityDelegate {
     private static final String TAG = "PlatformViewsController";
 
     private static final String CHANNEL_NAME = "flutter/platform_views";

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -29,6 +29,7 @@ import android.view.accessibility.AccessibilityNodeProvider;
 
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
+import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.util.Predicate;
 
 import java.nio.ByteBuffer;
@@ -89,6 +90,11 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     // turned on, as well as listen for changes to accessibility's activation.
     @NonNull
     private final AccessibilityManager accessibilityManager;
+
+    // The controller for the embedded platform views. Used to embed accessibility data for an embedded
+    // view in the accessibility tree.
+    @NonNull
+    private final PlatformViewsController platformViewsController;
 
     // Android's {@link ContentResolver}, which is used to observe the global TRANSITION_ANIMATION_SCALE,
     // which determines whether Flutter's animations should be enabled or disabled for accessibility
@@ -307,12 +313,14 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         @NonNull View rootAccessibilityView,
         @NonNull AccessibilityChannel accessibilityChannel,
         @NonNull AccessibilityManager accessibilityManager,
-        @NonNull ContentResolver contentResolver
+        @NonNull ContentResolver contentResolver,
+        @NonNull PlatformViewsController platformViewsController
     ) {
         this.rootAccessibilityView = rootAccessibilityView;
         this.accessibilityChannel = accessibilityChannel;
         this.accessibilityManager = accessibilityManager;
         this.contentResolver = contentResolver;
+        this.platformViewsController = platformViewsController;
 
         decorView = ((Activity) rootAccessibilityView.getContext()).getWindow().getDecorView();
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -15,7 +15,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.Settings;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.NonNull;
 import android.support.annotation.RequiresApi;
@@ -27,9 +26,8 @@ import android.view.accessibility.AccessibilityManager;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.view.accessibility.AccessibilityNodeProvider;
 
-import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.systemchannels.AccessibilityChannel;
-import io.flutter.plugin.platform.PlatformViewsController;
+import io.flutter.plugin.platform.PlatformViewsAccessibilityDelegate;
 import io.flutter.util.Predicate;
 
 import java.nio.ByteBuffer;
@@ -91,10 +89,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
     @NonNull
     private final AccessibilityManager accessibilityManager;
 
-    // The controller for the embedded platform views. Used to embed accessibility data for an embedded
+    // The delegate for interacting with embedded platform views. Used to embed accessibility data for an embedded
     // view in the accessibility tree.
     @NonNull
-    private final PlatformViewsController platformViewsController;
+    private final PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate;
 
     // Android's {@link ContentResolver}, which is used to observe the global TRANSITION_ANIMATION_SCALE,
     // which determines whether Flutter's animations should be enabled or disabled for accessibility
@@ -314,13 +312,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         @NonNull AccessibilityChannel accessibilityChannel,
         @NonNull AccessibilityManager accessibilityManager,
         @NonNull ContentResolver contentResolver,
-        @NonNull PlatformViewsController platformViewsController
+        @NonNull PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate
     ) {
         this.rootAccessibilityView = rootAccessibilityView;
         this.accessibilityChannel = accessibilityChannel;
         this.accessibilityManager = accessibilityManager;
         this.contentResolver = contentResolver;
-        this.platformViewsController = platformViewsController;
+        this.platformViewsAccessibilityDelegate = platformViewsAccessibilityDelegate;
 
         decorView = ((Activity) rootAccessibilityView.getContext()).getWindow().getDecorView();
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -43,6 +43,7 @@ import io.flutter.embedding.engine.systemchannels.SystemChannel;
 import io.flutter.plugin.common.*;
 import io.flutter.plugin.editing.TextInputPlugin;
 import io.flutter.plugin.platform.PlatformPlugin;
+import io.flutter.plugin.platform.PlatformViewsController;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -660,12 +661,15 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     protected void onAttachedToWindow() {
         super.onAttachedToWindow();
 
+        PlatformViewsController platformViewsController = getPluginRegistry().getPlatformViewsController();
         mAccessibilityNodeProvider = new AccessibilityBridge(
             this,
             new AccessibilityChannel(dartExecutor, getFlutterNativeView().getFlutterJNI()),
             (AccessibilityManager) getContext().getSystemService(Context.ACCESSIBILITY_SERVICE),
-            getContext().getContentResolver()
+            getContext().getContentResolver(),
+            platformViewsController
         );
+        platformViewsController.attachAccessibilityBridge(mAccessibilityNodeProvider);
         mAccessibilityNodeProvider.setOnAccessibilityChangeListener(onAccessibilityChangeListener);
 
         resetWillNotDraw(
@@ -678,6 +682,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
+        getPluginRegistry().getPlatformViewsController().detachAccessibiltyBridge();
         mAccessibilityNodeProvider.release();
         mAccessibilityNodeProvider = null;
     }


### PR DESCRIPTION
This is in preparation for implementing platform views a11y on Android.

And e2e working prototype is available here: https://github.com/amirh/engine/tree/a11y_hacks

https://github.com/flutter/flutter/issues/19418