### PR TITLE
Added a DartExecutor API for querying # of pending channel callbacks

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -198,10 +198,22 @@ public class DartExecutor implements BinaryMessenger {
   }
 
   /**
-   * Returns the number of pending platform channel callback replies.
+   * Returns the number of pending channel callback replies.
+   *
+   * <p>When sending messages to the Flutter application using {@link BinaryMessenger#send(String,
+   * ByteBuffer, io.flutter.plugin.common.BinaryMessenger.BinaryReply)}, devlopers can optional
+   * specify a reply callback if they expect a reply from the Flutter application.
+   *
+   * <p>This method tracks all the pending callbacks that are waiting for response, and is supposed
+   * to be called from the main thread (as other methods). Calling from a different thread could
+   * possibly capture an indeterministic internal state, and is strongly discouraged.
+   *
+   * <p>Currently, it's mainly useful for a testing framework like Espresso to determine whether all
+   * the async channel callbacks are properly handled and the app is idle.
    */
-  public int getNumOfPendingChannelCallbacks() {
-    return messenger.getNumOfPendingChannelCallbacks();
+  @UiThread
+  public int getPendingChannelResponseCount() {
+    return messenger.getPendingChannelResponseCount();
   }
 
   //------ END BinaryMessenger -----

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -196,6 +196,14 @@ public class DartExecutor implements BinaryMessenger {
   public void setMessageHandler(@NonNull String channel, @Nullable BinaryMessenger.BinaryMessageHandler handler) {
     messenger.setMessageHandler(channel, handler);
   }
+
+  /**
+   * Returns the number of pending platform channel callback replies.
+   */
+  public int getNumOfPendingChannelCallbacks() {
+    return messenger.getNumOfPendingChannelCallbacks();
+  }
+
   //------ END BinaryMessenger -----
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -201,15 +201,15 @@ public class DartExecutor implements BinaryMessenger {
    * Returns the number of pending channel callback replies.
    *
    * <p>When sending messages to the Flutter application using {@link BinaryMessenger#send(String,
-   * ByteBuffer, io.flutter.plugin.common.BinaryMessenger.BinaryReply)}, devlopers can optional
+   * ByteBuffer, io.flutter.plugin.common.BinaryMessenger.BinaryReply)}, developers can optionally
    * specify a reply callback if they expect a reply from the Flutter application.
    *
    * <p>This method tracks all the pending callbacks that are waiting for response, and is supposed
    * to be called from the main thread (as other methods). Calling from a different thread could
-   * possibly capture an indeterministic internal state, and is strongly discouraged.
+   * possibly capture an indeterministic internal state, so don't do it.
    *
    * <p>Currently, it's mainly useful for a testing framework like Espresso to determine whether all
-   * the async channel callbacks are properly handled and the app is idle.
+   * the async channel callbacks are handled and the app is idle.
    */
   @UiThread
   public int getPendingChannelResponseCount() {

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
@@ -120,8 +120,17 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
 
   /**
    * Returns the number of pending channel callback replies.
+   *
+   * <p>When sending messages to the Flutter application using {@link BinaryMessenger#send(String,
+   * ByteBuffer, io.flutter.plugin.common.BinaryMessenger.BinaryReply)}, devlopers can optional
+   * specify a reply callback if they expect a reply from the Flutter application.
+   *
+   * <p>This method tracks all the pending callbacks that are waiting for response, and is supposed
+   * to be called from the main thread (as other methods). Calling from a different thread could
+   * possibly capture an indeterministic internal state, and is strongly discouraged.
    */
-  public int getNumOfPendingChannelCallbacks() {
+  @UiThread
+  public int getPendingChannelResponseCount() {
     return pendingReplies.size();
   }
 

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
@@ -118,6 +118,13 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
     }
   }
 
+  /**
+   * Returns the number of pending channel callback replies.
+   */
+  public int getNumOfPendingChannelCallbacks() {
+    return pendingReplies.size();
+  }
+
   private static class Reply implements BinaryMessenger.BinaryReply {
     @NonNull
     private final FlutterJNI flutterJNI;

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
@@ -122,12 +122,12 @@ class DartMessenger implements BinaryMessenger, PlatformMessageHandler {
    * Returns the number of pending channel callback replies.
    *
    * <p>When sending messages to the Flutter application using {@link BinaryMessenger#send(String,
-   * ByteBuffer, io.flutter.plugin.common.BinaryMessenger.BinaryReply)}, devlopers can optional
+   * ByteBuffer, io.flutter.plugin.common.BinaryMessenger.BinaryReply)}, developers can optionally
    * specify a reply callback if they expect a reply from the Flutter application.
    *
    * <p>This method tracks all the pending callbacks that are waiting for response, and is supposed
    * to be called from the main thread (as other methods). Calling from a different thread could
-   * possibly capture an indeterministic internal state, and is strongly discouraged.
+   * possibly capture an indeterministic internal state, so don't do it.
    */
   @UiThread
   public int getPendingChannelResponseCount() {


### PR DESCRIPTION
This API will be used for monitoring the # of pending callbacks that shall be invoked by the platform in Espresso.

Relevant PR for monitoring the Dart land: https://github.com/flutter/flutter/pull/36599.