### PR TITLE
Revert "Increase the memory usage estimate for EngineLayer"

### DIFF
--- a/lib/ui/painting/engine_layer.cc
+++ b/lib/ui/painting/engine_layer.cc
@@ -24,9 +24,7 @@ size_t EngineLayer::GetAllocationSize() {
   // Provide an approximation of the total memory impact of this object to the
   // Dart GC.  The ContainerLayer may hold references to a tree of other layers,
   // which in turn may contain Skia objects.
-  // TODO(https://github.com/flutter/flutter/issues/31498): calculate the cost
-  // of the layer more accurately.
-  return 200000;
+  return 3000;
 };
 
 IMPLEMENT_WRAPPERTYPEINFO(ui, EngineLayer);


### PR DESCRIPTION
Reverts flutter/engine#8700

This causes the perf regression noted in https://github.com/flutter/flutter/issues/31590

The bug it was intended to fix also reports that this value may not be high enough and the memory leak is still showing up on some phones.