### PR TITLE
Cleanups to run_tests.sh script

### DIFF
--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -15,6 +15,12 @@ echo "Using build root: $BUILDROOT_DIR"
 OUT_DIR="$BUILDROOT_DIR/out"
 HOST_DIR="$OUT_DIR/${1:-host_debug_unopt}"
 
+# Check a Dart SDK has been built.
+if [[ ! -d "$HOST_DIR/dart-sdk" ]]; then
+  echo "Built Dart SDK not found at $HOST_DIR/dart-sdk. Exiting."
+  exit 1
+fi
+
 # Switch to buildroot dir. Some tests assume paths relative to buildroot.
 cd "$BUILDROOT_DIR"
 
@@ -38,15 +44,14 @@ echo "Running synchronization_unittests..."
 echo "Running txt_unittests..."
 "$HOST_DIR/txt_unittests" --font-directory="$BUILDROOT_DIR/flutter/third_party/txt/third_party/fonts"
 
-# pubspec.yaml points to these files
+# Build flutter/sky/packages.
+#
+# flutter/testing/dart/pubspec.yaml contains harcoded path deps to
+# host_debug_unopt packages.
 "$BUILDROOT_DIR/flutter/tools/gn" --unoptimized
 ninja -C $OUT_DIR/host_debug_unopt flutter/sky/packages
 
 # Fetch Dart test dependencies.
-if [[ ! -x "$HOST_DIR/dart-sdk/bin/pub" ]]; then
-  echo "Pub executable not found. Ensure Dart SDK has been built."
-  exit 1
-fi
 pushd "$BUILDROOT_DIR/flutter/testing/dart"
 "$HOST_DIR/dart-sdk/bin/pub" get
 popd


### PR DESCRIPTION
Bugfix:
* Use the `pub` from within the built Dart SDK (not whatever's on
  `$PATH`, if anything).

A few minor improvements:
* Allow running from below the src/ buildroot dir, as it's often
  convenient to work from within the flutter/engine git dir.
* Echo test name before running, for slightly better debuggability.
* Minor line-wrapping for readability.