### PR TITLE
Merge runtime lifecycle unittests into the base test target.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -47,7 +47,6 @@ group("flutter") {
     public_deps += [
       "$flutter_root/flow:flow_unittests",
       "$flutter_root/fml:fml_unittests",
-      "$flutter_root/runtime:runtime_lifecycle_unittests",
       "$flutter_root/runtime:runtime_unittests",
       "$flutter_root/shell/common:shell_unittests",
       "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper_unittests",

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -130,24 +130,9 @@ executable("runtime_unittests") {
 
   sources = [
     "dart_isolate_unittests.cc",
+    "dart_lifecycle_unittests.cc",
     "dart_service_isolate_unittests.cc",
     "dart_vm_unittests.cc",
-  ]
-
-  deps = [
-    ":runtime_unittests_common",
-  ]
-
-  if (is_linux) {
-    ldflags = [ "-rdynamic" ]
-  }
-}
-
-executable("runtime_lifecycle_unittests") {
-  testonly = true
-
-  sources = [
-    "dart_lifecycle_unittests.cc",
   ]
 
   deps = [

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -35,9 +35,6 @@ echo "Running fml_unittests..."
 echo "Running runtime_unittests..."
 "$HOST_DIR/runtime_unittests"
 
-echo "Running runtime_lifecycle_unittests..."
-"$HOST_DIR/runtime_lifecycle_unittests"
-
 echo "Running shell_unittests..."
 "$HOST_DIR/shell_unittests"
 


### PR DESCRIPTION
`//flutter/runtime: runtime_lifecycle_unittests` was added because the these assumed that there was no VM already running in the process. Running other tests in the base target would mess up that assumption. Now that all test targets have been updated to make sure the VM instance does not leak, the tests in this target can be merged.

LUCI bots don’t need to be patched as these tests were only ever run on the trybots.