### PR TITLE
make drain perform cleanup

### DIFF
--- a/flow/skia_gpu_object.cc
+++ b/flow/skia_gpu_object.cc
@@ -39,6 +39,7 @@ void SkiaUnrefQueue::Drain() {
     objects_.swap(skia_objects);
     drain_pending_ = false;
   }
+
   for (SkRefCnt* skia_object : skia_objects) {
     skia_object->unref();
   }

--- a/flow/skia_gpu_object.cc
+++ b/flow/skia_gpu_object.cc
@@ -39,7 +39,6 @@ void SkiaUnrefQueue::Drain() {
     objects_.swap(skia_objects);
     drain_pending_ = false;
   }
-  FML_DLOG(ERROR) << "Drain";
   for (SkRefCnt* skia_object : skia_objects) {
     skia_object->unref();
   }

--- a/flow/skia_gpu_object.cc
+++ b/flow/skia_gpu_object.cc
@@ -6,12 +6,16 @@
 
 #include "flutter/fml/message_loop.h"
 
+#include <chrono>
+
 namespace flutter {
 
 SkiaUnrefQueue::SkiaUnrefQueue(fml::RefPtr<fml::TaskRunner> task_runner,
-                               fml::TimeDelta delay)
+                               fml::TimeDelta delay,
+                               fml::WeakPtr<GrContext> context)
     : task_runner_(std::move(task_runner)),
       drain_delay_(delay),
+      context_(context),
       drain_pending_(false) {}
 
 SkiaUnrefQueue::~SkiaUnrefQueue() {
@@ -35,9 +39,12 @@ void SkiaUnrefQueue::Drain() {
     objects_.swap(skia_objects);
     drain_pending_ = false;
   }
-
+  FML_DLOG(ERROR) << "Drain";
   for (SkRefCnt* skia_object : skia_objects) {
     skia_object->unref();
+  }
+  if (context_) {
+    context_->performDeferredCleanup(std::chrono::milliseconds(250));
   }
 }
 

--- a/flow/skia_gpu_object.h
+++ b/flow/skia_gpu_object.h
@@ -12,6 +12,7 @@
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/task_runner.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
+#include "third_party/skia/include/gpu/GrContext.h"
 
 namespace flutter {
 
@@ -31,12 +32,14 @@ class SkiaUnrefQueue : public fml::RefCountedThreadSafe<SkiaUnrefQueue> {
  private:
   const fml::RefPtr<fml::TaskRunner> task_runner_;
   const fml::TimeDelta drain_delay_;
+  const fml::WeakPtr<GrContext> context_;
   std::mutex mutex_;
   std::deque<SkRefCnt*> objects_;
   bool drain_pending_;
 
   SkiaUnrefQueue(fml::RefPtr<fml::TaskRunner> task_runner,
-                 fml::TimeDelta delay);
+                 fml::TimeDelta delay,
+                 fml::WeakPtr<GrContext> context);
 
   ~SkiaUnrefQueue();
 

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -52,7 +52,8 @@ ShellIOManager::ShellIOManager(
                             : nullptr),
       unref_queue_(fml::MakeRefCounted<flutter::SkiaUnrefQueue>(
           std::move(unref_queue_task_runner),
-          fml::TimeDelta::FromMilliseconds(250))),
+          fml::TimeDelta::FromMilliseconds(250),
+          resource_context_weak_factory_->GetWeakPtr())),
       weak_factory_(this) {
   if (!resource_context_) {
 #ifndef OS_FUCHSIA


### PR DESCRIPTION
If the IO thread gets really busy decoding images, and then suddenly is not so busy for a while (e.g. it decodes a lot of large images that end up getting disposed of, and then there's nothing else for it to do), it can leave GrGLTextures laying around in memory for a while. According to @brianosman this call should fix that, and I'm seeing that it does.  Not 100% sure this usage of WeakPtr is safe in Drain - it seems like it might be but hoping one of you will know better.

Should help somewhat with https://github.com/flutter/flutter/issues/32143 but not a full fix.  That will probably require some kind of queuing of decoding to try to make us more efficient.  We can still run the risk of running out of GPU memory though :(