### PR TITLE
Eliminate deprecated super_goes_last lint

### DIFF
--- a/tools/licenses/analysis_options.yaml
+++ b/tools/licenses/analysis_options.yaml
@@ -136,7 +136,6 @@ linter:
     - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
-    - super_goes_last
     - test_types_in_equals
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types


### PR DESCRIPTION
This eliminates the (deprecated) super_goes_last lint in the license
tool's analysis options. It's been an error in the default analyzer since
Dart 2.

See the deprecation details at https://dart-lang.github.io/linter/lints/super_goes_last.html