### PR TITLE
Raster now returns an enum rather than boolean

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -60,8 +60,9 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
   context_.EndFrame(*this, instrumentation_enabled_);
 }
 
-bool CompositorContext::ScopedFrame::Raster(flutter::LayerTree& layer_tree,
-                                            bool ignore_raster_cache) {
+RasterStatus CompositorContext::ScopedFrame::Raster(
+    flutter::LayerTree& layer_tree,
+    bool ignore_raster_cache) {
   layer_tree.Preroll(*this, ignore_raster_cache);
   // Clearing canvas after preroll reduces one render target switch when preroll
   // paints some raster cache.
@@ -69,7 +70,7 @@ bool CompositorContext::ScopedFrame::Raster(flutter::LayerTree& layer_tree,
     canvas()->clear(SK_ColorTRANSPARENT);
   }
   layer_tree.Paint(*this, ignore_raster_cache);
-  return true;
+  return RasterStatus::kSuccess;
 }
 
 void CompositorContext::OnGrContextCreated() {

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -20,6 +20,10 @@ namespace flutter {
 
 class LayerTree;
 
+enum class RasterStatus {
+  kSuccess, kFailed
+};
+
 class CompositorContext {
  public:
   class ScopedFrame {
@@ -45,7 +49,8 @@ class CompositorContext {
 
     GrContext* gr_context() const { return gr_context_; }
 
-    virtual bool Raster(LayerTree& layer_tree, bool ignore_raster_cache);
+    virtual RasterStatus Raster(LayerTree& layer_tree,
+                                bool ignore_raster_cache);
 
    private:
     CompositorContext& context_;

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -20,9 +20,7 @@ namespace flutter {
 
 class LayerTree;
 
-enum class RasterStatus {
-  kSuccess, kFailed
-};
+enum class RasterStatus { kSuccess, kFailed };
 
 class CompositorContext {
  public:

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -187,7 +187,7 @@ void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
   PersistentCache* persistent_cache = PersistentCache::GetCacheForProcess();
   persistent_cache->ResetStoredNewShaders();
 
-  if (DrawToSurface(*layer_tree)) {
+  if (DrawToSurface(*layer_tree) == RasterStatus::kSuccess) {
     last_layer_tree_ = std::move(layer_tree);
   }
 
@@ -205,13 +205,13 @@ void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
   delegate_.OnFrameRasterized(timing);
 }
 
-bool Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
+RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
   FML_DCHECK(surface_);
 
   auto frame = surface_->AcquireFrame(layer_tree.frame_size());
 
   if (frame == nullptr) {
-    return false;
+    return RasterStatus::kFailed;
   }
 
   // There is no way for the compositor to know how long the layer tree
@@ -231,7 +231,11 @@ bool Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
       surface_->GetContext(), canvas, external_view_embedder,
       surface_->GetRootTransformation(), true);
 
-  if (compositor_frame && compositor_frame->Raster(layer_tree, false)) {
+  if (compositor_frame) {
+    RasterStatus raster_status = compositor_frame->Raster(layer_tree, false);
+    if (raster_status == RasterStatus::kFailed) {
+      return raster_status;
+    }
     frame->Submit();
     if (external_view_embedder != nullptr) {
       external_view_embedder->SubmitFrame(surface_->GetContext());
@@ -241,10 +245,10 @@ bool Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
     if (surface_->GetContext())
       surface_->GetContext()->performDeferredCleanup(kSkiaCleanupExpiration);
 
-    return true;
+    return raster_status;
   }
 
-  return false;
+  return RasterStatus::kFailed;
 }
 
 static sk_sp<SkData> SerializeTypeface(SkTypeface* typeface, void* ctx) {

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -116,7 +116,7 @@ class Rasterizer final : public SnapshotDelegate {
 
   void DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
 
-  bool DrawToSurface(flutter::LayerTree& layer_tree);
+  RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);
 
   void FireNextFrameCallbackIfPresent();
 

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -25,10 +25,10 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
  private:
   SessionConnection& session_connection_;
 
-  bool Raster(flutter::LayerTree& layer_tree,
-              bool ignore_raster_cache) override {
+  flutter::RasterStatus Raster(flutter::LayerTree& layer_tree,
+                               bool ignore_raster_cache) override {
     if (!session_connection_.has_metrics()) {
-      return true;
+      return flutter::RasterStatus::kSuccess;
     }
 
     {
@@ -52,7 +52,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
       session_connection_.Present(*this);
     }
 
-    return true;
+    return flutter::RasterStatus::kSuccess;
   }
 
   FML_DISALLOW_COPY_AND_ASSIGN(ScopedFrame);


### PR DESCRIPTION
This is part of a bigger change that will facilitate us
to act on this `RasterStatus`. The specific case is where
after pre-roll we might decide to want to merge the threads
and re-submit the frame -- `RasterStatus::kResubmit` can then
let us achieve this result.