### PR TITLE
Increase the memory usage estimate for EngineLayer

### DIFF
--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -24,7 +24,9 @@ size_t EngineLayer::GetAllocationSize() {
   // Provide an approximation of the total memory impact of this object to the
   // Dart GC.  The ContainerLayer may hold references to a tree of other layers,
   // which in turn may contain Skia objects.
-  return 3000;
+  // TODO(https://github.com/flutter/flutter/issues/31498): calculate the cost
+  // of the layer more accurately.
+  return 200000;
 };
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, EngineLayer);


### PR DESCRIPTION
EngineLayers can hold references to Skia objects and may consume significant
resources.  This change will result in more aggressive cleanup of EngineLayers
by the Dart GC.

See https://github.com/flutter/flutter/issues/31303