### PR TITLE
FLEViewController/Engine API changes

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FLEEngine.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEEngine.h
@@ -42,7 +42,7 @@ FLUTTER_EXPORT
  */
 - (nonnull instancetype)initWithName:(nonnull NSString*)labelPrefix
                              project:(nullable FLEDartProject*)project
-      allowHeadlessExecution:(BOOL)allowHeadlessExecution NS_DESIGNATED_INITIALIZER;
+              allowHeadlessExecution:(BOOL)allowHeadlessExecution NS_DESIGNATED_INITIALIZER;
 
 - (nonnull instancetype)init NS_UNAVAILABLE;
 

--- a/shell/platform/darwin/macos/framework/Headers/FLEEngine.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEEngine.h
@@ -26,13 +26,25 @@ FLUTTER_EXPORT
 /**
  * Initializes an engine with the given viewController.
  *
- * @param viewController The view controller associated with this engine. If nil, the engine
- *                       will be run headless.
+ * @param labelPrefix Currently unused; in the future, may be used for labelling threads
+ *                    as with the iOS FlutterEngine.
  * @param project The project configuration. If nil, a default FLEDartProject will be used.
  */
-- (nonnull instancetype)initWithViewController:(nullable FLEViewController*)viewController
-                                       project:(nullable FLEDartProject*)project
-    NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithName:(nonnull NSString*)labelPrefix
+                             project:(nullable FLEDartProject*)project;
+
+/**
+ * Initializes an engine with the given viewController.
+ *
+ * @param labelPrefix Currently unused; in the future, may be used for labelling threads
+ *                    as with the iOS FlutterEngine.
+ * @param project The project configuration. If nil, a default FLEDartProject will be used.
+ */
+- (nonnull instancetype)initWithName:(nonnull NSString*)labelPrefix
+                             project:(nullable FLEDartProject*)project
+      allowHeadlessExecution:(BOOL)allowHeadlessExecution NS_DESIGNATED_INITIALIZER;
+
+- (nonnull instancetype)init NS_UNAVAILABLE;
 
 /**
  * Runs `main()` from this engine's project.
@@ -42,18 +54,9 @@ FLUTTER_EXPORT
 - (BOOL)run;
 
 /**
- * The `FLEDartProject` associated with this engine. If nil, a default will be used for `run`.
- *
- * TODO(stuartmorgan): Remove this once FLEViewController takes the project as an initializer
- * argument. Blocked on currently needing to create it from a XIB due to the view issues
- * described in https://github.com/google/flutter-desktop-embedding/issues/10.
- */
-@property(nonatomic, nullable) FLEDartProject* project;
-
-/**
  * The `FLEViewController` associated with this engine, if any.
  */
-@property(nonatomic, nullable, readonly, weak) FLEViewController* viewController;
+@property(nonatomic, nullable, weak) FLEViewController* viewController;
 
 /**
  * The `FlutterBinaryMessenger` for communicating with this engine.

--- a/shell/platform/darwin/macos/framework/Headers/FLEEngine.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEEngine.h
@@ -47,11 +47,20 @@ FLUTTER_EXPORT
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
 /**
- * Runs `main()` from this engine's project.
+ * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
+ * contains `main()`).
  *
- * @return YES if the engine launched successfully.
+ * The first call to this method will create a new Isolate. Subsequent calls will return
+ * immediately.
+ *
+ * @param entrypoint The name of a top-level function from the same Dart
+ *   library that contains the app's main() function.  If this is nil, it will
+ *   default to `main()`.  If it is not the app's main() function, that function
+ *   must be decorated with `@pragma(vm:entry-point)` to ensure the method is not
+ *   tree-shaken by the Dart compiler.
+ * @return YES if the call succeeds in creating and running a Flutter Engine instance; NO otherwise.
  */
