### PR TITLE
Android Embedding PR25: Prevent black rectangle when launching FlutterActivity

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.android;
 
 import android.content.Context;
+import android.graphics.PixelFormat;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
@@ -90,6 +91,10 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
     // Grab a reference to our underlying Surface and register callbacks with that Surface so we
     // can monitor changes and forward those changes on to native Flutter code.
     getHolder().addCallback(surfaceCallback);
+
+    // Set this SurfaceView's PixelFormat to TRANSPARENT so that there is no initial black rectangle
+    // visible for a brief period of time before the alpha is set to zero.
+    getHolder().setFormat(PixelFormat.TRANSPARENT);
 
     // Keep this SurfaceView transparent until Flutter has a frame ready to render. This avoids
     // displaying a black rectangle in our place.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -13,7 +13,11 @@ import android.util.Log;
 import android.view.Surface;
 import android.view.TextureView;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
 
 /**
  * Paints a Flutter UI on a {@link SurfaceTexture}.
@@ -37,6 +41,8 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
   private boolean isAttachedToFlutterRenderer = false;
   @Nullable
   private FlutterRenderer flutterRenderer;
+  @NonNull
+  private Set<OnFirstFrameRenderedListener> onFirstFrameRenderedListeners = new HashSet<>();
 
   // Connects the {@code SurfaceTexture} beneath this {@code TextureView} with Flutter's native code.
   // Callbacks are received by this Object and then those messages are forwarded to our
@@ -181,9 +187,31 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
     flutterRenderer.surfaceDestroyed();
   }
 
+  /**
+   * Adds the given {@code listener} to this {@code FlutterTextureView}, to be notified upon Flutter's
+   * first rendered frame.
+   */
+  @Override
+  public void addOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener) {
+    onFirstFrameRenderedListeners.add(listener);
+  }
+
+  /**
+   * Removes the given {@code listener}, which was previously added with
+   * {@link #addOnFirstFrameRenderedListener(OnFirstFrameRenderedListener)}.
+   */
+  @Override
+  public void removeOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener) {
+    onFirstFrameRenderedListeners.remove(listener);
+  }
+
   @Override
   public void onFirstFrameRendered() {
     // TODO(mattcarroll): decide where this method should live and what it needs to do.
     Log.d(TAG, "onFirstFrameRendered()");
+
+    for (OnFirstFrameRenderedListener listener : onFirstFrameRenderedListeners) {
+      listener.onFirstFrameRendered();
+    }
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
 import io.flutter.plugin.editing.TextInputPlugin;
 import io.flutter.view.AccessibilityBridge;
 
@@ -145,6 +146,22 @@ public class FlutterView extends FrameLayout {
         addView(flutterTextureView);
         break;
     }
+  }
+
+  /**
+   * Adds the given {@code listener} to this {@code FlutterView}, to be notified upon Flutter's
+   * first rendered frame.
+   */
+  public void addOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener) {
+    renderSurface.addOnFirstFrameRenderedListener(listener);
+  }
+
+  /**
+   * Removes the given {@code listener}, which was previously added with
+   * {@link #addOnFirstFrameRenderedListener(OnFirstFrameRenderedListener)}.
+   */
+  public void removeOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener) {
+    renderSurface.removeOnFirstFrameRenderedListener(listener);
   }
 
   //------- Start: Process View configuration that Flutter cares about. ------

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -267,6 +267,18 @@ public class FlutterRenderer implements TextureRegistry {
      * never be called.
      */
     void onFirstFrameRendered();
+
+    /**
+     * Adds the given {@code listener} to this {@code FlutterRenderer}, to be notified upon Flutter's
+     * first rendered frame.
+     */
+    void addOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener);
+
+    /**
+     * Removes the given {@code listener}, which was previously added with
+     * {@link #addOnFirstFrameRenderedListener(OnFirstFrameRenderedListener)}.
+     */
+    void removeOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener);
   }
 
   /**

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -14,6 +14,7 @@ import io.flutter.embedding.engine.FlutterEngine.EngineLifecycleListener;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.FlutterRenderer.RenderSurface;
+import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
 import io.flutter.plugin.common.*;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -199,6 +200,12 @@ public class FlutterNativeView implements BinaryMessenger {
             }
             mFlutterView.onFirstFrame();
         }
+
+        @Override
+        public void addOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener) {}
+
+        @Override
+        public void removeOnFirstFrameRenderedListener(@NonNull OnFirstFrameRenderedListener listener) {}
     }
 
     private final class EngineLifecycleListenerImpl implements EngineLifecycleListener {


### PR DESCRIPTION
Android Embedding PR25: Prevent black rectangle when launching FlutterActivity.

This PR sets our `SurfaceView` to use `PixelFormat.TRANSPARENT` to avoid a brief black flicker when launching a `FlutterActivity`. This is a distinct problem from a black flicker that occurs when removing a `FlutterFragment`.

This change may have performance implications but I don't know what they are yet. I'm going to look into setting up benchmarks with the new embedding, but I think we want this change for @mjohnsullivan's code lab. We can adjust this implementation detail after the fact, if needed.

If any reviewers know anything concrete about the performance implications, please let me know.