### PR TITLE
Updates to the engine test runner script

### DIFF
--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -5,4 +5,4 @@ set -o pipefail -e;
 BUILD_VARIANT="${1:-host_debug_unopt}"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-python "${CURRENT_DIR}/run_tests.py" --variant "${BUILD_VARIANT}"
+python "${CURRENT_DIR}/run_tests.py" --variant="${BUILD_VARIANT}" --type=engine,dart


### PR DESCRIPTION
* Use separate filters for engine executables and Dart test scripts
* Do not run the benchmarks on Cirrus