### PR TITLE
Make AccessibilityViewEmbedder final

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
@@ -37,7 +37,7 @@ import java.util.Map;
  * for the virtual accessibility node IDs in the platform view's tree. Internally this class maintains a bidirectional
  * mapping between `flutterId`s and the corresponding platform view and `originId`.
  */
-class AccessibilityViewEmbedder {
+final class AccessibilityViewEmbedder {
     private static final String TAG = "AccessibilityBridge";
 
     private final ReflectionAccessors reflectionAccessors;


### PR DESCRIPTION
Since this class implements equals() and hashCode() it should either be
final or handle subclasses in equals(); given this is unlikely to be
subclassed, making it final is the simpler option.