### PR TITLE
Android Embedding Refactor PR32: Clean up logs in new embedding.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -18,7 +18,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
-import android.util.Log;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.ViewGroup;
@@ -26,6 +25,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
@@ -179,7 +179,6 @@ public class FlutterActivity extends FragmentActivity implements OnFirstFrameRen
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
-    Log.d(TAG, "onCreate()");
     super.onCreate(savedInstanceState);
     configureWindowForTransparency();
     setContentView(createFragmentContainer());
@@ -220,6 +219,8 @@ public class FlutterActivity extends FragmentActivity implements OnFirstFrameRen
       // Don't display an opaque cover view if the Activity is intended to be transparent.
       return;
     }
+
+    Log.v(TAG, "Showing cover view until first frame is rendered.");
 
     // Create the coverView.
     if (coverView == null) {
@@ -321,6 +322,13 @@ public class FlutterActivity extends FragmentActivity implements OnFirstFrameRen
   @NonNull
   protected FlutterFragment createFlutterFragment() {
     BackgroundMode backgroundMode = getBackgroundMode();
+
+    Log.d(TAG, "Creating FlutterFragment:\n"
+        + "Background transparency mode: " + backgroundMode + "\n"
+        + "Dart entrypoint: " + getDartEntrypoint() + "\n"
+        + "Initial route: " + getInitialRoute() + "\n"
+        + "App bundle path: " + getAppBundlePath() + "\n"
+        + "Will attach FlutterEngine to Activity: " + shouldAttachEngineToActivity());
 
     return new FlutterFragment.Builder()
         .dartEntrypoint(getDartEntrypoint())
@@ -515,6 +523,7 @@ public class FlutterActivity extends FragmentActivity implements OnFirstFrameRen
 
   @Override
   public void onFirstFrameRendered() {
+    Log.v(TAG, "First frame has been rendered. Hiding cover view.");
     hideCoverView();
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -17,11 +17,13 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.Arrays;
+
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
@@ -358,6 +360,7 @@ public class FlutterFragment extends Fragment {
       // which means there shouldn't be any possibility for the Fragment Lifecycle to get out of
       // sync with the Activity. We use the Fragment's Lifecycle because it is possible that the
       // attached Activity is not a LifecycleOwner.
+      Log.d(TAG, "Attaching FlutterEngine to the Activity that owns this Fragment.");
       flutterEngine.getActivityControlSurface().attachToActivity(getActivity(), getLifecycle());
     }
   }
@@ -385,6 +388,8 @@ public class FlutterFragment extends Fragment {
    * {@link FlutterEngine} is instantiated.
    */
   private void setupFlutterEngine() {
+    Log.d(TAG, "Setting up FlutterEngine.");
+
     // First, defer to subclasses for a custom FlutterEngine.
     flutterEngine = createFlutterEngine(getContextCompat());
     if (flutterEngine != null) {
@@ -407,8 +412,8 @@ public class FlutterFragment extends Fragment {
 
     // Neither our subclass, nor our owning Activity wanted to provide a custom FlutterEngine.
     // Create a FlutterEngine to back our FlutterView.
-    Log.d(TAG, "No subclass or our attached Activity provided a custom FlutterEngine. Creating a "
-        + "new FlutterEngine for this FlutterFragment.");
+    Log.d(TAG, "No preferred FlutterEngine was provided. Creating a new FlutterEngine for"
+        + " this FlutterFragment.");
     flutterEngine = new FlutterEngine(getContext());
     isFlutterEngineFromActivity = false;
   }
@@ -434,6 +439,7 @@ public class FlutterFragment extends Fragment {
   @Nullable
   @Override
   public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    Log.v(TAG, "Creating FlutterView.");
     flutterView = new FlutterView(getContext(), getRenderMode(), getTransparencyMode());
     flutterView.addOnFirstFrameRenderedListener(onFirstFrameRenderedListener);
     return flutterView;
@@ -454,6 +460,9 @@ public class FlutterFragment extends Fragment {
       // So this is expected behavior in many cases.
       return;
     }
+
+    Log.d(TAG, "Executing Dart entrypoint: " + getDartEntrypointFunctionName()
+        + ", and sending initial route: " + getInitialRoute());
 
     // The engine needs to receive the Flutter app's initial route before executing any
     // Dart code to ensure that the initial route arrives in time to be applied.
@@ -528,7 +537,7 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onStart() {
     super.onStart();
-    Log.d(TAG, "onStart()");
+    Log.v(TAG, "onStart()");
 
     // We post() the code that attaches the FlutterEngine to our FlutterView because there is
     // some kind of blocking logic on the native side when the surface is connected. That lag
@@ -538,6 +547,7 @@ public class FlutterFragment extends Fragment {
     new Handler().post(new Runnable() {
       @Override
       public void run() {
+        Log.v(TAG, "Attaching FlutterEngine to FlutterView.");
         flutterView.attachToFlutterEngine(flutterEngine);
 
         // TODO(mattcarroll): the following call should exist here, but the plugin system needs to be revamped.
@@ -552,13 +562,13 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onResume() {
     super.onResume();
-    Log.d(TAG, "onResume()");
+    Log.v(TAG, "onResume()");
     flutterEngine.getLifecycleChannel().appIsResumed();
   }
 
   // TODO(mattcarroll): determine why this can't be in onResume(). Comment reason, or move if possible.
   public void onPostResume() {
-    Log.d(TAG, "onPostResume()");
+    Log.v(TAG, "onPostResume()");
     if (flutterEngine != null) {
       // TODO(mattcarroll): find a better way to handle the update of UI overlays than calling through
       //                    to platformPlugin. We're implicitly entangling the Window, Activity, Fragment,
@@ -572,14 +582,14 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onPause() {
     super.onPause();
-    Log.d(TAG, "onPause()");
+    Log.v(TAG, "onPause()");
     flutterEngine.getLifecycleChannel().appIsInactive();
   }
 
   @Override
   public void onStop() {
     super.onStop();
-    Log.d(TAG, "onStop()");
+    Log.v(TAG, "onStop()");
     flutterEngine.getLifecycleChannel().appIsPaused();
     flutterView.detachFromFlutterEngine();
   }
@@ -587,17 +597,18 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onDestroyView() {
     super.onDestroyView();
-    Log.d(TAG, "onDestroyView()");
+    Log.v(TAG, "onDestroyView()");
     flutterView.removeOnFirstFrameRenderedListener(onFirstFrameRenderedListener);
   }
 
   @Override
   public void onDetach() {
     super.onDetach();
-    Log.d(TAG, "onDetach()");
+    Log.v(TAG, "onDetach()");
 
     if (shouldAttachEngineToActivity()) {
       // Notify plugins that they are no longer attached to an Activity.
+      Log.d(TAG, "Detaching FlutterEngine from the Activity that owns this Fragment.");
       if (getActivity().isChangingConfigurations()) {
         flutterEngine.getActivityControlSurface().detachFromActivityForConfigChanges();
       } else {
@@ -641,8 +652,8 @@ public class FlutterFragment extends Fragment {
    * See {@link android.app.Activity#onBackPressed()}
    */
   public void onBackPressed() {
-    Log.d(TAG, "onBackPressed()");
     if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding onBackPressed() to FlutterEngine.");
       flutterEngine.getNavigationChannel().popRoute();
     } else {
       Log.w(TAG, "Invoked onBackPressed() before FlutterFragment was attached to an Activity.");
@@ -660,6 +671,10 @@ public class FlutterFragment extends Fragment {
    */
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding onRequestPermissionsResult() to FlutterEngine:\n"
+        + "requestCode: " + requestCode + "\n"
+        + "permissions: " + Arrays.toString(permissions) + "\n"
+        + "grantResults: " + Arrays.toString(grantResults));
       flutterEngine.getActivityControlSurface().onRequestPermissionsResult(requestCode, permissions, grantResults);
     } else {
       Log.w(TAG, "onRequestPermissionResult() invoked before FlutterFragment was attached to an Activity.");
@@ -676,6 +691,7 @@ public class FlutterFragment extends Fragment {
    */
   public void onNewIntent(@NonNull Intent intent) {
     if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding onNewIntent() to FlutterEngine.");
       flutterEngine.getActivityControlSurface().onNewIntent(intent);
     } else {
       Log.w(TAG, "onNewIntent() invoked before FlutterFragment was attached to an Activity.");
@@ -692,6 +708,10 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding onActivityResult() to FlutterEngine:\n"
+          + "requestCode: " + requestCode + "\n"
+          + "resultCode: " + resultCode + "\n"
+          + "data: " + data);
       flutterEngine.getActivityControlSurface().onActivityResult(requestCode, resultCode, data);
     } else {
       Log.w(TAG, "onActivityResult() invoked before FlutterFragment was attached to an Activity.");
@@ -706,6 +726,7 @@ public class FlutterFragment extends Fragment {
    */
   public void onUserLeaveHint() {
     if (flutterEngine != null) {
+      Log.v(TAG, "Forwarding onUserLeaveHint() to FlutterEngine.");
       flutterEngine.getActivityControlSurface().onUserLeaveHint();
     } else {
       Log.w(TAG, "onUserLeaveHint() invoked before FlutterFragment was attached to an Activity.");
@@ -724,6 +745,7 @@ public class FlutterFragment extends Fragment {
       // Use a trim level delivered while the application is running so the
       // framework has a chance to react to the notification.
       if (level == TRIM_MEMORY_RUNNING_LOW) {
+        Log.v(TAG, "Forwarding onTrimMemory() to FlutterEngine. Level: " + level);
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();
       }
     } else {
@@ -739,6 +761,7 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onLowMemory() {
     super.onLowMemory();
+    Log.v(TAG, "Forwarding onLowMemory() to FlutterEngine.");
     flutterEngine.getSystemChannel().sendMemoryPressureWarning();
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -9,13 +9,13 @@ import android.graphics.PixelFormat;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
 
@@ -51,18 +51,17 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
   private final SurfaceHolder.Callback surfaceCallback = new SurfaceHolder.Callback() {
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
-      Log.d(TAG, "SurfaceHolder.Callback.surfaceCreated()");
+      Log.v(TAG, "SurfaceHolder.Callback.surfaceCreated()");
       isSurfaceAvailableForRendering = true;
 
       if (isAttachedToFlutterRenderer) {
-        Log.d(TAG, "Already attached to renderer. Notifying of surface creation.");
         connectSurfaceToRenderer();
       }
     }
 
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
-      Log.d(TAG, "SurfaceHolder.Callback.surfaceChanged()");
+      Log.v(TAG, "SurfaceHolder.Callback.surfaceChanged()");
       if (isAttachedToFlutterRenderer) {
         changeSurfaceSize(width, height);
       }
@@ -70,7 +69,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
 
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
-      Log.d(TAG, "SurfaceHolder.Callback.surfaceDestroyed()");
+      Log.v(TAG, "SurfaceHolder.Callback.surfaceDestroyed()");
       isSurfaceAvailableForRendering = false;
 
       if (isAttachedToFlutterRenderer) {
@@ -138,8 +137,9 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
    * Flutter's UI to this {@code FlutterSurfaceView}.
    */
   public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
-    Log.d(TAG, "attachToRenderer");
+    Log.v(TAG, "Attaching to FlutterRenderer.");
     if (this.flutterRenderer != null) {
+      Log.v(TAG, "Already connected to a FlutterRenderer. Detaching from old one and attaching to new one.");
       this.flutterRenderer.detachFromRenderSurface();
     }
 
@@ -149,7 +149,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
     // If we're already attached to an Android window then we're now attached to both a renderer
     // and the Android window. We can begin rendering now.
     if (isSurfaceAvailableForRendering) {
-      Log.d(TAG, "Surface is available for rendering. Connecting.");
+      Log.v(TAG, "Surface is available for rendering. Connecting FlutterRenderer to Android surface.");
       connectSurfaceToRenderer();
     }
   }
@@ -164,7 +164,9 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
     if (flutterRenderer != null) {
       // If we're attached to an Android window then we were rendering a Flutter UI. Now that
       // this FlutterSurfaceView is detached from the FlutterRenderer, we need to stop rendering.
+      // TODO(mattcarroll): introduce a isRendererConnectedToSurface() to wrap "getWindowToken() != null"
       if (getWindowToken() != null) {
+        Log.v(TAG, "Disconnecting FlutterRenderer from Android surface.");
         disconnectSurfaceFromRenderer();
       }
 
@@ -193,6 +195,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
       throw new IllegalStateException("changeSurfaceSize() should only be called when flutterRenderer is non-null.");
     }
 
+    Log.v(TAG, "Notifying FlutterRenderer that Android surface size has changed to " + width + " x " + height);
     flutterRenderer.surfaceChanged(width, height);
   }
 
@@ -226,7 +229,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
   @Override
   public void onFirstFrameRendered() {
     // TODO(mattcarroll): decide where this method should live and what it needs to do.
-    Log.d(TAG, "onFirstFrameRendered()");
+    Log.v(TAG, "onFirstFrameRendered()");
     // Now that a frame is ready to display, take this SurfaceView from transparent to opaque.
     setAlpha(1.0f);
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -9,13 +9,13 @@ import android.graphics.SurfaceTexture;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.Surface;
 import android.view.TextureView;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
 
@@ -50,19 +50,19 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
   private final SurfaceTextureListener surfaceTextureListener = new SurfaceTextureListener() {
     @Override
     public void onSurfaceTextureAvailable(SurfaceTexture surfaceTexture, int width, int height) {
-      Log.d(TAG, "SurfaceTextureListener.onSurfaceTextureAvailable()");
+      Log.v(TAG, "SurfaceTextureListener.onSurfaceTextureAvailable()");
       isSurfaceAvailableForRendering = true;
 
       // If we're already attached to a FlutterRenderer then we're now attached to both a renderer
       // and the Android window, so we can begin rendering now.
       if (isAttachedToFlutterRenderer) {
-        Log.d(TAG, "Already attached to renderer. Notifying of surface creation.");
         connectSurfaceToRenderer();
       }
     }
 
     @Override
     public void onSurfaceTextureSizeChanged(SurfaceTexture surface, int width, int height) {
+      Log.v(TAG, "SurfaceTextureListener.onSurfaceTextureSizeChanged()");
       if (isAttachedToFlutterRenderer) {
         changeSurfaceSize(width, height);
       }
@@ -75,7 +75,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
 
     @Override
     public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
-      Log.d(TAG, "SurfaceTextureListener.onSurfaceTextureDestroyed()");
+      Log.v(TAG, "SurfaceTextureListener.onSurfaceTextureDestroyed()");
       isSurfaceAvailableForRendering = false;
 
       // If we're attached to a FlutterRenderer then we need to notify it that our SurfaceTexture
@@ -125,7 +125,9 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
    * Flutter's UI to this {@code FlutterTextureView}.
    */
   public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
+    Log.v(TAG, "Attaching to FlutterRenderer.");
     if (this.flutterRenderer != null) {
+      Log.v(TAG, "Already connected to a FlutterRenderer. Detaching from old one and attaching to new one.");
       this.flutterRenderer.detachFromRenderSurface();
     }
 
@@ -135,6 +137,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
     // If we're already attached to an Android window then we're now attached to both a renderer
     // and the Android window. We can begin rendering now.
     if (isSurfaceAvailableForRendering) {
+      Log.v(TAG, "Surface is available for rendering. Connecting FlutterRenderer to Android surface.");
       connectSurfaceToRenderer();
     }
   }
@@ -149,7 +152,9 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
     if (flutterRenderer != null) {
       // If we're attached to an Android window then we were rendering a Flutter UI. Now that
       // this FlutterTextureView is detached from the FlutterRenderer, we need to stop rendering.
+      // TODO(mattcarroll): introduce a isRendererConnectedToSurface() to wrap "getWindowToken() != null"
       if (getWindowToken() != null) {
+        Log.v(TAG, "Disconnecting FlutterRenderer from Android surface.");
         disconnectSurfaceFromRenderer();
       }
 
@@ -175,6 +180,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
       throw new IllegalStateException("changeSurfaceSize() should only be called when flutterRenderer is non-null.");
     }
 
+    Log.v(TAG, "Notifying FlutterRenderer that Android surface size has changed to " + width + " x " + height);
     flutterRenderer.surfaceChanged(width, height);
   }
 
@@ -208,7 +214,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
   @Override
   public void onFirstFrameRendered() {
     // TODO(mattcarroll): decide where this method should live and what it needs to do.
-    Log.d(TAG, "onFirstFrameRendered()");
+    Log.v(TAG, "onFirstFrameRendered()");
 
     for (OnFirstFrameRenderedListener listener : onFirstFrameRenderedListeners) {
       listener.onFirstFrameRendered();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -15,7 +15,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 import android.text.format.DateFormat;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.WindowInsets;
@@ -26,9 +25,11 @@ import android.view.inputmethod.InputConnection;
 import android.widget.FrameLayout;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.renderer.FlutterRenderer;
 import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
@@ -162,17 +163,17 @@ public class FlutterView extends FrameLayout {
   }
 
   private void init() {
-    Log.d(TAG, "Initializing FlutterView");
+    Log.v(TAG, "Initializing FlutterView");
 
     switch (renderMode) {
       case surface:
-        Log.d(TAG, "Internally creating a FlutterSurfaceView.");
+        Log.v(TAG, "Internally using a FlutterSurfaceView.");
         FlutterSurfaceView flutterSurfaceView = new FlutterSurfaceView(getContext(), transparencyMode == TransparencyMode.transparent);
         renderSurface = flutterSurfaceView;
         addView(flutterSurfaceView);
         break;
       case texture:
-        Log.d(TAG, "Internally creating a FlutterTextureView.");
+        Log.v(TAG, "Internally using a FlutterTextureView.");
         FlutterTextureView flutterTextureView = new FlutterTextureView(getContext());
         renderSurface = flutterTextureView;
         addView(flutterTextureView);
@@ -234,6 +235,7 @@ public class FlutterView extends FrameLayout {
   @Override
   protected void onConfigurationChanged(Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
+    Log.v(TAG, "Configuration changed. Sending locales and user settings to Flutter.");
     sendLocalesToFlutter(newConfig);
     sendUserSettingsToFlutter();
   }
@@ -252,6 +254,9 @@ public class FlutterView extends FrameLayout {
   @Override
   protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
     super.onSizeChanged(width, height, oldWidth, oldHeight);
+    Log.v(TAG, "Size changed. Sending Flutter new viewport metrics. FlutterView was "
+        + oldWidth + " x " + oldHeight
+        + ", it is now " + width + " x " + height);
     viewportMetrics.width = width;
     viewportMetrics.height = height;
     sendViewportMetricsToFlutter();
@@ -284,6 +289,13 @@ public class FlutterView extends FrameLayout {
     viewportMetrics.viewInsetRight = 0;
     viewportMetrics.viewInsetBottom = insets.getSystemWindowInsetBottom();
     viewportMetrics.viewInsetLeft = 0;
+
+    Log.v(TAG, "Updating window insets (onApplyWindowInsets()):\n"
+      + "Status bar insets: Top: " + viewportMetrics.paddingTop
+        + ", Left: " + viewportMetrics.paddingLeft + ", Right: " + viewportMetrics.paddingRight + "\n"
+      + "Keyboard insets: Bottom: " + viewportMetrics.viewInsetBottom
+        + ", Left: " + viewportMetrics.viewInsetLeft + ", Right: " + viewportMetrics.viewInsetRight);
+
     sendViewportMetricsToFlutter();
 
     return newInsets;
@@ -311,6 +323,13 @@ public class FlutterView extends FrameLayout {
       viewportMetrics.viewInsetRight = 0;
       viewportMetrics.viewInsetBottom = insets.bottom;
       viewportMetrics.viewInsetLeft = 0;
+
+      Log.v(TAG, "Updating window insets (fitSystemWindows()):\n"
+          + "Status bar insets: Top: " + viewportMetrics.paddingTop
+          + ", Left: " + viewportMetrics.paddingLeft + ", Right: " + viewportMetrics.paddingRight + "\n"
+          + "Keyboard insets: Bottom: " + viewportMetrics.viewInsetBottom
+          + ", Left: " + viewportMetrics.viewInsetLeft + ", Right: " + viewportMetrics.viewInsetRight);
+
       sendViewportMetricsToFlutter();
       return true;
     } else {
@@ -486,7 +505,7 @@ public class FlutterView extends FrameLayout {
    * {@link FlutterEngine}.
    */
   public void attachToFlutterEngine(@NonNull FlutterEngine flutterEngine) {
-    Log.d(TAG, "attachToFlutterEngine()");
+    Log.d(TAG, "Attaching to a FlutterEngine: " + flutterEngine);
     if (isAttachedToFlutterEngine()) {
       if (flutterEngine == this.flutterEngine) {
         // We are already attached to this FlutterEngine
@@ -495,7 +514,8 @@ public class FlutterView extends FrameLayout {
       }
 
       // Detach from a previous FlutterEngine so we can attach to this new one.
-      Log.d(TAG, "Currently attached to a different engine. Detaching.");
+      Log.d(TAG, "Currently attached to a different engine. Detaching and then attaching"
+          + " to new engine.");
       detachFromFlutterEngine();
     }
 
@@ -554,12 +574,11 @@ public class FlutterView extends FrameLayout {
    * {@link FlutterEngine}.
    */
   public void detachFromFlutterEngine() {
-    Log.d(TAG, "detachFromFlutterEngine()");
+    Log.d(TAG, "Detaching from a FlutterEngine: " + flutterEngine);
     if (!isAttachedToFlutterEngine()) {
       Log.d(TAG, "Not attached to an engine. Doing nothing.");
       return;
     }
-    Log.d(TAG, "Detaching from Flutter Engine");
 
     // Disconnect and clean up the AccessibilityBridge.
     accessibilityBridge.release();
@@ -627,9 +646,9 @@ public class FlutterView extends FrameLayout {
 
   // TODO(mattcarroll): consider introducing a system channel for this communication instead of JNI
   private void sendViewportMetricsToFlutter() {
-    Log.d(TAG, "sendViewportMetricsToFlutter()");
     if (!isAttachedToFlutterEngine()) {
-      Log.w(TAG, "Tried to send viewport metrics from Android to Flutter but this FlutterView was not attached to a FlutterEngine.");
+      Log.w(TAG, "Tried to send viewport metrics from Android to Flutter but this "
+          + "FlutterView was not attached to a FlutterEngine.");
       return;
     }
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -12,6 +12,7 @@ import android.support.annotation.NonNull;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.plugins.PluginRegistry;
 import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
@@ -91,6 +92,7 @@ public class FlutterEngine implements LifecycleOwner {
   private final EngineLifecycleListener engineLifecycleListener = new EngineLifecycleListener() {
     @SuppressWarnings("unused")
     public void onPreEngineRestart() {
+      Log.v(TAG, "onPreEngineRestart()");
       for (EngineLifecycleListener lifecycleListener : engineLifecycleListeners) {
         lifecycleListener.onPreEngineRestart();
       }
@@ -143,6 +145,7 @@ public class FlutterEngine implements LifecycleOwner {
   }
 
   private void attachToJni() {
+    Log.v(TAG, "Attaching to JNI.");
     // TODO(mattcarroll): update native call to not take in "isBackgroundView"
     flutterJNI.attachToNative(false);
 
@@ -163,6 +166,7 @@ public class FlutterEngine implements LifecycleOwner {
    * This {@code FlutterEngine} instance should be discarded after invoking this method.
    */
   public void destroy() {
+    Log.d(TAG, "Destroying.");
     // The order that these things are destroyed is important.
     pluginRegistry.destroy();
     dartExecutor.onDetachedFromJNI();

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
@@ -84,6 +84,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   }
 
   public void destroy() {
+    Log.d(TAG, "Destroying.");
     // Detach from any Android component that we may currently be attached to, e.g., Activity, Service,
     // BroadcastReceiver, ContentProvider. This must happen before removing all plugins so that the
     // plugins have an opportunity to clean up references as a result of component detachment.
@@ -100,6 +101,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void add(@NonNull FlutterPlugin plugin) {
+    Log.v(TAG, "Adding plugin: " + plugin);
     // Add the plugin to our generic set of plugins and notify the plugin
     // that is has been attached to an engine.
     plugins.put(plugin.getClass(), plugin);
@@ -175,6 +177,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   public void remove(@NonNull Class<? extends FlutterPlugin> pluginClass) {
     FlutterPlugin plugin = plugins.get(pluginClass);
     if (plugin != null) {
+      Log.v(TAG, "Removing plugin: " + plugin);
       // For ActivityAware plugins, notify the plugin that it is detached from
       // an Activity if an Activity is currently attached to this engine. Then
       // remove the plugin from our set of ActivityAware plugins.
@@ -260,7 +263,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToActivity(@NonNull Activity activity, @NonNull Lifecycle lifecycle) {
-    Log.v(TAG, "Attaching to an Activity."
+    Log.v(TAG, "Attaching to an Activity: " + activity + "."
         + (isWaitingForActivityReattachment ? " This is after a config change." : ""));
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
@@ -282,8 +285,8 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void detachFromActivityForConfigChanges() {
-    Log.v(TAG, "Detaching from an Activity for config changes.");
     if (isAttachedToActivity()) {
+      Log.v(TAG, "Detaching from an Activity for config changes: " + activity);
       isWaitingForActivityReattachment = true;
 
       for (ActivityAware activityAware : activityAwarePlugins.values()) {
@@ -300,8 +303,8 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void detachFromActivity() {
-    Log.v(TAG, "Detaching from an Activity.");
     if (isAttachedToActivity()) {
+      Log.v(TAG, "Detaching from an Activity: " + activity);
       for (ActivityAware activityAware : activityAwarePlugins.values()) {
         activityAware.onDetachedFromActivity();
       }
@@ -364,6 +367,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToService(@NonNull Service service, @NonNull Lifecycle lifecycle, boolean isForeground) {
+    Log.v(TAG, "Attaching to a Service: " + service);
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
 
@@ -380,6 +384,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromService() {
     if (isAttachedToService()) {
+      Log.v(TAG, "Detaching from a Service: " + service);
       // Notify all ServiceAware plugins that they are no longer attached to a Service.
       for (ServiceAware serviceAware : serviceAwarePlugins.values()) {
         serviceAware.onDetachedFromService();
@@ -396,6 +401,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void onMoveToForeground() {
     if (isAttachedToService()) {
+      Log.v(TAG, "Attached Service moved to foreground.");
       servicePluginBinding.onMoveToForeground();
     }
   }
@@ -403,6 +409,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void onMoveToBackground() {
     if (isAttachedToService()) {
+      Log.v(TAG, "Attached Service moved to background.");
       servicePluginBinding.onMoveToBackground();
     }
   }
@@ -415,6 +422,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToBroadcastReceiver(@NonNull BroadcastReceiver broadcastReceiver, @NonNull Lifecycle lifecycle) {
+    Log.v(TAG, "Attaching to BroadcastReceiver: " + broadcastReceiver);
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
 
@@ -431,6 +439,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromBroadcastReceiver() {
     if (isAttachedToBroadcastReceiver()) {
+      Log.v(TAG, "Detaching from BroadcastReceiver: " + broadcastReceiver);
       // Notify all BroadcastReceiverAware plugins that they are no longer attached to a BroadcastReceiver.
       for (BroadcastReceiverAware broadcastReceiverAware : broadcastReceiverAwarePlugins.values()) {
         broadcastReceiverAware.onDetachedFromBroadcastReceiver();
@@ -448,6 +457,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToContentProvider(@NonNull ContentProvider contentProvider, @NonNull Lifecycle lifecycle) {
+    Log.v(TAG, "Attaching to ContentProvider: " + contentProvider);
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
 
@@ -464,6 +474,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromContentProvider() {
     if (isAttachedToContentProvider()) {
+      Log.v(TAG, "Detaching from ContentProvider: " + contentProvider);
       // Notify all ContentProviderAware plugins that they are no longer attached to a ContentProvider.
       for (ContentProviderAware contentProviderAware : contentProviderAwarePlugins.values()) {
         contentProviderAware.onDetachedFromContentProvider();

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -8,10 +8,10 @@ import android.content.res.AssetManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
-import android.util.Log;
 
 import java.nio.ByteBuffer;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.view.FlutterCallbackInformation;
@@ -62,6 +62,7 @@ public class DartExecutor implements BinaryMessenger {
    * </ul>
    */
   public void onAttachedToJNI() {
+    Log.v(TAG, "Attached to JNI. Registering the platform message handler for this Dart execution context.");
     flutterJNI.setPlatformMessageHandler(messenger);
   }
 
@@ -73,6 +74,7 @@ public class DartExecutor implements BinaryMessenger {
    * the Dart execution context.
    */
   public void onDetachedFromJNI() {
+    Log.v(TAG, "Detached from JNI. De-registering the platform message handler for this Dart execution context.");
     flutterJNI.setPlatformMessageHandler(null);
   }
 
@@ -97,6 +99,8 @@ public class DartExecutor implements BinaryMessenger {
       Log.w(TAG, "Attempted to run a DartExecutor that is already running.");
       return;
     }
+
+    Log.v(TAG, "Executing Dart entrypoint: " + dartEntrypoint);
 
     flutterJNI.runBundleAndSnapshotFromLibrary(
         new String[]{
@@ -123,6 +127,8 @@ public class DartExecutor implements BinaryMessenger {
       Log.w(TAG, "Attempted to run a DartExecutor that is already running.");
       return;
     }
+
+    Log.v(TAG, "Executing Dart callback: " + dartCallback);
 
     flutterJNI.runBundleAndSnapshotFromLibrary(
         new String[]{
@@ -234,6 +240,12 @@ public class DartExecutor implements BinaryMessenger {
       this.pathToFallbackBundle = pathToFallbackBundle;
       this.dartEntrypointFunctionName = dartEntrypointFunctionName;
     }
+
+    @Override
+    @NonNull
+    public String toString() {
+      return "DartEntrypoint( bundle path: " + pathToPrimaryBundle + ", function: " + dartEntrypointFunctionName + " )";
+    }
   }
 
   /**
@@ -284,6 +296,14 @@ public class DartExecutor implements BinaryMessenger {
       this.pathToPrimaryBundle = pathToPrimaryBundle;
       this.pathToFallbackBundle = pathToFallbackBundle;
       this.callbackHandle = callbackHandle;
+    }
+
+    @Override
+    @NonNull
+    public String toString() {
+      return "DartCallback( bundle path: " + pathToPrimaryBundle
+          + ", library path: " + callbackHandle.callbackLibraryPath
+          + ", function: " + callbackHandle.callbackName + " )";
     }
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
@@ -7,13 +7,13 @@ package io.flutter.embedding.engine.dart;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
-import android.util.Log;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.plugin.common.BinaryMessenger;
 
@@ -47,8 +47,10 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
   @Override
   public void setMessageHandler(@NonNull String channel, @Nullable BinaryMessenger.BinaryMessageHandler handler) {
     if (handler == null) {
+      Log.v(TAG, "Removing handler for channel '" + channel + "'");
       messageHandlers.remove(channel);
     } else {
+      Log.v(TAG, "Setting handler for channel '" + channel + "'");
       messageHandlers.put(channel, handler);
     }
   }
@@ -56,6 +58,7 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
   @Override
   @UiThread
   public void send(@NonNull String channel, @NonNull ByteBuffer message) {
+    Log.v(TAG, "Sending message over channel '" + channel + "'");
     send(channel, message, null);
   }
 
@@ -65,6 +68,7 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
       @Nullable ByteBuffer message,
       @Nullable BinaryMessenger.BinaryReply callback
   ) {
+    Log.v(TAG, "Sending message with callback over channel '" + channel + "'");
     int replyId = 0;
     if (callback != null) {
       replyId = nextReplyId++;
@@ -83,9 +87,11 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
       @Nullable byte[] message,
       final int replyId
   ) {
+    Log.v(TAG, "Received message from Dart over channel '" + channel + "'");
     BinaryMessenger.BinaryMessageHandler handler = messageHandlers.get(channel);
     if (handler != null) {
       try {
+        Log.v(TAG, "Deferring to registered handler to process message.");
         final ByteBuffer buffer = (message == null ? null : ByteBuffer.wrap(message));
         handler.onMessage(buffer, new Reply(flutterJNI, replyId));
       } catch (Exception ex) {
@@ -93,15 +99,18 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
         flutterJNI.invokePlatformMessageEmptyResponseCallback(replyId);
       }
     } else {
+      Log.v(TAG, "No registered handler for message. Responding to Dart with empty reply message.");
       flutterJNI.invokePlatformMessageEmptyResponseCallback(replyId);
     }
   }
 
   @Override
   public void handlePlatformMessageResponse(int replyId, @Nullable byte[] reply) {
+    Log.v(TAG, "Received message reply from Dart.");
     BinaryMessenger.BinaryReply callback = pendingReplies.remove(replyId);
     if (callback != null) {
       try {
+        Log.v(TAG, "Invoking registered callback for reply from Dart.");
         callback.reply(reply == null ? null : ByteBuffer.wrap(reply));
       } catch (Exception ex) {
         Log.e(TAG, "Uncaught exception in binary message reply handler", ex);

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
@@ -10,6 +10,7 @@ import android.support.annotation.NonNull;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.platform.PlatformViewsController;
@@ -32,12 +33,15 @@ import io.flutter.view.FlutterView;
  * }
  */
 public class ShimPluginRegistry implements PluginRegistry {
+  private static final String TAG = "ShimPluginRegistry";
+
   private final FlutterEngine flutterEngine;
   private final PlatformViewsController platformViewsController;
   private final Map<String, Object> pluginMap = new HashMap<>();
   private final FlutterEngine.EngineLifecycleListener engineLifecycleListener = new FlutterEngine.EngineLifecycleListener() {
     @Override
     public void onPreEngineRestart() {
+      Log.v(TAG, "onPreEngineRestart()");
       ShimPluginRegistry.this.onPreEngineRestart();
     }
   };
@@ -53,6 +57,7 @@ public class ShimPluginRegistry implements PluginRegistry {
 
   @Override
   public Registrar registrarFor(String pluginKey) {
+    Log.v(TAG, "Creating plugin Registrar for '" + pluginKey + "'");
     if (pluginMap.containsKey(pluginKey)) {
       throw new IllegalStateException("Plugin key " + pluginKey + " is already in use");
     }
@@ -75,10 +80,12 @@ public class ShimPluginRegistry implements PluginRegistry {
 
   //----- From FlutterPluginRegistry that aren't in the PluginRegistry interface ----//
   public void attach(FlutterView flutterView, Activity activity) {
+    Log.v(TAG, "Attaching to a FlutterView and an Activity.");
     platformViewsController.attach(activity, flutterEngine.getRenderer(), flutterEngine.getDartExecutor());
   }
 
   public void detach() {
+    Log.v(TAG, "Detaching from a FlutterView and an Activity.");
     platformViewsController.detach();
     platformViewsController.onFlutterViewDestroyed();
   }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimRegistrar.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimRegistrar.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
@@ -150,11 +151,13 @@ class ShimRegistrar implements PluginRegistry.Registrar, FlutterPlugin, Activity
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
+    Log.v(TAG, "Attached to FlutterEngine.");
     pluginBinding = binding;
   }
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    Log.v(TAG, "Detached from FlutterEngine.");
     for (PluginRegistry.ViewDestroyListener listener : viewDestroyListeners) {
       // The following invocation might produce unexpected behavior in old plugins because
       // we have no FlutterNativeView to pass to onViewDestroy(). This is a limitation of this shim.
@@ -166,23 +169,27 @@ class ShimRegistrar implements PluginRegistry.Registrar, FlutterPlugin, Activity
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
+    Log.v(TAG, "Attached to an Activity.");
     activityPluginBinding = binding;
     addExistingListenersToActivityPluginBinding();
   }
 
   @Override
   public void onDetachedFromActivityForConfigChanges() {
+    Log.v(TAG, "Detached from an Activity for config changes.");
     activityPluginBinding = null;
   }
 
   @Override
   public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
+    Log.v(TAG, "Reconnected to an Activity after config changes.");
     activityPluginBinding = binding;
     addExistingListenersToActivityPluginBinding();
   }
 
   @Override
   public void onDetachedFromActivity() {
+    Log.v(TAG, "Detached from an Activity.");
     activityPluginBinding = null;
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -16,6 +16,7 @@ import android.view.Surface;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
 
+import io.flutter.Log;
 import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.view.TextureRegistry;
@@ -35,6 +36,7 @@ import io.flutter.view.TextureRegistry;
  */
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
 public class FlutterRenderer implements TextureRegistry {
+  private static final String TAG = "FlutterRenderer";
 
   private final FlutterJNI flutterJNI;
   private final AtomicLong nextTextureId = new AtomicLong(0L);
@@ -53,8 +55,10 @@ public class FlutterRenderer implements TextureRegistry {
   }
 
   public void attachToRenderSurface(@NonNull RenderSurface renderSurface) {
+    Log.v(TAG, "Attaching to RenderSurface.");
     // TODO(mattcarroll): determine desired behavior when attaching to an already attached renderer
     if (this.renderSurface != null) {
+      Log.v(TAG, "Already attached to a RenderSurface. Detaching from old one and attaching to new one.");
       detachFromRenderSurface();
     }
 
@@ -64,6 +68,7 @@ public class FlutterRenderer implements TextureRegistry {
   }
 
   public void detachFromRenderSurface() {
+    Log.v(TAG, "Detaching from RenderSurface.");
     // TODO(mattcarroll): determine desired behavior if we're asked to detach without first being attached
     if (this.renderSurface != null) {
       this.renderSurface.detachFromRenderer();
@@ -86,12 +91,14 @@ public class FlutterRenderer implements TextureRegistry {
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   @Override
   public SurfaceTextureEntry createSurfaceTexture() {
+    Log.v(TAG, "Creating a SurfaceTexture.");
     final SurfaceTexture surfaceTexture = new SurfaceTexture(0);
     surfaceTexture.detachFromGLContext();
     final SurfaceTextureRegistryEntry entry = new SurfaceTextureRegistryEntry(
         nextTextureId.getAndIncrement(),
         surfaceTexture
     );
+    Log.v(TAG, "New SurfaceTexture ID: " + entry.id());
     registerTexture(entry.id(), surfaceTexture);
     return entry;
   }
@@ -146,6 +153,7 @@ public class FlutterRenderer implements TextureRegistry {
       if (released) {
         return;
       }
+      Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
       surfaceTexture.release();
       unregisterTexture(id);
       released = true;
@@ -170,6 +178,13 @@ public class FlutterRenderer implements TextureRegistry {
 
   // TODO(mattcarroll): describe the native behavior that this invokes
   public void setViewportMetrics(@NonNull ViewportMetrics viewportMetrics) {
+    Log.v(TAG, "Setting viewport metrics\n"
+      + "Size: " + viewportMetrics.width + " x " + viewportMetrics.height + "\n"
+      + "Padding - L: " + viewportMetrics.paddingLeft + ", T: " + viewportMetrics.paddingTop
+        + ", R: " + viewportMetrics.paddingRight + ", B: " + viewportMetrics.paddingBottom + "\n"
+      + "Insets - L: " + viewportMetrics.viewInsetLeft + ", T: " + viewportMetrics.viewInsetTop
+        + ", R: " + viewportMetrics.viewInsetRight + ", B: " + viewportMetrics.viewInsetBottom);
+
     flutterJNI.setViewportMetrics(
         viewportMetrics.devicePixelRatio,
         viewportMetrics.width,

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -4,8 +4,8 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.HashMap;
-import java.util.Map;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.BasicMessageChannel;
@@ -19,6 +19,8 @@ import io.flutter.view.AccessibilityBridge;
  * events that might be sent from Flutter to the Android platform.
  */
 public class AccessibilityChannel {
+  private static final String TAG = "AccessibilityChannel";
+
   @NonNull
   public final BasicMessageChannel<Object> channel;
   @NonNull
@@ -41,6 +43,7 @@ public class AccessibilityChannel {
       @SuppressWarnings("unchecked")
       final HashMap<String, Object> data = (HashMap<String, Object>) annotatedEvent.get("data");
 
+      Log.v(TAG, "Received " + type + " message.");
       switch (type) {
         case "announce":
           String announceMessage = (String) data.get("message");

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
@@ -6,6 +6,7 @@ package io.flutter.embedding.engine.systemchannels;
 
 import android.support.annotation.NonNull;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.StringCodec;
@@ -14,6 +15,7 @@ import io.flutter.plugin.common.StringCodec;
  * TODO(mattcarroll): fill in javadoc for LifecycleChannel.
  */
 public class LifecycleChannel {
+  private static final String TAG = "LifecycleChannel";
 
   @NonNull
   public final BasicMessageChannel<String> channel;
@@ -23,14 +25,17 @@ public class LifecycleChannel {
   }
 
   public void appIsInactive() {
+    Log.v(TAG, "Sending AppLifecycleState.inactive message.");
     channel.send("AppLifecycleState.inactive");
   }
 
   public void appIsResumed() {
+    Log.v(TAG, "Sending AppLifecycleState.resumed message.");
     channel.send("AppLifecycleState.resumed");
   }
 
   public void appIsPaused() {
+    Log.v(TAG, "Sending AppLifecycleState.paused message.");
     channel.send("AppLifecycleState.paused");
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -8,10 +8,10 @@ import android.os.Build;
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodChannel;
@@ -20,6 +20,7 @@ import io.flutter.plugin.common.MethodChannel;
  * Sends the platform's locales to Dart.
  */
 public class LocalizationChannel {
+  private static final String TAG = "LocalizationChannel";
 
   @NonNull
   public final MethodChannel channel;
@@ -32,8 +33,12 @@ public class LocalizationChannel {
    * Send the given {@code locales} to Dart.
    */
   public void sendLocales(List<Locale> locales) {
+    Log.v(TAG, "Sending Locales to Flutter.");
     List<String> data = new ArrayList<>();
     for (Locale locale : locales) {
+      Log.v(TAG, "Locale (Language: " + locale.getLanguage()
+          + ", Country: " + locale.getCountry()
+          + ", Variant: " + locale.getVariant() + ")");
       data.add(locale.getLanguage());
       data.add(locale.getCountry());
       // locale.getScript() was added in API 21.

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
@@ -7,6 +7,7 @@ package io.flutter.embedding.engine.systemchannels;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodChannel;
@@ -15,6 +16,7 @@ import io.flutter.plugin.common.MethodChannel;
  * TODO(mattcarroll): fill in javadoc for NavigationChannel.
  */
 public class NavigationChannel {
+  private static final String TAG = "NavigationChannel";
 
   @NonNull
   public final MethodChannel channel;
@@ -24,14 +26,17 @@ public class NavigationChannel {
   }
 
   public void setInitialRoute(String initialRoute) {
+    Log.v(TAG, "Sending message to set initial route to '" + initialRoute + "'");
     channel.invokeMethod("setInitialRoute", initialRoute);
   }
 
   public void pushRoute(String route) {
+    Log.v(TAG, "Sending message to push route '" + route + "'");
     channel.invokeMethod("pushRoute", route);
   }
 
   public void popRoute() {
+    Log.v(TAG, "Sending message to pop route.");
     channel.invokeMethod("popRoute", null);
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
@@ -25,6 +26,8 @@ import io.flutter.plugin.common.MethodChannel;
  * effects, system chrome configurations, and clipboard interaction.
  */
 public class PlatformChannel {
+  private static final String TAG = "PlatformChannel";
+
   @NonNull
   public final MethodChannel channel;
   @Nullable
@@ -41,6 +44,7 @@ public class PlatformChannel {
 
       String method = call.method;
       Object arguments = call.arguments;
+      Log.v(TAG, "Received '" + method + "' message.");
       try {
         switch (method) {
           case "SystemSound.play":

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -11,6 +11,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -23,6 +24,8 @@ import io.flutter.plugin.common.StandardMethodCodec;
  * Register a {@link PlatformViewsHandler} to implement the Android side of this channel.
  */
 public class PlatformViewsChannel {
+  private static final String TAG = "PlatformViewsChannel";
+
   private final MethodChannel channel;
   private PlatformViewsHandler handler;
 
@@ -42,6 +45,7 @@ public class PlatformViewsChannel {
         return;
       }
 
+      Log.v(TAG, "Received '" + call.method + "' message.");
       switch (call.method) {
         case "create":
           create(call, result);

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SettingsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SettingsChannel.java
@@ -1,6 +1,8 @@
 package io.flutter.embedding.engine.systemchannels;
 
 import android.support.annotation.NonNull;
+
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.JSONMessageCodec;
@@ -9,7 +11,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class SettingsChannel {
+  private static final String TAG = "SettingsChannel";
+
   public static final String CHANNEL_NAME = "flutter/settings";
+  private static final String TEXT_SCALE_FACTOR = "textScaleFactor";
+  private static final String ALWAYS_USE_24_HOUR_FORMAT = "alwaysUse24HourFormat";
+  private static final String PLATFORM_BRIGHTNESS = "platformBrightness";
   
   public final BasicMessageChannel<Object> channel;
   
@@ -30,21 +37,25 @@ public class SettingsChannel {
     }
     
     public MessageBuilder setTextScaleFactor(float textScaleFactor) {
-      message.put("textScaleFactor", textScaleFactor);
+      message.put(TEXT_SCALE_FACTOR, textScaleFactor);
       return this;
     }
     
     public MessageBuilder setUse24HourFormat(boolean use24HourFormat) {
-      message.put("alwaysUse24HourFormat", use24HourFormat);
+      message.put(ALWAYS_USE_24_HOUR_FORMAT, use24HourFormat);
       return this;
     }
     
     public MessageBuilder setPlatformBrightness(@NonNull PlatformBrightness brightness) {
-      message.put("platformBrightness", brightness.name);
+      message.put(PLATFORM_BRIGHTNESS, brightness.name);
       return this;
     }
     
     public void send() {
+      Log.v(TAG, "Sending message: \n"
+        + "textScaleFactor: " + message.get(TEXT_SCALE_FACTOR) + "\n"
+        + "alwaysUse24HourFormat: " + message.get(ALWAYS_USE_24_HOUR_FORMAT) + "\n"
+        + "platformBrightness: " + message.get(PLATFORM_BRIGHTNESS));
       channel.send(message);
     }
   }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SystemChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SystemChannel.java
@@ -9,6 +9,7 @@ import android.support.annotation.NonNull;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.JSONMessageCodec;
@@ -17,6 +18,7 @@ import io.flutter.plugin.common.JSONMessageCodec;
  * TODO(mattcarroll): fill in javadoc for SystemChannel.
  */
 public class SystemChannel {
+  private static final String TAG = "SystemChannel";
 
   @NonNull
   public final BasicMessageChannel<Object> channel;
@@ -26,6 +28,7 @@ public class SystemChannel {
   }
 
   public void sendMemoryPressureWarning() {
+    Log.v(TAG, "Sending memory pressure warning to Flutter.");
     Map<String, Object> message = new HashMap<>(1);
     message.put("type", "memoryPressure");
     channel.send(message);

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -11,6 +11,7 @@ import org.json.JSONObject;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
@@ -32,6 +33,7 @@ import io.flutter.plugin.common.MethodChannel;
  */
 public class TextInputChannel {
   private static final String TAG = "TextInputChannel";
+
   @NonNull
   public final MethodChannel channel;
   @Nullable
@@ -48,6 +50,7 @@ public class TextInputChannel {
 
       String method = call.method;
       Object args = call.arguments;
+      Log.v(TAG, "Received '" + method + "' message.");
       switch (method) {
         case "TextInput.show":
           textInputMethodHandler.show();
@@ -111,6 +114,13 @@ public class TextInputChannel {
    * Instructs Flutter to update its text input editing state to reflect the given configuration.
    */
   public void updateEditingState(int inputClientId, String text, int selectionStart, int selectionEnd, int composingStart, int composingEnd) {
+    Log.v(TAG, "Sending message to update editing state: \n"
+      + "Text: " + text + "\n"
+      + "Selection start: " + selectionStart + "\n"
+      + "Selection end: " + selectionEnd + "\n"
+      + "Composing start: " + composingStart + "\n"
+      + "Composing end: " + composingEnd);
+
     HashMap<Object, Object> state = new HashMap<>();
     state.put("text", text);
     state.put("selectionBase", selectionStart);
@@ -128,6 +138,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "newline" action.
    */
   public void newline(int inputClientId) {
+    Log.v(TAG, "Sending 'newline' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.newline")
@@ -138,6 +149,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "go" action.
    */
   public void go(int inputClientId) {
+    Log.v(TAG, "Sending 'go' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.go")
@@ -148,6 +160,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "search" action.
    */
   public void search(int inputClientId) {
+    Log.v(TAG, "Sending 'search' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.search")
@@ -158,6 +171,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "send" action.
    */
   public void send(int inputClientId) {
+    Log.v(TAG, "Sending 'send' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.send")
@@ -168,6 +182,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "done" action.
    */
   public void done(int inputClientId) {
+    Log.v(TAG, "Sending 'done' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.done")
@@ -178,6 +193,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "next" action.
    */
   public void next(int inputClientId) {
+    Log.v(TAG, "Sending 'next' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.next")
@@ -188,6 +204,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "previous" action.
    */
   public void previous(int inputClientId) {
+    Log.v(TAG, "Sending 'previous' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.previous")
@@ -198,6 +215,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute an "unspecified" action.
    */
   public void unspecifiedAction(int inputClientId) {
+    Log.v(TAG, "Sending 'unspecified' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.unspecified")


### PR DESCRIPTION
Android Embedding Refactor PR32: Clean up logs in new embedding.

This PR:

- Migrates all `Log` usages in the new embedding to the `io.flutter.Log` proxy
- Removes logs that I believe are not useful for typical embedding debugging
- Adds logs that I believe would be useful for typical embedding debugging
- Adjusts all log levels to what seemed like an appropriate level to me

Address #33544 and #33102