### PR TITLE
Convert VsyncWaiter reference to a shared_ptr

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -21,7 +21,7 @@ constexpr fml::TimeDelta kNotifyIdleTaskWaitTime =
 
 Animator::Animator(Delegate& delegate,
                    TaskRunners task_runners,
-                   std::unique_ptr<VsyncWaiter> waiter)
+                   std::shared_ptr<VsyncWaiter> waiter)
     : delegate_(delegate),
       task_runners_(std::move(task_runners)),
       waiter_(std::move(waiter)),

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -42,7 +42,7 @@ class Animator final {
 
   Animator(Delegate& delegate,
            TaskRunners task_runners,
-           std::unique_ptr<VsyncWaiter> waiter);
+           std::shared_ptr<VsyncWaiter> waiter);
 
   ~Animator();
 

--- a/shell/common/platform_view.cc
+++ b/shell/common/platform_view.cc
@@ -24,11 +24,11 @@ PlatformView::PlatformView(Delegate& delegate, TaskRunners task_runners)
 
 PlatformView::~PlatformView() = default;
 
-std::unique_ptr<VsyncWaiter> PlatformView::CreateVSyncWaiter() {
+std::shared_ptr<VsyncWaiter> PlatformView::CreateVSyncWaiter() {
   FML_DLOG(WARNING)
       << "This platform does not provide a Vsync waiter implementation. A "
          "simple timer based fallback is being used.";
-  return std::make_unique<VsyncWaiterFallback>(task_runners_);
+  return std::make_shared<VsyncWaiterFallback>(task_runners_);
 }
 
 void PlatformView::DispatchPlatformMessage(

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -246,7 +246,7 @@ class PlatformView {
   /// @return     A vsync waiter. If is an internal error to return a null
   ///             waiter.
   ///
-  virtual std::unique_ptr<VsyncWaiter> CreateVSyncWaiter();
+  virtual std::shared_ptr<VsyncWaiter> CreateVSyncWaiter();
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to dispatch a platform message to a

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -116,7 +116,7 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
                          shell = shell.get(),                               //
                          isolate_snapshot = std::move(isolate_snapshot),    //
                          shared_snapshot = std::move(shared_snapshot),      //
-                         vsync_waiter = std::move(vsync_waiter),            //
+                         vsync_waiter = vsync_waiter,                       //
                          snapshot_delegate = std::move(snapshot_delegate),  //
                          io_manager = io_manager->GetWeakPtr()              //
   ]() mutable {

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -377,8 +377,8 @@ void PlatformViewAndroid::RegisterExternalTexture(
 }
 
 // |PlatformView|
-std::unique_ptr<VsyncWaiter> PlatformViewAndroid::CreateVSyncWaiter() {
-  return std::make_unique<VsyncWaiterAndroid>(task_runners_);
+std::shared_ptr<VsyncWaiter> PlatformViewAndroid::CreateVSyncWaiter() {
+  return std::make_shared<VsyncWaiterAndroid>(task_runners_);
 }
 
 // |PlatformView|

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -94,7 +94,7 @@ class PlatformViewAndroid final : public PlatformView {
   void OnPreEngineRestart() const override;
 
   // |PlatformView|
-  std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
+  std::shared_ptr<VsyncWaiter> CreateVSyncWaiter() override;
 
   // |PlatformView|
   std::unique_ptr<Surface> CreateRenderingSurface() override;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -70,7 +70,7 @@ class PlatformViewIOS final : public PlatformView {
                        flutter::CustomAccessibilityActionUpdates actions) override;
 
   // |PlatformView|
-  std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
+  std::shared_ptr<VsyncWaiter> CreateVSyncWaiter() override;
 
   // |PlatformView|
   void OnPreEngineRestart() const override;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -128,8 +128,8 @@ void PlatformViewIOS::UpdateSemantics(flutter::SemanticsNodeUpdates update,
 }
 
 // |PlatformView|
-std::unique_ptr<VsyncWaiter> PlatformViewIOS::CreateVSyncWaiter() {
-  return std::make_unique<VsyncWaiterIOS>(task_runners_);
+std::shared_ptr<VsyncWaiter> PlatformViewIOS::CreateVSyncWaiter() {
+  return std::make_shared<VsyncWaiterIOS>(task_runners_);
 }
 
 void PlatformViewIOS::OnPreEngineRestart() const {

--- a/shell/platform/embedder/platform_view_embedder.cc
+++ b/shell/platform/embedder/platform_view_embedder.cc
@@ -79,13 +79,13 @@ sk_sp<GrContext> PlatformViewEmbedder::CreateResourceContext() const {
 }
 
 // |PlatformView|
-std::unique_ptr<VsyncWaiter> PlatformViewEmbedder::CreateVSyncWaiter() {
+std::shared_ptr<VsyncWaiter> PlatformViewEmbedder::CreateVSyncWaiter() {
   if (!platform_dispatch_table_.vsync_callback) {
     // Superclass implementation creates a timer based fallback.
     return PlatformView::CreateVSyncWaiter();
   }
 
-  return std::make_unique<VsyncWaiterEmbedder>(
+  return std::make_shared<VsyncWaiterEmbedder>(
       platform_dispatch_table_.vsync_callback, task_runners_);
 }
 

--- a/shell/platform/embedder/platform_view_embedder.h
+++ b/shell/platform/embedder/platform_view_embedder.h
@@ -71,7 +71,7 @@ class PlatformViewEmbedder final : public PlatformView {
   sk_sp<GrContext> CreateResourceContext() const override;
 
   // |PlatformView|
-  std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
+  std::shared_ptr<VsyncWaiter> CreateVSyncWaiter() override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewEmbedder);
 };

--- a/shell/platform/fuchsia/flutter/platform_view.cc
+++ b/shell/platform/fuchsia/flutter/platform_view.cc
@@ -557,8 +557,8 @@ void PlatformView::DeactivateIme() {
 }
 
 // |flutter::PlatformView|
-std::unique_ptr<flutter::VsyncWaiter> PlatformView::CreateVSyncWaiter() {
-  return std::make_unique<flutter_runner::VsyncWaiter>(
+std::shared_ptr<flutter::VsyncWaiter> PlatformView::CreateVSyncWaiter() {
+  return std::make_shared<flutter_runner::VsyncWaiter>(
       debug_label_, vsync_event_handle_, task_runners_);
 }
 

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -132,7 +132,7 @@ class PlatformView final : public flutter::PlatformView,
   void DeactivateIme();
 
   // |flutter::PlatformView|
-  std::unique_ptr<flutter::VsyncWaiter> CreateVSyncWaiter() override;
+  std::shared_ptr<flutter::VsyncWaiter> CreateVSyncWaiter() override;
 
   // |flutter::PlatformView|
   std::unique_ptr<flutter::Surface> CreateRenderingSurface() override;


### PR DESCRIPTION
- We wish to add support for task runner merging manager
  which can schedule unmerges after X (say 10) vsync events. This is
  so we can only merge the task runners when we have
  platform view mutations in the layer tree. We merge and then
  schedule an unmerge after X events.

- The new class will also need to reference the VsyncWaiter,
  hence converting it to a shared_ptr