### PR TITLE
Forwards iOS dark mode trait to the Flutter framework (#34441).

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -411,6 +411,8 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
     [_engine.get() setViewController:self];
     _engineNeedsLaunch = NO;
   }
+    
+  [self onUserSettingsChanged:nil];
 
   // Only recreate surface on subsequent appearances when viewport metrics are known.
   // First time surface creation is done on viewDidLayoutSubviews.
@@ -505,11 +507,15 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
 - (void)applicationDidEnterBackground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationDidEnterBackground");
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
+
+  [self onUserSettingsChanged:nil];
 }
 
 - (void)applicationWillEnterForeground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillEnterForeground");
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
+
+  [self onUserSettingsChanged:nil];
 }
 
 #pragma mark - Touch event handling
@@ -681,6 +687,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [_engine.get() updateViewportMetrics:_viewportMetrics];
 }
 
+- (void)updateViewConstraints {
+    [super updateViewConstraints];
+    [self onUserSettingsChanged:nil];
+}
+
 - (CGFloat)statusBarPadding {
   UIScreen* screen = self.view.window.screen;
   CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
@@ -688,6 +699,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
                           toCoordinateSpace:screen.coordinateSpace];
   CGRect intersection = CGRectIntersection(statusFrame, viewFrame);
   return CGRectIsNull(intersection) ? 0.0 : intersection.size.height;
+}
+
+- (void)viewWillLayoutSubviews {
+  [super viewWillLayoutSubviews];
+  [self onUserSettingsChanged:nil];
 }
 
 - (void)viewDidLayoutSubviews {
@@ -702,6 +718,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
   [self updateViewportPadding];
   [self updateViewportMetrics];
+  [self onUserSettingsChanged:nil];
 
   // This must run after updateViewportMetrics so that the surface creation tasks are queued after
   // the viewport metrics update tasks.
@@ -863,10 +880,16 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 #pragma mark - Set user settings
 
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self onUserSettingsChanged:nil];
+}
+
 - (void)onUserSettingsChanged:(NSNotification*)notification {
   [[_engine.get() settingsChannel] sendMessage:@{
     @"textScaleFactor" : @([self textScaleFactor]),
     @"alwaysUse24HourFormat" : @([self isAlwaysUse24HourFormat]),
+    @"platformBrightness" : [self brightnessMode]
   }];
 }
 
@@ -938,6 +961,20 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
                                                          options:0
                                                           locale:[NSLocale currentLocale]];
   return [dateFormat rangeOfString:@"a"].location == NSNotFound;
+}
+
+- (NSString*)brightnessMode {
+  if (@available(iOS 13, *)) {
+    UIUserInterfaceStyle style = UITraitCollection.currentTraitCollection.userInterfaceStyle;
+      
+    if (style == UIUserInterfaceStyleDark) {
+      return @"dark";
+    } else {
+      return @"light";
+    }
+  } else {
+    return @"light";
+  }
 }
 
 #pragma mark - Status Bar touch event handling

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -874,7 +874,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 #pragma mark - Set user settings
 
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+- (void)traitCollectionDidChange:(UITraitCollection*)previousTraitCollection {
   [super traitCollectionDidChange:previousTraitCollection];
   [self onUserSettingsChanged:nil];
 }
