### PR TITLE
Avoid using std::unary_function.

### DIFF
--- a/third_party/txt/src/utils/LruCache.h
+++ b/third_party/txt/src/utils/LruCache.h
@@ -85,14 +85,13 @@ class LruCache {
     const TKey& getKey() const final { return key; }
   };
 
-  struct HashForEntry : public std::unary_function<KeyedEntry*, hash_t> {
+  struct HashForEntry {
     size_t operator()(const KeyedEntry* entry) const {
       return hash_type(entry->getKey());
     };
   };
 
-  struct EqualityForHashedEntries
-      : public std::unary_function<KeyedEntry*, hash_t> {
+  struct EqualityForHashedEntries {
     bool operator()(const KeyedEntry* lhs, const KeyedEntry* rhs) const {
       return lhs->getKey() == rhs->getKey();
     };


### PR DESCRIPTION
This was deprecated in C++ 11 and removed entirely in C++ 17. We are going to migrate to 17 once https://github.com/flutter/buildroot/pull/261 lands and rolls in.

There should be no functional change since the call operator works as before for hashing the entry in the collection.