### PR TITLE
TextStyle.height property as a multiple of font size instead of multiple of ascent+descent+leading.

### DIFF
--- a/lib/stub_ui/lib/src/ui/text.dart
+++ b/lib/stub_ui/lib/src/ui/text.dart
@@ -298,7 +298,8 @@ class TextStyle {
   /// * `letterSpacing`: The amount of space (in logical pixels) to add between each letter.
   /// * `wordSpacing`: The amount of space (in logical pixels) to add at each sequence of white-space (i.e. between each word).
   /// * `textBaseline`: The common baseline that should be aligned between this text span and its parent text span, or, for the root text spans, with the line box.
-  /// * `height`: The height of this text span, as a multiple of the font size.
+  /// * `height`: The height of this text span, as a multiplier of the font size. Omitting `height` will allow the text
+  ///   to take the height as defined by the font, which may not be exactly the height of the fontSize.
   /// * `locale`: The locale used to select region-specific glyphs.
   /// * `background`: The paint drawn as a background for the text.
   /// * `foreground`: The paint used to draw the text. If this is specified, `color` must be null.
@@ -623,13 +624,11 @@ class ParagraphStyle {
   /// * `fontSize`: The size of glyphs (in logical pixels) to use when painting
   ///   the text.
   ///
-  /// * `height`: The minimum height of the line boxes, as a multiple of the
-  ///   font size. The lines of the paragraph will be at least
-  ///   `(height + leading) * fontSize` tall when fontSize
-  ///   is not null. When fontSize is null, there is no minimum line height. Tall
-  ///   glyphs due to baseline alignment or large [TextStyle.fontSize] may cause
-  ///   the actual line height after layout to be taller than specified here.
-  ///   [fontSize] must be provided for this property to take effect.
+  /// * `height`: The fallback height of the spans as a multiplier of the font
+  ///   size. The fallback height is used when no height is provided in through
+  ///   [TextStyle.height]. Omitting `height` here and in [TextStyle] will allow
+  ///   the text to take the height as defined by the font, which may not be
+  ///   exactly the height of the fontSize.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).
@@ -770,13 +769,15 @@ class StrutStyle {
   /// * `fontSize`: The size of glyphs (in logical pixels) to use when painting
   ///   the text.
   ///
-  /// * `lineHeight`: The minimum height of the line boxes, as a multiple of the
-  ///   font size. The lines of the paragraph will be at least
-  ///   `(lineHeight + leading) * fontSize` tall when fontSize
-  ///   is not null. When fontSize is null, there is no minimum line height. Tall
-  ///   glyphs due to baseline alignment or large [TextStyle.fontSize] may cause
-  ///   the actual line height after layout to be taller than specified here.
-  ///   [fontSize] must be provided for this property to take effect.
+  /// * `height`: The minimum height of the line boxes, as a multiplier of the
+  ///   font size. The lines of the paragraph will be at least `(height + leading)
+  ///   * fontSize` tall when fontSize is not null. Omitting `height` will allow
+  ///   the minimum line height to take the height as defined by the font, which
+  ///   may not be exactly the height of the fontSize. When fontSize is null, there
+  ///   is no minimum line height. Tall glyphs due to baseline alignment or large
+  ///   [TextStyle.fontSize] may cause the actual line height after layout to be
+  ///   taller than specified here. [fontSize] must be provided for this property
+  ///   to take effect.
   ///
   /// * `leading`: The minimum amount of leading between lines as a multiple of
   ///   the font size. [fontSize] must be provided for this property to take effect.

--- a/lib/stub_ui/lib/src/ui/text.dart
+++ b/lib/stub_ui/lib/src/ui/text.dart
@@ -298,7 +298,7 @@ class TextStyle {
   /// * `letterSpacing`: The amount of space (in logical pixels) to add between each letter.
   /// * `wordSpacing`: The amount of space (in logical pixels) to add at each sequence of white-space (i.e. between each word).
   /// * `textBaseline`: The common baseline that should be aligned between this text span and its parent text span, or, for the root text spans, with the line box.
-  /// * `height`: The height of this text span, as a multiplier of the font size. Omitting `height` will allow the text
+  /// * `height`: The height of this text span, as a multiplier of the font size. Omitting `height` will allow the line height
   ///   to take the height as defined by the font, which may not be exactly the height of the fontSize.
   /// * `locale`: The locale used to select region-specific glyphs.
   /// * `background`: The paint drawn as a background for the text.
@@ -627,8 +627,8 @@ class ParagraphStyle {
   /// * `height`: The fallback height of the spans as a multiplier of the font
   ///   size. The fallback height is used when no height is provided in through
   ///   [TextStyle.height]. Omitting `height` here and in [TextStyle] will allow
-  ///   the text to take the height as defined by the font, which may not be
-  ///   exactly the height of the fontSize.
+  ///   the line height to take the height as defined by the font, which may not
+  ///   be exactly the height of the fontSize.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).

--- a/lib/stub_ui/lib/src/ui/text.dart
+++ b/lib/stub_ui/lib/src/ui/text.dart
@@ -625,10 +625,10 @@ class ParagraphStyle {
   ///   the text.
   ///
   /// * `height`: The fallback height of the spans as a multiplier of the font
-  ///   size. The fallback height is used when no height is provided in through
+  ///   size. The fallback height is used when no height is provided through
   ///   [TextStyle.height]. Omitting `height` here and in [TextStyle] will allow
   ///   the line height to take the height as defined by the font, which may not
-  ///   be exactly the height of the fontSize.
+  ///   be exactly the height of the `fontSize`.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).
@@ -770,14 +770,14 @@ class StrutStyle {
   ///   the text.
   ///
   /// * `height`: The minimum height of the line boxes, as a multiplier of the
-  ///   font size. The lines of the paragraph will be at least `(height + leading)
-  ///   * fontSize` tall when fontSize is not null. Omitting `height` will allow
-  ///   the minimum line height to take the height as defined by the font, which
-  ///   may not be exactly the height of the fontSize. When fontSize is null, there
-  ///   is no minimum line height. Tall glyphs due to baseline alignment or large
-  ///   [TextStyle.fontSize] may cause the actual line height after layout to be
-  ///   taller than specified here. [fontSize] must be provided for this property
-  ///   to take effect.
+  ///   font size. The lines of the paragraph will be at least
+  ///   `(height + leading) * fontSize` tall when fontSize is not null. Omitting
+  ///   `height` will allow the minimum line height to take the height as defined
+  ///   by the font, which may not be exactly the height of the [fontSize]. When
+  ///   [fontSize] is null, there is no minimum line height. Tall glyphs due to
+  ///   baseline alignment or large [TextStyle.fontSize] may cause the actual line
+  ///   height after layout to be taller than specified here. The [fontSize] must
+  ///   be provided for this property to take effect.
   ///
   /// * `leading`: The minimum amount of leading between lines as a multiple of
   ///   the font size. [fontSize] must be provided for this property to take effect.

--- a/lib/stub_ui/lib/src/ui/text.dart
+++ b/lib/stub_ui/lib/src/ui/text.dart
@@ -763,24 +763,24 @@ class StrutStyle {
   /// * `fontFamily`: The name of the font to use when painting the text (e.g.,
   ///   Roboto).
   ///
-  /// * `fontFamilyFallback`: An ordered list of font family names that will be searched for when
-  ///    the font in `fontFamily` cannot be found.
+  /// * `fontFamilyFallback`: An ordered list of font family names that will be
+  ///    searched for when the font in `fontFamily` cannot be found.
   ///
   /// * `fontSize`: The size of glyphs (in logical pixels) to use when painting
   ///   the text.
   ///
   /// * `height`: The minimum height of the line boxes, as a multiplier of the
   ///   font size. The lines of the paragraph will be at least
-  ///   `(height + leading) * fontSize` tall when fontSize is not null. Omitting
+  ///   `(height + leading) * fontSize` tall when `fontSize` is not null. Omitting
   ///   `height` will allow the minimum line height to take the height as defined
-  ///   by the font, which may not be exactly the height of the [fontSize]. When
-  ///   [fontSize] is null, there is no minimum line height. Tall glyphs due to
+  ///   by the font, which may not be exactly the height of the `fontSize`. When
+  ///   `fontSize` is null, there is no minimum line height. Tall glyphs due to
   ///   baseline alignment or large [TextStyle.fontSize] may cause the actual line
-  ///   height after layout to be taller than specified here. The [fontSize] must
+  ///   height after layout to be taller than specified here. The `fontSize` must
   ///   be provided for this property to take effect.
   ///
   /// * `leading`: The minimum amount of leading between lines as a multiple of
-  ///   the font size. [fontSize] must be provided for this property to take effect.
+  ///   the font size. `fontSize` must be provided for this property to take effect.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).
@@ -789,11 +789,11 @@ class StrutStyle {
   ///   italics).
   ///
   /// * `forceStrutHeight`: When true, the paragraph will force all lines to be exactly
-  ///   `(lineHeight + leading) * fontSize` tall from baseline to baseline.
+  ///   `(height + leading) * fontSize` tall from baseline to baseline.
   ///   [TextStyle] is no longer able to influence the line height, and any tall
-  ///   glyphs may overlap with lines above. If a [fontFamily] is specified, the
+  ///   glyphs may overlap with lines above. If a `fontFamily` is specified, the
   ///   total ascent of the first line will be the min of the `Ascent + half-leading`
-  ///   of the [fontFamily] and `(lineHeight + leading) * fontSize`. Otherwise, it
+  ///   of the `fontFamily` and `(height + leading) * fontSize`. Otherwise, it
   ///   will be determined by the Ascent + half-leading of the first text.
   StrutStyle({
     String fontFamily,

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -527,7 +527,8 @@ class TextStyle {
   /// * `letterSpacing`: The amount of space (in logical pixels) to add between each letter.
   /// * `wordSpacing`: The amount of space (in logical pixels) to add at each sequence of white-space (i.e. between each word).
   /// * `textBaseline`: The common baseline that should be aligned between this text span and its parent text span, or, for the root text spans, with the line box.
-  /// * `height`: The height of this text span, as a multiplier of the font size.
+  /// * `height`: The height of this text span, as a multiplier of the font size. Omitting `height` will allow the text
+  ///   to take the height as defined by the font, which may not be exactly the height of the fontSize.
   /// * `locale`: The locale used to select region-specific glyphs.
   /// * `background`: The paint drawn as a background for the text.
   /// * `foreground`: The paint used to draw the text. If this is specified, `color` must be null.
@@ -776,9 +777,11 @@ class ParagraphStyle {
   /// * `fontSize`: The fallback size of glyphs (in logical pixels) to
   ///   use when painting the text. This is used when there is no [TextStyle].
   ///
-  /// * `height`: The height of the spans as a multiplier of the font size. The
-  ///   fallback height to use when no height is provided in through
-  ///   [TextStyle.height].
+  /// * `height`: The fallback height of the spans as a multiplier of the font
+  ///   size. The fallback height is used when no height is provided in through
+  ///   [TextStyle.height]. Omitting `height` here and in [TextStyle] will allow
+  ///   the text to take the height as defined by the font, which may not be
+  ///   exactly the height of the fontSize.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).
@@ -970,7 +973,9 @@ class StrutStyle {
   ///
   /// * `height`: The minimum height of the line boxes, as a multiplier of the
   ///   font size. The lines of the paragraph will be at least `(height + leading)
-  ///   * fontSize` tall when fontSize is not null. When fontSize is null, there
+  ///   * fontSize` tall when fontSize is not null. Omitting `height` will allow
+  ///   the minimum line height to take the height as defined by the font, which
+  ///   may not be exactly the height of the fontSize. When fontSize is null, there
   ///   is no minimum line height. Tall glyphs due to baseline alignment or large
   ///   [TextStyle.fontSize] may cause the actual line height after layout to be
   ///   taller than specified here. [fontSize] must be provided for this property

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -527,7 +527,7 @@ class TextStyle {
   /// * `letterSpacing`: The amount of space (in logical pixels) to add between each letter.
   /// * `wordSpacing`: The amount of space (in logical pixels) to add at each sequence of white-space (i.e. between each word).
   /// * `textBaseline`: The common baseline that should be aligned between this text span and its parent text span, or, for the root text spans, with the line box.
-  /// * `height`: The height of this text span, as a multiplier of the font size. Omitting `height` will allow the text
+  /// * `height`: The height of this text span, as a multiplier of the font size. Omitting `height` will allow the line height
   ///   to take the height as defined by the font, which may not be exactly the height of the fontSize.
   /// * `locale`: The locale used to select region-specific glyphs.
   /// * `background`: The paint drawn as a background for the text.
@@ -780,8 +780,8 @@ class ParagraphStyle {
   /// * `height`: The fallback height of the spans as a multiplier of the font
   ///   size. The fallback height is used when no height is provided in through
   ///   [TextStyle.height]. Omitting `height` here and in [TextStyle] will allow
-  ///   the text to take the height as defined by the font, which may not be
-  ///   exactly the height of the fontSize.
+  ///   the line height to take the height as defined by the font, which may not
+  ///   be exactly the height of the fontSize.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -778,10 +778,10 @@ class ParagraphStyle {
   ///   use when painting the text. This is used when there is no [TextStyle].
   ///
   /// * `height`: The fallback height of the spans as a multiplier of the font
-  ///   size. The fallback height is used when no height is provided in through
+  ///   size. The fallback height is used when no height is provided through
   ///   [TextStyle.height]. Omitting `height` here and in [TextStyle] will allow
   ///   the line height to take the height as defined by the font, which may not
-  ///   be exactly the height of the fontSize.
+  ///   be exactly the height of the `fontSize`.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).
@@ -972,14 +972,14 @@ class StrutStyle {
   ///   the text.
   ///
   /// * `height`: The minimum height of the line boxes, as a multiplier of the
-  ///   font size. The lines of the paragraph will be at least `(height + leading)
-  ///   * fontSize` tall when fontSize is not null. Omitting `height` will allow
-  ///   the minimum line height to take the height as defined by the font, which
-  ///   may not be exactly the height of the fontSize. When fontSize is null, there
-  ///   is no minimum line height. Tall glyphs due to baseline alignment or large
-  ///   [TextStyle.fontSize] may cause the actual line height after layout to be
-  ///   taller than specified here. [fontSize] must be provided for this property
-  ///   to take effect.
+  ///   font size. The lines of the paragraph will be at least
+  ///   `(height + leading) * fontSize` tall when fontSize is not null. Omitting
+  ///   `height` will allow the minimum line height to take the height as defined
+  ///   by the font, which may not be exactly the height of the [fontSize]. When
+  ///   [fontSize] is null, there is no minimum line height. Tall glyphs due to
+  ///   baseline alignment or large [TextStyle.fontSize] may cause the actual line
+  ///   height after layout to be taller than specified here. The [fontSize] must
+  ///   be provided for this property to take effect.
   ///
   /// * `leading`: The minimum amount of leading between lines as a multiple of
   ///   the font size. [fontSize] must be provided for this property to take effect.

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -965,24 +965,24 @@ class StrutStyle {
   /// * `fontFamily`: The name of the font to use when painting the text (e.g.,
   ///   Roboto).
   ///
-  /// * `fontFamilyFallback`: An ordered list of font family names that will be searched for when
-  ///    the font in `fontFamily` cannot be found.
+  /// * `fontFamilyFallback`: An ordered list of font family names that will be
+  ///    searched for when the font in `fontFamily` cannot be found.
   ///
   /// * `fontSize`: The size of glyphs (in logical pixels) to use when painting
   ///   the text.
   ///
   /// * `height`: The minimum height of the line boxes, as a multiplier of the
   ///   font size. The lines of the paragraph will be at least
-  ///   `(height + leading) * fontSize` tall when fontSize is not null. Omitting
+  ///   `(height + leading) * fontSize` tall when `fontSize` is not null. Omitting
   ///   `height` will allow the minimum line height to take the height as defined
-  ///   by the font, which may not be exactly the height of the [fontSize]. When
-  ///   [fontSize] is null, there is no minimum line height. Tall glyphs due to
+  ///   by the font, which may not be exactly the height of the `fontSize`. When
+  ///   `fontSize` is null, there is no minimum line height. Tall glyphs due to
   ///   baseline alignment or large [TextStyle.fontSize] may cause the actual line
-  ///   height after layout to be taller than specified here. The [fontSize] must
+  ///   height after layout to be taller than specified here. The `fontSize` must
   ///   be provided for this property to take effect.
   ///
   /// * `leading`: The minimum amount of leading between lines as a multiple of
-  ///   the font size. [fontSize] must be provided for this property to take effect.
+  ///   the font size. `fontSize` must be provided for this property to take effect.
   ///
   /// * `fontWeight`: The typeface thickness to use when painting the text
   ///   (e.g., bold).
@@ -993,9 +993,9 @@ class StrutStyle {
   /// * `forceStrutHeight`: When true, the paragraph will force all lines to be exactly
   ///   `(height + leading) * fontSize` tall from baseline to baseline.
   ///   [TextStyle] is no longer able to influence the line height, and any tall
-  ///   glyphs may overlap with lines above. If a [fontFamily] is specified, the
+  ///   glyphs may overlap with lines above. If a `fontFamily` is specified, the
   ///   total ascent of the first line will be the min of the `Ascent + half-leading`
-  ///   of the [fontFamily] and `(height + leading) * fontSize`. Otherwise, it
+  ///   of the `fontFamily` and `(height + leading) * fontSize`. Otherwise, it
   ///   will be determined by the Ascent + half-leading of the first text.
   StrutStyle({
     String fontFamily,

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -204,6 +204,7 @@ void decodeStrut(Dart_Handle strut_data,
   }
   if (mask & sHeightMask) {
     paragraph_style.strut_height = float_data[float_count++];
+    paragraph_style.strut_has_height_override = true;
   }
   if (mask & sLeadingMask) {
     paragraph_style.strut_leading = float_data[float_count++];
@@ -261,6 +262,7 @@ ParagraphBuilder::ParagraphBuilder(
 
   if (mask & psHeightMask) {
     style.height = height;
+    style.has_height_override = true;
   }
 
   if (mask & psStrutStyleMask) {
@@ -401,6 +403,7 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
 
   if (mask & tsHeightMask) {
     style.height = height;
+    style.has_height_override = true;
   }
 
   if (mask & tsLocaleMask) {

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1073,10 +1073,10 @@ void Paragraph::Layout(double width, bool force) {
           ascent = (-metrics.fAscent + metrics.fLeading / 2);
           descent = (metrics.fDescent + metrics.fLeading / 2);
         }
+        ComputePlaceholder(placeholder_run, ascent, descent);
+
         max_ascent = std::max(ascent, max_ascent);
         max_descent = std::max(descent, max_descent);
-
-        ComputePlaceholder(placeholder_run, ascent, descent);
       }
 
       max_unscaled_ascent = std::max(placeholder_run == nullptr
@@ -1496,6 +1496,8 @@ std::vector<Paragraph::TextBox> Paragraph::GetRectsForRange(
       top = baseline - run.placeholder_run->baseline_offset;
       bottom = baseline + run.placeholder_run->height -
                run.placeholder_run->baseline_offset;
+      FML_DLOG(ERROR) << baseline << " " << run.placeholder_run->baseline_offset
+                      << " " << run.placeholder_run->height;
     }
 
     max_line = std::max(run.line_number, max_line);

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1496,8 +1496,6 @@ std::vector<Paragraph::TextBox> Paragraph::GetRectsForRange(
       top = baseline - run.placeholder_run->baseline_offset;
       bottom = baseline + run.placeholder_run->height -
                run.placeholder_run->baseline_offset;
-      FML_DLOG(ERROR) << baseline << " " << run.placeholder_run->baseline_offset
-                      << " " << run.placeholder_run->height;
     }
 
     max_line = std::max(run.line_number, max_line);

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -507,14 +507,30 @@ void Paragraph::ComputeStrut(StrutMetrics* strut, SkFont& font) {
     SkFontMetrics strut_metrics;
     font.getMetrics(&strut_metrics);
 
-    strut->ascent = paragraph_style_.strut_height * -strut_metrics.fAscent;
-    strut->descent = paragraph_style_.strut_height * strut_metrics.fDescent;
-    strut->leading =
-        // Use font's leading if there is no user specified strut leading.
-        paragraph_style_.strut_leading < 0
-            ? strut_metrics.fLeading
-            : (paragraph_style_.strut_leading *
-               (strut_metrics.fDescent - strut_metrics.fAscent));
+    if (paragraph_style_.strut_has_height_override) {
+      double metrics_height = -strut_metrics.fAscent + strut_metrics.fDescent;
+      strut->ascent = (-strut_metrics.fAscent / metrics_height) *
+                      paragraph_style_.strut_height *
+                      paragraph_style_.strut_font_size;
+      strut->descent = (strut_metrics.fDescent / metrics_height) *
+                       paragraph_style_.strut_height *
+                       paragraph_style_.strut_font_size;
+      strut->leading =
+          // Zero leading if there is no user specified strut leading.
+          paragraph_style_.strut_leading < 0
+              ? 0
+              : (paragraph_style_.strut_leading *
+                 paragraph_style_.strut_font_size);
+    } else {
+      strut->ascent = paragraph_style_.strut_height * -strut_metrics.fAscent;
+      strut->descent = paragraph_style_.strut_height * strut_metrics.fDescent;
+      strut->leading =
+          // Use font's leading if there is no user specified strut leading.
+          paragraph_style_.strut_leading < 0
+              ? strut_metrics.fLeading
+              : (paragraph_style_.strut_leading *
+                 paragraph_style_.strut_font_size);
+    }
     strut->half_leading = strut->leading / 2;
     strut->line_height = strut->ascent + strut->descent + strut->leading;
   }

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1042,15 +1042,25 @@ void Paragraph::Layout(double width, bool force) {
                                    const TextStyle& style,
                                    PlaceholderRun* placeholder_run) {
       if (!strut_.force_strut) {
-        double ascent =
-            (-metrics.fAscent + metrics.fLeading / 2) * style.height;
-        double descent =
-            (metrics.fDescent + metrics.fLeading / 2) * style.height;
-
-        ComputePlaceholder(placeholder_run, ascent, descent);
-
+        double ascent;
+        double descent;
+        if (style.has_height_override) {
+          // Scale the ascent and descent such that the sum of ascent and
+          // descent is `fontsize * style.height * style.font_size`.
+          double metrics_height = -metrics.fAscent + metrics.fDescent;
+          ascent = (-metrics.fAscent / metrics_height) * style.height *
+                   style.font_size;
+          descent = (metrics.fDescent / metrics_height) * style.height *
+                    style.font_size;
+        } else {
+          // Use the font-provided ascent, descent, and leading directly.
+          ascent = (-metrics.fAscent + metrics.fLeading / 2);
+          descent = (metrics.fDescent + metrics.fLeading / 2);
+        }
         max_ascent = std::max(ascent, max_ascent);
         max_descent = std::max(descent, max_descent);
+
+        ComputePlaceholder(placeholder_run, ascent, descent);
       }
 
       max_unscaled_ascent = std::max(placeholder_run == nullptr

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -522,8 +522,8 @@ void Paragraph::ComputeStrut(StrutMetrics* strut, SkFont& font) {
               : (paragraph_style_.strut_leading *
                  paragraph_style_.strut_font_size);
     } else {
-      strut->ascent = paragraph_style_.strut_height * -strut_metrics.fAscent;
-      strut->descent = paragraph_style_.strut_height * strut_metrics.fDescent;
+      strut->ascent = -strut_metrics.fAscent;
+      strut->descent = strut_metrics.fDescent;
       strut->leading =
           // Use font's leading if there is no user specified strut leading.
           paragraph_style_.strut_leading < 0

--- a/third_party/txt/src/txt/paragraph_style.cc
+++ b/third_party/txt/src/txt/paragraph_style.cc
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include <vector>
-
 #include "paragraph_style.h"
+
+#include <vector>
 
 namespace txt {
 
@@ -30,6 +30,7 @@ TextStyle ParagraphStyle::GetTextStyle() const {
   }
   result.locale = locale;
   result.height = height;
+  result.has_height_override = has_height_override;
   return result;
 }
 

--- a/third_party/txt/src/txt/paragraph_style.h
+++ b/third_party/txt/src/txt/paragraph_style.h
@@ -50,6 +50,7 @@ class ParagraphStyle {
   std::string font_family = "";
   double font_size = 14;
   double height = 1;
+  bool has_height_override = false;
 
   // Strut properties. strut_enabled must be set to true for the rest of the
   // properties to take effect.
@@ -60,6 +61,7 @@ class ParagraphStyle {
   std::vector<std::string> strut_font_families;
   double strut_font_size = 14;
   double strut_height = 1;
+  bool strut_has_height_override = false;
   double strut_leading = -1;  // Negative to use font's default leading. [0,inf)
                               // to use custom leading as a ratio of font size.
   bool force_strut_height = false;

--- a/third_party/txt/src/txt/text_style.cc
+++ b/third_party/txt/src/txt/text_style.cc
@@ -15,6 +15,7 @@
  */
 
 #include "text_style.h"
+
 #include "font_style.h"
 #include "font_weight.h"
 #include "third_party/skia/include/core/SkColor.h"
@@ -45,6 +46,8 @@ bool TextStyle::equals(const TextStyle& other) const {
   if (word_spacing != other.word_spacing)
     return false;
   if (height != other.height)
+    return false;
+  if (has_height_override != other.has_height_override)
     return false;
   if (locale != other.locale)
     return false;

--- a/third_party/txt/src/txt/text_style.h
+++ b/third_party/txt/src/txt/text_style.h
@@ -51,6 +51,7 @@ class TextStyle {
   double letter_spacing = 0.0;
   double word_spacing = 0.0;
   double height = 1.0;
+  bool has_height_override = false;
   std::string locale;
   bool has_background = false;
   SkPaint background;

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -2389,9 +2389,6 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeTight)) {
 
 TEST_F(ParagraphTest,
        DISABLE_ON_WINDOWS(GetRectsForRangeIncludeLineSpacingMiddle)) {
-  // const char* text =
-  //     "12345,  \"67890\" 12345 67890 12345 67890 12345 67890 12345 67890
-  //     12345 " "67890 12345";
   const char* text =
       "(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("
       "　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("
@@ -2407,13 +2404,13 @@ TEST_F(ParagraphTest,
 
   txt::TextStyle text_style;
   text_style.font_families = std::vector<std::string>(1, "Roboto");
-  // text_style.font_families = std::vector<std::string>(1, "Roboto");
   text_style.font_size = 50;
   text_style.letter_spacing = 0;
   text_style.font_weight = FontWeight::w500;
   text_style.word_spacing = 0;
   text_style.color = SK_ColorBLACK;
-  text_style.height = 1.3;
+  text_style.height = 1.6;
+  text_style.has_height_override = true;
   builder.PushStyle(text_style);
 
   builder.AddText(u16_text);
@@ -2451,9 +2448,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.429688);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 82.958008);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473305);
 
   paint.setColor(SK_ColorBLUE);
   boxes =
@@ -2463,9 +2460,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.429688);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 82.958008);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473305);
 
   paint.setColor(SK_ColorGREEN);
   boxes =
@@ -2475,9 +2472,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.0625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 82.958008);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473312);
 
   paint.setColor(SK_ColorRED);
   boxes =
@@ -2487,34 +2484,34 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 8ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 82.786133);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 88.473312);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.6875);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 158.95801);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 168.47331);
 
   EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.6875);
-  EXPECT_FLOAT_EQ(boxes[1].rect.top(), 82.786133);
+  EXPECT_FLOAT_EQ(boxes[1].rect.top(), 88.473312);
   EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 158.95801);
+  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 168.4733);
 
   EXPECT_FLOAT_EQ(boxes[2].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[2].rect.top(), 158.78613);
+  EXPECT_FLOAT_EQ(boxes[2].rect.top(), 168.4733);
   EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.57422);
-  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 234.95801);
+  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 248.47331);
 
   EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.57422);
-  EXPECT_FLOAT_EQ(boxes[3].rect.top(), 158.78613);
+  EXPECT_FLOAT_EQ(boxes[3].rect.top(), 168.4733);
   EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 234.95801);
+  EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 248.47331);
 
   EXPECT_FLOAT_EQ(boxes[4].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[4].rect.top(), 234.78613);
+  EXPECT_FLOAT_EQ(boxes[4].rect.top(), 248.47331);
   EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 310.95801);
+  EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 328.4733);
 
   EXPECT_FLOAT_EQ(boxes[5].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[5].rect.top(), 310.78613);
+  EXPECT_FLOAT_EQ(boxes[5].rect.top(), 328.47333);
   EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 386.95801);
+  EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 408.4733);
 
   paint.setColor(SK_ColorBLUE);
   boxes =
@@ -2524,9 +2521,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.72656);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.23047);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 82.958008);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473305);
 
   paint.setColor(SK_ColorRED);
   boxes =
@@ -2541,9 +2538,6 @@ TEST_F(ParagraphTest,
 
 TEST_F(ParagraphTest,
        DISABLE_ON_WINDOWS(GetRectsForRangeIncludeLineSpacingTop)) {
-  // const char* text =
-  //     "12345,  \"67890\" 12345 67890 12345 67890 12345 67890 12345 67890
-  //     12345 " "67890 12345";
   const char* text =
       "(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("
       "　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("
@@ -2564,7 +2558,8 @@ TEST_F(ParagraphTest,
   text_style.font_weight = FontWeight::w500;
   text_style.word_spacing = 0;
   text_style.color = SK_ColorBLACK;
-  text_style.height = 1.3;
+  text_style.height = 1.6;
+  text_style.has_height_override = true;
   builder.PushStyle(text_style);
 
   builder.AddText(u16_text);
@@ -2602,9 +2597,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.429688);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 76);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorBLUE);
   boxes =
@@ -2614,9 +2609,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.429688);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 76);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorGREEN);
   boxes =
