### PR TITLE
Split out lifecycle protocol

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -18,7 +18,160 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol FlutterPluginRegistrar;
 @protocol FlutterPluginRegistry;
 
+#pragma mark -
+/***************************************************************************************************
+ * Protocol for listener of events from the UIApplication, typically a FlutterPlugin.
+ */
+@protocol FlutterApplicationLifeCycleDelegate
+@optional
 /**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `NO` if this vetoes application launch.
+ */
+- (BOOL)application:(UIApplication*)application
+    didFinishLaunchingWithOptions:(NSDictionary*)launchOptions;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `NO` if this vetoes application launch.
+ */
+- (BOOL)application:(UIApplication*)application
+    willFinishLaunchingWithOptions:(NSDictionary*)launchOptions;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)applicationDidBecomeActive:(UIApplication*)application;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)applicationWillResignActive:(UIApplication*)application;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)applicationDidEnterBackground:(UIApplication*)application;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)applicationWillEnterForeground:(UIApplication*)application;
+
+/**
+ Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)applicationWillTerminate:(UIApplication*)application;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)application:(UIApplication*)application
+    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
+    API_DEPRECATED(
+        "See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation",
+        ios(8.0, 10.0));
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)application:(UIApplication*)application
+    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application
+    didReceiveRemoteNotification:(NSDictionary*)userInfo
+          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
+
+/**
+ * Calls all plugins registered for `UIApplicationDelegate` callbacks.
+ */
+- (void)application:(UIApplication*)application
+    didReceiveLocalNotification:(UILocalNotification*)notification
+    API_DEPRECATED(
+        "See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation",
+        ios(4.0, 10.0));
+
+/**
+ * Calls all plugins registered for `UNUserNotificationCenterDelegate` callbacks.
+ */
+- (void)userNotificationCenter:(UNUserNotificationCenter*)center
+       willPresentNotification:(UNNotification*)notification
+         withCompletionHandler:
+             (void (^)(UNNotificationPresentationOptions options))completionHandler
+    API_AVAILABLE(ios(10));
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application
+            openURL:(NSURL*)url
+            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application
+              openURL:(NSURL*)url
+    sourceApplication:(NSString*)sourceApplication
+           annotation:(id)annotation;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application
+    performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
+               completionHandler:(void (^)(BOOL succeeded))completionHandler
+    API_AVAILABLE(ios(9.0));
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application
+    handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
+                      completionHandler:(nonnull void (^)(void))completionHandler;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application
+    performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
+
+/**
+ * Called if this has been registered for `UIApplicationDelegate` callbacks.
+ *
+ * @return `YES` if this handles the request.
+ */
+- (BOOL)application:(UIApplication*)application
+    continueUserActivity:(NSUserActivity*)userActivity
+      restorationHandler:(void (^)(NSArray*))restorationHandler;
+@end
+
+#pragma mark -
+/***************************************************************************************************
  * A plugin registration callback.
  *
  * Used for registering plugins with additional instances of
@@ -28,13 +181,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>* registry);
 
-/**
+#pragma mark -
+/***************************************************************************************************
  * Implemented by the iOS part of a Flutter plugin.
  *
  * Defines a set of optional callback methods and a method to set up the plugin
  * and register it to be called by other application components.
  */
