### PR TITLE
Expose pointer type and buttons in embedder.h

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -280,13 +280,53 @@ typedef struct {
 // The phase of the pointer event.
 typedef enum {
   kCancel,
+  // The pointer, which must have been down (see kDown), is now up.
+  //
+  // For touch, this means that the pointer is no longer in contact with the
+  // screen. For a mouse, it means the last button was released. Note that if
+  // any other buttons are still pressed when one button is released, that
+  // should be sent as a kMove rather than a kUp.
   kUp,
+  // The pointer, which must have been been up, is now up.
+  //
+  // For touch, this means that the pointer has come into contact with the
+  // screen. For a mouse, it means a button is now pressed. Note that if any
+  // other buttons are already pressed when a new button is pressed, that should
+  // be sent as a kMove rather than a kDown.
   kDown,
+  // The pointer moved while down.
   kMove,
+  // The pointer is now sending input to Flutter. For instance, a mouse has
+  // entered the area where the Flutter content is displayed.
+  //
+  // A pointer should always be added before sending any other events.
   kAdd,
+  // The pointer is no longer sending input to Flutter. For instance, a mouse
+  // has left the area where the Flutter content is displayed.
+  //
+  // A removed pointer should no longer send events until sending a new kAdd.
   kRemove,
+  // The pointer moved while up.
   kHover,
 } FlutterPointerPhase;
+
+// The device type that created a pointer event.
+typedef enum {
+  kFlutterPointerDeviceKindMouse = 1,
+  kFlutterPointerDeviceKindTouch,
+} FlutterPointerDeviceKind;
+
+// Flags for the |buttons| field of |FlutterPointerEvent| when |device_kind|
+// is |kFlutterPointerDeviceKindMouse|.
+typedef enum {
+  kFlutterPointerButtonMousePrimary = 1 << 0,
+  kFlutterPointerButtonMouseSecondary = 1 << 1,
+  kFlutterPointerButtonMouseMiddle = 1 << 2,
+  kFlutterPointerButtonMouseBack = 1 << 3,
+  kFlutterPointerButtonMouseForward = 1 << 4,
+  // If a mouse has more than five buttons, send higher bit shifted values
+  // corresponding to the button number: 1 << 5 for the 6th, etc.
+} FlutterPointerMouseButtons;
 
 // The type of a pointer signal.
 typedef enum {
@@ -307,6 +347,14 @@ typedef struct {
   FlutterPointerSignalKind signal_kind;
   double scroll_delta_x;
   double scroll_delta_y;
+  // The type of the device generating this event.
+  // Backwards compatibility note: If this is not set, the device will be
+  // treated as a mouse, with the primary button set for |kDown| and |kMove|.
+  // If set explicitly to |kFlutterPointerDeviceKindMouse|, you must set the
+  // correct buttons.
+  FlutterPointerDeviceKind device_kind;
+  // The buttons currently pressed, if any.
+  int64_t buttons;
 } FlutterPointerEvent;
 
 struct _FlutterPlatformMessageResponseHandle;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -287,7 +287,7 @@ typedef enum {
   // any other buttons are still pressed when one button is released, that
   // should be sent as a kMove rather than a kUp.
   kUp,
-  // The pointer, which must have been been up, is now up.
+  // The pointer, which must have been been up, is now down.
   //
   // For touch, this means that the pointer has come into contact with the
   // screen. For a mouse, it means a button is now pressed. Note that if any
@@ -295,6 +295,9 @@ typedef enum {
   // be sent as a kMove rather than a kDown.
   kDown,
   // The pointer moved while down.
+  //
+  // This is also used for changes in button state that don't cause a kDown or
+  // kUp, such as releasing one of two pressed buttons.
   kMove,
   // The pointer is now sending input to Flutter. For instance, a mouse has
   // entered the area where the Flutter content is displayed.


### PR DESCRIPTION
Rather than hard-coding the type of incoming events to mouse, and
synthesizing a primary button press for kDown/kUp, expose device kind
and buttons in the API.

For backwards compatibility, if the type is not set, the old behavior is
used. If an embedder sets the type to mouse explicitly, however, they
must also set correct button information.

For the touch type, the API abstracts away the framework's internal
expectation that a button is set for touch down/move for simplicity.

Fixes https://github.com/flutter/flutter/issues/32854