### PR TITLE
Remove call to SkFont::setLinearMetrics

### DIFF
--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -22,7 +22,6 @@ void DrawStatisticsText(SkCanvas& canvas,
     font = SkFont(SkTypeface::MakeFromFile(font_path.c_str()));
   }
   font.setSize(15);
-  font.setLinearMetrics(false);
   SkPaint paint;
   paint.setColor(SK_ColorGRAY);
   canvas.drawSimpleText(string.c_str(), string.size(), kUTF8_SkTextEncoding, x,


### PR DESCRIPTION
This particular call doesn't do anything since the default is false
anyway. In addition Skia is looking to remove this flag since setting it
to true is now synonymous with setting the hinting to none.