### PR TITLE
Revert "Export FlutterSemanticsUpdateNotification and improve docs"

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -146,16 +146,10 @@ FLUTTER_EXPORT
  * This method must only be called after launching the engine via
  * `-runWithEntrypoint:` or `-runWithEntryPoint:libraryURI`.
  *
- * Although this method returns synchronously, it does not guarantee that a
- * semantics tree is actually available when the method returns. It
- * synchronously ensures that the next frame the Flutter framework creates will
- * have a semantics tree.
- *
  * You can subscribe to semantics updates via `NSNotificationCenter` by adding
  * an observer for the name `FlutterSemanticsUpdateNotification`.  The `object`
  * parameter will be the `FlutterViewController` associated with the semantics
- * update.  This will asynchronously fire after a semantics tree has actually
- * built (which may be some time after the frame has been rendered).
+ * update.
  */
 - (void)ensureSemanticsEnabled;
 

--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -23,7 +23,6 @@
  * The object passed as the sender is the `FlutterViewController` associated
  * with the update.
  */
-FLUTTER_EXPORT
 extern NSNotificationName const FlutterSemanticsUpdateNotification;
 
 /**


### PR DESCRIPTION
Reverts flutter/engine#8203

Reason for revert: breaks engine mac build.