### PR TITLE
Reland Skia Caching improvements

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -164,6 +164,7 @@ if (current_toolchain == host_toolchain) {
       ":shell_unittests_gpu_configuration",
       "$flutter_root/common",
       "$flutter_root/flow",
+      "$flutter_root/lib/ui:ui",
       "$flutter_root/shell",
       "$flutter_root/testing:dart",
       "$flutter_root/testing:opengl",

--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert' show utf8;
 import 'dart:isolate';
+import 'dart:typed_data';
 import 'dart:ui';
 
 void main() {}
@@ -56,4 +58,20 @@ void secondaryIsolateMain(String message) {
 void testCanLaunchSecondaryIsolate() {
   Isolate.spawn(secondaryIsolateMain, 'Hello from root isolate.');
   notifyNative();
+}
+
+@pragma('vm:entry-point')
+void testSkiaResourceCacheSendsResponse() {
+  final PlatformMessageResponseCallback callback = (ByteData data) {
+    notifyNative();
+  };
+  const String json = '''{
+                            "method": "Skia.setResourceCacheMaxBytes",
+                            "args": 10000
+                          }''';
+  window.sendPlatformMessage(
+    'flutter/skia',
+    Uint8List.fromList(utf8.encode(json)).buffer.asByteData(),
+    callback,
+  );
 }

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -382,14 +382,17 @@ void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
   }
 }
 
