### PR TITLE
Add hooks for InputConnection lock and unlocking

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -97,28 +97,36 @@ public class TextInputPlugin {
     }
 
     /***
-     * Use the current platform view input connection until unlockPlatformViewInputConnection is called.
+     * Use the current platform view input connection until unlockPlatformViewInputConnection is
+     * called.
      *
-     * The current input connection instance is cached and any following call to @{link createInputConnection} returns
-     * the cached connection until unlockPlatformViewInputConnection is called.
+     * The current input connection instance is cached and any following call to
+     * {@link createInputConnection} returns the cached connection until
+     * unlockPlatformViewInputConnection is called.
      *
      * This is a no-op if the current input target isn't a platform view.
      *
-     * This is used to preserve an input connection when moving a platform view from one virtual display to another.
+     * This is used to preserve an input connection when moving a platform view from one virtual
+     * display to another.
+     *
+     * This triggers {@link PlatformView#onInputConnectionLocked}.
      */
     public void lockPlatformViewInputConnection() {
-        if (inputTarget.type == InputTarget.Type.PLATFORM_VIEW) {
-            isInputConnectionLocked = true;
+        if (inputTarget.type != InputTarget.Type.PLATFORM_VIEW) {
+            return;
         }
+        isInputConnectionLocked = true;
+        platformViewsController.onInputConnectionLocked(inputTarget.id);
     }
 
     /**
-     * Unlocks the input connection.
+     * Unlocks the input connection. This triggers {@link PlatformView#onInputConnectionUnlocked}.
      *
-     * See also: @{link lockPlatformViewInputConnection}.
+     * See also: {@link lockPlatformViewInputConnection}.
      */
     public void unlockPlatformViewInputConnection() {
         isInputConnectionLocked = false;
+        platformViewsController.onInputConnectionUnlocked(inputTarget.id);
     }
 
     /**

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -97,36 +97,28 @@ public class TextInputPlugin {
     }
 
     /***
-     * Use the current platform view input connection until unlockPlatformViewInputConnection is
-     * called.
+     * Use the current platform view input connection until unlockPlatformViewInputConnection is called.
      *
-     * The current input connection instance is cached and any following call to
-     * {@link createInputConnection} returns the cached connection until
-     * unlockPlatformViewInputConnection is called.
+     * The current input connection instance is cached and any following call to @{link createInputConnection} returns
+     * the cached connection until unlockPlatformViewInputConnection is called.
      *
      * This is a no-op if the current input target isn't a platform view.
      *
-     * This is used to preserve an input connection when moving a platform view from one virtual
-     * display to another.
-     *
-     * This triggers {@link PlatformView#onInputConnectionLocked}.
+     * This is used to preserve an input connection when moving a platform view from one virtual display to another.
      */
     public void lockPlatformViewInputConnection() {
-        if (inputTarget.type != InputTarget.Type.PLATFORM_VIEW) {
-            return;
+        if (inputTarget.type == InputTarget.Type.PLATFORM_VIEW) {
+            isInputConnectionLocked = true;
         }
-        isInputConnectionLocked = true;
-        platformViewsController.onInputConnectionLocked(inputTarget.id);
     }
 
     /**
-     * Unlocks the input connection. This triggers {@link PlatformView#onInputConnectionUnlocked}.
+     * Unlocks the input connection.
      *
-     * See also: {@link lockPlatformViewInputConnection}.
+     * See also: @{link lockPlatformViewInputConnection}.
      */
     public void unlockPlatformViewInputConnection() {
         isInputConnectionLocked = false;
-        platformViewsController.onInputConnectionUnlocked(inputTarget.id);
     }
 
     /**

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformView.java
@@ -4,6 +4,7 @@
 
 package io.flutter.plugin.platform;
 
+import android.annotation.SuppressLint;
 import android.view.View;
 
 /**
@@ -24,4 +25,26 @@ public interface PlatformView {
      * after this method is called. Failing to do so will result in a memory leak.
      */
     void dispose();
+
+    /**
+    * Callback fired when the platform's input connection is locked, or should be used. See also
+    * {@link TextInputPlugin#lockPlatformViewInputConnection}.
+    *
+    * <p>This hook only exists for rare cases where the plugin relies on the state of the input
+    * connection. This probably doesn't need to be implemented.
+    */
+    // Default interface methods are supported on all min SDK versions of Android.
+    @SuppressLint("NewApi")
+    default void onInputConnectionLocked() {};
+
+    /**
+    * Callback fired when the platform input connection has been unlocked. See also
+    * {@link TextInputPlugin#lockPlatformViewInputConnection}.
+    *
+    * <p>This hook only exists for rare cases where the plugin relies on the state of the input
+    * connection. This probably doesn't need to be implemented.
+    */
+    // Default interface methods are supported on all min SDK versions of Android.
+    @SuppressLint("NewApi")
+    default void onInputConnectionUnlocked() {};
 }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -366,6 +366,30 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         return controller.getView();
     }
 
