### PR TITLE
Report timings faster (100ms) in profile/debug

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -13,12 +13,13 @@ typedef FrameCallback = void Function(Duration duration);
 /// Signature for [Window.onReportTimings].
 ///
 /// {@template dart.ui.TimingsCallback.list}
-/// The callback takes a list of [FrameTiming] because it may not be immediately
-/// triggered after each frame. Instead, Flutter tries to batch frames together
-/// and send all their timings at once to decrease the overhead (as this is
-/// available in the release mode). The list is sorted in ascending order of
-/// time (earliest frame first). The timing of any frame will be sent within
-/// about 1 second even if there are no later frames to batch.
+/// The callback takes a list of [FrameTiming] because it may not be
+/// immediately triggered after each frame. Instead, Flutter tries to batch
+/// frames together and send all their timings at once to decrease the
+/// overhead (as this is available in the release mode). The list is sorted in
+/// ascending order of time (earliest frame first). The timing of any frame
+/// will be sent within about 1 second (100ms if in the profile/debug mode)
+/// even if there are no later frames to batch.
 /// {@endtemplate}
 typedef TimingsCallback = void Function(List<FrameTiming> timings);
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -434,5 +434,52 @@ TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
   }
 }
 
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
+#else
+TEST_F(ShellTest, ReportTimingsIsCalledLaterInNonReleaseMode) {
+#endif
+  fml::TimePoint start = fml::TimePoint::Now();
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(std::move(settings));
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+  configuration.SetEntrypoint("reportTimingsMain");
+  fml::AutoResetWaitableEvent reportLatch;
+  std::vector<int64_t> timestamps;
+  auto nativeTimingCallback = [&reportLatch,
+                               &timestamps](Dart_NativeArguments args) {
+    Dart_Handle exception = nullptr;
+    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
+        args, 0, exception);
+    reportLatch.Signal();
+  };
+  AddNativeCallback("NativeReportTimingsCallback",
+                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
+  RunEngine(shell.get(), std::move(configuration));
+
+  PumpOneFrame(shell.get());
+
+  reportLatch.Wait();
+  shell.reset();
+
+  fml::TimePoint finish = fml::TimePoint::Now();
+  fml::TimeDelta ellapsed = finish - start;
+
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+  // Our batch time is 1000ms. Hopefully the 800ms limit is relaxed enough to
+  // make it not too flaky.
+  ASSERT_TRUE(ellapsed >= fml::TimeDelta::FromMilliseconds(800));
+#else
+  // Our batch time is 100ms. Hopefully the 500ms limit is relaxed enough to
+  // make it not too flaky.
+  ASSERT_TRUE(ellapsed <= fml::TimeDelta::FromMilliseconds(500));
+#endif
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
This should satisfy the low-latency need of DevTools.

Test added:
* ReportTimingsIsCalledSoonerInNonReleaseMode
* ReportTimingsIsCalledLaterInReleaseMode