### PR TITLE
fix objcdoc generation

### DIFF
--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -64,7 +64,6 @@ FlutterViewController.html"
 ACTUAL_CLASSES=$(ls "$1/Classes" | sort)
 
 if [[ $EXPECTED_CLASSES != $ACTUAL_CLASSES ]]; then
-
   echo "Expected classes did not match actual classes"
   echo
   diff <(echo "$EXPECTED_CLASSES") <(echo "$ACTUAL_CLASSES")

--- a/tools/gen_objcdoc.sh
+++ b/tools/gen_objcdoc.sh
@@ -5,9 +5,10 @@
 
 # Generates objc docs for Flutter iOS libraries.
 
-if [[ ! -d "shell/platform/darwin/ios" ]]
+FLUTTER_UMBRELLA_HEADER=$(find ../out -maxdepth 4 -type f -name Flutter.h | grep 'ios_' | head -n 1)
+if [[ ! -f "$FLUTTER_UMBRELLA_HEADER" ]]
   then
-      echo "Error: This script must be run at the root of the Flutter source tree."
+      echo "Error: This script must be run at the root of the Flutter source tree with at least one built Flutter.framework in ../out/ios*/Flutter.framework."
       exit 1
 fi
 
@@ -35,7 +36,37 @@ jazzy \
   --github_url 'https://github.com/flutter'\
   --github-file-prefix 'http://github.com/flutter/engine/blob/master'\
   --module-version 1.0.0\
-  --xcodebuild-arguments --objc,shell/platform/darwin/ios/framework/Headers/Flutter.h,--,-x,objective-c,-isysroot,"$(xcrun --show-sdk-path --sdk iphonesimulator)",-I,"$(pwd)"\
+  --xcodebuild-arguments --objc,"$FLUTTER_UMBRELLA_HEADER",--,-x,objective-c,-isysroot,"$(xcrun --show-sdk-path --sdk iphonesimulator)",-I,"$(pwd)"\
   --module Flutter\
   --root-url https://docs.flutter.io/objc/\
   --output "$1"
+
+EXPECTED_CLASSES="FlutterAppDelegate.html
+FlutterBasicMessageChannel.html
+FlutterCallbackCache.html
+FlutterCallbackInformation.html
+FlutterDartProject.html
+FlutterEngine.html
+FlutterError.html
+FlutterEventChannel.html
+FlutterHeadlessDartRunner.html
+FlutterMethodCall.html
+FlutterMethodChannel.html
+FlutterPluginAppLifeCycleDelegate.html
+FlutterStandardMessageCodec.html
+FlutterStandardMethodCodec.html
+FlutterStandardReader.html
+FlutterStandardReaderWriter.html
+FlutterStandardTypedData.html
+FlutterStandardWriter.html
+FlutterViewController.html"
+
+ACTUAL_CLASSES=$(ls "$1/Classes" | sort)
+
+if [[ $EXPECTED_CLASSES != $ACTUAL_CLASSES ]]; then
+
+  echo "Expected classes did not match actual classes"
+  echo
+  diff <(echo "$EXPECTED_CLASSES") <(echo "$ACTUAL_CLASSES")
+  exit -1
+fi


### PR DESCRIPTION
https://github.com/flutter/engine/pull/9255 split up some of the header files into a common location - which means that our objective C document generation has been missing them, which broke some links on the website.

This pulls the source files from the out/ios_* directories instead of directly from the shell folder, and does a check that the expected class files get generated - whcih will need to be updated if classes get renamed, added, or removed from the embedding.

I'm keeping the cwd logic the same so we don't have to update the recipe and make it incompatible with older builds.

/cc @sfshaza2 