### PR TITLE
Eliminate unused write to local

### DIFF
--- a/third_party/txt/src/minikin/GraphemeBreak.cpp
+++ b/third_party/txt/src/minikin/GraphemeBreak.cpp
@@ -150,7 +150,6 @@ bool GraphemeBreak::isGraphemeBreak(const float* advances,
     if (p0 == U_GCB_EXTEND && offset_backback > start) {
       // skip over emoji variation selector
       U16_PREV(buf, start, offset_backback, c0);
-      p0 = tailoredGraphemeClusterBreak(c0);
     }
     if (isEmojiBase(c0)) {
       return false;


### PR DESCRIPTION
In GraphemeBreak::isGraphemeBreak() p0 is never read and
tailoredGraphemeClusterBreak() has no side-effects, so the call can be
eliminated.

In theory we could kill p0 altogether and just compare to p1, but I've left
it for consistency with our declaration of c0.