### PR TITLE
Add a unit test for PhysicalShapeLayer

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1090,4 +1090,37 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ====================================================================================================
-Total license count: 3
+
+====================================================================================================
+LIBRARY: engine
+ORIGIN: ../../../flutter/flow/layers/physical_shape_layer_unittests.cc + ../../../flutter/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../flutter/flow/layers/physical_shape_layer_unittests.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2019 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+Total license count: 4

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -89,6 +89,7 @@ FILE: ../../../flutter/flow/layers/performance_overlay_layer.h
 FILE: ../../../flutter/flow/layers/performance_overlay_layer_unittests.cc
 FILE: ../../../flutter/flow/layers/physical_shape_layer.cc
 FILE: ../../../flutter/flow/layers/physical_shape_layer.h
+FILE: ../../../flutter/flow/layers/physical_shape_layer_unittests.cc
 FILE: ../../../flutter/flow/layers/picture_layer.cc
 FILE: ../../../flutter/flow/layers/picture_layer.h
 FILE: ../../../flutter/flow/layers/platform_view_layer.cc
@@ -1090,37 +1091,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ====================================================================================================
-
-====================================================================================================
-LIBRARY: engine
-ORIGIN: ../../../flutter/flow/layers/physical_shape_layer_unittests.cc + ../../../flutter/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../flutter/flow/layers/physical_shape_layer_unittests.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2019 The Flutter Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above
-      copyright notice, this list of conditions and the following
-      disclaimer in the documentation and/or other materials provided
-      with the distribution.
-    * Neither the name of Google Inc. nor the names of its
-      contributors may be used to endorse or promote products derived
-      from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-Total license count: 4
+Total license count: 3

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -98,6 +98,7 @@ executable("flow_unittests") {
     "flow_test_utils.cc",
     "flow_test_utils.h",
     "layers/performance_overlay_layer_unittests.cc",
+    "layers/physical_shape_layer_unittests.cc",
     "matrix_decomposition_unittests.cc",
     "raster_cache_unittests.cc",
   ]

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -27,8 +27,7 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
                                      const SkMatrix& child_matrix,
                                      SkRect* child_paint_bounds) {
   for (auto& layer : layers_) {
-    PrerollContext child_context = *context;
-    layer->Preroll(&child_context, child_matrix);
+    layer->Preroll(context, child_matrix);
 
     if (layer->needs_system_composite()) {
       set_needs_system_composite(true);

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -47,6 +47,7 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
   total_elevation_ = context->total_elevation;
   SkRect child_paint_bounds;
   PrerollChildren(context, matrix, &child_paint_bounds);
+  context->total_elevation -= elevation_;
 
   if (elevation_ == 0) {
     set_paint_bounds(path_.getBounds());

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -52,6 +52,8 @@ class PhysicalShapeLayer : public ContainerLayer {
   bool isRect_;
   SkRRect frameRRect_;
   Clip clip_behavior_;
+
+  friend class PhysicalShapeLayer_TotalElevation_Test;
 };
 
 }  // namespace flow

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -1,4 +1,4 @@
-// Copyright 2013 The Flutter Authors. All rights reserved.
+// Copyright 2019 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/layers/physical_shape_layer.h"
+
+#include "gtest/gtest.h"
+
+namespace flow {
+
+TEST(PhysicalShapeLayer, TotalElevation) {
+  std::shared_ptr<PhysicalShapeLayer> layers[4];
+
+  for (int i = 0; i < 4; i += 1) {
+    layers[i] = std::make_shared<PhysicalShapeLayer>(Clip::none);
+    layers[i]->set_elevation((float)(i + 1));
+  }
+
+  layers[0]->Add(layers[1]);
+  layers[0]->Add(layers[2]);
+  layers[2]->Add(layers[3]);
+
+  const Stopwatch unused_stopwatch;
+  TextureRegistry unused_texture_registry;
+  PrerollContext preroll_context{
+      nullptr,                  // raster_cache (don't consult the cache)
+      nullptr,                  // gr_context  (used for the raster cache)
+      nullptr,                  // external view embedder
+      nullptr,                  // SkColorSpace* dst_color_space
+      kGiantRect,               // SkRect cull_rect
+      unused_stopwatch,         // frame time (dont care)
+      unused_stopwatch,         // engine time (dont care)
+      unused_texture_registry,  // texture registry (not supported)
+      false,                    // checkerboard_offscreen_layers
+      0.0f,                     // total elevation
+  };
+
+  SkMatrix identity;
+  identity.setIdentity();
+
+  layers[0]->Preroll(&preroll_context, identity);
+
+  // It should look like this:
+  // layers[0] +1.0f
+  // |       \
+  // |        \
+  // |         \
+  // |       layers[2] +3.0f
+  // |          |
+  // |       layers[3] +4.0f
+  // |
+  // |
+  // layers[1] + 2.0f
+  EXPECT_EQ(layers[0]->total_elevation_, 1.0f);
+  EXPECT_EQ(layers[1]->total_elevation_, 3.0f);
+  EXPECT_EQ(layers[2]->total_elevation_, 4.0f);
+  EXPECT_EQ(layers[3]->total_elevation_, 8.0f);
+}
+
+}  // namespace flow


### PR DESCRIPTION
An unnecessary PrerollContext copy is also removed. The added unit test will catch the error if we forget to subtract the elevation after the copy removal.

This change has been tested with the framework (`flutter test --local-engine=host_debug_unopt`).