### PR TITLE
Fix a11y in embedded Android views post O

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
@@ -4,6 +4,7 @@
 
 package io.flutter.view;
 
+import android.annotation.SuppressLint;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.Bundle;
@@ -419,6 +420,7 @@ final class AccessibilityViewEmbedder {
         private @Nullable final Field childNodesField;
         private @Nullable final Method longArrayGetIndex;
 
+        @SuppressLint("PrivateApi")
         private ReflectionAccessors() {
             Method getSourceNodeId = null;
             Method getParentNodeId = null;
@@ -500,13 +502,27 @@ final class AccessibilityViewEmbedder {
             if (getChildId != null) {
                 try {
                     return (Long) getChildId.invoke(node, child);
-                } catch (IllegalAccessException | InvocationTargetException e) {
+                // Using identical separate catch blocks to comply with the following lint:
+                // Error: Multi-catch with these reflection exceptions requires API level 19
+                // (current min is 16) because they get compiled to the common but new super
+                // type ReflectiveOperationException. As a workaround either create individual
+                // catch statements, or catch Exception. [NewApi]
+                } catch (IllegalAccessException e) {
+                    Log.w(TAG, e);
+                } catch (InvocationTargetException e) {
                     Log.w(TAG, e);
                 }
             } else {
                 try {
                     return (long) longArrayGetIndex.invoke(childNodesField.get(node), child);
-                } catch (IllegalAccessException | InvocationTargetException | ArrayIndexOutOfBoundsException e) {
+                // Using identical separate catch blocks to comply with the following lint:
+                // Error: Multi-catch with these reflection exceptions requires API level 19
+                // (current min is 16) because they get compiled to the common but new super
+                // type ReflectiveOperationException. As a workaround either create individual
+                // catch statements, or catch Exception. [NewApi]
+                } catch (IllegalAccessException e) {
+                    Log.w(TAG, e);
+                } catch (InvocationTargetException | ArrayIndexOutOfBoundsException e) {
                     Log.w(TAG, e);
                 }
             }
@@ -518,7 +534,14 @@ final class AccessibilityViewEmbedder {
             if (getParentNodeId != null) {
                 try {
                     return (long) getParentNodeId.invoke(node);
-                } catch (IllegalAccessException | InvocationTargetException e) {
+                // Using identical separate catch blocks to comply with the following lint:
+                // Error: Multi-catch with these reflection exceptions requires API level 19
+                // (current min is 16) because they get compiled to the common but new super
+                // type ReflectiveOperationException. As a workaround either create individual
+                // catch statements, or catch Exception. [NewApi]
+                } catch (IllegalAccessException e) {
+                    Log.w(TAG, e);
+                } catch (InvocationTargetException e) {
                     Log.w(TAG, e);
                 }
             }

--- a/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
@@ -438,14 +438,15 @@ final class AccessibilityViewEmbedder {
             } catch (NoSuchMethodException e) {
                 Log.w(TAG, "can't invoke AccessibiiltyRecord#getSourceNodeId with reflection");
             }
-            // Reflection access is not allowed starting Android P on these methods. Starting P we
-            // extract the child id from the mChildNodeIds field (see getChildId below).
+            // Reflection access is not allowed starting Android P on these methods.
             if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.O) {
                 try {
                     getParentNodeId = AccessibilityNodeInfo.class.getMethod("getParentNodeId");
                 } catch (NoSuchMethodException e) {
                     Log.w(TAG, "can't invoke getParentNodeId with reflection");
                 }
+                // Starting P we extract the child id from the mChildNodeIds field (see getChildId
+                // below).
                 try {
                     getChildId = AccessibilityNodeInfo.class.getMethod("getChildId", int.class);
                 } catch (NoSuchMethodException e) {


### PR DESCRIPTION
This patch works around Android's limitations on reflection. With it embedded platform views that use virtual node hierarchy trees should be accessible on all Android versions to date.

The workarounds in this PR are brittle. Ideally the methods would be made public in Android instead so we wouldn't need to employ tactics like these to work around the missing methods.

`AccessibilityNodeInfo#getChildId` is blocked from any type of reflection access, but the underlying private member that the getter accesses, `mChildNodeIds`, can still be reflected on. On Android versions where we can't access the getter, this patch falls back on reflectively accessing the field instead. Unfortunately this field is a [`LongArray`](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/util/LongArray.java), a utility data class private to Android. So in this case we're reflecting to both access the member and actually read data from it, since we need to use reflection to call `LongArray.get(index)`.

`AccessibilityNodeInfo#getParent()` doesn't have any lucky available underlying members. However, `AccessibilityNodeInfo` itself is `Parcelable`, and `mParentNodeId` is one of the pieces of data that's written to a parcel via `AccessibilityNodeInfo#writeToParcel`. So the fallback for that is to write the node to a parcel and then read the parcel for the ID in question. This will break if the implementation details of `AccessibilityNodeInfo#writeToParcel` ever change. The details have already changed enough in the past to require two sets of logic for reading from the parcel.

Note: the above parcelable hack will "work" for any of the data we need from the `AccessibilityNodeInfo`, and could function as a blanket alternative to reflection if absolutely needed. However it's genuinely much less safe than reflection and shouldn't be used unless absolutely required.

flutter/flutter#19418