### PR TITLE
Allow the task queues to be swapped in MessageLoops

### DIFF
--- a/fml/message_loop.cc
+++ b/fml/message_loop.cc
@@ -81,8 +81,10 @@ void MessageLoop::RunExpiredTasksNow() {
   loop_->RunExpiredTasksNow();
 }
 
-void MessageLoop::Swap(MessageLoop& other) {
-  other.loop_->Swap(*loop_);
+void MessageLoop::Swap(MessageLoop* other) {
+  FML_CHECK(loop_);
+  FML_CHECK(other->loop_);
+  loop_->Swap(other->loop_);
 }
 
 }  // namespace fml

--- a/fml/message_loop.cc
+++ b/fml/message_loop.cc
@@ -81,10 +81,10 @@ void MessageLoop::RunExpiredTasksNow() {
   loop_->RunExpiredTasksNow();
 }
 
-void MessageLoop::Swap(MessageLoop* other) {
+void MessageLoop::SwapTaskQueues(MessageLoop* other) {
   FML_CHECK(loop_);
   FML_CHECK(other->loop_);
-  loop_->Swap(other->loop_);
+  loop_->SwapTaskQueues(other->loop_);
 }
 
 }  // namespace fml

--- a/fml/message_loop.cc
+++ b/fml/message_loop.cc
@@ -81,4 +81,8 @@ void MessageLoop::RunExpiredTasksNow() {
   loop_->RunExpiredTasksNow();
 }
 
