### PR TITLE
Revert "Allow specification of std::functions as native entrypoints from Dart code."

### DIFF
--- a/shell/platform/embedder/fixtures/simple_main.dart
+++ b/shell/platform/embedder/fixtures/simple_main.dart
@@ -6,15 +6,3 @@ void customEntrypoint() {
 }
 
 void sayHiFromCustomEntrypoint() native "SayHiFromCustomEntrypoint";
-
-
-@pragma('vm:entry-point')
-void customEntrypoint1() {
-  sayHiFromCustomEntrypoint1();
-  sayHiFromCustomEntrypoint2();
-  sayHiFromCustomEntrypoint3();
-}
-
-void sayHiFromCustomEntrypoint1() native "SayHiFromCustomEntrypoint1";
-void sayHiFromCustomEntrypoint2() native "SayHiFromCustomEntrypoint2";
-void sayHiFromCustomEntrypoint3() native "SayHiFromCustomEntrypoint3";

--- a/shell/platform/embedder/tests/embedder_context.h
+++ b/shell/platform/embedder/tests/embedder_context.h
@@ -16,23 +16,11 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test_resolver.h"
 
-#define CREATE_NATIVE_ENTRY(native_entry)                                   \
-  ({                                                                        \
-    static ::shell::testing::EmbedderContext::NativeEntry closure;          \
-    static Dart_NativeFunction entrypoint = [](Dart_NativeArguments args) { \
-      closure(args);                                                        \
-    };                                                                      \
-    closure = (native_entry);                                               \
-    entrypoint;                                                             \
-  })
-
 namespace shell {
 namespace testing {
 
 class EmbedderContext {
  public:
-  using NativeEntry = std::function<void(Dart_NativeArguments)>;
-
   EmbedderContext(std::string assets_path = "");
 
   ~EmbedderContext();

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -59,45 +59,5 @@ TEST_F(EmbedderTest, CanInvokeCustomEntrypoint) {
   ASSERT_TRUE(engine.is_valid());
 }
 
-TEST_F(EmbedderTest, CanInvokeCustomEntrypointMacro) {
-  auto& context = GetEmbedderContext();
-
-  fml::AutoResetWaitableEvent latch1;
-  fml::AutoResetWaitableEvent latch2;
-  fml::AutoResetWaitableEvent latch3;
-
-  // Can be defined separately.
-  auto entry1 = [&latch1](Dart_NativeArguments args) {
-    FML_LOG(ERROR) << "In Callback 1";
-    latch1.Signal();
-  };
-  auto native_entry1 = CREATE_NATIVE_ENTRY(entry1);
-  context.AddNativeCallback("SayHiFromCustomEntrypoint1", native_entry1);
-
-  // Can be wrapped in in the args.
-  auto entry2 = [&latch2](Dart_NativeArguments args) {
-    FML_LOG(ERROR) << "In Callback 2";
-    latch2.Signal();
-  };
-  context.AddNativeCallback("SayHiFromCustomEntrypoint2",
-                            CREATE_NATIVE_ENTRY(entry2));
-
-  // Everything can be inline.
-  context.AddNativeCallback(
-      "SayHiFromCustomEntrypoint3",
-      CREATE_NATIVE_ENTRY([&latch3](Dart_NativeArguments args) {
-        FML_LOG(ERROR) << "In Callback 3";
-        latch3.Signal();
-      }));
-
-  EmbedderConfigBuilder builder(context);
-  builder.SetDartEntrypoint("customEntrypoint1");
-  auto engine = builder.LaunchEngine();
-  latch1.Wait();
-  latch2.Wait();
-  latch3.Wait();
-  ASSERT_TRUE(engine.is_valid());
-}
-
 }  // namespace testing
 }  // namespace shell


### PR DESCRIPTION
Reverts flutter/engine#8309 because of [Windows bot failures](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8917894354423876400/+/steps/build_host_debug_unopt/0/stdout).