### PR TITLE
Android Embedding PR28: Report app is active to Flutter in FlutterFragment.onResume() instead of onPostResume() forwarded from Activity.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -442,12 +442,16 @@ public class FlutterFragment extends Fragment {
     return FlutterView.TransparencyMode.valueOf(transparencyModeName);
   }
 
+  @Override
+  public void onResume() {
+    super.onResume();
+    flutterEngine.getLifecycleChannel().appIsResumed();
+  }
+
   // TODO(mattcarroll): determine why this can't be in onResume(). Comment reason, or move if possible.
   public void onPostResume() {
     Log.d(TAG, "onPostResume()");
     if (flutterEngine != null) {
-      flutterEngine.getLifecycleChannel().appIsResumed();
-
       // TODO(mattcarroll): find a better way to handle the update of UI overlays than calling through
       //                    to platformPlugin. We're implicitly entangling the Window, Activity, Fragment,
       //                    and engine all with this one call.


### PR DESCRIPTION
Android Embedding PR28: Report app is active to Flutter in FlutterFragment.onResume() instead of onPostResume() forwarded from Activity.

@mjohnsullivan was testing the latest engine with Flutter as a `Fragment`. The Flutter `Fragment` worked on initial presentation, but switching to an Android tab and then switching back to the Flutter tab, the Flutter UI would not display itself any more.

Based on some log tracing I believe the root cause is tied to when we are notifying the Flutter engine that the app is active. The host platform is responsible for telling the engine when the app is "active", "paused" or "inactive". The "active" message was being sent in response to the host `Activity` telling the `FlutterFragment` that `onPostResume()` had executed.

The problem with using `onPostResume()` is that `Fragment`s do not naturally receive this message. We have to forward it from the `Activity`. But `Fragment`s also come and go within an `Activity`'s lifecycle, which means a `FlutterFragment` might go from "active" to "inactive" to "active" again without ever receiving additional `onPostResume()` calls. As a result, the `FlutterFragment` would be recreated, it would setup its view hierarchy, it would resume, but it would never tell the engine that we're "active" because the `FlutterFragment` never got a repeat invocation of `onPostResume()`.

The solution I've chosen is to simply report that the app is "active" in the `Fragment`'s `onResume()`. I'm not sure why this was ever done in `onPostResume()` and I'm not immediately aware of anything that might stop working as a result of doing this in `onResume()` instead.