### PR TITLE
When setting up AOT snapshots from symbol references, make buffer sizes optional.

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -276,29 +276,27 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
   };
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
-    if (SAFE_ACCESS(args, vm_snapshot_data_size, 0) != 0 &&
-        SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
+    if (SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
       settings.vm_snapshot_data = make_mapping_callback(
-          args->vm_snapshot_data, args->vm_snapshot_data_size);
+          args->vm_snapshot_data, SAFE_ACCESS(args, vm_snapshot_data_size, 0));
     }
 
-    if (SAFE_ACCESS(args, vm_snapshot_instructions_size, 0) != 0 &&
-        SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) != nullptr) {
+    if (SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) != nullptr) {
       settings.vm_snapshot_instr = make_mapping_callback(
-          args->vm_snapshot_instructions, args->vm_snapshot_instructions_size);
+          args->vm_snapshot_instructions,
+          SAFE_ACCESS(args, vm_snapshot_instructions_size, 0));
     }
 
-    if (SAFE_ACCESS(args, isolate_snapshot_data_size, 0) != 0 &&
-        SAFE_ACCESS(args, isolate_snapshot_data, nullptr) != nullptr) {
+    if (SAFE_ACCESS(args, isolate_snapshot_data, nullptr) != nullptr) {
       settings.isolate_snapshot_data = make_mapping_callback(
-          args->isolate_snapshot_data, args->isolate_snapshot_data_size);
+          args->isolate_snapshot_data,
+          SAFE_ACCESS(args, isolate_snapshot_data_size, 0));
     }
 
-    if (SAFE_ACCESS(args, isolate_snapshot_instructions_size, 0) != 0 &&
-        SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr) != nullptr) {
-      settings.isolate_snapshot_instr =
-          make_mapping_callback(args->isolate_snapshot_instructions,
-                                args->isolate_snapshot_instructions_size);
+    if (SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr) != nullptr) {
+      settings.isolate_snapshot_instr = make_mapping_callback(
+          args->isolate_snapshot_instructions,
+          SAFE_ACCESS(args, isolate_snapshot_instructions_size, 0));
     }
   }
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -614,28 +614,32 @@ typedef struct {
   // the Wiki at
   // https://github.com/flutter/flutter/wiki/Flutter-engine-operation-in-AOT-Mode
   const uint8_t* vm_snapshot_data;
-  // The size of the VM snapshot data buffer.
+  // The size of the VM snapshot data buffer.  If vm_snapshot_data is a symbol
+  // reference, 0 may be passed here.
   size_t vm_snapshot_data_size;
   // The VM snapshot instructions buffer used in AOT operation. This buffer must
   // be mapped in as read-execute. For more information refer to the
   // documentation on the Wiki at
   // https://github.com/flutter/flutter/wiki/Flutter-engine-operation-in-AOT-Mode
   const uint8_t* vm_snapshot_instructions;
-  // The size of the VM snapshot instructions buffer.
+  // The size of the VM snapshot instructions buffer. If
+  // vm_snapshot_instructions is a symbol reference, 0 may be passed here.
   size_t vm_snapshot_instructions_size;
   // The isolate snapshot data buffer used in AOT operation. This buffer must be
   // mapped in as read-only. For more information refer to the documentation on
   // the Wiki at
   // https://github.com/flutter/flutter/wiki/Flutter-engine-operation-in-AOT-Mode
   const uint8_t* isolate_snapshot_data;
-  // The size of the isolate snapshot data buffer.
+  // The size of the isolate snapshot data buffer.  If isolate_snapshot_data is
+  // a symbol reference, 0 may be passed here.
   size_t isolate_snapshot_data_size;
   // The isolate snapshot instructions buffer used in AOT operation. This buffer
   // must be mapped in as read-execute. For more information refer to the
   // documentation on the Wiki at
   // https://github.com/flutter/flutter/wiki/Flutter-engine-operation-in-AOT-Mode
   const uint8_t* isolate_snapshot_instructions;
-  // The size of the isolate snapshot instructions buffer.
+  // The size of the isolate snapshot instructions buffer. If
+  // isolate_snapshot_instructions is a symbol reference, 0 may be passed here.
   size_t isolate_snapshot_instructions_size;
   // The callback invoked by the engine in root isolate scope. Called
   // immediately after the root isolate has been created and marked runnable.

--- a/shell/platform/embedder/tests/embedder_config_builder.cc
+++ b/shell/platform/embedder/tests/embedder_config_builder.cc
@@ -57,6 +57,10 @@ EmbedderConfigBuilder::EmbedderConfigBuilder(
 
 EmbedderConfigBuilder::~EmbedderConfigBuilder() = default;
 
+FlutterProjectArgs& EmbedderConfigBuilder::GetProjectArgs() {
+  return project_args_;
+}
+
 void EmbedderConfigBuilder::SetSoftwareRendererConfig() {
   renderer_config_.type = FlutterRendererType::kSoftware;
   renderer_config_.software = software_renderer_config_;

--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -40,6 +40,8 @@ class EmbedderConfigBuilder {
 
   ~EmbedderConfigBuilder();
 
+  FlutterProjectArgs& GetProjectArgs();
+
   void SetSoftwareRendererConfig();
 
   void SetOpenGLRendererConfig();

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -487,5 +487,28 @@ TEST_F(EmbedderTest, VMShutsDownWhenNoEnginesInProcess) {
   }
 }
 
+//------------------------------------------------------------------------------
+/// These snapshots may be materialized from symbols and the size field may not
+/// be relevant. Since this information is redundant, engine launch should not
+/// be gated on a non-zero buffer size.
+///
+TEST_F(EmbedderTest, VMAndIsolateSnapshotSizesAreRedundantInAOTMode) {
+  if (!DartVM::IsRunningPrecompiledCode()) {
+    GTEST_SKIP();
+    return;
+  }
+  auto& context = GetEmbedderContext();
+  EmbedderConfigBuilder builder(context);
+
+  // The fixture sets this up correctly. Intentionally mess up the args.
+  builder.GetProjectArgs().vm_snapshot_data_size = 0;
+  builder.GetProjectArgs().vm_snapshot_instructions_size = 0;
+  builder.GetProjectArgs().isolate_snapshot_data_size = 0;
+  builder.GetProjectArgs().isolate_snapshot_instructions_size = 0;
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
Embedders don't have this information (since they probably access the same using dlsym). The engine only uses the same for instrumentation. There is no reason to gate engine launch on advisory information (or make callers fake the same).