### PR TITLE
Allow per-platform customization of the default Skia font manager

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -711,6 +711,7 @@ FILE: ../../../flutter/synchronization/semaphore_unittest.cc
 FILE: ../../../flutter/third_party/txt/src/txt/platform.cc
 FILE: ../../../flutter/third_party/txt/src/txt/platform.h
 FILE: ../../../flutter/third_party/txt/src/txt/platform_android.cc
+FILE: ../../../flutter/third_party/txt/src/txt/platform_linux.cc
 FILE: ../../../flutter/third_party/txt/src/txt/platform_mac.mm
 FILE: ../../../flutter/vulkan/skia_vulkan_header.h
 FILE: ../../../flutter/vulkan/vulkan_application.cc

--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -46,7 +46,7 @@ void _LoadFontFromList(Dart_NativeArguments args) {
 
 FontCollection::FontCollection()
     : collection_(std::make_shared<txt::FontCollection>()) {
-  collection_->SetDefaultFontManager(SkFontMgr::RefDefault());
+  collection_->SetupDefaultFontManager();
 
   dynamic_font_manager_ = sk_make_sp<txt::DynamicFontManager>();
   collection_->SetDynamicFontManager(dynamic_font_manager_);

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -123,6 +123,8 @@ source_set("txt") {
     deps += [ "$flutter_root/fml" ]
   } else if (is_android) {
     sources += [ "src/txt/platform_android.cc" ]
+  } else if (is_linux) {
+    sources += [ "src/txt/platform_linux.cc" ]
   } else {
     sources += [ "src/txt/platform.cc" ]
   }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -87,8 +87,8 @@ size_t FontCollection::GetFontManagersCount() const {
   return GetFontManagerOrder().size();
 }
 
-void FontCollection::SetDefaultFontManager(sk_sp<SkFontMgr> font_manager) {
-  default_font_manager_ = font_manager;
+void FontCollection::SetupDefaultFontManager() {
+  default_font_manager_ = GetDefaultFontManager();
 }
 
 void FontCollection::SetAssetFontManager(sk_sp<SkFontMgr> font_manager) {

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -40,7 +40,7 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
 
   size_t GetFontManagersCount() const;
 
-  void SetDefaultFontManager(sk_sp<SkFontMgr> font_manager);
+  void SetupDefaultFontManager();
   void SetAssetFontManager(sk_sp<SkFontMgr> font_manager);
   void SetDynamicFontManager(sk_sp<SkFontMgr> font_manager);
   void SetTestFontManager(sk_sp<SkFontMgr> font_manager);

--- a/third_party/txt/src/txt/platform.h
+++ b/third_party/txt/src/txt/platform.h
@@ -8,9 +8,13 @@
 #include <string>
 #include "flutter/fml/macros.h"
 
+#include "third_party/skia/include/core/SkFontMgr.h"
+
 namespace txt {
 
 std::string GetDefaultFontFamily();
+
+sk_sp<SkFontMgr> GetDefaultFontManager();
 
 }  // namespace txt
 

--- a/third_party/txt/src/txt/platform_android.cc
+++ b/third_party/txt/src/txt/platform_android.cc
@@ -10,4 +10,8 @@ std::string GetDefaultFontFamily() {
   return "sans-serif";
 }
 
+sk_sp<SkFontMgr> GetDefaultFontManager() {
+  return SkFontMgr::RefDefault();
+}
+
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_linux.cc
+++ b/third_party/txt/src/txt/platform_linux.cc
@@ -4,6 +4,8 @@
 
 #include "txt/platform.h"
 
+#include "third_party/skia/include/ports/SkFontMgr_directory.h"
+
 namespace txt {
 
 std::string GetDefaultFontFamily() {
@@ -11,7 +13,7 @@ std::string GetDefaultFontFamily() {
 }
 
 sk_sp<SkFontMgr> GetDefaultFontManager() {
-  return SkFontMgr::RefDefault();
+  return SkFontMgr_New_Custom_Directory("/usr/share/fonts/");
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/platform_mac.mm
+++ b/third_party/txt/src/txt/platform_mac.mm
@@ -24,4 +24,8 @@ std::string GetDefaultFontFamily() {
   }
 }
 
+sk_sp<SkFontMgr> GetDefaultFontManager() {
+  return SkFontMgr::RefDefault();
+}
+
 }  // namespace txt


### PR DESCRIPTION
The font manager returned by SkFontMgr::RefDefault is determined by Skia's
build configuration flags.  Embedders may want to use a default font manager
other than the one selected by their build of Skia.