### PR TITLE
Always enable semantics in debug mode

### DIFF
--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -48,6 +48,10 @@ void PlatformView::DispatchSemanticsAction(int32_t id,
 }
 
 void PlatformView::SetSemanticsEnabled(bool enabled) {
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+  FML_DLOG(INFO) << "Debug build. Forcing semantics to enabled.";
+  enabled = true;
+#endif
   delegate_.OnPlatformViewSetSemanticsEnabled(enabled);
 }
 


### PR DESCRIPTION
Addresses the debug part of https://github.com/flutter/flutter/issues/34378

Forces semantics to always be on in debug mode.