### PR TITLE
Minor update to the Robolectric test harness

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -246,6 +246,7 @@ def RunJavaTests(filter, android_variant='android_debug_unopt'):
     '-Drobolectric.offline=true',
     '-Drobolectric.dependency.dir=' + robolectric_dir,
     '-classpath', ':'.join(classpath),
+    '-Drobolectric.logging=stdout',
     'org.junit.runner.JUnitCore',
     test_class
   ]


### PR DESCRIPTION
Make sure that any `android.util.Log`s during the tests are reported to
stdout.