### PR TITLE
Hide verbose dart snapshot during run_test.py

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -117,7 +117,7 @@ def RunEngineBenchmarks(build_dir, filter):
 
 
 
-def SnapshotTest(build_dir, dart_file, kernel_file_output, no_verbose):
+def SnapshotTest(build_dir, dart_file, kernel_file_output, verbose_dart_snapshot):
   print "Generating snapshot for test %s" % dart_file
 
   dart = os.path.join(build_dir, 'dart-sdk', 'bin', 'dart')
@@ -145,19 +145,19 @@ def SnapshotTest(build_dir, dart_file, kernel_file_output, no_verbose):
     dart_file
   ]
 
-  if (no_verbose):
+  if verbose_dart_snapshot:
+    subprocess.check_call(snapshot_command, cwd=buildroot_dir)
+  else:
     with open(os.devnull,"w") as out_file:
       subprocess.check_call(snapshot_command, cwd=buildroot_dir, stdout=out_file)
-  else:
-    subprocess.check_call(snapshot_command, cwd=buildroot_dir)
   assert os.path.exists(kernel_file_output)
 
 
-def RunDartTest(build_dir, dart_file, no_verbose):
+def RunDartTest(build_dir, dart_file, verbose_dart_snapshot):
   kernel_file_name = os.path.basename(dart_file) + '.kernel.dill'
   kernel_file_output = os.path.join(out_dir, kernel_file_name)
 
-  SnapshotTest(build_dir, dart_file, kernel_file_output, no_verbose)
+  SnapshotTest(build_dir, dart_file, kernel_file_output, verbose_dart_snapshot)
 
   print "Running test '%s' using 'flutter_tester'" % kernel_file_name
   RunEngineExecutable(build_dir, 'flutter_tester', None, [
@@ -252,7 +252,7 @@ def RunJavaTests(filter, android_variant='android_debug_unopt'):
 
   return subprocess.check_call(command)
 
-def RunDartTests(build_dir, filter, no_verbose):
+def RunDartTests(build_dir, filter, verbose_dart_snapshot):
   # This one is a bit messy. The pubspec.yaml at flutter/testing/dart/pubspec.yaml
   # has dependencies that are hardcoded to point to the sky packages at host_debug_unopt/
   # Before running Dart tests, make sure to run just that target (NOT the whole engine)
@@ -268,7 +268,7 @@ def RunDartTests(build_dir, filter, no_verbose):
       print "Skipping %s due to filter." % dart_test_file
     else:
       print "Testing dart file %s" % dart_test_file
-      RunDartTest(build_dir, dart_test_file, no_verbose)
+      RunDartTest(build_dir, dart_test_file, verbose_dart_snapshot)
 
 def main():
   parser = argparse.ArgumentParser();
@@ -285,8 +285,8 @@ def main():
   parser.add_argument('--android-variant', dest='android_variant', action='store',
       default='android_debug_unopt',
       help='The engine build variant to run java tests for')
-  parser.add_argument('--no-verbose', dest='no_verbose', action='store_true',
-      default=False, help='If set, extra verbose logging will be redirect to null device.')
+  parser.add_argument('--verbose-dart-snapshot', dest='verbose_dart_snapshot', action='store_true',
+      default=False, help='Show extra dart snapshot logging.')
 
   args = parser.parse_args()
 
@@ -306,7 +306,7 @@ def main():
   if 'dart' in types:
     assert not IsWindows(), "Dart tests can't be run on windows. https://github.com/flutter/flutter/issues/36301."
     dart_filter = args.dart_filter.split(',') if args.dart_filter else None
-    RunDartTests(build_dir, dart_filter, args.no_verbose)
+    RunDartTests(build_dir, dart_filter, args.verbose_dart_snapshot)
 
   if 'java' in types:
     assert not IsWindows(), "Android engine files can't be compiled on Windows."


### PR DESCRIPTION
Without this change, a single dart test will print out 306 lines.
With this change, a single dart test will only print out 33 lines.
This helps a lot in local tests.

In order to return to the old logging, set `--verbose-dart-snapshot` flag.