### PR TITLE
Ensure that platform messages without response handles can be dispatched.

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -823,7 +823,7 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
       SAFE_ACCESS(flutter_message, response_handle, nullptr);
 
   fml::RefPtr<flutter::PlatformMessageResponse> response;
-  if (response_handle->message) {
+  if (response_handle && response_handle->message) {
     response = response_handle->message->response();
   }
 

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui';
+import 'dart:convert';
 
 void main() {}
 
@@ -45,6 +46,7 @@ Float64List kTestTransform = () {
 }();
 
 void signalNativeTest() native 'SignalNativeTest';
+void signalNativeMessage(String message) native 'SignalNativeMessage';
 void notifySemanticsEnabled(bool enabled) native 'NotifySemanticsEnabled';
 void notifyAccessibilityFeatures(bool reduceMotion) native 'NotifyAccessibilityFeatures';
 void notifySemanticsAction(int nodeId, int action, List<int> data) native 'NotifySemanticsAction';
@@ -150,6 +152,18 @@ void a11y_main() async { // ignore: non_constant_identifier_names
 void platform_messages_response() {
   window.onPlatformMessage = (String name, ByteData data, PlatformMessageResponseCallback callback) {
     callback(data);
+  };
+  signalNativeTest();
+}
+
+@pragma('vm:entry-point')
+void platform_messages_no_response() {
+  window.onPlatformMessage = (String name, ByteData data, PlatformMessageResponseCallback callback) {
+    var list = data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+    signalNativeMessage(utf8.decode(list));
+    // This does nothing because no one is listening on the other side. But complete the loop anyway
+    // to make sure all null checking on response handles in the engine is in place.
+    callback(data); 
   };
   signalNativeTest();
 }

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -163,7 +163,7 @@ void platform_messages_no_response() {
     signalNativeMessage(utf8.decode(list));
     // This does nothing because no one is listening on the other side. But complete the loop anyway
     // to make sure all null checking on response handles in the engine is in place.
-    callback(data); 
+    callback(data);
   };
   signalNativeTest();
 }


### PR DESCRIPTION
Fixes regression introduced in https://github.com/flutter/engine/pull/9655 and pulls in the patch in https://github.com/flutter/engine/pull/9697 and adds a unit-test that asserts integrity of platform message sent without response handles.
