### PR TITLE
Add pipeline_state_observer interface

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -51,6 +51,8 @@ std::string Settings::ToString() const {
   stream << "icu_data_path: " << icu_data_path << std::endl;
   stream << "assets_dir: " << assets_dir << std::endl;
   stream << "assets_path: " << assets_path << std::endl;
+  stream << "pipeline_state_observer set: " << !!pipeline_state_observer
+         << std::endl;
   return stream.str();
 }
 

--- a/common/settings.h
+++ b/common/settings.h
@@ -15,6 +15,7 @@
 #include "flutter/fml/closure.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/unique_fd.h"
+#include "flutter/shell/common/pipeline.h"
 
 namespace flutter {
 
@@ -148,6 +149,12 @@ struct Settings {
   fml::UniqueFD::element_type assets_dir =
       fml::UniqueFD::traits_type::InvalidValue();
   std::string assets_path;
+
+  // An optional callback that allows the embedder to observe when pipeline
+  // items change state.  For example, it could be used to have access to
+  // pipeline item metrics in a region of code that has access to platform
+  // specific APIs.  Must be thread safe.
+  PipelineStateObserver pipeline_state_observer;
 
   std::string ToString() const;
 };

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -5,6 +5,7 @@
 #include "flutter/shell/common/animator.h"
 
 #include "flutter/fml/trace_event.h"
+#include "flutter/shell/common/pipeline.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 
 namespace flutter {
@@ -21,13 +22,16 @@ constexpr fml::TimeDelta kNotifyIdleTaskWaitTime =
 
 Animator::Animator(Delegate& delegate,
                    TaskRunners task_runners,
-                   std::unique_ptr<VsyncWaiter> waiter)
+                   std::unique_ptr<VsyncWaiter> waiter,
+                   PipelineStateObserver pipeline_state_observer)
     : delegate_(delegate),
       task_runners_(std::move(task_runners)),
       waiter_(std::move(waiter)),
       last_begin_frame_time_(),
       dart_frame_deadline_(0),
-      layer_tree_pipeline_(fml::MakeRefCounted<LayerTreePipeline>(2)),
+      layer_tree_pipeline_(fml::MakeRefCounted<LayerTreePipeline>(
+          2,
+          std::move(pipeline_state_observer))),
       pending_frame_semaphore_(1),
       frame_number_(1),
       paused_(false),

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -34,7 +34,8 @@ class Animator final {
 
   Animator(Delegate& delegate,
            TaskRunners task_runners,
-           std::unique_ptr<VsyncWaiter> waiter);
+           std::unique_ptr<VsyncWaiter> waiter,
+           PipelineStateObserver pipeline_state_observer);
 
   ~Animator();
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -118,15 +118,18 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
                          shared_snapshot = std::move(shared_snapshot),      //
                          vsync_waiter = std::move(vsync_waiter),            //
                          snapshot_delegate = std::move(snapshot_delegate),  //
-                         io_manager = io_manager->GetWeakPtr()              //
+                         io_manager = io_manager->GetWeakPtr(),             //
+                         pipeline_state_observer =                          //
+                             std::move(settings.pipeline_state_observer)    //
   ]() mutable {
         TRACE_EVENT0("flutter", "ShellSetupUISubsystem");
         const auto& task_runners = shell->GetTaskRunners();
 
         // The animator is owned by the UI thread but it gets its vsync pulses
         // from the platform.
-        auto animator = std::make_unique<Animator>(*shell, task_runners,
-                                                   std::move(vsync_waiter));
+        auto animator = std::make_unique<Animator>(
+            *shell, task_runners, std::move(vsync_waiter),
+            std::move(pipeline_state_observer));
 
         engine = std::make_unique<Engine>(*shell,                        //
                                           *shell->GetDartVM(),           //


### PR DESCRIPTION
Add a new pipeline observer interface, specified via an optionally set
|std::function| on |flutter::Settings|.  The callback is called by
|Pipeline|, and provides information similar to what is implied by the
existing pipeline flow events.  The difference between the flow events
and the new interface, is that this information is available at runtime
even when tracing isn't enabled, and can be sent to a region of code
that is able to call platform specific APIs.  For example, one might
want to provide this information to a system metrics API.

PT-154
CF-776