### PR TITLE
libtxt: track the start and end x positions of glyph blobs for more accurate rendering of text decorations

### DIFF
--- a/third_party/txt/src/txt/paint_record.cc
+++ b/third_party/txt/src/txt/paint_record.cc
@@ -26,27 +26,31 @@ PaintRecord::PaintRecord(TextStyle style,
                          sk_sp<SkTextBlob> text,
                          SkFontMetrics metrics,
                          size_t line,
-                         double run_width,
+                         double x_start,
+                         double x_end,
                          bool is_ghost)
     : style_(style),
       offset_(offset),
       text_(std::move(text)),
       metrics_(metrics),
       line_(line),
-      run_width_(run_width),
+      x_start_(x_start),
+      x_end_(x_end),
       is_ghost_(is_ghost) {}
 
 PaintRecord::PaintRecord(TextStyle style,
                          sk_sp<SkTextBlob> text,
                          SkFontMetrics metrics,
                          size_t line,
-                         double run_width,
+                         double x_start,
+                         double x_end,
                          bool is_ghost)
     : style_(style),
       text_(std::move(text)),
       metrics_(metrics),
       line_(line),
-      run_width_(run_width),
+      x_start_(x_start),
+      x_end_(x_end),
       is_ghost_(is_ghost) {}
 
 PaintRecord::PaintRecord(PaintRecord&& other) {
@@ -55,7 +59,9 @@ PaintRecord::PaintRecord(PaintRecord&& other) {
   text_ = std::move(other.text_);
   metrics_ = other.metrics_;
   line_ = other.line_;
-  run_width_ = other.run_width_, is_ghost_ = other.is_ghost_;
+  x_start_ = other.x_start_;
+  x_end_ = other.x_end_;
+  is_ghost_ = other.is_ghost_;
 }
 
 PaintRecord& PaintRecord::operator=(PaintRecord&& other) {
@@ -64,7 +70,8 @@ PaintRecord& PaintRecord::operator=(PaintRecord&& other) {
   text_ = std::move(other.text_);
   metrics_ = other.metrics_;
   line_ = other.line_;
-  run_width_ = other.run_width_;
+  x_start_ = other.x_start_;
+  x_end_ = other.x_end_;
   is_ghost_ = other.is_ghost_;
   return *this;
 }

--- a/third_party/txt/src/txt/paint_record.h
+++ b/third_party/txt/src/txt/paint_record.h
@@ -39,14 +39,16 @@ class PaintRecord {
               sk_sp<SkTextBlob> text,
               SkFontMetrics metrics,
               size_t line,
-              double run_width,
+              double x_start,
+              double x_end,
               bool is_ghost);
 
   PaintRecord(TextStyle style,
               sk_sp<SkTextBlob> text,
               SkFontMetrics metrics,
               size_t line,
-              double run_width,
+              double x_start,
+              double x_end,
               bool is_ghost);
 
   PaintRecord(PaintRecord&& other);
@@ -65,7 +67,9 @@ class PaintRecord {
 
   size_t line() const { return line_; }
 
-  double GetRunWidth() const { return run_width_; }
+  double x_start() const { return x_start_; }
+  double x_end() const { return x_end_; }
+  double GetRunWidth() const { return x_end_ - x_start_; }
 
   bool isGhost() const { return is_ghost_; }
 
@@ -78,7 +82,8 @@ class PaintRecord {
   // FontMetrics stores the measurements of the font used.
   SkFontMetrics metrics_;
   size_t line_;
-  double run_width_ = 0.0f;
+  double x_start_ = 0.0f;
+  double x_end_ = 0.0f;
   // 'Ghost' runs represent trailing whitespace. 'Ghost' runs should not have
   // decorations painted on them and do not impact layout of visible glyphs.
   bool is_ghost_ = false;

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -789,10 +789,13 @@ void Paragraph::Layout(double width, bool force) {
           continue;
         SkFontMetrics metrics;
         font.getMetrics(&metrics);
+        Range<double> record_x_pos(
+            glyph_positions.front().x_pos.start - run_x_offset,
+            glyph_positions.back().x_pos.end - run_x_offset);
         paint_records.emplace_back(
             run.style(), SkPoint::Make(run_x_offset + justify_x_offset, 0),
-            builder.make(), metrics, line_number,
-            layout.getAdvance() + justify_x_offset_delta, run.is_ghost());
+            builder.make(), metrics, line_number, record_x_pos.start,
+            record_x_pos.end, run.is_ghost());
         justify_x_offset += justify_x_offset_delta;
 
         line_glyph_positions.insert(line_glyph_positions.end(),
@@ -1070,7 +1073,7 @@ void Paragraph::PaintDecorations(SkCanvas* canvas,
                        record.style().decoration_thickness_multiplier);
 
   SkPoint record_offset = base_offset + record.offset();
-  SkScalar x = record_offset.x();
+  SkScalar x = record_offset.x() + record.x_start();
   SkScalar y = record_offset.y();
 
   // Setup the decorations.
@@ -1196,8 +1199,8 @@ void Paragraph::PaintBackground(SkCanvas* canvas,
     return;
 
   const SkFontMetrics& metrics = record.metrics();
-  SkRect rect(SkRect::MakeLTRB(0, metrics.fAscent, record.GetRunWidth(),
-                               metrics.fDescent));
+  SkRect rect(SkRect::MakeLTRB(record.x_start(), metrics.fAscent,
+                               record.x_end(), metrics.fDescent));
   rect.offset(base_offset + record.offset());
   canvas->drawRect(rect, record.style().background);
 }

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -2914,10 +2914,10 @@ TEST_F(ParagraphTest, FontFallbackParagraph) {
 
   ASSERT_EQ(paragraph->records_.size(), 5ull);
   ASSERT_DOUBLE_EQ(paragraph->records_[0].GetRunWidth(), 64.19921875);
-  ASSERT_DOUBLE_EQ(paragraph->records_[1].GetRunWidth(), 167.1171875);
-  ASSERT_DOUBLE_EQ(paragraph->records_[2].GetRunWidth(), 167.1171875);
-  ASSERT_DOUBLE_EQ(paragraph->records_[3].GetRunWidth(), 90.24609375);
-  ASSERT_DOUBLE_EQ(paragraph->records_[4].GetRunWidth(), 90.24609375);
+  ASSERT_DOUBLE_EQ(paragraph->records_[1].GetRunWidth(), 139.1171875);
+  ASSERT_DOUBLE_EQ(paragraph->records_[2].GetRunWidth(), 28);
+  ASSERT_DOUBLE_EQ(paragraph->records_[3].GetRunWidth(), 62.24609375);
+  ASSERT_DOUBLE_EQ(paragraph->records_[4].GetRunWidth(), 28);
   // When a different font is resolved, then the metrics are different.
   ASSERT_TRUE(paragraph->records_[2].metrics().fTop -
                   paragraph->records_[4].metrics().fTop !=


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/30041
Fixes https://github.com/flutter/flutter/issues/24337