### PR TITLE
Deprecate FlutterView#enableTransparentBackground

### DIFF
--- a/shell/platform/android/io/flutter/view/FlutterView.java
+++ b/shell/platform/android/io/flutter/view/FlutterView.java
@@ -320,8 +320,12 @@ public class FlutterView extends SurfaceView implements BinaryMessenger, Texture
      *
      * Sets it on top of its window. The background color still needs to be
      * controlled from within the Flutter UI itself.
+     *
+     * @deprecated This breaks accessibility highlighting. See https://github.com/flutter/flutter/issues/37025.
      */
+    @Deprecated
     public void enableTransparentBackground() {
+        Log.w(TAG, "Warning: FlutterView is set on top of the window. Accessibility highlights will not be visible in the Flutter UI. https://github.com/flutter/flutter/issues/37025");
         setZOrderOnTop(true);
         getHolder().setFormat(PixelFormat.TRANSPARENT);
     }


### PR DESCRIPTION
The API breaks accessibility highlighting because of
SurfaceView#setZOrderOnTop. Deprecate it since the underlying issue is
an Android SDK one that can't be worked around from within a
SurfaceView.

flutter/flutter#37025