### PR TITLE
Make flow layers' attributes immutable

### DIFF
--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -6,7 +6,8 @@
 
 namespace flutter {
 
-BackdropFilterLayer::BackdropFilterLayer() = default;
+BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
+    : filter_(std::move(filter)) {}
 
 BackdropFilterLayer::~BackdropFilterLayer() = default;
 

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -13,10 +13,8 @@ namespace flutter {
 
 class BackdropFilterLayer : public ContainerLayer {
  public:
-  BackdropFilterLayer();
+  BackdropFilterLayer(sk_sp<SkImageFilter> filter);
   ~BackdropFilterLayer() override;
-
-  void set_filter(sk_sp<SkImageFilter> filter) { filter_ = std::move(filter); }
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -12,8 +12,8 @@
 
 namespace flutter {
 
-ClipPathLayer::ClipPathLayer(Clip clip_behavior)
-    : clip_behavior_(clip_behavior) {
+ClipPathLayer::ClipPathLayer(const SkPath& clip_path, Clip clip_behavior)
+    : clip_path_(clip_path), clip_behavior_(clip_behavior) {
   FML_DCHECK(clip_behavior != Clip::none);
 }
 

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -11,10 +11,8 @@ namespace flutter {
 
 class ClipPathLayer : public ContainerLayer {
  public:
-  ClipPathLayer(Clip clip_behavior = Clip::antiAlias);
+  ClipPathLayer(const SkPath& clip_path, Clip clip_behavior = Clip::antiAlias);
   ~ClipPathLayer() override;
-
-  void set_clip_path(const SkPath& clip_path) { clip_path_ = clip_path; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -6,8 +6,8 @@
 
 namespace flutter {
 
-ClipRectLayer::ClipRectLayer(Clip clip_behavior)
-    : clip_behavior_(clip_behavior) {
+ClipRectLayer::ClipRectLayer(const SkRect& clip_rect, Clip clip_behavior)
+    : clip_rect_(clip_rect), clip_behavior_(clip_behavior) {
   FML_DCHECK(clip_behavior != Clip::none);
 }
 

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -11,10 +11,8 @@ namespace flutter {
 
 class ClipRectLayer : public ContainerLayer {
  public:
-  ClipRectLayer(Clip clip_behavior);
+  ClipRectLayer(const SkRect& clip_rect, Clip clip_behavior);
   ~ClipRectLayer() override;
-
-  void set_clip_rect(const SkRect& clip_rect) { clip_rect_ = clip_rect; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -6,8 +6,8 @@
 
 namespace flutter {
 
-ClipRRectLayer::ClipRRectLayer(Clip clip_behavior)
-    : clip_behavior_(clip_behavior) {
+ClipRRectLayer::ClipRRectLayer(const SkRRect& clip_rrect, Clip clip_behavior)
+    : clip_rrect_(clip_rrect), clip_behavior_(clip_behavior) {
   FML_DCHECK(clip_behavior != Clip::none);
 }
 

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -11,10 +11,8 @@ namespace flutter {
 
 class ClipRRectLayer : public ContainerLayer {
  public:
-  ClipRRectLayer(Clip clip_behavior);
+  ClipRRectLayer(const SkRRect& clip_rrect, Clip clip_behavior);
   ~ClipRRectLayer() override;
-
-  void set_clip_rrect(const SkRRect& clip_rrect) { clip_rrect_ = clip_rrect; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -6,7 +6,8 @@
 
 namespace flutter {
 
-ColorFilterLayer::ColorFilterLayer() = default;
+ColorFilterLayer::ColorFilterLayer(SkColor color, SkBlendMode blend_mode)
+    : color_(color), blend_mode_(blend_mode) {}
 
 ColorFilterLayer::~ColorFilterLayer() = default;
 

--- a/flow/layers/color_filter_layer.h
+++ b/flow/layers/color_filter_layer.h
@@ -11,12 +11,8 @@ namespace flutter {
 
 class ColorFilterLayer : public ContainerLayer {
  public:
-  ColorFilterLayer();
+  ColorFilterLayer(SkColor color, SkBlendMode blend_mode);
   ~ColorFilterLayer() override;
-
-  void set_color(SkColor color) { color_ = color; }
-
-  void set_blend_mode(SkBlendMode blend_mode) { blend_mode_ = blend_mode; }
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -8,7 +8,8 @@
 
 namespace flutter {
 
-OpacityLayer::OpacityLayer() = default;
+OpacityLayer::OpacityLayer(int alpha, const SkPoint& offset)
+    : alpha_(alpha), offset_(offset) {}
 
 OpacityLayer::~OpacityLayer() = default;
 
@@ -19,14 +20,12 @@ void OpacityLayer::EnsureSingleChild() {
     return;
   }
 
-  auto new_child = std::make_shared<flutter::TransformLayer>();
-
   // Be careful: SkMatrix's default constructor doesn't initialize the matrix to
   // identity. Hence we have to explicitly call SkMatrix::setIdentity.
   SkMatrix identity;
   identity.setIdentity();
+  auto new_child = std::make_shared<flutter::TransformLayer>(identity);
 
-  new_child->set_transform(identity);
   for (auto& child : layers()) {
     new_child->Add(child);
   }

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -15,11 +15,8 @@ namespace flutter {
 // |EnsureSingleChild| will assert if there are no children.
 class OpacityLayer : public ContainerLayer {
  public:
-  OpacityLayer();
+  OpacityLayer(int alpha, const SkPoint& offset);
   ~OpacityLayer() override;
-
-  void set_alpha(int alpha) { alpha_ = alpha; }
-  void set_offset(const SkPoint& offset) { offset_ = offset; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -12,14 +12,21 @@ namespace flutter {
 const SkScalar kLightHeight = 600;
 const SkScalar kLightRadius = 800;
 
-PhysicalShapeLayer::PhysicalShapeLayer(Clip clip_behavior)
-    : isRect_(false), clip_behavior_(clip_behavior) {}
-
-PhysicalShapeLayer::~PhysicalShapeLayer() = default;
-
-void PhysicalShapeLayer::set_path(const SkPath& path) {
-  path_ = path;
-  isRect_ = false;
+PhysicalShapeLayer::PhysicalShapeLayer(SkColor color,
+                                       SkColor shadow_color,
+                                       SkScalar device_pixel_ratio,
+                                       float viewport_depth,
+                                       float elevation,
+                                       const SkPath& path,
+                                       Clip clip_behavior)
+    : color_(color),
+      shadow_color_(shadow_color),
+      device_pixel_ratio_(device_pixel_ratio),
+      viewport_depth_(viewport_depth),
+      elevation_(elevation),
+      path_(path),
+      isRect_(false),
+      clip_behavior_(clip_behavior) {
   SkRect rect;
   if (path.isRect(&rect)) {
     isRect_ = true;
@@ -40,6 +47,8 @@ void PhysicalShapeLayer::set_path(const SkPath& path) {
     frameRRect_ = SkRRect::MakeRect(path.getBounds());
   }
 }
+
+PhysicalShapeLayer::~PhysicalShapeLayer() = default;
 
 void PhysicalShapeLayer::Preroll(PrerollContext* context,
                                  const SkMatrix& matrix) {

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -11,20 +11,14 @@ namespace flutter {
 
 class PhysicalShapeLayer : public ContainerLayer {
  public:
-  PhysicalShapeLayer(Clip clip_behavior);
+  PhysicalShapeLayer(SkColor color,
+                     SkColor shadow_color,
+                     SkScalar device_pixel_ratio,
+                     float viewport_depth,
+                     float elevation,
+                     const SkPath& path,
+                     Clip clip_behavior);
   ~PhysicalShapeLayer() override;
-
-  void set_path(const SkPath& path);
-
-  void set_color(SkColor color) { color_ = color; }
-  void set_shadow_color(SkColor shadow_color) { shadow_color_ = shadow_color; }
-  void set_device_pixel_ratio(SkScalar dpr) { device_pixel_ratio_ = dpr; }
-  void set_viewport_depth(float depth) { viewport_depth_ = depth; }
-
-  // Sets the elevation. This needs to be set before preroll because it's then
-  // cached by any children of this layer. Setting it after preroll will break
-  // their elevation calculations.
-  void set_elevation(float elevation) { elevation_ = elevation; }
 
   static void DrawShadow(SkCanvas* canvas,
                          const SkPath& path,
@@ -42,12 +36,12 @@ class PhysicalShapeLayer : public ContainerLayer {
 #endif  // defined(OS_FUCHSIA)
 
  private:
-  float elevation_ = 0.0f;
-  float total_elevation_ = 0.0f;
-  float viewport_depth_;
   SkColor color_;
   SkColor shadow_color_;
   SkScalar device_pixel_ratio_;
+  float viewport_depth_;
+  float elevation_ = 0.0f;
+  float total_elevation_ = 0.0f;
   SkPath path_;
   bool isRect_;
   SkRRect frameRRect_;

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -11,9 +11,15 @@ namespace flutter {
 TEST(PhysicalShapeLayer, TotalElevation) {
   std::shared_ptr<PhysicalShapeLayer> layers[4];
 
+  SkColor dummy_color = 0;
+  SkPath dummy_path;
   for (int i = 0; i < 4; i += 1) {
-    layers[i] = std::make_shared<PhysicalShapeLayer>(Clip::none);
-    layers[i]->set_elevation((float)(i + 1));
+    layers[i] =
+        std::make_shared<PhysicalShapeLayer>(dummy_color, dummy_color,
+                                             1.0f,            // pixel ratio,
+                                             1.0f,            // depth
+                                             (float)(i + 1),  // elevation
+                                             dummy_path, Clip::none);
   }
 
   layers[0]->Add(layers[1]);

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -8,7 +8,14 @@
 
 namespace flutter {
 
-PictureLayer::PictureLayer() = default;
+PictureLayer::PictureLayer(const SkPoint& offset,
+                           SkiaGPUObject<SkPicture> picture,
+                           bool is_complex,
+                           bool will_change)
+    : offset_(offset),
+      picture_(std::move(picture)),
+      is_complex_(is_complex),
+      will_change_(will_change) {}
 
 PictureLayer::~PictureLayer() = default;
 

--- a/flow/layers/picture_layer.h
+++ b/flow/layers/picture_layer.h
@@ -15,16 +15,11 @@ namespace flutter {
 
 class PictureLayer : public Layer {
  public:
-  PictureLayer();
+  PictureLayer(const SkPoint& offset,
+               SkiaGPUObject<SkPicture> picture,
+               bool is_complex,
+               bool will_change);
   ~PictureLayer() override;
-
-  void set_offset(const SkPoint& offset) { offset_ = offset; }
-  void set_picture(SkiaGPUObject<SkPicture> picture) {
-    picture_ = std::move(picture);
-  }
-
-  void set_is_complex(bool value) { is_complex_ = value; }
-  void set_will_change(bool value) { will_change_ = value; }
 
   SkPicture* picture() const { return picture_.get().get(); }
 

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -6,7 +6,10 @@
 
 namespace flutter {
 
-PlatformViewLayer::PlatformViewLayer() = default;
+PlatformViewLayer::PlatformViewLayer(const SkPoint& offset,
+                                     const SkSize& size,
+                                     int64_t view_id)
+    : offset_(offset), size_(size), view_id_(view_id) {}
 
 PlatformViewLayer::~PlatformViewLayer() = default;
 

--- a/flow/layers/platform_view_layer.h
+++ b/flow/layers/platform_view_layer.h
@@ -13,12 +13,8 @@ namespace flutter {
 
 class PlatformViewLayer : public Layer {
  public:
-  PlatformViewLayer();
+  PlatformViewLayer(const SkPoint& offset, const SkSize& size, int64_t view_id);
   ~PlatformViewLayer() override;
-
-  void set_offset(const SkPoint& offset) { offset_ = offset; }
-  void set_size(const SkSize& size) { size_ = size; }
-  void set_view_id(int64_t view_id) { view_id_ = view_id; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -6,7 +6,10 @@
 
 namespace flutter {
 
-ShaderMaskLayer::ShaderMaskLayer() = default;
+ShaderMaskLayer::ShaderMaskLayer(sk_sp<SkShader> shader,
+                                 const SkRect& mask_rect,
+                                 SkBlendMode blend_mode)
+    : shader_(shader), mask_rect_(mask_rect), blend_mode_(blend_mode) {}
 
 ShaderMaskLayer::~ShaderMaskLayer() = default;
 

--- a/flow/layers/shader_mask_layer.h
+++ b/flow/layers/shader_mask_layer.h
@@ -13,14 +13,10 @@ namespace flutter {
 
 class ShaderMaskLayer : public ContainerLayer {
  public:
-  ShaderMaskLayer();
+  ShaderMaskLayer(sk_sp<SkShader> shader,
+                  const SkRect& mask_rect,
+                  SkBlendMode blend_mode);
   ~ShaderMaskLayer() override;
-
-  void set_shader(sk_sp<SkShader> shader) { shader_ = shader; }
-
-  void set_mask_rect(const SkRect& mask_rect) { mask_rect_ = mask_rect; }
-
-  void set_blend_mode(SkBlendMode blend_mode) { blend_mode_ = blend_mode; }
 
   void Paint(PaintContext& context) const override;
 

--- a/flow/layers/texture_layer.cc
+++ b/flow/layers/texture_layer.cc
@@ -8,7 +8,11 @@
 
 namespace flutter {
 
-TextureLayer::TextureLayer() = default;
+TextureLayer::TextureLayer(const SkPoint& offset,
+                           const SkSize& size,
+                           int64_t texture_id,
+                           bool freeze)
+    : offset_(offset), size_(size), texture_id_(texture_id), freeze_(freeze) {}
 
 TextureLayer::~TextureLayer() = default;
 

--- a/flow/layers/texture_layer.h
+++ b/flow/layers/texture_layer.h
@@ -13,13 +13,11 @@ namespace flutter {
 
 class TextureLayer : public Layer {
  public:
-  TextureLayer();
+  TextureLayer(const SkPoint& offset,
+               const SkSize& size,
+               int64_t texture_id,
+               bool freeze);
   ~TextureLayer() override;
-
-  void set_offset(const SkPoint& offset) { offset_ = offset; }
-  void set_size(const SkSize& size) { size_ = size; }
-  void set_texture_id(int64_t texture_id) { texture_id_ = texture_id; }
-  void set_freeze(bool freeze) { freeze_ = freeze; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -6,17 +6,9 @@
 
 namespace flutter {
 
-TransformLayer::TransformLayer() {
-  transform_.setIdentity();
-}
-
-TransformLayer::~TransformLayer() = default;
-
-void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+TransformLayer::TransformLayer(const SkMatrix& transform)
+    : transform_(transform) {
   // Checks (in some degree) that SkMatrix transform_ is valid and initialized.
-  //
-  // We need this even if transform_ is initialized to identity since one can
-  // call set_transform with an uninitialized SkMatrix.
   //
   // If transform_ is uninitialized, this assert may look flaky as it doesn't
   // fail all the time, and some rerun may make it pass. But don't ignore it and
@@ -26,7 +18,11 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   // We have to write this flaky test because there is no reliable way to test
   // whether a variable is initialized or not in C++.
   FML_CHECK(transform_.isFinite());
+}
 
+TransformLayer::~TransformLayer() = default;
+
+void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkMatrix child_matrix;
   child_matrix.setConcat(matrix, transform_);
 

--- a/flow/layers/transform_layer.h
+++ b/flow/layers/transform_layer.h
@@ -13,10 +13,8 @@ namespace flutter {
 // at all. Hence |set_transform| must be called with an initialized SkMatrix.
 class TransformLayer : public ContainerLayer {
  public:
-  TransformLayer();
+  TransformLayer(const SkMatrix& transform);
   ~TransformLayer() override;
-
-  void set_transform(const SkMatrix& transform) { transform_ = transform; }
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -86,8 +86,7 @@ SceneBuilder::~SceneBuilder() = default;
 fml::RefPtr<EngineLayer> SceneBuilder::pushTransform(
     tonic::Float64List& matrix4) {
   SkMatrix sk_matrix = ToSkMatrix(matrix4);
-  auto layer = std::make_shared<flutter::TransformLayer>();
-  layer->set_transform(sk_matrix);
+  auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
   PushLayer(layer);
   // matrix4 has to be released before we can return another Dart object
   matrix4.Release();
@@ -96,8 +95,7 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushTransform(
 
 fml::RefPtr<EngineLayer> SceneBuilder::pushOffset(double dx, double dy) {
   SkMatrix sk_matrix = SkMatrix::MakeTrans(dx, dy);
-  auto layer = std::make_shared<flutter::TransformLayer>();
-  layer->set_transform(sk_matrix);
+  auto layer = std::make_shared<flutter::TransformLayer>(sk_matrix);
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
@@ -109,8 +107,8 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushClipRect(double left,
                                                     int clipBehavior) {
   SkRect clipRect = SkRect::MakeLTRB(left, top, right, bottom);
   flutter::Clip clip_behavior = static_cast<flutter::Clip>(clipBehavior);
-  auto layer = std::make_shared<flutter::ClipRectLayer>(clip_behavior);
-  layer->set_clip_rect(clipRect);
+  auto layer =
+      std::make_shared<flutter::ClipRectLayer>(clipRect, clip_behavior);
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
@@ -118,8 +116,8 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushClipRect(double left,
 fml::RefPtr<EngineLayer> SceneBuilder::pushClipRRect(const RRect& rrect,
                                                      int clipBehavior) {
   flutter::Clip clip_behavior = static_cast<flutter::Clip>(clipBehavior);
-  auto layer = std::make_shared<flutter::ClipRRectLayer>(clip_behavior);
-  layer->set_clip_rrect(rrect.sk_rrect);
+  auto layer =
+      std::make_shared<flutter::ClipRRectLayer>(rrect.sk_rrect, clip_behavior);
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
@@ -128,8 +126,8 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushClipPath(const CanvasPath* path,
                                                     int clipBehavior) {
   flutter::Clip clip_behavior = static_cast<flutter::Clip>(clipBehavior);
   FML_DCHECK(clip_behavior != flutter::Clip::none);
-  auto layer = std::make_shared<flutter::ClipPathLayer>(clip_behavior);
-  layer->set_clip_path(path->path());
+  auto layer =
+      std::make_shared<flutter::ClipPathLayer>(path->path(), clip_behavior);
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
@@ -137,25 +135,22 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushClipPath(const CanvasPath* path,
 fml::RefPtr<EngineLayer> SceneBuilder::pushOpacity(int alpha,
                                                    double dx,
                                                    double dy) {
-  auto layer = std::make_shared<flutter::OpacityLayer>();
-  layer->set_alpha(alpha);
-  layer->set_offset(SkPoint::Make(dx, dy));
+  auto layer =
+      std::make_shared<flutter::OpacityLayer>(alpha, SkPoint::Make(dx, dy));
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
 
 fml::RefPtr<EngineLayer> SceneBuilder::pushColorFilter(int color,
                                                        int blendMode) {
-  auto layer = std::make_shared<flutter::ColorFilterLayer>();
-  layer->set_color(static_cast<SkColor>(color));
-  layer->set_blend_mode(static_cast<SkBlendMode>(blendMode));
+  auto layer = std::make_shared<flutter::ColorFilterLayer>(
+      static_cast<SkColor>(color), static_cast<SkBlendMode>(blendMode));
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
 
 fml::RefPtr<EngineLayer> SceneBuilder::pushBackdropFilter(ImageFilter* filter) {
-  auto layer = std::make_shared<flutter::BackdropFilterLayer>();
-  layer->set_filter(filter->filter());
+  auto layer = std::make_shared<flutter::BackdropFilterLayer>(filter->filter());
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
@@ -168,10 +163,8 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushShaderMask(Shader* shader,
                                                       int blendMode) {
   SkRect rect = SkRect::MakeLTRB(maskRectLeft, maskRectTop, maskRectRight,
                                  maskRectBottom);
-  auto layer = std::make_shared<flutter::ShaderMaskLayer>();
-  layer->set_shader(shader->shader());
-  layer->set_mask_rect(rect);
-  layer->set_blend_mode(static_cast<SkBlendMode>(blendMode));
+  auto layer = std::make_shared<flutter::ShaderMaskLayer>(
+      shader->shader(), rect, static_cast<SkBlendMode>(blendMode));
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
@@ -181,17 +174,11 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushPhysicalShape(const CanvasPath* path,
                                                          int color,
                                                          int shadow_color,
                                                          int clipBehavior) {
-  const SkPath& sk_path = path->path();
-  flutter::Clip clip_behavior = static_cast<flutter::Clip>(clipBehavior);
-  auto layer = std::make_shared<flutter::PhysicalShapeLayer>(clip_behavior);
-  layer->set_path(sk_path);
-  layer->set_elevation(elevation);
-  layer->set_color(static_cast<SkColor>(color));
-  layer->set_shadow_color(static_cast<SkColor>(shadow_color));
-  layer->set_device_pixel_ratio(
-      UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio);
-  layer->set_viewport_depth(
-      UIDartState::Current()->window()->viewport_metrics().physical_depth);
+  auto layer = std::make_shared<flutter::PhysicalShapeLayer>(
+      static_cast<SkColor>(color), static_cast<SkColor>(shadow_color),
+      UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio,
+      UIDartState::Current()->window()->viewport_metrics().physical_depth,
+      elevation, path->path(), static_cast<flutter::Clip>(clipBehavior));
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }
@@ -220,11 +207,9 @@ void SceneBuilder::addPicture(double dx,
   SkPoint offset = SkPoint::Make(dx, dy);
   SkRect pictureRect = picture->picture()->cullRect();
   pictureRect.offset(offset.x(), offset.y());
-  auto layer = std::make_unique<flutter::PictureLayer>();
-  layer->set_offset(offset);
-  layer->set_picture(UIDartState::CreateGPUObject(picture->picture()));
-  layer->set_is_complex(!!(hints & 1));
-  layer->set_will_change(!!(hints & 2));
+  auto layer = std::make_unique<flutter::PictureLayer>(
+      offset, UIDartState::CreateGPUObject(picture->picture()), !!(hints & 1),
+      !!(hints & 2));
   current_layer_->Add(std::move(layer));
 }
 
@@ -237,11 +222,8 @@ void SceneBuilder::addTexture(double dx,
   if (!current_layer_) {
     return;
   }
-  auto layer = std::make_unique<flutter::TextureLayer>();
-  layer->set_offset(SkPoint::Make(dx, dy));
-  layer->set_size(SkSize::Make(width, height));
-  layer->set_texture_id(textureId);
-  layer->set_freeze(freeze);
+  auto layer = std::make_unique<flutter::TextureLayer>(
+      SkPoint::Make(dx, dy), SkSize::Make(width, height), textureId, freeze);
   current_layer_->Add(std::move(layer));
 }
 
@@ -253,10 +235,8 @@ void SceneBuilder::addPlatformView(double dx,
   if (!current_layer_) {
     return;
   }
-  auto layer = std::make_unique<flutter::PlatformViewLayer>();
-  layer->set_offset(SkPoint::Make(dx, dy));
-  layer->set_size(SkSize::Make(width, height));
-  layer->set_view_id(viewId);
+  auto layer = std::make_unique<flutter::PlatformViewLayer>(
+      SkPoint::Make(dx, dy), SkSize::Make(width, height), viewId);
   current_layer_->Add(std::move(layer));
 }
 

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -176,9 +176,14 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushPhysicalShape(const CanvasPath* path,
                                                          int clipBehavior) {
   auto layer = std::make_shared<flutter::PhysicalShapeLayer>(
       static_cast<SkColor>(color), static_cast<SkColor>(shadow_color),
-      UIDartState::Current()->window()->viewport_metrics().device_pixel_ratio,
-      UIDartState::Current()->window()->viewport_metrics().physical_depth,
-      elevation, path->path(), static_cast<flutter::Clip>(clipBehavior));
+      static_cast<float>(UIDartState::Current()
+                             ->window()
+                             ->viewport_metrics()
+                             .device_pixel_ratio),
+      static_cast<float>(
+          UIDartState::Current()->window()->viewport_metrics().physical_depth),
+      static_cast<float>(elevation), path->path(),
+      static_cast<flutter::Clip>(clipBehavior));
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -104,7 +104,9 @@ void ShellTest::PumpOneFrame(Shell* shell) {
   shell->GetTaskRunners().GetUITaskRunner()->PostTask(
       [&latch, runtime_delegate]() {
         auto layer_tree = std::make_unique<LayerTree>();
-        auto root_layer = std::make_shared<TransformLayer>();
+        SkMatrix identity;
+        identity.setIdentity();
+        auto root_layer = std::make_shared<TransformLayer>(identity);
         layer_tree->set_root_layer(root_layer);
         runtime_delegate->Render(std::move(layer_tree));
         latch.Signal();


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/33807

We still need to make layers' children immutable for full immutability.
That will require us to change the SceneBuilder API to build the layer
bottom up instead of top down (post-order traversal instead of pre-order
traversal).