### PR TITLE
Add --observatory-host switch

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -42,8 +42,8 @@ std::string Settings::ToString() const {
   stream << "enable_dart_profiling: " << enable_dart_profiling << std::endl;
   stream << "disable_dart_asserts: " << disable_dart_asserts << std::endl;
   stream << "enable_observatory: " << enable_observatory << std::endl;
+  stream << "observatory_host: " << observatory_host << std::endl;
   stream << "observatory_port: " << observatory_port << std::endl;
-  stream << "ipv6: " << ipv6 << std::endl;
   stream << "use_test_fonts: " << use_test_fonts << std::endl;
   stream << "enable_software_rendering: " << enable_software_rendering
          << std::endl;

--- a/common/settings.h
+++ b/common/settings.h
@@ -101,11 +101,17 @@ struct Settings {
   std::string advisory_script_entrypoint = "main";
 
   // Observatory settings
+
+  // Whether the Dart VM service should be enabled.
   bool enable_observatory = false;
-  // Port on target will be auto selected by the OS. A message will be printed
-  // on the target with the port after it has been selected.
+
+  // The IP address to which the Dart VM service is bound.
+  std::string observatory_host;
+
+  // The port to which the Dart VM service is bound. When set to `0`, a free
+  // port will be automatically selected by the OS. A message is logged on the
+  // target indicating the URL at which the VM service can be accessed.
   uint32_t observatory_port = 0;
-  bool ipv6 = false;
 
   // Determines whether an authentication code is required to communicate with
   // the VM service.

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -613,9 +613,9 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
 
   tonic::DartState::Scope scope(service_isolate);
   if (!DartServiceIsolate::Startup(
-          settings.ipv6 ? "::1" : "127.0.0.1",  // server IP address
-          settings.observatory_port,            // server observatory port
-          tonic::DartState::HandleLibraryTag,   // embedder library tag handler
+          settings.observatory_host,           // server IP address
+          settings.observatory_port,           // server observatory port
+          tonic::DartState::HandleLibraryTag,  // embedder library tag handler
           false,  //  disable websocket origin check
           settings.disable_service_auth_codes,  // disable VM service auth codes
           error                                 // error (out)

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -207,7 +207,8 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.disable_dart_asserts =
       command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));
 
-  settings.ipv6 = command_line.HasOption(FlagForSwitch(Switch::IPv6));
+  settings.observatory_host =
+      command_line.HasOption(FlagForSwitch(Switch::IPv6)) ? "::1" : "127.0.0.1";
 
   settings.start_paused =
       command_line.HasOption(FlagForSwitch(Switch::StartPaused));

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -188,6 +188,18 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.enable_observatory =
       !command_line.HasOption(FlagForSwitch(Switch::DisableObservatory));
 
+  // Set Observatory Host
+  if (command_line.HasOption(FlagForSwitch(Switch::DeviceObservatoryHost))) {
+    command_line.GetOptionValue(FlagForSwitch(Switch::DeviceObservatoryHost),
+                                &settings.observatory_host);
+  }
+  // Default the observatory port based on --ipv6 if not set.
+  if (settings.observatory_host.empty()) {
+    settings.observatory_host =
+        command_line.HasOption(FlagForSwitch(Switch::IPv6)) ? "::1"
+                                                            : "127.0.0.1";
+  }
+
   // Set Observatory Port
   if (command_line.HasOption(FlagForSwitch(Switch::DeviceObservatoryPort))) {
     if (!GetSwitchValue(command_line, Switch::DeviceObservatoryPort,
@@ -206,9 +218,6 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   // Checked mode overrides.
   settings.disable_dart_asserts =
       command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));
-
-  settings.observatory_host =
-      command_line.HasOption(FlagForSwitch(Switch::IPv6)) ? "::1" : "127.0.0.1";
 
   settings.start_paused =
       command_line.HasOption(FlagForSwitch(Switch::StartPaused));

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -61,6 +61,11 @@ DEF_SWITCH(DartFlags,
            "dart-flags",
            "Flags passed directly to the Dart VM without being interpreted "
            "by the Flutter shell.")
+DEF_SWITCH(DeviceObservatoryHost,
+           "observatory-host",
+           "The hostname/IP address on which the Dart Observatory should "
+           "be served. If not set, defaults to 127.0.0.1 or ::1 depending on "
+           "whether --ipv6 is specified.")
 DEF_SWITCH(DeviceObservatoryPort,
            "observatory-port",
            "A custom Dart Observatory port. The default is to pick a randomly "
@@ -71,7 +76,8 @@ DEF_SWITCH(DisableObservatory,
            "in release mode.")
 DEF_SWITCH(IPv6,
            "ipv6",
-           "Bind to the IPv6 localhost address for the Dart Observatory.")
+           "Bind to the IPv6 localhost address for the Dart Observatory. "
+           "Ignored if --observatory-host is set.")
 DEF_SWITCH(EnableDartProfiling,
            "enable-dart-profiling",
            "Enable Dart profiling. Profiling information can be viewed from "


### PR DESCRIPTION
Adds --observatory-host, which allows callers to specify the localhost
IP binding directly. Allows users to set 0.0.0.0 or the host IP address
as is possible in the standalone VM, rather than restricting users to
loopback.

We retain the default behaviour of binding to loopback since the vast
majority of observatory use-cases involve local access (e.g. host tests
on flutter_tester) or port-forwarded local access (e.g. flutter driver
device tests). However, some scenarios, such as QA test labs, may
benefit from binding to a publicly-accessible IP address.