### PR TITLE
Allow non-resizable windows in GLFW embedding

### DIFF
--- a/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
@@ -25,9 +25,7 @@ FlutterWindowController::~FlutterWindowController() {
 }
 
 bool FlutterWindowController::CreateWindow(
-    int width,
-    int height,
-    const std::string& title,
+    const WindowProperties& window_properties,
     const std::string& assets_path,
     const std::vector<std::string>& arguments) {
   if (!init_succeeded_) {
@@ -41,15 +39,26 @@ bool FlutterWindowController::CreateWindow(
     return false;
   }
 
-  std::vector<const char*> engine_arguments;
-  std::transform(
-      arguments.begin(), arguments.end(), std::back_inserter(engine_arguments),
-      [](const std::string& arg) -> const char* { return arg.c_str(); });
-  size_t arg_count = engine_arguments.size();
+  FlutterDesktopWindowProperties c_window_properties = {};
+  c_window_properties.title = window_properties.title.c_str();
+  c_window_properties.width = window_properties.width;
+  c_window_properties.height = window_properties.height;
+  c_window_properties.prevent_resize = window_properties.prevent_resize;
 
-  controller_ = FlutterDesktopCreateWindow(
-      width, height, title.c_str(), assets_path.c_str(), icu_data_path_.c_str(),
-      arg_count > 0 ? &engine_arguments[0] : nullptr, arg_count);
+  FlutterDesktopEngineProperties c_engine_properties = {};
+  c_engine_properties.assets_path = assets_path.c_str();
+  c_engine_properties.icu_data_path = icu_data_path_.c_str();
+  std::vector<const char*> engine_switches;
+  std::transform(
+      arguments.begin(), arguments.end(), std::back_inserter(engine_switches),
+      [](const std::string& arg) -> const char* { return arg.c_str(); });
+  if (engine_switches.size() > 0) {
+    c_engine_properties.switches = &engine_switches[0];
+    c_engine_properties.switches_count = engine_switches.size();
+  }
+
+  controller_ =
+      FlutterDesktopCreateWindow(c_window_properties, c_engine_properties);
   if (!controller_) {
     std::cerr << "Failed to create window." << std::endl;
     return false;

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
@@ -17,6 +17,19 @@
 
 namespace flutter {
 
+// Properties for Flutter window creation.
+struct WindowProperties {
+  // The display title.
+  std::string title;
+  // Width in screen coordinates.
+  int32_t width;
+  // Height in screen coordinates.
+  int32_t height;
+  // Whether or not the user is prevented from resizing the window.
+  // Reversed so that the default for a cleared struct is to allow resizing.
+  bool prevent_resize;
+};
+
 // A controller for a window displaying Flutter content.
 //
 // This is the primary wrapper class for the desktop C API.
@@ -51,9 +64,7 @@ class FlutterWindowController {
   // for details. Not all arguments will apply to desktop.
   //
   // Only one Flutter window can exist at a time; see constructor comment.
-  bool CreateWindow(int width,
-                    int height,
-                    const std::string& title,
+  bool CreateWindow(const WindowProperties& window_properties,
                     const std::string& assets_path,
                     const std::vector<std::string>& arguments);
 

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -49,17 +49,11 @@ void FlutterDesktopTerminate() {
 }
 
 FlutterDesktopWindowControllerRef FlutterDesktopCreateWindow(
-    int initial_width,
-    int initial_height,
-    const char* title,
-    const char* assets_path,
-    const char* icu_data_path,
-    const char** arguments,
-    size_t argument_count) {
+    const FlutterDesktopWindowProperties& window_properties,
+    const FlutterDesktopEngineProperties& engine_properties) {
   if (s_stub_implementation) {
-    return s_stub_implementation->CreateWindow(
-        initial_width, initial_height, title, assets_path, icu_data_path,
-        arguments, argument_count);
+    return s_stub_implementation->CreateWindow(window_properties,
+                                               engine_properties);
   }
   return nullptr;
 }
@@ -131,13 +125,10 @@ bool FlutterDesktopRunWindowEventLoopWithTimeout(
   return true;
 }
 
-FlutterDesktopEngineRef FlutterDesktopRunEngine(const char* assets_path,
-                                                const char* icu_data_path,
-                                                const char** arguments,
-                                                size_t argument_count) {
+FlutterDesktopEngineRef FlutterDesktopRunEngine(
+    const FlutterDesktopEngineProperties& properties) {
   if (s_stub_implementation) {
-    return s_stub_implementation->RunEngine(assets_path, icu_data_path,
-                                            arguments, argument_count);
+    return s_stub_implementation->RunEngine(properties);
   }
   return nullptr;
 }

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -37,13 +37,8 @@ class StubFlutterGlfwApi {
 
   // Called for FlutterDesktopCreateWindow.
   virtual FlutterDesktopWindowControllerRef CreateWindow(
-      int initial_width,
-      int initial_height,
-      const char* title,
-      const char* assets_path,
-      const char* icu_data_path,
-      const char** arguments,
-      size_t argument_count) {
+      const FlutterDesktopWindowProperties& window_properties,
+      const FlutterDesktopEngineProperties& engine_properties) {
     return nullptr;
   }
 
@@ -76,10 +71,8 @@ class StubFlutterGlfwApi {
   }
 
   // Called for FlutterDesktopRunEngine.
-  virtual FlutterDesktopEngineRef RunEngine(const char* assets_path,
-                                            const char* icu_data_path,
-                                            const char** arguments,
-                                            size_t argument_count) {
+  virtual FlutterDesktopEngineRef RunEngine(
+      const FlutterDesktopEngineProperties& properties) {
     return nullptr;
   }
 

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -26,6 +26,34 @@ typedef struct FlutterDesktopWindow* FlutterDesktopWindowRef;
 // Opaque reference to a Flutter engine instance.
 typedef struct FlutterDesktopEngineState* FlutterDesktopEngineRef;
 
+// Properties for configuring a Flutter engine instance.
+typedef struct {
+  // The path to the flutter_assets folder for the application to be run.
+  const char* assets_path;
+  // The path to the icudtl.dat file for the version of Flutter you are using.
+  const char* icu_data_path;
+  // The switches to pass to the Flutter engine.
+  //
+  // See: https://github.com/flutter/engine/blob/master/shell/common/switches.h
+  // for details. Not all arguments will apply to desktop.
+  const char** switches;
+  // The number of elements in |switches|.
+  size_t switches_count;
+} FlutterDesktopEngineProperties;
+
+// Properties for configuring the initial settings of a Flutter window.
+typedef struct {
+  // The display title.
+  const char* title;
+  // Width in screen coordinates.
+  int32_t width;
+  // Height in screen coordinates.
+  int32_t height;
+  // Whether or not the user is prevented from resizing the window.
+  // Reversed so that the default for a cleared struct is to allow resizing.
+  bool prevent_resize;
+} FlutterDesktopWindowProperties;
+
 // Sets up the library's graphic context. Must be called before any other
 // methods.
 //
@@ -41,26 +69,16 @@ FLUTTER_EXPORT void FlutterDesktopTerminate();
 //
 // FlutterDesktopInit() must be called prior to this function.
 //
-// The |assets_path| is the path to the flutter_assets folder for the Flutter
-// application to be run. |icu_data_path| is the path to the icudtl.dat file
-// for the version of Flutter you are using.
-//
-// The |arguments| are passed to the Flutter engine. See:
-// https://github.com/flutter/engine/blob/master/shell/common/switches.h for
-// for details. Not all arguments will apply to desktop.
+// This will set up and run an associated Flutter engine using the settings in
+// |engine_properties|.
 //
 // Returns a null pointer in the event of an error. Otherwise, the pointer is
 // valid until FlutterDesktopDestroyWindow is called.
 // Note that calling FlutterDesktopCreateWindow without later calling
 // FlutterDesktopDestroyWindow on the returned reference is a memory leak.
-FLUTTER_EXPORT FlutterDesktopWindowControllerRef
-FlutterDesktopCreateWindow(int initial_width,
-                           int initial_height,
-                           const char* title,
-                           const char* assets_path,
-                           const char* icu_data_path,
-                           const char** arguments,
-                           size_t argument_count);
+FLUTTER_EXPORT FlutterDesktopWindowControllerRef FlutterDesktopCreateWindow(
+    const FlutterDesktopWindowProperties& window_properties,
+    const FlutterDesktopEngineProperties& engine_properties);
 
 // Shuts down the engine instance associated with |controller|, and cleans up
 // associated state.
@@ -143,20 +161,9 @@ FLUTTER_EXPORT double FlutterDesktopWindowGetScaleFactor(
 
 // Runs an instance of a headless Flutter engine.
 //
-// The |assets_path| is the path to the flutter_assets folder for the Flutter
-// application to be run. |icu_data_path| is the path to the icudtl.dat file
-// for the version of Flutter you are using.
-//
-// The |arguments| are passed to the Flutter engine. See:
-// https://github.com/flutter/engine/blob/master/shell/common/switches.h for
-// for details. Not all arguments will apply to desktop.
-//
 // Returns a null pointer in the event of an error.
 FLUTTER_EXPORT FlutterDesktopEngineRef
-FlutterDesktopRunEngine(const char* assets_path,
-                        const char* icu_data_path,
-                        const char** arguments,
-                        size_t argument_count);
+FlutterDesktopRunEngine(const FlutterDesktopEngineProperties& properties);
 
 // Shuts down the given engine instance. Returns true if the shutdown was
 // successful. |engine_ref| is no longer valid after this call.


### PR DESCRIPTION
Adds a flag to create non-resizeable windows.

Since the number of parameters is getting awkward, extracts
window-related parameters and engine-related parameters into structs for
clarity. This also removes some duplication in method signatures.

The window parameters struct change is also made to the C++ wrapper,
making this a breaking change for the runners.

Fixes https://github.com/flutter/flutter/issues/37623