### PR TITLE
Matrix4 validation

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -57,10 +57,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack.
   EngineLayer pushTransform(Float64List matrix4) {
-    if (matrix4 == null)
-      throw new ArgumentError('"matrix4" argument cannot be null');
-    if (matrix4.length != 16)
-      throw new ArgumentError('"matrix4" must have 16 entries.');
+    assert(_matrix4IsValid(matrix4));
     return _pushTransform(matrix4);
   }
   EngineLayer _pushTransform(Float64List matrix4) native 'SceneBuilder_pushTransform';

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -42,6 +42,9 @@ bool _offsetIsValid(Offset offset) {
 bool _matrix4IsValid(Float64List matrix4) {
   assert(matrix4 != null, 'Matrix4 argument was null.');
   assert(matrix4.length == 16, 'Matrix4 must have 16 entries.');
+  assert(() {
+    return matrix4.every((double value) => value.isFinite);
+  }(), 'Matrix4 entries must be finite.');
   return true;
 }
 

--- a/testing/dart/compositing_test.dart
+++ b/testing/dart/compositing_test.dart
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+import 'dart:ui';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('pushTransform validates the matrix', () {
+    final SceneBuilder builder = SceneBuilder();
+    final Float64List matrix4 = Float64List.fromList(<double>[
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1,
+    ]);
+    expect(builder.pushTransform(matrix4), isNotNull);
+
+    final Float64List matrix4WrongLength = Float64List.fromList(<double>[
+      1, 0, 0, 0,
+      0, 1, 0,
+      0, 0, 1, 0,
+      0, 0, 0,
+    ]);
+    expect(
+      () => builder.pushTransform(matrix4WrongLength),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+
+    final Float64List matrix4NaN = Float64List.fromList(<double>[
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, double.nan,
+    ]);
+    expect(
+      () => builder.pushTransform(matrix4NaN),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+  });
+}


### PR DESCRIPTION
Helps two issues:

- `SceneBuilder.pushTransform` was using different matrix4 validation logic than painting.dart
- Makes sure that matrices passed in for transformations are finite before getting to the native side.

This would have helped catch https://github.com/flutter/flutter/issues/31650