### PR TITLE
Add flutter settings channel and window brightness to macOS shell

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -101,7 +101,6 @@ static const int kDefaultWindowFramebuffer = 0;
  */
 - (void)onSettingsChanged:(NSNotification*)notification;
 
-
 @end
 
 #pragma mark - Static methods provided to engine configuration
@@ -506,10 +505,10 @@ static void CommonInit(FLEViewController* controller) {
 
 - (void)sendInitialSettings {
   [[NSDistributedNotificationCenter defaultCenter]
-    addObserver:self
-        selector:@selector(onSettingsChanged:)
-            name:@"AppleInterfaceThemeChangedNotification"
-          object:nil];
+      addObserver:self
+         selector:@selector(onSettingsChanged:)
+             name:@"AppleInterfaceThemeChangedNotification"
+           object:nil];
   [self onSettingsChanged:nil];
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -493,6 +493,7 @@ static void CommonInit(FLEViewController* controller) {
 }
 
 - (void)onSettingsChanged:(NSNotification*)notification {
+  // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/32015.
   NSString* brightness =
       [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
   [_settingsChannel sendMessage:@{
@@ -504,6 +505,7 @@ static void CommonInit(FLEViewController* controller) {
 }
 
 - (void)sendInitialSettings {
+  // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/32015.
   [[NSDistributedNotificationCenter defaultCenter]
       addObserver:self
          selector:@selector(onSettingsChanged:)

--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -194,10 +194,11 @@ static bool HeadlessOnMakeResourceCurrent(FLEViewController* controller) {
 static void CommonInit(FLEViewController* controller) {
   controller->_messageHandlers = [[NSMutableDictionary alloc] init];
   controller->_additionalKeyResponders = [[NSMutableOrderedSet alloc] init];
-  [[NSDistributedNotificationCenter defaultCenter] addObserver:controller
-      selector:@selector(onSettingsChanged:)
-          name:@"AppleInterfaceThemeChangedNotification"
-        object:nil];
+  [[NSDistributedNotificationCenter defaultCenter]
+      addObserver:controller
+         selector:@selector(onSettingsChanged:)
+             name:@"AppleInterfaceThemeChangedNotification"
+           object:nil];
   [controller onSettingChanged:nil];
 }
 
@@ -307,9 +308,9 @@ static void CommonInit(FLEViewController* controller) {
                                          binaryMessenger:self
                                                    codec:[FlutterJSONMessageCodec sharedInstance]];
   _settingsChannel =
-    [FlutterBasicMessageChannel messageChannelWithName:@"flutter/settings"
-                                        binaryMessenger:self
-                                                  codec:[FlutterJSONMessageCodec sharedInstance]];
+      [FlutterBasicMessageChannel messageChannelWithName:@"flutter/settings"
+                                         binaryMessenger:self
+                                                   codec:[FlutterJSONMessageCodec sharedInstance]];
 }
 
 - (BOOL)launchEngineInternalWithAssetsPath:(NSURL*)assets
@@ -596,14 +597,15 @@ static void CommonInit(FLEViewController* controller) {
   [self dispatchMouseEvent:event phase:kHover];
 }
 
-- (void)onSettingsChanged:(NSNotification *)notification  {
-  NSString *brightness = [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
+- (void)onSettingsChanged:(NSNotification*)notification {
+  NSString* brightness =
+      [[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"];
   [_settingsChannel sendMessage:@{
-    @"platformBrightness": [brightness isEqualToString:@"Dark"] ? @"dark" : @"light",
+    @"platformBrightness" : [brightness isEqualToString:@"Dark"] ? @"dark" : @"light",
     // The values below are hard-coded, but the iOS implementation has heuristics
     // to generate them we should find a way to reuse. See FlutterViewController.mm#L861
-    @"textScaleFactor": @1.0,
-    @"alwaysUse24HourFormat": @false
+    @"textScaleFactor" : @1.0,
+    @"alwaysUse24HourFormat" : @false
   }];
 }
 


### PR DESCRIPTION
Adds the flutter/settings message channel to macOS and use it to send the platform brightness. This allows us to support dark mode on Mojave by connecting this setting to https://docs.flutter.dev/flutter/dart-ui/Window/platformBrightness.html.

The MaterialApp will automatically tween between the light and dark theme when this is changed thanks to the existing work of @matthew-carroll 