### PR TITLE
update buildroot dep for PR #227

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -121,7 +121,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ad098fcdb1b41fcf57c22e46e898d0dc04d3a178',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'e2ca4571fa39be20ab1bf67c65d4700612756af2',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
Update buildroot dep for [support another version of libnspr4](https://github.com/flutter/buildroot/pull/227).