### PR TITLE
Do not Prepare raster_cache if view_embedder is present

### DIFF
--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -46,7 +46,7 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   set_paint_bounds(paint_bounds().makeOffset(offset_.fX, offset_.fY));
   // See |EnsureSingleChild|.
   FML_DCHECK(layers().size() == 1);
-  if (context->raster_cache &&
+  if (context->view_embedder == nullptr && context->raster_cache &&
       SkRect::Intersects(context->cull_rect, paint_bounds())) {
     Layer* child = layers()[0].get();
     SkMatrix ctm = child_matrix;


### PR DESCRIPTION
Performance improvement as we do not use the cache in `Paint`.

RasterCache <-> PlatformViews interaction will be improved by: https://github.com/flutter/flutter/issues/38903