### PR TITLE
Flutter External Texture  Based On Share Texture Underlying Share Con…

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -539,6 +539,8 @@ FILE: ../../../flutter/shell/platform/android/android_environment_gl.h
 FILE: ../../../flutter/shell/platform/android/android_exports.lst
 FILE: ../../../flutter/shell/platform/android/android_external_texture_gl.cc
 FILE: ../../../flutter/shell/platform/android/android_external_texture_gl.h
+FILE: ../../../flutter/shell/platform/android/android_external_texture_gl_share_context.cc
+FILE: ../../../flutter/shell/platform/android/android_external_texture_gl_share_context.h
 FILE: ../../../flutter/shell/platform/android/android_native_window.cc
 FILE: ../../../flutter/shell/platform/android/android_native_window.h
 FILE: ../../../flutter/shell/platform/android/android_shell_holder.cc
@@ -775,6 +777,8 @@ FILE: ../../../flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_i
 FILE: ../../../flutter/shell/platform/darwin/ios/framework/module.modulemap
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_external_texture_gl.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_external_texture_gl.mm
+FILE: ../../../flutter/shell/platform/darwin/ios/ios_external_texture_gl_share_context.h
+FILE: ../../../flutter/shell/platform/darwin/ios/ios_external_texture_gl_share_context.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_gl_context.h
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_gl_context.mm
 FILE: ../../../flutter/shell/platform/darwin/ios/ios_gl_render_target.h

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -28,6 +28,8 @@ shared_library("flutter_shell_native") {
     "android_environment_gl.h",
     "android_external_texture_gl.cc",
     "android_external_texture_gl.h",
+    "android_external_texture_gl_share_context.cc",
+    "android_external_texture_gl_share_context.h",
     "android_native_window.cc",
     "android_native_window.h",
     "android_shell_holder.cc",

--- a/shell/platform/android/android_context_gl.cc
+++ b/shell/platform/android/android_context_gl.cc
@@ -272,4 +272,8 @@ bool AndroidContextGL::Resize(const SkISize& size) {
   return true;
 }
 
+EGLContext AndroidContextGL::GetShareContext() {
+  return context_;
+}
+
 }  // namespace flutter

