### PR TITLE
Revert "Change Rect internal representation from Float32List to Float64List (#8524)"

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -98,7 +98,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   EngineLayer pushClipRRect(RRect rrect, {Clip clipBehavior = Clip.antiAlias}) {
     assert(clipBehavior != null);
     assert(clipBehavior != Clip.none);
-    return _pushClipRRect(rrect._value32, clipBehavior.index);
+    return _pushClipRRect(rrect._value, clipBehavior.index);
   }
   EngineLayer _pushClipRRect(Float32List rrect, int clipBehavior) native 'SceneBuilder_pushClipRRect';
 

--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -666,9 +666,7 @@ class Rect {
   }
 
   static const int _kDataSize = 4;
-  final Float64List _value = new Float64List(_kDataSize);
-
-  Float32List get _value32 => Float32List.fromList(_value);
+  final Float32List _value = new Float32List(_kDataSize);
 
   /// The offset of the left edge of this rectangle from the x axis.
   double get left => _value[0];
@@ -1159,10 +1157,8 @@ class RRect {
   }
 
   static const int _kDataSize = 12;
-  final Float64List _value = new Float64List(_kDataSize);
+  final Float32List _value = new Float32List(_kDataSize);
   RRect _scaled; // same RRect with scaled radii per side
-
-  Float32List get _value32 => Float32List.fromList(_value);
 
   /// The offset of the left edge of this rectangle from the x axis.
   double get left => _value[0];

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2028,7 +2028,7 @@ class Path extends NativeFieldWrapperClass2 {
   /// argument.
   void addRRect(RRect rrect) {
     assert(_rrectIsValid(rrect));
-    _addRRect(rrect._value32);
+    _addRRect(rrect._value);
   }
   void _addRRect(Float32List rrect) native 'Path_addRRect';
 
@@ -3259,7 +3259,7 @@ class Canvas extends NativeFieldWrapperClass2 {
   void clipRRect(RRect rrect, {bool doAntiAlias = true}) {
     assert(_rrectIsValid(rrect));
     assert(doAntiAlias != null);
-    _clipRRect(rrect._value32, doAntiAlias);
+    _clipRRect(rrect._value, doAntiAlias);
   }
   void _clipRRect(Float32List rrect, bool doAntiAlias) native 'Canvas_clipRRect';
 
@@ -3336,7 +3336,7 @@ class Canvas extends NativeFieldWrapperClass2 {
   void drawRRect(RRect rrect, Paint paint) {
     assert(_rrectIsValid(rrect));
     assert(paint != null);
-    _drawRRect(rrect._value32, paint._objects, paint._data);
+    _drawRRect(rrect._value, paint._objects, paint._data);
   }
   void _drawRRect(Float32List rrect,
                   List<dynamic> paintObjects,
@@ -3351,7 +3351,7 @@ class Canvas extends NativeFieldWrapperClass2 {
     assert(_rrectIsValid(outer));
     assert(_rrectIsValid(inner));
     assert(paint != null);
-    _drawDRRect(outer._value32, inner._value32, paint._objects, paint._data);
+    _drawDRRect(outer._value, inner._value, paint._objects, paint._data);
   }
   void _drawDRRect(Float32List outer,
                    Float32List inner,
@@ -3651,7 +3651,7 @@ class Canvas extends NativeFieldWrapperClass2 {
     }
 
     final Int32List colorBuffer = colors.isEmpty ? null : _encodeColorList(colors);
-    final Float32List cullRectBuffer = cullRect?._value32;
+    final Float32List cullRectBuffer = cullRect?._value;
 
     _drawAtlas(
       paint._objects, paint._data, atlas, rstTransformBuffer, rectBuffer,
@@ -3698,7 +3698,7 @@ class Canvas extends NativeFieldWrapperClass2 {
 
     _drawAtlas(
       paint._objects, paint._data, atlas, rstTransforms, rects,
-      colors, blendMode.index, cullRect?._value32
+      colors, blendMode.index, cullRect?._value
     );
   }
 


### PR DESCRIPTION
This reverts commit 0b36d3e2f0235f25dc5b5657bd2e594fe7414aee.

cc/ @HansMuller 

Blocking engine roll due to failures similar to the following ([full logs here](https://api.cirrus-ci.com/v1/task/5135058510807040/logs/test.log)):

```
04:04 +3164 ~31 -6: /tmp/flutter sdk/packages/flutter/test/material/scaffold_test.dart: Scaffold and extreme window padding                                                                            
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following TestFailure object was thrown running a test:
  Expected: Rect:<Rect.fromLTRB(36.0, 255.0, 113.0, 332.0)>
  Actual: Rect:<Rect.fromLTRB(36.0, 255.0, 113.0, 332.0)>

When the exception was thrown, this was the stack:
#4      main.<anonymous closure> (file:///tmp/flutter%20sdk/packages/flutter/test/material/scaffold_test.dart:765:5)
<asynchronous suspension>
#5      testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:108:25)
<asynchronous suspension>
#6      TestWidgetsFlutterBinding._runTestBody (package:flutter_test/src/binding.dart:589:19)
<asynchronous suspension>
#9      TestWidgetsFlutterBinding._runTest (package:flutter_test/src/binding.dart:573:14)
#10     AutomatedTestWidgetsFlutterBinding.runTest.<anonymous closure> (package:flutter_test/src/binding.dart:920:24)
#16     AutomatedTestWidgetsFlutterBinding.runTest (package:flutter_test/src/binding.dart:917:15)
#17     testWidgets.<anonymous closure> (package:flutter_test/src/widget_tester.dart:106:22)
#18     Declarer.test.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart:168:27)
<asynchronous suspension>
#19     Invoker.waitForOutstandingCallbacks.<anonymous closure> (package:test_api/src/backend/invoker.dart:250:15)
<asynchronous suspension>
#24     Invoker.waitForOutstandingCallbacks (package:test_api/src/backend/invoker.dart:247:5)
#25     Declarer.test.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart:166:33)
#30     Declarer.test.<anonymous closure> (package:test_api/src/backend/declarer.dart:165:13)
<asynchronous suspension>
#31     Invoker._onRun.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/invoker.dart:400:25)
<asynchronous suspension>
#45     _Timer._runTimers (dart:isolate-patch/timer_impl.dart:382:19)
#46     _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:416:5)
#47     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:171:12)
(elided 28 frames from class _FakeAsync, package dart:async, package dart:async-patch, and package
stack_trace)

This was caught by the test expectation on the following line:
  file:///tmp/flutter%20sdk/packages/flutter/test/material/scaffold_test.dart line 765

The test description was:
Scaffold and extreme window padding
════════════════════════════════════════════════════════════════════════════════════════════════════
```