### PR TITLE
Move back to single threaded configuration.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -368,8 +368,11 @@
     flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
                                       fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
                                       fml::MessageLoop::GetCurrent().GetTaskRunner(),  // gpu
-                                      _threadHost.ui_thread->GetTaskRunner(),          // ui
-                                      _threadHost.io_thread->GetTaskRunner()           // io
+                                      // TODO(dnfield): Splitting the UI and IO threads separately leads to
+                                      // https://github.com/flutter/flutter/issues/31138
+                                      // It's possible that moving to Metal will fix this.
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // ui
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner()   // io
     );
     // Create the shell. This is a blocking operation.
     _shell = flutter::Shell::Create(std::move(task_runners),  // task runners


### PR DESCRIPTION
Running with multiple threads leads to very long GL calls to `Clear`.  This goes away if we set `presentsWithTransaction` to `NO`, or if we go back to a single thread.

We almost certainly want to keep `presentsWithTransaction`.  It's possible this issue will get better when we switch to Metal - we should try again at that point.

Addresses https://github.com/flutter/flutter/issues/31138 - to reproduce that bug, it's important to run in profile mode.  Introduce a TextField widget and just type steadily for about a minute and it should eventually hang for a few seconds and eventually catch up.  More details/traces in that bug.