### PR TITLE
Roll buildroot to ce7b5c786a12927c9e0b4543af267d48c52e0b3a

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -121,7 +121,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '94695026d9a1d8963089a470eef26470312c5b00',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'ce7b5c786a12927c9e0b4543af267d48c52e0b3a',
 
    # Fuchsia compatibility
    #


### PR DESCRIPTION
ce7b5c7 Don't assume anything above SSE2 when compiling X64 code (e.g. dart binary) (#233)