### PR TITLE
optimize vsync performance

### DIFF
--- a/shell/platform/android/io/flutter/view/VsyncWaiter.java
+++ b/shell/platform/android/io/flutter/view/VsyncWaiter.java
@@ -19,12 +19,11 @@ public class VsyncWaiter {
     private static HandlerThread handlerThread;
     private static Handler handler;
 
-    static {
-        handlerThread = new HandlerThread("FlutterVsyncThread");
-        handlerThread.start();
-    }
-
     public static void asyncWaitForVsync(final long cookie) {
+        if (handlerThread == null) {
+            handlerThread = new HandlerThread("FlutterVsyncThread");
+            handlerThread.start();
+        }
         if (handler == null) {
             handler = new Handler(handlerThread.getLooper());
         }
@@ -39,6 +38,12 @@ public class VsyncWaiter {
                 });
             }
         });
+    }
+
+    public static void release() {
+        handlerThread.quit();
+        handlerThread = null;
+        handler = null;
     }
 
     private static native void nativeOnVsync(long frameTimeNanos, long frameTargetTimeNanos, long cookie);

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -29,13 +29,11 @@ void VsyncWaiterAndroid::AwaitVSync() {
   auto* weak_this = new std::weak_ptr<VsyncWaiter>(shared_from_this());
   jlong java_baton = reinterpret_cast<jlong>(weak_this);
 
-  task_runners_.GetPlatformTaskRunner()->PostTask([java_baton]() {
-    JNIEnv* env = fml::jni::AttachCurrentThread();
-    env->CallStaticVoidMethod(g_vsync_waiter_class->obj(),     //
-                              g_async_wait_for_vsync_method_,  //
-                              java_baton                       //
-    );
-  });
+  JNIEnv* env = fml::jni::AttachCurrentThread();
+  env->CallStaticVoidMethod(g_vsync_waiter_class->obj(),     //
+                            g_async_wait_for_vsync_method_,  //
+                            java_baton                       //
+  );
 }
 
 float VsyncWaiterAndroid::GetDisplayRefreshRate() const {

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -28,6 +28,8 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
   // |VsyncWaiter|
   void AwaitVSync() override;
 
+  void Release();
+
   static void OnNativeVsync(JNIEnv* env,
                             jclass jcaller,
                             jlong frameTimeNanos,


### PR DESCRIPTION
This commit has 2 changes below:

1. For Android, `Choreographer.getInstance().postFrameCallback()`  is posted to platform thread task runnner at present which will cause low performance when platform thread is busy. This will most probable happen in hybrid flutter application. In this change, I create a independent thread for request vsync.

2.  In animator.cc, I use `fml::TaskRunner::RunNowOrPostTask` instead of `task_runners_.GetUITaskRunner()->PostTask` to avoid redundant cost for vsync request.

