### PR TITLE
Check for null response_handle in FlutterEngineSendPlatformMessage

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -823,7 +823,7 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
       SAFE_ACCESS(flutter_message, response_handle, nullptr);
 
   fml::RefPtr<flutter::PlatformMessageResponse> response;
-  if (response_handle->message) {
+  if (response_handle && response_handle->message) {
     response = response_handle->message->response();
   }
 


### PR DESCRIPTION
PR #9655 allows for providing a response handle when sending messages
into the Flutter engine, but didn't check for a null response handle;
this crashes all existing embedders that use
FlutterEngineSendPlatformMessage.