### PR TITLE
Removed VIRTUAL_KEYBOARD check in TextInputPlugin

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/AndroidKeyProcessor.java
+++ b/shell/platform/android/io/flutter/embedding/android/AndroidKeyProcessor.java
@@ -30,11 +30,9 @@ public class AndroidKeyProcessor {
   }
 
   public void onKeyDown(@NonNull KeyEvent keyEvent) {
-    if (keyEvent.getDeviceId() != KeyCharacterMap.VIRTUAL_KEYBOARD) {
-      if (textInputPlugin.getLastInputConnection() != null
-          && textInputPlugin.getInputMethodManager().isAcceptingText()) {
-        textInputPlugin.getLastInputConnection().sendKeyEvent(keyEvent);
-      }
+    if (textInputPlugin.getLastInputConnection() != null
+        && textInputPlugin.getInputMethodManager().isAcceptingText()) {
+      textInputPlugin.getLastInputConnection().sendKeyEvent(keyEvent);
     }
 
     Character complexCharacter = applyCombiningCharacterToBaseCharacter(keyEvent.getUnicodeChar());


### PR DESCRIPTION
Removed VIRTUAL_KEYBOARD check in TextInputPlugin because it's blocking Espresso work and we don't know why it exists.