### PR TITLE
[platform view] do not make clipping view and interceptor view clipToBounds

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -253,7 +253,6 @@ void FlutterPlatformViewsController::ApplyMutators(const MutatorsStack& mutators
                                                    UIView* embedded_view) {
   FML_DCHECK(CATransform3DEqualToTransform(embedded_view.layer.transform, CATransform3DIdentity));
   UIView* head = embedded_view;
-  //head.clipsToBounds = YES;
   ResetAnchor(head.layer);
 
   std::vector<std::shared_ptr<Mutator>>::const_reverse_iterator iter = mutators_stack.Bottom();
@@ -273,7 +272,6 @@ void FlutterPlatformViewsController::ApplyMutators(const MutatorsStack& mutators
                      rect:(*iter)->GetRect()
                     rrect:(*iter)->GetRRect()
                      path:(*iter)->GetPath()];
-        //head.clipsToBounds = YES;
         ResetAnchor(clipView.layer);
         head = clipView;
         break;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -253,7 +253,7 @@ void FlutterPlatformViewsController::ApplyMutators(const MutatorsStack& mutators
                                                    UIView* embedded_view) {
   FML_DCHECK(CATransform3DEqualToTransform(embedded_view.layer.transform, CATransform3DIdentity));
   UIView* head = embedded_view;
-  head.clipsToBounds = YES;
+  //head.clipsToBounds = YES;
   ResetAnchor(head.layer);
 
   std::vector<std::shared_ptr<Mutator>>::const_reverse_iterator iter = mutators_stack.Bottom();
@@ -273,7 +273,7 @@ void FlutterPlatformViewsController::ApplyMutators(const MutatorsStack& mutators
                      rect:(*iter)->GetRect()
                     rrect:(*iter)->GetRRect()
                      path:(*iter)->GetPath()];
-        head.clipsToBounds = YES;
+        //head.clipsToBounds = YES;
         ResetAnchor(clipView.layer);
         head = clipView;
         break;


### PR DESCRIPTION
View is not showing when clipToBounds is set as true after clipping. 

Fixes https://github.com/flutter/flutter/issues/35840

The integration test for platform view mutations is currently blocked because we haven't implemented screenshot for iOS platform views. (https://github.com/flutter/flutter/issues/23435)
I'm going to add the sample code to reproduce this issue into the integration test. When the screenshot is implemented, we will complete the integration tests.