### PR TITLE
Avoid root surface acquisition during custom composition with software renderer.

### DIFF
--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -9,8 +9,11 @@
 
 namespace flutter {
 
-GPUSurfaceSoftware::GPUSurfaceSoftware(GPUSurfaceSoftwareDelegate* delegate)
-    : delegate_(delegate), weak_factory_(this) {}
+GPUSurfaceSoftware::GPUSurfaceSoftware(GPUSurfaceSoftwareDelegate* delegate,
+                                       bool render_to_surface)
+    : delegate_(delegate),
+      render_to_surface_(render_to_surface),
+      weak_factory_(this) {}
 
 GPUSurfaceSoftware::~GPUSurfaceSoftware() = default;
 
@@ -22,6 +25,15 @@ bool GPUSurfaceSoftware::IsValid() {
 // |Surface|
 std::unique_ptr<SurfaceFrame> GPUSurfaceSoftware::AcquireFrame(
     const SkISize& logical_size) {
+  // TODO(38466): Refactor GPU surface APIs take into account the fact that an
+  // external view embedder may want to render to the root surface.
+  if (!render_to_surface_) {
+    return std::make_unique<SurfaceFrame>(
+        nullptr, [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
+          return true;
+        });
+  }
+
   if (!IsValid()) {
     return nullptr;
   }

--- a/shell/gpu/gpu_surface_software.h
+++ b/shell/gpu/gpu_surface_software.h
@@ -14,7 +14,8 @@ namespace flutter {
 
 class GPUSurfaceSoftware : public Surface {
  public:
-  GPUSurfaceSoftware(GPUSurfaceSoftwareDelegate* delegate);
+  GPUSurfaceSoftware(GPUSurfaceSoftwareDelegate* delegate,
+                     bool render_to_surface);
 
   ~GPUSurfaceSoftware() override;
 
@@ -35,6 +36,11 @@ class GPUSurfaceSoftware : public Surface {
 
  private:
   GPUSurfaceSoftwareDelegate* delegate_;
+  // TODO(38466): Refactor GPU surface APIs take into account the fact that an
+  // external view embedder may want to render to the root surface. This is a
+  // hack to make avoid allocating resources for the root surface when an
+  // external view embedder is present.
+  const bool render_to_surface_;
   fml::WeakPtrFactory<GPUSurfaceSoftware> weak_factory_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(GPUSurfaceSoftware);

--- a/shell/platform/android/android_surface_software.cc
+++ b/shell/platform/android/android_surface_software.cc
@@ -61,7 +61,8 @@ std::unique_ptr<Surface> AndroidSurfaceSoftware::CreateGPUSurface() {
     return nullptr;
   }
 
-  auto surface = std::make_unique<GPUSurfaceSoftware>(this);
+  auto surface =
+      std::make_unique<GPUSurfaceSoftware>(this, true /* render to surface */);
 
   if (!surface->IsValid()) {
     return nullptr;

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -43,7 +43,7 @@ std::unique_ptr<Surface> IOSSurfaceSoftware::CreateGPUSurface() {
     return nullptr;
   }
 
-  auto surface = std::make_unique<GPUSurfaceSoftware>(this);
+  auto surface = std::make_unique<GPUSurfaceSoftware>(this, true /* render to surface */);
 
   if (!surface->IsValid()) {
     return nullptr;

--- a/shell/platform/embedder/embedder_surface_gl.cc
+++ b/shell/platform/embedder/embedder_surface_gl.cc
@@ -81,7 +81,7 @@ EmbedderSurfaceGL::GLProcResolver EmbedderSurfaceGL::GetGLProcResolver() const {
 
 // |EmbedderSurface|
 std::unique_ptr<Surface> EmbedderSurfaceGL::CreateGPUSurface() {
-  bool render_to_surface = !external_view_embedder_;
+  const bool render_to_surface = !external_view_embedder_;
   return std::make_unique<GPUSurfaceGL>(this,  // GPU surface GL delegate
                                         render_to_surface  // render to surface
 

--- a/shell/platform/embedder/embedder_surface_software.cc
+++ b/shell/platform/embedder/embedder_surface_software.cc
@@ -32,8 +32,8 @@ std::unique_ptr<Surface> EmbedderSurfaceSoftware::CreateGPUSurface() {
   if (!IsValid()) {
     return nullptr;
   }
-
-  auto surface = std::make_unique<GPUSurfaceSoftware>(this);
+  const bool render_to_surface = !external_view_embedder_;
+  auto surface = std::make_unique<GPUSurfaceSoftware>(this, render_to_surface);
 
   if (!surface->IsValid()) {
     return nullptr;

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -143,6 +143,7 @@ bool EmbedderTestContext::GLClearCurrent() {
 }
 
 bool EmbedderTestContext::GLPresent() {
+  gl_surface_present_count_++;
   FML_CHECK(gl_surface_) << "GL surface must be initialized.";
 
   if (next_scene_callback_) {
@@ -198,6 +199,20 @@ void EmbedderTestContext::SetNextSceneCallback(
     return;
   }
   next_scene_callback_ = next_scene_callback;
+}
+
+bool EmbedderTestContext::SofwarePresent(sk_sp<SkImage> image) {
+  software_surface_present_count_++;
+  software_surface_ = std::move(image);
+  return software_surface_ != nullptr;
+}
+
+size_t EmbedderTestContext::GetGLSurfacePresentCount() const {
+  return gl_surface_present_count_;
+}
+
+size_t EmbedderTestContext::GetSoftwareSurfacePresentCount() const {
+  return software_surface_present_count_;
 }
 
 }  // namespace testing

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -61,6 +61,10 @@ class EmbedderTestContext {
   using NextSceneCallback = std::function<void(sk_sp<SkImage> image)>;
   void SetNextSceneCallback(NextSceneCallback next_scene_callback);
 
+  size_t GetGLSurfacePresentCount() const;
+
+  size_t GetSoftwareSurfacePresentCount() const;
+
  private:
   // This allows the builder to access the hooks.
   friend class EmbedderConfigBuilder;
@@ -76,8 +80,11 @@ class EmbedderTestContext {
   SemanticsActionCallback update_semantics_custom_action_callback_;
   std::function<void(const FlutterPlatformMessage*)> platform_message_callback_;
   std::unique_ptr<TestGLSurface> gl_surface_;
+  sk_sp<SkImage> software_surface_;
   std::unique_ptr<EmbedderTestCompositor> compositor_;
   NextSceneCallback next_scene_callback_;
+  size_t gl_surface_present_count_ = 0;
+  size_t software_surface_present_count_ = 0;
 
   static VoidCallback GetIsolateCreateCallbackHook();
 
@@ -106,6 +113,8 @@ class EmbedderTestContext {
   void* GLGetProcAddress(const char* name);
 
   void PlatformMessageCallback(const FlutterPlatformMessage* message);
+
+  bool SofwarePresent(sk_sp<SkImage> image);
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTestContext);
 };

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1105,6 +1105,10 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderKnownScene) {
   latch.Wait();
 
   ASSERT_TRUE(ImageMatchesFixture("compositor.png", scene_image));
+
+  // There should no present calls on the root surface.
+  ASSERT_EQ(context.GetSoftwareSurfacePresentCount(), 0u);
+  ASSERT_EQ(context.GetGLSurfacePresentCount(), 0u);
 }
 
 //------------------------------------------------------------------------------
@@ -1279,6 +1283,10 @@ TEST_F(EmbedderTest,
   latch.Wait();
 
   ASSERT_TRUE(ImageMatchesFixture("compositor_software.png", scene_image));
+
+  // There should no present calls on the root surface.
+  ASSERT_EQ(context.GetSoftwareSurfacePresentCount(), 0u);
+  ASSERT_EQ(context.GetGLSurfacePresentCount(), 0u);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Uses the same technique used during OpenGL composition to elide root surface access. The refactoring of this approach is tracked in https://github.com/flutter/flutter/issues/38466

Fixes https://github.com/flutter/flutter/issues/39009.
Fixes b/139825923