### PR TITLE
Fix engine platformviewscontroller leak

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -173,6 +173,7 @@
   [self resetChannels];
   _shell.reset();
   _threadHost.Reset();
+  _platformViewsController.reset();
 }
 
 - (FlutterViewController*)viewController {


### PR DESCRIPTION
1.Problem
When allowHeadlessExecution is false, we expect destroyContext and release the FlutterEngine. But when the platform view is enabled, there may be a retain cycle problem.
In the object that implement the FlutterPlatformViewFactory protocol, we may hold the FlutterPluginRegistrar,  just like this:
![image](https://user-images.githubusercontent.com/11627283/62464659-c5ff7300-b7bf-11e9-938f-14e62298bb72.png)
and it cause the retain cycle problem:
![image](https://user-images.githubusercontent.com/11627283/62465242-04496200-b7c1-11e9-8fa9-dc21d2bdcef6.png)

@cyanglaz Would you please take a look at this?
