### PR TITLE
[WIP] Consolidate testing APIs and remove assert

### DIFF
--- a/lib/stub_ui/lib/src/engine.dart
+++ b/lib/stub_ui/lib/src/engine.dart
@@ -64,6 +64,7 @@ part 'engine/text_editing.dart';
 part 'engine/util.dart';
 part 'engine/validators.dart';
 part 'engine/vector_math.dart';
+part 'engine/testing.dart';
 
 bool _engineInitialized = false;
 

--- a/lib/stub_ui/lib/src/engine/testing.dart
+++ b/lib/stub_ui/lib/src/engine/testing.dart
@@ -1,0 +1,197 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of engine;
+
+const _debugLogHistoryActions = false;
+
+/// An asset manager that gives fake empty responses for assets.
+class WebOnlyMockAssetManager implements AssetManager {
+  String defaultAssetsDir = '';
+  String defaultAssetManifest = '{}';
+  String defaultFontManifest = '[]';
+
+  @override
+  String get assetsDir => defaultAssetsDir;
+
+  @override
+  String getAssetUrl(String asset) => '$asset';
+
+  @override
+  Future<ByteData> load(String asset) {
+    if (asset == getAssetUrl('AssetManifest.json')) {
+      return Future.value(_toByteData(utf8.encode(defaultAssetManifest)));
+    }
+    if (asset == getAssetUrl('FontManifest.json')) {
+      return Future.value(_toByteData(utf8.encode(defaultFontManifest)));
+    }
+    throw AssetManagerException(asset, 404);
+  }
+
+  ByteData _toByteData(List<int> bytes) {
+    final byteData = ByteData(bytes.length);
+    for (var i = 0; i < bytes.length; i++) {
+      byteData.setUint8(i, bytes[i]);
+    }
+    return byteData;
+  }
+}
+
+class _HistoryEntry {
+  final dynamic state;
+  final String title;
+  final String url;
+
+  const _HistoryEntry(this.state, this.title, this.url);
+
+  @override
+  String toString() {
+    return '$runtimeType(state:$state, title:"$title", url:"$url")';
+  }
+}
+
+/// This location strategy mimics the browser's history as closely as possible
+/// while doing it all in memory with no interaction with the browser.
+///
+/// It keeps a list of history entries and event listeners in memory and
+/// manipulates them in order to achieve the desired functionality.
+class TestLocationStrategy extends ui.LocationStrategy {
+  /// Passing a [defaultRouteName] will make the app start at that route. The
+  /// way it does it is by using it as a path on the first history entry.
+  TestLocationStrategy([String defaultRouteName = ''])
+      : _currentEntryIndex = 0,
+        history = [_HistoryEntry(null, null, defaultRouteName)];
+
+  @override
+  String get path => ui.ensureLeading(currentEntry.url, '/');
+
+  int _currentEntryIndex;
+  final List<_HistoryEntry> history;
+
+  _HistoryEntry get currentEntry {
+    assert(withinAppHistory);
+    return history[_currentEntryIndex];
+  }
+
+  set currentEntry(_HistoryEntry entry) {
+    assert(withinAppHistory);
+    history[_currentEntryIndex] = entry;
+  }
+
+  /// Whether we are still within the history of the Flutter Web app. This
+  /// remains true until we go back in history beyond the entry where the app
+  /// started.
+  bool get withinAppHistory => _currentEntryIndex >= 0;
+
+  @override
+  void pushState(dynamic state, String title, String url) {
+    assert(withinAppHistory);
+    _currentEntryIndex++;
+    // When pushing a new state, we need to remove all entries that exist after
+    // the current entry.
+    //
+    // If the user goes A -> B -> C -> D, then goes back to B and pushes a new
+    // entry called E, we should end up with: A -> B -> E in the history list.
+    history.removeRange(_currentEntryIndex, history.length);
+    history.add(_HistoryEntry(state, title, url));
+
+    if (_debugLogHistoryActions) {
+      print('$runtimeType.pushState(...) -> $this');
+    }
+  }
+
+  @override
+  void replaceState(dynamic state, String title, String url) {
+    assert(withinAppHistory);
+    currentEntry = _HistoryEntry(state, title, url);
+
+    if (_debugLogHistoryActions) {
+      print('$runtimeType.replaceState(...) -> $this');
+    }
+  }
+
+  /// This simulates the case where a user types in a url manually. It causes
+  /// a new state to be pushed, and all event listeners will be invoked.
+  Future<void> simulateUserTypingUrl(String url) {
+    assert(withinAppHistory);
+    return _nextEventLoop(() {
+      pushState(null, '', url);
+      _firePopStateEvent();
+    });
+  }
+
+  @override
+  Future<void> back() {
+    assert(withinAppHistory);
+    // Browsers don't move back in history immediately. They do it at the next
+    // event loop. So let's simulate that.
+    return _nextEventLoop(() {
+      _currentEntryIndex--;
+      if (withinAppHistory) {
+        _firePopStateEvent();
+      }
+
+      if (_debugLogHistoryActions) {
+        print('$runtimeType.back() -> $this');
+      }
+    });
+  }
+
+  final List<html.EventListener> listeners = [];
+
+  @override
+  ui.VoidCallback onPopState(html.EventListener fn) {
+    listeners.add(fn);
+    return () {
+      // Schedule a micro task here to avoid removing the listener during
+      // iteration in [_firePopStateEvent].
+      scheduleMicrotask(() => listeners.remove(fn));
+    };
+  }
+
+  /// Simulates the scheduling of a new event loop by creating a delayed future.
+  /// Details explained here: https://webdev.dartlang.org/articles/performance/event-loop
+  Future<void> _nextEventLoop(ui.VoidCallback callback) {
+    return Future.delayed(Duration.zero).then((_) => callback());
+  }
+
+  /// Invokes all the attached event listeners in order of
+  /// attaching. This method should be called asynchronously to make it behave
+  /// like a real browser.
+  void _firePopStateEvent() {
+    assert(withinAppHistory);
+    var event = html.PopStateEvent('popstate', {'state': currentEntry.state});
+    listeners.forEach((fn) => fn(event));
+
+    if (_debugLogHistoryActions) {
+      print('$runtimeType: fired popstate event $event');
+    }
+  }
+
+  @override
+  String prepareExternalUrl(String url) {
+    return url;
+  }
+
+  @override
+  String toString() {
+    var lines = List(history.length);
+    for (int i = 0; i < history.length; i++) {
+      var entry = history[i];
+      lines[i] = _currentEntryIndex == i ? '* $entry' : '  $entry';
+    }
+    return '$runtimeType: [\n${lines.join('\n')}\n]';
+  }
+}
+
+/// Perform extra test setup for flutter web.
+Future<dynamic> webOnlyTestSetup() async {
+  // Force-initialize DomRenderer so it doesn't overwrite test pixel ratio.
+  domRenderer.debugIsInWidgetTest = true;
+  ui.window.devicePixelRatio = 3.0;
+  ui.window.webOnlyDebugPhysicalSizeOverride = ui.Size(800 * 3.0, 600 * 3.0);
+  ui.window.webOnlyScheduleFrameCallback = () {};
+  ui.window.webOnlyLocationStrategy = TestLocationStrategy();
+  await ui.webOnlyInitializePlatform(assetManager: WebOnlyMockAssetManager());
+}

