### PR TITLE
Run benchmarks on try jobs.

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -173,6 +173,8 @@ shell_host_executable("shell_benchmarks") {
   ]
 
   deps = [
+    ":shell_unittests_fixtures",
     "$flutter_root/benchmarking",
+    "$flutter_root/testing:testing_lib",
   ]
 }

--- a/shell/common/shell_benchmarks.cc
+++ b/shell/common/shell_benchmarks.cc
@@ -4,14 +4,18 @@
 
 #include "flutter/benchmarking/benchmarking.h"
 #include "flutter/fml/logging.h"
+#include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
+#include "flutter/testing/testing.h"
 
 namespace flutter {
 
 static void StartupAndShutdownShell(benchmark::State& state,
                                     bool measure_startup,
                                     bool measure_shutdown) {
+  auto assets_dir = fml::OpenDirectory(testing::GetFixturesPath(), false,
+                                       fml::FilePermission::kRead);
   std::unique_ptr<Shell> shell;
   std::unique_ptr<ThreadHost> thread_host;
   {
@@ -20,7 +24,35 @@ static void StartupAndShutdownShell(benchmark::State& state,
     settings.task_observer_add = [](intptr_t, fml::closure) {};
     settings.task_observer_remove = [](intptr_t) {};
 
-    // Measure the time it takes to setup the threads as well.
+    if (DartVM::IsRunningPrecompiledCode()) {
+      settings.vm_snapshot_data = [&]() {
+        return fml::FileMapping::CreateReadOnly(assets_dir, "vm_snapshot_data");
+      };
+
+      settings.isolate_snapshot_data = [&]() {
+        return fml::FileMapping::CreateReadOnly(assets_dir,
+                                                "isolate_snapshot_data");
+      };
+
+      settings.vm_snapshot_instr = [&]() {
+        return fml::FileMapping::CreateReadExecute(assets_dir,
+                                                   "vm_snapshot_instr");
+      };
+
+      settings.isolate_snapshot_instr = [&]() {
+        return fml::FileMapping::CreateReadExecute(assets_dir,
+                                                   "isolate_snapshot_instr");
+      };
+
+    } else {
+      settings.application_kernels = [&]() {
+        std::vector<std::unique_ptr<const fml::Mapping>> kernel_mappings;
+        kernel_mappings.emplace_back(
+            fml::FileMapping::CreateReadOnly(assets_dir, "kernel_blob.bin"));
+        return kernel_mappings;
+      };
+    }
+
     thread_host = std::make_unique<ThreadHost>(
         "io.flutter.bench.", ThreadHost::Type::Platform |
                                  ThreadHost::Type::GPU | ThreadHost::Type::IO |

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -2,23 +2,33 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-source_set("testing") {
+source_set("testing_lib") {
   testonly = true
 
   sources = [
-    "$flutter_root/testing/run_all_unittests.cc",
     "$flutter_root/testing/testing.cc",
     "$flutter_root/testing/testing.h",
-    "$flutter_root/testing/thread_test.cc",
-    "$flutter_root/testing/thread_test.h",
   ]
 
   public_deps = [
     "$flutter_root/fml",
     "//third_party/googletest:gtest",
   ]
-
   public_configs = [ "$flutter_root:config" ]
+}
+
+source_set("testing") {
+  testonly = true
+
+  sources = [
+    "$flutter_root/testing/run_all_unittests.cc",
+    "$flutter_root/testing/thread_test.cc",
+    "$flutter_root/testing/thread_test.h",
+  ]
+
+  public_deps = [
+    ":testing_lib",
+  ]
 }
 
 source_set("dart") {

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -32,11 +32,17 @@ echo "Running flow_unittests..."
 echo "Running fml_unittests..."
 "$HOST_DIR/fml_unittests" --gtest_filter="-*TimeSensitiveTest*"
 
+echo "Running fml_benchmarks..."
+"$HOST_DIR/fml_benchmarks"
+
 echo "Running runtime_unittests..."
 "$HOST_DIR/runtime_unittests"
 
 echo "Running shell_unittests..."
 "$HOST_DIR/shell_unittests"
+
+echo "Running shell_benchmarks..."
+"$HOST_DIR/shell_benchmarks"
 
 echo "Running client_wrapper_unittests..."
 "$HOST_DIR/client_wrapper_unittests"
@@ -46,6 +52,9 @@ echo "Running client_wrapper_glfw_unittests..."
 
 echo "Running txt_unittests..."
 "$HOST_DIR/txt_unittests" --font-directory="$BUILDROOT_DIR/flutter/third_party/txt/third_party/fonts"
+
+echo "Running txt_benchmarks..."
+"$HOST_DIR/txt_benchmarks" --font-directory="$BUILDROOT_DIR/flutter/third_party/txt/third_party/fonts"
 
 # Build flutter/sky/packages.
 #


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/35089.

These runs only ensure that the benchmark harnesses are valid. No information should be collected on the trybots because the environments are not consistent and the builds are not optimized.