### PR TITLE
GN Format all files in the engine.

### DIFF
--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -44,7 +44,8 @@ template("dart_pkg_helper") {
       sdk_ext_mappings += invoker.sdk_ext_mappings
     }
 
-    script = rebase_path("$flutter_root/build/dart/tools/dart_pkg.py", ".", "//")
+    script =
+        rebase_path("$flutter_root/build/dart/tools/dart_pkg.py", ".", "//")
 
     entrypoints = []
     if (defined(invoker.apps)) {
@@ -61,7 +62,8 @@ template("dart_pkg_helper") {
     if (defined(invoker.sources)) {
       sources += invoker.sources
     } else if (defined(invoker.pkg_dir)) {
-      list_script = rebase_path("$flutter_root/build/dart/tools/ls.py", ".", "//")
+      list_script =
+          rebase_path("$flutter_root/build/dart/tools/ls.py", ".", "//")
       extra_flags += [ "--read_only" ]
       ls_sources = exec_script(list_script,
                                [
@@ -113,7 +115,9 @@ template("dart_pkg") {
     pubspec_yaml_path = rebase_path("pubspec.yaml")
   }
   dart_package_name_script =
-      rebase_path("$flutter_root/build/dart/tools/dart_package_name.py", ".", "//")
+      rebase_path("$flutter_root/build/dart/tools/dart_package_name.py",
+                  ".",
+                  "//")
   dart_package_name = exec_script(dart_package_name_script,
                                   [
                                     "--pubspec",

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -80,8 +80,8 @@ source_set("flow") {
     ]
 
     public_deps += [
-      "//sdk/fidl/fuchsia.ui.scenic",
       "//garnet/public/lib/ui/scenic/cpp",
+      "//sdk/fidl/fuchsia.ui.scenic",
       "//topaz/public/dart-pkg/zircon",
     ]
 
@@ -94,18 +94,18 @@ executable("flow_unittests") {
 
   sources = [
     "flow_run_all_unittests.cc",
-    "flow_test_utils.h",
     "flow_test_utils.cc",
+    "flow_test_utils.h",
+    "layers/performance_overlay_layer_unittests.cc",
     "matrix_decomposition_unittests.cc",
     "raster_cache_unittests.cc",
-    "layers/performance_overlay_layer_unittests.cc",
   ]
 
   deps = [
     ":flow",
     "$flutter_root/fml",
-    "//third_party/googletest:gtest",
     "//third_party/dart/runtime:libdart_jit",  # for tracing
+    "//third_party/googletest:gtest",
     "//third_party/skia",
   ]
 }

--- a/flutter_kernel_transformers/BUILD.gn
+++ b/flutter_kernel_transformers/BUILD.gn
@@ -15,9 +15,9 @@ dart_library("flutter_kernel_transformers") {
   ]
 
   deps = [
+    "//third_party/dart-pkg/pub/meta",
     "//third_party/dart/pkg/front_end",
     "//third_party/dart/pkg/kernel",
     "//third_party/dart/pkg/vm",
-    "//third_party/dart-pkg/pub/meta",
   ]
 }

--- a/frontend_server/BUILD.gn
+++ b/frontend_server/BUILD.gn
@@ -15,14 +15,14 @@ if (is_fuchsia_host || is_fuchsia) {
     ]
 
     deps = [
+      "//third_party/dart-pkg/pub/args",
+      "//third_party/dart-pkg/pub/path",
+      "//third_party/dart-pkg/pub/usage",
       "//third_party/dart/pkg/build_integration",
       "//third_party/dart/pkg/front_end",
       "//third_party/dart/pkg/kernel",
       "//third_party/dart/pkg/vm",
-      "//third_party/dart-pkg/pub/args",
-      "//third_party/dart-pkg/pub/path",
-      "//third_party/dart-pkg/pub/usage",
-      "//third_party/flutter/flutter_kernel_transformers"
+      "//third_party/flutter/flutter_kernel_transformers",
     ]
   }
 
@@ -48,16 +48,34 @@ if (is_fuchsia_host || is_fuchsia) {
     ]
     dot_packages = rebase_path(".packages")
     flutter_patched_sdk = rebase_path("$root_out_dir/flutter_patched_sdk")
-    training_args = [ "--train", "--sdk-root=$flutter_patched_sdk" ]
+    training_args = [
+      "--train",
+      "--sdk-root=$flutter_patched_sdk",
+    ]
 
-    frontend_server_files = exec_script("//third_party/dart/tools/list_dart_files.py",
-      [ "absolute", rebase_path("."), ], "list lines")
+    frontend_server_files =
+        exec_script("//third_party/dart/tools/list_dart_files.py",
+                    [
+                      "absolute",
+                      rebase_path("."),
+                    ],
+                    "list lines")
 
-    frontend_server_files += exec_script("//third_party/dart/tools/list_dart_files.py",
-      [ "absolute", rebase_path("../flutter_kernel_transformers"), ], "list lines")
+    frontend_server_files +=
+        exec_script("//third_party/dart/tools/list_dart_files.py",
+                    [
+                      "absolute",
+                      rebase_path("../flutter_kernel_transformers"),
+                    ],
+                    "list lines")
 
-    frontend_server_files += exec_script("//third_party/dart/tools/list_dart_files.py",
-      [ "absolute", rebase_path("../../third_party/dart/pkg"), ], "list lines")
+    frontend_server_files +=
+        exec_script("//third_party/dart/tools/list_dart_files.py",
+                    [
+                      "absolute",
+                      rebase_path("../../third_party/dart/pkg"),
+                    ],
+                    "list lines")
 
     inputs = frontend_server_files
   }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -20,7 +20,8 @@ compiled_action("generate_snapshot_bin") {
   tool = "//third_party/dart/runtime/bin:gen_snapshot"
 
   if (is_fuchsia || is_fuchsia_host) {
-    platform_kernel = "$root_out_dir/flutter_runner_patched_sdk/platform_strong.dill"
+    platform_kernel =
+        "$root_out_dir/flutter_runner_patched_sdk/platform_strong.dill"
   } else {
     platform_kernel = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
   }
@@ -55,12 +56,10 @@ compiled_action("generate_snapshot_bin") {
   ]
 
   if (is_debug) {
-    args += [
-      "--enable_asserts",
-    ]
+    args += [ "--enable_asserts" ]
   }
 
-  args += [rebase_path(platform_kernel)]
+  args += [ rebase_path(platform_kernel) ]
 }
 
 # Generates an assembly file defining a given symbol with the bytes from a
@@ -219,21 +218,22 @@ source_set("snapshot") {
   deps = [
     ":isolate_snapshot_data_linkable",
     ":isolate_snapshot_instructions_linkable",
+    ":platform_strong_dill_linkable",
     ":vm_snapshot_data_linkable",
     ":vm_snapshot_instructions_linkable",
-    ":platform_strong_dill_linkable",
   ]
   sources = get_target_outputs(":isolate_snapshot_data_linkable") +
-    get_target_outputs(":isolate_snapshot_instructions_linkable") +
-    get_target_outputs(":vm_snapshot_data_linkable") +
-    get_target_outputs(":vm_snapshot_instructions_linkable") +
-    get_target_outputs(":platform_strong_dill_linkable")
+            get_target_outputs(":isolate_snapshot_instructions_linkable") +
+            get_target_outputs(":vm_snapshot_data_linkable") +
+            get_target_outputs(":vm_snapshot_instructions_linkable") +
+            get_target_outputs(":platform_strong_dill_linkable")
 }
 
 compile_platform("non_strong_platform") {
   single_root_scheme = "org-dartlang-sdk"
   single_root_base = rebase_path("../../../")
-  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
+  libraries_specification_uri =
+      "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform.dill",
@@ -249,7 +249,8 @@ compile_platform("non_strong_platform") {
 compile_platform("strong_platform") {
   single_root_scheme = "org-dartlang-sdk"
   single_root_base = rebase_path("../../../")
-  libraries_specification_uri = "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
+  libraries_specification_uri =
+      "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
 
   outputs = [
     "$root_out_dir/flutter_patched_sdk/platform_strong.dill",
@@ -266,7 +267,7 @@ compile_platform("strong_platform") {
 if (is_fuchsia || is_fuchsia_host) {
   group("kernel_platform_files") {
     public_deps = [
-      "//topaz/runtime/flutter_runner/kernel:kernel_platform_files"
+      "//topaz/runtime/flutter_runner/kernel:kernel_platform_files",
     ]
   }
 } else {

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -73,7 +73,9 @@ source_set("runtime") {
       flutter_runtime_mode != "dynamic_release" && !is_fuchsia) {
     # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
     # instead puts Observatory into the runner's package.
-    deps += [ "//third_party/dart/runtime/observatory:embedded_observatory_archive" ]
+    deps += [
+      "//third_party/dart/runtime/observatory:embedded_observatory_archive",
+    ]
   }
 }
 

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/testing/testing.gni")
 import("$flutter_root/shell/gpu/gpu.gni")
+import("$flutter_root/testing/testing.gni")
 
 # Template to generate a dart embedder resource.cc file.
 # Required invoker inputs:

--- a/shell/platform/BUILD.gn
+++ b/shell/platform/BUILD.gn
@@ -17,7 +17,7 @@ group("platform") {
     deps = [
       "windows",
     ]
-  } else if ( is_fuchsia) {
+  } else if (is_fuchsia) {
     # Fuchsia has its own runner implementation.
     deps = []
   } else {

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/config.gni")
-import("$flutter_root/shell/config.gni")
 import("//build/config/android/config.gni")
 import("//build/config/android/rules.gni")
+import("$flutter_root/common/config.gni")
+import("$flutter_root/shell/config.gni")
 import("$flutter_root/shell/gpu/gpu.gni")
 
 shell_gpu_configuration("android_gpu_configuration") {
@@ -20,6 +20,7 @@ shared_library("flutter_shell_native") {
   output_name = "flutter"
 
   sources = [
+    "$root_build_dir/flutter_icu/icudtl.o",
     "android_context_gl.cc",
     "android_context_gl.h",
     "android_environment_gl.cc",
@@ -49,7 +50,6 @@ shared_library("flutter_shell_native") {
     "platform_view_android_jni.h",
     "vsync_waiter_android.cc",
     "vsync_waiter_android.h",
-    "$root_build_dir/flutter_icu/icudtl.o",
   ]
 
   deps = [
@@ -96,7 +96,7 @@ shared_library("flutter_shell_native") {
     "GLESv2",
   ]
 
-  ldflags = ["-Wl,--version-script=" + rebase_path("android_exports.lst")]
+  ldflags = [ "-Wl,--version-script=" + rebase_path("android_exports.lst") ]
 }
 
 java_library("flutter_shell_java") {
@@ -181,17 +181,16 @@ java_library("flutter_shell_java") {
     "io/flutter/view/VsyncWaiter.java",
   ]
 
-  java_files += [
-    "$flutter_root/third_party/bsdiff/io/flutter/util/BSDiff.java",
-  ]
+  java_files +=
+      [ "$flutter_root/third_party/bsdiff/io/flutter/util/BSDiff.java" ]
 
   deps = [
-    ":android_support_v13",
+    ":android_arch_lifecycle_common",
+    ":android_arch_lifecycle_viewmodel",
     ":android_support_annotations",
     ":android_support_compat",
     ":android_support_fragment",
-    ":android_arch_lifecycle_common",
-    ":android_arch_lifecycle_viewmodel",
+    ":android_support_v13",
   ]
 
   jar_path = "$root_out_dir/flutter_java.jar"
@@ -230,7 +229,8 @@ java_prebuilt("android_arch_lifecycle_common") {
 java_prebuilt("android_arch_lifecycle_viewmodel") {
   supports_android = true
 
-  jar_path = "//third_party/android_support/android_arch_lifecycle_viewmodel.jar"
+  jar_path =
+      "//third_party/android_support/android_arch_lifecycle_viewmodel.jar"
 }
 
 action("icudtl_object") {
@@ -248,10 +248,14 @@ action("icudtl_object") {
   ]
 
   args = [
-    "--objcopy", rebase_path(android_objcopy),
-    "--input", rebase_path(icudtl_input),
-    "--output", rebase_path(icudtl_output),
-    "--arch", current_cpu,
+    "--objcopy",
+    rebase_path(android_objcopy),
+    "--input",
+    rebase_path(icudtl_input),
+    "--output",
+    rebase_path(icudtl_output),
+    "--arch",
+    current_cpu,
   ]
 }
 

--- a/shell/platform/darwin/framework_shared.gni
+++ b/shell/platform/darwin/framework_shared.gni
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-framework_shared_headers = get_path_info(
+framework_shared_headers =
+    get_path_info(
         [
           # TODO: Move these files, and their implementations, to a shared
           # location.

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -4,8 +4,8 @@
 
 assert(is_ios)
 
-import("$flutter_root/common/config.gni")
 import("//build/config/ios/ios_sdk.gni")
+import("$flutter_root/common/config.gni")
 import("$flutter_root/shell/gpu/gpu.gni")
 
 _flutter_framework_dir = "$root_out_dir/Flutter.framework"
@@ -61,9 +61,9 @@ shared_library("create_flutter_framework_dylib") {
     "framework/Source/FlutterOverlayView.mm",
     "framework/Source/FlutterPlatformPlugin.h",
     "framework/Source/FlutterPlatformPlugin.mm",
+    "framework/Source/FlutterPlatformViews.mm",
     "framework/Source/FlutterPlatformViews_Internal.h",
     "framework/Source/FlutterPlatformViews_Internal.mm",
-    "framework/Source/FlutterPlatformViews.mm",
     "framework/Source/FlutterPluginAppLifeCycleDelegate.mm",
     "framework/Source/FlutterStandardCodec.mm",
     "framework/Source/FlutterStandardCodec_Internal.h",

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -7,8 +7,8 @@ assert(is_linux)
 group("linux") {
   deps = [
     ":flutter_linux",
-    "$flutter_root/shell/platform/glfw:publish_headers_glfw",
     "$flutter_root/shell/platform/common/cpp/client_wrapper:publish_wrapper",
+    "$flutter_root/shell/platform/glfw:publish_headers_glfw",
     "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
   ]
 }

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -7,8 +7,8 @@ assert(is_win)
 group("windows") {
   deps = [
     ":flutter_windows",
-    "$flutter_root/shell/platform/glfw:publish_headers_glfw",
     "$flutter_root/shell/platform/common/cpp/client_wrapper:publish_wrapper",
+    "$flutter_root/shell/platform/glfw:publish_headers_glfw",
     "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
   ]
 }

--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -2,12 +2,12 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//third_party/dart/sdk/lib/_http/http_sources.gni")
 import("//third_party/dart/sdk/lib/async/async_sources.gni")
 import("//third_party/dart/sdk/lib/collection/collection_sources.gni")
 import("//third_party/dart/sdk/lib/convert/convert_sources.gni")
 import("//third_party/dart/sdk/lib/core/core_sources.gni")
 import("//third_party/dart/sdk/lib/developer/developer_sources.gni")
-import("//third_party/dart/sdk/lib/_http/http_sources.gni")
 import("//third_party/dart/sdk/lib/internal/internal_sources.gni")
 import("//third_party/dart/sdk/lib/io/io_sources.gni")
 import("//third_party/dart/sdk/lib/isolate/isolate_sources.gni")
@@ -29,75 +29,94 @@ if (!is_fuchsia) {
   }
 }
 
-
 dart_sdk_lib_path = rebase_path("//third_party/dart/sdk/lib")
 
 copy("async") {
   lib_path = rebase_path("async", "", dart_sdk_lib_path)
   sources = rebase_path(async_sdk_sources, "", lib_path)
   outputs = [
-    "$root_gen_dir/dart-pkg/sky_engine/lib/async/{{source_file_part}}"
+    "$root_gen_dir/dart-pkg/sky_engine/lib/async/{{source_file_part}}",
   ]
 }
 
 copy("collection") {
   lib_path = rebase_path("collection", "", dart_sdk_lib_path)
   sources = rebase_path(collection_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/collection/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/collection/{{source_file_part}}",
+  ]
 }
 
 copy("convert") {
   lib_path = rebase_path("convert", "", dart_sdk_lib_path)
   sources = rebase_path(convert_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/convert/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/convert/{{source_file_part}}",
+  ]
 }
 
 copy("core") {
   lib_path = rebase_path("core", "", dart_sdk_lib_path)
   sources = rebase_path(core_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/core/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/core/{{source_file_part}}",
+  ]
 }
 
 copy("developer") {
   lib_path = rebase_path("developer", "", dart_sdk_lib_path)
   sources = rebase_path(developer_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/developer/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/developer/{{source_file_part}}",
+  ]
 }
 
 copy("_http") {
   lib_path = rebase_path("_http", "", dart_sdk_lib_path)
   sources = rebase_path(http_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/_http/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/_http/{{source_file_part}}",
+  ]
 }
 
 copy("internal") {
   lib_path = rebase_path("internal", "", dart_sdk_lib_path)
   sources = rebase_path(internal_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/internal/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/internal/{{source_file_part}}",
+  ]
 }
 
 copy("io") {
   lib_path = rebase_path("io", "", dart_sdk_lib_path)
   sources = rebase_path(io_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/io/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/io/{{source_file_part}}",
+  ]
 }
 
 copy("isolate") {
   lib_path = rebase_path("isolate", "", dart_sdk_lib_path)
   sources = rebase_path(isolate_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/isolate/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/isolate/{{source_file_part}}",
+  ]
 }
 
 copy("math") {
   lib_path = rebase_path("math", "", dart_sdk_lib_path)
   sources = rebase_path(math_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/math/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/math/{{source_file_part}}",
+  ]
 }
 
 copy("typed_data") {
   lib_path = rebase_path("typed_data", "", dart_sdk_lib_path)
   sources = rebase_path(typed_data_sdk_sources, "", lib_path)
-  outputs = [ "$root_gen_dir/dart-pkg/sky_engine/lib/typed_data/{{source_file_part}}" ]
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/typed_data/{{source_file_part}}",
+  ]
 }
 
 copy("copy_dart_ui") {
@@ -110,12 +129,12 @@ copy("copy_dart_ui") {
 
 group("copy_dart_sdk") {
   deps = [
+    ":_http",
     ":async",
     ":collection",
     ":convert",
     ":core",
     ":developer",
-    ":_http",
     ":internal",
     ":io",
     ":isolate",

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/config.gni")
 import("//build/compiled_action.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
+import("$flutter_root/common/config.gni")
 
 # Builds test fixtures for a unit test.
 #
@@ -33,7 +33,8 @@ template("test_fixtures") {
   }
 
   fixtures_location = "$target_gen_dir/$target_name/assets"
-  fixtures_location_file = "$target_gen_dir/$target_name/test_fixtures_location.cc"
+  fixtures_location_file =
+      "$target_gen_dir/$target_name/test_fixtures_location.cc"
 
   fixtures_name_target_name = target_name + "_gen_fixtures_name"
   action(fixtures_name_target_name) {
@@ -73,30 +74,37 @@ template("test_fixtures") {
       fixture_paths += [ rebase_path(fixture) ]
     }
     inputs = fixture_paths
-    outputs = ["$fixtures_location/$kernel_out"]
+    outputs = [
+      "$fixtures_location/$kernel_out",
+    ]
 
     deps = [
-      "//third_party/dart/utils/kernel-service:frontend_server"
+      "//third_party/dart/utils/kernel-service:frontend_server",
     ]
 
     if (flutter_runtime_mode == "profile" || flutter_runtime_mode == "release") {
       args = [
-        "--sdk-root", rebase_path("$root_out_dir/flutter_patched_sdk"),
-        "--strong",
-        "--target=flutter",
-        "--aot",
-        "--tfa",
-        "-Ddart.vm.product=true",
-        "--output-dill", rebase_path("$fixtures_location/$kernel_out"),
-      ] + fixture_paths
+               "--sdk-root",
+               rebase_path("$root_out_dir/flutter_patched_sdk"),
+               "--strong",
+               "--target=flutter",
+               "--aot",
+               "--tfa",
+               "-Ddart.vm.product=true",
+               "--output-dill",
+               rebase_path("$fixtures_location/$kernel_out"),
+             ] + fixture_paths
 
       deps += [ "//flutter/lib/snapshot:strong_platform" ]
     } else {
       args = [
-        "--sdk-root", rebase_path("$root_out_dir/flutter_patched_sdk"),
-        "--target", "flutter",
-        "--output-dill", rebase_path("$fixtures_location/$kernel_out"),
-      ] + fixture_paths
+               "--sdk-root",
+               rebase_path("$root_out_dir/flutter_patched_sdk"),
+               "--target",
+               "flutter",
+               "--output-dill",
+               rebase_path("$fixtures_location/$kernel_out"),
+             ] + fixture_paths
     }
   }
 
@@ -106,7 +114,7 @@ template("test_fixtures") {
     tool = "//third_party/dart/runtime/bin:gen_snapshot"
 
     inputs = [
-      "$fixtures_location/$kernel_out"
+      "$fixtures_location/$kernel_out",
     ]
 
     outputs = [
@@ -120,11 +128,15 @@ template("test_fixtures") {
       "--causal_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-blobs",
-      "--vm_snapshot_data=" + rebase_path("$fixtures_location/vm_snapshot_data"),
-      "--vm_snapshot_instructions=" + rebase_path("$fixtures_location/vm_snapshot_instr"),
-      "--isolate_snapshot_data=" + rebase_path("$fixtures_location/isolate_snapshot_data"),
-      "--isolate_snapshot_instructions=" + rebase_path("$fixtures_location/isolate_snapshot_instr"),
-      rebase_path("$fixtures_location/$kernel_out")
+      "--vm_snapshot_data=" +
+          rebase_path("$fixtures_location/vm_snapshot_data"),
+      "--vm_snapshot_instructions=" +
+          rebase_path("$fixtures_location/vm_snapshot_instr"),
+      "--isolate_snapshot_data=" +
+          rebase_path("$fixtures_location/isolate_snapshot_data"),
+      "--isolate_snapshot_instructions=" +
+          rebase_path("$fixtures_location/isolate_snapshot_instr"),
+      rebase_path("$fixtures_location/$kernel_out"),
     ]
 
     deps = [

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -28,8 +28,8 @@ web_ui_sources = [
 
 group("web_sdk") {
   deps = [
-    ":generate_web_summary_sdk",
     ":flutter_dartdevc_kernel_sdk",
+    ":generate_web_summary_sdk",
   ]
 }
 
@@ -37,7 +37,7 @@ copy("web_ui_sources") {
   sources = web_ui_sources
 
   outputs = [
-    "$root_out_dir/flutter_web_sdk/lib/ui/{{source_file_part}}"
+    "$root_out_dir/flutter_web_sdk/lib/ui/{{source_file_part}}",
   ]
 }
 
@@ -47,7 +47,7 @@ copy("web_ui_library") {
   ]
 
   outputs = [
-    "$root_out_dir/flutter_web_sdk/{{source_file_part}}"
+    "$root_out_dir/flutter_web_sdk/{{source_file_part}}",
   ]
 }
 
@@ -70,8 +70,8 @@ prebuilt_dart_action("generate_web_summary_sdk") {
   ]
 
   deps = [
-    ":web_ui_sources",
     ":web_ui_library",
+    ":web_ui_sources",
     "//third_party/dart:create_sdk",
   ]
 }


### PR DESCRIPTION
No functional change. Just runs `find . -name "*gn" -exec gn format {} \;` over the files in a repo. I thought we already had a presubmit for this. Apparently not. I will enable the same in a subsequent patch.