### PR TITLE
Introduce RasterStatus::kResubmit to resubmit layer trees

### DIFF
--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -20,7 +20,7 @@ namespace flutter {
 
 class LayerTree;
 
-enum class RasterStatus { kSuccess, kFailed };
+enum class RasterStatus { kSuccess, kResubmit, kFailed };
 
 class CompositorContext {
  public:

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -99,6 +99,7 @@ void Rasterizer::DrawLastLayerTree() {
 
 void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
   TRACE_EVENT0("flutter", "GPURasterizer::Draw");
+  FML_DCHECK(task_runners_.GetGPUTaskRunner()->RunsTasksOnCurrentThread());
 
   RasterStatus raster_status = RasterStatus::kFailed;
   Pipeline<flutter::LayerTree>::Consumer consumer =

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -100,12 +100,24 @@ void Rasterizer::DrawLastLayerTree() {
 void Rasterizer::Draw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
   TRACE_EVENT0("flutter", "GPURasterizer::Draw");
 
+  RasterStatus raster_status = RasterStatus::kFailed;
   Pipeline<flutter::LayerTree>::Consumer consumer =
-      std::bind(&Rasterizer::DoDraw, this, std::placeholders::_1);
+      [&](std::unique_ptr<LayerTree> layer_tree) {
+        raster_status = DoDraw(std::move(layer_tree));
+      };
+
+  PipelineConsumeResult consume_result = pipeline->Consume(consumer);
+  // if the raster status is to resubmit the frame, we push the frame to the
+  // front of the queue and also change the consume status to more available.
+  if (raster_status == RasterStatus::kResubmit) {
+    auto front_continuation = pipeline->ProduceToFront();
+    front_continuation.Complete(std::move(last_layer_tree_));
+    consume_result = PipelineConsumeResult::MoreAvailable;
+  }
 
   // Consume as many pipeline items as possible. But yield the event loop
   // between successive tries.
-  switch (pipeline->Consume(consumer)) {
+  switch (consume_result) {
     case PipelineConsumeResult::MoreAvailable: {
       task_runners_.GetGPUTaskRunner()->PostTask(
           [weak_this = weak_factory_.GetWeakPtr(), pipeline]() {
@@ -172,12 +184,15 @@ sk_sp<SkImage> Rasterizer::MakeRasterSnapshot(sk_sp<SkPicture> picture,
   return nullptr;
 }
 
-void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
+RasterStatus Rasterizer::DoDraw(
+    std::unique_ptr<flutter::LayerTree> layer_tree) {
   FML_DCHECK(task_runners_.GetGPUTaskRunner()->RunsTasksOnCurrentThread());
 
   if (!layer_tree || !surface_) {
-    return;
+    return RasterStatus::kFailed;
   }
+
+  RasterStatus raster_status;
 
   FrameTiming timing;
   timing.Set(FrameTiming::kBuildStart, layer_tree->build_start());
@@ -187,8 +202,12 @@ void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
   PersistentCache* persistent_cache = PersistentCache::GetCacheForProcess();
   persistent_cache->ResetStoredNewShaders();
 
-  if (DrawToSurface(*layer_tree) == RasterStatus::kSuccess) {
+  raster_status = DrawToSurface(*layer_tree);
+  if (raster_status == RasterStatus::kSuccess) {
     last_layer_tree_ = std::move(layer_tree);
+  } else if (raster_status == RasterStatus::kResubmit) {
+    last_layer_tree_ = std::move(layer_tree);
+    return raster_status;
   }
 
   if (persistent_cache->IsDumpingSkp() &&
@@ -203,6 +222,8 @@ void Rasterizer::DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree) {
   // for Fuchsia to capture SceneUpdateContext::ExecutePaintTasks.
   timing.Set(FrameTiming::kRasterFinish, fml::TimePoint::Now());
   delegate_.OnFrameRasterized(timing);
+
+  return raster_status;
 }
 
 RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -114,7 +114,7 @@ class Rasterizer final : public SnapshotDelegate {
   sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                     SkISize picture_size) override;
 
-  void DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
+  RasterStatus DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
 
   RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);
 


### PR DESCRIPTION
This is for cases where we wish to re-draw the layer trees.
If this raster status is encountered we push the layer tree to the
front of the pipeline.

This kResubmit is not returned anywhere currently, but will be
we wish to merge the frames.

More detailed plan at [go/raster-merge-loops](https://goto.google.com/raster-merge-loops).