### PR TITLE
Release _ongoingTouches when FlutterViewController dealloc

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -523,6 +523,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
 - (void)dealloc {
   [_engine.get() notifyViewControllerDeallocated];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
+  [_ongoingTouches release];
   [super dealloc];
 }
 


### PR DESCRIPTION
When FlutterViewController dealloc，we should also release _ongoingTouches.