### PR TITLE
[flutter][a11y]Wire up ViewRef and initialize SemanticsManager

### DIFF
--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -17,6 +17,8 @@ if (using_fuchsia_sdk) {
       "compositor_context.h",
       "engine.cc",
       "engine.h",
+      "fuchsia_accessibility.cc",
+      "fuchsia_accessibility.h",
       "fuchsia_font_manager.cc",
       "fuchsia_font_manager.h",
       "isolate_configurator.cc",

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -523,15 +523,28 @@ void Application::CreateView(
            "create a shell for a view provider request.";
     return;
   }
+  // TODO(MI4-2490): remove once ViewRefControl and ViewRef come as a parameters
+  // to CreateView
+  fuchsia::ui::views::ViewRefControl view_ref_control;
+  fuchsia::ui::views::ViewRef view_ref;
+  zx_status_t status = zx::eventpair::create(
+      /*flags*/ 0u, &view_ref_control.reference, &view_ref.reference);
+  FML_DCHECK(status == ZX_OK);
+
+  status = view_ref.reference.replace(ZX_RIGHTS_BASIC, &view_ref.reference);
+  FML_DCHECK(status == ZX_OK);
 
   shell_holders_.emplace(std::make_unique<Engine>(
       *this,                         // delegate
       debug_label_,                  // thread label
       svc_,                          // Component incoming services
+      runner_incoming_services_,     // Runner incoming services
       settings_,                     // settings
       std::move(isolate_snapshot_),  // isolate snapshot
       std::move(shared_snapshot_),   // shared snapshot
       scenic::ToViewToken(std::move(view_token)),  // view token
+      std::move(view_ref_control),                 // view ref control
+      std::move(view_ref),                         // view ref
       std::move(fdio_ns_),                         // FDIO namespace
       std::move(directory_request_)                // outgoing request
       ));

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -5,6 +5,7 @@
 #include "engine.h"
 
 #include <lib/async/cpp/task.h>
+
 #include <sstream>
 
 #include "flutter/common/task_runners.h"
@@ -14,10 +15,10 @@
 #include "flutter/runtime/dart_vm_lifecycle.h"
 #include "flutter/shell/common/rasterizer.h"
 #include "flutter/shell/common/run_configuration.h"
-#include "runtime/dart/utils/files.h"
-
 #include "fuchsia_font_manager.h"
 #include "platform_view.h"
+#include "runtime/dart/utils/files.h"
+#include "runtime/dart_vm_lifecycle.h"
 #include "task_runner_adapter.h"
 #include "thread.h"
 
@@ -43,10 +44,13 @@ static void UpdateNativeThreadLabelNames(const std::string& label,
 Engine::Engine(Delegate& delegate,
                std::string thread_label,
                std::shared_ptr<sys::ServiceDirectory> svc,
+               std::shared_ptr<sys::ServiceDirectory> runner_services,
                flutter::Settings settings,
                fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
                fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
                fuchsia::ui::views::ViewToken view_token,
+               fuchsia::ui::views::ViewRefControl view_ref_control,
+               fuchsia::ui::views::ViewRef view_ref,
                UniqueFDIONS fdio_ns,
                fidl::InterfaceRequest<fuchsia::io::Directory> directory_request)
     : delegate_(delegate),
@@ -105,6 +109,9 @@ Engine::Engine(Delegate& delegate,
   flutter::Shell::CreateCallback<flutter::PlatformView>
       on_create_platform_view = fml::MakeCopyable(
           [debug_label = thread_label_,
+           view_ref_control = std::move(view_ref_control),
+           view_ref = std::move(view_ref),
+           runner_services = std::move(runner_services),
            parent_environment_service_provider =
                std::move(parent_environment_service_provider),
            session_listener_request = std::move(session_listener_request),
@@ -114,17 +121,24 @@ Engine::Engine(Delegate& delegate,
                std::move(on_session_metrics_change_callback),
            on_session_size_change_hint_callback =
                std::move(on_session_size_change_hint_callback),
+           accessibility_context_writer =
+               std::move(accessibility_context_writer),
            vsync_handle = vsync_event_.get()](flutter::Shell& shell) mutable {
             return std::make_unique<flutter_runner::PlatformView>(
-                shell,                                           // delegate
-                debug_label,                                     // debug label
-                shell.GetTaskRunners(),                          // task runners
+                shell,                        // delegate
+                debug_label,                  // debug label
+                std::move(view_ref_control),  // view control ref
+                std::move(view_ref),          // view ref
+                shell.GetTaskRunners(),       // task runners
+                std::move(runner_services),
                 std::move(parent_environment_service_provider),  // services
                 std::move(session_listener_request),  // session listener
                 std::move(on_session_listener_error_callback),
                 std::move(on_session_metrics_change_callback),
                 std::move(on_session_size_change_hint_callback),
-                vsync_handle  // vsync handle
+                std::move(accessibility_context_writer),  // accessibility
+                                                          // context writer
+                vsync_handle                              // vsync handle
             );
           });
 

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -28,14 +28,16 @@ class Engine final {
     virtual void OnEngineTerminate(const Engine* holder) = 0;
   };
 
-  Engine(Delegate& delegate,
-         std::string thread_label,
+
+  Engine(Delegate& delegate, std::string thread_label,
          std::shared_ptr<sys::ServiceDirectory> svc,
+         std::shared_ptr<sys::ServiceDirectory> runner_services,
          flutter::Settings settings,
          fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
          fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
          fuchsia::ui::views::ViewToken view_token,
-         UniqueFDIONS fdio_ns,
+         fuchsia::ui::views::ViewRefControl view_ref_control,
+         fuchsia::ui::views::ViewRef view_ref, UniqueFDIONS fdio_ns,
          fidl::InterfaceRequest<fuchsia::io::Directory> directory_request);
   ~Engine();
 

--- a/shell/platform/fuchsia/flutter/fuchsia_accessibility.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_accessibility.cc
@@ -1,0 +1,70 @@
+// Copyright 2019 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "fuchsia_accessibility.h"
+
+#include <src/lib/fxl/logging.h>
+#include <zircon/status.h>
+
+#include "fuchsia/accessibility/semantics/cpp/fidl.h"
+
+namespace flutter_runner {
+namespace {
+class FuchsiaAccessibilityImpl
+    : public FuchsiaAccessibility,
+      public fuchsia::accessibility::semantics::SemanticActionListener {
+ public:
+  FuchsiaAccessibilityImpl(std::shared_ptr<sys::ServiceDirectory> services,
+                           fuchsia::ui::views::ViewRef view_ref)
+      : binding_(this), view_ref_(std::move(view_ref)) {
+    services->Connect(
+        fuchsia::accessibility::semantics::SemanticsManager::Name_,
+        manager_.NewRequest().TakeChannel());
+    manager_.set_error_handler([this](zx_status_t status) {
+      FXL_LOG(ERROR)
+          << "Flutter cannot connect to SemanticsManager with status: "
+          << zx_status_get_string(status) << ".";
+    });
+    fidl::InterfaceHandle<
+        fuchsia::accessibility::semantics::SemanticActionListener>
+        listener_handle;
+    binding_.Bind(listener_handle.NewRequest());
+    manager_->RegisterView(std::move(view_ref_), std::move(listener_handle),
+                           tree_ptr_.NewRequest());
+  }
+
+  ~FuchsiaAccessibilityImpl() override = default;
+
+  void UpdateSemanticNodes(
+      std::vector<fuchsia::accessibility::semantics::Node> nodes) override {}
+  void DeleteSemanticNodes(std::vector<uint32_t> node_ids) override {}
+  void Commit() override {}
+
+ private:
+  // |fuchsia::accessibility::semantics::SemanticActionListener|
+  void OnAccessibilityActionRequested(
+      uint32_t node_id, fuchsia::accessibility::semantics::Action action,
+      fuchsia::accessibility::semantics::SemanticActionListener::
+          OnAccessibilityActionRequestedCallback callback) override {}
+
+  fuchsia::accessibility::semantics::SemanticsManagerPtr manager_;
+  fuchsia::accessibility::semantics::SemanticTreePtr tree_ptr_;
+  fidl::Binding<fuchsia::accessibility::semantics::SemanticActionListener>
+      binding_;
+  fuchsia::ui::views::ViewRef view_ref_;
+
+  FXL_DISALLOW_COPY_AND_ASSIGN(FuchsiaAccessibilityImpl);
+};
+
+}  // namespace
+
+// static
+std::unique_ptr<FuchsiaAccessibility> FuchsiaAccessibility::Create(
+    std::shared_ptr<sys::ServiceDirectory> services,
+    fuchsia::ui::views::ViewRef view_ref) {
+  return std::make_unique<FuchsiaAccessibilityImpl>(std::move(services),
+                                                    std::move(view_ref));
+}
+
+}  // namespace flutter_runner

--- a/shell/platform/fuchsia/flutter/fuchsia_accessibility.h
+++ b/shell/platform/fuchsia/flutter/fuchsia_accessibility.h
@@ -1,0 +1,40 @@
+// Copyright 2019 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TOPAZ_RUNTIME_FLUTTER_RUNNER_FUCHSIA_ACCESSIBILITY_H_
+#define TOPAZ_RUNTIME_FLUTTER_RUNNER_FUCHSIA_ACCESSIBILITY_H_
+
+#include <fuchsia/accessibility/semantics/cpp/fidl.h>
+#include <fuchsia/sys/cpp/fidl.h>
+#include <fuchsia/ui/views/cpp/fidl.h>
+#include <lib/fidl/cpp/binding_set.h>
+#include <lib/sys/cpp/service_directory.h>
+
+#include <memory>
+
+namespace flutter_runner {
+
+// Host platform accessibility API wrapper. Called by |AccessibilityBridge|.
+//
+// This provides an abstraction of the full set of host platform calls that
+// |AccessibilityBridge| needs to call. Implemented as an abstract base class
+// in order to allow passing a fake implementation to |AccessibilityBridge|
+// unit tests.
+class FuchsiaAccessibility {
+ public:
+  static std::unique_ptr<FuchsiaAccessibility> Create(
+      std::shared_ptr<sys::ServiceDirectory> services,
+      fuchsia::ui::views::ViewRef view_ref);
+
+  virtual ~FuchsiaAccessibility() = default;
+
+  virtual void UpdateSemanticNodes(
+      std::vector<fuchsia::accessibility::semantics::Node> nodes) = 0;
+  virtual void DeleteSemanticNodes(std::vector<uint32_t> node_ids) = 0;
+  virtual void Commit() = 0;
+};
+
+}  // namespace flutter_runner
+
+#endif  // TOPAZ_RUNTIME_FLUTTER_RUNNER_FUCHSIA_ACCESSIBILITY_H_

--- a/shell/platform/fuchsia/flutter/fuchsia_accessibility_unittest.cc
+++ b/shell/platform/fuchsia/flutter/fuchsia_accessibility_unittest.cc
@@ -1,0 +1,63 @@
+// Copyright 2019 The Fuchsia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "topaz/shell/platform/fuchsia/flutter/fuchsia_accessibility.h"
+
+#include <gtest/gtest.h>
+#include <lib/async-loop/cpp/loop.h>
+#include <lib/fidl/cpp/binding_set.h>
+#include <lib/fidl/cpp/interface_request.h>
+#include <lib/gtest/real_loop_fixture.h>
+#include <lib/sys/cpp/testing/service_directory_provider.h>
+
+namespace flutter_runner_a11y_test {
+using fuchsia::accessibility::semantics::SemanticsManager;
+using FuchsiaAccessibilityTests = gtest::RealLoopFixture;
+
+class MockSemanticsManager : public SemanticsManager {
+ public:
+  MockSemanticsManager() = default;
+  ~MockSemanticsManager() = default;
+
+  // |fuchsia::accessibility::semantics::SemanticsManager|:
+  void RegisterView(
+      fuchsia::ui::views::ViewRef view_ref,
+      fidl::InterfaceHandle<
+          fuchsia::accessibility::semantics::SemanticActionListener>
+          handle,
+      fidl::InterfaceRequest<fuchsia::accessibility::semantics::SemanticTree>
+          semantic_tree) override {
+    has_view_ref_ = true;
+  }
+
+  fidl::InterfaceRequestHandler<SemanticsManager> GetHandler(
+      async_dispatcher_t* dispatcher) {
+    return bindings_.GetHandler(this, dispatcher);
+  }
+
+  bool RegisterViewCalled() { return has_view_ref_; }
+
+ private:
+  bool has_view_ref_ = false;
+  fidl::BindingSet<SemanticsManager> bindings_;
+};
+
+TEST_F(FuchsiaAccessibilityTests, RegisterViewRef) {
+  MockSemanticsManager semantics_manager;
+  sys::testing::ServiceDirectoryProvider services_provider(dispatcher());
+  services_provider.AddService(semantics_manager.GetHandler(dispatcher()),
+                               SemanticsManager::Name_);
+  zx::eventpair a, b;
+  zx::eventpair::create(/* flags */ 0u, &a, &b);
+  auto view_ref = fuchsia::ui::views::ViewRef({
+      .reference = std::move(a),
+  });
+  auto fuchsia_accessibility = flutter_runner::FuchsiaAccessibility::Create(
+      services_provider.service_directory(), std::move(view_ref));
+
+  RunLoopUntilIdle();
+  EXPECT_TRUE(semantics_manager.RegisterViewCalled());
+}
+
+}  // namespace flutter_runner_a11y_test

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -9,6 +9,8 @@
             "deprecated-ambient-replace-as-executable"
         ],
         "services": [
+            "fuchsia.accessibility.SettingsManager",
+            "fuchsia.accessibility.semantics.SemanticsManager",
             "fuchsia.crash.Analyzer",
             "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -9,6 +9,8 @@
             "deprecated-ambient-replace-as-executable"
         ],
         "services": [
+            "fuchsia.accessibility.SettingsManager",
+            "fuchsia.accessibility.semantics.SemanticsManager",
             "fuchsia.crash.Analyzer",
             "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -10,6 +10,8 @@
         ],
         "services": [
             "fuchsia.device.manager.Administrator",
+            "fuchsia.accessibility.SettingsManager",
+            "fuchsia.accessibility.semantics.SemanticsManager",
             "fuchsia.crash.Analyzer",
             "fuchsia.fonts.Provider",
             "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -9,6 +9,8 @@
             "deprecated-ambient-replace-as-executable"
         ],
         "services": [
+            "fuchsia.accessibility.SettingsManager",
+            "fuchsia.accessibility.semantics.SemanticsManager",
             "fuchsia.crash.Analyzer",
             "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
@@ -7,6 +7,8 @@
             "deprecated-ambient-replace-as-executable"
         ],
         "services": [
+            "fuchsia.accessibility.SettingsManager",
+            "fuchsia.accessibility.semantics.SemanticsManager",
             "fuchsia.sys.Launcher"
         ]
     }

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -8,18 +8,22 @@
 #include <map>
 #include <set>
 
+#include <fuchsia/accessibility/cpp/fidl.h>
 #include <fuchsia/modular/cpp/fidl.h>
 #include <fuchsia/ui/gfx/cpp/fidl.h>
 #include <fuchsia/ui/input/cpp/fidl.h>
 #include <fuchsia/ui/scenic/cpp/fidl.h>
+#include <fuchsia/ui/views/cpp/fidl.h>
 #include <lib/fit/function.h>
+#include <lib/sys/cpp/service_directory.h>
 
+#include "context_writer_bridge.h"
 #include "flutter/fml/macros.h"
 #include "flutter/lib/ui/window/viewport_metrics.h"
 #include "flutter/shell/common/platform_view.h"
+#include "fuchsia_accessibility.h"
 #include "lib/fidl/cpp/binding.h"
 #include "lib/ui/scenic/cpp/id.h"
-
 #include "surface.h"
 
 namespace flutter_runner {
@@ -40,7 +44,10 @@ class PlatformView final : public flutter::PlatformView,
  public:
   PlatformView(PlatformView::Delegate& delegate,
                std::string debug_label,
+               fuchsia::ui::views::ViewRefControl view_ref_control,
+               fuchsia::ui::views::ViewRef view_ref,
                flutter::TaskRunners task_runners,
+               std::shared_ptr<sys::ServiceDirectory> runner_services,
                fidl::InterfaceHandle<fuchsia::sys::ServiceProvider>
                    parent_environment_service_provider,
                fidl::InterfaceRequest<fuchsia::ui::scenic::SessionListener>
@@ -62,6 +69,11 @@ class PlatformView final : public flutter::PlatformView,
 
  private:
   const std::string debug_label_;
+  // TODO(MI4-2490): remove once ViewRefControl is passed to Scenic and kept
+  // alive there
+  const fuchsia::ui::views::ViewRefControl view_ref_control_;
+  const fuchsia::ui::views::ViewRef view_ref_;
+  std::unique_ptr<FuchsiaAccessibility> accessibility_holder_;
 
   fidl::Binding<fuchsia::ui::scenic::SessionListener> session_listener_binding_;
   fit::closure session_listener_error_callback_;


### PR DESCRIPTION
A subsequent CL will introduce the AccessibilityManager,
which will consume the FuchsiaAccessibility object. This
object exists to make Flutter's AccessibiltyManager more
testable.

Eventually, the ViewRef will have to be cloned to the GPU
thread and passed to Scenic as well, but that API is still
WIP from what I understand.

MI4-2490 # Track where view_ref and view_ref_control come from

Change-Id: I9be51c3de73f689a80039f0fa1cac57892cc6810

Porting from topaz.