### PR TITLE
Clean up Windows and Linux build output

### DIFF
--- a/shell/platform/glfw/client_wrapper/BUILD.gn
+++ b/shell/platform/glfw/client_wrapper/BUILD.gn
@@ -44,14 +44,6 @@ source_set("client_wrapper_glfw") {
   ]
 }
 
-# Copies the GLFW client wrapper code to the output directory in the legacy
-# unsuffixed location.
-# TODO: Remove this copy once build recipes are using the _glfw version below.
-publish_client_wrapper_extension("publish_wrapper_unprefixed") {
-  public = _wrapper_includes
-  sources = _wrapper_sources
-}
-
 # Copies the GLFW client wrapper code to the output directory with a _glfw
 # suffix.
 publish_client_wrapper_extension("publish_wrapper_glfw") {

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -13,7 +13,6 @@ group("linux") {
       ":flutter_linux_glfw",
       "$flutter_root/shell/platform/glfw:publish_headers_glfw",
       "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
-      "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_unprefixed",
     ]
   }
 }

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -9,7 +9,6 @@ import("$flutter_root/shell/platform/glfw/config.gni")
 group("linux") {
   if (build_glfw_shell) {
     deps = [
-      ":flutter_linux",
       ":flutter_linux_glfw",
       "$flutter_root/shell/platform/glfw:publish_headers_glfw",
       "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
@@ -28,18 +27,6 @@ config("disable_fatal_link_warnings") {
 }
 
 if (build_glfw_shell) {
-  # TODO: Remove this target once the _glfw copy is being uploaded instead. See
-  # https://github.com/flutter/flutter/issues/38589
-  shared_library("flutter_linux") {
-    deps = [
-      "$flutter_root/shell/platform/glfw:flutter_glfw",
-    ]
-
-    configs += [ ":disable_fatal_link_warnings" ]
-
-    public_configs = [ "$flutter_root:config" ]
-  }
-
   shared_library("flutter_linux_glfw") {
     deps = [
       "$flutter_root/shell/platform/glfw:flutter_glfw",

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -92,19 +92,9 @@ copy("publish_headers_windows") {
   ]
 }
 
-shared_library("flutter_windows_win32") {
-  deps = [
-    ":flutter_windows_source",
-  ]
-
-  public_configs = [ "$flutter_root:config" ]
-}
-
-# TODO: Remove this target once the _glfw copy is being uploaded instead. See
-# https://github.com/flutter/flutter/issues/38589
 shared_library("flutter_windows") {
   deps = [
-    "$flutter_root/shell/platform/glfw:flutter_glfw",
+    ":flutter_windows_source",
   ]
 
   public_configs = [ "$flutter_root:config" ]
@@ -118,14 +108,6 @@ shared_library("flutter_windows_glfw") {
   public_configs = [ "$flutter_root:config" ]
 }
 
-group("windows_win32") {
-  deps = [
-    ":flutter_windows_win32",
-    ":publish_headers_windows",
-    "$flutter_root/shell/platform/windows/client_wrapper:publish_wrapper_windows",
-  ]
-}
-
 group("windows_glfw") {
   deps = [
     ":flutter_windows",
@@ -137,7 +119,9 @@ group("windows_glfw") {
 
 group("windows") {
   deps = [
-    ":windows_win32",
+    ":flutter_windows",
+    ":publish_headers_windows",
+    "$flutter_root/shell/platform/windows/client_wrapper:publish_wrapper_windows",
   ]
   if (build_glfw_shell) {
     deps += [ ":windows_glfw" ]

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -132,7 +132,6 @@ group("windows_glfw") {
     ":flutter_windows_glfw",
     "$flutter_root/shell/platform/glfw:publish_headers_glfw",
     "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
-    "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_unprefixed",
   ]
 }
 

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -40,12 +40,10 @@ source_set("client_wrapper_windows") {
   ]
 }
 
-# Copies the Windows client wrapper code to the output directory with a _windows
-# suffix.
+# Copies the Windows client wrapper code to the output directory.
 publish_client_wrapper_extension("publish_wrapper_windows") {
   public = _wrapper_includes
   sources = _wrapper_sources
-  directory_suffix = "windows"
 }
 
 source_set("client_wrapper_library_stubs_windows") {


### PR DESCRIPTION
Final portion of reworking the names of the Linux and Windows desktop build outputs.

See https://github.com/flutter/flutter/issues/38589