### PR TITLE
[lsc] Remove fuchsia.net.SocketProvider

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
@@ -10,9 +10,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracing.provider.Registry"
         ]

--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
@@ -10,9 +10,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracing.provider.Registry"
         ]

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
@@ -10,9 +10,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.process.Launcher",
             "fuchsia.process.Resolver",
             "fuchsia.timezone.Timezone",

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
@@ -10,9 +10,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.logger.LogSink",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.process.Launcher",
             "fuchsia.process.Resolver",
             "fuchsia.timezone.Timezone",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -11,9 +11,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.fonts.Provider",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -11,9 +11,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.fonts.Provider",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -11,9 +11,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.fonts.Provider",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracing.provider.Registry",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -11,9 +11,8 @@
         "services": [
             "fuchsia.crash.Analyzer",
             "fuchsia.fonts.Provider",
-            "fuchsia.posix.socket.Provider",
             "fuchsia.net.NameLookup",
-            "fuchsia.net.SocketProvider",
+            "fuchsia.posix.socket.Provider",
             "fuchsia.sysmem.Allocator",
             "fuchsia.timezone.Timezone",
             "fuchsia.tracing.provider.Registry",


### PR DESCRIPTION
fuchsia.net.SocketProvider has been replaced with fuchsia.net.NameLookup
and fuchsia.posix.socket.Provider.

@cbracken this was done in topaz in https://fuchsia.googlesource.com/topaz/+/a54ab50efb6186b3d6f73f12ca6b2b83230bf615.