### PR TITLE
Ios simulator unittests seem to not consider the full compilation unit

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -4,7 +4,7 @@
 
 #import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
-#import "flutter/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h"
+#import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 
 @interface FlutteEngineTest : XCTestCase
 @end


### PR DESCRIPTION
We were referencing internal engine headers which do not transitively include the full compilation unit. Landing this on red to address LUCI ios unit test failures. 