### PR TITLE
Add missing <memory> include to text_input_model.h

### DIFF
--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 #define FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 
+#include <memory>
 #include <string>
 
 #include "rapidjson/document.h"


### PR DESCRIPTION
It uses std::unique_ptr but does not include the memory header.