### PR TITLE
Make the resource context primary on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -33,7 +33,7 @@
 
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
-- (std::unique_ptr<shell::IOSSurface>)createSurface;
+- (std::unique_ptr<shell::IOSSurface>)createSurface:(std::shared_ptr<shell::IOSGLContext>)context;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -75,7 +75,7 @@ id<FlutterViewEngineDelegate> _delegate;
 #endif  // TARGET_IPHONE_SIMULATOR
 }
 
-- (std::unique_ptr<shell::IOSSurface>)createSurface {
+- (std::unique_ptr<shell::IOSSurface>)createSurface:(std::shared_ptr<shell::IOSGLContext>)context {
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
@@ -88,7 +88,7 @@ id<FlutterViewEngineDelegate> _delegate;
         eagl_layer.get().presentsWithTransaction = YES;
       }
     }
-    return std::make_unique<shell::IOSSurfaceGL>(std::move(eagl_layer),
+    return std::make_unique<shell::IOSSurfaceGL>(context, std::move(eagl_layer),
                                                  [_delegate platformViewsController]);
   } else {
     fml::scoped_nsobject<CALayer> layer(reinterpret_cast<CALayer*>([self.layer retain]));

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -13,14 +13,14 @@
 namespace shell {
 
 IOSGLContext::IOSGLContext() {
-  context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3]);
-  if (context_ != nullptr) {
-    resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
-                                                  sharegroup:context_.get().sharegroup]);
+  resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3]);
+  if (resource_context_ != nullptr) {
+    context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
+                                         sharegroup:resource_context_.get().sharegroup]);
   } else {
-    context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2]);
-    resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
-                                                  sharegroup:context_.get().sharegroup]);
+    resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2]);
+    context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
+                                         sharegroup:resource_context_.get().sharegroup]);
   }
 
   // TODO:

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -20,7 +20,8 @@ class IOSSurfaceGL : public IOSSurface,
                      public GPUSurfaceGLDelegate,
                      public flow::ExternalViewEmbedder {
  public:
-  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+  IOSSurfaceGL(std::shared_ptr<IOSGLContext> context,
+               fml::scoped_nsobject<CAEAGLLayer> layer,
                FlutterPlatformViewsController* platform_views_controller);
 
   IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer, std::shared_ptr<IOSGLContext> context);

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -9,10 +9,10 @@
 
 namespace shell {
 
-IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+IOSSurfaceGL::IOSSurfaceGL(std::shared_ptr<IOSGLContext> context,
+                           fml::scoped_nsobject<CAEAGLLayer> layer,
                            FlutterPlatformViewsController* platform_views_controller)
-    : IOSSurface(platform_views_controller) {
-  context_ = std::make_shared<IOSGLContext>();
+    : IOSSurface(platform_views_controller), context_(context) {
   render_target_ = context_->CreateRenderTarget(std::move(layer));
 }
 
@@ -29,7 +29,7 @@ bool IOSSurfaceGL::IsValid() const {
 }
 
 bool IOSSurfaceGL::ResourceContextMakeCurrent() {
-  return render_target_->IsValid() ? context_->ResourceMakeCurrent() : false;
+  return context_->ResourceMakeCurrent();
 }
 
 void IOSSurfaceGL::UpdateStorageSizeIfNecessary() {

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -17,6 +17,7 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/platform_message_router.h"
+#include "flutter/shell/platform/darwin/ios/ios_gl_context.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
 
 @class FlutterViewController;
@@ -46,6 +47,7 @@ class PlatformViewIOS final : public PlatformView {
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;
   std::unique_ptr<IOSSurface> ios_surface_;
+  std::shared_ptr<IOSGLContext> gl_context_;
   PlatformMessageRouter platform_message_router_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -22,9 +22,9 @@ namespace shell {
 PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate, blink::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
-      gl_context_ = std::make_shared<IOSGLContext>();
-#endif // !TARGET_IPHONE_SIMULATOR
-    }
+  gl_context_ = std::make_shared<IOSGLContext>();
+#endif  // !TARGET_IPHONE_SIMULATOR
+}
 
 PlatformViewIOS::~PlatformViewIOS() = default;
 
@@ -49,7 +49,8 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
   }
   owner_controller_ = owner_controller;
   if (owner_controller_) {
-    ios_surface_ = [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_context_];
+    ios_surface_ =
+        [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_context_];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {
@@ -83,8 +84,8 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
 sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
   if (!gl_context_ || !gl_context_->ResourceMakeCurrent()) {
     FML_DLOG(INFO) << "Could not make resource context current on IO thread. "
-                       "Async texture uploads will be disabled. On Simulators, "
-                       "this is expected.";
+                      "Async texture uploads will be disabled. On Simulators, "
+                      "this is expected.";
     return nullptr;
   }
 

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -20,7 +20,11 @@
 namespace shell {
 
 PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate, blink::TaskRunners task_runners)
-    : PlatformView(delegate, std::move(task_runners)) {}
+    : PlatformView(delegate, std::move(task_runners)) {
+#if !TARGET_IPHONE_SIMULATOR
+      gl_context_ = std::make_shared<IOSGLContext>();
+#endif // !TARGET_IPHONE_SIMULATOR
+    }
 
 PlatformViewIOS::~PlatformViewIOS() = default;
 
@@ -45,7 +49,7 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
   }
   owner_controller_ = owner_controller;
   if (owner_controller_) {
-    ios_surface_ = static_cast<FlutterView*>(owner_controller.get().view).createSurface;
+    ios_surface_ = [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_context_];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {
@@ -77,10 +81,10 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
 
 // |shell::PlatformView|
 sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
-  if (!ios_surface_ || !ios_surface_->ResourceContextMakeCurrent()) {
+  if (!gl_context_ || !gl_context_->ResourceMakeCurrent()) {
     FML_DLOG(INFO) << "Could not make resource context current on IO thread. "
-                      "Async texture uploads "
-                      "will be disabled.";
+                       "Async texture uploads will be disabled. On Simulators, "
+                       "this is expected.";
     return nullptr;
   }
 


### PR DESCRIPTION
Today, we create the GL context and resource loading context when we get a FlutterView.

This causes problems if the engine gets created before the ViewController - the shell initially thinks it doesn't have a resource context (so does the slow path for image uploads), and then later it does have one and things fail. For example, if you create `FlutterEngine`, attach a `FlutterViewController` that ends up showing an image, remove the view controller, and attach a new view controller that tries to show that image, it will fail as described in https://github.com/flutter/flutter/issues/29981

This patch makes the resource context be the primary one (so the drawing context is created after it), and makes the platform view own the IOSGLContext rather than the view (so that the resource context doesn't end up dying with the view).

Fixes https://github.com/flutter/flutter/issues/29981

@chinmaygarde discussed making this the default approach for all platforms, but I'm not sure how we can do that - this seems like an implementation detail of the embedder at present.

/cc @xster @amirh @IchordeDionysos @ForelaxX
