### PR TITLE
Delay platform view removal to submitFrame.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -255,22 +255,20 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
 void FlutterPlatformViewsController::DetachUnusedLayers() {
   // Clean up disposed views.
   if (!views_waiting_to_dispose_.empty()) {
-    for (std::vector<int64_t>::iterator it = active_composition_order_.begin(); it != active_composition_order_.end();) {
+    for (std::vector<int64_t>::iterator it = active_composition_order_.begin();
+         it != active_composition_order_.end();) {
       int64_t viewId = *it;
       if (views_waiting_to_dispose_.find(viewId) != views_waiting_to_dispose_.end()) {
-        UIView* touch_interceptor = touch_interceptors_[viewId].get();
-        [touch_interceptor removeFromSuperview];
-        views_.erase(viewId);
-        touch_interceptors_.erase(viewId);
-        overlays_.erase(viewId);
         active_composition_order_.erase(it);
       } else {
         ++it;
       }
     }
+    for (int64_t viewId : views_waiting_to_dispose_) {
+      DisposeViewWithID(viewId);
+    }
     views_waiting_to_dispose_.clear();
   }
-
 
   std::unordered_set<int64_t> composition_order_set;
 
@@ -284,6 +282,14 @@ void FlutterPlatformViewsController::DetachUnusedLayers() {
       [overlays_[view_id]->overlay_view.get() removeFromSuperview];
     }
   }
+}
+
+void FlutterPlatformViewsController::DisposeViewWithID(int64_t viewId) {
+  UIView* touch_interceptor = touch_interceptors_[viewId].get();
+  [touch_interceptor removeFromSuperview];
+  views_.erase(viewId);
+  touch_interceptors_.erase(viewId);
+  overlays_.erase(viewId);
 }
 
 void FlutterPlatformViewsController::EnsureOverlayInitialized(int64_t overlay_id) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -101,7 +101,7 @@ void FlutterPlatformViewsController::OnDispose(FlutterMethodCall* call, FlutterR
     return;
   }
   // We wait for next submitFrame to dispose views.
-  views_waiting_to_dispose_.insert(viewId);
+  views_to_dispose_.insert(viewId);
   result(nil);
 }
 
@@ -254,20 +254,20 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
 
 void FlutterPlatformViewsController::DetachUnusedLayers() {
   // Clean up disposed views.
-  if (!views_waiting_to_dispose_.empty()) {
+  if (!views_to_dispose_.empty()) {
     for (std::vector<int64_t>::iterator it = active_composition_order_.begin();
          it != active_composition_order_.end();) {
       int64_t viewId = *it;
-      if (views_waiting_to_dispose_.find(viewId) != views_waiting_to_dispose_.end()) {
+      if (views_to_dispose_.find(viewId) != views_to_dispose_.end()) {
         active_composition_order_.erase(it);
       } else {
         ++it;
       }
     }
-    for (int64_t viewId : views_waiting_to_dispose_) {
+    for (int64_t viewId : views_to_dispose_) {
       DisposeViewWithID(viewId);
     }
-    views_waiting_to_dispose_.clear();
+    views_to_dispose_.clear();
   }
 
   std::unordered_set<int64_t> composition_order_set;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -91,6 +91,8 @@ class FlutterPlatformViewsController {
   GrContext* overlays_gr_context_;
   SkISize frame_size_;
 
+  std::unordered_set<int64_t> views_waiting_to_dispose_;
+
   // A vector of embedded view IDs according to their composition order.
   // The last ID in this vector belond to the that is composited on top of all others.
   std::vector<int64_t> composition_order_;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -91,7 +91,9 @@ class FlutterPlatformViewsController {
   GrContext* overlays_gr_context_;
   SkISize frame_size_;
 
-  std::unordered_set<int64_t> views_waiting_to_dispose_;
+  // Method channel `OnDispose` calls adds the views to be disposed to this set to be disposed on
+  // the next frame.
+  std::unordered_set<int64_t> views_to_dispose_;
 
   // A vector of embedded view IDs according to their composition order.
   // The last ID in this vector belond to the that is composited on top of all others.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -116,6 +116,9 @@ class FlutterPlatformViewsController {
                                   std::shared_ptr<IOSGLContext> gl_context,
                                   GrContext* gr_context);
 
+  // Dispose the views in `views_to_dispose_`.
+  void DisposeViews();
+
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterPlatformViewsController);
 };
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -108,6 +108,7 @@ class FlutterPlatformViewsController {
   void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
 
   void DetachUnusedLayers();
+  void DisposeViewWithID(int64_t viewId);
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,
                                   std::shared_ptr<IOSGLContext> gl_context,

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -110,14 +110,12 @@ class FlutterPlatformViewsController {
   void OnRejectGesture(FlutterMethodCall* call, FlutterResult& result);
 
   void DetachUnusedLayers();
-  void DisposeViewWithID(int64_t viewId);
+  // Dispose the views in `views_to_dispose_`.
+  void DisposeViews();
   void EnsureOverlayInitialized(int64_t overlay_id);
   void EnsureGLOverlayInitialized(int64_t overlay_id,
                                   std::shared_ptr<IOSGLContext> gl_context,
                                   GrContext* gr_context);
-
-  // Dispose the views in `views_to_dispose_`.
-  void DisposeViews();
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterPlatformViewsController);
 };


### PR DESCRIPTION
Remove platform views inside OnDispose might cause issue if it happens before SubmitFrame and the active_composition_order has not been updated.
We will be left at a situation where the active_composition_order still contains the old view, but the view is actually removed from the UIView hierarchy. 

We now cache the views need to be removed in OnDispose and actually remove them in SubmitFrame. At the same time, we remove stop detaching the subviews if they were disposed. 

As a side effect, this update will also fix https://github.com/flutter/flutter/issues/30220