### PR TITLE
Add onReportTimings and FrameRasterizedCallback API

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -8,6 +8,8 @@
 
 namespace flutter {
 
+constexpr FrameTiming::Phase FrameTiming::kPhases[FrameTiming::kCount];
+
 Settings::Settings() = default;
 
 Settings::Settings(const Settings& other) = default;
@@ -51,6 +53,8 @@ std::string Settings::ToString() const {
   stream << "icu_data_path: " << icu_data_path << std::endl;
   stream << "assets_dir: " << assets_dir << std::endl;
   stream << "assets_path: " << assets_path << std::endl;
+  stream << "frame_rasterized_callback set: " << !!frame_rasterized_callback
+         << std::endl;
   return stream.str();
 }
 

--- a/common/settings.h
+++ b/common/settings.h
@@ -14,9 +14,26 @@
 
 #include "flutter/fml/closure.h"
 #include "flutter/fml/mapping.h"
+#include "flutter/fml/time/time_point.h"
 #include "flutter/fml/unique_fd.h"
 
 namespace flutter {
+
+class FrameTiming {
+ public:
+  enum Phase { kBuildStart, kBuildFinish, kRasterStart, kRasterFinish, kCount };
+
+  static constexpr Phase kPhases[kCount] = {kBuildStart, kBuildFinish,
+                                            kRasterStart, kRasterFinish};
+
+  fml::TimePoint Get(Phase phase) const { return data_[phase]; }
+  fml::TimePoint Set(Phase phase, fml::TimePoint value) {
+    return data_[phase] = value;
+  }
+
+ private:
+  fml::TimePoint data_[kCount];
+};
 
 using TaskObserverAdd =
     std::function<void(intptr_t /* key */, fml::closure /* callback */)>;
@@ -31,6 +48,8 @@ using UnhandledExceptionCallback =
 using MappingCallback = std::function<std::unique_ptr<fml::Mapping>(void)>;
 using MappingsCallback =
     std::function<std::vector<std::unique_ptr<const fml::Mapping>>(void)>;
+
+using FrameRasterizedCallback = std::function<void(const FrameTiming&)>;
 
 struct Settings {
   Settings();
@@ -148,6 +167,10 @@ struct Settings {
   fml::UniqueFD::element_type assets_dir =
       fml::UniqueFD::traits_type::InvalidValue();
   std::string assets_path;
+
+  // Callback to handle the timings of a rasterized frame. This is called as
+  // soon as a frame is rasterized.
+  FrameRasterizedCallback frame_rasterized_callback;
 
   std::string ToString() const;
 };

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -19,6 +19,11 @@ LayerTree::LayerTree()
 
 LayerTree::~LayerTree() = default;
 
+void LayerTree::RecordBuildTime(fml::TimePoint start) {
+  build_start_ = start;
+  build_finish_ = fml::TimePoint::Now();
+}
+
 void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
                         bool ignore_raster_cache) {
   TRACE_EVENT0("flutter", "LayerTree::Preroll");

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -47,11 +47,10 @@ class LayerTree {
 
   void set_frame_size(const SkISize& frame_size) { frame_size_ = frame_size; }
 
-  void set_construction_time(const fml::TimeDelta& delta) {
-    construction_time_ = delta;
-  }
-
-  const fml::TimeDelta& construction_time() const { return construction_time_; }
+  void RecordBuildTime(fml::TimePoint begin_start);
+  fml::TimePoint build_start() const { return build_start_; }
+  fml::TimePoint build_finish() const { return build_finish_; }
+  fml::TimeDelta build_time() const { return build_finish_ - build_start_; }
 
   // The number of frame intervals missed after which the compositor must
   // trace the rasterized picture to a trace file. Specify 0 to disable all
@@ -75,7 +74,8 @@ class LayerTree {
  private:
   SkISize frame_size_;  // Physical pixels.
   std::shared_ptr<Layer> root_layer_;
-  fml::TimeDelta construction_time_;
+  fml::TimePoint build_start_;
+  fml::TimePoint build_finish_;
   uint32_t rasterizer_tracing_threshold_;
   bool checkerboard_raster_cache_images_;
   bool checkerboard_offscreen_layers_;

--- a/lib/stub_ui/lib/src/ui/window.dart
+++ b/lib/stub_ui/lib/src/ui/window.dart
@@ -66,7 +66,14 @@ enum FramePhase {
 /// Therefore it's recommended to only monitor and analyze performance metrics
 /// in profile and release modes.
 class FrameTiming {
-  FrameTiming._(List<int> timestamps)
+  /// Construct [FrameTiming] with raw timestamps in microseconds.
+  ///
+  /// List [timestamps] must have the same number of elements as
+  /// [FramePhase.values].
+  ///
+  /// This constructor is usually only called by the Flutter engine, or a test.
+  /// To get the [FrameTiming] of your app, see [Window.onReportTimings].
+  FrameTiming(List<int> timestamps)
       : assert(timestamps.length == FramePhase.values.length), _timestamps = timestamps;
 
   /// This is a raw timestamp in microseconds from some epoch. The epoch in all
@@ -109,15 +116,11 @@ class FrameTiming {
 
   final List<int> _timestamps;  // in microseconds
 
+  String _formatMS(Duration duration) => '${duration.inMicroseconds * 0.001}ms';
+
   @override
   String toString() {
-    return '''
-$runtimeType(
-  buildDuration: $buildDuration,
-  rasterDuration: $rasterDuration,
-  totalSpan: $totalSpan,
-  timestamps: $_timestamps,
-)''';
+    return '$runtimeType(buildDuration: ${_formatMS(buildDuration)}, rasterDuration: ${_formatMS(rasterDuration)}, totalSpan: ${_formatMS(totalSpan)})';
   }
 }
 

--- a/lib/stub_ui/lib/src/ui/window.dart
+++ b/lib/stub_ui/lib/src/ui/window.dart
@@ -32,6 +32,95 @@ typedef PlatformMessageResponseCallback = void Function(ByteData data);
 typedef PlatformMessageCallback = void Function(
     String name, ByteData data, PlatformMessageResponseCallback callback);
 
+/// Various important time points in the lifetime of a frame.
+///
+/// [FrameTiming] records a timestamp of each phase for performance analysis.
+enum FramePhase {
+  /// When the UI thread starts building a frame.
+  ///
+  /// See also [FrameTiming.buildDuration].
+  buildStart,
+
+  /// When the UI thread finishes building a frame.
+  ///
+  /// See also [FrameTiming.buildDuration].
+  buildFinish,
+
+  /// When the GPU thread starts rasterizing a frame.
+  ///
+  /// See also [FrameTiming.rasterDuration].
+  rasterStart,
+
+  /// When the GPU thread finishes rasterizing a frame.
+  ///
+  /// See also [FrameTiming.rasterDuration].
+  rasterFinish,
+}
+
+/// Time-related performance metrics of a frame.
+///
+/// See [Window.onReportTimings] for how to get this.
+///
+/// The metrics in debug mode (`flutter run` without any flags) may be very
+/// different from those in profile and release modes due to the debug overhead.
+/// Therefore it's recommended to only monitor and analyze performance metrics
+/// in profile and release modes.
+class FrameTiming {
+  FrameTiming._(List<int> timestamps)
+      : assert(timestamps.length == FramePhase.values.length), _timestamps = timestamps;
+
+  /// This is a raw timestamp in microseconds from some epoch. The epoch in all
+  /// [FrameTiming] is the same, but it may not match [DateTime]'s epoch.
+  int timestampInMicroseconds(FramePhase phase) => _timestamps[phase.index];
+
+  Duration _rawDuration(FramePhase phase) => Duration(microseconds: _timestamps[phase.index]);
+
+  /// The duration to build the frame on the UI thread.
+  ///
+  /// The build starts approximately when [Window.onBeginFrame] is called. The
+  /// [Duration] in the [Window.onBeginFrame] callback is exactly the
+  /// `Duration(microseconds: timestampInMicroseconds(FramePhase.buildStart))`.
+  ///
+  /// The build finishes when [Window.render] is called.
+  ///
+  /// {@template dart.ui.FrameTiming.fps_smoothness_milliseconds}
+  /// To ensure smooth animations of X fps, this should not exceed 1000/X
+  /// milliseconds.
+  /// {@endtemplate}
+  /// {@template dart.ui.FrameTiming.fps_milliseconds}
+  /// That's about 16ms for 60fps, and 8ms for 120fps.
+  /// {@endtemplate}
+  Duration get buildDuration => _rawDuration(FramePhase.buildFinish) - _rawDuration(FramePhase.buildStart);
+
+  /// The duration to rasterize the frame on the GPU thread.
+  ///
+  /// {@macro dart.ui.FrameTiming.fps_smoothness_milliseconds}
+  /// {@macro dart.ui.FrameTiming.fps_milliseconds}
+  Duration get rasterDuration => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.rasterStart);
+
+  /// The timespan between build start and raster finish.
+  ///
+  /// To achieve the lowest latency on an X fps display, this should not exceed
+  /// 1000/X milliseconds.
+  /// {@macro dart.ui.FrameTiming.fps_milliseconds}
+  ///
+  /// See also [buildDuration] and [rasterDuration].
+  Duration get totalSpan => _rawDuration(FramePhase.rasterFinish) - _rawDuration(FramePhase.buildStart);
+
+  final List<int> _timestamps;  // in microseconds
+
+  @override
+  String toString() {
+    return '''
+$runtimeType(
+  buildDuration: $buildDuration,
+  rasterDuration: $rasterDuration,
+  totalSpan: $totalSpan,
+  timestamps: $_timestamps,
+)''';
+  }
+}
+
 /// States that an application can be in.
 ///
 /// The values below describe notifications from the operating system.
@@ -769,6 +858,30 @@ abstract class Window {
   VoidCallback _onDrawFrame;
   set onDrawFrame(VoidCallback callback) {
     _onDrawFrame = callback;
+  }
+
+  /// A callback that is invoked to report the [FrameTiming] of recently
+  /// rasterized frames.
+  ///
+  /// This can be used to see if the application has missed frames (through
+  /// [FrameTiming.buildDuration] and [FrameTiming.rasterDuration]), or high
+  /// latencies (through [FrameTiming.totalSpan]).
+  ///
+  /// Unlike [Timeline], the timing information here is available in the release
+  /// mode (additional to the profile and the debug mode). Hence this can be
+  /// used to monitor the application's performance in the wild.
+  ///
+  /// The callback may not be immediately triggered after each frame. Instead,
+  /// it tries to batch frames together and send all their timings at once to
+  /// decrease the overhead (as this is available in the release mode). The
+  /// timing of any frame will be sent within about 1 second even if there are
+  /// no later frames to batch.
+  TimingsCallback get onReportTimings => _onReportTimings;
+  TimingsCallback _onReportTimings;
+  Zone _onReportTimingsZone;
+  set onReportTimings(TimingsCallback callback) {
+    _onReportTimings = callback;
+    _onReportTimingsZone = Zone.current;
   }
 
   /// A callback that is invoked when pointer data is available.

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -179,6 +179,17 @@ void _beginFrame(int microseconds) {
 
 @pragma('vm:entry-point')
 // ignore: unused_element
+void _reportTimings(List<int> timings) {
+  assert(timings.length % FramePhase.values.length == 0);
+  final List<FrameTiming> frameTimings = <FrameTiming>[];
+  for (int i = 0; i < timings.length; i += FramePhase.values.length) {
+    frameTimings.add(FrameTiming(timings.sublist(i, i + FramePhase.values.length)));
+  }
+  _invoke1(window.onReportTimings, window._onReportTimingsZone, frameTimings);
+}
+
+@pragma('vm:entry-point')
+// ignore: unused_element
 void _drawFrame() {
   _invoke(window.onDrawFrame, window._onDrawFrameZone);
 }

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -19,6 +19,16 @@
 
 namespace tonic {
 class DartLibraryNatives;
+
+// So tonice::ToDart<std::vector<int64_t>> returns List<int> instead of
+// List<dynamic>.
+template <>
+struct DartListFactory<int64_t> {
+  static Dart_Handle NewList(intptr_t length) {
+    return Dart_NewListOf(Dart_CoreType_Int, length);
+  }
+};
+
 }  // namespace tonic
 
 namespace flutter {
@@ -46,6 +56,7 @@ class WindowClient {
   virtual FontCollection& GetFontCollection() = 0;
   virtual void UpdateIsolateDescription(const std::string isolate_name,
                                         int64_t isolate_port) = 0;
+  virtual void SetNeedsReportTimings(bool value) = 0;
 
  protected:
   virtual ~WindowClient();
@@ -74,6 +85,7 @@ class Window final {
                                SemanticsAction action,
                                std::vector<uint8_t> args);
   void BeginFrame(fml::TimePoint frameTime);
+  void ReportTimings(std::vector<int64_t> timings);
 
   void CompletePlatformMessageResponse(int response_id,
                                        std::vector<uint8_t> data);

--- a/runtime/runtime_controller.cc
+++ b/runtime/runtime_controller.cc
@@ -231,6 +231,14 @@ bool RuntimeController::BeginFrame(fml::TimePoint frame_time) {
   return false;
 }
 
+bool RuntimeController::ReportTimings(std::vector<int64_t> timings) {
+  if (auto* window = GetWindowIfAvailable()) {
+    window->ReportTimings(std::move(timings));
+    return true;
+  }
+  return false;
+}
+
 bool RuntimeController::NotifyIdle(int64_t deadline) {
   std::shared_ptr<DartIsolate> root_isolate = root_isolate_.lock();
   if (!root_isolate) {
@@ -318,6 +326,10 @@ FontCollection& RuntimeController::GetFontCollection() {
 void RuntimeController::UpdateIsolateDescription(const std::string isolate_name,
                                                  int64_t isolate_port) {
   client_.UpdateIsolateDescription(isolate_name, isolate_port);
+}
+
+void RuntimeController::SetNeedsReportTimings(bool value) {
+  client_.SetNeedsReportTimings(value);
 }
 
 Dart_Port RuntimeController::GetMainPort() {

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -59,6 +59,8 @@ class RuntimeController final : public WindowClient {
 
   bool BeginFrame(fml::TimePoint frame_time);
 
+  bool ReportTimings(std::vector<int64_t> timings);
+
   bool NotifyIdle(int64_t deadline);
 
   bool IsRootIsolateRunning() const;
@@ -176,6 +178,9 @@ class RuntimeController final : public WindowClient {
   // |WindowClient|
   void UpdateIsolateDescription(const std::string isolate_name,
                                 int64_t isolate_port) override;
+
+  // |WindowClient|
+  void SetNeedsReportTimings(bool value) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(RuntimeController);
 };

--- a/runtime/runtime_delegate.h
+++ b/runtime/runtime_delegate.h
@@ -35,6 +35,8 @@ class RuntimeDelegate {
   virtual void UpdateIsolateDescription(const std::string isolate_name,
                                         int64_t isolate_port) = 0;
 
+  virtual void SetNeedsReportTimings(bool value) = 0;
+
  protected:
   virtual ~RuntimeDelegate();
 };

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -161,6 +161,7 @@ shell_host_executable("shell_unittests") {
     ":shell_unittests_fixtures",
     ":shell_unittests_gpu_configuration",
     "$flutter_root/common",
+    "$flutter_root/flow",
     "$flutter_root/shell",
     "$flutter_root/testing:dart",
   ]

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -173,8 +173,7 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
 
   if (layer_tree) {
     // Note the frame time for instrumentation.
-    layer_tree->set_construction_time(fml::TimePoint::Now() -
-                                      last_begin_frame_time_);
+    layer_tree->RecordBuildTime(last_begin_frame_time_);
   }
 
   // Commit the pending continuation.

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -18,6 +18,10 @@
 
 namespace flutter {
 
+namespace testing {
+class ShellTest;
+}
+
 class Animator final {
  public:
   class Delegate {
@@ -86,6 +90,8 @@ class Animator final {
   std::deque<uint64_t> trace_flow_ids_;
 
   fml::WeakPtrFactory<Animator> weak_factory_;
+
+  friend class testing::ShellTest;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Animator);
 };

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -201,6 +201,11 @@ void Engine::BeginFrame(fml::TimePoint frame_time) {
   runtime_controller_->BeginFrame(frame_time);
 }
 
+void Engine::ReportTimings(std::vector<int64_t> timings) {
+  TRACE_EVENT0("flutter", "Engine::ReportTimings");
+  runtime_controller_->ReportTimings(std::move(timings));
+}
+
 void Engine::NotifyIdle(int64_t deadline) {
   TRACE_EVENT1("flutter", "Engine::NotifyIdle", "deadline_now_delta",
                std::to_string(deadline - Dart_TimelineGetMicros()).c_str());
@@ -430,6 +435,10 @@ void Engine::HandlePlatformMessage(fml::RefPtr<PlatformMessage> message) {
 void Engine::UpdateIsolateDescription(const std::string isolate_name,
                                       int64_t isolate_port) {
   delegate_.UpdateIsolateDescription(isolate_name, isolate_port);
+}
+
+void Engine::SetNeedsReportTimings(bool value) {
+  delegate_.SetNeedsReportTimings(value);
 }
 
 FontCollection& Engine::GetFontCollection() {

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -52,6 +52,8 @@ class Engine final : public RuntimeDelegate {
 
     virtual void UpdateIsolateDescription(const std::string isolate_name,
                                           int64_t isolate_port) = 0;
+
+    virtual void SetNeedsReportTimings(bool value) = 0;
   };
 
   Engine(Delegate& delegate,
@@ -83,6 +85,8 @@ class Engine final : public RuntimeDelegate {
   bool UpdateAssetManager(std::shared_ptr<AssetManager> asset_manager);
 
   void BeginFrame(fml::TimePoint frame_time);
+
+  void ReportTimings(std::vector<int64_t> timings);
 
   void NotifyIdle(int64_t deadline);
 
@@ -150,6 +154,8 @@ class Engine final : public RuntimeDelegate {
   void UpdateIsolateDescription(const std::string isolate_name,
                                 int64_t isolate_port) override;
 
+  void SetNeedsReportTimings(bool value) override;
+
   void StopAnimator();
 
   void StartAnimatorIfPossible();
@@ -167,6 +173,8 @@ class Engine final : public RuntimeDelegate {
   bool GetAssetAsBuffer(const std::string& name, std::vector<uint8_t>* data);
 
   RunStatus PrepareAndLaunchIsolate(RunConfiguration configuration);
+
+  friend class testing::ShellTest;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Engine);
 };

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -3,8 +3,40 @@
 // found in the LICENSE file.
 
 import 'dart:isolate';
+import 'dart:ui';
 
 void main() {}
+
+void nativeReportTimingsCallback(List<int> timings) native 'NativeReportTimingsCallback';
+void nativeOnBeginFrame(int microseconds) native 'NativeOnBeginFrame';
+
+@pragma('vm:entry-point')
+void reportTimingsMain() {
+  window.onReportTimings = (List<FrameTiming> timings) {
+    List<int> timestamps = [];
+    for (FrameTiming t in timings) {
+      for (FramePhase phase in FramePhase.values) {
+        timestamps.add(t.timestampInMicroseconds(phase));
+      }
+    }
+    nativeReportTimingsCallback(timestamps);
+  };
+}
+
+@pragma('vm:entry-point')
+void onBeginFrameMain() {
+  window.onBeginFrame = (Duration beginTime) {
+    nativeOnBeginFrame(beginTime.inMicroseconds);
+  };
+}
+
+@pragma('vm:entry-point')
+void emptyMain() {}
+
+@pragma('vm:entry-point')
+void dummyReportTimingsMain() {
+  window.onReportTimings = (List<FrameTiming> timings) {};
+}
 
 @pragma('vm:entry-point')
 void fixturesAreFunctionalMain() {

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"
 #include "flutter/flow/compositor_context.h"
 #include "flutter/flow/layers/layer_tree.h"
@@ -21,9 +22,14 @@ namespace flutter {
 
 class Rasterizer final : public SnapshotDelegate {
  public:
-  Rasterizer(TaskRunners task_runners);
+  class Delegate {
+   public:
+    virtual void OnFrameRasterized(const FrameTiming&) = 0;
+  };
+  Rasterizer(Delegate& delegate, TaskRunners task_runners);
 
-  Rasterizer(TaskRunners task_runners,
+  Rasterizer(Delegate& delegate,
+             TaskRunners task_runners,
              std::unique_ptr<flutter::CompositorContext> compositor_context);
 
   ~Rasterizer();
@@ -76,6 +82,7 @@ class Rasterizer final : public SnapshotDelegate {
   void SetResourceCacheMaxBytes(int max_bytes);
 
  private:
+  Delegate& delegate_;
   TaskRunners task_runners_;
   std::unique_ptr<Surface> surface_;
   std::unique_ptr<flutter::CompositorContext> compositor_context_;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -37,6 +37,7 @@ namespace flutter {
 class Shell final : public PlatformView::Delegate,
                     public Animator::Delegate,
                     public Engine::Delegate,
+                    public Rasterizer::Delegate,
                     public ServiceProtocol::Handler {
  public:
   template <class T>
@@ -93,6 +94,8 @@ class Shell final : public PlatformView::Delegate,
   std::unique_ptr<Rasterizer> rasterizer_;       // on GPU task runner
   std::unique_ptr<ShellIOManager> io_manager_;   // on IO task runner
 
+  fml::WeakPtr<Engine> weak_engine_;  // to be shared across threads
+
   std::unordered_map<std::string,  // method
                      std::pair<fml::RefPtr<fml::TaskRunner>,
                                ServiceProtocolHandler>  // task-runner/function
@@ -101,6 +104,22 @@ class Shell final : public PlatformView::Delegate,
       service_protocol_handlers_;
   bool is_setup_ = false;
   uint64_t next_pointer_flow_id_ = 0;
+
+  // Written in the UI thread and read from the GPU thread. Hence make it
+  // atomic.
+  std::atomic<bool> needs_report_timings_{false};
+
+  // Whether there's a task scheduled to report the timings to Dart through
+  // ui.Window.onReportTimings.
+  bool frame_timings_report_scheduled_ = false;
+
+  // Vector of FrameTiming::kCount * n timestamps for n frames whose timings
+  // have not been reported yet. Vector of ints instead of FrameTiming is stored
+  // here for easier conversions to Dart objects.
+  std::vector<int64_t> unreported_timings_;
+
+  // How many frames have been timed since last report.
+  size_t UnreportedFramesCount() const;
 
   Shell(TaskRunners task_runners, Settings settings);
   Shell(DartVMRef vm, TaskRunners task_runners, Settings settings);
@@ -118,6 +137,8 @@ class Shell final : public PlatformView::Delegate,
              std::unique_ptr<Engine> engine,
              std::unique_ptr<Rasterizer> rasterizer,
              std::unique_ptr<ShellIOManager> io_manager);
+
+  void ReportTimings();
 
   // |PlatformView::Delegate|
   void OnPlatformViewCreated(std::unique_ptr<Surface> surface) override;
@@ -193,6 +214,12 @@ class Shell final : public PlatformView::Delegate,
   void UpdateIsolateDescription(const std::string isolate_name,
                                 int64_t isolate_port) override;
 
+  // |Engine::Delegate|
+  void SetNeedsReportTimings(bool value) override;
+
+  // |Rasterizer::Delegate|
+  void OnFrameRasterized(const FrameTiming&) override;
+
   // |ServiceProtocol::Handler|
   fml::RefPtr<fml::TaskRunner> GetServiceProtocolHandlerTaskRunner(
       fml::StringView method) const override;
@@ -236,6 +263,10 @@ class Shell final : public PlatformView::Delegate,
   bool OnServiceProtocolGetDisplayRefreshRate(
       const ServiceProtocol::Handler::ServiceProtocolMap& params,
       rapidjson::Document& response);
+
+  fml::WeakPtrFactory<Shell> weak_factory_;
+
+  friend class testing::ShellTest;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Shell);
 };

--- a/shell/common/shell_benchmarks.cc
+++ b/shell/common/shell_benchmarks.cc
@@ -38,7 +38,7 @@ static void StartupAndShutdownShell(benchmark::State& state,
           return std::make_unique<PlatformView>(shell, shell.GetTaskRunners());
         },
         [](Shell& shell) {
-          return std::make_unique<Rasterizer>(shell.GetTaskRunners());
+          return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
         });
   }
 

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -26,10 +26,30 @@ class ShellTest : public ThreadTest {
   ~ShellTest();
 
   Settings CreateSettingsForFixture();
-
+  std::unique_ptr<Shell> CreateShell(Settings settings);
+  std::unique_ptr<Shell> CreateShell(Settings settings,
+                                     TaskRunners task_runners);
   TaskRunners GetTaskRunnersForFixture();
 
   void AddNativeCallback(std::string name, Dart_NativeFunction callback);
+
+  static void PlatformViewNotifyCreated(
+      Shell* shell);  // This creates the surface
+  static void RunEngine(Shell* shell, RunConfiguration configuration);
+
+  static void PumpOneFrame(Shell* shell);
+
+  // Declare |UnreportedTimingsCount|, |GetNeedsReportTimings| and
+  // |SetNeedsReportTimings| inside |ShellTest| mainly for easier friend class
+  // declarations as shell unit tests and Shell are in different name spaces.
+
+  static bool GetNeedsReportTimings(Shell* shell);
+  static void SetNeedsReportTimings(Shell* shell, bool value);
+
+  // Do not assert |UnreportedTimingsCount| to be positive in any tests.
+  // Otherwise those tests will be flaky as the clearing of unreported timings
+  // is unpredictive.
+  static int UnreportedTimingsCount(Shell* shell);
 
  protected:
   // |testing::ThreadTest|

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -73,7 +73,7 @@ AndroidShellHolder::AndroidShellHolder(
       };
 
   Shell::CreateCallback<Rasterizer> on_create_rasterizer = [](Shell& shell) {
-    return std::make_unique<Rasterizer>(shell.GetTaskRunners());
+    return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
   };
 
   // The current thread will be used as the platform thread. Ensure that the

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -353,7 +353,7 @@
 
   flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer =
       [](flutter::Shell& shell) {
-        return std::make_unique<flutter::Rasterizer>(shell.GetTaskRunners());
+        return std::make_unique<flutter::Rasterizer>(shell, shell.GetTaskRunners());
       };
 
   if (flutter::IsIosEmbeddedViewsPreviewEnabled()) {

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -527,7 +527,8 @@ FlutterEngineResult FlutterEngineRun(size_t version,
 
   flutter::Shell::CreateCallback<flutter::Rasterizer> on_create_rasterizer =
       [](flutter::Shell& shell) {
-        return std::make_unique<flutter::Rasterizer>(shell.GetTaskRunners());
+        return std::make_unique<flutter::Rasterizer>(shell,
+                                                     shell.GetTaskRunners());
       };
 
   // TODO(chinmaygarde): This is the wrong spot for this. It belongs in the

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -106,7 +106,7 @@ int RunTester(const flutter::Settings& settings, bool run_forever) {
       };
 
   Shell::CreateCallback<Rasterizer> on_create_rasterizer = [](Shell& shell) {
-    return std::make_unique<Rasterizer>(shell.GetTaskRunners());
+    return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
   };
 
   auto shell = Shell::Create(task_runners,             //

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -36,6 +36,7 @@ void main() {
     VoidCallback originalOnLocaleChanged;
     FrameCallback originalOnBeginFrame;
     VoidCallback originalOnDrawFrame;
+    TimingsCallback originalOnReportTimings;
     PointerDataPacketCallback originalOnPointerDataPacket;
     VoidCallback originalOnSemanticsEnabledChanged;
     SemanticsActionCallback originalOnSemanticsAction;
@@ -47,6 +48,7 @@ void main() {
       originalOnLocaleChanged = window.onLocaleChanged;
       originalOnBeginFrame = window.onBeginFrame;
       originalOnDrawFrame = window.onDrawFrame;
+      originalOnReportTimings = window.onReportTimings;
       originalOnPointerDataPacket = window.onPointerDataPacket;
       originalOnSemanticsEnabledChanged = window.onSemanticsEnabledChanged;
       originalOnSemanticsAction = window.onSemanticsAction;
@@ -59,6 +61,7 @@ void main() {
       window.onLocaleChanged = originalOnLocaleChanged;
       window.onBeginFrame = originalOnBeginFrame;
       window.onDrawFrame = originalOnDrawFrame;
+      window.onReportTimings = originalOnReportTimings;
       window.onPointerDataPacket = originalOnPointerDataPacket;
       window.onSemanticsEnabledChanged = originalOnSemanticsEnabledChanged;
       window.onSemanticsAction = originalOnSemanticsAction;
@@ -142,6 +145,22 @@ void main() {
       });
 
       _drawFrame();
+      expect(runZone, isNotNull);
+      expect(runZone, same(innerZone));
+    });
+
+    test('onReportTimings preserves callback zone', () {
+      Zone innerZone;
+      Zone runZone;
+
+      runZoned(() {
+        innerZone = Zone.current;
+        window.onReportTimings = (List<FrameTiming> timings) {
+          runZone = Zone.current;
+        };
+      });
+
+      _reportTimings(<int>[]);
       expect(runZone, isNotNull);
       expect(runZone, same(innerZone));
     });

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -19,4 +19,9 @@ void main() {
       }));
     });
   });
+
+  test('FrameTiming.toString has the correct format', () {
+    FrameTiming timing = FrameTiming(<int>[1000, 8000, 9000, 19500]);
+    expect(timing.toString(), 'FrameTiming(buildDuration: 7.0ms, rasterDuration: 10.5ms, totalSpan: 18.5ms)');
+  });
 }


### PR DESCRIPTION
Using it, a Flutter app can monitor missing frames in the release mode, and a custom Flutter runner (e.g., Fuchsia) can add a custom FrameRasterizedCallback.

Related issues:
https://github.com/flutter/flutter/issues/26154
https://github.com/flutter/flutter/issues/31444
https://github.com/flutter/flutter/issues/32447

Need review as soon as possible so we can merge this before the end of May to catch the milestone.

Tests added:
* NoNeedToReportTimingsByDefault
* NeedsReportTimingsIsSetWithCallback
* ReportTimingsIsCalled
* FrameRasterizedCallbackIsCalled
* FrameTimingSetsAndGetsProperly
* onReportTimings preserves callback zone
* FrameTiming.toString has the correct format

This will need a manual engine roll as the TestWindow defined in the framework needs to implement onReportTimings.