### PR TITLE
Handle Fuchsia SDK in license tool + roll SDK

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -473,7 +473,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': 'jlQvNeRMq6X81_VYiFI_Ol311YCXak0xACebeb8f6TcC'
+        'version': 'Cx51FRV5TCoqQ9nfs4E2QMfYkJ1JWt7arQXhV01tr7cC'
        }
      ],
      'condition': 'host_os == "mac"',
@@ -483,7 +483,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/clang/mac-amd64',
-        'version': '4OfgjQg8g3Ztj2OYJ4Zlz9Q6DGYjOTuHh3G8MSMhxg4C'
+        'version': 'BzmZEP9A83NSNSqnrff3k0tYJK7UXs0pknphn-quiZwC'
        }
      ],
      'condition': 'host_os == "mac"',
@@ -493,7 +493,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': '9-zyx3CzWylM-x9RYdL5UTT9uU-sl_0ysOCcEGCtot0C'
+        'version': 'udf6w2VmM5E8PyQm5ggugW_jjiEdWs-Xl6efeLf2JdkC'
        }
      ],
      'condition': 'host_os == "linux"',
@@ -503,7 +503,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/clang/linux-amd64',
-        'version': 'WPg0zzXLyTjFNrOrz4uA5vPaXUuEYvTJ5DPyYdiaN3MC'
+        'version': 'dV3r0yk4WXi1C-QwjzNUA-pIkHCG3COYnrlt80GFacYC'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: f3ae86bf01d57e552b045084f4601d6f
+Signature: 737b51ca06466992a94a6ad3a9956baa
 
 UNUSED LICENSES:
 
@@ -43,26 +43,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ====================================================================================================
 LIBRARY: fuchsia_sdk
