### PR TITLE
Request FlutterView focus when setting a platform view text client

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -262,6 +262,10 @@ public class TextInputPlugin {
     }
 
     private void setPlatformViewTextInputClient(int platformViewId) {
+        // We need to make sure that the Flutter view is focused so that no imm operations get short circuited.
+        // Not asking for focus here specifically manifested in a but on API 28 devices where the platform view's
+        // request to show a keyboard was ignored.
+        mView.requestFocus();
         inputTarget = new InputTarget(InputTarget.Type.PLATFORM_VIEW, platformViewId);
         mImm.restartInput(mView);
         mRestartInputPending = false;


### PR DESCRIPTION
When the FlutterView is not focused, imm operations may be short-circuited by the system.

I didn't see any issues with that starting API level 29, but on API 28 the webview could not show the keyboard unless a Flutter text field previously has shown the keyboard(since the TextInputPlugin is requesting focus when showing the keyboard, I guess for the same reason).

https://github.com/flutter/flutter/issues/19718