### PR TITLE
Android embedding refactor pr40 add static engine cache

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -481,7 +481,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/robolectric_bundle',
-        'version': 'last_updated:2019-07-29T15:27:42-0700'
+        'version': 'last_updated:2019-08-02T16:01:27-0700'
        }
      ],
      'condition': 'download_android_deps',

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -563,6 +563,7 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/Splas
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/android/SplashScreenProvider.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterEnginePluginRegistry.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/FlutterShellArgs.java

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -330,9 +330,9 @@ action("robolectric_tests") {
   sources = [
     "test/io/flutter/FlutterTestSuite.java",
     "test/io/flutter/SmokeTest.java",
+    "test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java",
     "test/io/flutter/embedding/android/FlutterActivityTest.java",
     "test/io/flutter/embedding/android/FlutterFragmentTest.java",
-    "test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java",
     "test/io/flutter/embedding/engine/FlutterEngineCacheTest.java",
     "test/io/flutter/util/PreconditionsTest.java",
   ]

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -329,6 +329,8 @@ action("robolectric_tests") {
   sources = [
     "test/io/flutter/FlutterTestSuite.java",
     "test/io/flutter/SmokeTest.java",
+    "test/io/flutter/embedding/android/FlutterActivityTest.java",
+    "test/io/flutter/embedding/android/FlutterFragmentTest.java",
     "test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java",
     "test/io/flutter/util/PreconditionsTest.java",
   ]

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -139,6 +139,7 @@ action("flutter_shell_java") {
     "io/flutter/embedding/android/SplashScreenProvider.java",
     "io/flutter/embedding/engine/FlutterEngine.java",
     "io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java",
+    "io/flutter/embedding/engine/FlutterEngineCache.java",
     "io/flutter/embedding/engine/FlutterEnginePluginRegistry.java",
     "io/flutter/embedding/engine/FlutterJNI.java",
     "io/flutter/embedding/engine/FlutterShellArgs.java",
@@ -332,6 +333,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/android/FlutterActivityTest.java",
     "test/io/flutter/embedding/android/FlutterFragmentTest.java",
     "test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java",
+    "test/io/flutter/embedding/engine/FlutterEngineCacheTest.java",
     "test/io/flutter/util/PreconditionsTest.java",
   ]
 
@@ -353,6 +355,7 @@ action("robolectric_tests") {
     "//third_party/robolectric/lib/common-1.1.1.jar",
     "//third_party/robolectric/lib/common-java8-1.1.1.jar",
     "//third_party/robolectric/lib/support-annotations-28.0.0.jar",
+    "//third_party/robolectric/lib/support-fragment-25.2.0.jar",
     "//third_party/robolectric/lib/mockito-all-1.10.19.jar",
   ]
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -69,6 +69,29 @@ import io.flutter.view.FlutterMain;
  * {@code IllegalStateException} will be thrown if a cached engine is requested but does not exist
  * in the cache.
  * <p>
+ * It is generally recommended to use a cached {@link FlutterEngine} to avoid a momentary delay
+ * when initializing a new {@link FlutterEngine}. The two exceptions to using a cached
+ * {@link FlutterEngine} are:
+ * <p>
+ * <ul>
+ *   <li>When {@code FlutterActivity} is the first {@code Activity} displayed by the app, because
+ *   pre-warming a {@link FlutterEngine} would have no impact in this situation.</li>
+ *   <li>When you are unsure when/if you will need to display a Flutter experience.</li>
+ * </ul>
+ * <p>
+ * The following illustrates how to pre-warm and cache a {@link FlutterEngine}:
+ * <p>
+ * {@code
+ *   // Create and pre-warm a FlutterEngine.
+ *   FlutterEngine flutterEngine = new FlutterEngine(context);
+ *   flutterEngine
+ *     .getDartExecutor()
+ *     .executeDartEntrypoint(DartEntrypoint.createDefault());
+ *
+ *   // Cache the pre-warmed FlutterEngine in the FlutterEngineCache.
+ *   FlutterEngineCache.getInstance().put("my_engine", flutterEngine);
+ * }
+ * <p>
  * If Flutter is needed in a location that cannot use an {@code Activity}, consider using
  * a {@link FlutterFragment}. Using a {@link FlutterFragment} requires forwarding some calls from
  * an {@code Activity} to the {@link FlutterFragment}.
@@ -261,7 +284,8 @@ public class FlutterActivity extends Activity
       return new Intent(context, activityClass)
           .putExtra(EXTRA_DART_ENTRYPOINT, dartEntrypoint)
           .putExtra(EXTRA_INITIAL_ROUTE, initialRoute)
-          .putExtra(EXTRA_BACKGROUND_MODE, backgroundMode);
+          .putExtra(EXTRA_BACKGROUND_MODE, backgroundMode)
+          .putExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, true);
     }
   }
 
@@ -306,7 +330,7 @@ public class FlutterActivity extends Activity
     }
 
     /**
-     * Returns true if the cached {@link FlutterEngine} should be destroyed and remoed from the
+     * Returns true if the cached {@link FlutterEngine} should be destroyed and removed from the
      * cache when this {@code FlutterActivity} is destroyed.
      * <p>
      * The default value is {@code false}.
@@ -633,6 +657,10 @@ public class FlutterActivity extends Activity
    * Returns false if the {@link FlutterEngine} backing this {@code FlutterActivity} should
    * outlive this {@code FlutterActivity}, or true to be destroyed when the {@code FlutterActivity}
    * is destroyed.
+   * <p>
+   * The default value is {@code true} in cases where {@code FlutterActivity} created its own
+   * {@link FlutterEngine}, and {@code false} in cases where a cached {@link FlutterEngine} was
+   * provided.
    */
   @Override
   public boolean shouldDestroyEngineWithHost() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -587,6 +587,11 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
     @NonNull
     FlutterShellArgs getFlutterShellArgs();
 