-ORIGIN: ../../../fuchsia/sdk/linux/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../fuchsia/sdk/linux/.build-id/0c/7180f0254d66fecfc84bef3339a7b71c457dcd.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/25/96d83da12ef9224f4df627b37dddb0f871b655.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/2f/341201ed67d5c7171b0a0d606861bd1c531eba.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/47/b16a99629da959039391bd8804d7d22dd27b50.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/59/896073939655951a6a08f9a376b4ae10244616.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/6d/ced323e99bc31a5afa28eca8d3d98ef09d46ef.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/73/1f40fcea15370e.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/7e/3f807cda5a47e60285a751b8265d621551de02.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/82/5b314d45feed623c70bf21bd7c9ceb62fb4d4e.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/83/ccf51a89d5bcf1709510507d66c3f0c291a969.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/90/1b18453902c341c25c57ef2e40c175614a5afe.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/9f/5e21c81427ad236ba27374a6a13f1bffc3e9dd.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/b0/ae926bebfc82c2.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/b0/cb33d5e533ba8f6dcb73cc9c158cb8247f0263.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/ba/5f203efc80a0dd.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/c9/0d4b5704d2b548e8488663b69bf86fdfef59ea.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/ca/acfd23dc9b1a5d8929f6da0e864e07e989353b.debug
-FILE: ../../../fuchsia/sdk/linux/.build-id/e5/d60a28793ffcc0.debug
+ORIGIN: ../../../fuchsia/sdk/linux/COPYRIGHT.musl
+TYPE: LicenseType.mit
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_core_validation.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_image_pipe_swapchain.so
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_object_tracker.so
@@ -95,7 +77,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/tftp.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/assert.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/endian.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ioctl.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ipc.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/reg.h
@@ -107,7 +88,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/endian.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/errno.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fcntl.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/io.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ioctl.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ipc.h
@@ -125,7 +105,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/statfs.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/termios.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/endian.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/io.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ioctl.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ipc.h
@@ -147,10 +126,8 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/errno.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fcntl.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/features.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fmtmsg.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fnmatch.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ftw.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/getopt.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/glob.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/grp.h
@@ -199,7 +176,1335 @@ FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/signal.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/spawn.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdio.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdlib.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdnoreturn.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/string.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/strings.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/acct.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/auxv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/dir.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/eventfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/file.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/fsuid.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/klog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mman.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mount.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mtio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/param.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/personality.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/quota.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/random.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/reboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/select.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/signalfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/statvfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/swap.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timeb.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timerfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/times.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ttydefaults.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/uio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/un.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/utsname.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/vfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sysexits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/tar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/threads.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/uchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/unistd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/utime.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/values.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wordexp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/Scrt1.o
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libdl.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libm.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libpthread.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/librt.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libzircon.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_core_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_image_pipe_swapchain.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_object_tracker.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_parameter_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_threading.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_unique_objects.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsync.a
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/alloca.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/ftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/inet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/nameser.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/nameser_compat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/telnet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/tftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/alltypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/posix.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/byteswap.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/complex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/cpio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/crypt.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/dirent.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/dlfcn.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/elf.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/err.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/features.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fmtmsg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fnmatch.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/getopt.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/glob.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/grp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/iconv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ifaddrs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/inttypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/iso646.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/langinfo.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/libgen.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/link.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/locale.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/malloc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/math.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/memory.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/monetary.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/ethernet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/if.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/if_arp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/route.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netdb.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/icmp6.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/if_ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/igmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/in.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/in_systm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip6.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip_icmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/tcp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/udp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netpacket/packet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/nl_types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/paths.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/pthread.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/pwd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/regex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/resolv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sched.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/search.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/semaphore.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/spawn.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdlib.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/string.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/strings.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/acct.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/auxv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/dir.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/eventfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/file.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/fsuid.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/klog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mman.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mount.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mtio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/param.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/personality.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/quota.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/random.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/reboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/select.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/signalfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/statvfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/swap.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timeb.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timerfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/times.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ttydefaults.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/uio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/un.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/utsname.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/vfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sysexits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/tar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/threads.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/uchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/unistd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/utime.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/values.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wordexp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/Scrt1.o
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libdl.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libm.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libpthread.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/librt.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libzircon.so
+FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/_layout_logic.dart
+FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fidl/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_logger/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_media/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/zircon/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth.oldtokens/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.gatt/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.le/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera.common/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castauth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsetup/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsysteminfo/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.cobalt/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.crash/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.deprecatedtimezone/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.developer.tiles/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.feedback/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.ethernet/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.address.space/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.control/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.pipe/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.intl/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.io/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ldsvc/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ledger/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.logger/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.math/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.audio/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.drm/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.playback/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.sessions/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mediacodec/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mem/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.auth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.session/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.http/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.mdns/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.oldhttp/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.netstack/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.process/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.speech/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysinfo/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysmem/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.app/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.gfx/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.policy/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.scenic/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.vectorial/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1token/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.common/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.service/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.stats/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-default/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-loop-cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-loop/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fdio/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl-async/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fit/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/images_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/memfs/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/scenic_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/svc/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/syslog/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sysroot/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/trace-engine/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_core_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_image_pipe_swapchain.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_object_tracker.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_parameter_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_standard_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_threading.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_unique_objects.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/meta.json
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fuchsia.zbi
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fvm.blk
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fvm.sparse.blk
+FILE: ../../../fuchsia/sdk/linux/target/arm64/qemu-kernel.bin
+FILE: ../../../fuchsia/sdk/linux/target/x64/fuchsia.zbi
+FILE: ../../../fuchsia/sdk/linux/target/x64/fvm.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/fvm.sparse.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/local.esp.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/qemu-kernel.bin
+FILE: ../../../fuchsia/sdk/linux/target/x64/zircon.vboot
+----------------------------------------------------------------------------------------------------
+musl as a whole is licensed under the following standard MIT license:
+
+Copyright © 2005-2014 Rich Felker, et al.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Authors/contributors include:
+
+Alex Dowad
+Alexander Monakov
+Anthony G. Basile
+Arvid Picciani
+Bobby Bingham
+Boris Brezillon
+Brent Cook
+Chris Spiegel
+Clément Vasseur
+Daniel Micay
+Denys Vlasenko
+Emil Renner Berthing
+Felix Fietkau
+Felix Janda
+Gianluca Anzolin
+Hauke Mehrtens
+Hiltjo Posthuma
+Isaac Dunham
+Jaydeep Patil
+Jens Gustedt
+Jeremy Huntwork
+Jo-Philipp Wich
+Joakim Sindholt
+John Spencer
+Josiah Worcester
+Justin Cormack
+Khem Raj
+Kylie McClain
+Luca Barbato
+Luka Perkov
+M Farkas-Dyck (Strake)
+Mahesh Bodapati
+Michael Forney
+Natanael Copa
+Nicholas J. Kain
+orc
+Pascal Cuoq
+Petr Hosek
+Pierre Carrier
+Rich Felker
+Richard Pennington
+Shiz
+sin
+Solar Designer
+Stefan Kristiansson
+Szabolcs Nagy
+Timo Teräs
+Trutz Behn
+Valentin Ochs
+William Haddon
+
+Portions of this software are derived from third-party works licensed
+under terms compatible with the above MIT license:
+
+Much of the math library code (third_party/math/* and
+third_party/complex/*, and third_party/include/libm.h) is
+Copyright © 1993,2004 Sun Microsystems or
+Copyright © 2003-2011 David Schultz or
+Copyright © 2003-2009 Steven G. Kargl or
+Copyright © 2003-2009 Bruce D. Evans or
+Copyright © 2008 Stephen L. Moshier
+and labelled as such in comments in the individual source files. All
+have been licensed under extremely permissive terms.
+
+The smoothsort implementation (third_party/smoothsort/qsort.c) is
+Copyright © 2011 Valentin Ochs and is licensed under an MIT-style
+license.
+
+The x86_64 files in third_party/arch were written by Nicholas J. Kain
+and is licensed under the standard MIT terms.
+
+All other files which have no copyright comments are original works
+produced specifically for use as part of this library, written either
+by Rich Felker, the main author of the library, or by one or more
+contibutors listed above. Details on authorship of individual files
+can be found in the git version control history of the project. The
+omission of copyright and license comments in each file is in the
+interest of source tree size.
+
+In addition, permission is hereby granted for all public header files
+(include/* and arch/*/bits/*) and crt files intended to be linked into
+applications (crt/*, ldso/dlstart.c, and arch/*/crt_arch.h) to omit
+the copyright notice and permission notice otherwise required by the
+license, and to use these files without any requirement of
+attribution. These files include substantial contributions from:
+
+Bobby Bingham
+John Spencer
+Nicholas J. Kain
+Rich Felker
+Richard Pennington
+Stefan Kristiansson
+Szabolcs Nagy
+
+all of whom have explicitly granted such permission.
+
+This file previously contained text expressing a belief that most of
+the files covered by the above exception were sufficiently trivial not
+to be subject to copyright, resulting in confusion over whether it
+negated the permissions granted in the license. In the spirit of
+permissive licensing, and of not having licensing issues being an
+obstacle to adoption, that text has been removed.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: fuchsia_sdk
+ORIGIN: ../../../fuchsia/sdk/linux/COPYRIGHT.vulkan
+TYPE: LicenseType.vulkan
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_core_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_image_pipe_swapchain.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_object_tracker.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_parameter_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_threading.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_unique_objects.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsync.a
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/alloca.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/ftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/inet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/nameser.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/nameser_compat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/telnet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/tftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/alltypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/posix.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/byteswap.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/complex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/cpio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/crypt.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/dirent.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/dlfcn.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/elf.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/err.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/features.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fmtmsg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fnmatch.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/getopt.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/glob.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/grp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/iconv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ifaddrs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/inttypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/iso646.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/langinfo.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/libgen.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/link.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/locale.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/malloc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/math.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/memory.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/monetary.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/ethernet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/if.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/if_arp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/route.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netdb.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/icmp6.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/if_ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/igmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/in.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/in_systm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip6.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip_icmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/tcp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/udp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netpacket/packet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/nl_types.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/paths.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/pthread.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/pwd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/regex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/resolv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sched.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/search.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/semaphore.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/spawn.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdlib.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/string.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/strings.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/acct.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/auxv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/dir.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/eventfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/file.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/fsuid.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/klog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mman.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mount.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mtio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/param.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/personality.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/quota.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/random.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/reboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/select.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/signalfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/statvfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/swap.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timeb.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timerfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/times.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ttydefaults.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/uio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/un.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/utsname.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/vfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sysexits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/tar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/threads.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/uchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/unistd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/utime.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/values.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wordexp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/Scrt1.o
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libdl.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libm.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libpthread.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/librt.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libzircon.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_core_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_image_pipe_swapchain.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_object_tracker.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_parameter_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_threading.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_unique_objects.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsync.a
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/alloca.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/ftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/inet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/nameser.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/nameser_compat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/telnet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/tftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/alltypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/posix.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/byteswap.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/complex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/cpio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/crypt.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/dirent.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/dlfcn.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/elf.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/err.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/features.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fmtmsg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fnmatch.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/getopt.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/glob.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/grp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/iconv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ifaddrs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/inttypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/iso646.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/langinfo.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/libgen.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/link.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/locale.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/malloc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/math.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/memory.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/monetary.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/ethernet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/if.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/if_arp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/route.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netdb.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/icmp6.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/if_ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/igmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/in.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/in_systm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip6.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip_icmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/tcp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/udp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netpacket/packet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/nl_types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/paths.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/pthread.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/pwd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/regex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/resolv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sched.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/search.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/semaphore.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/spawn.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdlib.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/string.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/strings.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/acct.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/auxv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/dir.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/eventfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/file.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/fsuid.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/klog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mman.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mount.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mtio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/param.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/personality.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/quota.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/random.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/reboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/select.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/signalfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/statvfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/swap.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timeb.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timerfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/times.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ttydefaults.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/uio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/un.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/utsname.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/vfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sysexits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/tar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/threads.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/uchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/unistd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/utime.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/values.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wordexp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/Scrt1.o
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libdl.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libm.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libpthread.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/librt.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libzircon.so
+FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/_layout_logic.dart
+FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fidl/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_logger/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_media/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/zircon/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth.oldtokens/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.gatt/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.le/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera.common/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castauth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsetup/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsysteminfo/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.cobalt/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.crash/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.deprecatedtimezone/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.developer.tiles/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.feedback/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.ethernet/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.address.space/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.control/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.pipe/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.intl/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.io/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ldsvc/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ledger/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.logger/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.math/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.audio/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.drm/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.playback/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.sessions/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mediacodec/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mem/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.auth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.session/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.http/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.mdns/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.oldhttp/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.netstack/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.process/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.speech/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysinfo/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysmem/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.app/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.gfx/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.policy/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.scenic/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.vectorial/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1token/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.common/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.service/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.stats/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-default/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-loop-cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-loop/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fdio/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl-async/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fit/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/images_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/memfs/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/scenic_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/svc/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/syslog/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sysroot/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/trace-engine/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_core_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_image_pipe_swapchain.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_object_tracker.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_parameter_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_standard_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_threading.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_unique_objects.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/meta.json
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fuchsia.zbi
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fvm.blk
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fvm.sparse.blk
+FILE: ../../../fuchsia/sdk/linux/target/arm64/qemu-kernel.bin
+FILE: ../../../fuchsia/sdk/linux/target/x64/fuchsia.zbi
+FILE: ../../../fuchsia/sdk/linux/target/x64/fvm.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/fvm.sparse.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/local.esp.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/qemu-kernel.bin
+FILE: ../../../fuchsia/sdk/linux/target/x64/zircon.vboot
+----------------------------------------------------------------------------------------------------
+This file contains other licenses and their copyrights that appear in this
+repository besides Apache 2.0 license.
+
+===================================================
+
+  Copyright (c) 2009 Dave Gamble
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+===================================================
+
+    Copyright Kevlin Henney, 1997, 2003, 2012. All rights reserved.
+
+    Permission to use, copy, modify, and distribute this software and its
+    documentation for any purpose is hereby granted without fee, provided
+    that this copyright and permissions notice appear in all copies and
+    derivatives.
+
+    This software is supplied "as is" without express or implied warranty.
+
+    But that said, if there are any problems please get in touch.
+
+===================================================
+Copyright 2008, Google Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===================================================
+Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+* Neither the names of Kitware, Inc., the Insight Software Consortium,
+  nor the names of their contributors may be used to endorse or promote
+  products derived from this software without specific prior written
+  permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===================================================
+Copyright (c) 2011 Fredrik Höglund <fredrik@kde.org>
+Copyright (c) 2008 Helio Chissini de Castro, <helio@kde.org>
+Copyright (c) 2007 Matthias Kretz, <kretz@kde.org>
+
+Redistribution and use is allowed according to the terms of the BSD license.
+
+===================================================
+/// Copyright (c) 2005 - 2014 G-Truc Creation (www.g-truc.net)
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: fuchsia_sdk
+ORIGIN: ../../../fuchsia/sdk/linux/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_core_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_image_pipe_swapchain.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_object_tracker.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_parameter_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_threading.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_unique_objects.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsync.a
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/alloca.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/ftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/inet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/nameser.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/nameser_compat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/telnet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/tftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/alltypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/posix.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/byteswap.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/complex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/cpio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/crypt.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/dirent.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/dlfcn.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/elf.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/err.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/features.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fmtmsg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fnmatch.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/getopt.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/glob.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/grp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/iconv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ifaddrs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/inttypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/iso646.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/langinfo.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/libgen.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/link.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/locale.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/malloc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/math.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/memory.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/monetary.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/ethernet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/if.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/if_arp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/route.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netdb.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/icmp6.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/if_ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/igmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/in.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/in_systm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip6.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip_icmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/tcp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/udp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netpacket/packet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/nl_types.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/paths.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/pthread.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/pwd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/regex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/resolv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sched.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/search.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/semaphore.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/spawn.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdlib.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/string.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/strings.h
 FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stropts.h