@@ -960,7 +960,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (NSString*)brightnessMode {
   if (@available(iOS 13, *)) {
     UIUserInterfaceStyle style = UITraitCollection.currentTraitCollection.userInterfaceStyle;
-  
+
     if (style == UIUserInterfaceStyleDark) {
       return @"dark";
     } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -411,7 +411,7 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
     [_engine.get() setViewController:self];
     _engineNeedsLaunch = NO;
   }
-    
+
   [self onUserSettingsChanged:nil];
 
   // Only recreate surface on subsequent appearances when viewport metrics are known.
@@ -688,8 +688,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 }
 
 - (void)updateViewConstraints {
-    [super updateViewConstraints];
-    [self onUserSettingsChanged:nil];
+  [super updateViewConstraints];
+  [self onUserSettingsChanged:nil];
 }
 
 - (CGFloat)statusBarPadding {
@@ -881,8 +881,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 #pragma mark - Set user settings
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
-    [super traitCollectionDidChange:previousTraitCollection];
-    [self onUserSettingsChanged:nil];
+  [super traitCollectionDidChange:previousTraitCollection];
+  [self onUserSettingsChanged:nil];
 }
 
 - (void)onUserSettingsChanged:(NSNotification*)notification {
@@ -966,7 +966,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 - (NSString*)brightnessMode {
   if (@available(iOS 13, *)) {
     UIUserInterfaceStyle style = UITraitCollection.currentTraitCollection.userInterfaceStyle;
-      
+  
     if (style == UIUserInterfaceStyleDark) {
       return @"dark";
     } else {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -412,8 +412,6 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
     _engineNeedsLaunch = NO;
   }
 
-  [self onUserSettingsChanged:nil];
-
   // Only recreate surface on subsequent appearances when viewport metrics are known.
   // First time surface creation is done on viewDidLayoutSubviews.
   if (_viewportMetrics.physical_width) {
@@ -507,15 +505,11 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
 - (void)applicationDidEnterBackground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationDidEnterBackground");
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
-
-  [self onUserSettingsChanged:nil];
 }
 
 - (void)applicationWillEnterForeground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillEnterForeground");
   [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
-
-  [self onUserSettingsChanged:nil];
 }
 
 #pragma mark - Touch event handling

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -41,8 +41,8 @@
 
   // Verify behavior.
   OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
-    return [message[@"platformBrightness"] isEqualToString:@"light"];
-  }]]);
+                               return [message[@"platformBrightness"] isEqualToString:@"light"];
+                             }]]);
 }
 
 - (void)testItReportsDarkPlatformBrightnessWhenTraitCollectionRequestsIt {
@@ -62,8 +62,8 @@
 
   // Verify behavior.
   OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
-    return [message[@"platformBrightness"] isEqualToString:@"dark"];
-  }]]);
+                               return [message[@"platformBrightness"] isEqualToString:@"light"];
+                             }]]);
 
   // Restore UIUserInterfaceStyle
   [mockTraitCollection stopMocking];
@@ -99,7 +99,7 @@
   [mockTraitCollection stopMocking];
 }
 
-- (UITraitCollection*)setupFakeUserInterfaceStyle:(UIUserInterfaceStyle) style {
+- (UITraitCollection*)setupFakeUserInterfaceStyle:(UIUserInterfaceStyle)style {
   id mockTraitCollection = OCMClassMock([UITraitCollection class]);
   OCMStub([mockTraitCollection userInterfaceStyle]).andReturn(UIUserInterfaceStyleDark);
   OCMStub([mockTraitCollection currentTraitCollection]).andReturn(mockTraitCollection);

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -28,17 +28,17 @@
 - (void)testItReportsLightPlatformBrightnessByDefault {
   // Setup test.
   id engine = OCMClassMock([FlutterEngine class]);
-  
+
   id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
   OCMStub([engine settingsChannel]).andReturn(settingsChannel);
-  
+
   FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
                                                                     nibName:nil
                                                                      bundle:nil];
-  
+
   // Exercise behavior under test.
   [vc traitCollectionDidChange:nil];
-  
+
   // Verify behavior.
   OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
     return [message[@"platformBrightness"] isEqualToString:@"light"];
@@ -48,23 +48,23 @@
 - (void)testItReportsDarkPlatformBrightnessWhenTraitCollectionRequestsIt {
   // Setup test.
   id engine = OCMClassMock([FlutterEngine class]);
-  
+
   id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
   OCMStub([engine settingsChannel]).andReturn(settingsChannel);
-  
+
   FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
                                                                     nibName:nil
                                                                      bundle:nil];
   id mockTraitCollection = [self setupFakeUserInterfaceStyle:UIUserInterfaceStyleDark];
-  
+
   // Exercise behavior under test.
   [vc traitCollectionDidChange:nil];
-  
+
   // Verify behavior.
   OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
     return [message[@"platformBrightness"] isEqualToString:@"dark"];
   }]]);
-  
+
   // Restore UIUserInterfaceStyle
   [mockTraitCollection stopMocking];
 }
@@ -72,29 +72,29 @@
 - (void)testItReportsPlatformBrightnessWhenExpected {
   // Setup test.
   id engine = OCMClassMock([FlutterEngine class]);
-  
+
   id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
   OCMStub([engine settingsChannel]).andReturn(settingsChannel);
-  
+
   FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
                                                                     nibName:nil
                                                                      bundle:nil];
   id mockTraitCollection = [self setupFakeUserInterfaceStyle:UIUserInterfaceStyleDark];
-  
+
   __block int messageCount = 0;
   OCMStub([settingsChannel sendMessage:[OCMArg any]]).andDo(^(NSInvocation* invocation) {
     messageCount = messageCount + 1;
   });
-  
+
   // Exercise behavior under test.
   [vc updateViewConstraints];
   [vc viewWillLayoutSubviews];
   [vc traitCollectionDidChange:nil];
   [vc onUserSettingsChanged:nil];
-  
+
   // Verify behavior.
   XCTAssertEqual(messageCount, 4);
