### PR TITLE
Add missing ifndef guard for count_down_latch.h

### DIFF
--- a/fml/synchronization/count_down_latch.h
+++ b/fml/synchronization/count_down_latch.h
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#ifndef FLUTTER_FML_SYNCHRONIZATION_COUNT_DOWN_LATCH_H_
+#define FLUTTER_FML_SYNCHRONIZATION_COUNT_DOWN_LATCH_H_
+
 #include <atomic>
 
 #include "flutter/fml/macros.h"
@@ -27,3 +30,5 @@ class CountDownLatch {
 };
 
 }  // namespace fml
+
+#endif  // FLUTTER_FML_SYNCHRONIZATION_COUNT_DOWN_LATCH_H_


### PR DESCRIPTION
I discovered this while experimenting with the timing API.