### PR TITLE
Switch to an incremental runloop for GLFW

### DIFF
--- a/build/install-build-deps-linux-desktop.sh
+++ b/build/install-build-deps-linux-desktop.sh
@@ -8,4 +8,4 @@
 
 set -e
 
-sudo apt-get -y install libgtk-3-dev libx11-dev
+sudo apt-get -y install libx11-dev

--- a/shell/platform/glfw/BUILD.gn
+++ b/shell/platform/glfw/BUILD.gn
@@ -64,7 +64,6 @@ source_set("flutter_glfw") {
     libs = [ "GL" ]
 
     configs += [
-      "$flutter_root/shell/platform/linux/config:gtk3",
       "$flutter_root/shell/platform/linux/config:x11",
     ]
   } else if (is_mac) {

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
@@ -5,11 +5,12 @@
 #ifndef FLUTTER_SHELL_PLATFORM_GLFW_CLIENT_WRAPPER_INCLUDE_FLUTTER_FLUTTER_WINDOW_CONTROLLER_H_
 #define FLUTTER_SHELL_PLATFORM_GLFW_CLIENT_WRAPPER_INCLUDE_FLUTTER_FLUTTER_WINDOW_CONTROLLER_H_
 
+#include <flutter_glfw.h>
+
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
-
-#include <flutter_glfw.h>
 
 #include "flutter_window.h"
 #include "plugin_registrar.h"
@@ -67,7 +68,14 @@ class FlutterWindowController {
   // before CreateWindow is called, and after RunEventLoop returns;
   FlutterWindow* window() { return window_.get(); }
 
-  // Loops on Flutter window events until the window closes.
+  // Processes the next event on this window, or returns early if |timeout| is
+  // reached before the next event.
+  //
+  // Returns false if the window was closed as a result of event processing.
+  bool RunEventLoopWithTimeout(
+      std::chrono::milliseconds timeout = std::chrono::milliseconds::max());
+
+  // Deprecated. Use RunEventLoopWithTimeout.
   void RunEventLoop();
 
  private:

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -121,10 +121,14 @@ double FlutterDesktopWindowGetScaleFactor(
   return 1.0;
 }
 
-void FlutterDesktopRunWindowLoop(FlutterDesktopWindowControllerRef controller) {
+bool FlutterDesktopRunWindowEventLoopWithTimeout(
+    FlutterDesktopWindowControllerRef controller,
+    uint32_t millisecond_timeout) {
   if (s_stub_implementation) {
-    s_stub_implementation->RunWindowLoop();
+    return s_stub_implementation->RunWindowEventLoopWithTimeout(
+        millisecond_timeout);
   }
+  return true;
 }
 
 FlutterDesktopEngineRef FlutterDesktopRunEngine(const char* assets_path,

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -70,8 +70,10 @@ class StubFlutterGlfwApi {
   // Called for FlutterDesktopWindowGetScaleFactor.
   virtual double GetWindowScaleFactor() { return 1.0; }
 
-  // Called for FlutterDesktopRunWindowLoop.
-  virtual void RunWindowLoop() {}
+  // Called for FlutterDesktopRunWindowEventLoopWithTimeout.
+  virtual bool RunWindowEventLoopWithTimeout(uint32_t millisecond_timeout) {
+    return true;
+  }
 
   // Called for FlutterDesktopRunEngine.
   virtual FlutterDesktopEngineRef RunEngine(const char* assets_path,

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -50,10 +50,9 @@ FLUTTER_EXPORT void FlutterDesktopTerminate();
 // for details. Not all arguments will apply to desktop.
 //
 // Returns a null pointer in the event of an error. Otherwise, the pointer is
-// valid until FlutterDesktopRunWindowLoop has been called and returned, or
-// FlutterDesktopDestroyWindow is called.
+// valid until FlutterDesktopDestroyWindow is called.
 // Note that calling FlutterDesktopCreateWindow without later calling
-// one of those two methods on the returned reference is a memory leak.
+// FlutterDesktopDestroyWindow on the returned reference is a memory leak.
 FLUTTER_EXPORT FlutterDesktopWindowControllerRef
 FlutterDesktopCreateWindow(int initial_width,
                            int initial_height,
@@ -70,15 +69,17 @@ FlutterDesktopCreateWindow(int initial_width,
 FLUTTER_EXPORT void FlutterDesktopDestroyWindow(
     FlutterDesktopWindowControllerRef controller);
 
-// Loops on Flutter window events until the window is closed.
+// Waits for and processes the next event before |timeout_milliseconds|.
 //
-// Once this function returns, |controller| is no longer valid, and must not be
-// be used again, as it calls FlutterDesktopDestroyWindow internally.
+// If |timeout_milliseconds| is zero, it will wait for the next event
+// indefinitely. A non-zero timeout is needed only if processing unrelated to
+// the event loop is necessary (e.g., to handle events from another source).
 //
-// TODO: Replace this with a method that allows running the runloop
-// incrementally.
-FLUTTER_EXPORT void FlutterDesktopRunWindowLoop(
-    FlutterDesktopWindowControllerRef controller);
+// Returns false if the window should be closed as a result of the last event
+// processed.
+FLUTTER_EXPORT bool FlutterDesktopRunWindowEventLoopWithTimeout(
+    FlutterDesktopWindowControllerRef controller,
+    uint32_t timeout_milliseconds);
 
 // Returns the window handle for the window associated with
 // FlutterDesktopWindowControllerRef.

--- a/shell/platform/linux/config/BUILD.gn
+++ b/shell/platform/linux/config/BUILD.gn
@@ -4,10 +4,6 @@
 
 import("//build/config/linux/pkg_config.gni")
 
-pkg_config("gtk3") {
-  packages = [ "gtk+-3.0" ]
-}
-
 pkg_config("x11") {
   packages = [ "x11" ]
 }


### PR DESCRIPTION
Rather than running the runloop forever, have the API expose an incremental runloop. This allows clients to do other processing if they need it.

This allows for removing the odd construction of having knowledge of GTK event handling built into the library even though nothing in the library uses it; instead runner applications that use GTK plugins (such as FDE's testbed) can do that processing at the application level instead.