### PR TITLE
Reland Update harfbuzz to 2.5.2 (#9406)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -126,7 +126,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '7a3ec7d15ccd753a270a714c3972cef4e8660ffb',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '5383f9c6ad891c28d0d2f3103864ff6ff377ceff',
 
    # Fuchsia compatibility
    #
@@ -147,7 +147,7 @@ deps = {
    Var('fuchsia_git') + '/third_party/rapidjson' + '@' + '32d07c55db1bb6c2ae17cba4033491a667647753',
 
   'src/third_party/harfbuzz':
-   Var('fuchsia_git') + '/third_party/harfbuzz' + '@' + '02caec6c1c6ad996666788b8e920ccaec8b385e5',
+   Var('fuchsia_git') + '/third_party/harfbuzz' + '@' + 'b1e7dc6416fb7f27534721d2a000135e8f433c0c',
 
   'src/third_party/libcxx':
    Var('fuchsia_git') + '/third_party/libcxx' + '@' + 'c5a5fa59789213c7dae68d2e51cb28ef681d8257',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 9d87240ddbe083ba518018d299ee47c7
+Signature: d7dfb58d77011223259704614a8e181f
 
 UNUSED LICENSES:
 
@@ -8432,10 +8432,11 @@ FILE: ../../../third_party/harfbuzz/docs/usermanual-clusters.xml
 FILE: ../../../third_party/harfbuzz/docs/usermanual-fonts-and-faces.xml
 FILE: ../../../third_party/harfbuzz/docs/usermanual-getting-started.xml
 FILE: ../../../third_party/harfbuzz/docs/usermanual-glyph-information.xml
-FILE: ../../../third_party/harfbuzz/docs/usermanual-hello-harfbuzz.xml
 FILE: ../../../third_party/harfbuzz/docs/usermanual-install-harfbuzz.xml
+FILE: ../../../third_party/harfbuzz/docs/usermanual-object-model.xml
 FILE: ../../../third_party/harfbuzz/docs/usermanual-opentype-features.xml
 FILE: ../../../third_party/harfbuzz/docs/usermanual-shaping-concepts.xml
+FILE: ../../../third_party/harfbuzz/docs/usermanual-utilities.xml
 FILE: ../../../third_party/harfbuzz/docs/usermanual-what-is-harfbuzz.xml
 FILE: ../../../third_party/harfbuzz/docs/version.xml.in
 FILE: ../../../third_party/harfbuzz/harfbuzz.doap
@@ -8450,13 +8451,15 @@ FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-indic-table.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use-table.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-tag-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ucd-table.hh
 FILE: ../../../third_party/harfbuzz/src/hb-unicode-emoji-table.hh
 ----------------------------------------------------------------------------------------------------
 HarfBuzz is licensed under the so-called "Old MIT" license.  Details follow.
 For parts of HarfBuzz that are licensed under different licenses see individual
 files names COPYING in subdirectories where applicable.
 
-Copyright © 2010,2011,2012  Google, Inc.
+Copyright © 2010,2011,2012,2013,2014,2015,2016,2017,2018,2019  Google, Inc.
+Copyright © 2019  Facebook, Inc.
 Copyright © 2012  Mozilla Foundation
 Copyright © 2011  Codethink Limited
 Copyright © 2008,2010  Nokia Corporation and/or its subsidiary(-ies)
@@ -8491,42 +8494,6 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/dump-emoji.cc
-TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/dump-emoji.cc
-FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-ankr-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-bsln-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-feat-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-aat-ltag-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-color-colr-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-color-sbix-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-color-svg-table.hh
-----------------------------------------------------------------------------------------------------
-Copyright © 2018  Ebrahim Byagowi
-
- This is part of HarfBuzz, a text shaping library.
-
-Permission is hereby granted, without written agreement and without
-license or royalty fees, to use, copy, modify, and distribute this
-software and its documentation for any purpose, provided that the
-above copyright notice and the following two paragraphs appear in
-all copies of this software.
-
-IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
-DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
-ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
-IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-
-THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
-ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
-PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: harfbuzz
 ORIGIN: ../../../third_party/harfbuzz/src/dump-indic-data.cc
 TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/dump-indic-data.cc
@@ -8534,36 +8501,32 @@ FILE: ../../../third_party/harfbuzz/src/dump-khmer-data.cc
 FILE: ../../../third_party/harfbuzz/src/dump-myanmar-data.cc
 FILE: ../../../third_party/harfbuzz/src/dump-use-data.cc
 FILE: ../../../third_party/harfbuzz/src/hb-aat-map.hh
-FILE: ../../../third_party/harfbuzz/src/hb-iter-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-iter.hh
-FILE: ../../../third_party/harfbuzz/src/hb-map-private.hh
+FILE: ../../../third_party/harfbuzz/src/hb-array.hh
 FILE: ../../../third_party/harfbuzz/src/hb-map.cc
 FILE: ../../../third_party/harfbuzz/src/hb-map.h
 FILE: ../../../third_party/harfbuzz/src/hb-map.hh
+FILE: ../../../third_party/harfbuzz/src/hb-meta.hh
 FILE: ../../../third_party/harfbuzz/src/hb-null.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-deprecated.h
 FILE: ../../../third_party/harfbuzz/src/hb-ot-face.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-hdmx-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-name-language.cc
+FILE: ../../../third_party/harfbuzz/src/hb-ot-name-language-static.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-name-language.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-name.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-os2-unicode-ranges.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-khmer-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-khmer.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-myanmar-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-myanmar.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-vowel-constraints.hh
 FILE: ../../../third_party/harfbuzz/src/hb-static.cc
-FILE: ../../../third_party/harfbuzz/src/hb-subset-glyf.cc
-FILE: ../../../third_party/harfbuzz/src/hb-subset-glyf.hh
 FILE: ../../../third_party/harfbuzz/src/hb-subset-input.cc
 FILE: ../../../third_party/harfbuzz/src/hb-subset-input.hh
 FILE: ../../../third_party/harfbuzz/src/hb-subset-plan.cc
 FILE: ../../../third_party/harfbuzz/src/hb-subset-plan.hh
-FILE: ../../../third_party/harfbuzz/src/hb-subset-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-subset.cc
 FILE: ../../../third_party/harfbuzz/src/hb-subset.h
 FILE: ../../../third_party/harfbuzz/src/hb-subset.hh
-FILE: ../../../third_party/harfbuzz/src/test-name-table.cc
+FILE: ../../../third_party/harfbuzz/src/test-iter.cc
+FILE: ../../../third_party/harfbuzz/src/test-ot-name.cc
 FILE: ../../../third_party/harfbuzz/src/test-unicode-ranges.cc
 ----------------------------------------------------------------------------------------------------
 Copyright © 2018  Google, Inc.
@@ -8591,16 +8554,55 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-aat-layout-common-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-aat-fdsc-table.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-common-private.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat-fdsc-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-ankr-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-bsln-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-feat-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-just-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-lcar-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat-layout.h
+FILE: ../../../third_party/harfbuzz/src/hb-aat-ltag-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-aat.h
+FILE: ../../../third_party/harfbuzz/src/hb-ot-color-colr-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-color-sbix-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-color-svg-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-gasp-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-stat-table.hh
+----------------------------------------------------------------------------------------------------
+Copyright © 2018  Ebrahim Byagowi
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-aat-layout-common.hh
+TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-common.hh
 FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-morx-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-aat-layout-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-aat-layout.cc
 FILE: ../../../third_party/harfbuzz/src/hb-aat-layout.hh
 FILE: ../../../third_party/harfbuzz/src/hb-debug.hh
-FILE: ../../../third_party/harfbuzz/src/hb-dsalgs.hh
+FILE: ../../../third_party/harfbuzz/src/hb-kern.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-kern-table.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-post-macroman.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-var-avar-table.hh
@@ -8667,6 +8669,36 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-aat-layout.cc
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/harfbuzz/src/hb-aat-layout.cc
+----------------------------------------------------------------------------------------------------
+Copyright © 2017  Google, Inc.
+Copyright © 2018  Ebrahim Byagowi
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
 ORIGIN: ../../../third_party/harfbuzz/src/hb-aat-map.cc
 TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-aat-map.cc
@@ -8698,18 +8730,12 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-atomic-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-algs.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-atomic-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-atomic.hh
-FILE: ../../../third_party/harfbuzz/src/hb-mutex-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-mutex.hh
-FILE: ../../../third_party/harfbuzz/src/hb-object-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-object.hh
+FILE: ../../../third_party/harfbuzz/src/hb-algs.hh
 ----------------------------------------------------------------------------------------------------
-Copyright © 2007  Chris Wilson
-Copyright © 2009,2010  Red Hat, Inc.
-Copyright © 2011,2012  Google, Inc.
+Copyright © 2017  Google, Inc.
+Copyright © 2019  Facebook, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -8734,13 +8760,15 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-blob-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-atomic.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-blob-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-blob.hh
+FILE: ../../../third_party/harfbuzz/src/hb-atomic.hh
+FILE: ../../../third_party/harfbuzz/src/hb-mutex.hh
+FILE: ../../../third_party/harfbuzz/src/hb-object.hh
 ----------------------------------------------------------------------------------------------------
-Copyright © 2009  Red Hat, Inc.
-Copyright © 2018  Google, Inc.
+Copyright © 2007  Chris Wilson
+Copyright © 2009,2010  Red Hat, Inc.
+Copyright © 2011,2012  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -8800,11 +8828,40 @@ TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-blob.h
 FILE: ../../../third_party/harfbuzz/src/hb-face.h
 FILE: ../../../third_party/harfbuzz/src/hb-font.h
-FILE: ../../../third_party/harfbuzz/src/hb-ot-tag.h
 FILE: ../../../third_party/harfbuzz/src/hb-ot.h
 FILE: ../../../third_party/harfbuzz/src/hb.h
 ----------------------------------------------------------------------------------------------------
 Copyright © 2009  Red Hat, Inc.
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-blob.hh
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/harfbuzz/src/hb-blob.hh
+----------------------------------------------------------------------------------------------------
+Copyright © 2009  Red Hat, Inc.
+Copyright © 2018  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -8865,15 +8922,11 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-buffer-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-buffer-serialize.cc
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-buffer-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-buffer.cc
-FILE: ../../../third_party/harfbuzz/src/hb-buffer.hh
+FILE: ../../../third_party/harfbuzz/src/hb-buffer-serialize.cc
 ----------------------------------------------------------------------------------------------------
-Copyright © 1998-2004  David Turner and Werner Lemberg
-Copyright © 2004,2007,2009,2010  Red Hat, Inc.
-Copyright © 2011,2012  Google, Inc.
+Copyright © 2012,2013  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -8898,11 +8951,14 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-buffer-serialize.cc
+ORIGIN: ../../../third_party/harfbuzz/src/hb-buffer.cc
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-buffer-serialize.cc
+FILE: ../../../third_party/harfbuzz/src/hb-buffer.cc
+FILE: ../../../third_party/harfbuzz/src/hb-buffer.hh
 ----------------------------------------------------------------------------------------------------
-Copyright © 2012,2013  Google, Inc.
+Copyright © 1998-2004  David Turner and Werner Lemberg
+Copyright © 2004,2007,2009,2010  Red Hat, Inc.
+Copyright © 2011,2012  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -8962,29 +9018,66 @@ ORIGIN: ../../../third_party/harfbuzz/src/hb-cache.hh
 TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-cache.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-arabic-fallback.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-indic-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-indic.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-fallback-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-fallback.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-normalize-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-normalize.hh
-FILE: ../../../third_party/harfbuzz/src/hb-set-digest-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-set-digest.hh
 FILE: ../../../third_party/harfbuzz/src/hb-set.cc
 FILE: ../../../third_party/harfbuzz/src/hb-set.h
-FILE: ../../../third_party/harfbuzz/src/hb-shape-plan-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-shape-plan.cc
 FILE: ../../../third_party/harfbuzz/src/hb-shape-plan.h
-FILE: ../../../third_party/harfbuzz/src/hb-shape-plan.hh
-FILE: ../../../third_party/harfbuzz/src/hb-shaper-impl-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-shaper-impl.hh
 FILE: ../../../third_party/harfbuzz/src/hb-shaper-list.hh
-FILE: ../../../third_party/harfbuzz/src/hb-shaper-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-shaper.cc
 FILE: ../../../third_party/harfbuzz/src/hb-shaper.hh
 FILE: ../../../third_party/harfbuzz/src/hb-warning.cc
 ----------------------------------------------------------------------------------------------------
 Copyright © 2012  Google, Inc.
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-cff-interp-common.hh
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/harfbuzz/src/hb-cff-interp-common.hh
+FILE: ../../../third_party/harfbuzz/src/hb-cff-interp-cs-common.hh
+FILE: ../../../third_party/harfbuzz/src/hb-cff-interp-dict-common.hh
+FILE: ../../../third_party/harfbuzz/src/hb-cff1-interp-cs.hh
+FILE: ../../../third_party/harfbuzz/src/hb-cff2-interp-cs.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-cff-common.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-cff1-table.cc
+FILE: ../../../third_party/harfbuzz/src/hb-ot-cff1-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-cff2-table.cc
+FILE: ../../../third_party/harfbuzz/src/hb-ot-cff2-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-vorg-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-subset-cff-common.cc
+FILE: ../../../third_party/harfbuzz/src/hb-subset-cff-common.hh
+FILE: ../../../third_party/harfbuzz/src/hb-subset-cff1.cc
+FILE: ../../../third_party/harfbuzz/src/hb-subset-cff1.hh
+FILE: ../../../third_party/harfbuzz/src/hb-subset-cff2.cc
+FILE: ../../../third_party/harfbuzz/src/hb-subset-cff2.hh
+----------------------------------------------------------------------------------------------------
+Copyright © 2018 Adobe Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -9042,11 +9135,42 @@ LIBRARY: harfbuzz
 ORIGIN: ../../../third_party/harfbuzz/src/hb-common.h
 TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-common.h
-FILE: ../../../third_party/harfbuzz/src/hb-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2007,2008,2009  Red Hat, Inc.
 Copyright © 2011,2012  Google, Inc.
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-config.hh
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/harfbuzz/src/hb-config.hh
+FILE: ../../../third_party/harfbuzz/src/hb-pool.hh
+FILE: ../../../third_party/harfbuzz/src/test-algs.cc
+FILE: ../../../third_party/harfbuzz/src/test-meta.cc
+----------------------------------------------------------------------------------------------------
+Copyright © 2019  Facebook, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -9133,37 +9257,9 @@ LIBRARY: harfbuzz
 ORIGIN: ../../../third_party/harfbuzz/src/hb-directwrite.cc
 TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-directwrite.cc
-----------------------------------------------------------------------------------------------------
-Copyright © 2015-2018  Ebrahim Byagowi
-
- This is part of HarfBuzz, a text shaping library.
-
-Permission is hereby granted, without written agreement and without
-license or royalty fees, to use, copy, modify, and distribute this
-software and its documentation for any purpose, provided that the
-above copyright notice and the following two paragraphs appear in
-all copies of this software.
-
-IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
-DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
-ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
-IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-
-THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
-ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
-PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-directwrite.h
-TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-directwrite.h
 ----------------------------------------------------------------------------------------------------
-Copyright © 2015  Ebrahim Byagowi
+Copyright © 2015-2019  Ebrahim Byagowi
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -9188,19 +9284,14 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-face-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-dispatch.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-face-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-face.hh
-FILE: ../../../third_party/harfbuzz/src/hb-font-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-font.hh
-FILE: ../../../third_party/harfbuzz/src/hb-glib.cc
-FILE: ../../../third_party/harfbuzz/src/hb-glib.h
-FILE: ../../../third_party/harfbuzz/src/hb-icu.h
-FILE: ../../../third_party/harfbuzz/src/hb-ot-tag.cc
+FILE: ../../../third_party/harfbuzz/src/hb-dispatch.hh
+FILE: ../../../third_party/harfbuzz/src/hb-machinery.hh
+FILE: ../../../third_party/harfbuzz/src/hb-sanitize.hh
 ----------------------------------------------------------------------------------------------------
-Copyright © 2009  Red Hat, Inc.
-Copyright © 2011  Google, Inc.
+Copyright © 2007,2008,2009,2010  Red Hat, Inc.
+Copyright © 2012,2018  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -9234,6 +9325,41 @@ FILE: ../../../third_party/harfbuzz/src/hb-shape.h
 ----------------------------------------------------------------------------------------------------
 Copyright © 2009  Red Hat, Inc.
 Copyright © 2012  Google, Inc.
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-face.hh
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/harfbuzz/src/hb-face.hh
+FILE: ../../../third_party/harfbuzz/src/hb-font.hh
+FILE: ../../../third_party/harfbuzz/src/hb-glib.cc
+FILE: ../../../third_party/harfbuzz/src/hb-glib.h
+FILE: ../../../third_party/harfbuzz/src/hb-icu.h
+FILE: ../../../third_party/harfbuzz/src/hb-ot-tag.cc
+----------------------------------------------------------------------------------------------------
+Copyright © 2009  Red Hat, Inc.
+Copyright © 2011  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -9447,13 +9573,12 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-machinery-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-iter.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-machinery-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-machinery.hh
+FILE: ../../../third_party/harfbuzz/src/hb-iter.hh
 ----------------------------------------------------------------------------------------------------
-Copyright © 2007,2008,2009,2010  Red Hat, Inc.
-Copyright © 2012,2018  Google, Inc.
+Copyright © 2018  Google, Inc.
+Copyright © 2019  Facebook, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -9478,9 +9603,8 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-open-file-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-open-file.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-open-file-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-open-file.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2007,2008,2009  Red Hat, Inc.
@@ -9509,9 +9633,8 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-open-type-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-open-type.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-open-type-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-open-type.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2007,2008,2009,2010  Red Hat, Inc.
@@ -9663,10 +9786,40 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-face-table-list.hh
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/harfbuzz/src/hb-ot-face-table-list.hh
+----------------------------------------------------------------------------------------------------
+Copyright © 2007,2008,2009  Red Hat, Inc.
+Copyright © 2012,2013  Google, Inc.
+Copyright © 2019, Facebook Inc.
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
 ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-face.hh
 TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-ot-face.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-layout-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-layout.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2007,2008,2009  Red Hat, Inc.
@@ -9789,7 +9942,6 @@ FILE: ../../../third_party/harfbuzz/src/hb-ot-hhea-table.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-hmtx-table.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-maxp-table.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-name-table.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-os2-table.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-indic-machine.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-indic-machine.rl
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-indic.cc
@@ -9832,6 +9984,7 @@ FILE: ../../../third_party/harfbuzz/src/hb-ot-layout-base-table.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2016 Elie Roux <elie.roux@telecom-bretagne.eu>
 Copyright © 2018  Google, Inc.
+Copyright © 2018  Ebrahim Byagowi
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -9856,9 +10009,8 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-layout-common-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-layout-common.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ot-layout-common-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-layout-common.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2007,2008,2009  Red Hat, Inc.
@@ -9948,9 +10100,8 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-layout-gsubgpos-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-layout-gsubgpos.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ot-layout-gsubgpos-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-layout-gsubgpos.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2007,2008,2009,2010  Red Hat, Inc.
@@ -10041,9 +10192,8 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-map-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-map.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ot-map-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-map.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2009,2010  Red Hat, Inc.
@@ -10132,18 +10282,12 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-arabic-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-os2-table.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-arabic-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-arabic.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use-machine.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use-machine.rl
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use.cc
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-os2-table.hh
 ----------------------------------------------------------------------------------------------------
-Copyright © 2015  Mozilla Foundation.
-Copyright © 2015  Google, Inc.
+Copyright © 2011,2012  Google, Inc.
+Copyright © 2018  Ebrahim Byagowi
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -10174,9 +10318,42 @@ FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-arabic.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-default.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-hebrew.cc
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-thai.cc
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-tibetan.cc
 ----------------------------------------------------------------------------------------------------
 Copyright © 2010,2012  Google, Inc.
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-arabic.hh
+TYPE: LicenseType.unknown
+FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-arabic.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use-machine.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use-machine.rl
+FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use.cc
+FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-use.hh
+----------------------------------------------------------------------------------------------------
+Copyright © 2015  Mozilla Foundation.
+Copyright © 2015  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -10231,42 +10408,11 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-shape-complex.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-complex.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2010,2011,2012  Google, Inc.
-
- This is part of HarfBuzz, a text shaping library.
-
-Permission is hereby granted, without written agreement and without
-license or royalty fees, to use, copy, modify, and distribute this
-software and its documentation for any purpose, provided that the
-above copyright notice and the following two paragraphs appear in
-all copies of this software.
-
-IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
-DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
-ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
-IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
-DAMAGE.
-
-THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
-BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
-ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
-PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-shape-private.hh
-TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape-private.hh
-FILE: ../../../third_party/harfbuzz/src/hb-ot-shape.hh
-----------------------------------------------------------------------------------------------------
-Copyright © 2010  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -10350,11 +10496,11 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-vorg-table.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ot-shape.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ot-vorg-table.hh
+FILE: ../../../third_party/harfbuzz/src/hb-ot-shape.hh
 ----------------------------------------------------------------------------------------------------
-Copyright © 2018 Adobe Systems Incorporated.
+Copyright © 2010  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -10379,9 +10525,39 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-set-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-serialize.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-set-private.hh
+FILE: ../../../third_party/harfbuzz/src/hb-serialize.hh
+----------------------------------------------------------------------------------------------------
+Copyright © 2007,2008,2009,2010  Red Hat, Inc.
+Copyright © 2012,2018  Google, Inc.
+Copyright © 2019  Facebook, Inc.
+
+ This is part of HarfBuzz, a text shaping library.
+
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: harfbuzz
+ORIGIN: ../../../third_party/harfbuzz/src/hb-set.hh
+TYPE: LicenseType.unknown
 FILE: ../../../third_party/harfbuzz/src/hb-set.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2012,2017  Google, Inc.
@@ -10409,33 +10585,38 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ucdn/COPYING
+ORIGIN: ../../../third_party/harfbuzz/src/hb-shape-plan.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ucdn/Makefile.sources
-FILE: ../../../third_party/harfbuzz/src/hb-ucdn/ucdn_db.h
+FILE: ../../../third_party/harfbuzz/src/hb-shape-plan.hh
 ----------------------------------------------------------------------------------------------------
-The contents of this directory are licensed under the following terms:
+Copyright © 2012,2018  Google, Inc.
 
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
+ This is part of HarfBuzz, a text shaping library.
 
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+Permission is hereby granted, without written agreement and without
+license or royalty fees, to use, copy, modify, and distribute this
+software and its documentation for any purpose, provided that the
+above copyright notice and the following two paragraphs appear in
+all copies of this software.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE TO ANY PARTY FOR
+DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN
+IF THE COPYRIGHT HOLDER HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+THE COPYRIGHT HOLDER SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING,
+BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ON AN "AS IS" BASIS, AND THE COPYRIGHT HOLDER HAS NO OBLIGATION TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 ====================================================================================================
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-ucdn/ucdn.c
+ORIGIN: ../../../third_party/harfbuzz/src/hb-ucd.cc
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-ucdn.cc
-FILE: ../../../third_party/harfbuzz/src/hb-ucdn/ucdn.c
-FILE: ../../../third_party/harfbuzz/src/hb-ucdn/ucdn.h
+FILE: ../../../third_party/harfbuzz/src/hb-ucd.cc
 ----------------------------------------------------------------------------------------------------
 Copyright (C) 2012 Grigori Goronzy <greg@kinoho.net>
 
@@ -10454,9 +10635,8 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-unicode-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-unicode.cc
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-unicode-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-unicode.cc
 FILE: ../../../third_party/harfbuzz/src/hb-unicode.hh
 ----------------------------------------------------------------------------------------------------
@@ -10518,9 +10698,8 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/hb-utf-private.hh
+ORIGIN: ../../../third_party/harfbuzz/src/hb-utf.hh
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/hb-utf-private.hh
 FILE: ../../../third_party/harfbuzz/src/hb-utf.hh
 ----------------------------------------------------------------------------------------------------
 Copyright © 2011,2012,2014  Google, Inc.
@@ -10606,12 +10785,13 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/test-ot-color.cc
+ORIGIN: ../../../third_party/harfbuzz/src/test-gpos-size-params.cc
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/test-ot-color.cc
+FILE: ../../../third_party/harfbuzz/src/test-gpos-size-params.cc
+FILE: ../../../third_party/harfbuzz/src/test-gsub-would-substitute.cc
+FILE: ../../../third_party/harfbuzz/src/test.cc
 ----------------------------------------------------------------------------------------------------
-Copyright © 2018  Ebrahim Byagowi
-Copyright © 2018  Khaled Hosny
+Copyright © 2010,2011  Google, Inc.
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -10636,13 +10816,12 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 
 ====================================================================================================
 LIBRARY: harfbuzz
-ORIGIN: ../../../third_party/harfbuzz/src/test-size-params.cc
+ORIGIN: ../../../third_party/harfbuzz/src/test-ot-color.cc
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/harfbuzz/src/test-size-params.cc
-FILE: ../../../third_party/harfbuzz/src/test-would-substitute.cc
-FILE: ../../../third_party/harfbuzz/src/test.cc
+FILE: ../../../third_party/harfbuzz/src/test-ot-color.cc
 ----------------------------------------------------------------------------------------------------
-Copyright © 2010,2011  Google, Inc.
+Copyright © 2018  Ebrahim Byagowi
+Copyright © 2018  Khaled Hosny
 
  This is part of HarfBuzz, a text shaping library.
 
@@ -14669,8 +14848,8 @@ We recommend reading one or more of these references before trying to
 understand the innards of the JPEG software.
 
 The best short technical introduction to the JPEG compression algorithm is
-	Wallace, Gregory K.  "The JPEG Still Picture Compression Standard",
-	Communications of the ACM, April 1991 (vol. 34 no. 4), pp. 30-44.
+  Wallace, Gregory K.  "The JPEG Still Picture Compression Standard",
+  Communications of the ACM, April 1991 (vol. 34 no. 4), pp. 30-44.
 (Adjacent articles in that issue discuss MPEG motion picture compression,
 applications of JPEG, and related topics.)  If you don't have the CACM issue
 handy, a PDF file containing a revised version of Wallace's article is
@@ -14738,8 +14917,8 @@ and other news.answers archive sites, including the official news.answers
 archive at rtfm.mit.edu: ftp://rtfm.mit.edu/pub/usenet/news.answers/jpeg-faq/.
 If you don't have Web or FTP access, send e-mail to mail-server@rtfm.mit.edu
 with body
-	send usenet/news.answers/jpeg-faq/part1
-	send usenet/news.answers/jpeg-faq/part2
+  send usenet/news.answers/jpeg-faq/part1
+  send usenet/news.answers/jpeg-faq/part2
 
 FILE FORMAT WARS
 ================
@@ -19302,4 +19481,4 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 ====================================================================================================
-Total license count: 321
+Total license count: 327


### PR DESCRIPTION
This reverts commit e32307e9f1409c9f0518956d9c695c1105565201.

The build error may have been a side effect of LUCI changes. Going to attempt this again with no changes from previous version as the appropriate flags seem to be present.