### PR TITLE
Provide a placeholder queue ID for the custom embedder task runner.

### DIFF
--- a/shell/platform/embedder/embedder_task_runner.cc
+++ b/shell/platform/embedder/embedder_task_runner.cc
@@ -5,12 +5,15 @@
 #include "flutter/shell/platform/embedder/embedder_task_runner.h"
 
 #include "flutter/fml/message_loop_impl.h"
+#include "flutter/fml/message_loop_task_queues.h"
 
 namespace flutter {
 
 EmbedderTaskRunner::EmbedderTaskRunner(DispatchTable table)
     : TaskRunner(nullptr /* loop implemenation*/),
-      dispatch_table_(std::move(table)) {
+      dispatch_table_(std::move(table)),
+      placeholder_id_(
+          fml::MessageLoopTaskQueues::GetInstance()->CreateTaskQueue()) {
   FML_DCHECK(dispatch_table_.post_task_callback);
   FML_DCHECK(dispatch_table_.runs_task_on_current_thread_callback);
 }
@@ -67,6 +70,11 @@ bool EmbedderTaskRunner::PostTask(uint64_t baton) {
   FML_DCHECK(task);
   task();
   return true;
+}
+
+// |fml::TaskRunner|
+fml::TaskQueueId EmbedderTaskRunner::GetTaskQueueId() {
+  return placeholder_id_;
 }
 
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_task_runner.h
+++ b/shell/platform/embedder/embedder_task_runner.h
@@ -42,12 +42,16 @@ class EmbedderTaskRunner final : public fml::TaskRunner {
   // |fml::TaskRunner|
   bool RunsTasksOnCurrentThread() override;
 
+  // |fml::TaskRunner|
+  fml::TaskQueueId GetTaskQueueId() override;
+
  private:
   DispatchTable dispatch_table_;
   std::mutex tasks_mutex_;
   uint64_t last_baton_ FML_GUARDED_BY(tasks_mutex_);
   std::unordered_map<uint64_t, fml::closure> pending_tasks_
       FML_GUARDED_BY(tasks_mutex_);
+  fml::TaskQueueId placeholder_id_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTaskRunner);
 };


### PR DESCRIPTION
This issue would only manifest when a custom task runner was being used with
a custom compositor. Both were tested separately but not together. A new
test has been added for this. We still create the GPU thread merger
unnecessarily but I can patch that later. I also cleaned up the existing
custom task runner test to not submit tasks on a dead engine as they just
log errors unnecessarily.

Filed new: flutter/flutter#38844