### PR TITLE
Initialize OpacityLayer's matrix to identity

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -22,8 +22,9 @@ void OpacityLayer::EnsureSingleChild() {
   auto new_child = std::make_shared<flow::TransformLayer>();
 
   // Be careful: SkMatrix's default constructor doesn't initialize the matrix to
-  // identity. Hence we have to explicitly call SkMatrix::MakeTrans(0, 0).
-  SkMatrix identity = SkMatrix::MakeTrans(0, 0);
+  // identity. Hence we have to explicitly call SkMatrix::setIdentity.
+  SkMatrix identity;
+  identity.setIdentity();
 
   new_child->set_transform(identity);
   for (auto& child : layers()) {

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -20,6 +20,12 @@ void OpacityLayer::EnsureSingleChild() {
   }
 
   auto new_child = std::make_shared<flow::TransformLayer>();
+
+  // Be careful: SkMatrix's default constructor doesn't initialize the matrix to
+  // identity. Hence we have to explicitly call SkMatrix::MakeTrans(0, 0).
+  SkMatrix identity = SkMatrix::MakeTrans(0, 0);
+
+  new_child->set_transform(identity);
   for (auto& child : layers()) {
     new_child->Add(child);
   }

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -9,6 +9,8 @@
 
 namespace flow {
 
+// Be careful that SkMatrix's default constructor doesn't initialize the matrix
+// at all. Hence |set_transform| must be called with an initialized SkMatrix.
 class TransformLayer : public ContainerLayer {
  public:
   TransformLayer();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/30586

Will try to add a test to framework to catch this. From my local test, SkASSERT should trigger during debug build for a `TextField` widget inside an `Opacity` widget.