### PR TITLE
Convert animated unpremul images to premul during decode

### DIFF
--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -401,7 +401,10 @@ sk_sp<SkImage> MultiFrameCodec::GetNextFrameImage(
                         : SkBitmap();
   const bool frameAlreadyCached = bitmap.getPixels();
   if (!frameAlreadyCached) {
-    const SkImageInfo info = codec_->getInfo().makeColorType(kN32_SkColorType);
+    SkImageInfo info = codec_->getInfo().makeColorType(kN32_SkColorType);
+    if (info.alphaType() == kUnpremul_SkAlphaType) {
+      info = info.makeAlphaType(kPremul_SkAlphaType);
+    }
     bitmap.allocPixels(info);
 
     SkCodec::Options options;


### PR DESCRIPTION
Skia allows drawing unpremul images, but filtering them can look bad.
Internally Skia performs this transformation when creating SkImages from
encoded data (so this already happens for MakeCrossContextFromEncoded),
and for consistency/quality it should be done here, too.

Fixes https://github.com/flutter/flutter/issues/28785