### PR TITLE
Replace Skia font macros with enums.

### DIFF
--- a/flow/layers/performance_overlay_layer.cc
+++ b/flow/layers/performance_overlay_layer.cc
@@ -24,7 +24,7 @@ void DrawStatisticsText(SkCanvas& canvas,
   font.setSize(15);
   SkPaint paint;
   paint.setColor(SK_ColorGRAY);
-  canvas.drawSimpleText(string.c_str(), string.size(), kUTF8_SkTextEncoding, x,
+  canvas.drawSimpleText(string.c_str(), string.size(), SkTextEncoding::kUTF8, x,
                         y, font, paint);
 }
 

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -495,7 +495,7 @@ void Paragraph::Layout(double width, bool force) {
   SkFont font;
   font.setEdging(SkFont::Edging::kAntiAlias);
   font.setSubpixel(true);
-  font.setHinting(kSlight_SkFontHinting);
+  font.setHinting(SkFontHinting::kSlight);
 
   records_.clear();
   line_heights_.clear();


### PR DESCRIPTION
This mechanically replaces kXXX_SkTextEncoding with SkTextEncoding::kXXX
and kXXX_SkFontHinting with SkFontHinting::kXXX. This will allow Skia to
remove these old macro constants and get everyone on the new enums.