### PR TITLE
Add platform screenshot provider to take screenshot (iOS)

### DIFF
--- a/flow/embedded_views.h
+++ b/flow/embedded_views.h
@@ -233,6 +233,11 @@ class ExternalViewEmbedder {
 
 };  // ExternalViewEmbedder
 
+class PlatformScreenShotProvider {
+ public:
+  virtual sk_sp<SkImage> TakeScreenShot() = 0;
+};  // PlatformScreenShotProvider
+
 }  // namespace flutter
 
 #endif  // FLUTTER_FLOW_EMBEDDED_VIEWS_H_

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -417,6 +417,12 @@ class Rasterizer final {
 
   RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);
 
+  sk_sp<SkData> ScreenshotLayerTreeAsImage(
+      flutter::LayerTree* tree,
+      flutter::CompositorContext& compositor_context,
+      GrContext* surface_context,
+      bool compressed);
+
   void FireNextFrameCallbackIfPresent();
 
   FML_DISALLOW_COPY_AND_ASSIGN(Rasterizer);

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -253,5 +253,10 @@ ExternalViewEmbedder* ShellTestPlatformView::GetExternalViewEmbedder() {
   return nullptr;
 }
 
+// |GPUSurfaceGLDelegate|
+PlatformScreenShotProvider* ShellTestPlatformView::GetScreenShotProvider() {
+  return nullptr;
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -102,6 +102,9 @@ class ShellTestPlatformView : public PlatformView, public GPUSurfaceGLDelegate {
   // |GPUSurfaceGLDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |GPUSurfaceGLDelegate|
+  PlatformScreenShotProvider* GetScreenShotProvider() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformView);
 };
 

--- a/shell/common/surface.cc
+++ b/shell/common/surface.cc
@@ -60,6 +60,10 @@ flutter::ExternalViewEmbedder* Surface::GetExternalViewEmbedder() {
   return nullptr;
 }
 
