### PR TITLE
Un-deprecated FlutterViewController's binaryMessenger.

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -721,6 +721,7 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterUmbrell
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterView.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterView.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm

--- a/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h
@@ -168,11 +168,9 @@ FLUTTER_EXPORT
  * The `FlutterBinaryMessenger` associated with this FlutterViewController (used for communicating
  * with channels).
  *
- * @deprecated Since |FlutterViewController| just forwards binary messenger calls to the
- * |FlutterEngine|, just use the FlutterEngine.binaryMessenger.
+ * This is just a convenient way to get the |FlutterEngine|'s binary messenger.
  */
-@property(nonatomic, readonly) NSObject<FlutterBinaryMessenger>* binaryMessenger
-    __attribute__((deprecated));
+@property(nonatomic, readonly) NSObject<FlutterBinaryMessenger>* binaryMessenger;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -25,6 +25,9 @@
 
 NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemanticsUpdate";
 
+// This is left a FlutterBinaryMessenger privately for now to give people a chance to notice the
+// change.  Unfortunately unless you have Werror turned on, incompatible pointers as arguments
+// are just a warning.
 @interface FlutterViewController () <FlutterBinaryMessenger>
 @end
 
@@ -44,7 +47,6 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
   BOOL _viewOpaque;
   BOOL _engineNeedsLaunch;
   NSMutableSet<NSNumber*>* _ongoingTouches;
-  FlutterBinaryMessengerRelay* _binaryMessenger;
 }
 
 #pragma mark - Manage and override all designated initializers
@@ -55,7 +57,6 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
   NSAssert(engine != nil, @"Engine is required");
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
-    _binaryMessenger = [[FlutterBinaryMessengerRelay alloc] initWithParent:self];
     _viewOpaque = YES;
     _engine.reset([engine retain]);
     _engineNeedsLaunch = NO;
@@ -75,7 +76,6 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
                          bundle:(NSBundle*)nibBundleOrNil {
   self = [super initWithNibName:nibNameOrNil bundle:nibBundleOrNil];
   if (self) {
-    _binaryMessenger = [[FlutterBinaryMessengerRelay alloc] initWithParent:self];
     _viewOpaque = YES;
     _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
     _engine.reset([[FlutterEngine alloc] initWithName:@"io.flutter"
@@ -473,8 +473,6 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
 }
 
 - (void)dealloc {
-  _binaryMessenger.parent = nil;
-  [_binaryMessenger release];
   [_engine.get() notifyViewControllerDeallocated];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [super dealloc];
@@ -988,7 +986,7 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
 }
 
 - (NSObject<FlutterBinaryMessenger>*)binaryMessenger {
-  return _binaryMessenger;
+  return _engine.get().binaryMessenger;
 }
 
 #pragma mark - FlutterBinaryMessenger

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -26,8 +26,8 @@
 NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemanticsUpdate";
 
 // This is left a FlutterBinaryMessenger privately for now to give people a chance to notice the
-// change.  Unfortunately unless you have Werror turned on, incompatible pointers as arguments
-// are just a warning.
+// change. Unfortunately unless you have Werror turned on, incompatible pointers as arguments are
+// just a warning.
 @interface FlutterViewController () <FlutterBinaryMessenger>
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -1,0 +1,26 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <OCMock/OCMock.h>
+#import <XCTest/XCTest.h>
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+
+@interface FlutterViewControllerTest : XCTestCase
+@end
+
+@implementation FlutterViewControllerTest
+
+- (void)testBinaryMessenger {
+  id engine = OCMClassMock([FlutterEngine class]);
+  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
+                                                                    nibName:nil
+                                                                     bundle:nil];
+  XCTAssertNotNil(vc);
+  id messenger = OCMProtocolMock(@protocol(FlutterBinaryMessenger));
+  OCMStub([engine binaryMessenger]).andReturn(messenger);
+  XCTAssertEqual(vc.binaryMessenger, messenger);
+  OCMVerify([engine binaryMessenger]);
+}
+
+@end

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0D17A5C022D78FCD0057279F /* FlutterViewControllerTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D17A5BF22D78FCD0057279F /* FlutterViewControllerTest.m */; };
 		0D52D3BD22C566D50011DEBD /* FlutterBinaryMessengerRelayTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0D52D3B622C566D50011DEBD /* FlutterBinaryMessengerRelayTest.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		0D6AB6B622BB05E100EEE540 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6B522BB05E100EEE540 /* AppDelegate.m */; };
 		0D6AB6B922BB05E100EEE540 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6B822BB05E100EEE540 /* ViewController.m */; };
@@ -72,6 +73,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0D17A5BF22D78FCD0057279F /* FlutterViewControllerTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FlutterViewControllerTest.m; sourceTree = "<group>"; };
 		0D52D3B622C566D50011DEBD /* FlutterBinaryMessengerRelayTest.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = FlutterBinaryMessengerRelayTest.mm; sourceTree = "<group>"; };
 		0D6AB6B122BB05E100EEE540 /* IosUnitTests.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IosUnitTests.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D6AB6B422BB05E100EEE540 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -160,6 +162,7 @@
 			children = (
 				0D52D3B622C566D50011DEBD /* FlutterBinaryMessengerRelayTest.mm */,
 				0D6AB6E722BB40CF00EEE540 /* FlutterEngineTest.mm */,
+				0D17A5BF22D78FCD0057279F /* FlutterViewControllerTest.m */,
 			);
 			name = Source;
 			path = ../../../../shell/platform/darwin/ios/framework/Source;
@@ -369,6 +372,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0D6AB6EB22BB40E700EEE540 /* FlutterEngineTest.mm in Sources */,
+				0D17A5C022D78FCD0057279F /* FlutterViewControllerTest.m in Sources */,
 				0D52D3BD22C566D50011DEBD /* FlutterBinaryMessengerRelayTest.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Leaving it as a valid convenience method and to help minimize a breaking change.

References: https://github.com/flutter/flutter/issues/35928