@@ -2626,9 +2621,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.0625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 76);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorRED);
   boxes =
@@ -2638,34 +2633,34 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 8ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 75.828125);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 80);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.6875);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 152);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 160);
 
   EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.6875);
-  EXPECT_FLOAT_EQ(boxes[1].rect.top(), 75.828125);
+  EXPECT_FLOAT_EQ(boxes[1].rect.top(), 80);
   EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 152);
+  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 160);
 
   EXPECT_FLOAT_EQ(boxes[2].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[2].rect.top(), 151.82812);
+  EXPECT_FLOAT_EQ(boxes[2].rect.top(), 160);
   EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.57422);
-  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 228);
+  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 240);
 
   EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.57422);
-  EXPECT_FLOAT_EQ(boxes[3].rect.top(), 151.82812);
+  EXPECT_FLOAT_EQ(boxes[3].rect.top(), 160);
   EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 228);
+  EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 240);
 
   EXPECT_FLOAT_EQ(boxes[4].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[4].rect.top(), 227.82812);
+  EXPECT_FLOAT_EQ(boxes[4].rect.top(), 240);
   EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 304);
+  EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 320);
 
   EXPECT_FLOAT_EQ(boxes[5].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[5].rect.top(), 303.82812);
+  EXPECT_FLOAT_EQ(boxes[5].rect.top(), 320);
   EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 380);
