### PR TITLE
Allow building without python2

### DIFF
--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -34,7 +34,7 @@ def main():
     'HEAD',
   ])
 
-  print version.strip()
+  print (version.strip())
 
   return 0
 


### PR DESCRIPTION
Almost all of the python build files in the flutter project work if
`python` is `python2` or `python3`. This is the only area where print is
incorrectly used (for `python3`).

Related issue: https://fuchsia-review.googlesource.com/c/fuchsia/+/272925