### PR TITLE
Do not remove the DartServiceIsolate status callback during FlutterMain destruction

### DIFF
--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -42,11 +42,7 @@ fml::jni::ScopedJavaGlobalRef<jclass>* g_flutter_jni_class = nullptr;
 FlutterMain::FlutterMain(flutter::Settings settings)
     : settings_(std::move(settings)), observatory_uri_callback_() {}
 
-FlutterMain::~FlutterMain() {
-  if (observatory_uri_callback_) {
-    DartServiceIsolate::RemoveServerStatusCallback(observatory_uri_callback_);
-  }
-}
+FlutterMain::~FlutterMain() = default;
 
 static std::unique_ptr<FlutterMain> g_flutter_main;
 


### PR DESCRIPTION
FlutterMain and the DartServiceIsolate callback list are both globals, and the
callback list state may have already been destructed when FlutterMain's
destructor runs.