### PR TITLE
Remove semi-redundant try-jobs.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,8 +14,8 @@ task:
     ENGINE_PATH: "/tmp/clean_engine"
     DEPOT_TOOLS: "/tmp/depot_tools"
     FLUTTER_ENGINE: "/tmp/clean_engine/src"
-    FRAMEWORK_PATH: "/tmp/master_framework"
     PATH: "$FLUTTER_ENGINE/third_party/dart/tools/sdks/dart-sdk/bin:$DEPOT_TOOLS:$PATH"
+    # Used to setup the gclient solution.
     USE_ANDROID: "False"
   setup_script: |
     git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS
@@ -35,61 +35,32 @@ task:
       test_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/testing/run_tests.sh host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-      test_web_script: |
-        cd $FRAMEWORK_PATH/flutter/dev/integration_tests/web
-        ../../../bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web
-        ../../../bin/flutter --local-engine=host_debug_unopt build web -v
-      test_framework_script: |
-        cd $FRAMEWORK_PATH/flutter/packages/flutter
-        ../../bin/flutter test --local-engine=host_debug_unopt
-    - name: build_and_test_linux_opt_profile
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --runtime-mode profile --no-lto
-        ninja -C out/host_profile
-      test_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/testing/run_tests.sh host_profile
-    - name: build_and_test_linux_opt_release
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --runtime-mode release --no-lto
-        ninja -C out/host_release
-      test_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/testing/run_tests.sh host_release
-    - name: build_and_test_android_unopt_debug
+    - name: build_and_test_android_profile_app
       env:
+        # Used to setup the gclient solution.
         USE_ANDROID: "True"
         ANDROID_HOME: $ENGINE_PATH/src/third_party/android_tools/sdk
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[3be31b3547bea4e70cff1d46f9a11ad8c6b42c1982a3964d81e437dee2035f674f12e130bde231352421d8de2029c55f]
       lint_host_script: |
         cd $ENGINE_PATH/src/flutter/tools/android_lint
         $ENGINE_PATH/src/third_party/dart/tools/sdks/dart-sdk/bin/pub get
         $ENGINE_PATH/src/third_party/dart/tools/sdks/dart-sdk/bin/dart bin/main.dart
       compile_host_script: |
         cd $ENGINE_PATH/src
-        ./flutter/tools/gn --android --unoptimized
-        ninja -C out/android_debug_unopt
-        mkdir javadoc_tmp
-        ./flutter/tools/gen_javadoc.py --out-dir javadoc_tmp
-      test_android_script: cd $ENGINE_PATH/src && python ./flutter/testing/run_tests.py --type=java
-    - name: build_and_test_android_profile_app
-      env:
-        USE_ANDROID: "True"
-        ANDROID_HOME: $ENGINE_PATH/src/third_party/android_tools/sdk
-        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[3be31b3547bea4e70cff1d46f9a11ad8c6b42c1982a3964d81e437dee2035f674f12e130bde231352421d8de2029c55f]
-      compile_host_script: |
-        cd $ENGINE_PATH/src
         ./flutter/tools/gn --runtime-mode=profile --no-lto
         autoninja -C out/host_profile
+      test_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/testing/run_tests.sh host_profile
+      make_javadoc: |
+        mkdir javadoc_tmp
+        ./flutter/tools/gen_javadoc.py --out-dir javadoc_tmp
       compile_android_script: |
         cd $ENGINE_PATH/src
         ./flutter/tools/gn --android --runtime-mode=profile --no-lto --android-cpu=arm64
         ninja -C out/android_profile_arm64
+      test_android_script: |
+        cd $ENGINE_PATH/src && python ./flutter/testing/run_tests.py --type=java --variant=android_profile_arm64
       compile_app_script: |
         cd $ENGINE_PATH/src/flutter/testing/scenario_app
         ./compile_android_aot.sh "$ENGINE_PATH/src/out/host_profile" "$ENGINE_PATH/src/out/android_profile_arm64/clang_x64"
@@ -105,10 +76,9 @@ task:
       build_script: |
         cd $ENGINE_PATH/src/flutter
         ./ci/build.sh
