### PR TITLE
Fix backspace crash on Chinese devices

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -168,10 +168,20 @@ class InputConnectionAdaptor extends BaseInputConnection {
                     // isRTLCharAt() call below is returning blanket direction assumption
                     // based on the first character in the line.
                     boolean isRtl = mLayout.isRtlCharAt(mLayout.getLineForOffset(selStart));
-                    if (isRtl) {
-                        Selection.extendRight(mEditable, mLayout);
-                    } else {
-                        Selection.extendLeft(mEditable, mLayout);
+                    try {
+                        if (isRtl) {
+                            Selection.extendRight(mEditable, mLayout);
+                        } else {
+                            Selection.extendLeft(mEditable, mLayout);
+                        }
+                    } catch (IndexOutOfBoundsException e) {
+                        // Unable to move Left or Right, so we will fall back to the simple
+                        // way of decrementing the buffer index. This will generally only
+                        // occur on Chinese keyboards, primarily on Huawei devices, when
+                        // attempting to delete with "obscureText" set to true. In this case,
+                        // the simple method should work well enough because the obscured text
+                        // dots will usually not be long emoji clusters.
+                        Selection.setSelection(mEditable, selStart, selStart - 1);
                     }
                     int newStart = clampIndexToEditable(Selection.getSelectionStart(mEditable), mEditable);
                     int newEnd = clampIndexToEditable(Selection.getSelectionEnd(mEditable), mEditable);

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -175,12 +175,12 @@ class InputConnectionAdaptor extends BaseInputConnection {
                             Selection.extendLeft(mEditable, mLayout);
                         }
                     } catch (IndexOutOfBoundsException e) {
-                        // Unable to move Left or Right, so we will fall back to the simple
-                        // way of decrementing the buffer index. This will generally only
-                        // occur on Chinese keyboards, primarily on Huawei devices, when
-                        // attempting to delete with "obscureText" set to true. In this case,
-                        // the simple method should work well enough because the obscured text
-                        // dots will usually not be long emoji clusters.
+                        // On Huaewi devices on initial app startup before focus is lost,
+                        // The Selection.extendLeft and extendRight calls always extend
+                        // from the index of the initial contents of mEditable. This
+                        // try-catch will prevent crashing on Huawei devices by falling
+                        // back to a simple way of deletion, although this a hack and will
+                        // not handle emojis.
                         Selection.setSelection(mEditable, selStart, selStart - 1);
                     }
                     int newStart = clampIndexToEditable(Selection.getSelectionStart(mEditable), mEditable);

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -175,7 +175,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
                             Selection.extendLeft(mEditable, mLayout);
                         }
                     } catch (IndexOutOfBoundsException e) {
-                        // On Huaewi devices on initial app startup before focus is lost,
+                        // On Huawei devices on initial app startup before focus is lost,
                         // The Selection.extendLeft and extendRight calls always extend
                         // from the index of the initial contents of mEditable. This
                         // try-catch will prevent crashing on Huawei devices by falling

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -175,12 +175,13 @@ class InputConnectionAdaptor extends BaseInputConnection {
                             Selection.extendLeft(mEditable, mLayout);
                         }
                     } catch (IndexOutOfBoundsException e) {
-                        // On Huawei devices on initial app startup before focus is lost,
-                        // The Selection.extendLeft and extendRight calls always extend
+                        // On some Chinese devices (primarily Huawei, some Xiaomi),
+                        // on initial app startup before focus is lost, the
+                        // Selection.extendLeft and extendRight calls always extend
                         // from the index of the initial contents of mEditable. This
                         // try-catch will prevent crashing on Huawei devices by falling
-                        // back to a simple way of deletion, although this a hack and will
-                        // not handle emojis.
+                        // back to a simple way of deletion, although this a hack and
+                        // will not handle emojis.
                         Selection.setSelection(mEditable, selStart, selStart - 1);
                     }
                     int newStart = clampIndexToEditable(Selection.getSelectionStart(mEditable), mEditable);


### PR DESCRIPTION
The Selection.extendLeft and extendRight calls on Huawei devices has a bug where it will ignore the selection indexes and always use the initial length of the editable. This works around it by falling back to a simpler algorithm.
