### PR TITLE
Add multi-line flag to semantics

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -288,6 +288,7 @@ class SemanticsFlag {
   static const int _kHasToggledStateIndex = 1 << 16;
   static const int _kIsToggledIndex = 1 << 17;
   static const int _kHasImplicitScrollingIndex = 1 << 18;
+  static const int _kIsMultilineIndex = 1 << 19;
   static const int _kIsReadOnlyIndex = 1 << 20;
 
   const SemanticsFlag._(this.index);
@@ -385,6 +386,13 @@ class SemanticsFlag {
   /// This is usually used for text fields to indicate that its content
   /// is a password or contains other sensitive information.
   static const SemanticsFlag isObscured = SemanticsFlag._(_kIsObscuredIndex);
+
+  /// Whether the value of the semantics node is coming from a multi-line text
+  /// field.
+  ///
+  /// This is used for text fields to distinguish single-line text fields from
+  /// multi-line ones.
+  static const SemanticsFlag isMultiline = SemanticsFlag._(_kIsMultilineIndex);
 
   /// Whether the semantics node is the root of a subtree for which a route name
   /// should be announced.
@@ -512,6 +520,7 @@ class SemanticsFlag {
     _kHasToggledStateIndex: hasToggledState,
     _kIsToggledIndex: isToggled,
     _kHasImplicitScrollingIndex: hasImplicitScrolling,
+    _kIsMultilineIndex: isMultiline,
     _kIsReadOnlyIndex: isReadOnly,
   };
 
@@ -556,6 +565,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isToggled';
       case _kHasImplicitScrollingIndex:
         return 'SemanticsFlag.hasImplicitScrolling';
+      case _kIsMultilineIndex:
+        return 'SemanticsFlag.isMultiline';
       case _kIsReadOnlyIndex:
         return 'SemanticsFlag.isReadOnly';
     }

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -520,7 +520,10 @@ class SemanticsFlag {
     _kHasToggledStateIndex: hasToggledState,
     _kIsToggledIndex: isToggled,
     _kHasImplicitScrollingIndex: hasImplicitScrolling,
-    _kIsMultilineIndex: isMultiline,
+    // TODO(mdebbar): Uncomment after both these PRs are landed:
+    //                - https://github.com/flutter/engine/pull/9850
+    //                - https://github.com/flutter/flutter/pull/36297
+    // _kIsMultilineIndex: isMultiline,
     _kIsReadOnlyIndex: isReadOnly,
   };
 

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -69,6 +69,8 @@ enum class SemanticsFlags : int32_t {
   kHasToggledState = 1 << 16,
   kIsToggled = 1 << 17,
   kHasImplicitScrolling = 1 << 18,
+  // The Dart API defines the following flag but it isn't used in iOS.
+  // kIsMultiline = 1 << 19,
   kIsReadOnly = 1 << 20,
 };
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1614,6 +1614,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         HAS_TOGGLED_STATE(1 << 16),
         IS_TOGGLED(1 << 17),
         HAS_IMPLICIT_SCROLLING(1 << 18),
+        // The Dart API defines the following flag but it isn't used in Android.
+        // IS_MULTILINE(1 << 19);
         IS_READ_ONLY(1 << 20);
 
         final int value;


### PR DESCRIPTION
This flag is currently only used in the web engine to decide whether to create an `<input>` or `<textarea>` element.

Related to the flutter PR: https://github.com/flutter/flutter/pull/36297

Fixes https://github.com/flutter/flutter/issues/34265