+  EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 400);
 
   paint.setColor(SK_ColorBLUE);
   boxes =
@@ -2675,9 +2670,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.72656);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.23047);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 76);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorRED);
   boxes =
@@ -2692,9 +2687,6 @@ TEST_F(ParagraphTest,
 
 TEST_F(ParagraphTest,
        DISABLE_ON_WINDOWS(GetRectsForRangeIncludeLineSpacingBottom)) {
-  // const char* text =
-  //     "12345,  \"67890\" 12345 67890 12345 67890 12345 67890 12345 67890
-  //     12345 " "67890 12345";
   const char* text =
       "(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("
       "　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)(　´･‿･｀)("
@@ -2715,7 +2707,8 @@ TEST_F(ParagraphTest,
   text_style.font_weight = FontWeight::w500;
   text_style.word_spacing = 0;
   text_style.color = SK_ColorBLACK;
-  text_style.height = 1.3;
+  text_style.height = 1.6;
+  text_style.has_height_override = true;
   builder.PushStyle(text_style);
 
   builder.AddText(u16_text);
@@ -2753,9 +2746,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.429688);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89.916016);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorBLUE);
   boxes =
@@ -2765,9 +2758,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.429688);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89.916016);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorGREEN);
   boxes =
@@ -2777,9 +2770,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.0625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89.916016);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorRED);
   boxes =
