### PR TITLE
Manually draw remainder curve for wavy decorations

### DIFF
--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1413,7 +1413,7 @@ void Paragraph::ComputeWavyDecoration(SkPath& path,
   //  * P(x) = -2x^2 - 2x
   //  * P0 = (0, 0)
   //  * P1 = 2P(0.5) - 0.5 * P0 - 0.5 * P2
-  //  * P2 = P(1)
+  //  * P2 = P(remaining / (wavelength / 2))
   double normalized_remaining = remaining / (quarter * 2);
   double p2_x = remaining;
   double p2_y = (wave_count % 2 != 0 ? -1 : 1) * quarter *

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1421,10 +1421,10 @@ void Paragraph::ComputeWavyDecoration(SkPath& path,
   // https://github.com/flutter/engine/pull/9468#discussion_r297879129
 
   double x1 = remaining / 2;
-  double y1 = remaining / 2 * (wave_count % 2 != 0 ? 1 : -1);
+  double y1 = remaining / 2 * (wave_count % 2 == 0 ? -1 : 1);
   double x2 = remaining;
   double y2 = (remaining - remaining * remaining / (quarter * 2)) *
-              (wave_count % 2 != 0 ? 1 : -1);
+              (wave_count % 2 == 0 ? -1 : 1);
   path.rQuadTo(x1, y1, x2, y2);
 }
 

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1414,18 +1414,18 @@ void Paragraph::ComputeWavyDecoration(SkPath& path,
   //  * P0 = (0, 0)
   //  * P1 = 2P(0.5) - 0.5 * P0 - 0.5 * P2
   //  * P2 = P(remaining / (wavelength / 2))
-  double normalized_remaining = remaining / (quarter * 2);
-  double p2_x = remaining;
-  double p2_y = (wave_count % 2 != 0 ? -1 : 1) * quarter *
-                (2 * normalized_remaining * normalized_remaining -
-                 2 * normalized_remaining);
-  double mid_x = remaining / 2;
-  double mid_y =
-      (wave_count % 2 != 0 ? -1 : 1) * quarter *
-      (normalized_remaining * normalized_remaining / 2 - normalized_remaining);
-  double p1_x = 2 * mid_x - p2_x / 2;
-  double p1_y = 2 * mid_y - p2_y / 2;
-  path.rQuadTo(p1_x, p1_y, p2_x, p2_y);
+  //
+  // Simplified implementation coursesy of @jim-flar at
+  // https://github.com/flutter/engine/pull/9468#discussion_r297872739
+  // Unsimplified original version at
+  // https://github.com/flutter/engine/pull/9468#discussion_r297879129
+
+  double x1 = remaining / 2;
+  double y1 = remaining / 2 * (wave_count % 2 != 0 ? 1 : -1);
+  double x2 = remaining;
+  double y2 = (remaining - remaining * remaining / (quarter * 2)) *
+              (wave_count % 2 != 0 ? 1 : -1);
+  path.rQuadTo(x1, y1, x2, y2);
 }
 
 void Paragraph::PaintBackground(SkCanvas* canvas,

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1397,7 +1397,7 @@ void Paragraph::ComputeWavyDecoration(SkPath& path,
   double quarter = thickness;
   path.moveTo(x, y);
   double remaining = width;
-  while (x_start + quarter * 2 < width) {
+  while (x_start + (quarter * 2) < width) {
     path.rQuadTo(quarter, wave_count % 2 == 0 ? -quarter : quarter, quarter * 2,
                  0);
     x_start += quarter * 2;

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1400,8 +1400,8 @@ void Paragraph::ComputeWavyDecoration(SkPath& path,
   while (x_start + quarter * 2 < width) {
     path.rQuadTo(quarter, wave_count % 2 == 0 ? -quarter : quarter, quarter * 2,
                  0);
-    remaining = width - (x_start + quarter * 2);
     x_start += quarter * 2;
+    remaining = width - x_start;
     ++wave_count;
   }
   // Manually add a final partial quad for the remaining width that do

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1407,21 +1407,25 @@ void Paragraph::ComputeWavyDecoration(SkPath& path,
   // Manually add a final partial quad for the remaining width that do
   // not fit nicely into a half-wavelength.
   // The following math is based off of quadratic bezier equations:
-  //   Let P0 = start (0,0), P1 = control point, P2 = end, and P(x) be the
-  //   equation for the curve. P(x) = -2x^2 - 2x P1 = 2P(0.5) - 0.5 * P0 - 0.5 *
-  //   P2
+  //
+  //  * Let P(x) be the equation for the curve.
+  //  * Let P0 = start, P1 = control point, P2 = end
+  //  * P(x) = -2x^2 - 2x
+  //  * P0 = (0, 0)
+  //  * P1 = 2P(0.5) - 0.5 * P0 - 0.5 * P2
+  //  * P2 = P(1)
   double normalized_remaining = remaining / (quarter * 2);
-  double end_x = remaining;
-  double end_y = (wave_count % 2 != 0 ? -1 : 1) * quarter *
-                 (2 * normalized_remaining * normalized_remaining -
-                  2 * normalized_remaining);
+  double p2_x = remaining;
+  double p2_y = (wave_count % 2 != 0 ? -1 : 1) * quarter *
+                (2 * normalized_remaining * normalized_remaining -
+                 2 * normalized_remaining);
   double mid_x = remaining / 2;
   double mid_y =
       (wave_count % 2 != 0 ? -1 : 1) * quarter *
       (normalized_remaining * normalized_remaining / 2 - normalized_remaining);
-  double control_x = 2 * mid_x - end_x / 2;
-  double control_y = 2 * mid_y - end_y / 2;
-  path.rQuadTo(control_x, control_y, end_x, end_y);
+  double p1_x = 2 * mid_x - p2_x / 2;
+  double p1_y = 2 * mid_y - p2_y / 2;
+  path.rQuadTo(p1_x, p1_y, p2_x, p2_y);
 }
 
 void Paragraph::PaintBackground(SkCanvas* canvas,

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1342,8 +1342,8 @@ void Paragraph::PaintDecorations(SkCanvas* canvas,
       double mid_x = remaining / 2;
       double mid_y = (wave_count % 2 != 0 ? -1 : 1) * quarter
         * (normalized_remaining * normalized_remaining / 2 - normalized_remaining);
-      double control_x = 2 * mid_x - 0.5 * end_x;
-      double control_y = 2 * mid_y - 0.5 * end_y;
+      double control_x = 2 * mid_x - end_x / 2;
+      double control_y = 2 * mid_y - end_y / 2;
       path.rQuadTo(control_x, control_y, end_x, end_y);
       break;
     }

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1316,35 +1316,42 @@ void Paragraph::PaintDecorations(SkCanvas* canvas,
       break;
     }
     case TextDecorationStyle::kWavy: {
-      int wave_count = 0;
-      double x_start = 0;
-      double quarter =
-          underline_thickness * record.style().decoration_thickness_multiplier;
-      path.moveTo(x, y);
-      double remaining = width;
-      while (x_start + quarter * 2 < width) {
-        path.rQuadTo(quarter, wave_count % 2 == 0 ? -quarter : quarter,
-                     quarter * 2, 0);
-        remaining = width - (x_start + quarter * 2);
-        x_start += quarter * 2;
-        ++wave_count;
-      }
-      // Manually add a final partial quad for the remaining width that do
-      // not fit nicely into a half-wavelength.
-      // The following math is based off of quadratic bezier equations:
-      //   Let P0 = start (0,0), P1 = control point, P2 = end, and P(x) be the equation for the curve.
-      //   P(x) = -2x^2 - 2x
-      //   P1 = 2P(0.5) - 0.5 * P0 - 0.5 * P2
-      double normalized_remaining = remaining / (quarter * 2);
-      double end_x = remaining;
-      double end_y = (wave_count % 2 != 0 ? -1 : 1) * quarter
-        * (2 * normalized_remaining * normalized_remaining - 2 * normalized_remaining);
-      double mid_x = remaining / 2;
-      double mid_y = (wave_count % 2 != 0 ? -1 : 1) * quarter
-        * (normalized_remaining * normalized_remaining / 2 - normalized_remaining);
-      double control_x = 2 * mid_x - end_x / 2;
-      double control_y = 2 * mid_y - end_y / 2;
-      path.rQuadTo(control_x, control_y, end_x, end_y);
+      ComputeWavyDecoration(
+          path, x, y, width,
+          underline_thickness * record.style().decoration_thickness_multiplier);
+      // int wave_count = 0;
+      // double x_start = 0;
+      // double quarter =
+      //     underline_thickness *
+      //     record.style().decoration_thickness_multiplier;
+      // path.moveTo(x, y);
+      // double remaining = width;
+      // while (x_start + quarter * 2 < width) {
+      //   path.rQuadTo(quarter, wave_count % 2 == 0 ? -quarter : quarter,
+      //                quarter * 2, 0);
+      //   remaining = width - (x_start + quarter * 2);
+      //   x_start += quarter * 2;
+      //   ++wave_count;
+      // }
+      // // Manually add a final partial quad for the remaining width that do
+      // // not fit nicely into a half-wavelength.
+      // // The following math is based off of quadratic bezier equations:
+      // //   Let P0 = start (0,0), P1 = control point, P2 = end, and P(x) be
+      // the equation for the curve.
+      // //   P(x) = -2x^2 - 2x
+      // //   P1 = 2P(0.5) - 0.5 * P0 - 0.5 * P2
+      // double normalized_remaining = remaining / (quarter * 2);
+      // double end_x = remaining;
+      // double end_y = (wave_count % 2 != 0 ? -1 : 1) * quarter
+      //   * (2 * normalized_remaining * normalized_remaining - 2 *
+      //   normalized_remaining);
+      // double mid_x = remaining / 2;
+      // double mid_y = (wave_count % 2 != 0 ? -1 : 1) * quarter
+      //   * (normalized_remaining * normalized_remaining / 2 -
+      //   normalized_remaining);
+      // double control_x = 2 * mid_x - end_x / 2;
+      // double control_y = 2 * mid_y - end_y / 2;
+      // path.rQuadTo(control_x, control_y, end_x, end_y);
       break;
     }
   }
@@ -1410,6 +1417,44 @@ void Paragraph::PaintDecorations(SkCanvas* canvas,
       y_offset = y_offset_original;
     }
   }
+}
+
+void Paragraph::ComputeWavyDecoration(SkPath& path,
+                                      double x,
+                                      double y,
+                                      double width,
+                                      double thickness) {
+  int wave_count = 0;
+  double x_start = 0;
+  // One full wavelength is 4 * thickness.
+  double quarter = thickness;
+  path.moveTo(x, y);
+  double remaining = width;
+  while (x_start + quarter * 2 < width) {
+    path.rQuadTo(quarter, wave_count % 2 == 0 ? -quarter : quarter, quarter * 2,
+                 0);
+    remaining = width - (x_start + quarter * 2);
+    x_start += quarter * 2;
+    ++wave_count;
+  }
+  // Manually add a final partial quad for the remaining width that do
+  // not fit nicely into a half-wavelength.
+  // The following math is based off of quadratic bezier equations:
+  //   Let P0 = start (0,0), P1 = control point, P2 = end, and P(x) be the
+  //   equation for the curve. P(x) = -2x^2 - 2x P1 = 2P(0.5) - 0.5 * P0 - 0.5 *
+  //   P2
+  double normalized_remaining = remaining / (quarter * 2);
+  double end_x = remaining;
+  double end_y = (wave_count % 2 != 0 ? -1 : 1) * quarter *
+                 (2 * normalized_remaining * normalized_remaining -
+                  2 * normalized_remaining);
+  double mid_x = remaining / 2;
+  double mid_y =
+      (wave_count % 2 != 0 ? -1 : 1) * quarter *
+      (normalized_remaining * normalized_remaining / 2 - normalized_remaining);
+  double control_x = 2 * mid_x - end_x / 2;
+  double control_y = 2 * mid_y - end_y / 2;
+  path.rQuadTo(control_x, control_y, end_x, end_y);
 }
 
 void Paragraph::PaintBackground(SkCanvas* canvas,

--- a/third_party/txt/src/txt/paragraph.cc
+++ b/third_party/txt/src/txt/paragraph.cc
@@ -1319,39 +1319,6 @@ void Paragraph::PaintDecorations(SkCanvas* canvas,
       ComputeWavyDecoration(
           path, x, y, width,
           underline_thickness * record.style().decoration_thickness_multiplier);
-      // int wave_count = 0;
-      // double x_start = 0;
-      // double quarter =
-      //     underline_thickness *
-      //     record.style().decoration_thickness_multiplier;
-      // path.moveTo(x, y);
-      // double remaining = width;
-      // while (x_start + quarter * 2 < width) {
-      //   path.rQuadTo(quarter, wave_count % 2 == 0 ? -quarter : quarter,
-      //                quarter * 2, 0);
-      //   remaining = width - (x_start + quarter * 2);
-      //   x_start += quarter * 2;
-      //   ++wave_count;
-      // }
-      // // Manually add a final partial quad for the remaining width that do
-      // // not fit nicely into a half-wavelength.
-      // // The following math is based off of quadratic bezier equations:
-      // //   Let P0 = start (0,0), P1 = control point, P2 = end, and P(x) be
-      // the equation for the curve.
-      // //   P(x) = -2x^2 - 2x
-      // //   P1 = 2P(0.5) - 0.5 * P0 - 0.5 * P2
-      // double normalized_remaining = remaining / (quarter * 2);
-      // double end_x = remaining;
-      // double end_y = (wave_count % 2 != 0 ? -1 : 1) * quarter
-      //   * (2 * normalized_remaining * normalized_remaining - 2 *
-      //   normalized_remaining);
-      // double mid_x = remaining / 2;
-      // double mid_y = (wave_count % 2 != 0 ? -1 : 1) * quarter
-      //   * (normalized_remaining * normalized_remaining / 2 -
-      //   normalized_remaining);
-      // double control_x = 2 * mid_x - end_x / 2;
-      // double control_y = 2 * mid_y - end_y / 2;
-      // path.rQuadTo(control_x, control_y, end_x, end_y);
       break;
     }
   }

--- a/third_party/txt/src/txt/paragraph.h
+++ b/third_party/txt/src/txt/paragraph.h
@@ -253,6 +253,7 @@ class Paragraph {
   FRIEND_TEST(ParagraphTest, RepeatLayoutParagraph);
   FRIEND_TEST(ParagraphTest, Ellipsize);
   FRIEND_TEST(ParagraphTest, UnderlineShiftParagraph);
+  FRIEND_TEST(ParagraphTest, WavyDecorationParagraph);
   FRIEND_TEST(ParagraphTest, SimpleShadow);
   FRIEND_TEST(ParagraphTest, ComplexShadow);
   FRIEND_TEST(ParagraphTest, FontFallbackParagraph);
@@ -477,6 +478,14 @@ class Paragraph {
   void PaintDecorations(SkCanvas* canvas,
                         const PaintRecord& record,
                         SkPoint base_offset);
+
+  // Computes the beziers for a wavy decoration. The results will be
+  // applied to path.
+  void ComputeWavyDecoration(SkPath& path,
+                             double x,
+                             double y,
+                             double width,
+                             double thickness);
 
   // Draws the background onto the canvas.
   void PaintBackground(SkCanvas* canvas,

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -20,6 +20,7 @@
 #include "render_test.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
 #include "third_party/skia/include/core/SkColor.h"
+#include "third_party/skia/include/core/SkPath.h"
 #include "txt/font_style.h"
 #include "txt/font_weight.h"
 #include "txt/paragraph.h"
@@ -1900,6 +1901,144 @@ TEST_F(ParagraphTest, DecorationsParagraph) {
             3.0);
   ASSERT_EQ(paragraph->records_[5].style().decoration_thickness_multiplier,
             1.0);
+}
+
+TEST_F(ParagraphTest, WavyDecorationParagraph) {
+  txt::ParagraphStyle paragraph_style;
+  paragraph_style.max_lines = 14;
+  paragraph_style.text_align = TextAlign::left;
+  txt::ParagraphBuilder builder(paragraph_style, GetTestFontCollection());
+
+  txt::TextStyle text_style;
+  text_style.font_families = std::vector<std::string>(1, "Roboto");
+  text_style.font_size = 26;
+  text_style.letter_spacing = 0;
+  text_style.word_spacing = 5;
+  text_style.color = SK_ColorBLACK;
+  text_style.height = 2;
+  text_style.decoration = TextDecoration::kUnderline |
+                          TextDecoration::kOverline |
+                          TextDecoration::kLineThrough;
+
+  text_style.decoration_style = txt::TextDecorationStyle::kWavy;
+  text_style.decoration_color = SK_ColorRED;
+  text_style.decoration_thickness_multiplier = 1.0;
+  builder.PushStyle(text_style);
+
+  builder.AddText(u" Otherwise, bad things happen.");
+
+  builder.Pop();
+
+  auto paragraph = builder.Build();
+  paragraph->Layout(GetTestCanvasWidth() - 100);
+
+  paragraph->Paint(GetCanvas(), 0, 0);
+
+  ASSERT_TRUE(Snapshot());
+  ASSERT_EQ(paragraph->runs_.size(), 1ull);
+  ASSERT_EQ(paragraph->records_.size(), 1ull);
+
+  for (size_t i = 0; i < 1; ++i) {
+    ASSERT_EQ(paragraph->records_[i].style().decoration,
+              TextDecoration::kUnderline | TextDecoration::kOverline |
+                  TextDecoration::kLineThrough);
+  }
+
+  ASSERT_EQ(paragraph->records_[0].style().decoration_style,
+            txt::TextDecorationStyle::kWavy);
+
+  ASSERT_EQ(paragraph->records_[0].style().decoration_color, SK_ColorRED);
+
+  ASSERT_EQ(paragraph->records_[0].style().decoration_thickness_multiplier,
+            1.0);
+
+  SkPath path0;
+  SkPath canonical_path0;
+  paragraph->ComputeWavyDecoration(path0, 1, 1, 9.56, 1);
+
+  canonical_path0.moveTo(1, 1);
+  canonical_path0.rQuadTo(1, -1, 2, 0);
+  canonical_path0.rQuadTo(1, 1, 2, 0);
+  canonical_path0.rQuadTo(1, -1, 2, 0);
+  canonical_path0.rQuadTo(1, 1, 2, 0);
+  canonical_path0.rQuadTo(0.78, -0.78, 1.56, -0.3432);
+
+  ASSERT_EQ(path0.countPoints(), canonical_path0.countPoints());
+  for (int i = 0; i < canonical_path0.countPoints(); ++i) {
+    ASSERT_EQ(path0.getPoint(i).x(), canonical_path0.getPoint(i).x());
+    ASSERT_EQ(path0.getPoint(i).y(), canonical_path0.getPoint(i).y());
+  }
+
+  SkPath path1;
+  SkPath canonical_path1;
+  paragraph->ComputeWavyDecoration(path1, 1, 1, 8.35, 1);
+
+  canonical_path1.moveTo(1, 1);
+  canonical_path1.rQuadTo(1, -1, 2, 0);
+  canonical_path1.rQuadTo(1, 1, 2, 0);
+  canonical_path1.rQuadTo(1, -1, 2, 0);
+  canonical_path1.rQuadTo(1, 1, 2, 0);
+  canonical_path1.rQuadTo(0.175, -0.175, 0.35, -0.28875);
+
+  ASSERT_EQ(path1.countPoints(), canonical_path1.countPoints());
+  for (int i = 0; i < canonical_path1.countPoints(); ++i) {
+    ASSERT_EQ(path1.getPoint(i).x(), canonical_path1.getPoint(i).x());
+    ASSERT_EQ(path1.getPoint(i).y(), canonical_path1.getPoint(i).y());
+  }
+
+  SkPath path2;
+  SkPath canonical_path2;
+  paragraph->ComputeWavyDecoration(path2, 1, 1, 10.59, 1);
+
+  canonical_path2.moveTo(1, 1);
+  canonical_path2.rQuadTo(1, -1, 2, 0);
+  canonical_path2.rQuadTo(1, 1, 2, 0);
+  canonical_path2.rQuadTo(1, -1, 2, 0);
+  canonical_path2.rQuadTo(1, 1, 2, 0);
+  canonical_path2.rQuadTo(1, -1, 2, 0);
+  canonical_path2.rQuadTo(0.295, 0.295, 0.59, 0.41595);
+
+  ASSERT_EQ(path2.countPoints(), canonical_path2.countPoints());
+  for (int i = 0; i < canonical_path2.countPoints(); ++i) {
+    ASSERT_EQ(path2.getPoint(i).x(), canonical_path2.getPoint(i).x());
+    ASSERT_EQ(path2.getPoint(i).y(), canonical_path2.getPoint(i).y());
+  }
+
+  SkPath path3;
+  SkPath canonical_path3;
+  paragraph->ComputeWavyDecoration(path3, 1, 1, 11.2, 1);
+
+  canonical_path3.moveTo(1, 1);
+  canonical_path3.rQuadTo(1, -1, 2, 0);
+  canonical_path3.rQuadTo(1, 1, 2, 0);
+  canonical_path3.rQuadTo(1, -1, 2, 0);
+  canonical_path3.rQuadTo(1, 1, 2, 0);
+  canonical_path3.rQuadTo(1, -1, 2, 0);
+  canonical_path3.rQuadTo(0.6, 0.6, 1.2, 0.48);
+
+  ASSERT_EQ(path3.countPoints(), canonical_path3.countPoints());
+  for (int i = 0; i < canonical_path3.countPoints(); ++i) {
+    ASSERT_EQ(path3.getPoint(i).x(), canonical_path3.getPoint(i).x());
+    ASSERT_EQ(path3.getPoint(i).y(), canonical_path3.getPoint(i).y());
+  }
+
+  SkPath path4;
+  SkPath canonical_path4;
+  paragraph->ComputeWavyDecoration(path4, 1, 1, 12, 1);
+
+  canonical_path4.moveTo(1, 1);
+  canonical_path4.rQuadTo(1, -1, 2, 0);
+  canonical_path4.rQuadTo(1, 1, 2, 0);
+  canonical_path4.rQuadTo(1, -1, 2, 0);
+  canonical_path4.rQuadTo(1, 1, 2, 0);
+  canonical_path4.rQuadTo(1, -1, 2, 0);
+  canonical_path4.rQuadTo(1, 1, 2, 0);
+
+  ASSERT_EQ(path4.countPoints(), canonical_path4.countPoints());
+  for (int i = 0; i < canonical_path4.countPoints(); ++i) {
+    ASSERT_EQ(path4.getPoint(i).x(), canonical_path4.getPoint(i).x());
+    ASSERT_EQ(path4.getPoint(i).y(), canonical_path4.getPoint(i).y());
+  }
 }
 
 TEST_F(ParagraphTest, ItalicsParagraph) {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/12794

Use bezier equations to manually compute the control and end points of the required beziers and draw the partial curve that are not integral intervals of the wavelangth.

See https://math.stackexchange.com/questions/1360891/find-quadratic-bezier-curve-equation-based-on-its-control-points and https://math.stackexchange.com/questions/1666026/find-the-control-point-of-quadratic-bezier-curve-having-only-the-end-points for reference on the math.