### PR TITLE
fix video player dismiss when there is a iOS platform view

### DIFF
--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -80,6 +80,7 @@ class Layer {
     // layers.
     SkCanvas* internal_nodes_canvas;
     SkCanvas* leaf_nodes_canvas;
+    GrContext* gr_context;
     ExternalViewEmbedder* view_embedder;
     const Stopwatch& frame_time;
     const Stopwatch& engine_time;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -81,6 +81,7 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
   Layer::PaintContext context = {
       (SkCanvas*)&internal_nodes_canvas,
       frame.canvas(),
+      frame.gr_context(),
       frame.view_embedder(),
       frame.context().frame_time(),
       frame.context().engine_time(),
@@ -127,6 +128,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
   Layer::PaintContext paint_context = {
       (SkCanvas*)&internal_nodes_canvas,
       canvas,  // canvas
+      nullptr,
       nullptr,
       unused_stopwatch,         // frame time (dont care)
       unused_stopwatch,         // engine time (dont care)

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -48,7 +48,7 @@ TEST(PerformanceOverlayLayer, Gold) {
   flow::TextureRegistry unused_texture_registry;
 
   flow::Layer::PaintContext paintContext = {
-      nullptr,        surface->getCanvas(),    nullptr, mock_stopwatch,
+      nullptr,        surface->getCanvas(),    nullptr, nullptr, mock_stopwatch,
       mock_stopwatch, unused_texture_registry, nullptr, false};
 
   // Specify font file to ensure the same font across different operation

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -23,7 +23,8 @@ void TextureLayer::Paint(PaintContext& context) const {
   if (!texture) {
     return;
   }
-  texture->Paint(*context.leaf_nodes_canvas, paint_bounds(), freeze_);
+  texture->Paint(*context.leaf_nodes_canvas, paint_bounds(), freeze_,
+                 context.gr_context);
 }
 
 }  // namespace flow

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -166,6 +166,7 @@ void RasterCache::Prepare(PrerollContext* context,
                               Layer::PaintContext paintContext = {
                                   (SkCanvas*)&internal_nodes_canvas,
                                   canvas,
+                                  context->gr_context,
                                   nullptr,
                                   context->frame_time,
                                   context->engine_time,

--- a/flow/texture.h
+++ b/flow/texture.h
@@ -22,7 +22,10 @@ class Texture {
   virtual ~Texture();
 
   // Called from GPU thread.
-  virtual void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) = 0;
+  virtual void Paint(SkCanvas& canvas,
+                     const SkRect& bounds,
+                     bool freeze,
+                     GrContext* context) = 0;
 
   // Called from GPU thread.
   virtual void OnGrContextCreated() = 0;

--- a/shell/platform/android/android_external_texture_gl.cc
+++ b/shell/platform/android/android_external_texture_gl.cc
@@ -32,7 +32,8 @@ void AndroidExternalTextureGL::MarkNewFrameAvailable() {
 
 void AndroidExternalTextureGL::Paint(SkCanvas& canvas,
                                      const SkRect& bounds,
-                                     bool freeze) {
+                                     bool freeze,
+                                     GrContext* context) {
   if (state_ == AttachmentState::detached) {
     return;
   }

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -19,7 +19,10 @@ class AndroidExternalTextureGL : public flow::Texture {
 
   ~AndroidExternalTextureGL() override;
 
-  void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) override;
+  void Paint(SkCanvas& canvas,
+             const SkRect& bounds,
+             bool freeze,
+             GrContext* context) override;
 
   void OnGrContextCreated() override;
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -18,7 +18,7 @@ class IOSExternalTextureGL : public flow::Texture {
   ~IOSExternalTextureGL() override;
 
   // Called from GPU thread.
-  void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) override;
+  void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze, GrContext* context) override;
 
   void OnGrContextCreated() override;
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -63,7 +63,7 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas,
   sk_sp<SkImage> image =
       SkImage::MakeFromTexture(context, backendTexture, kTopLeft_GrSurfaceOrigin,
                                kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
-  FML_CHECK(image) << "Failed to create SkImage from Texture.";
+  FML_DCHECK(image) << "Failed to create SkImage from Texture.";
   if (image) {
     canvas.drawImage(image, bounds.x(), bounds.y());
   }

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -60,8 +60,9 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas,
   GrGLTextureInfo textureInfo = {CVOpenGLESTextureGetTarget(texture_ref_),
                                  CVOpenGLESTextureGetName(texture_ref_), GL_RGBA8_OES};
   GrBackendTexture backendTexture(bounds.width(), bounds.height(), GrMipMapped::kNo, textureInfo);
-  sk_sp<SkImage> image = SkImage::MakeFromTexture(context, backendTexture, kTopLeft_GrSurfaceOrigin,
-                                                  kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
+  sk_sp<SkImage> image =
+      SkImage::MakeFromTexture(context, backendTexture, kTopLeft_GrSurfaceOrigin,
+                               kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
   FML_CHECK(image) << "Failed to create SkImage from Texture.";
   if (image) {
     canvas.drawImage(image, bounds.x(), bounds.y());

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -60,9 +60,9 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas,
   GrGLTextureInfo textureInfo = {CVOpenGLESTextureGetTarget(texture_ref_),
                                  CVOpenGLESTextureGetName(texture_ref_), GL_RGBA8_OES};
   GrBackendTexture backendTexture(bounds.width(), bounds.height(), GrMipMapped::kNo, textureInfo);
-  sk_sp<SkImage> image = SkImage::MakeFromTexture(
-      context == nullptr ? canvas.getGrContext() : context, backendTexture,
-      kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
+  sk_sp<SkImage> image = SkImage::MakeFromTexture(context, backendTexture, kTopLeft_GrSurfaceOrigin,
+                                                  kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
+  FML_CHECK(image) << "Failed to create SkImage from Texture.";
   if (image) {
     canvas.drawImage(image, bounds.x(), bounds.y());
   }

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -22,7 +22,10 @@ IOSExternalTextureGL::IOSExternalTextureGL(int64_t textureId,
 
 IOSExternalTextureGL::~IOSExternalTextureGL() = default;
 
-void IOSExternalTextureGL::Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) {
+void IOSExternalTextureGL::Paint(SkCanvas& canvas,
+                                 const SkRect& bounds,
+                                 bool freeze,
+                                 GrContext* context) {
   if (!cache_ref_) {
     CVOpenGLESTextureCacheRef cache;
     CVReturn err = CVOpenGLESTextureCacheCreate(kCFAllocatorDefault, NULL,
@@ -57,9 +60,9 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas, const SkRect& bounds, bool fr
   GrGLTextureInfo textureInfo = {CVOpenGLESTextureGetTarget(texture_ref_),
                                  CVOpenGLESTextureGetName(texture_ref_), GL_RGBA8_OES};
   GrBackendTexture backendTexture(bounds.width(), bounds.height(), GrMipMapped::kNo, textureInfo);
-  sk_sp<SkImage> image =
-      SkImage::MakeFromTexture(canvas.getGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin,
-                               kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
+  sk_sp<SkImage> image = SkImage::MakeFromTexture(
+      context == nullptr ? canvas.getGrContext() : context, backendTexture,
+      kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
   if (image) {
     canvas.drawImage(image, bounds.x(), bounds.y());
   }

--- a/shell/platform/embedder/embedder_external_texture_gl.cc
+++ b/shell/platform/embedder/embedder_external_texture_gl.cc
@@ -20,7 +20,8 @@ EmbedderExternalTextureGL::~EmbedderExternalTextureGL() = default;
 // |flow::Texture|
 void EmbedderExternalTextureGL::Paint(SkCanvas& canvas,
                                       const SkRect& bounds,
-                                      bool freeze) {
+                                      bool freeze,
+                                      GrContext* context) {
   if (auto image = external_texture_callback_(
           Id(),                                           //
           canvas.getGrContext(),                          //

--- a/shell/platform/embedder/embedder_external_texture_gl.h
+++ b/shell/platform/embedder/embedder_external_texture_gl.h
@@ -27,7 +27,10 @@ class EmbedderExternalTextureGL : public flow::Texture {
   sk_sp<SkImage> last_image_;
 
   // |flow::Texture|
-  void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze) override;
+  void Paint(SkCanvas& canvas,
+             const SkRect& bounds,
+             bool freeze,
+             GrContext* context) override;
 
   // |flow::Texture|
   void OnGrContextCreated() override;


### PR DESCRIPTION
1.Problem
https://github.com/flutter/flutter/issues/29503
2.Demo
https://github.com/Qxyat/Flutter-demo/tree/master/video_player
3.Solution
I think the reason is that: In the “FlutterPlatformViews.mm”，create a "ios_surface_gl" with a "gl_context", but the picture_recorders_.canvas has a different gl_context.And when there is a PlatformViewLayer in the layer tree，the leaf_nodes_canvas has changed to the picture_recorders_.canvas in “FlutterPlatformViews.mm”.So when getting the SkImage in IOSExternalTextureGL, current "canvas.getGrContext()" is not the actual context when drawing the FlutterOverlayView.
@amirh Hi，I wish you can take some time for this.