### PR TITLE
Remove breaking asserts

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -390,7 +390,9 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ColorFilterEngineLayer pushColorFilter(ColorFilter filter, { ColorFilterEngineLayer oldLayer }) {
     assert(filter != null);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushColorFilter'));
-    final ColorFilterEngineLayer layer = ColorFilterEngineLayer._(_pushColorFilter(filter._toNativeColorFilter()));
+    final _ColorFilter nativeFilter = filter._toNativeColorFilter();
+    assert(nativeFilter != null);
+    final ColorFilterEngineLayer layer = ColorFilterEngineLayer._(_pushColorFilter(nativeFilter));
     assert(_debugPushLayer(layer));
     return layer;
   }

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1343,16 +1343,17 @@ class Paint {
   }
 
   set colorFilter(ColorFilter value) {
-    if (value == null) {
+    final _ColorFilter nativeFilter = value?._toNativeColorFilter();
+    if (nativeFilter == null) {
       if (_objects != null) {
         _objects[_kColorFilterIndex] = null;
       }
     } else {
       if (_objects == null) {
         _objects = List<dynamic>(_kObjectCount);
-        _objects[_kColorFilterIndex] = value._toNativeColorFilter();
+        _objects[_kColorFilterIndex] = nativeFilter;
       } else if (_objects[_kColorFilterIndex]?.creator != value) {
-        _objects[_kColorFilterIndex] = value._toNativeColorFilter();
+        _objects[_kColorFilterIndex] = nativeFilter;
       }
     }
   }
@@ -2489,9 +2490,7 @@ class ColorFilter {
   /// to the [Paint.blendMode], using the output of this filter as the source
   /// and the background as the destination.
   const ColorFilter.mode(Color color, BlendMode blendMode)
-      : assert(color != null),
-        assert(blendMode != null),
-        _color = color,
+      : _color = color,
         _blendMode = blendMode,
         _matrix = null,
         _type = _TypeMode;
@@ -2500,8 +2499,7 @@ class ColorFilter {
   /// matrix is in row-major order and the translation column is specified in
   /// unnormalized, 0...255, space.
   const ColorFilter.matrix(List<double> matrix)
-      : assert(matrix != null, 'Color Matrix argument was null.'),
-        _color = null,
+      : _color = null,
         _blendMode = null,
         _matrix = matrix,
         _type = _TypeMatrix;
@@ -2555,8 +2553,14 @@ class ColorFilter {
   _ColorFilter _toNativeColorFilter() {
     switch (_type) {
       case _TypeMode:
+        if (_color == null || _blendMode == null) {
+          return null;
+        }
         return _ColorFilter.mode(this);
       case _TypeMatrix:
+        if (_matrix == null) {
+          return null;
+        }
         assert(_matrix.length == 20, 'Color Matrix must have 20 entries.');
         return _ColorFilter.matrix(this);
       case _TypeLinearToSrgbGamma:

--- a/testing/dart/color_filter_test.dart
+++ b/testing/dart/color_filter_test.dart
@@ -41,6 +41,14 @@ void main() {
     return bytes.buffer.asUint32List();
   }
 
+  test('ColorFilter - nulls', () async {
+    final Paint paint = Paint()..colorFilter = ColorFilter.mode(null, null);
+    expect(paint.colorFilter, null);
+
+    paint.colorFilter = ColorFilter.matrix(null);
+    expect(paint.colorFilter, null);
+  });
+
   test('ColorFilter - mode', () async {
     final Paint paint = Paint()
       ..color = green


### PR DESCRIPTION
I added some asserts when changing color filter that turned out to be breaking.

This returns to the previous behavior.  I have kept an assert on pushColorFilter, since that is new API as of a few days ago.

/cc @gspencergoog @Hixie 