### PR TITLE
Change the virtual display size restriction to warning

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -422,11 +422,11 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
     private void validateVirtualDisplayDimensions(int width, int height) {
         DisplayMetrics metrics = context.getResources().getDisplayMetrics();
         if (height > metrics.heightPixels || width > metrics.widthPixels) {
-            String error = "Creating a virtual display of size: "
+            String message = "Creating a virtual display of size: "
                 +  "[" + width + ", " + height + "]"
                 + " is not supported. It is larger than the device screen size: "
                 +  "[" + metrics.widthPixels + ", " + metrics.heightPixels + "].";
-            throw new IllegalArgumentException(error);
+            Log.w(TAG, message);
         }
     }
 

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -423,8 +423,9 @@ public class PlatformViewsController implements MethodChannel.MethodCallHandler,
         DisplayMetrics metrics = context.getResources().getDisplayMetrics();
         if (height > metrics.heightPixels || width > metrics.widthPixels) {
             String message = "Creating a virtual display of size: "
-                +  "[" + width + ", " + height + "]"
-                + " is not supported. It is larger than the device screen size: "
+                +  "[" + width + ", " + height + "] may result in problems"
+                +  "(https://github.com/flutter/flutter/issues/2897)."
+                +  "It is larger than the device screen size: "
                 +  "[" + metrics.widthPixels + ", " + metrics.heightPixels + "].";
             Log.w(TAG, message);
         }


### PR DESCRIPTION
- Fixes: https://github.com/flutter/flutter/issues/33290

- This is so we don't block usecases where users show the platform
  view partially.

- https://github.com/flutter/flutter/issues/31990 should address this
  issue more broadly.