### PR TITLE
Declare a copy of the enable_bitcode flag within the Flutter build scripts for use in Fuchsia builds

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -14,12 +14,21 @@ if (target_cpu == "arm" || target_cpu == "arm64") {
   import("//build/config/arm.gni")
 }
 
+if (is_ios || is_mac) {
+  import("//build/toolchain/clang.gni")
+}
+
 declare_args() {
   # The runtime mode ("debug", "profile", or "release")
   flutter_runtime_mode = "debug"
 
   # Whether to use the Skia text shaper module
   flutter_enable_skshaper = false
+
+  # A copy of the enable_bitcode flag from build/toolchain/clang.gni.
+  # This needs to be mirrored here because build/toolchain/clang.gni does
+  # not exist in the Fuchsia source tree.
+  flutter_enable_bitcode = false
 }
 
 # feature_defines_list ---------------------------------------------------------
@@ -42,4 +51,8 @@ if (flutter_runtime_mode == "debug") {
 
 if (is_fuchsia && using_fuchsia_sdk) {
   feature_defines_list += [ "FUCHSIA_SDK=1" ]
+}
+
+if (is_ios || is_mac) {
+  flutter_enable_bitcode = enable_bitcode
 }

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -5,7 +5,6 @@
 assert(is_ios)
 
 import("//build/config/ios/ios_sdk.gni")
-import("//build/toolchain/clang.gni")
 import("$flutter_root/common/config.gni")
 import("$flutter_root/shell/gpu/gpu.gni")
 import("$flutter_root/shell/platform/darwin/common/framework_shared.gni")
@@ -190,7 +189,7 @@ action("copy_framework_info_plist") {
   args = [
     rebase_path(sources[0]),
     rebase_path(outputs[0]),
-    "--bitcode=$enable_bitcode",
+    "--bitcode=$flutter_enable_bitcode",
   ]
 }
 

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//build/toolchain/clang.gni")
 import("$flutter_root/common/config.gni")
 import("$flutter_root/shell/gpu/gpu.gni")
 import("$flutter_root/shell/platform/embedder/embedder.gni")
@@ -166,7 +165,7 @@ if (is_mac && !embedder_for_target) {
     args = [
       rebase_path(sources[0]),
       rebase_path(outputs[0]),
-      "--bitcode=$enable_bitcode",
+      "--bitcode=$flutter_enable_bitcode",
     ]
   }
 


### PR DESCRIPTION
enable_bitcode is defined in build/toolchain/clang.gni, which exists in the
Flutter buildroot but not in the Fuchsia source tree.