### PR TITLE
Add a podspec for FlutterMacOS.framework

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -743,6 +743,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_software.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_surface_software.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/platform_view_ios.h
 FILE: ../../../flutter/shell/platform/darwin/ios/platform_view_ios.mm
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEOpenGLContextHandling.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEPlugin.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEPluginRegistrar.h

--- a/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
+++ b/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
@@ -1,0 +1,19 @@
+#
+# NOTE: This podspec is NOT to be published. It is only used as a local source!
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'FlutterMacOS'
+  s.version          = '1.0.0'
+  s.summary          = 'High-performance, high-fidelity cross-platform apps.'
+  s.description      = <<-DESC
+Flutter is Google's portable UI toolkit for building beautiful, natively-compiled applications for mobile, web, and desktop from a single codebase.
+                       DESC
+  s.homepage         = 'https://flutter.dev'
+  s.license          = { :type => 'MIT' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  # TODO: Decide what value should be here. See #33200.
+  s.osx.deployment_target = '10.13'
+  s.vendored_frameworks = 'FlutterMacOS.framework'
+end


### PR DESCRIPTION
Based on the iOS Flutter.podspec. This will be used for plugin
management via CocoaPods, as on iOS.

Part of https://github.com/flutter/flutter/issues/32718