--- a/shell/platform/android/android_context_gl.h
+++ b/shell/platform/android/android_context_gl.h
@@ -35,6 +35,8 @@ class AndroidContextGL : public fml::RefCountedThreadSafe<AndroidContextGL> {
 
   bool Resize(const SkISize& size);
 
+  EGLContext GetShareContext();
+
  private:
   fml::RefPtr<AndroidEnvironmentGL> environment_;
   fml::RefPtr<AndroidNativeWindow> window_;

--- a/shell/platform/android/android_external_texture_gl_share_context.cc
+++ b/shell/platform/android/android_external_texture_gl_share_context.cc
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/android/android_external_texture_gl_share_context.h"
+
+#include <GLES/glext.h>
+
+#include "flutter/shell/platform/android/platform_view_android_jni.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
+
+namespace flutter {
+
+AndroidExternalTextureShareContext::AndroidExternalTextureShareContext(
+    int64_t id,
+    int64_t shareTextureID)
+    : Texture(id), texture_id_(shareTextureID) {}
+
+AndroidExternalTextureShareContext::~AndroidExternalTextureShareContext() {}
+
+void AndroidExternalTextureShareContext::OnGrContextCreated() {}
+
+void AndroidExternalTextureShareContext::MarkNewFrameAvailable() {}
+
+void AndroidExternalTextureShareContext::Paint(SkCanvas& canvas,
+                                               const SkRect& bounds,
+                                               bool freeze,
+                                               GrContext* context) {
+  GrGLTextureInfo textureInfo = {GL_TEXTURE_EXTERNAL_OES, texture_id_,
+                                 GL_RGBA8_OES};
+
+  textureInfo.fTarget = GL_TEXTURE_2D;
+  transform.setIdentity();
+
+  GrBackendTexture backendTexture(1, 1, GrMipMapped::kNo, textureInfo);
+  sk_sp<SkImage> image = SkImage::MakeFromTexture(
+      canvas.getGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin,
+      kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
+  if (image) {
+    SkAutoCanvasRestore autoRestore(&canvas, true);
+    canvas.translate(bounds.x(), bounds.y());
+    canvas.scale(bounds.width(), bounds.height());
+    if (!transform.isIdentity()) {
+      SkMatrix transformAroundCenter(transform);
+
+      transformAroundCenter.preTranslate(-0.5, -0.5);
+      transformAroundCenter.postScale(1, -1);
+      transformAroundCenter.postTranslate(0.5, 0.5);
+      canvas.concat(transformAroundCenter);
+    }
+    canvas.drawImage(image, 0, 0);
+  }
+}
+
+void AndroidExternalTextureShareContext::OnGrContextDestroyed() {}
+}  // namespace flutter

--- a/shell/platform/android/android_external_texture_gl_share_context.h
+++ b/shell/platform/android/android_external_texture_gl_share_context.h
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_TEXTURE_SHARE_CONTEXT_H_
+#define FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_TEXTURE_SHARE_CONTEXT_H_
+
+#include <GLES/gl.h>
+#include "flutter/flow/texture.h"
+#include "flutter/fml/platform/android/jni_weak_ref.h"
+
+namespace flutter {
+
+class AndroidExternalTextureShareContext : public flutter::Texture {
+ public:
+  AndroidExternalTextureShareContext(int64_t id, int64_t shareTextureID);
+
+  ~AndroidExternalTextureShareContext() override;
+
+  void Paint(SkCanvas& canvas,
+             const SkRect& bounds,
+             bool freeze,
+             GrContext* context) override;
+
+  void OnGrContextCreated() override;
+
+  void OnGrContextDestroyed() override;
+
+  void MarkNewFrameAvailable() override;
+
+ private:
+  fml::jni::JavaObjectWeakGlobalRef surface_texture_;
+
+  GLuint texture_id_ = 0;
+
+  SkMatrix transform;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(AndroidExternalTextureShareContext);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_ANDROID_EXTERNAL_TEXTURE_GL_H_

--- a/shell/platform/android/android_surface.h
+++ b/shell/platform/android/android_surface.h
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include <EGL/egl.h>
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/android/jni_util.h"
 #include "flutter/fml/platform/android/jni_weak_ref.h"
@@ -36,6 +37,8 @@ class AndroidSurface {
   virtual bool ResourceContextClearCurrent() = 0;
 
   virtual bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) = 0;
+
+  virtual EGLContext GetShareContext() = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/android/android_surface_gl.cc
+++ b/shell/platform/android/android_surface_gl.cc
@@ -130,4 +130,7 @@ ExternalViewEmbedder* AndroidSurfaceGL::GetExternalViewEmbedder() {
   return nullptr;
 }
 
+EGLContext AndroidSurfaceGL::GetShareContext() {
+  return offscreen_context_->GetShareContext();
+}
 }  // namespace flutter

--- a/shell/platform/android/android_surface_gl.h
+++ b/shell/platform/android/android_surface_gl.h
@@ -46,6 +46,9 @@ class AndroidSurfaceGL final : public GPUSurfaceGLDelegate,
   // |AndroidSurface|
   bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
 
+  // |AndroidSurface|
+  EGLContext GetShareContext() override;
+
   // |GPUSurfaceGLDelegate|
   bool GLContextMakeCurrent() override;
 

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -159,4 +159,8 @@ bool AndroidSurfaceSoftware::SetNativeWindow(
   return true;
 }
 
+EGLContext AndroidSurfaceSoftware::GetShareContext() {
+  return 0;
+}
+
 }  // namespace flutter

--- a/shell/platform/android/android_surface_software.h
+++ b/shell/platform/android/android_surface_software.h
@@ -41,6 +41,9 @@ class AndroidSurfaceSoftware final : public AndroidSurface,
   // |AndroidSurface|
   bool SetNativeWindow(fml::RefPtr<AndroidNativeWindow> window) override;
 
+  // |AndroidSurface|
+  EGLContext GetShareContext() override;
+
   // |GPUSurfaceSoftwareDelegate|
   sk_sp<SkSurface> AcquireBackingStore(const SkISize& size) override;
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -14,6 +14,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
 import android.view.Surface;
 import android.view.SurfaceHolder;
+import android.opengl.EGLContext;
 
 import java.nio.ByteBuffer;
 import java.util.HashSet;
@@ -554,6 +555,23 @@ public class FlutterJNI {
   }
 
   private native void nativeRegisterTexture(long nativePlatformViewId, long textureId, @NonNull SurfaceTexture surfaceTexture);
+
+  
+  @UiThread
+  public void registerShareTexture(long texIndex, long shareTextureId) {
+    ensureAttachedToNative();
+    nativeRegisterShareTexture(nativePlatformViewId, texIndex, shareTextureId);
+  }
+  
+  private native void nativeRegisterShareTexture(long nativePlatformViewId, long texIndex, long shareTextureId);
+  
+  @UiThread
+  public EGLContext getShareContext(long sdkInt) {
+    ensureAttachedToNative();
+    return nativeGetShareContext(nativePlatformViewId,sdkInt);
+  }
+  
+  private native EGLContext nativeGetShareContext(long nativePlatformViewId,long sdkInt);
 
   /**
    * Call this method to inform Flutter that a texture previously registered with

--- a/shell/platform/android/io/flutter/view/TextureRegistry.java
+++ b/shell/platform/android/io/flutter/view/TextureRegistry.java
@@ -5,6 +5,7 @@
 package io.flutter.view;
 
 import android.graphics.SurfaceTexture;
+import android.opengl.EGLContext;
 
 /**
  * Registry of backend textures used with a single {@link FlutterView} instance.
@@ -36,6 +37,44 @@ public interface TextureRegistry {
 
         /**
          * Deregisters and releases this SurfaceTexture.
+         */
+        void release();
+    }
+  
+   /**
+   * Informs the the Flutter Engine that the external texture has been updated, and to start a new rendering pipeline.
+   */
+    void onShareFrameAvaliable(int textureIndex);
+  
+   /**
+   * The OpenGL context created in the Flutter Engine, which is safe to user for sharing
+   * Param: Android SDK version code
+   */
+    EGLContext getShareContext(long sdkInt);
+  
+   /**
+   * Create a ShareTextureEntry, and registers a External Texture in Flutter Engine
+   * The paramater is a OpenGL Texture ID
+   * Generally, this is used for users who process image frame with OpenGL(such as filter with GPUImage), and display the image frame using Flutter external texture
+   * Unlike SurfaceTexture, this can directly send the processed textures from OpenGL to flutter rendering pipeline.
+   * Avoid the performance consumption of data writing to SurfaceTexture
+   * Requirement: The OpenGL Texture should created in the EGLContext which is created using getShareContext(sdkInt) as a ShareContext
+   * @return A ShareTextureEntry.
+   */
+    ShareTextureEntry createShareTexture(long shareTextureID);
+  
+    /**
+     * A registry entry for a managed ShareTexture.
+     */
+    interface ShareTextureEntry {
+      
+        /**
+         * @return The identity of this ShareTexture.
+         */
+        long id();
+      
+        /**
+         * Deregisters and releases this ShareTexture.
          */
         void release();
     }

--- a/shell/platform/android/platform_view_android.cc
+++ b/shell/platform/android/platform_view_android.cc
@@ -11,6 +11,7 @@
 #include "flutter/shell/common/shell_io_manager.h"
 #include "flutter/shell/gpu/gpu_surface_gl_delegate.h"
 #include "flutter/shell/platform/android/android_external_texture_gl.h"
+#include "flutter/shell/platform/android/android_external_texture_gl_share_context.h"
 #include "flutter/shell/platform/android/android_surface_gl.h"
 #include "flutter/shell/platform/android/platform_message_response_android.h"
 #include "flutter/shell/platform/android/platform_view_android_jni.h"
@@ -374,6 +375,17 @@ void PlatformViewAndroid::RegisterExternalTexture(
     const fml::jni::JavaObjectWeakGlobalRef& surface_texture) {
   RegisterTexture(
       std::make_shared<AndroidExternalTextureGL>(texture_id, surface_texture));
+}
+
+void PlatformViewAndroid::RegisterExternalShareTexture(
+    int64_t texture_id,
+    int64_t share_texture_id) {
+  RegisterTexture(std::make_shared<AndroidExternalTextureShareContext>(
+      texture_id, share_texture_id));
+}
+
+EGLContext PlatformViewAndroid::GetShareContext() {
+  return android_surface_->GetShareContext();
 }
 
 // |PlatformView|

--- a/shell/platform/android/platform_view_android.h
+++ b/shell/platform/android/platform_view_android.h
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <EGL/egl.h>
 #include "flutter/fml/memory/weak_ptr.h"
 #include "flutter/fml/platform/android/jni_weak_ref.h"
 #include "flutter/fml/platform/android/scoped_java_ref.h"
@@ -72,6 +73,11 @@ class PlatformViewAndroid final : public PlatformView {
   void RegisterExternalTexture(
       int64_t texture_id,
       const fml::jni::JavaObjectWeakGlobalRef& surface_texture);
+
+  void RegisterExternalShareTexture(int64_t texture_id,
+                                    int64_t share_texture_id);
+
+  EGLContext GetShareContext();
 
  private:
   const fml::jni::JavaObjectWeakGlobalRef java_object_;

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -81,6 +81,8 @@ shared_library("create_flutter_framework_dylib") {
     "framework/Source/vsync_waiter_ios.mm",
     "ios_external_texture_gl.h",
     "ios_external_texture_gl.mm",
+    "ios_external_texture_gl_share_context.h",
+    "ios_external_texture_gl_share_context.mm",
     "ios_gl_context.h",
     "ios_gl_context.mm",
     "ios_gl_render_target.h",

--- a/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h
@@ -8,11 +8,21 @@
 #import <CoreMedia/CoreMedia.h>
 #import <Foundation/Foundation.h>
 
+#import <OpenGLES/EAGL.h>
 #include "FlutterMacros.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 FLUTTER_EXPORT
+@protocol FlutterShareTexture <NSObject>
+/*
+ *copy OpenGL Texture directly
+ *Returned Texture format should be GL_RGBA
+ *Returned Texture target should be GL_TEXTURE_2D
+ */
+- (GLuint)copyShareTexture;
+@end
+
 @protocol FlutterTexture <NSObject>
 - (CVPixelBufferRef _Nullable)copyPixelBuffer;
 @end
@@ -20,8 +30,10 @@ FLUTTER_EXPORT
 FLUTTER_EXPORT
 @protocol FlutterTextureRegistry <NSObject>
 - (int64_t)registerTexture:(NSObject<FlutterTexture>*)texture;
+- (int64_t)registerShareTexture:(NSObject<FlutterShareTexture>*)texture;
 - (void)textureFrameAvailable:(int64_t)textureId;
 - (void)unregisterTexture:(int64_t)textureId;
+- (EAGLSharegroup*)getShareGroup;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -554,12 +554,22 @@
   return textureId;
 }
 
+- (int64_t)registerShareTexture:(NSObject<FlutterShareTexture>*)texture {
+  int64_t textureId = _nextTextureId++;
+  self.iosPlatformView->RegisterExternalShareTexture(textureId, texture);
+  return textureId;
+}
+
 - (void)unregisterTexture:(int64_t)textureId {
   _shell->GetPlatformView()->UnregisterTexture(textureId);
 }
 
 - (void)textureFrameAvailable:(int64_t)textureId {
   _shell->GetPlatformView()->MarkTextureFrameAvailable(textureId);
+}
+
+- (EAGLSharegroup*)getShareGroup {
+  return self.iosPlatformView->GetGLShareGroup();
 }
 
 - (NSString*)lookupKeyForAsset:(NSString*)asset {

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1118,12 +1118,20 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
   return [_engine.get() registerTexture:texture];
 }
 
+- (int64_t)registerShareTexture:(NSObject<FlutterShareTexture>*)texture {
+  return [_engine.get() registerShareTexture:texture];
+}
+
 - (void)unregisterTexture:(int64_t)textureId {
   [_engine.get() unregisterTexture:textureId];
 }
 
 - (void)textureFrameAvailable:(int64_t)textureId {
   [_engine.get() textureFrameAvailable:textureId];
+}
+
+- (id)getShareGroup {
+  return [_engine.get() getShareGroup];
 }
 
 - (NSString*)lookupKeyForAsset:(NSString*)asset {

--- a/shell/platform/darwin/ios/ios_external_texture_gl_share_context.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl_share_context.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_SHARE_CONTEXT_H_
+#define FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_SHARE_CONTEXT_H_
+
+#include "flutter/flow/texture.h"
+#include "flutter/fml/platform/darwin/cf_utils.h"
+#include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterTexture.h"
+
+namespace flutter {
+
+class IOSExternalTextureShareContext : public flutter::Texture {
+ public:
+  IOSExternalTextureShareContext(int64_t textureId, NSObject<FlutterShareTexture>* externalTexture);
+
+  ~IOSExternalTextureShareContext() override;
+
+  // Called from GPU thread.
+  void Paint(SkCanvas& canvas, const SkRect& bounds, bool freeze, GrContext* context) override;
+
+  void OnGrContextCreated() override;
+
+  void OnGrContextDestroyed() override;
+
+  void MarkNewFrameAvailable() override;
+
+ private:
+  NSObject<FlutterShareTexture>* external_texture_;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureShareContext);
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_IOS_EXTERNAL_TEXTURE_SHARE_CONTEXT_H_

--- a/shell/platform/darwin/ios/ios_external_texture_gl_share_context.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl_share_context.mm
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/darwin/ios/ios_external_texture_gl_share_context.h"
+
+#import <OpenGLES/EAGL.h>
+#import <OpenGLES/ES2/gl.h>
+#import <OpenGLES/ES2/glext.h>
+
+#include "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
+#include "third_party/skia/include/core/SkSurface.h"
+#include "third_party/skia/include/gpu/GrBackendSurface.h"
+
+namespace flutter {
+
+IOSExternalTextureShareContext::IOSExternalTextureShareContext(
+    int64_t textureId,
+    NSObject<FlutterShareTexture>* externalTexture)
+    : Texture(textureId), external_texture_(externalTexture) {
+  FML_DCHECK(external_texture_);
+}
+
+IOSExternalTextureShareContext::~IOSExternalTextureShareContext() = default;
+
+void IOSExternalTextureShareContext::Paint(SkCanvas& canvas,
+                                           const SkRect& bounds,
+                                           bool freeze,
+                                           GrContext* context) {
+  GLuint texture_id = [external_texture_ copyShareTexture];
+  if (texture_id == 0) {
+    return;
+  }
+  GrGLTextureInfo textureInfo;
+  textureInfo.fFormat = GL_RGBA8_OES;
+  textureInfo.fID = texture_id;
+  textureInfo.fTarget = GL_TEXTURE_2D;
+
+  GrBackendTexture backendTexture(bounds.width(), bounds.height(), GrMipMapped::kNo, textureInfo);
+  printf("paint test back\n");
+  sk_sp<SkImage> image =
+      SkImage::MakeFromTexture(context, backendTexture, kTopLeft_GrSurfaceOrigin,
+                               kRGBA_8888_SkColorType, kPremul_SkAlphaType, nullptr);
+  FML_DCHECK(image) << "Failed to create SkImage from Texture.";
+  if (image) {
+    canvas.drawImage(image, bounds.x(), bounds.y());
+  }
+}
+
+void IOSExternalTextureShareContext::OnGrContextCreated() {}
+
+void IOSExternalTextureShareContext::OnGrContextDestroyed() {}
+
+void IOSExternalTextureShareContext::MarkNewFrameAvailable() {}
+
+}  // namespace flutter

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -32,6 +32,8 @@ class IOSGLContext {
 
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 
+  EAGLSharegroup* GetGLShareGroup();
+
  private:
   fml::scoped_nsobject<EAGLContext> context_;
   fml::scoped_nsobject<EAGLContext> resource_context_;

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -60,4 +60,9 @@ bool IOSGLContext::ResourceMakeCurrent() {
   return [EAGLContext setCurrentContext:resource_context_.get()];
 }
 
+EAGLSharegroup* IOSGLContext::GetGLShareGroup() {
+  EAGLSharegroup* shareGroup = context_.get().sharegroup;
+  return shareGroup;
+}
+
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface.h
+++ b/shell/platform/darwin/ios/ios_surface.h
@@ -39,6 +39,8 @@ class IOSSurface {
   virtual std::unique_ptr<Surface> CreateGPUSurface(
       GrContext* gr_context = nullptr) = 0;
 
+  virtual EAGLSharegroup* GetGLShareGroup() = 0;
+
  protected:
   FlutterPlatformViewsController* GetPlatformViewsController();
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -50,6 +50,8 @@ class IOSSurfaceGL final : public IOSSurface,
 
   bool UseOffscreenSurface() const override;
 
+  EAGLSharegroup* GetGLShareGroup() override;
+
   // |GPUSurfaceGLDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -73,6 +73,10 @@ bool IOSSurfaceGL::GLContextPresent() {
   return IsValid() && render_target_->PresentRenderBuffer();
 }
 
+EAGLSharegroup* IOSSurfaceGL::GetGLShareGroup() {
+  return context_.get()->GetGLShareGroup();
+}
+
 // |ExternalViewEmbedder|
 sk_sp<SkSurface> IOSSurfaceGL::GetRootSurface() {
   // On iOS, the root surface is created from the on-screen render target. Only the surfaces for the

--- a/shell/platform/darwin/ios/ios_surface_software.h
+++ b/shell/platform/darwin/ios/ios_surface_software.h
@@ -36,6 +36,9 @@ class IOSSurfaceSoftware final : public IOSSurface,
   // |IOSSurface|
   std::unique_ptr<Surface> CreateGPUSurface(GrContext* gr_context = nullptr) override;
 
+  // |IOSSurface|
+  EAGLSharegroup* GetGLShareGroup() override;
+
   // |GPUSurfaceSoftwareDelegate|
   sk_sp<SkSurface> AcquireBackingStore(const SkISize& size) override;
 

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -38,6 +38,10 @@ void IOSSurfaceSoftware::UpdateStorageSizeIfNecessary() {
   // Android oddities.
 }
 
+EAGLSharegroup* IOSSurfaceSoftware::GetGLShareGroup() {
+  return nullptr;
+}
+
 std::unique_ptr<Surface> IOSSurfaceSoftware::CreateGPUSurface(GrContext* gr_context) {
   if (!IsValid()) {
     return nullptr;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -37,12 +37,16 @@ class PlatformViewIOS final : public PlatformView {
 
   void RegisterExternalTexture(int64_t id, NSObject<FlutterTexture>* texture);
 
+  void RegisterExternalShareTexture(int64_t id, NSObject<FlutterShareTexture>* texture);
+
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> GetTextInputPlugin() const;
 
   void SetTextInputPlugin(fml::scoped_nsprotocol<FlutterTextInputPlugin*> plugin);
 
   // |PlatformView|
   void SetSemanticsEnabled(bool enabled) override;
+
+  EAGLSharegroup* GetGLShareGroup();
 
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -16,6 +16,7 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.h"
 #include "flutter/shell/platform/darwin/ios/ios_external_texture_gl.h"
+#include "flutter/shell/platform/darwin/ios/ios_external_texture_gl_share_context.h"
 
 namespace flutter {
 
@@ -69,6 +70,17 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
 void PlatformViewIOS::RegisterExternalTexture(int64_t texture_id,
                                               NSObject<FlutterTexture>* texture) {
   RegisterTexture(std::make_shared<IOSExternalTextureGL>(texture_id, texture));
+}
+
+void PlatformViewIOS::RegisterExternalShareTexture(int64_t texture_id,
+                                                   NSObject<FlutterShareTexture>* texture) {
+  RegisterTexture(std::make_shared<IOSExternalTextureShareContext>(texture_id, texture));
+}
+
+EAGLSharegroup* PlatformViewIOS::GetGLShareGroup() {
+  if (ios_surface_.get() == NULL)
+    return NULL;
+  return ios_surface_->GetGLShareGroup();
 }
 
 // |PlatformView|


### PR DESCRIPTION
Currently, external textures are very differently on iOS (CoreVideo) and Android (GL_OES_EGL_image_external).
In China, Portrait beauty effects are basically a must-have for a camera tool. We process our video frame on the GPU to generate a texture to be rendered. If flutter needs to display this texture, it requires a GPU->CPU->GPU process, wasting performance.
So we need to process the CoreVideo pixel buffer using OpenGL and give Flutter that texture directly instead of the pixel buffer
So we added an interface to Get Flutter GLContext on our Flutter branch. Based on this modification, we implemented the Flutter plugins such as Album, Video Capture, Video Editor.
And those plugins has been used by hundreds of millions of users on the Xianyu APP to verify its effectiveness。
We hope we can merge this change back to the flutter master so that more develop can use our plugins to develop video App。