### PR TITLE
Add Stroke/Border to LibTxt and dart:ui

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -431,6 +431,23 @@ enum TextDecorationStyle {
   wavy
 }
 
+
+/// The type of Stroke to draw.
+enum StrokeStyle {
+  /// No stroke.
+  kNone,
+
+  /// The stroke is drawn under the fill text.
+  ///
+  /// The stroke appears as an "outset" to the fill.
+  kUnder,
+
+  /// The stroke is drawn over the fill text.
+  ///
+  /// The fill text will be partially covered by the stroke.
+  kOver,
+}
+
 /// Determines if lists [a] and [b] are deep equivalent.
 ///
 /// Returns true if the lists are both null, or if they are both non-null, have
@@ -491,6 +508,9 @@ Int32List _encodeTextStyle(
   Locale locale,
   Paint background,
   Paint foreground,
+  StrokeStyle strokeStyle,
+  double strokeWidth,
+  Color strokeColor,
   List<Shadow> shadows,
   List<FontFeature> fontFeatures,
 ) {
@@ -523,47 +543,58 @@ Int32List _encodeTextStyle(
     result[0] |= 1 << 7;
     result[7] = textBaseline.index;
   }
-  if (decorationThickness != null) {
+  if (strokeStyle != null) {
     result[0] |= 1 << 8;
+    result[8] = strokeStyle.index;
+  }
+  if (strokeColor != null) {
+    result[0] |= 1 << 9;
+    result[9] = strokeColor.value;
+  }
+  if (strokeWidth != null) {
+    result[0] |= 1 << 10;
+  }
+  if (decorationThickness != null) {
+    result[0] |= 1 << 11;
   }
   if (fontFamily != null || (fontFamilyFallback != null && fontFamilyFallback.isNotEmpty)) {
-    result[0] |= 1 << 9;
-    // Passed separately to native.
-  }
-  if (fontSize != null) {
-    result[0] |= 1 << 10;
-    // Passed separately to native.
-  }
-  if (letterSpacing != null) {
-    result[0] |= 1 << 11;
-    // Passed separately to native.
-  }
-  if (wordSpacing != null) {
     result[0] |= 1 << 12;
     // Passed separately to native.
   }
-  if (height != null) {
+  if (fontSize != null) {
     result[0] |= 1 << 13;
     // Passed separately to native.
   }
-  if (locale != null) {
+  if (letterSpacing != null) {
     result[0] |= 1 << 14;
     // Passed separately to native.
   }
-  if (background != null) {
+  if (wordSpacing != null) {
     result[0] |= 1 << 15;
     // Passed separately to native.
   }
-  if (foreground != null) {
+  if (height != null) {
     result[0] |= 1 << 16;
     // Passed separately to native.
   }
-  if (shadows != null) {
+  if (locale != null) {
     result[0] |= 1 << 17;
     // Passed separately to native.
   }
-  if (fontFeatures != null) {
+  if (background != null) {
     result[0] |= 1 << 18;
+    // Passed separately to native.
+  }
+  if (foreground != null) {
+    result[0] |= 1 << 19;
+    // Passed separately to native.
+  }
+  if (shadows != null) {
+    result[0] |= 1 << 20;
+    // Passed separately to native.
+  }
+  if (fontFeatures != null) {
+    result[0] |= 1 << 21;
     // Passed separately to native.
   }
   return result;
@@ -622,6 +653,9 @@ class TextStyle {
     Locale locale,
     Paint background,
     Paint foreground,
+    StrokeStyle strokeStyle,
+    double strokeWidth,
+    Color strokeColor,
     List<Shadow> shadows,
     List<FontFeature> fontFeatures,
   }) : assert(color == null || foreground == null,
@@ -646,6 +680,9 @@ class TextStyle {
          locale,
          background,
          foreground,
+         strokeStyle,
+         strokeWidth,
+         strokeColor,
          shadows,
          fontFeatures,
        ),
@@ -659,6 +696,7 @@ class TextStyle {
        _locale = locale,
        _background = background,
        _foreground = foreground,
+       _strokeWidth = strokeWidth.
        _shadows = shadows,
        _fontFeatures = fontFeatures;
 
@@ -673,6 +711,7 @@ class TextStyle {
   final Locale _locale;
   final Paint _background;
   final Paint _foreground;
+  final double _strokeWidth;
   final List<Shadow> _shadows;
   final List<FontFeature> _fontFeatures;
 
@@ -1774,6 +1813,7 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
       style._wordSpacing,
       style._height,
       style._decorationThickness,
+      style._strokeWidth,
       _encodeLocale(style._locale),
       style._background?._objects,
       style._background?._data,
@@ -1792,6 +1832,7 @@ class ParagraphBuilder extends NativeFieldWrapperClass2 {
     double wordSpacing,
     double height,
     double decorationThickness,
+    double strokeWidth,
     String locale,
     List<dynamic> backgroundObjects,
     ByteData backgroundData,

--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -696,7 +696,7 @@ class TextStyle {
        _locale = locale,
        _background = background,
        _foreground = foreground,
-       _strokeWidth = strokeWidth.
+       _strokeWidth = strokeWidth,
        _shadows = shadows,
        _fontFeatures = fontFeatures;
 

--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -37,22 +37,28 @@ const int tsTextDecorationStyleIndex = 4;
 const int tsFontWeightIndex = 5;
 const int tsFontStyleIndex = 6;
 const int tsTextBaselineIndex = 7;
-const int tsTextDecorationThicknessIndex = 8;
-const int tsFontFamilyIndex = 9;
-const int tsFontSizeIndex = 10;
-const int tsLetterSpacingIndex = 11;
-const int tsWordSpacingIndex = 12;
-const int tsHeightIndex = 13;
-const int tsLocaleIndex = 14;
-const int tsBackgroundIndex = 15;
-const int tsForegroundIndex = 16;
-const int tsTextShadowsIndex = 17;
-const int tsFontFeaturesIndex = 18;
+const int tsStrokeStyleIndex = 8;
+const int tsStrokeColorIndex = 9;
+const int tsStrokeWidthIndex = 10;
+const int tsTextDecorationThicknessIndex = 11;
+const int tsFontFamilyIndex = 12;
+const int tsFontSizeIndex = 13;
+const int tsLetterSpacingIndex = 14;
+const int tsWordSpacingIndex = 15;
+const int tsHeightIndex = 16;
+const int tsLocaleIndex = 17;
+const int tsBackgroundIndex = 18;
+const int tsForegroundIndex = 19;
+const int tsTextShadowsIndex = 20;
+const int tsFontFeaturesIndex = 21;
 
 const int tsColorMask = 1 << tsColorIndex;
 const int tsTextDecorationMask = 1 << tsTextDecorationIndex;
 const int tsTextDecorationColorMask = 1 << tsTextDecorationColorIndex;
 const int tsTextDecorationStyleMask = 1 << tsTextDecorationStyleIndex;
+const int tsStrokeStyleMask = 1 << tsStrokeStyleIndex;
+const int tsStrokeColorMask = 1 << tsStrokeColorIndex;
+const int tsStrokeWidthMask = 1 << tsStrokeWidthIndex;
 const int tsTextDecorationThicknessMask = 1 << tsTextDecorationThicknessIndex;
 const int tsFontWeightMask = 1 << tsFontWeightIndex;
 const int tsFontStyleMask = 1 << tsFontStyleIndex;
@@ -345,6 +351,7 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
                                  double wordSpacing,
                                  double height,
                                  double decorationThickness,
+                                 double strokeWidth,
                                  const std::string& locale,
                                  Dart_Handle background_objects,
                                  Dart_Handle background_data,
@@ -382,6 +389,18 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
 
   if (mask & tsTextDecorationThicknessMask) {
     style.decoration_thickness_multiplier = decorationThickness;
+  }
+
+  if (mask & tsStrokeStyleMask) {
+    style.stroke_style =
+        static_cast<txt::StrokeStyle>(encoded[tsStrokeStyleIndex]);
+  }
+  if (mask & tsStrokeColorMask) {
+    style.stroke_color = encoded[tsStrokeColorIndex];
+  }
+
+  if (mask & tsStrokeWidthMask) {
+    style.stroke_width = strokeWidth;
   }
 
   if (mask & tsTextBaselineMask) {

--- a/lib/ui/text/paragraph_builder.h
+++ b/lib/ui/text/paragraph_builder.h
@@ -45,6 +45,7 @@ class ParagraphBuilder : public RefCountedDartWrappable<ParagraphBuilder> {
                  double wordSpacing,
                  double height,
                  double decorationThickness,
+                 double strokeWidth,
                  const std::string& locale,
                  Dart_Handle background_objects,
                  Dart_Handle background_data,

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -101,7 +101,7 @@ source_set("txt") {
     "src/txt/placeholder_run.cc",
     "src/txt/placeholder_run.h",
     "src/txt/platform.h",
-    "src/txt/stroke_type.h",
+    "src/txt/stroke_style.h",
     "src/txt/styled_runs.cc",
     "src/txt/styled_runs.h",
     "src/txt/test_font_manager.cc",

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -101,6 +101,7 @@ source_set("txt") {
     "src/txt/placeholder_run.cc",
     "src/txt/placeholder_run.h",
     "src/txt/platform.h",
+    "src/txt/stroke_type.h",
     "src/txt/styled_runs.cc",
     "src/txt/styled_runs.h",
     "src/txt/test_font_manager.cc",

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -1285,11 +1285,11 @@ void ParagraphTxt::Paint(SkCanvas* canvas, double x, double y) {
     SkPoint offset = base_offset + record.offset();
     if (record.GetPlaceholderRun() == nullptr) {
       PaintShadow(canvas, record, offset);
-      if (record.style().stroke_type == StrokeType::kUnder) {
+      if (record.style().stroke_style == StrokeStyle::kUnder) {
         PaintStroke(canvas, record, offset);
       }
       canvas->drawTextBlob(record.text(), offset.x(), offset.y(), paint);
-      if (record.style().stroke_type == StrokeType::kOver) {
+      if (record.style().stroke_style == StrokeStyle::kOver) {
         PaintStroke(canvas, record, offset);
       }
     }
@@ -1300,7 +1300,7 @@ void ParagraphTxt::Paint(SkCanvas* canvas, double x, double y) {
 void ParagraphTxt::PaintStroke(SkCanvas* canvas,
                                const PaintRecord& record,
                                SkPoint offset) {
-  if (record.style().stroke_type == StrokeType::kNone) {
+  if (record.style().stroke_style == StrokeStyle::kNone) {
     return;
   }
   SkPaint paint;

--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -1285,10 +1285,30 @@ void ParagraphTxt::Paint(SkCanvas* canvas, double x, double y) {
     SkPoint offset = base_offset + record.offset();
     if (record.GetPlaceholderRun() == nullptr) {
       PaintShadow(canvas, record, offset);
+      if (record.style().stroke_type == StrokeType::kUnder) {
+        PaintStroke(canvas, record, offset);
+      }
       canvas->drawTextBlob(record.text(), offset.x(), offset.y(), paint);
+      if (record.style().stroke_type == StrokeType::kOver) {
+        PaintStroke(canvas, record, offset);
+      }
     }
-    PaintDecorations(canvas, record, base_offset);
+    PaintDecorations(canvas, record, offset);
   }
+}
+
+void ParagraphTxt::PaintStroke(SkCanvas* canvas,
+                               const PaintRecord& record,
+                               SkPoint offset) {
+  if (record.style().stroke_type == StrokeType::kNone) {
+    return;
+  }
+  SkPaint paint;
+  paint.setColor(record.style().stroke_color);
+  paint.setStyle(SkPaint::kStroke_Style);
+  paint.setStrokeWidth(record.style().stroke_width);
+
+  canvas->drawTextBlob(record.text(), offset.x(), offset.y(), paint);
 }
 
 void ParagraphTxt::PaintDecorations(SkCanvas* canvas,

--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -149,6 +149,8 @@ class ParagraphTxt : public Paragraph {
   FRIEND_TEST(ParagraphTest, FontFallbackParagraph);
   FRIEND_TEST(ParagraphTest, InlinePlaceholder0xFFFCParagraph);
   FRIEND_TEST(ParagraphTest, FontFeaturesParagraph);
+  FRIEND_TEST(ParagraphTest, StrokeUnderParagraph);
+  FRIEND_TEST(ParagraphTest, StrokeOverParagraph);
 
   // Starting data to layout.
   std::vector<uint16_t> text_;

--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -364,6 +364,9 @@ class ParagraphTxt : public Paragraph {
   // alignment.
   double GetLineXOffset(double line_total_advance);
 
+  // Draws the stroke.
+  void PaintStroke(SkCanvas* canvas, const PaintRecord& record, SkPoint offset);
+
   // Creates and draws the decorations onto the canvas.
   void PaintDecorations(SkCanvas* canvas,
                         const PaintRecord& record,

--- a/third_party/txt/src/txt/stroke_style.h
+++ b/third_party/txt/src/txt/stroke_style.h
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#ifndef LIB_TXT_SRC_STROKE_TYPE_H_
-#define LIB_TXT_SRC_STROKE_TYPE_H_
+#ifndef LIB_TXT_SRC_STROKE_STYLE_H_
+#define LIB_TXT_SRC_STROKE_STYLE_H_
 
 namespace txt {
 
-enum class StrokeType {
+enum class StrokeStyle {
   // No stroke
   kNone,
   // The stroke is drawn under the fill text. The stroke appears as an
@@ -35,4 +35,4 @@ enum class StrokeType {
 
 }  // namespace txt
 
-#endif  // LIB_TXT_SRC_STROKE_TYPE_H_
+#endif  // LIB_TXT_SRC_STROKE_STYLE_H_

--- a/third_party/txt/src/txt/stroke_type.h
+++ b/third_party/txt/src/txt/stroke_type.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LIB_TXT_SRC_STROKE_TYPE_H_
+#define LIB_TXT_SRC_STROKE_TYPE_H_
+
+namespace txt {
+
+enum class StrokeType {
+  // No stroke
+  kNone,
+  // The stroke is drawn under the fill text. The stroke appears as an
+  // "outset" to the fill.
+  kUnder,
+  // The stroke is drawn over the fill text. The fill text will be
+  // partially covered by the stroke.
+  kOver,
+
+  // We may support a `kInset` stroke (kOver, clipped by the fill text)
+  // in the future.
+};
+
+}  // namespace txt
+
+#endif  // LIB_TXT_SRC_STROKE_TYPE_H_

--- a/third_party/txt/src/txt/styled_runs.h
+++ b/third_party/txt/src/txt/styled_runs.h
@@ -82,6 +82,8 @@ class StyledRuns {
   FRIEND_TEST(ParagraphTest, SimpleShadow);
   FRIEND_TEST(ParagraphTest, ComplexShadow);
   FRIEND_TEST(ParagraphTest, FontFallbackParagraph);
+  FRIEND_TEST(ParagraphTest, StrokeOverParagraph);
+  FRIEND_TEST(ParagraphTest, StrokeUnderParagraph);
 
   struct IndexedRun {
     size_t style_index = 0;

--- a/third_party/txt/src/txt/text_style.h
+++ b/third_party/txt/src/txt/text_style.h
@@ -23,7 +23,7 @@
 #include "font_features.h"
 #include "font_style.h"
 #include "font_weight.h"
-#include "stroke_type.h"
+#include "stroke_style.h"
 #include "text_baseline.h"
 #include "text_decoration.h"
 #include "text_shadow.h"
@@ -62,7 +62,7 @@ class TextStyle {
   // the bottom).
   std::vector<TextShadow> text_shadows;
 
-  StrokeType stroke_type = StrokeType::kNone;
+  StrokeStyle stroke_style = StrokeStyle::kNone;
   SkColor stroke_color = SK_ColorWHITE;
   double stroke_width = 1.0;
 

--- a/third_party/txt/src/txt/text_style.h
+++ b/third_party/txt/src/txt/text_style.h
@@ -23,6 +23,7 @@
 #include "font_features.h"
 #include "font_style.h"
 #include "font_weight.h"
+#include "stroke_type.h"
 #include "text_baseline.h"
 #include "text_decoration.h"
 #include "text_shadow.h"
@@ -60,6 +61,11 @@ class TextStyle {
   // An ordered list of shadows where the first shadow will be drawn first (at
   // the bottom).
   std::vector<TextShadow> text_shadows;
+
+  StrokeType stroke_type = StrokeType::kNone;
+  SkColor stroke_color = SK_ColorWHITE;
+  double stroke_width = 1.0;
+
   FontFeatures font_features;
 
   TextStyle();

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -5159,11 +5159,12 @@ TEST_F(ParagraphTest, StrokeUnderParagraph) {
   // be Arial default though as it is one of the most common fonts on host
   // platforms. On real devices/apps, Arial should be able to be resolved.
   text_style.font_families = std::vector<std::string>(1, "Roboto");
+  text_style.font_families.push_back("Source Han Serif CN");
   text_style.font_size = 70;
-  text_style.color = SK_ColorBLACK;
-  text_style.stroke_color = SK_ColorRED;
-  text_style.stroke_width = 3;
-  text_style.stroke_type = txt::StrokeType::kUnder;
+  text_style.color = SK_ColorGRAY;
+  text_style.stroke_color = SK_ColorBLACK;
+  text_style.stroke_width = 10;
+  text_style.stroke_style = txt::StrokeStyle::kUnder;
   builder.PushStyle(text_style);
   builder.AddText(u16_text);
 
@@ -5175,13 +5176,60 @@ TEST_F(ParagraphTest, StrokeUnderParagraph) {
   paragraph->Paint(GetCanvas(), 10.0, 15.0);
 
   // ASSERT_EQ(paragraph->text_.size(), std::string{text}.length());
-  // for (size_t i = 0; i < u16_text.length(); i++) {
-  //   ASSERT_EQ(paragraph->text_[i], u16_text[i]);
-  // }
-  // ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
-  // ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
-  // ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
-  // ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
+  for (size_t i = 0; i < u16_text.length(); i++) {
+    ASSERT_EQ(paragraph->text_[i], u16_text[i]);
+  }
+  ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
+  ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
+  ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
+  ASSERT_EQ(paragraph->records_[0].style().stroke_color, text_style.stroke_color);
+  ASSERT_EQ(paragraph->records_[0].style().stroke_style, text_style.stroke_style);
+  ASSERT_EQ(paragraph->records_[0].style().stroke_width, text_style.stroke_width);
+  ASSERT_TRUE(Snapshot());
+}
+
+TEST_F(ParagraphTest, StrokeOverParagraph) {
+  const char* text = "Stroke is a cool thing! 土豆很好吃";
+  auto icu_text = icu::UnicodeString::fromUTF8(text);
+  std::u16string u16_text(icu_text.getBuffer(),
+                          icu_text.getBuffer() + icu_text.length());
+
+  txt::ParagraphStyle paragraph_style;
+  txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
+
+  txt::TextStyle text_style;
+  // We must supply a font here, as the default is Arial, and we do not
+  // include Arial in our test fonts as it is proprietary. We want it to
+  // be Arial default though as it is one of the most common fonts on host
+  // platforms. On real devices/apps, Arial should be able to be resolved.
+  text_style.font_families = std::vector<std::string>(1, "Roboto");
+  text_style.font_families.push_back("Source Han Serif CN");
+  text_style.font_size = 70;
+  text_style.color = SK_ColorGRAY;
+  text_style.stroke_color = SK_ColorBLACK;
+  text_style.stroke_width = 5;
+  text_style.stroke_style = txt::StrokeStyle::kOver;
+  builder.PushStyle(text_style);
+  builder.AddText(u16_text);
+
+  builder.Pop();
+
+  auto paragraph = BuildParagraph(builder);
+  paragraph->Layout(GetTestCanvasWidth());
+
+  paragraph->Paint(GetCanvas(), 10.0, 15.0);
+
+  // ASSERT_EQ(paragraph->text_.size(), std::string{text}.length());
+  for (size_t i = 0; i < u16_text.length(); i++) {
+    ASSERT_EQ(paragraph->text_[i], u16_text[i]);
+  }
+  ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
+  ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
+  ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
+  ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
+  ASSERT_EQ(paragraph->records_[0].style().stroke_color, text_style.stroke_color);
+  ASSERT_EQ(paragraph->records_[0].style().stroke_style, text_style.stroke_style);
+  ASSERT_EQ(paragraph->records_[0].style().stroke_width, text_style.stroke_width);
   ASSERT_TRUE(Snapshot());
 }
 

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -5144,4 +5144,45 @@ TEST_F(ParagraphTest, FontFeaturesParagraph) {
   ASSERT_TRUE(Snapshot());
 }
 
+TEST_F(ParagraphTest, StrokeUnderParagraph) {
+  const char* text = "Stroke is a cool thing! 土豆很好吃";
+  auto icu_text = icu::UnicodeString::fromUTF8(text);
+  std::u16string u16_text(icu_text.getBuffer(),
+                          icu_text.getBuffer() + icu_text.length());
+
+  txt::ParagraphStyle paragraph_style;
+  txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
+
+  txt::TextStyle text_style;
+  // We must supply a font here, as the default is Arial, and we do not
+  // include Arial in our test fonts as it is proprietary. We want it to
+  // be Arial default though as it is one of the most common fonts on host
+  // platforms. On real devices/apps, Arial should be able to be resolved.
+  text_style.font_families = std::vector<std::string>(1, "Roboto");
+  text_style.font_size = 70;
+  text_style.color = SK_ColorBLACK;
+  text_style.stroke_color = SK_ColorRED;
+  text_style.stroke_width = 3;
+  text_style.stroke_type = txt::StrokeType::kUnder;
+  builder.PushStyle(text_style);
+  builder.AddText(u16_text);
+
+  builder.Pop();
+
+  auto paragraph = BuildParagraph(builder);
+  paragraph->Layout(GetTestCanvasWidth());
+
+  paragraph->Paint(GetCanvas(), 10.0, 15.0);
+
+  // ASSERT_EQ(paragraph->text_.size(), std::string{text}.length());
+  // for (size_t i = 0; i < u16_text.length(); i++) {
+  //   ASSERT_EQ(paragraph->text_[i], u16_text[i]);
+  // }
+  // ASSERT_EQ(paragraph->runs_.runs_.size(), 1ull);
+  // ASSERT_EQ(paragraph->runs_.styles_.size(), 2ull);
+  // ASSERT_TRUE(paragraph->runs_.styles_[1].equals(text_style));
+  // ASSERT_EQ(paragraph->records_[0].style().color, text_style.color);
+  ASSERT_TRUE(Snapshot());
+}
+
 }  // namespace txt


### PR DESCRIPTION
This adds the border/stroke feature requested in https://github.com/flutter/flutter/issues/24108

Three properties are added in TextStyle:

- StrokeStyle
  - under
  - over
- StrokeColor
- StrokeWidth

These properties allow LibTxt to natively draw stroke and borders.