### PR TITLE
Update component manifests for ambient replace-as-executable

### DIFF
--- a/shell/platform/fuchsia/dart/examples/goodbye_dart/meta/goodbye_dart_aot.cmx
+++ b/shell/platform/fuchsia/dart/examples/goodbye_dart/meta/goodbye_dart_aot.cmx
@@ -3,7 +3,9 @@
         "data": "data/goodbye_dart_aot"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/goodbye_dart/meta/goodbye_dart_jit.cmx
+++ b/shell/platform/fuchsia/dart/examples/goodbye_dart/meta/goodbye_dart_jit.cmx
@@ -3,7 +3,9 @@
         "data": "data/goodbye_dart_jit"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/hello_app_dart/meta/hello_app_dart_aot.cmx
+++ b/shell/platform/fuchsia/dart/examples/hello_app_dart/meta/hello_app_dart_aot.cmx
@@ -3,7 +3,9 @@
         "data": "data/hello_app_dart_aot"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/hello_app_dart/meta/hello_app_dart_jit.cmx
+++ b/shell/platform/fuchsia/dart/examples/hello_app_dart/meta/hello_app_dart_jit.cmx
@@ -3,7 +3,9 @@
         "data": "data/hello_app_dart_jit"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_aot.cmx
+++ b/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_aot.cmx
@@ -3,7 +3,9 @@
         "data": "data/hello_dart_aot"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_aot_product.cmx
+++ b/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_aot_product.cmx
@@ -3,7 +3,9 @@
         "data": "data/hello_dart_aot_product"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_debug.cmx
+++ b/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_debug.cmx
@@ -3,7 +3,9 @@
         "data": "data/hello_dart_debug"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_jit.cmx
+++ b/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_jit.cmx
@@ -3,7 +3,9 @@
         "data": "data/hello_dart_jit"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_jit_product.cmx
+++ b/shell/platform/fuchsia/dart/examples/hello_dart/meta/hello_dart_jit_product.cmx
@@ -3,7 +3,9 @@
         "data": "data/hello_dart_jit_product"
     },
     "sandbox": {
-        "features": [],
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Environment"
         ]

--- a/shell/platform/fuchsia/dart/integration/meta/dart_aot_runner_test.cmx
+++ b/shell/platform/fuchsia/dart/integration/meta/dart_aot_runner_test.cmx
@@ -3,6 +3,9 @@
         "data": "data/dart_aot_runner_test"
     },
     "sandbox": {
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.cobalt.LoggerFactory",
             "fuchsia.fonts.Provider",

--- a/shell/platform/fuchsia/dart/integration/meta/dart_jit_runner_test.cmx
+++ b/shell/platform/fuchsia/dart/integration/meta/dart_jit_runner_test.cmx
@@ -3,6 +3,9 @@
         "data": "data/dart_jit_runner_test"
     },
     "sandbox": {
+        "features": [
+          "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.cobalt.LoggerFactory",
             "fuchsia.fonts.Provider",

--- a/shell/platform/fuchsia/dart/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_aot_product_runner.cmx
@@ -5,6 +5,7 @@
     "sandbox": {
         "features": [
             "root-ssl-certificates"
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",

--- a/shell/platform/fuchsia/dart/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_aot_runner.cmx
@@ -4,7 +4,8 @@
     },
     "sandbox": {
         "features": [
-            "root-ssl-certificates"
+            "root-ssl-certificates",
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",

--- a/shell/platform/fuchsia/dart/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_jit_product_runner.cmx
@@ -5,6 +5,7 @@
     "sandbox": {
         "features": [
             "root-ssl-certificates"
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",

--- a/shell/platform/fuchsia/dart/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_jit_runner.cmx
@@ -4,7 +4,8 @@
     },
     "sandbox": {
         "features": [
-            "root-ssl-certificates"
+            "root-ssl-certificates",
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",

--- a/shell/platform/fuchsia/dart/meta/dart_zircon_test.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_zircon_test.cmx
@@ -5,6 +5,7 @@
     "sandbox": {
         "features": [
             "root-ssl-certificates"
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.sys.Environment"

--- a/shell/platform/fuchsia/dart/vmservice/meta/vmservice.cmx
+++ b/shell/platform/fuchsia/dart/vmservice/meta/vmservice.cmx
@@ -3,6 +3,9 @@
         "data": "data/vmservice"
     },
     "sandbox": {
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.cobalt.LoggerFactory",
             "fuchsia.fonts.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -5,7 +5,8 @@
     "sandbox": {
         "features": [
             "root-ssl-certificates",
-            "vulkan"
+            "vulkan",
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -5,7 +5,8 @@
     "sandbox": {
         "features": [
             "root-ssl-certificates",
-            "vulkan"
+            "vulkan",
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -5,7 +5,8 @@
     "sandbox": {
         "features": [
             "root-ssl-certificates",
-            "vulkan"
+            "vulkan",
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.device.manager.Administrator",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -5,7 +5,8 @@
     "sandbox": {
         "features": [
             "root-ssl-certificates",
-            "vulkan"
+            "vulkan",
+            "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",

--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
@@ -3,6 +3,9 @@
         "binary": "test/flutter_runner_tests"
     },
     "sandbox": {
+        "features": [
+            "deprecated-ambient-replace-as-executable"
+        ],
         "services": [
             "fuchsia.sys.Launcher"
         ]


### PR DESCRIPTION
Bug: SEC-314

Just adding this feature as a pre-flight step while we
restrict the ability for arbitrary processes to make
VMOs executable.