### PR TITLE
Minor fixes/adjustments to the GLFW shell

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/json_method_codec.cc
+++ b/shell/platform/common/cpp/client_wrapper/json_method_codec.cc
@@ -44,7 +44,12 @@ JsonMethodCodec::DecodeMethodCallInternal(const uint8_t* message,
     // Pull the arguments subtree up to the root of json_message. This is
     // destructive to json_message, but the full value is no longer needed, and
     // this avoids a subtree copy.
-    json_message->Swap(arguments_iter->value);
+    // Note: The static_cast is for compatibility with RapidJSON 1.1; master
+    // already allows swapping a Document with a Value directly. Once there is
+    // a new RapidJSON release (at which point clients can be expected to have
+    // that change in the version they depend on) remove the cast.
+    static_cast<rapidjson::Value*>(json_message.get())
+        ->Swap(arguments_iter->value);
     // Swap it into |arguments|. This moves the allocator ownership, so that
     // the data won't be deleted when json_message goes out of scope.
     arguments = std::make_unique<rapidjson::Document>();

--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -86,6 +86,7 @@ void TextInputPlugin::KeyboardHook(GLFWwindow* window,
         break;
       case GLFW_KEY_ENTER:
         EnterPressed(active_model_);
+        break;
       default:
         break;
     }


### PR DESCRIPTION
- Makes json_method_codec.cc compatible with the last stable RapidJSON release.
- Allows removing the GTK dependency with a compile flag.
- Fixes a missing break in a switch flagged by some toolchains.