### PR TITLE
Check for invalid indexes when performing InputAdpator backspace.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -151,9 +151,11 @@ class InputConnectionAdaptor extends BaseInputConnection {
                     // Delete to the left of the cursor.
                     Selection.extendLeft(mEditable, mLayout);
                     int newSel = Selection.getSelectionEnd(mEditable);
-                    Selection.setSelection(mEditable, newSel);
-                    mEditable.delete(newSel, selStart);
-                    updateEditingState();
+                    if (newSel >= 0) {
+                        Selection.setSelection(mEditable, newSel);
+                        mEditable.delete(newSel, selStart);
+                        updateEditingState();
+                    }
                     return true;
                 }
             } else if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_LEFT) {

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -139,7 +139,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
     // Sanitizes the index to ensure the index is within the range of the
     // contents of editable.
     private static int clampIndexToEditable(int index, Editable editable) {
-        // return index;
         return Math.max(0, Math.min(editable.length(), index));
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -158,6 +158,9 @@ class InputConnectionAdaptor extends BaseInputConnection {
                     return true;
                 } else if (selStart > 0) {
                     // Delete to the left/right of the cursor depending on direction of text.
+                    // TODO(garyq): Explore how to obtain per-character direction. The
+                    // isRTLCharAt() call below is returning blanket direction assumption
+                    // based on the first character in the line.
                     boolean isRtl = mLayout.isRtlCharAt(mLayout.getLineForOffset(selStart));
                     if (isRtl) {
                         Selection.extendRight(mEditable, mLayout);

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -16,7 +16,6 @@ import android.view.View;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
-import android.util.Log;
 
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.common.ErrorLogResult;

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -135,12 +135,18 @@ class InputConnectionAdaptor extends BaseInputConnection {
         return result;
     }
 
+    // Sanitizes the index to ensure the index is within the range of the
+    // contents of editable.
+    private static int clampIndexToEditable(int index, Editable editable) {
+        return Math.max(0, Math.min(editable.length() - 1, index));
+    }
+
     @Override
     public boolean sendKeyEvent(KeyEvent event) {
         if (event.getAction() == KeyEvent.ACTION_DOWN) {
             if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
-                int selStart = Selection.getSelectionStart(mEditable);
-                int selEnd = Selection.getSelectionEnd(mEditable);
+                int selStart = clampIndexToEditable(Selection.getSelectionStart(mEditable), mEditable);
+                int selEnd = clampIndexToEditable(Selection.getSelectionEnd(mEditable), mEditable);
                 if (selEnd > selStart) {
                     // Delete the selection.
                     Selection.setSelection(mEditable, selStart);
@@ -150,12 +156,10 @@ class InputConnectionAdaptor extends BaseInputConnection {
                 } else if (selStart > 0) {
                     // Delete to the left of the cursor.
                     Selection.extendLeft(mEditable, mLayout);
-                    int newSel = Selection.getSelectionEnd(mEditable);
-                    if (newSel >= 0) {
-                        Selection.setSelection(mEditable, newSel);
-                        mEditable.delete(newSel, selStart);
-                        updateEditingState();
-                    }
+                    int newSel = clampIndexToEditable(Selection.getSelectionEnd(mEditable), mEditable);
+                    Selection.setSelection(mEditable, newSel);
+                    mEditable.delete(newSel, selStart);
+                    updateEditingState();
                     return true;
                 }
             } else if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_LEFT) {

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -18,6 +18,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
+import io.flutter.Log;
 import io.flutter.plugin.common.ErrorLogResult;
 import io.flutter.plugin.common.MethodChannel;
 
@@ -139,7 +140,14 @@ class InputConnectionAdaptor extends BaseInputConnection {
     // Sanitizes the index to ensure the index is within the range of the
     // contents of editable.
     private static int clampIndexToEditable(int index, Editable editable) {
-        return Math.max(0, Math.min(editable.length(), index));
+        int clamped = Math.max(0, Math.min(editable.length(), index));
+        if (clamped != index) {
+            Log.d("flutter", "Text selection index was clamped ("
+                + index + "->" + clamped
+                + ") to remain in bounds. This may not be your fault, as some keyboards may select outside of bounds."
+            );
+        }
+        return clamped;
     }
 
     @Override

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -167,6 +167,8 @@ class InputConnectionAdaptor extends BaseInputConnection {
                     int newStart = clampIndexToEditable(Selection.getSelectionStart(mEditable), mEditable);
                     int newEnd = clampIndexToEditable(Selection.getSelectionEnd(mEditable), mEditable);
                     Selection.setSelection(mEditable, Math.min(newStart, newEnd));
+                    // Min/Max the values since RTL selections will start at a higher
+                    // index than they end at.
                     mEditable.delete(Math.min(newStart, newEnd), Math.max(newStart, newEnd));
                     updateEditingState();
                     return true;


### PR DESCRIPTION
`Selection.getSelectionStart` can return -1, which causes an index out of bounds. In the case of a invalid deletion, unspecifiable selections will not be deleted.

b/135036951 