### PR TITLE
ExternalViewEmbedder can CancelFrame after pre-roll

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -187,7 +187,7 @@ class ExternalViewEmbedder {
   // have mutated for last layer tree.
   virtual bool HasPendingViewOperations() = 0;
 
-  // Needs to be called before |SubmitFrame|. Clears pre-roll state and
+  // Call this in-lieu of |SubmitFrame| to clear pre-roll state and
   // sets the stage for the next pre-roll.
   virtual void CancelFrame() = 0;
 

--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -187,6 +187,10 @@ class ExternalViewEmbedder {
   // have mutated for last layer tree.
   virtual bool HasPendingViewOperations() = 0;
 
+  // Needs to be called before |SubmitFrame|. Clears pre-roll state and
+  // sets the stage for the next pre-roll.
+  virtual void CancelFrame() = 0;
+
   virtual void BeginFrame(SkISize frame_size) = 0;
 
   virtual void PrerollCompositeEmbeddedView(

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -160,6 +160,10 @@ void FlutterPlatformViewsController::SetFrameSize(SkISize frame_size) {
   frame_size_ = frame_size;
 }
 
+void FlutterPlatformViewsController::CancelFrame() {
+  composition_order_.clear();
+}
+
 bool FlutterPlatformViewsController::HasPendingViewOperations() {
   if (!views_to_recomposite_.empty()) {
     return true;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -81,6 +81,8 @@ class FlutterPlatformViewsController {
 
   bool HasPendingViewOperations();
 
+  void CancelFrame();
+
   void PrerollCompositeEmbeddedView(int view_id,
                                     std::unique_ptr<flutter::EmbeddedViewParams> params);
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -52,6 +52,9 @@ class IOSSurfaceGL final : public IOSSurface,
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |flutter::ExternalViewEmbedder|
+  void CancelFrame() override;
+
+  // |flutter::ExternalViewEmbedder|
   bool HasPendingViewOperations() override;
 
   // |flutter::ExternalViewEmbedder|

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -82,6 +82,15 @@ flutter::ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
   }
 }
 
+void IOSSurfaceGL::CancelFrame() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  platform_views_controller->CancelFrame();
+  // Committing the current transaction as |BeginFrame| will create a nested
+  // CATransaction otherwise.
+  [CATransaction commit];
+}
+
 bool IOSSurfaceGL::HasPendingViewOperations() {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -46,6 +46,9 @@ class IOSSurfaceSoftware final : public IOSSurface,
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |flutter::ExternalViewEmbedder|
+  void CancelFrame() override;
+
+  // |flutter::ExternalViewEmbedder|
   bool HasPendingViewOperations() override;
 
   // |flutter::ExternalViewEmbedder|

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -135,6 +135,12 @@ flutter::ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
   }
 }
 
+void IOSSurfaceSoftware::CancelFrame() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  FML_CHECK(platform_views_controller != nullptr);
+  platform_views_controller->CancelFrame();
+}
+
 bool IOSSurfaceSoftware::HasPendingViewOperations() {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);


### PR DESCRIPTION
- Resets the state so next pre-roll can be successful.
- Commit any pending `CATransaction` so we don't create
  nested transactions.