### PR TITLE
Removed outdated deprecation comments

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -127,15 +127,6 @@ public final class FlutterActivityDelegate
         return flutterView.getPluginRegistry().onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
-    /*
-     * Method onRequestPermissionResult(int, String[], int[]) was made
-     * unavailable on 2018-02-28, following deprecation. This comment is left as
-     * a temporary tombstone for reference, to be removed on 2018-03-28 (or at
-     * least four weeks after release of unavailability).
-     *
-     * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
-     */
-
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
         return flutterView.getPluginRegistry().onActivityResult(requestCode, resultCode, data);

--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -156,15 +156,6 @@ public class FlutterPluginRegistry
             return this;
         }
 
-       /*
-        * Method addRequestPermissionResultListener(RequestPermissionResultListener)
-        * was made unavailable on 2018-02-28, following deprecation.
-        * This comment is left as a temporary tombstone for reference, to be removed
-        * on 2018-03-28 (or at least four weeks after release of unavailability).
-        *
-        * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
-        */
-
         @Override
         public Registrar addRequestPermissionsResultListener(
                 RequestPermissionsResultListener listener) {
@@ -206,15 +197,6 @@ public class FlutterPluginRegistry
         }
         return false;
     }
-
-    /*
-     * Method onRequestPermissionResult(int, String[], int[]) was made
-     * unavailable on 2018-02-28, following deprecation. This comment is left as
-     * a temporary tombstone for reference, to be removed on 2018-03-28 (or at
-     * least four weeks after release of unavailability).
-     *
-     * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
-     */
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {

--- a/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
+++ b/shell/platform/android/io/flutter/plugin/common/PluginRegistry.java
@@ -163,26 +163,6 @@ public interface PluginRegistry {
          */
         Registrar addRequestPermissionsResultListener(RequestPermissionsResultListener listener);
 
-        /*
-         * Method addRequestPermissionResultListener(RequestPermissionResultListener listener)
-         * was made unavailable on 2018-02-28, leaving this comment as a temporary
-         * tombstone for reference. This comment will be removed on 2018-03-28
-         * (or at least four weeks after the unavailability is released).
-         *
-         * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
-         *
-         * Adds a callback allowing the plugin to take part in handling incoming
-         * calls to {@code Activity#onRequestPermissionsResult(int, String[], int[])}
-         * or {@code android.support.v4.app.ActivityCompat.OnRequestPermissionsResultCallback#onRequestPermissionsResult(int, String[], int[])}.
-         *
-         * @param listener a {@link RequestPermissionResultListener} callback.
-         * @return this {@link Registrar}.
-
-         * @deprecated on 2018-01-02 because of misspelling. This method will be made unavailable
-         * on 2018-02-06 (or at least four weeks after the deprecation is released). Use
-         * {@link #addRequestPermissionsResultListener(RequestPermissionsResultListener)} instead.
-         */
-
         /**
          * Adds a callback allowing the plugin to take part in handling incoming
          * calls to {@link Activity#onActivityResult(int, int, Intent)}.
@@ -230,22 +210,6 @@ public interface PluginRegistry {
          */
         boolean onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults);
     }
-
-    /*
-     * interface RequestPermissionResultListener was made unavailable on
-     * 2018-02-28, leaving this comment as a temporary tombstone for reference.
-     * This comment will be removed on 2018-03-28 (or at least four weeks after
-     * the unavailability is released).
-     *
-     * https://github.com/flutter/flutter/wiki/Changelog#typo-fixed-in-flutter-engine-android-api
-     *
-     * Delegate interface for handling result of permissions requests on
-     * behalf of the main {@link Activity}.
-     *
-     * Deprecated on 2018-01-02 because of misspelling. This interface will be made
-     * unavailable on 2018-02-06 (or at least four weeks after the deprecation is released).
-     * Use {@link RequestPermissionsResultListener} instead.
-     */
 
     /**
      * Delegate interface for handling activity results on behalf of the main


### PR DESCRIPTION
In breaking change flutter/engine#4487, a typo was fixed in our Android
APIs correcting RequestPermissionResult to RequestPermissionsResult
(note the 's' on Permissions) for consistency with the Android SDK.

Various tombstone comments were left to help guide developers in the
right direction. These comments were slated for removal in March of
2018; at over a year later, we can probably safely remove them.