### PR TITLE
Build the GLFW shell on Linux host builds but not target builds

### DIFF
--- a/shell/platform/glfw/config.gni
+++ b/shell/platform/glfw/config.gni
@@ -9,5 +9,5 @@ declare_args() {
   # but it can be enabled for supported platforms (Windows, macOS, and Linux)
   # as an extra build artifact with this flag. The native toolkit shell will
   # still be built as well.
-  build_glfw_shell = is_linux || is_win
+  build_glfw_shell = (is_linux || is_win) && current_toolchain == host_toolchain
 }

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -4,13 +4,17 @@
 
 assert(is_linux)
 
+import("$flutter_root/shell/platform/glfw/config.gni")
+
 group("linux") {
-  deps = [
-    ":flutter_linux",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:publish_wrapper",
-    "$flutter_root/shell/platform/glfw:publish_headers_glfw",
-    "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
-  ]
+  if (build_glfw_shell) {
+    deps = [
+      ":flutter_linux",
+      "$flutter_root/shell/platform/common/cpp/client_wrapper:publish_wrapper",
+      "$flutter_root/shell/platform/glfw:publish_headers_glfw",
+      "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
+    ]
+  }
 }
 
 # Temporary workraround for the issue describe in
@@ -23,12 +27,14 @@ config("disable_fatal_link_warnings") {
   ldflags = [ "-Wl,--no-fatal-warnings" ]
 }
 
-shared_library("flutter_linux") {
-  deps = [
-    "$flutter_root/shell/platform/glfw:flutter_glfw",
-  ]
+if (build_glfw_shell) {
+  shared_library("flutter_linux") {
+    deps = [
+      "$flutter_root/shell/platform/glfw:flutter_glfw",
+    ]
 
-  configs += [ ":disable_fatal_link_warnings" ]
+    configs += [ ":disable_fatal_link_warnings" ]
 
-  public_configs = [ "$flutter_root:config" ]
+    public_configs = [ "$flutter_root:config" ]
+  }
 }


### PR DESCRIPTION
Linux targets building the embedder library may be targeting environments
that do not support GLFW and GTK.