### PR TITLE
Remove use of epoxy from Linux shell

### DIFF
--- a/build/install-build-deps-linux-desktop.sh
+++ b/build/install-build-deps-linux-desktop.sh
@@ -8,4 +8,4 @@
 
 set -e
 
-sudo apt-get -y install libglfw3-dev libepoxy-dev libgtk-3-dev libx11-dev
+sudo apt-get -y install libglfw3-dev libgtk-3-dev libx11-dev

--- a/shell/platform/glfw/BUILD.gn
+++ b/shell/platform/glfw/BUILD.gn
@@ -59,7 +59,6 @@ source_set("flutter_glfw") {
     libs = [ "GL" ]
 
     configs += [
-      "$flutter_root/shell/platform/linux/config:epoxy",
       "$flutter_root/shell/platform/linux/config:glfw3",
       "$flutter_root/shell/platform/linux/config:gtk3",
       "$flutter_root/shell/platform/linux/config:x11",

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -10,11 +10,6 @@
 #include <cstdlib>
 #include <iostream>
 
-#ifdef __linux__
-// Epoxy must be included before any graphics-related code.
-#include <epoxy/gl.h>
-#endif
-
 #include <GLFW/glfw3.h>
 
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h"

--- a/shell/platform/linux/config/BUILD.gn
+++ b/shell/platform/linux/config/BUILD.gn
@@ -4,10 +4,6 @@
 
 import("//build/config/linux/pkg_config.gni")
 
-pkg_config("epoxy") {
-  packages = [ "epoxy" ]
-}
-
 pkg_config("glfw3") {
   packages = [ "glfw3" ]
 }


### PR DESCRIPTION
Simplifies the build and runtime requirements for the Linux shell.
Since the engine does GL extension lookup manually anway, an extension
loader library isn't necessary.