### PR TITLE
Revert "Forwards iOS dark mode trait to the Flutter framework.".

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -681,11 +681,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
   [_engine.get() updateViewportMetrics:_viewportMetrics];
 }
 
-- (void)updateViewConstraints {
-  [super updateViewConstraints];
-  [self onUserSettingsChanged:nil];
-}
-
 - (CGFloat)statusBarPadding {
   UIScreen* screen = self.view.window.screen;
   CGRect statusFrame = [UIApplication sharedApplication].statusBarFrame;
@@ -693,11 +688,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
                           toCoordinateSpace:screen.coordinateSpace];
   CGRect intersection = CGRectIntersection(statusFrame, viewFrame);
   return CGRectIsNull(intersection) ? 0.0 : intersection.size.height;
-}
-
-- (void)viewWillLayoutSubviews {
-  [super viewWillLayoutSubviews];
-  [self onUserSettingsChanged:nil];
 }
 
 - (void)viewDidLayoutSubviews {
@@ -712,7 +702,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
   [self updateViewportPadding];
   [self updateViewportMetrics];
-  [self onUserSettingsChanged:nil];
 
   // This must run after updateViewportMetrics so that the surface creation tasks are queued after
   // the viewport metrics update tasks.
@@ -874,16 +863,10 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
 
 #pragma mark - Set user settings
 
-- (void)traitCollectionDidChange:(UITraitCollection*)previousTraitCollection {
-  [super traitCollectionDidChange:previousTraitCollection];
-  [self onUserSettingsChanged:nil];
-}
-
 - (void)onUserSettingsChanged:(NSNotification*)notification {
   [[_engine.get() settingsChannel] sendMessage:@{
     @"textScaleFactor" : @([self textScaleFactor]),
     @"alwaysUse24HourFormat" : @([self isAlwaysUse24HourFormat]),
-    @"platformBrightness" : [self brightnessMode]
   }];
 }
 
@@ -955,20 +938,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
                                                          options:0
                                                           locale:[NSLocale currentLocale]];
   return [dateFormat rangeOfString:@"a"].location == NSNotFound;
-}
-
-- (NSString*)brightnessMode {
-  if (@available(iOS 13, *)) {
-    UIUserInterfaceStyle style = UITraitCollection.currentTraitCollection.userInterfaceStyle;
-
-    if (style == UIUserInterfaceStyleDark) {
-      return @"dark";
-    } else {
-      return @"light";
-    }
-  } else {
-    return @"light";
-  }
 }
 
 #pragma mark - Status Bar touch event handling

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -6,8 +6,6 @@
 #import <XCTest/XCTest.h>
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 
-#include "FlutterBinaryMessenger.h"
-
 @interface FlutterViewControllerTest : XCTestCase
 @end
 
@@ -23,87 +21,6 @@
   OCMStub([engine binaryMessenger]).andReturn(messenger);
   XCTAssertEqual(vc.binaryMessenger, messenger);
   OCMVerify([engine binaryMessenger]);
-}
-
-- (void)testItReportsLightPlatformBrightnessByDefault {
-  // Setup test.
-  id engine = OCMClassMock([FlutterEngine class]);
-
-  id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
-  OCMStub([engine settingsChannel]).andReturn(settingsChannel);
-
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-
-  // Exercise behavior under test.
-  [vc traitCollectionDidChange:nil];
-
-  // Verify behavior.
-  OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
-                               return [message[@"platformBrightness"] isEqualToString:@"light"];
-                             }]]);
-}
-
-- (void)testItReportsDarkPlatformBrightnessWhenTraitCollectionRequestsIt {
-  // Setup test.
-  id engine = OCMClassMock([FlutterEngine class]);
-
-  id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
-  OCMStub([engine settingsChannel]).andReturn(settingsChannel);
-
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-  id mockTraitCollection = [self setupFakeUserInterfaceStyle:UIUserInterfaceStyleDark];
-
-  // Exercise behavior under test.
-  [vc traitCollectionDidChange:nil];
-
-  // Verify behavior.
-  OCMVerify([settingsChannel sendMessage:[OCMArg checkWithBlock:^BOOL(id message) {
-                               return [message[@"platformBrightness"] isEqualToString:@"light"];
-                             }]]);
-
-  // Restore UIUserInterfaceStyle
-  [mockTraitCollection stopMocking];
-}
-
-- (void)testItReportsPlatformBrightnessWhenExpected {
-  // Setup test.
-  id engine = OCMClassMock([FlutterEngine class]);
-
-  id settingsChannel = OCMClassMock([FlutterBasicMessageChannel class]);
-  OCMStub([engine settingsChannel]).andReturn(settingsChannel);
-
-  FlutterViewController* vc = [[FlutterViewController alloc] initWithEngine:engine
-                                                                    nibName:nil
-                                                                     bundle:nil];
-  id mockTraitCollection = [self setupFakeUserInterfaceStyle:UIUserInterfaceStyleDark];
-
-  __block int messageCount = 0;
-  OCMStub([settingsChannel sendMessage:[OCMArg any]]).andDo(^(NSInvocation* invocation) {
-    messageCount = messageCount + 1;
-  });
-
-  // Exercise behavior under test.
-  [vc updateViewConstraints];
-  [vc viewWillLayoutSubviews];
-  [vc traitCollectionDidChange:nil];
-  [vc onUserSettingsChanged:nil];
-
-  // Verify behavior.
-  XCTAssertEqual(messageCount, 4);
-
-  // Restore UIUserInterfaceStyle
-  [mockTraitCollection stopMocking];
-}
-
-- (UITraitCollection*)setupFakeUserInterfaceStyle:(UIUserInterfaceStyle)style {
-  id mockTraitCollection = OCMClassMock([UITraitCollection class]);
-  OCMStub([mockTraitCollection userInterfaceStyle]).andReturn(UIUserInterfaceStyleDark);
-  OCMStub([mockTraitCollection currentTraitCollection]).andReturn(mockTraitCollection);
-  return mockTraitCollection;
 }
 
 @end

--- a/testing/ios/IosUnitTests/run_tests.sh
+++ b/testing/ios/IosUnitTests/run_tests.sh
@@ -12,6 +12,6 @@ fi
 
 set -o pipefail && xcodebuild -sdk iphonesimulator \
   -scheme IosUnitTests \
-  -destination 'platform=iOS Simulator,name=iPhone 8,OS=13.0' \
+  -destination 'platform=iOS Simulator,name=iPhone SE,OS=12.2' \
   test \
   FLUTTER_ENGINE=$FLUTTER_ENGINE | $PRETTY


### PR DESCRIPTION
Reverts flutter/engine#9722 to [fix LUCI](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8905650479855166128/+/steps/build_ios_debug_sim/0/stdout). This will be re-landed with a preprocessor guard that makes this commit take effect only on iOS 13 SDKs.