### PR TITLE
Standardize TimePoint implementaion on std::chrono

### DIFF
--- a/fml/time/time_point.cc
+++ b/fml/time/time_point.cc
@@ -6,51 +6,22 @@
 
 #include "flutter/fml/build_config.h"
 
-#if defined(OS_MACOSX) || defined(OS_IOS)
-#include <mach/kern_return.h>
-#include <mach/mach_time.h>
-#elif defined(OS_FUCHSIA)
+#if defined(OS_FUCHSIA)
 #include <zircon/syscalls.h>
-#elif defined(OS_WIN)
-#include <chrono>
 #else
-#include <time.h>
-#endif  // defined(OS_MACOSX) || defined(OS_IOS)
-
-#include "flutter/fml/logging.h"
+#include <chrono>
+#endif
 
 namespace fml {
 
-// Mac OS X/iOS don't have a (useful) |clock_gettime()|.
-// Note: Chromium's |base::TimeTicks::Now()| uses boot time (obtained via
-// |sysctl()| with |CTL_KERN|/|KERN_BOOTTIME|). For our current purposes,
-// monotonic time (which pauses during sleeps) is sufficient. TODO(vtl): If/when
-// we use this for other purposes, maybe we should use boot time (maybe also on
-// POSIX).
-#if defined(OS_MACOSX) || defined(OS_IOS)
-
-mach_timebase_info_data_t GetMachTimebaseInfo() {
-  mach_timebase_info_data_t timebase_info = {};
-  kern_return_t error = mach_timebase_info(&timebase_info);
-  FML_DCHECK(error == KERN_SUCCESS);
-  return timebase_info;
-}
-
-// static
-TimePoint TimePoint::Now() {
-  static mach_timebase_info_data_t timebase_info = GetMachTimebaseInfo();
-  return TimePoint(mach_absolute_time() * timebase_info.numer /
-                   timebase_info.denom);
-}
-
-#elif defined(OS_FUCHSIA)
+#if defined(OS_FUCHSIA)
 
 // static
 TimePoint TimePoint::Now() {
   return TimePoint(zx_clock_get(ZX_CLOCK_MONOTONIC));
 }
 
-#elif defined(OS_WIN)
+#else
 
 TimePoint TimePoint::Now() {
   // The base time is arbitrary; use the clock epoch for convenience.
@@ -60,17 +31,6 @@ TimePoint TimePoint::Now() {
           .count());
 }
 
-#else
-
-// static
-TimePoint TimePoint::Now() {
-  struct timespec ts;
-  int res = clock_gettime(CLOCK_MONOTONIC, &ts);
-  FML_DCHECK(res == 0);
-  (void)res;
-  return TimePoint::FromEpochDelta(TimeDelta::FromTimespec(ts));
-}
-
-#endif  // defined(OS_MACOSX) || defined(OS_IOS)
+#endif
 
 }  // namespace fml


### PR DESCRIPTION
In practice, the implementations of std::chrono seem to match our
implementations, so this makes the code simpler and easier to maintain,
as well as potentially improving over time without changes on our part.