### PR TITLE
Add mode to load AOT snapshots as a native lib

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -77,11 +77,16 @@ public class FlutterMain {
     private static String sFlutterAssetsDir = DEFAULT_FLUTTER_ASSETS_DIR;
 
     private static boolean sInitialized = false;
+    private static boolean sIsPrecompiledAsBlobs = false;
+    private static boolean sIsPrecompiledAsSharedLibrary = false;
+
+    @Nullable
     private static ResourceExtractor sResourceExtractor;
-    private static boolean sIsPrecompiledAsBlobs;
-    private static boolean sIsPrecompiledAsSharedLibrary;
+    @Nullable
     private static Settings sSettings;
+    @NonNull
     private static String sSnapshotPath;
+
 
     private static final class ImmutableSetBuilder<T> {
         static <T> ImmutableSetBuilder<T> newInstance() {

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -296,24 +296,24 @@ public class FlutterMain {
             throw new RuntimeException(e);
         }
 
-        String sAotVmSnapshotDataLib = "lib_" + sAotVmSnapshotData + ".so";
-        String sAotVmSnapshotInstrLib = "lib_" + sAotVmSnapshotInstr + ".so";
-        String sAotIsolateSnapshotDataLib = "lib_" + sAotIsolateSnapshotData + ".so";
-        String sAotIsolateSnapshotInstrLib = "lib_" + sAotIsolateSnapshotInstr + ".so";
+        String aotVmSnapshotDataLib = "lib_" + sAotVmSnapshotData + ".so";
+        String aotVmSnapshotInstrLib = "lib_" + sAotVmSnapshotInstr + ".so";
+        String aotIsolateSnapshotDataLib = "lib_" + sAotIsolateSnapshotData + ".so";
+        String aotIsolateSnapshotInstrLib = "lib_" + sAotIsolateSnapshotInstr + ".so";
 
-        sIsPrecompiledAsBlobs = listLibs(applicationContext)
+        sIsPrecompiledAsBlobLibraries = listLibs(applicationContext)
             .containsAll(Arrays.asList(
-                sAotVmSnapshotDataLib,
-                sAotVmSnapshotInstrLib,
-                sAotIsolateSnapshotDataLib,
-                sAotIsolateSnapshotInstrLib
+                aotVmSnapshotDataLib,
+                aotVmSnapshotInstrLib,
+                aotIsolateSnapshotDataLib,
+                aotIsolateSnapshotInstrLib
             ));
 
-        if (sIsPrecompiledAsBlobs) {
-            sAotVmSnapshotData = sAotVmSnapshotDataLib;
-            sAotVmSnapshotInstr = sAotVmSnapshotInstrLib;
-            sAotIsolateSnapshotData = sAotIsolateSnapshotDataLib;
-            sAotIsolateSnapshotInstr = sAotIsolateSnapshotInstrLib;
+        if (sIsPrecompiledAsBlobLibraries) {
+            sAotVmSnapshotData = aotVmSnapshotDataLib;
+            sAotVmSnapshotInstr = aotVmSnapshotInstrLib;
+            sAotIsolateSnapshotData = aotIsolateSnapshotDataLib;
+            sAotIsolateSnapshotInstr = aotIsolateSnapshotInstrLib;
         }
     }
 

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -291,6 +291,8 @@ public class FlutterMain {
     private static void initConfig(@NonNull Context applicationContext) {
         Bundle metadata = getApplicationInfo(applicationContext).metaData;
 
+        // There isn't a `<meta-data>` tag as a direct child of `<application>` in
+        // `AndroidManifest.xml`.
         if (metadata == null) {
             return;
         }
@@ -304,6 +306,10 @@ public class FlutterMain {
         sAotIsolateSnapshotInstr = metadata.getString(PUBLIC_AOT_ISOLATE_SNAPSHOT_INSTR_KEY, DEFAULT_AOT_ISOLATE_SNAPSHOT_INSTR);
     }
 
+    /**
+     * Extract the AOT blobs from the app's asset directory. 
+     * This is required by the Dart runtime, so it can read the blobs.
+     */
     private static void initResources(@NonNull Context applicationContext) {
         // When the AOT blobs are contained in the native library directory, 
         // we don't need to extract them manually because they are 
@@ -312,13 +318,12 @@ public class FlutterMain {
             return;
         }
 
-        Context context = applicationContext;
-        new ResourceCleaner(context).start();
+        new ResourceCleaner(applicationContext).start();
 
-        final String dataDirPath = PathUtils.getDataDirectory(context);
-        final String packageName = context.getPackageName();
-        final PackageManager packageManager = context.getPackageManager();
-        final AssetManager assetManager = context.getResources().getAssets();
+        final String dataDirPath = PathUtils.getDataDirectory(applicationContext);
+        final String packageName = applicationContext.getPackageName();
+        final PackageManager packageManager = applicationContext.getPackageManager();
+        final AssetManager assetManager = applicationContext.getResources().getAssets();
         sResourceExtractor = new ResourceExtractor(dataDirPath, packageName, packageManager, assetManager);
 
         sResourceExtractor

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -369,7 +369,7 @@ public class FlutterMain {
         String aotIsolateSnapshotDataLib = "lib_" + sAotIsolateSnapshotData + ".so";
         String aotIsolateSnapshotInstrLib = "lib_" + sAotIsolateSnapshotInstr + ".so";
 
-        Boolean isPrecompiledBlobInLib = libs
+        boolean isPrecompiledBlobInLib = libs
             .containsAll(Arrays.asList(
                 aotVmSnapshotDataLib,
                 aotVmSnapshotInstrLib,
@@ -392,8 +392,8 @@ public class FlutterMain {
             ));
         }
 
-        Boolean isSharedLibraryInLib = libs.contains(sAotSharedLibraryPath);
-        Boolean isSharedLibraryInAssets = assets.contains(sAotSharedLibraryPath);
+        boolean isSharedLibraryInLib = libs.contains(sAotSharedLibraryPath);
+        boolean isSharedLibraryInAssets = assets.contains(sAotSharedLibraryPath);
 
         if (isSharedLibraryInLib || isSharedLibraryInAssets) {
             sIsPrecompiledAsSharedLibrary = true;

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -186,7 +186,8 @@ public class FlutterMain {
             return;
         }
         try {
-            // Don't wait for the extractor 
+            // There are resources to extract. For example, the AOT blobs from the `assets` directory.
+            // `sResourceExtractor` is `null` if there isn't any AOT blob to extract.
             if (sResourceExtractor != null) {
                 sResourceExtractor.waitForCompletion();
             }

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -60,7 +60,6 @@ public class FlutterMain {
     private static final String DEFAULT_LIBRARY = "libflutter.so";
     private static final String DEFAULT_KERNEL_BLOB = "kernel_blob.bin";
     private static final String DEFAULT_FLUTTER_ASSETS_DIR = "flutter_assets";
-    private static final Boolean DEFAULT_AOT_ABI_SPLIT = false;
 
     private static String fromFlutterAssets(String filePath) {
         return sFlutterAssetsDir + File.separator + filePath;
@@ -212,7 +211,7 @@ public class FlutterMain {
                 shellArgs.add("--" + AOT_VM_SNAPSHOT_DATA_KEY + "=" + sAotVmSnapshotData);
                 shellArgs.add("--" + AOT_VM_SNAPSHOT_INSTR_KEY + "=" + sAotVmSnapshotInstr);
                 shellArgs.add("--" + AOT_ISOLATE_SNAPSHOT_DATA_KEY + "=" + sAotIsolateSnapshotData);
-                shellArgs.add("--" + AOT_ISOLATE_SNAPSHOT_INSTR_KEY + "=" + sAotIsolateSnapshotInstr); 
+                shellArgs.add("--" + AOT_ISOLATE_SNAPSHOT_INSTR_KEY + "=" + sAotIsolateSnapshotInstr);
             }
 
             if (sSettings.getLogTag() != null) {

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -4,17 +4,19 @@
 
 package io.flutter.view;
 
+import android.app.AlarmManager;
+import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
-import android.app.AlarmManager;
-import android.app.PendingIntent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import io.flutter.util.PathUtils;
 
@@ -61,7 +63,8 @@ public class FlutterMain {
     private static final String DEFAULT_KERNEL_BLOB = "kernel_blob.bin";
     private static final String DEFAULT_FLUTTER_ASSETS_DIR = "flutter_assets";
 
-    private static String fromFlutterAssets(String filePath) {
+    @NonNull
+    private static String fromFlutterAssets(@NonNull String filePath) {
         return sFlutterAssetsDir + File.separator + filePath;
     }
 
@@ -89,19 +92,22 @@ public class FlutterMain {
 
         private ImmutableSetBuilder() {}
 
-        ImmutableSetBuilder<T> add(T element) {
+        @NonNull
+        ImmutableSetBuilder<T> add(@NonNull T element) {
             set.add(element);
             return this;
         }
 
         @SafeVarargs
-        final ImmutableSetBuilder<T> add(T... elements) {
+        @NonNull
+        final ImmutableSetBuilder<T> add(@NonNull T... elements) {
             for (T element : elements) {
                 set.add(element);
             }
             return this;
         }
 
+        @NonNull
         Set<T> build() {
             return Collections.unmodifiableSet(set);
         }
@@ -110,6 +116,7 @@ public class FlutterMain {
     public static class Settings {
         private String logTag;
 
+        @Nullable
         public String getLogTag() {
             return logTag;
         }
@@ -127,7 +134,7 @@ public class FlutterMain {
      * Starts initialization of the native system.
      * @param applicationContext The Android application context.
      */
-    public static void startInitialization(Context applicationContext) {
+    public static void startInitialization(@NonNull Context applicationContext) {
         startInitialization(applicationContext, new Settings());
     }
 
@@ -136,7 +143,7 @@ public class FlutterMain {
      * @param applicationContext The Android application context.
      * @param settings Configuration settings.
      */
-    public static void startInitialization(Context applicationContext, Settings settings) {
+    public static void startInitialization(@NonNull Context applicationContext, @NonNull Settings settings) {
         if (Looper.myLooper() != Looper.getMainLooper()) {
           throw new IllegalStateException("startInitialization must be called on the main thread");
         }
@@ -168,7 +175,7 @@ public class FlutterMain {
      * @param applicationContext The Android application context.
      * @param args Flags sent to the Flutter runtime.
      */
-    public static void ensureInitializationComplete(Context applicationContext, String[] args) {
+    public static void ensureInitializationComplete(@NonNull Context applicationContext, @Nullable String[] args) {
         if (Looper.myLooper() != Looper.getMainLooper()) {
           throw new IllegalStateException("ensureInitializationComplete must be called on the main thread");
         }
@@ -179,6 +186,7 @@ public class FlutterMain {
             return;
         }
         try {
+            // Don't wait for the extractor 
             if (sResourceExtractor != null) {
                 sResourceExtractor.waitForCompletion();
             }
@@ -230,10 +238,10 @@ public class FlutterMain {
      * thread, then invoking {@code callback} on the {@code callbackHandler}.
      */
     public static void ensureInitializationCompleteAsync(
-        Context applicationContext,
-        String[] args,
-        Handler callbackHandler,
-        Runnable callback
+        @NonNull Context applicationContext,
+        @Nullable String[] args,
+        @NonNull Handler callbackHandler,
+        @NonNull Runnable callback
     ) {
         if (Looper.myLooper() != Looper.getMainLooper()) {
             throw new IllegalStateException("ensureInitializationComplete must be called on the main thread");
@@ -244,7 +252,6 @@ public class FlutterMain {
         if (sInitialized) {
             return;
         }
-
         new Thread(new Runnable() {
             @Override
             public void run() {
@@ -265,7 +272,8 @@ public class FlutterMain {
     private static native void nativeInit(Context context, String[] args, String bundlePath, String appStoragePath, String engineCachesPath);
     private static native void nativeRecordStartTimestamp(long initTimeMillis);
 
-    private static ApplicationInfo getApplicationInfo(Context applicationContext) {
+    @NonNull
+    private static ApplicationInfo getApplicationInfo(@NonNull Context applicationContext) {
         try {
             return applicationContext
                 .getPackageManager()
@@ -279,23 +287,26 @@ public class FlutterMain {
      * Initialize our Flutter config values by obtaining them from the
      * manifest XML file, falling back to default values.
      */
-    private static void initConfig(Context applicationContext) {
+    private static void initConfig(@NonNull Context applicationContext) {
         Bundle metadata = getApplicationInfo(applicationContext).metaData;
 
-        if (metadata != null) {
-            sAotSharedLibraryPath = metadata.getString(PUBLIC_AOT_AOT_SHARED_LIBRARY_PATH, DEFAULT_AOT_SHARED_LIBRARY_PATH);
-            sFlutterAssetsDir = metadata.getString(PUBLIC_FLUTTER_ASSETS_DIR_KEY, DEFAULT_FLUTTER_ASSETS_DIR);
-
-            sAotVmSnapshotData = metadata.getString(PUBLIC_AOT_VM_SNAPSHOT_DATA_KEY, DEFAULT_AOT_VM_SNAPSHOT_DATA);
-            sAotVmSnapshotInstr = metadata.getString(PUBLIC_AOT_VM_SNAPSHOT_INSTR_KEY, DEFAULT_AOT_VM_SNAPSHOT_INSTR);
-            sAotIsolateSnapshotData = metadata.getString(PUBLIC_AOT_ISOLATE_SNAPSHOT_DATA_KEY, DEFAULT_AOT_ISOLATE_SNAPSHOT_DATA);
-            sAotIsolateSnapshotInstr = metadata.getString(PUBLIC_AOT_ISOLATE_SNAPSHOT_INSTR_KEY, DEFAULT_AOT_ISOLATE_SNAPSHOT_INSTR);
+        if (metadata == null) {
+            return;
         }
+
+        sAotSharedLibraryPath = metadata.getString(PUBLIC_AOT_AOT_SHARED_LIBRARY_PATH, DEFAULT_AOT_SHARED_LIBRARY_PATH);
+        sFlutterAssetsDir = metadata.getString(PUBLIC_FLUTTER_ASSETS_DIR_KEY, DEFAULT_FLUTTER_ASSETS_DIR);
+
+        sAotVmSnapshotData = metadata.getString(PUBLIC_AOT_VM_SNAPSHOT_DATA_KEY, DEFAULT_AOT_VM_SNAPSHOT_DATA);
+        sAotVmSnapshotInstr = metadata.getString(PUBLIC_AOT_VM_SNAPSHOT_INSTR_KEY, DEFAULT_AOT_VM_SNAPSHOT_INSTR);
+        sAotIsolateSnapshotData = metadata.getString(PUBLIC_AOT_ISOLATE_SNAPSHOT_DATA_KEY, DEFAULT_AOT_ISOLATE_SNAPSHOT_DATA);
+        sAotIsolateSnapshotInstr = metadata.getString(PUBLIC_AOT_ISOLATE_SNAPSHOT_INSTR_KEY, DEFAULT_AOT_ISOLATE_SNAPSHOT_INSTR);
     }
 
-    private static void initResources(Context applicationContext) {
-        // The snapshots are loaded as native libs by the Android Package Manager, 
-        // so we don't need to extract them using ResourceExtractor.
+    private static void initResources(@NonNull Context applicationContext) {
+        // When the AOT blobs are contained in the native library directory, 
+        // we don't need to extract them manually because they are 
+        // extracted by the Android Package Manager automatically.
         if (!sSnapshotPath.equals(PathUtils.getDataDirectory(applicationContext))) {
             return;
         }
@@ -333,7 +344,8 @@ public class FlutterMain {
      * Returns a list of the file names at the root of the application's asset
      * path.
      */
-    private static Set<String> listAssets(Context applicationContext, String path) {
+    @NonNull
+    private static Set<String> listAssets(@NonNull Context applicationContext, @NonNull String path) {
         AssetManager manager = applicationContext.getResources().getAssets();
         try {
             return ImmutableSetBuilder.<String>newInstance()
@@ -347,9 +359,10 @@ public class FlutterMain {
 
     /**
      * Returns a list of the file names at the root of the application's 
-     * native library path.
+     * native library directory.
      */
-    private static Set<String> listLibs(Context applicationContext) {
+    @NonNull
+    private static Set<String> listLibs(@NonNull Context applicationContext) {
         ApplicationInfo applicationInfo = getApplicationInfo(applicationContext);
         File[] files = new File(applicationInfo.nativeLibraryDir).listFiles();
         
@@ -360,7 +373,30 @@ public class FlutterMain {
         return builder.build();
     }
 
-    private static void initAot(Context applicationContext) {
+    /**
+     * Determines if the APK contains a shared library or AOT snapshots, 
+     * the file name of the snapshots and the directory where they are contained.
+     *
+     * <p>The snapshots can be contained in the app's assets or in the native library 
+     * directory. The default names are:
+     *
+     * <ul>
+     * <li>`vm_snapshot_data`</li>
+     * <li>`vm_snapshot_instr`</li>
+     * <li>`isolate_snapshot_data`</li>
+     * <li>`isolate_snapshot_instr`</li>
+     * <li> Shared library: `app.so`</li>
+     * </ul>
+     *
+     * <p>When the blobs are contained in the native library directory,
+     * the format <b>`lib_%s.so`</b> is applied to the file name.
+     *
+     * <p>Note: The name of the files can be customized in the app's metadata, but the 
+     * format is preserved.
+     *
+     * <p>The AOT snapshots and the shared library cannot exist at the same time in the APK.
+     */
+    private static void initAot(@NonNull Context applicationContext) {
         Set<String> assets = listAssets(applicationContext, "");
         Set<String> libs = listLibs(applicationContext);
 
@@ -368,6 +404,7 @@ public class FlutterMain {
         String aotVmSnapshotInstrLib = "lib_" + sAotVmSnapshotInstr + ".so";
         String aotIsolateSnapshotDataLib = "lib_" + sAotIsolateSnapshotData + ".so";
         String aotIsolateSnapshotInstrLib = "lib_" + sAotIsolateSnapshotInstr + ".so";
+        String aotSharedLibraryLib = "lib_" + sAotSharedLibraryPath + ".so";
 
         boolean isPrecompiledBlobInLib = libs
             .containsAll(Arrays.asList(
@@ -391,11 +428,13 @@ public class FlutterMain {
                 sAotIsolateSnapshotInstr
             ));
         }
-
-        boolean isSharedLibraryInLib = libs.contains(sAotSharedLibraryPath);
+        boolean isSharedLibraryInLib = libs.contains(aotSharedLibraryLib);
         boolean isSharedLibraryInAssets = assets.contains(sAotSharedLibraryPath);
 
-        if (isSharedLibraryInLib || isSharedLibraryInAssets) {
+        if (isSharedLibraryInLib) {
+            sAotSharedLibraryPath = aotSharedLibraryLib;
+            sIsPrecompiledAsSharedLibrary = true;
+        } else if (isSharedLibraryInAssets) {
             sIsPrecompiledAsSharedLibrary = true;
         }
 
@@ -415,7 +454,8 @@ public class FlutterMain {
         return sIsPrecompiledAsBlobs || sIsPrecompiledAsSharedLibrary;
     }
 
-    public static String findAppBundlePath(Context applicationContext) {
+    @Nullable
+    public static String findAppBundlePath(@NonNull Context applicationContext) {
         String dataDirectory = PathUtils.getDataDirectory(applicationContext);
         File appBundle = new File(dataDirectory, sFlutterAssetsDir);
         return appBundle.exists() ? appBundle.getPath() : null;
@@ -429,7 +469,8 @@ public class FlutterMain {
      * @param asset the name of the asset. The name can be hierarchical
      * @return      the filename to be used with {@link android.content.res.AssetManager}
      */
-    public static String getLookupKeyForAsset(String asset) {
+    @NonNull
+    public static String getLookupKeyForAsset(@NonNull String asset) {
         return fromFlutterAssets(asset);
     }
 
@@ -442,7 +483,8 @@ public class FlutterMain {
      * @param packageName the name of the package from which the asset originates
      * @return            the file name to be used with {@link android.content.res.AssetManager}
      */
-    public static String getLookupKeyForAsset(String asset, String packageName) {
+    @NonNull
+    public static String getLookupKeyForAsset(@NonNull String asset, @NonNull String packageName) {
         return getLookupKeyForAsset(
             "packages" + File.separator + packageName + File.separator + asset);
     }


### PR DESCRIPTION
This enables a new mode in which we look at the snapshot from the `lib/` directory instead of `assets`.  This is required so that an app bundle `.aab` can contain AOT snapshots for arm and arm64 and users will only download the snapshots needed for the user's device ABI.

Tested=Manually.

As discussed, we need to add tests to the embedder, but there is some pending work here.


Related issue: https://github.com/flutter/flutter/issues/31922

\cc @dnfield