### PR TITLE
Expose isolateId for engine

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -242,6 +242,13 @@ FLUTTER_EXPORT
  */
 @property(nonatomic, readonly) NSObject<FlutterBinaryMessenger>* binaryMessenger;
 
+/**
+ * The UI Isolate ID of of the engine.
+ *
+ * This property will be nil if the engine is not running.
+ */
+@property(nonatomic, readonly) NSString* isolateId;
+
 @end
 
 #endif  // FLUTTER_FLUTTERENGINE_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -247,7 +247,7 @@ FLUTTER_EXPORT
  *
  * This property will be nil if the engine is not running.
  */
-@property(nonatomic, readonly) NSString* isolateId;
+@property(nonatomic, readonly, copy) NSString* isolateId;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -32,7 +32,7 @@
 // FlutterEngineRegistrar to implement a FlutterPluginRegistrar.
 @property(nonatomic, readonly) NSMutableDictionary* pluginPublications;
 
-@property(nonatomic, readwrite) NSString* isolateId;
+@property(nonatomic, readwrite, copy) NSString* isolateId;
 @end
 
 @interface FlutterEngineRegistrar : NSObject <FlutterPluginRegistrar>
@@ -236,13 +236,9 @@
 // Channels get a reference to the engine, and therefore need manual
 // cleanup for proper collection.
 - (void)setupChannels {
-  __block FlutterEngine* engine = self;
   [_binaryMessenger setMessageHandlerOnChannel:@"flutter/isolate"
                           binaryMessageHandler:^(NSData* message, FlutterBinaryReply reply) {
-                            if (engine) {
-                              engine.isolateId =
-                                  [[[FlutterStringCodec sharedInstance] decode:message] copy];
-                            }
+                            self.isolateId = [[FlutterStringCodec sharedInstance] decode:message];
                           }];
 
   _localizationChannel.reset([[FlutterMethodChannel alloc]

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -236,8 +236,8 @@
 // Channels get a reference to the engine, and therefore need manual
 // cleanup for proper collection.
 - (void)setupChannels {
-  // This will be invoked once the shell is done setting up and the isolate ID for the UI
-  // isolate is available.
+  // This will be invoked once the shell is done setting up and the isolate ID
+  // for the UI isolate is available.
   [_binaryMessenger setMessageHandlerOnChannel:@"flutter/isolate"
                           binaryMessageHandler:^(NSData* message, FlutterBinaryReply reply) {
                             self.isolateId = [[FlutterStringCodec sharedInstance] decode:message];

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -236,6 +236,8 @@
 // Channels get a reference to the engine, and therefore need manual
 // cleanup for proper collection.
 - (void)setupChannels {
+  // This will be invoked once the shell is done setting up and the isolate ID for the UI
+  // isolate is available.
   [_binaryMessenger setMessageHandlerOnChannel:@"flutter/isolate"
                           binaryMessageHandler:^(NSData* message, FlutterBinaryReply reply) {
                             self.isolateId = [[FlutterStringCodec sharedInstance] decode:message];

--- a/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/project.pbxproj
+++ b/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		248D76DA22E388380012F0C1 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 248D76D922E388380012F0C1 /* main.m */; };
 		248D76E422E388380012F0C1 /* ScenariosTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 248D76E322E388380012F0C1 /* ScenariosTests.m */; };
 		248D76EF22E388380012F0C1 /* ScenariosUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 248D76EE22E388380012F0C1 /* ScenariosUITests.m */; };
+		248FDFC422FE7CD0009CC7CD /* FlutterEngineTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 248FDFC322FE7CD0009CC7CD /* FlutterEngineTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,6 +96,7 @@
 		248D76EA22E388380012F0C1 /* ScenariosUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ScenariosUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		248D76EE22E388380012F0C1 /* ScenariosUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScenariosUITests.m; sourceTree = "<group>"; };
 		248D76F022E388380012F0C1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		248FDFC322FE7CD0009CC7CD /* FlutterEngineTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FlutterEngineTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -162,6 +164,7 @@
 		248D76E222E388380012F0C1 /* ScenariosTests */ = {
 			isa = PBXGroup;
 			children = (
+				248FDFC322FE7CD0009CC7CD /* FlutterEngineTest.m */,
 				0DB781FC22EA2C0300E9B371 /* FlutterViewControllerTest.m */,
 				248D76E322E388380012F0C1 /* ScenariosTests.m */,
 				248D76E522E388380012F0C1 /* Info.plist */,
@@ -329,6 +332,7 @@
 			files = (
 				248D76E422E388380012F0C1 /* ScenariosTests.m in Sources */,
 				0DB7820222EA493B00E9B371 /* FlutterViewControllerTest.m in Sources */,
+				248FDFC422FE7CD0009CC7CD /* FlutterEngineTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <XCTest/XCTest.h>
+#import "AppDelegate.h"
+
+@interface FlutterEngineTest : XCTestCase
+@end
+
+@implementation FlutterEngineTest
+XCTestExpectation* _isolateIdSetExpectation;
+
+- (void)testIsolateId {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
+  XCTAssertNil(engine.isolateId);
+  _isolateIdSetExpectation = [self expectationWithDescription:@"Isolate ID set"];
+  [engine addObserver:self forKeyPath:@"isolateId" options:0 context:nil];
+  
+  XCTAssertTrue([engine runWithEntrypoint:nil]);
+  
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+
+  XCTAssertNotNil(engine.isolateId);
+  XCTAssertTrue([engine.isolateId hasPrefix:@"isolates/"]);
+  
+  [engine destroyContext];
+  
+  XCTAssertNil(engine.isolateId);
+}
+
+- (void)observeValueForKeyPath:(NSString*)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary*)change
+                       context:(void*)context {
+  if ([keyPath isEqualToString:@"isolateId"]) {
+    [_isolateIdSetExpectation fulfill];
+    _isolateIdSetExpectation = nil;
+  }
+}
+@end

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
@@ -15,16 +15,16 @@
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   XCTAssertNil(engine.isolateId);
   [self keyValueObservingExpectationForObject:engine keyPath:@"isolateId" handler:nil];
-  
+
   XCTAssertTrue([engine runWithEntrypoint:nil]);
-  
+
   [self waitForExpectationsWithTimeout:30.0 handler:nil];
 
   XCTAssertNotNil(engine.isolateId);
   XCTAssertTrue([engine.isolateId hasPrefix:@"isolates/"]);
-  
+
   [engine destroyContext];
-  
+
   XCTAssertNil(engine.isolateId);
 }
 

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
@@ -10,13 +10,11 @@
 @end
 
 @implementation FlutterEngineTest
-XCTestExpectation* _isolateIdSetExpectation;
 
 - (void)testIsolateId {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"test" project:nil];
   XCTAssertNil(engine.isolateId);
-  _isolateIdSetExpectation = [self expectationWithDescription:@"Isolate ID set"];
-  [engine addObserver:self forKeyPath:@"isolateId" options:0 context:nil];
+  [self keyValueObservingExpectationForObject:engine keyPath:@"isolateId" handler:nil];
   
   XCTAssertTrue([engine runWithEntrypoint:nil]);
   
@@ -30,13 +28,4 @@ XCTestExpectation* _isolateIdSetExpectation;
   XCTAssertNil(engine.isolateId);
 }
 
-- (void)observeValueForKeyPath:(NSString*)keyPath
-                      ofObject:(id)object
-                        change:(NSDictionary*)change
-                       context:(void*)context {
-  if ([keyPath isEqualToString:@"isolateId"]) {
-    [_isolateIdSetExpectation fulfill];
-    _isolateIdSetExpectation = nil;
-  }
-}
 @end


### PR DESCRIPTION
Similar to functionality in what DartExecutor does on the Java side.  Earl Grey wants this so it can know which isolate to talk to using service protocol methods.

Should we document that the property written in such a way that it is observable? Also, we really should get these tests running on CI :D

/cc @AlbertWang0116 @matthew-carroll 