### PR TITLE
Fix the iOS accessibility tree structure of platform views.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -126,9 +126,16 @@ class AccessibilityBridge;
  * * `SemanticsObject` for the other type of semantics objects.
  * * `FlutterSemanticsObject` for default implementation of `SemanticsObject`.
  */
-@interface FlutterPlatformViewSemanticsContainer : UIAccessibilityElement
+@interface FlutterPlatformViewSemanticsContainer : NSObject
+
+/**
+ * The position inside an accessibility container.
+ */
+@property(nonatomic) NSInteger index;
 
 - (instancetype)init __attribute__((unavailable("Use initWithAccessibilityContainer: instead")));
+
+- (instancetype)initWithSemanticsObject:(SemanticsObject*)object;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -404,8 +404,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 @end
 
 @implementation FlutterPlatformViewSemanticsContainer {
-  SemanticsObject *_semanticsObject;
-  UIView *_platformView;
+  SemanticsObject* _semanticsObject;
+  UIView* _platformView;
 }
 
 // Method declared as unavailable in the interface
@@ -419,11 +419,12 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   FML_CHECK(object);
   if (self = [super init]) {
     _semanticsObject = object;
-    flutter::FlutterPlatformViewsController* controller = object.bridge->GetPlatformViewsController();
+    flutter::FlutterPlatformViewsController* controller =
+        object.bridge->GetPlatformViewsController();
     if (controller) {
       _platformView = [controller->GetPlatformViewByID(object.node.platformViewId) view];
     }
-    self.accessibilityElements = @[_semanticsObject, _platformView];
+    self.accessibilityElements = @[ _semanticsObject, _platformView ];
   }
   return self;
 }
@@ -627,8 +628,8 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
     if (object.node.IsPlatformViewNode()) {
       FlutterPlatformViewsController* controller = GetPlatformViewsController();
       if (controller) {
-        object.platformViewSemanticsContainer = [[FlutterPlatformViewSemanticsContainer alloc]
-            initWithSemanticsObject:object];
+        object.platformViewSemanticsContainer =
+            [[FlutterPlatformViewSemanticsContainer alloc] initWithSemanticsObject:object];
       }
     } else if (object.platformViewSemanticsContainer) {
       [object.platformViewSemanticsContainer release];

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -403,7 +403,10 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 
 @end
 
-@implementation FlutterPlatformViewSemanticsContainer
+@implementation FlutterPlatformViewSemanticsContainer {
+  SemanticsObject *_semanticsObject;
+  UIView *_platformView;
+}
 
 // Method declared as unavailable in the interface
 - (instancetype)init {
@@ -412,12 +415,33 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   return nil;
 }
 
-- (instancetype)initWithAccessibilityContainer:(id)container {
-  FML_CHECK(container);
-  if (self = [super initWithAccessibilityContainer:container]) {
-    self.isAccessibilityElement = NO;
+- (instancetype)initWithSemanticsObject:(SemanticsObject*)object {
+  FML_CHECK(object);
+  if (self = [super init]) {
+    _semanticsObject = object;
+    flutter::FlutterPlatformViewsController* controller = object.bridge->GetPlatformViewsController();
+    if (controller) {
+      _platformView = [controller->GetPlatformViewByID(object.node.platformViewId) view];
+    }
+    self.accessibilityElements = @[_semanticsObject, _platformView];
   }
   return self;
+}
+
+- (CGRect)accessibilityFrame {
+  return _semanticsObject.accessibilityFrame;
+}
+
+- (BOOL)isAccessibilityElement {
+  return NO;
+}
+
+- (id)accessibilityContainer {
+  return [_semanticsObject accessibilityContainer];
+}
+
+- (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
+  return [_platformView accessibilityScroll:direction];
 }
 
 @end
@@ -453,10 +477,6 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 
 - (NSInteger)accessibilityElementCount {
   NSInteger count = [[_semanticsObject children] count] + 1;
-  // Need to create an additional child that acts as accessibility container for the platform view.
-  if (_semanticsObject.node.IsPlatformViewNode()) {
-    count++;
-  }
   return count;
 }
 
@@ -467,14 +487,13 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
     return _semanticsObject;
   }
 
-  // Return the additional child acts as a container of platform view. The
-  // platformViewSemanticsContainer was created and cached in the updateSemantics path.
-  if (_semanticsObject.node.IsPlatformViewNode() && index == [self accessibilityElementCount] - 1) {
-    FML_CHECK(_semanticsObject.platformViewSemanticsContainer != nil);
-    return _semanticsObject.platformViewSemanticsContainer;
-  }
-
   SemanticsObject* child = [_semanticsObject children][index - 1];
+
+  // Swap the original `SemanticsObject` to a `PlatformViewSemanticsContainer`
+  if (child.node.IsPlatformViewNode()) {
+    child.platformViewSemanticsContainer.index = index;
+    return child.platformViewSemanticsContainer;
+  }
 
   if ([child hasChildren])
     return [child accessibilityContainer];
@@ -487,7 +506,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 
   // FlutterPlatformViewSemanticsContainer is always the last element of its parent.
   if ([element isKindOfClass:[FlutterPlatformViewSemanticsContainer class]]) {
-    return [self accessibilityElementCount] - 1;
+    return ((FlutterPlatformViewSemanticsContainer*)element).index;
   }
 
   NSMutableArray<SemanticsObject*>* children = [_semanticsObject children];
@@ -609,11 +628,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
       FlutterPlatformViewsController* controller = GetPlatformViewsController();
       if (controller) {
         object.platformViewSemanticsContainer = [[FlutterPlatformViewSemanticsContainer alloc]
-            initWithAccessibilityContainer:[object accessibilityContainer]];
-        UIView* platformView = [controller->GetPlatformViewByID(object.node.platformViewId) view];
-        if (platformView) {
-          object.platformViewSemanticsContainer.accessibilityElements = @[ platformView ];
-        }
+            initWithSemanticsObject:object];
       }
     } else if (object.platformViewSemanticsContainer) {
       [object.platformViewSemanticsContainer release];
@@ -659,7 +674,6 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
   [objects_ removeObjectsForKeys:doomed_uids];
 
   layoutChanged = layoutChanged || [doomed_uids count] > 0;
-
   if (routeChanged) {
     NSString* routeName = [lastAdded routeName];
     UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, routeName);


### PR DESCRIPTION
Partially fix the issue in https://github.com/flutter/flutter/issues/30804. This only fixes the focus issue for other platform views (Google maps and other custom platform views), but the same issue on WebView is not fixed. 

Before the change, the a11y tree with platform view looks like 

```
<some parent a11y container>
     <SemanticsObject for platform view>
     <FlutterPlatformViewSemanticsContainer>
          <platform view>
```


After the change, it looks like
```
<some parent a11y container>
     <FlutterPlatformViewSemanticsContainer>
          <SemanticsObject>
          <platform view>
```

This PR also updated the implementation of FlutterPlatformViewSemanticsContainer to use A11yContainer protocol to implement the details on various a11y attribute including the `accessibilityFrame` and `accessibilityScroll`.

As for the issue on WebView, I haven't found a good solution because the issue seems to be within the cocoa touch's WKWebView.
