### PR TITLE
Update macOS podspec version requirement

### DIFF
--- a/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
+++ b/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
@@ -14,6 +14,6 @@ Flutter is Google's portable UI toolkit for building beautiful, natively-compile
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
   # TODO: Decide what value should be here. See #33200.
-  s.osx.deployment_target = '10.13'
+  s.osx.deployment_target = '10.12'
   s.vendored_frameworks = 'FlutterMacOS.framework'
 end


### PR DESCRIPTION
The framework is currently built with a 10.12 deployment target, so the
podspec can be at 10.12 rather than 10.13.

The TODO is left because this is an update to the current reality rather
than a final decision about what should be supported.