### PR TITLE
Disable DartLifecycleTest::ShuttingDownTheVMShutsDownAllIsolates in runtime_unittests.

### DIFF
--- a/runtime/dart_lifecycle_unittests.cc
+++ b/runtime/dart_lifecycle_unittests.cc
@@ -105,7 +105,9 @@ static std::shared_ptr<DartIsolate> CreateAndRunRootIsolate(
   return isolate;
 }
 
-TEST_F(DartLifecycleTest, ShuttingDownTheVMShutsDownAllIsolates) {
+// TODO(chinmaygarde): This unit-test is flaky and indicates thread un-safety
+// during shutdown. https://github.com/flutter/flutter/issues/36782
+TEST_F(DartLifecycleTest, DISABLED_ShuttingDownTheVMShutsDownAllIsolates) {
   auto settings = CreateSettingsForFixture();
   settings.leak_vm = false;
   // Make sure the service protocol launches


### PR DESCRIPTION
Filed https://github.com/flutter/flutter/issues/36782 to track.