### PR TITLE
Add framework and web tests back

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -35,6 +35,17 @@ task:
       test_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/testing/run_tests.sh host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+      test_web_script: |
+        cd $FRAMEWORK_PATH/flutter/dev/integration_tests/web
+        ../../../bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web
+        ../../../bin/flutter --local-engine=host_debug_unopt build web -v
+      test_framework_script: |
+        cd $FRAMEWORK_PATH/flutter/packages/flutter
+        ../../bin/flutter test --local-engine=host_debug_unopt
     - name: build_and_test_android_profile_app
       env:
         # Used to setup the gclient solution.


### PR DESCRIPTION
Our infra should be capable to run all those deleted tests as now we've throttled the Fuchsia auto-rollers.