### PR TITLE
[WIP] Pipeline consume can re-draw a layer tree

### DIFF
--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -20,6 +20,8 @@ namespace flutter {
 
 class LayerTree;
 
+enum class RasterStatus { kSuccess, kFailed, kResubmit };
+
 class CompositorContext {
  public:
   class ScopedFrame {
@@ -45,7 +47,8 @@ class CompositorContext {
 
     GrContext* gr_context() const { return gr_context_; }
 
-    virtual bool Raster(LayerTree& layer_tree, bool ignore_raster_cache);
+    virtual RasterStatus Raster(LayerTree& layer_tree,
+                                bool ignore_raster_cache);
 
    private:
     CompositorContext& context_;

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -196,6 +196,8 @@ class ExternalViewEmbedder {
 
   virtual bool SubmitFrame(GrContext* context);
 
+  virtual bool MergeThreads() = 0;
+
   virtual ~ExternalViewEmbedder() = default;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ExternalViewEmbedder);

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -183,12 +183,14 @@ void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
   persistent_cache->ResetStoredNewShaders();
 
   RasterStatus draw_status = RasterStatus::kFailed;
+  flutter::LayerTree& layer_tree_raw = *layer_tree;
 
   // task - 1
   task_runners_.GetGPUTaskRunner()->PostTask(
-      [weak_this = weak_factory_.GetWeakPtr(), &layer_tree, &draw_status]() {
+      [weak_this = weak_factory_.GetWeakPtr(), &layer_tree_raw,
+       &draw_status]() {
         if (weak_this) {
-          draw_status = weak_this->DrawToSurface(*layer_tree);
+          draw_status = weak_this->DrawToSurface(layer_tree_raw);
         }
       });
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -107,12 +107,7 @@ void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
   // between successive tries.
   switch (pipeline->Consume(consumer)) {
     case PipelineConsumeResult::MoreAvailable: {
-      task_runners_.GetGPUTaskRunner()->PostTask(
-          [weak_this = weak_factory_.GetWeakPtr(), pipeline]() {
-            if (weak_this) {
-              weak_this->Draw(pipeline);
-            }
-          });
+      Draw(pipeline);
       break;
     }
     default:
@@ -173,6 +168,8 @@ sk_sp<SkImage> Rasterizer::MakeRasterSnapshot(sk_sp<SkPicture> picture,
 }
 
 void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
+  FML_CHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
+
   if (!layer_tree || !surface_) {
     return;
   }
@@ -185,31 +182,64 @@ void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
   PersistentCache* persistent_cache = PersistentCache::GetCacheForProcess();
   persistent_cache->ResetStoredNewShaders();
 
-  if (DrawToSurface(*layer_tree)) {
+  RasterStatus draw_status = DrawToSurfaceOnGPU(*layer_tree);
+  if (draw_status == RasterStatus::kResubmit) {
+    // TODO (kaushikiska): merge threads here, since we are on the ui thread.
+    const RasterStatus redraw_status = DrawToSurfaceOnGPU(*layer_tree);
+    FML_CHECK(draw_status == RasterStatus::kFailed ||
+              draw_status == RasterStatus::kSuccess)
+        << "Invalid re-draw status. It has to be success or failure.";
+    draw_status = redraw_status;
+  }
+
+  if (draw_status == RasterStatus::kSuccess) {
     last_layer_tree_ = std::move(layer_tree);
+  } else {
+    FML_DLOG(ERROR) << "Failed to rasterize the layer tree.";
+    return;
   }
 
-  if (persistent_cache->IsDumpingSkp() &&
-      persistent_cache->StoredNewShaders()) {
-    auto screenshot =
-        ScreenshotLastLayerTree(ScreenshotType::SkiaPicture, false);
-    persistent_cache->DumpSkp(*screenshot.data);
-  }
+  task_runners_.GetGPUTaskRunner()->PostTask(
+      [weak_this = weak_factory_.GetWeakPtr(), &persistent_cache, &timing]() {
+        if (!weak_this) {
+          return;
+        }
+        if (persistent_cache->IsDumpingSkp() &&
+            persistent_cache->StoredNewShaders()) {
+          auto screenshot = weak_this->ScreenshotLastLayerTree(
+              ScreenshotType::SkiaPicture, false);
+          persistent_cache->DumpSkp(*screenshot.data);
+        }
 
-  // TODO(liyuqian): in Fuchsia, the rasterization doesn't finish when
-  // Rasterizer::DoDraw finishes. Future work is needed to adapt the timestamp
-  // for Fuchsia to capture SceneUpdateContext::ExecutePaintTasks.
-  timing.Set(FrameTiming::kRasterFinish, fml::TimePoint::Now());
-  delegate_.OnFrameRasterized(timing);
+        // TODO(liyuqian): in Fuchsia, the rasterization doesn't finish when
+        // Rasterizer::DoDraw finishes. Future work is needed to adapt the
+        // timestamp for Fuchsia to capture
+        // SceneUpdateContext::ExecutePaintTasks.
+        timing.Set(FrameTiming::kRasterFinish, fml::TimePoint::Now());
+        weak_this->delegate_.OnFrameRasterized(timing);
+      });
 }
 
-bool Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
+RasterStatus Rasterizer::DrawToSurfaceOnGPU(flutter::LayerTree& layer_tree) {
+  RasterStatus draw_status = RasterStatus::kFailed;
+
+  task_runners_.GetGPUTaskRunner()->PostTask(
+      [weak_this = weak_factory_.GetWeakPtr(), &layer_tree, &draw_status]() {
+        if (weak_this) {
+          draw_status = weak_this->DrawToSurface(layer_tree);
+        }
+      });
+
+  return draw_status;
+}
+
+RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   FML_DCHECK(surface_);
 
   auto frame = surface_->AcquireFrame(layer_tree.frame_size());
 
   if (frame == nullptr) {
-    return false;
+    return RasterStatus::kFailed;
   }
 
   // There is no way for the compositor to know how long the layer tree
@@ -229,7 +259,11 @@ bool Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
       surface_->GetContext(), canvas, external_view_embedder,
       surface_->GetRootTransformation(), true);
 
-  if (compositor_frame && compositor_frame->Raster(layer_tree, false)) {
+  if (compositor_frame) {
+    RasterStatus raster_status = compositor_frame->Raster(layer_tree, false);
+    if (raster_status != RasterStatus::kSuccess) {
+      return raster_status;
+    }
     frame->Submit();
     if (external_view_embedder != nullptr) {
       external_view_embedder->SubmitFrame(surface_->GetContext());
@@ -239,10 +273,10 @@ bool Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
     if (surface_->GetContext())
       surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
 
-    return true;
+    return RasterStatus::kSuccess;
   }
 
-  return false;
+  return RasterStatus::kFailed;
 }
 
 static sk_sp<SkData> SerializeTypeface(SkTypeface* typeface, void* ctx) {

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -116,7 +116,8 @@ class Rasterizer final : public SnapshotDelegate {
 
   void DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
 
-  RasterStatus DrawToSurfaceOnGPU(flutter::LayerTree& layer_tree);
+  RasterStatus DrawToSurfaceOnGPU(flutter::LayerTree& layer_tree,
+                                  fml::AutoResetWaitableEvent& latch);
 
   RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);
 

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -116,7 +116,9 @@ class Rasterizer final : public SnapshotDelegate {
 
   void DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
 
-  bool DrawToSurface(flutter::LayerTree& layer_tree);
+  RasterStatus DrawToSurfaceOnGPU(flutter::LayerTree& layer_tree);
+
+  RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);
 
   void FireNextFrameCallbackIfPresent();
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -798,14 +798,9 @@ void Shell::OnAnimatorNotifyIdle(int64_t deadline) {
 // |Animator::Delegate|
 void Shell::OnAnimatorDraw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
   FML_DCHECK(is_setup_);
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
-  task_runners_.GetGPUTaskRunner()->PostTask(
-      [rasterizer = rasterizer_->GetWeakPtr(),
-       pipeline = std::move(pipeline)]() {
-        if (rasterizer) {
-          rasterizer->Draw(pipeline);
-        }
-      });
+  rasterizer_->Draw(pipeline);
 }
 
 // |Animator::Delegate|

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -161,10 +161,15 @@ void FlutterPlatformViewsController::SetFrameSize(SkISize frame_size) {
 }
 
 void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(int view_id) {
+  ui_view_bounds_modified_in_frame_ = false;
   picture_recorders_[view_id] = std::make_unique<SkPictureRecorder>();
   picture_recorders_[view_id]->beginRecording(SkRect::Make(frame_size_));
   picture_recorders_[view_id]->getRecordingCanvas()->clear(SK_ColorTRANSPARENT);
   composition_order_.push_back(view_id);
+}
+
+bool FlutterPlatformViewsController::UIViewBoundsModifiedInFrame() {
+  return ui_view_bounds_modified_in_frame_;
 }
 
 NSObject<FlutterPlatformView>* FlutterPlatformViewsController::GetPlatformViewByID(int view_id) {
@@ -307,6 +312,7 @@ SkCanvas* FlutterPlatformViewsController::CompositeEmbeddedView(
       current_composition_params_[view_id] == params) {
     return picture_recorders_[view_id]->getRecordingCanvas();
   }
+  ui_view_bounds_modified_in_frame_ = true;
   current_composition_params_[view_id] = EmbeddedViewParams(params);
   CompositeWithParams(view_id, params);
 
@@ -351,6 +357,7 @@ bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
     composition_order_.clear();
     return did_submit;
   }
+  ui_view_bounds_modified_in_frame_ = true;
   DetachUnusedLayers();
   active_composition_order_.clear();
   UIView* flutter_view = flutter_view_.get();

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -82,6 +82,8 @@ class FlutterPlatformViewsController {
 
   void PrerollCompositeEmbeddedView(int view_id);
 
+  bool UIViewBoundsModifiedInFrame();
+
   // Returns the `FlutterPlatformView` object associated with the view_id.
   //
   // If the `FlutterPlatformViewsController` does not contain any `FlutterPlatformView` object or
@@ -137,6 +139,11 @@ class FlutterPlatformViewsController {
 
   // The latest composition order that was presented in Present().
   std::vector<int64_t> active_composition_order_;
+
+  // Preroll sets this to false. In paint if any of the bounds for any of the platform views
+  // have changed. This is set to true. This is then used to determine if we need to merge the
+  // platform and gpu threads.
+  bool ui_view_bounds_modified_in_frame_;
 
   std::map<int64_t, std::unique_ptr<SkPictureRecorder>> picture_recorders_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -66,6 +66,9 @@ class IOSSurfaceGL final : public IOSSurface,
   // |flutter::ExternalViewEmbedder|
   bool SubmitFrame(GrContext* context) override;
 
+  // |flutter::ExternalViewEmbedder|
+  bool MergeThreads() override;
+
  private:
   std::shared_ptr<IOSGLContext> context_;
   std::unique_ptr<IOSGLRenderTarget> render_target_;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -119,4 +119,10 @@ bool IOSSurfaceGL::SubmitFrame(GrContext* context) {
   return submitted;
 }
 
+bool IOSSurfaceGL::MergeThreads() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  return platform_views_controller->UIViewBoundsModifiedInFrame();
+}
+
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -58,6 +58,9 @@ class IOSSurfaceSoftware final : public IOSSurface,
   SkCanvas* CompositeEmbeddedView(int view_id, const flutter::EmbeddedViewParams& params) override;
 
   // |flutter::ExternalViewEmbedder|
+  bool MergeThreads() override;
+
+  // |flutter::ExternalViewEmbedder|
   bool SubmitFrame(GrContext* context) override;
 
  private:

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -160,6 +160,12 @@ SkCanvas* IOSSurfaceSoftware::CompositeEmbeddedView(int view_id,
   return platform_views_controller->CompositeEmbeddedView(view_id, params);
 }
 
+bool IOSSurfaceSoftware::MergeThreads() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  return platform_views_controller->UIViewBoundsModifiedInFrame();
+}
+
 bool IOSSurfaceSoftware::SubmitFrame(GrContext* context) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   if (platform_views_controller == nullptr) {


### PR DESCRIPTION
- External view embedded after paint knows if it needs to
  be re-drawn.

- We use this information to determine whether we want to merge
  the platform and GPU threads.

- Rasterizer uses the raster status to resubmit the layer tree
  to be redrawn.