### PR TITLE
Add libglfw3-dev to linux build deps script

### DIFF
--- a/build/install-build-deps-linux-desktop.sh
+++ b/build/install-build-deps-linux-desktop.sh
@@ -8,4 +8,4 @@
 
 set -e
 
-sudo apt-get -y install libgtk-3-dev libx11-dev
+sudo apt-get -y install libgtk-3-dev libx11-dev libglfw3-dev


### PR DESCRIPTION
This ensures that the OpenGL headers and GLFW are installed.