### PR TITLE
[flutter_runner] Improve frame scheduling

### DIFF
--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -51,6 +51,21 @@ SessionConnection::~SessionConnection() = default;
 
 void SessionConnection::Present(
     flutter::CompositorContext::ScopedFrame& frame) {
+  TRACE_EVENT0("gfx", "SessionConnection::Present");
+  TRACE_FLOW_BEGIN("gfx", "SessionConnection::PresentSession",
+                   next_present_session_trace_id_);
+
+  // Throttle vsync if presentation callback is already pending. This allows
+  // the paint tasks for this frame to execute in parallel with presentation
+  // of last frame but still provides back-pressure to prevent us from queuing
+  // even more work.
+  if (presentation_callback_pending_) {
+    present_session_pending_ = true;
+    ToggleSignal(vsync_event_handle_, false);
+  } else {
+    PresentSession();
+  }
+
   // Flush all session ops. Paint tasks have not yet executed but those are
   // fenced. The compositor can start processing ops while we finalize paint
   // tasks.
@@ -62,10 +77,6 @@ void SessionConnection::Present(
   // Tell the surface producer that a present has occurred so it can perform
   // book-keeping on buffer caches.
   surface_producer_->OnSurfacesPresented(std::move(surfaces_to_submit));
-
-  // Prepare for the next frame. These ops won't be processed till the next
-  // present.
-  EnqueueClearOps();
 }
 
 void SessionConnection::OnSessionSizeChangeHint(float width_change_factor,
@@ -82,18 +93,44 @@ void SessionConnection::EnqueueClearOps() {
 
 void SessionConnection::PresentSession() {
   TRACE_EVENT0("gfx", "SessionConnection::PresentSession");
+  while (processed_present_session_trace_id_ < next_present_session_trace_id_) {
+    TRACE_FLOW_END("gfx", "SessionConnection::PresentSession",
+                   processed_present_session_trace_id_);
+    processed_present_session_trace_id_++;
+  }
   TRACE_FLOW_BEGIN("gfx", "Session::Present", next_present_trace_id_);
   next_present_trace_id_++;
 
+  // Presentation callback is pending as a result of Present() call below.
+  presentation_callback_pending_ = true;
+
+  // Flush all session ops. Paint tasks may not yet have executed but those are
+  // fenced. The compositor can start processing ops while we finalize paint
+  // tasks.
+
   ToggleSignal(vsync_event_handle_, false);
+
+  // Flush all session ops. Paint tasks may not yet have executed but those are
+  // fenced. The compositor can start processing ops while we finalize paint
+  // tasks.
   session_wrapper_.Present(
       0,  // presentation_time. (placeholder).
-      [handle = vsync_event_handle_](
+      [this, handle = vsync_event_handle_](
           fuchsia::images::PresentationInfo presentation_info) {
+        presentation_callback_pending_ = false;
         VsyncRecorder::GetInstance().UpdateVsyncInfo(presentation_info);
+        // Process pending PresentSession() calls.
+        if (present_session_pending_) {
+          present_session_pending_ = false;
+          PresentSession();
+        }
         ToggleSignal(handle, true);
       }  // callback
   );
+
+  // Prepare for the next frame. These ops won't be processed till the next
+  // present.
+  EnqueueClearOps();
 }
 
 void SessionConnection::ToggleSignal(zx_handle_t handle, bool set) {

--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -107,12 +107,6 @@ void SessionConnection::PresentSession() {
   // Flush all session ops. Paint tasks may not yet have executed but those are
   // fenced. The compositor can start processing ops while we finalize paint
   // tasks.
-
-  ToggleSignal(vsync_event_handle_, false);
-
-  // Flush all session ops. Paint tasks may not yet have executed but those are
-  // fenced. The compositor can start processing ops while we finalize paint
-  // tasks.
   session_wrapper_.Present(
       0,  // presentation_time. (placeholder).
       [this, handle = vsync_event_handle_](

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -75,6 +75,11 @@ class SessionConnection final {
   // convention, the Scenic side will also contain its own trace id that
   // begins at 0, and is incremented each |Session::Present| call.
   uint64_t next_present_trace_id_ = 0;
+  uint64_t next_present_session_trace_id_ = 0;
+  uint64_t processed_present_session_trace_id_ = 0;
+
+  bool presentation_callback_pending_ = false;
+  bool present_session_pending_ = false;
 
   void EnqueueClearOps();
 


### PR DESCRIPTION
This is a reland of e28c8beaca82998396aacbd37a03942892654e2b

Original change's description:
> [flutter_runner] Improve frame scheduling
>
> FL-233 #comment
>
> This allows the paint tasks for the next frame to execute in parallel
> with presentation of last frame but still provides back-pressure to
> prevent us from queuing up even more work.
>
> Vsync would be disabled whenever a presentation callback was pending
> prior to this change. That had the outcome of causing us to almost
> always miss one vsync interval. By not turning off vsync until
> another Present call is pending we avoid this problem.
>
> Test: fx shell run fuchsia-pkg://fuchsia.com/basemgr#meta/basemgr.cmx --base_shell=fuchsia-pkg://fuchsia.com/spinning_cube#meta/spinning_cube.cmx
> Test: topaz input latency benchmarks
> Test: end-2-end tests
> Change-Id: I46440052cd4f98cb0992ec5027584be80f4fb9d3

Change-Id: I1904683d0dfa509ef28482c4b751c28931ab7647