### PR TITLE
Correct nullability for FlutterStandardReader

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterCodecs.h
@@ -116,8 +116,8 @@ FLUTTER_EXPORT
 - (UInt32)readSize;
 - (void)readAlignment:(UInt8)alignment;
 - (NSString*)readUTF8;
-- (id)readValue;
-- (id)readValueOfType:(UInt8)type;
+- (nullable id)readValue;
+- (nullable id)readValueOfType:(UInt8)type;
 @end
 
 /**

--- a/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterStandardCodec.mm
@@ -408,11 +408,11 @@ using namespace flutter;
   return [FlutterStandardTypedData typedDataWithData:data type:type];
 }
 
-- (id)readValue {
+- (nullable id)readValue {
   return [self readValueOfType:[self readByte]];
 }
 
-- (id)readValueOfType:(UInt8)type {
+- (nullable id)readValueOfType:(UInt8)type {
   FlutterStandardField field = (FlutterStandardField)type;
   switch (field) {
     case FlutterStandardFieldNil:


### PR DESCRIPTION
FlutterStandardReader's `readValueOfType:` method returns nil when
called with `FlutterStandardFieldNil`. By extension, `readValue` can
also return nil values.

Review note: these declarations currently lie within an `NS_ASSUME_NONNULL` region.