### PR TITLE
fix iOS keyboard crash : -[__NSCFString substringWithRange:], range o…

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -433,6 +433,12 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 
 - (UITextPosition*)positionFromPosition:(UITextPosition*)position offset:(NSInteger)offset {
   NSUInteger offsetPosition = ((FlutterTextPosition*)position).index;
+
+  NSInteger newLocation = (NSInteger)offsetPosition + offset;
+  if (newLocation < 0 || newLocation > (NSInteger)self.text.length) {
+    return nil;
+  }
+
   if (offset >= 0) {
     for (NSInteger i = 0; i < offset && offsetPosition < self.text.length; ++i)
       offsetPosition = [self incrementOffsetPosition:offsetPosition];


### PR DESCRIPTION
1.Problem
https://github.com/flutter/flutter/issues/36688

2.Solution
Follow Apple’s advice : "A custom UITextPosition object that represents the location in a document that is at the specified offset from position. Return nil if the computed text position is less than 0 or greater than the length of the backing string."


@timsneath  Would you please take a look at this?