### PR TITLE
Include SkParagraph headers only when the enable-skshaper flag is on

### DIFF
--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -27,9 +27,12 @@
 #include "third_party/googletest/googletest/include/gtest/gtest_prod.h"  // nogncheck
 #include "third_party/skia/include/core/SkFontMgr.h"
 #include "third_party/skia/include/core/SkRefCnt.h"
-#include "third_party/skia/modules/skparagraph/include/FontCollection.h"
 #include "txt/asset_font_manager.h"
 #include "txt/text_style.h"
+
+#if FLUTTER_ENABLE_SKSHAPER
+#include "third_party/skia/modules/skparagraph/include/FontCollection.h"
+#endif
 
 namespace txt {
 

--- a/third_party/txt/src/txt/paragraph_builder.cc
+++ b/third_party/txt/src/txt/paragraph_builder.cc
@@ -15,10 +15,13 @@
  */
 
 #include "paragraph_builder.h"
-#include "flutter/third_party/txt/src/skia/paragraph_builder_skia.h"
 #include "paragraph_builder_txt.h"
 #include "paragraph_style.h"
 #include "third_party/icu/source/common/unicode/unistr.h"
+
+#if FLUTTER_ENABLE_SKSHAPER
+#include "flutter/third_party/txt/src/skia/paragraph_builder_skia.h"
+#endif
 
 namespace txt {
 


### PR DESCRIPTION
These headers are currently causing errors in MSVC-based Windows builds.