### PR TITLE
Allow native bindings in secondary isolates.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -392,7 +392,7 @@ FILE: ../../../flutter/runtime/dart_vm_lifecycle.h
 FILE: ../../../flutter/runtime/dart_vm_unittests.cc
 FILE: ../../../flutter/runtime/embedder_resources.cc
 FILE: ../../../flutter/runtime/embedder_resources.h
-FILE: ../../../flutter/runtime/fixtures/simple_main.dart
+FILE: ../../../flutter/runtime/fixtures/runtime_test.dart
 FILE: ../../../flutter/runtime/runtime_controller.cc
 FILE: ../../../flutter/runtime/runtime_controller.h
 FILE: ../../../flutter/runtime/runtime_delegate.cc
@@ -409,7 +409,7 @@ FILE: ../../../flutter/shell/common/animator.cc
 FILE: ../../../flutter/shell/common/animator.h
 FILE: ../../../flutter/shell/common/engine.cc
 FILE: ../../../flutter/shell/common/engine.h
-FILE: ../../../flutter/shell/common/fixtures/main.dart
+FILE: ../../../flutter/shell/common/fixtures/shell_test.dart
 FILE: ../../../flutter/shell/common/isolate_configuration.cc
 FILE: ../../../flutter/shell/common/isolate_configuration.h
 FILE: ../../../flutter/shell/common/persistent_cache.cc

