### PR TITLE
SendPlatformMessage allow null message value

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -814,8 +814,14 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
 
-  if (SAFE_ACCESS(flutter_message, channel, nullptr) == nullptr ||
-      SAFE_ACCESS(flutter_message, message, nullptr) == nullptr) {
+  if (SAFE_ACCESS(flutter_message, channel, nullptr) == nullptr) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments);
+  }
+
+  auto message_size = SAFE_ACCESS(flutter_message, message_size, 0);
+  auto message_data = SAFE_ACCESS(flutter_message, message, nullptr);
+
+  if (message_size != 0 && message_data == nullptr) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
 
@@ -827,12 +833,16 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
     response = response_handle->message->response();
   }
 
-  auto message = fml::MakeRefCounted<flutter::PlatformMessage>(
-      flutter_message->channel,
-      std::vector<uint8_t>(
-          flutter_message->message,
-          flutter_message->message + flutter_message->message_size),
-      response);
+  fml::RefPtr<flutter::PlatformMessage> message;
+  if (message_size == 0) {
+    message = fml::MakeRefCounted<flutter::PlatformMessage>(
+        flutter_message->channel, response);
+  } else {
+    message = fml::MakeRefCounted<flutter::PlatformMessage>(
+        flutter_message->channel,
+        std::vector<uint8_t>(message_data, message_data + message_size),
+        response);
+  }
 
   return reinterpret_cast<flutter::EmbedderEngine*>(engine)
                  ->SendPlatformMessage(std::move(message))

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -818,8 +818,8 @@ FlutterEngineResult FlutterEngineSendPlatformMessage(
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }
 
-  auto message_size = SAFE_ACCESS(flutter_message, message_size, 0);
-  auto message_data = SAFE_ACCESS(flutter_message, message, nullptr);
+  size_t message_size = SAFE_ACCESS(flutter_message, message_size, 0);
+  const uint8_t* message_data = SAFE_ACCESS(flutter_message, message, nullptr);
 
   if (message_size != 0 && message_data == nullptr) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments);

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -167,3 +167,14 @@ void platform_messages_no_response() {
   };
   signalNativeTest();
 }
+
+@pragma('vm:entry-point')
+void null_platform_messages() {
+  window.onPlatformMessage =
+      (String name, ByteData data, PlatformMessageResponseCallback callback) {
+    // This checks if the platform_message null data is converted to Flutter null.
+    signalNativeMessage((null == data).toString());
+    callback(data);
+  };
+  signalNativeTest();
+}


### PR DESCRIPTION
fixes: flutter/flutter#35434
- uses of SAFE_ACCESS
 - clang-format
 - providing default value of 0 for message_size