### PR TITLE
Make platform_view_android_jni delegate to platform_view_android

### DIFF
--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -179,9 +179,9 @@ void AndroidShellHolder::SetViewportMetrics(
   }
 
   shell_->GetTaskRunners().GetUITaskRunner()->PostTask(
-      [engine = shell_->GetEngine(), metrics]() {
-        if (engine) {
-          engine->SetViewportMetrics(metrics);
+      [platform_view = platform_view_, metrics]() {
+        if (platform_view) {
+          platform_view->SetViewportMetrics(metrics);
         }
       });
 }

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -276,7 +276,7 @@ static void SetViewportMetrics(JNIEnv* env,
       static_cast<double>(physicalViewInsetLeft),
   };
 
-  ANDROID_SHELL_HOLDER->SetViewportMetrics(metrics);
+  ANDROID_SHELL_HOLDER->GetPlatformView()->SetViewportMetrics(metrics);
 }
 
 static jobject GetBitmap(JNIEnv* env, jobject jcaller, jlong shell_holder) {
@@ -387,7 +387,8 @@ static void DispatchPointerDataPacket(JNIEnv* env,
                                       jint position) {
   uint8_t* data = static_cast<uint8_t*>(env->GetDirectBufferAddress(buffer));
   auto packet = std::make_unique<flutter::PointerDataPacket>(data, position);
-  ANDROID_SHELL_HOLDER->DispatchPointerDataPacket(std::move(packet));
+  ANDROID_SHELL_HOLDER->GetPlatformView()->DispatchPointerDataPacket(
+      std::move(packet));
 }
 
 static void DispatchSemanticsAction(JNIEnv* env,

--- a/shell/platform/android/platform_view_android_jni.cc
+++ b/shell/platform/android/platform_view_android_jni.cc
@@ -276,7 +276,7 @@ static void SetViewportMetrics(JNIEnv* env,
       static_cast<double>(physicalViewInsetLeft),
   };
 
-  ANDROID_SHELL_HOLDER->GetPlatformView()->SetViewportMetrics(metrics);
+  ANDROID_SHELL_HOLDER->SetViewportMetrics(metrics);
 }
 
 static jobject GetBitmap(JNIEnv* env, jobject jcaller, jlong shell_holder) {
@@ -387,8 +387,7 @@ static void DispatchPointerDataPacket(JNIEnv* env,
                                       jint position) {
   uint8_t* data = static_cast<uint8_t*>(env->GetDirectBufferAddress(buffer));
   auto packet = std::make_unique<flutter::PointerDataPacket>(data, position);
-  ANDROID_SHELL_HOLDER->GetPlatformView()->DispatchPointerDataPacket(
-      std::move(packet));
+  ANDROID_SHELL_HOLDER->DispatchPointerDataPacket(std::move(packet));
 }
 
 static void DispatchSemanticsAction(JNIEnv* env,


### PR DESCRIPTION
See https://github.com/flutter/engine/pull/9503#discussion_r301817797 for context

Fixing both instances where the JNI platform view didn't delegate to the similarly named platform view method.  

I could use some help with how to test this.

/cc @abhishekamit 