### PR TITLE
Preroll does not depend on GrContext or RasterCache

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -83,7 +83,7 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
                                     context_.ui_time(),
                                     context_.texture_registry(),
                                     checkerboard_offscreen_layers};
-    for (const auto raster_op : raster_ops->operations) {
+    for (const auto raster_op : raster_ops->GetOperations()) {
       raster_op(&raster_context);
     }
   }

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -63,8 +63,8 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 RasterStatus CompositorContext::ScopedFrame::Raster(
     flutter::LayerTree& layer_tree,
     bool ignore_raster_cache) {
-  std::shared_ptr<RasterOperations> raster_ops =
-      std::make_shared<RasterOperations>();
+  std::shared_ptr<PrerollRasterOperations> raster_ops =
+      std::make_shared<PrerollRasterOperations>();
   layer_tree.Preroll(*this, raster_ops, ignore_raster_cache);
 
   RasterCache* raster_cache =

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -59,9 +59,6 @@ using RasterOperation = std::function<void(RasterContext* raster_context)>;
 class RasterOperations {
  public:
   RasterOperations() = default;
-
-  // TODO(iskakaushik): is there a more efficient way to
-  // copy functions in c++? emplace??
   void PushOperation(RasterOperation&& oper) { operations.push_back(oper); }
   std::vector<RasterOperation> operations;
 };

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -54,20 +54,23 @@ struct RasterContext {
   const bool checkerboard_offscreen_layers;
 };
 
-using RasterOperation = std::function<void(RasterContext* raster_context)>;
+using PrerollRasterOperation =
+    std::function<void(RasterContext* raster_context)>;
 
-class RasterOperations {
+class PrerollRasterOperations {
  public:
-  RasterOperations() = default;
-  void PushOperation(RasterOperation&& oper) { operations.push_back(oper); }
-  std::vector<RasterOperation> operations;
+  PrerollRasterOperations() = default;
+  void PushOperation(PrerollRasterOperation&& oper) {
+    operations.push_back(oper);
+  }
+  std::vector<PrerollRasterOperation> operations;
 };
 
 struct PrerollContext {
   ExternalViewEmbedder* view_embedder;
   MutatorsStack& mutators_stack;
   SkRect cull_rect;
-  std::shared_ptr<RasterOperations> raster_ops;
+  std::shared_ptr<PrerollRasterOperations> raster_ops;
 
   // The following allows us to paint in the end of subtree preroll
   float total_elevation = 0.0f;

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -61,9 +61,15 @@ class PrerollRasterOperations {
  public:
   PrerollRasterOperations() = default;
   void PushOperation(PrerollRasterOperation&& oper) {
-    operations.push_back(oper);
+    operations_.push_back(oper);
   }
-  std::vector<PrerollRasterOperation> operations;
+  const std::vector<PrerollRasterOperation>& GetOperations() const {
+    return operations_;
+  }
+
+ private:
+  std::vector<PrerollRasterOperation> operations_;
+  FML_DISALLOW_COPY_AND_ASSIGN(PrerollRasterOperations);
 };
 
 struct PrerollContext {

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -25,7 +25,7 @@ void LayerTree::RecordBuildTime(fml::TimePoint start) {
 }
 
 void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
-                        std::shared_ptr<RasterOperations> raster_ops,
+                        std::shared_ptr<PrerollRasterOperations> raster_ops,
                         bool ignore_raster_cache) {
   TRACE_EVENT0("flutter", "LayerTree::Preroll");
   MutatorsStack stack;

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -24,6 +24,9 @@ class LayerTree {
 
   ~LayerTree();
 
+  // This is not guaranteed to happen on the GPU threads.
+  // For parts of preroll that need to happen on the GPU thread,
+  // add them to PrerollRasterOperations.
   void Preroll(CompositorContext::ScopedFrame& frame,
                std::shared_ptr<PrerollRasterOperations> raster_ops,
                bool ignore_raster_cache = false);

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -25,6 +25,7 @@ class LayerTree {
   ~LayerTree();
 
   void Preroll(CompositorContext::ScopedFrame& frame,
+               std::shared_ptr<RasterOperations> raster_ops,
                bool ignore_raster_cache = false);
 
 #if defined(OS_FUCHSIA)
@@ -69,6 +70,14 @@ class LayerTree {
 
   void set_checkerboard_offscreen_layers(bool checkerboard) {
     checkerboard_offscreen_layers_ = checkerboard;
+  }
+
+  bool ShouldCheckerboardOffscreenLayers() const {
+    return checkerboard_offscreen_layers_;
+  }
+
+  bool ShouldCheckerboardRasterCacheImages() const {
+    return checkerboard_raster_cache_images_;
   }
 
  private:

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -25,7 +25,7 @@ class LayerTree {
   ~LayerTree();
 
   void Preroll(CompositorContext::ScopedFrame& frame,
-               std::shared_ptr<RasterOperations> raster_ops,
+               std::shared_ptr<PrerollRasterOperations> raster_ops,
                bool ignore_raster_cache = false);
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -30,17 +30,11 @@ TEST(PhysicalShapeLayer, TotalElevation) {
   TextureRegistry unused_texture_registry;
   MutatorsStack unused_stack;
   PrerollContext preroll_context{
-      nullptr,                  // raster_cache (don't consult the cache)
-      nullptr,                  // gr_context  (used for the raster cache)
-      nullptr,                  // external view embedder
-      unused_stack,             // mutator stack
-      nullptr,                  // SkColorSpace* dst_color_space
-      kGiantRect,               // SkRect cull_rect
-      unused_stopwatch,         // frame time (dont care)
-      unused_stopwatch,         // engine time (dont care)
-      unused_texture_registry,  // texture registry (not supported)
-      false,                    // checkerboard_offscreen_layers
-      0.0f,                     // total elevation
+      nullptr,       // external view embedder
+      unused_stack,  // mutator stack
+      kGiantRect,    // SkRect cull_rect
+      nullptr,       // raster operations (don't care)
+      0.0f,          // total elevation
   };
 
   SkMatrix identity;

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -42,7 +42,7 @@ class RasterCacheResult {
   SkRect logical_rect_;
 };
 
-struct PrerollContext;
+struct RasterContext;
 
 class RasterCache {
  public:
@@ -88,7 +88,9 @@ class RasterCache {
                bool is_complex,
                bool will_change);
 
-  void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
+  void Prepare(RasterContext* raster_context,
+               Layer* layer,
+               const SkMatrix& ctm);
 
   RasterCacheResult Get(const SkPicture& picture, const SkMatrix& ctm) const;
 


### PR DESCRIPTION
Split `Preroll` into `Preroll` and GPU related operations (things that deal with `RasterCache` and `GrContext` specifically). What this lets us do is run `Preroll` on non GPU thread -- specifically the UI thread. This is needed to enable us to take actions based on the `Preroll` operations that need to happen on the UI thread. In this case it is to merge/un-merge the Platform and GPU threads.

This commit does not move the actual pre-roll to UI thread yet. It will follow.