### PR TITLE
Fix warning about settings unavailable GN arg build_glfw_shell

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -253,7 +253,8 @@ def to_gn_args(args):
 
     if sys.platform == 'darwin':
       gn_args['mac_sdk_path'] = args.mac_sdk_path
-      gn_args['build_glfw_shell'] = args.build_glfw_shell
+      if args.build_glfw_shell:
+        gn_args['build_glfw_shell'] = True
       if gn_args['mac_sdk_path'] == '':
         gn_args['mac_sdk_path'] = os.getenv('FLUTTER_MAC_SDK_PATH', '')
 


### PR DESCRIPTION
This is only available on Darwin & Linux host targets. On Android target builds,
the logic amounted to says “Don’t build GLFW on Android targets”. Since GLFW on
Android does not make sense and the target does not exist, GN was generating a
warning.