-    - name: build_fuchsia_artifacts
+    - name: build_fuchsia_debug_artifacts
       compile_host_script: |
         cd $ENGINE_PATH/src
-        rm -rf out
         ./flutter/tools/fuchsia/build_fuchsia_artifacts.py --engine-version HEAD --runtime-mode debug
 
 # WINDOWS
@@ -138,6 +108,7 @@ task:
       compile_host_script: |
         cd %ENGINE_PATH%/src
         python flutter/tools/gn --runtime-mode debug --unoptimized
+        rm -rf out
         ninja -C out/host_debug_unopt
     - name: build_windows_opt_debug
       compile_host_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,7 +52,6 @@ task:
       test_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/testing/run_tests.sh host_profile
-      make_javadoc: |
         mkdir javadoc_tmp
         ./flutter/tools/gen_javadoc.py --out-dir javadoc_tmp
       compile_android_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -107,7 +107,6 @@ task:
       compile_host_script: |
         cd %ENGINE_PATH%/src
         python flutter/tools/gn --runtime-mode debug --unoptimized
-        rm -rf out
         ninja -C out/host_debug_unopt
     - name: build_windows_opt_debug
       compile_host_script: |

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -216,11 +216,8 @@ def EnsureJavaTestsAreBuilt(android_out_dir):
   subprocess.check_call(gn_command, cwd=buildroot_dir)
   subprocess.check_call(ninja_command, cwd=buildroot_dir)
 
-def RunJavaTests(filter):
-  # There's no real reason why other Android build types couldn't be supported
-  # here. Could default to this but use any other variant of android_ if it
-  # exists, but it seems like overkill to add that logic in right now.
-  android_out_dir = os.path.join(out_dir, 'android_debug_unopt')
+def RunJavaTests(filter, android_build_variant):
+  android_out_dir = os.path.join(out_dir, android_build_variant)
   EnsureJavaTestsAreBuilt(android_out_dir)
 
   robolectric_dir = os.path.join(buildroot_dir, 'third_party', 'robolectric', 'lib')
@@ -277,7 +274,9 @@ def main():
   args = parser.parse_args()
 
   if args.type == 'all':
-    types = ['engine', 'dart', 'benchmarks', 'java']
+    types = ['engine', 'dart', 'benchmarks']
+    if 'android' in variant:
+      types.append('java')
   else:
     types = args.type.split(',')
 
@@ -300,7 +299,7 @@ def main():
     if ',' in java_filter or '*' in java_filter:
       print('Can only filter JUnit4 tests by single entire class name, eg "io.flutter.SmokeTest". Ignoring filter=' + java_filter)
       java_filter = None
-    RunJavaTests(java_filter)
+    RunJavaTests(java_filter, args.variant)
 
   # https://github.com/flutter/flutter/issues/36300
   if 'benchmarks' in types and not IsWindows():


### PR DESCRIPTION
We are severely resource constrained on the tryjobs. This is hindering progress on ToT due to scheduling failures and rate limits. There are no plans to requisition more resources in this infra scheme as the migration to tryjobs on LUCI is the preferred way forward. This patch removes presubmits that are somewhat redundant. Each removed presubmit and the justification is given below:

* `build_and_test_linux_opt_release`: The AOT variant is tested by `build_and_test_linux_opt_profile` (actually its replacement, see the next point).
* `build_and_test_linux_opt_profile`: When we build the host profile variant for Android, we test it as well instead of building the extra variant (since we already need a host for a target build).
* `build_and_test_android_unopt_debug`: `gen_javadoc` have been moved to the profile variant. `Roboelectric` tests have been moved to profile variant. JIT infra will be tested by the the host tests.
* ToT framework checks: These will be performed [by the autoroller](https://autoroll.skia.org/r/flutter-engine-flutter-autoroll?tab=status) which also has a sheriff rotation. This will also avoid us having to ignore red presubmits on manual changes.

Everything else is left as-is. To be clear, this causes strictly less checks to be performed on each commit.