### PR TITLE
Cache results of filters applied by BackdropFilter widgets.

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -39,8 +39,8 @@ std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
     bool instrumentation_enabled,
     fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger) {
   return std::make_unique<ScopedFrame>(
-      *this, surface, gr_context, canvas, view_embedder, root_surface_transformation,
-      instrumentation_enabled, gpu_thread_merger);
+      *this, surface, gr_context, canvas, view_embedder,
+      root_surface_transformation, instrumentation_enabled, gpu_thread_merger);
 }
 
 CompositorContext::ScopedFrame::ScopedFrame(

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -31,6 +31,7 @@ void CompositorContext::EndFrame(ScopedFrame& frame,
 }
 
 std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
+    SkSurface* surface,
     GrContext* gr_context,
     SkCanvas* canvas,
     ExternalViewEmbedder* view_embedder,
@@ -38,12 +39,13 @@ std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
     bool instrumentation_enabled,
     fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger) {
   return std::make_unique<ScopedFrame>(
-      *this, gr_context, canvas, view_embedder, root_surface_transformation,
+      *this, surface, gr_context, canvas, view_embedder, root_surface_transformation,
       instrumentation_enabled, gpu_thread_merger);
 }
 
 CompositorContext::ScopedFrame::ScopedFrame(
     CompositorContext& context,
+    SkSurface* surface,
     GrContext* gr_context,
     SkCanvas* canvas,
     ExternalViewEmbedder* view_embedder,
@@ -51,6 +53,7 @@ CompositorContext::ScopedFrame::ScopedFrame(
     bool instrumentation_enabled,
     fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger)
     : context_(context),
+      surface_(surface),
       gr_context_(gr_context),
       canvas_(canvas),
       view_embedder_(view_embedder),

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -40,6 +40,7 @@ class CompositorContext {
   class ScopedFrame {
    public:
     ScopedFrame(CompositorContext& context,
+                SkSurface* surface,
                 GrContext* gr_context,
                 SkCanvas* canvas,
                 ExternalViewEmbedder* view_embedder,
@@ -48,6 +49,8 @@ class CompositorContext {
                 fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger);
 
     virtual ~ScopedFrame();
+
+    SkSurface* surface() { return surface_; }
 
     SkCanvas* canvas() { return canvas_; }
 
@@ -66,6 +69,7 @@ class CompositorContext {
 
    private:
     CompositorContext& context_;
+    SkSurface* surface_;
     GrContext* gr_context_;
     SkCanvas* canvas_;
     ExternalViewEmbedder* view_embedder_;
@@ -81,6 +85,7 @@ class CompositorContext {
   virtual ~CompositorContext();
 
   virtual std::unique_ptr<ScopedFrame> AcquireFrame(
+      SkSurface* surface,
       GrContext* gr_context,
       SkCanvas* canvas,
       ExternalViewEmbedder* view_embedder,

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -11,13 +11,54 @@ BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
 
 BackdropFilterLayer::~BackdropFilterLayer() = default;
 
+void BackdropFilterLayer::initRetained(std::shared_ptr<Layer> retainedLayer) {
+  BackdropFilterLayer* bdfLayer = (BackdropFilterLayer*) retainedLayer.get();
+  if (bdfLayer->retainedBackdrop_) {
+    retainedBackdrop_ = bdfLayer->retainedBackdrop_;
+  } else {
+    retainedBackdrop_ = std::move(retainedLayer);
+  }
+}
+
+void BackdropFilterLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  ContainerLayer::Preroll(context, matrix);
+
+  if (retainedBackdrop_ && context->raster_cache && context->view_embedder == nullptr) {
+    context->raster_cache->PrepareForSnapshot(context, retainedBackdrop_.get());
+  }
+}
+
 void BackdropFilterLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "BackdropFilterLayer::Paint");
   FML_DCHECK(needs_painting());
 
-  Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
-      context,
-      SkCanvas::SaveLayerRec{&paint_bounds(), nullptr, filter_.get(), 0});
+  bool need_backdrop_paint = true;
+  bool need_snapshot = false;
+  if (retainedBackdrop_ && context.surface && context.view_embedder == nullptr) {
+    RasterCacheResult my_cache = context.raster_cache->Get(retainedBackdrop_.get(), SkMatrix::I());
+    if (my_cache.is_valid()) {
+      my_cache.drawSnapshot(*context.leaf_nodes_canvas);
+      need_backdrop_paint = false;
+    } else {
+      need_snapshot = true;
+    }
+  }
+
+  if (need_backdrop_paint) {
+    Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
+        context,
+        SkCanvas::SaveLayerRec{&paint_bounds(), nullptr, filter_.get(), 0});
+  }
+
+  if (need_snapshot) {
+    SkIRect dev_clip;
+    context.leaf_nodes_canvas->getDeviceClipBounds(&dev_clip);
+    context.raster_cache->PutSnapshot(retainedBackdrop_.get(),
+                                      context.surface,
+                                      dev_clip);
+  }
+
+  SkAutoCanvasRestore save(context.leaf_nodes_canvas, true);
   PaintChildren(context);
 }
 

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -3,9 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/flow/layers/backdrop_filter_layer.h"
-#include "flutter/flow/paint_utils.h"
-
-#include "third_party/skia/include/effects/SkImageFilters.h"
 
 namespace flutter {
 
@@ -23,50 +20,24 @@ void BackdropFilterLayer::initRetained(std::shared_ptr<Layer> retainedLayer) {
   }
 }
 
-void BackdropFilterLayer::Preroll(PrerollContext* context,
-                                  const SkMatrix& matrix) {
-  ContainerLayer::Preroll(context, matrix);
-
-  if (retainedBackdrop_ && context->raster_cache &&
-      context->view_embedder == nullptr) {
-    context->raster_cache->PrepareForSnapshot(context, retainedBackdrop_.get());
-  }
-}
-
 void BackdropFilterLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "BackdropFilterLayer::Paint");
   FML_DCHECK(needs_painting());
 
-  if (context.surface && context.raster_cache &&
-      context.view_embedder == nullptr && retainedBackdrop_) {
-    RasterCacheResult my_cache =
-        context.raster_cache->Get(retainedBackdrop_.get(), SkMatrix::I());
-    if (!my_cache.is_valid()) {
-      // FML_LOG(ERROR) << "Grabbing snapshot for layer: " << unique_id();
-      const SkImageInfo image_info = context.surface->imageInfo();
-      sk_sp<SkImageFilter> transformed_filter =
-          filter_.get()->makeWithLocalMatrix(
-              context.leaf_nodes_canvas->getTotalMatrix());
-
-      sk_sp<SkSurface> filter_surface = SkSurface::MakeRenderTarget(
-          context.gr_context, SkBudgeted::kYes, image_info);
-
-      SkCanvas* filter_canvas = filter_surface->getCanvas();
-      SkPaint filter_paint;
-      filter_paint.setImageFilter(transformed_filter);
-      context.surface->draw(filter_canvas, 0, 0, &filter_paint);
-
-      sk_sp<SkImage> filter_image = filter_surface->makeImageSnapshot();
-      my_cache = context.raster_cache->PutSnapshot(retainedBackdrop_.get(),
-                                                   filter_image);
-      FML_DCHECK(my_cache.is_valid());
+  if (retainedBackdrop_ && context.raster_cache && context.surface &&
+      context.view_embedder == nullptr) {
+    SkCanvas* canvas = context.leaf_nodes_canvas;
+    RasterCacheResult my_cache = context.raster_cache->GetSnapshot(
+        retainedBackdrop_.get(), context.gr_context, canvas->getTotalMatrix(),
+        context.surface, filter_.get());
+    if (my_cache.is_valid()) {
+      my_cache.drawSnapshot(canvas);
+      SkAutoCanvasRestore auto_restore(canvas, true);
+      PaintChildren(context);
+      return;
     }
-
-    my_cache.drawSnapshot(context.leaf_nodes_canvas);
-    SkAutoCanvasRestore auto_restore(context.leaf_nodes_canvas, true);
-    PaintChildren(context);
-    return;
   }
+
   // FML_LOG(ERROR) << "filtering using autosavelayer";
   Layer::AutoSaveLayer save = Layer::AutoSaveLayer::Create(
       context,

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -12,7 +12,7 @@ BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
 BackdropFilterLayer::~BackdropFilterLayer() = default;
 
 void BackdropFilterLayer::initRetained(std::shared_ptr<Layer> retainedLayer) {
-  BackdropFilterLayer* bdfLayer = (BackdropFilterLayer*) retainedLayer.get();
+  BackdropFilterLayer* bdfLayer = (BackdropFilterLayer*)retainedLayer.get();
   if (bdfLayer->retainedBackdrop_) {
     retainedBackdrop_ = bdfLayer->retainedBackdrop_;
   } else {
@@ -20,10 +20,12 @@ void BackdropFilterLayer::initRetained(std::shared_ptr<Layer> retainedLayer) {
   }
 }
 
-void BackdropFilterLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+void BackdropFilterLayer::Preroll(PrerollContext* context,
+                                  const SkMatrix& matrix) {
   ContainerLayer::Preroll(context, matrix);
 
-  if (retainedBackdrop_ && context->raster_cache && context->view_embedder == nullptr) {
+  if (retainedBackdrop_ && context->raster_cache &&
+      context->view_embedder == nullptr) {
     context->raster_cache->PrepareForSnapshot(context, retainedBackdrop_.get());
   }
 }
@@ -34,8 +36,10 @@ void BackdropFilterLayer::Paint(PaintContext& context) const {
 
   bool need_backdrop_paint = true;
   bool need_snapshot = false;
-  if (retainedBackdrop_ && context.surface && context.view_embedder == nullptr) {
-    RasterCacheResult my_cache = context.raster_cache->Get(retainedBackdrop_.get(), SkMatrix::I());
+  if (retainedBackdrop_ && context.surface &&
+      context.view_embedder == nullptr) {
+    RasterCacheResult my_cache =
+        context.raster_cache->Get(retainedBackdrop_.get(), SkMatrix::I());
     if (my_cache.is_valid()) {
       my_cache.drawSnapshot(*context.leaf_nodes_canvas);
       need_backdrop_paint = false;
@@ -53,8 +57,7 @@ void BackdropFilterLayer::Paint(PaintContext& context) const {
   if (need_snapshot) {
     SkIRect dev_clip;
     context.leaf_nodes_canvas->getDeviceClipBounds(&dev_clip);
-    context.raster_cache->PutSnapshot(retainedBackdrop_.get(),
-                                      context.surface,
+    context.raster_cache->PutSnapshot(retainedBackdrop_.get(), context.surface,
                                       dev_clip);
   }
 

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -16,10 +16,15 @@ class BackdropFilterLayer : public ContainerLayer {
   BackdropFilterLayer(sk_sp<SkImageFilter> filter);
   ~BackdropFilterLayer() override;
 
+  void initRetained(std::shared_ptr<Layer> retainedLayer);
+
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+
   void Paint(PaintContext& context) const override;
 
  private:
   sk_sp<SkImageFilter> filter_;
+  std::shared_ptr<Layer> retainedBackdrop_ = nullptr;
 
   FML_DISALLOW_COPY_AND_ASSIGN(BackdropFilterLayer);
 };

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -18,8 +18,6 @@ class BackdropFilterLayer : public ContainerLayer {
 
   void initRetained(std::shared_ptr<Layer> retainedLayer);
 
-  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
-
   void Paint(PaintContext& context) const override;
 
  private:

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -80,6 +80,7 @@ class Layer {
     // and applies the operations to all canvases.
     // The leaf_nodes_canvas is the "current" canvas and is used by leaf
     // layers.
+    SkSurface* surface;
     SkCanvas* internal_nodes_canvas;
     SkCanvas* leaf_nodes_canvas;
     GrContext* gr_context;
@@ -87,7 +88,7 @@ class Layer {
     const Stopwatch& raster_time;
     const Stopwatch& ui_time;
     TextureRegistry& texture_registry;
-    const RasterCache* raster_cache;
+    RasterCache* raster_cache;
     const bool checkerboard_offscreen_layers;
   };
 

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -86,6 +86,7 @@ void LayerTree::Paint(CompositorContext::ScopedFrame& frame,
   }
 
   Layer::PaintContext context = {
+      frame.surface(),
       (SkCanvas*)&internal_nodes_canvas,
       frame.canvas(),
       frame.gr_context(),
@@ -135,6 +136,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
   internal_nodes_canvas.addCanvas(canvas);
 
   Layer::PaintContext paint_context = {
+      nullptr,
       (SkCanvas*)&internal_nodes_canvas,
       canvas,  // canvas
       nullptr,

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -52,7 +52,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
 
   flutter::TextureRegistry unused_texture_registry;
   flutter::Layer::PaintContext paintContext = {
-      nullptr,        nullptr,        surface->getCanvas(),    nullptr, nullptr,
+      surface.get(),  nullptr,        surface->getCanvas(),    nullptr, nullptr,
       mock_stopwatch, mock_stopwatch, unused_texture_registry, nullptr, false};
 
   // Specify font file to ensure the same font across different operation

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -52,9 +52,8 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
 
   flutter::TextureRegistry unused_texture_registry;
   flutter::Layer::PaintContext paintContext = {
-      nullptr,
-      nullptr,        surface->getCanvas(),    nullptr, nullptr, mock_stopwatch,
-      mock_stopwatch, unused_texture_registry, nullptr, false};
+      nullptr,        nullptr,        surface->getCanvas(),    nullptr, nullptr,
+      mock_stopwatch, mock_stopwatch, unused_texture_registry, nullptr, false};
 
   // Specify font file to ensure the same font across different operation
   // systems.

--- a/flow/layers/performance_overlay_layer_unittests.cc
+++ b/flow/layers/performance_overlay_layer_unittests.cc
@@ -52,6 +52,7 @@ static void TestPerformanceOverlayLayerGold(int refresh_rate) {
 
   flutter::TextureRegistry unused_texture_registry;
   flutter::Layer::PaintContext paintContext = {
+      nullptr,
       nullptr,        surface->getCanvas(),    nullptr, nullptr, mock_stopwatch,
       mock_stopwatch, unused_texture_registry, nullptr, false};
 

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -194,8 +194,7 @@ void RasterCache::Prepare(PrerollContext* context,
   }
 }
 
-void RasterCache::PrepareForSnapshot(PrerollContext* context,
-                                     Layer* layer) {
+void RasterCache::PrepareForSnapshot(PrerollContext* context, Layer* layer) {
   LayerRasterCacheKey cache_key(layer->unique_id(), SkMatrix::I());
   Entry& entry = layer_cache_[cache_key];
   entry.access_count = ClampSize(entry.access_count + 1, 0, access_threshold_);
@@ -251,20 +250,21 @@ RasterCacheResult RasterCache::Get(const SkPicture& picture,
   return it == picture_cache_.end() ? RasterCacheResult() : it->second.image;
 }
 
-RasterCacheResult RasterCache::Get(const Layer* layer, const SkMatrix& ctm) const {
+RasterCacheResult RasterCache::Get(const Layer* layer,
+                                   const SkMatrix& ctm) const {
   LayerRasterCacheKey cache_key(layer->unique_id(), ctm);
   auto it = layer_cache_.find(cache_key);
   return it == layer_cache_.end() ? RasterCacheResult() : it->second.image;
 }
 
-void RasterCache::PutSnapshot(const Layer* layer, SkSurface* surface, SkIRect& dev_bounds) {
+void RasterCache::PutSnapshot(const Layer* layer,
+                              SkSurface* surface,
+                              SkIRect& dev_bounds) {
   LayerRasterCacheKey cache_key(layer->unique_id(), SkMatrix::I());
   auto it = layer_cache_.find(cache_key);
   if (it != layer_cache_.end()) {
-    it->second.image = {
-      surface->makeImageSnapshot(dev_bounds),
-      SkRect::Make(dev_bounds)
-    };
+    it->second.image = {surface->makeImageSnapshot(dev_bounds),
+                        SkRect::Make(dev_bounds)};
   }
 }
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -92,13 +92,15 @@ class RasterCache {
 
   void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
 
-  void PrepareForSnapshot(PrerollContext* context, Layer* layer);
-
   RasterCacheResult Get(const SkPicture& picture, const SkMatrix& ctm) const;
 
-  RasterCacheResult Get(const Layer* layer, const SkMatrix& ctm) const;
+  RasterCacheResult Get(Layer* layer, const SkMatrix& ctm) const;
 
-  RasterCacheResult PutSnapshot(const Layer* layer, sk_sp<SkImage> snapshot);
+  RasterCacheResult GetSnapshot(const Layer* layer,
+                                GrContext* context,
+                                const SkMatrix& ctm,
+                                SkSurface* surface,
+                                SkImageFilter* filter);
 
   void SweepAfterFrame();
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -31,6 +31,8 @@ class RasterCacheResult {
 
   bool is_valid() const { return static_cast<bool>(image_); };
 
+  void drawSnapshot(SkCanvas& canvas) const;
+
   void draw(SkCanvas& canvas, const SkPaint* paint = nullptr) const;
 
   SkISize image_dimensions() const {
@@ -90,9 +92,13 @@ class RasterCache {
 
   void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
 
+  void PrepareForSnapshot(PrerollContext* context, Layer* layer);
+
   RasterCacheResult Get(const SkPicture& picture, const SkMatrix& ctm) const;
 
-  RasterCacheResult Get(Layer* layer, const SkMatrix& ctm) const;
+  RasterCacheResult Get(const Layer* layer, const SkMatrix& ctm) const;
+
+  void PutSnapshot(const Layer* layer, SkSurface* surface, SkIRect& dev_bounds);
 
   void SweepAfterFrame();
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -31,7 +31,7 @@ class RasterCacheResult {
 
   bool is_valid() const { return static_cast<bool>(image_); };
 
-  void drawSnapshot(SkCanvas& canvas) const;
+  void drawSnapshot(SkCanvas* canvas) const;
 
   void draw(SkCanvas& canvas, const SkPaint* paint = nullptr) const;
 
@@ -98,7 +98,7 @@ class RasterCache {
 
   RasterCacheResult Get(const Layer* layer, const SkMatrix& ctm) const;
 
-  void PutSnapshot(const Layer* layer, SkSurface* surface, SkIRect& dev_bounds);
+  RasterCacheResult PutSnapshot(const Layer* layer, sk_sp<SkImage> snapshot);
 
   void SweepAfterFrame();
 

--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -197,7 +197,8 @@ SceneUpdateContext::ExecutePaintTasks(CompositorContext::ScopedFrame& frame) {
   for (auto& task : paint_tasks_) {
     FML_DCHECK(task.surface);
     SkCanvas* canvas = task.surface->GetSkiaSurface()->getCanvas();
-    Layer::PaintContext context = {canvas,
+    Layer::PaintContext context = {task.surface->GetSkiaSurface().get(),
+                                   canvas,
                                    canvas,
                                    frame.gr_context(),
                                    nullptr,

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -408,13 +408,13 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  BackdropFilterEngineLayer pushBackdropFilter(ImageFilter filter, { BackdropFilterEngineLayer oldLayer }) {
+  BackdropFilterEngineLayer pushBackdropFilter(ImageFilter filter, { bool isDynamic = true, BackdropFilterEngineLayer oldLayer }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushBackdropFilter'));
-    final BackdropFilterEngineLayer layer = BackdropFilterEngineLayer._(_pushBackdropFilter(filter));
+    final BackdropFilterEngineLayer layer = BackdropFilterEngineLayer._(_pushBackdropFilter(filter, isDynamic, oldLayer?._nativeLayer));
     assert(_debugPushLayer(layer));
     return layer;
   }
-  EngineLayer _pushBackdropFilter(ImageFilter filter) native 'SceneBuilder_pushBackdropFilter';
+  EngineLayer _pushBackdropFilter(ImageFilter filter, bool isDynamic, EngineLayer oldLayer) native 'SceneBuilder_pushBackdropFilter';
 
   /// Pushes a shader mask operation onto the operation stack.
   ///

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -149,8 +149,13 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushColorFilter(
   return EngineLayer::MakeRetained(layer);
 }
 
-fml::RefPtr<EngineLayer> SceneBuilder::pushBackdropFilter(ImageFilter* filter) {
+fml::RefPtr<EngineLayer> SceneBuilder::pushBackdropFilter(ImageFilter* filter,
+                                                          bool isDynamic,
+                                                          fml::RefPtr<EngineLayer> oldLayer) {
   auto layer = std::make_shared<flutter::BackdropFilterLayer>(filter->filter());
+  if (!isDynamic) {
+    layer.get()->initRetained(oldLayer ? oldLayer->Layer() : layer);
+  }
   PushLayer(layer);
   return EngineLayer::MakeRetained(layer);
 }

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -149,9 +149,10 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushColorFilter(
   return EngineLayer::MakeRetained(layer);
 }
 
-fml::RefPtr<EngineLayer> SceneBuilder::pushBackdropFilter(ImageFilter* filter,
-                                                          bool isDynamic,
-                                                          fml::RefPtr<EngineLayer> oldLayer) {
+fml::RefPtr<EngineLayer> SceneBuilder::pushBackdropFilter(
+    ImageFilter* filter,
+    bool isDynamic,
+    fml::RefPtr<EngineLayer> oldLayer) {
   auto layer = std::make_shared<flutter::BackdropFilterLayer>(filter->filter());
   if (!isDynamic) {
     layer.get()->initRetained(oldLayer ? oldLayer->Layer() : layer);

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -50,7 +50,9 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                                         int clipBehavior);
   fml::RefPtr<EngineLayer> pushOpacity(int alpha, double dx = 0, double dy = 0);
   fml::RefPtr<EngineLayer> pushColorFilter(const ColorFilter* color_filter);
-  fml::RefPtr<EngineLayer> pushBackdropFilter(ImageFilter* filter);
+  fml::RefPtr<EngineLayer> pushBackdropFilter(ImageFilter* filter,
+                                              bool isDynamic,
+                                              fml::RefPtr<EngineLayer> oldLayer);
   fml::RefPtr<EngineLayer> pushShaderMask(Shader* shader,
                                           double maskRectLeft,
                                           double maskRectRight,

--- a/lib/ui/compositing/scene_builder.h
+++ b/lib/ui/compositing/scene_builder.h
@@ -50,9 +50,10 @@ class SceneBuilder : public RefCountedDartWrappable<SceneBuilder> {
                                         int clipBehavior);
   fml::RefPtr<EngineLayer> pushOpacity(int alpha, double dx = 0, double dy = 0);
   fml::RefPtr<EngineLayer> pushColorFilter(const ColorFilter* color_filter);
-  fml::RefPtr<EngineLayer> pushBackdropFilter(ImageFilter* filter,
-                                              bool isDynamic,
-                                              fml::RefPtr<EngineLayer> oldLayer);
+  fml::RefPtr<EngineLayer> pushBackdropFilter(
+      ImageFilter* filter,
+      bool isDynamic,
+      fml::RefPtr<EngineLayer> oldLayer);
   fml::RefPtr<EngineLayer> pushShaderMask(Shader* shader,
                                           double maskRectLeft,
                                           double maskRectRight,

--- a/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
@@ -91,7 +91,7 @@ class LayerSceneBuilder implements ui.SceneBuilder {
 
   @override
   ui.BackdropFilterEngineLayer pushBackdropFilter(ui.ImageFilter filter,
-      {ui.EngineLayer oldLayer}) {
+      {bool isDynamic = true, ui.EngineLayer oldLayer}) {
     throw UnimplementedError();
   }
 

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -284,7 +284,7 @@ class SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   BackdropFilterEngineLayer pushBackdropFilter(ImageFilter filter,
-      {BackdropFilterEngineLayer oldLayer}) {
+      {bool isDynamic = true, BackdropFilterEngineLayer oldLayer}) {
     return _pushSurface(engine.PersistedBackdropFilter(oldLayer, filter));
   }
 

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -245,6 +245,7 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
                                  : frame->SkiaCanvas();
 
   auto compositor_frame = compositor_context_->AcquireFrame(
+      frame->SkiaSurface().get(),   // skia surface
       surface_->GetContext(),       // skia GrContext
       root_surface_canvas,          // root surface canvas
       external_view_embedder,       // external view embedder
@@ -293,7 +294,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsPicture(
   // TODO(amirh): figure out how to take a screenshot with embedded UIView.
   // https://github.com/flutter/flutter/issues/23435
   auto frame = compositor_context.AcquireFrame(
-      nullptr, recorder.getRecordingCanvas(), nullptr,
+      nullptr, nullptr, recorder.getRecordingCanvas(), nullptr,
       root_surface_transformation, false, nullptr);
 
   frame->Raster(*tree, true);
@@ -344,7 +345,8 @@ static sk_sp<SkData> ScreenshotLayerTreeAsImage(
   SkMatrix root_surface_transformation;
   root_surface_transformation.reset();
 
-  auto frame = compositor_context.AcquireFrame(surface_context, canvas, nullptr,
+  auto frame = compositor_context.AcquireFrame(snapshot_surface.get(),
+                                               surface_context, canvas, nullptr,
                                                root_surface_transformation,
                                                false, nullptr);
   canvas->clear(SK_ColorTRANSPARENT);

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -245,7 +245,7 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
                                  : frame->SkiaCanvas();
 
   auto compositor_frame = compositor_context_->AcquireFrame(
-      frame->SkiaSurface().get(),   // skia surface
+      frame->SkiaSurface().get(),   // skia SkSurface
       surface_->GetContext(),       // skia GrContext
       root_surface_canvas,          // root surface canvas
       external_view_embedder,       // external view embedder
@@ -345,10 +345,9 @@ static sk_sp<SkData> ScreenshotLayerTreeAsImage(
   SkMatrix root_surface_transformation;
   root_surface_transformation.reset();
 
-  auto frame = compositor_context.AcquireFrame(snapshot_surface.get(),
-                                               surface_context, canvas, nullptr,
-                                               root_surface_transformation,
-                                               false, nullptr);
+  auto frame = compositor_context.AcquireFrame(
+      snapshot_surface.get(), surface_context, canvas, nullptr,
+      root_surface_transformation, false, nullptr);
   canvas->clear(SK_ColorTRANSPARENT);
   frame->Raster(*tree, true);
   canvas->flush();

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -18,6 +18,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
                                                 nullptr,
                                                 nullptr,
                                                 nullptr,
+                                                nullptr,
                                                 root_surface_transformation,
                                                 instrumentation_enabled,
                                                 nullptr),
@@ -91,6 +92,7 @@ CompositorContext::~CompositorContext() = default;
 
 std::unique_ptr<flutter::CompositorContext::ScopedFrame>
 CompositorContext::AcquireFrame(
+    SkSurface* surface,
     GrContext* gr_context,
     SkCanvas* canvas,
     flutter::ExternalViewEmbedder* view_embedder,

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -40,6 +40,7 @@ class CompositorContext final : public flutter::CompositorContext {
 
   // |flutter::CompositorContext|
   std::unique_ptr<ScopedFrame> AcquireFrame(
+      SkSurface* surface,
       GrContext* gr_context,
       SkCanvas* canvas,
       flutter::ExternalViewEmbedder* view_embedder,


### PR DESCRIPTION
The changes here should hopefully be a non-breaking change
to the Engine API which will set the stage for a commit to
the framework repo that will start using the new flag.

These are the bulk of the changes to support the caching of
the backdrop filter results with only minor bookkeeping
changes in the framework to pass the flags along and to
pass in the BackdropFilter layer from frame to frame to
ensure that the cache is maintained through animations.

The naming of the new flags are up for suggestions. For now,
isDynamic should default to true everywhere and mean that
we should not cache the filter and the developer must set
it to false to enable the caching.