### PR TITLE
Log the sticky error during isolate shutdown

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -791,6 +791,14 @@ void DartIsolate::AddIsolateShutdownCallback(fml::closure closure) {
 }
 
 void DartIsolate::OnShutdownCallback() {
+  {
+    tonic::DartApiScope api_scope;
+    Dart_Handle sticky_error = Dart_GetStickyError();
+    if (!Dart_IsNull(sticky_error) && !Dart_IsFatalError(sticky_error)) {
+      FML_LOG(ERROR) << Dart_GetError(sticky_error);
+    }
+  }
+
   shutdown_callbacks_.clear();
   if (isolate_shutdown_callback_) {
     isolate_shutdown_callback_();


### PR DESCRIPTION
The sticky error may be set in cases such as an unhandled asynchronous
exception.  This is similar to the logging done in the Dart command line
embedder's isolate shutdown callback.