### PR TITLE
[flutter] Create the compositor context on the GPU task runner.

### DIFF
--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -62,13 +62,13 @@ CompositorContext::CompositorContext(
     std::string debug_label,
     fuchsia::ui::views::ViewToken view_token,
     fidl::InterfaceHandle<fuchsia::ui::scenic::Session> session,
-    fit::closure session_error_callback,
+    fml::closure session_error_callback,
     zx_handle_t vsync_event_handle)
     : debug_label_(std::move(debug_label)),
       session_connection_(debug_label_,
                           std::move(view_token),
                           std::move(session),
-                          std::move(session_error_callback),
+                          session_error_callback,
                           vsync_event_handle) {}
 
 void CompositorContext::OnSessionMetricsDidChange(

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -23,7 +23,7 @@ class CompositorContext final : public flutter::CompositorContext {
   CompositorContext(std::string debug_label,
                     fuchsia::ui::views::ViewToken view_token,
                     fidl::InterfaceHandle<fuchsia::ui::scenic::Session> session,
-                    fit::closure session_error_callback,
+                    fml::closure session_error_callback,
                     zx_handle_t vsync_event_handle);
 
   ~CompositorContext() override;

--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -16,7 +16,7 @@ SessionConnection::SessionConnection(
     std::string debug_label,
     fuchsia::ui::views::ViewToken view_token,
     fidl::InterfaceHandle<fuchsia::ui::scenic::Session> session,
-    fit::closure session_error_callback,
+    fml::closure session_error_callback,
     zx_handle_t vsync_event_handle)
     : debug_label_(std::move(debug_label)),
       session_wrapper_(session.Bind(), nullptr),
@@ -27,9 +27,7 @@ SessionConnection::SessionConnection(
       scene_update_context_(&session_wrapper_, surface_producer_.get()),
       vsync_event_handle_(vsync_event_handle) {
   session_wrapper_.set_error_handler(
-      [callback = std::move(session_error_callback)](zx_status_t status) {
-        callback();
-      });
+      [callback = session_error_callback](zx_status_t status) { callback(); });
 
   session_wrapper_.SetDebugName(debug_label_);
 

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -16,6 +16,7 @@
 
 #include "flutter/flow/compositor_context.h"
 #include "flutter/flow/scene_update_context.h"
+#include "flutter/fml/closure.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/trace_event.h"
 #include "vulkan_surface_producer.h"
@@ -29,7 +30,7 @@ class SessionConnection final {
   SessionConnection(std::string debug_label,
                     fuchsia::ui::views::ViewToken view_token,
                     fidl::InterfaceHandle<fuchsia::ui::scenic::Session> session,
-                    fit::closure session_error_callback,
+                    fml::closure session_error_callback,
                     zx_handle_t vsync_event_handle);
 
   ~SessionConnection();
@@ -68,6 +69,7 @@ class SessionConnection final {
 
   std::unique_ptr<VulkanSurfaceProducer> surface_producer_;
   flutter::SceneUpdateContext scene_update_context_;
+
   zx_handle_t vsync_event_handle_;
 
   // A flow event trace id for following |Session::Present| calls into


### PR DESCRIPTION
The compositor context owns the session connection. The creation of the
session connection also does the initial present to clear the node
hierarchy. This present was happening perviously on the platform task
runner while all subsequent presents were on the GPU task runner. This
has now been rectified so all presents are on the GPU task runner.

BUG: FL-288
Change-Id: Ib294666ffb3b4575f93ad0b02a5d0fda71bfa0a8