### PR TITLE
[fuchsia] Update zx_clock_get callers

### DIFF
--- a/fml/time/time_point.cc
+++ b/fml/time/time_point.cc
@@ -18,7 +18,7 @@ namespace fml {
 
 // static
 TimePoint TimePoint::Now() {
-  return TimePoint(zx_clock_get(ZX_CLOCK_MONOTONIC));
+  return TimePoint(zx_clock_get_monotonic());
 }
 
 #else

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -476,7 +476,9 @@ Dart_Handle System::VmoMap(fml::RefPtr<Handle> vmo) {
 }
 
 uint64_t System::ClockGet(uint32_t clock_id) {
-  return zx_clock_get(clock_id);
+  zx_time_t result = 0;
+  zx_clock_get_new(clock_id, &result);
+  return result;
 }
 
 // clang-format: off


### PR DESCRIPTION
Fuchsia is changing zx_clock_get to return a zx_status_t. This change
prepares us for that change.