### PR TITLE
Do not drop the DartExecutor's message handler when a FlutterNativeView is detached from the FlutterView

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -47,9 +47,8 @@ public class FlutterNativeView implements BinaryMessenger {
         assertAttached();
     }
 
-    public void detach() {
+    public void detachFromFlutterView() {
         mPluginRegistry.detach();
-        dartExecutor.onDetachedFromJNI();
         mFlutterView = null;
     }
 

--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -346,7 +346,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
         if (!isAttached())
             return null;
         getHolder().removeCallback(mSurfaceCallback);
-        mNativeView.detach();
+        mNativeView.detachFromFlutterView();
 
         FlutterNativeView view = mNativeView;
         mNativeView = null;


### PR DESCRIPTION
An activity can use ViewFactory.retainNativeFlutterView to reuse a
FlutterNativeView across multiple instances of the activity.  In this
scenario, the FlutterNativeView should continue to handle incoming messages
sent from Dart.