### PR TITLE
[trace clients] Remove fuchsia.tracelink.Registry

### DIFF
--- a/shell/platform/fuchsia/dart/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_aot_product_runner.cmx
@@ -14,7 +14,6 @@
             "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.timezone.Timezone",
-            "fuchsia.tracelink.Registry",
             "fuchsia.tracing.provider.Registry"
         ]
     }

--- a/shell/platform/fuchsia/dart/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_aot_runner.cmx
@@ -14,7 +14,6 @@
             "fuchsia.net.NameLookup",
             "fuchsia.net.SocketProvider",
             "fuchsia.timezone.Timezone",
-            "fuchsia.tracelink.Registry",
             "fuchsia.tracing.provider.Registry"
         ]
     }

--- a/shell/platform/fuchsia/dart/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_jit_product_runner.cmx
@@ -16,7 +16,6 @@
             "fuchsia.process.Launcher",
             "fuchsia.process.Resolver",
             "fuchsia.timezone.Timezone",
-            "fuchsia.tracelink.Registry",
             "fuchsia.tracing.provider.Registry"
         ]
     }

--- a/shell/platform/fuchsia/dart/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart/meta/dart_jit_runner.cmx
@@ -16,7 +16,6 @@
             "fuchsia.process.Launcher",
             "fuchsia.process.Resolver",
             "fuchsia.timezone.Timezone",
-            "fuchsia.tracelink.Registry",
             "fuchsia.tracing.provider.Registry"
         ]
     }


### PR DESCRIPTION
... replaced by fuchsia.tracing.provider.Registry.

PT-127

Change-Id: I8e1243e28292a2442c1ceb3b685a79979bd0bd42

This is a followup to 98f55f0e6115847c1f389c0e816d8e2d2a1555ff.
Ported from the Topaz tree.