### PR TITLE
Update Fuchsia macOS SDK

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -473,7 +473,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': 'Cx51FRV5TCoqQ9nfs4E2QMfYkJ1JWt7arQXhV01tr7cC'
+        'version': 'c7-ZlSIozNsClk6_pzfdWrkhaWC5Epa-bFFTLpkLrQkC'
        }
      ],
      'condition': 'host_os == "mac"',


### PR DESCRIPTION
TEST ONLY. This is not intended to land, but rather to help verify whether we can repro an issue the Skia auto-roller is hitting.