### PR TITLE
bump local podspec's ios deployment target version from 7.0 to 8.0

### DIFF
--- a/shell/platform/darwin/ios/framework/Flutter.podspec
+++ b/shell/platform/darwin/ios/framework/Flutter.podspec
@@ -13,6 +13,6 @@ Flutter provides an easy and productive way to build and deploy high-performance
   s.license          = { :type => 'MIT' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
   s.vendored_frameworks = 'Flutter.framework'
 end


### PR DESCRIPTION
When I run [flutter plugin example](https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#running-the-examples).

I got warning 'warning: The iOS deployment target is set to 7.0, but the range of supported deployment target versions for this platform is 8.0 to 12.4.99. (in target 'Flutter')'