+flutter::PlatformScreenShotProvider* Surface::GetScreenShotProvider() {
+  return nullptr;
+}
+
 bool Surface::MakeRenderContextCurrent() {
   return true;
 }

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -58,6 +58,8 @@ class Surface {
 
   virtual flutter::ExternalViewEmbedder* GetExternalViewEmbedder();
 
+  virtual flutter::PlatformScreenShotProvider* GetScreenShotProvider();
+
   virtual bool MakeRenderContextCurrent();
 
  private:

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -345,6 +345,11 @@ flutter::ExternalViewEmbedder* GPUSurfaceGL::GetExternalViewEmbedder() {
 }
 
 // |Surface|
+flutter::PlatformScreenShotProvider* GPUSurfaceGL::GetScreenShotProvider() {
+  return delegate_->GetScreenShotProvider();
+}
+
+// |Surface|
 bool GPUSurfaceGL::MakeRenderContextCurrent() {
   return delegate_->GLContextMakeCurrent();
 }

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -44,6 +44,9 @@ class GPUSurfaceGL : public Surface {
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
   // |Surface|
+  flutter::PlatformScreenShotProvider* GetScreenShotProvider() override;
+
+  // |Surface|
   bool MakeRenderContextCurrent() override;
 
  private:

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -46,6 +46,8 @@ class GPUSurfaceGLDelegate {
   // thread that the renderer is operating on.
   virtual ExternalViewEmbedder* GetExternalViewEmbedder() = 0;
 
+  virtual flutter::PlatformScreenShotProvider* GetScreenShotProvider() = 0;
+
   sk_sp<const GrGLInterface> GetGLInterface() const;
 
   // TODO(chinmaygarde): The presence of this method is to work around the fact

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -80,4 +80,9 @@ flutter::ExternalViewEmbedder* GPUSurfaceSoftware::GetExternalViewEmbedder() {
   return delegate_->GetExternalViewEmbedder();
 }
 
+flutter::PlatformScreenShotProvider*
+GPUSurfaceSoftware::GetScreenShotProvider() {
+  return delegate_->GetScreenShotProvider();
+}
+
 }  // namespace flutter

--- a/shell/gpu/gpu_surface_software.h
+++ b/shell/gpu/gpu_surface_software.h
@@ -33,6 +33,9 @@ class GPUSurfaceSoftware : public Surface {
   // |Surface|
   flutter::ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |Surface|
+  flutter::PlatformScreenShotProvider* GetScreenShotProvider() override;
+
  private:
   GPUSurfaceSoftwareDelegate* delegate_;
   fml::WeakPtrFactory<GPUSurfaceSoftware> weak_factory_;

--- a/shell/gpu/gpu_surface_software_delegate.h
+++ b/shell/gpu/gpu_surface_software_delegate.h
@@ -58,6 +58,8 @@ class GPUSurfaceSoftwareDelegate {
   ///             into a single on-screen surface.
   ///
   virtual ExternalViewEmbedder* GetExternalViewEmbedder() = 0;
+
+  virtual flutter::PlatformScreenShotProvider* GetScreenShotProvider() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -91,6 +91,8 @@ shared_library("create_flutter_framework_dylib") {
     "ios_surface_gl.mm",
     "ios_surface_software.h",
     "ios_surface_software.mm",
+    "ios_screenshot_provider.h",
+    "ios_screenshot_provider.mm",
     "platform_view_ios.h",
     "platform_view_ios.mm",
   ]

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -18,6 +18,10 @@
 
 namespace flutter {
 
+UIView* FlutterPlatformViewsController::GetFlutterView() {
+  return flutter_view_.get();
+}
+
 void FlutterPlatformViewsController::SetFlutterView(UIView* flutter_view) {
   flutter_view_.reset([flutter_view retain]);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -71,6 +71,8 @@ class FlutterPlatformViewsController {
 
   ~FlutterPlatformViewsController();
 
+  UIView* GetFlutterView();
+
   void SetFlutterView(UIView* flutter_view);
 
   void SetFlutterViewController(UIViewController* flutter_view_controller);

--- a/shell/platform/darwin/ios/ios_screenshot_provider.h
+++ b/shell/platform/darwin/ios/ios_screenshot_provider.h
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SCREENSHOT_PROVIDER_H_
+#define FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SCREENSHOT_PROVIDER_H_
+
+#import <UIKit/UIKit.h>
+#include "flutter/flow/embedded_views.h"
+
+namespace flutter {
+
+class IOSScreenShotProvider : public PlatformScreenShotProvider {
+ protected:
+  sk_sp<SkImage> TakeScreenShotForView(UIView* view);
+};
+
+}
+#endif  // FLUTTER_SHELL_PLATFORM_DARWIN_IOS_IOS_SCREENSHOT_PROVIDER_H_

--- a/shell/platform/darwin/ios/ios_screenshot_provider.mm
+++ b/shell/platform/darwin/ios/ios_screenshot_provider.mm
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/darwin/ios/ios_screenshot_provider.h"
+#include "third_party/skia/include/core/SkColorSpace.h"
+#include "third_party/skia/include/core/SkData.h"
+#include "third_party/skia/include/core/SkImage.h"
+#include "third_party/skia/include/core/SkImageInfo.h"
+#include "third_party/skia/include/core/SkRefCnt.h"
+
+namespace flutter {
+
+sk_sp<SkImage> IOSScreenShotProvider::TakeScreenShotForView(UIView* view) {
+  CGRect rect = view.bounds;
+  UIGraphicsBeginImageContext(rect.size);
+  CGContextRef ctx = UIGraphicsGetCurrentContext();
+
+  [[UIColor blackColor] set];
+  CGContextFillRect(ctx, rect);
+
+  [view.layer renderInContext:ctx];
+  UIImage* screenshot = UIGraphicsGetImageFromCurrentImageContext();
+
+  UIGraphicsEndImageContext();
+  CGImageRef imageRef = CGImageRetain(screenshot.CGImage);
+  CFDataRef data = CGDataProviderCopyData(CGImageGetDataProvider(imageRef));
+
+  size_t rowBtyes = CGImageGetBytesPerRow(imageRef);
+
+  sk_sp<SkData> rasterData = SkData::MakeWithCopy(CFDataGetBytePtr(data), CFDataGetLength(data));
+  const auto image_info =
+      SkImageInfo::Make(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef),
+                        kBGRA_8888_SkColorType, kOpaque_SkAlphaType, SkColorSpace::MakeSRGB());
+
+  sk_sp<SkImage> skImage = SkImage::MakeRasterData(image_info, rasterData, rowBtyes);
+
+  CGImageRelease(imageRef);
+  CFRelease(data);
+
+  return skImage;
+}
+}

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -10,6 +10,7 @@
 #include "flutter/shell/gpu/gpu_surface_gl.h"
 #include "flutter/shell/platform/darwin/ios/ios_gl_context.h"
 #include "flutter/shell/platform/darwin/ios/ios_gl_render_target.h"
+#include "flutter/shell/platform/darwin/ios/ios_screenshot_provider.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
 
 @class CAEAGLLayer;
@@ -18,7 +19,8 @@ namespace flutter {
 
 class IOSSurfaceGL final : public IOSSurface,
                            public GPUSurfaceGLDelegate,
-                           public ExternalViewEmbedder {
+                           public ExternalViewEmbedder,
+                           public IOSScreenShotProvider {
  public:
   IOSSurfaceGL(std::shared_ptr<IOSGLContext> context,
                fml::scoped_nsobject<CAEAGLLayer> layer,
@@ -51,6 +53,9 @@ class IOSSurfaceGL final : public IOSSurface,
   // |GPUSurfaceGLDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |GPUSurfaceGLDelegate|
+  PlatformScreenShotProvider* GetScreenShotProvider() override;
+
   // |ExternalViewEmbedder|
   sk_sp<SkSurface> GetRootSurface() override;
 
@@ -75,6 +80,9 @@ class IOSSurfaceGL final : public IOSSurface,
 
   // |ExternalViewEmbedder|
   bool SubmitFrame(GrContext* context) override;
+
+  // |PlatformScreenShotProvider|
+  sk_sp<SkImage> TakeScreenShot() override;
 
  private:
   std::shared_ptr<IOSGLContext> context_;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -91,6 +91,14 @@ flutter::ExternalViewEmbedder* IOSSurfaceGL::GetExternalViewEmbedder() {
 }
 
 // |ExternalViewEmbedder|
+flutter::PlatformScreenShotProvider* IOSSurfaceGL::GetScreenShotProvider() {
+  if (IsIosEmbeddedViewsPreviewEnabled()) {
+    return this;
+  } else {
+    return nullptr;
+  }
+}
+
 void IOSSurfaceGL::CancelFrame() {
   FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
   FML_CHECK(platform_views_controller != nullptr);
@@ -149,6 +157,16 @@ bool IOSSurfaceGL::SubmitFrame(GrContext* context) {
   bool submitted = platform_views_controller->SubmitFrame(true, std::move(context), context_);
   [CATransaction commit];
   return submitted;
+}
+
+sk_sp<SkImage> IOSSurfaceGL::TakeScreenShot() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  if (platform_views_controller == nullptr) {
+    return nullptr;
+  }
+  UIView* flutter_view = platform_views_controller->GetFlutterView();
+  FML_CHECK(flutter_view != nil);
+  return TakeScreenShotForView(flutter_view);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -9,6 +9,7 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/gpu/gpu_surface_software.h"
+#include "flutter/shell/platform/darwin/ios/ios_screenshot_provider.h"
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
 
 @class CALayer;
@@ -17,7 +18,8 @@ namespace flutter {
 
 class IOSSurfaceSoftware final : public IOSSurface,
                                  public GPUSurfaceSoftwareDelegate,
-                                 public ExternalViewEmbedder {
+                                 public ExternalViewEmbedder,
+                                 public IOSScreenShotProvider {
  public:
   IOSSurfaceSoftware(fml::scoped_nsobject<CALayer> layer,
                      FlutterPlatformViewsController* platform_views_controller);
@@ -45,6 +47,9 @@ class IOSSurfaceSoftware final : public IOSSurface,
   // |GPUSurfaceSoftwareDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |GPUSurfaceSoftwareDelegate|
+  PlatformScreenShotProvider* GetScreenShotProvider() override;
+
   // |ExternalViewEmbedder|
   sk_sp<SkSurface> GetRootSurface() override;
 
@@ -66,6 +71,9 @@ class IOSSurfaceSoftware final : public IOSSurface,
 
   // |ExternalViewEmbedder|
   bool SubmitFrame(GrContext* context) override;
+
+  // |PlatformScreenShotProvider|
+  sk_sp<SkImage> TakeScreenShot() override;
 
  private:
   fml::scoped_nsobject<CALayer> layer_;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -135,6 +135,14 @@ ExternalViewEmbedder* IOSSurfaceSoftware::GetExternalViewEmbedder() {
   }
 }
 
+flutter::PlatformScreenShotProvider* IOSSurfaceSoftware::GetScreenShotProvider() {
+  if (IsIosEmbeddedViewsPreviewEnabled()) {
+    return this;
+  } else {
+    return nullptr;
+  }
+}
+
 // |ExternalViewEmbedder|
 sk_sp<SkSurface> IOSSurfaceSoftware::GetRootSurface() {
   // On iOS, the root surface is created using a managed allocation that is submitted to the
@@ -185,6 +193,17 @@ bool IOSSurfaceSoftware::SubmitFrame(GrContext* context) {
     return true;
   }
   return platform_views_controller->SubmitFrame(false, nullptr, nullptr);
+}
+
+// |flutter::PlatformScreenShotProvider|
+sk_sp<SkImage> IOSSurfaceSoftware::TakeScreenShot() {
+  FlutterPlatformViewsController* platform_views_controller = GetPlatformViewsController();
+  if (platform_views_controller == nullptr) {
+    return nullptr;
+  }
+  UIView* flutter_view = platform_views_controller->GetFlutterView();
+  FML_CHECK(flutter_view != nil);
+  return TakeScreenShotForView(flutter_view);
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -111,4 +111,9 @@ sk_sp<GrContext> EmbedderSurfaceGL::CreateResourceContext() const {
   return nullptr;
 }
 
+// |GPUSurfaceGLDelegate|
+PlatformScreenShotProvider* EmbedderSurfaceGL::GetScreenShotProvider() {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_surface_gl.h
+++ b/shell/platform/embedder/embedder_surface_gl.h
@@ -73,6 +73,9 @@ class EmbedderSurfaceGL final : public EmbedderSurface,
   // |GPUSurfaceGLDelegate|
   GLProcResolver GetGLProcResolver() const override;
 
+  // |GPUSurfaceGLDelegate|
+  PlatformScreenShotProvider* GetScreenShotProvider() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSurfaceGL);
 };
 

--- a/shell/platform/embedder/embedder_surface_software.cc
+++ b/shell/platform/embedder/embedder_surface_software.cc
@@ -111,4 +111,9 @@ ExternalViewEmbedder* EmbedderSurfaceSoftware::GetExternalViewEmbedder() {
   return external_view_embedder_.get();
 }
 
+// |GPUSurfaceSoftwareDelegate|
+PlatformScreenShotProvider* EmbedderSurfaceSoftware::GetScreenShotProvider() {
+  return nullptr;
+}
+
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_surface_software.h
+++ b/shell/platform/embedder/embedder_surface_software.h
@@ -50,6 +50,9 @@ class EmbedderSurfaceSoftware final : public EmbedderSurface,
   // |GPUSurfaceSoftwareDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 
+  // |GPUSurfaceSoftwareDelegate|
+  PlatformScreenShotProvider* GetScreenShotProvider() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderSurfaceSoftware);
 };
 


### PR DESCRIPTION
### Background: 
For platforms use a PlatformViewLayer(e.g iOS) that composite the UI using native APIs, the screenshot by Skia won't take account of the native UI. For example, screenshot with a webview will show blank in the window that displays the webview on iOS.
We need to have a way to take screenshots with PlatformViewLayer in the scene to unblock screenshot testing for iOS platform views. 

### What does this PR do:
Introduced a `PlatformScreenshotProvider` class to handle the screenshot using APIs from the platform instead of Skia if necessary.
Also added iOS implementation for the `PlatformScreenshotProvider.