### PR TITLE
[all] add fuchsia.{net.NameLookup,posix.socket.Provider}

### DIFF
--- a/shell/platform/fuchsia/dart/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_aot_product_runner.cmx
@@ -4,12 +4,14 @@
     },
     "sandbox": {
         "features": [
-            "root-ssl-certificates"
+            "root-ssl-certificates",
             "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracelink.Registry"

--- a/shell/platform/fuchsia/dart/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_aot_runner.cmx
@@ -10,6 +10,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracelink.Registry"

--- a/shell/platform/fuchsia/dart/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_jit_product_runner.cmx
@@ -4,12 +4,14 @@
     },
     "sandbox": {
         "features": [
-            "root-ssl-certificates"
+            "root-ssl-certificates",
             "deprecated-ambient-replace-as-executable"
         ],
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.process.Launcher",
             "fuchsia.process.Resolver",

--- a/shell/platform/fuchsia/dart/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_jit_runner.cmx
@@ -10,6 +10,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.process.Launcher",
             "fuchsia.process.Resolver",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -12,6 +12,8 @@
             "fuchsia.crash.Analyzer",
             "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -12,6 +12,8 @@
             "fuchsia.crash.Analyzer",
             "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -12,6 +12,8 @@
             "fuchsia.device.manager.Administrator",
             "fuchsia.crash.Analyzer",
             "fuchsia.fonts.Provider",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -12,6 +12,8 @@
             "fuchsia.crash.Analyzer",
             "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",
+            "fuchsia.posix.socket.Provider",
+            "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",


### PR DESCRIPTION
These services will replace fuchsia.net.SocketProvider.

Note that dart_{aot,jit}_product_runner.cmx were invalid before this
change. I'm not sure how that was allowed to happen.

r? @zanderso 