### PR TITLE
Use code cache dir for engine cache (#14704).

### DIFF
--- a/shell/platform/android/io/flutter/util/PathUtils.java
+++ b/shell/platform/android/io/flutter/util/PathUtils.java
@@ -16,6 +16,6 @@ public final class PathUtils {
     }
 
     public static String getCacheDirectory(Context applicationContext) {
-        return applicationContext.getCacheDir().getPath();
+        return applicationContext.getCodeCacheDir().getPath();
     }
 }

--- a/shell/platform/android/io/flutter/util/PathUtils.java
+++ b/shell/platform/android/io/flutter/util/PathUtils.java
@@ -5,6 +5,7 @@
 package io.flutter.util;
 
 import android.content.Context;
+import android.os.Build;
 
 public final class PathUtils {
     public static String getFilesDir(Context applicationContext) {
@@ -16,6 +17,10 @@ public final class PathUtils {
     }
 
     public static String getCacheDirectory(Context applicationContext) {
-        return applicationContext.getCodeCacheDir().getPath();
+        if (Build.VERSION.SDK_INT >= 21) {
+            return applicationContext.getCodeCacheDir().getPath();
+        } else {
+            return applicationContext.getCacheDir().getPath();
+        }
     }
 }


### PR DESCRIPTION
Use code cache dir for engine cache (#14704).

Android docs say that the code cache directory will be deleted upon app upgrade and OS upgrade. I installed a Flutter in release mode using the code cache dir, ran the app, evicted the app, and then deleted the code directory via ADB. I was able to relaunch the app without issue.

I also checked the reported app size. I included those screenshots in the ticket, but I'll reproduce them here, too.

Before this change:
![android_app_release_regular_cache_dir](https://user-images.githubusercontent.com/7259036/55914495-21b44980-5b9c-11e9-8a96-e1a4ab4b92ba.png)

After this change:
![android_app_release_code_cache_dir](https://user-images.githubusercontent.com/7259036/55914502-2842c100-5b9c-11e9-98be-bef1030671e2.png)
