### PR TITLE
remove over-optimistic assert

### DIFF
--- a/lib/stub_ui/lib/src/ui/compositing.dart
+++ b/lib/stub_ui/lib/src/ui/compositing.dart
@@ -918,7 +918,7 @@ abstract class PersistedSurface implements EngineLayer {
   /// Creates a persisted surface.
   ///
   /// [paintedBy] points to the object that painted this surface.
-  PersistedSurface(this.paintedBy) : assert(paintedBy != null);
+  PersistedSurface(this.paintedBy);
 
   /// The strategy that should be used when attempting to reuse the resources
   /// owned by this surface.


### PR DESCRIPTION
We've disabled flutter web retained mode for flutter compat temporarily. Remove this assert so we can compile with dartdevc.