### PR TITLE
Correct greater than or equal logic in offset base

### DIFF
--- a/lib/stub_ui/geometry.dart
+++ b/lib/stub_ui/geometry.dart
@@ -73,7 +73,7 @@ abstract class OffsetBase {
   ///
   /// This is a partial ordering. It is possible for two values to be neither
   /// less, nor greater than, nor equal to, another.
-  bool operator >=(OffsetBase other) => _dx > other._dx && _dy >= other._dy;
+  bool operator >=(OffsetBase other) => _dx >= other._dx && _dy >= other._dy;
 
   /// Equality operator. Compares an [Offset] or [Size] to another [Offset] or
   /// [Size], and returns true if the horizontal and vertical values of the

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -73,7 +73,7 @@ abstract class OffsetBase {
   ///
   /// This is a partial ordering. It is possible for two values to be neither
   /// less, nor greater than, nor equal to, another.
-  bool operator >=(OffsetBase other) => _dx > other._dx && _dy >= other._dy;
+  bool operator >=(OffsetBase other) => _dx >= other._dx && _dy >= other._dy;
 
   /// Equality operator. Compares an [Offset] or [Size] to another [Offset] or
   /// [Size], and returns true if the horizontal and vertical values of the

--- a/testing/dart/geometry_test.dart
+++ b/testing/dart/geometry_test.dart
@@ -9,6 +9,40 @@ import 'dart:ui';
 import 'package:test/test.dart';
 
 void main() {
+  test('OffsetBase.>=', () {
+    expect(const Offset(0, 0), greaterThanOrEqualTo(const Offset(0, -1)));
+    expect(const Offset(0, 0), greaterThanOrEqualTo(const Offset(-1, 0)));
+    expect(const Offset(0, 0), greaterThanOrEqualTo(const Offset(-1, -1)));
+    expect(const Offset(0, 0), greaterThanOrEqualTo(const Offset(0, 0)));
+    expect(const Offset(0, 0), isNot(greaterThanOrEqualTo(const Offset(0, double.nan))));
+    expect(const Offset(0, 0), isNot(greaterThanOrEqualTo(const Offset(double.nan, 0))));
+    expect(const Offset(0, 0), isNot(greaterThanOrEqualTo(const Offset(10, -10))));
+  });
+  test('OffsetBase.<=', () {
+    expect(const Offset(0, 0), lessThanOrEqualTo(const Offset(0, 1)));
+    expect(const Offset(0, 0), lessThanOrEqualTo(const Offset(1, 0)));
+    expect(const Offset(0, 0), lessThanOrEqualTo(const Offset(0, 0)));
+    expect(const Offset(0, 0), isNot(lessThanOrEqualTo(const Offset(0, double.nan))));
+    expect(const Offset(0, 0), isNot(lessThanOrEqualTo(const Offset(double.nan, 0))));
+    expect(const Offset(0, 0), isNot(lessThanOrEqualTo(const Offset(10, -10))));
+  });
+  test('OffsetBase.>', () {
+    expect(const Offset(0, 0), greaterThan(const Offset(-1, -1)));
+    expect(const Offset(0, 0), isNot(greaterThan(const Offset(0, -1))));
+    expect(const Offset(0, 0), isNot(greaterThan(const Offset(-1, 0))));
+    expect(const Offset(0, 0), isNot(greaterThan(const Offset(double.nan, -1))));
+  });
+  test('OffsetBase.<', () {
+    expect(const Offset(0, 0), lessThan(const Offset(1, 1)));
+    expect(const Offset(0, 0), isNot(lessThan(const Offset(0, 1))));
+    expect(const Offset(0, 0), isNot(lessThan(const Offset(1, 0))));
+    expect(const Offset(0, 0), isNot(lessThan(const Offset(double.nan, 1))));
+  });
+  test('OffsetBase.==', () {
+    expect(const Offset(0, 0), equals(const Offset(0, 0)));
+    expect(const Offset(0, 0), isNot(equals(const Offset(1, 0))));
+    expect(const Offset(0, 0), isNot(equals(const Offset(0, 1))));
+  });
   test('Offset.direction', () {
     expect(const Offset(0.0, 0.0).direction, 0.0);
     expect(const Offset(0.0, 1.0).direction, pi / 2.0);

--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: engine_tests
 dependencies:
-  test: 1.3.0
+  test: 1.5.3
   path: 1.6.2
 
 dependency_overrides:

--- a/testing/dart/pubspec.yaml
+++ b/testing/dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: engine_tests
 dependencies:
-  test: 1.5.3
+  test: 1.3.0
   path: 1.6.2
 
 dependency_overrides:


### PR DESCRIPTION
Not sure what bugs this has been hiding.