### PR TITLE
Use App.framework in macOS FlutterDartProject

### DIFF
--- a/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h
@@ -23,8 +23,8 @@ FLUTTER_EXPORT
  * The bundle must either contain a flutter_assets resource directory, or set the Info.plist key
  * FLTAssetsPath to override that name (if you are doing a custom build using a different name).
  *
- * @param bundle The bundle containing the Flutter assets directory. If nil, the main bundle is
- *               used.
+ * @param bundle The bundle containing the Flutter assets directory. If nil, the App framework
+ *               created by Flutter will be used.
  */
 - (nonnull instancetype)initWithPrecompiledDartBundle:(nullable NSBundle*)bundle
     NS_DESIGNATED_INITIALIZER;

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -8,9 +8,10 @@
 #include <vector>
 
 static NSString* const kICUBundlePath = @"icudtl.dat";
+static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
 
 @implementation FlutterDartProject {
-  NSBundle* _bundle;
+  NSBundle* _dartBundle;
 }
 
 - (instancetype)init {
@@ -21,16 +22,18 @@ static NSString* const kICUBundlePath = @"icudtl.dat";
   self = [super init];
   NSAssert(self, @"Super init cannot be nil");
 
-  _bundle = bundle ?: [NSBundle mainBundle];
+  _dartBundle = bundle ?: [NSBundle bundleWithIdentifier:kAppBundleIdentifier];
   return self;
 }
 
 - (NSString*)assetsPath {
-  NSString* flutterAssetsName = [_bundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
+  // If there's no App.framework, fall back to checking the main bundle for assets.
+  NSBundle* assetBundle = _dartBundle ?: [NSBundle mainBundle];
+  NSString* flutterAssetsName = [assetBundle objectForInfoDictionaryKey:@"FLTAssetsPath"];
   if (flutterAssetsName == nil) {
     flutterAssetsName = @"flutter_assets";
   }
-  NSString* path = [_bundle pathForResource:flutterAssetsName ofType:@""];
+  NSString* path = [_dartBundle pathForResource:flutterAssetsName ofType:@""];
   if (!path) {
     NSLog(@"Failed to find path for \"%@\"", flutterAssetsName);
   }


### PR DESCRIPTION
Adds initial use of App.framework in the macOS project configuration,
using that rather than the main bundle as the default Dart bundle, and
expecting flutter_resources to be located there.

This is an incremental step toward aligning with the behvaior of the iOS
version of this class.

Fixes https://github.com/flutter/flutter/issues/38363