### PR TITLE
Allow overriding the GLFW pixel ratio

### DIFF
--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
@@ -80,6 +80,14 @@ class FlutterWindow {
     return FlutterDesktopWindowGetScaleFactor(window_);
   }
 
+  // Forces a specific pixel ratio for Flutter rendering, rather than one
+  // computed automatically from screen information.
+  //
+  // To clear a previously set override, pass an override value of zero.
+  void SetPixelRatioOverride(double pixel_ratio) {
+    FlutterDesktopWindowSetPixelRatioOverride(window_, pixel_ratio);
+  }
+
  private:
   // Handle for interacting with the C API's window.
   //

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -121,6 +121,14 @@ double FlutterDesktopWindowGetScaleFactor(
   return 1.0;
 }
 
+void FlutterDesktopWindowSetPixelRatioOverride(
+    FlutterDesktopWindowRef flutter_window,
+    double pixel_ratio) {
+  if (s_stub_implementation) {
+    return s_stub_implementation->SetPixelRatioOverride(pixel_ratio);
+  }
+}
+
 bool FlutterDesktopRunWindowEventLoopWithTimeout(
     FlutterDesktopWindowControllerRef controller,
     uint32_t millisecond_timeout) {

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -70,6 +70,9 @@ class StubFlutterGlfwApi {
   // Called for FlutterDesktopWindowGetScaleFactor.
   virtual double GetWindowScaleFactor() { return 1.0; }
 
+  // Called for FlutterDesktopWindowSetPixelRatioOverride.
+  virtual void SetPixelRatioOverride(double pixel_ratio) {}
+
   // Called for FlutterDesktopRunWindowEventLoopWithTimeout.
   virtual bool RunWindowEventLoopWithTimeout(uint32_t millisecond_timeout) {
     return true;

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -92,6 +92,10 @@ struct FlutterDesktopWindow {
   // The ratio of pixels per screen coordinate for the window.
   double pixels_per_screen_coordinate = 1.0;
 
+  // If non-zero, a forced pixel ratio to use instead of one computed based on
+  // screen information.
+  double pixel_ratio_override = 0.0;
+
   // Resizing triggers a window refresh, but the resize already updates Flutter.
   // To avoid double messages, the refresh after each resize is skipped.
   bool skip_next_window_refresh = false;
@@ -177,9 +181,14 @@ static void SendWindowMetrics(FlutterDesktopWindowControllerState* state,
   event.struct_size = sizeof(event);
   event.width = width;
   event.height = height;
-  // The Flutter pixel_ratio is defined as DPI/dp. Limit the ratio to a minimum
-  // of 1 to avoid rendering a smaller UI on standard resolution monitors.
-  event.pixel_ratio = std::max(dpi / kDpPerInch, 1.0);
+  if (state->window_wrapper->pixel_ratio_override == 0.0) {
+    // The Flutter pixel_ratio is defined as DPI/dp. Limit the ratio to a
+    // minimum of 1 to avoid rendering a smaller UI on standard resolution
+    // monitors.
+    event.pixel_ratio = std::max(dpi / kDpPerInch, 1.0);
+  } else {
+    event.pixel_ratio = state->window_wrapper->pixel_ratio_override;
+  }
   FlutterEngineSendWindowMetricsEvent(state->engine, &event);
 }
 
@@ -715,6 +724,19 @@ void FlutterDesktopWindowSetFrame(FlutterDesktopWindowRef flutter_window,
 double FlutterDesktopWindowGetScaleFactor(
     FlutterDesktopWindowRef flutter_window) {
   return flutter_window->pixels_per_screen_coordinate;
+}
+
+void FlutterDesktopWindowSetPixelRatioOverride(
+    FlutterDesktopWindowRef flutter_window,
+    double pixel_ratio) {
+  flutter_window->pixel_ratio_override = pixel_ratio;
+  // Send a metrics update using the new pixel ratio.
+  int width_px, height_px;
+  glfwGetFramebufferSize(flutter_window->window, &width_px, &height_px);
+  if (width_px > 0 && height_px > 0) {
+    auto* state = GetSavedWindowState(flutter_window->window);
+    SendWindowMetrics(state, width_px, height_px);
+  }
 }
 
 bool FlutterDesktopRunWindowEventLoopWithTimeout(

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -141,6 +141,14 @@ FLUTTER_EXPORT void FlutterDesktopWindowSetFrame(
 FLUTTER_EXPORT double FlutterDesktopWindowGetScaleFactor(
     FlutterDesktopWindowRef flutter_window);
 
+// Forces a specific pixel ratio for Flutter rendering in |flutter_window|,
+// rather than one computed automatically from screen information.
+//
+// To clear a previously set override, pass an override value of zero.
+FLUTTER_EXPORT void FlutterDesktopWindowSetPixelRatioOverride(
+    FlutterDesktopWindowRef flutter_window,
+    double pixel_ratio);
+
 // Runs an instance of a headless Flutter engine.
 //
 // The |assets_path| is the path to the flutter_assets folder for the Flutter


### PR DESCRIPTION
Allows a client to set a specific pixel ratio rather than using one
computed based on the screen details.

Fixes https://github.com/flutter/flutter/issues/37620