### PR TITLE
Reset NSNetService delegate to nil，when stop service.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterObservatoryPublisher.mm
@@ -80,6 +80,7 @@
   }
 #else   // TARGET_IPHONE_SIMULATOR
   [_netService.get() stop];
+  [_netService.get() setDelegate:nil];
 #endif  // TARGET_IPHONE_SIMULATOR
 }
 


### PR DESCRIPTION
Because the NSNetService's delegate is 'assign' property，we should reset it to nil when stop service.  Otherwise something unexpected happened. Like '__weak variable at 0x107489aa0 holds 0x113605fa0 instead of 0x1074e14e0. This is probably incorrect use of objc_storeWeak() and objc_loadWeak(). Break on objc_weak_error to debug.'