### PR TITLE
Add Dart SDK > 2.3.0 constraint to license script

### DIFF
--- a/tools/licenses/pubspec.yaml
+++ b/tools/licenses/pubspec.yaml
@@ -5,3 +5,5 @@ dependencies:
   crypto: ^2.0.2+1
   meta: ^1.1.6
   path: ^1.3.0
+environment:
+  sdk: '>=2.3.0 <3.0.0'


### PR DESCRIPTION
The license script uses Set literals among other Dart 2.3.0 features.