### PR TITLE
Plumb arguments from Settings to Dart entrypoint

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -62,6 +62,8 @@ struct Settings {
 
   std::string temp_directory_path;
   std::vector<std::string> dart_flags;
+  // Arguments passed as a List<String> to Dart's entrypoint function.
+  std::vector<std::string> dart_entrypoint_args;
 
   // Isolate settings
   bool start_paused = false;

--- a/lib/stub_ui/lib/hooks.dart
+++ b/lib/stub_ui/lib/hooks.dart
@@ -140,7 +140,9 @@ void _drawFrame() {
 }
 
 // ignore: unused_element
-void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction) {
+void _runMainZoned(Function startMainIsolateFunction,
+                   Function userMainFunction,
+                   List<String> args) {
   startMainIsolateFunction((){
     runZoned<Future<void>>(() {
       userMainFunction();

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -185,16 +185,17 @@ typedef _BinaryFunction(Null args, Null message);
 
 @pragma('vm:entry-point')
 // ignore: unused_element
-void _runMainZoned(Function startMainIsolateFunction, Function userMainFunction) {
+void _runMainZoned(Function startMainIsolateFunction,
+                   Function userMainFunction,
+                   List<String> args) {
   startMainIsolateFunction((){
     runZoned<Future<void>>(() {
-      const List<String> empty_args = <String>[];
       if (userMainFunction is _BinaryFunction) {
         // This seems to be undocumented but supported by the command line VM.
         // Let's do the same in case old entry-points are ported to Flutter.
-        (userMainFunction as dynamic)(empty_args, '');
+        (userMainFunction as dynamic)(args, '');
       } else if (userMainFunction is _UnaryFunction) {
-        (userMainFunction as dynamic)(empty_args);
+        (userMainFunction as dynamic)(args);
       } else {
         userMainFunction();
       }

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -89,11 +89,14 @@ class DartIsolate : public UIDartState {
       std::vector<std::unique_ptr<const fml::Mapping>> kernels);
 
   FML_WARN_UNUSED_RESULT
-  bool Run(const std::string& entrypoint, fml::closure on_run = nullptr);
+  bool Run(const std::string& entrypoint,
+           const std::vector<std::string>& args,
+           fml::closure on_run = nullptr);
 
   FML_WARN_UNUSED_RESULT
   bool RunFromLibrary(const std::string& library_name,
                       const std::string& entrypoint,
+                      const std::vector<std::string>& args,
                       fml::closure on_run = nullptr);
 
   FML_WARN_UNUSED_RESULT

--- a/runtime/dart_lifecycle_unittests.cc
+++ b/runtime/dart_lifecycle_unittests.cc
@@ -92,7 +92,7 @@ static std::shared_ptr<DartIsolate> CreateAndRunRootIsolate(
     return nullptr;
   }
 
-  if (!isolate->Run(entrypoint, settings.root_isolate_create_callback)) {
+  if (!isolate->Run(entrypoint, {}, settings.root_isolate_create_callback)) {
     FML_LOG(ERROR) << "Could not run entrypoint: " << entrypoint << ".";
     return nullptr;
   }

--- a/runtime/fixtures/runtime_test.dart
+++ b/runtime/fixtures/runtime_test.dart
@@ -55,3 +55,8 @@ void testCanLaunchSecondaryIsolate() {
   Isolate.spawn(secondaryIsolateMain, "Hello from root isolate.");
   NotifyNative();
 }
+
+@pragma('vm:entry-point')
+void testCanRecieveArguments(List<String> args) {
+  NotifyResult(args != null && args.length == 1 && args[0] == "arg1");
+}

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -179,13 +179,15 @@ Engine::RunStatus Engine::PrepareAndLaunchIsolate(
   }
 
   if (configuration.GetEntrypointLibrary().empty()) {
-    if (!isolate->Run(configuration.GetEntrypoint())) {
+    if (!isolate->Run(configuration.GetEntrypoint(),
+                      settings_.dart_entrypoint_args)) {
       FML_LOG(ERROR) << "Could not run the isolate.";
       return RunStatus::Failure;
     }
   } else {
     if (!isolate->RunFromLibrary(configuration.GetEntrypointLibrary(),
-                                 configuration.GetEntrypoint())) {
+                                 configuration.GetEntrypoint(),
+                                 settings_.dart_entrypoint_args)) {
       FML_LOG(ERROR) << "Could not run the isolate.";
       return RunStatus::Failure;
     }


### PR DESCRIPTION
This adds a `dart_entrypoint_args` field to Settings and plumbs it as a `List<String>` to the Dart entrypoint. This is primarily for FL-243, but may be generally useful for desktop as well.