### PR TITLE
Reduce z-fighting on Scenic

### DIFF
--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -80,11 +80,17 @@ class SceneUpdateContext {
       return entity_node_ptr_;
     }
 
+    scenic::ShapeNode& shape_node() { return *shape_node_ptr_; }
+    std::unique_ptr<scenic::ShapeNode>& shape_node_ptr() {
+      return shape_node_ptr_;
+    }
+
    private:
     SceneUpdateContext& context_;
     Entity* const previous_entity_;
 
     std::unique_ptr<scenic::EntityNode> entity_node_ptr_;
+    std::unique_ptr<scenic::ShapeNode> shape_node_ptr_;
   };
 
   class Clip : public Entity {
@@ -202,6 +208,7 @@ class SceneUpdateContext {
   // surface (and thus the entity_node) will be retained for that layer to
   // improve the performance.
   void CreateFrame(std::unique_ptr<scenic::EntityNode> entity_node,
+                   std::unique_ptr<scenic::ShapeNode> shape_node,
                    const SkRRect& rrect,
                    SkColor color,
                    const SkRect& paint_bounds,


### PR DESCRIPTION
Previously the engine was creating multiple `ShapeNode`s all underneath
the same root `EntityNode` at local space z=0. This caused frequent
z-fighting within Flutter layers.

This patch updates the engine to only create one ShapeNode per
EntityNode, which fixes the z-fighting independent of layer elevation.
Z-fighting is still possible from actually setting multiple layers to
the same z in world space using Flutter elevation.

flutter/flutter#25226