### PR TITLE
Gather demangled stack traces and report the same to console on crashes.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -7,6 +7,8 @@ import("$flutter_root/testing/testing.gni")
 
 source_set("fml") {
   sources = [
+    "backtrace.cc",
+    "backtrace.h",
     "base32.cc",
     "base32.h",
     "build_config.h",
@@ -198,6 +200,7 @@ executable("fml_unittests") {
   testonly = true
 
   sources = [
+    "backtrace_unittests.cc",
     "base32_unittest.cc",
     "command_line_unittest.cc",
     "file_unittest.cc",

--- a/fml/backtrace.cc
+++ b/fml/backtrace.cc
@@ -1,0 +1,132 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/fml/backtrace.h"
+
+#include <cxxabi.h>
+#include <sstream>
+
+#include <dlfcn.h>
+#include <execinfo.h>
+#include <signal.h>
+
+#include "flutter/fml/logging.h"
+
+namespace fml {
+
+static std::string kKUnknownFrameName = "Unknown";
+
+static std::string DemangleSymbolName(const std::string& mangled) {
+  if (mangled == kKUnknownFrameName) {
+    return kKUnknownFrameName;
+  }
+
+  int status = 0;
+  size_t length = 0;
+  char* demangled = __cxxabiv1::__cxa_demangle(
+      mangled.data(),  // mangled name
+      nullptr,         // output buffer (malloc-ed if nullptr)
+      &length,         // demangled length
+      &status);
+
+  if (demangled == nullptr || status != 0) {
+    return mangled;
+  }
+
+  auto demangled_string = std::string{demangled, length};
+  free(demangled);
+  return demangled_string;
+}
+
+static std::string GetSymbolName(void* symbol) {
+  Dl_info info = {};
+
+  if (::dladdr(symbol, &info) == 0) {
+    return kKUnknownFrameName;
+  }
+
+  return DemangleSymbolName({info.dli_sname});
+}
+
+std::string BacktraceHere(size_t offset) {
+  constexpr size_t kMaxFrames = 256;
+  void* symbols[kMaxFrames];
+  const auto available_frames = ::backtrace(symbols, kMaxFrames);
+  if (available_frames <= 0) {
+    return "";
+  }
+
+  std::stringstream stream;
+  for (int i = 1 + offset; i < available_frames; ++i) {
+    stream << "Frame " << i - 1 - offset << ": " << symbols[i] << " "
+           << GetSymbolName(symbols[i]) << std::endl;
+  }
+  return stream.str();
+}
+
+static size_t kKnownSignalHandlers[] = {
+    SIGABRT,  // abort program
+    SIGFPE,   // floating-point exception
+    SIGBUS,   // bus error
+    SIGSEGV,  // segmentation violation
+    SIGSYS,   // non-existent system call invoked
+    SIGPIPE,  // write on a pipe with no reader
+    SIGALRM,  // real-time timer expired
+    SIGTERM,  // software termination signal
+};
+
+static std::string SignalNameToString(int signal) {
+  switch (signal) {
+    case SIGABRT:
+      return "SIGABRT";
+    case SIGFPE:
+      return "SIGFPE";
+    case SIGBUS:
+      return "SIGBUS";
+    case SIGSEGV:
+      return "SIGSEGV";
+    case SIGSYS:
+      return "SIGSYS";
+    case SIGPIPE:
+      return "SIGPIPE";
+    case SIGALRM:
+      return "SIGALRM";
+    case SIGTERM:
+      return "SIGTERM";
+  };
+  return std::to_string(signal);
+}
+
+static void ToggleSignalHandlers(bool set);
+
+static void SignalHandler(int signal) {
+  // We are a crash signal handler. This can only happen once. Since we don't
+  // want to catch crashes while we are generating the crash reports, disable
+  // all set signal handlers to their default values before reporting the crash
+  // and re-raising the signal.
+  ToggleSignalHandlers(false);
+
+  FML_LOG(ERROR) << "Caught signal " << SignalNameToString(signal)
+                 << " during program execution." << std::endl
+                 << BacktraceHere(3);
+
+  ::raise(signal);
+}
+
+static void ToggleSignalHandlers(bool set) {
+  for (size_t i = 0; i < sizeof(kKnownSignalHandlers) / sizeof(size_t); ++i) {
+    auto signal_name = kKnownSignalHandlers[i];
+    auto handler = set ? &SignalHandler : SIG_DFL;
+
+    if (::signal(signal_name, handler) == SIG_ERR) {
+      FML_LOG(ERROR) << "Could not attach signal handler for " << signal_name;
+    }
+  }
+}
+
+void InstallCrashHandler() {
+  ToggleSignalHandlers(true);
+}
+
+}  // namespace fml

--- a/fml/backtrace.h
+++ b/fml/backtrace.h
@@ -1,0 +1,20 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_BACKTRACE_H_
+#define FLUTTER_FML_BACKTRACE_H_
+
+#include <string>
+
+#include "flutter/fml/macros.h"
+
+namespace fml {
+
+std::string BacktraceHere(size_t offset = 0);
+
+void InstallCrashHandler();
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_BACKTRACE_H_

--- a/fml/backtrace_unittests.cc
+++ b/fml/backtrace_unittests.cc
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "backtrace.h"
+#include "gtest/gtest.h"
+#include "logging.h"
+
+namespace fml {
+namespace testing {
+
+TEST(BacktraceTest, CanGatherBacktrace) {
+  {
+    auto trace = BacktraceHere(0);
+    ASSERT_GT(trace.size(), 0u);
+    ASSERT_NE(trace.find("Frame 0"), std::string::npos);
+  }
+
+  {
+    auto trace = BacktraceHere(1);
+    ASSERT_GT(trace.size(), 0u);
+    ASSERT_NE(trace.find("Frame 0"), std::string::npos);
+  }
+
+  {
+    auto trace = BacktraceHere(2);
+    ASSERT_GT(trace.size(), 0u);
+    ASSERT_NE(trace.find("Frame 0"), std::string::npos);
+  }
+}
+
+}  // namespace testing
+}  // namespace fml

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -8,6 +8,7 @@
 
 #include "flutter/assets/asset_manager.h"
 #include "flutter/assets/directory_asset_bundle.h"
+#include "flutter/fml/backtrace.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/message_loop.h"
@@ -198,6 +199,8 @@ int RunTester(const flutter::Settings& settings, bool run_forever) {
 }  // namespace flutter
 
 int main(int argc, char* argv[]) {
+  fml::InstallCrashHandler();
+
   dart::bin::SetExecutableName(argv[0]);
   dart::bin::SetExecutableArguments(argc - 1, argv);
 


### PR DESCRIPTION
These should only be used on host binaries for more detailed crash reports. Installing the handler on targets (iOS/Android) may cause use to break existing crash reporting mechanisms users may have installed themselves in the process.