### PR TITLE
Allow embedders to control Dart VM lifecycle on engine shutdown.

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -375,6 +375,7 @@ FlutterEngineResult FlutterEngineRun(size_t version,
 
   settings.icu_data_path = icu_data_path;
   settings.assets_path = args->assets_path;
+  settings.leak_vm = !SAFE_ACCESS(args, shutdown_dart_vm_when_done, false);
 
   if (!flutter::DartVM::IsRunningPrecompiledCode()) {
     // Verify the assets path contains Dart 2 kernel assets.

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -12,6 +12,7 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
     InitializationPreference preference)
     : context_(context) {
   project_args_.struct_size = sizeof(project_args_);
+  project_args_.shutdown_dart_vm_when_done = true;
   project_args_.platform_message_callback =
       [](const FlutterPlatformMessage* message, void* context) {
         reinterpret_cast<EmbedderContext*>(context)->PlatformMessageCallback(

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -13,6 +13,7 @@
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/thread.h"
+#include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/platform/embedder/tests/embedder_config_builder.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test.h"
 #include "flutter/testing/testing.h"
@@ -463,6 +464,27 @@ TEST_F(EmbedderTest, InvalidPlatformMessages) {
   auto result =
       FlutterEngineSendPlatformMessage(engine.get(), &platform_message);
   ASSERT_EQ(result, kInvalidArguments);
+}
+
+//------------------------------------------------------------------------------
+/// Asserts behavior of FlutterProjectArgs::shutdown_dart_vm_when_done (which is
+/// set to true by default in these unit-tests).
+///
+TEST_F(EmbedderTest, VMShutsDownWhenNoEnginesInProcess) {
+  auto& context = GetEmbedderContext();
+  EmbedderConfigBuilder builder(context);
+
+  const auto launch_count = DartVM::GetVMLaunchCount();
+
+  {
+    auto engine = builder.LaunchEngine();
+    ASSERT_EQ(launch_count + 1u, DartVM::GetVMLaunchCount());
+  }
+
+  {
+    auto engine = builder.LaunchEngine();
+    ASSERT_EQ(launch_count + 2u, DartVM::GetVMLaunchCount());
+  }
 }
 
 }  // namespace testing


### PR DESCRIPTION
This exposes the `Settings::leak_vm` flag to custom embedders. All embedder
unit-tests now shut down the VM on the shutdown of the last engine in the
process. The mechanics of VM shutdown are already tested in the Shell unit-tests
harness in the DartLifecycleUnittests set of of assertions. This just exposes
that functionality to custom embedders. Since it is part of the public stable
API, I also switched the name of the field to be something less snarky than the
field in private shell settings.