### PR TITLE
[dynamic_thread_merging] Resubmit only on the frame where the merge

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -182,10 +182,10 @@ PostPrerollResult FlutterPlatformViewsController::PostPrerollAction(
     } else {
       CancelFrame();
       gpu_thread_merger->MergeWithLease(kDefaultMergedLeaseDuration);
-      return PostPrerollResult::kSuccess;
+      return PostPrerollResult::kResubmitFrame;
     }
   }
-  return PostPrerollResult::kResubmitFrame;
+  return PostPrerollResult::kSuccess;
 }
 
 void FlutterPlatformViewsController::PrerollCompositeEmbeddedView(


### PR DESCRIPTION
I switched from boolean to enum to decide when to merge-unmerge the threads.

addresses: https://github.com/flutter/flutter/issues/38735