### PR TITLE
Make firebase test more LUCI friendly

### DIFF
--- a/ci/firebase_testlab.sh
+++ b/ci/firebase_testlab.sh
@@ -2,36 +2,39 @@
 
 set -e
 
-GIT_REVISION=$(git rev-parse HEAD)
 
 if [[ ! -f $1 ]]; then
   echo "File $1 not found."
   exit -1
 fi
 
-# New contributors will not have permissions to run this test - they won't be
-# able to access the service account information. We should just mark the test
-# as passed - it will run fine on post submit, where it will still catch
-# failures.
-# We can also still make sure that building a release app bundle still works.
-if [[ $GCLOUD_FIREBASE_TESTLAB_KEY == ENCRYPTED* ]]; then
-  echo "This user does not have permission to run this test."
-  exit 0
-fi
+GIT_REVISION=${$2:-$(git rev-parse HEAD)}
+BUILD_ID=${$3:-$CIRRUS_BUILD_ID}
 
-echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
-gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
-gcloud --quiet config set project flutter-infra
+if [[ ! -z $GCLOUD_FIREBASE_TESTLAB_KEY ]]; then
+  # New contributors will not have permissions to run this test - they won't be
+  # able to access the service account information. We should just mark the test
+  # as passed - it will run fine on post submit, where it will still catch
+  # failures.
+  # We can also still make sure that building a release app bundle still works.
+  if [[ $GCLOUD_FIREBASE_TESTLAB_KEY == ENCRYPTED* ]]; then
+    echo "This user does not have permission to run this test."
+    exit 0
+  fi
+
+  echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
+  gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+fi
 
 # Run the test.
 # game-loop tests are meant for OpenGL apps.
 # This type of test will give the application a handle to a file, and
 # we'll write the timeline JSON to that file.
 # See https://firebase.google.com/docs/test-lab/android/game-loop
-gcloud firebase test android run \
+gcloud --project flutter-infra firebase test android run \
   --type game-loop \
   --app $1 \
   --timeout 2m \
   --results-bucket=gs://flutter_firebase_testlab \
-  --results-dir=engine_scenario_test/$GIT_REVISION/$CIRRUS_BUILD_ID
+  --results-dir=engine_scenario_test/$GIT_REVISION/$BUILD_ID
 

--- a/ci/firebase_testlab.sh
+++ b/ci/firebase_testlab.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-
 if [[ ! -f $1 ]]; then
   echo "File $1 not found."
   exit -1

--- a/ci/firebase_testlab.sh
+++ b/ci/firebase_testlab.sh
@@ -7,8 +7,8 @@ if [[ ! -f $1 ]]; then
   exit -1
 fi
 
-GIT_REVISION=${$2:-$(git rev-parse HEAD)}
-BUILD_ID=${$3:-$CIRRUS_BUILD_ID}
+GIT_REVISION=${2:-$(git rev-parse HEAD)}
+BUILD_ID=${3:-$CIRRUS_BUILD_ID}
 
 if [[ ! -z $GCLOUD_FIREBASE_TESTLAB_KEY ]]; then
   # New contributors will not have permissions to run this test - they won't be

--- a/testing/scenario_app/android/gradle/wrapper/gradle-wrapper.properties
+++ b/testing/scenario_app/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip

--- a/testing/scenario_app/assemble_apk.sh
+++ b/testing/scenario_app/assemble_apk.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+./compile_android_aot.sh $1 $2
+
+pushd android
+./gradlew assembleDebug --no-daemon
+popd


### PR DESCRIPTION
This is backwards compatible with the cirrus version, but will use the service account on LUCI if the env var isn't specified.

Also creates another shell script to wrap the other one so LUCI can just invoke one script to build and one to test.