### PR TITLE
Re-create texture from pixel buffer onGrContextCreate

### DIFF
--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -26,10 +26,13 @@ class IOSExternalTextureGL : public flutter::Texture {
 
   void MarkNewFrameAvailable() override;
 
+  void CreateTextureFromPixelBuffer();
+
  private:
   NSObject<FlutterTexture>* external_texture_;
   fml::CFRef<CVOpenGLESTextureCacheRef> cache_ref_;
   fml::CFRef<CVOpenGLESTextureRef> texture_ref_;
+  fml::CFRef<CVPixelBufferRef> buffer_ref_;
   FML_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureGL);
 };
 

--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -26,9 +26,11 @@ class IOSExternalTextureGL : public flutter::Texture {
 
   void MarkNewFrameAvailable() override;
 
+ private:
   void CreateTextureFromPixelBuffer();
 
- private:
+  void EnsureTextureCacheExists();
+
   NSObject<FlutterTexture>* external_texture_;
   fml::CFRef<CVOpenGLESTextureCacheRef> cache_ref_;
   fml::CFRef<CVOpenGLESTextureRef> texture_ref_;

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -46,10 +46,10 @@ void IOSExternalTextureGL::CreateTextureFromPixelBuffer() {
       static_cast<int>(CVPixelBufferGetWidth(buffer_ref_)),
       static_cast<int>(CVPixelBufferGetHeight(buffer_ref_)), GL_BGRA, GL_UNSIGNED_BYTE, 0,
       &texture);
-  texture_ref_.Reset(texture);
   if (err != noErr) {
     FML_LOG(WARNING) << "Could not create texture from pixel buffer: " << err;
-    return;
+  } else {
+    texture_ref_.Reset(texture);
   }
 }
 
@@ -59,7 +59,10 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas,
                                  GrContext* context) {
   EnsureTextureCacheExists();
   if (!freeze) {
-    buffer_ref_.Reset([external_texture_ copyPixelBuffer]);
+    auto pixelBuffer = [external_texture_ copyPixelBuffer];
+    if (pixelBuffer) {
+      buffer_ref_.Reset(pixelBuffer);
+    }
     CreateTextureFromPixelBuffer();
   }
   if (!texture_ref_) {


### PR DESCRIPTION
OnGrContextDestroy we destroy the texture, this is because
we can not access it from the potentially new context that
we get on bringing the app back to foreground.

To show a valid texture on fg, we need to preserve the pixel
buffer, using which we will create the new texture.

Fixes https://github.com/flutter/flutter/issues/30491