### PR TITLE
Set FlutterMacOS podspec min version to 10.11

### DIFF
--- a/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
+++ b/shell/platform/darwin/macos/framework/FlutterMacOS.podspec
@@ -13,7 +13,6 @@ Flutter is Google's portable UI toolkit for building beautiful, natively-compile
   s.license          = { :type => 'MIT' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-  # TODO: Decide what value should be here. See #33200.
-  s.osx.deployment_target = '10.12'
+  s.osx.deployment_target = '10.11'
   s.vendored_frameworks = 'FlutterMacOS.framework'
 end


### PR DESCRIPTION
The framework is built using 10.11 as the deployment version; update the
podspec accordingly.

See https://github.com/flutter/flutter/issues/33200