### PR TITLE
Log dlopen errors only in debug mode

### DIFF
--- a/fml/platform/posix/native_library_posix.cc
+++ b/fml/platform/posix/native_library_posix.cc
@@ -13,8 +13,8 @@ NativeLibrary::NativeLibrary(const char* path) {
   ::dlerror();
   handle_ = ::dlopen(path, RTLD_NOW);
   if (handle_ == nullptr) {
-    FML_LOG(ERROR) << "Could not open library '" << path << "' due to error '"
-                   << ::dlerror() << "'.";
+    FML_DLOG(ERROR) << "Could not open library '" << path << "' due to error '"
+                    << ::dlerror() << "'.";
   }
 }
 


### PR DESCRIPTION
dlopen errors are expected behavior when locating libapp.so on some older
Android devices (see https://github.com/flutter/engine/pull/9762)