### PR TITLE
[glfw] Send the glfw key data to the framework.

### DIFF
--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -391,7 +391,6 @@ static void SetHoverCallbacksEnabled(GLFWwindow* window, bool enabled) {
 
 // Flushes event queue and then assigns default window callbacks.
 static void GLFWAssignEventCallbacks(GLFWwindow* window) {
-  std::cout << "Assigning callbacks \n";
   glfwPollEvents();
   glfwSetKeyCallback(window, GLFWKeyCallback);
   glfwSetCharCallback(window, GLFWCharCallback);

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -391,6 +391,7 @@ static void SetHoverCallbacksEnabled(GLFWwindow* window, bool enabled) {
 
 // Flushes event queue and then assigns default window callbacks.
 static void GLFWAssignEventCallbacks(GLFWwindow* window) {
+  std::cout << "Assigning callbacks \n";
   glfwPollEvents();
   glfwSetKeyCallback(window, GLFWKeyCallback);
   glfwSetCharCallback(window, GLFWCharCallback);

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -4,8 +4,6 @@
 
 #include "flutter/shell/platform/glfw/key_event_handler.h"
 
-#include <bits/stdint-uintn.h>
-
 #include <cstddef>
 #include <cstdint>
 #include <iostream>
@@ -21,7 +19,8 @@ static constexpr char kScanCodeKey[] = "scanCode";
 static constexpr char kModifiersKey[] = "modifiers";
 static constexpr char kTypeKey[] = "type";
 static constexpr char kToolkitKey[] = "toolkit";
-static constexpr char kCodePoint[] = "unicodeScalarValuesProduced";
+static constexpr char kUnicodeScalarValuesProduced[] =
+    "unicodeScalarValuesProduced";
 
 static constexpr char kLinuxKeyMap[] = "linux";
 static constexpr char kGLFWKey[] = "glfw";
@@ -103,7 +102,7 @@ void KeyEventHandler::KeyboardHook(GLFWwindow* window,
   const char* keyName = glfwGetKeyName(key, scancode);
   if (keyName != nullptr) {
     uint32_t unicodeInt = DecodeUTF8(keyName);
-    event.AddMember(kCodePoint, unicodeInt, allocator);
+    event.AddMember(kUnicodeScalarValuesProduced, unicodeInt, allocator);
   }
 
   switch (action) {

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -4,7 +4,9 @@
 
 #include "flutter/shell/platform/glfw/key_event_handler.h"
 
+#include <cstddef>
 #include <iostream>
+#include <map>
 
 #include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/json_message_codec.h"
 
@@ -16,7 +18,7 @@ static constexpr char kScanCodeKey[] = "scanCode";
 static constexpr char kModifiersKey[] = "modifiers";
 static constexpr char kTypeKey[] = "type";
 static constexpr char kToolkitKey[] = "toolkit";
-static constexpr char kCodePoint[] = "codePoint";
+static constexpr char kCodePoint[] = "unicodeScalarValuesProduced";
 
 static constexpr char kLinuxKeyMap[] = "linux";
 static constexpr char kGLFWKey[] = "glfw";
@@ -37,6 +39,48 @@ KeyEventHandler::~KeyEventHandler() = default;
 
 void KeyEventHandler::CharHook(GLFWwindow* window, unsigned int code_point) {}
 
+
+
+std::map<int, int> GetMasksMap() {
+  std::map<int, int> masks;
+  masks[4] = 0x07;
+  masks[3] = 0x0F;
+  masks[2] = 0x1F;
+  masks[1] = 0xFF;
+  return masks;
+}
+
+std::map<int, int> GetShiftMap() {
+  std::map<int, int> bits;
+  bits[1] = 0;
+  bits[2] = 6;
+  bits[3] = 12;
+  bits[4] = 18;
+  return bits;
+}
+
+int DecodeUTF8(const char* utf8) {
+  size_t length = strlen(utf8);
+  length = length >= 4 ? length : length;
+
+  int shift = length;
+  auto masks = GetMasksMap();
+  auto bits = GetShiftMap();
+  int complement_mask = 0x3F;
+  int result = 0;
+
+  size_t current_byte_index = 0;
+  while (current_byte_index < length) {
+    int current_byte = utf8[current_byte_index];
+    int mask =
+        current_byte_index == 0 ? masks[length] : complement_mask;
+
+    current_byte_index++;
+    result += (current_byte & mask) << bits[shift--];
+  }
+
+  return result;
+}
 void KeyEventHandler::KeyboardHook(GLFWwindow* window,
                                    int key,
                                    int scancode,
@@ -57,17 +101,23 @@ void KeyEventHandler::KeyboardHook(GLFWwindow* window,
   // layouts configured on their machines, will not always return the right
   // value. See: https://github.com/glfw/glfw/issues/1462
   const char* keyName = glfwGetKeyName(key, scancode);
-  std::string nameString(keyName);
-  int first = (int)nameString.at(0);
-  int total = first;
-  int second = 0;
-  if (nameString.size() > 1) {
-   second = (int)nameString.at(1);
-   total = (first << 16) | second;
-  }
   if (keyName != nullptr) {
-    event.AddMember(kCodePoint, total, allocator);
+  int unicodeInt = DecodeUTF8(keyName);
+  event.AddMember(kCodePoint, unicodeInt, allocator);
   }
+  // std::string nameString(keyName);
+  // int first = (int)nameString.at(0);
+  // int total = first;
+  // int second = 0;
+  // if (nameString.size() > 1) {
+  //  second = (int)nameString.at(1);
+  //  total = (first << 16) | second;
+  // }
+  // if (keyName != nullptr) {
+  //   event.AddMember(kCodePoint, total, allocator);
+  // }
+
+
 
   switch (action) {
     case GLFW_PRESS:

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -67,8 +67,8 @@ UTF8CodePointInfo GetUTF8CodePointInfo(int first_byte) {
 
 // Queries GLFW for the printable key name given a [key] and [scan_code] and
 // converts it to UTF-32. The Flutter framework accepts only one code point,
-// therefore, only the first code point will be used. This unlikely but there is
-// no guarantee that it won't happen.
+// therefore, only the first code point will be used. There is unlikely to be
+// more than one, but there is no guarantee that it won't happen.
 bool GetUTF32CodePointFromGLFWKey(int key,
                                   int scan_code,
                                   uint32_t* code_point) {

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -4,7 +4,6 @@
 
 #include "flutter/shell/platform/glfw/key_event_handler.h"
 
-#include <cstddef>
 #include <iostream>
 #include <vector>
 
@@ -29,9 +28,10 @@ static constexpr char kKeyDown[] = "keydown";
 
 namespace flutter {
 
-// Converts a utf8 const char* to a 32 bit int. The Flutter framework accepts
-// only one 32 bit int, therefore, only up to 4 bytes are accepted. If its
-// larger than 4 bytes, only the first 4 will be used.
+// Queries GLFW for the printable key name given a [key] and [scan_code] and
+// converts it to a 32 bit int.The Flutter framework accepts only one 32 bit
+// int, therefore, only up to 4 bytes are accepted. If the code point larger
+// than 4 bytes, only the first 4 will be used.
 //
 // Example:
 // 中 (11100100 10111000 10101101) converts to 20013 (1001110 00101101).

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -93,8 +93,6 @@ bool GetGLFWCodePoint(int key, int scan_code, uint32_t& code_point) {
   size_t current_byte_index = 0;
   while (current_byte_index < length) {
     int current_byte = utf8[current_byte_index];
-    // Get the relevant mask for the first byte. Otherwise, get the complement
-    // mask.
     int mask =
         current_byte_index == 0 ? byte_info.first_byte_mask : complement_mask;
     current_byte_index++;

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -4,7 +4,6 @@
 
 #include "flutter/shell/platform/glfw/key_event_handler.h"
 
-#include <cstdio>
 #include <iostream>
 #include <vector>
 

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -12,9 +12,16 @@ static constexpr char kChannelName[] = "flutter/keyevent";
 
 static constexpr char kKeyCodeKey[] = "keyCode";
 static constexpr char kKeyMapKey[] = "keymap";
+static constexpr char kScanCodeKey[] = "scanCode";
+static constexpr char kModifiersKey[] = "modifiers";
 static constexpr char kTypeKey[] = "type";
+static constexpr char kToolkitKey[] = "toolkit";
+static constexpr char kCharactersIgnoringModifiersKey[] =
+    "charactersIgnoringModifiers";
 
-static constexpr char kAndroidKeyMap[] = "android";
+static constexpr char kLinuxKeyMap[] = "linux";
+static constexpr char kGLFWKey[] = "glfw";
+
 static constexpr char kKeyUp[] = "keyup";
 static constexpr char kKeyDown[] = "keydown";
 
@@ -41,7 +48,20 @@ void KeyEventHandler::KeyboardHook(GLFWwindow* window,
   rapidjson::Document event(rapidjson::kObjectType);
   auto& allocator = event.GetAllocator();
   event.AddMember(kKeyCodeKey, key, allocator);
-  event.AddMember(kKeyMapKey, kAndroidKeyMap, allocator);
+  event.AddMember(kKeyMapKey, kLinuxKeyMap, allocator);
+  event.AddMember(kScanCodeKey, scancode, allocator);
+  event.AddMember(kModifiersKey, mods, allocator);
+  event.AddMember(kToolkitKey, kGLFWKey, allocator);
+
+  // Get the name of the printable key, encoded as UTF-8.
+  // There's a known issue with glfwGetKeyName, where users with multiple
+  // layouts configured on their machines, will not always return the right
+  // value. See: https://github.com/glfw/glfw/issues/1462
+  const char* keyName = glfwGetKeyName(key, scancode);
+  if (keyName != nullptr) {
+    event.AddMember(kCharactersIgnoringModifiersKey, std::string(keyName),
+                    allocator);
+  }
 
   switch (action) {
     case GLFW_PRESS:

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -16,8 +16,7 @@ static constexpr char kScanCodeKey[] = "scanCode";
 static constexpr char kModifiersKey[] = "modifiers";
 static constexpr char kTypeKey[] = "type";
 static constexpr char kToolkitKey[] = "toolkit";
-static constexpr char kUnicodeScalarValues[] =
-    "unicodeScalarValues";
+static constexpr char kUnicodeScalarValues[] = "unicodeScalarValues";
 
 static constexpr char kLinuxKeyMap[] = "linux";
 static constexpr char kGLFWKey[] = "glfw";

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -16,8 +16,8 @@ static constexpr char kScanCodeKey[] = "scanCode";
 static constexpr char kModifiersKey[] = "modifiers";
 static constexpr char kTypeKey[] = "type";
 static constexpr char kToolkitKey[] = "toolkit";
-static constexpr char kUnicodeScalarValuesProduced[] =
-    "unicodeScalarValuesProduced";
+static constexpr char kUnicodeScalarValues[] =
+    "unicodeScalarValues";
 
 static constexpr char kLinuxKeyMap[] = "linux";
 static constexpr char kGLFWKey[] = "glfw";
@@ -131,7 +131,7 @@ void KeyEventHandler::KeyboardHook(GLFWwindow* window,
   uint32_t unicodeInt;
   bool result = GetUTF32CodePointFromGLFWKey(key, scancode, &unicodeInt);
   if (result) {
-    event.AddMember(kUnicodeScalarValuesProduced, unicodeInt, allocator);
+    event.AddMember(kUnicodeScalarValues, unicodeInt, allocator);
   }
 
   switch (action) {

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -57,8 +57,16 @@ void KeyEventHandler::KeyboardHook(GLFWwindow* window,
   // layouts configured on their machines, will not always return the right
   // value. See: https://github.com/glfw/glfw/issues/1462
   const char* keyName = glfwGetKeyName(key, scancode);
+  std::string nameString(keyName);
+  int first = (int)nameString.at(0);
+  int total = first;
+  int second = 0;
+  if (nameString.size() > 1) {
+   second = (int)nameString.at(1);
+   total = (first << 16) | second;
+  }
   if (keyName != nullptr) {
-    event.AddMember(kCodePoint, std::string(keyName), allocator);
+    event.AddMember(kCodePoint, total, allocator);
   }
 
   switch (action) {

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -4,8 +4,6 @@
 
 #include "flutter/shell/platform/glfw/key_event_handler.h"
 
-#include <cstddef>
-#include <cstdint>
 #include <iostream>
 #include <map>
 

--- a/shell/platform/glfw/key_event_handler.cc
+++ b/shell/platform/glfw/key_event_handler.cc
@@ -16,8 +16,7 @@ static constexpr char kScanCodeKey[] = "scanCode";
 static constexpr char kModifiersKey[] = "modifiers";
 static constexpr char kTypeKey[] = "type";
 static constexpr char kToolkitKey[] = "toolkit";
-static constexpr char kCharactersIgnoringModifiersKey[] =
-    "charactersIgnoringModifiers";
+static constexpr char kCodePoint[] = "codePoint";
 
 static constexpr char kLinuxKeyMap[] = "linux";
 static constexpr char kGLFWKey[] = "glfw";
@@ -59,8 +58,7 @@ void KeyEventHandler::KeyboardHook(GLFWwindow* window,
   // value. See: https://github.com/glfw/glfw/issues/1462
   const char* keyName = glfwGetKeyName(key, scancode);
   if (keyName != nullptr) {
-    event.AddMember(kCharactersIgnoringModifiersKey, std::string(keyName),
-                    allocator);
+    event.AddMember(kCodePoint, std::string(keyName), allocator);
   }
 
   switch (action) {


### PR DESCRIPTION
Sends GLFW keyboard data as Linux key data, as opposed to Android. Includes the unmodified unicode character generated by the key.

Depends on https://github.com/flutter/flutter/pull/34752

Fixes https://github.com/flutter/flutter/issues/33395