### PR TITLE
buildfix: support build windows release/profile mode(#32746)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Victor Choueiri <victor@ctrlanddev.com>
 Simon Lightfoot <simon@devangels.london>
 Dwayne Slater <ds84182@gmail.com>
 Tetsuhiro Ueda <najeira@gmail.com>
+shoryukenn <naifu.guan@gmail.com>

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -87,9 +87,9 @@ source_set("runtime") {
     "//third_party/tonic",
   ]
 
-  // naifu: On Windows and Android (in debug mode) the engine finds the Dart snapshot
-  // data through symbols that are statically linked into the executable.
-  // On other platforms this data is obtained by a dynamic symbol lookup.
+  # naifu: On Windows and Android (in debug mode) the engine finds the Dart snapshot
+  # data through symbols that are statically linked into the executable.
+  # On other platforms this data is obtained by a dynamic symbol lookup.
   if (is_win) {
     if (flutter_runtime_mode == "profile" ||
         flutter_runtime_mode == "release") {

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -87,11 +87,11 @@ source_set("runtime") {
     "//third_party/tonic",
   ]
 
-  # naifu: On Windows the engine finds the Dart snapshot data through symbols
+  # On Windows the engine finds the Dart snapshot data through symbols
   # that are statically linked into the executable. On other platforms this
   # data is obtained by a dynamic symbol lookup.
-  # The current Windows platform uses static linking instead of dynamic lookups
-  # because:
+  # The current Windows platform uses static-link instead of dynamic lookups.
+  # Because:
   #  1. The size of the executable on Windows is not as concerned as on mobile
   #     platforms.
   #  2. If it is a dynamic lookup method, you need to modify the properties of

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -87,9 +87,21 @@ source_set("runtime") {
     "//third_party/tonic",
   ]
 
-  # naifu: On Windows and Android (in debug mode) the engine finds the Dart snapshot
-  # data through symbols that are statically linked into the executable.
-  # On other platforms this data is obtained by a dynamic symbol lookup.
+  # naifu: On Windows the engine finds the Dart snapshot data through symbols
+  # that are statically linked into the executable. On other platforms this
+  # data is obtained by a dynamic symbol lookup.
+  # The current Windows platform uses static linking instead of dynamic lookups
+  # because:
+  #  1. The size of the executable on Windows is not as concerned as on mobile
+  #     platforms.
+  #  2. If it is a dynamic lookup method, you need to modify the properties of
+  #     the memory page after the *.bin is dynamically loaded at runtime and
+  #     mark it as executable. This is feasible (similar to V8 on Windows), but
+  #     this increases the complexity of the implementation(These operations
+  #     involve the use of some system file/memory privilege APIs and there is
+  #     a risk of failure).
+  #  3. In the executable can enjoy the advantages of the windows preload
+  #     mechanism, speed up I/O.
   if (is_win) {
     if (flutter_runtime_mode == "profile" ||
         flutter_runtime_mode == "release") {

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -87,6 +87,9 @@ source_set("runtime") {
     "//third_party/tonic",
   ]
 
+  // naifu: On Windows and Android (in debug mode) the engine finds the Dart snapshot
+  // data through symbols that are statically linked into the executable.
+  // On other platforms this data is obtained by a dynamic symbol lookup.
   if (is_win) {
     if (flutter_runtime_mode == "profile" ||
         flutter_runtime_mode == "release") {

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -87,6 +87,13 @@ source_set("runtime") {
     "//third_party/tonic",
   ]
 
+  if (is_win) {
+    if (flutter_runtime_mode == "profile" ||
+        flutter_runtime_mode == "release") {
+      deps += [ "$flutter_root/lib/snapshot" ]
+    }
+  }
+
   public_deps = [
     "//third_party/rapidjson",
   ]


### PR DESCRIPTION
    ISSUSE: 
    https://github.com/flutter/flutter/issues/32746

    WHAT:
    buildbreak on Windows Release/Profile Mode.

    WHY:
    Windows platform does not link vm_snapshot_data.bin.o isolate_snapshot_instructions.bin.o vm_snapshot_instructions.bin.o vm_snapshot_data.bin.o generated by bin_to_coff.

    HOW:
    add deps to runtime build.gn