### PR TITLE
Picture shader

### DIFF
--- a/lib/stub_ui/lib/painting.dart
+++ b/lib/stub_ui/lib/painting.dart
@@ -1318,6 +1318,7 @@ class Paint {
   ///
   ///  * [Gradient], a shader that paints a color gradient.
   ///  * [ImageShader], a shader that tiles an [Image].
+  ///  * [PictureShader], a shader that tiles a [Picture].
   ///  * [colorFilter], which overrides [shader].
   ///  * [color], which is used if [shader] and [colorFilter] are null.
   Shader get shader {
@@ -2669,6 +2670,13 @@ class ImageShader extends Shader {
     super._();
 }
 
+/// A shader (as used by [Paint.shader]) that tiles a picture.
+class PictureShader extends Shader {
+  /// This class is created by the engine, and should not be instantiated
+  /// or extended directly.
+  PictureShader._() : super._();
+}
+
 /// Defines how a list of points is interpreted when drawing a set of triangles.
 ///
 /// Used by [Canvas.drawVertices].
@@ -3313,11 +3321,11 @@ class Picture {
     throw UnimplementedError();
   }
 
-  /// Creates a shader from this picture.
+  /// Creates a picture shader from this picture.
   ///
-  /// The picture is drawn using the number of pixels specified by the
-  /// given width and height.
-  Future<Shader> toShader(int width, int height, TileMode tmx, TileMode tmy, Float64List matrix4) {
+  /// The shader is returned asynchronously to allow time for the gpu to
+  /// draw the picture and compile a shader.
+  Future<PictureShader> toShader(TileMode tmx, TileMode tmy, Float64List matrix4) {
     throw UnimplementedError();
   }
 

--- a/lib/stub_ui/lib/painting.dart
+++ b/lib/stub_ui/lib/painting.dart
@@ -3312,6 +3312,15 @@ class Picture {
   Future<Image> toImage(int width, int height) {
     throw UnimplementedError();
   }
+
+  /// Creates a shader from this picture.
+  ///
+  /// The picture is drawn using the number of pixels specified by the
+  /// given width and height.
+  Future<Shader> toShader(int width, int height, TileMode tmx, TileMode tmy, Float64List matrix4) {
+    throw UnimplementedError();
+  }
+
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.
   void dispose() {

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -48,6 +48,8 @@ source_set("ui") {
     "painting/picture.h",
     "painting/picture_recorder.cc",
     "painting/picture_recorder.h",
+    "painting/picture_shader.cc",
+    "painting/picture_shader.h",
     "painting/rrect.cc",
     "painting/rrect.h",
     "painting/shader.cc",

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -3763,7 +3763,24 @@ class Picture extends NativeFieldWrapperClass2 {
     );
   }
 
+  /// Creates a shader from this picture.
+  ///
+  /// The picture is drawn using the number of pixels specified by the
+  /// given width and height.
+  Future<Shader> toShader(int width, int height, TileMode tmx, TileMode tmy, Float64List matrix4) {
+    if (width <= 0 || height <= 0)
+      throw new Exception('Invalid image dimensions.');
+    if(tmx == null || tmy == null)
+      throw new Exception('Invalid tile modes.');
+    if (matrix4.length != 16)
+      throw new ArgumentError('"matrix4" must have 16 entries.');
+    return _futurize(
+      (_Callback<Shader> callback) => _toShader(width, height, tmx, tmy, matrix4, callback)
+    );
+  }
+
   String _toImage(int width, int height, _Callback<Image> callback) native 'Picture_toImage';
+  String _toShader(int width, int height, TileMode tmx, TileMode tmy, Float64List matrix4, _Callback<Shader> callback) native 'Picture_toShader';
 
   /// Release the resources used by this object. The object is no longer usable
   /// after this method is called.

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -8,6 +8,7 @@
 #include "flutter/flow/skia_gpu_object.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/image.h"
+#include "flutter/lib/ui/painting/image_shader.h"
 #include "third_party/skia/include/core/SkPicture.h"
 
 namespace tonic {
@@ -31,6 +32,13 @@ class Picture : public RefCountedDartWrappable<Picture> {
                       uint32_t height,
                       Dart_Handle raw_image_callback);
 
+  Dart_Handle toShader(uint32_t width,
+                       uint32_t height,
+                       SkTileMode tmx,
+                       SkTileMode tmy,
+                       const tonic::Float64List& matrix4,
+                       Dart_Handle raw_shader_callback);
+
   void dispose();
 
   size_t GetAllocationSize() override;
@@ -41,6 +49,14 @@ class Picture : public RefCountedDartWrappable<Picture> {
                                       uint32_t width,
                                       uint32_t height,
                                       Dart_Handle raw_image_callback);
+
+  static Dart_Handle TransferToShader(sk_sp<SkPicture> picture,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      SkTileMode tmx,
+                                      SkTileMode tmy,
+                                      const tonic::Float64List& matrix4,
+                                      Dart_Handle raw_shader_callback);
 
  private:
   explicit Picture(flutter::SkiaGPUObject<SkPicture> picture);

--- a/lib/ui/painting/picture.h
+++ b/lib/ui/painting/picture.h
@@ -8,8 +8,11 @@
 #include "flutter/flow/skia_gpu_object.h"
 #include "flutter/lib/ui/dart_wrapper.h"
 #include "flutter/lib/ui/painting/image.h"
-#include "flutter/lib/ui/painting/image_shader.h"
+#include "flutter/lib/ui/painting/matrix.h"
+#include "flutter/lib/ui/painting/picture_shader.h"
+#include "third_party/skia/include/core/SkImage.h"
 #include "third_party/skia/include/core/SkPicture.h"
+#include "third_party/tonic/typed_data/float64_list.h"
 
 namespace tonic {
 class DartLibraryNatives;
@@ -32,9 +35,7 @@ class Picture : public RefCountedDartWrappable<Picture> {
                       uint32_t height,
                       Dart_Handle raw_image_callback);
 
-  Dart_Handle toShader(uint32_t width,
-                       uint32_t height,
-                       SkTileMode tmx,
+  Dart_Handle toShader(SkTileMode tmx,
                        SkTileMode tmy,
                        const tonic::Float64List& matrix4,
                        Dart_Handle raw_shader_callback);
@@ -51,8 +52,6 @@ class Picture : public RefCountedDartWrappable<Picture> {
                                       Dart_Handle raw_image_callback);
 
   static Dart_Handle TransferToShader(sk_sp<SkPicture> picture,
-                                      uint32_t width,
-                                      uint32_t height,
                                       SkTileMode tmx,
                                       SkTileMode tmy,
                                       const tonic::Float64List& matrix4,

--- a/lib/ui/painting/picture_shader.cc
+++ b/lib/ui/painting/picture_shader.cc
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/lib/ui/painting/picture_shader.h"
+
+namespace flutter {
+
+IMPLEMENT_WRAPPERTYPEINFO(ui, PictureShader);
+
+fml::RefPtr<PictureShader> PictureShader::Create() {
+  return fml::MakeRefCounted<PictureShader>();
+}
+
+PictureShader::PictureShader() = default;
+
+PictureShader::~PictureShader() = default;
+
+}  // namespace flutter

--- a/lib/ui/painting/picture_shader.h
+++ b/lib/ui/painting/picture_shader.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_LIB_UI_PAINTING_PICTURE_SHADER_H_
+#define FLUTTER_LIB_UI_PAINTING_PICTURE_SHADER_H_
+
+#include "flutter/lib/ui/dart_wrapper.h"
+#include "flutter/lib/ui/painting/shader.h"
+
+namespace flutter {
+
+class PictureShader : public Shader {
+  DEFINE_WRAPPERTYPEINFO();
+  FML_FRIEND_MAKE_REF_COUNTED(PictureShader);
+
+ public:
+  ~PictureShader() override;
+  static fml::RefPtr<PictureShader> Create();
+
+ private:
+  PictureShader();
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_LIB_UI_PAINTING_PICTURE_SHADER_H_

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -12,8 +12,11 @@ namespace flutter {
 
 class SnapshotDelegate {
  public:
-  virtual sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
-                                            SkISize picture_size) = 0;
+  virtual sk_sp<SkImage> MakeSnapshot(sk_sp<SkPicture> picture,
+                                            SkISize picture_size,
+                                            bool rasterize) = 0;
+  inline sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
+                                            SkISize picture_size) { return MakeSnapshot(picture, picture_size, true); };
 };
 
 }  // namespace flutter

--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -12,11 +12,8 @@ namespace flutter {
 
 class SnapshotDelegate {
  public:
-  virtual sk_sp<SkImage> MakeSnapshot(sk_sp<SkPicture> picture,
-                                            SkISize picture_size,
-                                            bool rasterize) = 0;
-  inline sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
-                                            SkISize picture_size) { return MakeSnapshot(picture, picture_size, true); };
+  virtual sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
+                                            SkISize picture_size) = 0;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
This PR is addressing:
   #https://github.com/flutter/flutter/issues/31338

It implements a new shader type: PictureShader. This is a shader that is constructed through Picture.toShader() which returns Future(PictureShader). The reason this does not follow the same construction as ImageShader (by passing in an image) is that PictureShader must be created on the GPU thread. If it was constructed through PictureShader(picture, ...) the actual shader would be blank until it is actually drawn by the GPU.

You can see in this Skia fiddle that an SkPictureShader cannot be allocated on the CPU path:
   [https://fiddle.skia.org/c/6090413aa2b53941221574f14f3fd383](https://fiddle.skia.org/c/6090413aa2b53941221574f14f3fd383)

If you comment out the beginning 'if' statement, the fiddle crashes...

Another thing to note is that the shader generation doesn't use SkPicture::makeShader. Unfortunately, the bulk of that function is copied here but without the use of SkResourceCache. If this shader is created every frame the SkResourceCache grows quickly and causes large collections by the time dart sees the shaders are no longer referenced. Even without the SkResourceCache, the collection of just these shaders is noticeable in Debug, in Release it is performant.

A better long-term solution may be to provide flutter the ability to use an SkSurface backed canvas instead of just a one time use Canvas with PictureRecorder.

cc @brianosman @fmalita 