### PR TITLE
Omit removed declaredVariables parameter to ProgramCompiler

### DIFF
--- a/web_sdk/flutter_kernel_sdk.dart
+++ b/web_sdk/flutter_kernel_sdk.dart
@@ -74,11 +74,9 @@ Future main(List<String> args) async {
   await Directory(outputDir).create(recursive: true);
   await writeComponentToBinary(component, outputPath);
 
-  var jsModule = ProgramCompiler(
-      component,
-      compilerResult.classHierarchy,
-      SharedCompilerOptions(moduleName: 'dart_sdk'),
-      {}).emitModule(component, [], [], {});
+  var jsModule = ProgramCompiler(component, compilerResult.classHierarchy,
+          SharedCompilerOptions(moduleName: 'dart_sdk'))
+      .emitModule(component, [], [], {});
   var moduleFormats = {
     'amd': ModuleFormat.amd,
   };


### PR DESCRIPTION
Patch this in when rolling Dart SDK at commit https://github.com/dart-lang/sdk/commit/fb8df61606faf1564fbb53f53115017fc4d76483 or newer.