### PR TITLE
delegate checkInputConnectionProxy to the relevant platform view

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -399,8 +399,7 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
 
     @Override
     public boolean checkInputConnectionProxy(View view) {
-        PlatformViewsController platformViewsController = mNativeView.getPluginRegistry().getPlatformViewsController();
-        return platformViewsController.isPlatformView(view);
+        return mNativeView.getPluginRegistry().getPlatformViewsController().checkInputConnectionProxy(view);
     }
 
     @Override


### PR DESCRIPTION
The previous logic allowed proxying for any view that belonged to one of the platform views' virtual displays which may lead to us allowing proxying for a view that the platform view isn't allowing proxying for, previous logic also didn't account for unattached views.

This change instead delegates the decision to the platform view.

We use the fact that each virtual display has its unique context to associate any view with its relevant virtual display.

A nice side effect of calling the platform view's checkInputConnectionProxy for webviews is that the plugin now has a way to get a handle to the ThreadedInputConnectionProxyView, which may be useful for getting keyboard working on webview's prior to Android N.

@jason-simmons @mklim @matthew-carroll 

https://github.com/flutter/flutter/issues/19718