### PR TITLE
Fix horizontal scroll direction for macOS

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -470,7 +470,7 @@ static void CommonInit(FLEViewController* controller) {
       }
     }
     double scaleFactor = self.view.layer.contentsScale;
-    flutterEvent.scroll_delta_x = event.scrollingDeltaX * pixelsPerLine * scaleFactor;
+    flutterEvent.scroll_delta_x = -event.scrollingDeltaX * pixelsPerLine * scaleFactor;
     flutterEvent.scroll_delta_y = -event.scrollingDeltaY * pixelsPerLine * scaleFactor;
   }
   FlutterEngineSendPointerEvent(_engine, &flutterEvent, 1);


### PR DESCRIPTION
macOS uses negative values to represent scrolls to the right, while
Flutter expects the opposite, so flip X deltas.