### PR TITLE
Minor: Wait on latch on same thread

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -583,7 +583,6 @@ void Shell::OnPlatformViewDestroyed() {
     // wasn't executed, and we just run it here as the platform thread
     // is the GPU thread.
     gpu_task();
-    latch.Wait();
   }
 }
 


### PR DESCRIPTION
Remove redundant `latch.Wait` for `OnPlatformViewDestroyed`