### PR TITLE
Fall back to a fully qualified path to libapp.so if the library can not be loaded by name

### DIFF
--- a/common/settings.cc
+++ b/common/settings.cc
@@ -25,8 +25,10 @@ std::string Settings::ToString() const {
          << std::endl;
   stream << "isolate_snapshot_instr_path: " << isolate_snapshot_instr_path
          << std::endl;
-  stream << "application_library_path: " << application_library_path
-         << std::endl;
+  stream << "application_library_path:" << std::endl;
+  for (const auto& path : application_library_path) {
+    stream << "    " << path << std::endl;
+  }
   stream << "temp_directory_path: " << temp_directory_path << std::endl;
   stream << "dart_flags:" << std::endl;
   for (const auto& dart_flag : dart_flags) {

--- a/common/settings.h
+++ b/common/settings.h
@@ -73,7 +73,10 @@ struct Settings {
   // libraries.
   MappingCallback dart_library_sources_kernel;
 
-  std::string application_library_path;
+  // Path to a library containing the application's compiled Dart code.
+  // This is a vector so that the embedder can provide fallback paths in
+  // case the primary path to the library can not be loaded.
+  std::vector<std::string> application_library_path;
 
   std::string application_kernel_asset;       // deprecated
   std::string application_kernel_list_asset;  // deprecated

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -44,7 +44,7 @@ static std::unique_ptr<const fml::Mapping> GetFileMapping(
 static std::shared_ptr<const fml::Mapping> SearchMapping(
     MappingCallback embedder_mapping_callback,
     const std::string& file_path,
-    const std::string& native_library_path,
+    const std::vector<std::string>& native_library_path,
     const char* native_library_symbol_name,
     bool is_executable) {
   // Ask the embedder. There is no fallback as we expect the embedders (via
@@ -61,9 +61,8 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
   }
 
   // Look in application specified native library if specified.
-  if (native_library_path.size() > 0) {
-    auto native_library =
-        fml::NativeLibrary::Create(native_library_path.c_str());
+  for (const std::string& path : native_library_path) {
+    auto native_library = fml::NativeLibrary::Create(path.c_str());
     auto symbol_mapping = std::make_unique<const fml::SymbolMapping>(
         native_library, native_library_symbol_name);
     if (symbol_mapping->GetMapping() != nullptr) {

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -244,9 +244,8 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   command_line.GetOptionValue(FlagForSwitch(Switch::FlutterAssetsDir),
                               &settings.assets_path);
 
-  std::string aot_shared_library_name;
-  command_line.GetOptionValue(FlagForSwitch(Switch::AotSharedLibraryName),
-                              &aot_shared_library_name);
+  std::vector<std::string_view> aot_shared_library_name =
+      command_line.GetOptionValues(FlagForSwitch(Switch::AotSharedLibraryName));
 
   std::string snapshot_asset_path;
   command_line.GetOptionValue(FlagForSwitch(Switch::SnapshotAssetPath),
@@ -270,7 +269,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
       &isolate_snapshot_instr_filename);
 
   if (aot_shared_library_name.size() > 0) {
-    settings.application_library_path = aot_shared_library_name;
+    for (std::string_view name : aot_shared_library_name) {
+      settings.application_library_path.emplace_back(name);
+    }
   } else if (snapshot_asset_path.size() > 0) {
     settings.vm_snapshot_data_path =
         fml::paths::JoinPaths({snapshot_asset_path, vm_snapshot_data_filename});

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -173,6 +173,11 @@ public class FlutterMain {
                 shellArgs.add("--" + ISOLATE_SNAPSHOT_DATA_KEY + "=" + sIsolateSnapshotData);
             } else {
                 shellArgs.add("--" + AOT_SHARED_LIBRARY_NAME + "=" + sAotSharedLibraryName);
+
+                // Most devices can load the AOT shared library based on the library name
+                // with no directory path.  Provide a fully qualified path to the library
+                // as a workaround for devices where that fails.
+                shellArgs.add("--" + AOT_SHARED_LIBRARY_NAME + "=" + applicationInfo.nativeLibraryDir + File.separator + sAotSharedLibraryName);
             }
 
             shellArgs.add("--cache-dir-path=" + PathUtils.getCacheDirectory(applicationContext));

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -70,7 +70,7 @@ static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
     if (hasExplicitBundle) {
       NSString* executablePath = bundle.executablePath;
       if ([[NSFileManager defaultManager] fileExistsAtPath:executablePath]) {
-        settings.application_library_path = executablePath.UTF8String;
+        settings.application_library_path.push_back(executablePath.UTF8String);
       }
     }
 
@@ -81,7 +81,7 @@ static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
       if (libraryPath.length > 0) {
         NSString* executablePath = [NSBundle bundleWithPath:libraryPath].executablePath;
         if (executablePath.length > 0) {
-          settings.application_library_path = executablePath.UTF8String;
+          settings.application_library_path.push_back(executablePath.UTF8String);
         }
       }
     }
@@ -95,7 +95,7 @@ static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
         NSString* executablePath =
             [NSBundle bundleWithPath:applicationFrameworkPath].executablePath;
         if (executablePath.length > 0) {
-          settings.application_library_path = executablePath.UTF8String;
+          settings.application_library_path.push_back(executablePath.UTF8String);
         }
       }
     }


### PR DESCRIPTION
libapp.so contains compiled application Dart code.  On most Android systems,
this library can be loaded by calling dlopen("libapp.so"), which will search
Android's default library directories.

On some Android devices this does not work as expected.  As a workaround, this
patch provides a fallback path to libapp.so based on ApplicationInfo.nativeLibraryDir.

Fixes https://github.com/flutter/flutter/issues/35838