@@ -308,7 +1613,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/tftp.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/assert.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/endian.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ioctl.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ipc.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/reg.h
@@ -320,7 +1624,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/endian.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/errno.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fcntl.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/io.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ioctl.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ipc.h
@@ -338,7 +1641,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/statfs.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/termios.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/endian.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/io.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ioctl.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ipc.h
@@ -360,10 +1662,8 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/errno.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fcntl.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/features.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fenv.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/float.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fmtmsg.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fnmatch.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ftw.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/getopt.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/glob.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/grp.h
@@ -412,7 +1712,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/signal.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/spawn.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdio.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdlib.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdnoreturn.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/string.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/strings.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stropts.h
@@ -493,6 +1792,7 @@ FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/composition_deleg
 FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/composition_delegate/composition_delegate.dart
 FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/_layout_logic.dart
 FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/_layout_strategy.dart
+FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/copresent_strategy/copresent_strategy.dart
 FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/split_evenly_strategy/split_evenly_strategy.dart
 FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/stack_strategy/stack_strategy.dart
 FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/tree/_surface_node.dart
@@ -504,6 +1804,19 @@ FILE: ../../../fuchsia/sdk/linux/dart/fidl/lib/src/bits.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fidl/lib/src/xunion.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fidl/meta.json
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/inspect.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/inspect/inspect.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/inspect/internal/_inspect_impl.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/inspect/node.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/inspect/property.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/vmo/bitfield64.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/vmo/block.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/vmo/heap.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/vmo/util.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/vmo/vmo_fields.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/vmo/vmo_holder.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/lib/src/vmo/vmo_writer.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/meta.json
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_logger/meta.json
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_media/meta.json
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/module/internal/_ongoing_activity_impl.dart
@@ -518,19 +1831,37 @@ FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/meta.json
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/lib/src/incoming.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/lib/src/outgoing.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/lib/src/composed_pseudo_dir.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/lib/src/internal/_flags.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/lib/src/vmo_file.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/sl4f.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/audio.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/dump.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/exceptions.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/input.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/inspect.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/modular.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/performance.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/scenic.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/setui.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/sl4f_client.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/storage.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/lib/src/traceutil.dart
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/meta.json
 FILE: ../../../fuchsia/sdk/linux/dart/zircon/meta.json
