### PR TITLE
Add null check in FLETextInputPlugin

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FLETextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLETextInputPlugin.mm
@@ -242,11 +242,13 @@ static NSString* const kMultilineInputType = @"TextInputType.multiline";
 }
 
 - (void)insertNewline:(id)sender {
-  if ([self.activeModel.inputType isEqualToString:kMultilineInputType]) {
-    [self insertText:@"\n" replacementRange:self.activeModel.selectedRange];
+  if (self.activeModel != nil) {
+    if ([self.activeModel.inputType isEqualToString:kMultilineInputType]) {
+      [self insertText:@"\n" replacementRange:self.activeModel.selectedRange];
+    }
+    [_channel invokeMethod:kPerformAction
+                 arguments:@[ _activeClientID, self.activeModel.inputAction ]];
   }
-  [_channel invokeMethod:kPerformAction
-               arguments:@[ _activeClientID, self.activeModel.inputAction ]];
 }
 
 - (void)setMarkedText:(id)string


### PR DESCRIPTION
Adds a guard on `_activeClientID` in `insertNewline:`. The conditional around the `insertText:replacementRange:` call already catches this for that call, but we then unconditionally pack `_activeClientID` into an `NSArray`, which disallows nil.

Review notes: 

This patch works off a paranoid local copy to reduce the chance of future threading naughtiness. This isn't strictly required given that all async callbacks that modify `_activeClientID` occur over
platform thread callbacks.

Alternatively, we could just swap this out for an `if (self.activeModel != nil)` for consistency with other methods, for the sake of readability. The tradeoff against future paranoia is it looks like this is one of the few/only cases we'll actively blow up if this field is nil. Thoughts?