### PR TITLE
Add an adjustment to the line width check in LineBreaker::addWordBreak

### DIFF
--- a/third_party/txt/src/minikin/LineBreaker.cpp
+++ b/third_party/txt/src/minikin/LineBreaker.cpp
@@ -248,7 +248,10 @@ void LineBreaker::addWordBreak(size_t offset,
                                HyphenationType hyph) {
   Candidate cand;
   ParaWidth width = mCandidates.back().preBreak;
-  if (postBreak - width > currentLineWidth()) {
+  // libtxt: add a fudge factor to this comparison.  The currentLineWidth passed
+  // by the framework is based on maxIntrinsicWidth/Layout::measureText
+  // calculations that may not precisely match the postBreak width.
+  if (postBreak - width > currentLineWidth() + 0.00001) {
     // Add desperate breaks.
     // Note: these breaks are based on the shaping of the (non-broken) original
     // text; they are imprecise especially in the presence of kerning,


### PR DESCRIPTION
currentLineWidth is the width passed into Paragraph layout, which comes
from the maxIntrinsicWidth returned by a previous call to Paragraph layout.
That width is calculated by Layout::measureText.

postBreak is calculated from the character widths in the LineBreaker.

A slight mismatch between these two widths may unnecessarily cause the
insertion of desperate breaks in addWordBreak.  Adding some slack to
currentLineWidth works around this.

Fixes https://github.com/flutter/flutter/issues/30347