### PR TITLE
Add FLEPluginRegistry for macOS

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FLEPluginRegistrar.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEPluginRegistrar.h
@@ -16,6 +16,9 @@
 #import "FlutterMacros.h"
 #endif
 
+// TODO: Merge this file and FLEPlugin.h with FlutterPlugin.h, sharing all but
+// the platform-specific methods.
+
 /**
  * The protocol for an object managing registration for a plugin. It provides access to application
  * context, as as allowing registering for callbacks for handling various conditions.
@@ -44,5 +47,32 @@ FLUTTER_EXPORT
  */
 - (void)addMethodCallDelegate:(nonnull id<FLEPlugin>)delegate
                       channel:(nonnull FlutterMethodChannel*)channel;
+
+@end
+
+/**
+ * A registry of Flutter macOS plugins.
+ *
+ * Plugins are identified by unique string keys, typically the name of the
+ * plugin's main class.
+ *
+ * Plugins typically need contextual information and the ability to register
+ * callbacks for various application events. To keep the API of the registry
+ * focused, these facilities are not provided directly by the registry, but by
+ * a `FlutterPluginRegistrar`, created by the registry in exchange for the unique
+ * key of the plugin.
+ *
+ * There is no implied connection between the registry and the registrar.
+ * Specifically, callbacks registered by the plugin via the registrar may be
+ * relayed directly to the underlying iOS application objects.
+ */
+@protocol FLEPluginRegistry <NSObject>
+
+/**
+ * Returns a registrar for registering a plugin.
+ *
+ * @param pluginKey The unique key identifying the plugin.
+ */
+- (nonnull id<FLEPluginRegistrar>)registrarForPlugin:(nonnull NSString*)pluginKey;
 
 @end

--- a/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
@@ -35,10 +35,10 @@ typedef NS_ENUM(NSInteger, FlutterMouseTrackingMode) {
  * Flutter engine in non-interactive mode, or with a drawable Flutter canvas.
  */
 FLUTTER_EXPORT
-@interface FLEViewController : NSViewController<FlutterBinaryMessenger,
-                                                FLEPluginRegistrar,
-                                                FLEPluginRegistry,
-                                                FLEReshapeListener>
+@interface FLEViewController : NSViewController <FlutterBinaryMessenger,
+                                                 FLEPluginRegistrar,
+                                                 FLEPluginRegistry,
+                                                 FLEReshapeListener>
 
 /**
  * The view this controller manages when launched in interactive mode (headless set to false). Must

--- a/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
@@ -35,8 +35,10 @@ typedef NS_ENUM(NSInteger, FlutterMouseTrackingMode) {
  * Flutter engine in non-interactive mode, or with a drawable Flutter canvas.
  */
 FLUTTER_EXPORT
-@interface FLEViewController
-    : NSViewController <FlutterBinaryMessenger, FLEPluginRegistrar, FLEReshapeListener>
+@interface FLEViewController : NSViewController<FlutterBinaryMessenger,
+                                                FLEPluginRegistrar,
+                                                FLEPluginRegistry,
+                                                FLEReshapeListener>
 
 /**
  * The view this controller manages when launched in interactive mode (headless set to false). Must
@@ -72,10 +74,5 @@ FLUTTER_EXPORT
  */
 - (BOOL)launchHeadlessEngineWithAssetsPath:(nonnull NSURL*)assets
                       commandLineArguments:(nullable NSArray<NSString*>*)arguments;
-
-/**
- * Returns the FLEPluginRegistrar that should be used to register the plugin with the given name.
- */
-- (nonnull id<FLEPluginRegistrar>)registrarForPlugin:(nonnull NSString*)pluginName;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -251,13 +251,6 @@ static void CommonInit(FLEViewController* controller) {
                              commandLineArguments:arguments];
 }
 
-- (id<FLEPluginRegistrar>)registrarForPlugin:(NSString*)pluginName {
-  // Currently, the view controller acts as the registrar for all plugins, so the
-  // name is ignored. It is part of the API to reduce churn in the future when
-  // aligning more closely with the Flutter registrar system.
-  return self;
-}
-
 #pragma mark - Framework-internal methods
 
 - (void)addKeyResponder:(NSResponder*)responder {
@@ -527,6 +520,14 @@ static void CommonInit(FLEViewController* controller) {
   [channel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
     [delegate handleMethodCall:call result:result];
   }];
+}
+
+#pragma mark - FLEPluginRegistry
+
+- (id<FLEPluginRegistrar>)registrarForPlugin:(NSString*)pluginName {
+  // Currently, the view controller acts as the registrar for all plugins, so the
+  // name is ignored.
+  return self;
 }
 
 #pragma mark - NSResponder


### PR DESCRIPTION
Creates a minimal FLEPluginRegistry protocol, which is a subset of the
FlutterPluginRegistry.

This is a small step toward eventually merging the APIs, but allows
changing the example project structure to better reflect what a future
template will look like.