### PR TITLE
Switch PlatformViewsController from Activity ref to Application ref.

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -80,7 +80,7 @@ public class FlutterPluginRegistry
     public void attach(FlutterView flutterView, Activity activity) {
         mFlutterView = flutterView;
         mActivity = activity;
-        mPlatformViewsController.attach(activity, flutterView, flutterView.getDartExecutor());
+        mPlatformViewsController.attach(activity.getApplicationContext(), flutterView, flutterView.getDartExecutor());
     }
 
     public void detach() {

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
@@ -75,7 +75,7 @@ public class ShimPluginRegistry implements PluginRegistry {
 
   //----- From FlutterPluginRegistry that aren't in the PluginRegistry interface ----//
   public void attach(FlutterView flutterView, Activity activity) {
-    platformViewsController.attach(activity, flutterEngine.getRenderer(), flutterEngine.getDartExecutor());
+    platformViewsController.attach(activity.getApplicationContext(), flutterEngine.getRenderer(), flutterEngine.getDartExecutor());
   }
 
   public void detach() {

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -227,7 +227,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
      * Attaches this platform views controller to its input and output channels.
      *
      * @param context The base context that will be passed to embedded views created by this controller.
-     *                This should be the context of the Activity hosting the Flutter application.
+     *                This should be the {@code Application} {@code Context}.
      * @param textureRegistry The texture registry which provides the output textures into which the embedded views
      *                        will be rendered.
      * @param dartExecutor The dart execution context, which is used to setup a system channel.
@@ -239,7 +239,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                             "attach was called while the PlatformViewsController was already attached."
             );
         }
-        this.context = context;
+        this.context = context.getApplicationContext();
         this.textureRegistry = textureRegistry;
         platformViewsChannel = new PlatformViewsChannel(dartExecutor);
         platformViewsChannel.setPlatformViewsHandler(channelHandler);


### PR DESCRIPTION
Switch PlatformViewsController from Activity ref to Application ref.

This change is being made to facilitate add-to-app use-cases where an Activity may come and go. We should be OK using the Application Context instead of an Activity.

I ran the webview plugin's sample project against a local engine with this change. It appeared to run fine.