### PR TITLE
https://github.com/flutter/flutter/issues/30675

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1306,7 +1306,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                     event.setScrollX((int) position);
                     event.setMaxScrollX((int) max);
                 }
-                if (object.scrollChildren > 0) {
+                if (object.scrollChildren > 0 && object.childrenInHitTestOrder != null) {
                     // We don't need to add 1 to the scroll index because TalkBack does this automagically.
                     event.setItemCount(object.scrollChildren);
                     event.setFromIndex(object.scrollIndex);


### PR DESCRIPTION
childrenInHitTestOrder is set to null if the child count == 0 (line 1870), add null
check to accommodate.