### PR TITLE
Initialize next_pointer_flow_id_ to 0

### DIFF
--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -52,7 +52,7 @@ class AndroidShellHolder {
   std::unique_ptr<Shell> shell_;
   bool is_valid_ = false;
   pthread_key_t thread_destruct_key_;
-  uint64_t next_pointer_flow_id_;
+  uint64_t next_pointer_flow_id_ = 0;
 
   static void ThreadDestructCallback(void* value);
 

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -75,7 +75,7 @@ class EmbedderEngine {
   const EmbedderExternalTextureGL::ExternalTextureCallback
       external_texture_callback_;
   bool is_valid_ = false;
-  uint64_t next_pointer_flow_id_;
+  uint64_t next_pointer_flow_id_ = 0;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderEngine);
 };


### PR DESCRIPTION
This member variable was added to three classes in #7807, but only
initialized to 0 in one of them. Initialize to 0 in the other two.