### PR TITLE
Fix gn breakage on non-Fuchsia macOS host builds

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -6,9 +6,7 @@ if (is_android) {
   import("//build/config/android/config.gni")
 }
 
-if (is_fuchsia || is_fuchsia_host) {
-  import("//build/fuchsia/sdk.gni")
-}
+import("//build/fuchsia/sdk.gni")
 
 if (target_cpu == "arm" || target_cpu == "arm64") {
   import("//build/config/arm.gni")


### PR DESCRIPTION
Ensure that we always pull in the ensure_fuchsia_sdk gn variable.

Fixes breakage introduced in flutter/engine#11016 when building outside
of a Fuchsia tree (e.g. in a stock Flutter engine tree0 on macOS hosts.