### PR TITLE
Ios unit tests choose engine

### DIFF
--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0D6AB6C422BB05E200EEE540 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6C322BB05E200EEE540 /* main.m */; };
 		0D6AB6EB22BB40E700EEE540 /* FlutterEngineTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6E722BB40CF00EEE540 /* FlutterEngineTest.mm */; };
 		0D6AB72C22BC339F00EEE540 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D6AB72522BC336100EEE540 /* libOCMock.a */; };
+		0D6AB73F22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -84,6 +85,7 @@
 		0D6AB6CF22BB05E200EEE540 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0D6AB6E722BB40CF00EEE540 /* FlutterEngineTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterEngineTest.mm; sourceTree = "<group>"; };
 		0D6AB71722BC336100EEE540 /* OCMock.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = OCMock.xcodeproj; path = ../../../../../third_party/ocmock/Source/OCMock.xcodeproj; sourceTree = "<group>"; };
+		0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = FlutterEngineConfig.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,6 +148,7 @@
 				0D6AB71722BC336100EEE540 /* OCMock.xcodeproj */,
 				0D6AB6E622BB409F00EEE540 /* Source */,
 				0D6AB6CF22BB05E200EEE540 /* Info.plist */,
+				0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -321,6 +324,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0D6AB73F22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -549,6 +553,7 @@
 		};
 		0D6AB6D622BB05E200EEE540 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
@@ -577,7 +582,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-L",
-					../../../../out/ios_debug_sim_unopt,
+					../../../../out/$FLUTTER_ENGINE,
 					"-lFlutter",
 					"-lOCMock",
 					"-ObjC",
@@ -592,6 +597,7 @@
 		};
 		0D6AB6D722BB05E200EEE540 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
@@ -620,7 +626,7 @@
 				);
 				OTHER_LDFLAGS = (
 					"-L",
-					../../../../out/ios_debug_sim_unopt,
+					../../../../out/$FLUTTER_ENGINE,
 					"-lFlutter",
 					"-lOCMock",
 					"-ObjC",

--- a/testing/ios/IosUnitTests/Tests/FlutterEngineConfig.xcconfig
+++ b/testing/ios/IosUnitTests/Tests/FlutterEngineConfig.xcconfig
@@ -1,0 +1,1 @@
+FLUTTER_ENGINE=ios_debug_sim_unopt

--- a/testing/ios/IosUnitTests/build_and_run_tests.sh
+++ b/testing/ios/IosUnitTests/build_and_run_tests.sh
@@ -1,0 +1,6 @@
+pushd $PWD
+cd ../../../..
+./flutter/tools/gn --ios --simulator --unoptimized
+ninja -j 100 -C out/ios_debug_sim_unopt
+popd
+./run_tests.sh

--- a/testing/ios/IosUnitTests/build_and_run_tests.sh
+++ b/testing/ios/IosUnitTests/build_and_run_tests.sh
@@ -3,4 +3,4 @@ cd ../../../..
 ./flutter/tools/gn --ios --simulator --unoptimized
 ninja -j 100 -C out/ios_debug_sim_unopt
 popd
-./run_tests.sh
+./run_tests.sh ios_debug_sim_unopt

--- a/testing/ios/IosUnitTests/run_tests.sh
+++ b/testing/ios/IosUnitTests/run_tests.sh
@@ -1,9 +1,16 @@
-pushd $PWD
-cd ../../../..
-./flutter/tools/gn --ios --simulator --unoptimized
-ninja -j 100 -C out/ios_debug_sim_unopt/
-popd
+FLUTTER_ENGINE=ios_debug_sim_unopt
+
+if [ $# -eq 1 ]; then
+  FLUTTER_ENGINE=$1
+fi
+
+PRETTY="cat"
+if which xcpretty; then
+  PRETTY="xcpretty"
+fi
+
 xcodebuild -sdk iphonesimulator \
   -scheme IosUnitTests \
   -destination 'platform=iOS Simulator,name=iPhone SE,OS=12.2' \
-  test
+  test \
+  FLUTTER_ENGINE=$FLUTTER_ENGINE | $PRETTY


### PR DESCRIPTION
Split out the _run_tests_ script to a _build_and_run_tests_ script to make it easier to run the tests on LUCI with whatever engine is already built.