### PR TITLE
Copy the macOS podspec during builds

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -200,9 +200,20 @@ action("_generate_symlinks") {
   ]
 }
 
+copy("copy_framework_podspec") {
+  visibility = [ ":*" ]
+  sources = [
+    "framework/FlutterMacOS.podspec",
+  ]
+  outputs = [
+    "$root_out_dir/FlutterMacOS.podspec",
+  ]
+}
+
 group("flutter_framework") {
   deps = [
     ":_generate_symlinks",
+    ":copy_framework_podspec",
   ]
 }
 


### PR DESCRIPTION
The podspec must be copied to the build output root, otherwise
--local-engine won't work in projects containing plugins.

Mirrors the iOS podspec copy rule.