### PR TITLE
Throw on unhandled license type

### DIFF
--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 216610bcb9040235083834b2ddcb2f0d
+Signature: 5b10e36374c7d600de6c632fde955f7d
 

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: ad6590b867473860a1e6b08bf9e98667
+Signature: 216610bcb9040235083834b2ddcb2f0d
 

--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -176,6 +176,7 @@ abstract class License implements Comparable<License> {
     if (!reformatted)
       body = _reformat(body);
     final License result = _registry.putIfAbsent(body, () {
+      assert(type != null);
       switch (type) {
         case LicenseType.bsd:
         case LicenseType.mit:
@@ -200,7 +201,7 @@ abstract class License implements Comparable<License> {
         case LicenseType.libpng:
           return BlankLicense._(body, type, origin: origin);
       }
-      throw 'unhandled license type: $type';
+      return null;
     });
     assert(result.type == type);
     return result;

--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -200,6 +200,7 @@ abstract class License implements Comparable<License> {
         case LicenseType.libpng:
           return BlankLicense._(body, type, origin: origin);
       }
+      throw 'unhandled license type: $type';
     });
     assert(result.type == type);
     return result;


### PR DESCRIPTION
If a LicenseType is ever left unhandled in the switch statement, we now
throw an exception. This also fixes a 'missing return statements' lint.