### PR TITLE
In a single frame codec, release the encoded image buffer after giving it to the decoder

### DIFF
--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -21,11 +21,17 @@
 #include "third_party/tonic/logging/dart_invoke.h"
 #include "third_party/tonic/typed_data/typed_list.h"
 
+#if OS_ANDROID
+#include <sys/mman.h>
+#endif
+
 using tonic::DartInvoke;
 using tonic::DartPersistentValue;
 using tonic::ToDart;
 
 namespace flutter {
+
+namespace {
 
 // This needs to be kept in sync with _kDoNotResizeDimension in painting.dart
 const int kDoNotResizeDimension = -1;
@@ -35,6 +41,51 @@ enum PixelFormat {
   kRGBA8888,
   kBGRA8888,
 };
+
+#if OS_ANDROID
+
+// Compressed image buffers are allocated on the UI thread but are deleted on a
+// decoder worker thread.  Android's implementation of malloc appears to
+// continue growing the native heap size when the allocating thread is
+// different from the freeing thread.  To work around this, create an SkData
+// backed by an anonymous mapping.
+sk_sp<SkData> MakeSkDataWithCopy(const void* data, size_t length) {
+  if (length == 0) {
+    return SkData::MakeEmpty();
+  }
+
+  size_t mapping_length = length + sizeof(size_t);
+  void* mapping = ::mmap(nullptr, mapping_length, PROT_READ | PROT_WRITE,
+                         MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+
+  if (mapping == MAP_FAILED) {
+    return SkData::MakeEmpty();
+  }
+
+  *reinterpret_cast<size_t*>(mapping) = mapping_length;
+  void* mapping_data = reinterpret_cast<char*>(mapping) + sizeof(size_t);
+  ::memcpy(mapping_data, data, length);
+
+  SkData::ReleaseProc proc = [](const void* ptr, void* context) {
+    size_t* size_ptr = reinterpret_cast<size_t*>(context);
+    FML_DCHECK(ptr == size_ptr + 1);
+    if (::munmap(const_cast<void*>(context), *size_ptr) == -1) {
+      FML_LOG(ERROR) << "munmap of codec SkData failed";
+    }
+  };
+
+  return SkData::MakeWithProc(mapping_data, length, proc, mapping);
+}
+
+#else
+
+sk_sp<SkData> MakeSkDataWithCopy(const void* data, size_t length) {
+  return SkData::MakeWithCopy(data, length);
+}
+
+#endif  // OS_ANDROID
+
+}  // anonymous namespace
 
 static std::variant<ImageDecoder::ImageInfo, std::string> ConvertImageInfo(
     Dart_Handle image_info_handle,
@@ -129,7 +180,7 @@ static void InstantiateImageCodec(Dart_NativeArguments args) {
       Dart_SetReturnValue(args, exception);
       return;
     }
-    buffer = SkData::MakeWithCopy(list.data(), list.num_elements());
+    buffer = MakeSkDataWithCopy(list.data(), list.num_elements());
   }
 
   if (image_info) {

--- a/lib/ui/painting/single_frame_codec.h
+++ b/lib/ui/painting/single_frame_codec.h
@@ -7,6 +7,7 @@
 
 #include "flutter/fml/macros.h"
 #include "flutter/lib/ui/painting/codec.h"
+#include "flutter/lib/ui/painting/frame_info.h"
 #include "flutter/lib/ui/painting/image_decoder.h"
 
 namespace flutter {
@@ -30,7 +31,11 @@ class SingleFrameCodec : public Codec {
   size_t GetAllocationSize() override;
 
  private:
+  enum class Status { kNew, kInProgress, kComplete };
+  Status status_;
   ImageDecoder::ImageDescriptor descriptor_;
+  fml::RefPtr<FrameInfo> cached_frame_;
+  std::vector<DartPersistentValue> pending_callbacks_;
 
   FML_FRIEND_MAKE_REF_COUNTED(SingleFrameCodec);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(SingleFrameCodec);


### PR DESCRIPTION
The codec will retain a reference to the decoded frame so it can be returned
in repeated calls to getNextFrame.

See https://github.com/flutter/flutter/issues/36079