### PR TITLE
Remove more forced crashes from FlutterJNI

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -461,8 +461,11 @@ public class FlutterJNI {
 
   @UiThread
   public void dispatchEmptyPlatformMessage(String channel, int responseId) {
-    ensureAttachedToNative();
-    nativeDispatchEmptyPlatformMessage(nativePlatformViewId, channel, responseId);
+    if (isAttached()) {
+      nativeDispatchEmptyPlatformMessage(nativePlatformViewId, channel, responseId);
+    } else {
+      Log.w(TAG, "Tried to send a platform message to Flutter, but FlutterJNI was detached from native C++. Could not send. Channel: " + channel + ". Response ID: " + responseId);
+    }
   }
 
   // Send an empty platform message to Dart.
@@ -474,14 +477,17 @@ public class FlutterJNI {
 
   @UiThread
   public void dispatchPlatformMessage(String channel, ByteBuffer message, int position, int responseId) {
-    ensureAttachedToNative();
-    nativeDispatchPlatformMessage(
-        nativePlatformViewId,
-        channel,
-        message,
-        position,
-        responseId
-    );
+    if (isAttached()) {
+      nativeDispatchPlatformMessage(
+          nativePlatformViewId,
+          channel,
+          message,
+          position,
+          responseId
+      );
+    } else {
+      Log.w(TAG, "Tried to send a platform message to Flutter, but FlutterJNI was detached from native C++. Could not send. Channel: " + channel + ". Response ID: " + responseId);
+    }
   }
 
   // Send a data-carrying platform message to Dart.


### PR DESCRIPTION
FlutterJNI no longer asserts it is attached when dispatching platform messages and instead fizzles with a warning if not attached. Not sure what root cause of issue is, but this is necessary to avoid crashes.

Original bug: #28651

New bug created to find root cause:
https://github.com/flutter/flutter/issues/29757
