### PR TITLE
Fix dartdevc build

### DIFF
--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -6,7 +6,7 @@ import("//third_party/dart/build/dart/dart_action.gni")
 import("//third_party/dart/utils/compile_platform.gni")
 
 sdk_dill = "$root_out_dir/flutter_web_sdk/kernel/flutter_ddc_sdk.dill"
-sdk_libraries_json = "$flutter_root/web_sdk/libraries.json"
+sdk_libraries_json = "$root_out_dir/flutter_web_sdk/libraries.json"
 
 web_ui_sources = [
   "$flutter_root/lib/stub_ui/lib/ui.dart",

--- a/web_sdk/flutter_kernel_sdk.dart
+++ b/web_sdk/flutter_kernel_sdk.dart
@@ -26,7 +26,6 @@ Future main(List<String> args) async {
     ..addOption('libraries',
         defaultsTo: path.join(ddcPath, '../../sdk/lib/libraries.json'));
   var parserOptions = parser.parse(args);
-
   var outputPath = parserOptions['output'] as String;
   if (outputPath == null) {
     var sdkRoot = path.absolute(path.dirname(path.dirname(ddcPath)));

--- a/web_sdk/libraries.json
+++ b/web_sdk/libraries.json
@@ -125,114 +125,117 @@
   "dartdevc": {
     "libraries": {
       "async": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/async_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/async/async.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/async_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/async/async.dart"
       },
       "_runtime": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/ddc_runtime/runtime.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/ddc_runtime/runtime.dart"
       },
       "_interceptors": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/interceptors.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/interceptors.dart"
       },
       "mirrors": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/mirrors_patch.dart",
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/mirrors_patch.dart",
         "supported": false,
-        "uri": "../../third_party/dart/sdk/lib/mirrors/mirrors.dart"
+        "uri": "../../../third_party/dart/sdk/lib/mirrors/mirrors.dart"
       },
       "_debugger": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/debugger.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/debugger.dart"
       },
       "io": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/io_patch.dart",
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/io_patch.dart",
         "supported": false,
-        "uri": "../../third_party/dart/sdk/lib/io/io.dart"
+        "uri": "../../../third_party/dart/sdk/lib/io/io.dart"
       },
       "_internal": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/internal_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/internal/internal.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/internal_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/internal/internal.dart"
       },
       "_metadata": {
-        "uri": "../../third_party/dart/sdk/lib/html/html_common/metadata.dart"
+        "uri": "../../../third_party/dart/sdk/lib/html/html_common/metadata.dart"
       },
       "_http": {
-        "uri": "../../third_party/dart/sdk/lib/_http/http.dart"
+        "uri": "../../../third_party/dart/sdk/lib/_http/http.dart"
       },
       "_js_primitives": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/js_primitives.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/js_primitives.dart"
       },
       "_js_helper": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/js_helper.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/js_helper.dart"
       },
       "ui": {
-        "uri": "../lib/ui/ui.dart"
+        "uri": "lib/ui/ui.dart"
+      },
+      "_engine": {
+        "uri": "lib/_engine/engine.dart"
       },
       "js": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/lib/js/dart2js/js_dart2js.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/lib/js/dart2js/js_dart2js.dart"
       },
       "_js_mirrors": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/js_mirrors.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/js_mirrors.dart"
       },
       "html_common": {
-        "uri": "../../third_party/dart/sdk/lib/html/html_common/html_common_dart2js.dart"
+        "uri": "../../../third_party/dart/sdk/lib/html/html_common/html_common_dart2js.dart"
       },
       "_native_typed_data": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/native_typed_data.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/native_typed_data.dart"
       },
       "core": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/core_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/core/core.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/core_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/core/core.dart"
       },
       "js_util": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/lib/js_util/dart2js/js_util_dart2js.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/lib/js_util/dart2js/js_util_dart2js.dart"
       },
       "collection": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/collection_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/collection/collection.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/collection_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/collection/collection.dart"
       },
       "typed_data": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/typed_data_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/typed_data/typed_data.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/typed_data_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/typed_data/typed_data.dart"
       },
       "web_audio": {
-        "uri": "../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart"
+        "uri": "../../../third_party/dart/sdk/lib/web_audio/dart2js/web_audio_dart2js.dart"
       },
       "html": {
-        "uri": "../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart"
+        "uri": "../../../third_party/dart/sdk/lib/html/dart2js/html_dart2js.dart"
       },
       "developer": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/developer_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/developer/developer.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/developer_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/developer/developer.dart"
       },
       "isolate": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/isolate_patch.dart",
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/isolate_patch.dart",
         "supported": false,
-        "uri": "../../third_party/dart/sdk/lib/isolate/isolate.dart"
+        "uri": "../../../third_party/dart/sdk/lib/isolate/isolate.dart"
       },
       "web_gl": {
-        "uri": "../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart"
+        "uri": "../../../third_party/dart/sdk/lib/web_gl/dart2js/web_gl_dart2js.dart"
       },
       "indexed_db": {
-        "uri": "../../third_party/dart/sdk/lib/indexed_db/dart2js/indexed_db_dart2js.dart"
+        "uri": "../../../third_party/dart/sdk/lib/indexed_db/dart2js/indexed_db_dart2js.dart"
       },
       "convert": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/convert_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/convert/convert.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/convert_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/convert/convert.dart"
       },
       "_isolate_helper": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/isolate_helper.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/isolate_helper.dart"
       },
       "math": {
-        "patches": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/math_patch.dart",
-        "uri": "../../third_party/dart/sdk/lib/math/math.dart"
+        "patches": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/patch/math_patch.dart",
+        "uri": "../../../third_party/dart/sdk/lib/math/math.dart"
       },
       "_foreign_helper": {
-        "uri": "../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/foreign_helper.dart"
+        "uri": "../../../third_party/dart/pkg/dev_compiler/tool/input_sdk/private/foreign_helper.dart"
       },
       "web_sql": {
-        "uri": "../../third_party/dart/sdk/lib/web_sql/dart2js/web_sql_dart2js.dart"
+        "uri": "../../../third_party/dart/sdk/lib/web_sql/dart2js/web_sql_dart2js.dart"
       },
       "svg": {
-        "uri": "../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart"
+        "uri": "../../../third_party/dart/sdk/lib/svg/dart2js/svg_dart2js.dart"
       }
     }
   }

--- a/web_sdk/libraries.yaml
+++ b/web_sdk/libraries.yaml
@@ -123,7 +123,10 @@ dartdevc:
       uri: "../../third_party/dart/sdk/lib/web_sql/dart2js/web_sql_dart2js.dart"
 
     ui:
-      uri: "../lib/ui/ui.dart"
+      uri: "lib/ui/ui.dart"
+
+  _engine:
+      uri: "lib/_engine/engine.dart"
 
 dart2js:
   libraries:


### PR DESCRIPTION
Use the `libraries.json` that is copied into the output directory so the paths to ui and _engine are correct. Otherwise the summary fails to include _engine and uses the native dart:ui!