### PR TITLE
Rename tightWidth to longestLine

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1319,7 +1319,7 @@ class Paragraph extends NativeFieldWrapperClass2 {
   /// the rightmost glyph in the paragraph.
   ///
   /// Valid only after [layout] has been called.
-  double get tightWidth native 'Paragraph_tightWidth';
+  double get longestLine native 'Paragraph_longestLine';
 
   /// The minimum width that this paragraph could be without failing to paint
   /// its contents within itself.

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -22,7 +22,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Paragraph);
 #define FOR_EACH_BINDING(V)         \
   V(Paragraph, width)               \
   V(Paragraph, height)              \
-  V(Paragraph, longestLine)          \
+  V(Paragraph, longestLine)         \
   V(Paragraph, minIntrinsicWidth)   \
   V(Paragraph, maxIntrinsicWidth)   \
   V(Paragraph, alphabeticBaseline)  \

--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -22,7 +22,7 @@ IMPLEMENT_WRAPPERTYPEINFO(ui, Paragraph);
 #define FOR_EACH_BINDING(V)         \
   V(Paragraph, width)               \
   V(Paragraph, height)              \
-  V(Paragraph, tightWidth)          \
+  V(Paragraph, longestLine)          \
   V(Paragraph, minIntrinsicWidth)   \
   V(Paragraph, maxIntrinsicWidth)   \
   V(Paragraph, alphabeticBaseline)  \
@@ -57,8 +57,8 @@ double Paragraph::height() {
   return m_paragraphImpl->height();
 }
 
