### PR TITLE
Decorate UIApplicationDelegate wrappers with matching UIKit deprecation

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -120,11 +120,8 @@ typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>*
 /**
  * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
  */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings;
-#pragma GCC diagnostic pop
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings API_DEPRECATED("See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation", ios(8.0, 10.0));
 
 /**
  * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
@@ -145,7 +142,7 @@ typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>*
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
-    didReceiveLocalNotification:(UILocalNotification*)notification;
+    didReceiveLocalNotification:(UILocalNotification*)notification API_DEPRECATED("See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation", ios(4.0, 10.0));
 
 /**
  * Calls all plugins registered for `UNUserNotificationCenterDelegate` callbacks.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -121,7 +121,10 @@ typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>*
  * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings API_DEPRECATED("See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation", ios(8.0, 10.0));
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
+    API_DEPRECATED(
+        "See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation",
+        ios(8.0, 10.0));
 
 /**
  * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
@@ -142,7 +145,10 @@ typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>*
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
-    didReceiveLocalNotification:(UILocalNotification*)notification API_DEPRECATED("See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation", ios(4.0, 10.0));
+    didReceiveLocalNotification:(UILocalNotification*)notification
+    API_DEPRECATED(
+        "See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation",
+        ios(4.0, 10.0));
 
 /**
  * Calls all plugins registered for `UNUserNotificationCenterDelegate` callbacks.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -68,7 +68,10 @@ FLUTTER_EXPORT
  * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings API_DEPRECATED("See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation", ios(8.0, 10.0));
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
+    API_DEPRECATED(
+        "See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation",
+        ios(8.0, 10.0));
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
@@ -87,7 +90,10 @@ FLUTTER_EXPORT
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
-    didReceiveLocalNotification:(UILocalNotification*)notification API_DEPRECATED("See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation", ios(4.0, 10.0));
+    didReceiveLocalNotification:(UILocalNotification*)notification
+    API_DEPRECATED(
+        "See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation",
+        ios(4.0, 10.0));
 
 /**
  * Calls all plugins registered for `UNUserNotificationCenterDelegate` callbacks.

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -67,11 +67,8 @@ FLUTTER_EXPORT
 /**
  * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
  */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings;
-#pragma GCC diagnostic pop
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings API_DEPRECATED("See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation", ios(8.0, 10.0));
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
@@ -90,7 +87,7 @@ FLUTTER_EXPORT
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
-    didReceiveLocalNotification:(UILocalNotification*)notification;
+    didReceiveLocalNotification:(UILocalNotification*)notification API_DEPRECATED("See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation", ios(4.0, 10.0));
 
 /**
  * Calls all plugins registered for `UNUserNotificationCenterDelegate` callbacks.

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -92,10 +92,13 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
       didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didReceiveLocalNotification:(UILocalNotification*)notification {
   [_lifeCycleDelegate application:application didReceiveLocalNotification:notification];
 }
+#pragma GCC diagnostic pop
 
 - (void)userNotificationCenter:(UNUserNotificationCenter*)center
        willPresentNotification:(UNNotification*)notification

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -228,7 +228,6 @@ static BOOL isPowerOfTwo(NSUInteger x) {
   }
 }
 
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -228,6 +228,9 @@ static BOOL isPowerOfTwo(NSUInteger x) {
   }
 }
 
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didReceiveLocalNotification:(UILocalNotification*)notification {
   for (id<FlutterPlugin> plugin in _pluginDelegates) {
@@ -239,6 +242,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
     }
   }
 }
+#pragma GCC diagnostic pop
 
 - (void)userNotificationCenter:(UNUserNotificationCenter*)center
        willPresentNotification:(UNNotification*)notification


### PR DESCRIPTION
The API added in https://github.com/flutter/engine/pull/6858 used deprecated UIKit symbols.  Add the API_DEPRECATED decorators to match the UIApplicationDelegate deprecation.

1. Projects targeting iOS SDK 10 and greater will no longer see a build warning.
2. Projects targeting less than iOS SDK 10 will continue to _not_ see a build warning.
3. Code will generate a build warning if it actually uses the deprecated UIKit APIs in projects targeting iOS SDK 10 and greater.  This will let developers know it's no longer supported by UIKit and to migrate to something else.

Change the deprecation suppression added in https://github.com/flutter/engine/pull/6672 to the finer-grained API_DEPRECATED to generate warnings where appropriate.

Fixes https://github.com/flutter/flutter/issues/26094.