### PR TITLE
Locale._toLanguageTag(): check separator before returning cached string

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -478,6 +478,7 @@ class Locale {
   int get hashCode => hashValues(languageCode, scriptCode, countryCode);
 
   static Locale cachedLocale;
+  static String cachedSeparator;
   static String cachedLocaleString;
 
   /// Returns a string representing the locale.
@@ -496,8 +497,9 @@ class Locale {
   String toLanguageTag() => _toLanguageTag();
 
   String _toLanguageTag([String separator = '-']) {
-    if (!identical(cachedLocale, this)) {
+    if (!identical(cachedLocale, this) || cachedSeparator != separator) {
       cachedLocale = this;
+      cachedSeparator = separator;
       cachedLocaleString = _rawToString(separator);
     }
     return cachedLocaleString;

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -24,4 +24,10 @@ void main() {
     FrameTiming timing = FrameTiming(<int>[1000, 8000, 9000, 19500]);
     expect(timing.toString(), 'FrameTiming(buildDuration: 7.0ms, rasterDuration: 10.5ms, totalSpan: 18.5ms)');
   });
+
+  test('Locale._toLanguageTag() checks separator before returning cached string', () {
+    final Locale locale = Locale('en', 'us');
+    expect(locale.toString(), 'en_us');
+    expect(locale.toLanguageTag(), 'en-us');
+  });
 }


### PR DESCRIPTION
closes flutter/flutter#34307