### PR TITLE
Change Rect internal representation from Float32List to Float64List

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -98,7 +98,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   EngineLayer pushClipRRect(RRect rrect, {Clip clipBehavior = Clip.antiAlias}) {
     assert(clipBehavior != null);
     assert(clipBehavior != Clip.none);
-    return _pushClipRRect(rrect._value, clipBehavior.index);
+    return _pushClipRRect(rrect._value32, clipBehavior.index);
   }
   EngineLayer _pushClipRRect(Float32List rrect, int clipBehavior) native 'SceneBuilder_pushClipRRect';
 

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -666,7 +666,9 @@ class Rect {
   }
 
   static const int _kDataSize = 4;
-  final Float32List _value = new Float32List(_kDataSize);
+  final Float64List _value = new Float64List(_kDataSize);
+
+  Float32List get _value32 => Float32List.fromList(_value);
 
   /// The offset of the left edge of this rectangle from the x axis.
   double get left => _value[0];
@@ -1157,8 +1159,10 @@ class RRect {
   }
 
   static const int _kDataSize = 12;
-  final Float32List _value = new Float32List(_kDataSize);
+  final Float64List _value = new Float64List(_kDataSize);
   RRect _scaled; // same RRect with scaled radii per side
+
+  Float32List get _value32 => Float32List.fromList(_value);
 
   /// The offset of the left edge of this rectangle from the x axis.
   double get left => _value[0];

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2028,7 +2028,7 @@ class Path extends NativeFieldWrapperClass2 {
   /// argument.
   void addRRect(RRect rrect) {
     assert(_rrectIsValid(rrect));
-    _addRRect(rrect._value);
+    _addRRect(rrect._value32);
   }
   void _addRRect(Float32List rrect) native 'Path_addRRect';
 
@@ -3259,7 +3259,7 @@ class Canvas extends NativeFieldWrapperClass2 {
   void clipRRect(RRect rrect, {bool doAntiAlias = true}) {
     assert(_rrectIsValid(rrect));
     assert(doAntiAlias != null);
-    _clipRRect(rrect._value, doAntiAlias);
+    _clipRRect(rrect._value32, doAntiAlias);
   }
   void _clipRRect(Float32List rrect, bool doAntiAlias) native 'Canvas_clipRRect';
 
@@ -3336,7 +3336,7 @@ class Canvas extends NativeFieldWrapperClass2 {
   void drawRRect(RRect rrect, Paint paint) {
     assert(_rrectIsValid(rrect));
     assert(paint != null);
-    _drawRRect(rrect._value, paint._objects, paint._data);
+    _drawRRect(rrect._value32, paint._objects, paint._data);
   }
   void _drawRRect(Float32List rrect,
                   List<dynamic> paintObjects,
@@ -3351,7 +3351,7 @@ class Canvas extends NativeFieldWrapperClass2 {
     assert(_rrectIsValid(outer));
     assert(_rrectIsValid(inner));
     assert(paint != null);
-    _drawDRRect(outer._value, inner._value, paint._objects, paint._data);
+    _drawDRRect(outer._value32, inner._value32, paint._objects, paint._data);
   }
   void _drawDRRect(Float32List outer,
                    Float32List inner,
@@ -3651,7 +3651,7 @@ class Canvas extends NativeFieldWrapperClass2 {
     }
 
     final Int32List colorBuffer = colors.isEmpty ? null : _encodeColorList(colors);
-    final Float32List cullRectBuffer = cullRect?._value;
+    final Float32List cullRectBuffer = cullRect?._value32;
 
     _drawAtlas(
       paint._objects, paint._data, atlas, rstTransformBuffer, rectBuffer,
@@ -3698,7 +3698,7 @@ class Canvas extends NativeFieldWrapperClass2 {
 
     _drawAtlas(
       paint._objects, paint._data, atlas, rstTransforms, rects,
-      colors, blendMode.index, cullRect?._value
+      colors, blendMode.index, cullRect?._value32
     );
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/27320.

The ui.Rect API is defined in terms of double. The internal representation of ui.Rect and ui.RRect had been Float32List to make it convenient to pass the Rect along to native SKIA methods.

The loss of precision has occasionally led to confusion and in the case of https://github.com/flutter/flutter/issues/27320 it causes a crash. The crash occurs in trivial app with a Hero whose height is based on a Column with MainAxisSize.min. The source of the crash is that the overall height of the layout when the hero is "in flight" is 0.000017438 smaller than the initial layout. This causes the app's Column to "overflow".

The expected height is stored in a Rect in the hero implementation and that's what introduces the error. Not to put too fine a point on it but with the current implementation: (Offset.zero & size).height doesn't necessarily equal size.height.

This PR: when a Rect's Float32List is needed it's created with Float32List.fromList(). This adds a small performance cost and generates an additional four element Float32List of ephemeral garbage for each native SKIA call with a Rect parameter. The change does not appear to have an impact on the complex_layout/scroll_perf benchmark or macrobenchmarks/cull_opacity_perf.