-@protocol FlutterPlugin <NSObject>
+@protocol FlutterPlugin <NSObject, FlutterApplicationLifeCycleDelegate>
 @required
 /**
  * Registers this plugin using the context information and callback registration
@@ -75,154 +229,10 @@ typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>*
  * @param result A callback for submitting the result of the call.
  */
 - (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `NO` if this plugin vetoes application launch.
- */
-- (BOOL)application:(UIApplication*)application
-    didFinishLaunchingWithOptions:(NSDictionary*)launchOptions;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `NO` if this plugin vetoes application launch.
- */
-- (BOOL)application:(UIApplication*)application
-    willFinishLaunchingWithOptions:(NSDictionary*)launchOptions;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- */
-- (void)applicationDidBecomeActive:(UIApplication*)application;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- */
-- (void)applicationWillResignActive:(UIApplication*)application;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- */
-- (void)applicationDidEnterBackground:(UIApplication*)application;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- */
-- (void)applicationWillEnterForeground:(UIApplication*)application;
-
-/**
- Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- */
-- (void)applicationWillTerminate:(UIApplication*)application;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- */
-- (void)application:(UIApplication*)application
-    didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings
-    API_DEPRECATED(
-        "See -[UIApplicationDelegate application:didRegisterUserNotificationSettings:] deprecation",
-        ios(8.0, 10.0));
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- */
-- (void)application:(UIApplication*)application
-    didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-    didReceiveRemoteNotification:(NSDictionary*)userInfo
-          fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
-
-/**
- * Calls all plugins registered for `UIApplicationDelegate` callbacks.
- */
-- (void)application:(UIApplication*)application
-    didReceiveLocalNotification:(UILocalNotification*)notification
-    API_DEPRECATED(
-        "See -[UIApplicationDelegate application:didReceiveLocalNotification:] deprecation",
-        ios(4.0, 10.0));
-
-/**
- * Calls all plugins registered for `UNUserNotificationCenterDelegate` callbacks.
- */
-- (void)userNotificationCenter:(UNUserNotificationCenter*)center
-       willPresentNotification:(UNNotification*)notification
-         withCompletionHandler:
-             (void (^)(UNNotificationPresentationOptions options))completionHandler
-    API_AVAILABLE(ios(10));
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-            openURL:(NSURL*)url
-            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-              openURL:(NSURL*)url
-    sourceApplication:(NSString*)sourceApplication
-           annotation:(id)annotation;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-    performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
-               completionHandler:(void (^)(BOOL succeeded))completionHandler
-    API_AVAILABLE(ios(9.0));
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-    handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
-                      completionHandler:(nonnull void (^)(void))completionHandler;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-    performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
-
-/**
- * Called if this plugin has been registered for `UIApplicationDelegate` callbacks.
- *
- * @return `YES` if this plugin handles the request.
- */
-- (BOOL)application:(UIApplication*)application
-    continueUserActivity:(NSUserActivity*)userActivity
-      restorationHandler:(void (^)(NSArray*))restorationHandler;
 @end
 
-/**
+#pragma mark -
+/***************************************************************************************************
  *Registration context for a single `FlutterPlugin`, providing a one stop shop
  *for the plugin to access contextual information and register callbacks for
  *various application events.
@@ -312,7 +322,8 @@ typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>*
 - (NSString*)lookupKeyForAsset:(NSString*)asset fromPackage:(NSString*)package;
 @end
 
-/**
+#pragma mark -
+/***************************************************************************************************
  * A registry of Flutter iOS plugins.
  *
  * Plugins are identified by unique string keys, typically the name of the
@@ -357,12 +368,13 @@ typedef void (*FlutterPluginRegistrantCallback)(NSObject<FlutterPluginRegistry>*
 - (NSObject*)valuePublishedByPlugin:(NSString*)pluginKey;
 @end
 
-/**
+#pragma mark -
+/***************************************************************************************************
  * Implement this in the `UIAppDelegate` of your app to enable Flutter plugins to register
  * themselves to the application life cycle events.
  */
 @protocol FlutterAppLifeCycleProvider
-- (void)addApplicationLifeCycleDelegate:(NSObject<FlutterPlugin>*)delegate;
+- (void)addApplicationLifeCycleDelegate:(NSObject<FlutterApplicationLifeCycleDelegate>*)delegate;
 @end
 
 NS_ASSUME_NONNULL_END;

--- a/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPluginAppLifeCycleDelegate.h
@@ -21,7 +21,7 @@ FLUTTER_EXPORT
  *
  * `delegate` will only referenced weakly.
  */
-- (void)addDelegate:(NSObject<FlutterPlugin>*)delegate;
+- (void)addDelegate:(NSObject<FlutterApplicationLifeCycleDelegate>*)delegate;
 
 /**
  * Calls all plugins registered for `UIApplicationDelegate` callbacks.

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -50,7 +50,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (BOOL)hasPluginThatRespondsToSelector:(SEL)selector {
-  for (id<FlutterPlugin> plugin in [_pluginDelegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in [_pluginDelegates allObjects]) {
     if (!plugin) {
       continue;
     }
@@ -61,7 +61,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
   return NO;
 }
 
-- (void)addDelegate:(NSObject<FlutterPlugin>*)delegate {
+- (void)addDelegate:(NSObject<FlutterApplicationLifeCycleDelegate>*)delegate {
   [_pluginDelegates addPointer:(__bridge void*)delegate];
   if (isPowerOfTwo([_pluginDelegates count])) {
     [_pluginDelegates compact];
@@ -70,7 +70,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-  for (id<FlutterPlugin> plugin in [_pluginDelegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in [_pluginDelegates allObjects]) {
     if (!plugin) {
       continue;
     }
@@ -86,7 +86,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     willFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   flutter::DartCallbackCache::LoadCacheFromDisk();
-  for (id<FlutterPlugin> plugin in [_pluginDelegates allObjects]) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in [_pluginDelegates allObjects]) {
     if (!plugin) {
       continue;
     }
@@ -127,7 +127,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
                          "To reconnect, launch your application again via 'flutter run'";
                 }];
 #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -141,7 +141,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   [application endBackgroundTask:_debugBackgroundTask];
 #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -152,7 +152,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (void)applicationWillResignActive:(UIApplication*)application {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -163,7 +163,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -174,7 +174,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (void)applicationWillTerminate:(UIApplication*)application {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -188,7 +188,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -201,7 +201,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -214,7 +214,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -232,7 +232,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didReceiveLocalNotification:(UILocalNotification*)notification {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -248,7 +248,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
          withCompletionHandler:
              (void (^)(UNNotificationPresentationOptions options))completionHandler {
   if (@available(iOS 10.0, *)) {
-    for (id<FlutterPlugin> plugin in _pluginDelegates) {
+    for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
       if (!plugin) {
         continue;
       }
@@ -264,7 +264,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -278,7 +278,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -295,7 +295,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
               openURL:(NSURL*)url
     sourceApplication:(NSString*)sourceApplication
            annotation:(id)annotation {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -314,7 +314,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (void)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler NS_AVAILABLE_IOS(9_0) {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -331,7 +331,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
                       completionHandler:(nonnull void (^)())completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -348,7 +348,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (BOOL)application:(UIApplication*)application
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }
@@ -364,7 +364,7 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
       restorationHandler:(void (^)(NSArray*))restorationHandler {
-  for (id<FlutterPlugin> plugin in _pluginDelegates) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
     if (!plugin) {
       continue;
     }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -19,20 +19,20 @@ static const SEL selectorsHandledByPlugins[] = {
   UIBackgroundTaskIdentifier _debugBackgroundTask;
 
   // Weak references to registered plugins.
-  NSPointerArray* _pluginDelegates;
+  NSPointerArray* _delegates;
 }
 
 - (instancetype)init {
   if (self = [super init]) {
     std::string cachePath = fml::paths::JoinPaths({getenv("HOME"), kCallbackCacheSubDir});
     [FlutterCallbackCache setCachePath:[NSString stringWithUTF8String:cachePath.c_str()]];
-    _pluginDelegates = [[NSPointerArray weakObjectsPointerArray] retain];
+    _delegates = [[NSPointerArray weakObjectsPointerArray] retain];
   }
   return self;
 }
 
 - (void)dealloc {
-  [_pluginDelegates release];
+  [_delegates release];
   [super dealloc];
 }
 
@@ -50,11 +50,11 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (BOOL)hasPluginThatRespondsToSelector:(SEL)selector {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in [_pluginDelegates allObjects]) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:selector]) {
+    if ([delegate respondsToSelector:selector]) {
       return YES;
     }
   }
@@ -62,20 +62,20 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (void)addDelegate:(NSObject<FlutterApplicationLifeCycleDelegate>*)delegate {
-  [_pluginDelegates addPointer:(__bridge void*)delegate];
-  if (isPowerOfTwo([_pluginDelegates count])) {
-    [_pluginDelegates compact];
+  [_delegates addPointer:(__bridge void*)delegate];
+  if (isPowerOfTwo([_delegates count])) {
+    [_delegates compact];
   }
 }
 
 - (BOOL)application:(UIApplication*)application
     didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in [_pluginDelegates allObjects]) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if (![plugin application:application didFinishLaunchingWithOptions:launchOptions]) {
+    if ([delegate respondsToSelector:_cmd]) {
+      if (![delegate application:application didFinishLaunchingWithOptions:launchOptions]) {
         return NO;
       }
     }
@@ -86,12 +86,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     willFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   flutter::DartCallbackCache::LoadCacheFromDisk();
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in [_pluginDelegates allObjects]) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in [_delegates allObjects]) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if (![plugin application:application willFinishLaunchingWithOptions:launchOptions]) {
+    if ([delegate respondsToSelector:_cmd]) {
+      if (![delegate application:application willFinishLaunchingWithOptions:launchOptions]) {
         return NO;
       }
     }
@@ -127,12 +127,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
                          "To reconnect, launch your application again via 'flutter run'";
                 }];
 #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationDidEnterBackground:application];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate applicationDidEnterBackground:application];
     }
   }
 }
@@ -141,45 +141,45 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   [application endBackgroundTask:_debugBackgroundTask];
 #endif  // FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationWillEnterForeground:application];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate applicationWillEnterForeground:application];
     }
   }
 }
 
 - (void)applicationWillResignActive:(UIApplication*)application {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationWillResignActive:application];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate applicationWillResignActive:application];
     }
   }
 }
 
 - (void)applicationDidBecomeActive:(UIApplication*)application {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationDidBecomeActive:application];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate applicationDidBecomeActive:application];
     }
   }
 }
 
 - (void)applicationWillTerminate:(UIApplication*)application {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin applicationWillTerminate:application];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate applicationWillTerminate:application];
     }
   }
 }
@@ -188,12 +188,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings*)notificationSettings {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin application:application didRegisterUserNotificationSettings:notificationSettings];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate application:application didRegisterUserNotificationSettings:notificationSettings];
     }
   }
 }
@@ -201,12 +201,13 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (void)application:(UIApplication*)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData*)deviceToken {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate application:application
+          didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
     }
   }
 }
@@ -214,12 +215,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (void)application:(UIApplication*)application
     didReceiveRemoteNotification:(NSDictionary*)userInfo
           fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application
               didReceiveRemoteNotification:userInfo
                     fetchCompletionHandler:completionHandler]) {
         return;
@@ -232,12 +233,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (void)application:(UIApplication*)application
     didReceiveLocalNotification:(UILocalNotification*)notification {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      [plugin application:application didReceiveLocalNotification:notification];
+    if ([delegate respondsToSelector:_cmd]) {
+      [delegate application:application didReceiveLocalNotification:notification];
     }
   }
 }
@@ -248,14 +249,14 @@ static BOOL isPowerOfTwo(NSUInteger x) {
          withCompletionHandler:
              (void (^)(UNNotificationPresentationOptions options))completionHandler {
   if (@available(iOS 10.0, *)) {
-    for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-      if (!plugin) {
+    for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+      if (!delegate) {
         continue;
       }
-      if ([plugin respondsToSelector:_cmd]) {
-        [plugin userNotificationCenter:center
-               willPresentNotification:notification
-                 withCompletionHandler:completionHandler];
+      if ([delegate respondsToSelector:_cmd]) {
+        [delegate userNotificationCenter:center
+                 willPresentNotification:notification
+                   withCompletionHandler:completionHandler];
       }
     }
   }
@@ -264,12 +265,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
             openURL:(NSURL*)url
             options:(NSDictionary<UIApplicationOpenURLOptionsKey, id>*)options {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application openURL:url options:options]) {
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application openURL:url options:options]) {
         return YES;
       }
     }
@@ -278,12 +279,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 }
 
 - (BOOL)application:(UIApplication*)application handleOpenURL:(NSURL*)url {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application handleOpenURL:url]) {
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application handleOpenURL:url]) {
         return YES;
       }
     }
@@ -295,12 +296,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
               openURL:(NSURL*)url
     sourceApplication:(NSString*)sourceApplication
            annotation:(id)annotation {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application
                         openURL:url
               sourceApplication:sourceApplication
                      annotation:annotation]) {
@@ -314,12 +315,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (void)application:(UIApplication*)application
     performActionForShortcutItem:(UIApplicationShortcutItem*)shortcutItem
                completionHandler:(void (^)(BOOL succeeded))completionHandler NS_AVAILABLE_IOS(9_0) {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application
               performActionForShortcutItem:shortcutItem
                          completionHandler:completionHandler]) {
         return;
@@ -331,12 +332,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     handleEventsForBackgroundURLSession:(nonnull NSString*)identifier
                       completionHandler:(nonnull void (^)())completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application
               handleEventsForBackgroundURLSession:identifier
                                 completionHandler:completionHandler]) {
         return YES;
@@ -348,12 +349,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 
 - (BOOL)application:(UIApplication*)application
     performFetchWithCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application performFetchWithCompletionHandler:completionHandler]) {
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application performFetchWithCompletionHandler:completionHandler]) {
         return YES;
       }
     }
@@ -364,12 +365,12 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (BOOL)application:(UIApplication*)application
     continueUserActivity:(NSUserActivity*)userActivity
       restorationHandler:(void (^)(NSArray*))restorationHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* plugin in _pluginDelegates) {
-    if (!plugin) {
+  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+    if (!delegate) {
       continue;
     }
-    if ([plugin respondsToSelector:_cmd]) {
-      if ([plugin application:application
+    if ([delegate respondsToSelector:_cmd]) {
+      if ([delegate application:application
               continueUserActivity:userActivity
                 restorationHandler:restorationHandler]) {
         return YES;


### PR DESCRIPTION
This puts iOS slightly more inline with Android without breaking current functionality.  It is more "clean" too since this new protocol is a nice logical grouping and it makes FlutterPlugin more grokable.

Related issue: https://github.com/flutter/flutter/issues/33071