### PR TITLE
Show all license diffs

### DIFF
--- a/ci/licenses.sh
+++ b/ci/licenses.sh
@@ -71,5 +71,8 @@ then
     exitStatus=1
 fi
 
-echo "Licenses are as expected."
+if [ "$exitStatus" -eq "0" ]
+then
+  echo "Licenses are as expected."
+fi
 exit $exitStatus

--- a/ci/licenses.sh
+++ b/ci/licenses.sh
@@ -5,6 +5,8 @@ shopt -s nullglob
 echo "Verifying license script is still happy..."
 echo "Using pub from `which pub`, dart from `which dart`"
 
+exitStatus=0
+
 dart --version
 
 (cd flutter/tools/licenses; pub get; dart --enable-asserts lib/main.dart --src ../../.. --out ../../../out/license_script_output --golden ../../ci/licenses_golden)
@@ -22,7 +24,9 @@ for f in out/license_script_output/licenses_*; do
         echo "  https://github.com/flutter/engine/tree/master/tools/licenses"
         echo ""
         diff -U 6 flutter/ci/licenses_golden/$(basename $f) $f
-        exit 1
+        echo "================================================================="
+        echo ""
+        exitStatus=1
     fi
 done
 
@@ -41,7 +45,9 @@ then
     echo "  https://github.com/flutter/engine/tree/master/tools/licenses"
     echo ""
     diff -U 6 flutter/ci/licenses_golden/tool_signature out/license_script_output/tool_signature
-    exit 1
+    echo "================================================================="
+    echo ""
+    exitStatus=1
 fi
 
 echo "Checking license count in licenses_flutter..."
@@ -60,8 +66,10 @@ then
     echo "Files in 'third_party/txt' may have an Apache license header instead."
     echo "If you're absolutely sure that the change in license count is"
     echo "intentional, update 'flutter/ci/licenses.sh' with the new count."
-    exit 1
+    echo "================================================================="
+    echo ""
+    exitStatus=1
 fi
 
 echo "Licenses are as expected."
-exit 0
+exit $exitStatus


### PR DESCRIPTION
Instead of gathering all license diffs but only showing the changes to
the first directory that has a diff, show all diffs before exiting
licenses.sh.

Fixes https://github.com/flutter/flutter/issues/38634