### PR TITLE
Add stub implementation that doesn't throw

### DIFF
--- a/lib/stub_ui/lib/src/ui/text.dart
+++ b/lib/stub_ui/lib/src/ui/text.dart
@@ -1593,7 +1593,7 @@ class Paragraph {
   /// where positive y values indicate down.
   List<TextBox> getBoxesForPlaceholders() {
     // TODO(garyq): Implement stub_ui version of this.
-    throw UnimplementedError();
+    return const <TextBox>[];
   }
 
   /// Returns the text position closest to the given offset.


### PR DESCRIPTION
Because we unconditionally call paragraph. getBoxesForPlaceholders we need a placeholder that doesn't throw