### PR TITLE
Remove more asserts and fix a11y check

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
@@ -42,13 +42,13 @@ public final class BasicMessageChannel<T> {
     public BasicMessageChannel(BinaryMessenger messenger, String name, MessageCodec<T> codec) {
         if (BuildConfig.DEBUG) {
             if (messenger == null) {
-                throw new AssertionError("Parameter messenger must not be null.");
+                Log.e(TAG, "Parameter messenger must not be null.");
             }
             if (name == null) {
-                throw new AssertionError("Parameter name must not be null.");
+                Log.e(TAG, "Parameter name must not be null.");
             }
             if (codec == null) {
-                throw new AssertionError("Parameter codec must not be null.");
+                Log.e(TAG, "Parameter codec must not be null.");
             }
         }
         this.messenger = messenger;

--- a/shell/platform/android/io/flutter/plugin/common/EventChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/EventChannel.java
@@ -59,13 +59,13 @@ public final class EventChannel {
     public EventChannel(BinaryMessenger messenger, String name, MethodCodec codec) {
         if (BuildConfig.DEBUG) {
             if (messenger == null) {
-                throw new AssertionError("Parameter messenger must not be null.");
+                Log.e(TAG, "Parameter messenger must not be null.");
             }
             if (name == null) {
-                throw new AssertionError("Parameter name must not be null.");
+                Log.e(TAG, "Parameter name must not be null.");
             }
             if (codec == null) {
-                throw new AssertionError("Parameter codec must not be null.");
+                Log.e(TAG, "Parameter codec must not be null.");
             }
         }
         this.messenger = messenger;

--- a/shell/platform/android/io/flutter/plugin/common/FlutterException.java
+++ b/shell/platform/android/io/flutter/plugin/common/FlutterException.java
@@ -4,6 +4,8 @@
 
 package io.flutter.plugin.common;
 
+import android.util.Log;
+
 import io.flutter.BuildConfig;
 
 /**

--- a/shell/platform/android/io/flutter/plugin/common/FlutterException.java
+++ b/shell/platform/android/io/flutter/plugin/common/FlutterException.java
@@ -10,13 +10,15 @@ import io.flutter.BuildConfig;
  * Thrown to indicate that a Flutter method invocation failed on the Flutter side.
  */
 public class FlutterException extends RuntimeException {
+  private static final String TAG = "FlutterException#";
+
   public final String code;
   public final Object details;
 
   FlutterException(String code, String message, Object details) {
     super(message);
     if (BuildConfig.DEBUG && code == null) {
-      throw new AssertionError("Parameter code must not be null.");
+      Log.e(TAG, "Parameter code must not be null.");
     }
     this.code = code;
     this.details = details;

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -58,13 +58,13 @@ public final class MethodChannel {
     public MethodChannel(BinaryMessenger messenger, String name, MethodCodec codec) {
         if (BuildConfig.DEBUG) {
             if (messenger == null) {
-                throw new AssertionError("Parameter messenger must not be null.");
+                Log.e(TAG, "Parameter messenger must not be null.");
             }
             if (name == null) {
-                throw new AssertionError("Parameter name must not be null.");
+                Log.e(TAG, "Parameter name must not be null.");
             }
             if (codec == null) {
-                throw new AssertionError("Parameter codec must not be null.");
+                Log.e(TAG, "Parameter codec must not be null.");
             }
         }
         this.messenger = messenger;

--- a/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@@ -60,6 +60,7 @@ import java.util.Map.Entry;
  * <p>To extend the codec, overwrite the writeValue and readValueOfType methods.</p>
  */
 public class StandardMessageCodec implements MessageCodec<Object> {
+    private static final String TAG = "StandardMessageCodec#";
     public static final StandardMessageCodec INSTANCE = new StandardMessageCodec();
 
     @Override
@@ -110,7 +111,7 @@ public class StandardMessageCodec implements MessageCodec<Object> {
      */
     protected static final void writeSize(ByteArrayOutputStream stream, int value) {
         if (BuildConfig.DEBUG && 0 > value) {
-            throw new AssertionError("Attempted to write a negative size.");
+            Log.e(TAG, "Attempted to write a negative size.");
         }
         if (value < 254) {
             stream.write(value);

--- a/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@@ -4,6 +4,8 @@
 
 package io.flutter.plugin.common;
 
+import android.util.Log;
+
 import io.flutter.BuildConfig;
 
 import java.io.ByteArrayOutputStream;

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1330,7 +1330,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                         if (object.scrollIndex + visibleChildren > object.scrollChildren) {
                             Log.e(TAG, "Scroll index is out of bounds.");
                         }
-                        if (object.childrenInHitTestOrder.get(object.scrollIndex).hasFlag(Flag.IS_HIDDEN)) {
+                        if (object.childrenInHitTestOrder.size() <= object.scrollIndex) {
+                            Log.e(TAG, String.format("Got a scroll index %d, but only %d children in hit test order.", object.scrollIndex, object.childrenInHitTestOrder.size()));
+                        } else if (object.childrenInHitTestOrder.get(object.scrollIndex).hasFlag(Flag.IS_HIDDEN)) {
                             Log.e(TAG, "Attempted to move Accessibility Focus to hidden child.");
                         }
                     }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1330,11 +1330,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                         if (object.scrollIndex + visibleChildren > object.scrollChildren) {
                             Log.e(TAG, "Scroll index is out of bounds.");
                         }
-                        if (object.childrenInHitTestOrder.size() <= object.scrollIndex) {
-                            Log.e(TAG, String.format("Got a scroll index %d, but only %d children in hit test order.", object.scrollIndex, object.childrenInHitTestOrder.size()));
-                        } else if (object.childrenInHitTestOrder.get(object.scrollIndex).hasFlag(Flag.IS_HIDDEN)) {
-                            Log.e(TAG, "Attempted to move Accessibility Focus to hidden child.");
-                        }
                     }
                     // The setToIndex should be the index of the last visible child. Because we counted all
                     // children, including the first index we need to subtract one.

--- a/shell/platform/android/io/flutter/view/ResourceExtractor.java
+++ b/shell/platform/android/io/flutter/view/ResourceExtractor.java
@@ -172,7 +172,7 @@ class ResourceExtractor {
 
     ResourceExtractor start() {
         if (BuildConfig.DEBUG && mExtractTask != null) {
-            throw new AssertionError("Attempted to start resource extraction while another extraction was in progress.");
+            Log.e(TAG, "Attempted to start resource extraction while another extraction was in progress.");
         }
         mExtractTask = new ExtractTask(mDataDirPath, mResources, mPackageName, mPackageManager, mAssetManager);
         mExtractTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);


### PR DESCRIPTION
This converts the rest of the `AssertionError` throws from my previous PR to `Log.e`.

Also fixes a `Log.e` in the accessibility bridge so that it won't itself throw if the index is out of range.

Makes https://github.com/flutter/flutter/issues/32047 not be a crasher/TODAY bug.