### PR TITLE
Removed unnecessary call to find the App.framework.

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
@@ -18,10 +18,10 @@
 }
 
 - (void)tearDown {
-  [super tearDown];
   if (self.flutterViewController) {
     [self.flutterViewController removeFromParentViewController];
   }
+  [super tearDown];
 }
 
 - (void)testFirstFrameCallback {

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewControllerTest.m
@@ -6,15 +6,6 @@
 #import <XCTest/XCTest.h>
 #import "AppDelegate.h"
 
-static NSBundle* FindTestBundle() {
-  for (NSBundle* bundle in [NSBundle allBundles]) {
-    if ([bundle.bundlePath containsString:@".xctext"]) {
-      return bundle;
-    }
-  }
-  return nil;
-}
-
 @interface FlutterViewControllerTest : XCTestCase
 @property(nonatomic, strong) FlutterViewController* flutterViewController;
 @end
@@ -34,9 +25,7 @@ static NSBundle* FindTestBundle() {
 }
 
 - (void)testFirstFrameCallback {
-  NSBundle* bundle = FindTestBundle();
-  FlutterDartProject* project = [[FlutterDartProject alloc] initWithPrecompiledDartBundle:bundle];
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:project];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   [engine runWithEntrypoint:nil];
   self.flutterViewController = [[FlutterViewController alloc] initWithEngine:engine
                                                                      nibName:nil


### PR DESCRIPTION
This is necessary for UITests, but regular tests are built into the same app bundle so it isn't necessary here (not to mention the typo in it).