-- (BOOL)run;
+- (BOOL)runWithEntrypoint:(nullable NSString*)entrypoint;
 
 /**
  * The `FLEViewController` associated with this engine, if any.

--- a/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
@@ -42,13 +42,15 @@ FLUTTER_EXPORT
 
 /**
  * Initializes a controller that will run the given project.
- * 
+ *
  * @param project The project to run in this view controller. If nil, a default `FLEDartProject`
  *                will be used.
  */
 - (nonnull instancetype)initWithProject:(nullable FLEDartProject*)project NS_DESIGNATED_INITIALIZER;
 
-- (nonnull instancetype)initWithNibName:(nullable NSString*)nibNameOrNil bundle:(nullable NSBundle*)nibBundleOrNil NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithNibName:(nullable NSString*)nibNameOrNil
+                                 bundle:(nullable NSBundle*)nibBundleOrNil
+    NS_DESIGNATED_INITIALIZER;
 - (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
+++ b/shell/platform/darwin/macos/framework/Headers/FLEViewController.h
@@ -41,12 +41,14 @@ FLUTTER_EXPORT
 @property(nonatomic) FlutterMouseTrackingMode mouseTrackingMode;
 
 /**
- * Launches the Flutter engine with the provided project.
- *
+ * Initializes a controller that will run the given project.
+ * 
  * @param project The project to run in this view controller. If nil, a default `FLEDartProject`
  *                will be used.
- * @return YES if the engine launched successfully.
  */
-- (BOOL)launchEngineWithProject:(nullable FLEDartProject*)project;
+- (nonnull instancetype)initWithProject:(nullable FLEDartProject*)project NS_DESIGNATED_INITIALIZER;
+
+- (nonnull instancetype)initWithNibName:(nullable NSString*)nibNameOrNil bundle:(nullable NSBundle*)nibBundleOrNil NS_DESIGNATED_INITIALIZER;
+- (nonnull instancetype)initWithCoder:(nonnull NSCoder*)nibNameOrNil NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/shell/platform/darwin/macos/framework/Source/FLEEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEEngine.mm
@@ -44,7 +44,7 @@
 /**
  * Shuts the Flutter engine if it is running.
  */
- - (void)shutDownEngine;
+- (void)shutDownEngine;
 
 @end
 
@@ -138,13 +138,12 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FLEEngine* 
   BOOL _allowHeadlessExecution;
 }
 
-- (instancetype)initWithName:(NSString*)labelPrefix
-                             project:(FLEDartProject*)project {
+- (instancetype)initWithName:(NSString*)labelPrefix project:(FLEDartProject*)project {
   return [self initWithName:labelPrefix project:project allowHeadlessExecution:YES];
 }
 
 - (instancetype)initWithName:(NSString*)labelPrefix
-                             project:(FLEDartProject*)project
+                     project:(FLEDartProject*)project
       allowHeadlessExecution:(BOOL)allowHeadlessExecution {
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
@@ -224,12 +223,10 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FLEEngine* 
 - (NSOpenGLContext*)resourceContext {
   if (!_resourceContext) {
     NSOpenGLPixelFormatAttribute attributes[] = {
-      NSOpenGLPFAColorSize, 24, NSOpenGLPFAAlphaSize, 8,
-      NSOpenGLPFADoubleBuffer, 0,
-  };
-  NSOpenGLPixelFormat* pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attributes];
-    _resourceContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat
-                                                  shareContext:nil];
+        NSOpenGLPFAColorSize, 24, NSOpenGLPFAAlphaSize, 8, NSOpenGLPFADoubleBuffer, 0,
+    };
+    NSOpenGLPixelFormat* pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attributes];
+    _resourceContext = [[NSOpenGLContext alloc] initWithFormat:pixelFormat shareContext:nil];
   }
   return _resourceContext;
 }
@@ -241,7 +238,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FLEEngine* 
   NSView* view = _viewController.view;
   CGSize scaledSize = [view convertRectToBacking:view.bounds].size;
   double pixelRatio = view.bounds.size.width == 0 ? 1 : scaledSize.width / view.bounds.size.width;