+    @Nullable
+    String getCachedEngineId();
+
+    boolean shouldDestroyCachedEngineWithActivity();
+
     /**
      * Returns the Dart entrypoint that should run when a new {@link FlutterEngine} is
      * created.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import io.flutter.Log;
 import io.flutter.app.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
@@ -182,7 +183,11 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
   /**
    * Obtains a reference to a FlutterEngine to back this delegate and its {@code host}.
    * <p>
-   * First, the {@code host} is given an opportunity to provide a {@link FlutterEngine} via
+   * <p>
+   * First, the {@code host} is asked if it would like to use a cached {@link FlutterEngine}, and
+   * if so, the cached {@link FlutterEngine} is retrieved.
+   * <p>
+   * Second, the {@code host} is given an opportunity to provide a {@link FlutterEngine} via
    * {@link Host#provideFlutterEngine(Context)}.
    * <p>
    * If the {@code host} does not provide a {@link FlutterEngine}, then a new {@link FlutterEngine}
@@ -191,9 +196,21 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
   private void setupFlutterEngine() {
     Log.d(TAG, "Setting up FlutterEngine.");
 
-    // First, defer to subclasses for a custom FlutterEngine.
+    // First, check if the host wants to use a cached FlutterEngine.
+    String cachedEngineId = host.getCachedEngineId();
+    if (cachedEngineId != null) {
+      flutterEngine = FlutterEngineCache.getInstance().get(cachedEngineId);
+      isFlutterEngineFromHost = true;
+      if (flutterEngine == null) {
+        throw new IllegalStateException("The requested cached FlutterEngine did not exist in the FlutterEngineCache: '" + cachedEngineId + "'");
+      }
+      return;
+    }
+
+    // Second, defer to subclasses for a custom FlutterEngine.
     flutterEngine = host.provideFlutterEngine(host.getContext());
     if (flutterEngine != null) {
+      isFlutterEngineFromHost = true;
       return;
     }
 
@@ -275,6 +292,11 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
    * {@code flutterEngine} must be non-null when invoking this method.
    */
   private void doInitialFlutterViewRun() {
+    // Don't attempt to start a FlutterEngine if we're using a cached FlutterEngine.
+    if (host.getCachedEngineId() != null) {
+      return;
+    }
+
     if (flutterEngine.getDartExecutor().isExecutingDart()) {
       // No warning is logged because this situation will happen on every config
       // change if the developer does not choose to retain the Fragment instance.
@@ -387,7 +409,8 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
    *   if it was previously attached.</li>
    *   <li>Destroys this delegate's {@link PlatformPlugin}.</li>
    *   <li>Destroys this delegate's {@link FlutterEngine} if
-   *   {@link Host#retainFlutterEngineAfterHostDestruction()} returns false.</li>
+   *   {@link Host#shouldDestroyEngineWithHost()} ()} returns true, or if this delegate
+   *   was responsible for internally creating the {@link FlutterEngine}.</li>
    * </ol>
    */
   void onDetach() {
@@ -412,8 +435,13 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
     }
 
     // Destroy our FlutterEngine if we're not set to retain it.
-    if (!host.retainFlutterEngineAfterHostDestruction() && !isFlutterEngineFromHost) {
+    if (host.shouldDestroyEngineWithHost() || !isFlutterEngineFromHost) {
       flutterEngine.destroy();
+
+      if (host.getCachedEngineId() != null) {
+        FlutterEngineCache.getInstance().remove(host.getCachedEngineId());
+      }
+
       flutterEngine = null;
     }
   }
@@ -587,10 +615,19 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
     @NonNull
     FlutterShellArgs getFlutterShellArgs();
 
+    /**
+     * Returns the ID of a statically cached {@link FlutterEngine} to use within this
+     * delegate's host, or {@code null} if this delegate's host does not want to
+     * use a cached {@link FlutterEngine}.
+     */
     @Nullable
     String getCachedEngineId();
 
-    boolean shouldDestroyCachedEngineWithActivity();
+    /**
+     * Returns true if the {@link FlutterEngine} used in this delegate should be destroyed
+     * when the host/delegate are destroyed.
+     */
+    boolean shouldDestroyEngineWithHost();
 
     /**
      * Returns the Dart entrypoint that should run when a new {@link FlutterEngine} is
@@ -653,15 +690,6 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
      * host {@link Activity}, allowing plugins to interact with it.
      */
     boolean shouldAttachEngineToActivity();
-
-    /**
-     * Returns true if the {@link FlutterEngine} used in this delegate should outlive the
-     * delegate.
-     * <p>
-     * If {@code false} is returned, the {@link FlutterEngine} used in this delegate will be
-     * destroyed when the delegate is destroyed.
-     */
-    boolean retainFlutterEngineAfterHostDestruction();
 
     /**
      * Invoked by this delegate when its {@link FlutterView} has rendered its first Flutter

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -409,8 +409,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
    *   if it was previously attached.</li>
    *   <li>Destroys this delegate's {@link PlatformPlugin}.</li>
    *   <li>Destroys this delegate's {@link FlutterEngine} if
-   *   {@link Host#shouldDestroyEngineWithHost()} ()} returns true, or if this delegate
-   *   was responsible for internally creating the {@link FlutterEngine}.</li>
+   *   {@link Host#shouldDestroyEngineWithHost()} ()} returns true.</li>
    * </ol>
    */
   void onDetach() {
@@ -435,7 +434,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
     }
 
     // Destroy our FlutterEngine if we're not set to retain it.
-    if (host.shouldDestroyEngineWithHost() || !isFlutterEngineFromHost) {
+    if (host.shouldDestroyEngineWithHost()) {
       flutterEngine.destroy();
 
       if (host.getCachedEngineId() != null) {
@@ -626,6 +625,10 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
     /**
      * Returns true if the {@link FlutterEngine} used in this delegate should be destroyed
      * when the host/delegate are destroyed.
+     * <p>
+     * The default value is {@code true} in cases where {@code FlutterFragment} created its own
+     * {@link FlutterEngine}, and {@code false} in cases where a cached {@link FlutterEngine} was
+     * provided.
      */
     boolean shouldDestroyEngineWithHost();
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -52,6 +52,29 @@ import io.flutter.view.FlutterMain;
  * {@link FlutterEngineCache} and then use {@link #withCachedEngine(String)} to build a
  * {@code FlutterFragment} with the cached {@link FlutterEngine}'s ID.
  * <p>
+ * It is generally recommended to use a cached {@link FlutterEngine} to avoid a momentary delay
+ * when initializing a new {@link FlutterEngine}. The two exceptions to using a cached
+ * {@link FlutterEngine} are:
+ * <p>
+ * <ul>
+ *   <li>When {@code FlutterFragment} is in the first {@code Activity} displayed by the app, because
+ *   pre-warming a {@link FlutterEngine} would have no impact in this situation.</li>
+ *   <li>When you are unsure when/if you will need to display a Flutter experience.</li>
+ * </ul>
+ * <p>
+ * The following illustrates how to pre-warm and cache a {@link FlutterEngine}:
+ * <p>
+ * {@code
+ *   // Create and pre-warm a FlutterEngine.
+ *   FlutterEngine flutterEngine = new FlutterEngine(context);
+ *   flutterEngine
+ *     .getDartExecutor()
+ *     .executeDartEntrypoint(DartEntrypoint.createDefault());
+ *
+ *   // Cache the pre-warmed FlutterEngine in the FlutterEngineCache.
+ *   FlutterEngineCache.getInstance().put("my_engine", flutterEngine);
+ * }
+ * <p>
  * If Flutter is needed in a location that can only use a {@code View}, consider using a
  * {@link FlutterView}. Using a {@link FlutterView} requires forwarding some calls from an
  * {@code Activity}, as well as forwarding lifecycle calls from an {@code Activity} or a
@@ -323,6 +346,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
       args.putString(ARG_FLUTTERVIEW_RENDER_MODE, renderMode != null ? renderMode.name() : FlutterView.RenderMode.surface.name());
       args.putString(ARG_FLUTTERVIEW_TRANSPARENCY_MODE, transparencyMode != null ? transparencyMode.name() : FlutterView.TransparencyMode.transparent.name());
       args.putBoolean(ARG_SHOULD_ATTACH_ENGINE_TO_ACTIVITY, shouldAttachEngineToActivity);
+      args.putBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, true);
       return args;
     }
 

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -711,13 +711,6 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
       : getActivity();
   }
 
-  @NonNull
-  @Override
-  public Lifecycle getLifecycle() {
-    // TODO:
-    return null;
-  }
-
   /**
    * {@link FlutterActivityAndFragmentDelegate.Host} method that is used by
    * {@link FlutterActivityAndFragmentDelegate} to obtain Flutter shell arguments when

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineAndroidLifecycle.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.embedding.engine;
 
 import android.arch.lifecycle.DefaultLifecycleObserver;

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
@@ -2,6 +2,7 @@ package io.flutter.embedding.engine;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,8 +14,8 @@ import java.util.Map;
  * {@link io.flutter.embedding.android.FlutterActivity} and
  * {@link io.flutter.embedding.android.FlutterFragment} use the {@code FlutterEngineCache} singleton
  * internally when instructed to use a cached {@link FlutterEngine} based on a given ID. See
- * {@link io.flutter.embedding.android.FlutterActivity.IntentBuilder} and
- * {@link io.flutter.embedding.android.FlutterFragment.Builder} for related APIs.
+ * {@link io.flutter.embedding.android.FlutterActivity.CachedEngineIntentBuilder} and
+ * {@link io.flutter.embedding.android.FlutterFragment#withCachedEngine(String)} for related APIs.
  */
 public class FlutterEngineCache {
   private static FlutterEngineCache instance;
@@ -34,7 +35,8 @@ public class FlutterEngineCache {
 
   private final Map<String, FlutterEngine> cachedEngines = new HashMap<>();
 
-  private FlutterEngineCache() {}
+  @VisibleForTesting
+  /* package */ FlutterEngineCache() {}
 
   /**
    * Returns {@code true} if a {@link FlutterEngine} in this cache is associated with the
@@ -60,7 +62,19 @@ public class FlutterEngineCache {
    * If a {@link FlutterEngine} already exists in this cache for the given {@code engineId}, that
    * {@link FlutterEngine} is removed from this cache.
    */
-  public void put(@NonNull String engineId, @NonNull FlutterEngine engine) {
-    cachedEngines.put(engineId, engine);
+  public void put(@NonNull String engineId, @Nullable FlutterEngine engine) {
+    if (engine != null) {
+      cachedEngines.put(engineId, engine);
+    } else {
+      cachedEngines.remove(engineId);
+    }
+  }
+
+  /**
+   * Removes any {@link FlutterEngine} that is currently in the cache that is identified by
+   * the given {@code engineId}.
+   */
+  public void remove(@NonNull String engineId) {
+    put(engineId, null);
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter.embedding.engine;
 
 import android.support.annotation.NonNull;

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
@@ -1,0 +1,66 @@
+package io.flutter.embedding.engine;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Static singleton cache that holds {@link FlutterEngine} instances identified by {@code String}s.
+ * <p>
+ * {@code FlutterEngineCache} is useful for storing pre-warmed {@link FlutterEngine} instances.
+ * {@link io.flutter.embedding.android.FlutterActivity} and
+ * {@link io.flutter.embedding.android.FlutterFragment} use the {@code FlutterEngineCache} singleton
+ * internally when instructed to use a cached {@link FlutterEngine} based on a given ID. See
+ * {@link io.flutter.embedding.android.FlutterActivity.IntentBuilder} and
+ * {@link io.flutter.embedding.android.FlutterFragment.Builder} for related APIs.
+ */
+public class FlutterEngineCache {
+  private static FlutterEngineCache instance;
+
+  /**
+   * Returns the static singleton instance of {@code FlutterEngineCache}.
+   * <p>
+   * Creates a new instance if one does not yet exist.
+   */
+  @NonNull
+  public static FlutterEngineCache getInstance() {
+    if (instance == null) {
+      instance = new FlutterEngineCache();
+    }
+    return instance;
+  }
+
+  private final Map<String, FlutterEngine> cachedEngines = new HashMap<>();
+
+  private FlutterEngineCache() {}
+
+  /**
+   * Returns {@code true} if a {@link FlutterEngine} in this cache is associated with the
+   * given {@code engineId}.
+   */
+  public boolean contains(@NonNull String engineId) {
+    return cachedEngines.containsKey(engineId);
+  }
+
+  /**
+   * Returns the {@link FlutterEngine} in this cache that is associated with the given
+   * {@code engineId}, or {@code null} is no such {@link FlutterEngine} exists.
+   */
+  @Nullable
+  public FlutterEngine get(@NonNull String engineId) {
+    return cachedEngines.get(engineId);
+  }
+
+  /**
+   * Places the given {@link FlutterEngine} in this cache and associates it with the given
+   * {@code engineId}.
+   * <p>
+   * If a {@link FlutterEngine} already exists in this cache for the given {@code engineId}, that
+   * {@link FlutterEngine} is removed from this cache.
+   */
+  public void put(@NonNull String engineId, @NonNull FlutterEngine engine) {
+    cachedEngines.put(engineId, engine);
+  }
+}

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngineCache.java
@@ -14,6 +14,8 @@ import java.util.Map;
 /**
  * Static singleton cache that holds {@link FlutterEngine} instances identified by {@code String}s.
  * <p>
+ * The ID of a given {@link FlutterEngine} can be whatever {@code String} is desired.
+ * <p>
  * {@code FlutterEngineCache} is useful for storing pre-warmed {@link FlutterEngine} instances.
  * {@link io.flutter.embedding.android.FlutterActivity} and
  * {@link io.flutter.embedding.android.FlutterFragment} use the {@code FlutterEngineCache} singleton

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -4,15 +4,15 @@
 
 package io.flutter;
 
-import io.flutter.SmokeTest;
-import io.flutter.embedding.android.FlutterActivityTest;
-import io.flutter.embedding.android.FlutterFragmentTest;
-import io.flutter.util.PreconditionsTest;
-import io.flutter.embedding.android.FlutterActivityAndFragmentDelegateTest;
-
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
+
+import io.flutter.embedding.android.FlutterActivityAndFragmentDelegateTest;
+import io.flutter.embedding.android.FlutterActivityTest;
+import io.flutter.embedding.android.FlutterFragmentTest;
+import io.flutter.embedding.engine.FlutterEngineCacheTest;
+import io.flutter.util.PreconditionsTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -20,7 +20,8 @@ import org.junit.runners.Suite.SuiteClasses;
     SmokeTest.class,
     FlutterActivityTest.class,
     FlutterFragmentTest.class,
-    FlutterActivityAndFragmentDelegateTest.class
+    FlutterActivityAndFragmentDelegateTest.class,
+    FlutterEngineCacheTest.class
 })
 /** Runs all of the unit tests listed in the {@code @SuiteClasses} annotation. */
 public class FlutterTestSuite {}

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -5,6 +5,8 @@
 package io.flutter;
 
 import io.flutter.SmokeTest;
+import io.flutter.embedding.android.FlutterActivityTest;
+import io.flutter.embedding.android.FlutterFragmentTest;
 import io.flutter.util.PreconditionsTest;
 import io.flutter.embedding.android.FlutterActivityAndFragmentDelegateTest;
 
@@ -16,7 +18,9 @@ import org.junit.runners.Suite.SuiteClasses;
 @SuiteClasses({
     PreconditionsTest.class,
     SmokeTest.class,
-    FlutterActivityAndFragmentDelegateTest.class,
+    FlutterActivityTest.class,
+    FlutterFragmentTest.class,
+    FlutterActivityAndFragmentDelegateTest.class
 })
 /** Runs all of the unit tests listed in the {@code @SuiteClasses} annotation. */
 public class FlutterTestSuite {}

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -33,7 +33,6 @@ import io.flutter.view.FlutterMain;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -46,7 +45,7 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class FlutterActivityAndFragmentDelegateTest {
   private FlutterEngine mockFlutterEngine;
-  private FlutterActivityAndFragmentDelegate.Host fakeHost;
+  private FlutterActivityAndFragmentDelegate.Host mockHost;
 
   @Before
   public void setup() {
@@ -59,19 +58,19 @@ public class FlutterActivityAndFragmentDelegateTest {
     mockFlutterEngine = mockFlutterEngine();
 
     // Create a mocked Host, which is required by the delegate being tested.
-    fakeHost = mock(FlutterActivityAndFragmentDelegate.Host.class);
-    when(fakeHost.getContext()).thenReturn(RuntimeEnvironment.application);
-    when(fakeHost.getActivity()).thenReturn(Robolectric.setupActivity(Activity.class));
-    when(fakeHost.getLifecycle()).thenReturn(mock(Lifecycle.class));
-    when(fakeHost.getFlutterShellArgs()).thenReturn(new FlutterShellArgs(new String[]{}));
-    when(fakeHost.getDartEntrypointFunctionName()).thenReturn("main");
-    when(fakeHost.getAppBundlePath()).thenReturn("/fake/path");
-    when(fakeHost.getInitialRoute()).thenReturn("/");
-    when(fakeHost.getRenderMode()).thenReturn(FlutterView.RenderMode.surface);
-    when(fakeHost.getTransparencyMode()).thenReturn(FlutterView.TransparencyMode.transparent);
-    when(fakeHost.provideFlutterEngine(any(Context.class))).thenReturn(mockFlutterEngine);
-    when(fakeHost.shouldAttachEngineToActivity()).thenReturn(true);
-    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(true);
+    mockHost = mock(FlutterActivityAndFragmentDelegate.Host.class);
+    when(mockHost.getContext()).thenReturn(RuntimeEnvironment.application);
+    when(mockHost.getActivity()).thenReturn(Robolectric.setupActivity(Activity.class));
+    when(mockHost.getLifecycle()).thenReturn(mock(Lifecycle.class));
+    when(mockHost.getFlutterShellArgs()).thenReturn(new FlutterShellArgs(new String[]{}));
+    when(mockHost.getDartEntrypointFunctionName()).thenReturn("main");
+    when(mockHost.getAppBundlePath()).thenReturn("/fake/path");
+    when(mockHost.getInitialRoute()).thenReturn("/");
+    when(mockHost.getRenderMode()).thenReturn(FlutterView.RenderMode.surface);
+    when(mockHost.getTransparencyMode()).thenReturn(FlutterView.TransparencyMode.transparent);
+    when(mockHost.provideFlutterEngine(any(Context.class))).thenReturn(mockFlutterEngine);
+    when(mockHost.shouldAttachEngineToActivity()).thenReturn(true);
+    when(mockHost.shouldDestroyEngineWithHost()).thenReturn(true);
   }
 
   @After
@@ -84,7 +83,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itSendsLifecycleEventsToFlutter() {
     // ---- Test setup ----
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // We're testing lifecycle behaviors, which require/expect that certain methods have already
     // been executed by the time they run. Therefore, we run those expected methods first.
@@ -124,14 +123,14 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itDefersToTheHostToProvideFlutterEngine() {
     // ---- Test setup ----
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is created in onAttach().
     delegate.onAttach(RuntimeEnvironment.application);
 
     // Verify that the host was asked to provide a FlutterEngine.
-    verify(fakeHost, times(1)).provideFlutterEngine(any(Context.class));
+    verify(mockHost, times(1)).provideFlutterEngine(any(Context.class));
 
     // Verify that the delegate's FlutterEngine is our mock FlutterEngine.
     assertEquals("The delegate failed to use the host's FlutterEngine.", mockFlutterEngine, delegate.getFlutterEngine());
@@ -145,10 +144,10 @@ public class FlutterActivityAndFragmentDelegateTest {
     FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
 
     // Adjust fake host to request cached engine.
-    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+    when(mockHost.getCachedEngineId()).thenReturn("my_flutter_engine");
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is obtained in onAttach().
@@ -172,10 +171,10 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itThrowsExceptionIfCachedEngineDoesNotExist() {
     // ---- Test setup ----
     // Adjust fake host to request cached engine that does not exist.
-    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+    when(mockHost.getCachedEngineId()).thenReturn("my_flutter_engine");
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine existence is verified in onAttach()
@@ -188,24 +187,24 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itGivesHostAnOpportunityToConfigureFlutterEngine() {
     // ---- Test setup ----
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is created in onAttach().
     delegate.onAttach(RuntimeEnvironment.application);
 
     // Verify that the host was asked to configure our FlutterEngine.
-    verify(fakeHost, times(1)).configureFlutterEngine(mockFlutterEngine);
+    verify(mockHost, times(1)).configureFlutterEngine(mockFlutterEngine);
   }
 
   @Test
   public void itSendsInitialRouteToFlutter() {
     // ---- Test setup ----
     // Set initial route on our fake Host.
-    when(fakeHost.getInitialRoute()).thenReturn("/my/route");
+    when(mockHost.getInitialRoute()).thenReturn("/my/route");
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The initial route is sent in onStart().
@@ -221,8 +220,8 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itExecutesDartEntrypointProvidedByHost() {
     // ---- Test setup ----
     // Set Dart entrypoint parameters on fake host.
-    when(fakeHost.getAppBundlePath()).thenReturn("/my/bundle/path");
-    when(fakeHost.getDartEntrypointFunctionName()).thenReturn("myEntrypoint");
+    when(mockHost.getAppBundlePath()).thenReturn("/my/bundle/path");
+    when(mockHost.getDartEntrypointFunctionName()).thenReturn("myEntrypoint");
 
     // Create the DartEntrypoint that we expect to be executed.
     DartExecutor.DartEntrypoint dartEntrypoint = new DartExecutor.DartEntrypoint(
@@ -231,7 +230,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     );
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
@@ -250,10 +249,10 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itAttachesFlutterToTheActivityIfDesired() {
     // ---- Test setup ----
     // Declare that the host wants Flutter to attach to the surrounding Activity.
-    when(fakeHost.shouldAttachEngineToActivity()).thenReturn(true);
+    when(mockHost.shouldAttachEngineToActivity()).thenReturn(true);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // Flutter is attached to the surrounding Activity in onAttach.
@@ -276,10 +275,10 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itDoesNotAttachFlutterToTheActivityIfNotDesired() {
     // ---- Test setup ----
     // Declare that the host does NOT want Flutter to attach to the surrounding Activity.
-    when(fakeHost.shouldAttachEngineToActivity()).thenReturn(false);
+    when(mockHost.shouldAttachEngineToActivity()).thenReturn(false);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // Flutter is attached to the surrounding Activity in onAttach.
@@ -298,7 +297,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itSendsPopRouteMessageToFlutterWhenHardwareBackButtonIsPressed() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -314,7 +313,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnRequestPermissionsResultToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -330,7 +329,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnNewIntentToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -346,7 +345,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnActivityResultToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -362,7 +361,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnUserLeaveHintToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -378,7 +377,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itSendsMessageOverSystemChannelWhenToldToTrimMemory() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -394,7 +393,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itSendsMessageOverSystemChannelWhenInformedOfLowMemory() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -411,10 +410,10 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itDestroysItsOwnEngineIfHostRequestsIt() {
     // ---- Test setup ----
     // Adjust fake host to request engine destruction.
-    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(true);
+    when(mockHost.shouldDestroyEngineWithHost()).thenReturn(true);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
@@ -435,10 +434,10 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itDoesNotDestroyItsOwnEngineWhenHostSaysNotTo() {
     // ---- Test setup ----
     // Adjust fake host to request engine destruction.
-    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(false);
+    when(mockHost.shouldDestroyEngineWithHost()).thenReturn(false);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
@@ -463,13 +462,13 @@ public class FlutterActivityAndFragmentDelegateTest {
     FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
 
     // Adjust fake host to request cached engine.
-    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+    when(mockHost.getCachedEngineId()).thenReturn("my_flutter_engine");
 
     // Adjust fake host to request engine destruction.
-    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(true);
+    when(mockHost.shouldDestroyEngineWithHost()).thenReturn(true);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.
@@ -495,13 +494,13 @@ public class FlutterActivityAndFragmentDelegateTest {
     FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
 
     // Adjust fake host to request cached engine.
-    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+    when(mockHost.getCachedEngineId()).thenReturn("my_flutter_engine");
 
     // Adjust fake host to request engine retention.
-    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(false);
+    when(mockHost.shouldDestroyEngineWithHost()).thenReturn(false);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(mockHost);
 
     // --- Execute the behavior under test ---
     // Push the delegate through all lifecycle methods all the way to destruction.

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -33,6 +33,7 @@ import io.flutter.view.FlutterMain;
 
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -353,6 +354,21 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(mockFlutterEngine.getSystemChannel(), times(1)).sendMemoryPressureWarning();
   }
 
+  @Test
+  public void itUsesCachedEngineWhenProvided() {
+    assertTrue(false);
+  }
+
+  @Test
+  public void itDoesNotDestroyCachedEngineByDefault() {
+    assertTrue(false);
+  }
+
+  @Test
+  public void itDestroysCachedEngineWhenRequested() {
+    assertTrue(false);
+  }
+
   /**
    * Creates a mock {@link FlutterEngine}.
    * <p>
@@ -432,6 +448,17 @@ public class FlutterActivityAndFragmentDelegateTest {
     @Override
     public FlutterShellArgs getFlutterShellArgs() {
       return new FlutterShellArgs(new String[]{});
+    }
+
+    @Nullable
+    @Override
+    public String getCachedEngineId() {
+      return null;
+    }
+
+    @Override
+    public boolean shouldDestroyCachedEngineWithActivity() {
+      return false;
     }
 
     @NonNull

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -5,7 +5,6 @@ import android.arch.lifecycle.Lifecycle;
 import android.content.Context;
 import android.content.Intent;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 
 import org.junit.After;
 import org.junit.Before;
@@ -17,6 +16,7 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
@@ -27,18 +27,17 @@ import io.flutter.embedding.engine.systemchannels.LocalizationChannel;
 import io.flutter.embedding.engine.systemchannels.NavigationChannel;
 import io.flutter.embedding.engine.systemchannels.SettingsChannel;
 import io.flutter.embedding.engine.systemchannels.SystemChannel;
-import io.flutter.plugin.platform.PlatformPlugin;
 import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.view.FlutterMain;
 
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -47,8 +46,7 @@ import static org.mockito.Mockito.when;
 @RunWith(RobolectricTestRunner.class)
 public class FlutterActivityAndFragmentDelegateTest {
   private FlutterEngine mockFlutterEngine;
-  private FakeHost fakeHost;
-  private FakeHost spyHost;
+  private FlutterActivityAndFragmentDelegate.Host fakeHost;
 
   @Before
   public void setup() {
@@ -60,12 +58,20 @@ public class FlutterActivityAndFragmentDelegateTest {
     // being tested.
     mockFlutterEngine = mockFlutterEngine();
 
-    // Create a fake Host, which is required by the delegate being tested.
-    fakeHost = new FakeHost();
-    fakeHost.flutterEngine = mockFlutterEngine;
-
-    // Create a spy around the FakeHost so that we can verify method invocations.
-    spyHost = spy(fakeHost);
+    // Create a mocked Host, which is required by the delegate being tested.
+    fakeHost = mock(FlutterActivityAndFragmentDelegate.Host.class);
+    when(fakeHost.getContext()).thenReturn(RuntimeEnvironment.application);
+    when(fakeHost.getActivity()).thenReturn(Robolectric.setupActivity(Activity.class));
+    when(fakeHost.getLifecycle()).thenReturn(mock(Lifecycle.class));
+    when(fakeHost.getFlutterShellArgs()).thenReturn(new FlutterShellArgs(new String[]{}));
+    when(fakeHost.getDartEntrypointFunctionName()).thenReturn("main");
+    when(fakeHost.getAppBundlePath()).thenReturn("/fake/path");
+    when(fakeHost.getInitialRoute()).thenReturn("/");
+    when(fakeHost.getRenderMode()).thenReturn(FlutterView.RenderMode.surface);
+    when(fakeHost.getTransparencyMode()).thenReturn(FlutterView.TransparencyMode.transparent);
+    when(fakeHost.provideFlutterEngine(any(Context.class))).thenReturn(mockFlutterEngine);
+    when(fakeHost.shouldAttachEngineToActivity()).thenReturn(true);
+    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(true);
   }
 
   @After
@@ -118,41 +124,88 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itDefersToTheHostToProvideFlutterEngine() {
     // ---- Test setup ----
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is created in onAttach().
     delegate.onAttach(RuntimeEnvironment.application);
 
     // Verify that the host was asked to provide a FlutterEngine.
-    verify(spyHost, times(1)).provideFlutterEngine(any(Context.class));
+    verify(fakeHost, times(1)).provideFlutterEngine(any(Context.class));
 
     // Verify that the delegate's FlutterEngine is our mock FlutterEngine.
     assertEquals("The delegate failed to use the host's FlutterEngine.", mockFlutterEngine, delegate.getFlutterEngine());
   }
 
   @Test
+  public void itUsesCachedEngineWhenProvided() {
+    // ---- Test setup ----
+    // Place a FlutterEngine in the static cache.
+    FlutterEngine cachedEngine = mockFlutterEngine();
+    FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
+
+    // Adjust fake host to request cached engine.
+    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine is obtained in onAttach().
+    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onCreateView(null, null, null);
+    delegate.onStart();
+    delegate.onResume();
+
+    // --- Verify that the cached engine was used ---
+    // Verify that the non-cached engine was not used.
+    verify(mockFlutterEngine.getDartExecutor(), never()).executeDartEntrypoint(any(DartExecutor.DartEntrypoint.class));
+
+    // We should never instruct a cached engine to execute Dart code - it should already be executing it.
+    verify(cachedEngine.getDartExecutor(), never()).executeDartEntrypoint(any(DartExecutor.DartEntrypoint.class));
+
+    // If the cached engine is being used, it should have sent a resumed lifecycle event.
+    verify(cachedEngine.getLifecycleChannel(), times(1)).appIsResumed();
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void itThrowsExceptionIfCachedEngineDoesNotExist() {
+    // ---- Test setup ----
+    // Adjust fake host to request cached engine that does not exist.
+    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+
+    // --- Execute the behavior under test ---
+    // The FlutterEngine existence is verified in onAttach()
+    delegate.onAttach(RuntimeEnvironment.application);
+
+    // Expect IllegalStateException.
+  }
+
+  @Test
   public void itGivesHostAnOpportunityToConfigureFlutterEngine() {
     // ---- Test setup ----
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is created in onAttach().
     delegate.onAttach(RuntimeEnvironment.application);
 
     // Verify that the host was asked to configure our FlutterEngine.
-    verify(spyHost, times(1)).configureFlutterEngine(mockFlutterEngine);
+    verify(fakeHost, times(1)).configureFlutterEngine(mockFlutterEngine);
   }
 
   @Test
   public void itSendsInitialRouteToFlutter() {
     // ---- Test setup ----
     // Set initial route on our fake Host.
-    spyHost.initialRoute = "/my/route";
+    when(fakeHost.getInitialRoute()).thenReturn("/my/route");
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The initial route is sent in onStart().
@@ -168,8 +221,8 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itExecutesDartEntrypointProvidedByHost() {
     // ---- Test setup ----
     // Set Dart entrypoint parameters on fake host.
-    spyHost.appBundlePath = "/my/bundle/path";
-    spyHost.dartEntrypointFunctionName = "myEntrypoint";
+    when(fakeHost.getAppBundlePath()).thenReturn("/my/bundle/path");
+    when(fakeHost.getDartEntrypointFunctionName()).thenReturn("myEntrypoint");
 
     // Create the DartEntrypoint that we expect to be executed.
     DartExecutor.DartEntrypoint dartEntrypoint = new DartExecutor.DartEntrypoint(
@@ -178,7 +231,7 @@ public class FlutterActivityAndFragmentDelegateTest {
     );
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // Dart is executed in onStart().
@@ -197,10 +250,10 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itAttachesFlutterToTheActivityIfDesired() {
     // ---- Test setup ----
     // Declare that the host wants Flutter to attach to the surrounding Activity.
-    spyHost.shouldAttachToActivity = true;
+    when(fakeHost.shouldAttachEngineToActivity()).thenReturn(true);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // Flutter is attached to the surrounding Activity in onAttach.
@@ -223,10 +276,10 @@ public class FlutterActivityAndFragmentDelegateTest {
   public void itDoesNotAttachFlutterToTheActivityIfNotDesired() {
     // ---- Test setup ----
     // Declare that the host does NOT want Flutter to attach to the surrounding Activity.
-    spyHost.shouldAttachToActivity = false;
+    when(fakeHost.shouldAttachEngineToActivity()).thenReturn(false);
 
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // Flutter is attached to the surrounding Activity in onAttach.
@@ -245,7 +298,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itSendsPopRouteMessageToFlutterWhenHardwareBackButtonIsPressed() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -261,7 +314,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnRequestPermissionsResultToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -277,7 +330,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnNewIntentToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -293,7 +346,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnActivityResultToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -309,7 +362,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itForwardsOnUserLeaveHintToFlutterEngine() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -325,7 +378,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itSendsMessageOverSystemChannelWhenToldToTrimMemory() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -341,7 +394,7 @@ public class FlutterActivityAndFragmentDelegateTest {
   @Test
   public void itSendsMessageOverSystemChannelWhenInformedOfLowMemory() {
     // Create the real object that we're testing.
-    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(spyHost);
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
 
     // --- Execute the behavior under test ---
     // The FlutterEngine is setup in onAttach().
@@ -355,18 +408,114 @@ public class FlutterActivityAndFragmentDelegateTest {
   }
 
   @Test
-  public void itUsesCachedEngineWhenProvided() {
-    assertTrue(false);
+  public void itDestroysItsOwnEngineIfHostRequestsIt() {
+    // ---- Test setup ----
+    // Adjust fake host to request engine destruction.
+    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(true);
+
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+
+    // --- Execute the behavior under test ---
+    // Push the delegate through all lifecycle methods all the way to destruction.
+    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onCreateView(null, null, null);
+    delegate.onStart();
+    delegate.onResume();
+    delegate.onPause();
+    delegate.onStop();
+    delegate.onDestroyView();
+    delegate.onDetach();
+
+    // --- Verify that the cached engine was destroyed ---
+    verify(mockFlutterEngine, times(1)).destroy();
   }
 
   @Test
-  public void itDoesNotDestroyCachedEngineByDefault() {
-    assertTrue(false);
+  public void itDoesNotDestroyItsOwnEngineWhenHostSaysNotTo() {
+    // ---- Test setup ----
+    // Adjust fake host to request engine destruction.
+    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(false);
+
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+
+    // --- Execute the behavior under test ---
+    // Push the delegate through all lifecycle methods all the way to destruction.
+    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onCreateView(null, null, null);
+    delegate.onStart();
+    delegate.onResume();
+    delegate.onPause();
+    delegate.onStop();
+    delegate.onDestroyView();
+    delegate.onDetach();
+
+    // --- Verify that the cached engine was destroyed ---
+    verify(mockFlutterEngine, never()).destroy();
   }
 
   @Test
-  public void itDestroysCachedEngineWhenRequested() {
-    assertTrue(false);
+  public void itDestroysCachedEngineWhenHostRequestsIt() {
+    // ---- Test setup ----
+    // Place a FlutterEngine in the static cache.
+    FlutterEngine cachedEngine = mockFlutterEngine();
+    FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
+
+    // Adjust fake host to request cached engine.
+    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+
+    // Adjust fake host to request engine destruction.
+    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(true);
+
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+
+    // --- Execute the behavior under test ---
+    // Push the delegate through all lifecycle methods all the way to destruction.
+    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onCreateView(null, null, null);
+    delegate.onStart();
+    delegate.onResume();
+    delegate.onPause();
+    delegate.onStop();
+    delegate.onDestroyView();
+    delegate.onDetach();
+
+    // --- Verify that the cached engine was destroyed ---
+    verify(cachedEngine, times(1)).destroy();
+    assertNull(FlutterEngineCache.getInstance().get("my_flutter_engine"));
+  }
+
+  @Test
+  public void itDoesNotDestroyCachedEngineWhenHostSaysNotTo() {
+    // ---- Test setup ----
+    // Place a FlutterEngine in the static cache.
+    FlutterEngine cachedEngine = mockFlutterEngine();
+    FlutterEngineCache.getInstance().put("my_flutter_engine", cachedEngine);
+
+    // Adjust fake host to request cached engine.
+    when(fakeHost.getCachedEngineId()).thenReturn("my_flutter_engine");
+
+    // Adjust fake host to request engine retention.
+    when(fakeHost.shouldDestroyEngineWithHost()).thenReturn(false);
+
+    // Create the real object that we're testing.
+    FlutterActivityAndFragmentDelegate delegate = new FlutterActivityAndFragmentDelegate(fakeHost);
+
+    // --- Execute the behavior under test ---
+    // Push the delegate through all lifecycle methods all the way to destruction.
+    delegate.onAttach(RuntimeEnvironment.application);
+    delegate.onCreateView(null, null, null);
+    delegate.onStart();
+    delegate.onResume();
+    delegate.onPause();
+    delegate.onStop();
+    delegate.onDestroyView();
+    delegate.onDetach();
+
+    // --- Verify that the cached engine was NOT destroyed ---
+    verify(cachedEngine, never()).destroy();
   }
 
   /**
@@ -402,127 +551,5 @@ public class FlutterActivityAndFragmentDelegateTest {
     when(engine.getActivityControlSurface()).thenReturn(mock(ActivityControlSurface.class));
 
     return engine;
-  }
-
-  /**
-   * A {@link FlutterActivityAndFragmentDelegate.Host} that returns values desired by this
-   * test suite.
-   * <p>
-   * Sane defaults are set for all properties. Tests in this suite can alter {@code FakeHost}
-   * properties as needed for each test.
-   */
-  private static class FakeHost implements FlutterActivityAndFragmentDelegate.Host {
-    private FlutterEngine flutterEngine;
-    private String initialRoute = null;
-    private String appBundlePath = "fake/path/";
-    private String dartEntrypointFunctionName = "main";
-    private Activity activity;
-    private boolean shouldAttachToActivity = false;
-    private boolean retainFlutterEngine = false;
-
-    @NonNull
-    @Override
-    public Context getContext() {
-      return RuntimeEnvironment.application;
-    }
-
-    @Nullable
-    @Override
-    public Activity getActivity() {
-      if (activity == null) {
-        // We must provide a real (or close to real) Activity because it is passed to
-        // the FlutterView that the delegate instantiates.
-        activity = Robolectric.setupActivity(Activity.class);
-      }
-
-      return activity;
-    }
-
-    @NonNull
-    @Override
-    public Lifecycle getLifecycle() {
-      return mock(Lifecycle.class);
-    }
-
-    @NonNull
-    @Override
-    public FlutterShellArgs getFlutterShellArgs() {
-      return new FlutterShellArgs(new String[]{});
-    }
-
-    @Nullable
-    @Override
-    public String getCachedEngineId() {
-      return null;
-    }
-
-    @Override
-    public boolean shouldDestroyCachedEngineWithActivity() {
-      return false;
-    }
-
-    @NonNull
-    @Override
-    public String getDartEntrypointFunctionName() {
-      return dartEntrypointFunctionName;
-    }
-
-    @NonNull
-    @Override
-    public String getAppBundlePath() {
-      return appBundlePath;
-    }
-
-    @Nullable
-    @Override
-    public String getInitialRoute() {
-      return initialRoute;
-    }
-
-    @NonNull
-    @Override
-    public FlutterView.RenderMode getRenderMode() {
-      return FlutterView.RenderMode.surface;
-    }
-
-    @NonNull
-    @Override
-    public FlutterView.TransparencyMode getTransparencyMode() {
-      return FlutterView.TransparencyMode.opaque;
-    }
-
-    @Nullable
-    @Override
-    public SplashScreen provideSplashScreen() {
-      return null;
-    }
-
-    @Nullable
-    @Override
-    public FlutterEngine provideFlutterEngine(@NonNull Context context) {
-      return flutterEngine;
-    }
-
-    @Nullable
-    @Override
-    public PlatformPlugin providePlatformPlugin(@Nullable Activity activity, @NonNull FlutterEngine flutterEngine) {
-      return null;
-    }
-
-    @Override
-    public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {}
-
-    @Override
-    public boolean shouldAttachEngineToActivity() {
-      return shouldAttachToActivity;
-    }
-
-    @Override
-    public boolean retainFlutterEngineAfterHostDestruction() {
-      return retainFlutterEngine;
-    }
-
-    @Override
-    public void onFirstFrameRendered() {}
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -10,7 +10,10 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Config(manifest=Config.NONE)
@@ -20,22 +23,65 @@ public class FlutterActivityTest {
   public void itCreatesDefaultIntentWithExpectedDefaults() {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
     ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
 
-    assertEquals("main", activityController.get().getDartEntrypointFunctionName());
+    assertEquals("main", flutterActivity.getDartEntrypointFunctionName());
+    assertEquals("/", flutterActivity.getInitialRoute());
+    assertArrayEquals(new String[]{}, flutterActivity.getFlutterShellArgs().toArray());
+    assertTrue(flutterActivity.shouldAttachEngineToActivity());
+    assertNull(flutterActivity.getCachedEngineId());
+    assertFalse(flutterActivity.shouldDestroyEngineWithHost());
+    assertEquals(FlutterActivity.BackgroundMode.opaque, flutterActivity.getBackgroundMode());
+    assertEquals(FlutterView.RenderMode.surface, flutterActivity.getRenderMode());
+    assertEquals(FlutterView.TransparencyMode.opaque, flutterActivity.getTransparencyMode());
   }
 
   @Test
   public void itCreatesNewEngineIntentWithRequestedSettings() {
-    assertTrue(false);
+    Intent intent = FlutterActivity.withNewEngine()
+        .dartEntrypoint("custom_entrypoint")
+        .initialRoute("/custom/route")
+        .backgroundMode(FlutterActivity.BackgroundMode.transparent)
+        .build(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertEquals("custom_entrypoint", flutterActivity.getDartEntrypointFunctionName());
+    assertEquals("/custom/route", flutterActivity.getInitialRoute());
+    assertArrayEquals(new String[]{}, flutterActivity.getFlutterShellArgs().toArray());
+    assertTrue(flutterActivity.shouldAttachEngineToActivity());
+    assertNull(flutterActivity.getCachedEngineId());
+    assertFalse(flutterActivity.shouldDestroyEngineWithHost());
+    assertEquals(FlutterActivity.BackgroundMode.transparent, flutterActivity.getBackgroundMode());
+    assertEquals(FlutterView.RenderMode.texture, flutterActivity.getRenderMode());
+    assertEquals(FlutterView.TransparencyMode.transparent, flutterActivity.getTransparencyMode());
   }
 
   @Test
   public void itCreatesCachedEngineIntentThatDoesNotDestroyTheEngine() {
-    assertTrue(false);
+    Intent intent = FlutterActivity.withCachedEngine("my_cached_engine")
+        .destroyEngineWithActivity(false)
+        .build(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertArrayEquals(new String[]{}, flutterActivity.getFlutterShellArgs().toArray());
+    assertTrue(flutterActivity.shouldAttachEngineToActivity());
+    assertEquals("my_cached_engine", flutterActivity.getCachedEngineId());
+    assertFalse(flutterActivity.shouldDestroyEngineWithHost());
   }
 
   @Test
   public void itCreatesCachedEngineIntentThatDestroysTheEngine() {
-    assertTrue(false);
+    Intent intent = FlutterActivity.withCachedEngine("my_cached_engine")
+        .destroyEngineWithActivity(true)
+        .build(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertArrayEquals(new String[]{}, flutterActivity.getFlutterShellArgs().toArray());
+    assertTrue(flutterActivity.shouldAttachEngineToActivity());
+    assertEquals("my_cached_engine", flutterActivity.getCachedEngineId());
+    assertTrue(flutterActivity.shouldDestroyEngineWithHost());
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -30,7 +30,7 @@ public class FlutterActivityTest {
     assertArrayEquals(new String[]{}, flutterActivity.getFlutterShellArgs().toArray());
     assertTrue(flutterActivity.shouldAttachEngineToActivity());
     assertNull(flutterActivity.getCachedEngineId());
-    assertFalse(flutterActivity.shouldDestroyEngineWithHost());
+    assertTrue(flutterActivity.shouldDestroyEngineWithHost());
     assertEquals(FlutterActivity.BackgroundMode.opaque, flutterActivity.getBackgroundMode());
     assertEquals(FlutterView.RenderMode.surface, flutterActivity.getRenderMode());
     assertEquals(FlutterView.TransparencyMode.opaque, flutterActivity.getTransparencyMode());
@@ -51,7 +51,7 @@ public class FlutterActivityTest {
     assertArrayEquals(new String[]{}, flutterActivity.getFlutterShellArgs().toArray());
     assertTrue(flutterActivity.shouldAttachEngineToActivity());
     assertNull(flutterActivity.getCachedEngineId());
-    assertFalse(flutterActivity.shouldDestroyEngineWithHost());
+    assertTrue(flutterActivity.shouldDestroyEngineWithHost());
     assertEquals(FlutterActivity.BackgroundMode.transparent, flutterActivity.getBackgroundMode());
     assertEquals(FlutterView.RenderMode.texture, flutterActivity.getRenderMode());
     assertEquals(FlutterView.TransparencyMode.transparent, flutterActivity.getTransparencyMode());

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -1,0 +1,41 @@
+package io.flutter.embedding.android;
+
+import android.content.Intent;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Config(manifest=Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterActivityTest {
+  @Test
+  public void itCreatesDefaultIntentWithExpectedDefaults() {
+    Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
+    ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
+
+    assertEquals("main", activityController.get().getDartEntrypointFunctionName());
+  }
+
+  @Test
+  public void itCreatesNewEngineIntentWithRequestedSettings() {
+    assertTrue(false);
+  }
+
+  @Test
+  public void itCreatesCachedEngineIntentThatDoesNotDestroyTheEngine() {
+    assertTrue(false);
+  }
+
+  @Test
+  public void itCreatesCachedEngineIntentThatDestroysTheEngine() {
+    assertTrue(false);
+  }
+}

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -1,0 +1,10 @@
+package io.flutter.embedding.android;
+
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@Config(manifest=Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterFragmentTest {
+}

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -1,10 +1,73 @@
 package io.flutter.embedding.android;
 
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 @Config(manifest=Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class FlutterFragmentTest {
+  @Test
+  public void itCreatesDefaultFragmentWithExpectedDefaults() {
+    FlutterFragment fragment = FlutterFragment.createDefault();
+
+    assertEquals("main", fragment.getDartEntrypointFunctionName());
+    assertEquals("/", fragment.getInitialRoute());
+    assertArrayEquals(new String[]{}, fragment.getFlutterShellArgs().toArray());
+    assertTrue(fragment.shouldAttachEngineToActivity());
+    assertNull(fragment.getCachedEngineId());
+    assertFalse(fragment.shouldDestroyEngineWithHost());
+    assertEquals(FlutterView.RenderMode.surface, fragment.getRenderMode());
+    assertEquals(FlutterView.TransparencyMode.transparent, fragment.getTransparencyMode());
+  }
+
+  @Test
+  public void itCreatesNewEngineFragmentWithRequestedSettings() {
+    FlutterFragment fragment = FlutterFragment.withNewEngine()
+        .dartEntrypoint("custom_entrypoint")
+        .initialRoute("/custom/route")
+        .shouldAttachEngineToActivity(false)
+        .renderMode(FlutterView.RenderMode.texture)
+        .transparencyMode(FlutterView.TransparencyMode.opaque)
+        .build();
+
+    assertEquals("custom_entrypoint", fragment.getDartEntrypointFunctionName());
+    assertEquals("/custom/route", fragment.getInitialRoute());
+    assertArrayEquals(new String[]{}, fragment.getFlutterShellArgs().toArray());
+    assertFalse(fragment.shouldAttachEngineToActivity());
+    assertNull(fragment.getCachedEngineId());
+    assertFalse(fragment.shouldDestroyEngineWithHost());
+    assertEquals(FlutterView.RenderMode.texture, fragment.getRenderMode());
+    assertEquals(FlutterView.TransparencyMode.opaque, fragment.getTransparencyMode());
+  }
+
+  @Test
+  public void itCreatesCachedEngineFragmentThatDoesNotDestroyTheEngine() {
+    FlutterFragment fragment = FlutterFragment
+        .withCachedEngine("my_cached_engine")
+        .build();
+
+    assertTrue(fragment.shouldAttachEngineToActivity());
+    assertEquals("my_cached_engine", fragment.getCachedEngineId());
+    assertFalse(fragment.shouldDestroyEngineWithHost());
+  }
+
+  @Test
+  public void itCreatesCachedEngineFragmentThatDestroysTheEngine() {
+    FlutterFragment fragment = FlutterFragment
+        .withCachedEngine("my_cached_engine")
+        .destroyEngineWithFragment(true)
+        .build();
+
+    assertTrue(fragment.shouldAttachEngineToActivity());
+    assertEquals("my_cached_engine", fragment.getCachedEngineId());
+    assertTrue(fragment.shouldDestroyEngineWithHost());
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -23,7 +23,7 @@ public class FlutterFragmentTest {
     assertArrayEquals(new String[]{}, fragment.getFlutterShellArgs().toArray());
     assertTrue(fragment.shouldAttachEngineToActivity());
     assertNull(fragment.getCachedEngineId());
-    assertFalse(fragment.shouldDestroyEngineWithHost());
+    assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(FlutterView.RenderMode.surface, fragment.getRenderMode());
     assertEquals(FlutterView.TransparencyMode.transparent, fragment.getTransparencyMode());
   }
@@ -43,7 +43,7 @@ public class FlutterFragmentTest {
     assertArrayEquals(new String[]{}, fragment.getFlutterShellArgs().toArray());
     assertFalse(fragment.shouldAttachEngineToActivity());
     assertNull(fragment.getCachedEngineId());
-    assertFalse(fragment.shouldDestroyEngineWithHost());
+    assertTrue(fragment.shouldDestroyEngineWithHost());
     assertEquals(FlutterView.RenderMode.texture, fragment.getRenderMode());
     assertEquals(FlutterView.TransparencyMode.opaque, fragment.getTransparencyMode());
   }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineCacheTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineCacheTest.java
@@ -1,0 +1,58 @@
+package io.flutter.embedding.engine;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@Config(manifest=Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterEngineCacheTest {
+  @Test
+  public void itHoldsFlutterEngines() {
+    // --- Test Setup ---
+    FlutterEngine flutterEngine = mock(FlutterEngine.class);
+    FlutterEngineCache cache = new FlutterEngineCache();
+
+    // --- Execute Test ---
+    cache.put("my_flutter_engine", flutterEngine);
+
+    // --- Verify Results ---
+    assertEquals(flutterEngine, cache.get("my_flutter_engine"));
+  }
+
+  @Test
+  public void itQueriesFlutterEngineExistence() {
+    // --- Test Setup ---
+    FlutterEngine flutterEngine = mock(FlutterEngine.class);
+    FlutterEngineCache cache = new FlutterEngineCache();
+
+    // --- Execute Test ---
+    assertFalse(cache.contains("my_flutter_engine"));
+
+    cache.put("my_flutter_engine", flutterEngine);
+
+    // --- Verify Results ---
+    assertTrue(cache.contains("my_flutter_engine"));
+  }
+
+  @Test
+  public void itRemovesFlutterEngines() {
+    // --- Test Setup ---
+    FlutterEngine flutterEngine = mock(FlutterEngine.class);
+    FlutterEngineCache cache = new FlutterEngineCache();
+
+    // --- Execute Test ---
+    cache.put("my_flutter_engine", flutterEngine);
+    cache.remove("my_flutter_engine");
+
+    // --- Verify Results ---
+    assertNull(cache.get("my_flutter_engine"));
+  }
+}


### PR DESCRIPTION
Android embedding refactor pr40 add static engine cache.

This PR includes testing dependency updates. Those updates have already been uploaded to CIPD and tagged, then re-synced locally to verify.

This PR changes the canonical way to use `FlutterActivity` and `FlutterFragment` to the following:

Create a default `FlutterActivity`:
`Intent intent = FlutterActivity.createDefaultIntent();`

Create a custom `FlutterActivity` with new `FlutterEngine`:
`Intent intent = FlutterActivity.withNewEngine().dartEntrypoint("myEntry")...build();`

Create a custom `FlutterActivity` with a cached `FlutterEngine`:
`Intent intent = FlutterActivity.withCachedEngine("my_engine_id")...build();`

Create a default `FlutterFragment`:
`FlutterFragment fragment = FlutterFragment.createDefault();`

Create a custom `FlutterFragment` with a new `FlutterEngine`:
`FlutterFragment fragment = FlutterFragment.withNewEngine().dartEntrypoint("myEntry")...build();`

Create a custom `FlutterFragment` with a cached `FlutterEngine`:
`FlutterFragment fragment = FlutterFragment.withCachedEngine("my_engine_id")...build();`

To cache a `FlutterEngine`:
```
FlutterEngine engine = new FlutterEngine(context);
// steps to begin executing Dart are omitted.
FlutterEngineCache.getInstance().put("my_engine_id", engine);
```