-size_t Rasterizer::GetResourceCacheMaxBytes() const {
+std::optional<size_t> Rasterizer::GetResourceCacheMaxBytes() const {
+  if (!surface_) {
+    return std::nullopt;
+  }
   GrContext* context = surface_->GetContext();
   if (context) {
     size_t max_bytes;
     context->getResourceCacheLimits(nullptr, &max_bytes);
     return max_bytes;
   }
-  return 0;
+  return std::nullopt;
 }
 
 Rasterizer::Screenshot::Screenshot() {}

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -56,6 +56,9 @@ fml::WeakPtr<Rasterizer> Rasterizer::GetWeakPtr() const {
 
 void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
   surface_ = std::move(surface);
+  if (max_cache_bytes_.has_value()) {
+    SetResourceCacheMaxBytes(max_cache_bytes_.value(), false);
+  }
   compositor_context_->OnGrContextCreated();
 }
 
@@ -362,6 +365,11 @@ void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
   if (!from_user && user_override_resource_cache_bytes_) {
     // We should not update the setting here if a user has explicitly set a
     // value for this over the flutter/skia channel.
+    return;
+  }
+
+  max_cache_bytes_ = max_bytes;
+  if (!surface_) {
     return;
   }
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -43,6 +43,7 @@ Rasterizer::Rasterizer(
     : delegate_(delegate),
       task_runners_(std::move(task_runners)),
       compositor_context_(std::move(compositor_context)),
+      user_override_resource_cache_bytes_(false),
       weak_factory_(this) {
   FML_DCHECK(compositor_context_);
 }
@@ -355,13 +356,31 @@ void Rasterizer::FireNextFrameCallbackIfPresent() {
   callback();
 }
 
-void Rasterizer::SetResourceCacheMaxBytes(int max_bytes) {
+void Rasterizer::SetResourceCacheMaxBytes(size_t max_bytes, bool from_user) {
+  user_override_resource_cache_bytes_ |= from_user;
+
+  if (!from_user && user_override_resource_cache_bytes_) {
+    // We should not update the setting here if a user has explicitly set a
+    // value for this over the flutter/skia channel.
+    return;
+  }
+
   GrContext* context = surface_->GetContext();
   if (context) {
     int max_resources;
     context->getResourceCacheLimits(&max_resources, nullptr);
     context->setResourceCacheLimits(max_resources, max_bytes);
   }
+}
+
+size_t Rasterizer::GetResourceCacheMaxBytes() const {
+  GrContext* context = surface_->GetContext();
+  if (context) {
+    size_t max_bytes;
+    context->getResourceCacheLimits(nullptr, &max_bytes);
+    return max_bytes;
+  }
+  return 0;
 }
 
 Rasterizer::Screenshot::Screenshot() {}

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -57,7 +57,8 @@ fml::WeakPtr<Rasterizer> Rasterizer::GetWeakPtr() const {
 void Rasterizer::Setup(std::unique_ptr<Surface> surface) {
   surface_ = std::move(surface);
   if (max_cache_bytes_.has_value()) {
-    SetResourceCacheMaxBytes(max_cache_bytes_.value(), false);
+    SetResourceCacheMaxBytes(max_cache_bytes_.value(),
+                             user_override_resource_cache_bytes_);
   }
   compositor_context_->OnGrContextCreated();
 }

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -6,6 +6,7 @@
 #define SHELL_COMMON_RASTERIZER_H_
 
 #include <memory>
+#include <optional>
 
 #include "flutter/common/settings.h"
 #include "flutter/common/task_runners.h"

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -374,8 +374,28 @@ class Rasterizer final {
   ///
   /// @param[in]  max_bytes  The maximum byte size of resource that may be
   ///                        cached for GPU rendering.
+  /// @param[in]  from_user  Whether this request was from user code, e.g. via
+  ///                        the flutter/skia message channel, in which case
+  ///                        it should not be overridden by the platform.
   ///
-  void SetResourceCacheMaxBytes(int max_bytes);
+  void SetResourceCacheMaxBytes(size_t max_bytes, bool from_user);
+
+  //----------------------------------------------------------------------------
+  /// @brief      The current value of Skia's resource cache size.
+  ///
+  /// @attention  This cache setting will be invalidated when the surface is
+  ///             torn down via `Rasterizer::Teardown`. This call must be made
+  ///             again with new limits after surface re-acquisition.
+  ///
+  /// @attention  This cache does not describe the entirety of GPU resources
+  ///             that may be cached. The `RasterCache` also holds very large
+  ///             GPU resources.
+  ///
+  /// @see        `RasterCache`
+  ///
+  /// @return     The size of Skia's resource cache.
+  ///
+  size_t GetResourceCacheMaxBytes() const;
 
  private:
   Delegate& delegate_;
@@ -384,6 +404,7 @@ class Rasterizer final {
   std::unique_ptr<flutter::CompositorContext> compositor_context_;
   std::unique_ptr<flutter::LayerTree> last_layer_tree_;
   fml::closure next_frame_callback_;
+  bool user_override_resource_cache_bytes_;
   fml::WeakPtrFactory<Rasterizer> weak_factory_;
 
   void DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -381,7 +381,8 @@ class Rasterizer final {
   void SetResourceCacheMaxBytes(size_t max_bytes, bool from_user);
 
   //----------------------------------------------------------------------------
-  /// @brief      The current value of Skia's resource cache size.
+  /// @brief      The current value of Skia's resource cache size, if a surface
+  ///             is present.
   ///
   /// @attention  This cache setting will be invalidated when the surface is
   ///             torn down via `Rasterizer::Teardown`. This call must be made
@@ -393,9 +394,9 @@ class Rasterizer final {
   ///
   /// @see        `RasterCache`
   ///
-  /// @return     The size of Skia's resource cache.
+  /// @return     The size of Skia's resource cache, if available.
   ///
-  size_t GetResourceCacheMaxBytes() const;
+  std::optional<size_t> GetResourceCacheMaxBytes() const;
 
  private:
   Delegate& delegate_;

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -405,6 +405,7 @@ class Rasterizer final {
   std::unique_ptr<flutter::LayerTree> last_layer_tree_;
   fml::closure next_frame_callback_;
   bool user_override_resource_cache_bytes_;
+  std::optional<size_t> max_cache_bytes_;
   fml::WeakPtrFactory<Rasterizer> weak_factory_;
 
   void DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -384,10 +384,6 @@ class Rasterizer final {
   /// @brief      The current value of Skia's resource cache size, if a surface
   ///             is present.
   ///
-  /// @attention  This cache setting will be invalidated when the surface is
-  ///             torn down via `Rasterizer::Teardown`. This call must be made
-  ///             again with new limits after surface re-acquisition.
-  ///
   /// @attention  This cache does not describe the entirety of GPU resources
   ///             that may be cached. The `RasterCache` also holds very large
   ///             GPU resources.

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -684,7 +684,7 @@ void Shell::OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) {
 
   // This is the formula Android uses.
   // https://android.googlesource.com/platform/frameworks/base/+/master/libs/hwui/renderthread/CacheManager.cpp#41
-  int max_bytes = metrics.physical_width * metrics.physical_height * 12 * 4;
+  size_t max_bytes = metrics.physical_width * metrics.physical_height * 12 * 4;
   task_runners_.GetGPUTaskRunner()->PostTask(
       [rasterizer = rasterizer_->GetWeakPtr(), max_bytes] {
         if (rasterizer) {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -682,6 +682,16 @@ void Shell::OnPlatformViewSetViewportMetrics(const ViewportMetrics& metrics) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
+  // This is the formula Android uses.
+  // https://android.googlesource.com/platform/frameworks/base/+/master/libs/hwui/renderthread/CacheManager.cpp#41
+  int max_bytes = metrics.physical_width * metrics.physical_height * 12 * 4;
+  task_runners_.GetGPUTaskRunner()->PostTask(
+      [rasterizer = rasterizer_->GetWeakPtr(), max_bytes] {
+        if (rasterizer) {
+          rasterizer->SetResourceCacheMaxBytes(max_bytes, false);
+        }
+      });
+
   task_runners_.GetUITaskRunner()->PostTask(
       [engine = engine_->GetWeakPtr(), metrics]() {
         if (engine) {
@@ -942,7 +952,8 @@ void Shell::HandleEngineSkiaMessage(fml::RefPtr<PlatformMessage> message) {
       [rasterizer = rasterizer_->GetWeakPtr(),
        max_bytes = args->value.GetInt()] {
         if (rasterizer) {
-          rasterizer->SetResourceCacheMaxBytes(max_bytes);
+          rasterizer->SetResourceCacheMaxBytes(static_cast<size_t>(max_bytes),
+                                               true);
         }
       });
 }

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -949,11 +949,14 @@ void Shell::HandleEngineSkiaMessage(fml::RefPtr<PlatformMessage> message) {
     return;
 
   task_runners_.GetGPUTaskRunner()->PostTask(
-      [rasterizer = rasterizer_->GetWeakPtr(),
-       max_bytes = args->value.GetInt()] {
+      [rasterizer = rasterizer_->GetWeakPtr(), max_bytes = args->value.GetInt(),
+       response = std::move(message->response())] {
         if (rasterizer) {
           rasterizer->SetResourceCacheMaxBytes(static_cast<size_t>(max_bytes),
                                                true);
+        }
+        if (response) {
+          response->CompleteEmpty();
         }
       });
 }

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -29,10 +29,9 @@ void ShellTest::SendEnginePlatformMessage(
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(),
       [shell, &latch, message = std::move(message)]() {
-        if (!shell->weak_engine_) {
-          return;
+        if (auto engine = shell->weak_engine_) {
+          engine->HandlePlatformMessage(std::move(message));
         }
-        shell->weak_engine_->HandlePlatformMessage(std::move(message));
         latch.Signal();
       });
   latch.Wait();

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -22,6 +22,22 @@ ShellTest::ShellTest()
 
 ShellTest::~ShellTest() = default;
 
+void ShellTest::SendEnginePlatformMessage(
+    Shell* shell,
+    fml::RefPtr<PlatformMessage> message) {
+  fml::AutoResetWaitableEvent latch;
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetPlatformTaskRunner(),
+      [shell, &latch, message = std::move(message)]() {
+        if (!shell->weak_engine_) {
+          return;
+        }
+        shell->weak_engine_->HandlePlatformMessage(std::move(message));
+        latch.Signal();
+      });
+  latch.Wait();
+}
+
 void ShellTest::SetSnapshotsAndAssets(Settings& settings) {
   if (!assets_dir_.is_valid()) {
     return;

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -9,6 +9,7 @@
 
 #include "flutter/common/settings.h"
 #include "flutter/fml/macros.h"
+#include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/shell/common/run_configuration.h"
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
@@ -31,6 +32,9 @@ class ShellTest : public ThreadTest {
   std::unique_ptr<Shell> CreateShell(Settings settings,
                                      TaskRunners task_runners);
   TaskRunners GetTaskRunnersForFixture();
+
+  void SendEnginePlatformMessage(Shell* shell,
+                                 fml::RefPtr<PlatformMessage> message);
 
   void AddNativeCallback(std::string name, Dart_NativeFunction callback);
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -26,589 +26,589 @@
 namespace flutter {
 namespace testing {
 
-// static bool ValidateShell(Shell* shell) {
-//   if (!shell) {
-//     return false;
-//   }
-
-//   if (!shell->IsSetup()) {
-//     return false;
-//   }
-
-//   ShellTest::PlatformViewNotifyCreated(shell);
-
-//   {
-//     fml::AutoResetWaitableEvent latch;
-//     fml::TaskRunner::RunNowOrPostTask(
-//         shell->GetTaskRunners().GetPlatformTaskRunner(), [shell, &latch]() {
-//           shell->GetPlatformView()->NotifyDestroyed();
-//           latch.Signal();
-//         });
-//     latch.Wait();
-//   }
-
-//   return true;
-// }
-
-// TEST_F(ShellTest, InitializeWithInvalidThreads) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   Settings settings = CreateSettingsForFixture();
-//   TaskRunners task_runners("test", nullptr, nullptr, nullptr, nullptr);
-//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
-//   ASSERT_FALSE(shell);
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST_F(ShellTest, InitializeWithDifferentThreads) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   Settings settings = CreateSettingsForFixture();
-//   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-//                          ThreadHost::Type::Platform | ThreadHost::Type::GPU |
-//                              ThreadHost::Type::IO | ThreadHost::Type::UI);
-//   TaskRunners task_runners("test",
-//   thread_host.platform_thread->GetTaskRunner(),
-//                            thread_host.gpu_thread->GetTaskRunner(),
-//                            thread_host.ui_thread->GetTaskRunner(),
-//                            thread_host.io_thread->GetTaskRunner());
-//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
-//   ASSERT_TRUE(ValidateShell(shell.get()));
-//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-//   shell.reset();
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST_F(ShellTest, InitializeWithSingleThread) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   Settings settings = CreateSettingsForFixture();
-//   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-//                          ThreadHost::Type::Platform);
-//   auto task_runner = thread_host.platform_thread->GetTaskRunner();
-//   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-//                            task_runner);
-//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
-//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-//   ASSERT_TRUE(ValidateShell(shell.get()));
-//   shell.reset();
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   Settings settings = CreateSettingsForFixture();
-//   fml::MessageLoop::EnsureInitializedForCurrentThread();
-//   auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
-//   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-//                            task_runner);
-//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
-//   ASSERT_TRUE(ValidateShell(shell.get()));
-//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-//   shell.reset();
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST_F(ShellTest,
-//        InitializeWithMultipleThreadButCallingThreadAsPlatformThread) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   Settings settings = CreateSettingsForFixture();
-//   ThreadHost thread_host(
-//       "io.flutter.test." + GetCurrentTestName() + ".",
-//       ThreadHost::Type::GPU | ThreadHost::Type::IO | ThreadHost::Type::UI);
-//   fml::MessageLoop::EnsureInitializedForCurrentThread();
-//   TaskRunners task_runners("test",
-//                            fml::MessageLoop::GetCurrent().GetTaskRunner(),
-//                            thread_host.gpu_thread->GetTaskRunner(),
-//                            thread_host.ui_thread->GetTaskRunner(),
-//                            thread_host.io_thread->GetTaskRunner());
-//   auto shell = Shell::Create(
-//       std::move(task_runners), settings,
-//       [](Shell& shell) {
-//         return std::make_unique<ShellTestPlatformView>(shell,
-//                                                        shell.GetTaskRunners());
-//       },
-//       [](Shell& shell) {
-//         return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
-//       });
-//   ASSERT_TRUE(ValidateShell(shell.get()));
-//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-//   shell.reset();
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   Settings settings = CreateSettingsForFixture();
-//   ThreadHost thread_host(
-//       "io.flutter.test." + GetCurrentTestName() + ".",
-//       ThreadHost::Type::Platform | ThreadHost::Type::IO |
-//       ThreadHost::Type::UI);
-//   TaskRunners task_runners(
-//       "test",
-//       thread_host.platform_thread->GetTaskRunner(),  // platform
-//       thread_host.platform_thread->GetTaskRunner(),  // gpu
-//       thread_host.ui_thread->GetTaskRunner(),        // ui
-//       thread_host.io_thread->GetTaskRunner()         // io
-//   );
-//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
-//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-//   ASSERT_TRUE(ValidateShell(shell.get()));
-//   shell.reset();
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST_F(ShellTest, FixturesAreFunctional) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   auto settings = CreateSettingsForFixture();
-//   auto shell = CreateShell(settings);
-//   ASSERT_TRUE(ValidateShell(shell.get()));
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   ASSERT_TRUE(configuration.IsValid());
-//   configuration.SetEntrypoint("fixturesAreFunctionalMain");
-
-//   fml::AutoResetWaitableEvent main_latch;
-//   AddNativeCallback(
-//       "SayHiFromFixturesAreFunctionalMain",
-//       CREATE_NATIVE_ENTRY([&main_latch](auto args) { main_latch.Signal();
-//       }));
-
-//   RunEngine(shell.get(), std::move(configuration));
-//   main_latch.Wait();
-//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-//   shell.reset();
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-//   auto settings = CreateSettingsForFixture();
-//   auto shell = CreateShell(settings);
-//   ASSERT_TRUE(ValidateShell(shell.get()));
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   ASSERT_TRUE(configuration.IsValid());
-//   configuration.SetEntrypoint("testCanLaunchSecondaryIsolate");
-
-//   fml::CountDownLatch latch(2);
-//   AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&latch](auto args) {
-//                       latch.CountDown();
-//                     }));
-
-//   RunEngine(shell.get(), std::move(configuration));
-
-//   latch.Wait();
-
-//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-//   shell.reset();
-//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-// }
-
-// TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
-//   if (DartVM::IsRunningPrecompiledCode()) {
-//     // This covers profile and release modes which use AOT (where this flag
-//     does
-//     // not make sense anyway).
-//     GTEST_SKIP();
-//     return;
-//   }
-
-//   const std::vector<fml::CommandLine::Option> options = {
-//       fml::CommandLine::Option("dart-flags", "--enable_mirrors")};
-//   fml::CommandLine command_line("", options, std::vector<std::string>());
-//   flutter::Settings settings =
-//   flutter::SettingsFromCommandLine(command_line);
-//   EXPECT_EQ(settings.dart_flags.size(), 1u);
-// }
-
-// TEST_F(ShellTest, BlacklistedDartVMFlag) {
-//   // Run this test in a thread-safe manner, otherwise gtest will complain.
-//   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
-//   const std::vector<fml::CommandLine::Option> options = {
-//       fml::CommandLine::Option("dart-flags", "--verify_after_gc")};
-//   fml::CommandLine command_line("", options, std::vector<std::string>());
-
-// #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
-//   // Upon encountering a non-whitelisted Dart flag the process terminates.
-//   const char* expected =
-//       "Encountered blacklisted Dart VM flag: --verify_after_gc";
-//   ASSERT_DEATH(flutter::SettingsFromCommandLine(command_line), expected);
-// #else
-//   flutter::Settings settings =
-//   flutter::SettingsFromCommandLine(command_line);
-//   EXPECT_EQ(settings.dart_flags.size(), 0u);
-// #endif
-// }
-
-// TEST_F(ShellTest, WhitelistedDartVMFlag) {
-//   const std::vector<fml::CommandLine::Option> options = {
-//       fml::CommandLine::Option("dart-flags",
-//                                "--max_profile_depth 1,--random_seed 42")};
-//   fml::CommandLine command_line("", options, std::vector<std::string>());
-//   flutter::Settings settings =
-//   flutter::SettingsFromCommandLine(command_line);
-
-// #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
-//   EXPECT_EQ(settings.dart_flags.size(), 2u);
-//   EXPECT_EQ(settings.dart_flags[0], "--max_profile_depth 1");
-//   EXPECT_EQ(settings.dart_flags[1], "--random_seed 42");
-// #else
-//   EXPECT_EQ(settings.dart_flags.size(), 0u);
-// #endif
-// }
-
-// TEST_F(ShellTest, NoNeedToReportTimingsByDefault) {
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   configuration.SetEntrypoint("emptyMain");
-
-//   RunEngine(shell.get(), std::move(configuration));
-//   PumpOneFrame(shell.get());
-//   ASSERT_FALSE(GetNeedsReportTimings(shell.get()));
-
-//   // This assertion may or may not be the direct result of
-//   needs_report_timings_
-//   // being false. The count could be 0 simply because we just cleared
-//   unreported
-//   // timings by reporting them. Hence this can't replace the
-//   // ASSERT_FALSE(GetNeedsReportTimings(shell.get())) check. We added this
-//   // assertion for an additional confidence that we're not pushing back to
-//   // unreported timings unnecessarily.
-//   //
-//   // Conversely, do not assert UnreportedTimingsCount(shell.get()) to be
-//   // positive in any tests. Otherwise those tests will be flaky as the
-//   clearing
-//   // of unreported timings is unpredictive.
-//   ASSERT_EQ(UnreportedTimingsCount(shell.get()), 0);
-// }
-
-// TEST_F(ShellTest, NeedsReportTimingsIsSetWithCallback) {
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   configuration.SetEntrypoint("dummyReportTimingsMain");
-
-//   RunEngine(shell.get(), std::move(configuration));
-//   PumpOneFrame(shell.get());
-//   ASSERT_TRUE(GetNeedsReportTimings(shell.get()));
-// }
-
-// static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
-//                               fml::TimePoint start,
-//                               fml::TimePoint finish) {
-//   fml::TimePoint last_frame_start;
-//   for (size_t i = 0; i < timings.size(); i += 1) {
-//     // Ensure that timings are sorted.
-//     ASSERT_TRUE(timings[i].Get(FrameTiming::kPhases[0]) >= last_frame_start);
-//     last_frame_start = timings[i].Get(FrameTiming::kPhases[0]);
-
-//     fml::TimePoint last_phase_time;
-//     for (auto phase : FrameTiming::kPhases) {
-//       ASSERT_TRUE(timings[i].Get(phase) >= start);
-//       ASSERT_TRUE(timings[i].Get(phase) <= finish);
-
-//       // phases should have weakly increasing time points
-//       ASSERT_TRUE(last_phase_time <= timings[i].Get(phase));
-//       last_phase_time = timings[i].Get(phase);
-//     }
-//   }
-// }
-
-// TEST_F(ShellTest, ReportTimingsIsCalled) {
-//   fml::TimePoint start = fml::TimePoint::Now();
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   ASSERT_TRUE(configuration.IsValid());
-//   configuration.SetEntrypoint("reportTimingsMain");
-//   fml::AutoResetWaitableEvent reportLatch;
-//   std::vector<int64_t> timestamps;
-//   auto nativeTimingCallback = [&reportLatch,
-//                                &timestamps](Dart_NativeArguments args) {
-//     Dart_Handle exception = nullptr;
-//     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-//         args, 0, exception);
-//     reportLatch.Signal();
-//   };
-//   AddNativeCallback("NativeReportTimingsCallback",
-//                     CREATE_NATIVE_ENTRY(nativeTimingCallback));
-//   RunEngine(shell.get(), std::move(configuration));
-
-//   // Pump many frames so we can trigger the report quickly instead of waiting
-//   // for the 1 second threshold.
-//   for (int i = 0; i < 200; i += 1) {
-//     PumpOneFrame(shell.get());
-//   }
-
-//   reportLatch.Wait();
-//   shell.reset();
-
-//   fml::TimePoint finish = fml::TimePoint::Now();
-//   ASSERT_TRUE(timestamps.size() > 0);
-//   ASSERT_TRUE(timestamps.size() % FrameTiming::kCount == 0);
-//   std::vector<FrameTiming> timings(timestamps.size() / FrameTiming::kCount);
-
-//   for (size_t i = 0; i * FrameTiming::kCount < timestamps.size(); i += 1) {
-//     for (auto phase : FrameTiming::kPhases) {
-//       timings[i].Set(
-//           phase,
-//           fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(
-//               timestamps[i * FrameTiming::kCount + phase])));
-//     }
-//   }
-//   CheckFrameTimings(timings, start, finish);
-// }
-
-// TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
-//   fml::TimePoint start = fml::TimePoint::Now();
-
-//   auto settings = CreateSettingsForFixture();
-//   fml::AutoResetWaitableEvent timingLatch;
-//   FrameTiming timing;
-
-//   for (auto phase : FrameTiming::kPhases) {
-//     timing.Set(phase, fml::TimePoint());
-//     // Check that the time points are initially smaller than start, so
-//     // CheckFrameTimings will fail if they're not properly set later.
-//     ASSERT_TRUE(timing.Get(phase) < start);
-//   }
-
-//   settings.frame_rasterized_callback = [&timing,
-//                                         &timingLatch](const FrameTiming& t) {
-//     timing = t;
-//     timingLatch.Signal();
-//   };
-
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   configuration.SetEntrypoint("onBeginFrameMain");
-
-//   int64_t begin_frame;
-//   auto nativeOnBeginFrame = [&begin_frame](Dart_NativeArguments args) {
-//     Dart_Handle exception = nullptr;
-//     begin_frame =
-//         tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
-//   };
-//   AddNativeCallback("NativeOnBeginFrame",
-//                     CREATE_NATIVE_ENTRY(nativeOnBeginFrame));
-
-//   RunEngine(shell.get(), std::move(configuration));
-
-//   PumpOneFrame(shell.get());
-
-//   // Check that timing is properly set. This implies that
-//   // settings.frame_rasterized_callback is called.
-//   timingLatch.Wait();
-//   fml::TimePoint finish = fml::TimePoint::Now();
-//   std::vector<FrameTiming> timings = {timing};
-//   CheckFrameTimings(timings, start, finish);
-
-//   // Check that onBeginFrame has the same timestamp as FrameTiming's build
-//   start int64_t build_start =
-//       timing.Get(FrameTiming::kBuildStart).ToEpochDelta().ToMicroseconds();
-//   ASSERT_EQ(build_start, begin_frame);
-// }
-
-// TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
-//   // Ensure that all phases are in kPhases.
-//   ASSERT_EQ(sizeof(FrameTiming::kPhases),
-//             FrameTiming::kCount * sizeof(FrameTiming::Phase));
-
-//   int lastPhaseIndex = -1;
-//   FrameTiming timing;
-//   for (auto phase : FrameTiming::kPhases) {
-//     ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in
-//     order. lastPhaseIndex = phase; auto fake_time =
-//         fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(phase));
-//     timing.Set(phase, fake_time);
-//     ASSERT_TRUE(timing.Get(phase) == fake_time);
-//   }
-// }
-
-// #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
-// TEST_F(ShellTest, ReportTimingsIsCalledLaterInReleaseMode) {
-// #else
-// TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
-// #endif
-//   fml::TimePoint start = fml::TimePoint::Now();
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   ASSERT_TRUE(configuration.IsValid());
-//   configuration.SetEntrypoint("reportTimingsMain");
-
-//   // Wait for 2 reports: the first one is the immediate callback of the first
-//   // frame; the second one will exercise the batching logic.
-//   fml::CountDownLatch reportLatch(2);
-//   std::vector<int64_t> timestamps;
-//   auto nativeTimingCallback = [&reportLatch,
-//                                &timestamps](Dart_NativeArguments args) {
-//     Dart_Handle exception = nullptr;
-//     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-//         args, 0, exception);
-//     reportLatch.CountDown();
-//   };
-//   AddNativeCallback("NativeReportTimingsCallback",
-//                     CREATE_NATIVE_ENTRY(nativeTimingCallback));
-//   RunEngine(shell.get(), std::move(configuration));
-
-//   PumpOneFrame(shell.get());
-//   PumpOneFrame(shell.get());
-
-//   reportLatch.Wait();
-//   shell.reset();
-
-//   fml::TimePoint finish = fml::TimePoint::Now();
-//   fml::TimeDelta ellapsed = finish - start;
-
-// #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
-//   // Our batch time is 1000ms. Hopefully the 800ms limit is relaxed enough to
-//   // make it not too flaky.
-//   ASSERT_TRUE(ellapsed >= fml::TimeDelta::FromMilliseconds(800));
-// #else
-//   // Our batch time is 100ms. Hopefully the 500ms limit is relaxed enough to
-//   // make it not too flaky.
-//   ASSERT_TRUE(ellapsed <= fml::TimeDelta::FromMilliseconds(500));
-// #endif
-// }
-
-// TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   ASSERT_TRUE(configuration.IsValid());
-//   configuration.SetEntrypoint("reportTimingsMain");
-//   fml::AutoResetWaitableEvent reportLatch;
-//   std::vector<int64_t> timestamps;
-//   auto nativeTimingCallback = [&reportLatch,
-//                                &timestamps](Dart_NativeArguments args) {
-//     Dart_Handle exception = nullptr;
-//     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-//         args, 0, exception);
-//     reportLatch.Signal();
-//   };
-//   AddNativeCallback("NativeReportTimingsCallback",
-//                     CREATE_NATIVE_ENTRY(nativeTimingCallback));
-//   RunEngine(shell.get(), std::move(configuration));
-
-//   for (int i = 0; i < 10; i += 1) {
-//     PumpOneFrame(shell.get());
-//   }
-
-//   reportLatch.Wait();
-//   shell.reset();
-
-//   // Check for the immediate callback of the first frame that doesn't wait
-//   for
-//   // the other 9 frames to be rasterized.
-//   ASSERT_EQ(timestamps.size(), FrameTiming::kCount);
-// }
-
-// TEST_F(ShellTest, WaitForFirstFrame) {
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   configuration.SetEntrypoint("emptyMain");
-
-//   RunEngine(shell.get(), std::move(configuration));
-//   PumpOneFrame(shell.get());
-//   fml::Status result =
-//       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
-//   ASSERT_TRUE(result.ok());
-// }
-
-// TEST_F(ShellTest, WaitForFirstFrameTimeout) {
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   configuration.SetEntrypoint("emptyMain");
-
-//   RunEngine(shell.get(), std::move(configuration));
-//   fml::Status result =
-//       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(10));
-//   ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
-// }
-
-// TEST_F(ShellTest, WaitForFirstFrameMultiple) {
-//   auto settings = CreateSettingsForFixture();
-//   std::unique_ptr<Shell> shell = CreateShell(settings);
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   configuration.SetEntrypoint("emptyMain");
-
-//   RunEngine(shell.get(), std::move(configuration));
-//   PumpOneFrame(shell.get());
-//   fml::Status result =
-//       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
-//   ASSERT_TRUE(result.ok());
-//   for (int i = 0; i < 100; ++i) {
-//     result = shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1));
-//     ASSERT_TRUE(result.ok());
-//   }
-// }
-
-// /// Makes sure that WaitForFirstFrame works if we rendered a frame with the
-// /// single-thread setup.
-// TEST_F(ShellTest, WaitForFirstFrameInlined) {
-//   Settings settings = CreateSettingsForFixture();
-//   auto task_runner = GetThreadTaskRunner();
-//   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-//                            task_runner);
-//   std::unique_ptr<Shell> shell =
-//       CreateShell(std::move(settings), std::move(task_runners));
-
-//   // Create the surface needed by rasterizer
-//   PlatformViewNotifyCreated(shell.get());
-
-//   auto configuration = RunConfiguration::InferFromSettings(settings);
-//   configuration.SetEntrypoint("emptyMain");
-
-//   RunEngine(shell.get(), std::move(configuration));
-//   PumpOneFrame(shell.get());
-//   fml::AutoResetWaitableEvent event;
-//   task_runner->PostTask([&shell, &event] {
-//     fml::Status result =
-//         shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
-//     ASSERT_EQ(result.code(), fml::StatusCode::kFailedPrecondition);
-//     event.Signal();
-//   });
-//   ASSERT_FALSE(event.WaitWithTimeout(fml::TimeDelta::FromMilliseconds(1000)));
-// }
+static bool ValidateShell(Shell* shell) {
+  if (!shell) {
+    return false;
+  }
+
+  if (!shell->IsSetup()) {
+    return false;
+  }
+
+  ShellTest::PlatformViewNotifyCreated(shell);
+
+  {
+    fml::AutoResetWaitableEvent latch;
+    fml::TaskRunner::RunNowOrPostTask(
+        shell->GetTaskRunners().GetPlatformTaskRunner(), [shell, &latch]() {
+          shell->GetPlatformView()->NotifyDestroyed();
+          latch.Signal();
+        });
+    latch.Wait();
+  }
+
+  return true;
+}
+
+TEST_F(ShellTest, InitializeWithInvalidThreads) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  TaskRunners task_runners("test", nullptr, nullptr, nullptr, nullptr);
+  auto shell = CreateShell(std::move(settings), std::move(task_runners));
+  ASSERT_FALSE(shell);
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, InitializeWithDifferentThreads) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::Platform | ThreadHost::Type::GPU |
+                             ThreadHost::Type::IO | ThreadHost::Type::UI);
+  TaskRunners task_runners("test",
+  thread_host.platform_thread->GetTaskRunner(),
+                           thread_host.gpu_thread->GetTaskRunner(),
+                           thread_host.ui_thread->GetTaskRunner(),
+                           thread_host.io_thread->GetTaskRunner());
+  auto shell = CreateShell(std::move(settings), std::move(task_runners));
+  ASSERT_TRUE(ValidateShell(shell.get()));
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  shell.reset();
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, InitializeWithSingleThread) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+                         ThreadHost::Type::Platform);
+  auto task_runner = thread_host.platform_thread->GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), std::move(task_runners));
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  ASSERT_TRUE(ValidateShell(shell.get()));
+  shell.reset();
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  auto shell = CreateShell(std::move(settings), std::move(task_runners));
+  ASSERT_TRUE(ValidateShell(shell.get()));
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  shell.reset();
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest,
+       InitializeWithMultipleThreadButCallingThreadAsPlatformThread) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  ThreadHost thread_host(
+      "io.flutter.test." + GetCurrentTestName() + ".",
+      ThreadHost::Type::GPU | ThreadHost::Type::IO | ThreadHost::Type::UI);
+  fml::MessageLoop::EnsureInitializedForCurrentThread();
+  TaskRunners task_runners("test",
+                           fml::MessageLoop::GetCurrent().GetTaskRunner(),
+                           thread_host.gpu_thread->GetTaskRunner(),
+                           thread_host.ui_thread->GetTaskRunner(),
+                           thread_host.io_thread->GetTaskRunner());
+  auto shell = Shell::Create(
+      std::move(task_runners), settings,
+      [](Shell& shell) {
+        return std::make_unique<ShellTestPlatformView>(shell,
+                                                       shell.GetTaskRunners());
+      },
+      [](Shell& shell) {
+        return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
+      });
+  ASSERT_TRUE(ValidateShell(shell.get()));
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  shell.reset();
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  Settings settings = CreateSettingsForFixture();
+  ThreadHost thread_host(
+      "io.flutter.test." + GetCurrentTestName() + ".",
+      ThreadHost::Type::Platform | ThreadHost::Type::IO |
+      ThreadHost::Type::UI);
+  TaskRunners task_runners(
+      "test",
+      thread_host.platform_thread->GetTaskRunner(),  // platform
+      thread_host.platform_thread->GetTaskRunner(),  // gpu
+      thread_host.ui_thread->GetTaskRunner(),        // ui
+      thread_host.io_thread->GetTaskRunner()         // io
+  );
+  auto shell = CreateShell(std::move(settings), std::move(task_runners));
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  ASSERT_TRUE(ValidateShell(shell.get()));
+  shell.reset();
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, FixturesAreFunctional) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  auto settings = CreateSettingsForFixture();
+  auto shell = CreateShell(settings);
+  ASSERT_TRUE(ValidateShell(shell.get()));
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+  configuration.SetEntrypoint("fixturesAreFunctionalMain");
+
+  fml::AutoResetWaitableEvent main_latch;
+  AddNativeCallback(
+      "SayHiFromFixturesAreFunctionalMain",
+      CREATE_NATIVE_ENTRY([&main_latch](auto args) { main_latch.Signal();
+      }));
+
+  RunEngine(shell.get(), std::move(configuration));
+  main_latch.Wait();
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  shell.reset();
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+  auto settings = CreateSettingsForFixture();
+  auto shell = CreateShell(settings);
+  ASSERT_TRUE(ValidateShell(shell.get()));
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+  configuration.SetEntrypoint("testCanLaunchSecondaryIsolate");
+
+  fml::CountDownLatch latch(2);
+  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&latch](auto args) {
+                      latch.CountDown();
+                    }));
+
+  RunEngine(shell.get(), std::move(configuration));
+
+  latch.Wait();
+
+  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+  shell.reset();
+  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+}
+
+TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
+  if (DartVM::IsRunningPrecompiledCode()) {
+    // This covers profile and release modes which use AOT (where this flag
+    does
+    // not make sense anyway).
+    GTEST_SKIP();
+    return;
+  }
+
+  const std::vector<fml::CommandLine::Option> options = {
+      fml::CommandLine::Option("dart-flags", "--enable_mirrors")};
+  fml::CommandLine command_line("", options, std::vector<std::string>());
+  flutter::Settings settings =
+  flutter::SettingsFromCommandLine(command_line);
+  EXPECT_EQ(settings.dart_flags.size(), 1u);
+}
+
+TEST_F(ShellTest, BlacklistedDartVMFlag) {
+  // Run this test in a thread-safe manner, otherwise gtest will complain.
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+  const std::vector<fml::CommandLine::Option> options = {
+      fml::CommandLine::Option("dart-flags", "--verify_after_gc")};
+  fml::CommandLine command_line("", options, std::vector<std::string>());
+
+#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
+  // Upon encountering a non-whitelisted Dart flag the process terminates.
+  const char* expected =
+      "Encountered blacklisted Dart VM flag: --verify_after_gc";
+  ASSERT_DEATH(flutter::SettingsFromCommandLine(command_line), expected);
+#else
+  flutter::Settings settings =
+  flutter::SettingsFromCommandLine(command_line);
+  EXPECT_EQ(settings.dart_flags.size(), 0u);
+#endif
+}
+
+TEST_F(ShellTest, WhitelistedDartVMFlag) {
+  const std::vector<fml::CommandLine::Option> options = {
+      fml::CommandLine::Option("dart-flags",
+                               "--max_profile_depth 1,--random_seed 42")};
+  fml::CommandLine command_line("", options, std::vector<std::string>());
+  flutter::Settings settings =
+  flutter::SettingsFromCommandLine(command_line);
+
+#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
+  EXPECT_EQ(settings.dart_flags.size(), 2u);
+  EXPECT_EQ(settings.dart_flags[0], "--max_profile_depth 1");
+  EXPECT_EQ(settings.dart_flags[1], "--random_seed 42");
+#else
+  EXPECT_EQ(settings.dart_flags.size(), 0u);
+#endif
+}
+
+TEST_F(ShellTest, NoNeedToReportTimingsByDefault) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+  ASSERT_FALSE(GetNeedsReportTimings(shell.get()));
+
+  // This assertion may or may not be the direct result of
+  needs_report_timings_
+  // being false. The count could be 0 simply because we just cleared
+  unreported
+  // timings by reporting them. Hence this can't replace the
+  // ASSERT_FALSE(GetNeedsReportTimings(shell.get())) check. We added this
+  // assertion for an additional confidence that we're not pushing back to
+  // unreported timings unnecessarily.
+  //
+  // Conversely, do not assert UnreportedTimingsCount(shell.get()) to be
+  // positive in any tests. Otherwise those tests will be flaky as the
+  clearing
+  // of unreported timings is unpredictive.
+  ASSERT_EQ(UnreportedTimingsCount(shell.get()), 0);
+}
+
+TEST_F(ShellTest, NeedsReportTimingsIsSetWithCallback) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("dummyReportTimingsMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+  ASSERT_TRUE(GetNeedsReportTimings(shell.get()));
+}
+
+static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
+                              fml::TimePoint start,
+                              fml::TimePoint finish) {
+  fml::TimePoint last_frame_start;
+  for (size_t i = 0; i < timings.size(); i += 1) {
+    // Ensure that timings are sorted.
+    ASSERT_TRUE(timings[i].Get(FrameTiming::kPhases[0]) >= last_frame_start);
+    last_frame_start = timings[i].Get(FrameTiming::kPhases[0]);
+
+    fml::TimePoint last_phase_time;
+    for (auto phase : FrameTiming::kPhases) {
+      ASSERT_TRUE(timings[i].Get(phase) >= start);
+      ASSERT_TRUE(timings[i].Get(phase) <= finish);
+
+      // phases should have weakly increasing time points
+      ASSERT_TRUE(last_phase_time <= timings[i].Get(phase));
+      last_phase_time = timings[i].Get(phase);
+    }
+  }
+}
+
+TEST_F(ShellTest, ReportTimingsIsCalled) {
+  fml::TimePoint start = fml::TimePoint::Now();
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+  configuration.SetEntrypoint("reportTimingsMain");
+  fml::AutoResetWaitableEvent reportLatch;
+  std::vector<int64_t> timestamps;
+  auto nativeTimingCallback = [&reportLatch,
+                               &timestamps](Dart_NativeArguments args) {
+    Dart_Handle exception = nullptr;
+    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
+        args, 0, exception);
+    reportLatch.Signal();
+  };
+  AddNativeCallback("NativeReportTimingsCallback",
+                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
+  RunEngine(shell.get(), std::move(configuration));
+
+  // Pump many frames so we can trigger the report quickly instead of waiting
+  // for the 1 second threshold.
+  for (int i = 0; i < 200; i += 1) {
+    PumpOneFrame(shell.get());
+  }
+
+  reportLatch.Wait();
+  shell.reset();
+
+  fml::TimePoint finish = fml::TimePoint::Now();
+  ASSERT_TRUE(timestamps.size() > 0);
+  ASSERT_TRUE(timestamps.size() % FrameTiming::kCount == 0);
+  std::vector<FrameTiming> timings(timestamps.size() / FrameTiming::kCount);
+
+  for (size_t i = 0; i * FrameTiming::kCount < timestamps.size(); i += 1) {
+    for (auto phase : FrameTiming::kPhases) {
+      timings[i].Set(
+          phase,
+          fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(
+              timestamps[i * FrameTiming::kCount + phase])));
+    }
+  }
+  CheckFrameTimings(timings, start, finish);
+}
+
+TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
+  fml::TimePoint start = fml::TimePoint::Now();
+
+  auto settings = CreateSettingsForFixture();
+  fml::AutoResetWaitableEvent timingLatch;
+  FrameTiming timing;
+
+  for (auto phase : FrameTiming::kPhases) {
+    timing.Set(phase, fml::TimePoint());
+    // Check that the time points are initially smaller than start, so
+    // CheckFrameTimings will fail if they're not properly set later.
+    ASSERT_TRUE(timing.Get(phase) < start);
+  }
+
+  settings.frame_rasterized_callback = [&timing,
+                                        &timingLatch](const FrameTiming& t) {
+    timing = t;
+    timingLatch.Signal();
+  };
+
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("onBeginFrameMain");
+
+  int64_t begin_frame;
+  auto nativeOnBeginFrame = [&begin_frame](Dart_NativeArguments args) {
+    Dart_Handle exception = nullptr;
+    begin_frame =
+        tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
+  };
+  AddNativeCallback("NativeOnBeginFrame",
+                    CREATE_NATIVE_ENTRY(nativeOnBeginFrame));
+
+  RunEngine(shell.get(), std::move(configuration));
+
+  PumpOneFrame(shell.get());
+
+  // Check that timing is properly set. This implies that
+  // settings.frame_rasterized_callback is called.
+  timingLatch.Wait();
+  fml::TimePoint finish = fml::TimePoint::Now();
+  std::vector<FrameTiming> timings = {timing};
+  CheckFrameTimings(timings, start, finish);
+
+  // Check that onBeginFrame has the same timestamp as FrameTiming's build
+  start int64_t build_start =
+      timing.Get(FrameTiming::kBuildStart).ToEpochDelta().ToMicroseconds();
+  ASSERT_EQ(build_start, begin_frame);
+}
+
+TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
+  // Ensure that all phases are in kPhases.
+  ASSERT_EQ(sizeof(FrameTiming::kPhases),
+            FrameTiming::kCount * sizeof(FrameTiming::Phase));
+
+  int lastPhaseIndex = -1;
+  FrameTiming timing;
+  for (auto phase : FrameTiming::kPhases) {
+    ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in
+    order. lastPhaseIndex = phase; auto fake_time =
+        fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(phase));
+    timing.Set(phase, fake_time);
+    ASSERT_TRUE(timing.Get(phase) == fake_time);
+  }
+}
+
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+TEST_F(ShellTest, ReportTimingsIsCalledLaterInReleaseMode) {
+#else
+TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
+#endif
+  fml::TimePoint start = fml::TimePoint::Now();
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+  configuration.SetEntrypoint("reportTimingsMain");
+
+  // Wait for 2 reports: the first one is the immediate callback of the first
+  // frame; the second one will exercise the batching logic.
+  fml::CountDownLatch reportLatch(2);
+  std::vector<int64_t> timestamps;
+  auto nativeTimingCallback = [&reportLatch,
+                               &timestamps](Dart_NativeArguments args) {
+    Dart_Handle exception = nullptr;
+    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
+        args, 0, exception);
+    reportLatch.CountDown();
+  };
+  AddNativeCallback("NativeReportTimingsCallback",
+                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
+  RunEngine(shell.get(), std::move(configuration));
+
+  PumpOneFrame(shell.get());
+  PumpOneFrame(shell.get());
+
+  reportLatch.Wait();
+  shell.reset();
+
+  fml::TimePoint finish = fml::TimePoint::Now();
+  fml::TimeDelta ellapsed = finish - start;
+
+#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+  // Our batch time is 1000ms. Hopefully the 800ms limit is relaxed enough to
+  // make it not too flaky.
+  ASSERT_TRUE(ellapsed >= fml::TimeDelta::FromMilliseconds(800));
+#else
+  // Our batch time is 100ms. Hopefully the 500ms limit is relaxed enough to
+  // make it not too flaky.
+  ASSERT_TRUE(ellapsed <= fml::TimeDelta::FromMilliseconds(500));
+#endif
+}
+
+TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  ASSERT_TRUE(configuration.IsValid());
+  configuration.SetEntrypoint("reportTimingsMain");
+  fml::AutoResetWaitableEvent reportLatch;
+  std::vector<int64_t> timestamps;
+  auto nativeTimingCallback = [&reportLatch,
+                               &timestamps](Dart_NativeArguments args) {
+    Dart_Handle exception = nullptr;
+    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
+        args, 0, exception);
+    reportLatch.Signal();
+  };
+  AddNativeCallback("NativeReportTimingsCallback",
+                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
+  RunEngine(shell.get(), std::move(configuration));
+
+  for (int i = 0; i < 10; i += 1) {
+    PumpOneFrame(shell.get());
+  }
+
+  reportLatch.Wait();
+  shell.reset();
+
+  // Check for the immediate callback of the first frame that doesn't wait
+  for
+  // the other 9 frames to be rasterized.
+  ASSERT_EQ(timestamps.size(), FrameTiming::kCount);
+}
+
+TEST_F(ShellTest, WaitForFirstFrame) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+  fml::Status result =
+      shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
+  ASSERT_TRUE(result.ok());
+}
+
+TEST_F(ShellTest, WaitForFirstFrameTimeout) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+  fml::Status result =
+      shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(10));
+  ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
+}
+
+TEST_F(ShellTest, WaitForFirstFrameMultiple) {
+  auto settings = CreateSettingsForFixture();
+  std::unique_ptr<Shell> shell = CreateShell(settings);
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+  fml::Status result =
+      shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
+  ASSERT_TRUE(result.ok());
+  for (int i = 0; i < 100; ++i) {
+    result = shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1));
+    ASSERT_TRUE(result.ok());
+  }
+}
+
+/// Makes sure that WaitForFirstFrame works if we rendered a frame with the
+/// single-thread setup.
+TEST_F(ShellTest, WaitForFirstFrameInlined) {
+  Settings settings = CreateSettingsForFixture();
+  auto task_runner = GetThreadTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  std::unique_ptr<Shell> shell =
+      CreateShell(std::move(settings), std::move(task_runners));
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+  fml::AutoResetWaitableEvent event;
+  task_runner->PostTask([&shell, &event] {
+    fml::Status result =
+        shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
+    ASSERT_EQ(result.code(), fml::StatusCode::kFailedPrecondition);
+    event.Signal();
+  });
+  ASSERT_FALSE(event.WaitWithTimeout(fml::TimeDelta::FromMilliseconds(1000)));
+}
 
 TEST_F(ShellTest, SetResourceCacheSize) {
   Settings settings = CreateSettingsForFixture();

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -26,555 +26,591 @@
 namespace flutter {
 namespace testing {
 
-static bool ValidateShell(Shell* shell) {
-  if (!shell) {
-    return false;
-  }
-
-  if (!shell->IsSetup()) {
-    return false;
-  }
-
-  ShellTest::PlatformViewNotifyCreated(shell);
-
-  {
-    fml::AutoResetWaitableEvent latch;
-    fml::TaskRunner::RunNowOrPostTask(
-        shell->GetTaskRunners().GetPlatformTaskRunner(), [shell, &latch]() {
-          shell->GetPlatformView()->NotifyDestroyed();
-          latch.Signal();
-        });
-    latch.Wait();
-  }
-
-  return true;
-}
-
-TEST_F(ShellTest, InitializeWithInvalidThreads) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  Settings settings = CreateSettingsForFixture();
-  TaskRunners task_runners("test", nullptr, nullptr, nullptr, nullptr);
-  auto shell = CreateShell(std::move(settings), std::move(task_runners));
-  ASSERT_FALSE(shell);
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST_F(ShellTest, InitializeWithDifferentThreads) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-                         ThreadHost::Type::Platform | ThreadHost::Type::GPU |
-                             ThreadHost::Type::IO | ThreadHost::Type::UI);
-  TaskRunners task_runners("test", thread_host.platform_thread->GetTaskRunner(),
-                           thread_host.gpu_thread->GetTaskRunner(),
-                           thread_host.ui_thread->GetTaskRunner(),
-                           thread_host.io_thread->GetTaskRunner());
-  auto shell = CreateShell(std::move(settings), std::move(task_runners));
-  ASSERT_TRUE(ValidateShell(shell.get()));
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST_F(ShellTest, InitializeWithSingleThread) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
-                         ThreadHost::Type::Platform);
-  auto task_runner = thread_host.platform_thread->GetTaskRunner();
-  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-                           task_runner);
-  auto shell = CreateShell(std::move(settings), std::move(task_runners));
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  ASSERT_TRUE(ValidateShell(shell.get()));
-  shell.reset();
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  Settings settings = CreateSettingsForFixture();
-  fml::MessageLoop::EnsureInitializedForCurrentThread();
-  auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
-  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
-                           task_runner);
-  auto shell = CreateShell(std::move(settings), std::move(task_runners));
-  ASSERT_TRUE(ValidateShell(shell.get()));
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST_F(ShellTest,
-       InitializeWithMultipleThreadButCallingThreadAsPlatformThread) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host(
-      "io.flutter.test." + GetCurrentTestName() + ".",
-      ThreadHost::Type::GPU | ThreadHost::Type::IO | ThreadHost::Type::UI);
-  fml::MessageLoop::EnsureInitializedForCurrentThread();
-  TaskRunners task_runners("test",
-                           fml::MessageLoop::GetCurrent().GetTaskRunner(),
-                           thread_host.gpu_thread->GetTaskRunner(),
-                           thread_host.ui_thread->GetTaskRunner(),
-                           thread_host.io_thread->GetTaskRunner());
-  auto shell = Shell::Create(
-      std::move(task_runners), settings,
-      [](Shell& shell) {
-        return std::make_unique<ShellTestPlatformView>(shell,
-                                                       shell.GetTaskRunners());
-      },
-      [](Shell& shell) {
-        return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
-      });
-  ASSERT_TRUE(ValidateShell(shell.get()));
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  Settings settings = CreateSettingsForFixture();
-  ThreadHost thread_host(
-      "io.flutter.test." + GetCurrentTestName() + ".",
-      ThreadHost::Type::Platform | ThreadHost::Type::IO | ThreadHost::Type::UI);
-  TaskRunners task_runners(
-      "test",
-      thread_host.platform_thread->GetTaskRunner(),  // platform
-      thread_host.platform_thread->GetTaskRunner(),  // gpu
-      thread_host.ui_thread->GetTaskRunner(),        // ui
-      thread_host.io_thread->GetTaskRunner()         // io
-  );
-  auto shell = CreateShell(std::move(settings), std::move(task_runners));
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  ASSERT_TRUE(ValidateShell(shell.get()));
-  shell.reset();
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST_F(ShellTest, FixturesAreFunctional) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  auto settings = CreateSettingsForFixture();
-  auto shell = CreateShell(settings);
-  ASSERT_TRUE(ValidateShell(shell.get()));
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  ASSERT_TRUE(configuration.IsValid());
-  configuration.SetEntrypoint("fixturesAreFunctionalMain");
-
-  fml::AutoResetWaitableEvent main_latch;
-  AddNativeCallback(
-      "SayHiFromFixturesAreFunctionalMain",
-      CREATE_NATIVE_ENTRY([&main_latch](auto args) { main_latch.Signal(); }));
-
-  RunEngine(shell.get(), std::move(configuration));
-  main_latch.Wait();
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-  auto settings = CreateSettingsForFixture();
-  auto shell = CreateShell(settings);
-  ASSERT_TRUE(ValidateShell(shell.get()));
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  ASSERT_TRUE(configuration.IsValid());
-  configuration.SetEntrypoint("testCanLaunchSecondaryIsolate");
-
-  fml::CountDownLatch latch(2);
-  AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&latch](auto args) {
-                      latch.CountDown();
-                    }));
-
-  RunEngine(shell.get(), std::move(configuration));
-
-  latch.Wait();
-
-  ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
-  ASSERT_FALSE(DartVMRef::IsInstanceRunning());
-}
-
-TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
-  if (DartVM::IsRunningPrecompiledCode()) {
-    // This covers profile and release modes which use AOT (where this flag does
-    // not make sense anyway).
-    GTEST_SKIP();
-    return;
-  }
-
-  const std::vector<fml::CommandLine::Option> options = {
-      fml::CommandLine::Option("dart-flags", "--enable_mirrors")};
-  fml::CommandLine command_line("", options, std::vector<std::string>());
-  flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
-  EXPECT_EQ(settings.dart_flags.size(), 1u);
-}
-
-TEST_F(ShellTest, BlacklistedDartVMFlag) {
-  // Run this test in a thread-safe manner, otherwise gtest will complain.
-  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
-
-  const std::vector<fml::CommandLine::Option> options = {
-      fml::CommandLine::Option("dart-flags", "--verify_after_gc")};
-  fml::CommandLine command_line("", options, std::vector<std::string>());
-
-#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
-  // Upon encountering a non-whitelisted Dart flag the process terminates.
-  const char* expected =
-      "Encountered blacklisted Dart VM flag: --verify_after_gc";
-  ASSERT_DEATH(flutter::SettingsFromCommandLine(command_line), expected);
-#else
-  flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
-  EXPECT_EQ(settings.dart_flags.size(), 0u);
-#endif
-}
-
-TEST_F(ShellTest, WhitelistedDartVMFlag) {
-  const std::vector<fml::CommandLine::Option> options = {
-      fml::CommandLine::Option("dart-flags",
-                               "--max_profile_depth 1,--random_seed 42")};
-  fml::CommandLine command_line("", options, std::vector<std::string>());
-  flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
-
-#if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
-  EXPECT_EQ(settings.dart_flags.size(), 2u);
-  EXPECT_EQ(settings.dart_flags[0], "--max_profile_depth 1");
-  EXPECT_EQ(settings.dart_flags[1], "--random_seed 42");
-#else
-  EXPECT_EQ(settings.dart_flags.size(), 0u);
-#endif
-}
-
-TEST_F(ShellTest, NoNeedToReportTimingsByDefault) {
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("emptyMain");
-
-  RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
-  ASSERT_FALSE(GetNeedsReportTimings(shell.get()));
-
-  // This assertion may or may not be the direct result of needs_report_timings_
-  // being false. The count could be 0 simply because we just cleared unreported
-  // timings by reporting them. Hence this can't replace the
-  // ASSERT_FALSE(GetNeedsReportTimings(shell.get())) check. We added this
-  // assertion for an additional confidence that we're not pushing back to
-  // unreported timings unnecessarily.
-  //
-  // Conversely, do not assert UnreportedTimingsCount(shell.get()) to be
-  // positive in any tests. Otherwise those tests will be flaky as the clearing
-  // of unreported timings is unpredictive.
-  ASSERT_EQ(UnreportedTimingsCount(shell.get()), 0);
-}
-
-TEST_F(ShellTest, NeedsReportTimingsIsSetWithCallback) {
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("dummyReportTimingsMain");
-
-  RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
-  ASSERT_TRUE(GetNeedsReportTimings(shell.get()));
-}
-
-static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
-                              fml::TimePoint start,
-                              fml::TimePoint finish) {
-  fml::TimePoint last_frame_start;
-  for (size_t i = 0; i < timings.size(); i += 1) {
-    // Ensure that timings are sorted.
-    ASSERT_TRUE(timings[i].Get(FrameTiming::kPhases[0]) >= last_frame_start);
-    last_frame_start = timings[i].Get(FrameTiming::kPhases[0]);
-
-    fml::TimePoint last_phase_time;
-    for (auto phase : FrameTiming::kPhases) {
-      ASSERT_TRUE(timings[i].Get(phase) >= start);
-      ASSERT_TRUE(timings[i].Get(phase) <= finish);
-
-      // phases should have weakly increasing time points
-      ASSERT_TRUE(last_phase_time <= timings[i].Get(phase));
-      last_phase_time = timings[i].Get(phase);
-    }
-  }
-}
-
-TEST_F(ShellTest, ReportTimingsIsCalled) {
-  fml::TimePoint start = fml::TimePoint::Now();
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  ASSERT_TRUE(configuration.IsValid());
-  configuration.SetEntrypoint("reportTimingsMain");
-  fml::AutoResetWaitableEvent reportLatch;
-  std::vector<int64_t> timestamps;
-  auto nativeTimingCallback = [&reportLatch,
-                               &timestamps](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
-    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-        args, 0, exception);
-    reportLatch.Signal();
-  };
-  AddNativeCallback("NativeReportTimingsCallback",
-                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
-  RunEngine(shell.get(), std::move(configuration));
-
-  // Pump many frames so we can trigger the report quickly instead of waiting
-  // for the 1 second threshold.
-  for (int i = 0; i < 200; i += 1) {
-    PumpOneFrame(shell.get());
-  }
-
-  reportLatch.Wait();
-  shell.reset();
-
-  fml::TimePoint finish = fml::TimePoint::Now();
-  ASSERT_TRUE(timestamps.size() > 0);
-  ASSERT_TRUE(timestamps.size() % FrameTiming::kCount == 0);
-  std::vector<FrameTiming> timings(timestamps.size() / FrameTiming::kCount);
-
-  for (size_t i = 0; i * FrameTiming::kCount < timestamps.size(); i += 1) {
-    for (auto phase : FrameTiming::kPhases) {
-      timings[i].Set(
-          phase,
-          fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(
-              timestamps[i * FrameTiming::kCount + phase])));
-    }
-  }
-  CheckFrameTimings(timings, start, finish);
-}
-
-TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
-  fml::TimePoint start = fml::TimePoint::Now();
-
-  auto settings = CreateSettingsForFixture();
-  fml::AutoResetWaitableEvent timingLatch;
-  FrameTiming timing;
-
-  for (auto phase : FrameTiming::kPhases) {
-    timing.Set(phase, fml::TimePoint());
-    // Check that the time points are initially smaller than start, so
-    // CheckFrameTimings will fail if they're not properly set later.
-    ASSERT_TRUE(timing.Get(phase) < start);
-  }
-
-  settings.frame_rasterized_callback = [&timing,
-                                        &timingLatch](const FrameTiming& t) {
-    timing = t;
-    timingLatch.Signal();
-  };
-
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("onBeginFrameMain");
-
-  int64_t begin_frame;
-  auto nativeOnBeginFrame = [&begin_frame](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
-    begin_frame =
-        tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
-  };
-  AddNativeCallback("NativeOnBeginFrame",
-                    CREATE_NATIVE_ENTRY(nativeOnBeginFrame));
-
-  RunEngine(shell.get(), std::move(configuration));
-
-  PumpOneFrame(shell.get());
-
-  // Check that timing is properly set. This implies that
-  // settings.frame_rasterized_callback is called.
-  timingLatch.Wait();
-  fml::TimePoint finish = fml::TimePoint::Now();
-  std::vector<FrameTiming> timings = {timing};
-  CheckFrameTimings(timings, start, finish);
-
-  // Check that onBeginFrame has the same timestamp as FrameTiming's build start
-  int64_t build_start =
-      timing.Get(FrameTiming::kBuildStart).ToEpochDelta().ToMicroseconds();
-  ASSERT_EQ(build_start, begin_frame);
-}
-
-TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
-  // Ensure that all phases are in kPhases.
-  ASSERT_EQ(sizeof(FrameTiming::kPhases),
-            FrameTiming::kCount * sizeof(FrameTiming::Phase));
-
-  int lastPhaseIndex = -1;
-  FrameTiming timing;
-  for (auto phase : FrameTiming::kPhases) {
-    ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in order.
-    lastPhaseIndex = phase;
-    auto fake_time =
-        fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(phase));
-    timing.Set(phase, fake_time);
-    ASSERT_TRUE(timing.Get(phase) == fake_time);
-  }
-}
-
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
-TEST_F(ShellTest, ReportTimingsIsCalledLaterInReleaseMode) {
-#else
-TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
-#endif
-  fml::TimePoint start = fml::TimePoint::Now();
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  ASSERT_TRUE(configuration.IsValid());
-  configuration.SetEntrypoint("reportTimingsMain");
-
-  // Wait for 2 reports: the first one is the immediate callback of the first
-  // frame; the second one will exercise the batching logic.
-  fml::CountDownLatch reportLatch(2);
-  std::vector<int64_t> timestamps;
-  auto nativeTimingCallback = [&reportLatch,
-                               &timestamps](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
-    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-        args, 0, exception);
-    reportLatch.CountDown();
-  };
-  AddNativeCallback("NativeReportTimingsCallback",
-                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
-  RunEngine(shell.get(), std::move(configuration));
-
-  PumpOneFrame(shell.get());
-  PumpOneFrame(shell.get());
-
-  reportLatch.Wait();
-  shell.reset();
-
-  fml::TimePoint finish = fml::TimePoint::Now();
-  fml::TimeDelta ellapsed = finish - start;
-
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
-  // Our batch time is 1000ms. Hopefully the 800ms limit is relaxed enough to
-  // make it not too flaky.
-  ASSERT_TRUE(ellapsed >= fml::TimeDelta::FromMilliseconds(800));
-#else
-  // Our batch time is 100ms. Hopefully the 500ms limit is relaxed enough to
-  // make it not too flaky.
-  ASSERT_TRUE(ellapsed <= fml::TimeDelta::FromMilliseconds(500));
-#endif
-}
-
-TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  ASSERT_TRUE(configuration.IsValid());
-  configuration.SetEntrypoint("reportTimingsMain");
-  fml::AutoResetWaitableEvent reportLatch;
-  std::vector<int64_t> timestamps;
-  auto nativeTimingCallback = [&reportLatch,
-                               &timestamps](Dart_NativeArguments args) {
-    Dart_Handle exception = nullptr;
-    timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
-        args, 0, exception);
-    reportLatch.Signal();
-  };
-  AddNativeCallback("NativeReportTimingsCallback",
-                    CREATE_NATIVE_ENTRY(nativeTimingCallback));
-  RunEngine(shell.get(), std::move(configuration));
-
-  for (int i = 0; i < 10; i += 1) {
-    PumpOneFrame(shell.get());
-  }
-
-  reportLatch.Wait();
-  shell.reset();
-
-  // Check for the immediate callback of the first frame that doesn't wait for
-  // the other 9 frames to be rasterized.
-  ASSERT_EQ(timestamps.size(), FrameTiming::kCount);
-}
-
-TEST_F(ShellTest, WaitForFirstFrame) {
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("emptyMain");
-
-  RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
-  fml::Status result =
-      shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
-  ASSERT_TRUE(result.ok());
-}
-
-TEST_F(ShellTest, WaitForFirstFrameTimeout) {
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("emptyMain");
-
-  RunEngine(shell.get(), std::move(configuration));
-  fml::Status result =
-      shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(10));
-  ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
-}
-
-TEST_F(ShellTest, WaitForFirstFrameMultiple) {
-  auto settings = CreateSettingsForFixture();
-  std::unique_ptr<Shell> shell = CreateShell(settings);
-
-  // Create the surface needed by rasterizer
-  PlatformViewNotifyCreated(shell.get());
-
-  auto configuration = RunConfiguration::InferFromSettings(settings);
-  configuration.SetEntrypoint("emptyMain");
-
-  RunEngine(shell.get(), std::move(configuration));
-  PumpOneFrame(shell.get());
-  fml::Status result =
-      shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
-  ASSERT_TRUE(result.ok());
-  for (int i = 0; i < 100; ++i) {
-    result = shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1));
-    ASSERT_TRUE(result.ok());
-  }
-}
-
-/// Makes sure that WaitForFirstFrame works if we rendered a frame with the
-/// single-thread setup.
-TEST_F(ShellTest, WaitForFirstFrameInlined) {
+// static bool ValidateShell(Shell* shell) {
+//   if (!shell) {
+//     return false;
+//   }
+
+//   if (!shell->IsSetup()) {
+//     return false;
+//   }
+
+//   ShellTest::PlatformViewNotifyCreated(shell);
+
+//   {
+//     fml::AutoResetWaitableEvent latch;
+//     fml::TaskRunner::RunNowOrPostTask(
+//         shell->GetTaskRunners().GetPlatformTaskRunner(), [shell, &latch]() {
+//           shell->GetPlatformView()->NotifyDestroyed();
+//           latch.Signal();
+//         });
+//     latch.Wait();
+//   }
+
+//   return true;
+// }
+
+// TEST_F(ShellTest, InitializeWithInvalidThreads) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   Settings settings = CreateSettingsForFixture();
+//   TaskRunners task_runners("test", nullptr, nullptr, nullptr, nullptr);
+//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
+//   ASSERT_FALSE(shell);
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST_F(ShellTest, InitializeWithDifferentThreads) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   Settings settings = CreateSettingsForFixture();
+//   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+//                          ThreadHost::Type::Platform | ThreadHost::Type::GPU |
+//                              ThreadHost::Type::IO | ThreadHost::Type::UI);
+//   TaskRunners task_runners("test",
+//   thread_host.platform_thread->GetTaskRunner(),
+//                            thread_host.gpu_thread->GetTaskRunner(),
+//                            thread_host.ui_thread->GetTaskRunner(),
+//                            thread_host.io_thread->GetTaskRunner());
+//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
+//   ASSERT_TRUE(ValidateShell(shell.get()));
+//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+//   shell.reset();
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST_F(ShellTest, InitializeWithSingleThread) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   Settings settings = CreateSettingsForFixture();
+//   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
+//                          ThreadHost::Type::Platform);
+//   auto task_runner = thread_host.platform_thread->GetTaskRunner();
+//   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+//                            task_runner);
+//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
+//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+//   ASSERT_TRUE(ValidateShell(shell.get()));
+//   shell.reset();
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   Settings settings = CreateSettingsForFixture();
+//   fml::MessageLoop::EnsureInitializedForCurrentThread();
+//   auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
+//   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+//                            task_runner);
+//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
+//   ASSERT_TRUE(ValidateShell(shell.get()));
+//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+//   shell.reset();
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST_F(ShellTest,
+//        InitializeWithMultipleThreadButCallingThreadAsPlatformThread) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   Settings settings = CreateSettingsForFixture();
+//   ThreadHost thread_host(
+//       "io.flutter.test." + GetCurrentTestName() + ".",
+//       ThreadHost::Type::GPU | ThreadHost::Type::IO | ThreadHost::Type::UI);
+//   fml::MessageLoop::EnsureInitializedForCurrentThread();
+//   TaskRunners task_runners("test",
+//                            fml::MessageLoop::GetCurrent().GetTaskRunner(),
+//                            thread_host.gpu_thread->GetTaskRunner(),
+//                            thread_host.ui_thread->GetTaskRunner(),
+//                            thread_host.io_thread->GetTaskRunner());
+//   auto shell = Shell::Create(
+//       std::move(task_runners), settings,
+//       [](Shell& shell) {
+//         return std::make_unique<ShellTestPlatformView>(shell,
+//                                                        shell.GetTaskRunners());
+//       },
+//       [](Shell& shell) {
+//         return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
+//       });
+//   ASSERT_TRUE(ValidateShell(shell.get()));
+//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+//   shell.reset();
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   Settings settings = CreateSettingsForFixture();
+//   ThreadHost thread_host(
+//       "io.flutter.test." + GetCurrentTestName() + ".",
+//       ThreadHost::Type::Platform | ThreadHost::Type::IO |
+//       ThreadHost::Type::UI);
+//   TaskRunners task_runners(
+//       "test",
+//       thread_host.platform_thread->GetTaskRunner(),  // platform
+//       thread_host.platform_thread->GetTaskRunner(),  // gpu
+//       thread_host.ui_thread->GetTaskRunner(),        // ui
+//       thread_host.io_thread->GetTaskRunner()         // io
+//   );
+//   auto shell = CreateShell(std::move(settings), std::move(task_runners));
+//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+//   ASSERT_TRUE(ValidateShell(shell.get()));
+//   shell.reset();
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST_F(ShellTest, FixturesAreFunctional) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   auto settings = CreateSettingsForFixture();
+//   auto shell = CreateShell(settings);
+//   ASSERT_TRUE(ValidateShell(shell.get()));
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   ASSERT_TRUE(configuration.IsValid());
+//   configuration.SetEntrypoint("fixturesAreFunctionalMain");
+
+//   fml::AutoResetWaitableEvent main_latch;
+//   AddNativeCallback(
+//       "SayHiFromFixturesAreFunctionalMain",
+//       CREATE_NATIVE_ENTRY([&main_latch](auto args) { main_latch.Signal();
+//       }));
+
+//   RunEngine(shell.get(), std::move(configuration));
+//   main_latch.Wait();
+//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+//   shell.reset();
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+//   auto settings = CreateSettingsForFixture();
+//   auto shell = CreateShell(settings);
+//   ASSERT_TRUE(ValidateShell(shell.get()));
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   ASSERT_TRUE(configuration.IsValid());
+//   configuration.SetEntrypoint("testCanLaunchSecondaryIsolate");
+
+//   fml::CountDownLatch latch(2);
+//   AddNativeCallback("NotifyNative", CREATE_NATIVE_ENTRY([&latch](auto args) {
+//                       latch.CountDown();
+//                     }));
+
+//   RunEngine(shell.get(), std::move(configuration));
+
+//   latch.Wait();
+
+//   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
+//   shell.reset();
+//   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
+// }
+
+// TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
+//   if (DartVM::IsRunningPrecompiledCode()) {
+//     // This covers profile and release modes which use AOT (where this flag
+//     does
+//     // not make sense anyway).
+//     GTEST_SKIP();
+//     return;
+//   }
+
+//   const std::vector<fml::CommandLine::Option> options = {
+//       fml::CommandLine::Option("dart-flags", "--enable_mirrors")};
+//   fml::CommandLine command_line("", options, std::vector<std::string>());
+//   flutter::Settings settings =
+//   flutter::SettingsFromCommandLine(command_line);
+//   EXPECT_EQ(settings.dart_flags.size(), 1u);
+// }
+
+// TEST_F(ShellTest, BlacklistedDartVMFlag) {
+//   // Run this test in a thread-safe manner, otherwise gtest will complain.
+//   ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+
+//   const std::vector<fml::CommandLine::Option> options = {
+//       fml::CommandLine::Option("dart-flags", "--verify_after_gc")};
+//   fml::CommandLine command_line("", options, std::vector<std::string>());
+
+// #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
+//   // Upon encountering a non-whitelisted Dart flag the process terminates.
+//   const char* expected =
+//       "Encountered blacklisted Dart VM flag: --verify_after_gc";
+//   ASSERT_DEATH(flutter::SettingsFromCommandLine(command_line), expected);
+// #else
+//   flutter::Settings settings =
+//   flutter::SettingsFromCommandLine(command_line);
+//   EXPECT_EQ(settings.dart_flags.size(), 0u);
+// #endif
+// }
+
+// TEST_F(ShellTest, WhitelistedDartVMFlag) {
+//   const std::vector<fml::CommandLine::Option> options = {
+//       fml::CommandLine::Option("dart-flags",
+//                                "--max_profile_depth 1,--random_seed 42")};
+//   fml::CommandLine command_line("", options, std::vector<std::string>());
+//   flutter::Settings settings =
+//   flutter::SettingsFromCommandLine(command_line);
+
+// #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
+//   EXPECT_EQ(settings.dart_flags.size(), 2u);
+//   EXPECT_EQ(settings.dart_flags[0], "--max_profile_depth 1");
+//   EXPECT_EQ(settings.dart_flags[1], "--random_seed 42");
+// #else
+//   EXPECT_EQ(settings.dart_flags.size(), 0u);
+// #endif
+// }
+
+// TEST_F(ShellTest, NoNeedToReportTimingsByDefault) {
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   configuration.SetEntrypoint("emptyMain");
+
+//   RunEngine(shell.get(), std::move(configuration));
+//   PumpOneFrame(shell.get());
+//   ASSERT_FALSE(GetNeedsReportTimings(shell.get()));
+
+//   // This assertion may or may not be the direct result of
+//   needs_report_timings_
+//   // being false. The count could be 0 simply because we just cleared
+//   unreported
+//   // timings by reporting them. Hence this can't replace the
+//   // ASSERT_FALSE(GetNeedsReportTimings(shell.get())) check. We added this
+//   // assertion for an additional confidence that we're not pushing back to
+//   // unreported timings unnecessarily.
+//   //
+//   // Conversely, do not assert UnreportedTimingsCount(shell.get()) to be
+//   // positive in any tests. Otherwise those tests will be flaky as the
+//   clearing
+//   // of unreported timings is unpredictive.
+//   ASSERT_EQ(UnreportedTimingsCount(shell.get()), 0);
+// }
+
+// TEST_F(ShellTest, NeedsReportTimingsIsSetWithCallback) {
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   configuration.SetEntrypoint("dummyReportTimingsMain");
+
+//   RunEngine(shell.get(), std::move(configuration));
+//   PumpOneFrame(shell.get());
+//   ASSERT_TRUE(GetNeedsReportTimings(shell.get()));
+// }
+
+// static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
+//                               fml::TimePoint start,
+//                               fml::TimePoint finish) {
+//   fml::TimePoint last_frame_start;
+//   for (size_t i = 0; i < timings.size(); i += 1) {
+//     // Ensure that timings are sorted.
+//     ASSERT_TRUE(timings[i].Get(FrameTiming::kPhases[0]) >= last_frame_start);
+//     last_frame_start = timings[i].Get(FrameTiming::kPhases[0]);
+
+//     fml::TimePoint last_phase_time;
+//     for (auto phase : FrameTiming::kPhases) {
+//       ASSERT_TRUE(timings[i].Get(phase) >= start);
+//       ASSERT_TRUE(timings[i].Get(phase) <= finish);
+
+//       // phases should have weakly increasing time points
+//       ASSERT_TRUE(last_phase_time <= timings[i].Get(phase));
+//       last_phase_time = timings[i].Get(phase);
+//     }
+//   }
+// }
+
+// TEST_F(ShellTest, ReportTimingsIsCalled) {
+//   fml::TimePoint start = fml::TimePoint::Now();
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   ASSERT_TRUE(configuration.IsValid());
+//   configuration.SetEntrypoint("reportTimingsMain");
+//   fml::AutoResetWaitableEvent reportLatch;
+//   std::vector<int64_t> timestamps;
+//   auto nativeTimingCallback = [&reportLatch,
+//                                &timestamps](Dart_NativeArguments args) {
+//     Dart_Handle exception = nullptr;
+//     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
+//         args, 0, exception);
+//     reportLatch.Signal();
+//   };
+//   AddNativeCallback("NativeReportTimingsCallback",
+//                     CREATE_NATIVE_ENTRY(nativeTimingCallback));
+//   RunEngine(shell.get(), std::move(configuration));
+
+//   // Pump many frames so we can trigger the report quickly instead of waiting
+//   // for the 1 second threshold.
+//   for (int i = 0; i < 200; i += 1) {
+//     PumpOneFrame(shell.get());
+//   }
+
+//   reportLatch.Wait();
+//   shell.reset();
+
+//   fml::TimePoint finish = fml::TimePoint::Now();
+//   ASSERT_TRUE(timestamps.size() > 0);
+//   ASSERT_TRUE(timestamps.size() % FrameTiming::kCount == 0);
+//   std::vector<FrameTiming> timings(timestamps.size() / FrameTiming::kCount);
+
+//   for (size_t i = 0; i * FrameTiming::kCount < timestamps.size(); i += 1) {
+//     for (auto phase : FrameTiming::kPhases) {
+//       timings[i].Set(
+//           phase,
+//           fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(
+//               timestamps[i * FrameTiming::kCount + phase])));
+//     }
+//   }
+//   CheckFrameTimings(timings, start, finish);
+// }
+
+// TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
+//   fml::TimePoint start = fml::TimePoint::Now();
+
+//   auto settings = CreateSettingsForFixture();
+//   fml::AutoResetWaitableEvent timingLatch;
+//   FrameTiming timing;
+
+//   for (auto phase : FrameTiming::kPhases) {
+//     timing.Set(phase, fml::TimePoint());
+//     // Check that the time points are initially smaller than start, so
+//     // CheckFrameTimings will fail if they're not properly set later.
+//     ASSERT_TRUE(timing.Get(phase) < start);
+//   }
+
+//   settings.frame_rasterized_callback = [&timing,
+//                                         &timingLatch](const FrameTiming& t) {
+//     timing = t;
+//     timingLatch.Signal();
+//   };
+
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   configuration.SetEntrypoint("onBeginFrameMain");
+
+//   int64_t begin_frame;
+//   auto nativeOnBeginFrame = [&begin_frame](Dart_NativeArguments args) {
+//     Dart_Handle exception = nullptr;
+//     begin_frame =
+//         tonic::DartConverter<int64_t>::FromArguments(args, 0, exception);
+//   };
+//   AddNativeCallback("NativeOnBeginFrame",
+//                     CREATE_NATIVE_ENTRY(nativeOnBeginFrame));
+
+//   RunEngine(shell.get(), std::move(configuration));
+
+//   PumpOneFrame(shell.get());
+
+//   // Check that timing is properly set. This implies that
+//   // settings.frame_rasterized_callback is called.
+//   timingLatch.Wait();
+//   fml::TimePoint finish = fml::TimePoint::Now();
+//   std::vector<FrameTiming> timings = {timing};
+//   CheckFrameTimings(timings, start, finish);
+
+//   // Check that onBeginFrame has the same timestamp as FrameTiming's build
+//   start int64_t build_start =
+//       timing.Get(FrameTiming::kBuildStart).ToEpochDelta().ToMicroseconds();
+//   ASSERT_EQ(build_start, begin_frame);
+// }
+
+// TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
+//   // Ensure that all phases are in kPhases.
+//   ASSERT_EQ(sizeof(FrameTiming::kPhases),
+//             FrameTiming::kCount * sizeof(FrameTiming::Phase));
+
+//   int lastPhaseIndex = -1;
+//   FrameTiming timing;
+//   for (auto phase : FrameTiming::kPhases) {
+//     ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in
+//     order. lastPhaseIndex = phase; auto fake_time =
+//         fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(phase));
+//     timing.Set(phase, fake_time);
+//     ASSERT_TRUE(timing.Get(phase) == fake_time);
+//   }
+// }
+
+// #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+// TEST_F(ShellTest, ReportTimingsIsCalledLaterInReleaseMode) {
+// #else
+// TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
+// #endif
+//   fml::TimePoint start = fml::TimePoint::Now();
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   ASSERT_TRUE(configuration.IsValid());
+//   configuration.SetEntrypoint("reportTimingsMain");
+
+//   // Wait for 2 reports: the first one is the immediate callback of the first
+//   // frame; the second one will exercise the batching logic.
+//   fml::CountDownLatch reportLatch(2);
+//   std::vector<int64_t> timestamps;
+//   auto nativeTimingCallback = [&reportLatch,
+//                                &timestamps](Dart_NativeArguments args) {
+//     Dart_Handle exception = nullptr;
+//     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
+//         args, 0, exception);
+//     reportLatch.CountDown();
+//   };
+//   AddNativeCallback("NativeReportTimingsCallback",
+//                     CREATE_NATIVE_ENTRY(nativeTimingCallback));
+//   RunEngine(shell.get(), std::move(configuration));
+
+//   PumpOneFrame(shell.get());
+//   PumpOneFrame(shell.get());
+
+//   reportLatch.Wait();
+//   shell.reset();
+
+//   fml::TimePoint finish = fml::TimePoint::Now();
+//   fml::TimeDelta ellapsed = finish - start;
+
+// #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_RELEASE
+//   // Our batch time is 1000ms. Hopefully the 800ms limit is relaxed enough to
+//   // make it not too flaky.
+//   ASSERT_TRUE(ellapsed >= fml::TimeDelta::FromMilliseconds(800));
+// #else
+//   // Our batch time is 100ms. Hopefully the 500ms limit is relaxed enough to
+//   // make it not too flaky.
+//   ASSERT_TRUE(ellapsed <= fml::TimeDelta::FromMilliseconds(500));
+// #endif
+// }
+
+// TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   ASSERT_TRUE(configuration.IsValid());
+//   configuration.SetEntrypoint("reportTimingsMain");
+//   fml::AutoResetWaitableEvent reportLatch;
+//   std::vector<int64_t> timestamps;
+//   auto nativeTimingCallback = [&reportLatch,
+//                                &timestamps](Dart_NativeArguments args) {
+//     Dart_Handle exception = nullptr;
+//     timestamps = tonic::DartConverter<std::vector<int64_t>>::FromArguments(
+//         args, 0, exception);
+//     reportLatch.Signal();
+//   };
+//   AddNativeCallback("NativeReportTimingsCallback",
+//                     CREATE_NATIVE_ENTRY(nativeTimingCallback));
+//   RunEngine(shell.get(), std::move(configuration));
+
+//   for (int i = 0; i < 10; i += 1) {
+//     PumpOneFrame(shell.get());
+//   }
+
+//   reportLatch.Wait();
+//   shell.reset();
+
+//   // Check for the immediate callback of the first frame that doesn't wait
+//   for
+//   // the other 9 frames to be rasterized.
+//   ASSERT_EQ(timestamps.size(), FrameTiming::kCount);
+// }
+
+// TEST_F(ShellTest, WaitForFirstFrame) {
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   configuration.SetEntrypoint("emptyMain");
+
+//   RunEngine(shell.get(), std::move(configuration));
+//   PumpOneFrame(shell.get());
+//   fml::Status result =
+//       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
+//   ASSERT_TRUE(result.ok());
+// }
+
+// TEST_F(ShellTest, WaitForFirstFrameTimeout) {
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   configuration.SetEntrypoint("emptyMain");
+
+//   RunEngine(shell.get(), std::move(configuration));
+//   fml::Status result =
+//       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(10));
+//   ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
+// }
+
+// TEST_F(ShellTest, WaitForFirstFrameMultiple) {
+//   auto settings = CreateSettingsForFixture();
+//   std::unique_ptr<Shell> shell = CreateShell(settings);
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   configuration.SetEntrypoint("emptyMain");
+
+//   RunEngine(shell.get(), std::move(configuration));
+//   PumpOneFrame(shell.get());
+//   fml::Status result =
+//       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
+//   ASSERT_TRUE(result.ok());
+//   for (int i = 0; i < 100; ++i) {
+//     result = shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1));
+//     ASSERT_TRUE(result.ok());
+//   }
+// }
+
+// /// Makes sure that WaitForFirstFrame works if we rendered a frame with the
+// /// single-thread setup.
+// TEST_F(ShellTest, WaitForFirstFrameInlined) {
+//   Settings settings = CreateSettingsForFixture();
+//   auto task_runner = GetThreadTaskRunner();
+//   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+//                            task_runner);
+//   std::unique_ptr<Shell> shell =
+//       CreateShell(std::move(settings), std::move(task_runners));
+
+//   // Create the surface needed by rasterizer
+//   PlatformViewNotifyCreated(shell.get());
+
+//   auto configuration = RunConfiguration::InferFromSettings(settings);
+//   configuration.SetEntrypoint("emptyMain");
+
+//   RunEngine(shell.get(), std::move(configuration));
+//   PumpOneFrame(shell.get());
+//   fml::AutoResetWaitableEvent event;
+//   task_runner->PostTask([&shell, &event] {
+//     fml::Status result =
+//         shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
+//     ASSERT_EQ(result.code(), fml::StatusCode::kFailedPrecondition);
+//     event.Signal();
+//   });
+//   ASSERT_FALSE(event.WaitWithTimeout(fml::TimeDelta::FromMilliseconds(1000)));
+// }
+
+TEST_F(ShellTest, SetResourceCacheSize) {
   Settings settings = CreateSettingsForFixture();
   auto task_runner = GetThreadTaskRunner();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
@@ -590,14 +626,36 @@ TEST_F(ShellTest, WaitForFirstFrameInlined) {
 
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
-  fml::AutoResetWaitableEvent event;
-  task_runner->PostTask([&shell, &event] {
-    fml::Status result =
-        shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
-    ASSERT_EQ(result.code(), fml::StatusCode::kFailedPrecondition);
-    event.Signal();
-  });
-  ASSERT_FALSE(event.WaitWithTimeout(fml::TimeDelta::FromMilliseconds(1000)));
+
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(),
+            static_cast<size_t>(24 * (1 << 20)));
+
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
+        shell->GetPlatformView()->SetViewportMetrics(
+            {1.0, 400, 200, 0, 0, 0, 0, 0, 0, 0, 0});
+      });
+  PumpOneFrame(shell.get());
+
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 3840000U);
+
+  std::string request_json =
+      "{\"method\": \"Skia.setResourceCacheMaxBytes\", \"args\": 10000}";
+  std::vector<uint8_t> data(request_json.begin(), request_json.end());
+  auto platform_message = fml::MakeRefCounted<PlatformMessage>(
+      "flutter/skia", std::move(data), nullptr);
+  SendEnginePlatformMessage(shell.get(), std::move(platform_message));
+  PumpOneFrame(shell.get());
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 10000U);
+
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
+        shell->GetPlatformView()->SetViewportMetrics(
+            {1.0, 800, 400, 0, 0, 0, 0, 0, 0, 0, 0});
+      });
+  PumpOneFrame(shell.get());
+
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 10000U);
 }
 
 }  // namespace testing

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -617,7 +617,7 @@ TEST_F(ShellTest, SetResourceCacheSize) {
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
 
-  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(),
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes().value_or(0U),
             static_cast<size_t>(24 * (1 << 20)));
 
   fml::TaskRunner::RunNowOrPostTask(
@@ -627,10 +627,11 @@ TEST_F(ShellTest, SetResourceCacheSize) {
       });
   PumpOneFrame(shell.get());
 
