### PR TITLE
Allow FlutterEngine to be used on back-to-back screens (#31264).

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -378,25 +378,6 @@ public class FlutterFragment extends Fragment {
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
     flutterView = new FlutterView(getContext(), getRenderMode(), getTransparencyMode());
     flutterView.addOnFirstFrameRenderedListener(onFirstFrameRenderedListener);
-
-    // We post() the code that attaches the FlutterEngine to our FlutterView because there is
-    // some kind of blocking logic on the native side when the surface is connected. That lag
-    // causes launching Activitys to wait a second or two before launching. By post()'ing this
-    // behavior we are able to move this blocking logic to after the Activity's launch.
-    // TODO(mattcarroll): figure out how to avoid blocking the MAIN thread when connecting a surface
-    new Handler().post(new Runnable() {
-      @Override
-      public void run() {
-        flutterView.attachToFlutterEngine(flutterEngine);
-
-        // TODO(mattcarroll): the following call should exist here, but the plugin system needs to be revamped.
-        //                    The existing attach() method does not know how to handle this kind of FlutterView.
-        //flutterEngine.getPluginRegistry().attach(this, getActivity());
-
-        doInitialFlutterViewRun();
-      }
-    });
-
     return flutterView;
   }
 
@@ -487,8 +468,33 @@ public class FlutterFragment extends Fragment {
   }
 
   @Override
+  public void onStart() {
+    super.onStart();
+    Log.d(TAG, "onStart()");
+
+    // We post() the code that attaches the FlutterEngine to our FlutterView because there is
+    // some kind of blocking logic on the native side when the surface is connected. That lag
+    // causes launching Activitys to wait a second or two before launching. By post()'ing this
+    // behavior we are able to move this blocking logic to after the Activity's launch.
+    // TODO(mattcarroll): figure out how to avoid blocking the MAIN thread when connecting a surface
+    new Handler().post(new Runnable() {
+      @Override
+      public void run() {
+        flutterView.attachToFlutterEngine(flutterEngine);
+
+        // TODO(mattcarroll): the following call should exist here, but the plugin system needs to be revamped.
+        //                    The existing attach() method does not know how to handle this kind of FlutterView.
+        //flutterEngine.getPluginRegistry().attach(this, getActivity());
+
+        doInitialFlutterViewRun();
+      }
+    });
+  }
+
+  @Override
   public void onResume() {
     super.onResume();
+    Log.d(TAG, "onResume()");
     flutterEngine.getLifecycleChannel().appIsResumed();
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -523,6 +523,7 @@ public class FlutterFragment extends Fragment {
     super.onStop();
     Log.d(TAG, "onStop()");
     flutterEngine.getLifecycleChannel().appIsPaused();
+    flutterView.detachFromFlutterEngine();
   }
 
   @Override
@@ -530,7 +531,6 @@ public class FlutterFragment extends Fragment {
     super.onDestroyView();
     Log.d(TAG, "onDestroyView()");
     flutterView.removeOnFirstFrameRenderedListener(onFirstFrameRenderedListener);
-    flutterView.detachFromFlutterEngine();
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -547,7 +547,7 @@ public class FlutterView extends FrameLayout {
   }
 
   private boolean isAttachedToFlutterEngine() {
-    return flutterEngine != null;
+    return flutterEngine != null && flutterEngine.getRenderer().isAttachedTo(renderSurface);
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -10,6 +10,7 @@ import android.graphics.SurfaceTexture;
 import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.view.Surface;
 
 import java.nio.ByteBuffer;
@@ -41,6 +42,14 @@ public class FlutterRenderer implements TextureRegistry {
 
   public FlutterRenderer(@NonNull FlutterJNI flutterJNI) {
     this.flutterJNI = flutterJNI;
+  }
+
+  /**
+   * Returns true if this {@code FlutterRenderer} is attached to the given {@link RenderSurface},
+   * false otherwise.
+   */
+  public boolean isAttachedTo(@NonNull RenderSurface renderSurface) {
+    return this.renderSurface == renderSurface;
   }
 
   public void attachToRenderSurface(@NonNull RenderSurface renderSurface) {


### PR DESCRIPTION
Allow FlutterEngine to be used on back-to-back screens ( #31264 ).

The referenced bug occurs when going from one `Activity` to another `Activity`, sharing the same FlutterEngine, then going back. The problem was that the point at which the FlutterEngine was being attached to the FlutterView was executed in a lifecycle method that does not repeat. Thus, this PR moves that attachment to `onStart()` instead of `onCreateView()`.

Even with this solution, a developer may not use the same `FlutterEngine` between 2 `Activity`s where the 2nd `Activity` is translucent, or using the same `FlutterEngine` in a dialog. This is because such a situation expects that both UIs are simultaneously visible, but a `FlutterEngine` cannot be attached to 2 surfaces at the same time, let alone render 2 different user interfaces at the same time.