### PR TITLE
Log.v -> Log.d

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -224,7 +224,7 @@ public class FlutterActivity extends FragmentActivity implements OnFirstFrameRen
       return;
     }
 
-    Log.v(TAG, "Showing cover view until first frame is rendered.");
+    Log.d(TAG, "Showing cover view until first frame is rendered.");
 
     // Create the coverView.
     if (coverView == null) {
@@ -527,7 +527,7 @@ public class FlutterActivity extends FragmentActivity implements OnFirstFrameRen
 
   @Override
   public void onFirstFrameRendered() {
-    Log.v(TAG, "First frame has been rendered. Hiding cover view.");
+    Log.d(TAG, "First frame has been rendered. Hiding cover view.");
     hideCoverView();
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -439,7 +439,7 @@ public class FlutterFragment extends Fragment {
   @Nullable
   @Override
   public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-    Log.v(TAG, "Creating FlutterView.");
+    Log.d(TAG, "Creating FlutterView.");
     flutterView = new FlutterView(getContext(), getRenderMode(), getTransparencyMode());
     flutterView.addOnFirstFrameRenderedListener(onFirstFrameRenderedListener);
     return flutterView;
@@ -537,7 +537,7 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onStart() {
     super.onStart();
-    Log.v(TAG, "onStart()");
+    Log.d(TAG, "onStart()");
 
     // We post() the code that attaches the FlutterEngine to our FlutterView because there is
     // some kind of blocking logic on the native side when the surface is connected. That lag
@@ -547,7 +547,7 @@ public class FlutterFragment extends Fragment {
     new Handler().post(new Runnable() {
       @Override
       public void run() {
-        Log.v(TAG, "Attaching FlutterEngine to FlutterView.");
+        Log.d(TAG, "Attaching FlutterEngine to FlutterView.");
         flutterView.attachToFlutterEngine(flutterEngine);
 
         // TODO(mattcarroll): the following call should exist here, but the plugin system needs to be revamped.
@@ -562,13 +562,13 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onResume() {
     super.onResume();
-    Log.v(TAG, "onResume()");
+    Log.d(TAG, "onResume()");
     flutterEngine.getLifecycleChannel().appIsResumed();
   }
 
   // TODO(mattcarroll): determine why this can't be in onResume(). Comment reason, or move if possible.
   public void onPostResume() {
-    Log.v(TAG, "onPostResume()");
+    Log.d(TAG, "onPostResume()");
     if (flutterEngine != null) {
       // TODO(mattcarroll): find a better way to handle the update of UI overlays than calling through
       //                    to platformPlugin. We're implicitly entangling the Window, Activity, Fragment,
@@ -582,14 +582,14 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onPause() {
     super.onPause();
-    Log.v(TAG, "onPause()");
+    Log.d(TAG, "onPause()");
     flutterEngine.getLifecycleChannel().appIsInactive();
   }
 
   @Override
   public void onStop() {
     super.onStop();
-    Log.v(TAG, "onStop()");
+    Log.d(TAG, "onStop()");
     flutterEngine.getLifecycleChannel().appIsPaused();
     flutterView.detachFromFlutterEngine();
   }
@@ -597,14 +597,14 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onDestroyView() {
     super.onDestroyView();
-    Log.v(TAG, "onDestroyView()");
+    Log.d(TAG, "onDestroyView()");
     flutterView.removeOnFirstFrameRenderedListener(onFirstFrameRenderedListener);
   }
 
   @Override
   public void onDetach() {
     super.onDetach();
-    Log.v(TAG, "onDetach()");
+    Log.d(TAG, "onDetach()");
 
     if (shouldAttachEngineToActivity()) {
       // Notify plugins that they are no longer attached to an Activity.
@@ -653,7 +653,7 @@ public class FlutterFragment extends Fragment {
    */
   public void onBackPressed() {
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onBackPressed() to FlutterEngine.");
+      Log.d(TAG, "Forwarding onBackPressed() to FlutterEngine.");
       flutterEngine.getNavigationChannel().popRoute();
     } else {
       Log.w(TAG, "Invoked onBackPressed() before FlutterFragment was attached to an Activity.");
@@ -671,7 +671,7 @@ public class FlutterFragment extends Fragment {
    */
   public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onRequestPermissionsResult() to FlutterEngine:\n"
+      Log.d(TAG, "Forwarding onRequestPermissionsResult() to FlutterEngine:\n"
         + "requestCode: " + requestCode + "\n"
         + "permissions: " + Arrays.toString(permissions) + "\n"
         + "grantResults: " + Arrays.toString(grantResults));
@@ -691,7 +691,7 @@ public class FlutterFragment extends Fragment {
    */
   public void onNewIntent(@NonNull Intent intent) {
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onNewIntent() to FlutterEngine.");
+      Log.d(TAG, "Forwarding onNewIntent() to FlutterEngine.");
       flutterEngine.getActivityControlSurface().onNewIntent(intent);
     } else {
       Log.w(TAG, "onNewIntent() invoked before FlutterFragment was attached to an Activity.");
@@ -708,7 +708,7 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onActivityResult() to FlutterEngine:\n"
+      Log.d(TAG, "Forwarding onActivityResult() to FlutterEngine:\n"
           + "requestCode: " + requestCode + "\n"
           + "resultCode: " + resultCode + "\n"
           + "data: " + data);
@@ -726,7 +726,7 @@ public class FlutterFragment extends Fragment {
    */
   public void onUserLeaveHint() {
     if (flutterEngine != null) {
-      Log.v(TAG, "Forwarding onUserLeaveHint() to FlutterEngine.");
+      Log.d(TAG, "Forwarding onUserLeaveHint() to FlutterEngine.");
       flutterEngine.getActivityControlSurface().onUserLeaveHint();
     } else {
       Log.w(TAG, "onUserLeaveHint() invoked before FlutterFragment was attached to an Activity.");
@@ -745,7 +745,7 @@ public class FlutterFragment extends Fragment {
       // Use a trim level delivered while the application is running so the
       // framework has a chance to react to the notification.
       if (level == TRIM_MEMORY_RUNNING_LOW) {
-        Log.v(TAG, "Forwarding onTrimMemory() to FlutterEngine. Level: " + level);
+        Log.d(TAG, "Forwarding onTrimMemory() to FlutterEngine. Level: " + level);
         flutterEngine.getSystemChannel().sendMemoryPressureWarning();
       }
     } else {
@@ -761,7 +761,7 @@ public class FlutterFragment extends Fragment {
   @Override
   public void onLowMemory() {
     super.onLowMemory();
-    Log.v(TAG, "Forwarding onLowMemory() to FlutterEngine.");
+    Log.d(TAG, "Forwarding onLowMemory() to FlutterEngine.");
     flutterEngine.getSystemChannel().sendMemoryPressureWarning();
   }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterSurfaceView.java
@@ -51,7 +51,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
   private final SurfaceHolder.Callback surfaceCallback = new SurfaceHolder.Callback() {
     @Override
     public void surfaceCreated(@NonNull SurfaceHolder holder) {
-      Log.v(TAG, "SurfaceHolder.Callback.surfaceCreated()");
+      Log.d(TAG, "SurfaceHolder.Callback.surfaceCreated()");
       isSurfaceAvailableForRendering = true;
 
       if (isAttachedToFlutterRenderer) {
@@ -61,7 +61,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
 
     @Override
     public void surfaceChanged(@NonNull SurfaceHolder holder, int format, int width, int height) {
-      Log.v(TAG, "SurfaceHolder.Callback.surfaceChanged()");
+      Log.d(TAG, "SurfaceHolder.Callback.surfaceChanged()");
       if (isAttachedToFlutterRenderer) {
         changeSurfaceSize(width, height);
       }
@@ -69,7 +69,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
 
     @Override
     public void surfaceDestroyed(@NonNull SurfaceHolder holder) {
-      Log.v(TAG, "SurfaceHolder.Callback.surfaceDestroyed()");
+      Log.d(TAG, "SurfaceHolder.Callback.surfaceDestroyed()");
       isSurfaceAvailableForRendering = false;
 
       if (isAttachedToFlutterRenderer) {
@@ -137,9 +137,9 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
    * Flutter's UI to this {@code FlutterSurfaceView}.
    */
   public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
-    Log.v(TAG, "Attaching to FlutterRenderer.");
+    Log.d(TAG, "Attaching to FlutterRenderer.");
     if (this.flutterRenderer != null) {
-      Log.v(TAG, "Already connected to a FlutterRenderer. Detaching from old one and attaching to new one.");
+      Log.d(TAG, "Already connected to a FlutterRenderer. Detaching from old one and attaching to new one.");
       this.flutterRenderer.detachFromRenderSurface();
     }
 
@@ -149,7 +149,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
     // If we're already attached to an Android window then we're now attached to both a renderer
     // and the Android window. We can begin rendering now.
     if (isSurfaceAvailableForRendering) {
-      Log.v(TAG, "Surface is available for rendering. Connecting FlutterRenderer to Android surface.");
+      Log.d(TAG, "Surface is available for rendering. Connecting FlutterRenderer to Android surface.");
       connectSurfaceToRenderer();
     }
   }
@@ -166,7 +166,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
       // this FlutterSurfaceView is detached from the FlutterRenderer, we need to stop rendering.
       // TODO(mattcarroll): introduce a isRendererConnectedToSurface() to wrap "getWindowToken() != null"
       if (getWindowToken() != null) {
-        Log.v(TAG, "Disconnecting FlutterRenderer from Android surface.");
+        Log.d(TAG, "Disconnecting FlutterRenderer from Android surface.");
         disconnectSurfaceFromRenderer();
       }
 
@@ -195,7 +195,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
       throw new IllegalStateException("changeSurfaceSize() should only be called when flutterRenderer is non-null.");
     }
 
-    Log.v(TAG, "Notifying FlutterRenderer that Android surface size has changed to " + width + " x " + height);
+    Log.d(TAG, "Notifying FlutterRenderer that Android surface size has changed to " + width + " x " + height);
     flutterRenderer.surfaceChanged(width, height);
   }
 
@@ -229,7 +229,7 @@ public class FlutterSurfaceView extends SurfaceView implements FlutterRenderer.R
   @Override
   public void onFirstFrameRendered() {
     // TODO(mattcarroll): decide where this method should live and what it needs to do.
-    Log.v(TAG, "onFirstFrameRendered()");
+    Log.d(TAG, "onFirstFrameRendered()");
     // Now that a frame is ready to display, take this SurfaceView from transparent to opaque.
     setAlpha(1.0f);
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -50,7 +50,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
   private final SurfaceTextureListener surfaceTextureListener = new SurfaceTextureListener() {
     @Override
     public void onSurfaceTextureAvailable(SurfaceTexture surfaceTexture, int width, int height) {
-      Log.v(TAG, "SurfaceTextureListener.onSurfaceTextureAvailable()");
+      Log.d(TAG, "SurfaceTextureListener.onSurfaceTextureAvailable()");
       isSurfaceAvailableForRendering = true;
 
       // If we're already attached to a FlutterRenderer then we're now attached to both a renderer
@@ -62,7 +62,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
 
     @Override
     public void onSurfaceTextureSizeChanged(@NonNull SurfaceTexture surface, int width, int height) {
-      Log.v(TAG, "SurfaceTextureListener.onSurfaceTextureSizeChanged()");
+      Log.d(TAG, "SurfaceTextureListener.onSurfaceTextureSizeChanged()");
       if (isAttachedToFlutterRenderer) {
         changeSurfaceSize(width, height);
       }
@@ -75,7 +75,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
 
     @Override
     public boolean onSurfaceTextureDestroyed(@NonNull SurfaceTexture surface) {
-      Log.v(TAG, "SurfaceTextureListener.onSurfaceTextureDestroyed()");
+      Log.d(TAG, "SurfaceTextureListener.onSurfaceTextureDestroyed()");
       isSurfaceAvailableForRendering = false;
 
       // If we're attached to a FlutterRenderer then we need to notify it that our SurfaceTexture
@@ -125,9 +125,9 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
    * Flutter's UI to this {@code FlutterTextureView}.
    */
   public void attachToRenderer(@NonNull FlutterRenderer flutterRenderer) {
-    Log.v(TAG, "Attaching to FlutterRenderer.");
+    Log.d(TAG, "Attaching to FlutterRenderer.");
     if (this.flutterRenderer != null) {
-      Log.v(TAG, "Already connected to a FlutterRenderer. Detaching from old one and attaching to new one.");
+      Log.d(TAG, "Already connected to a FlutterRenderer. Detaching from old one and attaching to new one.");
       this.flutterRenderer.detachFromRenderSurface();
     }
 
@@ -137,7 +137,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
     // If we're already attached to an Android window then we're now attached to both a renderer
     // and the Android window. We can begin rendering now.
     if (isSurfaceAvailableForRendering) {
-      Log.v(TAG, "Surface is available for rendering. Connecting FlutterRenderer to Android surface.");
+      Log.d(TAG, "Surface is available for rendering. Connecting FlutterRenderer to Android surface.");
       connectSurfaceToRenderer();
     }
   }
@@ -154,7 +154,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
       // this FlutterTextureView is detached from the FlutterRenderer, we need to stop rendering.
       // TODO(mattcarroll): introduce a isRendererConnectedToSurface() to wrap "getWindowToken() != null"
       if (getWindowToken() != null) {
-        Log.v(TAG, "Disconnecting FlutterRenderer from Android surface.");
+        Log.d(TAG, "Disconnecting FlutterRenderer from Android surface.");
         disconnectSurfaceFromRenderer();
       }
 
@@ -180,7 +180,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
       throw new IllegalStateException("changeSurfaceSize() should only be called when flutterRenderer is non-null.");
     }
 
-    Log.v(TAG, "Notifying FlutterRenderer that Android surface size has changed to " + width + " x " + height);
+    Log.d(TAG, "Notifying FlutterRenderer that Android surface size has changed to " + width + " x " + height);
     flutterRenderer.surfaceChanged(width, height);
   }
 
@@ -214,7 +214,7 @@ public class FlutterTextureView extends TextureView implements FlutterRenderer.R
   @Override
   public void onFirstFrameRendered() {
     // TODO(mattcarroll): decide where this method should live and what it needs to do.
-    Log.v(TAG, "onFirstFrameRendered()");
+    Log.d(TAG, "onFirstFrameRendered()");
 
     for (OnFirstFrameRenderedListener listener : onFirstFrameRenderedListeners) {
       listener.onFirstFrameRendered();

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -168,17 +168,17 @@ public class FlutterView extends FrameLayout {
   }
 
   private void init() {
-    Log.v(TAG, "Initializing FlutterView");
+    Log.d(TAG, "Initializing FlutterView");
 
     switch (renderMode) {
       case surface:
-        Log.v(TAG, "Internally using a FlutterSurfaceView.");
+        Log.d(TAG, "Internally using a FlutterSurfaceView.");
         FlutterSurfaceView flutterSurfaceView = new FlutterSurfaceView(getContext(), transparencyMode == TransparencyMode.transparent);
         renderSurface = flutterSurfaceView;
         addView(flutterSurfaceView);
         break;
       case texture:
-        Log.v(TAG, "Internally using a FlutterTextureView.");
+        Log.d(TAG, "Internally using a FlutterTextureView.");
         FlutterTextureView flutterTextureView = new FlutterTextureView(getContext());
         renderSurface = flutterTextureView;
         addView(flutterTextureView);
@@ -240,7 +240,7 @@ public class FlutterView extends FrameLayout {
   @Override
   protected void onConfigurationChanged(@NonNull Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
-    Log.v(TAG, "Configuration changed. Sending locales and user settings to Flutter.");
+    Log.d(TAG, "Configuration changed. Sending locales and user settings to Flutter.");
     sendLocalesToFlutter(newConfig);
     sendUserSettingsToFlutter();
   }
@@ -259,7 +259,7 @@ public class FlutterView extends FrameLayout {
   @Override
   protected void onSizeChanged(int width, int height, int oldWidth, int oldHeight) {
     super.onSizeChanged(width, height, oldWidth, oldHeight);
-    Log.v(TAG, "Size changed. Sending Flutter new viewport metrics. FlutterView was "
+    Log.d(TAG, "Size changed. Sending Flutter new viewport metrics. FlutterView was "
         + oldWidth + " x " + oldHeight
         + ", it is now " + width + " x " + height);
     viewportMetrics.width = width;
@@ -296,7 +296,7 @@ public class FlutterView extends FrameLayout {
     viewportMetrics.viewInsetBottom = insets.getSystemWindowInsetBottom();
     viewportMetrics.viewInsetLeft = 0;
 
-    Log.v(TAG, "Updating window insets (onApplyWindowInsets()):\n"
+    Log.d(TAG, "Updating window insets (onApplyWindowInsets()):\n"
       + "Status bar insets: Top: " + viewportMetrics.paddingTop
         + ", Left: " + viewportMetrics.paddingLeft + ", Right: " + viewportMetrics.paddingRight + "\n"
       + "Keyboard insets: Bottom: " + viewportMetrics.viewInsetBottom
@@ -330,7 +330,7 @@ public class FlutterView extends FrameLayout {
       viewportMetrics.viewInsetBottom = insets.bottom;
       viewportMetrics.viewInsetLeft = 0;
 
-      Log.v(TAG, "Updating window insets (fitSystemWindows()):\n"
+      Log.d(TAG, "Updating window insets (fitSystemWindows()):\n"
           + "Status bar insets: Top: " + viewportMetrics.paddingTop
           + ", Left: " + viewportMetrics.paddingLeft + ", Right: " + viewportMetrics.paddingRight + "\n"
           + "Keyboard insets: Bottom: " + viewportMetrics.viewInsetBottom

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -94,7 +94,7 @@ public class FlutterEngine implements LifecycleOwner {
   private final EngineLifecycleListener engineLifecycleListener = new EngineLifecycleListener() {
     @SuppressWarnings("unused")
     public void onPreEngineRestart() {
-      Log.v(TAG, "onPreEngineRestart()");
+      Log.d(TAG, "onPreEngineRestart()");
       for (EngineLifecycleListener lifecycleListener : engineLifecycleListeners) {
         lifecycleListener.onPreEngineRestart();
       }
@@ -147,7 +147,7 @@ public class FlutterEngine implements LifecycleOwner {
   }
 
   private void attachToJni() {
-    Log.v(TAG, "Attaching to JNI.");
+    Log.d(TAG, "Attaching to JNI.");
     // TODO(mattcarroll): update native call to not take in "isBackgroundView"
     flutterJNI.attachToNative(false);
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
@@ -116,7 +116,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void add(@NonNull FlutterPlugin plugin) {
-    Log.v(TAG, "Adding plugin: " + plugin);
+    Log.d(TAG, "Adding plugin: " + plugin);
     // Add the plugin to our generic set of plugins and notify the plugin
     // that is has been attached to an engine.
     plugins.put(plugin.getClass(), plugin);
@@ -192,7 +192,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   public void remove(@NonNull Class<? extends FlutterPlugin> pluginClass) {
     FlutterPlugin plugin = plugins.get(pluginClass);
     if (plugin != null) {
-      Log.v(TAG, "Removing plugin: " + plugin);
+      Log.d(TAG, "Removing plugin: " + plugin);
       // For ActivityAware plugins, notify the plugin that it is detached from
       // an Activity if an Activity is currently attached to this engine. Then
       // remove the plugin from our set of ActivityAware plugins.
@@ -278,7 +278,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToActivity(@NonNull Activity activity, @NonNull Lifecycle lifecycle) {
-    Log.v(TAG, "Attaching to an Activity: " + activity + "."
+    Log.d(TAG, "Attaching to an Activity: " + activity + "."
         + (isWaitingForActivityReattachment ? " This is after a config change." : ""));
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
@@ -301,7 +301,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromActivityForConfigChanges() {
     if (isAttachedToActivity()) {
-      Log.v(TAG, "Detaching from an Activity for config changes: " + activity);
+      Log.d(TAG, "Detaching from an Activity for config changes: " + activity);
       isWaitingForActivityReattachment = true;
 
       for (ActivityAware activityAware : activityAwarePlugins.values()) {
@@ -319,7 +319,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromActivity() {
     if (isAttachedToActivity()) {
-      Log.v(TAG, "Detaching from an Activity: " + activity);
+      Log.d(TAG, "Detaching from an Activity: " + activity);
       for (ActivityAware activityAware : activityAwarePlugins.values()) {
         activityAware.onDetachedFromActivity();
       }
@@ -334,7 +334,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public boolean onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResult) {
-    Log.v(TAG, "Forwarding onRequestPermissionsResult() to plugins.");
+    Log.d(TAG, "Forwarding onRequestPermissionsResult() to plugins.");
     if (isAttachedToActivity()) {
       return activityPluginBinding.onRequestPermissionsResult(requestCode, permissions, grantResult);
     } else {
@@ -345,7 +345,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public boolean onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
-    Log.v(TAG, "Forwarding onActivityResult() to plugins.");
+    Log.d(TAG, "Forwarding onActivityResult() to plugins.");
     if (isAttachedToActivity()) {
       return activityPluginBinding.onActivityResult(requestCode, resultCode, data);
     } else {
@@ -356,7 +356,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void onNewIntent(@NonNull Intent intent) {
-    Log.v(TAG, "Forwarding onNewIntent() to plugins.");
+    Log.d(TAG, "Forwarding onNewIntent() to plugins.");
     if (isAttachedToActivity()) {
       activityPluginBinding.onNewIntent(intent);
     } else {
@@ -366,7 +366,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void onUserLeaveHint() {
-    Log.v(TAG, "Forwarding onUserLeaveHint() to plugins.");
+    Log.d(TAG, "Forwarding onUserLeaveHint() to plugins.");
     if (isAttachedToActivity()) {
       activityPluginBinding.onUserLeaveHint();
     } else {
@@ -382,7 +382,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToService(@NonNull Service service, @NonNull Lifecycle lifecycle, boolean isForeground) {
-    Log.v(TAG, "Attaching to a Service: " + service);
+    Log.d(TAG, "Attaching to a Service: " + service);
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
 
@@ -399,7 +399,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromService() {
     if (isAttachedToService()) {
-      Log.v(TAG, "Detaching from a Service: " + service);
+      Log.d(TAG, "Detaching from a Service: " + service);
       // Notify all ServiceAware plugins that they are no longer attached to a Service.
       for (ServiceAware serviceAware : serviceAwarePlugins.values()) {
         serviceAware.onDetachedFromService();
@@ -416,7 +416,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void onMoveToForeground() {
     if (isAttachedToService()) {
-      Log.v(TAG, "Attached Service moved to foreground.");
+      Log.d(TAG, "Attached Service moved to foreground.");
       servicePluginBinding.onMoveToForeground();
     }
   }
@@ -424,7 +424,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void onMoveToBackground() {
     if (isAttachedToService()) {
-      Log.v(TAG, "Attached Service moved to background.");
+      Log.d(TAG, "Attached Service moved to background.");
       servicePluginBinding.onMoveToBackground();
     }
   }
@@ -437,7 +437,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToBroadcastReceiver(@NonNull BroadcastReceiver broadcastReceiver, @NonNull Lifecycle lifecycle) {
-    Log.v(TAG, "Attaching to BroadcastReceiver: " + broadcastReceiver);
+    Log.d(TAG, "Attaching to BroadcastReceiver: " + broadcastReceiver);
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
 
@@ -454,7 +454,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromBroadcastReceiver() {
     if (isAttachedToBroadcastReceiver()) {
-      Log.v(TAG, "Detaching from BroadcastReceiver: " + broadcastReceiver);
+      Log.d(TAG, "Detaching from BroadcastReceiver: " + broadcastReceiver);
       // Notify all BroadcastReceiverAware plugins that they are no longer attached to a BroadcastReceiver.
       for (BroadcastReceiverAware broadcastReceiverAware : broadcastReceiverAwarePlugins.values()) {
         broadcastReceiverAware.onDetachedFromBroadcastReceiver();
@@ -472,7 +472,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
 
   @Override
   public void attachToContentProvider(@NonNull ContentProvider contentProvider, @NonNull Lifecycle lifecycle) {
-    Log.v(TAG, "Attaching to ContentProvider: " + contentProvider);
+    Log.d(TAG, "Attaching to ContentProvider: " + contentProvider);
     // If we were already attached to an Android component, detach from it.
     detachFromAndroidComponent();
 
@@ -489,7 +489,7 @@ class FlutterEnginePluginRegistry implements PluginRegistry,
   @Override
   public void detachFromContentProvider() {
     if (isAttachedToContentProvider()) {
-      Log.v(TAG, "Detaching from ContentProvider: " + contentProvider);
+      Log.d(TAG, "Detaching from ContentProvider: " + contentProvider);
       // Notify all ContentProviderAware plugins that they are no longer attached to a ContentProvider.
       for (ContentProviderAware contentProviderAware : contentProviderAwarePlugins.values()) {
         contentProviderAware.onDetachedFromContentProvider();

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -79,7 +79,7 @@ public class DartExecutor implements BinaryMessenger {
    * </ul>
    */
   public void onAttachedToJNI() {
-    Log.v(TAG, "Attached to JNI. Registering the platform message handler for this Dart execution context.");
+    Log.d(TAG, "Attached to JNI. Registering the platform message handler for this Dart execution context.");
     flutterJNI.setPlatformMessageHandler(messenger);
   }
 
@@ -91,7 +91,7 @@ public class DartExecutor implements BinaryMessenger {
    * the Dart execution context.
    */
   public void onDetachedFromJNI() {
-    Log.v(TAG, "Detached from JNI. De-registering the platform message handler for this Dart execution context.");
+    Log.d(TAG, "Detached from JNI. De-registering the platform message handler for this Dart execution context.");
     flutterJNI.setPlatformMessageHandler(null);
   }
 
@@ -117,7 +117,7 @@ public class DartExecutor implements BinaryMessenger {
       return;
     }
 
-    Log.v(TAG, "Executing Dart entrypoint: " + dartEntrypoint);
+    Log.d(TAG, "Executing Dart entrypoint: " + dartEntrypoint);
 
     flutterJNI.runBundleAndSnapshotFromLibrary(
         new String[]{
@@ -145,7 +145,7 @@ public class DartExecutor implements BinaryMessenger {
       return;
     }
 
-    Log.v(TAG, "Executing Dart callback: " + dartCallback);
+    Log.d(TAG, "Executing Dart callback: " + dartCallback);
 
     flutterJNI.runBundleAndSnapshotFromLibrary(
         new String[]{

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
@@ -47,10 +47,10 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
   @Override
   public void setMessageHandler(@NonNull String channel, @Nullable BinaryMessenger.BinaryMessageHandler handler) {
     if (handler == null) {
-      Log.v(TAG, "Removing handler for channel '" + channel + "'");
+      Log.d(TAG, "Removing handler for channel '" + channel + "'");
       messageHandlers.remove(channel);
     } else {
-      Log.v(TAG, "Setting handler for channel '" + channel + "'");
+      Log.d(TAG, "Setting handler for channel '" + channel + "'");
       messageHandlers.put(channel, handler);
     }
   }
@@ -58,7 +58,7 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
   @Override
   @UiThread
   public void send(@NonNull String channel, @NonNull ByteBuffer message) {
-    Log.v(TAG, "Sending message over channel '" + channel + "'");
+    Log.d(TAG, "Sending message over channel '" + channel + "'");
     send(channel, message, null);
   }
 
@@ -68,7 +68,7 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
       @Nullable ByteBuffer message,
       @Nullable BinaryMessenger.BinaryReply callback
   ) {
-    Log.v(TAG, "Sending message with callback over channel '" + channel + "'");
+    Log.d(TAG, "Sending message with callback over channel '" + channel + "'");
     int replyId = 0;
     if (callback != null) {
       replyId = nextReplyId++;
@@ -87,11 +87,11 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
       @Nullable byte[] message,
       final int replyId
   ) {
-    Log.v(TAG, "Received message from Dart over channel '" + channel + "'");
+    Log.d(TAG, "Received message from Dart over channel '" + channel + "'");
     BinaryMessenger.BinaryMessageHandler handler = messageHandlers.get(channel);
     if (handler != null) {
       try {
-        Log.v(TAG, "Deferring to registered handler to process message.");
+        Log.d(TAG, "Deferring to registered handler to process message.");
         final ByteBuffer buffer = (message == null ? null : ByteBuffer.wrap(message));
         handler.onMessage(buffer, new Reply(flutterJNI, replyId));
       } catch (Exception ex) {
@@ -99,18 +99,18 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
         flutterJNI.invokePlatformMessageEmptyResponseCallback(replyId);
       }
     } else {
-      Log.v(TAG, "No registered handler for message. Responding to Dart with empty reply message.");
+      Log.d(TAG, "No registered handler for message. Responding to Dart with empty reply message.");
       flutterJNI.invokePlatformMessageEmptyResponseCallback(replyId);
     }
   }
 
   @Override
   public void handlePlatformMessageResponse(int replyId, @Nullable byte[] reply) {
-    Log.v(TAG, "Received message reply from Dart.");
+    Log.d(TAG, "Received message reply from Dart.");
     BinaryMessenger.BinaryReply callback = pendingReplies.remove(replyId);
     if (callback != null) {
       try {
-        Log.v(TAG, "Invoking registered callback for reply from Dart.");
+        Log.d(TAG, "Invoking registered callback for reply from Dart.");
         callback.reply(reply == null ? null : ByteBuffer.wrap(reply));
       } catch (Exception ex) {
         Log.e(TAG, "Uncaught exception in binary message reply handler", ex);

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimPluginRegistry.java
@@ -41,7 +41,7 @@ public class ShimPluginRegistry implements PluginRegistry {
   private final FlutterEngine.EngineLifecycleListener engineLifecycleListener = new FlutterEngine.EngineLifecycleListener() {
     @Override
     public void onPreEngineRestart() {
-      Log.v(TAG, "onPreEngineRestart()");
+      Log.d(TAG, "onPreEngineRestart()");
       ShimPluginRegistry.this.onPreEngineRestart();
     }
   };
@@ -57,7 +57,7 @@ public class ShimPluginRegistry implements PluginRegistry {
 
   @Override
   public Registrar registrarFor(String pluginKey) {
-    Log.v(TAG, "Creating plugin Registrar for '" + pluginKey + "'");
+    Log.d(TAG, "Creating plugin Registrar for '" + pluginKey + "'");
     if (pluginMap.containsKey(pluginKey)) {
       throw new IllegalStateException("Plugin key " + pluginKey + " is already in use");
     }
@@ -80,12 +80,12 @@ public class ShimPluginRegistry implements PluginRegistry {
 
   //----- From FlutterPluginRegistry that aren't in the PluginRegistry interface ----//
   public void attach(FlutterView flutterView, Activity activity) {
-    Log.v(TAG, "Attaching to a FlutterView and an Activity.");
+    Log.d(TAG, "Attaching to a FlutterView and an Activity.");
     platformViewsController.attach(activity, flutterEngine.getRenderer(), flutterEngine.getDartExecutor());
   }
 
   public void detach() {
-    Log.v(TAG, "Detaching from a FlutterView and an Activity.");
+    Log.d(TAG, "Detaching from a FlutterView and an Activity.");
     platformViewsController.detach();
     platformViewsController.onFlutterViewDestroyed();
   }

--- a/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimRegistrar.java
+++ b/shell/platform/android/io/flutter/embedding/engine/plugins/shim/ShimRegistrar.java
@@ -151,13 +151,13 @@ class ShimRegistrar implements PluginRegistry.Registrar, FlutterPlugin, Activity
 
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding binding) {
-    Log.v(TAG, "Attached to FlutterEngine.");
+    Log.d(TAG, "Attached to FlutterEngine.");
     pluginBinding = binding;
   }
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    Log.v(TAG, "Detached from FlutterEngine.");
+    Log.d(TAG, "Detached from FlutterEngine.");
     for (PluginRegistry.ViewDestroyListener listener : viewDestroyListeners) {
       // The following invocation might produce unexpected behavior in old plugins because
       // we have no FlutterNativeView to pass to onViewDestroy(). This is a limitation of this shim.
@@ -169,27 +169,27 @@ class ShimRegistrar implements PluginRegistry.Registrar, FlutterPlugin, Activity
 
   @Override
   public void onAttachedToActivity(@NonNull ActivityPluginBinding binding) {
-    Log.v(TAG, "Attached to an Activity.");
+    Log.d(TAG, "Attached to an Activity.");
     activityPluginBinding = binding;
     addExistingListenersToActivityPluginBinding();
   }
 
   @Override
   public void onDetachedFromActivityForConfigChanges() {
-    Log.v(TAG, "Detached from an Activity for config changes.");
+    Log.d(TAG, "Detached from an Activity for config changes.");
     activityPluginBinding = null;
   }
 
   @Override
   public void onReattachedToActivityForConfigChanges(@NonNull ActivityPluginBinding binding) {
-    Log.v(TAG, "Reconnected to an Activity after config changes.");
+    Log.d(TAG, "Reconnected to an Activity after config changes.");
     activityPluginBinding = binding;
     addExistingListenersToActivityPluginBinding();
   }
 
   @Override
   public void onDetachedFromActivity() {
-    Log.v(TAG, "Detached from an Activity.");
+    Log.d(TAG, "Detached from an Activity.");
     activityPluginBinding = null;
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
+++ b/shell/platform/android/io/flutter/embedding/engine/renderer/FlutterRenderer.java
@@ -55,10 +55,10 @@ public class FlutterRenderer implements TextureRegistry {
   }
 
   public void attachToRenderSurface(@NonNull RenderSurface renderSurface) {
-    Log.v(TAG, "Attaching to RenderSurface.");
+    Log.d(TAG, "Attaching to RenderSurface.");
     // TODO(mattcarroll): determine desired behavior when attaching to an already attached renderer
     if (this.renderSurface != null) {
-      Log.v(TAG, "Already attached to a RenderSurface. Detaching from old one and attaching to new one.");
+      Log.d(TAG, "Already attached to a RenderSurface. Detaching from old one and attaching to new one.");
       detachFromRenderSurface();
     }
 
@@ -68,7 +68,7 @@ public class FlutterRenderer implements TextureRegistry {
   }
 
   public void detachFromRenderSurface() {
-    Log.v(TAG, "Detaching from RenderSurface.");
+    Log.d(TAG, "Detaching from RenderSurface.");
     // TODO(mattcarroll): determine desired behavior if we're asked to detach without first being attached
     if (this.renderSurface != null) {
       this.renderSurface.detachFromRenderer();
@@ -91,14 +91,14 @@ public class FlutterRenderer implements TextureRegistry {
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
   @Override
   public SurfaceTextureEntry createSurfaceTexture() {
-    Log.v(TAG, "Creating a SurfaceTexture.");
+    Log.d(TAG, "Creating a SurfaceTexture.");
     final SurfaceTexture surfaceTexture = new SurfaceTexture(0);
     surfaceTexture.detachFromGLContext();
     final SurfaceTextureRegistryEntry entry = new SurfaceTextureRegistryEntry(
         nextTextureId.getAndIncrement(),
         surfaceTexture
     );
-    Log.v(TAG, "New SurfaceTexture ID: " + entry.id());
+    Log.d(TAG, "New SurfaceTexture ID: " + entry.id());
     registerTexture(entry.id(), surfaceTexture);
     return entry;
   }
@@ -155,7 +155,7 @@ public class FlutterRenderer implements TextureRegistry {
       if (released) {
         return;
       }
-      Log.v(TAG, "Releasing a SurfaceTexture (" + id + ").");
+      Log.d(TAG, "Releasing a SurfaceTexture (" + id + ").");
       surfaceTexture.release();
       unregisterTexture(id);
       released = true;
@@ -180,7 +180,7 @@ public class FlutterRenderer implements TextureRegistry {
 
   // TODO(mattcarroll): describe the native behavior that this invokes
   public void setViewportMetrics(@NonNull ViewportMetrics viewportMetrics) {
-    Log.v(TAG, "Setting viewport metrics\n"
+    Log.d(TAG, "Setting viewport metrics\n"
       + "Size: " + viewportMetrics.width + " x " + viewportMetrics.height + "\n"
       + "Padding - L: " + viewportMetrics.paddingLeft + ", T: " + viewportMetrics.paddingTop
         + ", R: " + viewportMetrics.paddingRight + ", B: " + viewportMetrics.paddingBottom + "\n"

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/AccessibilityChannel.java
@@ -43,7 +43,7 @@ public class AccessibilityChannel {
       @SuppressWarnings("unchecked")
       final HashMap<String, Object> data = (HashMap<String, Object>) annotatedEvent.get("data");
 
-      Log.v(TAG, "Received " + type + " message.");
+      Log.d(TAG, "Received " + type + " message.");
       switch (type) {
         case "announce":
           String announceMessage = (String) data.get("message");

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
@@ -25,17 +25,17 @@ public class LifecycleChannel {
   }
 
   public void appIsInactive() {
-    Log.v(TAG, "Sending AppLifecycleState.inactive message.");
+    Log.d(TAG, "Sending AppLifecycleState.inactive message.");
     channel.send("AppLifecycleState.inactive");
   }
 
   public void appIsResumed() {
-    Log.v(TAG, "Sending AppLifecycleState.resumed message.");
+    Log.d(TAG, "Sending AppLifecycleState.resumed message.");
     channel.send("AppLifecycleState.resumed");
   }
 
   public void appIsPaused() {
-    Log.v(TAG, "Sending AppLifecycleState.paused message.");
+    Log.d(TAG, "Sending AppLifecycleState.paused message.");
     channel.send("AppLifecycleState.paused");
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LocalizationChannel.java
@@ -33,10 +33,10 @@ public class LocalizationChannel {
    * Send the given {@code locales} to Dart.
    */
   public void sendLocales(@NonNull List<Locale> locales) {
-    Log.v(TAG, "Sending Locales to Flutter.");
+    Log.d(TAG, "Sending Locales to Flutter.");
     List<String> data = new ArrayList<>();
     for (Locale locale : locales) {
-      Log.v(TAG, "Locale (Language: " + locale.getLanguage()
+      Log.d(TAG, "Locale (Language: " + locale.getLanguage()
           + ", Country: " + locale.getCountry()
           + ", Variant: " + locale.getVariant() + ")");
       data.add(locale.getLanguage());

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/NavigationChannel.java
@@ -26,17 +26,17 @@ public class NavigationChannel {
   }
 
   public void setInitialRoute(@NonNull String initialRoute) {
-    Log.v(TAG, "Sending message to set initial route to '" + initialRoute + "'");
+    Log.d(TAG, "Sending message to set initial route to '" + initialRoute + "'");
     channel.invokeMethod("setInitialRoute", initialRoute);
   }
 
   public void pushRoute(@NonNull String route) {
-    Log.v(TAG, "Sending message to push route '" + route + "'");
+    Log.d(TAG, "Sending message to push route '" + route + "'");
     channel.invokeMethod("pushRoute", route);
   }
 
   public void popRoute() {
-    Log.v(TAG, "Sending message to pop route.");
+    Log.d(TAG, "Sending message to pop route.");
     channel.invokeMethod("popRoute", null);
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformChannel.java
@@ -44,7 +44,7 @@ public class PlatformChannel {
 
       String method = call.method;
       Object arguments = call.arguments;
-      Log.v(TAG, "Received '" + method + "' message.");
+      Log.d(TAG, "Received '" + method + "' message.");
       try {
         switch (method) {
           case "SystemSound.play":

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/PlatformViewsChannel.java
@@ -45,7 +45,7 @@ public class PlatformViewsChannel {
         return;
       }
 
-      Log.v(TAG, "Received '" + call.method + "' message.");
+      Log.d(TAG, "Received '" + call.method + "' message.");
       switch (call.method) {
         case "create":
           create(call, result);

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SettingsChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SettingsChannel.java
@@ -20,7 +20,7 @@ public class SettingsChannel {
 
   @NonNull
   public final BasicMessageChannel<Object> channel;
-  
+
   public SettingsChannel(@NonNull DartExecutor dartExecutor) {
     this.channel = new BasicMessageChannel<>(dartExecutor, CHANNEL_NAME, JSONMessageCodec.INSTANCE);
   }
@@ -29,13 +29,13 @@ public class SettingsChannel {
   public MessageBuilder startMessage() {
     return new MessageBuilder(channel);
   }
-  
+
   public static class MessageBuilder {
     @NonNull
     private final BasicMessageChannel<Object> channel;
     @NonNull
     private Map<String, Object> message = new HashMap<>();
-    
+
     MessageBuilder(@NonNull BasicMessageChannel<Object> channel) {
       this.channel = channel;
     }
@@ -57,16 +57,16 @@ public class SettingsChannel {
       message.put(PLATFORM_BRIGHTNESS, brightness.name);
       return this;
     }
-    
+
     public void send() {
-      Log.v(TAG, "Sending message: \n"
+      Log.d(TAG, "Sending message: \n"
         + "textScaleFactor: " + message.get(TEXT_SCALE_FACTOR) + "\n"
         + "alwaysUse24HourFormat: " + message.get(ALWAYS_USE_24_HOUR_FORMAT) + "\n"
         + "platformBrightness: " + message.get(PLATFORM_BRIGHTNESS));
       channel.send(message);
     }
   }
-  
+
   /**
    * The brightness mode of the host platform.
    *
@@ -79,7 +79,7 @@ public class SettingsChannel {
 
     @NonNull
     public String name;
-    
+
     PlatformBrightness(@NonNull String name) {
       this.name = name;
     }

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/SystemChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/SystemChannel.java
@@ -28,7 +28,7 @@ public class SystemChannel {
   }
 
   public void sendMemoryPressureWarning() {
-    Log.v(TAG, "Sending memory pressure warning to Flutter.");
+    Log.d(TAG, "Sending memory pressure warning to Flutter.");
     Map<String, Object> message = new HashMap<>(1);
     message.put("type", "memoryPressure");
     channel.send(message);

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -50,7 +50,7 @@ public class TextInputChannel {
 
       String method = call.method;
       Object args = call.arguments;
-      Log.v(TAG, "Received '" + method + "' message.");
+      Log.d(TAG, "Received '" + method + "' message.");
       switch (method) {
         case "TextInput.show":
           textInputMethodHandler.show();
@@ -114,7 +114,7 @@ public class TextInputChannel {
    * Instructs Flutter to update its text input editing state to reflect the given configuration.
    */
   public void updateEditingState(int inputClientId, String text, int selectionStart, int selectionEnd, int composingStart, int composingEnd) {
-    Log.v(TAG, "Sending message to update editing state: \n"
+    Log.d(TAG, "Sending message to update editing state: \n"
       + "Text: " + text + "\n"
       + "Selection start: " + selectionStart + "\n"
       + "Selection end: " + selectionEnd + "\n"
@@ -138,7 +138,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "newline" action.
    */
   public void newline(int inputClientId) {
-    Log.v(TAG, "Sending 'newline' message.");
+    Log.d(TAG, "Sending 'newline' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.newline")
@@ -149,7 +149,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "go" action.
    */
   public void go(int inputClientId) {
-    Log.v(TAG, "Sending 'go' message.");
+    Log.d(TAG, "Sending 'go' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.go")
@@ -160,7 +160,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "search" action.
    */
   public void search(int inputClientId) {
-    Log.v(TAG, "Sending 'search' message.");
+    Log.d(TAG, "Sending 'search' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.search")
@@ -171,7 +171,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "send" action.
    */
   public void send(int inputClientId) {
-    Log.v(TAG, "Sending 'send' message.");
+    Log.d(TAG, "Sending 'send' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.send")
@@ -182,7 +182,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "done" action.
    */
   public void done(int inputClientId) {
-    Log.v(TAG, "Sending 'done' message.");
+    Log.d(TAG, "Sending 'done' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.done")
@@ -193,7 +193,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "next" action.
    */
   public void next(int inputClientId) {
-    Log.v(TAG, "Sending 'next' message.");
+    Log.d(TAG, "Sending 'next' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.next")
@@ -204,7 +204,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute a "previous" action.
    */
   public void previous(int inputClientId) {
-    Log.v(TAG, "Sending 'previous' message.");
+    Log.d(TAG, "Sending 'previous' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.previous")
@@ -215,7 +215,7 @@ public class TextInputChannel {
    * Instructs Flutter to execute an "unspecified" action.
    */
   public void unspecifiedAction(int inputClientId) {
-    Log.v(TAG, "Sending 'unspecified' message.");
+    Log.d(TAG, "Sending 'unspecified' message.");
     channel.invokeMethod(
         "TextInputClient.performAction",
         Arrays.asList(inputClientId, "TextInputAction.unspecified")


### PR DESCRIPTION
Verbose logs show up in tool output.  We should not have that happen unless the developer has specified `--verbose-system-logs`, or the log is critical to all Flutter developers in all scenarios.

Fixes https://github.com/flutter/flutter/issues/34876

