### PR TITLE
Handle one-way platform messages in the embedder library

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -842,11 +842,13 @@ FlutterEngineResult FlutterEngineSendPlatformMessageResponse(
 
   auto response = handle->message->response();
 
-  if (data_length == 0) {
-    response->CompleteEmpty();
-  } else {
-    response->Complete(std::make_unique<fml::DataMapping>(
-        std::vector<uint8_t>({data, data + data_length})));
+  if (response) {
+    if (data_length == 0) {
+      response->CompleteEmpty();
+    } else {
+      response->Complete(std::make_unique<fml::DataMapping>(
+          std::vector<uint8_t>({data, data + data_length})));
+    }
   }
 
   delete handle;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -373,11 +373,10 @@ typedef struct {
   // The response handle on which to invoke
   // |FlutterEngineSendPlatformMessageResponse| when the response is ready. This
   // field is ignored for messages being sent from the embedder to the
-  // framework. If the embedder ever receives a message with a non-null response
-  // handle, that handle must always be used with a
-  // |FlutterEngineSendPlatformMessageResponse| call. If not, this is a memory
-  // leak. It is not safe to send multiple responses on a single response
-  // object.
+  // framework. |FlutterEngineSendPlatformMessageResponse| must be called for
+  // all messages received by the embedder. Failure to call
+  // |FlutterEngineSendPlatformMessageResponse| will cause a memory leak. It is
+  // not safe to send multiple responses on a single response object.
   const FlutterPlatformMessageResponseHandle* response_handle;
 } FlutterPlatformMessage;
 

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -49,12 +49,10 @@ void PlatformViewEmbedder::HandlePlatformMessage(
     return;
   }
 
-  if (!message->response()) {
-    return;
-  }
-
   if (platform_dispatch_table_.platform_message_response_callback == nullptr) {
-    message->response()->CompleteEmpty();
+    if (message->response()) {
+      message->response()->CompleteEmpty();
+    }
     return;
   }
 


### PR DESCRIPTION
Messages sent to the embedder host may be one-way messages with no response
handler.  If the host calls FlutterEngineSendPlatformMessageResponse on a
one-way message, then just delete the message response handle.

Also update the documentation to indicate that
FlutterEngineSendPlatformMessageResponse must be called for all messages.
Previously the docs implied that some FlutterPlatformMessage objects may
have a null response_handle.  The embedder will now set a response_handle for
every message (even if the sender does not expect a response).