### PR TITLE
Reland "Allow specification of std::functions as native entrypoints from Dart code."

### DIFF
--- a/shell/platform/embedder/fixtures/simple_main.dart
+++ b/shell/platform/embedder/fixtures/simple_main.dart
@@ -6,3 +6,15 @@ void customEntrypoint() {
 }
 
 void sayHiFromCustomEntrypoint() native "SayHiFromCustomEntrypoint";
+
+
+@pragma('vm:entry-point')
+void customEntrypoint1() {
+  sayHiFromCustomEntrypoint1();
+  sayHiFromCustomEntrypoint2();
+  sayHiFromCustomEntrypoint3();
+}
+
+void sayHiFromCustomEntrypoint1() native "SayHiFromCustomEntrypoint1";
+void sayHiFromCustomEntrypoint2() native "SayHiFromCustomEntrypoint2";
+void sayHiFromCustomEntrypoint3() native "SayHiFromCustomEntrypoint3";

--- a/shell/platform/embedder/tests/embedder_context.h
+++ b/shell/platform/embedder/tests/embedder_context.h
@@ -16,11 +16,23 @@
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test_resolver.h"
 
+#define CREATE_NATIVE_ENTRY(native_entry)                                   \
+  ([&]() {                                                                  \
+    static ::shell::testing::EmbedderContext::NativeEntry closure;          \
+    static Dart_NativeFunction entrypoint = [](Dart_NativeArguments args) { \
+      closure(args);                                                        \
+    };                                                                      \
+    closure = (native_entry);                                               \
+    return entrypoint;                                                      \
+  })()
+
 namespace shell {
 namespace testing {
 
 class EmbedderContext {
  public:
+  using NativeEntry = std::function<void(Dart_NativeArguments)>;
+
   EmbedderContext(std::string assets_path = "");
 
   ~EmbedderContext();


### PR DESCRIPTION
This reverts commit 7e77d5c484a08cc1c189619e80ae71a7f1df62fb after fixing Windows issues.