### PR TITLE
Export extern constants in embedder.h

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -343,6 +343,7 @@ typedef struct {
 
 // |FlutterSemanticsNode| ID used as a sentinel to signal the end of a batch of
 // semantics node updates.
+FLUTTER_EXPORT
 extern const int32_t kFlutterSemanticsNodeIdBatchEnd;
 
 // A node that represents some semantic data.
@@ -414,6 +415,7 @@ typedef struct {
 
 // |FlutterSemanticsCustomAction| ID used as a sentinel to signal the end of a
 // batch of semantics custom action updates.
+FLUTTER_EXPORT
 extern const int32_t kFlutterSemanticsCustomActionIdBatchEnd;
 
 // A custom semantics action, or action override.


### PR DESCRIPTION
PR #8498 made these constants extern, but forgot to export them so they
would be public symbols.