### PR TITLE
Rename the blink namespace to flutter.

### DIFF
--- a/assets/asset_manager.cc
+++ b/assets/asset_manager.cc
@@ -7,7 +7,7 @@
 #include "flutter/assets/directory_asset_bundle.h"
 #include "flutter/fml/trace_event.h"
 
-namespace blink {
+namespace flutter {
 
 AssetManager::AssetManager() = default;
 
@@ -29,7 +29,7 @@ void AssetManager::PushBack(std::unique_ptr<AssetResolver> resolver) {
   resolvers_.push_back(std::move(resolver));
 }
 
-// |blink::AssetResolver|
+// |flutter::AssetResolver|
 std::unique_ptr<fml::Mapping> AssetManager::GetAsMapping(
     const std::string& asset_name) const {
   if (asset_name.size() == 0) {
@@ -47,9 +47,9 @@ std::unique_ptr<fml::Mapping> AssetManager::GetAsMapping(
   return nullptr;
 }
 
-// |blink::AssetResolver|
+// |flutter::AssetResolver|
 bool AssetManager::IsValid() const {
   return resolvers_.size() > 0;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/assets/asset_manager.h
+++ b/assets/asset_manager.h
@@ -13,7 +13,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/memory/ref_counted.h"
 
-namespace blink {
+namespace flutter {
 
 class AssetManager final : public AssetResolver {
  public:
@@ -25,10 +25,10 @@ class AssetManager final : public AssetResolver {
 
   void PushBack(std::unique_ptr<AssetResolver> resolver);
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   bool IsValid() const override;
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 
@@ -38,6 +38,6 @@ class AssetManager final : public AssetResolver {
   FML_DISALLOW_COPY_AND_ASSIGN(AssetManager);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_ASSETS_ASSET_MANAGER_H_

--- a/assets/asset_resolver.h
+++ b/assets/asset_resolver.h
@@ -11,7 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/mapping.h"
 
-namespace blink {
+namespace flutter {
 
 class AssetResolver {
  public:
@@ -29,6 +29,6 @@ class AssetResolver {
   FML_DISALLOW_COPY_AND_ASSIGN(AssetResolver);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_ASSETS_ASSET_RESOLVER_H_

--- a/assets/directory_asset_bundle.cc
+++ b/assets/directory_asset_bundle.cc
@@ -10,7 +10,7 @@
 #include "flutter/fml/file.h"
 #include "flutter/fml/mapping.h"
 
-namespace blink {
+namespace flutter {
 
 DirectoryAssetBundle::DirectoryAssetBundle(fml::UniqueFD descriptor)
     : descriptor_(std::move(descriptor)) {
@@ -22,12 +22,12 @@ DirectoryAssetBundle::DirectoryAssetBundle(fml::UniqueFD descriptor)
 
 DirectoryAssetBundle::~DirectoryAssetBundle() = default;
 
-// |blink::AssetResolver|
+// |flutter::AssetResolver|
 bool DirectoryAssetBundle::IsValid() const {
   return is_valid_;
 }
 
-// |blink::AssetResolver|
+// |flutter::AssetResolver|
 std::unique_ptr<fml::Mapping> DirectoryAssetBundle::GetAsMapping(
     const std::string& asset_name) const {
   if (!is_valid_) {
@@ -45,4 +45,4 @@ std::unique_ptr<fml::Mapping> DirectoryAssetBundle::GetAsMapping(
   return mapping;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/assets/directory_asset_bundle.h
+++ b/assets/directory_asset_bundle.h
@@ -10,7 +10,7 @@
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/unique_fd.h"
 
-namespace blink {
+namespace flutter {
 
 class DirectoryAssetBundle : public AssetResolver {
  public:
@@ -22,16 +22,16 @@ class DirectoryAssetBundle : public AssetResolver {
   const fml::UniqueFD descriptor_;
   bool is_valid_ = false;
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   bool IsValid() const override;
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(DirectoryAssetBundle);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_ASSETS_DIRECTORY_ASSET_BUNDLE_H_

--- a/assets/zip_asset_store.cc
+++ b/assets/zip_asset_store.cc
@@ -16,7 +16,7 @@
 
 #include "flutter/fml/trace_event.h"
 
-namespace blink {
+namespace flutter {
 
 void UniqueUnzipperTraits::Free(void* file) {
   unzClose(file);
@@ -33,12 +33,12 @@ UniqueUnzipper ZipAssetStore::CreateUnzipper() const {
   return UniqueUnzipper{::unzOpen2(file_path_.c_str(), nullptr)};
 }
 
-// |blink::AssetResolver|
+// |flutter::AssetResolver|
 bool ZipAssetStore::IsValid() const {
   return stat_cache_.size() > 0;
 }
 
-// |blink::AssetResolver|
+// |flutter::AssetResolver|
 std::unique_ptr<fml::Mapping> ZipAssetStore::GetAsMapping(
     const std::string& asset_name) const {
   TRACE_EVENT1("flutter", "ZipAssetStore::GetAsMapping", "name",
@@ -126,4 +126,4 @@ void ZipAssetStore::BuildStatCache() {
   } while (unzGoToNextFile(unzipper.get()) == UNZ_OK);
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/assets/zip_asset_store.h
+++ b/assets/zip_asset_store.h
@@ -11,7 +11,7 @@
 #include "flutter/fml/macros.h"
 #include "third_party/zlib/contrib/minizip/unzip.h"
 
-namespace blink {
+namespace flutter {
 
 struct UniqueUnzipperTraits {
   static inline void* InvalidValue() { return nullptr; }
@@ -40,10 +40,10 @@ class ZipAssetStore final : public AssetResolver {
 
   mutable std::map<std::string, CacheEntry> stat_cache_;
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   bool IsValid() const override;
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 
@@ -54,6 +54,6 @@ class ZipAssetStore final : public AssetResolver {
   FML_DISALLOW_COPY_AND_ASSIGN(ZipAssetStore);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_ASSETS_ZIP_ASSET_STORE_H_

--- a/common/settings.cc
+++ b/common/settings.cc
@@ -6,7 +6,7 @@
 
 #include <sstream>
 
-namespace blink {
+namespace flutter {
 
 Settings::Settings() = default;
 
@@ -54,4 +54,4 @@ std::string Settings::ToString() const {
   return stream.str();
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/common/settings.h
+++ b/common/settings.h
@@ -16,7 +16,7 @@
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/unique_fd.h"
 
-namespace blink {
+namespace flutter {
 
 using TaskObserverAdd =
     std::function<void(intptr_t /* key */, fml::closure /* callback */)>;
@@ -145,6 +145,6 @@ struct Settings {
   std::string ToString() const;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_COMMON_SETTINGS_H_

--- a/common/task_runners.cc
+++ b/common/task_runners.cc
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-namespace blink {
+namespace flutter {
 
 TaskRunners::TaskRunners(std::string label,
                          fml::RefPtr<fml::TaskRunner> platform,
@@ -47,4 +47,4 @@ bool TaskRunners::IsValid() const {
   return platform_ && gpu_ && ui_ && io_;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/common/task_runners.h
+++ b/common/task_runners.h
@@ -10,7 +10,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/task_runner.h"
 
-namespace blink {
+namespace flutter {
 
 class TaskRunners {
  public:
@@ -44,6 +44,6 @@ class TaskRunners {
   fml::RefPtr<fml::TaskRunner> io_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_COMMON_TASK_RUNNERS_H_

--- a/common/version/version.cc
+++ b/common/version/version.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/common/version/version.h"
 
-namespace blink {
+namespace flutter {
 
 const char* GetFlutterEngineVersion() {
   return FLUTTER_ENGINE_VERSION;
@@ -18,4 +18,4 @@ const char* GetDartVersion() {
   return DART_VERSION;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/common/version/version.h
+++ b/common/version/version.h
@@ -5,7 +5,7 @@
 #ifndef FLUTTER_COMMON_VERSION_VERSION_H_
 #define FLUTTER_COMMON_VERSION_VERSION_H_
 
-namespace blink {
+namespace flutter {
 
 const char* GetFlutterEngineVersion();
 
@@ -13,6 +13,6 @@ const char* GetSkiaVersion();
 
 const char* GetDartVersion();
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_COMMON_VERSION_VERSION_H_

--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -10,7 +10,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 void DartIO::InitForIsolate() {
   Dart_Handle result = Dart_SetNativeResolver(
@@ -25,4 +25,4 @@ bool DartIO::EntropySource(uint8_t* buffer, intptr_t length) {
   return dart::bin::GetEntropy(buffer, length);
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/io/dart_io.h
+++ b/lib/io/dart_io.h
@@ -9,7 +9,7 @@
 
 #include "flutter/fml/macros.h"
 
-namespace blink {
+namespace flutter {
 
 class DartIO {
  public:
@@ -20,6 +20,6 @@ class DartIO {
   FML_DISALLOW_IMPLICIT_CONSTRUCTORS(DartIO);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_IO_DART_IO_H_

--- a/lib/ui/compositing/scene.cc
+++ b/lib/ui/compositing/scene.cc
@@ -14,7 +14,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Scene);
 
@@ -72,4 +72,4 @@ std::unique_ptr<flow::LayerTree> Scene::takeLayerTree() {
   return std::move(m_layerTree);
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/compositing/scene.h
+++ b/lib/ui/compositing/scene.h
@@ -16,7 +16,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class Scene : public RefCountedDartWrappable<Scene> {
   DEFINE_WRAPPERTYPEINFO();
@@ -48,6 +48,6 @@ class Scene : public RefCountedDartWrappable<Scene> {
   std::unique_ptr<flow::LayerTree> m_layerTree;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_COMPOSITING_SCENE_H_

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -35,7 +35,7 @@
 #include "flutter/flow/layers/child_scene_layer.h"
 #endif
 
-namespace blink {
+namespace flutter {
 
 static void SceneBuilder_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&SceneBuilder::create, args);
@@ -327,4 +327,4 @@ void SceneBuilder::PushLayer(std::shared_ptr<flow::ContainerLayer> layer) {
   current_layer_ = newLayer;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -24,7 +24,7 @@
 #include "flutter/lib/ui/compositing/scene_host.h"
 #endif
 
-namespace blink {
+namespace flutter {
 
 class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   DEFINE_WRAPPERTYPEINFO();
@@ -120,6 +120,6 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
   FML_DISALLOW_COPY_AND_ASSIGN(SceneBuilder);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_COMPOSITING_SCENE_BUILDER_H_

--- a/lib/ui/compositing/scene_host.cc
+++ b/lib/ui/compositing/scene_host.cc
@@ -18,14 +18,14 @@
 
 namespace {
 
-using SceneHostBindings = std::unordered_map<zx_koid_t, blink::SceneHost*>;
+using SceneHostBindings = std::unordered_map<zx_koid_t, flutter::SceneHost*>;
 
 FML_THREAD_LOCAL fml::ThreadLocal tls_scene_host_bindings([](intptr_t value) {
   delete reinterpret_cast<SceneHostBindings*>(value);
 });
 
 void SceneHost_constructor(Dart_NativeArguments args) {
-  tonic::DartCallConstructor(&blink::SceneHost::Create, args);
+  tonic::DartCallConstructor(&flutter::SceneHost::Create, args);
 }
 
 void SceneHost_constructorViewHolderToken(Dart_NativeArguments args) {
@@ -36,10 +36,10 @@ void SceneHost_constructorViewHolderToken(Dart_NativeArguments args) {
         reinterpret_cast<intptr_t>(new SceneHostBindings()));
   }
 
-  tonic::DartCallConstructor(&blink::SceneHost::CreateViewHolder, args);
+  tonic::DartCallConstructor(&flutter::SceneHost::CreateViewHolder, args);
 }
 
-blink::SceneHost* GetSceneHost(scenic::ResourceId id) {
+flutter::SceneHost* GetSceneHost(scenic::ResourceId id) {
   auto* bindings =
       reinterpret_cast<SceneHostBindings*>(tls_scene_host_bindings.Get());
   FML_DCHECK(bindings);
@@ -80,7 +80,7 @@ void InvokeDartFunction(tonic::DartPersistentValue* function, T& arg) {
 
 }  // namespace
 
-namespace blink {
+namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, SceneHost);
 
@@ -229,4 +229,4 @@ void SceneHost::dispose() {
   ClearDartWrapper();
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/compositing/scene_host.h
+++ b/lib/ui/compositing/scene_host.h
@@ -16,7 +16,7 @@
 #include "flutter/fml/task_runner.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 
-namespace blink {
+namespace flutter {
 
 class SceneHost : public RefCountedDartWrappable<SceneHost> {
   DEFINE_WRAPPERTYPEINFO();
@@ -64,6 +64,6 @@ class SceneHost : public RefCountedDartWrappable<SceneHost> {
   bool use_view_holder_ = false;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_COMPOSITING_SCENE_HOST_H_

--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -41,7 +41,7 @@ using tonic::DartConverter;
 using tonic::LogIfError;
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 #define REGISTER_FUNCTION(name, count) {"" #name, name, count, true},
 #define DECLARE_FUNCTION(name, count) \
@@ -344,4 +344,4 @@ void GetCallbackFromHandle(Dart_NativeArguments args) {
   Dart_SetReturnValue(args, DartCallbackCache::GetCallback(handle));
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/dart_runtime_hooks.h
+++ b/lib/ui/dart_runtime_hooks.h
@@ -9,7 +9,7 @@
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 class DartRuntimeHooks {
  public:
@@ -20,6 +20,6 @@ class DartRuntimeHooks {
   FML_DISALLOW_IMPLICIT_CONSTRUCTORS(DartRuntimeHooks);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_DART_RUNTIME_HOOKS_H_

--- a/lib/ui/dart_ui.cc
+++ b/lib/ui/dart_ui.cc
@@ -38,7 +38,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 namespace {
 
 static tonic::DartLibraryNatives* g_natives;
@@ -117,4 +117,4 @@ void DartUI::InitForIsolate(bool is_root_isolate) {
   }
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/dart_ui.h
+++ b/lib/ui/dart_ui.h
@@ -7,7 +7,7 @@
 
 #include "flutter/fml/macros.h"
 
-namespace blink {
+namespace flutter {
 
 class DartUI {
  public:
@@ -18,6 +18,6 @@ class DartUI {
   FML_DISALLOW_IMPLICIT_CONSTRUCTORS(DartUI);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_DART_UI_H_

--- a/lib/ui/dart_wrapper.h
+++ b/lib/ui/dart_wrapper.h
@@ -8,7 +8,7 @@
 #include "flutter/fml/memory/ref_counted.h"
 #include "third_party/tonic/dart_wrappable.h"
 
-namespace blink {
+namespace flutter {
 
 template <typename T>
 class RefCountedDartWrappable : public fml::RefCountedThreadSafe<T>,
@@ -23,6 +23,6 @@ class RefCountedDartWrappable : public fml::RefCountedThreadSafe<T>,
   }
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_DART_WRAPPER_H_

--- a/lib/ui/io_manager.h
+++ b/lib/ui/io_manager.h
@@ -9,7 +9,7 @@
 #include "flutter/fml/memory/weak_ptr.h"
 #include "third_party/skia/include/gpu/GrContext.h"
 
-namespace blink {
+namespace flutter {
 // Interface for methods that manage access to the resource GrContext and Skia
 // unref queue.  Meant to be implemented by the owner of the resource GrContext,
 // i.e. the shell's IOManager.
@@ -20,6 +20,6 @@ class IOManager {
   virtual fml::RefPtr<flow::SkiaUnrefQueue> GetSkiaUnrefQueue() const = 0;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_IO_MANAGER_H_

--- a/lib/ui/isolate_name_server/isolate_name_server.cc
+++ b/lib/ui/isolate_name_server/isolate_name_server.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/lib/ui/isolate_name_server/isolate_name_server.h"
 
-namespace blink {
+namespace flutter {
 
 IsolateNameServer::IsolateNameServer() {}
 
@@ -45,4 +45,4 @@ bool IsolateNameServer::RemoveIsolateNameMapping(const std::string& name) {
   return true;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/isolate_name_server/isolate_name_server.h
+++ b/lib/ui/isolate_name_server/isolate_name_server.h
@@ -13,7 +13,7 @@
 #include "flutter/fml/synchronization/thread_annotations.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
-namespace blink {
+namespace flutter {
 
 class IsolateNameServer {
  public:
@@ -46,6 +46,6 @@ class IsolateNameServer {
   FML_DISALLOW_COPY_AND_ASSIGN(IsolateNameServer);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_ISOLATE_NAME_SERVER_H_

--- a/lib/ui/isolate_name_server/isolate_name_server_natives.cc
+++ b/lib/ui/isolate_name_server/isolate_name_server_natives.cc
@@ -10,7 +10,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 Dart_Handle IsolateNameServerNatives::LookupPortByName(
     const std::string& name) {
@@ -67,4 +67,4 @@ void IsolateNameServerNatives::RegisterNatives(
   natives->Register({FOR_EACH_BINDING(DART_REGISTER_NATIVE_STATIC_)});
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/isolate_name_server/isolate_name_server_natives.h
+++ b/lib/ui/isolate_name_server/isolate_name_server_natives.h
@@ -12,7 +12,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class IsolateNameServerNatives {
  public:
@@ -23,6 +23,6 @@ class IsolateNameServerNatives {
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_ISOLATE_NAME_SERVER_NATIVES_H_

--- a/lib/ui/painting/canvas.cc
+++ b/lib/ui/painting/canvas.cc
@@ -22,7 +22,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 static void Canvas_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&Canvas::Create, args);
@@ -431,4 +431,4 @@ bool Canvas::IsRecording() const {
   return !!canvas_;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/canvas.h
+++ b/lib/ui/painting/canvas.h
@@ -22,7 +22,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 class CanvasImage;
 
 class Canvas : public RefCountedDartWrappable<Canvas> {
@@ -181,6 +181,6 @@ class Canvas : public RefCountedDartWrappable<Canvas> {
   SkCanvas* canvas_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_CANVAS_H_

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -21,7 +21,7 @@ using tonic::DartInvoke;
 using tonic::DartPersistentValue;
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 namespace {
 
@@ -553,4 +553,4 @@ void Codec::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({FOR_EACH_BINDING(DART_REGISTER_NATIVE)});
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/codec.h
+++ b/lib/ui/painting/codec.h
@@ -17,7 +17,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 // A handle to an SkCodec object.
 //
@@ -96,6 +96,6 @@ class SingleFrameCodec : public Codec {
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(SingleFrameCodec);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_CODEC_H_

--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -13,7 +13,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 EngineLayer::EngineLayer(std::shared_ptr<flow::ContainerLayer> layer)
     : layer_(layer) {}
@@ -33,4 +33,4 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, EngineLayer);
 
 DART_BIND_ALL(EngineLayer, FOR_EACH_BINDING)
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/engine_layer.h
+++ b/lib/ui/painting/engine_layer.h
@@ -13,7 +13,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class EngineLayer;
 
@@ -41,6 +41,6 @@ class EngineLayer : public RefCountedDartWrappable<EngineLayer> {
   FML_FRIEND_MAKE_REF_COUNTED(EngineLayer);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_ENGINE_LAYER_H_

--- a/lib/ui/painting/frame_info.cc
+++ b/lib/ui/painting/frame_info.cc
@@ -8,7 +8,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, FrameInfo);
 
@@ -27,4 +27,4 @@ void FrameInfo::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({FOR_EACH_BINDING(DART_REGISTER_NATIVE)});
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/frame_info.h
+++ b/lib/ui/painting/frame_info.h
@@ -12,7 +12,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 // A single animation frame.
 class FrameInfo final : public RefCountedDartWrappable<FrameInfo> {
@@ -36,6 +36,6 @@ class FrameInfo final : public RefCountedDartWrappable<FrameInfo> {
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(FrameInfo);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_FRAME_INFO_H_

--- a/lib/ui/painting/gradient.cc
+++ b/lib/ui/painting/gradient.cc
@@ -11,7 +11,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 typedef CanvasGradient
     Gradient;  // Because the C++ name doesn't match the Dart name.
@@ -143,4 +143,4 @@ CanvasGradient::CanvasGradient() = default;
 
 CanvasGradient::~CanvasGradient() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/gradient.h
+++ b/lib/ui/painting/gradient.h
@@ -17,7 +17,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 // TODO: update this if/when Skia adds Decal mode skbug.com/7638
 static_assert(kSkTileModeCount >= 3, "Need to update tile mode enum");
@@ -69,6 +69,6 @@ class CanvasGradient : public Shader {
   CanvasGradient();
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_GRADIENT_H_

--- a/lib/ui/painting/image.cc
+++ b/lib/ui/painting/image.cc
@@ -10,7 +10,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 typedef CanvasImage Image;
 
@@ -48,4 +48,4 @@ size_t CanvasImage::GetAllocationSize() {
   }
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/image.h
+++ b/lib/ui/painting/image.h
@@ -14,7 +14,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class CanvasImage final : public RefCountedDartWrappable<CanvasImage> {
   DEFINE_WRAPPERTYPEINFO();
@@ -49,6 +49,6 @@ class CanvasImage final : public RefCountedDartWrappable<CanvasImage> {
   flow::SkiaGPUObject<SkImage> image_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_IMAGE_H_

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -25,7 +25,7 @@ using tonic::DartInvoke;
 using tonic::DartPersistentValue;
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 namespace {
 
 // This must be kept in sync with the enum in painting.dart
@@ -231,4 +231,4 @@ Dart_Handle EncodeImage(CanvasImage* canvas_image,
   return Dart_Null();
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/image_encoding.h
+++ b/lib/ui/painting/image_encoding.h
@@ -7,7 +7,7 @@
 
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 class CanvasImage;
 
@@ -15,6 +15,6 @@ Dart_Handle EncodeImage(CanvasImage* canvas_image,
                         int format,
                         Dart_Handle callback_handle);
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_IMAGE_ENCODING_H_

--- a/lib/ui/painting/image_filter.cc
+++ b/lib/ui/painting/image_filter.cc
@@ -13,7 +13,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 static void ImageFilter_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&ImageFilter::Create, args);
@@ -63,4 +63,4 @@ void ImageFilter::initMatrix(const tonic::Float64List& matrix4,
       nullptr);
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/image_filter.h
+++ b/lib/ui/painting/image_filter.h
@@ -11,7 +11,7 @@
 #include "third_party/skia/include/core/SkImageFilter.h"
 #include "third_party/tonic/typed_data/float64_list.h"
 
-namespace blink {
+namespace flutter {
 
 class ImageFilter : public RefCountedDartWrappable<ImageFilter> {
   DEFINE_WRAPPERTYPEINFO();
@@ -36,6 +36,6 @@ class ImageFilter : public RefCountedDartWrappable<ImageFilter> {
   sk_sp<SkImageFilter> filter_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_IMAGE_FILTER_H_

--- a/lib/ui/painting/image_shader.cc
+++ b/lib/ui/painting/image_shader.cc
@@ -12,7 +12,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 static void ImageShader_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&ImageShader::Create, args);
@@ -51,4 +51,4 @@ ImageShader::ImageShader() = default;
 
 ImageShader::~ImageShader() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/image_shader.h
+++ b/lib/ui/painting/image_shader.h
@@ -18,7 +18,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class ImageShader : public Shader {
   DEFINE_WRAPPERTYPEINFO();
@@ -39,6 +39,6 @@ class ImageShader : public Shader {
   ImageShader();
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_IMAGE_SHADER_H_

--- a/lib/ui/painting/matrix.cc
+++ b/lib/ui/painting/matrix.cc
@@ -6,7 +6,7 @@
 
 #include "flutter/fml/logging.h"
 
-namespace blink {
+namespace flutter {
 
 // Mappings from SkMatrix-index to input-index.
 static const int kSkMatrixIndexToMatrix4Index[] = {
@@ -38,4 +38,4 @@ tonic::Float64List ToMatrix4(const SkMatrix& sk_matrix) {
   return matrix4;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/matrix.h
+++ b/lib/ui/painting/matrix.h
@@ -8,11 +8,11 @@
 #include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/tonic/typed_data/float64_list.h"
 
-namespace blink {
+namespace flutter {
 
 SkMatrix ToSkMatrix(const tonic::Float64List& matrix4);
 tonic::Float64List ToMatrix4(const SkMatrix& sk_matrix);
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_MATRIX_H_

--- a/lib/ui/painting/paint.cc
+++ b/lib/ui/painting/paint.cc
@@ -13,7 +13,7 @@
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 #include "third_party/tonic/typed_data/float32_list.h"
 
-namespace blink {
+namespace flutter {
 
 // Indices for 32bit values.
 constexpr int kIsAntiAliasIndex = 0;
@@ -202,11 +202,11 @@ Paint::Paint(Dart_Handle paint_objects, Dart_Handle paint_data) {
   }
 }
 
-}  // namespace blink
+}  // namespace flutter
 
 namespace tonic {
 
-blink::Paint DartConverter<blink::Paint>::FromArguments(
+flutter::Paint DartConverter<flutter::Paint>::FromArguments(
     Dart_NativeArguments args,
     int index,
     Dart_Handle& exception) {
@@ -216,14 +216,14 @@ blink::Paint DartConverter<blink::Paint>::FromArguments(
   Dart_Handle paint_data = Dart_GetNativeArgument(args, index + 1);
   FML_DCHECK(!LogIfError(paint_data));
 
-  return blink::Paint(paint_objects, paint_data);
+  return flutter::Paint(paint_objects, paint_data);
 }
 
-blink::PaintData DartConverter<blink::PaintData>::FromArguments(
+flutter::PaintData DartConverter<flutter::PaintData>::FromArguments(
     Dart_NativeArguments args,
     int index,
     Dart_Handle& exception) {
-  return blink::PaintData();
+  return flutter::PaintData();
 }
 
 }  // namespace tonic

--- a/lib/ui/painting/paint.h
+++ b/lib/ui/painting/paint.h
@@ -8,7 +8,7 @@
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/tonic/converter/dart_converter.h"
 
-namespace blink {
+namespace flutter {
 
 class Paint {
  public:
@@ -30,22 +30,22 @@ class Paint {
 // data for a Paint object).
 class PaintData {};
 
-}  // namespace blink
+}  // namespace flutter
 
 namespace tonic {
 
 template <>
-struct DartConverter<blink::Paint> {
-  static blink::Paint FromArguments(Dart_NativeArguments args,
-                                    int index,
-                                    Dart_Handle& exception);
+struct DartConverter<flutter::Paint> {
+  static flutter::Paint FromArguments(Dart_NativeArguments args,
+                                      int index,
+                                      Dart_Handle& exception);
 };
 
 template <>
-struct DartConverter<blink::PaintData> {
-  static blink::PaintData FromArguments(Dart_NativeArguments args,
-                                        int index,
-                                        Dart_Handle& exception);
+struct DartConverter<flutter::PaintData> {
+  static flutter::PaintData FromArguments(Dart_NativeArguments args,
+                                          int index,
+                                          Dart_Handle& exception);
 };
 
 }  // namespace tonic

--- a/lib/ui/painting/path.cc
+++ b/lib/ui/painting/path.cc
@@ -15,7 +15,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 typedef CanvasPath Path;
 
@@ -299,4 +299,4 @@ fml::RefPtr<CanvasPath> CanvasPath::clone() {
   return path;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/path.h
+++ b/lib/ui/painting/path.h
@@ -16,7 +16,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class CanvasPath : public RefCountedDartWrappable<CanvasPath> {
   DEFINE_WRAPPERTYPEINFO();
@@ -112,6 +112,6 @@ class CanvasPath : public RefCountedDartWrappable<CanvasPath> {
   SkPath path_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_PATH_H_

--- a/lib/ui/painting/path_measure.cc
+++ b/lib/ui/painting/path_measure.cc
@@ -15,7 +15,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 typedef CanvasPathMeasure PathMeasure;
 
@@ -132,4 +132,4 @@ bool CanvasPathMeasure::nextContour() {
   return false;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/path_measure.h
+++ b/lib/ui/painting/path_measure.h
@@ -20,7 +20,7 @@ class DartLibraryNatives;
 // Be sure that the client doesn't modify a path on us before Skia finishes
 // See AOSP's reasoning in PathMeasure.cpp
 
-namespace blink {
+namespace flutter {
 
 class CanvasPathMeasure : public RefCountedDartWrappable<CanvasPathMeasure> {
   DEFINE_WRAPPERTYPEINFO();
@@ -52,6 +52,6 @@ class CanvasPathMeasure : public RefCountedDartWrappable<CanvasPathMeasure> {
   std::vector<sk_sp<SkContourMeasure>> measures_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_PATH_MEASURE_H_

--- a/lib/ui/painting/picture.cc
+++ b/lib/ui/painting/picture.cc
@@ -15,7 +15,7 @@
 #include "third_party/tonic/dart_persistent_value.h"
 #include "third_party/tonic/logging/dart_invoke.h"
 
-namespace blink {
+namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Picture);
 
@@ -125,4 +125,4 @@ Dart_Handle Picture::RasterizeToImage(sk_sp<SkPicture> picture,
   return Dart_Null();
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -14,7 +14,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 class Canvas;
 
 class Picture : public RefCountedDartWrappable<Picture> {
@@ -48,6 +48,6 @@ class Picture : public RefCountedDartWrappable<Picture> {
   flow::SkiaGPUObject<SkPicture> picture_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_PICTURE_H_

--- a/lib/ui/painting/picture_recorder.cc
+++ b/lib/ui/painting/picture_recorder.cc
@@ -11,7 +11,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 static void PictureRecorder_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&PictureRecorder::Create, args);
@@ -60,4 +60,4 @@ fml::RefPtr<Picture> PictureRecorder::endRecording() {
   return picture;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/picture_recorder.h
+++ b/lib/ui/painting/picture_recorder.h
@@ -12,7 +12,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 class Canvas;
 class Picture;
 
@@ -41,6 +41,6 @@ class PictureRecorder : public RefCountedDartWrappable<PictureRecorder> {
   fml::RefPtr<Canvas> canvas_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_PICTURE_RECORDER_H_

--- a/lib/ui/painting/rrect.cc
+++ b/lib/ui/painting/rrect.cc
@@ -8,7 +8,7 @@
 #include "third_party/tonic/logging/dart_error.h"
 #include "third_party/tonic/typed_data/float32_list.h"
 
-using namespace blink;
+using namespace flutter;
 
 namespace tonic {
 

--- a/lib/ui/painting/rrect.h
+++ b/lib/ui/painting/rrect.h
@@ -9,7 +9,7 @@
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/tonic/converter/dart_converter.h"
 
-namespace blink {
+namespace flutter {
 
 class RRect {
  public:
@@ -17,16 +17,16 @@ class RRect {
   bool is_null;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 namespace tonic {
 
 template <>
-struct DartConverter<blink::RRect> {
-  static blink::RRect FromDart(Dart_Handle handle);
-  static blink::RRect FromArguments(Dart_NativeArguments args,
-                                    int index,
-                                    Dart_Handle& exception);
+struct DartConverter<flutter::RRect> {
+  static flutter::RRect FromDart(Dart_Handle handle);
+  static flutter::RRect FromArguments(Dart_NativeArguments args,
+                                      int index,
+                                      Dart_Handle& exception);
 };
 
 }  // namespace tonic

--- a/lib/ui/painting/shader.cc
+++ b/lib/ui/painting/shader.cc
@@ -6,7 +6,7 @@
 
 #include "flutter/lib/ui/ui_dart_state.h"
 
-namespace blink {
+namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Shader);
 
@@ -15,4 +15,4 @@ Shader::Shader(flow::SkiaGPUObject<SkShader> shader)
 
 Shader::~Shader() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/shader.h
+++ b/lib/ui/painting/shader.h
@@ -10,7 +10,7 @@
 #include "flutter/lib/ui/ui_dart_state.h"
 #include "third_party/skia/include/core/SkShader.h"
 
-namespace blink {
+namespace flutter {
 
 class Shader : public RefCountedDartWrappable<Shader> {
   DEFINE_WRAPPERTYPEINFO();
@@ -32,6 +32,6 @@ class Shader : public RefCountedDartWrappable<Shader> {
   flow::SkiaGPUObject<SkShader> shader_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_SHADER_H_

--- a/lib/ui/painting/vertices.cc
+++ b/lib/ui/painting/vertices.cc
@@ -7,7 +7,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 namespace {
 
@@ -83,4 +83,4 @@ void Vertices::init(SkVertices::VertexMode vertex_mode,
   vertices_ = builder.detach();
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/painting/vertices.h
+++ b/lib/ui/painting/vertices.h
@@ -14,7 +14,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class Vertices : public RefCountedDartWrappable<Vertices> {
   DEFINE_WRAPPERTYPEINFO();
@@ -41,6 +41,6 @@ class Vertices : public RefCountedDartWrappable<Vertices> {
   sk_sp<SkVertices> vertices_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PAINTING_VERTICES_H_

--- a/lib/ui/plugins/callback_cache.cc
+++ b/lib/ui/plugins/callback_cache.cc
@@ -19,7 +19,7 @@ using rapidjson::StringBuffer;
 using rapidjson::Writer;
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 static const char* kHandleKey = "handle";
 static const char* kRepresentationKey = "representation";
@@ -192,4 +192,4 @@ Dart_Handle DartCallbackCache::LookupDartClosure(
   return closure;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/plugins/callback_cache.h
+++ b/lib/ui/plugins/callback_cache.h
@@ -14,7 +14,7 @@
 #include "flutter/fml/synchronization/thread_annotations.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
-namespace blink {
+namespace flutter {
 
 typedef struct {
   std::string name;
@@ -55,6 +55,6 @@ class DartCallbackCache {
   FML_DISALLOW_IMPLICIT_CONSTRUCTORS(DartCallbackCache);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_CALLBACK_CACHE_H_

--- a/lib/ui/semantics/custom_accessibility_action.cc
+++ b/lib/ui/semantics/custom_accessibility_action.cc
@@ -4,10 +4,10 @@
 
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 
-namespace blink {
+namespace flutter {
 
 CustomAccessibilityAction::CustomAccessibilityAction() = default;
 
 CustomAccessibilityAction::~CustomAccessibilityAction() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/semantics/custom_accessibility_action.h
+++ b/lib/ui/semantics/custom_accessibility_action.h
@@ -10,7 +10,7 @@
 #include "third_party/tonic/typed_data/float64_list.h"
 #include "third_party/tonic/typed_data/int32_list.h"
 
-namespace blink {
+namespace flutter {
 
 /// A custom accessibility action is used to indicate additional semantics
 /// actions that a user can perform on a semantics node beyond the
@@ -32,6 +32,6 @@ struct CustomAccessibilityAction {
 using CustomAccessibilityActionUpdates =
     std::unordered_map<int32_t, CustomAccessibilityAction>;
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_SEMANTICS_LOCAL_CONTEXT_ACTION_H_

--- a/lib/ui/semantics/semantics_node.cc
+++ b/lib/ui/semantics/semantics_node.cc
@@ -6,7 +6,7 @@
 
 #include <string.h>
 
-namespace blink {
+namespace flutter {
 
 constexpr int32_t kMinPlatformViewId = -1;
 
@@ -28,4 +28,4 @@ bool SemanticsNode::IsPlatformViewNode() const {
   return platformViewId > kMinPlatformViewId;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -14,7 +14,7 @@
 #include "third_party/skia/include/core/SkMatrix44.h"
 #include "third_party/skia/include/core/SkRect.h"
 
-namespace blink {
+namespace flutter {
 
 // Must match the SemanticsAction enum in semantics.dart and in each of the
 // embedders.
@@ -117,6 +117,6 @@ struct SemanticsNode {
 // semantic information for the node corresponding to the ID.
 using SemanticsNodeUpdates = std::unordered_map<int32_t, SemanticsNode>;
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_SEMANTICS_SEMANTICS_NODE_H_

--- a/lib/ui/semantics/semantics_update.cc
+++ b/lib/ui/semantics/semantics_update.cc
@@ -12,7 +12,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, SemanticsUpdate);
 
@@ -45,4 +45,4 @@ void SemanticsUpdate::dispose() {
   ClearDartWrapper();
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/semantics/semantics_update.h
+++ b/lib/ui/semantics/semantics_update.h
@@ -13,7 +13,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class SemanticsUpdate : public RefCountedDartWrappable<SemanticsUpdate> {
   DEFINE_WRAPPERTYPEINFO();
@@ -41,6 +41,6 @@ class SemanticsUpdate : public RefCountedDartWrappable<SemanticsUpdate> {
   CustomAccessibilityActionUpdates actions_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_SEMANTICS_SEMANTICS_UPDATE_H_

--- a/lib/ui/semantics/semantics_update_builder.cc
+++ b/lib/ui/semantics/semantics_update_builder.cc
@@ -9,7 +9,7 @@
 #include "third_party/tonic/dart_binding_macros.h"
 #include "third_party/tonic/dart_library_natives.h"
 
-namespace blink {
+namespace flutter {
 
 static void SemanticsUpdateBuilder_constructor(Dart_NativeArguments args) {
   DartCallConstructor(&SemanticsUpdateBuilder::create, args);
@@ -114,4 +114,4 @@ fml::RefPtr<SemanticsUpdate> SemanticsUpdateBuilder::build() {
   return SemanticsUpdate::create(std::move(nodes_), std::move(actions_));
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/semantics/semantics_update_builder.h
+++ b/lib/ui/semantics/semantics_update_builder.h
@@ -10,7 +10,7 @@
 #include "third_party/tonic/typed_data/float64_list.h"
 #include "third_party/tonic/typed_data/int32_list.h"
 
-namespace blink {
+namespace flutter {
 
 class SemanticsUpdateBuilder
     : public RefCountedDartWrappable<SemanticsUpdateBuilder> {
@@ -68,6 +68,6 @@ class SemanticsUpdateBuilder
   CustomAccessibilityActionUpdates actions_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_SEMANTICS_SEMANTICS_UPDATE_BUILDER_H_

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -8,7 +8,7 @@
 #include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPicture.h"
 
-namespace blink {
+namespace flutter {
 
 class SnapshotDelegate {
  public:
@@ -16,6 +16,6 @@ class SnapshotDelegate {
                                             SkISize picture_size) = 0;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_SNAPSHOT_DELEGATE_H_

--- a/lib/ui/text/asset_manager_font_provider.cc
+++ b/lib/ui/text/asset_manager_font_provider.cc
@@ -10,7 +10,7 @@
 #include "third_party/skia/include/core/SkString.h"
 #include "third_party/skia/include/core/SkTypeface.h"
 
-namespace blink {
+namespace flutter {
 
 namespace {
 
@@ -21,7 +21,7 @@ void MappingReleaseProc(const void* ptr, void* context) {
 }  // anonymous namespace
 
 AssetManagerFontProvider::AssetManagerFontProvider(
-    std::shared_ptr<blink::AssetManager> asset_manager)
+    std::shared_ptr<flutter::AssetManager> asset_manager)
     : asset_manager_(asset_manager) {}
 
 AssetManagerFontProvider::~AssetManagerFontProvider() = default;
@@ -65,7 +65,7 @@ void AssetManagerFontProvider::RegisterAsset(std::string family_name,
 }
 
 AssetManagerFontStyleSet::AssetManagerFontStyleSet(
-    std::shared_ptr<blink::AssetManager> asset_manager)
+    std::shared_ptr<flutter::AssetManager> asset_manager)
     : asset_manager_(asset_manager) {}
 
 AssetManagerFontStyleSet::~AssetManagerFontStyleSet() = default;
@@ -131,4 +131,4 @@ AssetManagerFontStyleSet::TypefaceAsset::TypefaceAsset(
 
 AssetManagerFontStyleSet::TypefaceAsset::~TypefaceAsset() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/text/asset_manager_font_provider.h
+++ b/lib/ui/text/asset_manager_font_provider.h
@@ -16,11 +16,12 @@
 #include "third_party/skia/include/core/SkTypeface.h"
 #include "txt/font_asset_provider.h"
 
-namespace blink {
+namespace flutter {
 
 class AssetManagerFontStyleSet : public SkFontStyleSet {
  public:
-  AssetManagerFontStyleSet(std::shared_ptr<blink::AssetManager> asset_manager);
+  AssetManagerFontStyleSet(
+      std::shared_ptr<flutter::AssetManager> asset_manager);
 
   ~AssetManagerFontStyleSet() override;
 
@@ -39,7 +40,7 @@ class AssetManagerFontStyleSet : public SkFontStyleSet {
   SkTypeface* matchStyle(const SkFontStyle& pattern) override;
 
  private:
-  std::shared_ptr<blink::AssetManager> asset_manager_;
+  std::shared_ptr<flutter::AssetManager> asset_manager_;
 
   struct TypefaceAsset {
     TypefaceAsset(std::string a);
@@ -58,7 +59,8 @@ class AssetManagerFontStyleSet : public SkFontStyleSet {
 
 class AssetManagerFontProvider : public txt::FontAssetProvider {
  public:
-  AssetManagerFontProvider(std::shared_ptr<blink::AssetManager> asset_manager);
+  AssetManagerFontProvider(
+      std::shared_ptr<flutter::AssetManager> asset_manager);
 
   ~AssetManagerFontProvider() override;
 
@@ -82,6 +84,6 @@ class AssetManagerFontProvider : public txt::FontAssetProvider {
   FML_DISALLOW_COPY_AND_ASSIGN(AssetManagerFontProvider);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_TEXT_ASSET_MANAGER_FONT_PROVIDER_H_

--- a/lib/ui/text/font_collection.cc
+++ b/lib/ui/text/font_collection.cc
@@ -23,7 +23,7 @@
 #include "txt/asset_font_manager.h"
 #include "txt/test_font_manager.h"
 
-namespace blink {
+namespace flutter {
 
 namespace {
 
@@ -161,4 +161,4 @@ void FontCollection::LoadFontFromList(const uint8_t* font_data,
   collection_->ClearFontFamilyCache();
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/text/font_collection.h
+++ b/lib/ui/text/font_collection.h
@@ -17,7 +17,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class FontCollection {
  public:
@@ -44,6 +44,6 @@ class FontCollection {
   FML_DISALLOW_COPY_AND_ASSIGN(FontCollection);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_TEXT_FONT_COLLECTION_H_

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -15,7 +15,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, Paragraph);
 
@@ -101,4 +101,4 @@ Dart_Handle Paragraph::getWordBoundary(unsigned offset) {
   return m_paragraphImpl->getWordBoundary(offset);
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/text/paragraph.h
+++ b/lib/ui/text/paragraph.h
@@ -17,7 +17,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class Paragraph : public RefCountedDartWrappable<Paragraph> {
   DEFINE_WRAPPERTYPEINFO();
@@ -59,6 +59,6 @@ class Paragraph : public RefCountedDartWrappable<Paragraph> {
   explicit Paragraph(std::unique_ptr<txt::Paragraph> paragraph);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_TEXT_PARAGRAPH_H_

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -24,7 +24,7 @@
 #include "third_party/tonic/dart_library_natives.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
-namespace blink {
+namespace flutter {
 namespace {
 
 // TextStyle
@@ -275,7 +275,7 @@ ParagraphBuilder::ParagraphBuilder(
       UIDartState::Current()->window()->client()->GetFontCollection();
   m_paragraphBuilder = std::make_unique<txt::ParagraphBuilder>(
       style, font_collection.GetFontCollection());
-}  // namespace blink
+}  // namespace flutter
 
 ParagraphBuilder::~ParagraphBuilder() = default;
 
@@ -434,4 +434,4 @@ fml::RefPtr<Paragraph> ParagraphBuilder::build() {
   return Paragraph::Create(m_paragraphBuilder->Build());
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/text/paragraph_builder.h
+++ b/lib/ui/text/paragraph_builder.h
@@ -16,7 +16,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class Paragraph;
 
@@ -72,6 +72,6 @@ class ParagraphBuilder : public RefCountedDartWrappable<ParagraphBuilder> {
   std::unique_ptr<txt::ParagraphBuilder> m_paragraphBuilder;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_TEXT_PARAGRAPH_BUILDER_H_

--- a/lib/ui/text/paragraph_impl.cc
+++ b/lib/ui/text/paragraph_impl.cc
@@ -4,4 +4,4 @@
 
 #include "flutter/lib/ui/text/paragraph_impl.h"
 
-namespace blink {}  // namespace blink
+namespace flutter {}  // namespace flutter

--- a/lib/ui/text/paragraph_impl.h
+++ b/lib/ui/text/paragraph_impl.h
@@ -9,7 +9,7 @@
 #include "flutter/lib/ui/text/text_box.h"
 #include "flutter/third_party/txt/src/txt/paragraph.h"
 
-namespace blink {
+namespace flutter {
 
 class ParagraphImpl {
  public:
@@ -44,6 +44,6 @@ class ParagraphImpl {
   virtual Dart_Handle getWordBoundary(unsigned offset) = 0;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_TEXT_PARAGRAPH_IMPL_H_

--- a/lib/ui/text/paragraph_impl_txt.cc
+++ b/lib/ui/text/paragraph_impl_txt.cc
@@ -14,7 +14,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 ParagraphImplTxt::ParagraphImplTxt(std::unique_ptr<txt::Paragraph> paragraph)
     : m_paragraph(std::move(paragraph)) {}
@@ -71,7 +71,7 @@ std::vector<TextBox> ParagraphImplTxt::getRectsForRange(
       start, end, rect_height_style, rect_width_style);
   for (const txt::Paragraph::TextBox& box : boxes) {
     result.emplace_back(box.rect,
-                        static_cast<blink::TextDirection>(box.direction));
+                        static_cast<flutter::TextDirection>(box.direction));
   }
   return result;
 }
@@ -93,4 +93,4 @@ Dart_Handle ParagraphImplTxt::getWordBoundary(unsigned offset) {
   return result;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/text/paragraph_impl_txt.h
+++ b/lib/ui/text/paragraph_impl_txt.h
@@ -9,7 +9,7 @@
 #include "flutter/lib/ui/text/paragraph_impl.h"
 #include "flutter/lib/ui/text/text_box.h"
 
-namespace blink {
+namespace flutter {
 
 class ParagraphImplTxt : public ParagraphImpl {
  public:
@@ -41,6 +41,6 @@ class ParagraphImplTxt : public ParagraphImpl {
   double m_width = -1.0;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_TEXT_PARAGRAPH_IMPL_TXT_H_

--- a/lib/ui/text/text_box.cc
+++ b/lib/ui/text/text_box.cc
@@ -9,7 +9,7 @@
 #include "third_party/tonic/dart_state.h"
 #include "third_party/tonic/logging/dart_error.h"
 
-using namespace blink;
+using namespace flutter;
 
 namespace tonic {
 

--- a/lib/ui/text/text_box.h
+++ b/lib/ui/text/text_box.h
@@ -9,7 +9,7 @@
 #include "third_party/skia/include/core/SkRect.h"
 #include "third_party/tonic/converter/dart_converter.h"
 
-namespace blink {
+namespace flutter {
 
 enum class TextDirection {
   rtl,
@@ -23,17 +23,17 @@ struct TextBox {
   TextBox(SkRect r, TextDirection d) : rect(r), direction(d) {}
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 namespace tonic {
 
 template <>
-struct DartConverter<blink::TextBox> {
-  static Dart_Handle ToDart(const blink::TextBox& val);
+struct DartConverter<flutter::TextBox> {
+  static Dart_Handle ToDart(const flutter::TextBox& val);
 };
 
 template <>
-struct DartListFactory<blink::TextBox> {
+struct DartListFactory<flutter::TextBox> {
   static Dart_Handle NewList(intptr_t length);
 };
 

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -11,7 +11,7 @@
 
 using tonic::ToDart;
 
-namespace blink {
+namespace flutter {
 
 UIDartState::UIDartState(
     TaskRunners task_runners,
@@ -149,4 +149,4 @@ void UIDartState::ReportUnhandledException(const std::string& error,
                  << stack_trace;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -23,7 +23,7 @@
 #include "third_party/tonic/dart_persistent_value.h"
 #include "third_party/tonic/dart_state.h"
 
-namespace blink {
+namespace flutter {
 class FontSelector;
 class Window;
 
@@ -112,6 +112,6 @@ class UIDartState : public tonic::DartState {
   void AddOrRemoveTaskObserver(bool add);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_UI_DART_STATE_H_

--- a/lib/ui/versions.cc
+++ b/lib/ui/versions.cc
@@ -12,7 +12,7 @@
 
 using tonic::DartConverter;
 
-namespace blink {
+namespace flutter {
 
 // returns a vector with 3 versions.
 // Dart, Skia and Flutter engine versions in this order.
@@ -28,4 +28,4 @@ void Versions::RegisterNatives(tonic::DartLibraryNatives* natives) {
   natives->Register({{"Versions_getVersions", GetVersions, 0, true}});
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/versions.h
+++ b/lib/ui/versions.h
@@ -9,13 +9,13 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 
 class Versions final {
  public:
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_VERSIONS_H_

--- a/lib/ui/window/platform_message.cc
+++ b/lib/ui/window/platform_message.cc
@@ -6,7 +6,7 @@
 
 #include <utility>
 
-namespace blink {
+namespace flutter {
 
 PlatformMessage::PlatformMessage(std::string channel,
                                  std::vector<uint8_t> data,
@@ -24,4 +24,4 @@ PlatformMessage::PlatformMessage(std::string channel,
 
 PlatformMessage::~PlatformMessage() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/window/platform_message.h
+++ b/lib/ui/window/platform_message.h
@@ -12,7 +12,7 @@
 #include "flutter/fml/memory/ref_ptr.h"
 #include "flutter/lib/ui/window/platform_message_response.h"
 
-namespace blink {
+namespace flutter {
 
 class PlatformMessage : public fml::RefCountedThreadSafe<PlatformMessage> {
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(PlatformMessage);
@@ -41,6 +41,6 @@ class PlatformMessage : public fml::RefCountedThreadSafe<PlatformMessage> {
   fml::RefPtr<PlatformMessageResponse> response_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PLATFORM_PLATFORM_MESSAGE_H_

--- a/lib/ui/window/platform_message_response.cc
+++ b/lib/ui/window/platform_message_response.cc
@@ -4,10 +4,10 @@
 
 #include "flutter/lib/ui/window/platform_message_response.h"
 
-namespace blink {
+namespace flutter {
 
 PlatformMessageResponse::PlatformMessageResponse() = default;
 
 PlatformMessageResponse::~PlatformMessageResponse() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/window/platform_message_response.h
+++ b/lib/ui/window/platform_message_response.h
@@ -11,7 +11,7 @@
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/memory/ref_ptr.h"
 
-namespace blink {
+namespace flutter {
 
 class PlatformMessageResponse
     : public fml::RefCountedThreadSafe<PlatformMessageResponse> {
@@ -31,6 +31,6 @@ class PlatformMessageResponse
   bool is_complete_ = false;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PLATFORM_PLATFORM_MESSAGE_RESPONSE_H_

--- a/lib/ui/window/platform_message_response_dart.cc
+++ b/lib/ui/window/platform_message_response_dart.cc
@@ -12,7 +12,7 @@
 #include "third_party/tonic/dart_state.h"
 #include "third_party/tonic/logging/dart_invoke.h"
 
-namespace blink {
+namespace flutter {
 
 namespace {
 
@@ -92,4 +92,4 @@ void PlatformMessageResponseDart::CompleteEmpty() {
       }));
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/window/platform_message_response_dart.h
+++ b/lib/ui/window/platform_message_response_dart.h
@@ -9,7 +9,7 @@
 #include "flutter/lib/ui/window/platform_message_response.h"
 #include "third_party/tonic/dart_persistent_value.h"
 
-namespace blink {
+namespace flutter {
 
 class PlatformMessageResponseDart : public PlatformMessageResponse {
   FML_FRIEND_MAKE_REF_COUNTED(PlatformMessageResponseDart);
@@ -29,6 +29,6 @@ class PlatformMessageResponseDart : public PlatformMessageResponse {
   fml::RefPtr<fml::TaskRunner> ui_task_runner_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_PLATFORM_PLATFORM_MESSAGE_RESPONSE_DART_H_

--- a/lib/ui/window/pointer_data.cc
+++ b/lib/ui/window/pointer_data.cc
@@ -6,7 +6,7 @@
 
 #include <string.h>
 
-namespace blink {
+namespace flutter {
 
 // If this value changes, update the pointer data unpacking code in hooks.dart.
 static constexpr int kPointerDataFieldCount = 24;
@@ -18,4 +18,4 @@ void PointerData::Clear() {
   memset(this, 0, sizeof(PointerData));
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 
-namespace blink {
+namespace flutter {
 
 // This structure is unpacked by hooks.dart.
 struct alignas(8) PointerData {
@@ -64,6 +64,6 @@ struct alignas(8) PointerData {
   void Clear();
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_WINDOW_POINTER_DATA_H_

--- a/lib/ui/window/pointer_data_packet.cc
+++ b/lib/ui/window/pointer_data_packet.cc
@@ -6,7 +6,7 @@
 
 #include <string.h>
 
-namespace blink {
+namespace flutter {
 
 PointerDataPacket::PointerDataPacket(size_t count)
     : data_(count * sizeof(PointerData)) {}
@@ -20,4 +20,4 @@ void PointerDataPacket::SetPointerData(size_t i, const PointerData& data) {
   memcpy(&data_[i * sizeof(PointerData)], &data, sizeof(PointerData));
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/window/pointer_data_packet.h
+++ b/lib/ui/window/pointer_data_packet.h
@@ -12,7 +12,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/lib/ui/window/pointer_data.h"
 
-namespace blink {
+namespace flutter {
 
 class PointerDataPacket {
  public:
@@ -29,6 +29,6 @@ class PointerDataPacket {
   FML_DISALLOW_COPY_AND_ASSIGN(PointerDataPacket);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_WINDOW_POINTER_DATA_PACKET_H_

--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/lib/ui/window/viewport_metrics.h"
 
-namespace blink {
+namespace flutter {
 ViewportMetrics::ViewportMetrics() = default;
 
 ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
@@ -32,4 +32,4 @@ ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
 
 ViewportMetrics::ViewportMetrics(const ViewportMetrics& other) = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 
-namespace blink {
+namespace flutter {
 
 struct ViewportMetrics {
   ViewportMetrics();
@@ -58,6 +58,6 @@ struct LogicalMetrics {
   LogicalInset view_inset;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_WINDOW_VIEWPORT_METRICS_H_

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -14,7 +14,7 @@
 #include "third_party/tonic/logging/dart_invoke.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
-namespace blink {
+namespace flutter {
 namespace {
 
 void DefaultRouteName(Dart_NativeArguments args) {
@@ -356,4 +356,4 @@ void Window::RegisterNatives(tonic::DartLibraryNatives* natives) {
   });
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -21,7 +21,7 @@ namespace tonic {
 class DartLibraryNatives;
 }  // namespace tonic
 
-namespace blink {
+namespace flutter {
 class FontCollection;
 class Scene;
 
@@ -88,10 +88,10 @@ class Window final {
 
   // We use id 0 to mean that no response is expected.
   int next_response_id_ = 1;
-  std::unordered_map<int, fml::RefPtr<blink::PlatformMessageResponse>>
+  std::unordered_map<int, fml::RefPtr<flutter::PlatformMessageResponse>>
       pending_responses_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_LIB_UI_WINDOW_WINDOW_H_

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -27,7 +27,7 @@
 #include "third_party/tonic/scopes/dart_api_scope.h"
 #include "third_party/tonic/scopes/dart_isolate_scope.h"
 
-namespace blink {
+namespace flutter {
 
 std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
     const Settings& settings,
@@ -547,7 +547,7 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
     return nullptr;
   }
 
-  blink::TaskRunners null_task_runners(
+  flutter::TaskRunners null_task_runners(
       "io.flutter." DART_VM_SERVICE_ISOLATE_NAME, nullptr, nullptr, nullptr,
       nullptr);
 
@@ -659,8 +659,8 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
   if (!is_root_isolate) {
     auto* raw_embedder_isolate = embedder_isolate.release();
 
-    blink::TaskRunners null_task_runners(advisory_script_uri, nullptr, nullptr,
-                                         nullptr, nullptr);
+    flutter::TaskRunners null_task_runners(advisory_script_uri, nullptr,
+                                           nullptr, nullptr, nullptr);
 
     embedder_isolate = std::make_unique<std::shared_ptr<DartIsolate>>(
         std::make_shared<DartIsolate>(
@@ -773,4 +773,4 @@ DartIsolate::AutoFireClosure::~AutoFireClosure() {
   }
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -21,7 +21,7 @@
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/dart_state.h"
 
-namespace blink {
+namespace flutter {
 class DartVM;
 
 class DartIsolate : public UIDartState {
@@ -184,6 +184,6 @@ class DartIsolate : public UIDartState {
   FML_DISALLOW_COPY_AND_ASSIGN(DartIsolate);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_DART_ISOLATE_H_

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -15,7 +15,7 @@
 #include "flutter/testing/thread_test.h"
 #include "third_party/tonic/scopes/dart_isolate_scope.h"
 
-namespace blink {
+namespace flutter {
 namespace testing {
 
 using DartIsolateTest = RuntimeTest;
@@ -88,7 +88,7 @@ class AutoIsolateShutdown {
  public:
   AutoIsolateShutdown() = default;
 
-  AutoIsolateShutdown(std::shared_ptr<blink::DartIsolate> isolate,
+  AutoIsolateShutdown(std::shared_ptr<flutter::DartIsolate> isolate,
                       fml::RefPtr<fml::TaskRunner> runner)
       : isolate_(std::move(isolate)), runner_(std::move(runner)) {}
 
@@ -131,13 +131,13 @@ class AutoIsolateShutdown {
     return true;
   }
 
-  blink::DartIsolate* get() {
+  flutter::DartIsolate* get() {
     FML_CHECK(isolate_);
     return isolate_.get();
   }
 
  private:
-  std::shared_ptr<blink::DartIsolate> isolate_;
+  std::shared_ptr<flutter::DartIsolate> isolate_;
   fml::RefPtr<fml::TaskRunner> runner_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AutoIsolateShutdown);
@@ -307,4 +307,4 @@ TEST_F(DartIsolateTest, CanRegisterNativeCallback) {
 }
 
 }  // namespace testing
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_lifecycle_unittests.cc
+++ b/runtime/dart_lifecycle_unittests.cc
@@ -9,7 +9,7 @@
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/runtime/runtime_test.h"
 
-namespace blink {
+namespace flutter {
 namespace testing {
 
 using DartLifecycleTest = RuntimeTest;
@@ -139,4 +139,4 @@ TEST_F(DartLifecycleTest, ShuttingDownTheVMShutsDownTheIsolate) {
 }
 
 }  // namespace testing
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -27,7 +27,7 @@
     return false;                           \
   }
 
-namespace blink {
+namespace flutter {
 namespace {
 
 static Dart_LibraryTagHandler g_embedder_tag_handler;
@@ -199,4 +199,4 @@ bool DartServiceIsolate::Startup(std::string server_ip,
   return true;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_service_isolate.h
+++ b/runtime/dart_service_isolate.h
@@ -15,7 +15,7 @@
 
 #include "third_party/dart/runtime/include/dart_api.h"
 
-namespace blink {
+namespace flutter {
 
 class DartServiceIsolate {
  public:
@@ -51,6 +51,6 @@ class DartServiceIsolate {
       FML_GUARDED_BY(callbacks_mutex_);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_DART_SERVICE_ISOLATE_H_

--- a/runtime/dart_service_isolate_unittests.cc
+++ b/runtime/dart_service_isolate_unittests.cc
@@ -5,7 +5,7 @@
 #include "flutter/runtime/dart_service_isolate.h"
 #include "flutter/testing/testing.h"
 
-namespace blink {
+namespace flutter {
 
 TEST(DartServiceIsolateTest, CanAddAndRemoveHandles) {
   ASSERT_EQ(DartServiceIsolate::AddServerStatusCallback(nullptr), 0);
@@ -14,4 +14,4 @@ TEST(DartServiceIsolateTest, CanAddAndRemoveHandles) {
   ASSERT_TRUE(DartServiceIsolate::RemoveServerStatusCallback(handle));
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -13,7 +13,7 @@
 #include "flutter/runtime/dart_snapshot_buffer.h"
 #include "flutter/runtime/dart_vm.h"
 
-namespace blink {
+namespace flutter {
 
 const char* DartSnapshot::kVMDataSymbol = "kDartVmSnapshotData";
 const char* DartSnapshot::kVMInstructionsSymbol = "kDartVmSnapshotInstructions";
@@ -232,4 +232,4 @@ const uint8_t* DartSnapshot::GetInstructionsIfPresent() const {
   return instructions_ ? instructions_->GetSnapshotPointer() : nullptr;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_snapshot.h
+++ b/runtime/dart_snapshot.h
@@ -13,7 +13,7 @@
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/runtime/dart_snapshot_buffer.h"
 
-namespace blink {
+namespace flutter {
 
 class DartSnapshot : public fml::RefCountedThreadSafe<DartSnapshot> {
  public:
@@ -56,6 +56,6 @@ class DartSnapshot : public fml::RefCountedThreadSafe<DartSnapshot> {
   FML_DISALLOW_COPY_AND_ASSIGN(DartSnapshot);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_DART_SNAPSHOT_H_

--- a/runtime/dart_snapshot_buffer.cc
+++ b/runtime/dart_snapshot_buffer.cc
@@ -8,7 +8,7 @@
 
 #include "flutter/fml/mapping.h"
 
-namespace blink {
+namespace flutter {
 
 class NativeLibrarySnapshotBuffer final : public DartSnapshotBuffer {
  public:
@@ -99,4 +99,4 @@ DartSnapshotBuffer::CreateWithUnmanagedAllocation(const uint8_t* allocation) {
 
 DartSnapshotBuffer::~DartSnapshotBuffer() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_snapshot_buffer.h
+++ b/runtime/dart_snapshot_buffer.h
@@ -13,7 +13,7 @@
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/native_library.h"
 
-namespace blink {
+namespace flutter {
 
 // TODO(chinmaygarde): Replace this with just |fml::Mapping|.
 // https://github.com/flutter/flutter/issues/26782
@@ -40,6 +40,6 @@ class DartSnapshotBuffer {
   virtual size_t GetSnapshotSize() const = 0;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_DART_SNAPSHOT_BUFFER_H_

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -54,7 +54,7 @@ extern const uint8_t* observatory_assets_archive;
 }  // namespace observatory
 }  // namespace dart
 
-namespace blink {
+namespace flutter {
 
 // Arguments passed to the Dart VM in all configurations.
 static const char* kDartLanguageArgs[] = {
@@ -385,14 +385,15 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     // the very first frame gives us a good idea about Flutter's startup time.
     // Use a duration event so about:tracing will consider this event when
     // deciding the earliest event to use as time 0.
-    if (blink::engine_main_enter_ts != 0) {
-      Dart_TimelineEvent("FlutterEngineMainEnter",     // label
-                         blink::engine_main_enter_ts,  // timestamp0
-                         blink::engine_main_enter_ts,  // timestamp1_or_async_id
-                         Dart_Timeline_Event_Duration,  // event type
-                         0,                             // argument_count
-                         nullptr,                       // argument_names
-                         nullptr                        // argument_values
+    if (flutter::engine_main_enter_ts != 0) {
+      Dart_TimelineEvent(
+          "FlutterEngineMainEnter",       // label
+          flutter::engine_main_enter_ts,  // timestamp0
+          flutter::engine_main_enter_ts,  // timestamp1_or_async_id
+          Dart_Timeline_Event_Duration,   // event type
+          0,                              // argument_count
+          nullptr,                        // argument_names
+          nullptr                         // argument_values
       );
     }
   }
@@ -501,4 +502,4 @@ void DartVM::UnregisterActiveIsolate(std::shared_ptr<DartIsolate> isolate) {
   active_isolates_.erase(isolate);
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_vm.h
+++ b/runtime/dart_vm.h
@@ -22,7 +22,7 @@
 #include "flutter/runtime/service_protocol.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
-namespace blink {
+namespace flutter {
 
 class DartVM {
  public:
@@ -75,6 +75,6 @@ class DartVM {
   FML_DISALLOW_COPY_AND_ASSIGN(DartVM);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_DART_VM_H_

--- a/runtime/dart_vm_data.cc
+++ b/runtime/dart_vm_data.cc
@@ -4,7 +4,7 @@
 
 #include "flutter/runtime/dart_vm_data.h"
 
-namespace blink {
+namespace flutter {
 
 std::shared_ptr<const DartVMData> DartVMData::Create(
     Settings settings,
@@ -76,4 +76,4 @@ fml::RefPtr<const DartSnapshot> DartVMData::GetSharedSnapshot() const {
   return shared_snapshot_;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_vm_data.h
+++ b/runtime/dart_vm_data.h
@@ -8,7 +8,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/runtime/dart_snapshot.h"
 
-namespace blink {
+namespace flutter {
 
 class DartVMData {
  public:
@@ -42,6 +42,6 @@ class DartVMData {
   FML_DISALLOW_COPY_AND_ASSIGN(DartVMData);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_DART_VM_DATA_H_

--- a/runtime/dart_vm_lifecycle.cc
+++ b/runtime/dart_vm_lifecycle.cc
@@ -6,7 +6,7 @@
 
 #include <mutex>
 
-namespace blink {
+namespace flutter {
 
 // We need to explicitly put the constructor and destructor of the DartVM in the
 // critical section. All accesses (not just const members) to the global VM
@@ -121,4 +121,4 @@ DartVM* DartVMRef::GetRunningVM() {
   return vm;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/dart_vm_lifecycle.h
+++ b/runtime/dart_vm_lifecycle.h
@@ -12,7 +12,7 @@
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/runtime/service_protocol.h"
 
-namespace blink {
+namespace flutter {
 
 // A strong reference to the Dart VM. There can only be one VM running in the
 // process at any given time. A reference to the VM may only be obtained via the
@@ -77,6 +77,6 @@ class DartVMRef {
   FML_DISALLOW_COPY_AND_ASSIGN(DartVMRef);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_DART_VM_LIFECYCLE_H_

--- a/runtime/dart_vm_unittests.cc
+++ b/runtime/dart_vm_unittests.cc
@@ -6,7 +6,7 @@
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "gtest/gtest.h"
 
-namespace blink {
+namespace flutter {
 
 TEST(DartVM, SimpleInitialization) {
   Settings settings = {};
@@ -32,4 +32,4 @@ TEST(DartVM, SimpleIsolateNameServer) {
   ASSERT_TRUE(ns->RemoveIsolateNameMapping("foobar"));
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/embedder_resources.cc
+++ b/runtime/embedder_resources.cc
@@ -8,7 +8,7 @@
 
 #include "flutter/fml/logging.h"
 
-namespace blink {
+namespace flutter {
 
 using flutter::runtime::ResourcesEntry;
 
@@ -49,4 +49,4 @@ ResourcesEntry* EmbedderResources::At(int idx) {
   return nullptr;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/embedder_resources.h
+++ b/runtime/embedder_resources.h
@@ -17,7 +17,7 @@ struct ResourcesEntry {
 }  // namespace runtime
 }  // namespace flutter
 
-namespace blink {
+namespace flutter {
 
 class EmbedderResources {
  public:
@@ -34,6 +34,6 @@ class EmbedderResources {
   flutter::runtime::ResourcesEntry* resources_table_;
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_EMBEDDER_RESOURCES_H_

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -12,7 +12,7 @@
 #include "flutter/runtime/runtime_delegate.h"
 #include "third_party/tonic/dart_message_handler.h"
 
-namespace blink {
+namespace flutter {
 
 RuntimeController::RuntimeController(
     RuntimeDelegate& p_client,
@@ -344,4 +344,4 @@ RuntimeController::WindowData::WindowData(const WindowData& other) = default;
 
 RuntimeController::WindowData::~WindowData() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -20,7 +20,7 @@
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 
-namespace blink {
+namespace flutter {
 class Scene;
 class RuntimeDelegate;
 class View;
@@ -149,31 +149,31 @@ class RuntimeController final : public WindowClient {
 
   bool FlushRuntimeStateToIsolate();
 
-  // |blink::WindowClient|
+  // |flutter::WindowClient|
   std::string DefaultRouteName() override;
 
-  // |blink::WindowClient|
+  // |flutter::WindowClient|
   void ScheduleFrame() override;
 
-  // |blink::WindowClient|
+  // |flutter::WindowClient|
   void Render(Scene* scene) override;
 
-  // |blink::WindowClient|
+  // |flutter::WindowClient|
   void UpdateSemantics(SemanticsUpdate* update) override;
 
-  // |blink::WindowClient|
+  // |flutter::WindowClient|
   void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) override;
 
-  // |blink::WindowClient|
+  // |flutter::WindowClient|
   FontCollection& GetFontCollection() override;
 
-  // |blink::WindowClient|
+  // |flutter::WindowClient|
   void UpdateIsolateDescription(const std::string isolate_name,
                                 int64_t isolate_port) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RuntimeController);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_RUNTIME_CONTROLLER_H_

--- a/runtime/runtime_delegate.cc
+++ b/runtime/runtime_delegate.cc
@@ -4,8 +4,8 @@
 
 #include "flutter/runtime/runtime_delegate.h"
 
-namespace blink {
+namespace flutter {
 
 RuntimeDelegate::~RuntimeDelegate() = default;
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -15,7 +15,7 @@
 #include "flutter/lib/ui/window/platform_message.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 
-namespace blink {
+namespace flutter {
 
 class RuntimeDelegate {
  public:
@@ -26,8 +26,8 @@ class RuntimeDelegate {
   virtual void Render(std::unique_ptr<flow::LayerTree> layer_tree) = 0;
 
   virtual void UpdateSemantics(
-      blink::SemanticsNodeUpdates update,
-      blink::CustomAccessibilityActionUpdates actions) = 0;
+      flutter::SemanticsNodeUpdates update,
+      flutter::CustomAccessibilityActionUpdates actions) = 0;
 
   virtual void HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) = 0;
 
@@ -40,6 +40,6 @@ class RuntimeDelegate {
   virtual ~RuntimeDelegate();
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_RUNTIME_DELEGATE_H_

--- a/runtime/runtime_test.cc
+++ b/runtime/runtime_test.cc
@@ -7,7 +7,7 @@
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/testing/testing.h"
 
-namespace blink {
+namespace flutter {
 namespace testing {
 
 RuntimeTest::RuntimeTest()
@@ -108,4 +108,4 @@ void RuntimeTest::AddNativeCallback(std::string name,
 }
 
 }  // namespace testing
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/runtime_test.h
+++ b/runtime/runtime_test.h
@@ -12,7 +12,7 @@
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/thread_test.h"
 
-namespace blink {
+namespace flutter {
 namespace testing {
 
 class RuntimeTest : public ::testing::ThreadTest {
@@ -40,6 +40,6 @@ class RuntimeTest : public ::testing::ThreadTest {
 };
 
 }  // namespace testing
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_RUNTIME_TEST_H_

--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -18,7 +18,7 @@
 #include "rapidjson/writer.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 
-namespace blink {
+namespace flutter {
 
 const fml::StringView ServiceProtocol::kScreenshotExtensionName =
     "_flutter.screenshot";
@@ -276,4 +276,4 @@ bool ServiceProtocol::HandleListViewsMethod(
   return true;
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/service_protocol.h
+++ b/runtime/service_protocol.h
@@ -18,7 +18,7 @@
 #include "flutter/fml/task_runner.h"
 #include "rapidjson/document.h"
 
-namespace blink {
+namespace flutter {
 
 class ServiceProtocol {
  public:
@@ -100,6 +100,6 @@ class ServiceProtocol {
   FML_DISALLOW_COPY_AND_ASSIGN(ServiceProtocol);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_SERVICE_PROTOCOL_H_

--- a/runtime/start_up.cc
+++ b/runtime/start_up.cc
@@ -4,8 +4,8 @@
 
 #include "flutter/runtime/start_up.h"
 
-namespace blink {
+namespace flutter {
 
 int64_t engine_main_enter_ts = 0;
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/start_up.h
+++ b/runtime/start_up.h
@@ -7,7 +7,7 @@
 
 #include <stdint.h>
 
-namespace blink {
+namespace flutter {
 
 // The earliest available timestamp in the application's lifecycle. The
 // difference between this timestamp and the time we render the very first
@@ -19,6 +19,6 @@ namespace blink {
 // user code prior to initializing Flutter.
 extern int64_t engine_main_enter_ts;
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_START_UP_H_

--- a/runtime/test_font_data.cc
+++ b/runtime/test_font_data.cc
@@ -1215,7 +1215,7 @@ static const unsigned int kAhemFontLength = 0;
 
 #endif  // EMBED_TEST_FONT_DATA
 
-namespace blink {
+namespace flutter {
 
 std::unique_ptr<SkStreamAsset> GetTestFontData() {
   if (kAhemFontLength == 0) {
@@ -1229,4 +1229,4 @@ std::string GetTestFontFamilyName() {
   return "Ahem";
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/runtime/test_font_data.h
+++ b/runtime/test_font_data.h
@@ -10,11 +10,11 @@
 
 #include "third_party/skia/include/core/SkStream.h"
 
-namespace blink {
+namespace flutter {
 
 std::unique_ptr<SkStreamAsset> GetTestFontData();
 std::string GetTestFontFamilyName();
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_RUNTIME_TEST_FONT_DATA_H_

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -20,7 +20,7 @@ constexpr fml::TimeDelta kNotifyIdleTaskWaitTime =
 }  // namespace
 
 Animator::Animator(Delegate& delegate,
-                   blink::TaskRunners task_runners,
+                   flutter::TaskRunners task_runners,
                    std::unique_ptr<VsyncWaiter> waiter)
     : delegate_(delegate),
       task_runners_(std::move(task_runners)),

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -33,7 +33,7 @@ class Animator final {
   };
 
   Animator(Delegate& delegate,
-           blink::TaskRunners task_runners,
+           flutter::TaskRunners task_runners,
            std::unique_ptr<VsyncWaiter> waiter);
 
   ~Animator();
@@ -68,7 +68,7 @@ class Animator final {
   const char* FrameParity();
 
   Delegate& delegate_;
-  blink::TaskRunners task_runners_;
+  flutter::TaskRunners task_runners_;
   std::shared_ptr<VsyncWaiter> waiter_;
 
   fml::TimePoint last_begin_frame_time_;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -36,14 +36,14 @@ static constexpr char kLocalizationChannel[] = "flutter/localization";
 static constexpr char kSettingsChannel[] = "flutter/settings";
 
 Engine::Engine(Delegate& delegate,
-               blink::DartVM& vm,
-               fml::RefPtr<const blink::DartSnapshot> isolate_snapshot,
-               fml::RefPtr<const blink::DartSnapshot> shared_snapshot,
-               blink::TaskRunners task_runners,
-               blink::Settings settings,
+               flutter::DartVM& vm,
+               fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
+               fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
+               flutter::TaskRunners task_runners,
+               flutter::Settings settings,
                std::unique_ptr<Animator> animator,
-               fml::WeakPtr<blink::SnapshotDelegate> snapshot_delegate,
-               fml::WeakPtr<blink::IOManager> io_manager)
+               fml::WeakPtr<flutter::SnapshotDelegate> snapshot_delegate,
+               fml::WeakPtr<flutter::IOManager> io_manager)
     : delegate_(delegate),
       settings_(std::move(settings)),
       animator_(std::move(animator)),
@@ -53,7 +53,7 @@ Engine::Engine(Delegate& delegate,
   // Runtime controller is initialized here because it takes a reference to this
   // object as its delegate. The delegate may be called in the constructor and
   // we want to be fully initilazed by that point.
-  runtime_controller_ = std::make_unique<blink::RuntimeController>(
+  runtime_controller_ = std::make_unique<flutter::RuntimeController>(
       *this,                                 // runtime delegate
       &vm,                                   // VM
       std::move(isolate_snapshot),           // isolate snapshot
@@ -78,7 +78,7 @@ fml::WeakPtr<Engine> Engine::GetWeakPtr() const {
 }
 
 bool Engine::UpdateAssetManager(
-    std::shared_ptr<blink::AssetManager> new_asset_manager) {
+    std::shared_ptr<flutter::AssetManager> new_asset_manager) {
   if (asset_manager_ == new_asset_manager) {
     return false;
   }
@@ -127,11 +127,11 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
     return isolate_launch_status;
   }
 
-  std::shared_ptr<blink::DartIsolate> isolate =
+  std::shared_ptr<flutter::DartIsolate> isolate =
       runtime_controller_->GetRootIsolate().lock();
 
   bool isolate_running =
-      isolate && isolate->GetPhase() == blink::DartIsolate::Phase::Running;
+      isolate && isolate->GetPhase() == flutter::DartIsolate::Phase::Running;
 
   if (isolate_running) {
     tonic::DartState::Scope scope(isolate.get());
@@ -158,7 +158,7 @@ shell::Engine::RunStatus Engine::PrepareAndLaunchIsolate(
 
   auto isolate_configuration = configuration.TakeIsolateConfiguration();
 
-  std::shared_ptr<blink::DartIsolate> isolate =
+  std::shared_ptr<flutter::DartIsolate> isolate =
       runtime_controller_->GetRootIsolate().lock();
 
   if (!isolate) {
@@ -167,7 +167,7 @@ shell::Engine::RunStatus Engine::PrepareAndLaunchIsolate(
 
   // This can happen on iOS after a plugin shows a native window and returns to
   // the Flutter ViewController.
-  if (isolate->GetPhase() == blink::DartIsolate::Phase::Running) {
+  if (isolate->GetPhase() == flutter::DartIsolate::Phase::Running) {
     FML_DLOG(WARNING) << "Isolate was already running!";
     return RunStatus::FailureAlreadyRunning;
   }
@@ -235,7 +235,7 @@ void Engine::OnOutputSurfaceDestroyed() {
   StopAnimator();
 }
 
-void Engine::SetViewportMetrics(const blink::ViewportMetrics& metrics) {
+void Engine::SetViewportMetrics(const flutter::ViewportMetrics& metrics) {
   bool dimensions_changed =
       viewport_metrics_.physical_height != metrics.physical_height ||
       viewport_metrics_.physical_width != metrics.physical_width;
@@ -250,7 +250,7 @@ void Engine::SetViewportMetrics(const blink::ViewportMetrics& metrics) {
 }
 
 void Engine::DispatchPlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   if (message->channel() == kLifecycleChannel) {
     if (HandleLifecyclePlatformMessage(message.get()))
       return;
@@ -272,7 +272,7 @@ void Engine::DispatchPlatformMessage(
     HandleNavigationPlatformMessage(std::move(message));
 }
 
-bool Engine::HandleLifecyclePlatformMessage(blink::PlatformMessage* message) {
+bool Engine::HandleLifecyclePlatformMessage(flutter::PlatformMessage* message) {
   const auto& data = message->data();
   std::string state(reinterpret_cast<const char*>(data.data()), data.size());
   if (state == "AppLifecycleState.paused" ||
@@ -297,7 +297,7 @@ bool Engine::HandleLifecyclePlatformMessage(blink::PlatformMessage* message) {
 }
 
 bool Engine::HandleNavigationPlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   const auto& data = message->data();
 
   rapidjson::Document document;
@@ -314,7 +314,7 @@ bool Engine::HandleNavigationPlatformMessage(
 }
 
 bool Engine::HandleLocalizationPlatformMessage(
-    blink::PlatformMessage* message) {
+    flutter::PlatformMessage* message) {
   const auto& data = message->data();
 
   rapidjson::Document document;
@@ -348,7 +348,7 @@ bool Engine::HandleLocalizationPlatformMessage(
   return runtime_controller_->SetLocales(locale_data);
 }
 
-void Engine::HandleSettingsPlatformMessage(blink::PlatformMessage* message) {
+void Engine::HandleSettingsPlatformMessage(flutter::PlatformMessage* message) {
   const auto& data = message->data();
   std::string jsonData(reinterpret_cast<const char*>(data.data()), data.size());
   if (runtime_controller_->SetUserSettingsData(std::move(jsonData)) &&
@@ -357,7 +357,7 @@ void Engine::HandleSettingsPlatformMessage(blink::PlatformMessage* message) {
   }
 }
 
-void Engine::DispatchPointerDataPacket(const blink::PointerDataPacket& packet,
+void Engine::DispatchPointerDataPacket(const flutter::PointerDataPacket& packet,
                                        uint64_t trace_flow_id) {
   TRACE_EVENT0("flutter", "Engine::DispatchPointerDataPacket");
   TRACE_FLOW_STEP("flutter", "PointerEvent", trace_flow_id);
@@ -366,7 +366,7 @@ void Engine::DispatchPointerDataPacket(const blink::PointerDataPacket& packet,
 }
 
 void Engine::DispatchSemanticsAction(int id,
-                                     blink::SemanticsAction action,
+                                     flutter::SemanticsAction action,
                                      std::vector<uint8_t> args) {
   runtime_controller_->DispatchSemanticsAction(id, action, std::move(args));
 }
@@ -412,13 +412,14 @@ void Engine::Render(std::unique_ptr<flow::LayerTree> layer_tree) {
   animator_->Render(std::move(layer_tree));
 }
 
-void Engine::UpdateSemantics(blink::SemanticsNodeUpdates update,
-                             blink::CustomAccessibilityActionUpdates actions) {
+void Engine::UpdateSemantics(
+    flutter::SemanticsNodeUpdates update,
+    flutter::CustomAccessibilityActionUpdates actions) {
   delegate_.OnEngineUpdateSemantics(std::move(update), std::move(actions));
 }
 
 void Engine::HandlePlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   if (message->channel() == kAssetChannel) {
     HandleAssetPlatformMessage(std::move(message));
   } else {
@@ -431,13 +432,13 @@ void Engine::UpdateIsolateDescription(const std::string isolate_name,
   delegate_.UpdateIsolateDescription(isolate_name, isolate_port);
 }
 
-blink::FontCollection& Engine::GetFontCollection() {
+flutter::FontCollection& Engine::GetFontCollection() {
   return font_collection_;
 }
 
 void Engine::HandleAssetPlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
-  fml::RefPtr<blink::PlatformMessageResponse> response = message->response();
+    fml::RefPtr<flutter::PlatformMessage> message) {
+  fml::RefPtr<flutter::PlatformMessageResponse> response = message->response();
   if (!response) {
     return;
   }

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -29,7 +29,7 @@
 
 namespace shell {
 
-class Engine final : public blink::RuntimeDelegate {
+class Engine final : public flutter::RuntimeDelegate {
  public:
   // Used by Engine::Run
   enum class RunStatus {
@@ -42,11 +42,11 @@ class Engine final : public blink::RuntimeDelegate {
   class Delegate {
    public:
     virtual void OnEngineUpdateSemantics(
-        blink::SemanticsNodeUpdates update,
-        blink::CustomAccessibilityActionUpdates actions) = 0;
+        flutter::SemanticsNodeUpdates update,
+        flutter::CustomAccessibilityActionUpdates actions) = 0;
 
     virtual void OnEngineHandlePlatformMessage(
-        fml::RefPtr<blink::PlatformMessage> message) = 0;
+        fml::RefPtr<flutter::PlatformMessage> message) = 0;
 
     virtual void OnPreEngineRestart() = 0;
 
@@ -55,14 +55,14 @@ class Engine final : public blink::RuntimeDelegate {
   };
 
   Engine(Delegate& delegate,
-         blink::DartVM& vm,
-         fml::RefPtr<const blink::DartSnapshot> isolate_snapshot,
-         fml::RefPtr<const blink::DartSnapshot> shared_snapshot,
-         blink::TaskRunners task_runners,
-         blink::Settings settings,
+         flutter::DartVM& vm,
+         fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
+         fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
+         flutter::TaskRunners task_runners,
+         flutter::Settings settings,
          std::unique_ptr<Animator> animator,
-         fml::WeakPtr<blink::SnapshotDelegate> snapshot_delegate,
-         fml::WeakPtr<blink::IOManager> io_manager);
+         fml::WeakPtr<flutter::SnapshotDelegate> snapshot_delegate,
+         fml::WeakPtr<flutter::IOManager> io_manager);
 
   ~Engine() override;
 
@@ -80,7 +80,7 @@ class Engine final : public blink::RuntimeDelegate {
   FML_WARN_UNUSED_RESULT
   bool Restart(RunConfiguration configuration);
 
-  bool UpdateAssetManager(std::shared_ptr<blink::AssetManager> asset_manager);
+  bool UpdateAssetManager(std::shared_ptr<flutter::AssetManager> asset_manager);
 
   void BeginFrame(fml::TimePoint frame_time);
 
@@ -100,15 +100,15 @@ class Engine final : public blink::RuntimeDelegate {
 
   void OnOutputSurfaceDestroyed();
 
-  void SetViewportMetrics(const blink::ViewportMetrics& metrics);
+  void SetViewportMetrics(const flutter::ViewportMetrics& metrics);
 
-  void DispatchPlatformMessage(fml::RefPtr<blink::PlatformMessage> message);
+  void DispatchPlatformMessage(fml::RefPtr<flutter::PlatformMessage> message);
 
-  void DispatchPointerDataPacket(const blink::PointerDataPacket& packet,
+  void DispatchPointerDataPacket(const flutter::PointerDataPacket& packet,
                                  uint64_t trace_flow_id);
 
   void DispatchSemanticsAction(int id,
-                               blink::SemanticsAction action,
+                               flutter::SemanticsAction action,
                                std::vector<uint8_t> args);
 
   void SetSemanticsEnabled(bool enabled);
@@ -117,38 +117,38 @@ class Engine final : public blink::RuntimeDelegate {
 
   void ScheduleFrame(bool regenerate_layer_tree = true) override;
 
-  // |blink::RuntimeDelegate|
-  blink::FontCollection& GetFontCollection() override;
+  // |flutter::RuntimeDelegate|
+  flutter::FontCollection& GetFontCollection() override;
 
  private:
   Engine::Delegate& delegate_;
-  const blink::Settings settings_;
+  const flutter::Settings settings_;
   std::unique_ptr<Animator> animator_;
-  std::unique_ptr<blink::RuntimeController> runtime_controller_;
+  std::unique_ptr<flutter::RuntimeController> runtime_controller_;
   std::string initial_route_;
-  blink::ViewportMetrics viewport_metrics_;
-  std::shared_ptr<blink::AssetManager> asset_manager_;
+  flutter::ViewportMetrics viewport_metrics_;
+  std::shared_ptr<flutter::AssetManager> asset_manager_;
   bool activity_running_;
   bool have_surface_;
-  blink::FontCollection font_collection_;
+  flutter::FontCollection font_collection_;
   fml::WeakPtrFactory<Engine> weak_factory_;
 
-  // |blink::RuntimeDelegate|
+  // |flutter::RuntimeDelegate|
   std::string DefaultRouteName() override;
 
-  // |blink::RuntimeDelegate|
+  // |flutter::RuntimeDelegate|
   void Render(std::unique_ptr<flow::LayerTree> layer_tree) override;
 
-  // |blink::RuntimeDelegate|
+  // |flutter::RuntimeDelegate|
   void UpdateSemantics(
-      blink::SemanticsNodeUpdates update,
-      blink::CustomAccessibilityActionUpdates actions) override;
+      flutter::SemanticsNodeUpdates update,
+      flutter::CustomAccessibilityActionUpdates actions) override;
 
-  // |blink::RuntimeDelegate|
+  // |flutter::RuntimeDelegate|
   void HandlePlatformMessage(
-      fml::RefPtr<blink::PlatformMessage> message) override;
+      fml::RefPtr<flutter::PlatformMessage> message) override;
 
-  // |blink::RuntimeDelegate|
+  // |flutter::RuntimeDelegate|
   void UpdateIsolateDescription(const std::string isolate_name,
                                 int64_t isolate_port) override;
 
@@ -156,16 +156,17 @@ class Engine final : public blink::RuntimeDelegate {
 
   void StartAnimatorIfPossible();
 
-  bool HandleLifecyclePlatformMessage(blink::PlatformMessage* message);
+  bool HandleLifecyclePlatformMessage(flutter::PlatformMessage* message);
 
   bool HandleNavigationPlatformMessage(
-      fml::RefPtr<blink::PlatformMessage> message);
+      fml::RefPtr<flutter::PlatformMessage> message);
 
-  bool HandleLocalizationPlatformMessage(blink::PlatformMessage* message);
+  bool HandleLocalizationPlatformMessage(flutter::PlatformMessage* message);
 
-  void HandleSettingsPlatformMessage(blink::PlatformMessage* message);
+  void HandleSettingsPlatformMessage(flutter::PlatformMessage* message);
 
-  void HandleAssetPlatformMessage(fml::RefPtr<blink::PlatformMessage> message);
+  void HandleAssetPlatformMessage(
+      fml::RefPtr<flutter::PlatformMessage> message);
 
   bool GetAssetAsBuffer(const std::string& name, std::vector<uint8_t>* data);
 

--- a/shell/common/io_manager.h
+++ b/shell/common/io_manager.h
@@ -15,7 +15,7 @@
 
 namespace shell {
 
-class IOManager : public blink::IOManager {
+class IOManager : public flutter::IOManager {
  public:
   // Convenience methods for platforms to create a GrContext used to supply to
   // the IOManager. The platforms may create the context themselves if they so

--- a/shell/common/isolate_configuration.cc
+++ b/shell/common/isolate_configuration.cc
@@ -13,8 +13,8 @@ IsolateConfiguration::IsolateConfiguration() = default;
 
 IsolateConfiguration::~IsolateConfiguration() = default;
 
-bool IsolateConfiguration::PrepareIsolate(blink::DartIsolate& isolate) {
-  if (isolate.GetPhase() != blink::DartIsolate::Phase::LibrariesSetup) {
+bool IsolateConfiguration::PrepareIsolate(flutter::DartIsolate& isolate) {
+  if (isolate.GetPhase() != flutter::DartIsolate::Phase::LibrariesSetup) {
     FML_DLOG(ERROR)
         << "Isolate was in incorrect phase to be prepared for running.";
     return false;
@@ -28,7 +28,7 @@ class AppSnapshotIsolateConfiguration final : public IsolateConfiguration {
   AppSnapshotIsolateConfiguration() = default;
 
   // |shell::IsolateConfiguration|
-  bool DoPrepareIsolate(blink::DartIsolate& isolate) override {
+  bool DoPrepareIsolate(flutter::DartIsolate& isolate) override {
     return isolate.PrepareForRunningFromPrecompiledCode();
   }
 
@@ -42,8 +42,8 @@ class KernelIsolateConfiguration : public IsolateConfiguration {
       : kernel_(std::move(kernel)) {}
 
   // |shell::IsolateConfiguration|
-  bool DoPrepareIsolate(blink::DartIsolate& isolate) override {
-    if (blink::DartVM::IsRunningPrecompiledCode()) {
+  bool DoPrepareIsolate(flutter::DartIsolate& isolate) override {
+    if (flutter::DartVM::IsRunningPrecompiledCode()) {
       return false;
     }
     return isolate.PrepareForRunningFromKernel(std::move(kernel_));
@@ -63,8 +63,8 @@ class KernelListIsolateConfiguration final : public IsolateConfiguration {
       : kernel_pieces_(std::move(kernel_pieces)) {}
 
   // |shell::IsolateConfiguration|
-  bool DoPrepareIsolate(blink::DartIsolate& isolate) override {
-    if (blink::DartVM::IsRunningPrecompiledCode()) {
+  bool DoPrepareIsolate(flutter::DartIsolate& isolate) override {
+    if (flutter::DartVM::IsRunningPrecompiledCode()) {
       return false;
     }
 
@@ -115,7 +115,7 @@ static std::vector<std::string> ParseKernelListPaths(
 
 static std::vector<std::future<std::unique_ptr<const fml::Mapping>>>
 PrepareKernelMappings(std::vector<std::string> kernel_pieces_paths,
-                      std::shared_ptr<blink::AssetManager> asset_manager,
+                      std::shared_ptr<flutter::AssetManager> asset_manager,
                       fml::RefPtr<fml::TaskRunner> io_worker) {
   FML_DCHECK(asset_manager);
   std::vector<std::future<std::unique_ptr<const fml::Mapping>>> fetch_futures;
@@ -142,11 +142,11 @@ PrepareKernelMappings(std::vector<std::string> kernel_pieces_paths,
 }
 
 std::unique_ptr<IsolateConfiguration> IsolateConfiguration::InferFromSettings(
-    const blink::Settings& settings,
-    std::shared_ptr<blink::AssetManager> asset_manager,
+    const flutter::Settings& settings,
+    std::shared_ptr<flutter::AssetManager> asset_manager,
     fml::RefPtr<fml::TaskRunner> io_worker) {
   // Running in AOT mode.
-  if (blink::DartVM::IsRunningPrecompiledCode()) {
+  if (flutter::DartVM::IsRunningPrecompiledCode()) {
     return CreateForAppSnapshot();
   }
 

--- a/shell/common/isolate_configuration.h
+++ b/shell/common/isolate_configuration.h
@@ -22,8 +22,8 @@ namespace shell {
 class IsolateConfiguration {
  public:
   static std::unique_ptr<IsolateConfiguration> InferFromSettings(
-      const blink::Settings& settings,
-      std::shared_ptr<blink::AssetManager> asset_manager,
+      const flutter::Settings& settings,
+      std::shared_ptr<flutter::AssetManager> asset_manager,
       fml::RefPtr<fml::TaskRunner> io_worker);
 
   static std::unique_ptr<IsolateConfiguration> CreateForAppSnapshot();
@@ -42,10 +42,10 @@ class IsolateConfiguration {
 
   virtual ~IsolateConfiguration();
 
-  bool PrepareIsolate(blink::DartIsolate& isolate);
+  bool PrepareIsolate(flutter::DartIsolate& isolate);
 
  protected:
-  virtual bool DoPrepareIsolate(blink::DartIsolate& isolate) = 0;
+  virtual bool DoPrepareIsolate(flutter::DartIsolate& isolate) = 0;
 
  private:
   FML_DISALLOW_COPY_AND_ASSIGN(IsolateConfiguration);

--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -61,8 +61,8 @@ PersistentCache::PersistentCache(bool read_only) : is_read_only_(read_only) {
   if (cache_base_dir.is_valid()) {
     cache_directory_ = std::make_shared<fml::UniqueFD>(
         CreateDirectory(cache_base_dir,
-                        {"flutter_engine", blink::GetFlutterEngineVersion(),
-                         "skia", blink::GetSkiaVersion()},
+                        {"flutter_engine", flutter::GetFlutterEngineVersion(),
+                         "skia", flutter::GetSkiaVersion()},
                         read_only ? fml::FilePermission::kRead
                                   : fml::FilePermission::kReadWrite));
   }

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -16,7 +16,8 @@
 
 namespace shell {
 
-PlatformView::PlatformView(Delegate& delegate, blink::TaskRunners task_runners)
+PlatformView::PlatformView(Delegate& delegate,
+                           flutter::TaskRunners task_runners)
     : delegate_(delegate),
       task_runners_(std::move(task_runners)),
       size_(SkISize::Make(0, 0)),
@@ -32,17 +33,17 @@ std::unique_ptr<VsyncWaiter> PlatformView::CreateVSyncWaiter() {
 }
 
 void PlatformView::DispatchPlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   delegate_.OnPlatformViewDispatchPlatformMessage(std::move(message));
 }
 
 void PlatformView::DispatchPointerDataPacket(
-    std::unique_ptr<blink::PointerDataPacket> packet) {
+    std::unique_ptr<flutter::PointerDataPacket> packet) {
   delegate_.OnPlatformViewDispatchPointerDataPacket(std::move(packet));
 }
 
 void PlatformView::DispatchSemanticsAction(int32_t id,
-                                           blink::SemanticsAction action,
+                                           flutter::SemanticsAction action,
                                            std::vector<uint8_t> args) {
   delegate_.OnPlatformViewDispatchSemanticsAction(id, action, std::move(args));
 }
@@ -55,7 +56,7 @@ void PlatformView::SetAccessibilityFeatures(int32_t flags) {
   delegate_.OnPlatformViewSetAccessibilityFeatures(flags);
 }
 
-void PlatformView::SetViewportMetrics(const blink::ViewportMetrics& metrics) {
+void PlatformView::SetViewportMetrics(const flutter::ViewportMetrics& metrics) {
   delegate_.OnPlatformViewSetViewportMetrics(metrics);
 }
 
@@ -93,11 +94,11 @@ fml::WeakPtr<PlatformView> PlatformView::GetWeakPtr() const {
 }
 
 void PlatformView::UpdateSemantics(
-    blink::SemanticsNodeUpdates update,
-    blink::CustomAccessibilityActionUpdates actions) {}
+    flutter::SemanticsNodeUpdates update,
+    flutter::CustomAccessibilityActionUpdates actions) {}
 
 void PlatformView::HandlePlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   if (auto response = message->response())
     response->CompleteEmpty();
 }

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -36,17 +36,17 @@ class PlatformView {
     virtual void OnPlatformViewSetNextFrameCallback(fml::closure closure) = 0;
 
     virtual void OnPlatformViewSetViewportMetrics(
-        const blink::ViewportMetrics& metrics) = 0;
+        const flutter::ViewportMetrics& metrics) = 0;
 
     virtual void OnPlatformViewDispatchPlatformMessage(
-        fml::RefPtr<blink::PlatformMessage> message) = 0;
+        fml::RefPtr<flutter::PlatformMessage> message) = 0;
 
     virtual void OnPlatformViewDispatchPointerDataPacket(
-        std::unique_ptr<blink::PointerDataPacket> packet) = 0;
+        std::unique_ptr<flutter::PointerDataPacket> packet) = 0;
 
     virtual void OnPlatformViewDispatchSemanticsAction(
         int32_t id,
-        blink::SemanticsAction action,
+        flutter::SemanticsAction action,
         std::vector<uint8_t> args) = 0;
 
     virtual void OnPlatformViewSetSemanticsEnabled(bool enabled) = 0;
@@ -62,23 +62,23 @@ class PlatformView {
         int64_t texture_id) = 0;
   };
 
-  explicit PlatformView(Delegate& delegate, blink::TaskRunners task_runners);
+  explicit PlatformView(Delegate& delegate, flutter::TaskRunners task_runners);
 
   virtual ~PlatformView();
 
   virtual std::unique_ptr<VsyncWaiter> CreateVSyncWaiter();
 
-  void DispatchPlatformMessage(fml::RefPtr<blink::PlatformMessage> message);
+  void DispatchPlatformMessage(fml::RefPtr<flutter::PlatformMessage> message);
 
   void DispatchSemanticsAction(int32_t id,
-                               blink::SemanticsAction action,
+                               flutter::SemanticsAction action,
                                std::vector<uint8_t> args);
 
   virtual void SetSemanticsEnabled(bool enabled);
 
   virtual void SetAccessibilityFeatures(int32_t flags);
 
-  void SetViewportMetrics(const blink::ViewportMetrics& metrics);
+  void SetViewportMetrics(const flutter::ViewportMetrics& metrics);
 
   void NotifyCreated();
 
@@ -94,18 +94,19 @@ class PlatformView {
 
   fml::WeakPtr<PlatformView> GetWeakPtr() const;
 
-  virtual void UpdateSemantics(blink::SemanticsNodeUpdates updates,
-                               blink::CustomAccessibilityActionUpdates actions);
+  virtual void UpdateSemantics(
+      flutter::SemanticsNodeUpdates updates,
+      flutter::CustomAccessibilityActionUpdates actions);
 
   virtual void HandlePlatformMessage(
-      fml::RefPtr<blink::PlatformMessage> message);
+      fml::RefPtr<flutter::PlatformMessage> message);
 
   virtual void OnPreEngineRestart() const;
 
   void SetNextFrameCallback(fml::closure closure);
 
   void DispatchPointerDataPacket(
-      std::unique_ptr<blink::PointerDataPacket> packet);
+      std::unique_ptr<flutter::PointerDataPacket> packet);
 
   // Called once per texture, on the platform thread.
   void RegisterTexture(std::shared_ptr<flow::Texture> texture);
@@ -118,7 +119,7 @@ class PlatformView {
 
  protected:
   PlatformView::Delegate& delegate_;
-  const blink::TaskRunners task_runners_;
+  const flutter::TaskRunners task_runners_;
 
   SkISize size_;
   fml::WeakPtrFactory<PlatformView> weak_factory_;

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -22,12 +22,12 @@ namespace shell {
 // used within this interval.
 static constexpr std::chrono::milliseconds kSkiaCleanupExpiration(15000);
 
-Rasterizer::Rasterizer(blink::TaskRunners task_runners)
+Rasterizer::Rasterizer(flutter::TaskRunners task_runners)
     : Rasterizer(std::move(task_runners),
                  std::make_unique<flow::CompositorContext>()) {}
 
 Rasterizer::Rasterizer(
-    blink::TaskRunners task_runners,
+    flutter::TaskRunners task_runners,
     std::unique_ptr<flow::CompositorContext> compositor_context)
     : task_runners_(std::move(task_runners)),
       compositor_context_(std::move(compositor_context)),
@@ -41,7 +41,8 @@ fml::WeakPtr<Rasterizer> Rasterizer::GetWeakPtr() const {
   return weak_factory_.GetWeakPtr();
 }
 
-fml::WeakPtr<blink::SnapshotDelegate> Rasterizer::GetSnapshotDelegate() const {
+fml::WeakPtr<flutter::SnapshotDelegate> Rasterizer::GetSnapshotDelegate()
+    const {
   return weak_factory_.GetWeakPtr();
 }
 

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -19,11 +19,11 @@
 
 namespace shell {
 
-class Rasterizer final : public blink::SnapshotDelegate {
+class Rasterizer final : public flutter::SnapshotDelegate {
  public:
-  Rasterizer(blink::TaskRunners task_runners);
+  Rasterizer(flutter::TaskRunners task_runners);
 
-  Rasterizer(blink::TaskRunners task_runners,
+  Rasterizer(flutter::TaskRunners task_runners,
              std::unique_ptr<flow::CompositorContext> compositor_context);
 
   ~Rasterizer();
@@ -34,7 +34,7 @@ class Rasterizer final : public blink::SnapshotDelegate {
 
   fml::WeakPtr<Rasterizer> GetWeakPtr() const;
 
-  fml::WeakPtr<blink::SnapshotDelegate> GetSnapshotDelegate() const;
+  fml::WeakPtr<flutter::SnapshotDelegate> GetSnapshotDelegate() const;
 
   flow::LayerTree* GetLastLayerTree();
 
@@ -76,14 +76,14 @@ class Rasterizer final : public blink::SnapshotDelegate {
   void SetResourceCacheMaxBytes(int max_bytes);
 
  private:
-  blink::TaskRunners task_runners_;
+  flutter::TaskRunners task_runners_;
   std::unique_ptr<Surface> surface_;
   std::unique_ptr<flow::CompositorContext> compositor_context_;
   std::unique_ptr<flow::LayerTree> last_layer_tree_;
   fml::closure next_frame_callback_;
   fml::WeakPtrFactory<Rasterizer> weak_factory_;
 
-  // |blink::SnapshotDelegate|
+  // |flutter::SnapshotDelegate|
   sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                     SkISize picture_size) override;
 

--- a/shell/common/run_configuration.cc
+++ b/shell/common/run_configuration.cc
@@ -13,15 +13,15 @@
 namespace shell {
 
 RunConfiguration RunConfiguration::InferFromSettings(
-    const blink::Settings& settings,
+    const flutter::Settings& settings,
     fml::RefPtr<fml::TaskRunner> io_worker) {
-  auto asset_manager = std::make_shared<blink::AssetManager>();
+  auto asset_manager = std::make_shared<flutter::AssetManager>();
 
-  asset_manager->PushBack(std::make_unique<blink::DirectoryAssetBundle>(
+  asset_manager->PushBack(std::make_unique<flutter::DirectoryAssetBundle>(
       fml::Duplicate(settings.assets_dir)));
 
   asset_manager->PushBack(
-      std::make_unique<blink::DirectoryAssetBundle>(fml::OpenDirectory(
+      std::make_unique<flutter::DirectoryAssetBundle>(fml::OpenDirectory(
           settings.assets_path.c_str(), false, fml::FilePermission::kRead)));
 
   return {IsolateConfiguration::InferFromSettings(settings, asset_manager,
@@ -32,11 +32,11 @@ RunConfiguration RunConfiguration::InferFromSettings(
 RunConfiguration::RunConfiguration(
     std::unique_ptr<IsolateConfiguration> configuration)
     : RunConfiguration(std::move(configuration),
-                       std::make_shared<blink::AssetManager>()) {}
+                       std::make_shared<flutter::AssetManager>()) {}
 
 RunConfiguration::RunConfiguration(
     std::unique_ptr<IsolateConfiguration> configuration,
-    std::shared_ptr<blink::AssetManager> asset_manager)
+    std::shared_ptr<flutter::AssetManager> asset_manager)
     : isolate_configuration_(std::move(configuration)),
       asset_manager_(std::move(asset_manager)) {}
 
@@ -49,7 +49,7 @@ bool RunConfiguration::IsValid() const {
 }
 
 bool RunConfiguration::AddAssetResolver(
-    std::unique_ptr<blink::AssetResolver> resolver) {
+    std::unique_ptr<flutter::AssetResolver> resolver) {
   if (!resolver || !resolver->IsValid()) {
     return false;
   }
@@ -68,7 +68,8 @@ void RunConfiguration::SetEntrypointAndLibrary(std::string entrypoint,
   entrypoint_library_ = std::move(library);
 }
 
-std::shared_ptr<blink::AssetManager> RunConfiguration::GetAssetManager() const {
+std::shared_ptr<flutter::AssetManager> RunConfiguration::GetAssetManager()
+    const {
   return asset_manager_;
 }
 

--- a/shell/common/run_configuration.h
+++ b/shell/common/run_configuration.h
@@ -21,13 +21,13 @@ namespace shell {
 class RunConfiguration {
  public:
   static RunConfiguration InferFromSettings(
-      const blink::Settings& settings,
+      const flutter::Settings& settings,
       fml::RefPtr<fml::TaskRunner> io_worker = nullptr);
 
   RunConfiguration(std::unique_ptr<IsolateConfiguration> configuration);
 
   RunConfiguration(std::unique_ptr<IsolateConfiguration> configuration,
-                   std::shared_ptr<blink::AssetManager> asset_manager);
+                   std::shared_ptr<flutter::AssetManager> asset_manager);
 
   RunConfiguration(RunConfiguration&&);
 
@@ -35,13 +35,13 @@ class RunConfiguration {
 
   bool IsValid() const;
 
-  bool AddAssetResolver(std::unique_ptr<blink::AssetResolver> resolver);
+  bool AddAssetResolver(std::unique_ptr<flutter::AssetResolver> resolver);
 
   void SetEntrypoint(std::string entrypoint);
 
   void SetEntrypointAndLibrary(std::string entrypoint, std::string library);
 
-  std::shared_ptr<blink::AssetManager> GetAssetManager() const;
+  std::shared_ptr<flutter::AssetManager> GetAssetManager() const;
 
   const std::string& GetEntrypoint() const;
 
@@ -51,7 +51,7 @@ class RunConfiguration {
 
  private:
   std::unique_ptr<IsolateConfiguration> isolate_configuration_;
-  std::shared_ptr<blink::AssetManager> asset_manager_;
+  std::shared_ptr<flutter::AssetManager> asset_manager_;
   std::string entrypoint_ = "main";
   std::string entrypoint_library_ = "";
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -37,7 +37,7 @@ namespace shell {
 class Shell final : public PlatformView::Delegate,
                     public Animator::Delegate,
                     public Engine::Delegate,
-                    public blink::ServiceProtocol::Handler {
+                    public flutter::ServiceProtocol::Handler {
  public:
   template <class T>
   using CreateCallback = std::function<std::unique_ptr<T>(Shell&)>;
@@ -45,27 +45,27 @@ class Shell final : public PlatformView::Delegate,
   // Create a shell with the given task runners and settings. The isolate
   // snapshot will be shared with the snapshot of the service isolate.
   static std::unique_ptr<Shell> Create(
-      blink::TaskRunners task_runners,
-      blink::Settings settings,
+      flutter::TaskRunners task_runners,
+      flutter::Settings settings,
       CreateCallback<PlatformView> on_create_platform_view,
       CreateCallback<Rasterizer> on_create_rasterizer);
 
   // Creates a shell with the given task runners and settings. The isolate
   // snapshot is specified upfront.
   static std::unique_ptr<Shell> Create(
-      blink::TaskRunners task_runners,
-      blink::Settings settings,
-      fml::RefPtr<const blink::DartSnapshot> isolate_snapshot,
-      fml::RefPtr<const blink::DartSnapshot> shared_snapshot,
+      flutter::TaskRunners task_runners,
+      flutter::Settings settings,
+      fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
+      fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
       CreateCallback<PlatformView> on_create_platform_view,
       CreateCallback<Rasterizer> on_create_rasterizer,
-      blink::DartVMRef vm);
+      flutter::DartVMRef vm);
 
   ~Shell();
 
-  const blink::Settings& GetSettings() const;
+  const flutter::Settings& GetSettings() const;
 
-  const blink::TaskRunners& GetTaskRunners() const;
+  const flutter::TaskRunners& GetTaskRunners() const;
 
   fml::WeakPtr<Rasterizer> GetRasterizer();
 
@@ -73,7 +73,7 @@ class Shell final : public PlatformView::Delegate,
 
   fml::WeakPtr<PlatformView> GetPlatformView();
 
-  blink::DartVM* GetDartVM();
+  flutter::DartVM* GetDartVM();
 
   bool IsSetup() const;
 
@@ -82,12 +82,12 @@ class Shell final : public PlatformView::Delegate,
 
  private:
   using ServiceProtocolHandler = std::function<bool(
-      const blink::ServiceProtocol::Handler::ServiceProtocolMap&,
+      const flutter::ServiceProtocol::Handler::ServiceProtocolMap&,
       rapidjson::Document&)>;
 
-  const blink::TaskRunners task_runners_;
-  const blink::Settings settings_;
-  blink::DartVMRef vm_;
+  const flutter::TaskRunners task_runners_;
+  const flutter::Settings settings_;
+  flutter::DartVMRef vm_;
   std::unique_ptr<PlatformView> platform_view_;  // on platform task runner
   std::unique_ptr<Engine> engine_;               // on UI task runner
   std::unique_ptr<Rasterizer> rasterizer_;       // on GPU task runner
@@ -102,17 +102,17 @@ class Shell final : public PlatformView::Delegate,
   bool is_setup_ = false;
   uint64_t next_pointer_flow_id_ = 0;
 
-  Shell(blink::TaskRunners task_runners, blink::Settings settings);
-  Shell(blink::DartVMRef vm,
-        blink::TaskRunners task_runners,
-        blink::Settings settings);
+  Shell(flutter::TaskRunners task_runners, flutter::Settings settings);
+  Shell(flutter::DartVMRef vm,
+        flutter::TaskRunners task_runners,
+        flutter::Settings settings);
 
   static std::unique_ptr<Shell> CreateShellOnPlatformThread(
-      blink::DartVMRef vm,
-      blink::TaskRunners task_runners,
-      blink::Settings settings,
-      fml::RefPtr<const blink::DartSnapshot> isolate_snapshot,
-      fml::RefPtr<const blink::DartSnapshot> shared_snapshot,
+      flutter::DartVMRef vm,
+      flutter::TaskRunners task_runners,
+      flutter::Settings settings,
+      fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
+      fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
       Shell::CreateCallback<PlatformView> on_create_platform_view,
       Shell::CreateCallback<Rasterizer> on_create_rasterizer);
 
@@ -129,20 +129,20 @@ class Shell final : public PlatformView::Delegate,
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewSetViewportMetrics(
-      const blink::ViewportMetrics& metrics) override;
+      const flutter::ViewportMetrics& metrics) override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewDispatchPlatformMessage(
-      fml::RefPtr<blink::PlatformMessage> message) override;
+      fml::RefPtr<flutter::PlatformMessage> message) override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewDispatchPointerDataPacket(
-      std::unique_ptr<blink::PointerDataPacket> packet) override;
+      std::unique_ptr<flutter::PointerDataPacket> packet) override;
 
   // |shell::PlatformView::Delegate|
   void OnPlatformViewDispatchSemanticsAction(
       int32_t id,
-      blink::SemanticsAction action,
+      flutter::SemanticsAction action,
       std::vector<uint8_t> args) override;
 
   // |shell::PlatformView::Delegate|
@@ -179,14 +179,14 @@ class Shell final : public PlatformView::Delegate,
 
   // |shell::Engine::Delegate|
   void OnEngineUpdateSemantics(
-      blink::SemanticsNodeUpdates update,
-      blink::CustomAccessibilityActionUpdates actions) override;
+      flutter::SemanticsNodeUpdates update,
+      flutter::CustomAccessibilityActionUpdates actions) override;
 
   // |shell::Engine::Delegate|
   void OnEngineHandlePlatformMessage(
-      fml::RefPtr<blink::PlatformMessage> message) override;
+      fml::RefPtr<flutter::PlatformMessage> message) override;
 
-  void HandleEngineSkiaMessage(fml::RefPtr<blink::PlatformMessage> message);
+  void HandleEngineSkiaMessage(fml::RefPtr<flutter::PlatformMessage> message);
 
   // |shell::Engine::Delegate|
   void OnPreEngineRestart() override;
@@ -195,48 +195,48 @@ class Shell final : public PlatformView::Delegate,
   void UpdateIsolateDescription(const std::string isolate_name,
                                 int64_t isolate_port) override;
 
-  // |blink::ServiceProtocol::Handler|
+  // |flutter::ServiceProtocol::Handler|
   fml::RefPtr<fml::TaskRunner> GetServiceProtocolHandlerTaskRunner(
       fml::StringView method) const override;
 
-  // |blink::ServiceProtocol::Handler|
+  // |flutter::ServiceProtocol::Handler|
   bool HandleServiceProtocolMessage(
       fml::StringView method,  // one if the extension names specified above.
       const ServiceProtocolMap& params,
       rapidjson::Document& response) override;
 
-  // |blink::ServiceProtocol::Handler|
-  blink::ServiceProtocol::Handler::Description GetServiceProtocolDescription()
+  // |flutter::ServiceProtocol::Handler|
+  flutter::ServiceProtocol::Handler::Description GetServiceProtocolDescription()
       const override;
 
   // Service protocol handler
   bool OnServiceProtocolScreenshot(
-      const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+      const flutter::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 
   // Service protocol handler
   bool OnServiceProtocolScreenshotSKP(
-      const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+      const flutter::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 
   // Service protocol handler
   bool OnServiceProtocolRunInView(
-      const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+      const flutter::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 
   // Service protocol handler
   bool OnServiceProtocolFlushUIThreadTasks(
-      const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+      const flutter::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 
   // Service protocol handler
   bool OnServiceProtocolSetAssetBundlePath(
-      const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+      const flutter::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 
   // Service protocol handler
   bool OnServiceProtocolGetDisplayRefreshRate(
-      const blink::ServiceProtocol::Handler::ServiceProtocolMap& params,
+      const flutter::ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
 
   FML_DISALLOW_COPY_AND_ASSIGN(Shell);

--- a/shell/common/shell_benchmarks.cc
+++ b/shell/common/shell_benchmarks.cc
@@ -16,7 +16,7 @@ static void StartupAndShutdownShell(benchmark::State& state,
   std::unique_ptr<ThreadHost> thread_host;
   {
     benchmarking::ScopedPauseTiming pause(state, !measure_startup);
-    blink::Settings settings = {};
+    flutter::Settings settings = {};
     settings.task_observer_add = [](intptr_t, fml::closure) {};
     settings.task_observer_remove = [](intptr_t) {};
 
@@ -26,7 +26,7 @@ static void StartupAndShutdownShell(benchmark::State& state,
                                  ThreadHost::Type::GPU | ThreadHost::Type::IO |
                                  ThreadHost::Type::UI);
 
-    blink::TaskRunners task_runners(
+    flutter::TaskRunners task_runners(
         "test", thread_host->platform_thread->GetTaskRunner(),
         thread_host->gpu_thread->GetTaskRunner(),
         thread_host->ui_thread->GetTaskRunner(),

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -44,7 +44,7 @@ static std::unique_ptr<fml::Mapping> GetMapping(const fml::UniqueFD& directory,
   return mapping;
 }
 
-void ShellTest::SetSnapshotsAndAssets(blink::Settings& settings) {
+void ShellTest::SetSnapshotsAndAssets(flutter::Settings& settings) {
   if (!assets_dir_.is_valid()) {
     return;
   }
@@ -53,7 +53,7 @@ void ShellTest::SetSnapshotsAndAssets(blink::Settings& settings) {
 
   // In JIT execution, all snapshots are present within the binary itself and
   // don't need to be explicitly suppiled by the embedder.
-  if (blink::DartVM::IsRunningPrecompiledCode()) {
+  if (flutter::DartVM::IsRunningPrecompiledCode()) {
     settings.vm_snapshot_data = [this]() {
       return GetMapping(assets_dir_, "vm_snapshot_data", false);
     };
@@ -62,7 +62,7 @@ void ShellTest::SetSnapshotsAndAssets(blink::Settings& settings) {
       return GetMapping(assets_dir_, "isolate_snapshot_data", false);
     };
 
-    if (blink::DartVM::IsRunningPrecompiledCode()) {
+    if (flutter::DartVM::IsRunningPrecompiledCode()) {
       settings.vm_snapshot_instr = [this]() {
         return GetMapping(assets_dir_, "vm_snapshot_instr", true);
       };
@@ -81,8 +81,8 @@ void ShellTest::SetSnapshotsAndAssets(blink::Settings& settings) {
   }
 }
 
-blink::Settings ShellTest::CreateSettingsForFixture() {
-  blink::Settings settings;
+flutter::Settings ShellTest::CreateSettingsForFixture() {
+  flutter::Settings settings;
   settings.task_observer_add = [](intptr_t key, fml::closure handler) {
     fml::MessageLoop::GetCurrent().AddTaskObserver(key, handler);
   };
@@ -96,7 +96,7 @@ blink::Settings ShellTest::CreateSettingsForFixture() {
   return settings;
 }
 
-blink::TaskRunners ShellTest::GetTaskRunnersForFixture() {
+flutter::TaskRunners ShellTest::GetTaskRunnersForFixture() {
   return {
       "test",
       thread_host_->platform_thread->GetTaskRunner(),  // platform

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -23,9 +23,9 @@ class ShellTest : public ::testing::ThreadTest {
 
   ~ShellTest();
 
-  blink::Settings CreateSettingsForFixture();
+  flutter::Settings CreateSettingsForFixture();
 
-  blink::TaskRunners GetTaskRunnersForFixture();
+  flutter::TaskRunners GetTaskRunnersForFixture();
 
   void AddNativeCallback(std::string name, Dart_NativeFunction callback);
 
@@ -41,7 +41,7 @@ class ShellTest : public ::testing::ThreadTest {
   std::shared_ptr<::testing::TestDartNativeResolver> native_resolver_;
   std::unique_ptr<ThreadHost> thread_host_;
 
-  void SetSnapshotsAndAssets(blink::Settings& settings);
+  void SetSnapshotsAndAssets(flutter::Settings& settings);
 };
 
 }  // namespace testing

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -27,7 +27,7 @@ class TestPlatformView : public PlatformView,
                          public GPUSurfaceSoftwareDelegate {
  public:
   TestPlatformView(PlatformView::Delegate& delegate,
-                   blink::TaskRunners task_runners)
+                   flutter::TaskRunners task_runners)
       : PlatformView(delegate, std::move(task_runners)) {}
 
  private:
@@ -84,8 +84,8 @@ static bool ValidateShell(Shell* shell) {
 }
 
 TEST_F(ShellTest, InitializeWithInvalidThreads) {
-  blink::Settings settings = CreateSettingsForFixture();
-  blink::TaskRunners task_runners("test", nullptr, nullptr, nullptr, nullptr);
+  flutter::Settings settings = CreateSettingsForFixture();
+  flutter::TaskRunners task_runners("test", nullptr, nullptr, nullptr, nullptr);
   auto shell = Shell::Create(
       std::move(task_runners), settings,
       [](Shell& shell) {
@@ -99,16 +99,16 @@ TEST_F(ShellTest, InitializeWithInvalidThreads) {
 }
 
 TEST_F(ShellTest, InitializeWithDifferentThreads) {
-  blink::Settings settings = CreateSettingsForFixture();
+  flutter::Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host(
       "io.flutter.test." + ::testing::GetCurrentTestName() + ".",
       ThreadHost::Type::Platform | ThreadHost::Type::GPU |
           ThreadHost::Type::IO | ThreadHost::Type::UI);
-  blink::TaskRunners task_runners("test",
-                                  thread_host.platform_thread->GetTaskRunner(),
-                                  thread_host.gpu_thread->GetTaskRunner(),
-                                  thread_host.ui_thread->GetTaskRunner(),
-                                  thread_host.io_thread->GetTaskRunner());
+  flutter::TaskRunners task_runners(
+      "test", thread_host.platform_thread->GetTaskRunner(),
+      thread_host.gpu_thread->GetTaskRunner(),
+      thread_host.ui_thread->GetTaskRunner(),
+      thread_host.io_thread->GetTaskRunner());
   auto shell = Shell::Create(
       std::move(task_runners), settings,
       [](Shell& shell) {
@@ -122,13 +122,13 @@ TEST_F(ShellTest, InitializeWithDifferentThreads) {
 }
 
 TEST_F(ShellTest, InitializeWithSingleThread) {
-  blink::Settings settings = CreateSettingsForFixture();
+  flutter::Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host(
       "io.flutter.test." + ::testing::GetCurrentTestName() + ".",
       ThreadHost::Type::Platform);
   auto task_runner = thread_host.platform_thread->GetTaskRunner();
-  blink::TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-                                  task_runner);
+  flutter::TaskRunners task_runners("test", task_runner, task_runner,
+                                    task_runner, task_runner);
   auto shell = Shell::Create(
       std::move(task_runners), settings,
       [](Shell& shell) {
@@ -142,11 +142,11 @@ TEST_F(ShellTest, InitializeWithSingleThread) {
 }
 
 TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
-  blink::Settings settings = CreateSettingsForFixture();
+  flutter::Settings settings = CreateSettingsForFixture();
   fml::MessageLoop::EnsureInitializedForCurrentThread();
   auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
-  blink::TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-                                  task_runner);
+  flutter::TaskRunners task_runners("test", task_runner, task_runner,
+                                    task_runner, task_runner);
   auto shell = Shell::Create(
       std::move(task_runners), settings,
       [](Shell& shell) {
@@ -161,12 +161,12 @@ TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
 
 TEST_F(ShellTest,
        InitializeWithMultipleThreadButCallingThreadAsPlatformThread) {
-  blink::Settings settings = CreateSettingsForFixture();
+  flutter::Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host(
       "io.flutter.test." + ::testing::GetCurrentTestName() + ".",
       ThreadHost::Type::GPU | ThreadHost::Type::IO | ThreadHost::Type::UI);
   fml::MessageLoop::EnsureInitializedForCurrentThread();
-  blink::TaskRunners task_runners(
+  flutter::TaskRunners task_runners(
       "test", fml::MessageLoop::GetCurrent().GetTaskRunner(),
       thread_host.gpu_thread->GetTaskRunner(),
       thread_host.ui_thread->GetTaskRunner(),
@@ -184,11 +184,11 @@ TEST_F(ShellTest,
 }
 
 TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
-  blink::Settings settings = CreateSettingsForFixture();
+  flutter::Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host(
       "io.flutter.test." + ::testing::GetCurrentTestName() + ".",
       ThreadHost::Type::Platform | ThreadHost::Type::IO | ThreadHost::Type::UI);
-  blink::TaskRunners task_runners(
+  flutter::TaskRunners task_runners(
       "test",
       thread_host.platform_thread->GetTaskRunner(),  // platform
       thread_host.platform_thread->GetTaskRunner(),  // gpu

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -46,11 +46,11 @@ void PrintUsage(const std::string& executable_name) {
 
   std::cerr << "Versions: " << std::endl << std::endl;
 
-  std::cerr << "Flutter Engine Version: " << blink::GetFlutterEngineVersion()
+  std::cerr << "Flutter Engine Version: " << flutter::GetFlutterEngineVersion()
             << std::endl;
-  std::cerr << "Skia Version: " << blink::GetSkiaVersion() << std::endl;
+  std::cerr << "Skia Version: " << flutter::GetSkiaVersion() << std::endl;
 
-  std::cerr << "Dart Version: " << blink::GetDartVersion() << std::endl
+  std::cerr << "Dart Version: " << flutter::GetDartVersion() << std::endl
             << std::endl;
 
   std::cerr << "Available Flags:" << std::endl;
@@ -150,8 +150,9 @@ std::unique_ptr<fml::Mapping> GetSymbolMapping(std::string symbol_prefix,
   return std::make_unique<fml::NonOwnedMapping>(mapping, size);
 }
 
-blink::Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
-  blink::Settings settings = {};
+flutter::Settings SettingsFromCommandLine(
+    const fml::CommandLine& command_line) {
+  flutter::Settings settings = {};
 
   // Enable Observatory
   settings.enable_observatory =

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -151,7 +151,7 @@ void PrintUsage(const std::string& executable_name);
 
 const fml::StringView FlagForSwitch(Switch swtch);
 
-blink::Settings SettingsFromCommandLine(const fml::CommandLine& command_line);
+flutter::Settings SettingsFromCommandLine(const fml::CommandLine& command_line);
 
 }  // namespace shell
 

--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -23,7 +23,7 @@ static constexpr const char* kVsyncTraceName = "VSYNC";
 
 static constexpr const char* kVsyncFlowName = "VsyncFlow";
 
-VsyncWaiter::VsyncWaiter(blink::TaskRunners task_runners)
+VsyncWaiter::VsyncWaiter(flutter::TaskRunners task_runners)
     : task_runners_(std::move(task_runners)) {}
 
 VsyncWaiter::~VsyncWaiter() = default;

--- a/shell/common/vsync_waiter.h
+++ b/shell/common/vsync_waiter.h
@@ -36,9 +36,9 @@ class VsyncWaiter : public std::enable_shared_from_this<VsyncWaiter> {
   friend class VsyncWaiterAndroid;
   friend class VsyncWaiterEmbedder;
 
-  const blink::TaskRunners task_runners_;
+  const flutter::TaskRunners task_runners_;
 
-  VsyncWaiter(blink::TaskRunners task_runners);
+  VsyncWaiter(flutter::TaskRunners task_runners);
 
   // Implementations are meant to override this method and arm their vsync
   // latches when in response to this invocation. On vsync, they are meant to

--- a/shell/common/vsync_waiter_fallback.cc
+++ b/shell/common/vsync_waiter_fallback.cc
@@ -20,7 +20,7 @@ static fml::TimePoint SnapToNextTick(fml::TimePoint value,
 
 }  // namespace
 
-VsyncWaiterFallback::VsyncWaiterFallback(blink::TaskRunners task_runners)
+VsyncWaiterFallback::VsyncWaiterFallback(flutter::TaskRunners task_runners)
     : VsyncWaiter(std::move(task_runners)), phase_(fml::TimePoint::Now()) {}
 
 VsyncWaiterFallback::~VsyncWaiterFallback() = default;

--- a/shell/common/vsync_waiter_fallback.h
+++ b/shell/common/vsync_waiter_fallback.h
@@ -14,7 +14,7 @@ namespace shell {
 
 class VsyncWaiterFallback final : public VsyncWaiter {
  public:
-  VsyncWaiterFallback(blink::TaskRunners task_runners);
+  VsyncWaiterFallback(flutter::TaskRunners task_runners);
 
   ~VsyncWaiterFallback() override;
 

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -22,7 +22,7 @@
 namespace shell {
 
 AndroidShellHolder::AndroidShellHolder(
-    blink::Settings settings,
+    flutter::Settings settings,
     fml::jni::JavaObjectWeakGlobalRef java_object,
     bool is_background_view)
     : settings_(std::move(settings)), java_object_(java_object) {
@@ -94,11 +94,11 @@ AndroidShellHolder::AndroidShellHolder(
     ui_runner = thread_host_.ui_thread->GetTaskRunner();
     io_runner = thread_host_.io_thread->GetTaskRunner();
   }
-  blink::TaskRunners task_runners(thread_label,     // label
-                                  platform_runner,  // platform
-                                  gpu_runner,       // gpu
-                                  ui_runner,        // ui
-                                  io_runner         // io
+  flutter::TaskRunners task_runners(thread_label,     // label
+                                    platform_runner,  // platform
+                                    gpu_runner,       // gpu
+                                    ui_runner,        // ui
+                                    io_runner         // io
   );
 
   shell_ =
@@ -148,7 +148,7 @@ bool AndroidShellHolder::IsValid() const {
   return is_valid_;
 }
 
-const blink::Settings& AndroidShellHolder::GetSettings() const {
+const flutter::Settings& AndroidShellHolder::GetSettings() const {
   return settings_;
 }
 
@@ -173,7 +173,7 @@ void AndroidShellHolder::Launch(RunConfiguration config) {
 }
 
 void AndroidShellHolder::SetViewportMetrics(
-    const blink::ViewportMetrics& metrics) {
+    const flutter::ViewportMetrics& metrics) {
   if (!IsValid()) {
     return;
   }
@@ -187,7 +187,7 @@ void AndroidShellHolder::SetViewportMetrics(
 }
 
 void AndroidShellHolder::DispatchPointerDataPacket(
-    std::unique_ptr<blink::PointerDataPacket> packet) {
+    std::unique_ptr<flutter::PointerDataPacket> packet) {
   if (!IsValid()) {
     return;
   }

--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -20,7 +20,7 @@ namespace shell {
 
 class AndroidShellHolder {
  public:
-  AndroidShellHolder(blink::Settings settings,
+  AndroidShellHolder(flutter::Settings settings,
                      fml::jni::JavaObjectWeakGlobalRef java_object,
                      bool is_background_view);
 
@@ -30,22 +30,22 @@ class AndroidShellHolder {
 
   void Launch(RunConfiguration configuration);
 
-  void SetViewportMetrics(const blink::ViewportMetrics& metrics);
+  void SetViewportMetrics(const flutter::ViewportMetrics& metrics);
 
   void DispatchPointerDataPacket(
-      std::unique_ptr<blink::PointerDataPacket> packet);
+      std::unique_ptr<flutter::PointerDataPacket> packet);
 
-  const blink::Settings& GetSettings() const;
+  const flutter::Settings& GetSettings() const;
 
   fml::WeakPtr<PlatformViewAndroid> GetPlatformView();
 
   Rasterizer::Screenshot Screenshot(Rasterizer::ScreenshotType type,
                                     bool base64_encode);
 
-  void UpdateAssetManager(fml::RefPtr<blink::AssetManager> asset_manager);
+  void UpdateAssetManager(fml::RefPtr<flutter::AssetManager> asset_manager);
 
  private:
-  const blink::Settings settings_;
+  const flutter::Settings settings_;
   const fml::jni::JavaObjectWeakGlobalRef java_object_;
   fml::WeakPtr<PlatformViewAndroid> platform_view_;
   ThreadHost thread_host_;

--- a/shell/platform/android/apk_asset_provider.cc
+++ b/shell/platform/android/apk_asset_provider.cc
@@ -5,7 +5,7 @@
 #include "flutter/fml/logging.h"
 #include "flutter/shell/platform/android/apk_asset_provider.h"
 
-namespace blink {
+namespace flutter {
 
 APKAssetProvider::APKAssetProvider(JNIEnv* env,
                                    jobject jassetManager,
@@ -52,4 +52,4 @@ std::unique_ptr<fml::Mapping> APKAssetProvider::GetAsMapping(
   return std::make_unique<APKAssetMapping>(asset);
 }
 
-}  // namespace blink
+}  // namespace flutter

--- a/shell/platform/android/apk_asset_provider.h
+++ b/shell/platform/android/apk_asset_provider.h
@@ -12,7 +12,7 @@
 #include "flutter/fml/memory/ref_counted.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
 
-namespace blink {
+namespace flutter {
 
 class APKAssetProvider final : public AssetResolver {
  public:
@@ -26,16 +26,16 @@ class APKAssetProvider final : public AssetResolver {
   AAssetManager* assetManager_;
   const std::string directory_;
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   bool IsValid() const override;
 
-  // |blink::AssetResolver|
+  // |flutter::AssetResolver|
   std::unique_ptr<fml::Mapping> GetAsMapping(
       const std::string& asset_name) const override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(APKAssetProvider);
 };
 
-}  // namespace blink
+}  // namespace flutter
 
 #endif  // FLUTTER_ASSETS_APK_ASSET_PROVIDER_H

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -33,7 +33,7 @@ extern const intptr_t kPlatformStrongDillSize;
 #endif
 }
 
-FlutterMain::FlutterMain(blink::Settings settings)
+FlutterMain::FlutterMain(flutter::Settings settings)
     : settings_(std::move(settings)) {}
 
 FlutterMain::~FlutterMain() = default;
@@ -46,7 +46,7 @@ FlutterMain& FlutterMain::Get() {
   return *g_flutter_main;
 }
 
-const blink::Settings& FlutterMain::GetSettings() const {
+const flutter::Settings& FlutterMain::GetSettings() const {
   return settings_;
 }
 
@@ -71,15 +71,15 @@ void FlutterMain::Init(JNIEnv* env,
   // Restore the callback cache.
   // TODO(chinmaygarde): Route all cache file access through FML and remove this
   // setter.
-  blink::DartCallbackCache::SetCachePath(
+  flutter::DartCallbackCache::SetCachePath(
       fml::jni::JavaStringToString(env, appStoragePath));
 
   fml::paths::InitializeAndroidCachesPath(
       fml::jni::JavaStringToString(env, engineCachesPath));
 
-  blink::DartCallbackCache::LoadCacheFromDisk();
+  flutter::DartCallbackCache::LoadCacheFromDisk();
 
-  if (!blink::DartVM::IsRunningPrecompiledCode()) {
+  if (!flutter::DartVM::IsRunningPrecompiledCode()) {
     // Check to see if the appropriate kernel files are present and configure
     // settings accordingly.
     auto application_kernel_path =
@@ -121,7 +121,7 @@ static void RecordStartTimestamp(JNIEnv* env,
                                  jlong initTimeMillis) {
   int64_t initTimeMicros =
       static_cast<int64_t>(initTimeMillis) * static_cast<int64_t>(1000);
-  blink::engine_main_enter_ts = Dart_TimelineGetMicros() - initTimeMicros;
+  flutter::engine_main_enter_ts = Dart_TimelineGetMicros() - initTimeMicros;
 }
 
 bool FlutterMain::Register(JNIEnv* env) {

--- a/shell/platform/android/flutter_main.h
+++ b/shell/platform/android/flutter_main.h
@@ -20,12 +20,12 @@ class FlutterMain {
 
   static FlutterMain& Get();
 
-  const blink::Settings& GetSettings() const;
+  const flutter::Settings& GetSettings() const;
 
  private:
-  const blink::Settings settings_;
+  const flutter::Settings settings_;
 
-  FlutterMain(blink::Settings settings);
+  FlutterMain(flutter::Settings settings);
 
   static void Init(JNIEnv* env,
                    jclass clazz,

--- a/shell/platform/android/platform_message_response_android.cc
+++ b/shell/platform/android/platform_message_response_android.cc
@@ -19,7 +19,7 @@ PlatformMessageResponseAndroid::PlatformMessageResponseAndroid(
 
 PlatformMessageResponseAndroid::~PlatformMessageResponseAndroid() = default;
 
-// |blink::PlatformMessageResponse|
+// |flutter::PlatformMessageResponse|
 void PlatformMessageResponseAndroid::Complete(
     std::unique_ptr<fml::Mapping> data) {
   platform_task_runner_->PostTask(
@@ -51,7 +51,7 @@ void PlatformMessageResponseAndroid::Complete(
       }));
 }
 
-// |blink::PlatformMessageResponse|
+// |flutter::PlatformMessageResponse|
 void PlatformMessageResponseAndroid::CompleteEmpty() {
   platform_task_runner_->PostTask(
       fml::MakeCopyable([response = response_id_,              //

--- a/shell/platform/android/platform_message_response_android.h
+++ b/shell/platform/android/platform_message_response_android.h
@@ -12,12 +12,12 @@
 
 namespace shell {
 
-class PlatformMessageResponseAndroid : public blink::PlatformMessageResponse {
+class PlatformMessageResponseAndroid : public flutter::PlatformMessageResponse {
  public:
-  // |blink::PlatformMessageResponse|
+  // |flutter::PlatformMessageResponse|
   void Complete(std::unique_ptr<fml::Mapping> data) override;
 
-  // |blink::PlatformMessageResponse|
+  // |flutter::PlatformMessageResponse|
   void CompleteEmpty() override;
 
  private:

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -20,7 +20,7 @@ namespace shell {
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,
-    blink::TaskRunners task_runners,
+    flutter::TaskRunners task_runners,
     fml::jni::JavaObjectWeakGlobalRef java_object,
     bool use_software_rendering)
     : PlatformView(delegate, std::move(task_runners)),
@@ -33,7 +33,7 @@ PlatformViewAndroid::PlatformViewAndroid(
 
 PlatformViewAndroid::PlatformViewAndroid(
     PlatformView::Delegate& delegate,
-    blink::TaskRunners task_runners,
+    flutter::TaskRunners task_runners,
     fml::jni::JavaObjectWeakGlobalRef java_object)
     : PlatformView(delegate, std::move(task_runners)),
       java_object_(java_object),
@@ -99,29 +99,29 @@ void PlatformViewAndroid::DispatchPlatformMessage(JNIEnv* env,
   std::vector<uint8_t> message =
       std::vector<uint8_t>(message_data, message_data + java_message_position);
 
-  fml::RefPtr<blink::PlatformMessageResponse> response;
+  fml::RefPtr<flutter::PlatformMessageResponse> response;
   if (response_id) {
     response = fml::MakeRefCounted<PlatformMessageResponseAndroid>(
         response_id, java_object_, task_runners_.GetPlatformTaskRunner());
   }
 
   PlatformView::DispatchPlatformMessage(
-      fml::MakeRefCounted<blink::PlatformMessage>(
+      fml::MakeRefCounted<flutter::PlatformMessage>(
           std::move(name), std::move(message), std::move(response)));
 }
 
 void PlatformViewAndroid::DispatchEmptyPlatformMessage(JNIEnv* env,
                                                        std::string name,
                                                        jint response_id) {
-  fml::RefPtr<blink::PlatformMessageResponse> response;
+  fml::RefPtr<flutter::PlatformMessageResponse> response;
   if (response_id) {
     response = fml::MakeRefCounted<PlatformMessageResponseAndroid>(
         response_id, java_object_, task_runners_.GetPlatformTaskRunner());
   }
 
   PlatformView::DispatchPlatformMessage(
-      fml::MakeRefCounted<blink::PlatformMessage>(std::move(name),
-                                                  std::move(response)));
+      fml::MakeRefCounted<flutter::PlatformMessage>(std::move(name),
+                                                    std::move(response)));
 }
 
 void PlatformViewAndroid::InvokePlatformMessageResponseCallback(
@@ -159,7 +159,7 @@ void PlatformViewAndroid::InvokePlatformMessageEmptyResponseCallback(
 
 // |shell::PlatformView|
 void PlatformViewAndroid::HandlePlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   JNIEnv* env = fml::jni::AttachCurrentThread();
   fml::jni::ScopedJavaLocalRef<jobject> view = java_object_.get(env);
   if (view.is_null())
@@ -210,7 +210,7 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
   if (env->IsSameObject(args, NULL)) {
     std::vector<uint8_t> args_vector;
     PlatformView::DispatchSemanticsAction(
-        id, static_cast<blink::SemanticsAction>(action), args_vector);
+        id, static_cast<flutter::SemanticsAction>(action), args_vector);
     return;
   }
 
@@ -219,13 +219,14 @@ void PlatformViewAndroid::DispatchSemanticsAction(JNIEnv* env,
       std::vector<uint8_t>(args_data, args_data + args_position);
 
   PlatformView::DispatchSemanticsAction(
-      id, static_cast<blink::SemanticsAction>(action), std::move(args_vector));
+      id, static_cast<flutter::SemanticsAction>(action),
+      std::move(args_vector));
 }
 
 // |shell::PlatformView|
 void PlatformViewAndroid::UpdateSemantics(
-    blink::SemanticsNodeUpdates update,
-    blink::CustomAccessibilityActionUpdates actions) {
+    flutter::SemanticsNodeUpdates update,
+    flutter::CustomAccessibilityActionUpdates actions) {
   constexpr size_t kBytesPerNode = 39 * sizeof(int32_t);
   constexpr size_t kBytesPerChild = sizeof(int32_t);
   constexpr size_t kBytesPerAction = 4 * sizeof(int32_t);
@@ -256,7 +257,7 @@ void PlatformViewAndroid::UpdateSemantics(
       // If you edit this code, make sure you update kBytesPerNode
       // and/or kBytesPerChild above to match the number of values you are
       // sending.
-      const blink::SemanticsNode& node = value.second;
+      const flutter::SemanticsNode& node = value.second;
       buffer_int32[position++] = node.id;
       buffer_int32[position++] = node.flags;
       buffer_int32[position++] = node.actions;
@@ -330,7 +331,7 @@ void PlatformViewAndroid::UpdateSemantics(
       // If you edit this code, make sure you update kBytesPerAction
       // to match the number of values you are
       // sending.
-      const blink::CustomAccessibilityAction& action = value.second;
+      const flutter::CustomAccessibilityAction& action = value.second;
       actions_buffer_int32[actions_position++] = action.id;
       actions_buffer_int32[actions_position++] = action.overrideId;
       if (action.label.empty()) {

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -27,12 +27,12 @@ class PlatformViewAndroid final : public PlatformView {
   // Creates a PlatformViewAndroid with no rendering surface for use with
   // background execution.
   PlatformViewAndroid(PlatformView::Delegate& delegate,
-                      blink::TaskRunners task_runners,
+                      flutter::TaskRunners task_runners,
                       fml::jni::JavaObjectWeakGlobalRef java_object);
 
   // Creates a PlatformViewAndroid with a rendering surface.
   PlatformViewAndroid(PlatformView::Delegate& delegate,
-                      blink::TaskRunners task_runners,
+                      flutter::TaskRunners task_runners,
                       fml::jni::JavaObjectWeakGlobalRef java_object,
                       bool use_software_rendering);
 
@@ -78,17 +78,17 @@ class PlatformViewAndroid final : public PlatformView {
   const std::unique_ptr<AndroidSurface> android_surface_;
   // We use id 0 to mean that no response is expected.
   int next_response_id_ = 1;
-  std::unordered_map<int, fml::RefPtr<blink::PlatformMessageResponse>>
+  std::unordered_map<int, fml::RefPtr<flutter::PlatformMessageResponse>>
       pending_responses_;
 
   // |shell::PlatformView|
   void UpdateSemantics(
-      blink::SemanticsNodeUpdates update,
-      blink::CustomAccessibilityActionUpdates actions) override;
+      flutter::SemanticsNodeUpdates update,
+      flutter::CustomAccessibilityActionUpdates actions) override;
 
   // |shell::PlatformView|
   void HandlePlatformMessage(
-      fml::RefPtr<blink::PlatformMessage> message) override;
+      fml::RefPtr<flutter::PlatformMessage> message) override;
 
   // |shell::PlatformView|
   void OnPreEngineRestart() const override;

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -166,7 +166,7 @@ static void DestroyJNI(JNIEnv* env, jobject jcaller, jlong shell_holder) {
 
 static jstring GetObservatoryUri(JNIEnv* env, jclass clazz) {
   return env->NewStringUTF(
-      blink::DartServiceIsolate::GetObservatoryUri().c_str());
+      flutter::DartServiceIsolate::GetObservatoryUri().c_str());
 }
 
 static void SurfaceCreated(JNIEnv* env,
@@ -196,8 +196,8 @@ static void SurfaceDestroyed(JNIEnv* env, jobject jcaller, jlong shell_holder) {
 }
 
 std::unique_ptr<IsolateConfiguration> CreateIsolateConfiguration(
-    const blink::AssetManager& asset_manager) {
-  if (blink::DartVM::IsRunningPrecompiledCode()) {
+    const flutter::AssetManager& asset_manager) {
+  if (flutter::DartVM::IsRunningPrecompiledCode()) {
     return IsolateConfiguration::CreateForAppSnapshot();
   }
 
@@ -236,7 +236,7 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
                                             jstring jEntrypoint,
                                             jstring jLibraryUrl,
                                             jobject jAssetManager) {
-  auto asset_manager = std::make_shared<blink::AssetManager>();
+  auto asset_manager = std::make_shared<flutter::AssetManager>();
   for (const auto& bundlepath :
        fml::jni::StringArrayToVector(env, jbundlepaths)) {
     if (bundlepath.empty()) {
@@ -247,12 +247,12 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
     // bundle or a zip asset bundle.
     const auto file_ext_index = bundlepath.rfind(".");
     if (bundlepath.substr(file_ext_index) == ".zip") {
-      asset_manager->PushBack(std::make_unique<blink::ZipAssetStore>(
+      asset_manager->PushBack(std::make_unique<flutter::ZipAssetStore>(
           bundlepath, "assets/flutter_assets"));
 
     } else {
       asset_manager->PushBack(
-          std::make_unique<blink::DirectoryAssetBundle>(fml::OpenDirectory(
+          std::make_unique<flutter::DirectoryAssetBundle>(fml::OpenDirectory(
               bundlepath.c_str(), false, fml::FilePermission::kRead)));
 
       // Use the last path component of the bundle path to determine the
@@ -262,7 +262,7 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
         auto apk_asset_dir = bundlepath.substr(
             last_slash_index + 1, bundlepath.size() - last_slash_index);
 
-        asset_manager->PushBack(std::make_unique<blink::APKAssetProvider>(
+        asset_manager->PushBack(std::make_unique<flutter::APKAssetProvider>(
             env,                       // jni environment
             jAssetManager,             // asset manager
             std::move(apk_asset_dir))  // apk asset dir
@@ -299,7 +299,7 @@ static void RunBundleAndSnapshotFromLibrary(JNIEnv* env,
 static jobject LookupCallbackInformation(JNIEnv* env,
                                          /* unused */ jobject,
                                          jlong handle) {
-  auto cbInfo = blink::DartCallbackCache::GetCallbackInformation(handle);
+  auto cbInfo = flutter::DartCallbackCache::GetCallbackInformation(handle);
   if (cbInfo == nullptr) {
     return nullptr;
   }
@@ -321,7 +321,7 @@ static void SetViewportMetrics(JNIEnv* env,
                                jint physicalViewInsetRight,
                                jint physicalViewInsetBottom,
                                jint physicalViewInsetLeft) {
-  const blink::ViewportMetrics metrics{
+  const flutter::ViewportMetrics metrics{
       static_cast<double>(devicePixelRatio),
       static_cast<double>(physicalWidth),
       static_cast<double>(physicalHeight),
@@ -445,7 +445,7 @@ static void DispatchPointerDataPacket(JNIEnv* env,
                                       jobject buffer,
                                       jint position) {
   uint8_t* data = static_cast<uint8_t*>(env->GetDirectBufferAddress(buffer));
-  auto packet = std::make_unique<blink::PointerDataPacket>(data, position);
+  auto packet = std::make_unique<flutter::PointerDataPacket>(data, position);
   ANDROID_SHELL_HOLDER->DispatchPointerDataPacket(std::move(packet));
 }
 

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -19,7 +19,7 @@ namespace shell {
 static fml::jni::ScopedJavaGlobalRef<jclass>* g_vsync_waiter_class = nullptr;
 static jmethodID g_async_wait_for_vsync_method_ = nullptr;
 
-VsyncWaiterAndroid::VsyncWaiterAndroid(blink::TaskRunners task_runners)
+VsyncWaiterAndroid::VsyncWaiterAndroid(flutter::TaskRunners task_runners)
     : VsyncWaiter(std::move(task_runners)) {}
 
 VsyncWaiterAndroid::~VsyncWaiterAndroid() = default;

--- a/shell/platform/android/vsync_waiter_android.h
+++ b/shell/platform/android/vsync_waiter_android.h
@@ -18,7 +18,7 @@ class VsyncWaiterAndroid final : public VsyncWaiter {
  public:
   static bool Register(JNIEnv* env);
 
-  VsyncWaiterAndroid(blink::TaskRunners task_runners);
+  VsyncWaiterAndroid(flutter::TaskRunners task_runners);
 
   ~VsyncWaiterAndroid() override;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterCallbackCache.mm
@@ -12,7 +12,7 @@
 @implementation FlutterCallbackCache
 
 + (FlutterCallbackInformation*)lookupCallbackInformation:(int64_t)handle {
-  auto info = blink::DartCallbackCache::GetCallbackInformation(handle);
+  auto info = flutter::DartCallbackCache::GetCallbackInformation(handle);
   if (info == nullptr) {
     return nil;
   }
@@ -25,9 +25,9 @@
 
 + (void)setCachePath:(NSString*)path {
   assert(path != nil);
-  blink::DartCallbackCache::SetCachePath([path UTF8String]);
+  flutter::DartCallbackCache::SetCachePath([path UTF8String]);
   NSString* cache_path =
-      [NSString stringWithUTF8String:blink::DartCallbackCache::GetCachePath().c_str()];
+      [NSString stringWithUTF8String:flutter::DartCallbackCache::GetCachePath().c_str()];
   // Set the "Do Not Backup" flag to ensure that the cache isn't moved off disk in
   // low-memory situations.
   if (![[NSFileManager defaultManager] fileExistsAtPath:cache_path]) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -25,7 +25,7 @@ extern const intptr_t kPlatformStrongDillSize;
 
 static const char* kApplicationKernelSnapshotFileName = "kernel_blob.bin";
 
-static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
+static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
   auto command_line = shell::CommandLineFromNSProcessInfo();
 
   // Precedence:
@@ -66,7 +66,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
     }
   }
 
-  if (blink::DartVM::IsRunningPrecompiledCode()) {
+  if (flutter::DartVM::IsRunningPrecompiledCode()) {
     if (hasExplicitBundle) {
       NSString* executablePath = bundle.executablePath;
       if ([[NSFileManager defaultManager] fileExistsAtPath:executablePath]) {
@@ -118,7 +118,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
       // Check if there is an application kernel snapshot in the assets directory we could
       // potentially use.  Looking for the snapshot makes sense only if we have a VM that can use
       // it.
-      if (!blink::DartVM::IsRunningPrecompiledCode()) {
+      if (!flutter::DartVM::IsRunningPrecompiledCode()) {
         NSURL* applicationKernelSnapshotURL =
             [NSURL URLWithString:@(kApplicationKernelSnapshotFileName)
                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
@@ -147,7 +147,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 
 @implementation FlutterDartProject {
   fml::scoped_nsobject<NSBundle> _precompiledDartBundle;
-  blink::Settings _settings;
+  flutter::Settings _settings;
 }
 
 #pragma mark - Override base class designated initializers
@@ -171,7 +171,7 @@ static blink::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
 
 #pragma mark - Settings accessors
 
-- (const blink::Settings&)settings {
+- (const flutter::Settings&)settings {
   return _settings;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject_Internal.h
@@ -11,7 +11,7 @@
 
 @interface FlutterDartProject ()
 
-- (const blink::Settings&)settings;
+- (const flutter::Settings&)settings;
 
 - (shell::RunConfiguration)runConfiguration;
 - (shell::RunConfiguration)runConfigurationForEntrypoint:(NSString*)entrypointOrNil;

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -110,7 +110,7 @@
   return _weakFactory->GetWeakPtr();
 }
 
-- (void)updateViewportMetrics:(blink::ViewportMetrics)viewportMetrics {
+- (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics {
   self.shell.GetTaskRunners().GetUITaskRunner()->PostTask(
       [engine = self.shell.GetEngine(), metrics = viewportMetrics]() {
         if (engine) {
@@ -119,7 +119,7 @@
       });
 }
 
-- (void)dispatchPointerDataPacket:(std::unique_ptr<blink::PointerDataPacket>)packet {
+- (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet {
   TRACE_EVENT0("flutter", "dispatchPointerDataPacket");
   TRACE_FLOW_BEGIN("flutter", "PointerEvent", _nextPointerFlowId);
   self.shell.GetTaskRunners().GetUITaskRunner()->PostTask(fml::MakeCopyable(
@@ -360,11 +360,11 @@
     // TODO(amirh/chinmaygarde): remove this, and dynamically change the thread configuration.
     // https://github.com/flutter/flutter/issues/23975
 
-    blink::TaskRunners task_runners(threadLabel.UTF8String,                          // label
-                                    fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                    fml::MessageLoop::GetCurrent().GetTaskRunner(),  // gpu
-                                    _threadHost.ui_thread->GetTaskRunner(),          // ui
-                                    _threadHost.io_thread->GetTaskRunner()           // io
+    flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // gpu
+                                      _threadHost.ui_thread->GetTaskRunner(),          // ui
+                                      _threadHost.io_thread->GetTaskRunner()           // io
     );
     // Create the shell. This is a blocking operation.
     _shell = shell::Shell::Create(std::move(task_runners),  // task runners
@@ -373,11 +373,11 @@
                                   on_create_rasterizer      // rasterzier creation
     );
   } else {
-    blink::TaskRunners task_runners(threadLabel.UTF8String,                          // label
-                                    fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                    _threadHost.gpu_thread->GetTaskRunner(),         // gpu
-                                    _threadHost.ui_thread->GetTaskRunner(),          // ui
-                                    _threadHost.io_thread->GetTaskRunner()           // io
+    flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
+                                      _threadHost.gpu_thread->GetTaskRunner(),         // gpu
+                                      _threadHost.ui_thread->GetTaskRunner(),          // ui
+                                      _threadHost.io_thread->GetTaskRunner()           // io
     );
     // Create the shell. This is a blocking operation.
     _shell = shell::Shell::Create(std::move(task_runners),  // task runners
@@ -510,9 +510,9 @@
                                 callback(reply);
                               },
                               _shell->GetTaskRunners().GetPlatformTaskRunner());
-  fml::RefPtr<blink::PlatformMessage> platformMessage =
-      (message == nil) ? fml::MakeRefCounted<blink::PlatformMessage>(channel.UTF8String, response)
-                       : fml::MakeRefCounted<blink::PlatformMessage>(
+  fml::RefPtr<flutter::PlatformMessage> platformMessage =
+      (message == nil) ? fml::MakeRefCounted<flutter::PlatformMessage>(channel.UTF8String, response)
+                       : fml::MakeRefCounted<flutter::PlatformMessage>(
                              channel.UTF8String, shell::GetVectorFromNSData(message), response);
 
   _shell->GetPlatformView()->DispatchPlatformMessage(platformMessage);

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -28,8 +28,8 @@
 
 - (shell::Shell&)shell;
 
-- (void)updateViewportMetrics:(blink::ViewportMetrics)viewportMetrics;
-- (void)dispatchPointerDataPacket:(std::unique_ptr<blink::PointerDataPacket>)packet;
+- (void)updateViewportMetrics:(flutter::ViewportMetrics)viewportMetrics;
+- (void)dispatchPointerDataPacket:(std::unique_ptr<flutter::PointerDataPacket>)packet;
 
 - (fml::RefPtr<fml::TaskRunner>)platformTaskRunner;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -42,7 +42,7 @@
   fml::scoped_nsobject<NSNetService> _netService;
 #endif  // TARGET_IPHONE_SIMULATOR
 
-  blink::DartServiceIsolate::CallbackHandle _callbackHandle;
+  flutter::DartServiceIsolate::CallbackHandle _callbackHandle;
   std::unique_ptr<fml::WeakPtrFactory<FlutterObservatoryPublisher>> _weakFactory;
 }
 
@@ -54,7 +54,7 @@
 
   fml::MessageLoop::EnsureInitializedForCurrentThread();
 
-  _callbackHandle = blink::DartServiceIsolate::AddServerStatusCallback(
+  _callbackHandle = flutter::DartServiceIsolate::AddServerStatusCallback(
       [weak = _weakFactory->GetWeakPtr(),
        runner = fml::MessageLoop::GetCurrent().GetTaskRunner()](const std::string& uri) {
         runner->PostTask([weak, uri]() {
@@ -81,7 +81,7 @@
 - (void)dealloc {
   [self stopService];
 
-  blink::DartServiceIsolate::RemoveServerStatusCallback(std::move(_callbackHandle));
+  flutter::DartServiceIsolate::RemoveServerStatusCallback(std::move(_callbackHandle));
   [super dealloc];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -60,7 +60,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (BOOL)application:(UIApplication*)application
     willFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-  blink::DartCallbackCache::LoadCacheFromDisk();
+  flutter::DartCallbackCache::LoadCacheFromDisk();
   for (id<FlutterPlugin> plugin in [_pluginDelegates allObjects]) {
     if (!plugin) {
       continue;

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -55,12 +55,12 @@ class AccessibilityBridge;
 /**
  * The semantics node used to produce this semantics object.
  */
-@property(nonatomic, readonly) blink::SemanticsNode node;
+@property(nonatomic, readonly) flutter::SemanticsNode node;
 
 /**
  * Updates this semantics object using data from the `node` argument.
  */
-- (void)setSemanticsNode:(const blink::SemanticsNode*)node NS_REQUIRES_SUPER;
+- (void)setSemanticsNode:(const flutter::SemanticsNode*)node NS_REQUIRES_SUPER;
 
 /**
  * Whether this semantics object has child semantics objects.
@@ -78,7 +78,7 @@ class AccessibilityBridge;
  */
 @property(strong, nonatomic) FlutterPlatformViewSemanticsContainer* platformViewSemanticsContainer;
 
-- (BOOL)nodeWillCauseLayoutChange:(const blink::SemanticsNode*)node;
+- (BOOL)nodeWillCauseLayoutChange:(const flutter::SemanticsNode*)node;
 
 #pragma mark - Designated initializers
 
@@ -142,11 +142,11 @@ class AccessibilityBridge final {
                       FlutterPlatformViewsController* platform_views_controller);
   ~AccessibilityBridge();
 
-  void UpdateSemantics(blink::SemanticsNodeUpdates nodes,
-                       blink::CustomAccessibilityActionUpdates actions);
-  void DispatchSemanticsAction(int32_t id, blink::SemanticsAction action);
+  void UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
+                       flutter::CustomAccessibilityActionUpdates actions);
+  void DispatchSemanticsAction(int32_t id, flutter::SemanticsAction action);
   void DispatchSemanticsAction(int32_t id,
-                               blink::SemanticsAction action,
+                               flutter::SemanticsAction action,
                                std::vector<uint8_t> args);
 
   UIView<UITextInput>* textInputView();
@@ -162,7 +162,7 @@ class AccessibilityBridge final {
   void clearState();
 
  private:
-  SemanticsObject* GetOrCreateObject(int32_t id, blink::SemanticsNodeUpdates& updates);
+  SemanticsObject* GetOrCreateObject(int32_t id, flutter::SemanticsNodeUpdates& updates);
   void VisitObjectsRecursivelyAndRemove(SemanticsObject* object,
                                         NSMutableArray<NSNumber*>* doomed_uids);
   void HandleEvent(NSDictionary<NSString*, id>* annotatedEvent);
@@ -174,7 +174,7 @@ class AccessibilityBridge final {
   fml::scoped_nsprotocol<FlutterBasicMessageChannel*> accessibility_channel_;
   fml::WeakPtrFactory<AccessibilityBridge> weak_factory_;
   int32_t previous_route_id_;
-  std::unordered_map<int32_t, blink::CustomAccessibilityAction> actions_;
+  std::unordered_map<int32_t, flutter::CustomAccessibilityAction> actions_;
   std::vector<int32_t> previous_routes_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(AccessibilityBridge);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -186,10 +186,10 @@
 
 #pragma mark - SemanticsObject overrides
 
-- (void)setSemanticsNode:(const blink::SemanticsNode*)node {
+- (void)setSemanticsNode:(const flutter::SemanticsNode*)node {
   [super setSemanticsNode:node];
   _inactive_text_input.text = @(node->value.data());
-  if ([self node].HasFlag(blink::SemanticsFlags::kIsFocused)) {
+  if ([self node].HasFlag(flutter::SemanticsFlags::kIsFocused)) {
     // The text input view must have a non-trivial size for the accessibility
     // system to send text editing events.
     [self bridge] -> textInputView().frame = CGRectMake(0.0, 0.0, 1.0, 1.0);
@@ -207,7 +207,7 @@
  * we use an FlutterInactiveTextInput.
  */
 - (UIView<UITextInput>*)textInputSurrogate {
-  if ([self node].HasFlag(blink::SemanticsFlags::kIsFocused)) {
+  if ([self node].HasFlag(flutter::SemanticsFlags::kIsFocused)) {
     return [self bridge] -> textInputView();
   } else {
     return _inactive_text_input;
@@ -229,7 +229,7 @@
 }
 
 - (BOOL)accessibilityElementIsFocused {
-  return [self node].HasFlag(blink::SemanticsFlags::kIsFocused);
+  return [self node].HasFlag(flutter::SemanticsFlags::kIsFocused);
 }
 
 - (BOOL)accessibilityActivate {

--- a/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_response_darwin.h
@@ -18,7 +18,7 @@ typedef void (^PlatformMessageResponseCallback)(NSData*);
 
 namespace shell {
 
-class PlatformMessageResponseDarwin : public blink::PlatformMessageResponse {
+class PlatformMessageResponseDarwin : public flutter::PlatformMessageResponse {
  public:
   void Complete(std::unique_ptr<fml::Mapping> data) override;
 

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.h
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.h
@@ -19,7 +19,8 @@ class PlatformMessageRouter {
   PlatformMessageRouter();
   ~PlatformMessageRouter();
 
-  void HandlePlatformMessage(fml::RefPtr<blink::PlatformMessage> message) const;
+  void HandlePlatformMessage(
+      fml::RefPtr<flutter::PlatformMessage> message) const;
 
   void SetMessageHandler(const std::string& channel,
                          FlutterBinaryMessageHandler handler);

--- a/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
+++ b/shell/platform/darwin/ios/framework/Source/platform_message_router.mm
@@ -15,8 +15,8 @@ PlatformMessageRouter::PlatformMessageRouter() = default;
 PlatformMessageRouter::~PlatformMessageRouter() = default;
 
 void PlatformMessageRouter::HandlePlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) const {
-  fml::RefPtr<blink::PlatformMessageResponse> completer = message->response();
+    fml::RefPtr<flutter::PlatformMessage> message) const {
+  fml::RefPtr<flutter::PlatformMessageResponse> completer = message->response();
   auto it = message_handlers_.find(message->channel());
   if (it != message_handlers_.end()) {
     FlutterBinaryMessageHandler handler = it->second;

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h
@@ -16,7 +16,7 @@ namespace shell {
 
 class VsyncWaiterIOS final : public VsyncWaiter {
  public:
-  VsyncWaiterIOS(blink::TaskRunners task_runners);
+  VsyncWaiterIOS(flutter::TaskRunners task_runners);
 
   ~VsyncWaiterIOS() override;
 

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -27,7 +27,7 @@
 
 namespace shell {
 
-VsyncWaiterIOS::VsyncWaiterIOS(blink::TaskRunners task_runners)
+VsyncWaiterIOS::VsyncWaiterIOS(flutter::TaskRunners task_runners)
     : VsyncWaiter(std::move(task_runners)),
       client_([[VSyncClient alloc] initWithTaskRunner:task_runners_.GetUITaskRunner()
                                              callback:std::bind(&VsyncWaiterIOS::FireCallback,

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -26,7 +26,7 @@ namespace shell {
 
 class PlatformViewIOS final : public PlatformView {
  public:
-  explicit PlatformViewIOS(PlatformView::Delegate& delegate, blink::TaskRunners task_runners);
+  explicit PlatformViewIOS(PlatformView::Delegate& delegate, flutter::TaskRunners task_runners);
 
   ~PlatformViewIOS() override;
 
@@ -54,7 +54,7 @@ class PlatformViewIOS final : public PlatformView {
   fml::closure firstFrameCallback_;
 
   // |shell::PlatformView|
-  void HandlePlatformMessage(fml::RefPtr<blink::PlatformMessage> message) override;
+  void HandlePlatformMessage(fml::RefPtr<flutter::PlatformMessage> message) override;
 
   // |shell::PlatformView|
   std::unique_ptr<Surface> CreateRenderingSurface() override;
@@ -66,8 +66,8 @@ class PlatformViewIOS final : public PlatformView {
   void SetAccessibilityFeatures(int32_t flags) override;
 
   // |shell::PlatformView|
-  void UpdateSemantics(blink::SemanticsNodeUpdates update,
-                       blink::CustomAccessibilityActionUpdates actions) override;
+  void UpdateSemantics(flutter::SemanticsNodeUpdates update,
+                       flutter::CustomAccessibilityActionUpdates actions) override;
 
   // |shell::PlatformView|
   std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -19,7 +19,8 @@
 
 namespace shell {
 
-PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate, blink::TaskRunners task_runners)
+PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
+                                 flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
   gl_context_ = std::make_shared<IOSGLContext>();
@@ -33,7 +34,7 @@ PlatformMessageRouter& PlatformViewIOS::GetPlatformMessageRouter() {
 }
 
 // |shell::PlatformView|
-void PlatformViewIOS::HandlePlatformMessage(fml::RefPtr<blink::PlatformMessage> message) {
+void PlatformViewIOS::HandlePlatformMessage(fml::RefPtr<flutter::PlatformMessage> message) {
   platform_message_router_.HandlePlatformMessage(std::move(message));
 }
 
@@ -116,8 +117,8 @@ void PlatformViewIOS::SetAccessibilityFeatures(int32_t flags) {
 }
 
 // |shell::PlatformView|
-void PlatformViewIOS::UpdateSemantics(blink::SemanticsNodeUpdates update,
-                                      blink::CustomAccessibilityActionUpdates actions) {
+void PlatformViewIOS::UpdateSemantics(flutter::SemanticsNodeUpdates update,
+                                      flutter::CustomAccessibilityActionUpdates actions) {
   FML_DCHECK(owner_controller_);
   if (accessibility_bridge_) {
     accessibility_bridge_->UpdateSemantics(std::move(update), std::move(actions));

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -258,11 +258,11 @@ InferPlatformViewCreationCallback(
 }
 
 struct _FlutterPlatformMessageResponseHandle {
-  fml::RefPtr<blink::PlatformMessage> message;
+  fml::RefPtr<flutter::PlatformMessage> message;
 };
 
 void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
-                                      blink::Settings& settings) {
+                                      flutter::Settings& settings) {
   // There are no ownership concerns here as all mappings are owned by the
   // embedder and not the engine.
   auto make_mapping_callback = [](const uint8_t* mapping, size_t size) {
@@ -271,7 +271,7 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
     };
   };
 
-  if (blink::DartVM::IsRunningPrecompiledCode()) {
+  if (flutter::DartVM::IsRunningPrecompiledCode()) {
     if (SAFE_ACCESS(args, vm_snapshot_data_size, 0) != 0 &&
         SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
       settings.vm_snapshot_data = make_mapping_callback(
@@ -363,14 +363,14 @@ FlutterEngineResult FlutterEngineRun(size_t version,
         SAFE_ACCESS(args, command_line_argv, nullptr));
   }
 
-  blink::Settings settings = shell::SettingsFromCommandLine(command_line);
+  flutter::Settings settings = shell::SettingsFromCommandLine(command_line);
 
   PopulateSnapshotMappingCallbacks(args, settings);
 
   settings.icu_data_path = icu_data_path;
   settings.assets_path = args->assets_path;
 
-  if (!blink::DartVM::IsRunningPrecompiledCode()) {
+  if (!flutter::DartVM::IsRunningPrecompiledCode()) {
     // Verify the assets path contains Dart 2 kernel assets.
     const std::string kApplicationKernelSnapshotFileName = "kernel_blob.bin";
     std::string application_kernel_path = fml::paths::JoinPaths(
@@ -402,7 +402,7 @@ FlutterEngineResult FlutterEngineRun(size_t version,
   if (SAFE_ACCESS(args, update_semantics_node_callback, nullptr) != nullptr) {
     update_semantics_nodes_callback =
         [ptr = args->update_semantics_node_callback,
-         user_data](blink::SemanticsNodeUpdates update) {
+         user_data](flutter::SemanticsNodeUpdates update) {
           for (const auto& value : update) {
             const auto& node = value.second;
             SkMatrix transform = static_cast<SkMatrix>(node.transform);
@@ -461,7 +461,7 @@ FlutterEngineResult FlutterEngineRun(size_t version,
       nullptr) {
     update_semantics_custom_actions_callback =
         [ptr = args->update_semantics_custom_action_callback,
-         user_data](blink::CustomAccessibilityActionUpdates actions) {
+         user_data](flutter::CustomAccessibilityActionUpdates actions) {
           for (const auto& value : actions) {
             const auto& action = value.second;
             const FlutterSemanticsCustomAction embedder_action = {
@@ -486,7 +486,7 @@ FlutterEngineResult FlutterEngineRun(size_t version,
   if (SAFE_ACCESS(args, platform_message_callback, nullptr) != nullptr) {
     platform_message_response_callback =
         [ptr = args->platform_message_callback,
-         user_data](fml::RefPtr<blink::PlatformMessage> message) {
+         user_data](fml::RefPtr<flutter::PlatformMessage> message) {
           auto handle = new FlutterPlatformMessageResponseHandle();
           const FlutterPlatformMessage incoming_message = {
               sizeof(FlutterPlatformMessage),  // struct_size
@@ -624,11 +624,11 @@ FlutterEngineResult FlutterEngineRun(size_t version,
   }
 
   run_configuration.AddAssetResolver(
-      std::make_unique<blink::DirectoryAssetBundle>(
+      std::make_unique<flutter::DirectoryAssetBundle>(
           fml::Duplicate(settings.assets_dir)));
 
   run_configuration.AddAssetResolver(
-      std::make_unique<blink::DirectoryAssetBundle>(fml::OpenDirectory(
+      std::make_unique<flutter::DirectoryAssetBundle>(fml::OpenDirectory(
           settings.assets_path.c_str(), false, fml::FilePermission::kRead)));
   if (!run_configuration.IsValid()) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
@@ -660,7 +660,7 @@ FlutterEngineResult FlutterEngineSendWindowMetricsEvent(
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
 
-  blink::ViewportMetrics metrics;
+  flutter::ViewportMetrics metrics;
 
   metrics.physical_width = SAFE_ACCESS(flutter_metrics, width, 0.0);
   metrics.physical_height = SAFE_ACCESS(flutter_metrics, height, 0.0);
@@ -672,39 +672,39 @@ FlutterEngineResult FlutterEngineSendWindowMetricsEvent(
              : LOG_EMBEDDER_ERROR(kInvalidArguments);
 }
 
-// Returns the blink::PointerData::Change for the given FlutterPointerPhase.
-inline blink::PointerData::Change ToPointerDataChange(
+// Returns the flutter::PointerData::Change for the given FlutterPointerPhase.
+inline flutter::PointerData::Change ToPointerDataChange(
     FlutterPointerPhase phase) {
   switch (phase) {
     case kCancel:
-      return blink::PointerData::Change::kCancel;
+      return flutter::PointerData::Change::kCancel;
     case kUp:
-      return blink::PointerData::Change::kUp;
+      return flutter::PointerData::Change::kUp;
     case kDown:
-      return blink::PointerData::Change::kDown;
+      return flutter::PointerData::Change::kDown;
     case kMove:
-      return blink::PointerData::Change::kMove;
+      return flutter::PointerData::Change::kMove;
     case kAdd:
-      return blink::PointerData::Change::kAdd;
+      return flutter::PointerData::Change::kAdd;
     case kRemove:
-      return blink::PointerData::Change::kRemove;
+      return flutter::PointerData::Change::kRemove;
     case kHover:
-      return blink::PointerData::Change::kHover;
+      return flutter::PointerData::Change::kHover;
   }
-  return blink::PointerData::Change::kCancel;
+  return flutter::PointerData::Change::kCancel;
 }
 
-// Returns the blink::PointerData::SignalKind for the given
+// Returns the flutter::PointerData::SignalKind for the given
 // FlutterPointerSignaKind.
-inline blink::PointerData::SignalKind ToPointerDataSignalKind(
+inline flutter::PointerData::SignalKind ToPointerDataSignalKind(
     FlutterPointerSignalKind kind) {
   switch (kind) {
     case kFlutterPointerSignalKindNone:
-      return blink::PointerData::SignalKind::kNone;
+      return flutter::PointerData::SignalKind::kNone;
     case kFlutterPointerSignalKindScroll:
-      return blink::PointerData::SignalKind::kScroll;
+      return flutter::PointerData::SignalKind::kScroll;
   }
-  return blink::PointerData::SignalKind::kNone;
+  return flutter::PointerData::SignalKind::kNone;
 }
 
 FlutterEngineResult FlutterEngineSendPointerEvent(
@@ -715,17 +715,17 @@ FlutterEngineResult FlutterEngineSendPointerEvent(
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
 
-  auto packet = std::make_unique<blink::PointerDataPacket>(events_count);
+  auto packet = std::make_unique<flutter::PointerDataPacket>(events_count);
 
   const FlutterPointerEvent* current = pointers;
 
   for (size_t i = 0; i < events_count; ++i) {
-    blink::PointerData pointer_data;
+    flutter::PointerData pointer_data;
     pointer_data.Clear();
     pointer_data.time_stamp = SAFE_ACCESS(current, timestamp, 0);
     pointer_data.change = ToPointerDataChange(
         SAFE_ACCESS(current, phase, FlutterPointerPhase::kCancel));
-    pointer_data.kind = blink::PointerData::DeviceKind::kMouse;
+    pointer_data.kind = flutter::PointerData::DeviceKind::kMouse;
     pointer_data.physical_x = SAFE_ACCESS(current, x, 0.0);
     pointer_data.physical_y = SAFE_ACCESS(current, y, 0.0);
     pointer_data.device = SAFE_ACCESS(current, device, 0);
@@ -756,7 +756,7 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
 
-  auto message = fml::MakeRefCounted<blink::PlatformMessage>(
+  auto message = fml::MakeRefCounted<flutter::PlatformMessage>(
       flutter_message->channel,
       std::vector<uint8_t>(
           flutter_message->message,
@@ -872,7 +872,7 @@ FlutterEngineResult FlutterEngineDispatchSemanticsAction(
   if (engine == nullptr) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
-  auto engine_action = static_cast<blink::SemanticsAction>(action);
+  auto engine_action = static_cast<flutter::SemanticsAction>(action);
   if (!reinterpret_cast<shell::EmbedderEngine*>(engine)
            ->DispatchSemanticsAction(
                id, engine_action,

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -11,8 +11,8 @@ namespace shell {
 
 EmbedderEngine::EmbedderEngine(
     std::unique_ptr<EmbedderThreadHost> thread_host,
-    blink::TaskRunners task_runners,
-    blink::Settings settings,
+    flutter::TaskRunners task_runners,
+    flutter::Settings settings,
     Shell::CreateCallback<PlatformView> on_create_platform_view,
     Shell::CreateCallback<Rasterizer> on_create_rasterizer,
     EmbedderExternalTextureGL::ExternalTextureCallback
@@ -74,7 +74,7 @@ bool EmbedderEngine::Run(RunConfiguration run_configuration) {
   return true;
 }
 
-bool EmbedderEngine::SetViewportMetrics(blink::ViewportMetrics metrics) {
+bool EmbedderEngine::SetViewportMetrics(flutter::ViewportMetrics metrics) {
   if (!IsValid()) {
     return false;
   }
@@ -89,7 +89,7 @@ bool EmbedderEngine::SetViewportMetrics(blink::ViewportMetrics metrics) {
 }
 
 bool EmbedderEngine::DispatchPointerDataPacket(
-    std::unique_ptr<blink::PointerDataPacket> packet) {
+    std::unique_ptr<flutter::PointerDataPacket> packet) {
   if (!IsValid() || !packet) {
     return false;
   }
@@ -110,7 +110,7 @@ bool EmbedderEngine::DispatchPointerDataPacket(
 }
 
 bool EmbedderEngine::SendPlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   if (!IsValid() || !message) {
     return false;
   }
@@ -178,7 +178,7 @@ bool EmbedderEngine::SetAccessibilityFeatures(int32_t flags) {
 }
 
 bool EmbedderEngine::DispatchSemanticsAction(int id,
-                                             blink::SemanticsAction action,
+                                             flutter::SemanticsAction action,
                                              std::vector<uint8_t> args) {
   if (!IsValid()) {
     return false;

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -23,8 +23,8 @@ namespace shell {
 class EmbedderEngine {
  public:
   EmbedderEngine(std::unique_ptr<EmbedderThreadHost> thread_host,
-                 blink::TaskRunners task_runners,
-                 blink::Settings settings,
+                 flutter::TaskRunners task_runners,
+                 flutter::Settings settings,
                  Shell::CreateCallback<PlatformView> on_create_platform_view,
                  Shell::CreateCallback<Rasterizer> on_create_rasterizer,
                  EmbedderExternalTextureGL::ExternalTextureCallback
@@ -40,12 +40,12 @@ class EmbedderEngine {
 
   bool IsValid() const;
 
-  bool SetViewportMetrics(blink::ViewportMetrics metrics);
+  bool SetViewportMetrics(flutter::ViewportMetrics metrics);
 
   bool DispatchPointerDataPacket(
-      std::unique_ptr<blink::PointerDataPacket> packet);
+      std::unique_ptr<flutter::PointerDataPacket> packet);
 
-  bool SendPlatformMessage(fml::RefPtr<blink::PlatformMessage> message);
+  bool SendPlatformMessage(fml::RefPtr<flutter::PlatformMessage> message);
 
   bool RegisterTexture(int64_t texture);
 
@@ -58,7 +58,7 @@ class EmbedderEngine {
   bool SetAccessibilityFeatures(int32_t flags);
 
   bool DispatchSemanticsAction(int id,
-                               blink::SemanticsAction action,
+                               flutter::SemanticsAction action,
                                std::vector<uint8_t> args);
 
   bool OnVsyncEvent(intptr_t baton,

--- a/shell/platform/embedder/embedder_thread_host.cc
+++ b/shell/platform/embedder/embedder_thread_host.cc
@@ -108,7 +108,7 @@ EmbedderThreadHost::CreateEmbedderManagedThreadHost(
                                                  ThreadHost::Type::IO |
                                                  ThreadHost::Type::UI);
 
-  blink::TaskRunners task_runners(
+  flutter::TaskRunners task_runners(
       kFlutterThreadName,
       platform_task_runner,                     // platform
       thread_host.gpu_thread->GetTaskRunner(),  // gpu
@@ -150,7 +150,7 @@ EmbedderThreadHost::CreateEngineManagedThreadHost() {
   // implementation.
   auto platform_task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
 
-  blink::TaskRunners task_runners(
+  flutter::TaskRunners task_runners(
       kFlutterThreadName,
       platform_task_runner,                     // platform
       thread_host.gpu_thread->GetTaskRunner(),  // gpu
@@ -177,7 +177,7 @@ EmbedderThreadHost::CreateEngineManagedThreadHost() {
 
 EmbedderThreadHost::EmbedderThreadHost(
     ThreadHost host,
-    blink::TaskRunners runners,
+    flutter::TaskRunners runners,
     std::set<fml::RefPtr<EmbedderTaskRunner>> embedder_task_runners)
     : host_(std::move(host)), runners_(std::move(runners)) {
   for (const auto& runner : embedder_task_runners) {
@@ -191,7 +191,7 @@ bool EmbedderThreadHost::IsValid() const {
   return runners_.IsValid();
 }
 
-const blink::TaskRunners& EmbedderThreadHost::GetTaskRunners() const {
+const flutter::TaskRunners& EmbedderThreadHost::GetTaskRunners() const {
   return runners_;
 }
 

--- a/shell/platform/embedder/embedder_thread_host.h
+++ b/shell/platform/embedder/embedder_thread_host.h
@@ -25,20 +25,20 @@ class EmbedderThreadHost {
 
   EmbedderThreadHost(
       ThreadHost host,
-      blink::TaskRunners runners,
+      flutter::TaskRunners runners,
       std::set<fml::RefPtr<EmbedderTaskRunner>> embedder_task_runners);
 
   ~EmbedderThreadHost();
 
   bool IsValid() const;
 
-  const blink::TaskRunners& GetTaskRunners() const;
+  const flutter::TaskRunners& GetTaskRunners() const;
 
   bool PostTask(int64_t runner, uint64_t task) const;
 
  private:
   ThreadHost host_;
-  blink::TaskRunners runners_;
+  flutter::TaskRunners runners_;
   std::map<int64_t, fml::RefPtr<EmbedderTaskRunner>> runners_map_;
 
   static std::unique_ptr<EmbedderThreadHost> CreateEmbedderManagedThreadHost(

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -8,7 +8,7 @@ namespace shell {
 
 PlatformViewEmbedder::PlatformViewEmbedder(
     PlatformView::Delegate& delegate,
-    blink::TaskRunners task_runners,
+    flutter::TaskRunners task_runners,
     EmbedderSurfaceGL::GLDispatchTable gl_dispatch_table,
     bool fbo_reset_after_present,
     PlatformDispatchTable platform_dispatch_table)
@@ -20,7 +20,7 @@ PlatformViewEmbedder::PlatformViewEmbedder(
 
 PlatformViewEmbedder::PlatformViewEmbedder(
     PlatformView::Delegate& delegate,
-    blink::TaskRunners task_runners,
+    flutter::TaskRunners task_runners,
     EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
     PlatformDispatchTable platform_dispatch_table)
     : PlatformView(delegate, std::move(task_runners)),
@@ -31,8 +31,8 @@ PlatformViewEmbedder::PlatformViewEmbedder(
 PlatformViewEmbedder::~PlatformViewEmbedder() = default;
 
 void PlatformViewEmbedder::UpdateSemantics(
-    blink::SemanticsNodeUpdates update,
-    blink::CustomAccessibilityActionUpdates actions) {
+    flutter::SemanticsNodeUpdates update,
+    flutter::CustomAccessibilityActionUpdates actions) {
   if (platform_dispatch_table_.update_semantics_nodes_callback != nullptr) {
     platform_dispatch_table_.update_semantics_nodes_callback(std::move(update));
   }
@@ -44,7 +44,7 @@ void PlatformViewEmbedder::UpdateSemantics(
 }
 
 void PlatformViewEmbedder::HandlePlatformMessage(
-    fml::RefPtr<blink::PlatformMessage> message) {
+    fml::RefPtr<flutter::PlatformMessage> message) {
   if (!message) {
     return;
   }

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -20,11 +20,11 @@ namespace shell {
 class PlatformViewEmbedder final : public PlatformView {
  public:
   using UpdateSemanticsNodesCallback =
-      std::function<void(blink::SemanticsNodeUpdates update)>;
+      std::function<void(flutter::SemanticsNodeUpdates update)>;
   using UpdateSemanticsCustomActionsCallback =
-      std::function<void(blink::CustomAccessibilityActionUpdates actions)>;
+      std::function<void(flutter::CustomAccessibilityActionUpdates actions)>;
   using PlatformMessageResponseCallback =
-      std::function<void(fml::RefPtr<blink::PlatformMessage>)>;
+      std::function<void(fml::RefPtr<flutter::PlatformMessage>)>;
 
   struct PlatformDispatchTable {
     UpdateSemanticsNodesCallback update_semantics_nodes_callback;  // optional
@@ -37,7 +37,7 @@ class PlatformViewEmbedder final : public PlatformView {
 
   // Creates a platform view that sets up an OpenGL rasterizer.
   PlatformViewEmbedder(PlatformView::Delegate& delegate,
-                       blink::TaskRunners task_runners,
+                       flutter::TaskRunners task_runners,
                        EmbedderSurfaceGL::GLDispatchTable gl_dispatch_table,
                        bool fbo_reset_after_present,
                        PlatformDispatchTable platform_dispatch_table);
@@ -45,7 +45,7 @@ class PlatformViewEmbedder final : public PlatformView {
   // Create a platform view that sets up a software rasterizer.
   PlatformViewEmbedder(
       PlatformView::Delegate& delegate,
-      blink::TaskRunners task_runners,
+      flutter::TaskRunners task_runners,
       EmbedderSurfaceSoftware::SoftwareDispatchTable software_dispatch_table,
       PlatformDispatchTable platform_dispatch_table);
 
@@ -53,12 +53,12 @@ class PlatformViewEmbedder final : public PlatformView {
 
   // |shell::PlatformView|
   void UpdateSemantics(
-      blink::SemanticsNodeUpdates update,
-      blink::CustomAccessibilityActionUpdates actions) override;
+      flutter::SemanticsNodeUpdates update,
+      flutter::CustomAccessibilityActionUpdates actions) override;
 
   // |shell::PlatformView|
   void HandlePlatformMessage(
-      fml::RefPtr<blink::PlatformMessage> message) override;
+      fml::RefPtr<flutter::PlatformMessage> message) override;
 
  private:
   std::unique_ptr<EmbedderSurface> embedder_surface_;

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -137,7 +137,7 @@ TEST_F(Embedder11yTest, A11yTreeIsConsistent) {
 
     int64_t action_id;
     Dart_GetNativeIntegerArgument(args, 1, &action_id);
-    ASSERT_EQ(static_cast<int32_t>(blink::SemanticsAction::kTap), action_id);
+    ASSERT_EQ(static_cast<int32_t>(flutter::SemanticsAction::kTap), action_id);
 
     Dart_Handle semantic_args = Dart_GetNativeArgument(args, 2);
     int64_t data;

--- a/shell/platform/embedder/tests/embedder_context.cc
+++ b/shell/platform/embedder/tests/embedder_context.cc
@@ -44,7 +44,7 @@ EmbedderContext::EmbedderContext(std::string assets_path)
   isolate_snapshot_data_ =
       GetMapping(assets_dir, "isolate_snapshot_data", false);
 
-  if (blink::DartVM::IsRunningPrecompiledCode()) {
+  if (flutter::DartVM::IsRunningPrecompiledCode()) {
     vm_snapshot_instructions_ =
         GetMapping(assets_dir, "vm_snapshot_instr", true);
     isolate_snapshot_instructions_ =

--- a/shell/platform/embedder/vsync_waiter_embedder.cc
+++ b/shell/platform/embedder/vsync_waiter_embedder.cc
@@ -7,7 +7,7 @@
 namespace shell {
 
 VsyncWaiterEmbedder::VsyncWaiterEmbedder(VsyncCallback vsync_callback,
-                                         blink::TaskRunners task_runners)
+                                         flutter::TaskRunners task_runners)
     : VsyncWaiter(std::move(task_runners)), vsync_callback_(vsync_callback) {
   FML_DCHECK(vsync_callback_);
 }

--- a/shell/platform/embedder/vsync_waiter_embedder.h
+++ b/shell/platform/embedder/vsync_waiter_embedder.h
@@ -14,7 +14,8 @@ class VsyncWaiterEmbedder final : public VsyncWaiter {
  public:
   using VsyncCallback = std::function<void(intptr_t)>;
 
-  VsyncWaiterEmbedder(VsyncCallback callback, blink::TaskRunners task_runners);
+  VsyncWaiterEmbedder(VsyncCallback callback,
+                      flutter::TaskRunners task_runners);
 
   ~VsyncWaiterEmbedder() override;
 

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -85,7 +85,7 @@ class ScriptCompletionTaskObserver {
   FML_DISALLOW_COPY_AND_ASSIGN(ScriptCompletionTaskObserver);
 };
 
-int RunTester(const blink::Settings& settings, bool run_forever) {
+int RunTester(const flutter::Settings& settings, bool run_forever) {
   const auto thread_label = "io.flutter.test";
 
   fml::MessageLoop::EnsureInitializedForCurrentThread();
@@ -93,11 +93,11 @@ int RunTester(const blink::Settings& settings, bool run_forever) {
   auto current_task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
 
   // Setup a single threaded test runner configuration.
-  const blink::TaskRunners task_runners(thread_label,  // dart thread label
-                                        current_task_runner,  // platform
-                                        current_task_runner,  // gpu
-                                        current_task_runner,  // ui
-                                        current_task_runner   // io
+  const flutter::TaskRunners task_runners(thread_label,  // dart thread label
+                                          current_task_runner,  // platform
+                                          current_task_runner,  // gpu
+                                          current_task_runner,  // ui
+                                          current_task_runner   // io
   );
 
   Shell::CreateCallback<PlatformView> on_create_platform_view =
@@ -133,10 +133,10 @@ int RunTester(const blink::Settings& settings, bool run_forever) {
       "\"CN\",\"\",\"\"]}";
   std::vector<uint8_t> locale_bytes(locale_json,
                                     locale_json + std::strlen(locale_json));
-  fml::RefPtr<blink::PlatformMessageResponse> response;
+  fml::RefPtr<flutter::PlatformMessageResponse> response;
   shell->GetPlatformView()->DispatchPlatformMessage(
-      fml::MakeRefCounted<blink::PlatformMessage>("flutter/localization",
-                                                  locale_bytes, response));
+      fml::MakeRefCounted<flutter::PlatformMessage>("flutter/localization",
+                                                    locale_bytes, response));
 
   std::initializer_list<fml::FileMapping::Protection> protection = {
       fml::FileMapping::Protection::kRead};
@@ -154,11 +154,11 @@ int RunTester(const blink::Settings& settings, bool run_forever) {
     return EXIT_FAILURE;
   }
 
-  auto asset_manager = std::make_shared<blink::AssetManager>();
-  asset_manager->PushBack(std::make_unique<blink::DirectoryAssetBundle>(
+  auto asset_manager = std::make_shared<flutter::AssetManager>();
+  asset_manager->PushBack(std::make_unique<flutter::DirectoryAssetBundle>(
       fml::Duplicate(settings.assets_dir)));
   asset_manager->PushBack(
-      std::make_unique<blink::DirectoryAssetBundle>(fml::OpenDirectory(
+      std::make_unique<flutter::DirectoryAssetBundle>(fml::OpenDirectory(
           settings.assets_path.c_str(), false, fml::FilePermission::kRead)));
 
   RunConfiguration run_configuration(std::move(isolate_configuration),
@@ -189,7 +189,7 @@ int RunTester(const blink::Settings& settings, bool run_forever) {
             shell::Engine::RunStatus::Failure) {
           engine_did_run = true;
 
-          blink::ViewportMetrics metrics;
+          flutter::ViewportMetrics metrics;
           metrics.device_pixel_ratio = 3.0;
           metrics.physical_width = 2400;   // 800 at 3x resolution
           metrics.physical_height = 1800;  // 600 at 3x resolution


### PR DESCRIPTION
Some components in the Flutter engine were derived from the forked blink codebase. While the forked components have either been removed or rewritten, the use of the blink namespace has mostly (and inconsistently) remained. This renames the blink namesapce to flutter for consistency. There are no functional changes in this patch.