### PR TITLE
Remove deprecated ThreadTest::GetThreadTaskRunner and use the newer CreateNewThread API.

### DIFF
--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -105,11 +105,12 @@ static sk_sp<SkData> OpenFixtureAsSkData(const char* name) {
 
 TEST_F(ImageDecoderFixtureTest, CanCreateImageDecoder) {
   auto loop = fml::ConcurrentMessageLoop::Create();
-  TaskRunners runners(GetCurrentTestName(),   // label
-                      GetThreadTaskRunner(),  // platform
-                      GetThreadTaskRunner(),  // gpu
-                      GetThreadTaskRunner(),  // ui
-                      GetThreadTaskRunner()   // io
+  auto thread_task_runner = CreateNewThread();
+  TaskRunners runners(GetCurrentTestName(),  // label
+                      thread_task_runner,    // platform
+                      thread_task_runner,    // gpu
+                      thread_task_runner,    // ui
+                      thread_task_runner     // io
 
   );
 
@@ -125,15 +126,16 @@ TEST_F(ImageDecoderFixtureTest, CanCreateImageDecoder) {
 
 TEST_F(ImageDecoderFixtureTest, InvalidImageResultsError) {
   auto loop = fml::ConcurrentMessageLoop::Create();
-  TaskRunners runners(GetCurrentTestName(),   // label
-                      GetThreadTaskRunner(),  // platform
-                      GetThreadTaskRunner(),  // gpu
-                      GetThreadTaskRunner(),  // ui
-                      GetThreadTaskRunner()   // io
+  auto thread_task_runner = CreateNewThread();
+  TaskRunners runners(GetCurrentTestName(),  // label
+                      thread_task_runner,    // platform
+                      thread_task_runner,    // gpu
+                      thread_task_runner,    // ui
+                      thread_task_runner     // io
   );
 
   fml::AutoResetWaitableEvent latch;
-  GetThreadTaskRunner()->PostTask([&]() {
+  thread_task_runner->PostTask([&]() {
     TestIOManager manager(runners.GetIOTaskRunner());
     ImageDecoder decoder(runners, loop->GetTaskRunner(),
                          manager.GetWeakIOManager());
@@ -155,11 +157,11 @@ TEST_F(ImageDecoderFixtureTest, InvalidImageResultsError) {
 
 TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
   auto loop = fml::ConcurrentMessageLoop::Create();
-  TaskRunners runners(GetCurrentTestName(),    // label
-                      GetThreadTaskRunner(),   // platform
-                      CreateNewThread("gpu"),  // gpu
-                      CreateNewThread("ui"),   // ui
-                      CreateNewThread("io")    // io
+  TaskRunners runners(GetCurrentTestName(),         // label
+                      CreateNewThread("platform"),  // platform
+                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("ui"),        // ui
+                      CreateNewThread("io")         // io
   );
 
   fml::AutoResetWaitableEvent latch;
@@ -197,11 +199,11 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
 
 TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
   auto loop = fml::ConcurrentMessageLoop::Create();
-  TaskRunners runners(GetCurrentTestName(),    // label
-                      GetThreadTaskRunner(),   // platform
-                      CreateNewThread("gpu"),  // gpu
-                      CreateNewThread("ui"),   // ui
-                      CreateNewThread("io")    // io
+  TaskRunners runners(GetCurrentTestName(),         // label
+                      CreateNewThread("platform"),  // platform
+                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("ui"),        // ui
+                      CreateNewThread("io")         // io
   );
 
   fml::AutoResetWaitableEvent latch;
@@ -244,11 +246,11 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
 
 TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
   auto loop = fml::ConcurrentMessageLoop::Create();
-  TaskRunners runners(GetCurrentTestName(),    // label
-                      GetThreadTaskRunner(),   // platform
-                      CreateNewThread("gpu"),  // gpu
-                      CreateNewThread("ui"),   // ui
-                      CreateNewThread("io")    // io
+  TaskRunners runners(GetCurrentTestName(),         // label
+                      CreateNewThread("platform"),  // platform
+                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("ui"),        // ui
+                      CreateNewThread("io")         // io
   );
 
   fml::AutoResetWaitableEvent latch;
@@ -295,11 +297,11 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   ASSERT_NE(image_dimensions.width(), image_dimensions.height());
 
   auto loop = fml::ConcurrentMessageLoop::Create();
-  TaskRunners runners(GetCurrentTestName(),    // label
-                      GetThreadTaskRunner(),   // platform
-                      CreateNewThread("gpu"),  // gpu
-                      CreateNewThread("ui"),   // ui
-                      CreateNewThread("io")    // io
+  TaskRunners runners(GetCurrentTestName(),         // label
+                      CreateNewThread("platform"),  // platform
+                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("ui"),        // ui
+                      CreateNewThread("io")         // io
   );
 
   fml::AutoResetWaitableEvent latch;
@@ -380,11 +382,11 @@ TEST_F(ImageDecoderFixtureTest, CanResizeWithoutDecode) {
   ASSERT_NE(image_dimensions.width(), image_dimensions.height());
 
   auto loop = fml::ConcurrentMessageLoop::Create();
-  TaskRunners runners(GetCurrentTestName(),    // label
-                      GetThreadTaskRunner(),   // platform
-                      CreateNewThread("gpu"),  // gpu
-                      CreateNewThread("ui"),   // ui
-                      CreateNewThread("io")    // io
+  TaskRunners runners(GetCurrentTestName(),         // label
+                      CreateNewThread("platform"),  // platform
+                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("ui"),        // ui
+                      CreateNewThread("io")         // io
   );
 
   fml::AutoResetWaitableEvent latch;

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -327,7 +327,7 @@ TEST_F(DartIsolateTest, CanRegisterNativeCallback) {
                     })));
   const auto settings = CreateSettingsForFixture();
   auto vm_ref = DartVMRef::Create(settings);
-  auto isolate = RunDartCodeInIsolate(vm_ref, settings, GetThreadTaskRunner(),
+  auto isolate = RunDartCodeInIsolate(vm_ref, settings, CreateNewThread(),
                                       "canRegisterNativeCallback", {});
   ASSERT_TRUE(isolate);
   ASSERT_EQ(isolate->get()->GetPhase(), DartIsolate::Phase::Running);
@@ -350,7 +350,7 @@ TEST_F(DartIsolateTest, CanSaveCompilationTrace) {
 
   const auto settings = CreateSettingsForFixture();
   auto vm_ref = DartVMRef::Create(settings);
-  auto isolate = RunDartCodeInIsolate(vm_ref, settings, GetThreadTaskRunner(),
+  auto isolate = RunDartCodeInIsolate(vm_ref, settings, CreateNewThread(),
                                       "testCanSaveCompilationTrace", {});
   ASSERT_TRUE(isolate);
   ASSERT_EQ(isolate->get()->GetPhase(), DartIsolate::Phase::Running);
@@ -373,7 +373,7 @@ TEST_F(DartIsolateTest, CanLaunchSecondaryIsolates) {
       })));
   const auto settings = CreateSettingsForFixture();
   auto vm_ref = DartVMRef::Create(settings);
-  auto isolate = RunDartCodeInIsolate(vm_ref, settings, GetThreadTaskRunner(),
+  auto isolate = RunDartCodeInIsolate(vm_ref, settings, CreateNewThread(),
                                       "testCanLaunchSecondaryIsolate", {});
   ASSERT_TRUE(isolate);
   ASSERT_EQ(isolate->get()->GetPhase(), DartIsolate::Phase::Running);
@@ -392,7 +392,7 @@ TEST_F(DartIsolateTest, CanRecieveArguments) {
 
   const auto settings = CreateSettingsForFixture();
   auto vm_ref = DartVMRef::Create(settings);
-  auto isolate = RunDartCodeInIsolate(vm_ref, settings, GetThreadTaskRunner(),
+  auto isolate = RunDartCodeInIsolate(vm_ref, settings, CreateNewThread(),
                                       "testCanRecieveArguments", {"arg1"});
   ASSERT_TRUE(isolate);
   ASSERT_EQ(isolate->get()->GetPhase(), DartIsolate::Phase::Running);

--- a/runtime/dart_lifecycle_unittests.cc
+++ b/runtime/dart_lifecycle_unittests.cc
@@ -113,6 +113,8 @@ TEST_F(DartLifecycleTest, DISABLED_ShuttingDownTheVMShutsDownAllIsolates) {
   // Make sure the service protocol launches
   settings.enable_observatory = true;
 
+  auto thread_task_runner = CreateNewThread();
+
   for (size_t i = 0; i < 3; i++) {
     ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 
@@ -127,7 +129,6 @@ TEST_F(DartLifecycleTest, DISABLED_ShuttingDownTheVMShutsDownAllIsolates) {
 
     fml::CountDownLatch latch(isolate_count);
     auto vm_data = vm_ref.GetVMData();
-    auto thread_task_runner = GetThreadTaskRunner();
     for (size_t i = 0; i < isolate_count; ++i) {
       thread_task_runner->PostTask(
           [vm_data, &settings, &latch, thread_task_runner]() {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -577,7 +577,7 @@ TEST_F(ShellTest, WaitForFirstFrameMultiple) {
 /// single-thread setup.
 TEST_F(ShellTest, WaitForFirstFrameInlined) {
   Settings settings = CreateSettingsForFixture();
-  auto task_runner = GetThreadTaskRunner();
+  auto task_runner = CreateNewThread();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
   std::unique_ptr<Shell> shell =
@@ -617,7 +617,7 @@ static size_t GetRasterizerResourceCacheBytesSync(Shell& shell) {
 
 TEST_F(ShellTest, SetResourceCacheSize) {
   Settings settings = CreateSettingsForFixture();
-  auto task_runner = GetThreadTaskRunner();
+  auto task_runner = CreateNewThread();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
   std::unique_ptr<Shell> shell =
@@ -667,7 +667,7 @@ TEST_F(ShellTest, SetResourceCacheSize) {
 
 TEST_F(ShellTest, SetResourceCacheSizeEarly) {
   Settings settings = CreateSettingsForFixture();
-  auto task_runner = GetThreadTaskRunner();
+  auto task_runner = CreateNewThread();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
   std::unique_ptr<Shell> shell =
@@ -695,7 +695,7 @@ TEST_F(ShellTest, SetResourceCacheSizeEarly) {
 
 TEST_F(ShellTest, SetResourceCacheSizeNotifiesDart) {
   Settings settings = CreateSettingsForFixture();
-  auto task_runner = GetThreadTaskRunner();
+  auto task_runner = CreateNewThread();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
   std::unique_ptr<Shell> shell =
@@ -733,7 +733,7 @@ TEST_F(ShellTest, SetResourceCacheSizeNotifiesDart) {
 
 TEST_F(ShellTest, CanCreateImagefromDecompressedBytes) {
   Settings settings = CreateSettingsForFixture();
-  auto task_runner = GetThreadTaskRunner();
+  auto task_runner = CreateNewThread();
 
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -313,7 +313,7 @@ TEST_F(EmbedderTest, PlatformMessagesCanReceiveResponse) {
   };
   Captures captures;
 
-  GetThreadTaskRunner()->PostTask([&]() {
+  CreateNewThread()->PostTask([&]() {
     captures.thread_id = std::this_thread::get_id();
     auto& context = GetEmbedderContext();
     EmbedderConfigBuilder builder(context);

--- a/testing/thread_test.cc
+++ b/testing/thread_test.cc
@@ -11,27 +11,18 @@ namespace testing {
 
 // |testing::Test|
 void ThreadTest::SetUp() {
-  thread_ = std::make_unique<fml::Thread>();
-  thread_task_runner_ = thread_->GetTaskRunner();
-
   fml::MessageLoop::EnsureInitializedForCurrentThread();
   current_task_runner_ = fml::MessageLoop::GetCurrent().GetTaskRunner();
 }
 
 // |testing::Test|
 void ThreadTest::TearDown() {
-  thread_task_runner_ = nullptr;
-  thread_ = nullptr;
   current_task_runner_ = nullptr;
   extra_threads_.clear();
 }
 
 fml::RefPtr<fml::TaskRunner> ThreadTest::GetCurrentTaskRunner() {
   return current_task_runner_;
-}
-
-fml::RefPtr<fml::TaskRunner> ThreadTest::GetThreadTaskRunner() {
-  return thread_task_runner_;
 }
 
 fml::RefPtr<fml::TaskRunner> ThreadTest::CreateNewThread(std::string name) {

--- a/testing/thread_test.h
+++ b/testing/thread_test.h
@@ -45,22 +45,6 @@ class ThreadTest : public ::testing::Test {
   fml::RefPtr<fml::TaskRunner> GetCurrentTaskRunner();
 
   //----------------------------------------------------------------------------
-  /// @brief      Get the task runner for a dedicated thread created for this
-  ///             test instance by this fixture. This threads message loop will
-  ///             be terminated and the thread joined when the test is done.
-  ///
-  /// @attention  Prefer using the `CreateNewThread` call.
-  ///
-  /// @bug        This is an older call that should probably be deprecated and
-  ///             eventually removed from use. It is redundant now that the
-  ///             `CreateNewThread` call allows tests to create new threads (and
-  ///             name them to boot) as necessary.
-  ///
-  /// @return     The task runner for a dedicated thread created for the test.
-  ///
-  fml::RefPtr<fml::TaskRunner> GetThreadTaskRunner();
-
-  //----------------------------------------------------------------------------
   /// @brief      Creates a new thread, initializes a message loop on it, and,
   ///             returns its task runner to the unit-test. The message loop is
   ///             terminated (and its thread joined) when the test ends. This
@@ -80,8 +64,6 @@ class ThreadTest : public ::testing::Test {
   void TearDown() override;
 
  private:
-  std::unique_ptr<fml::Thread> thread_;
-  fml::RefPtr<fml::TaskRunner> thread_task_runner_;
   fml::RefPtr<fml::TaskRunner> current_task_runner_;
   std::vector<std::unique_ptr<fml::Thread>> extra_threads_;
 };


### PR DESCRIPTION
We will end up creating fewer threads in tests.