### PR TITLE
Shrink cirrus docker image: reduce RUN count, apt-get clean

### DIFF
--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -2,24 +2,22 @@ FROM ubuntu:16.04
 
 ENV DEPOT_TOOLS_PATH $HOME/depot_tools
 ENV ENGINE_PATH $HOME/engine
-
-RUN apt-get update
-RUN apt-get install -y git wget curl unzip python lsb-release sudo apt-transport-https
-
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS_PATH
 ENV PATH $PATH:$DEPOT_TOOLS_PATH
 
-RUN mkdir --parents $ENGINE_PATH
+RUN apt-get update && \
+    apt-get install -y git wget curl unzip python lsb-release sudo apt-transport-https && \
+    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS_PATH && \
+    mkdir --parents $ENGINE_PATH
 WORKDIR $ENGINE_PATH
 ADD engine_gclient .gclient
 RUN gclient sync
 
 WORKDIR $ENGINE_PATH/src
-RUN ./build/install-build-deps.sh --no-prompt
-RUN ./build/install-build-deps-android.sh --no-prompt
-RUN ./flutter/build/install-build-deps-linux-desktop.sh
+RUN ./build/install-build-deps.sh --no-prompt && \
+    ./build/install-build-deps-android.sh --no-prompt && \
+    ./flutter/build/install-build-deps-linux-desktop.sh
 
- # Add repo for gcloud sdk and install it
+# Add repo for gcloud sdk and install it
 RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
     tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
@@ -32,4 +30,5 @@ RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' |
 
 RUN apt-get update && apt-get install -y google-cloud-sdk google-chrome-stable && \
     gcloud config set core/disable_usage_reporting true && \
-    gcloud config set component_manager/disable_update_check true
+    gcloud config set component_manager/disable_update_check true && \
+    apt-get clean

--- a/ci/docker/build/Dockerfile
+++ b/ci/docker/build/Dockerfile
@@ -1,34 +1,26 @@
 FROM ubuntu:16.04
 
 ENV DEPOT_TOOLS_PATH $HOME/depot_tools
+ENV BUILDROOT_PATH $HOME/buildroot
 ENV ENGINE_PATH $HOME/engine
 ENV PATH $PATH:$DEPOT_TOOLS_PATH
 
+# Notes:
+# - libx11-dev is used by Flutter for desktop linux (see also install-build-deps-linux-desktop.sh)
+# - chrome is used by Flutter for web.
 RUN apt-get update && \
     apt-get install -y git wget curl unzip python lsb-release sudo apt-transport-https && \
     git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git $DEPOT_TOOLS_PATH && \
-    mkdir --parents $ENGINE_PATH
-WORKDIR $ENGINE_PATH
-ADD engine_gclient .gclient
-RUN gclient sync
-
-WORKDIR $ENGINE_PATH/src
-RUN ./build/install-build-deps.sh --no-prompt && \
+    mkdir --parents $ENGINE_PATH && \
+    git clone https://github.com/flutter/buildroot.git $BUILDROOT_PATH && \
+    cd $BUILDROOT_PATH && \
+    ./build/install-build-deps.sh --no-prompt && \
     ./build/install-build-deps-android.sh --no-prompt && \
-    ./flutter/build/install-build-deps-linux-desktop.sh
-
-# Add repo for gcloud sdk and install it
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
-    tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
-    apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-
-# Add repo for chrome stable
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
-
-RUN apt-get update && apt-get install -y google-cloud-sdk google-chrome-stable && \
+    (echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list) && \
+    (curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -) && \
+    (wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -) && \
+    echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && apt-get install -y google-cloud-sdk google-chrome-stable libx11-dev && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     apt-get clean


### PR DESCRIPTION
Combine `RUN` commands so we have fewer runs and therefore fewer layers.
Call `apt-get clean` at the end so we don't carry apt metadata around.

These suggestions are courtesy of @fkorotkov.