### PR TITLE
Fix mac gen_snapshot uploader

### DIFF
--- a/sky/tools/create_macos_gen_snapshot.py
+++ b/sky/tools/create_macos_gen_snapshot.py
@@ -20,7 +20,7 @@ def main():
 
   fat_gen_snapshot = os.path.join(args.dst, 'gen_snapshot')
   arm64_gen_snapshot = os.path.join(args.arm64_out_dir, 'clang_x64', 'gen_snapshot')
-  armv7_gen_snapshot = os.path.join(args.armv7_out_dir, 'clang_x86', 'gen_snapshot')
+  armv7_gen_snapshot = os.path.join(args.armv7_out_dir, 'clang_x64', 'gen_snapshot')
 
   if not os.path.isfile(arm64_gen_snapshot):
     print 'Cannot find x86_64 (arm64) gen_snapshot at', arm64_gen_snapshot


### PR DESCRIPTION
Upload is failing here:
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8906297163890139520/+/steps/Create_macOS_debug_gen_snapshot/0/logs/execution_details/0
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8906297163890139520/+/steps/Create_macOS_debug_gen_snapshot/0/stdout

The simarm_x64 changes move gen_snapshot from clang_x86 to clang_x64. The fix updates the path.