### PR TITLE
Fix rare crash on HuaWei device when use AndroidView.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -131,6 +131,8 @@ class VirtualDisplayController {
 
     public void dispose() {
         PlatformView view = presentation.getView();
+        // Fix rare crash on HuaWei device described in: https://github.com/flutter/engine/pull/9192
+        presentation.cancel();
         presentation.detachState();
         view.dispose();
         virtualDisplay.release();


### PR DESCRIPTION
Stacktrace:
java.lang.NullPointerException: Attempt to invoke virtual method 'android.view.DisplayAdjustments android.view.Display.getDisplayAdjustments()' on a null object reference
at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:1793)
at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:1558)
at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:7463)
at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1041)
at android.view.Choreographer.doCallbacks(Choreographer.java:847)
at android.view.Choreographer.doFrame(Choreographer.java:774)
at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1027)
at android.os.Handler.handleCallback(Handler.java:809)
at android.os.Handler.dispatchMessage(Handler.java:102)
at android.os.Looper.loop(Looper.java:166)
at android.app.ActivityThread.main(ActivityThread.java:7555)
at java.lang.reflect.Method.invoke(Method.java)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:469)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:963)