### PR TITLE
Alf stable v1.5.4 xy

### DIFF
--- a/flow/layers/transform_layer.cc
+++ b/flow/layers/transform_layer.cc
@@ -25,7 +25,14 @@ void TransformLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   //
   // We have to write this flaky test because there is no reliable way to test
   // whether a variable is initialized or not in C++.
-  FML_CHECK(transform_.isFinite());
+
+  //fix crash:https://github.com/flutter/flutter/issues/31650
+  // FML_CHECK(transform_.isFinite());
+  FML_DCHECK(transform_.isFinite());
+  if (!transform_.isFinite()) {
+    FML_LOG(ERROR) << "TransformLayer is constructed with an invalid matrix.";
+    transform_.setIdentity();
+  }
 
   SkMatrix child_matrix;
   child_matrix.setConcat(matrix, transform_);

--- a/fml/message_loop_impl.h
+++ b/fml/message_loop_impl.h
@@ -43,6 +43,19 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
 
   void DoTerminate();
 
+  void EnableMessageLoop(bool isEnable) { is_loop_enabled_ = isEnable; }
+
+  void SetTaskLimitPerLoopRun(int task_limit_per_looprun) {
+    task_limit_per_looprun_ = task_limit_per_looprun;
+  }
+
+  inline bool IsMessageLoopEnabled() { return is_loop_enabled_; }
+
+  inline bool IsRunningingExpiredTasks() {
+    return is_runninging_expired_tasks_;
+  }
+
+
  protected:
   // Exposed for the embedder shell which allows clients to poll for events
   // instead of dedicating a thread to the message loop.
