### PR TITLE
Let first frame listeners self remove

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -407,6 +407,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/android/FlutterActivityTest.java",
     "test/io/flutter/embedding/android/FlutterFragmentTest.java",
     "test/io/flutter/embedding/engine/FlutterEngineCacheTest.java",
+    "test/io/flutter/embedding/engine/FlutterJNITest.java",
     "test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java",
     "test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java",
     "test/io/flutter/util/PreconditionsTest.java",

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -407,6 +407,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/android/FlutterActivityTest.java",
     "test/io/flutter/embedding/android/FlutterFragmentTest.java",
     "test/io/flutter/embedding/engine/FlutterEngineCacheTest.java",
+    "test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java",
     "test/io/flutter/embedding/engine/systemchannels/TextInputChannelTest.java",
     "test/io/flutter/util/PreconditionsTest.java",
   ]

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -12,12 +12,14 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+import android.support.annotation.VisibleForTesting;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 
 import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterEngine.EngineLifecycleListener;
@@ -275,15 +277,17 @@ public class FlutterJNI {
 
   // Called by native to notify first Flutter frame rendered.
   @SuppressWarnings("unused")
+  @VisibleForTesting
   @UiThread
-  private void onFirstFrame() {
+  protected void onFirstFrame() {
     ensureRunningOnMainThread();
     if (renderSurface != null) {
       renderSurface.onFirstFrameRendered();
     }
     // TODO(mattcarroll): log dropped messages when in debug mode (https://github.com/flutter/flutter/issues/25391)
-
-    for (OnFirstFrameRenderedListener listener : firstFrameListeners) {
+    CopyOnWriteArrayList<OnFirstFrameRenderedListener> mutableListeners =
+        new CopyOnWriteArrayList<>(firstFrameListeners);
+    for (OnFirstFrameRenderedListener listener : mutableListeners) {
       listener.onFirstFrameRendered();
     }
   }

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -12,6 +12,7 @@ import io.flutter.embedding.android.FlutterActivityAndFragmentDelegateTest;
 import io.flutter.embedding.android.FlutterActivityTest;
 import io.flutter.embedding.android.FlutterFragmentTest;
 import io.flutter.embedding.engine.FlutterEngineCacheTest;
+import io.flutter.embedding.engine.FlutterJNITest;
 import io.flutter.embedding.engine.renderer.FlutterRendererTest;
 import io.flutter.embedding.engine.systemchannels.TextInputChannelTest;
 import io.flutter.util.PreconditionsTest;
@@ -24,6 +25,7 @@ import io.flutter.util.PreconditionsTest;
     FlutterFragmentTest.class,
     // FlutterActivityAndFragmentDelegateTest.class, TODO(mklim): Fix and re-enable this
     FlutterEngineCacheTest.class,
+    FlutterJNITest.class,
     FlutterRendererTest.class,
     TextInputChannelTest.class
 })

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -12,6 +12,7 @@ import io.flutter.embedding.android.FlutterActivityAndFragmentDelegateTest;
 import io.flutter.embedding.android.FlutterActivityTest;
 import io.flutter.embedding.android.FlutterFragmentTest;
 import io.flutter.embedding.engine.FlutterEngineCacheTest;
+import io.flutter.embedding.engine.renderer.FlutterRendererTest;
 import io.flutter.embedding.engine.systemchannels.TextInputChannelTest;
 import io.flutter.util.PreconditionsTest;
 
@@ -23,6 +24,7 @@ import io.flutter.util.PreconditionsTest;
     FlutterFragmentTest.class,
     // FlutterActivityAndFragmentDelegateTest.class, TODO(mklim): Fix and re-enable this
     FlutterEngineCacheTest.class,
+    FlutterRendererTest.class,
     TextInputChannelTest.class
 })
 /** Runs all of the unit tests listed in the {@code @SuiteClasses} annotation. */

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -1,0 +1,51 @@
+package io.flutter.embedding.engine;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Config(manifest=Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterJNITest {
+  FlutterJNI jniUnderTest;
+
+  @Before
+  public void setUp() {
+    jniUnderTest = new FlutterJNI();
+  }
+
+  @Test
+  public void firstFrameListenerCanRemoveThemselves() {
+    AtomicInteger callbackCalled = new AtomicInteger(0);
+    OnFirstFrameRenderedListener callback = new OnFirstFrameRenderedListener() {
+      @Override
+      public void onFirstFrameRendered() {
+        callbackCalled.incrementAndGet();
+        jniUnderTest.removeOnFirstFrameRenderedListener(this);
+      };
+    };
+
+    jniUnderTest.addOnFirstFrameRenderedListener(callback);
+    jniUnderTest.onFirstFrame();
+
+    assertEquals(1, callbackCalled.get());
+
+    // The callback removed itself from the listener list. A second call doesn't call the callback.
+    jniUnderTest.onFirstFrame();
+    assertEquals(1, callbackCalled.get());
+  }
+}

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -29,7 +29,8 @@ public class FlutterJNITest {
   }
 
   @Test
-  public void firstFrameListenerCanRemoveThemselves() {
+  public void itAllowsFirstFrameListenersToRemoveThemselves() {
+    // --- Test Setup ---
     AtomicInteger callbackCalled = new AtomicInteger(0);
     OnFirstFrameRenderedListener callback = new OnFirstFrameRenderedListener() {
       @Override
@@ -38,14 +39,19 @@ public class FlutterJNITest {
         jniUnderTest.removeOnFirstFrameRenderedListener(this);
       };
     };
-
     jniUnderTest.addOnFirstFrameRenderedListener(callback);
+
+    // --- Execute Test ---
     jniUnderTest.onFirstFrame();
 
+    // --- Verify Results ---
     assertEquals(1, callbackCalled.get());
 
+    // --- Execute Test ---
     // The callback removed itself from the listener list. A second call doesn't call the callback.
     jniUnderTest.onFirstFrame();
+
+    // --- Verify Results ---
     assertEquals(1, callbackCalled.get());
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterJNITest.java
@@ -29,7 +29,7 @@ public class FlutterJNITest {
   }
 
   @Test
-  public void itAllowsFirstFrameListenersToRemoveThemselves() {
+  public void itAllowsFirstFrameListenersToRemoveThemselvesInline() {
     // --- Test Setup ---
     AtomicInteger callbackCalled = new AtomicInteger(0);
     OnFirstFrameRenderedListener callback = new OnFirstFrameRenderedListener() {

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -31,7 +31,8 @@ public class FlutterRendererTest {
   }
 
   @Test
-  public void firstFrameListenerCanRemoveThemselves() {
+  public void itAllowsFirstFrameListenersToRemoveThemselves() {
+    // --- Test Setup ---
     AtomicInteger callbackCalled = new AtomicInteger(0);
     OnFirstFrameRenderedListener callback = new OnFirstFrameRenderedListener() {
       @Override
@@ -40,14 +41,19 @@ public class FlutterRendererTest {
         rendererUnderTest.removeOnFirstFrameRenderedListener(this);
       };
     };
-
     rendererUnderTest.addOnFirstFrameRenderedListener(callback);
+
+    // --- Execute Test ---
     jniUnderTest.onFirstFrame();
 
+    // --- Verify Results ---
     assertEquals(1, callbackCalled.get());
 
+    // --- Execute Test ---
     // The callback removed itself from the listener list. A second call doesn't call the callback.
     jniUnderTest.onFirstFrame();
+
+    // --- Verify Results ---
     assertEquals(1, callbackCalled.get());
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -31,7 +31,7 @@ public class FlutterRendererTest {
   }
 
   @Test
-  public void itHoldsFlutterEngines() {
+  public void firstFrameListenerCanRemoveThemselves() {
     AtomicInteger callbackCalled = new AtomicInteger(0);
     OnFirstFrameRenderedListener callback = new OnFirstFrameRenderedListener() {
       @Override

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -31,7 +31,7 @@ public class FlutterRendererTest {
   }
 
   @Test
-  public void itAllowsFirstFrameListenersToRemoveThemselves() {
+  public void itAllowsFirstFrameListenersToRemoveThemselvesInline() {
     // --- Test Setup ---
     AtomicInteger callbackCalled = new AtomicInteger(0);
     OnFirstFrameRenderedListener callback = new OnFirstFrameRenderedListener() {

--- a/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/renderer/FlutterRendererTest.java
@@ -1,0 +1,60 @@
+package io.flutter.embedding.engine.renderer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.renderer.FlutterRenderer;
+import io.flutter.embedding.engine.renderer.OnFirstFrameRenderedListener;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Config(manifest=Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterRendererTest {
+  FlutterJNITest jniUnderTest;
+  FlutterRenderer rendererUnderTest;
+
+  @Before
+  public void setUp() {
+    jniUnderTest = new FlutterJNITest();
+    rendererUnderTest = new FlutterRenderer(jniUnderTest);
+  }
+
+  @Test
+  public void itHoldsFlutterEngines() {
+    AtomicInteger callbackCalled = new AtomicInteger(0);
+    OnFirstFrameRenderedListener callback = new OnFirstFrameRenderedListener() {
+      @Override
+      public void onFirstFrameRendered() {
+        callbackCalled.incrementAndGet();
+        rendererUnderTest.removeOnFirstFrameRenderedListener(this);
+      };
+    };
+
+    rendererUnderTest.addOnFirstFrameRenderedListener(callback);
+    jniUnderTest.onFirstFrame();
+
+    assertEquals(1, callbackCalled.get());
+
+    // The callback removed itself from the listener list. A second call doesn't call the callback.
+    jniUnderTest.onFirstFrame();
+    assertEquals(1, callbackCalled.get());
+  }
+
+  private static class FlutterJNITest extends FlutterJNI {
+    protected void onFirstFrame() {
+      // Exposed here for tests.
+      super.onFirstFrame();
+    }
+  }
+}

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -205,7 +205,7 @@ def EnsureDebugUnoptSkyPackagesAreBuilt():
 
 def EnsureJavaTestsAreBuilt(android_out_dir):
   ninja_command = [
-    'ninja',
+    'autoninja',
     '-C',
     android_out_dir,
     'flutter/shell/platform/android:robolectric_tests'


### PR DESCRIPTION
See test:

Let the listener callbacks remove themselves for a one-time callback without java.util.ConcurrentModificationException. 