### PR TITLE
Synthesize buttons for embedders

### DIFF
--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -9,6 +9,9 @@
 
 namespace flutter {
 
+// Must match the button constants in events.dart.
+const int64_t kPrimaryButton = 0x01;
+
 // This structure is unpacked by hooks.dart.
 struct alignas(8) PointerData {
   // Must match the PointerChange enum in pointer.dart.

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -10,18 +10,22 @@
 namespace flutter {
 
 // Must match the button constants in events.dart.
-enum PointerButton : int64_t {
-  kPrimaryMouseButton = 1 << 0,
-  kSecondaryMouseButton = 1 << 1,
-  kMiddleMouseButton = 1 << 2,
-  kBackMouseButton = 1 << 3,
-  kForwardMouseButton = 1 << 4,
+enum PointerButtonMouse : int64_t {
+  kPointerButtonMousePrimary = 1 << 0,
+  kPointerButtonMouseSecondary = 1 << 1,
+  kPointerButtonMouseMiddle = 1 << 2,
+  kPointerButtonMouseBack = 1 << 3,
+  kPointerButtonMouseForward = 1 << 4,
+};
 
-  kTouchContact = 1 << 0,
+enum PointerButtonTouch : int64_t {
+  kPointerButtonTouchContact = 1 << 0,
+};
 
-  kStylusContact = 1 << 0,
-  kPrimaryStylusButton = 1 << 1,
-  kSecondaryStylusButton = 1 << 2,
+enum PointerButtonStylus : int64_t {
+  kPointerButtonStylusContact = 1 << 0,
+  kPointerButtonStylusPrimary = 1 << 1,
+  kPointerButtonStylusSecondary = 1 << 2,
 };
 
 // This structure is unpacked by hooks.dart.

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -10,27 +10,20 @@
 namespace flutter {
 
 // Must match the button constants in events.dart.
-namespace PointerButton {
-const int64_t kPrimary = 1 << 0;
-const int64_t kSecondary = 1 << 1;
-
-namespace Mouse {
-const int64_t kPrimary = 1 << 0;
-const int64_t kSecondary = 1 << 1;
-const int64_t kBack = 1 << 2;
-const int64_t kForward = 1 << 3;
-}  // namespace Mouse
-
-namespace Touch {
-const int64_t kContact = 1 << 0;
-}
-
-namespace Stylus {
-const int64_t kContact = 1 << 0;
-const int64_t kPrimary = 1 << 1;
-const int64_t kSecondary = 1 << 2;
-}  // namespace Stylus
-}  // namespace PointerButton
+enum PointerMouseButton : int64_t {
+  kPrimaryMouseButton = 1 << 0,
+  kSecondaryMouseButton = 1 << 1,
+  kBackMouseButton = 1 << 0,
+  kForwardMouseButton = 1 << 1,
+};
+enum PointerTouchButton : int64_t {
+  kTouchContact = 1 << 0,
+};
+enum PointerStylusButton : int64_t {
+  kStylusContact = 1 << 0,
+  kPrimaryStylusButton = 1 << 0,
+  kSecondaryStylusButton = 1 << 0,
+};
 
 // This structure is unpacked by hooks.dart.
 struct alignas(8) PointerData {

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -10,7 +10,27 @@
 namespace flutter {
 
 // Must match the button constants in events.dart.
-const int64_t kPrimaryButton = 0x01;
+namespace PointerButton {
+  const int64_t kPrimary = 1 << 0;
+  const int64_t kSecondary = 1 << 1;
+
+  namespace Mouse {
+    const int64_t kPrimary = 1 << 0;
+    const int64_t kSecondary = 1 << 1;
+    const int64_t kBack = 1 << 2;
+    const int64_t kForward = 1 << 3;
+  }
+
+  namespace Touch {
+    const int64_t kContact = 1 << 0;
+  }
+
+  namespace Stylus {
+    const int64_t kContact = 1 << 0;
+    const int64_t kPrimary = 1 << 1;
+    const int64_t kSecondary = 1 << 2;
+  }
+}
 
 // This structure is unpacked by hooks.dart.
 struct alignas(8) PointerData {

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -10,19 +10,18 @@
 namespace flutter {
 
 // Must match the button constants in events.dart.
-enum PointerMouseButton : int64_t {
+enum PointerButton : int64_t {
   kPrimaryMouseButton = 1 << 0,
   kSecondaryMouseButton = 1 << 1,
-  kBackMouseButton = 1 << 0,
-  kForwardMouseButton = 1 << 1,
-};
-enum PointerTouchButton : int64_t {
+  kMiddleMouseButton = 1 << 2,
+  kBackMouseButton = 1 << 3,
+  kForwardMouseButton = 1 << 4,
+
   kTouchContact = 1 << 0,
-};
-enum PointerStylusButton : int64_t {
+
   kStylusContact = 1 << 0,
-  kPrimaryStylusButton = 1 << 0,
-  kSecondaryStylusButton = 1 << 0,
+  kPrimaryStylusButton = 1 << 1,
+  kSecondaryStylusButton = 1 << 2,
 };
 
 // This structure is unpacked by hooks.dart.

--- a/lib/ui/window/pointer_data.h
+++ b/lib/ui/window/pointer_data.h
@@ -11,26 +11,26 @@ namespace flutter {
 
 // Must match the button constants in events.dart.
 namespace PointerButton {
-  const int64_t kPrimary = 1 << 0;
-  const int64_t kSecondary = 1 << 1;
+const int64_t kPrimary = 1 << 0;
+const int64_t kSecondary = 1 << 1;
 
-  namespace Mouse {
-    const int64_t kPrimary = 1 << 0;
-    const int64_t kSecondary = 1 << 1;
-    const int64_t kBack = 1 << 2;
-    const int64_t kForward = 1 << 3;
-  }
+namespace Mouse {
+const int64_t kPrimary = 1 << 0;
+const int64_t kSecondary = 1 << 1;
+const int64_t kBack = 1 << 2;
+const int64_t kForward = 1 << 3;
+}  // namespace Mouse
 
-  namespace Touch {
-    const int64_t kContact = 1 << 0;
-  }
-
-  namespace Stylus {
-    const int64_t kContact = 1 << 0;
-    const int64_t kPrimary = 1 << 1;
-    const int64_t kSecondary = 1 << 2;
-  }
+namespace Touch {
+const int64_t kContact = 1 << 0;
 }
+
+namespace Stylus {
+const int64_t kContact = 1 << 0;
+const int64_t kPrimary = 1 << 1;
+const int64_t kSecondary = 1 << 2;
+}  // namespace Stylus
+}  // namespace PointerButton
 
 // This structure is unpacked by hooks.dart.
 struct alignas(8) PointerData {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -719,31 +719,23 @@ inline int64_t ToPointerDataButtons(int64_t buttons,
   switch (change) {
     case flutter::PointerData::Change::kDown:
     case flutter::PointerData::Change::kMove:
-    case flutter::PointerData::Change::kCancel:
-      // These kinds of change should always have a non-zero `buttons`.
-      // In case of violation, it synthesizes a primary button and log a warning
-      // to inform the embedder to send the correct buttons.
+      // These kinds of change must have a non-zero `buttons`, otherwise gesture
+      // recognizers will ignore these events. To avoid breaking legacy
+      // embedders, it synthesizes a primary button when seeing `button = 0` and
+      // log a warning to inform them to update.
       if (buttons == 0) {
         // TODO(tongmu): Log a warning to inform the embedder to send the
         // correct buttons. See
         // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
-        return flutter::PointerButton::kPrimary;
+        return flutter::kPrimaryMouseButton;
       }
       return buttons;
 
+    case flutter::PointerData::Change::kCancel:
     case flutter::PointerData::Change::kAdd:
     case flutter::PointerData::Change::kRemove:
     case flutter::PointerData::Change::kHover:
     case flutter::PointerData::Change::kUp:
-      // These kinds of change should always have a zero `buttons`. However we
-      // are not synthesizing a 0 until a solid reason is found.
-      // In case of violation, it log a warning to inform the embedder to send
-      // the correct buttons.
-      if (buttons != 0) {
-        // TODO(tongmu): Log a warning to inform the embedder to send the
-        // correct buttons. See
-        // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
-      }
       return buttons;
   }
 }

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -724,7 +724,7 @@ inline int64_t ToPointerDataButtons(
       // Synthesize primary button if the embedder fails to follow the contract.
       // TODO(tongmu): Log a warning to inform the embedder to send the correct
       // buttons.
-      return kPrimaryButton;
+      return flutter::kPrimaryButton;
     }
     return buttons;
   }

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -717,18 +717,36 @@ inline flutter::PointerData::SignalKind ToPointerDataSignalKind(
 inline int64_t ToPointerDataButtons(
     int64_t buttons,
     flutter::PointerData::Change change) {
-  // `buttons` should be non-zero when and only when the pointer is down.
-  if (change == flutter::PointerData::Change::kDown ||
-      change == flutter::PointerData::Change::kMove) {
-    if (buttons == 0) {
-      // Synthesize primary button if the embedder fails to follow the contract.
-      // TODO(tongmu): Log a warning to inform the embedder to send the correct
-      // buttons.
-      return flutter::kPrimaryButton;
-    }
-    return buttons;
+  switch (change) {
+    case flutter::PointerData::Change::kDown:
+    case flutter::PointerData::Change::kMove:
+    case flutter::PointerData::Change::kCancel:
+      // These kinds of change should always have a non-zero `buttons`.
+      // In case of violation, it synthesizes a primary button and log a warning
+      // to inform the embedder to send the correct buttons.
+      if (buttons == 0) {
+        // TODO(tongmu): Log a warning to inform the embedder to send the correct
+        // buttons. See
+        // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
+        return flutter::PointerButton::kPrimary;
+      }
+      return buttons;
+
+    case flutter::PointerData::Change::kAdd:
+    case flutter::PointerData::Change::kRemove:
+    case flutter::PointerData::Change::kHover:
+    case flutter::PointerData::Change::kUp:
+      // These kinds of change should always have a zero `buttons`. However we
+      // are not synthesizing a 0 until a solid reason is found.
+      // In case of violation, it log a warning to inform the embedder to send
+      // the correct buttons.
+      if (buttons != 0) {
+        // TODO(tongmu): Log a warning to inform the embedder to send the correct
+        // buttons. See
+        // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
+      }
+      return buttons;
   }
-  return 0;
 }
 
 FlutterEngineResult FlutterEngineSendPointerEvent(
@@ -750,10 +768,6 @@ FlutterEngineResult FlutterEngineSendPointerEvent(
     pointer_data.change = ToPointerDataChange(
         SAFE_ACCESS(current, phase, FlutterPointerPhase::kCancel));
     pointer_data.kind = flutter::PointerData::DeviceKind::kMouse;
-    // TODO(tong): Change 0 to a SAFE_ACCESS to current.buttons once this
-    // field is added.
-    // See https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
-    pointer_data.buttons = ToPointerDataButtons(0, pointer_data.change);
     pointer_data.physical_x = SAFE_ACCESS(current, x, 0.0);
     pointer_data.physical_y = SAFE_ACCESS(current, y, 0.0);
     pointer_data.device = SAFE_ACCESS(current, device, 0);
@@ -761,6 +775,10 @@ FlutterEngineResult FlutterEngineSendPointerEvent(
         SAFE_ACCESS(current, signal_kind, kFlutterPointerSignalKindNone));
     pointer_data.scroll_delta_x = SAFE_ACCESS(current, scroll_delta_x, 0.0);
     pointer_data.scroll_delta_y = SAFE_ACCESS(current, scroll_delta_y, 0.0);
+    // TODO(tong): Change 0 to a SAFE_ACCESS to current.buttons once this
+    // field is added. See
+    // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
+    pointer_data.buttons = ToPointerDataButtons(0, pointer_data.change);
     packet->SetPointerData(i, pointer_data);
     current = reinterpret_cast<const FlutterPointerEvent*>(
         reinterpret_cast<const uint8_t*>(current) + current->struct_size);

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -714,9 +714,8 @@ inline flutter::PointerData::SignalKind ToPointerDataSignalKind(
 
 // Returns the buttons for PointerData for the given buttons and change from a
 // FlutterPointerEvent.
-inline int64_t ToPointerDataButtons(
-    int64_t buttons,
-    flutter::PointerData::Change change) {
+inline int64_t ToPointerDataButtons(int64_t buttons,
+                                    flutter::PointerData::Change change) {
   switch (change) {
     case flutter::PointerData::Change::kDown:
     case flutter::PointerData::Change::kMove:
@@ -725,8 +724,8 @@ inline int64_t ToPointerDataButtons(
       // In case of violation, it synthesizes a primary button and log a warning
       // to inform the embedder to send the correct buttons.
       if (buttons == 0) {
-        // TODO(tongmu): Log a warning to inform the embedder to send the correct
-        // buttons. See
+        // TODO(tongmu): Log a warning to inform the embedder to send the
+        // correct buttons. See
         // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
         return flutter::PointerButton::kPrimary;
       }
@@ -741,8 +740,8 @@ inline int64_t ToPointerDataButtons(
       // In case of violation, it log a warning to inform the embedder to send
       // the correct buttons.
       if (buttons != 0) {
-        // TODO(tongmu): Log a warning to inform the embedder to send the correct
-        // buttons. See
+        // TODO(tongmu): Log a warning to inform the embedder to send the
+        // correct buttons. See
         // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
       }
       return buttons;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -727,7 +727,7 @@ inline int64_t ToPointerDataButtons(int64_t buttons,
         // TODO(tongmu): Log a warning to inform the embedder to send the
         // correct buttons. See
         // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
-        return flutter::kPrimaryMouseButton;
+        return flutter::kPointerButtonMousePrimary;
       }
       return buttons;
 
@@ -738,6 +738,7 @@ inline int64_t ToPointerDataButtons(int64_t buttons,
     case flutter::PointerData::Change::kUp:
       return buttons;
   }
+  return buttons;
 }
 
 FlutterEngineResult FlutterEngineSendPointerEvent(

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -722,9 +722,9 @@ inline int64_t ToPointerDataButtons(int64_t buttons,
       // These kinds of change must have a non-zero `buttons`, otherwise gesture
       // recognizers will ignore these events. To avoid breaking legacy
       // embedders, it synthesizes a primary button when seeing `button = 0` and
-      // log a warning to inform them to update.
+      // logs a warning to inform them to update.
       if (buttons == 0) {
-        // TODO(tongmu): Log a warning to inform the embedder to send the
+        // TODO: Log a warning to inform the embedder to send the
         // correct buttons. See
         // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
         return flutter::kPointerButtonMousePrimary;
@@ -767,7 +767,7 @@ FlutterEngineResult FlutterEngineSendPointerEvent(
         SAFE_ACCESS(current, signal_kind, kFlutterPointerSignalKindNone));
     pointer_data.scroll_delta_x = SAFE_ACCESS(current, scroll_delta_x, 0.0);
     pointer_data.scroll_delta_y = SAFE_ACCESS(current, scroll_delta_y, 0.0);
-    // TODO(tong): Change 0 to a SAFE_ACCESS to current.buttons once this
+    // TODO: Change 0 to a SAFE_ACCESS to current.buttons once this
     // field is added. See
     // https://github.com/flutter/flutter/issues/32052#issuecomment-489278965
     pointer_data.buttons = ToPointerDataButtons(0, pointer_data.change);


### PR DESCRIPTION
## Description

This PR is a placeholder for button support for embedders. Currently the embedder API does not have button information at all, which leads to `PointerData.buttons = 0` and blocks the corresponding framework change. This PR synthesizes a `buttons = kPrimaryButton` for events of down and move.

In the future when we have added `FlutterPointerEvent::buttons` (without breaking existing binaries), make sure to fix these 2 TODOs.

## Related issues
- Discussion: https://github.com/flutter/flutter/issues/31884
- Fixes: https://github.com/flutter/flutter/issues/32052
- Unblocks: https://github.com/flutter/flutter/pull/31935

