### PR TITLE
Create a view in loadView method and assign it to view property, do additional initialization of view.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -232,6 +232,10 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
 
 - (void)loadView {
   self.view = _flutterView.get();
+}
+
+- (void)viewDidLoad {
+  [super viewDidLoad];
   self.view.multipleTouchEnabled = YES;
   self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
 


### PR DESCRIPTION
according to the [Apple Developer Documentation](
https://developer.apple.com/documentation/uikit/uiviewcontroller/1621454-loadview?language=objc), and the viewDidLoad method will called at `self.view.multipleTouchEnabled = YES`, which is earlier than expected.
