### PR TITLE
Add the key event source, vendorId, and productId from Android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
@@ -4,6 +4,7 @@
 
 package io.flutter.embedding.engine.systemchannels;
 
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.InputDevice;
@@ -57,12 +58,15 @@ public class KeyEventChannel {
       message.put("character", event.complexCharacter.toString());
     }
     message.put("source", event.source);
+    message.put("vendorId", event.vendorId);
+    message.put("productId", event.productId);
   }
 
   /**
    * Key event as defined by Flutter.
    */
   public static class FlutterKeyEvent {
+    public final int deviceId;
     public final int flags;
     public final int plainCodePoint;
     public final int codePoint;
@@ -72,6 +76,8 @@ public class KeyEventChannel {
     public final int scanCode;
     public final int metaState;
     public final int source;
+    public final int vendorId;
+    public final int productId;
 
     public FlutterKeyEvent(
         @NonNull KeyEvent androidKeyEvent
@@ -84,6 +90,7 @@ public class KeyEventChannel {
         @Nullable Character complexCharacter
     ) {
       this(
+          androidKeyEvent.getDeviceId(),
           androidKeyEvent.getFlags(),
           androidKeyEvent.getUnicodeChar(0x0),
           androidKeyEvent.getUnicodeChar(),
@@ -96,6 +103,7 @@ public class KeyEventChannel {
     }
 
     public FlutterKeyEvent(
+        int deviceId,
         int flags,
         int plainCodePoint,
         int codePoint,
@@ -105,6 +113,7 @@ public class KeyEventChannel {
         int metaState,
         int source
     ) {
+      this.deviceId = deviceId;
       this.flags = flags;
       this.plainCodePoint = plainCodePoint;
       this.codePoint = codePoint;
@@ -113,6 +122,19 @@ public class KeyEventChannel {
       this.scanCode = scanCode;
       this.metaState = metaState;
       this.source = source;
+      InputDevice device = InputDevice.getDevice(deviceId);
+      if (device != null) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+          this.vendorId = device.getVendorId();
+          this.productId = device.getProductId();
+        } else {
+          this.vendorId = 0;
+          this.productId = 0;
+        }
+      } else {
+        this.vendorId = 0;
+        this.productId = 0;
+      }
     }
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/KeyEventChannel.java
@@ -6,6 +6,7 @@ package io.flutter.embedding.engine.systemchannels;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.view.InputDevice;
 import android.view.KeyEvent;
 
 import java.util.HashMap;
@@ -55,6 +56,7 @@ public class KeyEventChannel {
     if (event.complexCharacter != null) {
       message.put("character", event.complexCharacter.toString());
     }
+    message.put("source", event.source);
   }
 
   /**
@@ -69,6 +71,7 @@ public class KeyEventChannel {
     public final Character complexCharacter;
     public final int scanCode;
     public final int metaState;
+    public final int source;
 
     public FlutterKeyEvent(
         @NonNull KeyEvent androidKeyEvent
@@ -87,7 +90,8 @@ public class KeyEventChannel {
           androidKeyEvent.getKeyCode(),
           complexCharacter,
           androidKeyEvent.getScanCode(),
-          androidKeyEvent.getMetaState()
+          androidKeyEvent.getMetaState(),
+          androidKeyEvent.getSource()
       );
     }
 
@@ -98,7 +102,8 @@ public class KeyEventChannel {
         int keyCode,
         @Nullable Character complexCharacter,
         int scanCode,
-        int metaState
+        int metaState,
+        int source
     ) {
       this.flags = flags;
       this.plainCodePoint = plainCodePoint;
@@ -107,6 +112,7 @@ public class KeyEventChannel {
       this.complexCharacter = complexCharacter;
       this.scanCode = scanCode;
       this.metaState = metaState;
+      this.source = source;
     }
   }
 }


### PR DESCRIPTION
This adds the key event source from Android so that the framework can differentiate between keyboard events and game controller events.

Paired with https://github.com/flutter/flutter/pull/33868