### PR TITLE
Redo a fix for cull rect calculation on TransformLayers with a perspective transform

### DIFF
--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -16,7 +16,9 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
   SkRect previous_cull_rect = context->cull_rect;
   SkMatrix inverse_transform_;
-  if (transform_.invert(&inverse_transform_)) {
+  // Perspective projections don't produce rectangles that are useful for
+  // culling for some reason.
+  if (!transform_.hasPerspective() && transform_.invert(&inverse_transform_)) {
     inverse_transform_.mapRect(&context->cull_rect);
   } else {
     context->cull_rect = kGiantRect;


### PR DESCRIPTION
This was originally implemented in https://github.com/flutter/engine/commit/d217a951262df45a9e874403267b9d4bb0d9016c
but was not retained when cull rects were removed from the SceneBuilder.

Fixes https://github.com/flutter/flutter/issues/30819