### PR TITLE
Add factory methods to FileMapping that make it easy to create common mappings.

### DIFF
--- a/fml/mapping.cc
+++ b/fml/mapping.cc
@@ -14,6 +14,55 @@ uint8_t* FileMapping::GetMutableMapping() {
   return mutable_mapping_;
 }
 
+std::unique_ptr<FileMapping> FileMapping::CreateReadOnly(
+    const std::string& path) {
+  return CreateReadOnly(OpenFile(path.c_str(), false, FilePermission::kRead),
+                        "");
+}
+
+std::unique_ptr<FileMapping> FileMapping::CreateReadOnly(
+    const fml::UniqueFD& base_fd,
+    const std::string& sub_path) {
+  if (sub_path.size() != 0) {
+    return CreateReadOnly(
+        OpenFile(base_fd, sub_path.c_str(), false, FilePermission::kRead), "");
+  }
+
+  auto mapping = std::make_unique<FileMapping>(
+      base_fd, std::initializer_list<Protection>{Protection::kRead});
+
+  if (mapping->GetSize() == 0 || mapping->GetMapping() == nullptr) {
+    return nullptr;
+  }
+
+  return mapping;
+}
+
+std::unique_ptr<FileMapping> FileMapping::CreateReadExecute(
+    const std::string& path) {
+  return CreateReadExecute(
+      OpenFile(path.c_str(), false, FilePermission::kRead));
+}
+
+std::unique_ptr<FileMapping> FileMapping::CreateReadExecute(
+    const fml::UniqueFD& base_fd,
+    const std::string& sub_path) {
+  if (sub_path.size() != 0) {
+    return CreateReadExecute(
+        OpenFile(base_fd, sub_path.c_str(), false, FilePermission::kRead), "");
+  }
+
+  auto mapping = std::make_unique<FileMapping>(
+      base_fd, std::initializer_list<Protection>{Protection::kRead,
+                                                 Protection::kExecute});
+
+  if (mapping->GetSize() == 0 || mapping->GetMapping() == nullptr) {
+    return nullptr;
+  }
+
+  return mapping;
+}
+
 // Data Mapping
 
 DataMapping::DataMapping(std::vector<uint8_t> data) : data_(std::move(data)) {}

--- a/fml/mapping.h
+++ b/fml/mapping.h
@@ -46,6 +46,19 @@ class FileMapping final : public Mapping {
 
   ~FileMapping() override;
 
+  static std::unique_ptr<FileMapping> CreateReadOnly(const std::string& path);
+
+  static std::unique_ptr<FileMapping> CreateReadOnly(
+      const fml::UniqueFD& base_fd,
+      const std::string& sub_path = "");
+
+  static std::unique_ptr<FileMapping> CreateReadExecute(
+      const std::string& path);
+
+  static std::unique_ptr<FileMapping> CreateReadExecute(
+      const fml::UniqueFD& base_fd,
+      const std::string& sub_path = "");
+
   // |Mapping|
   size_t GetSize() const override;
 

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -21,33 +21,13 @@ const char* DartSnapshot::kIsolateInstructionsSymbol =
     "kDartIsolateSnapshotInstructions";
 
 static std::unique_ptr<const fml::Mapping> GetFileMapping(
-    const std::string path,
+    const std::string& path,
     bool executable) {
-  fml::UniqueFD file =
-      fml::OpenFile(path.c_str(),               // file path
-                    false,                      // create file if necessary
-                    fml::FilePermission::kRead  // file permissions
-      );
-
-  if (!file.is_valid()) {
-    return nullptr;
-  }
-
-  using Prot = fml::FileMapping::Protection;
-  std::unique_ptr<fml::FileMapping> mapping;
   if (executable) {
-    mapping = std::make_unique<fml::FileMapping>(
-        file, std::initializer_list<Prot>{Prot::kRead, Prot::kExecute});
+    return fml::FileMapping::CreateReadExecute(path);
   } else {
-    mapping = std::make_unique<fml::FileMapping>(
-        file, std::initializer_list<Prot>{Prot::kRead});
+    return fml::FileMapping::CreateReadOnly(path);
   }
-
-  if (mapping->GetSize() == 0 || mapping->GetMapping() == nullptr) {
-    return nullptr;
-  }
-
-  return mapping;
 }
 
 // The first party embedders don't yet use the stable embedder API and depend on

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -18,32 +18,6 @@ ShellTest::ShellTest()
 
 ShellTest::~ShellTest() = default;
 
-static std::unique_ptr<fml::Mapping> GetMapping(const fml::UniqueFD& directory,
-                                                const char* path,
-                                                bool executable) {
-  fml::UniqueFD file = fml::OpenFile(directory, path, false /* create */,
-                                     fml::FilePermission::kRead);
-  if (!file.is_valid()) {
-    return nullptr;
-  }
-
-  using Prot = fml::FileMapping::Protection;
-  std::unique_ptr<fml::FileMapping> mapping;
-  if (executable) {
-    mapping = std::make_unique<fml::FileMapping>(
-        file, std::initializer_list<Prot>{Prot::kRead, Prot::kExecute});
-  } else {
-    mapping = std::make_unique<fml::FileMapping>(
-        file, std::initializer_list<Prot>{Prot::kRead});
-  }
-
-  if (mapping->GetSize() == 0 || mapping->GetMapping() == nullptr) {
-    return nullptr;
-  }
-
-  return mapping;
-}
-
 void ShellTest::SetSnapshotsAndAssets(Settings& settings) {
   if (!assets_dir_.is_valid()) {
     return;
@@ -55,27 +29,30 @@ void ShellTest::SetSnapshotsAndAssets(Settings& settings) {
   // don't need to be explicitly suppiled by the embedder.
   if (DartVM::IsRunningPrecompiledCode()) {
     settings.vm_snapshot_data = [this]() {
-      return GetMapping(assets_dir_, "vm_snapshot_data", false);
+      return fml::FileMapping::CreateReadOnly(assets_dir_, "vm_snapshot_data");
     };
 
     settings.isolate_snapshot_data = [this]() {
-      return GetMapping(assets_dir_, "isolate_snapshot_data", false);
+      return fml::FileMapping::CreateReadOnly(assets_dir_,
+                                              "isolate_snapshot_data");
     };
 
     if (DartVM::IsRunningPrecompiledCode()) {
       settings.vm_snapshot_instr = [this]() {
-        return GetMapping(assets_dir_, "vm_snapshot_instr", true);
+        return fml::FileMapping::CreateReadExecute(assets_dir_,
+                                                   "vm_snapshot_instr");
       };
 
       settings.isolate_snapshot_instr = [this]() {
-        return GetMapping(assets_dir_, "isolate_snapshot_instr", true);
+        return fml::FileMapping::CreateReadExecute(assets_dir_,
+                                                   "isolate_snapshot_instr");
       };
     }
   } else {
     settings.application_kernels = [this]() {
       std::vector<std::unique_ptr<const fml::Mapping>> kernel_mappings;
       kernel_mappings.emplace_back(
-          GetMapping(assets_dir_, "kernel_blob.bin", false));
+          fml::FileMapping::CreateReadOnly(assets_dir_, "kernel_blob.bin"));
       return kernel_mappings;
     };
   }


### PR DESCRIPTION
The GetMapping calls removed in this patch had the same code and had to be repeated across different test harnesses as well as in dart_snapshot.cc. Just make this a factory method so the code is less verbose.