### PR TITLE
Add a minimal set of symbols to the dynamic symbol table for Linux executables

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -73,6 +73,15 @@ config("config") {
   include_dirs = [ ".." ]
 }
 
+config("export_dynamic_symbols") {
+  if (is_linux) {
+    inputs = [
+      "$flutter_root/common/exported_symbols.sym",
+    ]
+    ldflags = [ "-Wl,--dynamic-list=" + rebase_path(inputs[0], root_build_dir) ]
+  }
+}
+
 group("dist") {
   testonly = true
 

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -50,6 +50,7 @@ FILE: ../../../flutter/assets/zip_asset_store.cc
 FILE: ../../../flutter/assets/zip_asset_store.h
 FILE: ../../../flutter/benchmarking/benchmarking.cc
 FILE: ../../../flutter/benchmarking/benchmarking.h
+FILE: ../../../flutter/common/exported_symbols.sym
 FILE: ../../../flutter/common/settings.cc
 FILE: ../../../flutter/common/settings.h
 FILE: ../../../flutter/common/task_runners.cc

--- a/common/exported_symbols.sym
+++ b/common/exported_symbols.sym
@@ -1,0 +1,8 @@
+# These symbols are looked up from within the executable at runtime and must
+# be exported in the dynamic symbol table.
+{
+  kDartVmSnapshotData;
+  kDartVmSnapshotInstructions;
+  kDartIsolateSnapshotData;
+  kDartIsolateSnapshotInstructions;
+};

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -126,6 +126,8 @@ source_set("runtime_unittests_common") {
 executable("runtime_unittests") {
   testonly = true
 
+  configs += [ "$flutter_root:export_dynamic_symbols" ]
+
   sources = [
     "dart_isolate_unittests.cc",
     "dart_lifecycle_unittests.cc",
@@ -136,8 +138,4 @@ executable("runtime_unittests") {
   deps = [
     ":runtime_unittests_common",
   ]
-
-  if (is_linux) {
-    ldflags = [ "-rdynamic" ]
-  }
 }

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -135,9 +135,7 @@ template("shell_host_executable") {
       "//third_party/tonic",
     ]
 
-    if (is_linux) {
-      ldflags += [ "-rdynamic" ]
-    }
+    public_configs = [ "$flutter_root:export_dynamic_symbols" ]
   }
 }
 

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -63,6 +63,8 @@ test_fixtures("fixtures") {
 executable("embedder_unittests") {
   testonly = true
 
+  configs += [ "$flutter_root:export_dynamic_symbols" ]
+
   include_dirs = [ "." ]
 
   sources = [
@@ -85,10 +87,6 @@ executable("embedder_unittests") {
     "//third_party/skia",
     "//third_party/tonic",
   ]
-
-  if (is_linux) {
-    ldflags = [ "-rdynamic" ]
-  }
 }
 
 shared_library("flutter_engine_library") {

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -9,7 +9,10 @@ executable("testing") {
 
   output_name = "flutter_tester"
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [
+    "$flutter_root:config",
+    "$flutter_root:export_dynamic_symbols",
+  ]
 
   sources = [
     "tester_main.cc",
@@ -33,9 +36,5 @@ executable("testing") {
       "//zircon/public/lib/trace",
       "//zircon/public/lib/trace-provider",
     ]
-  }
-
-  if (is_linux) {
-    ldflags = [ "-rdynamic" ]
   }
 }


### PR DESCRIPTION
This will reduce executable size.