### PR TITLE
add observatoryUrl property to FlutterEngine

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -228,6 +228,15 @@ FLUTTER_EXPORT
  */
 @property(nonatomic, readonly) FlutterBasicMessageChannel* settingsChannel;
 
+/**
+ * The `NSURL` of the observatory for the service isolate.
+ *
+ * This is only set in debug and profile runtime modes, and only after the
+ * observatory service is ready. In release mode or before the observatory has
+ * started, it returns `nil`.
+ */
+@property(nonatomic, readonly) NSURL* observatoryUrl;
+
 @end
 
 #endif  // FLUTTER_FLUTTERENGINE_H_

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -207,6 +207,10 @@
   return _settingsChannel.get();
 }
 
+- (NSURL*)observatoryUrl {
+  return [_publisher.get() url];
+}
+
 - (void)resetChannels {
   _localizationChannel.reset();
   _navigationChannel.reset();

--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.h
@@ -9,6 +9,8 @@
 
 @interface FlutterObservatoryPublisher : NSObject
 
+@property(nonatomic, readonly) NSURL* url;
+
 @end
 
 #endif  // FLUTTER_FLUTTEROBSERVATORYPUBLISHER_H_


### PR DESCRIPTION
EarlGrey wants this.  Brings iOS side into parity with Android side, where this is also available as a property.

Fixes flutter/flutter#32655

/cc @Albertwang0116