### PR TITLE
[flutter_runner] Port: Add connectToService, wrapping fdio_ns_connect.

### DIFF
--- a/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
+++ b/shell/platform/fuchsia/dart-pkg/zircon/lib/src/system.dart
@@ -125,8 +125,8 @@ class System extends NativeFieldWrapperClass2 {
       native 'System_ChannelCreate';
   static HandleResult channelFromFile(String path)
       native 'System_ChannelFromFile';
-  static int reboot()
-      native 'System_Reboot';
+  static int connectToService(String path, Handle channel)
+    native 'System_ConnectToService';
   static int channelWrite(Handle channel, ByteData data, List<Handle> handles)
       native 'System_ChannelWrite';
   static ReadResult channelQueryAndRead(Handle channel)
@@ -158,4 +158,7 @@ class System extends NativeFieldWrapperClass2 {
 
   // Time operations.
   static int clockGet(int clockId) native 'System_ClockGet';
+
+  // TODO(edcoyne): Remove this, it is required to safely do an API transition across repos.
+  static int reboot() { return -2; /*ZX_ERR_NOT_SUPPORTED*/ }
 }

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.cc
@@ -134,7 +134,7 @@ Dart_Handle ConstructDartObject(const char* class_name, Args&&... args) {
   return object;
 }
 
-fml::UniqueFD FdFromPath(std::string path) {
+fdio_ns_t* GetNamespace() {
   // Grab the fdio_ns_t* out of the isolate.
   Dart_Handle zircon_lib = Dart_LookupLibrary(ToDart("dart:zircon"));
   FML_DCHECK(!tonic::LogIfError(zircon_lib));
@@ -148,8 +148,12 @@ fml::UniqueFD FdFromPath(std::string path) {
   Dart_Handle result = Dart_IntegerToUint64(namespace_field, &fdio_ns_ptr);
   FML_DCHECK(!tonic::LogIfError(result));
 
+  return reinterpret_cast<fdio_ns_t*>(fdio_ns_ptr);
+}
+
+fml::UniqueFD FdFromPath(std::string path) {
   // Get a VMO for the file.
-  fdio_ns_t* ns = reinterpret_cast<fdio_ns_t*>(fdio_ns_ptr);
+  fdio_ns_t* ns = reinterpret_cast<fdio_ns_t*>(GetNamespace());
   fml::UniqueFD dirfd(fdio_ns_opendir(ns));
   if (!dirfd.is_valid())
     return fml::UniqueFD();
@@ -176,36 +180,11 @@ Dart_Handle System::ChannelCreate(uint32_t options) {
   }
 }
 
-zx_status_t System::Reboot() {
-#if defined(FUCHSIA_SDK)
-  FML_CHECK(false);
-  return ZX_ERR_NOT_SUPPORTED;
-#else   // !defined(FUCHSIA_SDK)
-  zx::channel local, remote;
-  auto status = zx::channel::create(0, &local, &remote);
-  if (status != ZX_OK) {
-    return status;
-  }
-
-  const std::string service =
-      std::string{"/svc/"} + fuchsia::device::manager::Administrator::Name_;
-  status = fdio_service_connect(service.c_str(), remote.get());
-  if (status != ZX_OK) {
-    printf("failed to connect to service %s: %d\n", service.c_str(), status);
-    return status;
-  }
-
-  zx_status_t call_status;
-  fuchsia::device::manager::Administrator_SyncProxy administrator(
-      std::move(local));
-  status = administrator.Suspend(DEVICE_SUSPEND_FLAG_REBOOT, &call_status);
-  if (status != ZX_OK || call_status != ZX_OK) {
-    printf("Call to %s failed: ret: %d  remote: %d\n", service.c_str(), status,
-           call_status);
-  }
-
-  return status != ZX_OK ? status : call_status;
-#endif  // !defined(FUCHSIA_SDK)
+zx_status_t System::ConnectToService(std::string path,
+                                     fml::RefPtr<Handle> channel) {
+  return fdio_ns_connect(GetNamespace(), path.c_str(),
+                         ZX_FS_RIGHT_READABLE | ZX_FS_RIGHT_WRITABLE,
+                         channel->ReleaseHandle());
 }
 
 zx::channel System::CloneChannelFromFileDescriptor(int fd) {
@@ -500,7 +479,7 @@ uint64_t System::ClockGet(uint32_t clock_id) {
   V(System, ChannelWrite)          \
   V(System, ChannelQueryAndRead)   \
   V(System, EventpairCreate)       \
-  V(System, Reboot)                \
+  V(System, ConnectToService)      \
   V(System, SocketCreate)          \
   V(System, SocketWrite)           \
   V(System, SocketRead)            \

--- a/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
+++ b/shell/platform/fuchsia/dart-pkg/zircon/sdk_ext/system.h
@@ -13,6 +13,15 @@
 #include "third_party/tonic/dart_wrappable.h"
 #include "third_party/tonic/typed_data/dart_byte_data.h"
 
+// TODO (kaushikiska): Once fuchsia adds fs to their sdk,
+// use the rights macros from "fs/vfs.h"
+
+// Rights
+// The file may be read.
+#define ZX_FS_RIGHT_READABLE 0x00000001
+// The file may be written.
+#define ZX_FS_RIGHT_WRITABLE 0x00000002
+
 namespace zircon {
 namespace dart {
 
@@ -56,7 +65,8 @@ class System : public fml::RefCountedThreadSafe<System>,
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 
-  static zx_status_t Reboot();
+  static zx_status_t ConnectToService(std::string path,
+                                      fml::RefPtr<Handle> channel);
 
  private:
   static void VmoMapFinalizer(void* isolate_callback_data,

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -10,7 +10,6 @@
         ],
         "services": [
             "fuchsia.crash.Analyzer",
-            "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",
             "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -10,7 +10,6 @@
         ],
         "services": [
             "fuchsia.crash.Analyzer",
-            "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",
             "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -9,7 +9,6 @@
             "deprecated-ambient-replace-as-executable"
         ],
         "services": [
-            "fuchsia.device.manager.Administrator",
             "fuchsia.crash.Analyzer",
             "fuchsia.fonts.Provider",
             "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -10,7 +10,6 @@
         ],
         "services": [
             "fuchsia.crash.Analyzer",
-            "fuchsia.device.manager.Administrator",
             "fuchsia.fonts.Provider",
             "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",


### PR DESCRIPTION
Use fdio_ns_connect to connect to services in a namespace. For pure
persistant fidl services the old path of creating a file descriptor and
then opening a channel to that file descriptor doesn't work.

We should provide a way to directly connect to a service without first
treating it as a file.

Test:
* workstation.frank, reboot button on main menu works.
* astro, device_settings "erase user data" reboot works.

Change-Id: I725ba9350547309bebb5530aa44236f841d88f99