### PR TITLE
[ios] Set contentsScale before we commit CATransaction

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -23,6 +23,7 @@
 - (instancetype)initWithCoder:(NSCoder*)aDecoder NS_UNAVAILABLE;
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
+- (instancetype)initForGLWithContentsScale:(CGFloat)contentsScale;
 - (std::unique_ptr<shell::IOSSurface>)createSoftwareSurface;
 - (std::unique_ptr<shell::IOSSurfaceGL>)createGLSurfaceWithContext:
     (std::shared_ptr<shell::IOSGLContext>)gl_context;

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -23,7 +23,7 @@
 - (instancetype)initWithCoder:(NSCoder*)aDecoder NS_UNAVAILABLE;
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
-- (instancetype)initForGLWithContentsScale:(CGFloat)contentsScale;
+- (instancetype)initWithContentsScale:(CGFloat)contentsScale;
 - (std::unique_ptr<shell::IOSSurface>)createSoftwareSurface;
 - (std::unique_ptr<shell::IOSSurfaceGL>)createGLSurfaceWithContext:
     (std::shared_ptr<shell::IOSGLContext>)gl_context;

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -21,13 +21,13 @@
 @implementation FlutterOverlayView
 
 - (instancetype)initWithFrame:(CGRect)frame {
-  @throw([NSException exceptionWithName:@"FlutterOverlayView must initWithDelegate"
+  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initForGLWithContentsScale"
                                  reason:nil
                                userInfo:nil]);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)aDecoder {
-  @throw([NSException exceptionWithName:@"FlutterOverlayView must initWithDelegate"
+  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initForGLWithContentsScale"
                                  reason:nil
                                userInfo:nil]);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -56,10 +56,6 @@
   return self;
 }
 
-- (void)layoutSubviews {
-  [super layoutSubviews];
-}
-
 + (Class)layerClass {
 #if TARGET_IPHONE_SIMULATOR
   return [CALayer class];

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -21,13 +21,13 @@
 @implementation FlutterOverlayView
 
 - (instancetype)initWithFrame:(CGRect)frame {
-  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initForGLWithContentsScale"
+  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initWithContentsScale"
                                  reason:nil
                                userInfo:nil]);
 }
 
 - (instancetype)initWithCoder:(NSCoder*)aDecoder {
-  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initForGLWithContentsScale"
+  @throw([NSException exceptionWithName:@"FlutterOverlayView must init or initWithContentsScale"
                                  reason:nil
                                userInfo:nil]);
 }
@@ -43,10 +43,10 @@
   return self;
 }
 
-- (instancetype)initForGLWithContentsScale:(CGFloat)contentsScale {
+- (instancetype)initWithContentsScale:(CGFloat)contentsScale {
   self = [self init];
 
-  if (self) {
+  if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     CAEAGLLayer* layer = reinterpret_cast<CAEAGLLayer*>(self.layer);
     layer.allowsGroupOpacity = NO;
     layer.contentsScale = contentsScale;

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -43,15 +43,20 @@
   return self;
 }
 
-- (void)layoutSubviews {
-  if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
+- (instancetype)initForGLWithContentsScale:(CGFloat)contentsScale {
+  self = [self init];
+
+  if (self) {
     CAEAGLLayer* layer = reinterpret_cast<CAEAGLLayer*>(self.layer);
     layer.allowsGroupOpacity = NO;
-    CGFloat screenScale = [UIScreen mainScreen].scale;
-    layer.contentsScale = screenScale;
-    layer.rasterizationScale = screenScale;
+    layer.contentsScale = contentsScale;
+    layer.rasterizationScale = contentsScale;
   }
 
+  return self;
+}
+
+- (void)layoutSubviews {
   [super layoutSubviews];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -277,7 +277,8 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
     return;
   }
   auto contentsScale = flutter_view_.get().layer.contentsScale;
-  FlutterOverlayView* overlay_view = [[FlutterOverlayView alloc] initForGLWithContentsScale:contentsScale];
+  FlutterOverlayView* overlay_view =
+      [[FlutterOverlayView alloc] initForGLWithContentsScale:contentsScale];
   overlay_view.frame = flutter_view_.get().bounds;
   overlay_view.autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -214,8 +214,7 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
     } else {
       EnsureOverlayInitialized(view_id);
     }
-    auto& ios_surface = overlays_[view_id]->surface;
-    auto frame = ios_surface->AcquireFrame(frame_size_);
+    auto frame = overlays_[view_id]->surface->AcquireFrame(frame_size_);
     SkCanvas* canvas = frame->SkiaCanvas();
     canvas->drawPicture(picture_recorders_[view_id]->finishRecordingAsPicture());
     canvas->flush();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -278,7 +278,7 @@ void FlutterPlatformViewsController::EnsureGLOverlayInitialized(
   }
   auto contentsScale = flutter_view_.get().layer.contentsScale;
   FlutterOverlayView* overlay_view =
-      [[FlutterOverlayView alloc] initForGLWithContentsScale:contentsScale];
+      [[FlutterOverlayView alloc] initWithContentsScale:contentsScale];
   overlay_view.frame = flutter_view_.get().bounds;
   overlay_view.autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);


### PR DESCRIPTION
Layout occurs after `[CATransaction commit]`. `layoutSubviews` was where we set the `contentsScale` on the `CALayer`. This meant that for one frame, we would see content on the overlay view which was did not have the correct content scale.

This change makes it so that we initialize the `FlutterOverlayView` with the correct `contentsScale`.

This also updates the `overlay_gr_context_` when we first create the `overlay_view`. This is an artifact of https://github.com/flutter/engine/pull/8175.

This manifests as jank as seen in: https://github.com/flutter/flutter/issues/29573