### PR TITLE
New Plugin API PR5: Integrates plugin lifecycle control with FlutterFragment.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
@@ -260,7 +260,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToActivity(@NonNull Activity activity, @NonNull Lifecycle lifecycle) {
-    Log.d(TAG, "Attaching to an Activity."
+    Log.v(TAG, "Attaching to an Activity."
         + (isWaitingForActivityReattachment ? " This is after a config change." : ""));
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
@@ -282,7 +282,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void detachFromActivityForConfigChanges() {
-    Log.d(TAG, "Detaching from an Activity for config changes.");
+    Log.v(TAG, "Detaching from an Activity for config changes.");
     if (isAttachedToActivity()) {
       isWaitingForActivityReattachment = true;
 
@@ -300,7 +300,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void detachFromActivity() {
-    Log.d(TAG, "Detaching from an Activity.");
+    Log.v(TAG, "Detaching from an Activity.");
     if (isAttachedToActivity()) {
       for (ActivityAware activityAware : activityAwarePlugins.values()) {
         activityAware.onDetachedFromActivity();
@@ -316,7 +316,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public boolean onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResult) {
-    Log.d(TAG, "Forwarding onRequestPermissionsResult() to plugins.");
+    Log.v(TAG, "Forwarding onRequestPermissionsResult() to plugins.");
     if (isAttachedToActivity()) {
       return activityPluginBinding.onRequestPermissionsResult(requestCode, permissions, grantResult);
     } else {
@@ -327,7 +327,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public boolean onActivityResult(int requestCode, int resultCode, @NonNull Intent data) {
-    Log.d(TAG, "Forwarding onActivityResult() to plugins.");
+    Log.v(TAG, "Forwarding onActivityResult() to plugins.");
     if (isAttachedToActivity()) {
       return activityPluginBinding.onActivityResult(requestCode, resultCode, data);
     } else {
@@ -338,7 +338,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void onNewIntent(@NonNull Intent intent) {
-    Log.d(TAG, "Forwarding onNewIntent() to plugins.");
+    Log.v(TAG, "Forwarding onNewIntent() to plugins.");
     if (isAttachedToActivity()) {
       activityPluginBinding.onNewIntent(intent);
     } else {
@@ -348,7 +348,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void onUserLeaveHint() {
-    Log.d(TAG, "Forwarding onUserLeaveHint() to plugins.");
+    Log.v(TAG, "Forwarding onUserLeaveHint() to plugins.");
     if (isAttachedToActivity()) {
       activityPluginBinding.onUserLeaveHint();
     } else {

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityControlSurface.java
@@ -59,16 +59,6 @@ public interface ActivityControlSurface {
   void detachFromActivityForConfigChanges();
 
   /**
-   * Call this method from the {@link Activity} that was previously attached to this
-   * {@code ActivityControlSurface}'s {@link FlutterEngine}, and was just recreated after a
-   * configuration change.
-   * <p>
-   * This method gives each {@link ActivityAware} plugin an opportunity to re-establish necessary
-   * references to the given {@link Activity}.
-   */
-  void reattachToActivityAfterConfigChange(@NonNull Activity activity, @NonNull Lifecycle lifecycle);
-
-  /**
    * Call this method from the {@link Activity} that is attached to this {@code ActivityControlSurfaces}'s
    * {@link FlutterEngine} when the {@link Activity} is about to be destroyed for non-configuration-change
    * reasons.


### PR DESCRIPTION
New Plugin API PR5: Integrates plugin lifecycle control with FlutterFragment.

This should be the last of planned API work on the plugin API. The only remaining work should be the plugin shim that allows old plugins to work with the new embedding.