### PR TITLE
Use NSSelectorFromString instead of @selector for dynamically added UIApplicationDelegate methods

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -83,13 +83,6 @@ FLUTTER_EXPORT
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.
  */
 - (void)application:(UIApplication*)application
-    didReceiveRemoteNotification:(NSDictionary*)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
-
-/**
- * Calls all plugins registered for `UIApplicationDelegate` callbacks.
- */
-- (void)application:(UIApplication*)application
     didReceiveLocalNotification:(UILocalNotification*)notification
     API_DEPRECATED(
         "See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation",
@@ -150,15 +143,6 @@ FLUTTER_EXPORT
 - (BOOL)application:(UIApplication*)application
     handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
                       completionHandler:(nonnull void (^)(void))completionHandler;
-
-/**
- * Calls all plugins registered for `UIApplicationDelegate` callbacks in order of registration until
- * some plugin handles the request.
- *
- * @returns `YES` if any plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-    performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks in order of registration until

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -215,7 +215,8 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
 }
 
 - (id)forwardingTargetForSelector:(SEL)aSelector {
-  if ([_lifeCycleDelegate isSelectorAddedDynamically:aSelector]) {
+  if ([_lifeCycleDelegate isSelectorAddedDynamically:aSelector] &&
+      [_lifeCycleDelegate hasPluginThatRespondsToSelector:aSelector]) {
     [self logCapabilityConfigurationWarningIfNeeded:aSelector];
     return _lifeCycleDelegate;
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -40,6 +40,20 @@ static BOOL isPowerOfTwo(NSUInteger x) {
   return x != 0 && (x & (x - 1)) == 0;
 }
 
+- (id)forwardingTargetForSelector:(SEL)selector {
+  if ([self isSelectorAddedDynamically:selector]) {
+    for (id<FlutterPlugin> plugin in [_pluginDelegates allObjects]) {
+      if (!plugin) {
+        continue;
+      }
+      if ([plugin respondsToSelector:selector]) {
+        return plugin;
+      }
+    }
+  }
+  return [super forwardingTargetForSelector:selector];
+}
+
 - (BOOL)isSelectorAddedDynamically:(SEL)selector {
   for (const SEL& aSelector : selectorsHandledByPlugins) {
     if (selector == aSelector) {
@@ -211,23 +225,6 @@ static BOOL isPowerOfTwo(NSUInteger x) {
   }
 }
 
-- (void)application:(UIApplication*)application
-    didReceiveRemoteNotification:(NSDictionary*)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
-      continue;
-    }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
-              didReceiveRemoteNotification:userInfo
-                    fetchCompletionHandler:completionHandler]) {
-        return;
-      }
-    }
-  }
-}
-
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
@@ -339,21 +336,6 @@ static BOOL isPowerOfTwo(NSUInteger x) {
       if ([plugin application:application
               handleEventsForBackgroundURLSession:identifier
                                 completionHandler:completionHandler]) {
-        return YES;
-      }
-    }
-  }
-  return NO;
-}
-
-- (BOOL)application:(UIApplication*)application
-    performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
-    if (!plugin) {
-      continue;
-    }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application performFetchWithCompletionHandler:completionHandler]) {
         return YES;
       }
     }


### PR DESCRIPTION
Possible (untested) fix for flutter/flutter#9984

![image](https://user-images.githubusercontent.com/394889/60996152-ee9f6480-a308-11e9-8f41-82c889a31f0a.png)

Using `NSSelectorFromString` we may be able to avoid having selectors for push messaging APIs flagged in the submission process.

Since the submitted apps aren't actually using push messages it seems likely to me that one of two things are happening:

1. The submission scanning process is checking statically for the selectors in the compiled app.
1. The submission scanning process is running the app and seeing what selectors are created at runtime.

This PR should work for the former case. More effort is required in the latter case to avoid tripping the warning (doing string comparisons instead of directly comparing selectors). This might be unnecessary complexity though so we should probably test if the simple fix works before doing the more complicated one.