+void MessageLoop::Swap(MessageLoop& other) {
+  other.loop_->Swap(*loop_);
+}
+
 }  // namespace fml

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -38,7 +38,7 @@ class MessageLoop {
   // instead of dedicating a thread to the message loop.
   void RunExpiredTasksNow();
 
-  void Swap(MessageLoop* other);
+  void SwapTaskQueues(MessageLoop* other);
 
   static void EnsureInitializedForCurrentThread();
 

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -38,7 +38,7 @@ class MessageLoop {
   // instead of dedicating a thread to the message loop.
   void RunExpiredTasksNow();
 
-  void Swap(MessageLoop& other);
+  void Swap(MessageLoop* other);
 
   static void EnsureInitializedForCurrentThread();
 

--- a/fml/message_loop.h
+++ b/fml/message_loop.h
@@ -38,6 +38,8 @@ class MessageLoop {
   // instead of dedicating a thread to the message loop.
   void RunExpiredTasksNow();
 
+  void Swap(MessageLoop& other);
+
   static void EnsureInitializedForCurrentThread();
 
   static bool IsInitializedForCurrentThread();

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -53,6 +53,7 @@ void MessageLoopImpl::AddTaskObserver(intptr_t key, fml::closure callback) {
   FML_DCHECK(MessageLoop::GetCurrent().GetLoopImpl().get() == this)
       << "Message loop task observer must be added on the same thread as the "
          "loop.";
+  std::lock_guard<std::mutex> observers_lock(observers_mutex_);
   task_observers_[key] = std::move(callback);
 }
 
@@ -60,6 +61,7 @@ void MessageLoopImpl::RemoveTaskObserver(intptr_t key) {
   FML_DCHECK(MessageLoop::GetCurrent().GetLoopImpl().get() == this)
       << "Message loop task observer must be removed from the same thread as "
          "the loop.";
+  std::lock_guard<std::mutex> observers_lock(observers_mutex_);
   task_observers_.erase(key);
 }
 
@@ -95,6 +97,29 @@ void MessageLoopImpl::DoTerminate() {
   Terminate();
 }
 
+void MessageLoopImpl::Swap(MessageLoopImpl& other)
+    FML_NO_THREAD_SAFETY_ANALYSIS {
+  if (terminated_ || other.terminated_) {
+    return;
+  }
+
+  // task_observers locks
+  std::unique_lock<std::mutex> o1(observers_mutex_, std::defer_lock);
+  std::unique_lock<std::mutex> o2(other.observers_mutex_, std::defer_lock);
+
+  // delayed_tasks locks
+  std::unique_lock<std::mutex> d1(delayed_tasks_mutex_, std::defer_lock);
+  std::unique_lock<std::mutex> d2(other.delayed_tasks_mutex_, std::defer_lock);
+
+  // we need to first lock the task_obervers_mutex_ and only then lock
+  // delayed_tasks_mutex_.
+  std::lock(o1, o2);
+  std::lock(d1, d2);
+
+  std::swap(task_observers_, other.task_observers_);
+  std::swap(delayed_tasks_, other.delayed_tasks_);
+}
+
 void MessageLoopImpl::RegisterTask(fml::closure task,
                                    fml::TimePoint target_time) {
   FML_DCHECK(task != nullptr);
@@ -111,6 +136,14 @@ void MessageLoopImpl::RegisterTask(fml::closure task,
 void MessageLoopImpl::FlushTasks(FlushType type) {
   TRACE_EVENT0("fml", "MessageLoop::FlushTasks");
   std::vector<fml::closure> invocations;
+
+  // We are grabbing this lock here as a proxy to indicate
+  // tht we are running tasks and will invoke the
+  // "right" observers, we are trying to avoid the scenario
+  // where:
+  // gather invocations -> Swap -> execute invocations
+  // will lead us to run invocations on the wrong thread.
+  std::lock_guard<std::mutex> observers_lock(observers_mutex_);
 
   {
     std::lock_guard<std::mutex> lock(delayed_tasks_mutex_);

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -97,27 +97,27 @@ void MessageLoopImpl::DoTerminate() {
   Terminate();
 }
 
-void MessageLoopImpl::Swap(MessageLoopImpl& other)
+void MessageLoopImpl::Swap(const fml::RefPtr<MessageLoopImpl>& other)
     FML_NO_THREAD_SAFETY_ANALYSIS {
-  if (terminated_ || other.terminated_) {
+  if (terminated_ || other->terminated_) {
     return;
   }
 
   // task_observers locks
   std::unique_lock<std::mutex> o1(observers_mutex_, std::defer_lock);
-  std::unique_lock<std::mutex> o2(other.observers_mutex_, std::defer_lock);
+  std::unique_lock<std::mutex> o2(other->observers_mutex_, std::defer_lock);
 
   // delayed_tasks locks
   std::unique_lock<std::mutex> d1(delayed_tasks_mutex_, std::defer_lock);
-  std::unique_lock<std::mutex> d2(other.delayed_tasks_mutex_, std::defer_lock);
+  std::unique_lock<std::mutex> d2(other->delayed_tasks_mutex_, std::defer_lock);
 
   // we need to first lock the task_obervers_mutex_ and only then lock
   // delayed_tasks_mutex_.
   std::lock(o1, o2);
   std::lock(d1, d2);
 
-  std::swap(task_observers_, other.task_observers_);
-  std::swap(delayed_tasks_, other.delayed_tasks_);
+  std::swap(task_observers_, other->task_observers_);
+  std::swap(delayed_tasks_, other->delayed_tasks_);
 }
 
 void MessageLoopImpl::RegisterTask(fml::closure task,

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -97,7 +97,7 @@ void MessageLoopImpl::DoTerminate() {
   Terminate();
 }
 
-void MessageLoopImpl::Swap(const fml::RefPtr<MessageLoopImpl>& other)
+void MessageLoopImpl::SwapTaskQueues(const fml::RefPtr<MessageLoopImpl>& other)
     FML_NO_THREAD_SAFETY_ANALYSIS {
   if (terminated_ || other->terminated_) {
     return;

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -43,7 +43,7 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
 
   void DoTerminate();
 
-  void Swap(const fml::RefPtr<MessageLoopImpl>& other);
+  void SwapTaskQueues(const fml::RefPtr<MessageLoopImpl>& other);
 
  protected:
   // Exposed for the embedder shell which allows clients to poll for events

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -82,10 +82,9 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
   using DelayedTaskQueue = std::
       priority_queue<DelayedTask, std::deque<DelayedTask>, DelayedTaskCompare>;
 
-  // all this is state which controls what will be run on this message loop.
-  // we ideally want to have a mechanism to change all of this?!
   std::mutex observers_mutex_;
-  std::map<intptr_t, fml::closure> task_observers_ FML_GUARDED_BY(observers_mutex_);
+  std::map<intptr_t, fml::closure> task_observers_
+      FML_GUARDED_BY(observers_mutex_);
 
   std::mutex delayed_tasks_mutex_;
   DelayedTaskQueue delayed_tasks_ FML_GUARDED_BY(delayed_tasks_mutex_);

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -43,7 +43,7 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
 
   void DoTerminate();
 
-  void Swap(MessageLoopImpl& other);
+  void Swap(const fml::RefPtr<MessageLoopImpl>& other);
 
  protected:
   // Exposed for the embedder shell which allows clients to poll for events

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -82,6 +82,8 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
   using DelayedTaskQueue = std::
       priority_queue<DelayedTask, std::deque<DelayedTask>, DelayedTaskCompare>;
 
+  std::mutex tasks_flushing_mutex_;
+
   std::mutex observers_mutex_;
   std::map<intptr_t, fml::closure> task_observers_
       FML_GUARDED_BY(observers_mutex_);

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -43,6 +43,8 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
 
   void DoTerminate();
 
+  void Swap(MessageLoopImpl& other);
+
  protected:
   // Exposed for the embedder shell which allows clients to poll for events
   // instead of dedicating a thread to the message loop.
@@ -80,7 +82,11 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
   using DelayedTaskQueue = std::
       priority_queue<DelayedTask, std::deque<DelayedTask>, DelayedTaskCompare>;
 
-  std::map<intptr_t, fml::closure> task_observers_;
+  // all this is state which controls what will be run on this message loop.
+  // we ideally want to have a mechanism to change all of this?!
+  std::mutex observers_mutex_;
+  std::map<intptr_t, fml::closure> task_observers_ FML_GUARDED_BY(observers_mutex_);
+
   std::mutex delayed_tasks_mutex_;
   DelayedTaskQueue delayed_tasks_ FML_GUARDED_BY(delayed_tasks_mutex_);
   size_t order_ FML_GUARDED_BY(delayed_tasks_mutex_);

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -296,38 +296,63 @@ TEST(MessageLoop, CanCreateConcurrentMessageLoop) {
   latch.Wait();
 }
 
-TEST(MessageLoop, CanSwapMessageLoopQueues) {
+TEST(MessageLoop, CanSwapMessageLoops) {
+  // synchronization notes:
+  // 1. term1 and term2 are to wait for Swap.
+  // 2. tr_term1 (read as task_runner terminated latch) is to
+  //    wait for the task runners to signal that they are done.
+  // 3. latch1 and latch2 are to wait for the message loops to
+  //    get initialized.
+
   fml::MessageLoop* loop1 = nullptr;
   fml::AutoResetWaitableEvent latch1;
-
-  std::thread thread1([&loop1, &latch1]() {
+  fml::AutoResetWaitableEvent tr_term1;
+  fml::AutoResetWaitableEvent term1;
+  std::thread thread1([&loop1, &latch1, &term1, &tr_term1]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     loop1 = &fml::MessageLoop::GetCurrent();
+    ASSERT_TRUE(loop1->GetTaskRunner());
+    loop1->GetTaskRunner()->PostTask([&tr_term1]() {
+      tr_term1.Signal();
+      fml::MessageLoop::GetCurrent().Terminate();
+    });
     latch1.Signal();
+    term1.Wait();
+    loop1->Run();
   });
 
   fml::MessageLoop* loop2 = nullptr;
   fml::AutoResetWaitableEvent latch2;
-  std::thread thread2([&loop2, &latch2]() {
+  fml::AutoResetWaitableEvent tr_term2;
+  fml::AutoResetWaitableEvent term2;
+  std::thread thread2([&loop2, &latch2, &term2, &tr_term2]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     loop2 = &fml::MessageLoop::GetCurrent();
+    ASSERT_TRUE(loop2->GetTaskRunner());
+    loop2->GetTaskRunner()->PostTask([&tr_term2]() {
+      tr_term2.Signal();
+      fml::MessageLoop::GetCurrent().Terminate();
+    });
     latch2.Signal();
+    term2.Wait();
+    loop2->Run();
   });
 
   // wait for loops to initialize.
   latch1.Wait();
   latch2.Wait();
 
-  fml::AutoResetWaitableEvent term1, term2;
-  loop1->GetTaskRunner()->PostTask([&term1]() { term1.Signal(); });
-  loop2->GetTaskRunner()->PostTask([&term2]() { term2.Signal(); });
+  // swap the loops.
+  loop1->Swap(loop2);
 
-  loop1->Swap(*loop2);
+  // thread_1 should wait for tr_term2 latch.
+  term1.Signal();
+  tr_term2.Wait();
 
-  // now that we have swapped, loop1 can wait for term2.
-  loop1->Run();
-  term2.Wait();
+  // thread_2 should wait for tr_term2 latch.
+  term2.Signal();
+  tr_term1.Wait();
 
-  loop2->Run();
-  term1.Wait();
+  thread1.join();
+  thread2.join();
 }

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -345,7 +345,7 @@ TEST(MessageLoop, CanSwapMessageLoopsAndPreserveThreadConfiguration) {
   latch2.Wait();
 
   // swap the loops.
-  loop1->Swap(loop2);
+  loop1->SwapTaskQueues(loop2);
 
   // thread_1 should wait for tr_term2 latch.
   term1.Signal();

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -299,62 +299,135 @@ TEST(MessageLoop, CanCreateConcurrentMessageLoop) {
 TEST(MessageLoop, CanSwapMessageLoopsAndPreserveThreadConfiguration) {
   // synchronization notes:
   // 1. term1 and term2 are to wait for Swap.
-  // 2. tr_term1 (read as task_runner terminated latch) is to
-  //    wait for the task runners to signal that they are done.
-  // 3. latch1 and latch2 are to wait for the message loops to
+  // 2. task_started_1 is to wait for the task runners
+  //    to signal that they are done.
+  // 3. loop_init_1 and loop_init_2 are to wait for the message loops to
   //    get initialized.
 
   fml::MessageLoop* loop1 = nullptr;
-  fml::AutoResetWaitableEvent latch1;
-  fml::AutoResetWaitableEvent tr_term1;
+  fml::AutoResetWaitableEvent loop_init_1;
+  fml::AutoResetWaitableEvent task_started_1;
   fml::AutoResetWaitableEvent term1;
-  std::thread thread1([&loop1, &latch1, &term1, &tr_term1]() {
+  std::thread thread1([&loop1, &loop_init_1, &term1, &task_started_1]() {
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     loop1 = &fml::MessageLoop::GetCurrent();
     // this task will be run on thread1 after Swap.
-    loop1->GetTaskRunner()->PostTask([&tr_term1]() {
-      tr_term1.Signal();
+    loop1->GetTaskRunner()->PostTask([&task_started_1]() {
+      task_started_1.Signal();
       fml::MessageLoop::GetCurrent().Terminate();
     });
-    latch1.Signal();
+    loop_init_1.Signal();
     term1.Wait();
     loop1->Run();
   });
 
-  latch1.Wait();
+  loop_init_1.Wait();
 
   fml::MessageLoop* loop2 = nullptr;
-  fml::AutoResetWaitableEvent latch2;
-  fml::AutoResetWaitableEvent tr_term2;
+  fml::AutoResetWaitableEvent loop_init_2;
+  fml::AutoResetWaitableEvent task_started_2;
   fml::AutoResetWaitableEvent term2;
-  std::thread thread2([&loop2, &latch2, &term2, &tr_term2, &loop1]() {
-    fml::MessageLoop::EnsureInitializedForCurrentThread();
-    loop2 = &fml::MessageLoop::GetCurrent();
-    // this task will be run on thread1 after Swap.
-    loop2->GetTaskRunner()->PostTask([&tr_term2, &loop1]() {
-      // ensure that we run the task on loop1 after the swap.
-      ASSERT_TRUE(loop1 == &fml::MessageLoop::GetCurrent());
-      tr_term2.Signal();
-      fml::MessageLoop::GetCurrent().Terminate();
-    });
-    latch2.Signal();
-    term2.Wait();
-    loop2->Run();
-  });
+  std::thread thread2(
+      [&loop2, &loop_init_2, &term2, &task_started_2, &loop1]() {
+        fml::MessageLoop::EnsureInitializedForCurrentThread();
+        loop2 = &fml::MessageLoop::GetCurrent();
+        // this task will be run on thread1 after Swap.
+        loop2->GetTaskRunner()->PostTask([&task_started_2, &loop1]() {
+          // ensure that we run the task on loop1 after the swap.
+          ASSERT_TRUE(loop1 == &fml::MessageLoop::GetCurrent());
+          task_started_2.Signal();
+          fml::MessageLoop::GetCurrent().Terminate();
+        });
+        loop_init_2.Signal();
+        term2.Wait();
+        loop2->Run();
+      });
 
-  latch2.Wait();
+  loop_init_2.Wait();
 
   // swap the loops.
   loop1->SwapTaskQueues(loop2);
 
   // thread_1 should wait for tr_term2 latch.
   term1.Signal();
-  tr_term2.Wait();
+  task_started_2.Wait();
 
   // thread_2 should wait for tr_term2 latch.
   term2.Signal();
-  tr_term1.Wait();
+  task_started_1.Wait();
 
   thread1.join();
   thread2.join();
+}
+
+TEST(MessageLoop, TIME_SENSITIVE(DelayedTaskSwap)) {
+  // Task execution order:
+  // time (ms): 0    10   20   30  40
+  // thread 1:  A1   A2   A3   A4  TERM
+  // thread 2:       B1   B2   B3  TERM
+
+  // At time 15, we swap thread 1 and 2, and assert
+  // that tasks run on the right threads.
+
+  std::thread::id t1, t2;
+  fml::AutoResetWaitableEvent tid_1, tid_2;
+  fml::MessageLoop* loop1 = nullptr;
+  fml::MessageLoop* loop2 = nullptr;
+
+  std::thread thread_1([&loop1, &t1, &t2, &tid_1, &tid_2]() {
+    t1 = std::this_thread::get_id();
+    tid_1.Signal();
+    tid_2.Wait();
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop1 = &fml::MessageLoop::GetCurrent();
+    for (int t = 0; t <= 4; t++) {
+      loop1->GetTaskRunner()->PostDelayedTask(
+          [t, &t1, &t2]() {
+            auto cur_tid = std::this_thread::get_id();
+            if (t <= 1) {
+              ASSERT_EQ(cur_tid, t1);
+            } else {
+              ASSERT_EQ(cur_tid, t2);
+            }
+
+            if (t == 4) {
+              fml::MessageLoop::GetCurrent().Terminate();
+            }
+          },
+          fml::TimeDelta::FromMilliseconds(t * 10));
+    }
+    loop1->Run();
+  });
+
+  std::thread thread_2([&loop2, &t1, &t2, &tid_1, &tid_2]() {
+    t2 = std::this_thread::get_id();
+    tid_2.Signal();
+    tid_1.Wait();
+    fml::MessageLoop::EnsureInitializedForCurrentThread();
+    loop2 = &fml::MessageLoop::GetCurrent();
+    for (int t = 1; t <= 4; t++) {
+      loop2->GetTaskRunner()->PostDelayedTask(
+          [t, &t1, &t2]() {
+            auto cur_tid = std::this_thread::get_id();
+            if (t <= 1) {
+              ASSERT_EQ(cur_tid, t2);
+            } else {
+              ASSERT_EQ(cur_tid, t1);
+            }
+
+            if (t == 4) {
+              fml::MessageLoop::GetCurrent().Terminate();
+            }
+          },
+          fml::TimeDelta::FromMilliseconds(t * 10));
+    }
+    loop2->Run();
+  });
+
+  // on main thread we swap the threads at 15 ms.
+  std::this_thread::sleep_for(std::chrono::milliseconds(15));
+  loop1->SwapTaskQueues(loop2);
+
+  thread_1.join();
+  thread_2.join();
 }


### PR DESCRIPTION
Added `Swap` method to `MessageLoop` which swaps the underlying task queues. This is a prerequisite to allow us to have dynamic thread merging, refer: https://github.com/flutter/engine/pull/9001/files#r290090655 for more details.