### PR TITLE
Glitchiness with Tab Characters

### DIFF
--- a/third_party/txt/src/minikin/LineBreaker.cpp
+++ b/third_party/txt/src/minikin/LineBreaker.cpp
@@ -32,8 +32,6 @@ using std::vector;
 
 namespace minikin {
 
-const int CHAR_TAB = 0x0009;
-
 // Large scores in a hierarchy; we prefer desperate breaks to an overfull line.
 // All these constants are larger than any reasonable actual width score.
 const float SCORE_INFTY = std::numeric_limits<float>::max();
@@ -159,22 +157,13 @@ float LineBreaker::addStyleRun(MinikinPaint* paint,
   size_t postSpaceCount = mSpaceCount;
   for (size_t i = start; i < end; i++) {
     uint16_t c = mTextBuf[i];
-    if (c == CHAR_TAB) {
-      mWidth = mPreBreak + mTabStops.nextTab(mWidth - mPreBreak);
-      if (mFirstTabIndex == INT_MAX) {
-        mFirstTabIndex = (int)i;
-      }
-      // fall back to greedy; other modes don't know how to deal with tabs
-      mStrategy = kBreakStrategy_Greedy;
-    } else {
-      if (isWordSpace(c))
-        mSpaceCount += 1;
-      mWidth += mCharWidths[i];
-      if (!isLineEndSpace(c)) {
-        postBreak = mWidth;
-        postSpaceCount = mSpaceCount;
-        afterWord = i + 1;
-      }
+    if (isWordSpace(c))
+      mSpaceCount += 1;
+    mWidth += mCharWidths[i];
+    if (!isLineEndSpace(c)) {
+      postBreak = mWidth;
+      postSpaceCount = mSpaceCount;
+      afterWord = i + 1;
     }
     if (i + 1 == current) {
       size_t wordStart = mWordBreaker.wordStart();

--- a/third_party/txt/src/minikin/LineBreaker.cpp
+++ b/third_party/txt/src/minikin/LineBreaker.cpp
@@ -157,6 +157,7 @@ float LineBreaker::addStyleRun(MinikinPaint* paint,
   size_t postSpaceCount = mSpaceCount;
   for (size_t i = start; i < end; i++) {
     uint16_t c = mTextBuf[i];
+    // libtxt: Tab handling was removed here.
     if (isWordSpace(c))
       mSpaceCount += 1;
     mWidth += mCharWidths[i];

--- a/third_party/txt/src/minikin/LineBreaker.h
+++ b/third_party/txt/src/minikin/LineBreaker.h
@@ -85,30 +85,6 @@ class LineWidths {
   std::vector<float> mIndents;
 };
 
-class TabStops {
- public:
-  void set(const int* stops, size_t nStops, int tabWidth) {
-    if (stops != nullptr) {
-      mStops.assign(stops, stops + nStops);
-    } else {
-      mStops.clear();
-    }
-    mTabWidth = tabWidth;
-  }
-  float nextTab(float widthSoFar) const {
-    for (size_t i = 0; i < mStops.size(); i++) {
-      if (mStops[i] > widthSoFar) {
-        return mStops[i];
-      }
-    }
-    return floor(widthSoFar / mTabWidth + 1) * mTabWidth;
-  }
-
- private:
-  std::vector<int> mStops;
-  int mTabWidth;
-};
-
 class LineBreaker {
  public:
   const static int kTab_Shift =
@@ -142,10 +118,6 @@ class LineBreaker {
                      float restWidth);
 
   void setIndents(const std::vector<float>& indents);
-
-  void setTabStops(const int* stops, size_t nStops, int tabWidth) {
-    mTabStops.set(stops, nStops, tabWidth);
-  }
 
   BreakStrategy getStrategy() const { return mStrategy; }
 
@@ -246,7 +218,6 @@ class LineBreaker {
   HyphenationFrequency mHyphenationFrequency = kHyphenationFrequency_Normal;
   bool mJustified;
   LineWidths mLineWidths;
-  TabStops mTabStops;
 
   // result of line breaking
   std::vector<int> mBreaks;

--- a/third_party/txt/src/minikin/LineBreaker.h
+++ b/third_party/txt/src/minikin/LineBreaker.h
@@ -87,26 +87,18 @@ class LineWidths {
 
 class TabStops {
  public:
-  void set(const int* stops, size_t nStops, int tabWidth) {
-    if (stops != nullptr) {
-      mStops.assign(stops, stops + nStops);
-    } else {
-      mStops.clear();
-    }
-    mTabWidth = tabWidth;
-  }
   float nextTab(float widthSoFar) const {
     for (size_t i = 0; i < mStops.size(); i++) {
       if (mStops[i] > widthSoFar) {
         return mStops[i];
       }
     }
-    return floor(widthSoFar / mTabWidth + 1) * mTabWidth;
+    return floor(widthSoFar / kTabWidth + 1) * kTabWidth;
   }
 
  private:
   std::vector<int> mStops;
-  int mTabWidth;
+  const static int kTabWidth = 2;
 };
 
 class LineBreaker {
@@ -142,10 +134,6 @@ class LineBreaker {
                      float restWidth);
 
   void setIndents(const std::vector<float>& indents);
-
-  void setTabStops(const int* stops, size_t nStops, int tabWidth) {
-    mTabStops.set(stops, nStops, tabWidth);
-  }
 
   BreakStrategy getStrategy() const { return mStrategy; }
 

--- a/third_party/txt/src/minikin/LineBreaker.h
+++ b/third_party/txt/src/minikin/LineBreaker.h
@@ -87,18 +87,26 @@ class LineWidths {
 
 class TabStops {
  public:
+  void set(const int* stops, size_t nStops, int tabWidth) {
+    if (stops != nullptr) {
+      mStops.assign(stops, stops + nStops);
+    } else {
+      mStops.clear();
+    }
+    mTabWidth = tabWidth;
+  }
   float nextTab(float widthSoFar) const {
     for (size_t i = 0; i < mStops.size(); i++) {
       if (mStops[i] > widthSoFar) {
         return mStops[i];
       }
     }
-    return floor(widthSoFar / kTabWidth + 1) * kTabWidth;
+    return floor(widthSoFar / mTabWidth + 1) * mTabWidth;
   }
 
  private:
   std::vector<int> mStops;
-  const static int kTabWidth = 2;
+  int mTabWidth;
 };
 
 class LineBreaker {
@@ -134,6 +142,10 @@ class LineBreaker {
                      float restWidth);
 
   void setIndents(const std::vector<float>& indents);
+
+  void setTabStops(const int* stops, size_t nStops, int tabWidth) {
+    mTabStops.set(stops, nStops, tabWidth);
+  }
 
   BreakStrategy getStrategy() const { return mStrategy; }
 

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -224,7 +224,6 @@ void Paragraph::CodeUnitRun::Shift(double delta) {
 
 Paragraph::Paragraph() {
   breaker_.setLocale(icu::Locale(), nullptr);
-  breaker_.setTabStops(nullptr, 0, 2);
 }
 
 Paragraph::~Paragraph() = default;

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -224,6 +224,7 @@ void Paragraph::CodeUnitRun::Shift(double delta) {
 
 Paragraph::Paragraph() {
   breaker_.setLocale(icu::Locale(), nullptr);
+  breaker_.setTabStops(nullptr, 0, 2);
 }
 
 Paragraph::~Paragraph() = default;


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/30173

Entering tab characters into a text field is causing some glitchiness.  It may suddenly cause a single line input to wrap, or the text to flash, etc. at random moments.  Here is a gif from the issue:

<img src="https://user-images.githubusercontent.com/21172855/55217821-b9ab4e00-5200-11e9-96de-06f32889456e.gif" width="300" />

It seems like this happens because `mTabWidth` is unassigned and never set, so it contains random values from memory, sometimes zero and sometimes in the billions.  It looks to me like the code that is supposed to set this variable is never called.

My proposed solution in this PR is to hardcode the tab width to 2 and delete the code that's never called.  This fixes the problem for me and seems to give some reasonable behavior for tab characters.  Does anyone else know what the intention of the original code was?  Or any opinions on the width of tabs or what should happen when a tab is entered?

For the record, here is the original commit that added this code in 2015: https://github.com/flutter/engine/commit/01f5266144