### PR TITLE
Fix incorrect vertices colors length check

### DIFF
--- a/lib/ui/painting/vertices.cc
+++ b/lib/ui/painting/vertices.cc
@@ -73,7 +73,7 @@ void Vertices::init(SkVertices::VertexMode vertex_mode,
   }
   if (colors.data()) {
     // SkVertices::Builder assumes equal numbers of elements
-    FML_DCHECK(positions.num_elements() == colors.num_elements());
+    FML_DCHECK(positions.num_elements() / 2 == colors.num_elements());
     DecodeInts<SkColor>(colors, builder.colors());
   }
 


### PR DESCRIPTION
This check was throwing an error in my [pan and zoom PR](https://github.com/flutter/flutter/pull/25164) in the examples smoke tests.  It seems to be due to the check itself being incorrect.

I create an instance of the `Vertices` class in my PR [here](https://github.com/flutter/flutter/pull/25164/files#diff-1fbc461251f0590d931c9a5329470939R183), passing equal-length lists of `colors` and `positions`.  The engine receives this in [Vertices' constructor](https://github.com/flutter/engine/blob/master/lib/ui/painting.dart#L2884) and asserts that the lengths of the two lists are equal, and all is well so far.  However the positions list, and not the colors list, is then encoded as an `Int32List`, where each x and y value is its own int in the list, doubling its length.  Later in vertices.cc, [the problematic check](https://github.com/flutter/engine/blob/master/lib/ui/painting/vertices.cc#L76) asserts that the lengths are still equal, and this fails in my PR.

It seems to me like that check is a mistake.  It's been in the codebase for awhile though and I'm not sure why it hasn't caused problems before.