### PR TITLE
Move the mutators stack handling to preroll

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -185,13 +185,13 @@ class ExternalViewEmbedder {
 
   virtual void BeginFrame(SkISize frame_size) = 0;
 
-  virtual void PrerollCompositeEmbeddedView(int view_id) = 0;
+  virtual void PrerollCompositeEmbeddedView(int view_id,
+                                            const flutter::EmbeddedViewParams& params) = 0;
 
   virtual std::vector<SkCanvas*> GetCurrentCanvases() = 0;
 
   // Must be called on the UI thread.
-  virtual SkCanvas* CompositeEmbeddedView(int view_id,
-                                          const EmbeddedViewParams& params) = 0;
+  virtual SkCanvas* CompositeEmbeddedView(int view_id) = 0;
 
   virtual bool SubmitFrame(GrContext* context);
 

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -22,17 +22,17 @@ ClipPathLayer::~ClipPathLayer() = default;
 void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect previous_cull_rect = context->cull_rect;
   SkRect clip_path_bounds = clip_path_.getBounds();
-  context->mutators_stack.pushClipPath(clip_path_);
   if (context->cull_rect.intersect(clip_path_bounds)) {
+    context->mutators_stack.pushClipPath(clip_path_);
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
 
     if (child_paint_bounds.intersect(clip_path_bounds)) {
       set_paint_bounds(child_paint_bounds);
     }
+    context->mutators_stack.pop();
   }
   context->cull_rect = previous_cull_rect;
-  context->mutators_stack.pop();
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -15,17 +15,17 @@ ClipRectLayer::~ClipRectLayer() = default;
 
 void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect previous_cull_rect = context->cull_rect;
-  context->mutators_stack.pushClipRect(clip_rect_);
   if (context->cull_rect.intersect(clip_rect_)) {
+    context->mutators_stack.pushClipRect(clip_rect_);
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
 
     if (child_paint_bounds.intersect(clip_rect_)) {
       set_paint_bounds(child_paint_bounds);
     }
+    context->mutators_stack.pop();
   }
   context->cull_rect = previous_cull_rect;
-  context->mutators_stack.pop();
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -15,6 +15,7 @@ ClipRectLayer::~ClipRectLayer() = default;
 
 void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect previous_cull_rect = context->cull_rect;
+  context->mutators_stack.pushClipRect(clip_rect_);
   if (context->cull_rect.intersect(clip_rect_)) {
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
@@ -24,6 +25,7 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
     }
   }
   context->cull_rect = previous_cull_rect;
+  context->mutators_stack.pop();
 }
 
 #if defined(OS_FUCHSIA)
@@ -50,7 +52,6 @@ void ClipRectLayer::Paint(PaintContext& context) const {
   SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
   context.internal_nodes_canvas->clipRect(clip_rect_,
                                           clip_behavior_ != Clip::hardEdge);
-  context.mutators_stack.pushClipRect(clip_rect_);
 
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
     context.internal_nodes_canvas->saveLayer(clip_rect_, nullptr);
@@ -59,7 +60,6 @@ void ClipRectLayer::Paint(PaintContext& context) const {
   if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
     context.internal_nodes_canvas->restore();
   }
-  context.mutators_stack.pop();
 }
 
 }  // namespace flutter

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -16,17 +16,17 @@ ClipRRectLayer::~ClipRRectLayer() = default;
 void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect previous_cull_rect = context->cull_rect;
   SkRect clip_rrect_bounds = clip_rrect_.getBounds();
-  context->mutators_stack.pushClipRRect(clip_rrect_);
   if (context->cull_rect.intersect(clip_rrect_bounds)) {
+    context->mutators_stack.pushClipRRect(clip_rrect_);
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
 
     if (child_paint_bounds.intersect(clip_rrect_bounds)) {
       set_paint_bounds(child_paint_bounds);
     }
+    context->mutators_stack.pop();
   }
   context->cull_rect = previous_cull_rect;