+    /**
+    * Callback fired when the platform's input connection is locked, or should be used. See also
+    * {@link TextInputPlugin#lockPlatformViewInputConnection}.
+    */
+    public void onInputConnectionLocked(int viewId) {
+        VirtualDisplayController controller = vdControllers.get(viewId);
+        if (controller == null) {
+            return;
+        }
+        controller.onInputConnectionLocked();
+    }
+
+    /**
+    * Callback fired when the platform input connection has been unlocked. See also
+    * {@link TextInputPlugin#lockPlatformViewInputConnection}.
+    */
+    public void onInputConnectionUnlocked(int viewId) {
+        VirtualDisplayController controller = vdControllers.get(viewId);
+        if (controller == null) {
+            return;
+        }
+        controller.onInputConnectionUnlocked();
+    }
+
     private static boolean validateDirection(int direction) {
         return direction == View.LAYOUT_DIRECTION_LTR || direction == View.LAYOUT_DIRECTION_RTL;
     }

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -148,7 +148,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         public void resizePlatformView(@NonNull PlatformViewsChannel.PlatformViewResizeRequest request, @NonNull Runnable onComplete) {
             ensureValidAndroidVersion();
 
-            VirtualDisplayController vdController = vdControllers.get(request.viewId);
+            final VirtualDisplayController vdController = vdControllers.get(request.viewId);
             if (vdController == null) {
                 throw new IllegalStateException("Trying to resize a platform view with unknown id: "
                     + request.viewId);
@@ -158,22 +158,18 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             int physicalHeight = toPhysicalPixels(request.newLogicalHeight);
             validateVirtualDisplayDimensions(physicalWidth, physicalHeight);
 
-            if (textInputPlugin != null) {
-                // Resizing involved moving the platform view to a new virtual display.
-                // Doing so potentially results in losing an active input connection.
-                // To make sure we preserve the input connection when resizing we lock it here
-                // and unlock after the resize is complete.
-                textInputPlugin.lockPlatformViewInputConnection();
-            }
+            // Resizing involved moving the platform view to a new virtual display. Doing so
+            // potentially results in losing an active input connection. To make sure we preserve
+            // the input connection when resizing we lock it here and unlock after the resize is
+            // complete.
+            lockInputConnection(vdController);
             vdController.resize(
                     physicalWidth,
                     physicalHeight,
                     new Runnable() {
                         @Override
                         public void run() {
-                            if (textInputPlugin != null) {
-                                textInputPlugin.unlockPlatformViewInputConnection();
-                            }
+                            unlockInputConnection(vdController);
                             onComplete.run();
                         }
                     }
@@ -366,27 +362,19 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
         return controller.getView();
     }
 
-    /**
-    * Callback fired when the platform's input connection is locked, or should be used. See also
-    * {@link TextInputPlugin#lockPlatformViewInputConnection}.
-    */
-    public void onInputConnectionLocked(int viewId) {
-        VirtualDisplayController controller = vdControllers.get(viewId);
-        if (controller == null) {
+    private void lockInputConnection(@NonNull VirtualDisplayController controller) {
+        if (textInputPlugin == null) {
             return;
         }
+        textInputPlugin.lockPlatformViewInputConnection();
         controller.onInputConnectionLocked();
     }
 
-    /**
-    * Callback fired when the platform input connection has been unlocked. See also
-    * {@link TextInputPlugin#lockPlatformViewInputConnection}.
-    */
-    public void onInputConnectionUnlocked(int viewId) {
-        VirtualDisplayController controller = vdControllers.get(viewId);
-        if (controller == null) {
+    private void unlockInputConnection(@NonNull VirtualDisplayController controller) {
+        if (textInputPlugin == null) {
             return;
         }
+        textInputPlugin.unlockPlatformViewInputConnection();
         controller.onInputConnectionUnlocked();
     }
 

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -159,6 +159,20 @@ class VirtualDisplayController {
         textureEntry.release();
     }
 
+    /*package*/ void onInputConnectionLocked() {
+        if (presentation == null || presentation.getView() == null) {
+            return;
+        }
+        presentation.getView().onInputConnectionLocked();
+    }
+
+    /*package*/ void onInputConnectionUnlocked() {
+        if (presentation == null || presentation.getView() == null) {
+            return;
+        }
+        presentation.getView().onInputConnectionUnlocked();
+    }
+
     public View getView() {
         if (presentation == null)
             return null;


### PR DESCRIPTION
With this, plugins can know whether or not their input connection should
be cached. In very rare cases this can be used by plugins to know how to
more properly handle their own input connections, in cases where they're
overriding typical input behavior themselves.

This adds a hook needed for flutter/flutter#19718