### PR TITLE
Add support for Android's visible password input type

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -371,7 +371,8 @@ public class TextInputChannel {
     PHONE("TextInputType.phone"),
     MULTILINE("TextInputType.multiline"),
     EMAIL_ADDRESS("TextInputType.emailAddress"),
-    URL("TextInputType.url");
+    URL("TextInputType.url"),
+    VISIBLE_PASSWORD("TextInputType.visiblePassword");
 
     static TextInputType fromValue(@NonNull String encodedName) throws NoSuchFieldException {
       for (TextInputType textInputType : TextInputType.values()) {

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -155,6 +155,8 @@ public class TextInputPlugin {
             textType |= InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS;
         } else if (type.type == TextInputChannel.TextInputType.URL) {
             textType |= InputType.TYPE_TEXT_VARIATION_URI;
+        } else if (type.type == TextInputChannel.TextInputType.VISIBLE_PASSWORD) {
+            textType |= InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD;
         }
 
         if (obscureText) {


### PR DESCRIPTION
Just add support for the [VisibleText](https://developer.android.com/reference/android/text/InputType.html#TYPE_TEXT_VARIATION_PASSWORD) input type for https://github.com/flutter/flutter/issues/31738.