-FILE: ../../../fuchsia/sdk/linux/docs/low_level.json
-FILE: ../../../fuchsia/sdk/linux/docs/metadata_schemas.json
-FILE: ../../../fuchsia/sdk/linux/docs/open_source.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth.oldtokens/credentials_producer.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth.oldtokens/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.gatt/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.le/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth/address.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth/id.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth/uuid.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera.common/common.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera.common/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera.common/virtual.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castauth/cast_auth.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castauth/meta.json
@@ -540,11 +1871,22 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsysteminfo/cast_system_info.fi
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsysteminfo/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.cobalt/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.crash/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.deprecatedtimezone/deprecated_time_service.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.deprecatedtimezone/deprecated_time_zone.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.deprecatedtimezone/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.developer.tiles/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.feedback/data_provider.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.feedback/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/provider.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/styles.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.ethernet/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.address.space/goldfish-address-space.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.address.space/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.control/goldfish-control.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.control/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.pipe/goldfish-pipe.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.pipe/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.intl/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.intl/property_provider.fidl
@@ -565,7 +1907,10 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mediacodec/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mem/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.auth/meta.json
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/component/message_queue.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.session/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.session/modular_config.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.testing/test_harness.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_shell_factory.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.http/meta.json
@@ -577,15 +1922,18 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.netstack/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.process/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.speech/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/types.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysinfo/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysmem/heap.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysmem/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.app/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.app/view.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.app/view_config.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.gfx/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.gfx/tokens.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/events.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/keys.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/modifiers.fidl
@@ -594,35 +1942,17 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.scenic/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.vectorial/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/view.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/view_config.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/view_token.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1token/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/context.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/debug.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/frame.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/navigation.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.common/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.service/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.stats/meta.json
-FILE: ../../../fuchsia/sdk/linux/images/fuchsia.zbi-meta.json
-FILE: ../../../fuchsia/sdk/linux/images/fvm.blk-meta.json
-FILE: ../../../fuchsia/sdk/linux/images/fvm.sparse.blk-meta.json
-FILE: ../../../fuchsia/sdk/linux/images/local.esp.blk-meta.json
-FILE: ../../../fuchsia/sdk/linux/images/qemu-kernel.bin-meta.json
-FILE: ../../../fuchsia/sdk/linux/images/zircon.vboot-meta.json
-FILE: ../../../fuchsia/sdk/linux/meta/manifest.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/cc_prebuilt_library.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/cc_source_library.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/common.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/dart_library.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/documentation.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/fidl_library.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/host_tool.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/image.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/loadable_module.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/manifest.json
-FILE: ../../../fuchsia/sdk/linux/meta/schemas/sysroot.json
 FILE: ../../../fuchsia/sdk/linux/pkg/async-cpp/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/async-default/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/async-loop-cpp/meta.json
@@ -638,19 +1968,71 @@ FILE: ../../../fuchsia/sdk/linux/pkg/fidl_base/include/lib/fidl/internal_callabl
 FILE: ../../../fuchsia/sdk/linux/pkg/fidl_base/include/lib/fidl/visitor.h
 FILE: ../../../fuchsia/sdk/linux/pkg/fidl_base/internal.cpp
 FILE: ../../../fuchsia/sdk/linux/pkg/fidl_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp/include/lib/fidl/cpp/event_sender.h
 FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_sync/include/lib/fidl/cpp/internal/message_sender.h
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_sync/internal/message_sender.cc
 FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fit/include/lib/fit/constructors_internal.h
