### PR TITLE
Remove Dead Scenic Clipping Code Path.

### DIFF
--- a/ci/format.sh
+++ b/ci/format.sh
@@ -26,7 +26,7 @@ case "$(uname -s)" in
 esac
 
 # Tools
-CLANG_FORMAT="../../buildtools/$OS/clang/bin/clang-format"
+CLANG_FORMAT="../buildtools/$OS/clang/bin/clang-format"
 $CLANG_FORMAT --version
 
 # Compute the diffs.

--- a/ci/format.sh
+++ b/ci/format.sh
@@ -26,7 +26,7 @@ case "$(uname -s)" in
 esac
 
 # Tools
-CLANG_FORMAT="../buildtools/$OS/clang/bin/clang-format"
+CLANG_FORMAT="../../buildtools/$OS/clang/bin/clang-format"
 $CLANG_FORMAT --version
 
 # Compute the diffs.

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -40,16 +40,8 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 void ClipPathLayer::UpdateScene(SceneUpdateContext& context) {
   FML_DCHECK(needs_system_composite());
 
-  // TODO(SCN-140): Must be able to specify paths as shapes to nodes.
-  //               Treating the shape as a rectangle for now.
-  auto bounds = clip_path_.getBounds();
-  scenic::Rectangle shape(context.session(),  // session
-                          bounds.width(),     //  width
-                          bounds.height()     //  height
-  );
-
   // TODO(liyuqian): respect clip_behavior_
-  SceneUpdateContext::Clip clip(context, shape, bounds);
+  SceneUpdateContext::Clip clip(context, clip_path_.getBounds());
   UpdateSceneChildren(context);
 }
 

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -33,13 +33,8 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 void ClipRectLayer::UpdateScene(SceneUpdateContext& context) {
   FML_DCHECK(needs_system_composite());
 
-  scenic::Rectangle shape(context.session(),   // session
-                          clip_rect_.width(),  //  width
-                          clip_rect_.height()  //  height
-  );
-
   // TODO(liyuqian): respect clip_behavior_
-  SceneUpdateContext::Clip clip(context, shape, clip_rect_);
+  SceneUpdateContext::Clip clip(context, clip_rect_);
   UpdateSceneChildren(context);
 }
 

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -34,20 +34,8 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 void ClipRRectLayer::UpdateScene(SceneUpdateContext& context) {
   FML_DCHECK(needs_system_composite());
 
-  // TODO(SCN-137): Need to be able to express the radii as vectors.
-  scenic::RoundedRectangle shape(
-      context.session(),                                   // session
-      clip_rrect_.width(),                                 //  width
-      clip_rrect_.height(),                                //  height
-      clip_rrect_.radii(SkRRect::kUpperLeft_Corner).x(),   //  top_left_radius
-      clip_rrect_.radii(SkRRect::kUpperRight_Corner).x(),  //  top_right_radius
-      clip_rrect_.radii(SkRRect::kLowerRight_Corner)
-          .x(),                                          //  bottom_right_radius
-      clip_rrect_.radii(SkRRect::kLowerLeft_Corner).x()  //  bottom_left_radius
-  );
-
   // TODO(liyuqian): respect clip_behavior_
-  SceneUpdateContext::Clip clip(context, shape, clip_rrect_.getBounds());
+  SceneUpdateContext::Clip clip(context, clip_rrect_.getBounds());
   UpdateSceneChildren(context);
 }
 

--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -328,15 +328,8 @@ void SceneUpdateContext::Frame::AddPaintLayer(Layer* layer) {
 }
 
 SceneUpdateContext::Clip::Clip(SceneUpdateContext& context,
-                               scenic::Shape& shape,
                                const SkRect& shape_bounds)
     : Entity(context) {
-  shape_node().SetShape(shape);
-  shape_node().SetTranslation(shape_bounds.width() * 0.5f + shape_bounds.left(),
-                              shape_bounds.height() * 0.5f + shape_bounds.top(),
-                              0.f);
-  entity_node().SetClip(0u, true /* clip to self */);
-
   SetEntityNodeClipPlanes(&entity_node(), shape_bounds);
 }
 

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -77,6 +77,7 @@ class SceneUpdateContext {
       return entity_node_ptr_;
     }
 
+    protected:
     scenic::ShapeNode& shape_node() { return *shape_node_ptr_; }
     std::unique_ptr<scenic::ShapeNode>& shape_node_ptr() {
       return shape_node_ptr_;
@@ -133,7 +134,6 @@ class SceneUpdateContext {
   class Clip : public Entity {
    public:
     Clip(SceneUpdateContext& context,
-         scenic::Shape& shape,
          const SkRect& shape_bounds);
     ~Clip() = default;
   };

--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -77,7 +77,7 @@ class SceneUpdateContext {
       return entity_node_ptr_;
     }
 
-    protected:
+   protected:
     scenic::ShapeNode& shape_node() { return *shape_node_ptr_; }
     std::unique_ptr<scenic::ShapeNode>& shape_node_ptr() {
       return shape_node_ptr_;
@@ -133,8 +133,7 @@ class SceneUpdateContext {
 
   class Clip : public Entity {
    public:
-    Clip(SceneUpdateContext& context,
-         const SkRect& shape_bounds);
+    Clip(SceneUpdateContext& context, const SkRect& shape_bounds);
     ~Clip() = default;
   };
 


### PR DESCRIPTION
Scenic has now fully transitioned to clipping by adding lists
of planes to Nodes; the old approach of adding a ShapeNode
"part" is now a no-op, and is safe to remove.