-double Paragraph::tightWidth() {
-  return m_paragraphImpl->tightWidth();
+double Paragraph::longestLine() {
+  return m_paragraphImpl->longestLine();
 }
 
 double Paragraph::minIntrinsicWidth() {

--- a/lib/ui/text/paragraph.h
+++ b/lib/ui/text/paragraph.h
@@ -33,7 +33,7 @@ class Paragraph : public RefCountedDartWrappable<Paragraph> {
 
   double width();
   double height();
-  double tightWidth();
+  double longestLine();
   double minIntrinsicWidth();
   double maxIntrinsicWidth();
   double alphabeticBaseline();

--- a/lib/ui/text/paragraph_impl.h
+++ b/lib/ui/text/paragraph_impl.h
@@ -19,7 +19,7 @@ class ParagraphImpl {
 
   virtual double height() = 0;
 
-  virtual double tightWidth() = 0;
+  virtual double longestLine() = 0;
 
   virtual double minIntrinsicWidth() = 0;
 

--- a/lib/ui/text/paragraph_impl_txt.cc
+++ b/lib/ui/text/paragraph_impl_txt.cc
@@ -29,8 +29,8 @@ double ParagraphImplTxt::height() {
   return m_paragraph->GetHeight();
 }
 
-double ParagraphImplTxt::tightWidth() {
-  return m_paragraph->GetTightWidth();
+double ParagraphImplTxt::longestLine() {
+  return m_paragraph->GetLongestLine();
 }
 
 double ParagraphImplTxt::minIntrinsicWidth() {

--- a/lib/ui/text/paragraph_impl_txt.h
+++ b/lib/ui/text/paragraph_impl_txt.h
@@ -19,7 +19,7 @@ class ParagraphImplTxt : public ParagraphImpl {
 
   double width() override;
   double height() override;
-  double tightWidth() override;
+  double longestLine() override;
   double minIntrinsicWidth() override;
   double maxIntrinsicWidth() override;
   double alphabeticBaseline() override;

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -946,7 +946,7 @@ void Paragraph::Layout(double width, bool force) {
               return a.code_units.start < b.code_units.start;
             });
 
-  tight_width_ = max_right_ - min_left_;
+  longest_line_ = max_right_ - min_left_;
 }
 
 double Paragraph::GetLineXOffset(double line_total_advance) {
@@ -998,8 +998,8 @@ double Paragraph::GetMaxWidth() const {
   return width_;
 }
 
-double Paragraph::GetTightWidth() const {
-  return tight_width_;
+double Paragraph::GetLongestLine() const {
+  return longest_line_;
 }
 
 void Paragraph::SetParagraphStyle(const ParagraphStyle& style) {

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -155,11 +155,9 @@ class Paragraph {
   // GetMaxWidth() >= GetLayoutWidth().
   double GetMaxWidth() const;
 
-  // Returns the tight width found in Layout(), which is defined as the
-  // horizontal distance from the left edge of the leftmost glyph to the right
-  // edge of the rightmost glyph. We expect that GetTightWidth() <=
-  // GetMaxWidth().
-  double GetTightWidth() const;
+  // Returns the width of the longest line as found in Layout(). We expect that
+  // GetLongestLine() <= GetMaxWidth().
+  double GetLongestLine() const;
 
   // Distance from top of paragraph to the Alphabetic baseline of the first
   // line. Used for alphabetic fonts (A-Z, a-z, greek, etc.)
@@ -354,7 +352,7 @@ class Paragraph {
   // The max width of the paragraph as provided in the most recent Layout()
   // call.
   double width_ = -1.0f;
-  double tight_width_ = -1.0f;
+  double longest_line_ = -1.0f;
   double max_intrinsic_width_ = 0;
   double min_intrinsic_width_ = 0;
   double alphabetic_baseline_ = FLT_MAX;

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -157,8 +157,8 @@ class Paragraph {
 
   // Returns the width of the longest line as found in Layout(), which is
   // defined as the horizontal distance from the left edge of the leftmost glyph
-  // to the right edge of the rightmost glyph. We expect that GetTightWidth() <=
-  // GetMaxWidth().
+  // to the right edge of the rightmost glyph. We expect that
+  // GetLongestLine() <= GetMaxWidth().
   double GetLongestLine() const;
 
   // Distance from top of paragraph to the Alphabetic baseline of the first

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -155,8 +155,10 @@ class Paragraph {
   // GetMaxWidth() >= GetLayoutWidth().
   double GetMaxWidth() const;
 
-  // Returns the width of the longest line as found in Layout(). We expect that
-  // GetLongestLine() <= GetMaxWidth().
+  // Returns the width of the longest line as found in Layout(), which is
+  // defined as the horizontal distance from the left edge of the leftmost glyph
+  // to the right edge of the rightmost glyph. We expect that GetTightWidth() <=
+  // GetMaxWidth().
   double GetLongestLine() const;
 
   // Distance from top of paragraph to the Alphabetic baseline of the first

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -265,17 +265,17 @@ TEST_F(ParagraphTest, BoldParagraph) {
   ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
   ASSERT_TRUE(Snapshot());
 
-  // width_ takes the full available space, but tight_width_ is only the width
+  // width_ takes the full available space, but longest_line_ is only the width
   // of the text, which is less than one line.
   ASSERT_DOUBLE_EQ(paragraph->width_, GetTestCanvasWidth());
-  ASSERT_TRUE(paragraph->tight_width_ < paragraph->width_);
+  ASSERT_TRUE(paragraph->longest_line_< paragraph->width_);
   Paragraph::RectHeightStyle rect_height_style =
       Paragraph::RectHeightStyle::kMax;
   Paragraph::RectWidthStyle rect_width_style =
       Paragraph::RectWidthStyle::kTight;
   std::vector<txt::Paragraph::TextBox> boxes = paragraph->GetRectsForRange(
       0, strlen(text), rect_height_style, rect_width_style);
-  ASSERT_DOUBLE_EQ(paragraph->tight_width_,
+  ASSERT_DOUBLE_EQ(paragraph->longest_line_,
                    boxes[boxes.size() - 1].rect.right() - boxes[0].rect.left());
 }
 
@@ -446,13 +446,13 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
           paragraph->breaker_.getWidths()[paragraph->records_[0].line()],
       2.0);
 
-  // width_ takes the full available space, while tight_width_ wraps the glyphs
+  // width_ takes the full available space, while longest_line_ wraps the glyphs
   // as tightly as possible. Even though this text is more than one line long,
-  // no line perfectly spans the width of the full line, so tight_width_ is less
+  // no line perfectly spans the width of the full line, so longest_line_ is less
   // than width_.
   ASSERT_DOUBLE_EQ(paragraph->width_, available_width);
-  ASSERT_TRUE(paragraph->tight_width_ < available_width);
-  ASSERT_DOUBLE_EQ(paragraph->tight_width_, 880.765625);
+  ASSERT_TRUE(paragraph->longest_line_ < available_width);
+  ASSERT_DOUBLE_EQ(paragraph->longest_line_, 880.765625);
 
   ASSERT_TRUE(paragraph->records_[2].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[2].offset().y(), expected_y);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -268,7 +268,7 @@ TEST_F(ParagraphTest, BoldParagraph) {
   // width_ takes the full available space, but longest_line_ is only the width
   // of the text, which is less than one line.
   ASSERT_DOUBLE_EQ(paragraph->width_, GetTestCanvasWidth());
-  ASSERT_TRUE(paragraph->longest_line_< paragraph->width_);
+  ASSERT_TRUE(paragraph->longest_line_ < paragraph->width_);
   Paragraph::RectHeightStyle rect_height_style =
       Paragraph::RectHeightStyle::kMax;
   Paragraph::RectWidthStyle rect_width_style =
@@ -448,8 +448,8 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
 
   // width_ takes the full available space, while longest_line_ wraps the glyphs
   // as tightly as possible. Even though this text is more than one line long,
-  // no line perfectly spans the width of the full line, so longest_line_ is less
-  // than width_.
+  // no line perfectly spans the width of the full line, so longest_line_ is
+  // less than width_.
   ASSERT_DOUBLE_EQ(paragraph->width_, available_width);
   ASSERT_TRUE(paragraph->longest_line_ < available_width);
   ASSERT_DOUBLE_EQ(paragraph->longest_line_, 880.765625);


### PR DESCRIPTION
Closes https://github.com/flutter/flutter/issues/15300

See discussion here: https://github.com/flutter/flutter/pull/30988

Originally created `tightWidth` in this engine PR: https://github.com/flutter/engine/pull/8530