-  
+
   const FlutterWindowMetricsEvent event = {
       .struct_size = sizeof(event),
       .width = static_cast<size_t>(scaledSize.width),

--- a/shell/platform/darwin/macos/framework/Source/FLEEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEEngine.mm
@@ -158,7 +158,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FLEEngine* 
   [self shutDownEngine];
 }
 
-- (BOOL)run {
+- (BOOL)runWithEntrypoint:(NSString*)entrypoint {
   if (self.running) {
     return NO;
   }
@@ -188,6 +188,7 @@ static void OnPlatformMessage(const FlutterPlatformMessage* message, FLEEngine* 
   flutterArguments.command_line_argc = static_cast<int>(arguments.size());
   flutterArguments.command_line_argv = &arguments[0];
   flutterArguments.platform_message_callback = (FlutterPlatformMessageCallback)OnPlatformMessage;
+  flutterArguments.custom_dart_entrypoint = entrypoint.UTF8String;
 
   FlutterEngineResult result = FlutterEngineRun(
       FLUTTER_ENGINE_VERSION, &rendererConfig, &flutterArguments, (__bridge void*)(self), &_engine);

--- a/shell/platform/darwin/macos/framework/Source/FLEEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FLEEngine_Internal.h
@@ -4,9 +4,22 @@
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FLEEngine.h"
 
+#import <Cocoa/Cocoa.h>
+
 #import "flutter/shell/platform/embedder/embedder.h"
 
 @interface FLEEngine ()
+
+/**
+ * True if the engine is currently running.
+ */
+@property(nonatomic, readonly) BOOL running;
+
+/**
+ * The resource context used by the engine for texture uploads. FlutterViews associated with this
+ * engine should be created to share with this context.
+ */
+@property(nonatomic, readonly, nullable) NSOpenGLContext* resourceContext;
 
 /**
  * Informs the engine that the display region's size has changed.

--- a/shell/platform/darwin/macos/framework/Source/FLEEngine_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FLEEngine_Internal.h
@@ -22,12 +22,9 @@
 @property(nonatomic, readonly, nullable) NSOpenGLContext* resourceContext;
 
 /**
- * Informs the engine that the display region's size has changed.
- *
- * @param size The size of the display, in pixels.
- * @param pixelRatio The number of pixels per screen coordinate.
+ * Informs the engine that the associated view controller's view size has changed.
  */
-- (void)updateWindowMetricsWithSize:(CGSize)size pixelRatio:(double)pixelRatio;
+- (void)updateWindowMetrics;
 
 /**
  * Dispatches the given pointer event data to engine.

--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -262,7 +262,7 @@ static void CommonInit(FLEViewController* controller) {
   [self addInternalPlugins];
 
   _engine.viewController = self;
-  if (![_engine run]) {
+  if (![_engine runWithEntrypoint:nil]) {
     return NO;
   }
   // Send the initial user settings such as brightness and text scale factor

--- a/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController.mm
@@ -174,8 +174,8 @@ struct MouseState {
  */
 static void CommonInit(FLEViewController* controller) {
   controller->_engine = [[FLEEngine alloc] initWithName:@"io.flutter"
-   project:controller->_project
-   allowHeadlessExecution:NO];
+                                                project:controller->_project
+                                 allowHeadlessExecution:NO];
   controller->_additionalKeyResponders = [[NSMutableOrderedSet alloc] init];
   controller->_mouseTrackingMode = FlutterMouseTrackingModeInKeyWindow;
 }

--- a/shell/platform/darwin/macos/framework/Source/FLEViewController_Internal.h
+++ b/shell/platform/darwin/macos/framework/Source/FLEViewController_Internal.h
@@ -22,10 +22,4 @@
  */
 - (void)removeKeyResponder:(nonnull NSResponder*)responder;
 
-/**
- * Called when the engine wants to make the resource context current. This must be a context
- * that is in the same share group as this controller's view.
- */
-- (void)makeResourceContextCurrent;
-
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -21,10 +21,12 @@
 @interface FlutterView : NSOpenGLView
 
 - (nullable instancetype)initWithFrame:(NSRect)frame
+shareContext:(nonnull NSOpenGLContext*)shareContext
                        reshapeListener:(nonnull id<FlutterViewReshapeListener>)reshapeListener
     NS_DESIGNATED_INITIALIZER;
 
-- (nullable instancetype)initWithReshapeListener:
+- (nullable instancetype)initWithShareContext:(nonnull NSOpenGLContext*)shareContext
+reshapeListener:
     (nonnull id<FlutterViewReshapeListener>)reshapeListener;
 
 - (nullable instancetype)initWithFrame:(NSRect)frameRect

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -21,13 +21,13 @@
 @interface FlutterView : NSOpenGLView
 
 - (nullable instancetype)initWithFrame:(NSRect)frame
-shareContext:(nonnull NSOpenGLContext*)shareContext
+                          shareContext:(nonnull NSOpenGLContext*)shareContext
                        reshapeListener:(nonnull id<FlutterViewReshapeListener>)reshapeListener
     NS_DESIGNATED_INITIALIZER;
 
 - (nullable instancetype)initWithShareContext:(nonnull NSOpenGLContext*)shareContext
-reshapeListener:
-    (nonnull id<FlutterViewReshapeListener>)reshapeListener;
+                              reshapeListener:
+                                  (nonnull id<FlutterViewReshapeListener>)reshapeListener;
 
 - (nullable instancetype)initWithFrame:(NSRect)frameRect
                            pixelFormat:(nullable NSOpenGLPixelFormat*)format NS_UNAVAILABLE;

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -8,18 +8,18 @@
   __weak id<FlutterViewReshapeListener> _reshapeListener;
 }
 
-- (instancetype)initWithReshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
-  return [self initWithFrame:NSZeroRect reshapeListener:reshapeListener];
+- (instancetype)initWithShareContext:(NSOpenGLContext*)shareContext
+reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
+  return [self initWithFrame:NSZeroRect shareContext:shareContext reshapeListener:reshapeListener];
 }
 
 - (instancetype)initWithFrame:(NSRect)frame