+FILE: ../../../fuchsia/sdk/linux/pkg/fit/include/lib/fit/in_place_internal.h
+FILE: ../../../fuchsia/sdk/linux/pkg/fit/include/lib/fit/storage_internal.h
+FILE: ../../../fuchsia/sdk/linux/pkg/fit/include/lib/fit/utility_internal.h
 FILE: ../../../fuchsia/sdk/linux/pkg/fit/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/images_cpp/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/memfs/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/scenic_cpp/include/lib/ui/scenic/cpp/view_token_pair.h
 FILE: ../../../fuchsia/sdk/linux/pkg/scenic_cpp/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/svc/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sync/include/lib/sync/internal/mutex-internal.h
 FILE: ../../../fuchsia/sdk/linux/pkg/sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/component_context.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/file_descriptor.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/include/lib/sys/cpp/component_context.h
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/include/lib/sys/cpp/file_descriptor.h
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/include/lib/sys/cpp/outgoing_directory.h
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/include/lib/sys/cpp/service_directory.h
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/outgoing_directory.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/service_directory.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/termination_reason.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/component_context_provider.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/service_directory_provider.cc
 FILE: ../../../fuchsia/sdk/linux/pkg/syslog/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/sysroot/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/trace-engine/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/flags.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/connection.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/directory.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/directory_connection.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/dirent_filler.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/file.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/file_connection.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/node.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/internal/node_connection.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/lazy_dir.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/node_kind.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/pseudo_dir.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/pseudo_file.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/remote_dir.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/service.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/vmo_file.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/connection.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/directory.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/directory_connection.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/dirent_filler.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/file.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/file_connection.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/node.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/internal/node_connection.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/lazy_dir.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/pseudo_dir.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/pseudo_file.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/remote_dir.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/service.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/vmo_file.cc
 FILE: ../../../fuchsia/sdk/linux/pkg/vulkan/meta.json
 FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_core_validation.json
 FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_image_pipe_swapchain.json
@@ -673,49 +2055,6 @@ FILE: ../../../fuchsia/sdk/linux/target/x64/fvm.sparse.blk
 FILE: ../../../fuchsia/sdk/linux/target/x64/local.esp.blk
 FILE: ../../../fuchsia/sdk/linux/target/x64/qemu-kernel.bin
 FILE: ../../../fuchsia/sdk/linux/target/x64/zircon.vboot
-FILE: ../../../fuchsia/sdk/linux/tools/bootserver
-FILE: ../../../fuchsia/sdk/linux/tools/bootserver-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/cmc
-FILE: ../../../fuchsia/sdk/linux/tools/cmc-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/dart
-FILE: ../../../fuchsia/sdk/linux/tools/dart_kernel_compiler-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/dart_prebuilts/dart_runner/platform_strong.dill
-FILE: ../../../fuchsia/sdk/linux/tools/dart_prebuilts/flutter_runner/platform_strong.dill
-FILE: ../../../fuchsia/sdk/linux/tools/dart_prebuilts/frontend_server_tool.snapshot
-FILE: ../../../fuchsia/sdk/linux/tools/dart_prebuilts/kernel_compiler.snapshot
-FILE: ../../../fuchsia/sdk/linux/tools/dev_finder
-FILE: ../../../fuchsia/sdk/linux/tools/dev_finder-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/far
-FILE: ../../../fuchsia/sdk/linux/tools/far-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/fidl-format
-FILE: ../../../fuchsia/sdk/linux/tools/fidl-format-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/fidlc
-FILE: ../../../fuchsia/sdk/linux/tools/fidlc-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/fidlgen
-FILE: ../../../fuchsia/sdk/linux/tools/fidlgen-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/fidlgen_dart
-FILE: ../../../fuchsia/sdk/linux/tools/fidlgen_dart-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/fvm
-FILE: ../../../fuchsia/sdk/linux/tools/fvm-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/gen_snapshot-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/gen_snapshot.arm64
-FILE: ../../../fuchsia/sdk/linux/tools/gen_snapshot.x64
-FILE: ../../../fuchsia/sdk/linux/tools/gen_snapshot_product.arm64
-FILE: ../../../fuchsia/sdk/linux/tools/gen_snapshot_product.x64
-FILE: ../../../fuchsia/sdk/linux/tools/loglistener
-FILE: ../../../fuchsia/sdk/linux/tools/loglistener-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/merkleroot
-FILE: ../../../fuchsia/sdk/linux/tools/merkleroot-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/minfs
-FILE: ../../../fuchsia/sdk/linux/tools/minfs-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/pm
-FILE: ../../../fuchsia/sdk/linux/tools/pm-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/symbolize
-FILE: ../../../fuchsia/sdk/linux/tools/symbolize-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/zbi
-FILE: ../../../fuchsia/sdk/linux/tools/zbi-meta.json
-FILE: ../../../fuchsia/sdk/linux/tools/zxdb
-FILE: ../../../fuchsia/sdk/linux/tools/zxdb-meta.json
 ----------------------------------------------------------------------------------------------------
 Copyright 2019 The Fuchsia Authors. All rights reserved.
 