--- a/common/settings.h
+++ b/common/settings.h
@@ -113,9 +113,11 @@ struct Settings {
   // The main isolate is current when this callback is made. This is a good spot
   // to perform native Dart bindings for libraries not built in.
   fml::closure root_isolate_create_callback;
+  fml::closure isolate_create_callback;
   // The isolate is not current and may have already been destroyed when this
   // call is made.
   fml::closure root_isolate_shutdown_callback;
+  fml::closure isolate_shutdown_callback;
   // The callback made on the UI thread in an isolate scope when the engine
   // detects that the framework is idle. The VM also uses this time to perform
   // tasks suitable when idling. Due to this, embedders are still advised to be

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -96,7 +96,7 @@ source_set("runtime") {
 }
 
 test_fixtures("runtime_fixtures") {
-  fixtures = [ "fixtures/simple_main.dart" ]
+  fixtures = [ "fixtures/runtime_test.dart" ]
 }
 
 source_set("runtime_unittests_common") {

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -39,7 +39,9 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
     fml::WeakPtr<IOManager> io_manager,
     std::string advisory_script_uri,
     std::string advisory_script_entrypoint,
-    Dart_IsolateFlags* flags) {
+    Dart_IsolateFlags* flags,
+    fml::closure isolate_create_callback,
+    fml::closure isolate_shutdown_callback) {
   TRACE_EVENT0("flutter", "DartIsolate::CreateRootIsolate");
   Dart_Isolate vm_isolate = nullptr;
   std::weak_ptr<DartIsolate> embedder_isolate;
@@ -49,6 +51,9 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
   // Since this is the root isolate, we fake a parent embedder data object. We
   // cannot use unique_ptr here because the destructor is private (since the
   // isolate lifecycle is entirely managed by the VM).
+  //
+  // The child isolate preparer is null but will be set when the isolate is
+  // being prepared to run.
   auto root_embedder_data = std::make_unique<std::shared_ptr<DartIsolate>>(
       std::make_shared<DartIsolate>(
           settings,                      // settings
@@ -59,8 +64,9 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
           std::move(io_manager),         // IO manager
           advisory_script_uri,           // advisory URI
           advisory_script_entrypoint,    // advisory entrypoint
-          nullptr  // child isolate preparer will be set when this isolate is
-                   // prepared to run
+          nullptr,                       // child isolate preparer
+          isolate_create_callback,       // isolate create callback
+          isolate_shutdown_callback      // isolate shutdown callback
           ));
 
   std::tie(vm_isolate, embedder_isolate) = CreateDartVMAndEmbedderObjectPair(
@@ -102,7 +108,9 @@ DartIsolate::DartIsolate(const Settings& settings,
                          fml::WeakPtr<IOManager> io_manager,
                          std::string advisory_script_uri,
                          std::string advisory_script_entrypoint,
-                         ChildIsolatePreparer child_isolate_preparer)
+                         ChildIsolatePreparer child_isolate_preparer,
+                         fml::closure isolate_create_callback,
+                         fml::closure isolate_shutdown_callback)
     : UIDartState(std::move(task_runners),
                   settings.task_observer_add,
                   settings.task_observer_remove,
@@ -116,7 +124,9 @@ DartIsolate::DartIsolate(const Settings& settings,
       settings_(settings),
       isolate_snapshot_(std::move(isolate_snapshot)),
       shared_snapshot_(std::move(shared_snapshot)),
-      child_isolate_preparer_(std::move(child_isolate_preparer)) {
+      child_isolate_preparer_(std::move(child_isolate_preparer)),
+      isolate_create_callback_(isolate_create_callback),
+      isolate_shutdown_callback_(isolate_shutdown_callback) {
   FML_DCHECK(isolate_snapshot_) << "Must contain a valid isolate snapshot.";
   phase_ = Phase::Uninitialized;
 }
@@ -245,6 +255,10 @@ bool DartIsolate::LoadLibraries(bool is_root_isolate) {
   DartIO::InitForIsolate();
 
   DartUI::InitForIsolate(is_root_isolate);
+
+  if (isolate_create_callback_) {
+    isolate_create_callback_();
+  }
 
   const bool is_service_isolate = Dart_IsServiceIsolate(isolate());
 
@@ -563,7 +577,9 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
           {},                             // IO Manager
           DART_VM_SERVICE_ISOLATE_NAME,   // script uri
           DART_VM_SERVICE_ISOLATE_NAME,   // script entrypoint
-          flags                           // flags
+          flags,                          // flags
+          nullptr,                        // isolate create callback
+          nullptr                         // isolate shutdown callback
       );
 
   std::shared_ptr<DartIsolate> service_isolate = weak_service_isolate.lock();
@@ -662,6 +678,7 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
     TaskRunners null_task_runners(advisory_script_uri, nullptr, nullptr,
                                   nullptr, nullptr);
 
+    // Copy most fields from the parent to the child.
     embedder_isolate = std::make_unique<std::shared_ptr<DartIsolate>>(
         std::make_shared<DartIsolate>(
             (*raw_embedder_isolate)->GetSettings(),         // settings
@@ -672,7 +689,12 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
             fml::WeakPtr<IOManager>{},                      // io_manager
             advisory_script_uri,         // advisory_script_uri
             advisory_script_entrypoint,  // advisory_script_entrypoint
-            (*raw_embedder_isolate)->child_isolate_preparer_));
+            (*raw_embedder_isolate)->child_isolate_preparer_,    // preparer
+            (*raw_embedder_isolate)->isolate_create_callback_,   // on create
+            (*raw_embedder_isolate)->isolate_shutdown_callback_  // on shutdown
+            )
+
+    );
   }
 
   // Create the Dart VM isolate and give it the embedder object as the baton.
@@ -755,6 +777,9 @@ void DartIsolate::AddIsolateShutdownCallback(fml::closure closure) {
 
 void DartIsolate::OnShutdownCallback() {
   shutdown_callbacks_.clear();
+  if (isolate_shutdown_callback_) {
+    isolate_shutdown_callback_();
+  }
 }
 
 DartIsolate::AutoFireClosure::AutoFireClosure(fml::closure closure)

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -256,10 +256,6 @@ bool DartIsolate::LoadLibraries(bool is_root_isolate) {
 
   DartUI::InitForIsolate(is_root_isolate);
 
-  if (isolate_create_callback_) {
-    isolate_create_callback_();
-  }
-
   const bool is_service_isolate = Dart_IsServiceIsolate(isolate());
 
   DartRuntimeHooks::Install(is_root_isolate && !is_service_isolate,
@@ -293,6 +289,11 @@ bool DartIsolate::PrepareForRunningFromPrecompiledCode() {
   child_isolate_preparer_ = [](DartIsolate* isolate) {
     return isolate->PrepareForRunningFromPrecompiledCode();
   };
+
+  if (isolate_create_callback_) {
+    isolate_create_callback_();
+  }
+
   phase_ = Phase::Ready;
   return true;
 }
@@ -379,7 +380,13 @@ bool DartIsolate::PrepareForRunningFromKernel(
       return true;
     };
   }
+
+  if (isolate_create_callback_) {
+    isolate_create_callback_();
+  }
+
   phase_ = Phase::Ready;
+
   return true;
 }
 

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -51,7 +51,9 @@ class DartIsolate : public UIDartState {
       fml::WeakPtr<IOManager> io_manager,
       std::string advisory_script_uri,
       std::string advisory_script_entrypoint,
-      Dart_IsolateFlags* flags = nullptr);
+      Dart_IsolateFlags* flags,
+      fml::closure isolate_create_callback,
+      fml::closure isolate_shutdown_callback);
 
   DartIsolate(const Settings& settings,
               fml::RefPtr<const DartSnapshot> isolate_snapshot,
@@ -61,7 +63,9 @@ class DartIsolate : public UIDartState {
               fml::WeakPtr<IOManager> io_manager,
               std::string advisory_script_uri,
               std::string advisory_script_entrypoint,
-              ChildIsolatePreparer child_isolate_preparer);
+              ChildIsolatePreparer child_isolate_preparer,
+              fml::closure isolate_create_callback,
+              fml::closure isolate_shutdown_callback);
 
   ~DartIsolate() override;
 
@@ -128,9 +132,11 @@ class DartIsolate : public UIDartState {
   std::vector<std::unique_ptr<AutoFireClosure>> shutdown_callbacks_;
   ChildIsolatePreparer child_isolate_preparer_ = nullptr;
   fml::RefPtr<fml::TaskRunner> message_handling_task_runner_;
+  const fml::closure isolate_create_callback_;
+  const fml::closure isolate_shutdown_callback_;
 
-  FML_WARN_UNUSED_RESULT
-  bool Initialize(Dart_Isolate isolate, bool is_root_isolate);
+  FML_WARN_UNUSED_RESULT bool Initialize(Dart_Isolate isolate,
+                                         bool is_root_isolate);
 
   void SetMessageHandlingTaskRunner(fml::RefPtr<fml::TaskRunner> runner,
                                     bool is_root_isolate);

--- a/runtime/dart_lifecycle_unittests.cc
+++ b/runtime/dart_lifecycle_unittests.cc
@@ -51,16 +51,18 @@ static std::shared_ptr<DartIsolate> CreateAndRunRootIsolate(
   TaskRunners runners("io.flutter.test", task_runner, task_runner, task_runner,
                       task_runner);
   auto isolate_weak = DartIsolate::CreateRootIsolate(
-      vm.GetSettings(),         // settings
-      vm.GetIsolateSnapshot(),  // isolate_snapshot
-      vm.GetSharedSnapshot(),   // shared_snapshot
-      runners,                  // task_runners
-      {},                       // window
-      {},                       // snapshot_delegate
-      {},                       // io_manager
-      "main.dart",              // advisory_script_uri
-      entrypoint.c_str(),       // advisory_script_entrypoint
-      nullptr                   // flags
+      vm.GetSettings(),                   // settings
+      vm.GetIsolateSnapshot(),            // isolate_snapshot
+      vm.GetSharedSnapshot(),             // shared_snapshot
+      runners,                            // task_runners
+      {},                                 // window
+      {},                                 // snapshot_delegate
+      {},                                 // io_manager
+      "main.dart",                        // advisory_script_uri
+      entrypoint.c_str(),                 // advisory_script_entrypoint
+      nullptr,                            // flags
+      settings.isolate_create_callback,   // isolate create callback
+      settings.isolate_shutdown_callback  // isolate shutdown callback
   );
 
   auto isolate = isolate_weak.lock();

--- a/runtime/fixtures/runtime_test.dart
+++ b/runtime/fixtures/runtime_test.dart
@@ -42,3 +42,16 @@ void testCanSaveCompilationTrace() {
 }
 
 void NotifyResult(bool success) native "NotifyNative";
+void PassMessage(String message) native "PassMessage";
+
+void secondaryIsolateMain(String message) {
+  print("Secondary isolate got message: " + message);
+  PassMessage("Hello from code is secondary isolate.");
+  NotifyNative();
+}
+
+@pragma('vm:entry-point')
+void testCanLaunchSecondaryIsolate() {
+  Isolate.spawn(secondaryIsolateMain, "Hello from root isolate.");
+  NotifyNative();
+}

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -37,7 +37,9 @@ class RuntimeController final : public WindowClient {
                     fml::WeakPtr<IOManager> io_manager,
                     std::string advisory_script_uri,
                     std::string advisory_script_entrypoint,
-                    std::function<void(int64_t)> idle_notification_callback);
+                    std::function<void(int64_t)> idle_notification_callback,
+                    fml::closure isolate_create_callback,
+                    fml::closure isolate_shutdown_callback);
 
   ~RuntimeController() override;
 
@@ -132,6 +134,8 @@ class RuntimeController final : public WindowClient {
   WindowData window_data_;
   std::weak_ptr<DartIsolate> root_isolate_;
   std::pair<bool, uint32_t> root_isolate_return_code_ = {false, 0};
+  const fml::closure isolate_create_callback_;
+  const fml::closure isolate_shutdown_callback_;
 
   RuntimeController(RuntimeDelegate& client,
                     DartVM* vm,
@@ -143,7 +147,9 @@ class RuntimeController final : public WindowClient {
                     std::string advisory_script_uri,
                     std::string advisory_script_entrypoint,
                     std::function<void(int64_t)> idle_notification_callback,
-                    WindowData data);
+                    WindowData data,
+                    fml::closure isolate_create_callback,
+                    fml::closure isolate_shutdown_callback);
 
   Window* GetWindowIfAvailable();
 

--- a/runtime/runtime_test.cc
+++ b/runtime/runtime_test.cc
@@ -60,7 +60,7 @@ Settings RuntimeTest::CreateSettingsForFixture() {
   settings.leak_vm = false;
   settings.task_observer_add = [](intptr_t, fml::closure) {};
   settings.task_observer_remove = [](intptr_t) {};
-  settings.root_isolate_create_callback = [this]() {
+  settings.isolate_create_callback = [this]() {
     native_resolver_->SetNativeResolverForIsolate();
   };
   SetSnapshotsAndAssets(settings);

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -148,7 +148,7 @@ shell_gpu_configuration("shell_unittests_gpu_configuration") {
 }
 
 test_fixtures("shell_unittests_fixtures") {
-  fixtures = [ "fixtures/main.dart" ]
+  fixtures = [ "fixtures/shell_test.dart" ]
 }
 
 shell_host_executable("shell_unittests") {

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -62,7 +62,9 @@ Engine::Engine(Delegate& delegate,
       std::move(io_manager),                 // io manager
       settings_.advisory_script_uri,         // advisory script uri
       settings_.advisory_script_entrypoint,  // advisory script entrypoint
-      settings_.idle_notification_callback   // idle notification callback
+      settings_.idle_notification_callback,  // idle notification callback
+      settings_.isolate_create_callback,     // isolate create callback
+      settings_.isolate_shutdown_callback    // isolate shutdown callback
   );
 }
 

--- a/shell/common/fixtures/main.dart
+++ b/shell/common/fixtures/main.dart
@@ -1,8 +1,0 @@
-main() {}
-
-@pragma('vm:entry-point')
-fixturesAreFunctionalMain() {
-  SayHiFromFixturesAreFunctionalMain();
-}
-
-void SayHiFromFixturesAreFunctionalMain() native "SayHiFromFixturesAreFunctionalMain";

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:isolate';
+
+main() {}
+
+@pragma('vm:entry-point')
+fixturesAreFunctionalMain() {
+  SayHiFromFixturesAreFunctionalMain();
+}
+
+void SayHiFromFixturesAreFunctionalMain() native "SayHiFromFixturesAreFunctionalMain";
+
+void NotifyNative() native "NotifyNative";
+
+void secondaryIsolateMain(String message) {
+  print("Secondary isolate got message: " + message);
+  NotifyNative();
+}
+
+@pragma('vm:entry-point')
+void testCanLaunchSecondaryIsolate() {
+  Isolate.spawn(secondaryIsolateMain, "Hello from root isolate.");
+  NotifyNative();
+}

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -67,7 +67,7 @@ Settings ShellTest::CreateSettingsForFixture() {
   settings.task_observer_remove = [](intptr_t key) {
     fml::MessageLoop::GetCurrent().RemoveTaskObserver(key);
   };
-  settings.root_isolate_create_callback = [this]() {
+  settings.isolate_create_callback = [this]() {
     native_resolver_->SetNativeResolverForIsolate();
   };
   SetSnapshotsAndAssets(settings);


### PR DESCRIPTION
The callbacks can be wired in via the Settings object. Both runtime and shell unit-tests have been patched to test this.