### PR TITLE
Add PrerollDryrun capability to the layer tree

### DIFF
--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -24,6 +24,9 @@ class LayerTree {
 
   ~LayerTree();
 
+  // This version of preroll can occur on a non-gpu thread.
+  void PrerollDryrun(ExternalViewEmbedder* view_embedder);
+
   void Preroll(CompositorContext::ScopedFrame& frame,
                bool ignore_raster_cache = false);
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -798,6 +798,7 @@ void Shell::OnAnimatorNotifyIdle(int64_t deadline) {
 // |Animator::Delegate|
 void Shell::OnAnimatorDraw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
   FML_DCHECK(is_setup_);
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetGPUTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(),
@@ -811,6 +812,7 @@ void Shell::OnAnimatorDraw(fml::RefPtr<Pipeline<flutter::LayerTree>> pipeline) {
 // |Animator::Delegate|
 void Shell::OnAnimatorDrawLastLayerTree() {
   FML_DCHECK(is_setup_);
+  FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   task_runners_.GetGPUTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr()]() {


### PR DESCRIPTION
- This version can be run on UI-thread.
- This is so on IOS we can make the decision to merge
  the threads on UI thread so we can merge the platform
  and GPU threads.