### PR TITLE
Fix memory overrun in minikin patch

### DIFF
--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -334,7 +334,7 @@ bool ParagraphTxt::ComputeLineBreaks() {
 
         // Inject custom width into minikin breaker. (Uses LibTxt-minikin
         // patch).
-        breaker_.setCustomCharWidth(run.start, placeholder_run.width);
+        breaker_.setCustomCharWidth(run_start, placeholder_run.width);
 
         // Called with nullptr as paint in order to use the custom widths passed
         // above.


### PR DESCRIPTION
Fixes a crash that happens in WidgetSpan usage due to writing into unallocated memory.

Fixes https://github.com/flutter/flutter/issues/36176 https://github.com/flutter/flutter/issues/35877 and parts of https://github.com/flutter/flutter/issues/31844