### PR TITLE
Use Fuchsia trace macros when targeting Fuchsia SDK

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -160,7 +160,9 @@ source_set("fml") {
   if (is_fuchsia) {
     sources += [ "platform/fuchsia/paths_fuchsia.cc" ]
 
-    if (!using_fuchsia_sdk) {
+    if (using_fuchsia_sdk) {
+      public_deps += [ "$fuchsia_sdk_root/pkg:trace" ]
+    } else {
       public_deps += [ "//zircon/public/lib/trace" ]
     }
   }

--- a/fml/trace_event.h
+++ b/fml/trace_event.h
@@ -8,11 +8,10 @@
 #include "flutter/fml/build_config.h"
 
 #if defined(OS_FUCHSIA)
-#if !defined(FUCHSIA_SDK)
 
 // Forward to the system tracing mechanism on Fuchsia.
 
-#include <trace/event.h>
+#include <lib/trace/event.h>
 
 // TODO(DNO-448): This is disabled because the Fuchsia counter id json parsing
 // only handles ints whereas this can produce ints or strings.
@@ -28,7 +27,6 @@
 #define TRACE_EVENT_ASYNC_END1(a, b, c, d, e) TRACE_ASYNC_END(a, b, c, d, e)
 #define TRACE_EVENT_INSTANT0(a, b) TRACE_INSTANT(a, b, TRACE_SCOPE_THREAD)
 
-#endif  //  !defined(FUCHSIA_SDK)
 #endif  //  defined(OS_FUCHSIA)
 
 #include <cstddef>
@@ -41,7 +39,7 @@
 #include "flutter/fml/time/time_point.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 
-#if !defined(OS_FUCHSIA) || defined(FUCHSIA_SDK)
+#if !defined(OS_FUCHSIA)
 #ifndef TRACE_EVENT_HIDE_MACROS
 
 #define __FML__TOKEN_CAT__(x, y) x##y
@@ -104,7 +102,7 @@
   ::fml::tracing::TraceEventFlowEnd0(category, name, id);
 
 #endif  // TRACE_EVENT_HIDE_MACROS
-#endif  // !defined(OS_FUCHSIA) || defined(FUCHSIA_SDK)
+#endif  // !defined(OS_FUCHSIA)
 
 namespace fml {
 namespace tracing {

--- a/shell/common/skia_event_tracer_impl.cc
+++ b/shell/common/skia_event_tracer_impl.cc
@@ -32,7 +32,7 @@ class FlutterEventTracer : public SkEventTracer {
                                       const uint8_t* p_arg_types,
                                       const uint64_t* p_arg_values,
                                       uint8_t flags) override {
-#if defined(OS_FUCHSIA) && !defined(FUCHSIA_SDK)
+#if defined(OS_FUCHSIA)
     // In a manner analogous to "fml/trace_event.h", use Fuchsia's system
     // tracing macros when running on Fuchsia.
     switch (phase) {

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
@@ -313,16 +313,16 @@ void VulkanSurfacePool::TraceStats() {
   const size_t skia_cache_purgeable =
       context_->getResourceCachePurgeableBytes();
 
-  FML_TRACE_COUNTER("flutter", "SurfacePool", 0u,                     //
-                    "CachedCount", cached_surfaces,                   //
-                    "CachedBytes", cached_surfaces_bytes,             //
-                    "Created", trace_surfaces_created_,               //
-                    "Reused", trace_surfaces_reused_,                 //
-                    "PendingInCompositor", pending_surfaces_.size(),  //
-                    "Retained", retained_surfaces_.size(),            //
-                    "SkiaCacheResources", skia_resources,             //
-                    "SkiaCacheBytes", skia_bytes,                     //
-                    "SkiaCachePurgeable", skia_cache_purgeable        //
+  TRACE_COUNTER("flutter", "SurfacePool", 0u,                     //
+                "CachedCount", cached_surfaces,                   //
+                "CachedBytes", cached_surfaces_bytes,             //
+                "Created", trace_surfaces_created_,               //
+                "Reused", trace_surfaces_reused_,                 //
+                "PendingInCompositor", pending_surfaces_.size(),  //
+                "Retained", retained_surfaces_.size(),            //
+                "SkiaCacheResources", skia_resources,             //
+                "SkiaCacheBytes", skia_bytes,                     //
+                "SkiaCachePurgeable", skia_cache_purgeable        //
   );
 
   // Reset per present/frame stats.


### PR DESCRIPTION
When |OS_FUCHSIA| is defined (even when |FUCHSIA_SDK| is defined as
well), use the Fuchsia SDK trace macros rather than the Dart timeline.

Reasons for doing this include:

Fuchsia's trace macros support categories.  This allows one to
distinguish between (e.g.) "flutter" and "skia" trace events for trace
recording and trace visualization.

Fuchsia has existing in tree benchmarks that depend on finding certain
events under category "flutter".

See the Fuchsia performance mailing list discussion for more context.