### PR TITLE
Create a new resource loading EGL context for each PlatformView instance on Android

### DIFF
--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -11,35 +11,23 @@
 
 namespace shell {
 
-static fml::RefPtr<AndroidContextGL> GlobalResourceLoadingContext() {
-  // AndroidSurfaceGL instances are only ever created on the platform thread. So
-  // there is no need to lock here.
-
-  static fml::RefPtr<AndroidContextGL> global_context;
-
-  if (global_context) {
-    return global_context;
-  }
-
+static fml::RefPtr<AndroidContextGL> CreateResourceLoadingContext() {
   auto environment = fml::MakeRefCounted<AndroidEnvironmentGL>();
-
   if (!environment->IsValid()) {
     return nullptr;
   }
 
   auto context = fml::MakeRefCounted<AndroidContextGL>(environment);
-
   if (!context->IsValid()) {
     return nullptr;
   }
 
-  global_context = context;
-  return global_context;
+  return context;
 }
 
 AndroidSurfaceGL::AndroidSurfaceGL() {
   // Acquire the offscreen context.
-  offscreen_context_ = GlobalResourceLoadingContext();
+  offscreen_context_ = CreateResourceLoadingContext();
 
   if (!offscreen_context_ || !offscreen_context_->IsValid()) {
     offscreen_context_ = nullptr;


### PR DESCRIPTION
Using one global resource loading context will fail if two PlatformViews are
running concurrently with two different IO threads.