### PR TITLE
Rename macOS FLEPlugin* to FlutterPlugin*

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -745,12 +745,12 @@ FILE: ../../../flutter/shell/platform/darwin/ios/platform_view_ios.h
 FILE: ../../../flutter/shell/platform/darwin/ios/platform_view_ios.mm
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEOpenGLContextHandling.h
-FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEPlugin.h
-FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEPluginRegistrar.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEReshapeListener.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEView.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FlutterMacOS.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FlutterPluginMacOS.h
+FILE: ../../../flutter/shell/platform/darwin/macos/framework/Headers/FlutterPluginRegistrarMacOS.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Info.plist
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FLETextInputModel.h
 FILE: ../../../flutter/shell/platform/darwin/macos/framework/Source/FLETextInputModel.mm

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -31,9 +31,9 @@ _flutter_framework_dir = "$root_out_dir/$_flutter_framework_filename"
 # the Flutter engine source root.
 _flutter_framework_headers = [
   "framework/Headers/FlutterMacOS.h",
+  "framework/Headers/FlutterPluginMacOS.h",
+  "framework/Headers/FlutterPluginRegistrarMacOS.h",
   "framework/Headers/FLEOpenGLContextHandling.h",
-  "framework/Headers/FLEPlugin.h",
-  "framework/Headers/FLEPluginRegistrar.h",
   "framework/Headers/FLEReshapeListener.h",
   "framework/Headers/FLEView.h",
   "framework/Headers/FLEViewController.h",

--- a/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
@@ -5,8 +5,8 @@
 #import <Cocoa/Cocoa.h>
 
 #import "FLEOpenGLContextHandling.h"
-#import "FLEPluginRegistrar.h"
 #import "FLEReshapeListener.h"
+#import "FlutterPluginRegistrarMacOS.h"
 
 #if defined(FLUTTER_FRAMEWORK)
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterBinaryMessenger.h"
@@ -36,8 +36,8 @@ typedef NS_ENUM(NSInteger, FlutterMouseTrackingMode) {
  */
 FLUTTER_EXPORT
 @interface FLEViewController : NSViewController <FlutterBinaryMessenger,
-                                                 FLEPluginRegistrar,
-                                                 FLEPluginRegistry,
+                                                 FlutterPluginRegistrar,
+                                                 FlutterPluginRegistry,
                                                  FLEReshapeListener>
 
 /**

--- a/shell/platform/darwin/macos/framework/Headers/FlutterMacOS.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterMacOS.h
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 #import "FLEOpenGLContextHandling.h"
-#import "FLEPlugin.h"
-#import "FLEPluginRegistrar.h"
 #import "FLEReshapeListener.h"
 #import "FLEView.h"
 #import "FLEViewController.h"
@@ -12,3 +10,5 @@
 #import "FlutterChannels.h"
 #import "FlutterCodecs.h"
 #import "FlutterMacros.h"
+#import "FlutterPluginMacOS.h"
+#import "FlutterPluginRegistrarMacOS.h"

--- a/shell/platform/darwin/macos/framework/Headers/FlutterPluginMacOS.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterPluginMacOS.h
@@ -14,7 +14,10 @@
 #import "FlutterMacros.h"
 #endif
 
-@protocol FLEPluginRegistrar;
+// TODO: Merge this file and FlutterPluginRegistrarMacOS.h with the iOS FlutterPlugin.h, sharing
+// all but the platform-specific methods.
+
+@protocol FlutterPluginRegistrar;
 
 /**
  * Implemented by the platform side of a Flutter plugin.
@@ -22,23 +25,23 @@
  * Defines a set of optional callback methods and a method to set up the plugin
  * and register it to be called by other application components.
  *
- * Currently FLEPlugin has very limited functionality, but is expected to expand over time to
- * more closely match the functionality of FlutterPlugin.
+ * Currently the macOS version of FlutterPlugin has very limited functionality, but is expected to
+ * expand over time to more closely match the functionality of the iOS FlutterPlugin.
  */
 FLUTTER_EXPORT
-@protocol FLEPlugin <NSObject>
+@protocol FlutterPlugin <NSObject>
 
 /**
  * Creates an instance of the plugin to register with |registrar| using the desired
- * FLEPluginRegistrar methods.
+ * FlutterPluginRegistrar methods.
  */
-+ (void)registerWithRegistrar:(nonnull id<FLEPluginRegistrar>)registrar;
++ (void)registerWithRegistrar:(nonnull id<FlutterPluginRegistrar>)registrar;
 
 @optional
 
 /**
  * Called when a message is sent from Flutter on a channel that a plugin instance has subscribed
- * to via -[FLEPluginRegistrar addMethodCallDelegate:channel:].
+ * to via -[FlutterPluginRegistrar addMethodCallDelegate:channel:].
  *
  * The |result| callback must be called exactly once, with one of:
  * - FlutterMethodNotImplemented, if the method call is unknown.

--- a/shell/platform/darwin/macos/framework/Headers/FlutterPluginRegistrarMacOS.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterPluginRegistrarMacOS.h
@@ -4,7 +4,7 @@
 
 #import <Cocoa/Cocoa.h>
 
-#import "FLEPlugin.h"
+#import "FlutterPluginMacOS.h"
 
 #if defined(FLUTTER_FRAMEWORK)
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterBinaryMessenger.h"
@@ -16,18 +16,18 @@
 #import "FlutterMacros.h"
 #endif
 
-// TODO: Merge this file and FLEPlugin.h with FlutterPlugin.h, sharing all but
+// TODO: Merge this file and FlutterPluginMacOS.h with the iOS FlutterPlugin.h, sharing all but
 // the platform-specific methods.
 
 /**
  * The protocol for an object managing registration for a plugin. It provides access to application
  * context, as as allowing registering for callbacks for handling various conditions.
  *
- * Currently FLEPluginRegistrar has very limited functionality, but is expected to expand over time
- * to more closely match the functionality of FlutterPluginRegistrar.
+ * Currently the macOS PluginRegistrar has very limited functionality, but is expected to expand
+ * over time to more closely match the functionality of FlutterPluginRegistrar.
  */
 FLUTTER_EXPORT
-@protocol FLEPluginRegistrar <NSObject>
+@protocol FlutterPluginRegistrar <NSObject>
 
 /**
  * The binary messenger used for creating channels to communicate with the Flutter engine.
@@ -35,9 +35,9 @@ FLUTTER_EXPORT
 @property(nonnull, readonly) id<FlutterBinaryMessenger> messenger;
 
 /**
- * The view displaying Flutter content.
+ * The view displaying Flutter content. May return |nil|, for instance in a headless environment.
  *
- * WARNING: If/when multiple Flutter views within the same application are supported (#98), this
+ * WARNING: If/when multiple Flutter views within the same application are supported (#30701), this
  * API will change.
  */
 @property(nullable, readonly) NSView* view;
@@ -45,7 +45,7 @@ FLUTTER_EXPORT
 /**
  * Registers |delegate| to receive handleMethodCall:result: callbacks for the given |channel|.
  */
-- (void)addMethodCallDelegate:(nonnull id<FLEPlugin>)delegate
+- (void)addMethodCallDelegate:(nonnull id<FlutterPlugin>)delegate
                       channel:(nonnull FlutterMethodChannel*)channel;
 
 @end
@@ -66,13 +66,13 @@ FLUTTER_EXPORT
  * Specifically, callbacks registered by the plugin via the registrar may be
  * relayed directly to the underlying iOS application objects.
  */
-@protocol FLEPluginRegistry <NSObject>
+@protocol FlutterPluginRegistry <NSObject>
 
 /**
  * Returns a registrar for registering a plugin.
  *
  * @param pluginKey The unique key identifying the plugin.
  */
-- (nonnull id<FLEPluginRegistrar>)registrarForPlugin:(nonnull NSString*)pluginKey;
+- (nonnull id<FlutterPluginRegistrar>)registrarForPlugin:(nonnull NSString*)pluginKey;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FLETextInputPlugin.h
+++ b/shell/platform/darwin/macos/framework/Source/FLETextInputPlugin.h
@@ -13,7 +13,7 @@
  * Responsible for bridging the native macOS text input system with the Flutter framework text
  * editing classes, via system channels.
  *
- * This is not an FLEPlugin since it needs access to FLEViewController internals, so needs to be
+ * This is not an FlutterPlugin since it needs access to FLEViewController internals, so needs to be
  * managed differently.
  */
 @interface FLETextInputPlugin : NSResponder

--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -240,7 +240,8 @@ static bool HeadlessOnMakeResourceCurrent(FLEViewController* controller) {
   // A mapping of channel names to the registered handlers for those channels.
   NSMutableDictionary<NSString*, FlutterBinaryMessageHandler>* _messageHandlers;
 
-  // The plugin used to handle text input. This is not an FLEPlugin, so must be owned separately.
+  // The plugin used to handle text input. This is not an FlutterPlugin, so must be owned
+  // separately.
   FLETextInputPlugin* _textInputPlugin;
 
   // A message channel for passing key events to the Flutter engine. This should be replaced with
@@ -653,22 +654,22 @@ static void CommonInit(FLEViewController* controller) {
   _messageHandlers[channel] = [handler copy];
 }
 
-#pragma mark - FLEPluginRegistrar
+#pragma mark - FlutterPluginRegistrar
 
 - (id<FlutterBinaryMessenger>)messenger {
   return self;
 }
 
-- (void)addMethodCallDelegate:(nonnull id<FLEPlugin>)delegate
+- (void)addMethodCallDelegate:(nonnull id<FlutterPlugin>)delegate
                       channel:(nonnull FlutterMethodChannel*)channel {
   [channel setMethodCallHandler:^(FlutterMethodCall* call, FlutterResult result) {
     [delegate handleMethodCall:call result:result];
   }];
 }
 
-#pragma mark - FLEPluginRegistry
+#pragma mark - FlutterPluginRegistry
 
-- (id<FLEPluginRegistrar>)registrarForPlugin:(NSString*)pluginName {
+- (id<FlutterPluginRegistrar>)registrarForPlugin:(NSString*)pluginName {
   // Currently, the view controller acts as the registrar for all plugins, so the
   // name is ignored.
   return self;


### PR DESCRIPTION
As another step toward aligning the macOS plugin API with the iOS plugin
API, and with its final form, rename the plugin-related classes from
FLEPlugin* to FlutterPlugin*. This makes the names of the clasess the
same between iOS and macOS. Eventually they should actually merge, with
annotations/ifdefs for platform differences, but for now since the macOS
version uses the same method names and is simply a subset of the iOS
APIs (with one to-be-stabilized method that is macOS-specific) doing the
merge later won't be a breaking change.

Doing this now allows for building out plugin tooling and plugin
implementations on macOS without creating a growing body of code that
will experience a breaking change later.

See:
https://github.com/flutter/flutter/issues/31735
https://github.com/flutter/flutter/issues/32718