### PR TITLE
Simplify buildtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ pubspec.lock
 .vscode/
 docs/doxygen/
 xcuserdata
+
+third_party/gn/
+

--- a/DEPS
+++ b/DEPS
@@ -107,8 +107,6 @@ vars = {
   # Build bot tooling for iOS
   'ios_tools_revision': '69b7c1b160e7107a6a98d948363772dc9caea46f',
 
-  'buildtools_revision': 'bac220c15490dcf7b7d8136f75100bbc77e8d217',
-
   # Checkout Android dependencies only on platforms where we build for Android targets.
   'download_android_deps': 'host_os == "mac" or host_os == "linux"',
 
@@ -162,9 +160,6 @@ deps = {
    #
    # As part of integrating with Fuchsia, we should eventually remove all these
    # Chromium-style dependencies.
-
-  'src/buildtools':
-   Var('fuchsia_git') + '/buildtools' + '@' +  Var('buildtools_revision'),
 
   'src/ios_tools':
    Var('chromium_git') + '/chromium/src/ios.git' + '@' + Var('ios_tools_revision'),
@@ -473,6 +468,28 @@ deps = {
      'dep_type': 'cipd',
    },
 
+  'src/buildtools/{host_os}-x64': {
+    'packages': [
+      {
+        'package': 'gn/gn/${{platform}}',
+        'version': 'git_revision:bdb0fd02324b120cacde634a9235405061c8ea06'
+      },
+    ],
+    'condition': 'host_os == "mac" or host_os == "linux"',
+    'dep_type': 'cipd',
+  },
+
+  'src/buildtools/{host_os}-x64/clang': {
+    'packages': [
+      {
+        'package': 'fuchsia/clang/${{platform}}',
+        'version': 'git_revision:de39621f0f03f20633bdfa50bde97a3908bf6e98'
+      }
+    ],
+    'condition': 'host_os == "mac" or host_os == "linux"',
+    'dep_type': 'cipd',
+  },
+
    # Get the SDK from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core at the 'latest' tag
    # Get the toolchain from https://chrome-infra-packages.appspot.com/p/fuchsia/clang at the 'goma' tag
 
@@ -544,14 +561,6 @@ hooks = [
     'action': [
         'python',
         'src/flutter/tools/android_support/download_android_support.py',
-    ],
-  },
-  {
-    'name': 'buildtools',
-    'pattern': '.',
-    'action': [
-      'python',
-      'src/tools/buildtools/update.py',
     ],
   },
   {

--- a/DEPS
+++ b/DEPS
@@ -468,14 +468,13 @@ deps = {
      'dep_type': 'cipd',
    },
 
-  'src/buildtools/{host_os}-x64': {
+  'src/buildtools': {
     'packages': [
       {
         'package': 'gn/gn/${{platform}}',
         'version': 'git_revision:bdb0fd02324b120cacde634a9235405061c8ea06'
       },
     ],
-    'condition': 'host_os == "mac" or host_os == "linux"',
     'dep_type': 'cipd',
   },
 

--- a/DEPS
+++ b/DEPS
@@ -468,7 +468,7 @@ deps = {
      'dep_type': 'cipd',
    },
 
-  'src/buildtools': {
+  'src/flutter/third_party/gn': {
     'packages': [
       {
         'package': 'gn/gn/${{platform}}',

--- a/ci/check_gn_format.py
+++ b/ci/check_gn_format.py
@@ -43,7 +43,7 @@ def main():
     if subprocess.call(gn_command + [ gn_file ]) != 0:
       print "ERROR: '%s' is incorrectly formatted." % os.path.relpath(gn_file, args.root_directory)
       print "Format the same with 'gn format' using the 'gn' binary in //buildtools."
-      print "Or, run ./ci/check_gn_format.py with '--dry-run false'" 
+      print "Or, run ./ci/check_gn_format.py with '--dry-run false'"
       return -1
 
   return 0

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -75,4 +75,4 @@ if [[ ! -z "$TRAILING_SPACES" ]]; then
 fi
 
 # Check GN format consistency
-./ci/check_gn_format.py --dry-run true --root-directory . --gn-binary "../buildtools/$OS/gn"
+./ci/check_gn_format.py --dry-run true --root-directory . --gn-binary "../buildtools/gn"

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -75,4 +75,4 @@ if [[ ! -z "$TRAILING_SPACES" ]]; then
 fi
 
 # Check GN format consistency
-./ci/check_gn_format.py --dry-run true --root-directory . --gn-binary "../buildtools/gn"
+./ci/check_gn_format.py --dry-run true --root-directory . --gn-binary "third_party/gn/gn"

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 028d24b0ed18e117e64d68853b628ca9
+Signature: 4c7d6cd5eae91f55c0c64a635057135a
 

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 4c7d6cd5eae91f55c0c64a635057135a
+Signature: aceb453d2bca05fab3734ed5f7949c51
 

--- a/tools/gn
+++ b/tools/gn
@@ -348,7 +348,7 @@ def main(argv):
   exe = '.exe' if sys.platform.startswith(('cygwin', 'win')) else ''
 
   command = [
-    '%s/buildtools/gn%s' % (SRC_ROOT, exe),
+    '%s/flutter/third_party/gn/gn%s' % (SRC_ROOT, exe),
     'gen',
     '--check',
   ]

--- a/tools/gn
+++ b/tools/gn
@@ -345,8 +345,10 @@ def parse_args(args):
 def main(argv):
   args = parse_args(argv)
 
+  exe = '.exe' if sys.platform.startswith(('cygwin', 'win')) else ''
+
   command = [
-    '%s/buildtools/gn' % (SRC_ROOT),
+    '%s/buildtools/gn%s' % (SRC_ROOT, exe),
     'gen',
     '--check',
   ]

--- a/tools/gn
+++ b/tools/gn
@@ -345,17 +345,8 @@ def parse_args(args):
 def main(argv):
   args = parse_args(argv)
 
-  if sys.platform.startswith(('cygwin', 'win')):
-    subdir = 'win'
-  elif sys.platform == 'darwin':
-    subdir = 'mac-x64'
-  elif sys.platform.startswith('linux'):
-     subdir = 'linux-x64'
-  else:
-    raise Error('Unknown platform: ' + sys.platform)
-
   command = [
-    '%s/buildtools/%s/gn' % (SRC_ROOT, subdir),
+    '%s/buildtools/gn' % (SRC_ROOT),
     'gen',
     '--check',
   ]

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -888,7 +888,6 @@ class _RepositoryDirectory extends _RepositoryEntry implements LicenseSource {
 
   void crawl() {
     for (fs.IoNode entry in io.walk) {
-      print(entry.fullName);
       if (shouldRecurse(entry)) {
         assert(!_childrenByName.containsKey(entry.name));
         if (entry is fs.Directory) {

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -888,6 +888,7 @@ class _RepositoryDirectory extends _RepositoryEntry implements LicenseSource {
 
   void crawl() {
     for (fs.IoNode entry in io.walk) {
+      print(entry.fullName);
       if (shouldRecurse(entry)) {
         assert(!_childrenByName.containsKey(entry.name));
         if (entry is fs.Directory) {
@@ -926,17 +927,18 @@ class _RepositoryDirectory extends _RepositoryEntry implements LicenseSource {
   List<_RepositoryDirectory> get virtualSubdirectories => <_RepositoryDirectory>[];
 
   bool shouldRecurse(fs.IoNode entry) {
-    return entry.name != '.cipd' &&
-           entry.name != '.git' &&
-           entry.name != '.github' &&
-           entry.name != '.gitignore' &&
-           entry.name != '.vscode' &&
-           entry.name != 'test' &&
-           entry.name != 'test.disabled' &&
-           entry.name != 'test_support' &&
-           entry.name != 'tests' &&
-           entry.name != 'javatests' &&
-           entry.name != 'testing';
+    return !entry.fullName.endsWith('third_party/gn') &&
+            entry.name != '.cipd' &&
+            entry.name != '.git' &&
+            entry.name != '.github' &&
+            entry.name != '.gitignore' &&
+            entry.name != '.vscode' &&
+            entry.name != 'test' &&
+            entry.name != 'test.disabled' &&
+            entry.name != 'test_support' &&
+            entry.name != 'tests' &&
+            entry.name != 'javatests' &&
+            entry.name != 'testing';
   }
 
   _RepositoryDirectory createSubdirectory(fs.Directory entry) {


### PR DESCRIPTION
This gets rid of references to the no-longer-maintained buildtools repo, and makes us just pull down clang and GN.

This does not push any versions forward - we can do that as a next step when we're sure this hasn't broken anything.  @chinmaygarde we may want to synchronize this and the way we're pulling down stuff for the Fuchsia builds anyway.  I think we can get rid of the funky version strings and just directly use the GOMA tag, or at least just start using a git_revision based tag.  To move to Clang-9 will require some other changes in our buildroot.

This reduces the size of the `src/buildtools` from ~2gb down to 839mb on my macbook.  Should make CI a little faster.