-  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 3840000U);
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes().value_or(0U),
+            3840000U);
 
   std::string request_json = R"json({
-                                "mesthod": "Skia.setResourceCacheMaxBytes",
+                                "method": "Skia.setResourceCacheMaxBytes",
                                 "args": 10000
                               })json";
   std::vector<uint8_t> data(request_json.begin(), request_json.end());
@@ -638,7 +639,8 @@ TEST_F(ShellTest, SetResourceCacheSize) {
       "flutter/skia", std::move(data), nullptr);
   SendEnginePlatformMessage(shell.get(), std::move(platform_message));
   PumpOneFrame(shell.get());
-  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 10000U);
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes().value_or(0U),
+            10000U);
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
@@ -647,7 +649,8 @@ TEST_F(ShellTest, SetResourceCacheSize) {
       });
   PumpOneFrame(shell.get());
 
-  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 10000U);
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes().value_or(0U),
+            10000U);
 }
 
 TEST_F(ShellTest, SetResourceCacheSizeEarly) {
@@ -674,7 +677,7 @@ TEST_F(ShellTest, SetResourceCacheSizeEarly) {
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
 
-  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(),
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes().value_or(0),
             static_cast<size_t>(3840000U));
 }
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -65,8 +65,7 @@ TEST_F(ShellTest, InitializeWithDifferentThreads) {
   ThreadHost thread_host("io.flutter.test." + GetCurrentTestName() + ".",
                          ThreadHost::Type::Platform | ThreadHost::Type::GPU |
                              ThreadHost::Type::IO | ThreadHost::Type::UI);
-  TaskRunners task_runners("test",
-  thread_host.platform_thread->GetTaskRunner(),
+  TaskRunners task_runners("test", thread_host.platform_thread->GetTaskRunner(),
                            thread_host.gpu_thread->GetTaskRunner(),
                            thread_host.ui_thread->GetTaskRunner(),
                            thread_host.io_thread->GetTaskRunner());
@@ -139,8 +138,7 @@ TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
   Settings settings = CreateSettingsForFixture();
   ThreadHost thread_host(
       "io.flutter.test." + GetCurrentTestName() + ".",
-      ThreadHost::Type::Platform | ThreadHost::Type::IO |
-      ThreadHost::Type::UI);
+      ThreadHost::Type::Platform | ThreadHost::Type::IO | ThreadHost::Type::UI);
   TaskRunners task_runners(
       "test",
       thread_host.platform_thread->GetTaskRunner(),  // platform
@@ -168,8 +166,7 @@ TEST_F(ShellTest, FixturesAreFunctional) {
   fml::AutoResetWaitableEvent main_latch;
   AddNativeCallback(
       "SayHiFromFixturesAreFunctionalMain",
-      CREATE_NATIVE_ENTRY([&main_latch](auto args) { main_latch.Signal();
-      }));
+      CREATE_NATIVE_ENTRY([&main_latch](auto args) { main_latch.Signal(); }));
 
   RunEngine(shell.get(), std::move(configuration));
   main_latch.Wait();
@@ -204,8 +201,7 @@ TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
 
 TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
   if (DartVM::IsRunningPrecompiledCode()) {
-    // This covers profile and release modes which use AOT (where this flag
-    does
+    // This covers profile and release modes which use AOT (where this flag does
     // not make sense anyway).
     GTEST_SKIP();
     return;
@@ -214,8 +210,7 @@ TEST(ShellTestNoFixture, EnableMirrorsIsWhitelisted) {
   const std::vector<fml::CommandLine::Option> options = {
       fml::CommandLine::Option("dart-flags", "--enable_mirrors")};
   fml::CommandLine command_line("", options, std::vector<std::string>());
-  flutter::Settings settings =
-  flutter::SettingsFromCommandLine(command_line);
+  flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
   EXPECT_EQ(settings.dart_flags.size(), 1u);
 }
 
@@ -233,8 +228,7 @@ TEST_F(ShellTest, BlacklistedDartVMFlag) {
       "Encountered blacklisted Dart VM flag: --verify_after_gc";
   ASSERT_DEATH(flutter::SettingsFromCommandLine(command_line), expected);
 #else
-  flutter::Settings settings =
-  flutter::SettingsFromCommandLine(command_line);
+  flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
   EXPECT_EQ(settings.dart_flags.size(), 0u);
 #endif
 }
@@ -244,8 +238,7 @@ TEST_F(ShellTest, WhitelistedDartVMFlag) {
       fml::CommandLine::Option("dart-flags",
                                "--max_profile_depth 1,--random_seed 42")};
   fml::CommandLine command_line("", options, std::vector<std::string>());
-  flutter::Settings settings =
-  flutter::SettingsFromCommandLine(command_line);
+  flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
 
 #if FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_RELEASE
   EXPECT_EQ(settings.dart_flags.size(), 2u);
@@ -270,18 +263,15 @@ TEST_F(ShellTest, NoNeedToReportTimingsByDefault) {
   PumpOneFrame(shell.get());
   ASSERT_FALSE(GetNeedsReportTimings(shell.get()));
 
-  // This assertion may or may not be the direct result of
-  needs_report_timings_
+  // This assertion may or may not be the direct result of needs_report_timings_
   // being false. The count could be 0 simply because we just cleared
-  unreported
-  // timings by reporting them. Hence this can't replace the
-  // ASSERT_FALSE(GetNeedsReportTimings(shell.get())) check. We added this
-  // assertion for an additional confidence that we're not pushing back to
-  // unreported timings unnecessarily.
+  // unreported timings by reporting them. Hence this can't replace the
+  // ASSERT_FALSE(GetNeedsReportTimings(shell.get())) check. We added
+  // this assertion for an additional confidence that we're not pushing
+  // back to unreported timings unnecessarily.
   //
   // Conversely, do not assert UnreportedTimingsCount(shell.get()) to be
-  // positive in any tests. Otherwise those tests will be flaky as the
-  clearing
+  // positive in any tests. Otherwise those tests will be flaky as the clearing
   // of unreported timings is unpredictive.
   ASSERT_EQ(UnreportedTimingsCount(shell.get()), 0);
 }
@@ -419,8 +409,8 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
   std::vector<FrameTiming> timings = {timing};
   CheckFrameTimings(timings, start, finish);
 
-  // Check that onBeginFrame has the same timestamp as FrameTiming's build
-  start int64_t build_start =
+  // Check that onBeginFrame has the same timestamp as FrameTiming's build start
+  int64_t build_start =
       timing.Get(FrameTiming::kBuildStart).ToEpochDelta().ToMicroseconds();
   ASSERT_EQ(build_start, begin_frame);
 }
@@ -433,8 +423,9 @@ TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
   int lastPhaseIndex = -1;
   FrameTiming timing;
   for (auto phase : FrameTiming::kPhases) {
-    ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in
-    order. lastPhaseIndex = phase; auto fake_time =
+    ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in ƒorder.
+    lastPhaseIndex = phase;
+    auto fake_time =
         fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(phase));
     timing.Set(phase, fake_time);
     ASSERT_TRUE(timing.Get(phase) == fake_time);
@@ -522,8 +513,7 @@ TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
   reportLatch.Wait();
   shell.reset();
 
-  // Check for the immediate callback of the first frame that doesn't wait
-  for
+  // Check for the immediate callback of the first frame that doesn't wait for
   // the other 9 frames to be rasterized.
   ASSERT_EQ(timestamps.size(), FrameTiming::kCount);
 }

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -423,7 +423,7 @@ TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
   int lastPhaseIndex = -1;
   FrameTiming timing;
   for (auto phase : FrameTiming::kPhases) {
-    ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in ƒorder.
+    ASSERT_TRUE(phase > lastPhaseIndex);  // Ensure that kPhases are in order.
     lastPhaseIndex = phase;
     auto fake_time =
         fml::TimePoint::FromEpochDelta(fml::TimeDelta::FromMicroseconds(phase));
@@ -629,8 +629,10 @@ TEST_F(ShellTest, SetResourceCacheSize) {
 
   EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 3840000U);
 
-  std::string request_json =
-      "{\"method\": \"Skia.setResourceCacheMaxBytes\", \"args\": 10000}";
+  std::string request_json = R"json({
+                                "mesthod": "Skia.setResourceCacheMaxBytes",
+                                "args": 10000
+                              })json";
   std::vector<uint8_t> data(request_json.begin(), request_json.end());
   auto platform_message = fml::MakeRefCounted<PlatformMessage>(
       "flutter/skia", std::move(data), nullptr);
