### PR TITLE
Add resize functions to GLFW shell

### DIFF
--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
@@ -14,6 +14,14 @@
 
 namespace flutter {
 
+// A data type for window position and size.
+struct WindowFrame {
+  int left;
+  int top;
+  int width;
+  int height;
+};
+
 // A window displaying Flutter content.
 class FlutterWindow {
  public:
@@ -46,6 +54,30 @@ class FlutterWindow {
   // to the default icon.
   void SetIcon(uint8_t* pixel_data, int width, int height) {
     FlutterDesktopWindowSetIcon(window_, pixel_data, width, height);
+  }
+
+  // Returns the frame of the window, including any decoration (e.g., title
+  // bar), in screen coordinates.
+  WindowFrame GetFrame() {
+    WindowFrame frame = {};
+    FlutterDesktopWindowGetFrame(window_, &frame.left, &frame.top, &frame.width,
+                                 &frame.height);
+    return frame;
+  }
+
+  // Set the frame of the window, including any decoration (e.g., title
+  // bar), in screen coordinates.
+  void SetFrame(const WindowFrame& frame) {
+    FlutterDesktopWindowSetFrame(window_, frame.left, frame.top, frame.width,
+                                 frame.height);
+  }
+
+  // Returns the number of pixels per screen coordinate for the window.
+  //
+  // Flutter uses pixel coordinates, so this is the ratio of positions and sizes
+  // seen by Flutter as compared to the screen.
+  double GetScaleFactor() {
+    return FlutterDesktopWindowGetScaleFactor(window_);
   }
 
  private:

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -93,6 +93,34 @@ void FlutterDesktopWindowSetIcon(FlutterDesktopWindowRef flutter_window,
   }
 }
 
+void FlutterDesktopWindowGetFrame(FlutterDesktopWindowRef flutter_window,
+                                  int* x,
+                                  int* y,
+                                  int* width,
+                                  int* height) {
+  if (s_stub_implementation) {
+    s_stub_implementation->GetWindowFrame(x, y, width, height);
+  }
+}
+
+void FlutterDesktopWindowSetFrame(FlutterDesktopWindowRef flutter_window,
+                                  int x,
+                                  int y,
+                                  int width,
+                                  int height) {
+  if (s_stub_implementation) {
+    s_stub_implementation->SetWindowFrame(x, y, width, height);
+  }
+}
+
+double FlutterDesktopWindowGetScaleFactor(
+    FlutterDesktopWindowRef flutter_window) {
+  if (s_stub_implementation) {
+    return s_stub_implementation->GetWindowScaleFactor();
+  }
+  return 1.0;
+}
+
 void FlutterDesktopRunWindowLoop(FlutterDesktopWindowControllerRef controller) {
   if (s_stub_implementation) {
     s_stub_implementation->RunWindowLoop();

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -59,6 +59,17 @@ class StubFlutterGlfwApi {
   //  Called for FlutterDesktopWindowSetIcon.
   virtual void SetWindowIcon(uint8_t* pixel_data, int width, int height) {}
 
+  // Called for FlutterDesktopWindowGetFrame.
+  virtual void GetWindowFrame(int* x, int* y, int* width, int* height) {
+    x = y = width = height = 0;
+  }
+
+  // Called for FlutterDesktopWindowGetFrame.
+  virtual void SetWindowFrame(int x, int y, int width, int height) {}
+
+  // Called for FlutterDesktopWindowGetScaleFactor.
+  virtual double GetWindowScaleFactor() { return 1.0; }
+
   // Called for FlutterDesktopRunWindowLoop.
   virtual void RunWindowLoop() {}
 

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -119,6 +119,27 @@ FLUTTER_EXPORT void FlutterDesktopWindowSetIcon(
     int width,
     int height);
 
+// Gets the position and size of |flutter_window| in screen coordinates.
+FLUTTER_EXPORT void FlutterDesktopWindowGetFrame(
+    FlutterDesktopWindowRef flutter_window,
+    int* x,
+    int* y,
+    int* width,
+    int* height);
+
+// Sets the position and size of |flutter_window| in screen coordinates.
+FLUTTER_EXPORT void FlutterDesktopWindowSetFrame(
+    FlutterDesktopWindowRef flutter_window,
+    int x,
+    int y,
+    int width,
+    int height);
+
+// Returns the scale factor--the number of pixels per screen coordinate--for
+// |flutter_window|.
+FLUTTER_EXPORT double FlutterDesktopWindowGetScaleFactor(
+    FlutterDesktopWindowRef flutter_window);
+
 // Runs an instance of a headless Flutter engine.
 //
 // The |assets_path| is the path to the flutter_assets folder for the Flutter


### PR DESCRIPTION
Adds methods to get and set the window size, as well as to query the
window's scale factor. This is useful both for custom clients, and for
building a window resize plugin to prototype what will eventually likely
be a system channel.