### PR TITLE
move webOnlyScheduleFrameCallback off of window

### DIFF
--- a/lib/stub_ui/lib/src/engine.dart
+++ b/lib/stub_ui/lib/src/engine.dart
@@ -120,7 +120,7 @@ void webOnlyInitializeEngine() {
   domRenderer;
 
   bool waitingForAnimation = false;
-  ui.window.webOnlyScheduleFrameCallback = () {
+  ui.webOnlyScheduleFrameCallback = () {
     // We're asked to schedule a frame and call `frameHandler` when the frame
     // fires.
     if (!waitingForAnimation) {

--- a/lib/stub_ui/lib/src/ui/test_embedding.dart
+++ b/lib/stub_ui/lib/src/ui/test_embedding.dart
@@ -45,7 +45,7 @@ Future<void> webOnlyInitializeTestDomRenderer({double devicePixelRatio = 3.0}) {
   engine.window.debugOverrideDevicePixelRatio(devicePixelRatio);
   engine.window.webOnlyDebugPhysicalSizeOverride =
       Size(800 * devicePixelRatio, 600 * devicePixelRatio);
-  window.webOnlyScheduleFrameCallback = () {};
+  webOnlyScheduleFrameCallback = () {};
   engine.domRenderer.debugIsInWidgetTest = true;
 
   if (_platformInitializedFuture != null) {

--- a/lib/stub_ui/lib/src/ui/window.dart
+++ b/lib/stub_ui/lib/src/ui/window.dart
@@ -804,8 +804,6 @@ abstract class Window {
     _onLocaleChanged = callback;
   }
 
-  VoidCallback webOnlyScheduleFrameCallback;
-
   /// Requests that, at the next appropriate opportunity, the [onBeginFrame]
   /// and [onDrawFrame] callbacks be invoked.
   ///
@@ -1223,6 +1221,8 @@ class IsolateNameServer {
     throw UnimplementedError();
   }
 }
+
+VoidCallback webOnlyScheduleFrameCallback;
 
 /// The [Window] singleton. This object exposes the size of the display, the
 /// core scheduler API, the input event callback, the graphics drawing API, and


### PR DESCRIPTION
Allows us to compile tests for flutter web, see CL/251991320