### PR TITLE
Fix platform views channel regression

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -430,9 +430,4 @@ public class PlatformViewsChannel {
       this.flags = flags;
     }
   }
-
-  /**
-   * The provided platform view ID does not correspond to any existing platform view.
-   */
-  public static class NoSuchPlatformViewException extends IllegalStateException {}
 }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -51,8 +51,9 @@ public class PlatformViewsChannel {
         case "setDirection":
           setDirection(call, result);
           break;
+        default:
+          result.notImplemented();
       }
-      result.notImplemented();
     }
 
     private void create(MethodCall call, MethodChannel.Result result) {


### PR DESCRIPTION
This regression was introduced in #7847.

The PlatformViewsChannel method call handler was always setting the result to `notImplemented` even after handling a result, this resulted in a "Reply already submitted" exception being thrown.
Note that the method channel code is swallowing this exception and logging an error, so we didn't crash instead we were logging an error(this is why the integration test didn't fail), sample error that was logged whenever platform views were used on Android:

```
06-04 12:01:05.997 11978 11978 E DartMessenger: Uncaught exception in binary message listener
06-04 12:01:05.997 11978 11978 E DartMessenger: java.lang.IllegalStateException: Reply already submitted
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:126)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:240)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:90)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:234)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at android.os.MessageQueue.nativePollOnce(Native Method)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at android.os.MessageQueue.next(MessageQueue.java:325)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at android.os.Looper.loop(Looper.java:142)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at android.app.ActivityThread.main(ActivityThread.java:6591)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at java.lang.reflect.Method.invoke(Native Method)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
06-04 12:01:05.997 11978 11978 E DartMessenger: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:772)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: Failed to handle method call
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: java.lang.IllegalStateException: Reply already submitted
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:126)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.notImplemented(MethodChannel.java:235)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at io.flutter.embedding.engine.systemchannels.PlatformViewsChannel$1.onMethodCall(PlatformViewsChannel.java:55)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:222)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:90)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:234)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at android.os.MessageQueue.nativePollOnce(Native Method)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at android.os.MessageQueue.next(MessageQueue.java:325)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at android.os.Looper.loop(Looper.java:142)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at android.app.ActivityThread.main(ActivityThread.java:6591)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at java.lang.reflect.Method.invoke(Native Method)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
06-04 12:01:06.002 11978 11978 E MethodChannel#flutter/platform_views: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:772)
```

Filed https://github.com/flutter/flutter/issues/33863 to make sure tests fail when such exceptions are thrown.

This PR also cleans up an unused `NoSuchPlatformViewException` that was introduced in #7847.

https://github.com/flutter/flutter/issues/33866