### PR TITLE
Linking Higher & Lower Class Docs

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1520,6 +1520,11 @@ class _ImageInfo {
 ///
 /// To draw an [Image], use one of the methods on the [Canvas] class, such as
 /// [Canvas.drawImage].
+///
+/// See also:
+///
+///  * [Image], the class in the [widgets] library that encapsulates this class.
+///
 @pragma('vm:entry-point')
 class Image extends NativeFieldWrapperClass2 {
   // This class is created by the engine, and should not be instantiated
@@ -2678,6 +2683,11 @@ Float32List _encodeTwoPoints(Offset pointA, Offset pointB) {
 ///
 /// There are several types of gradients, represented by the various constructors
 /// on this class.
+///
+/// See also:
+///
+///  * [Gradient], the class in the [painting] library that encapsulates this class.
+///
 class Gradient extends Shader {
 
   void _constructor() native 'Gradient_constructor';

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -796,6 +796,7 @@ ByteData _encodeStrut(
 
   return ByteData.view(data.buffer, 0,  byteCount);
 }
+///
 /// See also:
 ///
 ///  * [StrutStyle], the class in the [painting] library that encapsulates this class.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -796,7 +796,7 @@ ByteData _encodeStrut(
 
   return ByteData.view(data.buffer, 0,  byteCount);
 }
-///
+
 /// See also:
 ///
 ///  * [StrutStyle], the class in the [painting] library that encapsulates this class.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -352,6 +352,11 @@ Int32List _encodeTextStyle(
 }
 
 /// An opaque object that determines the size, position, and rendering of text.
+///
+/// See also:
+///
+///  * [TextStyle], the class in the [painting] library that encapsulates this class.
+///
 class TextStyle {
   /// Creates a new TextStyle object.
   ///
@@ -791,7 +796,10 @@ ByteData _encodeStrut(
 
   return ByteData.view(data.buffer, 0,  byteCount);
 }
-
+/// See also:
+///
+///  * [StrutStyle], the class in the [painting] library that encapsulates this class.
+///
 class StrutStyle {
   /// Creates a new StrutStyle object.
   ///


### PR DESCRIPTION

This PR links lower layer classes to their corresponding higher level classes in the API Docs.
Links for higher -->lower here: [#29758](https://github.com/flutter/flutter/pull/29758) in [flutter/flutter](https://github.com/flutter/flutter).

This will fix [#22859](https://github.com/flutter/flutter/issues/22859), where there is confusion when referencing higher and lower classes in documentation.