@@ -80,11 +93,15 @@ class MessageLoopImpl : public fml::RefCountedThreadSafe<MessageLoopImpl> {
   using DelayedTaskQueue = std::
       priority_queue<DelayedTask, std::deque<DelayedTask>, DelayedTaskCompare>;
 
+  bool is_loop_enabled_ = true; 
   std::map<intptr_t, fml::closure> task_observers_;
   std::mutex delayed_tasks_mutex_;
   DelayedTaskQueue delayed_tasks_ FML_GUARDED_BY(delayed_tasks_mutex_);
   size_t order_ FML_GUARDED_BY(delayed_tasks_mutex_);
   std::atomic_bool terminated_;
+
+  bool is_runninging_expired_tasks_;
+  int task_limit_per_looprun_;
 
   void RegisterTask(fml::closure task, fml::TimePoint target_time);
 

--- a/fml/task_runner.cc
+++ b/fml/task_runner.cc
@@ -39,6 +39,14 @@ bool TaskRunner::RunsTasksOnCurrentThread() {
   return MessageLoop::GetCurrent().GetLoopImpl() == loop_;
 }
 
+void TaskRunner::EnableMessageLoop(bool isEnable) {
+  loop_->EnableMessageLoop(isEnable);
+}
+
+MessageLoopImpl* TaskRunner::getMessageLoop() {
+  return loop_.get();
+}
+
 void TaskRunner::RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
                                   fml::closure task) {
   FML_DCHECK(runner);

--- a/fml/task_runner.h
+++ b/fml/task_runner.h
@@ -27,6 +27,9 @@ class TaskRunner : public fml::RefCountedThreadSafe<TaskRunner> {
 
   virtual bool RunsTasksOnCurrentThread();
 
+  void EnableMessageLoop(bool isEnable);
+  MessageLoopImpl* getMessageLoop();
+
   static void RunNowOrPostTask(fml::RefPtr<fml::TaskRunner> runner,
                                fml::closure task);
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1109,6 +1109,14 @@ Rasterizer::Screenshot Shell::Screenshot(
     Rasterizer::ScreenshotType screenshot_type,
     bool base64_encode) {
   TRACE_EVENT0("flutter", "Shell::Screenshot");
+  fml::TaskRunner* taskRunner =
+      (fml::TaskRunner*)this->GetTaskRunners().GetUITaskRunner().get();
+  taskRunner->EnableMessageLoop(true);
+
+  taskRunner =
+      (fml::TaskRunner*)this->GetTaskRunners().GetGPUTaskRunner().get();
+  taskRunner->EnableMessageLoop(true);
+
   fml::AutoResetWaitableEvent latch;
   Rasterizer::Screenshot screenshot;
   fml::TaskRunner::RunNowOrPostTask(

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -65,6 +65,12 @@ static EGLResult<EGLSurface> CreateContext(EGLDisplay display,
   EGLint attributes[] = {EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE};
 
   EGLContext context = eglCreateContext(display, config, share, attributes);
+  if (context == EGL_NO_CONTEXT) {
+    EGLint last_error = eglGetError();
+    if (last_error == EGL_BAD_MATCH && share != EGL_NO_CONTEXT) {
+      context = eglCreateContext(display, config, EGL_NO_CONTEXT, attributes);
+    }
+  }
 
   return {context != EGL_NO_CONTEXT, context};
 }

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -143,6 +143,10 @@ bool AndroidContextGL::CreatePBufferSurface() {
   return surface_ != EGL_NO_SURFACE;
 }
 
+void* AndroidContextGL::GetContext() {
+  return context_;
+}
+
 AndroidContextGL::AndroidContextGL(fml::RefPtr<AndroidEnvironmentGL> env,
                                    const AndroidContextGL* share_context)
     : environment_(env),

--- a/shell/platform/android/android_context_gl.h
+++ b/shell/platform/android/android_context_gl.h
@@ -35,6 +35,8 @@ class AndroidContextGL : public fml::RefCountedThreadSafe<AndroidContextGL> {
 
   bool Resize(const SkISize& size);
 
+  void* GetContext();
+
  private:
   fml::RefPtr<AndroidEnvironmentGL> environment_;
   fml::RefPtr<AndroidNativeWindow> window_;

--- a/shell/platform/android/android_external_texture_gl.h
+++ b/shell/platform/android/android_external_texture_gl.h
@@ -16,6 +16,7 @@ class AndroidExternalTextureGL : public flutter::Texture {
   AndroidExternalTextureGL(
       int64_t id,
       const fml::jni::JavaObjectWeakGlobalRef& surfaceTexture);
+  AndroidExternalTextureGL(int64_t id, int64_t texture_id);
 
   ~AndroidExternalTextureGL() override;
 
@@ -46,6 +47,8 @@ class AndroidExternalTextureGL : public flutter::Texture {
   AttachmentState state_ = AttachmentState::uninitialized;
 
   bool new_frame_ready_ = false;
+
+  bool use_out_texture_ = false;
 
   GLuint texture_name_ = 0;
 

--- a/shell/platform/android/android_surface.h
+++ b/shell/platform/android/android_surface.h
@@ -36,6 +36,8 @@ class AndroidSurface {
   virtual bool ResourceContextClearCurrent() = 0;
 
   virtual bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) = 0;
+    
+  virtual void* GetContext() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -75,6 +75,10 @@ bool AndroidSurfaceGL::ResourceContextClearCurrent() {
   return offscreen_context_->ClearCurrent();
 }
 
+void* AndroidSurfaceGL::GetContext() {
+  return offscreen_context_->GetContext();
+}
+
 bool AndroidSurfaceGL::SetNativeWindow(
     fml::RefPtr<AndroidNativeWindow> window) {
   // In any case, we want to get rid of our current onscreen context.

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -58,6 +58,7 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   // |GPUSurfaceGLDelegate|
   intptr_t GLContextFBO() const override;
 
+  void* GetContext() override;
  private:
   fml::RefPtr<AndroidContextGL> onscreen_context_;
   fml::RefPtr<AndroidContextGL> offscreen_context_;

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -140,6 +140,10 @@ bool AndroidSurfaceSoftware::OnScreenSurfaceResize(const SkISize& size) const {
   return true;
 }
 
+void* AndroidSurfaceSoftware::GetContext() {
+  return 0;
+}
+
 bool AndroidSurfaceSoftware::SetNativeWindow(
     fml::RefPtr<AndroidNativeWindow> window) {
   native_window_ = std::move(window);

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -47,6 +47,8 @@ class AndroidSurfaceSoftware final : public AndroidSurface,
   // |GPUSurfaceSoftwareDelegate|
   bool PresentBackingStore(sk_sp<SkSurface> backing_store) override;
 
+  void* GetContext() override;
+                                         
  private:
   sk_sp<SkSurface> sk_surface_;
   fml::RefPtr<AndroidNativeWindow> native_window_;

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -12,6 +12,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.util.Log;
 import android.view.Surface;
+import android.opengl.EGLContext;
 
 import java.nio.ByteBuffer;
 import java.util.HashSet;
@@ -409,7 +410,25 @@ public class FlutterJNI {
   }
 
   private native void nativeUnregisterTexture(long nativePlatformViewId, long textureId);
-  //------- End from FlutterView -----
+
+  @UiThread
+  public void registerGLTexture(long texIndex, long textureId) {
+    ensureAttachedToNative();
+    nativeGLRegisterTexture(nativePlatformViewId, texIndex, textureId);
+  }
+  
+  private native void nativeGLRegisterTexture(long nativePlatformViewId, long texIndex, long textureId);
+
+  @UiThread
+  public EGLContext getGLContext() {
+    ensureAttachedToNative();
+    return nativeGetContext(nativePlatformViewId);
+  }
+
+  private native EGLContext nativeGetContext(long nativePlatformViewId);
+  
+
+    //------- End from FlutterView -----
 
   // TODO(mattcarroll): rename comments after refactor is done and their origin no longer matters (https://github.com/flutter/flutter/issues/25533)
   //------ Start from FlutterNativeView ----

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -506,7 +506,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             // For platform views we delegate the node creation to the accessibility view embedder.
             View embeddedView = platformViewsAccessibilityDelegate.getPlatformViewById(semanticsNode.platformViewId);
             Rect bounds = semanticsNode.getGlobalRect();
-            return accessibilityViewEmbedder.getRootNode(embeddedView, semanticsNode.id, bounds);
+            if (embeddedView!=null && bounds!=null) {
+                return accessibilityViewEmbedder.getRootNode(embeddedView, semanticsNode.id, bounds);
+            }
         }
 
         AccessibilityNodeInfo result = AccessibilityNodeInfo.obtain(rootAccessibilityView, virtualViewId);
@@ -1116,10 +1118,13 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             return false;
         }
 
-        SemanticsNode semanticsNodeUnderCursor = getRootSemanticsNode().hitTest(new float[] {event.getX(), event.getY(), 0, 1});
-        if (semanticsNodeUnderCursor.platformViewId != -1) {
-            return accessibilityViewEmbedder.onAccessibilityHoverEvent(semanticsNodeUnderCursor.id, event);
+        if (getRootSemanticsNode()!=null){
+            SemanticsNode semanticsNodeUnderCursor = getRootSemanticsNode().hitTest(new float[] {event.getX(), event.getY(), 0, 1});
+            if (semanticsNodeUnderCursor.platformViewId != -1) {
+                return accessibilityViewEmbedder.onAccessibilityHoverEvent(semanticsNodeUnderCursor.id, event);
+            }
         }
+
 
         if (event.getAction() == MotionEvent.ACTION_HOVER_ENTER || event.getAction() == MotionEvent.ACTION_HOVER_MOVE) {
             handleTouchExploration(event.getX(), event.getY());
@@ -1441,7 +1446,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             return;
         }
         // TODO(mattcarroll): why are we explicitly talking to the root view's parent?
-        rootAccessibilityView.getParent().requestSendAccessibilityEvent(rootAccessibilityView, event);
+        if (rootAccessibilityView.getParent()!=null) {
+            rootAccessibilityView.getParent().requestSendAccessibilityEvent(rootAccessibilityView, event);
+        }
     }
 
     /**
@@ -2015,8 +2022,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 if (globalTransform == null) {
                     globalTransform = new float[16];
                 }
-                Matrix.multiplyMM(globalTransform, 0, ancestorTransform, 0, transform, 0);
-
+                if (globalTransform!=null && ancestorTransform!=null && transform!=null) {
+                    Matrix.multiplyMM(globalTransform, 0, ancestorTransform, 0, transform, 0);
+                }
                 final float[] sample = new float[4];
                 sample[2] = 0;
                 sample[3] = 1;

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -5,6 +5,7 @@
 package io.flutter.view;
 
 import android.graphics.SurfaceTexture;
+import android.opengl.EGLContext;
 
 /**
  * Registry of backend textures used with a single {@link FlutterView} instance.
@@ -19,6 +20,42 @@ public interface TextureRegistry {
     * @return A SurfaceTextureEntry.
     */
     SurfaceTextureEntry createSurfaceTexture();
+    
+    void onGLFrameAvaliable(int index);
+    
+    long registerGLTexture(long textureID);
+    
+    EGLContext getGLContext();
+    
+    GLTextureEntry createGLTexture(long textureID);
+    
+    /**
+     * A registry entry for a managed SurfaceTexture.
+     */
+    interface GLTextureEntry {
+        
+        /**
+         * @return The identity of this SurfaceTexture.
+         */
+        long id();
+        
+        /**
+         * Deregisters and releases this SurfaceTexture.
+         */
+        void release();
+        
+        /**
+         * suspend the SurfaceTexture
+         * this will unregister the texture and release the existed surfaceeTexture,but
+         * the id will be reserved
+         */
+        void suspend();
+        
+        /**
+         * this will create a new SurfaceTexture, and register texture
+         */
+        void resume(long textureID);
+    }
 
     /**
      * A registry entry for a managed SurfaceTexture.
@@ -38,5 +75,18 @@ public interface TextureRegistry {
          * Deregisters and releases this SurfaceTexture.
          */
         void release();
+        
+        /**
+         * suspend the SurfaceTexture
+         * this will unregister the texture and release the existed surfaceeTexture,but
+         * the id will be reserved
+         */
+        void suspend();
+        
+        /**
+         * this will create a new SurfaceTexture, and register texture
+         */
+        void resume();
+
     }
 }

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -375,6 +375,17 @@ void PlatformViewAndroid::RegisterExternalTexture(
   RegisterTexture(
       std::make_shared<AndroidExternalTextureGL>(texture_id, surface_texture));
 }
+    
+void PlatformViewAndroid::RegisterGLExternalTexture(int64_t texture_index,
+                                                    int64_t texture_id) {
+    RegisterTexture(
+                    std::make_shared<AndroidExternalTextureGL>(texture_index, texture_id));
+}
+
+void* PlatformViewAndroid::GetContext() {
+    return android_surface_->GetContext();
+}
+    
 
 // |PlatformView|
 std::unique_ptr<VsyncWaiter> PlatformViewAndroid::CreateVSyncWaiter() {

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -73,6 +73,10 @@ class PlatformViewAndroid final : public PlatformView {
       int64_t texture_id,
       const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
 
+  void RegisterGLExternalTexture(int64_t texture_index, int64_t texture_id);
+
+  void* GetContext();
+
  private:
   const fml::jni::JavaObjectWeakGlobalRef java_object_;
   const std::unique_ptr<AndroidSurface> android_surface_;

--- a/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
@@ -7,6 +7,7 @@
 
 #import <CoreMedia/CoreMedia.h>
 #import <Foundation/Foundation.h>
+#import <OpenGLES/EAGL.h>
 
 #include "FlutterMacros.h"
 
@@ -15,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 FLUTTER_EXPORT
 @protocol FlutterTexture <NSObject>
 - (CVPixelBufferRef _Nullable)copyPixelBuffer;
+- (GLuint)copyTextureID;
 @end
 
 FLUTTER_EXPORT
@@ -22,6 +24,7 @@ FLUTTER_EXPORT
 - (int64_t)registerTexture:(NSObject<FlutterTexture>*)texture;
 - (void)textureFrameAvailable:(int64_t)textureId;
 - (void)unregisterTexture:(int64_t)textureId;
+- (EAGLSharegroup*)glShareGroup;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -527,6 +527,9 @@
 }
 
 #pragma mark - FlutterTextureRegistry
+- (EAGLSharegroup*)glShareGroup {
+    return (EAGLSharegroup*)(self.iosPlatformView -> GetGLShareGroup());
+}
 
 - (int64_t)registerTexture:(NSObject<FlutterTexture>*)texture {
   int64_t textureId = _nextTextureId++;

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -64,11 +64,11 @@ id<FlutterViewEngineDelegate> _delegate;
 }
 
 + (Class)layerClass {
-#if TARGET_IPHONE_SIMULATOR
-  return [CALayer class];
-#else   // TARGET_IPHONE_SIMULATOR
+// #if TARGET_IPHONE_SIMULATOR
+//   return [CALayer class];
+// #else   // TARGET_IPHONE_SIMULATOR
   return [CAEAGLLayer class];
-#endif  // TARGET_IPHONE_SIMULATOR
+// #endif  // TARGET_IPHONE_SIMULATOR
 }
 
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -23,6 +23,7 @@
 #include "flutter/shell/platform/darwin/ios/platform_view_ios.h"
 
 NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemanticsUpdate";
+static double kTouchTrackerCheckInterval = 1.f;
 
 @implementation FlutterViewController {
   std::unique_ptr<fml::WeakPtrFactory<FlutterViewController>> _weakFactory;
@@ -40,6 +41,8 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
   BOOL _viewOpaque;
   BOOL _engineNeedsLaunch;
   NSMutableSet<NSNumber*>* _ongoingTouches;
+  NSMutableSet* _touchTrackerSet;
+  NSMutableDictionary<NSValue*, NSNumber*>* _touchTrackerDict;
 }
 
 #pragma mark - Manage and override all designated initializers
@@ -119,7 +122,8 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
 
   _orientationPreferences = UIInterfaceOrientationMaskAll;
   _statusBarStyle = UIStatusBarStyleDefault;
-
+  _touchTrackerSet = [[NSMutableSet set] retain];
+  _touchTrackerDict = [[NSMutableDictionary dictionary] retain];
   [self setupNotificationCenterObservers];
 }
 
@@ -471,6 +475,8 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
 - (void)dealloc {
   [_engine.get() notifyViewControllerDeallocated];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+  [_touchTrackerSet release];
+  [_touchTrackerDict release];
   [super dealloc];
 }
 
@@ -540,17 +546,40 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 // in the status bar area are available to framework code. The change type (optional) of the faked
 // touch is specified in the second argument.
 - (void)dispatchTouches:(NSSet*)touches
-    pointerDataChangeOverride:(flutter::PointerData::Change*)overridden_change {
+    pointerDataChangeOverride:(blink::PointerData::Change*)overridden_change
+                 trackTouches:(BOOL)bTrack {
   const CGFloat scale = [UIScreen mainScreen].scale;
   auto packet = std::make_unique<flutter::PointerDataPacket>(touches.count);
-
+  NSTimeInterval tsNow = [[NSDate date] timeIntervalSinceReferenceDate];
   size_t pointer_index = 0;
 
   for (UITouch* touch in touches) {
     CGPoint windowCoordinates = [touch locationInView:self.view];
 
+    UITouchPhase phase = touch.phase;
+    NSValue* key = [NSValue valueWithPointer:(void*)touch];
     flutter::PointerData pointer_data;
     pointer_data.Clear();
+
+    switch (phase) {
+      case UITouchPhaseBegan:
+      case UITouchPhaseMoved:
+      case UITouchPhaseStationary:
+        if (bTrack) {
+          [_touchTrackerSet addObject:touch];
+          _touchTrackerDict[key] = @(tsNow + kTouchTrackerCheckInterval);
+        }
+        break;
+      case UITouchPhaseEnded:
+      case UITouchPhaseCancelled:
+        if (bTrack) {
+          [_touchTrackerDict removeObjectForKey:key];
+          [_touchTrackerSet removeObject:touch];
+        }
+        break;
+      default:
+        break;
+    }
 
     constexpr int kMicrosecondsPerSecond = 1000 * 1000;
     pointer_data.time_stamp = touch.timestamp * kMicrosecondsPerSecond;
@@ -647,19 +676,45 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event {
-  [self dispatchTouches:touches pointerDataChangeOverride:nullptr];
+  [self dispatchTouches:touches pointerDataChangeOverride:nullptr trackTouches:TRUE];
+  [self checkIfCompleteTouches];
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {
-  [self dispatchTouches:touches pointerDataChangeOverride:nullptr];
+  [self dispatchTouches:touches pointerDataChangeOverride:nullptr trackTouches:TRUE];
 }
 
 - (void)touchesEnded:(NSSet*)touches withEvent:(UIEvent*)event {
-  [self dispatchTouches:touches pointerDataChangeOverride:nullptr];
+  [self dispatchTouches:touches pointerDataChangeOverride:nullptr trackTouches:TRUE];
 }
 
 - (void)touchesCancelled:(NSSet*)touches withEvent:(UIEvent*)event {
-  [self dispatchTouches:touches pointerDataChangeOverride:nullptr];
+  [self dispatchTouches:touches pointerDataChangeOverride:nullptr trackTouches:TRUE];
+}
+
+- (BOOL)checkIfCompleteTouches {
+  NSInteger cnt = _touchTrackerSet.count;
+  if (cnt <= 0)
+    return FALSE;
+  NSTimeInterval tsNow = [[NSDate date] timeIntervalSinceReferenceDate];
+  NSSet* tmpTrackingTouches = [_touchTrackerSet copy];
+  NSMutableSet* set = [NSMutableSet set];
+  for (UITouch* touch in tmpTrackingTouches) {
+    NSValue* key = [NSValue valueWithPointer:(void*)touch];
+    NSNumber* expiredTime = [_touchTrackerDict objectForKey:key];
+    if (expiredTime.doubleValue <= tsNow) {
+      [touch setValue:@(UITouchPhaseEnded) forKey:@"phase"];
+      [set addObject:touch];
+      [_touchTrackerDict removeObjectForKey:key];
+      [_touchTrackerSet removeObject:touch];
+    }
+  }
+  if (set.count > 0) {
+    [self dispatchTouches:set pointerDataChangeOverride:nullptr trackTouches:FALSE];
+    [self dispatchTouches:set pointerDataChangeOverride:nullptr trackTouches:FALSE];
+    return TRUE;
+  }
+  return FALSE;
 }
 
 #pragma mark - Handle view resizing
@@ -955,9 +1010,9 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
         NSSet* statusbarTouches = [NSSet setWithObject:touch];
 
         flutter::PointerData::Change change = flutter::PointerData::Change::kDown;
-        [self dispatchTouches:statusbarTouches pointerDataChangeOverride:&change];
+        [self dispatchTouches:statusbarTouches pointerDataChangeOverride:&change trackTouches:TRUE];
         change = flutter::PointerData::Change::kUp;
-        [self dispatchTouches:statusbarTouches pointerDataChangeOverride:&change];
+        [self dispatchTouches:statusbarTouches pointerDataChangeOverride:&change trackTouches:TRUE];
         return;
       }
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1016,6 +1016,9 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
 }
 
 #pragma mark - FlutterTextureRegistry
+- (EAGLSharegroup*)glShareGroup {
+  return [_engine.get() glShareGroup];
+}
 
 - (int64_t)registerTexture:(NSObject<FlutterTexture>*)texture {
   return [_engine.get() registerTexture:texture];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -8,9 +8,10 @@
 #import "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 
 #include <memory>
-
+#include "flutter/common/task_runners.h"
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/message_loop.h"
+#include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/platform/darwin/platform_version.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/common/thread_host.h"
@@ -609,7 +610,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 // in the status bar area are available to framework code. The change type (optional) of the faked
 // touch is specified in the second argument.
 - (void)dispatchTouches:(NSSet*)touches
-    pointerDataChangeOverride:(blink::PointerData::Change*)overridden_change
+    pointerDataChangeOverride:(flutter::PointerData::Change*)overridden_change
                  trackTouches:(BOOL)bTrack {
   const CGFloat scale = [UIScreen mainScreen].scale;
   auto packet = std::make_unique<flutter::PointerDataPacket>(touches.count);
@@ -646,7 +647,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
     constexpr int kMicrosecondsPerSecond = 1000 * 1000;
     pointer_data.time_stamp = touch.timestamp * kMicrosecondsPerSecond;
-
+    
     pointer_data.change = overridden_change != nullptr
                               ? *overridden_change
                               : PointerDataChangeFromUITouchPhase(touch.phase);

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -30,6 +30,8 @@ class IOSGLContext {
 
   bool ResourceMakeCurrent();
 
+  void* GetGLShareGroup();
+
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 
  private:

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -13,9 +13,9 @@
 namespace flutter {
 
 IOSGLContext::IOSGLContext() {
-  resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3]);
+  resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2]);
   if (resource_context_ != nullptr) {
-    context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
+    context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
                                          sharegroup:resource_context_.get().sharegroup]);
   } else {
     resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2]);
@@ -58,6 +58,11 @@ bool IOSGLContext::MakeCurrent() {
 
 bool IOSGLContext::ResourceMakeCurrent() {
   return [EAGLContext setCurrentContext:resource_context_.get()];
+}
+    
+void* IOSGLContext::GetGLShareGroup() {
+    EAGLSharegroup* shareGroup = context_.get().sharegroup;
+    return (void*)shareGroup;
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -33,6 +33,8 @@ class IOSSurface {
 
   virtual std::unique_ptr<Surface> CreateGPUSurface() = 0;
 
+  virtual void* GetGLShareGroup() = 0;
+
  protected:
   FlutterPlatformViewsController* GetPlatformViewsController();
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -40,6 +40,8 @@ class IOSSurfaceGL : public IOSSurface,
 
   bool GLContextMakeCurrent() override;
 
+  void* GetGLShareGroup() override;
+
   bool GLContextClearCurrent() override;
 
   bool GLContextPresent() override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -50,6 +50,10 @@ intptr_t IOSSurfaceGL::GLContextFBO() const {
   return IsValid() ? render_target_->framebuffer() : GL_NONE;
 }
 
+void* IOSSurfaceGL::GetGLShareGroup() {
+  return context_.get()->GetGLShareGroup();
+}
+
 bool IOSSurfaceGL::UseOffscreenSurface() const {
   // The onscreen surface wraps a GL renderbuffer, which is extremely slow to read.
   // Certain filter effects require making a copy of the current destination, so we

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -35,7 +35,10 @@ class IOSSurfaceSoftware final : public IOSSurface,
 
   // |IOSSurface|
   std::unique_ptr<Surface> CreateGPUSurface() override;
-
+                                     
+  // |IOSSurface|
+  void* GetGLShareGroup() override;
+                                     
   // |GPUSurfaceSoftwareDelegate|
   sk_sp<SkSurface> AcquireBackingStore(const SkISize& size) override;
 

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -52,6 +52,10 @@ std::unique_ptr<Surface> IOSSurfaceSoftware::CreateGPUSurface() {
   return surface;
 }
 
+void* IOSSurfaceSoftware::GetGLShareGroup() {
+  return nullptr;
+}
+
 sk_sp<SkSurface> IOSSurfaceSoftware::AcquireBackingStore(const SkISize& size) {
   TRACE_EVENT0("flutter", "IOSSurfaceSoftware::AcquireBackingStore");
   if (!IsValid()) {

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -37,6 +37,8 @@ class PlatformViewIOS final : public PlatformView {
 
   void RegisterExternalTexture(int64_t id, NSObject<FlutterTexture>* texture);
 
+  void* GetGLShareGroup();
+
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> GetTextInputPlugin() const;
 
   void SetTextInputPlugin(fml::scoped_nsprotocol<FlutterTextInputPlugin*> plugin);

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -70,6 +70,12 @@ void PlatformViewIOS::RegisterExternalTexture(int64_t texture_id,
                                               NSObject<FlutterTexture>* texture) {
   RegisterTexture(std::make_shared<IOSExternalTextureGL>(texture_id, texture));
 }
+    
+void* PlatformViewIOS::GetGLShareGroup() {
+    if (ios_surface_.get() == NULL)
+     return NULL;
+    return ios_surface_->GetGLShareGroup();
+}
 
 // |PlatformView|
 std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {


### PR DESCRIPTION
Hi, everyone. I am a member of alibaba xianyu team. At the invitation of [xster](https://github.com/xster), I would like to present some patches that have been repaired by the team for reference.

For the current online 1.5.4 version engine, we have sorted out some internal patches. I know these codes are not a perfect solution, but I hope to share them and explain some specific problems and demands in some scenarios.

Here are some stability and some extended capabilities of texture. As xianyu has 300 million users at present, we have some requirements on online stability and performance

I focus on the reasons for the two commit and the ideas for the modifications, which I hope will help the stability of the engine in the future.
Some of the other such as commit aa40f57 has been handled by my colleague kangwang1988 illustrated in https://github.com/flutter/engine/pull/6145, I will not repeat.

## Commit 3755a5d

Problem description: Flutter will crash when rendered in the background

```
Exception Type: SIGSEGV
Exception Codes: SEGV_ACCERR at 0x1
Triggered by Thread: 24

Thread 24 Crashed:
0 libGPUSupportMercury.dylib 0x000000018b1d1f90 _gpus_ReturnNotPermittedKillClient :12 (in libGPUSupportMercury.dylib)
1 GLEngine 0x0000000185d691f4 0x0000000185c78000 + 987636
2 GLEngine 0x0000000185d690f8 0x0000000185c78000 + 987384
3 OpenGLES 0x0000000185d77c58 -[EAGLContext presentRenderbuffer:] :72 (in OpenGLES)
4 Flutter 0x0000000103a75de8 0x0000000103a54000 + 138728
5 Flutter 0x0000000103a7880c 0x0000000103a54000 + 149516
6 Flutter 0x0000000103aa7744 0x0000000103a54000 + 341828
7 Flutter 0x0000000103aa7c34 0x0000000103a54000 + 343092
8 Flutter 0x0000000103aa7fd0 0x0000000103a54000 + 344016
9 Flutter 0x0000000103aa7acc 0x0000000103a54000 + 342732
10 Flutter 0x0000000103aab4a0 0x0000000103a54000 + 357536
11 Flutter 0x0000000103a82968 0x0000000103a54000 + 190824
12 Flutter 0x0000000103a83884 0x0000000103a54000 + 194692
```

Problem analysis: the Flutter Engine instance corresponds to four taskrunners :Platform, UI, GPU and IO. GPU and IO are involved in GPU operation. The current Message Loop cannot guarantee that there is no GPU/IO operation when the App goes back to the background.

Solutions:
1. Control the size of tasks in each message Loop to ensure that they do not accumulate too many.
2. Before switching to the background, check whether the GPU and IO TaskRunner have any unfinished tasks, if so, block the main thread until the task is completed.


## Commit dfe3d98

Problem description: xianyu hopes to reuse Native image library and video library in the App. After it is implemented directly through the Flutter Texture mechanism, it is found that the memory is large and the whole rendering process is long, which cannot meet the online requirements.

Problem analysis:
The specific scheme is shown in the figure below
![image.png](https://ata2-img.cn-hangzhou.oss-pub.aliyun-inc.com/d82fa6b1f5515f1312af4ca62637ae59.png)

Solutions:
If you want to implement the scenario in the figure above, you need to expose some of the specified interfaces on the engine side.