### PR TITLE
Fix objects equal to null not being detected as null

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
+++ b/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java
@@ -221,7 +221,7 @@ public class StandardMessageCodec implements MessageCodec<Object> {
      * super for values that the extension does not handle.</p>
      */
     protected void writeValue(ByteArrayOutputStream stream, Object value) {
-        if (value == null) {
+        if (value == null || value.equals(null)) {
             stream.write(NULL);
         } else if (value == Boolean.TRUE) {
             stream.write(TRUE);


### PR DESCRIPTION
This PR fixes https://github.com/flutter/flutter/issues/37681 by allowing objects equal to null to be used in the StandardMessageCodec, since JSONObject.NULL.equals(null) is true