### PR TITLE
Add copy_gen_snapshots.py tool

### DIFF
--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import argparse
+import shutil
+import sys
+import os
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Copies architecture-dependent gen_snapshot binaries to output dir')
+
+  parser.add_argument('--dst', type=str, required=True)
+  parser.add_argument('--arm64-out-dir', type=str, required=True)
+  parser.add_argument('--armv7-out-dir', type=str, required=True)
+
+  args = parser.parse_args()
+
+  arm64_gen_snapshot = os.path.join(args.arm64_out_dir, 'clang_x64', 'gen_snapshot')
+  armv7_gen_snapshot = os.path.join(args.armv7_out_dir, 'clang_x64', 'gen_snapshot')
+
+  if not os.path.isfile(arm64_gen_snapshot):
+    print 'Cannot find x86_64 (arm64) gen_snapshot at', arm64_gen_snapshot
+    return 1
+
+  if not os.path.isfile(armv7_gen_snapshot):
+    print 'Cannot find i386 (armv7) gen_snapshot at', armv7_gen_snapshot
+    return 1
+
+  shutil.copy(armv7_gen_snapshot, os.path.join(args.dst, 'gen_snapshot_armv7'))
+  shutil.copy(arm64_gen_snapshot, os.path.join(args.dst, 'gen_snapshot_arm64'))
+
+
+if __name__ == '__main__':
+  sys.exit(main())
+


### PR DESCRIPTION
Copies and renames the architecture-dependent iOS variants of
gen_snapshot to a destination directory. Now that the armv7-emitting
variant of gen_snapshot is 64-bit we can no longer bundle up
gen_snapshot as a fat binary with the x86 armv7 variant merged with the
x86_64 arm64 variant.