### PR TITLE
Don't try to use unset assets_dir setting

### DIFF
--- a/shell/common/run_configuration.cc
+++ b/shell/common/run_configuration.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/assets/directory_asset_bundle.h"
 #include "flutter/fml/file.h"
+#include "flutter/fml/unique_fd.h"
 #include "flutter/runtime/dart_vm.h"
 
 namespace flutter {
@@ -17,8 +18,10 @@ RunConfiguration RunConfiguration::InferFromSettings(
     fml::RefPtr<fml::TaskRunner> io_worker) {
   auto asset_manager = std::make_shared<AssetManager>();
 
-  asset_manager->PushBack(std::make_unique<DirectoryAssetBundle>(
-      fml::Duplicate(settings.assets_dir)));
+  if (fml::UniqueFD::traits_type::IsValid(settings.assets_dir)) {
+    asset_manager->PushBack(std::make_unique<DirectoryAssetBundle>(
+        fml::Duplicate(settings.assets_dir)));
+  }
 
   asset_manager->PushBack(
       std::make_unique<DirectoryAssetBundle>(fml::OpenDirectory(

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -631,13 +631,6 @@ FlutterEngineResult FlutterEngineRun(size_t version,
     }
   }
 
-  run_configuration.AddAssetResolver(
-      std::make_unique<flutter::DirectoryAssetBundle>(
-          fml::Duplicate(settings.assets_dir)));
-
-  run_configuration.AddAssetResolver(
-      std::make_unique<flutter::DirectoryAssetBundle>(fml::OpenDirectory(
-          settings.assets_path.c_str(), false, fml::FilePermission::kRead)));
   if (!run_configuration.IsValid()) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments);
   }


### PR DESCRIPTION
Debug builds log invalid file errors on launch of anything using the
embedding API due to an unconditional use of assets_dir, even though
only one of assets_dir or assets_path needs to be set (and the embedding
API currently uses the latter). This checks that the FD has been set
before trying to use it to create an asset resolver.

Also eliminates a duplicate code path in embedder.cc, where it was
calling RunConfiguration::InferFromSettings, then running exactly the
same asset manager creation code again locally.