### PR TITLE
More updates to the Robolectric test harness

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -449,6 +449,7 @@ action("robolectric_tests") {
   args += rebase_path(sources, root_build_dir)
 
   deps = [
+    ":android",
     ":flutter_shell_java",
   ]
 }


### PR DESCRIPTION
Previously the test wasn't correctly re-building the engine when its
files changed on multiple runs of `testing/run_tests.py`. It looks like
this is because the test build target wasn't depending on the entire
engine Android dependency, so some code changes were being ignored.
Update the build.