### PR TITLE
Only build embedder unit tests for host builds

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -60,7 +60,7 @@ test_fixtures("fixtures") {
   dart_main = "fixtures/main.dart"
 }
 
-if (is_mac || is_linux || is_win) {
+if (current_toolchain == host_toolchain) {
   executable("embedder_unittests") {
     testonly = true
 


### PR DESCRIPTION
Linux target builds for non-x86/x64 platforms were failing due to the
dependency on SwiftShader