### PR TITLE
Send the isolate service ID from the engine to the embedder

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -141,6 +141,13 @@ DartIsolate::Phase DartIsolate::GetPhase() const {
   return phase_;
 }
 
+std::string DartIsolate::GetServiceId() {
+  const char* service_id_buf = Dart_IsolateServiceId(isolate());
+  std::string service_id(service_id_buf);
+  free(const_cast<char*>(service_id_buf));
+  return service_id;
+}
+
 bool DartIsolate::Initialize(Dart_Isolate dart_isolate, bool is_root_isolate) {
   TRACE_EVENT0("flutter", "DartIsolate::Initialize");
   if (phase_ != Phase::Uninitialized) {

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -73,6 +73,8 @@ class DartIsolate : public UIDartState {
 
   Phase GetPhase() const;
 
+  std::string GetServiceId();
+
   FML_WARN_UNUSED_RESULT
   bool PrepareForRunningFromPrecompiledCode();
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -33,6 +33,7 @@ static constexpr char kLifecycleChannel[] = "flutter/lifecycle";
 static constexpr char kNavigationChannel[] = "flutter/navigation";
 static constexpr char kLocalizationChannel[] = "flutter/localization";
 static constexpr char kSettingsChannel[] = "flutter/settings";
+static constexpr char kIsolateChannel[] = "flutter/isolate";
 
 Engine::Engine(Delegate& delegate,
                DartVM& vm,
@@ -145,6 +146,14 @@ Engine::RunStatus Engine::Run(RunConfiguration configuration) {
       isolate->AddIsolateShutdownCallback(
           settings_.root_isolate_shutdown_callback);
     }
+
+    std::string service_id = isolate->GetServiceId();
+    fml::RefPtr<PlatformMessage> service_id_message =
+        fml::MakeRefCounted<flutter::PlatformMessage>(
+            kIsolateChannel,
+            std::vector<uint8_t>(service_id.begin(), service_id.end()),
+            nullptr);
+    HandlePlatformMessage(service_id_message);
   }
 
   return isolate_running ? Engine::RunStatus::Success

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -12,6 +12,11 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     InitializationPreference preference)
     : context_(context) {
   project_args_.struct_size = sizeof(project_args_);
+  project_args_.platform_message_callback =
+      [](const FlutterPlatformMessage* message, void* context) {
+        reinterpret_cast<EmbedderContext*>(context)->PlatformMessageCallback(
+            message);
+      };
 
   custom_task_runners_.struct_size = sizeof(FlutterCustomTaskRunners);
 
@@ -124,6 +129,11 @@ void EmbedderConfigBuilder::SetPlatformTaskRunner(
   }
   custom_task_runners_.platform_task_runner = runner;
   project_args_.custom_task_runners = &custom_task_runners_;
+}
+
+void EmbedderConfigBuilder::SetPlatformMessageCallback(
+    std::function<void(const FlutterPlatformMessage*)> callback) {
+  context_.SetPlatformMessageCallback(callback);
 }
 
 UniqueEngine EmbedderConfigBuilder::LaunchEngine() {

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -58,6 +58,9 @@ class EmbedderConfigBuilder {
 
   void SetPlatformTaskRunner(const FlutterTaskRunnerDescription* runner);
 
+  void SetPlatformMessageCallback(
+      std::function<void(const FlutterPlatformMessage*)> callback);
+
   UniqueEngine LaunchEngine();
 
  private:

--- a/shell/platform/embedder/tests/embedder_context.cc
+++ b/shell/platform/embedder/tests/embedder_context.cc
@@ -91,6 +91,18 @@ void EmbedderContext::SetSemanticsCustomActionCallback(
       update_semantics_custom_action_callback;
 }
 
+void EmbedderContext::SetPlatformMessageCallback(
+    std::function<void(const FlutterPlatformMessage*)> callback) {
+  platform_message_callback_ = callback;
+}
+
+void EmbedderContext::PlatformMessageCallback(
+    const FlutterPlatformMessage* message) {
+  if (platform_message_callback_) {
+    platform_message_callback_(message);
+  }
+}
+
 FlutterUpdateSemanticsNodeCallback
 EmbedderContext::GetUpdateSemanticsNodeCallbackHook() {
   return [](const FlutterSemanticsNode* semantics_node, void* user_data) {

--- a/shell/platform/embedder/tests/embedder_context.h
+++ b/shell/platform/embedder/tests/embedder_context.h
@@ -49,6 +49,9 @@ class EmbedderContext {
   void SetSemanticsCustomActionCallback(
       SemanticsActionCallback semantics_custom_action);
 
+  void SetPlatformMessageCallback(
+      std::function<void(const FlutterPlatformMessage*)> callback);
+
  private:
   // This allows the builder to access the hooks.
   friend class EmbedderConfigBuilder;
@@ -63,6 +66,7 @@ class EmbedderContext {
   SemanticsNodeCallback update_semantics_node_callback_;
   SemanticsActionCallback update_semantics_custom_action_callback_;
   std::unique_ptr<EmbedderTestGLSurface> gl_surface_;  // lazy
+  std::function<void(const FlutterPlatformMessage*)> platform_message_callback_;
 
   static VoidCallback GetIsolateCreateCallbackHook();
 
@@ -89,6 +93,8 @@ class EmbedderContext {
   bool GLMakeResourceCurrent();
 
   void* GLGetProcAddress(const char* name);
+
+  void PlatformMessageCallback(const FlutterPlatformMessage* message);
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderContext);
 };


### PR DESCRIPTION
Applications can use an embedder API to obtain the isolate ID and then use it in calls to the Dart service protocol.
