### PR TITLE
Android Embedding PR30: Make FlutterView focusable so that the keyboard can interact with it.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -170,6 +170,10 @@ public class FlutterView extends FrameLayout {
         addView(flutterTextureView);
         break;
     }
+
+    // FlutterView needs to be focusable so that the InputMethodManager can interact with it.
+    setFocusable(true);
+    setFocusableInTouchMode(true);
   }
 
   /**


### PR DESCRIPTION
Android Embedding PR30: Make FlutterView focusable so that the keyboard can interact with it.

Bug reported in:
https://github.com/flutter/flutter/issues/30505