### PR TITLE
Improve caching limits for Skia

### DIFF
--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -407,8 +407,7 @@ void Rasterizer::FireNextFrameCallbackIfPresent() {
 }
 
 void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
-  user_override_resource_cache_bytes_.store(
-      user_override_resource_cache_bytes_ || from_user);
+  user_override_resource_cache_bytes_ |= from_user;
 
   if (!from_user && user_override_resource_cache_bytes_) {
     // We should not update the setting here if a user has explicitly set a

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -406,7 +406,7 @@ void Rasterizer::FireNextFrameCallbackIfPresent() {
   callback();
 }
 
-void Rasterizer::SetResourceCacheMaxBytes(int max_bytes, bool from_user) {
+void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
   user_override_resource_cache_bytes_ |= from_user;
 
   if (!from_user && user_override_resource_cache_bytes_) {
@@ -423,14 +423,13 @@ void Rasterizer::SetResourceCacheMaxBytes(int max_bytes, bool from_user) {
   }
 }
 
-int Rasterizer::GetResourceCacheMaxBytes() const {
+size_t Rasterizer::GetResourceCacheMaxBytes() const {
   GrContext* context = surface_->GetContext();
   if (context) {
-    int max_resources;
-    context->getResourceCacheLimits(&max_resources, nullptr);
-    return max_resources;
+    size_t max_bytes;
+    context->getResourceCacheLimits(nullptr, &max_bytes);
+    return max_bytes;
   }
-  FML_DLOG(ERROR) << "There is no context?!";
   return 0;
 }
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -407,7 +407,8 @@ void Rasterizer::FireNextFrameCallbackIfPresent() {
 }
 
 void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
-  user_override_resource_cache_bytes_ |= from_user;
+  user_override_resource_cache_bytes_.store(
+      user_override_resource_cache_bytes_ || from_user);
 
   if (!from_user && user_override_resource_cache_bytes_) {
     // We should not update the setting here if a user has explicitly set a

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -92,7 +92,13 @@ class Rasterizer final : public SnapshotDelegate {
     return compositor_context_.get();
   }
 
-  void SetResourceCacheMaxBytes(int max_bytes);
+  // Sets the max size in bytes of the Skia resource cache. If this call is
+  // originating from the user, e.g. over the flutter/skia system channel,
+  // set from_user to true and the value will take precedence over system
+  // generated values, e.g. from a display resolution change.
+  void SetResourceCacheMaxBytes(int max_bytes, bool from_user);
+
+  int GetResourceCacheMaxBytes() const;
 
  private:
   Delegate& delegate_;
@@ -101,6 +107,7 @@ class Rasterizer final : public SnapshotDelegate {
   std::unique_ptr<flutter::CompositorContext> compositor_context_;
   std::unique_ptr<flutter::LayerTree> last_layer_tree_;
   fml::closure next_frame_callback_;
+  bool user_override_resource_cache_bytes_;
   fml::WeakPtrFactory<Rasterizer> weak_factory_;
 
   // |SnapshotDelegate|

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -107,7 +107,7 @@ class Rasterizer final : public SnapshotDelegate {
   std::unique_ptr<flutter::CompositorContext> compositor_context_;
   std::unique_ptr<flutter::LayerTree> last_layer_tree_;
   fml::closure next_frame_callback_;
-  bool user_override_resource_cache_bytes_;
+  std::atomic<bool> user_override_resource_cache_bytes_;
   fml::WeakPtrFactory<Rasterizer> weak_factory_;
 
   // |SnapshotDelegate|

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -96,9 +96,9 @@ class Rasterizer final : public SnapshotDelegate {
   // originating from the user, e.g. over the flutter/skia system channel,
   // set from_user to true and the value will take precedence over system
   // generated values, e.g. from a display resolution change.
-  void SetResourceCacheMaxBytes(int max_bytes, bool from_user);
+  void SetResourceCacheMaxBytes(size_t max_bytes, bool from_user);
 
-  int GetResourceCacheMaxBytes() const;
+  size_t GetResourceCacheMaxBytes() const;
 
  private:
   Delegate& delegate_;

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -107,7 +107,7 @@ class Rasterizer final : public SnapshotDelegate {
   std::unique_ptr<flutter::CompositorContext> compositor_context_;
   std::unique_ptr<flutter::LayerTree> last_layer_tree_;
   fml::closure next_frame_callback_;
-  std::atomic<bool> user_override_resource_cache_bytes_;
+  bool user_override_resource_cache_bytes_;
   fml::WeakPtrFactory<Rasterizer> weak_factory_;
 
   // |SnapshotDelegate|

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -873,7 +873,8 @@ void Shell::HandleEngineSkiaMessage(fml::RefPtr<PlatformMessage> message) {
       [rasterizer = rasterizer_->GetWeakPtr(),
        max_bytes = args->value.GetInt()] {
         if (rasterizer) {
-          rasterizer->SetResourceCacheMaxBytes(max_bytes, true);
+          rasterizer->SetResourceCacheMaxBytes(static_cast<size_t>(max_bytes),
+                                               true);
         }
       });
 }

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -106,10 +106,10 @@ class Shell final : public PlatformView::Delegate,
   fml::WeakPtr<Engine> weak_engine_;          // to be shared across threads
   fml::WeakPtr<Rasterizer> weak_rasterizer_;  // to be shared across threads
   fml::WeakPtr<PlatformView>
-      weak_platform_view_;                   // to be shared across threads
+      weak_platform_view_;                 // to be shared across threads
   int raster_cache_max_bytes_user_value_;  // The user-requested value for the
-                                             // Skia resource cache. -1 if not
-                                             // set.
+                                           // Skia resource cache. -1 if not
+                                           // set.
 
   std::unordered_map<std::string,  // method
                      std::pair<fml::RefPtr<fml::TaskRunner>,

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -106,7 +106,10 @@ class Shell final : public PlatformView::Delegate,
   fml::WeakPtr<Engine> weak_engine_;          // to be shared across threads
   fml::WeakPtr<Rasterizer> weak_rasterizer_;  // to be shared across threads
   fml::WeakPtr<PlatformView>
-      weak_platform_view_;  // to be shared across threads
+      weak_platform_view_;                   // to be shared across threads
+  int raster_cache_max_bytes_user_value_;  // The user-requested value for the
+                                             // Skia resource cache. -1 if not
+                                             // set.
 
   std::unordered_map<std::string,  // method
                      std::pair<fml::RefPtr<fml::TaskRunner>,

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -106,10 +106,7 @@ class Shell final : public PlatformView::Delegate,
   fml::WeakPtr<Engine> weak_engine_;          // to be shared across threads
   fml::WeakPtr<Rasterizer> weak_rasterizer_;  // to be shared across threads
   fml::WeakPtr<PlatformView>
-      weak_platform_view_;                 // to be shared across threads
-  int raster_cache_max_bytes_user_value_;  // The user-requested value for the
-                                           // Skia resource cache. -1 if not
-                                           // set.
+      weak_platform_view_;  // to be shared across threads
 
   std::unordered_map<std::string,  // method
                      std::pair<fml::RefPtr<fml::TaskRunner>,

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -28,7 +28,10 @@ static const int kGrCacheMaxCount = 8192;
 
 // Default maximum number of bytes of GPU memory of budgeted resources in the
 // cache.
-static const size_t kGrCacheMaxByteSize = 512 * (1 << 20);
+// The shell will dynamically increase or decrease this cache based on the
+// viewport size, unless a user has specifically requested a size on the Skia
+// system channel.
+static const size_t kGrCacheMaxByteSize = 24 * (1 << 20);
 
 GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
     : delegate_(delegate), weak_factory_(this) {


### PR DESCRIPTION
Our current Skia cache limit for the on screen GrContext is 512mb.  We already know this is too big for some lower end devices, and so we've implemented a custom channel to allow applications or embedders to easily set a lower value.

The value is just too high for lower end devices with little ram.  Android P+ uses the formula added here - I've also set the initial value substantially lower so we don't end up allocating lots of memory while waiting for the screen metrics to get pumped through.

Fixes https://github.com/flutter/flutter/issues/35091
Fixes https://github.com/flutter/flutter/issues/35038

/cc @ened

/cc @nathanrogersgoogle 