### PR TITLE
Fix iOS crash when in background for 3 minutes

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -94,6 +94,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
   _debugBackgroundTask = [application
       beginBackgroundTaskWithName:@"Flutter debug task"
                 expirationHandler:^{
+                  [application endBackgroundTask:_debugBackgroundTask];
                   FML_LOG(WARNING)
                       << "\nThe OS has terminated the Flutter debug connection for being "
                          "inactive in the background for too long.\n\n"


### PR DESCRIPTION
Fix iOS crash when in background for 3 minutes https://github.com/flutter/flutter/issues/32461

As mentioned in [Apple Document](https://developer.apple.com/documentation/uikit/uiapplication/1623031-beginbackgroundtask#parameters), the `expirationHandler` should be used to "to clean up and mark the end of the background task" and "failure to end the task explicitly will result in the termination of the app".

The bug is easily reproducible following the steps in https://github.com/flutter/flutter/issues/32461