### PR TITLE
expose max depth on Window

### DIFF
--- a/lib/stub_ui/lib/src/engine/window.dart
+++ b/lib/stub_ui/lib/src/engine/window.dart
@@ -60,6 +60,9 @@ class EngineWindow extends ui.Window {
   /// Overrides the value of [physicalSize] in tests.
   ui.Size webOnlyDebugPhysicalSizeOverride;
 
+  @override
+  double get physicalDepth => double.maxFinite;
+
   /// Handles the browser history integration to allow users to use the back
   /// button, etc.
   final BrowserHistory _browserHistory = BrowserHistory();

--- a/lib/stub_ui/lib/src/ui/window.dart
+++ b/lib/stub_ui/lib/src/ui/window.dart
@@ -542,6 +542,19 @@ abstract class Window {
   ///    observe when this value changes.
   Size get physicalSize;
 
+  /// The physical depth is the maximum elevation that the Window allows.
+  ///
+  /// Physical layers drawn at or above this elevation will have their elevation
+  /// clamped to this value. This can happen if the physical layer itself has
+  /// an elevation larger than available depth, or if some ancestor of the layer
+  /// causes it to have a cumulative elevation that is larger than the available
+  /// depth.
+  ///
+  /// The default value is [double.maxFinite], which is used for platforms that
+  /// do not specify a maximum elevation. This property is currently on expected
+  /// to be set to a non-default value on Fuchsia.
+  double get physicalDepth;
+
   /// The number of physical pixels on each side of the display rectangle into
   /// which the application can render, but over which the operating system
   /// will likely place system UI, such as the keyboard, that fully obscures

--- a/lib/ui/hooks.dart
+++ b/lib/ui/hooks.dart
@@ -21,6 +21,7 @@ dynamic _decodeJSON(String message) {
 void _updateWindowMetrics(double devicePixelRatio,
                           double width,
                           double height,
+                          double depth,
                           double viewPaddingTop,
                           double viewPaddingRight,
                           double viewPaddingBottom,
@@ -32,6 +33,7 @@ void _updateWindowMetrics(double devicePixelRatio,
   window
     .._devicePixelRatio = devicePixelRatio
     .._physicalSize = Size(width, height)
+    .._physicalDepth = depth
     .._viewPadding = WindowPadding._(
         top: viewPaddingTop,
         right: viewPaddingRight,

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -627,7 +627,8 @@ class Window {
   /// depth.
   ///
   /// The default value is [double.maxFinite], which is used for platforms that
-  /// do not specify a maximum elevation.
+  /// do not specify a maximum elevation. This property is currently on expected
+  /// to be set to a non-default value on Fuchsia.
   double get physicalDepth => _physicalDepth;
   double _physicalDepth = double.maxFinite;
 

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -618,6 +618,16 @@ class Window {
   Size get physicalSize => _physicalSize;
   Size _physicalSize = Size.zero;
 
+  /// The physical depth is the maximum elevation that the Window allows.
+  ///
+  /// Physical layers drawn at or above this elevation will have their elevation
+  /// clamped to this value.
+  ///
+  /// The default value is [double.maxFinite], which is used for platforms that
+  /// do not specify a maximum elevation.
+  double get physicalDepth => _physicalDepth;
+  double _physicalDepth = double.maxFinite;
+
   /// The number of physical pixels on each side of the display rectangle into
   /// which the application can render, but over which the operating system
   /// will likely place system UI, such as the keyboard, that fully obscures

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -621,7 +621,10 @@ class Window {
   /// The physical depth is the maximum elevation that the Window allows.
   ///
   /// Physical layers drawn at or above this elevation will have their elevation
-  /// clamped to this value.
+  /// clamped to this value. This can happen if the physical layer itself has
+  /// an elevation larger than available depth, or if some ancestor of the layer
+  /// causes it to have a cumulative elevation that is larger than the available
+  /// depth.
   ///
   /// The default value is [double.maxFinite], which is used for platforms that
   /// do not specify a maximum elevation.

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -9,7 +9,11 @@
 
 namespace flutter {
 
-static const double kUnsetDepth = -1;
+// This is the value of double.maxFinite from dart:core.
+// Platforms that do not explicitly set a depth will use this value, which
+// avoids the need to special case logic that wants to check the max depth on
+// the Dart side.
+static const double kUnsetDepth = 1.7976931348623157e+308;
 
 struct ViewportMetrics {
   ViewportMetrics();

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -185,6 +185,7 @@ void Window::UpdateWindowMetrics(const ViewportMetrics& metrics) {
           tonic::ToDart(metrics.device_pixel_ratio),
           tonic::ToDart(metrics.physical_width),
           tonic::ToDart(metrics.physical_height),
+          tonic::ToDart(metrics.physical_depth),
           tonic::ToDart(metrics.physical_padding_top),
           tonic::ToDart(metrics.physical_padding_right),
           tonic::ToDart(metrics.physical_padding_bottom),

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -43,7 +43,19 @@ void main() {
     PlatformMessageCallback originalOnPlatformMessage;
     VoidCallback originalOnTextScaleFactorChanged;
 
+    double oldDPR;
+    Size oldSize;
+    double oldDepth;
+    WindowPadding oldPadding;
+    WindowPadding oldInsets;
+
     setUp(() {
+      oldDPR = window.devicePixelRatio;
+      oldSize = window.physicalSize;
+      oldDepth = window.physicalDepth;
+      oldPadding = window.viewPadding;
+      oldInsets = window.viewInsets;
+
       originalOnMetricsChanged = window.onMetricsChanged;
       originalOnLocaleChanged = window.onLocaleChanged;
       originalOnBeginFrame = window.onBeginFrame;
@@ -57,6 +69,20 @@ void main() {
     });
 
     tearDown(() {
+      _updateWindowMetrics(
+        oldDPR,             // DPR
+        oldSize.width,      // width
+        oldSize.height,     // height
+        oldDepth,           // depth
+        oldPadding.top,     // padding top
+        oldPadding.right,   // padding right
+        oldPadding.bottom,  // padding bottom
+        oldPadding.left,    // padding left
+        oldInsets.top,      // inset top
+        oldInsets.right,    // inset right
+        oldInsets.bottom,   // inset bottom
+        oldInsets.left,     // inset left
+      );
       window.onMetricsChanged = originalOnMetricsChanged;
       window.onLocaleChanged = originalOnLocaleChanged;
       window.onBeginFrame = originalOnBeginFrame;
@@ -290,14 +316,6 @@ void main() {
 
 
     test('Window padding/insets/viewPadding', () {
-      final double oldDPR = window.devicePixelRatio;
-      final Size oldSize = window.physicalSize;
-      final double oldDepth = window.physicalDepth;
-      final WindowPadding oldPadding = window.viewPadding;
-      final WindowPadding oldInsets = window.viewInsets;
-
-      expect(oldDepth, double.maxFinite);
-
       _updateWindowMetrics(
         1.0,   // DPR
         800.0, // width
@@ -337,21 +355,6 @@ void main() {
       expect(window.viewPadding.bottom, 40.0);
       expect(window.padding.bottom, 0.0);
       expect(window.physicalDepth, 100.0);
-
-       _updateWindowMetrics(
-        oldDPR,             // DPR
-        oldSize.width,      // width
-        oldSize.height,     // height
-        oldDepth,           // depth
-        oldPadding.top,     // padding top
-        oldPadding.right,   // padding right
-        oldPadding.bottom,  // padding bottom
-        oldPadding.left,    // padding left
-        oldInsets.top,      // inset top
-        oldInsets.right,    // inset right
-        oldInsets.bottom,   // inset bottom
-        oldInsets.left,     // inset left
-      );
     });
   });
 }

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -89,7 +89,7 @@ void main() {
       });
 
       window.onMetricsChanged();
-      _updateWindowMetrics(0.1234, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+      _updateWindowMetrics(0.1234, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
       expect(runZone, isNotNull);
       expect(runZone, same(innerZone));
       expect(devicePixelRatio, equals(0.1234));

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -292,13 +292,17 @@ void main() {
     test('Window padding/insets/viewPadding', () {
       final double oldDPR = window.devicePixelRatio;
       final Size oldSize = window.physicalSize;
+      final double oldDepth = window.physicalDepth;
       final WindowPadding oldPadding = window.viewPadding;
       final WindowPadding oldInsets = window.viewInsets;
+
+      expect(oldDepth, double.maxFinite);
 
       _updateWindowMetrics(
         1.0,   // DPR
         800.0, // width
         600.0, // height
+        100.0, // depth
         50.0,  // padding top
         0.0,   // padding right
         40.0,  // padding bottom
@@ -312,11 +316,13 @@ void main() {
       expect(window.viewInsets.bottom, 0.0);
       expect(window.viewPadding.bottom, 40.0);
       expect(window.padding.bottom, 40.0);
+      expect(window.physicalDepth, 100.0);
 
       _updateWindowMetrics(
         1.0,   // DPR
         800.0, // width
         600.0, // height
+        100.0, // depth
         50.0,  // padding top
         0.0,   // padding right
         40.0,  // padding bottom
@@ -330,11 +336,13 @@ void main() {
       expect(window.viewInsets.bottom, 400.0);
       expect(window.viewPadding.bottom, 40.0);
       expect(window.padding.bottom, 0.0);
+      expect(window.physicalDepth, 100.0);
 
        _updateWindowMetrics(
         oldDPR,             // DPR
         oldSize.width,      // width
         oldSize.height,     // height
+        oldDepth,           // depth
         oldPadding.top,     // padding top
         oldPadding.right,   // padding right
         oldPadding.bottom,  // padding bottom


### PR DESCRIPTION
Exposes max depth on Window.  Currently, this value is dropped when updating the viewport metrics.

Also changes the C++ side default to the value of dart:core's double.maxFinite, which will allow platforms that do not expose this concept to work a bit better with code that wants to check it.

Fixes https://github.com/flutter/flutter/issues/33853

This will break framework tests, which rely on being able to implement Window.  It will require a manual roll.