### PR TITLE
Have the AccessibilityBridge attach/detach itself to the

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsAccessibilityDelegate.java
@@ -4,10 +4,28 @@
 
 package io.flutter.plugin.platform;
 
+import io.flutter.view.AccessibilityBridge;
+
 /**
  * Facilitates interaction between the accessibility bridge and embedded platform views.
  */
 public interface PlatformViewsAccessibilityDelegate {
     // TODO(amirh): add a View getViewById(int id) here.
     // not filing a tracking issue as this is going to be done in the next PR.
+
+    /**
+     * Attaches an accessibility bridge for this platform views accessibility delegate.
+     *
+     * Accessibility events originating in platform views belonging to this delegate will be delegated
+     * to this accessibility bridge.
+     */
+    void attachAccessibilityBridge(AccessibilityBridge accessibilityBridge);
+
+    /**
+     * Detaches the current accessibility bridge.
+     *
+     * Any accessibility events sent by platform views belonging to this delegate will be ignored until
+     * a new accessibility bridge is attached.
+     */
+    void detachAccessibiltyBridge();
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -98,21 +98,12 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
         mTextureRegistry = null;
     }
 
-    /**
-     * Attaches an accessibility bridge for this platform views controller.
-     *
-     * Accessibility events sent by platform views that belonging to this controller will be
-     * dispatched to this accessibility bridge.
-     */
+    @Override
     public void attachAccessibilityBridge(AccessibilityBridge accessibilityBridge) {
         this.accessibilityBridge = accessibilityBridge;
     }
 
-    /**
-     * Detaches the current accessibility bridge.
-     *
-     * Any accessibility events sent by platform views belonging to this controller will be ignored.
-     */
+    @Override
     public void detachAccessibiltyBridge() {
         this.accessibilityBridge = null;
     }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -312,7 +312,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         @NonNull AccessibilityChannel accessibilityChannel,
         @NonNull AccessibilityManager accessibilityManager,
         @NonNull ContentResolver contentResolver,
-        @NonNull PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate
+        // This should be @NonNull once the plumbing for io.flutter.embedding.engine.android.FlutterView is done.
+        // TODO(mattcarrol): Add the annotation once the plumbing is done.
+        // https://github.com/flutter/flutter/issues/29618
+        PlatformViewsAccessibilityDelegate platformViewsAccessibilityDelegate
     ) {
         this.rootAccessibilityView = rootAccessibilityView;
         this.accessibilityChannel = accessibilityChannel;
@@ -362,6 +365,14 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             Uri transitionUri = Settings.Global.getUriFor(Settings.Global.TRANSITION_ANIMATION_SCALE);
             this.contentResolver.registerContentObserver(transitionUri, false, animationScaleObserver);
         }
+
+        // platformViewsAccessibilityDelegate should be @NonNull once the plumbing
+        // for io.flutter.embedding.engine.android.FlutterView is done.
+        // TODO(mattcarrol): Remove the null check once the plumbing is done.
+        // https://github.com/flutter/flutter/issues/29618
+        if (platformViewsAccessibilityDelegate != null) {
+            platformViewsAccessibilityDelegate.attachAccessibilityBridge(this);
+        }
     }
 
     /**
@@ -372,6 +383,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
      * on this {@code AccessibilityBridge} after invoking {@code release()} is undefined.
      */
     public void release() {
+        // platformViewsAccessibilityDelegate should be @NonNull once the plumbing
+        // for io.flutter.embedding.engine.android.FlutterView is done.
+        // TODO(mattcarrol): Remove the null check once the plumbing is done.
+        // https://github.com/flutter/flutter/issues/29618
+        if (platformViewsAccessibilityDelegate != null) {
+            platformViewsAccessibilityDelegate.detachAccessibiltyBridge();
+        }
         setOnAccessibilityChangeListener(null);
         accessibilityManager.removeAccessibilityStateChangeListener(accessibilityStateChangeListener);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -669,7 +669,6 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
             getContext().getContentResolver(),
             platformViewsController
         );
-        platformViewsController.attachAccessibilityBridge(mAccessibilityNodeProvider);
         mAccessibilityNodeProvider.setOnAccessibilityChangeListener(onAccessibilityChangeListener);
 
         resetWillNotDraw(
@@ -682,7 +681,6 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
 
-        getPluginRegistry().getPlatformViewsController().detachAccessibiltyBridge();
         mAccessibilityNodeProvider.release();
         mAccessibilityNodeProvider = null;
     }


### PR DESCRIPTION
PlatformViewsDelegate.

Since onDetachedFromWindow can be called after the activity was
destroyed, the previous call to detach the accessibility bridge could
have crash as the NativeFlutterView was already null.