### PR TITLE
Disable Fuchsia Debug & Release presubmits and only attempt the Profile unopt variant.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -139,18 +139,8 @@ task:
     gclient sync
 
   matrix:
-    - name: build_fuchsia_debug
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --fuchsia --full-dart-sdk
-        ninja -C out/fuchsia_debug_unopt
     - name: build_fuchsia_profile
       compile_host_script: |
         cd $ENGINE_PATH/src
-        ./flutter/tools/gn --runtime-mode profile --fuchsia --no-lto
-        ninja -C out/fuchsia_profile
-    - name: build_fuchsia_release
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --runtime-mode release --fuchsia --no-lto
-        ninja -C out/fuchsia_release
+        ./flutter/tools/gn --runtime-mode profile --fuchsia --no-lto --unopt
+        ninja -C out/fuchsia_profile_unopt


### PR DESCRIPTION
The build sources are identical. Also, the previous debug variant was unnecessarily building the Full Dart SDK. The extra builds were causing increased queue times on other jobs.