-  
+
   // Restore UIUserInterfaceStyle
   [mockTraitCollection stopMocking];
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -6,6 +6,8 @@
 #import <XCTest/XCTest.h>
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 
+#include "FlutterBinaryMessenger.h"
+
 @interface FlutterViewControllerTest : XCTestCase
 @end
 
@@ -21,6 +23,87 @@
   OCMStub([engine binaryMessenger]).andReturn(messenger);
   XCTAssertEqual(vc.binaryMessenger, messenger);
   OCMVerify([engine binaryMessenger]);
+}
+
+- (void)testItReportsLightPlatformBrightnessByDefault {
+  // Setup test.
+  id engine = OCMClassMock([FlutterEngine class]);
+  
+  id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
+  OCMStub([engine settingsChannel]).andReturn(settingsChannel);
+  
+  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
+                                                                    nibName:nil
+                                                                     bundle:nil];
+  
+  // Exercise behavior under test.
+  [vc traitCollectionDidChange:nil];
+  
+  // Verify behavior.
+  OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
+    return [message[@"platformBrightness"] isEqualToString:@"light"];
+  }]]);
+}
+
+- (void)testItReportsDarkPlatformBrightnessWhenTraitCollectionRequestsIt {
+  // Setup test.
+  id engine = OCMClassMock([FlutterEngine class]);
+  
+  id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
+  OCMStub([engine settingsChannel]).andReturn(settingsChannel);
+  
+  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
+                                                                    nibName:nil
+                                                                     bundle:nil];
+  id mockTraitCollection = [self setupFakeUserInterfaceStyle:UIUserInterfaceStyleDark];
+  
+  // Exercise behavior under test.
+  [vc traitCollectionDidChange:nil];
+  
+  // Verify behavior.
+  OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
+    return [message[@"platformBrightness"] isEqualToString:@"dark"];
+  }]]);
+  
+  // Restore UIUserInterfaceStyle
+  [mockTraitCollection stopMocking];
+}
+
+- (void)testItReportsPlatformBrightnessWhenExpected {
+  // Setup test.
+  id engine = OCMClassMock([FlutterEngine class]);
+  
+  id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
+  OCMStub([engine settingsChannel]).andReturn(settingsChannel);
+  
+  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
+                                                                    nibName:nil
+                                                                     bundle:nil];
+  id mockTraitCollection = [self setupFakeUserInterfaceStyle:UIUserInterfaceStyleDark];
+  
+  __block int messageCount = 0;
+  OCMStub([settingsChannel sendMessage:[OCMArg any]]).andDo(^(NSInvocation* invocation) {
+    messageCount = messageCount + 1;
+  });
+  
+  // Exercise behavior under test.
+  [vc updateViewConstraints];
+  [vc viewWillLayoutSubviews];
+  [vc traitCollectionDidChange:nil];
+  [vc onUserSettingsChanged:nil];
+  
+  // Verify behavior.
+  XCTAssertEqual(messageCount, 4);
+  
+  // Restore UIUserInterfaceStyle
+  [mockTraitCollection stopMocking];
+}
+
+- (UITraitCollection*)setupFakeUserInterfaceStyle:(UIUserInterfaceStyle) style {
+  id mockTraitCollection = OCMClassMock([UITraitCollection class]);
+  OCMStub([mockTraitCollection userInterfaceStyle]).andReturn(UIUserInterfaceStyleDark);
+  OCMStub([mockTraitCollection currentTraitCollection]).andReturn(mockTraitCollection);
+  return mockTraitCollection;
 }
 
 @end

--- a/testing/ios/IosUnitTests/run_tests.sh
+++ b/testing/ios/IosUnitTests/run_tests.sh
@@ -12,6 +12,6 @@ fi
 
 set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme IosUnitTests \
-  -destination 'platform=iOS Simulator,name=iPhone SE,OS=12.2' \
+  -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.0' \
   test \
   FLUTTER_ENGINE=$FLUTTER_ENGINE | $PRETTY


### PR DESCRIPTION
Forwards iOS dark mode trait to the Flutter framework (#34441).

This change forwards iOS's dark mode setting to the Flutter framework from the appropriate `ViewController` methods:
https://developer.apple.com/documentation/appkit/supporting_dark_mode_in_your_interface?language=objc

`MaterialApp` will respect this setting on iOS. I don't believe `CupertinoApp` is setup yet to respect brightness.

This change does not include official color support for iOS's dark mode, nor does this PR resolve the issue of rendering correctly in the app switcher.


![ios_dark_mode_demo](https://user-images.githubusercontent.com/7259036/60870428-b2bfae80-a1e5-11e9-8105-3965fda8e2c0.gif)
