### PR TITLE
Use Android text selection shifting API to delete

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -32,6 +32,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     private static final MethodChannel.Result logger =
         new ErrorLogResult("FlutterTextInput");
 
+    @SuppressWarnings("deprecation")
     public InputConnectionAdaptor(
         View view,
         int client,
@@ -44,7 +45,9 @@ class InputConnectionAdaptor extends BaseInputConnection {
         this.textInputChannel = textInputChannel;
         mEditable = editable;
         mBatchCount = 0;
-        mLayout = DynamicLayout.Builder.obtain(mEditable, new TextPaint(), Integer.MAX_VALUE).build();
+        // We create a dummy Layout with max width so that the selection
+        // shifting acts as if all text were in one line.
+        mLayout = new DynamicLayout(mEditable, new TextPaint(), Integer.MAX_VALUE, Layout.Alignment.ALIGN_NORMAL, 1.0f, 0.0f, false);
         mImm = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -5,8 +5,11 @@
 package io.flutter.plugin.editing;
 
 import android.content.Context;
+import android.text.DynamicLayout;
 import android.text.Editable;
+import android.text.Layout;
 import android.text.Selection;
+import android.text.TextPaint;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.BaseInputConnection;
@@ -24,6 +27,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     private final Editable mEditable;
     private int mBatchCount;
     private InputMethodManager mImm;
+    private final Layout mLayout;
 
     private static final MethodChannel.Result logger =
         new ErrorLogResult("FlutterTextInput");
@@ -40,6 +44,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
         this.textInputChannel = textInputChannel;
         mEditable = editable;
         mBatchCount = 0;
+        mLayout = DynamicLayout.Builder.obtain(mEditable, new TextPaint(), Integer.MAX_VALUE).build();
         mImm = (InputMethodManager) view.getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
     }
 
@@ -144,7 +149,8 @@ class InputConnectionAdaptor extends BaseInputConnection {
                     return true;
                 } else if (selStart > 0) {
                     // Delete to the left of the cursor.
-                    int newSel = Math.max(selStart - 1, 0);
+                    Selection.extendLeft(mEditable, mLayout);
+                    int newSel = Selection.getSelectionEnd(mEditable);
                     Selection.setSelection(mEditable, newSel);
                     mEditable.delete(newSel, selStart);
                     updateEditingState();


### PR DESCRIPTION
Previously, we were subtracting a hard coded 1 index from the selection.

Here, we make use of Android's capability of distinguishing grapheme clusters to properly shift over by one glyph.

This fixes Chinese keyboards not being able to delete emojis.

Fixes https://github.com/flutter/flutter/issues/23496