@@ -655,7 +657,6 @@ TEST_F(ShellTest, SetResourceCacheSizeEarly) {
                            task_runner);
   std::unique_ptr<Shell> shell =
       CreateShell(std::move(settings), std::move(task_runners));
-
 
   fml::TaskRunner::RunNowOrPostTask(
       shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -648,5 +648,34 @@ TEST_F(ShellTest, SetResourceCacheSize) {
   EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(), 10000U);
 }
 
+TEST_F(ShellTest, SetResourceCacheSizeEarly) {
+  Settings settings = CreateSettingsForFixture();
+  auto task_runner = GetThreadTaskRunner();
+  TaskRunners task_runners("test", task_runner, task_runner, task_runner,
+                           task_runner);
+  std::unique_ptr<Shell> shell =
+      CreateShell(std::move(settings), std::move(task_runners));
+
+
+  fml::TaskRunner::RunNowOrPostTask(
+      shell->GetTaskRunners().GetPlatformTaskRunner(), [&shell]() {
+        shell->GetPlatformView()->SetViewportMetrics(
+            {1.0, 400, 200, 0, 0, 0, 0, 0, 0, 0, 0});
+      });
+  PumpOneFrame(shell.get());
+
+  // Create the surface needed by rasterizer
+  PlatformViewNotifyCreated(shell.get());
+
+  auto configuration = RunConfiguration::InferFromSettings(settings);
+  configuration.SetEntrypoint("emptyMain");
+
+  RunEngine(shell.get(), std::move(configuration));
+  PumpOneFrame(shell.get());
+
+  EXPECT_EQ(shell->GetRasterizer()->GetResourceCacheMaxBytes(),
+            static_cast<size_t>(3840000U));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -28,7 +28,10 @@ static const int kGrCacheMaxCount = 8192;
 
 // Default maximum number of bytes of GPU memory of budgeted resources in the
 // cache.
-static const size_t kGrCacheMaxByteSize = 512 * (1 << 20);
+// The shell will dynamically increase or decrease this cache based on the
+// viewport size, unless a user has specifically requested a size on the Skia
+// system channel.
+static const size_t kGrCacheMaxByteSize = 24 * (1 << 20);
 
 GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate)
     : delegate_(delegate), weak_factory_(this) {


### PR DESCRIPTION
This relands #9503, which was reverted because it didn't work.  The underlying problem of letting embedders get the engine directly to set the viewport metrics has been resolved by #9747 

This additionally adds a test to make sure these values get set correctly on the Rasterizer.

This patch is important because our current default (512MB) is simply too large for lower end devices with small amounts of RAM.  There have been numerous reports of memory usage related crashes when this cache is allowed to grow to its current limit, e.g. on an iPhone with 1GB of RAM.

/cc @abhishekamit - Please let me know if you have concerns with this patch.  