### PR TITLE
Get prebuilt Dart via CIPD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,9 +12,9 @@ task:
     CIRRUS_WORKING_DIR: "/tmp/github_repo"
     ENGINE_PATH: "/tmp/clean_engine"
     DEPOT_TOOLS: "/tmp/depot_tools"
-    PATH: "$DEPOT_TOOLS:$PATH"
     FLUTTER_ENGINE: "/tmp/clean_engine/src"
     FRAMEWORK_PATH: "/tmp/master_framework"
+    PATH: "$FLUTTER_ENGINE/third_party/dart/tools/sdks/dart-sdk/bin:$DEPOT_TOOLS:$PATH"
   depot_tools_script:
     git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS
   gclient_sync_script: |

--- a/DEPS
+++ b/DEPS
@@ -446,6 +446,16 @@ deps = {
      'dep_type': 'cipd',
    },
 
+   'src/third_party/dart/tools/sdks': {
+     'packages': [
+       {
+         'package': 'dart/dart-sdk/${{platform}}',
+         'version': 'version:2.2.0'
+       }
+     ],
+     'dep_type': 'cipd',
+   },
+
    # Get the SDK from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core at the 'latest' tag
    # Get the toolchain from https://chrome-infra-packages.appspot.com/p/fuchsia/clang at the 'goma' tag
 
@@ -509,12 +519,6 @@ hooks = [
     'condition': 'download_windows_deps',
     'pattern': '.',
     'action': ['python', 'src/build/vs_toolchain.py', 'update'],
-  },
-  {
-    # Pull prebuilt dart sdk.
-    'name': 'dart',
-    'pattern': '.',
-    'action': ['python', 'src/tools/dart/update.py'],
   },
   {
     'name': 'download_android_support',

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -18,9 +18,3 @@ WORKDIR $ENGINE_PATH/src
 RUN ./build/install-build-deps.sh --no-prompt
 RUN ./build/install-build-deps-android.sh --no-prompt
 RUN ./flutter/build/install-build-deps-linux-desktop.sh
-
-WORKDIR $HOME/dart
-RUN wget https://storage.googleapis.com/dart-archive/channels/dev/release/2.1.0-dev.7.1/sdk/dartsdk-linux-x64-release.zip
-RUN unzip dartsdk-linux-x64-release.zip
-ENV PATH $PATH:$HOME/dart/dart-sdk/bin
-

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: c7cd915ea6867222fc2d444c9c692fdc
+Signature: 6d315fb6c8e9e949011f57c32b16cb48
 

--- a/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
+++ b/flutter_kernel_transformers/lib/track_widget_constructor_locations.dart
@@ -419,7 +419,7 @@ class WidgetCreatorTracker implements ProgramTransformer {
   }
 
   Component _computeFullProgram(Component deltaProgram) {
-    final Set<Library> libraries = new Set<Library>();
+    final Set<Library> libraries = <Library>{};
     final List<Library> workList = <Library>[];
     for (Library library in deltaProgram.libraries) {
       if (libraries.add(library)) {

--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -376,7 +376,7 @@ abstract class License implements Comparable<License> {
 
   Iterable<String> get licensees => _licensees;
   final List<String> _licensees = <String>[];
-  final Set<String> _libraries = Set<String>();
+  final Set<String> _libraries = <String>{};
 
   bool get isUsed => _licensees.isNotEmpty;
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -1172,7 +1172,7 @@ class _RepositoryDirectory extends _RepositoryEntry implements LicenseSource {
   }
 
   Set<License> getLicenses(_Progress progress) {
-    final Set<License> result = Set<License>();
+    final Set<License> result = <License>{};
     for (_RepositoryDirectory directory in _subdirectories)
       result.addAll(directory.getLicenses(progress));
     for (_RepositoryLicensedFile file in _files) {
@@ -1344,7 +1344,7 @@ class _RepositoryFreetypeDocsDirectory extends _RepositoryDirectory {
     // We don't ship anything in this directory so don't bother looking for licenses there.
     // However, there are licenses in this directory referenced from elsewhere, so we do
     // want to crawl it and expose them.
-    return Set<License>();
+    return <License>{};
   }
 }
 
@@ -1631,7 +1631,7 @@ class _RepositorySkiaLibWebPDirectory extends _RepositoryDirectory {
   @override
   _RepositoryDirectory createSubdirectory(fs.Directory entry) {
     if (entry.name == 'webp')
-      return _RepositoryReachOutDirectory(this, entry, Set<String>.from(const <String>['config.h']), 3);
+      return _RepositoryReachOutDirectory(this, entry, const <String>{'config.h'}, 3);
     return super.createSubdirectory(entry);
   }
 }
@@ -1662,9 +1662,9 @@ class _RepositorySkiaThirdPartyDirectory extends _RepositoryGenericThirdPartyDir
   @override
   _RepositoryDirectory createSubdirectory(fs.Directory entry) {
     if (entry.name == 'ktx')
-      return _RepositoryReachOutDirectory(this, entry, Set<String>.from(const <String>['ktx.h', 'ktx.cpp']), 2);
+      return _RepositoryReachOutDirectory(this, entry, const <String>{'ktx.h', 'ktx.cpp'}, 2);
     if (entry.name == 'libmicrohttpd')
-      return _RepositoryReachOutDirectory(this, entry, Set<String>.from(const <String>['MHD_config.h']), 2);
+      return _RepositoryReachOutDirectory(this, entry, const <String>{'MHD_config.h'}, 2);
     if (entry.name == 'libwebp')
       return _RepositorySkiaLibWebPDirectory(this, entry);
     if (entry.name == 'libsdl')


### PR DESCRIPTION
I split this out from the lint PR.

Today, we bake a prebuilt dart into the Docker image.  This makes it challenging to update that when needed, e.g. when adding new analysis lints for CI checks.

We also grab a pre-built dart as a gclient hook, which is controlled by a custom python script in buildroot.

We can get rid of both of these things by just getting dart via CIPD as a regular dep.