### PR TITLE
Fix empty composing range on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -591,7 +591,7 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
   NSUInteger selectionBase = ((FlutterTextPosition*)_selectedTextRange.start).index;
   NSUInteger selectionExtent = ((FlutterTextPosition*)_selectedTextRange.end).index;
 
-  // Empty compositing range is represented by [TextRange.empty].
+  // Empty compositing range is represented by the framework's TextRange.empty.
   NSInteger composingBase = -1;
   NSInteger composingExtent = -1;
   if (self.markedTextRange != nil) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -591,8 +591,9 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
   NSUInteger selectionBase = ((FlutterTextPosition*)_selectedTextRange.start).index;
   NSUInteger selectionExtent = ((FlutterTextPosition*)_selectedTextRange.end).index;
 
-  NSUInteger composingBase = 0;
-  NSUInteger composingExtent = 0;
+  // Empty compositing range is represented by [TextRange.empty].
+  NSInteger composingBase = -1;
+  NSInteger composingExtent = -1;
   if (self.markedTextRange != nil) {
     composingBase = ((FlutterTextPosition*)self.markedTextRange.start).index;
     composingExtent = ((FlutterTextPosition*)self.markedTextRange.end).index;


### PR DESCRIPTION
An empty compositing range is represented on Android and within the framework by setting the composing base and extend to -1 (see https://master-api.flutter.dev/flutter/services/TextRange/empty-constant.html). On iOS we incorrectly defined an empty compositing range by setting these values to 0. This can lead to an infinite loop where the engine tells the framework that the compositing range is [0, 0], to which the framework responds that the composing range now is [-1,-1], to which the engine responds that the compositing range is [0,0] and so on.... users were seeing these fights as flickering text in a text field for example.

Fixes https://github.com/flutter/flutter/issues/36971.

Related issue: We really shouldn't be sending NSUIntegers: https://github.com/flutter/flutter/issues/37462