### PR TITLE
Remove the flutter_aot GN argument.

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -11,9 +11,6 @@ if (target_cpu == "arm" || target_cpu == "arm64") {
 }
 
 declare_args() {
-  # Enable ahead-of-time compilation on platforms where AOT is optional.
-  flutter_aot = false
-
   # The runtime mode ("debug", "profile", "release", "dynamic_profile", or "dynamic_release")
   flutter_runtime_mode = "debug"
 }
@@ -40,8 +37,4 @@ if (flutter_runtime_mode == "debug") {
   feature_defines_list += [ "FLUTTER_RUNTIME_MODE=5" ]
 } else {
   feature_defines_list += [ "FLUTTER_RUNTIME_MODE=0" ]
-}
-
-if (flutter_aot) {
-  feature_defines_list += [ "FLUTTER_AOT=1" ]
 }

--- a/tools/gn
+++ b/tools/gn
@@ -110,18 +110,13 @@ def to_gn_args(args):
       # The GN arg is not available in the windows toolchain.
       gn_args['enable_lto'] = enable_lto
 
-    aot = not runtime_mode in ['debug', 'dynamic_profile', 'dynamic_release']
     if args.target_os == 'android':
         gn_args['target_os'] = 'android'
     elif args.target_os == 'ios':
         gn_args['target_os'] = 'ios'
         gn_args['use_ios_simulator'] = args.simulator
-        if not args.simulator:
-          aot = True
     elif args.target_os is not None:
         gn_args['target_os'] = args.target_os
-    else:
-      aot = False
 
     gn_args['dart_lib_export_symbols'] = False
 
@@ -189,7 +184,6 @@ def to_gn_args(args):
       gn_args["host_cpu"] = "x86"
 
     gn_args['flutter_runtime_mode'] = runtime_mode
-    gn_args['flutter_aot'] = aot
 
     if args.target_sysroot:
       gn_args['target_sysroot'] = args.target_sysroot


### PR DESCRIPTION
This argument has been defunct for a while. It was originally added as a
means of testing the AOT machinery in debug modes.