@@ -744,6 +2083,713 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: fuchsia_sdk
+ORIGIN: ../../../fuchsia/sdk/linux/LICENSE.vulkan
+TYPE: LicenseType.apache
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_core_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_image_pipe_swapchain.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_object_tracker.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_parameter_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_threading.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libVkLayer_unique_objects.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/dist/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsync.a
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/lib/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/alloca.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/ftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/inet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/nameser.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/nameser_compat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/telnet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/arpa/tftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/aarch64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/alltypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/posix.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/bits/x86_64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/byteswap.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/complex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/cpio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/crypt.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/dirent.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/dlfcn.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/elf.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/err.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/features.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fmtmsg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/fnmatch.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/getopt.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/glob.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/grp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/iconv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ifaddrs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/inttypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/iso646.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/langinfo.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/libgen.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/link.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/locale.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/malloc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/math.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/memory.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/monetary.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/ethernet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/if.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/if_arp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/net/route.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netdb.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/icmp6.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/if_ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/igmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/in.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/in_systm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip6.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/ip_icmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/tcp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netinet/udp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/netpacket/packet.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/nl_types.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/paths.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/pthread.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/pwd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/regex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/resolv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sched.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/search.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/semaphore.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/spawn.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stdlib.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/string.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/strings.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/acct.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/auxv.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/dir.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/eventfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/file.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/fsuid.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/klog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mman.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mount.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/mtio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/param.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/personality.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/quota.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/random.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/reboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/select.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/signalfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/statvfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/swap.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timeb.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timerfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/times.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/timex.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ttydefaults.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/uio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/un.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/utsname.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/vfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sys/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/sysexits.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/tar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/threads.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/uchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/unistd.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/utime.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/values.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/wordexp.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/Scrt1.o
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libc.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libdl.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libm.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libpthread.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/librt.so
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/lib/libzircon.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_core_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_image_pipe_swapchain.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_object_tracker.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_parameter_validation.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_threading.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libVkLayer_unique_objects.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/dist/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libasync-default.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libfdio.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libmemfs.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsvc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsync.a
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libsyslog.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libtrace-engine.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/lib/libvulkan.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/alloca.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/ftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/inet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/nameser.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/nameser_compat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/telnet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/arpa/tftp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/aarch64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/alltypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/posix.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/bits/x86_64/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/byteswap.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/complex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/cpio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/crypt.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/dirent.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/dlfcn.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/elf.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/endian.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/err.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/features.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fenv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fmtmsg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/fnmatch.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/getopt.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/glob.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/grp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/iconv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ifaddrs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/inttypes.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/iso646.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/langinfo.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/libgen.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/limits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/link.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/locale.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/malloc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/math.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/memory.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/monetary.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/ethernet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/if.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/if_arp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/net/route.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netdb.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/icmp6.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/if_ether.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/igmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/in.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/in_systm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip6.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/ip_icmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/tcp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netinet/udp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/netpacket/packet.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/nl_types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/paths.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/pthread.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/pwd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/regex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/resolv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sched.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/search.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/semaphore.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/setjmp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/spawn.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stdlib.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/string.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/strings.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/acct.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/auxv.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/dir.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/errno.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/eventfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/fcntl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/file.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/fsuid.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/io.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ioctl.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ipc.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/klog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mman.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mount.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/msg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/mtio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/param.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/personality.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/poll.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/quota.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/random.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/reboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/reg.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/select.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/sem.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/shm.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/signal.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/signalfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/socket.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/stat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/statfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/statvfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/stropts.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/swap.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timeb.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timerfd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/times.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/timex.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ttydefaults.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/uio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/un.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/utsname.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/vfs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sys/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/sysexits.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/syslog.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/tar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/termios.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/threads.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/time.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/uchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/ucontext.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/unistd.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/utime.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/values.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wait.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wchar.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wctype.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/wordexp.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/Scrt1.o
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libc.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libdl.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libm.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libpthread.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/librt.so
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/lib/libzircon.so
+FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/lib/src/internal/layout_logic/_layout_logic.dart
+FILE: ../../../fuchsia/sdk/linux/dart/composition_delegate/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fidl/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_inspect/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_logger/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_media/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/sl4f/meta.json
+FILE: ../../../fuchsia/sdk/linux/dart/zircon/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth.oldtokens/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.auth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.gatt/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth.le/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.bluetooth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera.common/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.camera/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castauth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsetup/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.castsysteminfo/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.cobalt/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.crash/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.deprecatedtimezone/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.developer.tiles/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.feedback/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.ethernet/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.address.space/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.control/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.hardware.goldfish.pipe/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.images/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.intl/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.io/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ldsvc/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ledger/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.logger/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.math/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.audio/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.drm/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.playback/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.sessions/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mediacodec/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.mem/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.auth/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.session/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.http/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.mdns/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.oldhttp/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.netstack/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.process/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.speech/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysinfo/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysmem/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.app/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.gfx/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.policy/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.scenic/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.vectorial/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1token/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.common/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.service/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.stats/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-default/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-loop-cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async-loop/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/async/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fdio/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl-async/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_base/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fidl_cpp_sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/fit/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/images_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/memfs/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/scenic_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/svc/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sync/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/syslog/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/sysroot/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/trace-engine/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_core_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_image_pipe_swapchain.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_object_tracker.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_parameter_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_standard_validation.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_threading.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/data/vulkan/explicit_layer.d/VkLayer_unique_objects.json
+FILE: ../../../fuchsia/sdk/linux/pkg/vulkan_layers/meta.json
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/meta.json
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fuchsia.zbi
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fvm.blk
+FILE: ../../../fuchsia/sdk/linux/target/arm64/fvm.sparse.blk
+FILE: ../../../fuchsia/sdk/linux/target/arm64/qemu-kernel.bin
+FILE: ../../../fuchsia/sdk/linux/target/x64/fuchsia.zbi
+FILE: ../../../fuchsia/sdk/linux/target/x64/fvm.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/fvm.sparse.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/local.esp.blk
+FILE: ../../../fuchsia/sdk/linux/target/x64/qemu-kernel.bin
+FILE: ../../../fuchsia/sdk/linux/target/x64/zircon.vboot
+----------------------------------------------------------------------------------------------------
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as
+defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner
+that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that
+control, are controlled by, or are under common control with that entity. For the
+purposes of this definition, "control" means (i) the power, direct or indirect, to
+cause the direction or management of such entity, whether by contract or otherwise,
+or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or
+(iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions
+granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not
+limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included in or
+attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based
+on (or derived from) the Work and for which the editorial revisions, annotations,
+elaborations, or other modifications represent, as a whole, an original work of
+authorship. For the purposes of this License, Derivative Works shall not include works
+that remain separable from, or merely link (or bind by name) to the interfaces of, the
+Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the
+Work and any modifications or additions to that Work or Derivative Works thereof, that
+is intentionally submitted to Licensor for inclusion in the Work by the copyright owner
+or by an individual or Legal Entity authorized to submit on behalf of the copyright owner.
+For the purposes of this definition, "submitted" means any form of electronic, verbal,
+or written communication sent to the Licensor or its representatives, including but not
+limited to communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose
+of discussing and improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a
+Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each
+Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each
+Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge,
+royalty-free, irrevocable (except as stated in this section) patent license to make,
+have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such
+license applies only to those patent claims licensable by such Contributor that are
+necessarily infringed by their Contribution(s) alone or by combination of their
+Contribution(s) with the Work to which such Contribution(s) was submitted. If You
+institute patent litigation against any entity (including a cross-claim or counterclaim
+in a lawsuit) alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses granted
+to You under this License for that Work shall terminate as of the date such litigation
+is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative
+Works thereof in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this
+License; and
+You must cause any modified files to carry prominent notices stating that You changed
+the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all
+copyright, patent, trademark, and attribution notices from the Source form of the Work,
+excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the attribution
+notices contained within such NOTICE file, excluding those notices that do not pertain
+to any part of the Derivative Works, in at least one of the following places: within a
+NOTICE text file distributed as part of the Derivative Works; within the Source form or
+documentation, if provided along with the Derivative Works; or, within a display
+generated by the Derivative Works, if and wherever such third-party notices normally
+appear. The contents of the NOTICE file are for informational purposes only and do not
+modify the License. You may add Your own attribution notices within Derivative Works
+that You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as modifying
+the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies with
+the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution
+intentionally submitted for inclusion in the Work by You to the Licensor shall be under
+the terms and conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of any
+separate license agreement you may have executed with Licensor regarding such
+Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and reproducing the
+content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing,
+Licensor provides the Work (and each Contributor provides its Contributions) on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+ including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+ MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for
+ determining the appropriateness of using or redistributing the Work and assume any
+ risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort
+(including negligence), contract, or otherwise, unless required by applicable law (such
+as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor
+be liable to You for damages, including any direct, indirect, special, incidental, or
+consequential damages of any character arising as a result of this License or out of the
+use or inability to use the Work (including but not limited to damages for loss of
+goodwill, work stoppage, computer failure or malfunction, or any and all other
+commercial damages or losses), even if such Contributor has been advised of the
+possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of
+support, warranty, indemnity, or other liability obligations and/or rights consistent
+with this License. However, in accepting such obligations, You may act only on Your own
+behalf and on Your sole responsibility, not on behalf of any other Contributor, and only
+if You agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your accepting
+any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: HOW TO APPLY THE APACHE LICENSE TO YOUR WORK
+To apply the Apache License to your work, attach the following boilerplate notice, with
+the fields enclosed by brackets "[]" replaced with your own identifying information.
+(Don't include the brackets!) The text should be enclosed in the appropriate comment
+syntax for the file format. We also recommend that a file or class name and description
+of purpose be included on the same "printed page" as the copyright notice for easier
+identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ====================================================================================================
 
 ====================================================================================================
@@ -813,7 +2859,6 @@ FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/entity.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/lifecycle.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/logger.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/module.dart
-FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/proposal.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/service_connection.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/agent/agent.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/agent/agent_task_handler.dart
@@ -835,11 +2880,12 @@ FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/module/internal/_m
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/module/module.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/module/module_state_exception.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/module/noop_intent_handler.dart
-FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/proposal/internal/_proposal_listener_impl.dart
-FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/proposal/proposal.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_modular/lib/src/service_connection/agent_service_connection.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/child_view.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/child_view_connection.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/src/child_view.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/src/child_view_connection.dart
+FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/src/child_view_render_box.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/lib/services.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/lib/src/service_provider_impl.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_vfs/lib/src/internal/_error_node.dart
@@ -926,7 +2972,6 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.scenic/session.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.vectorial/commands.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.vectorial/events.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/commands.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.views/events.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1/view_snapshot.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.common/wlan_common.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.wlan.stats/wlan_stats.fidl
@@ -1034,9 +3079,13 @@ FILE: ../../../fuchsia/sdk/linux/pkg/svc/include/lib/svc/dir.h
 FILE: ../../../fuchsia/sdk/linux/pkg/sync/include/lib/sync/condition.h
 FILE: ../../../fuchsia/sdk/linux/pkg/sync/include/lib/sync/internal/condition-template.h
 FILE: ../../../fuchsia/sdk/linux/pkg/sync/include/lib/sync/mutex.h
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/fake_component.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp_testing/fake_launcher.cc
 FILE: ../../../fuchsia/sdk/linux/pkg/syslog/include/lib/syslog/global.h
 FILE: ../../../fuchsia/sdk/linux/pkg/syslog/include/lib/syslog/logger.h
 FILE: ../../../fuchsia/sdk/linux/pkg/syslog/include/lib/syslog/wire_format.h
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/composed_service_dir.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/vfs_cpp/include/lib/vfs/cpp/composed_service_dir.h
 FILE: ../../../fuchsia/sdk/linux/pkg/zx/bti.cpp
 FILE: ../../../fuchsia/sdk/linux/pkg/zx/debuglog.cpp
 FILE: ../../../fuchsia/sdk/linux/pkg/zx/guest.cpp
@@ -1135,9 +3184,9 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular.auth/account_provider.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/agent/agent.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/agent/agent_context.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/agent/agent_controller/agent_controller.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/agent/agent_provider.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/clipboard/clipboard.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/component/component_context.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/component/message_queue.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/config/config.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/context/context_engine.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/context/debug.fidl
@@ -1152,12 +3201,10 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module/link_path.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module/module_data.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module/module_state.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module_resolver/module_resolver.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/session/device_map.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/create_link.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/create_module_parameter_map.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_shell.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_state.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/debug.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/surface/container.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/surface/surface.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/user_intelligence/intelligence_services.fidl
@@ -1264,8 +3311,6 @@ ORIGIN: ../../../fuchsia/sdk/linux/dart/fidl/lib/fidl.dart + ../../../LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../fuchsia/sdk/linux/dart/fidl/lib/fidl.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia/lib/fuchsia.dart
-FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/child_view.dart
-FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/child_view_connection.dart
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/lib/src/startup_context.dart
 FILE: ../../../fuchsia/sdk/linux/dart/zircon/lib/src/fakes/zircon_fakes.dart
 FILE: ../../../fuchsia/sdk/linux/dart/zircon/lib/zircon.dart
@@ -1309,6 +3354,8 @@ LIBRARY: fuchsia_sdk
 ORIGIN: ../../../fuchsia/sdk/linux/dart/fuchsia_services/lib/src/internal/_startup_context_impl.dart + ../../../LICENSE
 TYPE: LicenseType.bsd
 FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_services/lib/src/internal/_startup_context_impl.dart
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/cache.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.web/cookie.fidl
 ----------------------------------------------------------------------------------------------------
 Copyright 2019 The Chromium Authors. All rights reserved.
 
@@ -1591,7 +3638,6 @@ FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/resour
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/types.h
 FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/types.h
 FILE: ../../../fuchsia/sdk/linux/dart/fidl/lib/src/interface.dart
-FILE: ../../../fuchsia/sdk/linux/dart/fuchsia_scenic_flutter/lib/src/child_scene_layer.dart
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/font_provider.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ledger/ledger.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.math/math.fidl
@@ -1612,13 +3658,6 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/link.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_controller.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_info.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_provider.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/proposal.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/proposal_publisher.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/query_handler.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/suggestion_display.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/suggestion_engine.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/suggestion_provider.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/suggestion/user_input.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.oldhttp/url_body.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.policy/presenter.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.viewsv1/view_containers.fidl
@@ -1630,6 +3669,7 @@ FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/io.h
 FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/vfs.h
 FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/watcher.h
 FILE: ../../../fuchsia/sdk/linux/pkg/sync/include/lib/sync/completion.h
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/include/lib/sys/cpp/termination_reason.h
 FILE: ../../../fuchsia/sdk/linux/pkg/zx/channel.cpp
 FILE: ../../../fuchsia/sdk/linux/pkg/zx/event.cpp
 FILE: ../../../fuchsia/sdk/linux/pkg/zx/eventpair.cpp
@@ -1683,4 +3723,4 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
-Total license count: 13
+Total license count: 16

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 499a560047281c7ce35f227b57030b8b
+Signature: 79db3ae5f054461f1e7fc34ff6ffdf06
 

--- a/tools/licenses/lib/licenses.dart
+++ b/tools/licenses/lib/licenses.dart
@@ -13,13 +13,14 @@ import 'patterns.dart';
 
 class FetchedContentsOf extends Key { FetchedContentsOf(dynamic value) : super(value); }
 
-enum LicenseType { unknown, bsd, gpl, lgpl, mpl, afl, mit, freetype, apache, apacheNotice, eclipse, ijg, zlib, icu, apsl, libpng, openssl }
+enum LicenseType { unknown, bsd, gpl, lgpl, mpl, afl, mit, freetype, apache, apacheNotice, eclipse, ijg, zlib, icu, apsl, libpng, openssl, vulkan }
 
 LicenseType convertLicenseNameToType(String name) {
   switch (name) {
     case 'Apache':
     case 'apache-license-2.0':
     case 'LICENSE-APACHE-2.0.txt':
+    case 'LICENSE.vulkan':
       return LicenseType.apache;
     case 'BSD':
     case 'BSD.txt':
@@ -45,6 +46,8 @@ LicenseType convertLicenseNameToType(String name) {
     case 'LICENSE.MPLv2':
     case 'COPYING-MPL-1.1':
       return LicenseType.mpl;
+    case 'COPYRIGHT.vulkan':
+      return LicenseType.vulkan;
     // common file names that don't say what the type is
     case 'COPYING':
     case 'COPYING.txt':
@@ -63,6 +66,7 @@ LicenseType convertLicenseNameToType(String name) {
     case 'license.txt':
       return LicenseType.unknown;
     // particularly weird file names
+    case 'COPYRIGHT.musl':
     case 'LICENSE-APPLE':
     case 'extreme.indiana.edu.license.TXT':
     case 'extreme.indiana.edu.license.txt':
@@ -196,6 +200,7 @@ abstract class License implements Comparable<License> {
         case LicenseType.ijg:
         case LicenseType.apsl:
           return MessageLicense._(body, type, origin: origin);
+        case LicenseType.vulkan:
         case LicenseType.openssl:
           return MultiLicense._(body, type, origin: origin);
         case LicenseType.libpng:
@@ -329,6 +334,7 @@ abstract class License implements Comparable<License> {
             assert(this is BlankLicense);
             break;
           case LicenseType.openssl:
+          case LicenseType.vulkan:
             assert(this is MultiLicense);
             break;
         }
@@ -338,6 +344,11 @@ abstract class License implements Comparable<License> {
       return true;
     }());
     final LicenseType detectedType = convertBodyToType(body);
+
+    // Fuchsia SDK Vulkan license is Apache 2.0 with some additional BSD-matching copyrights.
+    if (type == LicenseType.vulkan)
+      yesWeKnowWhatItLooksLikeButItIsNot = true;
+
     if (detectedType != LicenseType.unknown && detectedType != type && !yesWeKnowWhatItLooksLikeButItIsNot)
       throw 'Created a license of type $type but it looks like $detectedType\.';
     if (type != LicenseType.apache && type != LicenseType.apacheNotice) {

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2064,6 +2064,37 @@ class _RepositoryFuchsiaDirectory extends _RepositoryDirectory {
     return entry.name != 'toolchain'
         && super.shouldRecurse(entry);
   }
+
+  @override
+  _RepositoryDirectory createSubdirectory(fs.Directory entry) {
+    if (entry.name == 'sdk')
+      return _RepositoryFuchsiaSdkDirectory(this, entry);
+    return super.createSubdirectory(entry);
+  }
+}
+
+class _RepositoryFuchsiaSdkDirectory extends _RepositoryDirectory {
+  _RepositoryFuchsiaSdkDirectory(_RepositoryDirectory parent, fs.Directory io) : super(parent, io);
+
+  @override
+  _RepositoryDirectory createSubdirectory(fs.Directory entry) {
+    if (entry.name == 'linux' || entry.name == 'mac')
+      return _RepositoryFuchsiaSdkLinuxDirectory(this, entry);
+    return super.createSubdirectory(entry);
+  }
+}
+
+class _RepositoryFuchsiaSdkLinuxDirectory extends _RepositoryDirectory {
+  _RepositoryFuchsiaSdkLinuxDirectory(_RepositoryDirectory parent, fs.Directory io) : super(parent, io);
+
+  @override
+  bool shouldRecurse(fs.IoNode entry) {
+    return entry.name != '.build-id'
+        && entry.name != 'docs'
+        && entry.name != 'images'
+        && entry.name != 'meta'
+        && entry.name != 'tools';
+  }
 }
 
 class _RepositoryFlutterThirdPartyDirectory extends _RepositoryDirectory {


### PR DESCRIPTION
The Fuchsia SDK includes a root directory with multiple
license/copyright files. For files that don't include a copyright header
matching them to a specific license (e.g. shared library binaries) we
match them to all licenses.

Specifically, the SDK includes:
* LICENSE: the Fuchsia license
* LICENSE.vulkan: Apache 2.0 license for Vulkan
* COPYRIGHT.vulkan: additional non-Apache licenses/copyrights for Vulkan
* COPYRIGHT.musl: musl license/copyrights

Also rolls the Fuchsia SDK CIPD packages.