### PR TITLE
Re-enable firebase test and don't use google login

### DIFF
--- a/ci/firebase_testlab.sh
+++ b/ci/firebase_testlab.sh
@@ -35,4 +35,5 @@ gcloud --project flutter-infra firebase test android run \
   --app $1 \
   --timeout 2m \
   --results-bucket=gs://flutter_firebase_testlab \
-  --results-dir=engine_scenario_test/$GIT_REVISION/$BUILD_ID || exit 0
+  --results-dir=engine_scenario_test/$GIT_REVISION/$BUILD_ID \
+  --no-auto-google-login


### PR DESCRIPTION
Re-enable the test, and just skip the google login part - we don't need that for our tests, and it's the part that's failing currently on Firebase.