### PR TITLE
Avoid leaking the VM in runtime_unittests and update failing tests.

### DIFF
--- a/runtime/dart_vm_unittests.cc
+++ b/runtime/dart_vm_unittests.cc
@@ -4,23 +4,23 @@
 
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/runtime/dart_vm_lifecycle.h"
+#include "flutter/runtime/runtime_test.h"
 #include "gtest/gtest.h"
 
 namespace flutter {
+namespace testing {
 
-TEST(DartVM, SimpleInitialization) {
-  Settings settings = {};
-  settings.task_observer_add = [](intptr_t, fml::closure) {};
-  settings.task_observer_remove = [](intptr_t) {};
-  auto vm = DartVMRef::Create(settings);
+using DartVMTest = RuntimeTest;
+
+TEST_F(DartVMTest, SimpleInitialization) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  auto vm = DartVMRef::Create(CreateSettingsForFixture());
   ASSERT_TRUE(vm);
 }
 
-TEST(DartVM, SimpleIsolateNameServer) {
-  Settings settings = {};
-  settings.task_observer_add = [](intptr_t, fml::closure) {};
-  settings.task_observer_remove = [](intptr_t) {};
-  auto vm = DartVMRef::Create(settings);
+TEST_F(DartVMTest, SimpleIsolateNameServer) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  auto vm = DartVMRef::Create(CreateSettingsForFixture());
   ASSERT_TRUE(vm);
   ASSERT_TRUE(vm.GetVMData());
   auto ns = vm->GetIsolateNameServer();
@@ -32,4 +32,5 @@ TEST(DartVM, SimpleIsolateNameServer) {
   ASSERT_TRUE(ns->RemoveIsolateNameMapping("foobar"));
 }
 
+}  // namespace testing
 }  // namespace flutter

--- a/runtime/runtime_test.cc
+++ b/runtime/runtime_test.cc
@@ -80,6 +80,7 @@ void RuntimeTest::SetSnapshotsAndAssets(Settings& settings) {
 
 Settings RuntimeTest::CreateSettingsForFixture() {
   Settings settings;
+  settings.leak_vm = false;
   settings.task_observer_add = [](intptr_t, fml::closure) {};
   settings.task_observer_remove = [](intptr_t) {};
   settings.root_isolate_create_callback = [this]() {


### PR DESCRIPTION
The failing tests were depending on the old assumption that the VM would never
shutdown.