### PR TITLE
Manually roll Skia to pull in iOS armv7 build failure fix.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -26,7 +26,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
-  'skia_revision': '4acbab33bd40a60bf04340c0add3afb57674e602',
+  'skia_revision': '04580795746b095a005eadefadcb48a7fc1651da',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: 95161b63041a9e5af66756e64cb4f718
+Signature: db6253ae92ac5535be76ee7646db4827
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
Rolls Skia to 04580795746b095a005eadefadcb48a7fc1651da.
Pulls in https://github.com/google/skia/commit/04580795746b095a005eadefadcb48a7fc1651da which will fix LUCI.

The autoroller will not process this since it checks for the ToT to be green.