### PR TITLE
Roll buildroot for ANGLE support

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -137,7 +137,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'c6bd1f1e25048a97d99cf2fa679bd54ebad94697',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '182ad4097eda82feddc7250b4fa4552269e807b7',
 
    # Fuchsia compatibility
    #

--- a/ci/licenses_golden/tool_signature
+++ b/ci/licenses_golden/tool_signature
@@ -1,2 +1,2 @@
-Signature: 2466ecf1e64cad529ef59c97c07cd1a9
+Signature: 2949b64d096f5b6f13e028bf9cc53b40
 

--- a/tools/licenses/lib/main.dart
+++ b/tools/licenses/lib/main.dart
@@ -2171,6 +2171,7 @@ class _RepositoryRoot extends _RepositoryDirectory {
     return entry.name != 'testing' // only used by tests
         && entry.name != 'build' // only used by build
         && entry.name != 'buildtools' // only used by build
+        && entry.name != 'build_overrides' // only used by build
         && entry.name != 'ios_tools' // only used by build
         && entry.name != 'tools' // not distributed in binary
         && entry.name != 'out' // output of build


### PR DESCRIPTION
Rolls buildroot forward to pick up support for building ANGLE. Needed for #9835

Updates license check to ignore a new top-level buildfile-only directory added as part of that support.