### PR TITLE
Add window title/icon support to GLFW shell

### DIFF
--- a/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
@@ -24,6 +24,7 @@ FlutterWindowController::~FlutterWindowController() {
 bool FlutterWindowController::CreateWindow(
     int width,
     int height,
+    const std::string& title,
     const std::string& assets_path,
     const std::vector<std::string>& arguments) {
   if (!init_succeeded_) {
@@ -44,7 +45,7 @@ bool FlutterWindowController::CreateWindow(
   size_t arg_count = engine_arguments.size();
 
   window_ = FlutterDesktopCreateWindow(
-      width, height, assets_path.c_str(), icu_data_path_.c_str(),
+      width, height, title.c_str(), assets_path.c_str(), icu_data_path_.c_str(),
       arg_count > 0 ? &engine_arguments[0] : nullptr, arg_count);
   if (!window_) {
     std::cerr << "Failed to create window." << std::endl;
@@ -66,6 +67,10 @@ FlutterDesktopPluginRegistrarRef FlutterWindowController::GetRegistrarForPlugin(
 
 void FlutterWindowController::SetHoverEnabled(bool enabled) {
   FlutterDesktopSetHoverEnabled(window_, enabled);
+}
+
+void FlutterWindowController::SetTitle(const std::string& title) {
+  FlutterDesktopSetWindowTitle(window_, title.c_str());
 }
 
 void FlutterWindowController::RunEventLoop() {

--- a/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
@@ -73,6 +73,12 @@ void FlutterWindowController::SetTitle(const std::string& title) {
   FlutterDesktopSetWindowTitle(window_, title.c_str());
 }
 
+void FlutterWindowController::SetIcon(uint8_t* pixel_data,
+                                      int width,
+                                      int height) {
+  FlutterDesktopSetWindowIcon(window_, pixel_data, width, height);
+}
+
 void FlutterWindowController::RunEventLoop() {
   if (window_) {
     FlutterDesktopRunWindowLoop(window_);

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
@@ -46,6 +46,7 @@ class FlutterWindowController {
   // Only one Flutter window can exist at a time; see constructor comment.
   bool CreateWindow(int width,
                     int height,
+                    const std::string& title,
                     const std::string& assets_path,
                     const std::vector<std::string>& arguments);
 
@@ -62,6 +63,9 @@ class FlutterWindowController {
   // engine, rather than only tracking the mouse while the button is pressed.
   // Defaults to off.
   void SetHoverEnabled(bool enabled);
+
+  // Sets the displayed title of the window.
+  void SetTitle(const std::string& title);
 
   // Loops on Flutter window events until the window closes.
   void RunEventLoop();

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
@@ -67,6 +67,13 @@ class FlutterWindowController {
   // Sets the displayed title of the window.
   void SetTitle(const std::string& title);
 
+  // Sets the displayed icon for the window.
+  //
+  // The pixel format is 32-bit RGBA. The provided image data only needs to be
+  // valid for the duration of the call to this method. Pass a nullptr to revert
+  // to the default icon.
+  void SetIcon(uint8_t* pixel_data, int width, int height);
+
   // Loops on Flutter window events until the window closes.
   void RunEventLoop();
 

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -50,14 +50,15 @@ void FlutterDesktopTerminate() {
 
 FlutterDesktopWindowRef FlutterDesktopCreateWindow(int initial_width,
                                                    int initial_height,
+                                                   const char* title,
                                                    const char* assets_path,
                                                    const char* icu_data_path,
                                                    const char** arguments,
                                                    size_t argument_count) {
   if (s_stub_implementation) {
-    return s_stub_implementation->CreateWindow(initial_width, initial_height,
-                                               assets_path, icu_data_path,
-                                               arguments, argument_count);
+    return s_stub_implementation->CreateWindow(
+        initial_width, initial_height, title, assets_path, icu_data_path,
+        arguments, argument_count);
   }
   return nullptr;
 }
@@ -66,6 +67,22 @@ void FlutterDesktopSetHoverEnabled(FlutterDesktopWindowRef flutter_window,
                                    bool enabled) {
   if (s_stub_implementation) {
     s_stub_implementation->SetHoverEnabled(enabled);
+  }
+}
+
+void FlutterDesktopSetWindowTitle(FlutterDesktopWindowRef flutter_window,
+                                  const char* title) {
+  if (s_stub_implementation) {
+    s_stub_implementation->SetWindowTitle(title);
+  }
+}
+
+void FlutterDesktopSetWindowIcon(FlutterDesktopWindowRef flutter_window,
+                                 uint8_t* pixel_data,
+                                 int width,
+                                 int height) {
+  if (s_stub_implementation) {
+    s_stub_implementation->SetWindowIcon(pixel_data, width, height);
   }
 }
 

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -38,6 +38,7 @@ class StubFlutterGlfwApi {
   // Called for FlutterDesktopCreateWindow.
   virtual FlutterDesktopWindowRef CreateWindow(int initial_width,
                                                int initial_height,
+                                               const char* title,
                                                const char* assets_path,
                                                const char* icu_data_path,
                                                const char** arguments,
@@ -45,8 +46,14 @@ class StubFlutterGlfwApi {
     return nullptr;
   }
 
-  // Called for FlutterDesktopSetHoverEnabled
+  // Called for FlutterDesktopSetHoverEnabled.
   virtual void SetHoverEnabled(bool enabled) {}
+
+  // Called for FlutterDesktopSetWindowTitle.
+  virtual void SetWindowTitle(const char* title) {}
+
+  //  Called for FlutterDesktopSetWindowIcon.
+  virtual void SetWindowIcon(uint8_t* pixel_data, int width, int height) {}
 
   // Called for FlutterDesktopRunWindowLoop.
   virtual void RunWindowLoop() {}

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -548,6 +548,16 @@ void FlutterDesktopSetWindowTitle(FlutterDesktopWindowRef flutter_window,
   glfwSetWindowTitle(window, title);
 }
 
+FLUTTER_EXPORT void FlutterDesktopSetWindowIcon(
+    FlutterDesktopWindowRef flutter_window,
+    uint8_t* pixel_data,
+    int width,
+    int height) {
+  GLFWwindow* window = flutter_window->window;
+  GLFWimage image = {width, height, static_cast<unsigned char*>(pixel_data)};
+  glfwSetWindowIcon(window, pixel_data ? 1 : 0, &image);
+}
+
 void FlutterDesktopRunWindowLoop(FlutterDesktopWindowRef flutter_window) {
   GLFWwindow* window = flutter_window->window;
 #ifdef __linux__

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -94,8 +94,6 @@ struct FlutterDesktopMessenger {
   shell::IncomingMessageDispatcher* dispatcher;
 };
 
-static constexpr char kDefaultWindowTitle[] = "Flutter";
-
 // Retrieves state bag for the window in question from the GLFWWindow.
 static FlutterDesktopWindowState* GetSavedWindowState(GLFWwindow* window) {
   return reinterpret_cast<FlutterDesktopWindowState*>(
@@ -473,6 +471,7 @@ void FlutterDesktopTerminate() {
 
 FlutterDesktopWindowRef FlutterDesktopCreateWindow(int initial_width,
                                                    int initial_height,
+                                                   const char* title,
                                                    const char* assets_path,
                                                    const char* icu_data_path,
                                                    const char** arguments,
@@ -481,8 +480,8 @@ FlutterDesktopWindowRef FlutterDesktopCreateWindow(int initial_width,
   gtk_init(0, nullptr);
 #endif
   // Create the window.
-  auto window = glfwCreateWindow(initial_width, initial_height,
-                                 kDefaultWindowTitle, NULL, NULL);
+  auto window =
+      glfwCreateWindow(initial_width, initial_height, title, NULL, NULL);
   if (window == nullptr) {
     return nullptr;
   }
@@ -541,6 +540,12 @@ void FlutterDesktopSetHoverEnabled(FlutterDesktopWindowRef flutter_window,
                                    bool enabled) {
   flutter_window->hover_tracking_enabled = enabled;
   SetHoverCallbacksEnabled(flutter_window->window, enabled);
+}
+
+void FlutterDesktopSetWindowTitle(FlutterDesktopWindowRef flutter_window,
+                                  const char* title) {
+  GLFWwindow* window = flutter_window->window;
+  glfwSetWindowTitle(window, title);
 }
 
 void FlutterDesktopRunWindowLoop(FlutterDesktopWindowRef flutter_window) {

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -548,11 +548,10 @@ void FlutterDesktopSetWindowTitle(FlutterDesktopWindowRef flutter_window,
   glfwSetWindowTitle(window, title);
 }
 
-FLUTTER_EXPORT void FlutterDesktopSetWindowIcon(
-    FlutterDesktopWindowRef flutter_window,
-    uint8_t* pixel_data,
-    int width,
-    int height) {
+void FlutterDesktopSetWindowIcon(FlutterDesktopWindowRef flutter_window,
+                                 uint8_t* pixel_data,
+                                 int width,
+                                 int height) {
   GLFWwindow* window = flutter_window->window;
   GLFWimage image = {width, height, static_cast<unsigned char*>(pixel_data)};
   glfwSetWindowIcon(window, pixel_data ? 1 : 0, &image);

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -52,6 +52,7 @@ FLUTTER_EXPORT void FlutterDesktopTerminate();
 FLUTTER_EXPORT FlutterDesktopWindowRef
 FlutterDesktopCreateWindow(int initial_width,
                            int initial_height,
+                           const char* title,
                            const char* assets_path,
                            const char* icu_data_path,
                            const char** arguments,
@@ -65,6 +66,11 @@ FlutterDesktopCreateWindow(int initial_width,
 FLUTTER_EXPORT void FlutterDesktopSetHoverEnabled(
     FlutterDesktopWindowRef flutter_window,
     bool enabled);
+
+// Sets the displayed title for |flutter_window|.
+FLUTTER_EXPORT void FlutterDesktopSetWindowTitle(
+    FlutterDesktopWindowRef flutter_window,
+    const char* title);
 
 // Loops on Flutter window events until the window is closed.
 //

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -72,6 +72,17 @@ FLUTTER_EXPORT void FlutterDesktopSetWindowTitle(
     FlutterDesktopWindowRef flutter_window,
     const char* title);
 
+// Sets the displayed icon for |flutter_window|.
+//
+// The pixel format is 32-bit RGBA. The provided image data only needs to be
+// valid for the duration of the call to this method. Pass a nullptr to revert
+// to the default icon.
+FLUTTER_EXPORT void FlutterDesktopSetWindowIcon(
+    FlutterDesktopWindowRef flutter_window,
+    uint8_t* pixel_data,
+    int width,
+    int height);
+
 // Loops on Flutter window events until the window is closed.
 //
 // Once this function returns, FlutterDesktopWindowRef is no longer valid, and


### PR DESCRIPTION
The GLFW shell used a hard-coded title for the window, but this is
something that an client should be able to control, as well as change
over time.