### PR TITLE
Ensure OpacityLayer to have a single child

### DIFF
--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -35,6 +35,9 @@ class ContainerLayer : public Layer {
   void UpdateSceneChildren(SceneUpdateContext& context);
 #endif  // defined(OS_FUCHSIA)
 
+  // For OpacityLayer to restructure to have a single child.
+  void ClearChildren() { layers_.clear(); }
+
  private:
   std::vector<std::shared_ptr<Layer>> layers_;
 

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -28,11 +28,13 @@ class OpacityLayer : public ContainerLayer {
   int alpha_;
   SkPoint offset_;
 
-  // Manually ensured that OpacityLayer has only one child so we can optimize
-  // the costly saveLayer.
+  // Restructure (if necessary) OpacityLayer to have only one child.
   //
-  // If there are multiple children, we'll create a new identity TransformLayer,
-  // set all children to be the children of that TransformLayer, and set that
+  // This is needed to ensure that retained rendering can always be applied to
+  // save the costly saveLayer.
+  //
+  // If there are multiple children, this creates a new identity TransformLayer,
+  // sets all children to be the TransformLayer's children, and sets that
   // TransformLayer as the single child of this OpacityLayer.
   void EnsureSingleChild();
 

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -28,6 +28,14 @@ class OpacityLayer : public ContainerLayer {
   int alpha_;
   SkPoint offset_;
 
+  // Manually ensured that OpacityLayer has only one child so we can optimize
+  // the costly saveLayer.
+  //
+  // If there are multiple children, we'll create a new identity TransformLayer,
+  // set all children to be the children of that TransformLayer, and set that
+  // TransformLayer as the single child of this OpacityLayer.
+  void EnsureSingleChild();
+
   FML_DISALLOW_COPY_AND_ASSIGN(OpacityLayer);
 };
 


### PR DESCRIPTION
It ensures that every OpacityLayer can be optimized by retained
rendering.

Tested with `flutter test --local-engine=host_debug_unopt` in
flutter/flutter/packages/flutter.

Related issues: flutter/flutter#21756 flutter/flutter#23535