### PR TITLE
Add an option to build the GLFW shell on macOS

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -121,7 +121,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5311c632822d0d2d4e4cf8cba3053cde5183c89c',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '94695026d9a1d8963089a470eef26470312c5b00',
 
    # Fuchsia compatibility
    #

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -14,7 +14,7 @@ group("darwin") {
   }
   if (is_mac) {
     deps = [
-      "macos:flutter_framework",
+      "macos",
     ]
   }
 }

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -7,6 +7,21 @@ assert(is_mac)
 import("//build/config/mac/mac_sdk.gni")
 import("$flutter_root/common/config.gni")
 import("$flutter_root/shell/platform/darwin/framework_shared.gni")
+import("$flutter_root/shell/platform/glfw/config.gni")
+
+group("macos") {
+  deps = [
+    ":flutter_framework",
+  ]
+  if (build_glfw_shell) {
+    deps += [
+      ":flutter_macos_glfw",
+      "$flutter_root/shell/platform/common/cpp/client_wrapper:publish_wrapper",
+      "$flutter_root/shell/platform/glfw:publish_headers_glfw",
+      "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
+    ]
+  }
+}
 
 _flutter_framework_name = "FlutterMacOS"
 _flutter_framework_filename = "$_flutter_framework_name.framework"
@@ -193,4 +208,14 @@ group("flutter_framework") {
   deps = [
     ":_generate_symlinks",
   ]
+}
+
+if (build_glfw_shell) {
+  shared_library("flutter_macos_glfw") {
+    deps = [
+      "$flutter_root/shell/platform/glfw:flutter_glfw",
+    ]
+
+    public_configs = [ "$flutter_root:config" ]
+  }
 }

--- a/shell/platform/glfw/config.gni
+++ b/shell/platform/glfw/config.gni
@@ -1,0 +1,13 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+declare_args() {
+  # Whether to build the GLFW shell for the host platform, if available.
+  #
+  # By default, the GLFW shell is not built if there is a native toolkit shell,
+  # but it can be enabled for supported platforms (Windows, macOS, and Linux)
+  # as an extra build artifact with this flag. The native toolkit shell will
+  # still be built as well.
+  build_glfw_shell = is_linux || is_win
+}


### PR DESCRIPTION
Since the GLFW shell is likely to continue to exist in at least the
medium term, it is useful for maintenance to be able to build and use it
on any desktop platform.

Includes a buildroot roll to pick up the macOS build suppport for
third_party/glfw.