### PR TITLE
Prevent redundant layouts when floor(width) is the same

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -477,13 +477,15 @@ void Paragraph::ComputeStrut(StrutMetrics* strut, SkFont& font) {
 }
 
 void Paragraph::Layout(double width, bool force) {
+  double rounded_width = floor(width);
   // Do not allow calling layout multiple times without changing anything.
-  if (!needs_layout_ && width == width_ && !force) {
+  if (!needs_layout_ && rounded_width == width_ && !force) {
     return;
   }
-  needs_layout_ = false;
 
-  width_ = floor(width);
+  width_ = rounded_width;
+
+  needs_layout_ = false;
 
   if (!ComputeLineBreaks())
     return;


### PR DESCRIPTION
It is possible to pass two widths that `floor` to the same value, and end up doing a redundant layout. This change prevents this from happening. It is incorrect to always perform layout if a non-integer value is passed as width.

This is purposefully missing a test, as we are currently discussing removing the `floor` behavior altogether, and a test would be cementing in likely unnecessary behavior.