### PR TITLE
Wire intent args for observatory port

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -312,6 +312,13 @@ public final class FlutterActivityDelegate
         if (intent.getBooleanExtra("verbose-logging", false)) {
             args.add("--verbose-logging");
         }
+        final int observatoryPort = intent.getIntExtra("observatory-port", 0);
+        if (observatoryPort > 0) {
+            args.add("--observatory-port=" + Integer.toString(observatoryPort));
+        }
+        if (intent.getBooleanExtra("disable-service-auth-codes", false)) {
+            args.add("--disable-service-auth-codes");
+        }
         // NOTE: all flags provided with this argument are subject to filtering
         // based on a whitelist in shell/common/switches.cc. If any flag provided
         // is not present in the whitelist, the process will immediately

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java
@@ -43,6 +43,8 @@ public class FlutterShellArgs {
   public static final String ARG_DUMP_SHADER_SKP_ON_SHADER_COMPILATION = "--dump-skp-on-shader-compilation";
   public static final String ARG_KEY_VERBOSE_LOGGING = "verbose-logging";
   public static final String ARG_VERBOSE_LOGGING = "--verbose-logging";
+  public static final String ARG_KEY_OBSERVATORY_PORT = "observatory-port";
+  public static final String ARG_OBSERVATORY_PORT = "--observatory-port=";
 
   @NonNull
   public static FlutterShellArgs fromIntent(@NonNull Intent intent) {
@@ -57,6 +59,10 @@ public class FlutterShellArgs {
     }
     if (intent.getBooleanExtra(ARG_KEY_START_PAUSED, false)) {
       args.add(ARG_START_PAUSED);
+    }
+    final int observatoryPort = intent.getIntExtra(ARG_KEY_OBSERVATORY_PORT, 0);
+    if (observatoryPort > 0) {
+      args.add(ARG_OBSERVATORY_PORT + Integer.toString(observatoryPort));
     }
     if (intent.getBooleanExtra(ARG_KEY_DISABLE_SERVICE_AUTH_CODES, false)) {
       args.add(ARG_DISABLE_SERVICE_AUTH_CODES);


### PR DESCRIPTION
Addresses engine part of https://github.com/flutter/flutter/issues/34731

This will allow people (particularly add-to-app) to specify the observatory port as arguments to the app.