+shareContext:(NSOpenGLContext*)shareContext
               reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
-  NSOpenGLPixelFormatAttribute attributes[] = {
-      NSOpenGLPFAColorSize, 24, NSOpenGLPFAAlphaSize, 8, NSOpenGLPFADoubleBuffer, 0,
-  };
-  NSOpenGLPixelFormat* pixelFormat = [[NSOpenGLPixelFormat alloc] initWithAttributes:attributes];
-  self = [super initWithFrame:frame pixelFormat:pixelFormat];
+  self = [super initWithFrame:frame];
   if (self) {
+    self.openGLContext = [[NSOpenGLContext alloc] initWithFormat:shareContext.pixelFormat
+                                                  shareContext:shareContext];
     _reshapeListener = reshapeListener;
     self.wantsBestResolutionOpenGLSurface = YES;
   }

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -9,17 +9,17 @@
 }
 
 - (instancetype)initWithShareContext:(NSOpenGLContext*)shareContext
-reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
+                     reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
   return [self initWithFrame:NSZeroRect shareContext:shareContext reshapeListener:reshapeListener];
 }
 
 - (instancetype)initWithFrame:(NSRect)frame
-shareContext:(NSOpenGLContext*)shareContext
+                 shareContext:(NSOpenGLContext*)shareContext
               reshapeListener:(id<FlutterViewReshapeListener>)reshapeListener {
   self = [super initWithFrame:frame];
   if (self) {
     self.openGLContext = [[NSOpenGLContext alloc] initWithFormat:shareContext.pixelFormat
-                                                  shareContext:shareContext];
+                                                    shareContext:shareContext];
     _reshapeListener = reshapeListener;
     self.wantsBestResolutionOpenGLSurface = YES;
   }


### PR DESCRIPTION
Updates the way FLEViewController and FLEEngine interact,
making their APIs much more closely aligned with the iOS versions
of the classes.

As part of the change, removes the need for an explicit launch
call on FLEViewController. Also adds entrypoint support when
running an engine directly, matching iOS.

Breaking change for macOS runners.