--- a/lib/stub_ui/lib/src/ui/painting.dart
+++ b/lib/stub_ui/lib/src/ui/painting.dart
@@ -1050,11 +1050,7 @@ class Paint {
   bool get invertColors {
     return false;
   }
-
   set invertColors(bool value) {
-    if (engine.assertionsEnabled) {
-      throw UnsupportedError('Paint.invertColors is not supported.');
-    }
   }
 
   Color _color = _defaultPaintColor;

--- a/lib/stub_ui/lib/ui.dart
+++ b/lib/stub_ui/lib/ui.dart
@@ -17,6 +17,7 @@ import 'dart:js_util' as js_util;
 import 'dart:isolate' show SendPort;
 
 import 'src/engine.dart' as engine;
+export 'src/engine.dart' show webOnlyTestSetup;
 
 import 'package:meta/meta.dart';
 

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -75,6 +75,7 @@ web_engine_sources = [
   "$flutter_root/lib/stub_ui/lib/src/engine/util.dart",
   "$flutter_root/lib/stub_ui/lib/src/engine/validators.dart",
   "$flutter_root/lib/stub_ui/lib/src/engine/vector_math.dart",
+  "$flutter_root/lib/stub_ui/lib/src/engine/testing.dart",
 ]
 
 group("web_sdk") {

--- a/web_sdk/sdk_rewriter.dart
+++ b/web_sdk/sdk_rewriter.dart
@@ -20,9 +20,11 @@ const List<List<String>> uiPatterns = <List<String>>[
   <String>[
 r'''
 import 'src/engine.dart' as engine;
+export 'src/engine.dart' show webOnlyTestSetup;
 ''',
 r'''
 import 'dart:_engine' as engine;
+export 'dart:_engine' show webOnlyTestSetup;
 '''
   ]
 ];


### PR DESCRIPTION
This allows us to inject the test setup into the generated test entrypoint, instead of trying to manage it in the framework.

Also the invertColors assert is tripped constantly and needs to be removed.