### PR TITLE
Run engine unit-tests on Windows in the presubmits.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,8 @@ task:
         cd %ENGINE_PATH%/src
         python flutter/tools/gn --runtime-mode debug --unoptimized
         ninja -C out/host_debug_unopt
-      test_host_script: $ENGINE_PATH/src/flutter/testing/run_tests.py --variant host_debug_unopt
+      test_host_script: |
+        %ENGINE_PATH%/src/flutter/testing/run_tests.py --variant host_debug_unopt
 
 task:
   gke_container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -106,7 +106,7 @@ task:
         python flutter/tools/gn --runtime-mode debug --unoptimized
         ninja -C out/host_debug_unopt
       test_host_script: |
-        %ENGINE_PATH%/src/flutter/testing/run_tests.py --variant host_debug_unopt
+        python %ENGINE_PATH%/src/flutter/testing/run_tests.py --variant host_debug_unopt
 
 task:
   gke_container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,12 +27,12 @@ task:
     gclient sync
 
   matrix:
-    - name: build_and_test_host
+    - name: build_and_test_host_debug
       compile_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/tools/gn --unoptimized --full-dart-sdk
         ninja -C out/host_debug_unopt
-      test_host_script: cd $ENGINE_PATH/src && ./flutter/testing/run_tests.sh host_debug_unopt
+      test_host_script: $ENGINE_PATH/src/flutter/testing/run_tests.py --variant host_debug_unopt
       fetch_framework_script: |
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH
@@ -48,14 +48,14 @@ task:
         cd $ENGINE_PATH/src
         ./flutter/tools/gn --runtime-mode profile --no-lto
         ninja -C out/host_profile
-      test_host_script: cd $ENGINE_PATH/src && ./flutter/testing/run_tests.sh host_profile
+      test_host_script: $ENGINE_PATH/src/flutter/testing/run_tests.py --variant host_profile
     - name: build_and_test_host_release
       compile_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/tools/gn --runtime-mode release --no-lto
         ninja -C out/host_release
-      test_host_script: cd $ENGINE_PATH/src && ./flutter/testing/run_tests.sh host_release
-    - name: build_android
+      test_host_script: $ENGINE_PATH/src/flutter/testing/run_tests.py --variant host_release
+    - name: build_android_debug
       get_android_sdk_script: |
         echo 'solutions = [{"managed": False,"name": "src/flutter","url": "git@github.com:flutter/engine.git","deps_file": "DEPS", "custom_vars": {"download_windows_deps" : False,},},]' > $ENGINE_PATH/.gclient
         cd $ENGINE_PATH/src
@@ -105,12 +105,7 @@ task:
         cd %ENGINE_PATH%/src
         python flutter/tools/gn --runtime-mode debug --unoptimized
         ninja -C out/host_debug_unopt
-
-    - name: build_windows_debug_unopt
-      compile_host_script: |
-        cd %ENGINE_PATH%/src
-        python flutter/tools/gn --runtime-mode debug
-        ninja -C out/host_debug
+      test_host_script: $ENGINE_PATH/src/flutter/testing/run_tests.py --variant host_debug_unopt
 
 task:
   gke_container:

--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -o pipefail -e;
-
-BUILD_VARIANT="${1:-host_debug_unopt}"
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-
-python "${CURRENT_DIR}/run_tests.py" --variant "${BUILD_VARIANT}"


### PR DESCRIPTION
Also removes a redundant Windows build and the old run_tests.sh script.