### PR TITLE
Android Embedding Refactor 38: Removed AssetManager from DartEntrypoint.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -293,7 +293,6 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 
     // Configure the Dart entrypoint and execute it.
     DartExecutor.DartEntrypoint entrypoint = new DartExecutor.DartEntrypoint(
-        host.getContext().getResources().getAssets(),
         host.getAppBundlePath(),
         host.getDartEntrypointFunctionName()
     );

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -128,7 +128,7 @@ public class FlutterEngine implements LifecycleOwner {
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
     attachToJni();
 
-    this.dartExecutor = new DartExecutor(flutterJNI);
+    this.dartExecutor = new DartExecutor(flutterJNI, context.getAssets());
     this.dartExecutor.onAttachedToJNI();
 
     // TODO(mattcarroll): FlutterRenderer is temporally coupled to attach(). Remove that coupling if possible.

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -10,13 +10,13 @@ import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 
 import java.nio.ByteBuffer;
-import java.util.Objects;
 
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.StringCodec;
 import io.flutter.view.FlutterCallbackInformation;
+import io.flutter.view.FlutterMain;
 
 /**
  * Configures, bootstraps, and starts executing Dart code.
@@ -254,6 +254,14 @@ public class DartExecutor implements BinaryMessenger {
    * to find that entrypoint and other assets required for Dart execution.
    */
   public static class DartEntrypoint {
+    @NonNull
+    public static DartEntrypoint createDefault() {
+      return new DartEntrypoint(
+          FlutterMain.findAppBundlePath(),
+          "main"
+      );
+    }
+
     /**
      * The path within the AssetManager where the app will look for assets.
      */

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -44,6 +44,8 @@ public class DartExecutor implements BinaryMessenger {
   @NonNull
   private final FlutterJNI flutterJNI;
   @NonNull
+  private final AssetManager assetManager;
+  @NonNull
   private final DartMessenger messenger;
   private boolean isApplicationRunning = false;
   @Nullable
@@ -62,8 +64,9 @@ public class DartExecutor implements BinaryMessenger {
         }
       };
 
-  public DartExecutor(@NonNull FlutterJNI flutterJNI) {
+  public DartExecutor(@NonNull FlutterJNI flutterJNI, @NonNull AssetManager assetManager) {
     this.flutterJNI = flutterJNI;
+    this.assetManager = assetManager;
     this.messenger = new DartMessenger(flutterJNI);
     messenger.setMessageHandler("flutter/isolate", isolateChannelMessageHandler);
   }
@@ -124,7 +127,7 @@ public class DartExecutor implements BinaryMessenger {
         dartEntrypoint.pathToBundle,
         dartEntrypoint.dartEntrypointFunctionName,
         null,
-        dartEntrypoint.androidAssetManager
+        assetManager
     );
 
     isApplicationRunning = true;
@@ -252,12 +255,6 @@ public class DartExecutor implements BinaryMessenger {
    */
   public static class DartEntrypoint {
     /**
-     * Standard Android AssetManager, provided from some {@code Context} or {@code Resources}.
-     */
-    @NonNull
-    public final AssetManager androidAssetManager;
-
-    /**
      * The path within the AssetManager where the app will look for assets.
      */
     @NonNull
@@ -270,11 +267,9 @@ public class DartExecutor implements BinaryMessenger {
     public final String dartEntrypointFunctionName;
 
     public DartEntrypoint(
-        @NonNull AssetManager androidAssetManager,
         @NonNull String pathToBundle,
         @NonNull String dartEntrypointFunctionName
     ) {
-      this.androidAssetManager = androidAssetManager;
       this.pathToBundle = pathToBundle;
       this.dartEntrypointFunctionName = dartEntrypointFunctionName;
     }

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -315,6 +315,12 @@ public class FlutterMain {
         }
     }
 
+    @NonNull
+    public static String findAppBundlePath() {
+        return sFlutterAssetsDir;
+    }
+
+    @Deprecated
     @Nullable
     public static String findAppBundlePath(@NonNull Context applicationContext) {
         return sFlutterAssetsDir;

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -43,7 +43,7 @@ public class FlutterNativeView implements BinaryMessenger {
         mPluginRegistry = new FlutterPluginRegistry(this, context);
         mFlutterJNI = new FlutterJNI();
         mFlutterJNI.setRenderSurface(new RenderSurfaceImpl());
-        this.dartExecutor = new DartExecutor(mFlutterJNI);
+        this.dartExecutor = new DartExecutor(mFlutterJNI, context.getAssets());
         mFlutterJNI.addEngineLifecycleListener(new EngineLifecycleListenerImpl());
         attach(this, isBackgroundView);
         assertAttached();

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -172,7 +172,6 @@ public class FlutterActivityAndFragmentDelegateTest {
 
     // Create the DartEntrypoint that we expect to be executed.
     DartExecutor.DartEntrypoint dartEntrypoint = new DartExecutor.DartEntrypoint(
-        RuntimeEnvironment.application.getAssets(),
         "/my/bundle/path",
         "myEntrypoint"
     );


### PR DESCRIPTION
Android Embedding Refactor 38: Removed AssetManager from DartEntrypoint.

I moved the resolution of `AssetManager` into `DartExecutor` as a constructor dependency instead of giving it to `DartEntrypoint` because `DartEntrypoint` should only be a data structure that configures execution.