### PR TITLE
SkCanvas::flush after drawing text

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1029,6 +1029,7 @@ void Paragraph::Paint(SkCanvas* canvas, double x, double y) {
     PaintShadow(canvas, record, offset);
     canvas->drawTextBlob(record.text(), offset.x(), offset.y(), paint);
     PaintDecorations(canvas, record, base_offset);
+    canvas->flush();
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/30522

If a `Text` widget is scaled to 0 and then scaled back up in a subsequent frame, the text ends up disappearing.  Flushing the canvas fixes that.