### PR TITLE
New Plugin API PR4: Adds Lifecycle support to the new plugin system.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -543,6 +543,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/Flutt
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/FlutterView.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -128,6 +128,7 @@ action("flutter_shell_java") {
     "io/flutter/embedding/android/FlutterTextureView.java",
     "io/flutter/embedding/android/FlutterView.java",
     "io/flutter/embedding/engine/FlutterEngine.java",
+    "io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java",
     "io/flutter/embedding/engine/FlutterEnginePluginRegistry.java",
     "io/flutter/embedding/engine/FlutterJNI.java",
     "io/flutter/embedding/engine/FlutterShellArgs.java",
@@ -216,6 +217,8 @@ action("flutter_shell_java") {
     "//third_party/android_support/android_support_annotations.jar",
     "//third_party/android_support/android_support_fragment.jar",
     "//third_party/android_support/android_arch_lifecycle_common.jar",
+    "//third_party/android_support/android_arch_lifecycle_common_java8.jar",
+    "//third_party/android_support/android_arch_lifecycle_runtime.jar",
     "//third_party/android_support/android_arch_lifecycle_viewmodel.jar",
   ]
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -274,7 +274,24 @@ public class FlutterActivity extends FragmentActivity implements OnFirstFrameRen
         .flutterShellArgs(FlutterShellArgs.fromIntent(getIntent()))
         .renderMode(FlutterView.RenderMode.surface)
         .transparencyMode(FlutterView.TransparencyMode.opaque)
+        .shouldAttachEngineToActivity(shouldAttachEngineToActivity())
         .build();
+  }
+
+  /**
+   * Hook for subclasses to control whether or not the {@link FlutterFragment} within this
+   * {@code Activity} automatically attaches its {@link FlutterEngine} to this {@code Activity}.
+   * <p>
+   * For an explanation of why this control exists, see {@link FlutterFragment.Builder#shouldAttachEngineToActivity()}.
+   * <p>
+   * This property is controlled with a protected method instead of an {@code Intent} argument because
+   * the only situation where changing this value would help, is a situation in which
+   * {@code FlutterActivity} is being subclassed to utilize a custom and/or cached {@link FlutterEngine}.
+   * <p>
+   * Defaults to {@code true}.
+   */
+  protected boolean shouldAttachEngineToActivity() {
+    return true;
   }
 
   @Override

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
@@ -33,7 +33,7 @@ import android.support.annotation.Nullable;
  * default {@link Lifecycle.State#CREATED} state until some other backing {@link Lifecycle} is
  * registered.
  */
-class FlutterEngineAndroidLifecycle extends LifecycleRegistry {
+final class FlutterEngineAndroidLifecycle extends LifecycleRegistry {
   private static final String TAG = "FlutterEngineAndroidLifecycle";
 
   @Nullable

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
@@ -1,0 +1,126 @@
+package io.flutter.embedding.engine;
+
+import android.arch.lifecycle.DefaultLifecycleObserver;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.LifecycleRegistry;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+/**
+ * Android {@link Lifecycle} that is owned by a {@link FlutterEngine}.
+ * <p>
+ * {@code FlutterEngineAndroidLifecycle} exists so that {@code FlutterPlugin}s can monitor Android
+ * lifecycle events. When the associated {@link FlutterEngine} is running in an {@code Activity},
+ * that {@code Activity}'s {@link Lifecycle} can be set as the {@code backingLifecycle} of this
+ * class, allowing all Flutter plugins to receive the {@code Activity}'s lifecycle events. Likewise,
+ * when the associated {@link FlutterEngine} is running in a {@code Service}, that {@code Service}'s
+ * {@link Lifecycle} can be set as the {@code backingLifecycle}.
+ * <p>
+ * Sometimes a {@link FlutterEngine} exists in a non-lifecycle location, e.g., an {@code Application},
+ * {@code ContentProvider}, or {@code BroadcastReceiver}. In these cases, this lifecycle reports
+ * itself in the {@link Lifecycle.State#CREATED} state.
+ * <p>
+ * Regardless of what happens to a backing {@code Activity} or @{code Service}, this lifecycle
+ * will only report itself as {@link Lifecycle.State#DESTROYED} when the associated {@link FlutterEngine}
+ * itself is destroyed. This is because a {@link Lifecycle} is not allowed to emit any events after
+ * going to the {@link Lifecycle.State#DESTROYED} state. Thus, this lifecycle cannot emit such an
+ * event until its associated {@link FlutterEngine} is destroyed. This then begs the question, what
+ * happens when the backing {@code Activity} or {@code Service} is destroyed? This lifecycle will
+ * report the process up to the {@link Lifecycle.Event#ON_STOP} event, but will ignore the
+ * {@link Lifecycle.Event#ON_DESTROY} event. At that point, this lifecycle will be back in its
+ * default {@link Lifecycle.State#CREATED} state until some other backing {@link Lifecycle} is
+ * registered.
+ */
+class FlutterEngineAndroidLifecycle extends LifecycleRegistry {
+  private static final String TAG = "FlutterEngineAndroidLifecycle";
+
+  @Nullable
+  private Lifecycle backingLifecycle;
+  private boolean isDestroyed = false;
+
+  private final LifecycleObserver forwardingObserver = new DefaultLifecycleObserver() {
+    @Override
+    public void onCreate(@NonNull LifecycleOwner owner) {
+      // No-op. The FlutterEngine's Lifecycle is always at least Created
+      // until it is Destroyed, so we ignore onCreate() events from
+      // backing Lifecycles.
+    }
+
+    @Override
+    public void onStart(@NonNull LifecycleOwner owner) {
+      handleLifecycleEvent(Event.ON_START);
+    }
+
+    @Override
+    public void onResume(@NonNull LifecycleOwner owner) {
+      handleLifecycleEvent(Event.ON_RESUME);
+    }
+
+    @Override
+    public void onPause(@NonNull LifecycleOwner owner) {
+      handleLifecycleEvent(Event.ON_PAUSE);
+    }
+
+    @Override
+    public void onStop(@NonNull LifecycleOwner owner) {
+      handleLifecycleEvent(Event.ON_STOP);
+    }
+
+    @Override
+    public void onDestroy(@NonNull LifecycleOwner owner) {
+      // No-op. We don't allow FlutterEngine's Lifecycle to report destruction
+      // until the FlutterEngine itself is destroyed. This is because a Lifecycle
+      // is contractually obligated to send no more event once it gets to the
+      // Destroyed state, which would prevent FlutterEngine from switching to
+      // the next Lifecycle that is attached.
+    }
+  };
+
+  FlutterEngineAndroidLifecycle(@NonNull LifecycleOwner provider) {
+    super(provider);
+  }
+
+  public void setBackingLifecycle(@Nullable Lifecycle lifecycle) {
+    ensureNotDestroyed();
+
+    // We no longer want to propagate events from the old Lifecycle. Deregister our forwarding observer.
+    if (backingLifecycle != null) {
+      backingLifecycle.removeObserver(forwardingObserver);
+    }
+
+    // Manually move us to the Stopped state before we switch out the underlying Lifecycle.
+    handleLifecycleEvent(Event.ON_STOP);
+
+    // Switch out the underlying lifecycle.
+    backingLifecycle = lifecycle;
+
+    if (backingLifecycle != null) {
+      // Add our forwardingObserver to the new backing Lifecycle so that this PluginRegistry is
+      // controlled by that backing lifecycle. Adding our forwarding observer will automatically
+      // result in invocations of the necessary Lifecycle events to bring us up to speed with the
+      // new backingLifecycle, e.g., onStart(), onResume().
+      lifecycle.addObserver(forwardingObserver);
+    }
+  }
+
+  @Override
+  public void handleLifecycleEvent(@NonNull Event event) {
+    ensureNotDestroyed();
+    super.handleLifecycleEvent(event);
+  }
+
+  public void destroy() {
+    ensureNotDestroyed();
+    setBackingLifecycle(null);
+    markState(State.DESTROYED);
+    isDestroyed = true;
+  }
+
+  private void ensureNotDestroyed() {
+    if (isDestroyed) {
+      throw new IllegalStateException("Tried to invoke a method on a destroyed FlutterEngineAndroidLifecycle.");
+    }
+  }
+}

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
@@ -5,6 +5,7 @@
 package io.flutter.embedding.engine.plugins;
 
 import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleOwner;
 import android.content.Context;
 import android.support.annotation.NonNull;
 
@@ -87,12 +88,12 @@ public interface FlutterPlugin {
    * {@link FlutterEngine#getDartExecutor()}.
    * <p>
    * A {@link FlutterEngine} may move from foreground to background, from an {@code Activity} to
-   * a {@code Service}, and {@code FlutterPluginBinding}'s {@code lifecycle} generalizes those
+   * a {@code Service}. {@code FlutterPluginBinding}'s {@code lifecycle} generalizes those
    * lifecycles so that a {@code FlutterPlugin} can react to lifecycle events without being
    * concerned about which Android Component is currently holding the {@link FlutterEngine}.
    * TODO(mattcarroll): add info about ActivityAware and ServiceAware for plugins that care.
    */
-  class FlutterPluginBinding {
+  class FlutterPluginBinding implements LifecycleOwner {
         private final Context applicationContext;
         private final FlutterEngine flutterEngine;
         private final Lifecycle lifecycle;
@@ -117,6 +118,7 @@ public interface FlutterPlugin {
             return flutterEngine;
         }
 
+        @Override
         @NonNull
         public Lifecycle getLifecycle() {
             return lifecycle;

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
@@ -66,7 +66,7 @@ public interface ActivityControlSurface {
    * This method gives each {@link ActivityAware} plugin an opportunity to re-establish necessary
    * references to the given {@link Activity}.
    */
-  void reattachToActivityAfterConfigChange(@NonNull Activity activity);
+  void reattachToActivityAfterConfigChange(@NonNull Activity activity, @NonNull Lifecycle lifecycle);
 
   /**
    * Call this method from the {@link Activity} that is attached to this {@code ActivityControlSurfaces}'s

--- a/tools/android_support/files.json
+++ b/tools/android_support/files.json
@@ -1,5 +1,7 @@
 {
   "android_arch_lifecycle_common.jar": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/common/1.1.1/common-1.1.1.jar",
+  "android_arch_lifecycle_common_java8.jar": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/common-java8/1.1.1/common-java8-1.1.1.jar",
+  "android_arch_lifecycle_runtime.jar": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/runtime/1.1.1/runtime-1.1.1.aar",
   "android_arch_lifecycle_viewmodel.jar": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/viewmodel/1.1.1/viewmodel-1.1.1.aar",
   "android_support_fragment.jar": "https://dl.google.com/dl/android/maven2/com/android/support/support-fragment/28.0.0/support-fragment-28.0.0.aar",
   "android_support_v13.jar": "https://dl.google.com/dl/android/maven2/com/android/support/support-v13/28.0.0/support-v13-28.0.0.aar",


### PR DESCRIPTION
New Plugin API PR4: Adds Lifecycle support to the new plugin system.

I still need to send in a real `Lifecycle` from `FlutterFragment`, but this PR creates the behavior within the new plugin system to respond to `Lifecycle` events.

This PR adds 2 Android libs to the engine:

- lifecycle-common-java8, which complements our existing lifecycle-common by adding one class that is needed for Java 8 compliance
- lifecycle-runtime, which was needed to utilize `PluginRegistry`.

**Intended lifecycle behavior**
When there is no backing lifecycle, e.g., `Activity` or `Service`, the `FlutterEngine` reports itself in the `CREATED` state. When either an `Activity` or a `Service` is attached to the `FlutterEngine`, the `FlutterEngine` defers to whatever the lifecycle of that component reports. The only caveat to this behavior is that even if the backing `Activity` or `Service` is destroyed, the `FlutterEngine` will not send a destruction event. This is because any `Lifecycle` that emits a destruction event is obligated to never send any future events, which would be inappropriate in our case.