@@ -2789,34 +2782,34 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 8ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 89.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 96.946617);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.6875);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 165.91602);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 176.94661);
 
   EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.6875);
-  EXPECT_FLOAT_EQ(boxes[1].rect.top(), 89.744141);
+  EXPECT_FLOAT_EQ(boxes[1].rect.top(), 96.946617);
   EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 165.91602);
+  EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 176.94661);
 
   EXPECT_FLOAT_EQ(boxes[2].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[2].rect.top(), 165.74414);
+  EXPECT_FLOAT_EQ(boxes[2].rect.top(), 176.94661);
   EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.57422);
-  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 241.91602);
+  EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 256.94662);
 
   EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.57422);
-  EXPECT_FLOAT_EQ(boxes[3].rect.top(), 165.74414);
+  EXPECT_FLOAT_EQ(boxes[3].rect.top(), 176.94661);
   EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 241.91602);
+  EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 256.94662);
 
   EXPECT_FLOAT_EQ(boxes[4].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[4].rect.top(), 241.74414);
+  EXPECT_FLOAT_EQ(boxes[4].rect.top(), 256.94662);
   EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 317.91602);
+  EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 336.94662);
 
   EXPECT_FLOAT_EQ(boxes[5].rect.left(), 0);
-  EXPECT_FLOAT_EQ(boxes[5].rect.top(), 317.74414);
+  EXPECT_FLOAT_EQ(boxes[5].rect.top(), 336.94662);
   EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.02344);
-  EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 393.91602);
+  EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 416.94662);
 
   paint.setColor(SK_ColorBLUE);
   boxes =
@@ -2826,9 +2819,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.72656);
-  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 13.744141);
+  EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.23047);
-  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 89.916016);
+  EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorRED);
   boxes =
@@ -3365,6 +3358,7 @@ TEST_F(ParagraphTest, GetWordBoundaryParagraph) {
   text_style.word_spacing = 5;
   text_style.color = SK_ColorBLACK;
   text_style.height = 1.5;
+  text_style.has_height_override = true;
   builder.PushStyle(text_style);
 
   builder.AddText(u16_text);


### PR DESCRIPTION
In order to better match the API description of `TextStyle.height`, this ensures that the height of the line is exactly `fontSize * height` logical pixels tall when a height is specified. When unspecified/omitted, the font's height will be used, which may be taller or shorter then the EM square.

This is a breaking change, even though it brings behavior back in line with the description.

Even though this changes a very fundamental API, it seems to not break as much as expected. Most implementations are not as dependent on the height property as I had suspected.

Fixes https://github.com/flutter/flutter/issues/29479