-  context->mutators_stack.pop();
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -48,6 +48,7 @@ struct PrerollContext {
   RasterCache* raster_cache;
   GrContext* gr_context;
   ExternalViewEmbedder* view_embedder;
+  MutatorsStack& mutators_stack;
   SkColorSpace* dst_color_space;
   SkRect cull_rect;
 
@@ -83,7 +84,6 @@ class Layer {
     SkCanvas* leaf_nodes_canvas;
     GrContext* gr_context;
     ExternalViewEmbedder* view_embedder;
-    MutatorsStack& mutators_stack;
     const Stopwatch& raster_time;
     const Stopwatch& ui_time;
     TextureRegistry& texture_registry;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -31,10 +31,12 @@ void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       frame.canvas() ? frame.canvas()->imageInfo().colorSpace() : nullptr;
   frame.context().raster_cache().SetCheckboardCacheImages(
       checkerboard_raster_cache_images_);
+  MutatorsStack stack;
   PrerollContext context = {
       ignore_raster_cache ? nullptr : &frame.context().raster_cache(),
       frame.gr_context(),
       frame.view_embedder(),
+      stack,
       color_space,
       kGiantRect,
       frame.context().raster_time(),
@@ -83,13 +85,11 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
     }
   }
 
-  MutatorsStack stack;
   Layer::PaintContext context = {
       (SkCanvas*)&internal_nodes_canvas,
       frame.canvas(),
       frame.gr_context(),
       frame.view_embedder(),
-      stack,
       frame.context().raster_time(),
       frame.context().ui_time(),
       frame.context().texture_registry(),
@@ -121,6 +121,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
       nullptr,                  // raster_cache (don't consult the cache)
       nullptr,                  // gr_context  (used for the raster cache)
       nullptr,                  // external view embedder
+      unused_stack,              // mutator stack
       nullptr,                  // SkColorSpace* dst_color_space
       kGiantRect,               // SkRect cull_rect
       unused_stopwatch,         // frame time (dont care)
@@ -138,7 +139,6 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
       canvas,  // canvas
       nullptr,
       nullptr,
-      unused_stack,
       unused_stopwatch,         // frame time (dont care)
       unused_stopwatch,         // engine time (dont care)
       unused_texture_registry,  // texture registry (not supported)

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -47,11 +47,10 @@ TEST(PerformanceOverlayLayer, Gold) {
   ASSERT_TRUE(surface != nullptr);
 
   flutter::TextureRegistry unused_texture_registry;
-  flutter::MutatorsStack unused_stack;
   flutter::Layer::PaintContext paintContext = {
       nullptr,        surface->getCanvas(),
       nullptr,        nullptr,
-      unused_stack,   mock_stopwatch,
+        mock_stopwatch,
       mock_stopwatch, unused_texture_registry,
       nullptr,        false};
 

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -28,10 +28,12 @@ TEST(PhysicalShapeLayer, TotalElevation) {
 
   const Stopwatch unused_stopwatch;
   TextureRegistry unused_texture_registry;
+  MutatorsStack unused_stack;
   PrerollContext preroll_context{
       nullptr,                  // raster_cache (don't consult the cache)
       nullptr,                  // gr_context  (used for the raster cache)
       nullptr,                  // external view embedder
+      unused_stack,             // mutator stack
       nullptr,                  // SkColorSpace* dst_color_space
       kGiantRect,               // SkRect cull_rect
       unused_stopwatch,         // frame time (dont care)

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -23,7 +23,12 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
                       "does not support embedding";
     return;
   }
-  context->view_embedder->PrerollCompositeEmbeddedView(view_id_);
+  EmbeddedViewParams params;
+  params.offsetPixels =
+  SkPoint::Make(matrix.getTranslateX(), matrix.getTranslateY());
+  params.sizePoints = size_;
+  params.mutatorsStack = context->mutators_stack;
+  context->view_embedder->PrerollCompositeEmbeddedView(view_id_, params);
 }
 
 void PlatformViewLayer::Paint(PaintContext& context) const {
@@ -32,15 +37,7 @@ void PlatformViewLayer::Paint(PaintContext& context) const {
                       "does not support embedding";
     return;
   }
-  EmbeddedViewParams params;
-  SkMatrix transform = context.leaf_nodes_canvas->getTotalMatrix();
-  params.offsetPixels =
-      SkPoint::Make(transform.getTranslateX(), transform.getTranslateY());
-  params.sizePoints = size_;
-  params.mutatorsStack = context.mutators_stack;
-
-  SkCanvas* canvas =
-      context.view_embedder->CompositeEmbeddedView(view_id_, params);
+  SkCanvas* canvas = context.view_embedder->CompositeEmbeddedView(view_id_);
   context.leaf_nodes_canvas = canvas;
 }
 }  // namespace flutter

--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -29,7 +29,7 @@ TransformLayer::~TransformLayer() = default;
 void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkMatrix child_matrix;
   child_matrix.setConcat(matrix, transform_);
-
+  context->mutators_stack.pushTransform(transform_);
   SkRect previous_cull_rect = context->cull_rect;
   SkMatrix inverse_transform_;
   // Perspective projections don't produce rectangles that are useful for
@@ -47,6 +47,7 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   set_paint_bounds(child_paint_bounds);
 
   context->cull_rect = previous_cull_rect;
+  context->mutators_stack.pop();
 }
 
 #if defined(OS_FUCHSIA)
@@ -66,10 +67,8 @@ void TransformLayer::Paint(PaintContext& context) const {
 
   SkAutoCanvasRestore save(context.internal_nodes_canvas, true);
   context.internal_nodes_canvas->concat(transform_);
-  context.mutators_stack.pushTransform(transform_);
 
   PaintChildren(context);
-  context.mutators_stack.pop();
 }
 
 }  // namespace flutter

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -159,7 +159,6 @@ void RasterCache::Prepare(PrerollContext* context,
     entry.image = Rasterize(context->gr_context, ctm, context->dst_color_space,
                             checkerboard_images_, layer->paint_bounds(),
                             [layer, context](SkCanvas* canvas) {
-                              MutatorsStack stack;
                               SkISize canvas_size = canvas->getBaseLayerSize();
                               SkNWayCanvas internal_nodes_canvas(
                                   canvas_size.width(), canvas_size.height());
@@ -169,7 +168,6 @@ void RasterCache::Prepare(PrerollContext* context,
                                   canvas,
                                   context->gr_context,
                                   nullptr,
-                                  stack,
                                   context->raster_time,
                                   context->ui_time,
                                   context->texture_registry,

--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -198,12 +198,10 @@ SceneUpdateContext::ExecutePaintTasks(CompositorContext::ScopedFrame& frame) {
   for (auto& task : paint_tasks_) {
     FML_DCHECK(task.surface);
     SkCanvas* canvas = task.surface->GetSkiaSurface()->getCanvas();
-    flutter::MutatorsStack stack;
     Layer::PaintContext context = {canvas,
                                    canvas,
                                    frame.gr_context(),
                                    nullptr,
-                                   stack,
                                    frame.context().raster_time(),
                                    frame.context().ui_time(),
                                    frame.context().texture_registry(),

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -174,7 +174,7 @@ void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(
     return;
   }
   current_composition_params_[view_id] = EmbeddedViewParams(*params.get());
-  views_need_recomposite.insert(view_id);
+  views_to_recomposite_.insert(view_id);
 }
 
 NSObject<FlutterPlatformView>* FlutterPlatformViewsController::GetPlatformViewByID(int view_id) {
@@ -308,11 +308,11 @@ SkCanvas* FlutterPlatformViewsController::CompositeEmbeddedView(int view_id) {
   // embedded views thread configuration.
 
   // Do nothing if the view doesn't need to be composited.
-  if (views_need_recomposite.count(view_id) == 0) {
+  if (views_to_recomposite_.count(view_id) == 0) {
     return picture_recorders_[view_id]->getRecordingCanvas();
   }
   CompositeWithParams(view_id, current_composition_params_[view_id]);
-  views_need_recomposite.erase(view_id);
+  views_to_recomposite_.erase(view_id);
   return picture_recorders_[view_id]->getRecordingCanvas();
 }
 
@@ -328,7 +328,7 @@ void FlutterPlatformViewsController::Reset() {
   picture_recorders_.clear();
   current_composition_params_.clear();
   clip_count_.clear();
-  views_need_recomposite.clear();
+  views_to_recomposite_.clear();
 }
 
 bool FlutterPlatformViewsController::SubmitFrame(bool gl_rendering,
@@ -420,7 +420,7 @@ void FlutterPlatformViewsController::DisposeViews() {
     overlays_.erase(viewId);
     current_composition_params_.erase(viewId);
     clip_count_.erase(viewId);
-    views_need_recomposite.erase(viewId);
+    views_to_recomposite_.erase(viewId);
   }
   views_to_dispose_.clear();
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -139,7 +139,7 @@ class FlutterPlatformViewsController {
   std::vector<int64_t> active_composition_order_;
 
   // Only compoiste platform views in this set.
-  std::unordered_set<int64_t> views_need_recomposite;
+  std::unordered_set<int64_t> views_to_recomposite_;
 
   std::map<int64_t, std::unique_ptr<SkPictureRecorder>> picture_recorders_;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -79,7 +79,8 @@ class FlutterPlatformViewsController {
 
   void SetFrameSize(SkISize frame_size);
 
-  void PrerollCompositeEmbeddedView(int view_id);
+  void PrerollCompositeEmbeddedView(int view_id,
+                                    const flutter::EmbeddedViewParams& params);
 
   // Returns the `FlutterPlatformView` object associated with the view_id.
   //
@@ -90,7 +91,7 @@ class FlutterPlatformViewsController {
 
   std::vector<SkCanvas*> GetCurrentCanvases();
 
-  SkCanvas* CompositeEmbeddedView(int view_id, const flutter::EmbeddedViewParams& params);
+  SkCanvas* CompositeEmbeddedView(int view_id);
 
   // Discards all platform views instances and auxiliary resources.
   void Reset();
@@ -136,6 +137,9 @@ class FlutterPlatformViewsController {
 
   // The latest composition order that was presented in Present().
   std::vector<int64_t> active_composition_order_;
+
+  // Only compoiste platform views in this set.
+  std::unordered_set<int64_t> views_need_recomposite;
 
   std::map<int64_t, std::unique_ptr<SkPictureRecorder>> picture_recorders_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -55,13 +55,14 @@ class IOSSurfaceGL final : public IOSSurface,
   void BeginFrame(SkISize frame_size) override;
 
   // |flutter::ExternalViewEmbedder|
-  void PrerollCompositeEmbeddedView(int view_id) override;
+                             void PrerollCompositeEmbeddedView(int view_id,
+                                                               const flutter::EmbeddedViewParams& params) override;
 
   // |flutter::ExternalViewEmbedder|
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |flutter::ExternalViewEmbedder|
-  SkCanvas* CompositeEmbeddedView(int view_id, const flutter::EmbeddedViewParams& params) override;
+  SkCanvas* CompositeEmbeddedView(int view_id) override;
 
   // |flutter::ExternalViewEmbedder|
   bool SubmitFrame(GrContext* context) override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -89,10 +89,11 @@ void IOSSurfaceGL::BeginFrame(SkISize frame_size) {
   [CATransaction begin];
 }
 
-void IOSSurfaceGL::PrerollCompositeEmbeddedView(int view_id) {
+  void IOSSurfaceGL::PrerollCompositeEmbeddedView(int view_id,
+                                                  const flutter::EmbeddedViewParams& params) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);
-  platform_views_controller->PrerollCompositeEmbeddedView(view_id);
+  platform_views_controller->PrerollCompositeEmbeddedView(view_id, params);
 }
 
 std::vector<SkCanvas*> IOSSurfaceGL::GetCurrentCanvases() {
@@ -101,11 +102,10 @@ std::vector<SkCanvas*> IOSSurfaceGL::GetCurrentCanvases() {
   return platform_views_controller->GetCurrentCanvases();
 }
 
-SkCanvas* IOSSurfaceGL::CompositeEmbeddedView(int view_id,
-                                              const flutter::EmbeddedViewParams& params) {
+SkCanvas* IOSSurfaceGL::CompositeEmbeddedView(int view_id) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);
-  return platform_views_controller->CompositeEmbeddedView(view_id, params);
+  return platform_views_controller->CompositeEmbeddedView(view_id);
 }
 
 bool IOSSurfaceGL::SubmitFrame(GrContext* context) {

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -49,13 +49,14 @@ class IOSSurfaceSoftware final : public IOSSurface,
   void BeginFrame(SkISize frame_size) override;
 
   // |flutter::ExternalViewEmbedder|
-  void PrerollCompositeEmbeddedView(int view_id) override;
+                                   void PrerollCompositeEmbeddedView(int view_id,
+                                                                     const flutter::EmbeddedViewParams& params) override;
 
   // |flutter::ExternalViewEmbedder|
   std::vector<SkCanvas*> GetCurrentCanvases() override;
 
   // |flutter::ExternalViewEmbedder|
-  SkCanvas* CompositeEmbeddedView(int view_id, const flutter::EmbeddedViewParams& params) override;
+  SkCanvas* CompositeEmbeddedView(int view_id) override;
 
   // |flutter::ExternalViewEmbedder|
   bool SubmitFrame(GrContext* context) override;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -141,10 +141,11 @@ void IOSSurfaceSoftware::BeginFrame(SkISize frame_size) {
   platform_views_controller->SetFrameSize(frame_size);
 }
 
-void IOSSurfaceSoftware::PrerollCompositeEmbeddedView(int view_id) {
+  void IOSSurfaceSoftware::PrerollCompositeEmbeddedView(int view_id,
+                                                        const flutter::EmbeddedViewParams& params) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);
-  platform_views_controller->PrerollCompositeEmbeddedView(view_id);
+  platform_views_controller->PrerollCompositeEmbeddedView(view_id, params);
 }
 
 std::vector<SkCanvas*> IOSSurfaceSoftware::GetCurrentCanvases() {
@@ -153,11 +154,10 @@ std::vector<SkCanvas*> IOSSurfaceSoftware::GetCurrentCanvases() {
   return platform_views_controller->GetCurrentCanvases();
 }
 
-SkCanvas* IOSSurfaceSoftware::CompositeEmbeddedView(int view_id,
-                                                    const flutter::EmbeddedViewParams& params) {
+SkCanvas* IOSSurfaceSoftware::CompositeEmbeddedView(int view_id) {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);
-  return platform_views_controller->CompositeEmbeddedView(view_id, params);
+  return platform_views_controller->CompositeEmbeddedView(view_id);
 }
 
 bool IOSSurfaceSoftware::SubmitFrame(GrContext* context) {


### PR DESCRIPTION
Move the mutator stack handling to tree preroll. And the platform view is going to decide if it should composite or not, and set a flag.
In paint (Composite), based on the flag, we composite with the cached embedded view params.