### PR TITLE
Remove the use of SharedMutex/Lock in fml in favor of using the libc++ variants.

### DIFF
--- a/runtime/service_protocol.cc
+++ b/runtime/service_protocol.cc
@@ -48,8 +48,7 @@ ServiceProtocol::ServiceProtocol()
           kFlushUIThreadTasksExtensionName,
           kSetAssetBundlePathExtensionName,
           kGetDisplayRefreshRateExtensionName,
-      }),
-      handlers_mutex_(fml::SharedMutex::Create()) {}
+      }) {}
 
 ServiceProtocol::~ServiceProtocol() {
   ToggleHooks(false);
@@ -57,18 +56,18 @@ ServiceProtocol::~ServiceProtocol() {
 
 void ServiceProtocol::AddHandler(Handler* handler,
                                  Handler::Description description) {
-  fml::UniqueLock lock(*handlers_mutex_);
+  std::unique_lock<std::shared_timed_mutex> lock(handlers_mutex_);
   handlers_.emplace(handler, description);
 }
 
 void ServiceProtocol::RemoveHandler(Handler* handler) {
-  fml::UniqueLock lock(*handlers_mutex_);
+  std::unique_lock<std::shared_timed_mutex> lock(handlers_mutex_);
   handlers_.erase(handler);
 }
 
 void ServiceProtocol::SetHandlerDescription(Handler* handler,
                                             Handler::Description description) {
-  fml::SharedLock lock(*handlers_mutex_);
+  std::shared_lock<std::shared_timed_mutex> lock(handlers_mutex_);
   auto it = handlers_.find(handler);
   if (it != handlers_.end())
     it->second.Store(description);
@@ -179,7 +178,7 @@ bool ServiceProtocol::HandleMessage(fml::StringView method,
     return HandleListViewsMethod(response);
   }
 
-  fml::SharedLock lock(*handlers_mutex_);
+  std::shared_lock<std::shared_timed_mutex> lock(handlers_mutex_);
 
   if (handlers_.size() == 0) {
     WriteServerErrorResponse(response,
@@ -250,7 +249,7 @@ void ServiceProtocol::Handler::Description::Write(
 
 bool ServiceProtocol::HandleListViewsMethod(
     rapidjson::Document& response) const {
-  fml::SharedLock lock(*handlers_mutex_);
+  std::shared_lock<std::shared_timed_mutex> lock(handlers_mutex_);
   std::vector<std::pair<intptr_t, Handler::Description>> descriptions;
   for (const auto& handler : handlers_) {
     descriptions.emplace_back(reinterpret_cast<intptr_t>(handler.first),

--- a/runtime/service_protocol.h
+++ b/runtime/service_protocol.h
@@ -7,6 +7,7 @@
 
 #include <map>
 #include <set>
+#include <shared_mutex>
 #include <string>
 
 #include "flutter/fml/compiler_specific.h"
@@ -74,7 +75,7 @@ class ServiceProtocol {
 
  private:
   const std::set<fml::StringView> endpoints_;
-  std::unique_ptr<fml::SharedMutex> handlers_mutex_;
+  mutable std::shared_timed_mutex handlers_mutex_;
   std::map<Handler*, fml::AtomicObject<Handler::Description>> handlers_;
 
   FML_WARN_UNUSED_RESULT


### PR DESCRIPTION
Will get rid of our wrappers in a subsequent patch. I believe they were added because we were not on C++14 when they were necessary. This is no longer the case.