### PR TITLE
Revert "Roll fuchsia/sdk/core/mac-amd64 from Cx51F... to e8sS_..."

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -480,7 +480,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': 'e8sS_5Rpuo7cSjSWPCdxwTEAg2VbS9NPH2tjhBhPwsUC'
+        'version': 'Cx51FRV5TCoqQ9nfs4E2QMfYkJ1JWt7arQXhV01tr7cC'
        }
      ],
      'condition': 'host_os == "mac"',


### PR DESCRIPTION
Reverts flutter/engine#9442

Reason: this breaks "build fuchsia_debug" post-submit test (see https://ci.chromium.org/p/flutter/builders/prod/Mac%20Host%20Engine/928)

TBR: @cbracken 