### PR TITLE
Forward key presses received by text input fields.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -200,6 +200,13 @@ public class TextInputChannel {
     );
   }
 
+  public void forwardDeleteKey(int inputClientId) {
+    channel.invokeMethod(
+        "TextInputClient.forwardKey",
+        Arrays.asList(inputClientId, "TextInputKey.delete")
+    );
+  }
+
   /**
    * Sets the {@link TextInputMethodHandler} which receives all events and requests
    * that are parsed from the underlying platform channel.

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -68,6 +68,14 @@ class InputConnectionAdaptor extends BaseInputConnection {
         );
     }
 
+    private void forwardKey(int keyCode) {
+        switch (keyCode) {
+            case KeyEvent.KEYCODE_DEL:
+            textInputChannel.forwardDeleteKey(mClient);
+            default:
+        }
+    }
+
     @Override
     public Editable getEditable() {
         return mEditable;
@@ -141,6 +149,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
                     Selection.setSelection(mEditable, selStart);
                     mEditable.delete(selStart, selEnd);
                     updateEditingState();
+                    forwardKey(KeyEvent.KEYCODE_DEL);
                     return true;
                 } else if (selStart > 0) {
                     // Delete to the left of the cursor.
@@ -148,6 +157,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
                     Selection.setSelection(mEditable, newSel);
                     mEditable.delete(newSel, selStart);
                     updateEditingState();
+                    forwardKey(KeyEvent.KEYCODE_DEL);
                     return true;
                 }
             } else if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_LEFT) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -493,7 +493,7 @@
       break;
   }
   [_textInputChannel.get() invokeMethod:@"TextInputClient.forwardKey"
-                              arguments:@[ @(client), keyString]];
+                              arguments:@[ @(client), keyString ]];
 }
 
 #pragma mark - Screenshot Delegate

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -485,6 +485,17 @@
                               arguments:@[ @(client), actionString ]];
 }
 
+- (void)forwardKey:(FlutterTextInputKey)key withClient:(int)client {
+  NSString* keyString;
+  switch (key) {
+    case FlutterTextInputKeyDelete:
+        keyString = @"TextInputKey.delete";
+        break;
+  }
+  [_textInputChannel.get() invokeMethod:@"TextInputClient.forwardKey"
+                              arguments:@[ @(client), keyString]];
+}
+
 #pragma mark - Screenshot Delegate
 
 - (shell::Rasterizer::Screenshot)takeScreenshot:(shell::Rasterizer::ScreenshotType)type

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -489,8 +489,8 @@
   NSString* keyString;
   switch (key) {
     case FlutterTextInputKeyDelete:
-        keyString = @"TextInputKey.delete";
-        break;
+      keyString = @"TextInputKey.delete";
+      break;
   }
   [_textInputChannel.get() invokeMethod:@"TextInputClient.forwardKey"
                               arguments:@[ @(client), keyString]];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -28,7 +28,7 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 };
 
 typedef NS_ENUM(NSInteger, FlutterTextInputKey) {
-    FlutterTextInputKeyDelete,
+  FlutterTextInputKeyDelete,
 };
 
 @protocol FlutterTextInputDelegate <NSObject>

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputDelegate.h
@@ -27,6 +27,10 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
   FlutterFloatingCursorDragStateEnd,
 };
 
+typedef NS_ENUM(NSInteger, FlutterTextInputKey) {
+    FlutterTextInputKeyDelete,
+};
+
 @protocol FlutterTextInputDelegate <NSObject>
 
 - (void)updateEditingClient:(int)client withState:(NSDictionary*)state;
@@ -34,6 +38,7 @@ typedef NS_ENUM(NSInteger, FlutterFloatingCursorDragState) {
 - (void)updateFloatingCursor:(FlutterFloatingCursorDragState)state
                   withClient:(int)client
                 withPosition:(NSDictionary*)point;
+- (void)forwardKey:(FlutterTextInputKey)key withClient:(int)client;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -645,8 +645,7 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
   if (!_selectedTextRange.isEmpty)
     [self replaceRange:_selectedTextRange withText:@""];
 
-  [_textInputDelegate forwardKey:FlutterTextInputKeyDelete
-                      withClient:_textInputClient];
+  [_textInputDelegate forwardKey:FlutterTextInputKeyDelete withClient:_textInputClient];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -644,6 +644,9 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 
   if (!_selectedTextRange.isEmpty)
     [self replaceRange:_selectedTextRange withText:@""];
+
+  [_textInputDelegate forwardKey:FlutterTextInputKeyDelete
+                      withClient:_textInputClient];
 }
 
 @end


### PR DESCRIPTION
This PR introduces a `forwardKey` method in `FlutterTextInputDelegate` that is intended to forward incoming key events. 

We had a requirement to track delete key presses in text fields even when there was no text present. For now this PR only forwards the `delete` key. 

Refer to flutter/flutter#29845 for corresponding changes on the framework.