### PR TITLE
Add trace events for creating minikin fonts

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -200,7 +200,8 @@ std::shared_ptr<minikin::FontFamily> FontCollection::FindFontFamilyInManagers(
 std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
     const sk_sp<SkFontMgr>& manager,
     const std::string& family_name) {
-  TRACE_EVENT0("flutter", "FontCollection::CreateMinikinFontFamily");
+  TRACE_EVENT1("flutter", "FontCollection::CreateMinikinFontFamily",
+               "family_name", family_name.c_str());
   sk_sp<SkFontStyleSet> font_style_set(
       manager->matchFamily(family_name.c_str()));
   if (font_style_set == nullptr || font_style_set->count() == 0) {
@@ -229,8 +230,8 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
     minikin_fonts.emplace_back(std::move(minikin_font));
   }
 
-  TRACE_EVENT1("flutter", "minikin::FontFamily",
-      "MinikinFontsCount", std::to_string(minikin_fonts.size()).c_str());
+  TRACE_EVENT1("flutter", "minikin::FontFamily", "MinikinFontsCount",
+               std::to_string(minikin_fonts.size()).c_str());
   return std::make_shared<minikin::FontFamily>(std::move(minikin_fonts));
 }
 

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <vector>
 #include "flutter/fml/logging.h"
+#include "flutter/fml/trace_event.h"
 #include "font_skia.h"
 #include "txt/platform.h"
 #include "txt/text_style.h"
@@ -184,6 +185,7 @@ FontCollection::GetMinikinFontCollectionForFamilies(
 
 std::shared_ptr<minikin::FontFamily> FontCollection::FindFontFamilyInManagers(
     const std::string& family_name) {
+  TRACE_EVENT0("flutter", "FontCollection::FindFontFamilyInManagers");
   // Search for the font family in each font manager.
   for (sk_sp<SkFontMgr>& manager : GetFontManagerOrder()) {
     std::shared_ptr<minikin::FontFamily> minikin_family =
@@ -198,6 +200,7 @@ std::shared_ptr<minikin::FontFamily> FontCollection::FindFontFamilyInManagers(
 std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
     const sk_sp<SkFontMgr>& manager,
     const std::string& family_name) {
+  TRACE_EVENT0("flutter", "FontCollection::CreateMinikinFontFamily");
   sk_sp<SkFontStyleSet> font_style_set(
       manager->matchFamily(family_name.c_str()));
   if (font_style_set == nullptr || font_style_set->count() == 0) {
@@ -208,6 +211,7 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
 
   // Add fonts to the Minikin font family.
   for (int i = 0; i < font_style_set->count(); ++i) {
+    TRACE_EVENT0("flutter", "CreateMinikinFont")
     // Create the skia typeface.
     sk_sp<SkTypeface> skia_typeface(
         sk_sp<SkTypeface>(font_style_set->createTypeface(i)));
@@ -225,6 +229,8 @@ std::shared_ptr<minikin::FontFamily> FontCollection::CreateMinikinFontFamily(
     minikin_fonts.emplace_back(std::move(minikin_font));
   }
 
+  TRACE_EVENT1("flutter", "minikin::FontFamily",
+      "MinikinFontsCount", std::to_string(minikin_fonts.size()).c_str());
   return std::make_shared<minikin::FontFamily>(std::move(minikin_fonts));
 }
 
@@ -270,6 +276,7 @@ const std::shared_ptr<minikin::FontFamily>& FontCollection::DoMatchFallbackFont(
 const std::shared_ptr<minikin::FontFamily>&
 FontCollection::GetFallbackFontFamily(const sk_sp<SkFontMgr>& manager,
                                       const std::string& family_name) {
+  TRACE_EVENT0("flutter", "FontCollection::GetFallbackFontFamily");
   auto fallback_it = fallback_fonts_.find(family_name);
   if (fallback_it != fallback_fonts_.end()) {
     return fallback_it->second;


### PR DESCRIPTION
Creating fonts can take a long time (50ms+) during frame build in the UI
thread.  Trace them to help us understand when it's causing a jank.

For example:
<img width="1120" alt="Screen Shot 2019-04-07 at 11 37 11 AM" src="https://user-images.githubusercontent.com/22987568/55688090-9f245380-5929-11e9-803f-09a040fde1d2.png">
