### PR TITLE
Add flush to canvas

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3191,6 +3191,14 @@ class Canvas extends NativeFieldWrapperClass2 {
   /// This number cannot go below 1.
   int getSaveCount() native 'Canvas_getSaveCount';
 
+  /// Flush the operations on this canvas so far.
+  ///
+  /// This prevents Skia's GPU backend to group the operations across the flush
+  /// boundary. It's useful for [ShaderWarmUp] to force Skia's GPU backend to
+  /// warm up different shaders that may otherwise be combined by grouping the
+  /// operations together.
+  void flush() native 'Canvas_flush';
+
   /// Add a translation to the current transform, shifting the coordinate space
   /// horizontally by the first argument and vertically by the second argument.
   void translate(double dx, double dy) native 'Canvas_translate';

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -36,6 +36,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Canvas);
   V(Canvas, saveLayer)              \
   V(Canvas, restore)                \
   V(Canvas, getSaveCount)           \
+  V(Canvas, flush)                  \
   V(Canvas, translate)              \
   V(Canvas, scale)                  \
   V(Canvas, rotate)                 \
@@ -124,6 +125,12 @@ int Canvas::getSaveCount() {
   if (!canvas_)
     return 0;
   return canvas_->getSaveCount();
+}
+
+void Canvas::flush() {
+  if (!canvas_)
+    return;
+  canvas_->flush();
 }
 
 void Canvas::translate(double dx, double dy) {

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -49,6 +49,8 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
   void restore();
   int getSaveCount();
 
+  void flush();
+
   void translate(double dx, double dy);
   void scale(double sx, double sy);
   void rotate(double radians);


### PR DESCRIPTION
This is required for a high-priority Google client. I've tested it
locally and the ShaderWarmUp can now generate multiple shaders in one
frame that were not possible before.

The engine roll with this PR needs a manual fix on `_MulticastCanvas`

Related issue: https://github.com/flutter/flutter/issues/813