### PR TITLE
remove unnecessary usage of runtimeType in dart:ui

### DIFF
--- a/lib/ui/geometry.dart
+++ b/lib/ui/geometry.dart
@@ -92,7 +92,7 @@ abstract class OffsetBase {
   int get hashCode => hashValues(_dx, _dy);
 
   @override
-  String toString() => '$runtimeType(${_dx?.toStringAsFixed(1)}, ${_dy?.toStringAsFixed(1)})';
+  String toString() => 'OffsetBase(${_dx?.toStringAsFixed(1)}, ${_dy?.toStringAsFixed(1)})';
 }
 
 /// An immutable 2D floating-point offset.

--- a/lib/ui/pointer.dart
+++ b/lib/ui/pointer.dart
@@ -232,7 +232,7 @@ class PointerData {
   final double scrollDeltaY;
 
   @override
-  String toString() => '$runtimeType(x: $physicalX, y: $physicalY)';
+  String toString() => 'PointerData(x: $physicalX, y: $physicalY)';
 
   /// Returns a complete textual description of the information in this object.
   String toStringFull() {

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -714,7 +714,7 @@ class ParagraphStyle {
 
   @override
   String toString() {
-    return '$runtimeType('
+    return 'ParagraphStyle('
              'textAlign: ${     _encoded[0] & 0x002 == 0x002 ? TextAlign.values[_encoded[1]]     : "unspecified"}, '
              'textDirection: ${ _encoded[0] & 0x004 == 0x004 ? TextDirection.values[_encoded[2]] : "unspecified"}, '
              'fontWeight: ${    _encoded[0] & 0x008 == 0x008 ? FontWeight.values[_encoded[3]]    : "unspecified"}, '
@@ -1174,7 +1174,7 @@ class TextPosition {
 
   @override
   String toString() {
-    return '$runtimeType(offset: $offset, affinity: $affinity)';
+    return 'TextPosition(offset: $offset, affinity: $affinity)';
   }
 }
 
@@ -1223,7 +1223,7 @@ class ParagraphConstraints {
   int get hashCode => width.hashCode;
 
   @override
-  String toString() => '$runtimeType(width: $width)';
+  String toString() => 'ParagraphConstraints(width: $width)';
 }
 
 /// Defines various ways to vertically bound the boxes returned by

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -112,7 +112,7 @@ class WindowPadding {
 
   @override
   String toString() {
-    return '$runtimeType(left: $left, top: $top, right: $right, bottom: $bottom)';
+    return 'WindowPadding(left: $left, top: $top, right: $right, bottom: $bottom)';
   }
 }
 


### PR DESCRIPTION
These toString methods should be updated to match the other implementations which provide the type name as a String instead of calling runtimeType, which is expensive.