### PR TITLE
iOS external texture causes OOM

### DIFF
--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -64,6 +64,9 @@ void IOSExternalTextureGL::Paint(SkCanvas& canvas,
       buffer_ref_.Reset(pixelBuffer);
     }
     CreateTextureFromPixelBuffer();
+    if (buffer_ref_) {
+      buffer_ref_.Reset(nullptr);
+    }
   }
   if (!texture_ref_) {
     return;


### PR DESCRIPTION
IOSExternalTextureGL use fml::CFRef to release an old CVPixelBufferRef and reference a new CVPixelBufferRef. However, if the new CVPixelBufferRef has same memory address as the old, the old one will not be released though they contain different data. This bug causes serious memory leak when using video plugin supported by external texture. @chinmaygarde Would you please take a look at this?