### PR TITLE
Remove jsoncpp from desktop Linux shell setup

### DIFF
--- a/build/install-build-deps-linux-desktop.sh
+++ b/build/install-build-deps-linux-desktop.sh
@@ -8,5 +8,4 @@
 
 set -e
 
-sudo apt-get -y install libglfw3-dev libepoxy-dev libjsoncpp-dev libgtk-3-dev \
-    libx11-dev
+sudo apt-get -y install libglfw3-dev libepoxy-dev libgtk-3-dev libx11-dev


### PR DESCRIPTION
The jsoncpp requirement was removed in the migration from FDE to this
repository, so it doesn't need to be installed by the script.