### PR TITLE
Default the animated frame cache to 0 when unset

### DIFF
--- a/lib/stub_ui/lib/painting.dart
+++ b/lib/stub_ui/lib/painting.dart
@@ -1632,7 +1632,7 @@ class Codec {
 /// The returned future can complete with an error if the image decoding has
 /// failed.
 Future<Codec> instantiateImageCodec(Uint8List list, {
-  double decodedCacheRatioCap = double.infinity,
+  double decodedCacheRatioCap = 0,
 }) {
   throw UnimplementedError();
 }
@@ -1668,7 +1668,7 @@ void decodeImageFromPixels(
   int height,
   PixelFormat format,
   ImageDecoderCallback callback,
-  {int rowBytes, double decodedCacheRatioCap = double.infinity}
+  {int rowBytes, double decodedCacheRatioCap = 0}
 ) {
   throw UnimplementedError();
 }

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1654,7 +1654,7 @@ class Codec extends NativeFieldWrapperClass2 {
 /// The returned future can complete with an error if the image decoding has
 /// failed.
 Future<Codec> instantiateImageCodec(Uint8List list, {
-  double decodedCacheRatioCap = double.infinity,
+  double decodedCacheRatioCap = 0,
 }) {
   return _futurize(
     (_Callback<Codec> callback) => _instantiateImageCodec(list, callback, null, decodedCacheRatioCap),
@@ -1704,7 +1704,7 @@ void decodeImageFromPixels(
   int height,
   PixelFormat format,
   ImageDecoderCallback callback,
-  {int rowBytes, double decodedCacheRatioCap = double.infinity}
+  {int rowBytes, double decodedCacheRatioCap = 0}
 ) {
   final _ImageInfo imageInfo = new _ImageInfo(width, height, format.index, rowBytes);
   final Future<Codec> codecFuture = _futurize(


### PR DESCRIPTION
This default is already set in the framework, but this also needs to be
set in the binding layer to preserve the same behavior when the
deprecated framework parameter is removed.

flutter/flutter#26081