### PR TITLE
Text wrap width build tests

### DIFF
--- a/lib/stub_ui/lib/text.dart
+++ b/lib/stub_ui/lib/text.dart
@@ -1310,6 +1310,14 @@ class Paragraph {
     throw UnimplementedError();
   }
 
+  /// The distance from the left edge of the leftmost glyph to the right edge of
+  /// the rightmost glyph in the paragraph.
+  ///
+  /// Valid only after [layout] has been called.
+  double get longestLine {
+    throw UnimplementedError();
+  }
+
   /// Returns the smallest width beyond which increasing the width never
   /// decreases the height.
   ///


### PR DESCRIPTION
For https://github.com/flutter/flutter/pull/31987

`longestLine` was missing from stub_ui, so build tests were reporting it didn't exist.  This will fix it.