### PR TITLE
Change ParagraphBuilder to replace the parent style's font families with the child style's font families

### DIFF
--- a/lib/ui/text/paragraph_builder.cc
+++ b/lib/ui/text/paragraph_builder.cc
@@ -438,8 +438,10 @@ void ParagraphBuilder::pushStyle(tonic::Int32List& encoded,
   }
 
   if (mask & tsFontFamilyMask) {
-    style.font_families.insert(style.font_families.end(), fontFamilies.begin(),
-                               fontFamilies.end());
+    // The child style's font families override the parent's font families.
+    // If the child's fonts are not available, then the font collection will
+    // use the system fallback fonts (not the parent's fonts).
+    style.font_families = fontFamilies;
   }
 
   if (mask & tsFontFeaturesMask) {


### PR DESCRIPTION
Previously ParagraphBuilder was concatenating the child's fonts to the
parent's font list, causing the parent's fonts to take precedence.

Fixes https://github.com/flutter/flutter/issues/35992