### PR TITLE
Use the DartServiceIsolate status callback to publish the observatory URI to the Android embedder

### DIFF
--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -32,7 +32,7 @@ namespace {
 
 static Dart_LibraryTagHandler g_embedder_tag_handler;
 static tonic::DartLibraryNatives* g_natives;
-static std::string observatory_uri_;
+static std::string g_observatory_uri;
 
 Dart_NativeFunction GetNativeFunction(Dart_Handle name,
                                       int argument_count,
@@ -63,7 +63,7 @@ void DartServiceIsolate::NotifyServerState(Dart_NativeArguments args) {
     return;
   }
 
-  observatory_uri_ = uri;
+  g_observatory_uri = uri;
 
   // Collect callbacks to fire in a separate collection and invoke them outside
   // the lock.
@@ -79,10 +79,6 @@ void DartServiceIsolate::NotifyServerState(Dart_NativeArguments args) {
   for (auto callback_to_fire : callbacks_to_fire) {
     callback_to_fire(uri);
   }
-}
-
-std::string DartServiceIsolate::GetObservatoryUri() {
-  return observatory_uri_;
 }
 
 DartServiceIsolate::CallbackHandle DartServiceIsolate::AddServerStatusCallback(
@@ -102,8 +98,8 @@ DartServiceIsolate::CallbackHandle DartServiceIsolate::AddServerStatusCallback(
     callbacks_.insert(std::move(callback_pointer));
   }
 
-  if (!observatory_uri_.empty()) {
-    callback(observatory_uri_);
+  if (!g_observatory_uri.empty()) {
+    callback(g_observatory_uri);
   }
 
   return handle;

--- a/runtime/dart_service_isolate.h
+++ b/runtime/dart_service_isolate.h
@@ -29,8 +29,6 @@ class DartServiceIsolate {
                       bool disable_service_auth_codes,
                       char** error);
 
-  static std::string GetObservatoryUri();
-
   using CallbackHandle = ptrdiff_t;
 
   // Returns a handle for the callback that can be used in

--- a/shell/platform/android/flutter_main.h
+++ b/shell/platform/android/flutter_main.h
@@ -9,6 +9,7 @@
 
 #include "flutter/common/settings.h"
 #include "flutter/fml/macros.h"
+#include "flutter/runtime/dart_service_isolate.h"
 
 namespace flutter {
 
@@ -24,6 +25,7 @@ class FlutterMain {
 
  private:
   const flutter::Settings settings_;
+  DartServiceIsolate::CallbackHandle observatory_uri_callback_;
 
   FlutterMain(flutter::Settings settings);
 
@@ -34,6 +36,8 @@ class FlutterMain {
                    jstring bundlePath,
                    jstring appRootPath,
                    jstring engineCachesPath);
+
+  void SetupObservatoryUriCallback(JNIEnv* env);
 
   FML_DISALLOW_COPY_AND_ASSIGN(FlutterMain);
 };

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -86,17 +86,21 @@ import io.flutter.view.AccessibilityBridge;
  * To invoke a native method that is not associated with a platform view, invoke it statically:
  *
  * {@code
- *    String uri = FlutterJNI.nativeGetObservatoryUri();
+ *    bool enabled = FlutterJNI.nativeGetIsSoftwareRenderingEnabled();
  * }
  */
 public class FlutterJNI {
   private static final String TAG = "FlutterJNI";
 
+  // This is set from native code via JNI.
+  private static String observatoryUri;
+
   @UiThread
   public static native boolean nativeGetIsSoftwareRenderingEnabled();
 
-  @UiThread
-  public static native String nativeGetObservatoryUri();
+  public static String getObservatoryUri() {
+    return observatoryUri;
+  }
 
   private Long nativePlatformViewId;
   private FlutterRenderer.RenderSurface renderSurface;

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -135,7 +135,7 @@ public class FlutterNativeView implements BinaryMessenger {
     }
 
     public static String getObservatoryUri() {
-        return FlutterJNI.nativeGetObservatoryUri();
+        return FlutterJNI.getObservatoryUri();
     }
 
     @Override

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -164,11 +164,6 @@ static void DestroyJNI(JNIEnv* env, jobject jcaller, jlong shell_holder) {
   delete ANDROID_SHELL_HOLDER;
 }
 
-static jstring GetObservatoryUri(JNIEnv* env, jclass clazz) {
-  return env->NewStringUTF(
-      flutter::DartServiceIsolate::GetObservatoryUri().c_str());
-}
-
 static void SurfaceCreated(JNIEnv* env,
                            jobject jcaller,
                            jlong shell_holder,
@@ -552,11 +547,6 @@ bool RegisterApi(JNIEnv* env) {
           .signature = "(J[Ljava/lang/String;Ljava/lang/String;"
                        "Ljava/lang/String;Landroid/content/res/AssetManager;)V",
           .fnPtr = reinterpret_cast<void*>(&RunBundleAndSnapshotFromLibrary),
-      },
-      {
-          .name = "nativeGetObservatoryUri",
-          .signature = "()Ljava/lang/String;",
-          .fnPtr = reinterpret_cast<void*>(&GetObservatoryUri),
       },
       {
           .name = "nativeDispatchEmptyPlatformMessage",


### PR DESCRIPTION
The Android embedder had been using a JNI call to get the observatory URI from
DartServiceIsolate.  This call was not thread safe and was redundant with the
server status callback mechanism used on iOS.