### PR TITLE
fix FlutterOverlayView doesn't remove from superview in some cases

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -411,6 +411,9 @@ void FlutterPlatformViewsController::DisposeViews() {
     views_.erase(viewId);
     touch_interceptors_.erase(viewId);
     root_views_.erase(viewId);
+    if (overlays_.find(viewId) != overlays_.end()) {
+      [overlays_[viewId]->overlay_view.get() removeFromSuperview];
+    }
     overlays_.erase(viewId);
     current_composition_params_.erase(viewId);
     clip_count_.erase(viewId);


### PR DESCRIPTION
1.Problem
https://github.com/flutter/flutter/issues/35177

2.Demo
https://github.com/Qxyat/Flutter-demo/tree/master/platform_view_demo

3.Solution
The 'views_to_dispose_' cache the view removed in 'OnDispose'，and the overlays_ attach to that 'viewId' should also remove from superview.