### PR TITLE
Set identity instead of crash in opt build

### DIFF
--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -17,7 +17,10 @@ TransformLayer::TransformLayer(const SkMatrix& transform)
   //
   // We have to write this flaky test because there is no reliable way to test
   // whether a variable is initialized or not in C++.
-  FML_CHECK(transform_.isFinite());
+  FML_DCHECK(transform_.isFinite());
+  if (!transform_.isFinite()) {
+    transform_.setIdentity();
+  }
 }
 
 TransformLayer::~TransformLayer() = default;

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -19,6 +19,7 @@ TransformLayer::TransformLayer(const SkMatrix& transform)
   // whether a variable is initialized or not in C++.
   FML_DCHECK(transform_.isFinite());
   if (!transform_.isFinite()) {
+    FML_LOG(ERROR) << "TransformLayer is constructed with an invalid matrix.";
     transform_.setIdentity();
   }
 }


### PR DESCRIPTION
According to https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#expectations-around-potential-crashes-in-the-engine

This should address https://github.com/flutter/flutter/issues/31650#issuecomment-494935507

We'll instead use `FML_LOG(ERROR)` to report errors to our CI tests. See https://github.com/flutter/flutter/issues/34194