### PR TITLE
Revert "Roll fuchsia/sdk/core/mac-amd64 from Cx51F... to w-3t4..."

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -480,7 +480,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/mac-amd64',
-        'version': 'w-3t4XiGPWI6UnY7zV2vTMAbS83-U8is0P168iq230oC'
+        'version': 'Cx51FRV5TCoqQ9nfs4E2QMfYkJ1JWt7arQXhV01tr7cC'
        }
      ],
      'condition': 'host_os == "mac"',


### PR DESCRIPTION
Reverts flutter/engine#9447

Reason: this PR breaks LUCI bots

TBR: @cbracken