### PR TITLE
Assert that all VM launches in the process have the same opinion on whether the VM should be leaked in the process.

### DIFF
--- a/runtime/dart_vm_lifecycle.cc
+++ b/runtime/dart_vm_lifecycle.cc
@@ -50,6 +50,15 @@ DartVMRef DartVMRef::Create(Settings settings,
                             fml::RefPtr<DartSnapshot> shared_snapshot) {
   std::lock_guard<std::mutex> lifecycle_lock(gVMMutex);
 
+  if (!settings.leak_vm) {
+    FML_CHECK(!gVMLeak)
+        << "Launch settings indicated that the VM should shut down in the "
+           "process when done but a previous launch asked the VM to leak in "
+           "the same process. For proper VM shutdown, all VM launches must "
+           "indicate that they should shut down when done.";
+    return {nullptr};
+  }
+
   // If there is already a running VM in the process, grab a strong reference to
   // it.
   if (auto vm = gVM.lock()) {

--- a/runtime/dart_vm_lifecycle.cc
+++ b/runtime/dart_vm_lifecycle.cc
@@ -56,7 +56,6 @@ DartVMRef DartVMRef::Create(Settings settings,
            "process when done but a previous launch asked the VM to leak in "
            "the same process. For proper VM shutdown, all VM launches must "
            "indicate that they should shut down when done.";
-    return {nullptr};
   }
 
   // If there is already a running VM in the process, grab a strong reference to


### PR DESCRIPTION
There is a possibility for a VM launch to not have a requisite shutdown if a previous launch asked to leak the VM instance in the process. Embedders have to ensure (via their Embedding APIs) that all instances of VM launch use consistent settings.