### PR TITLE
Bitcode only for release

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -89,7 +89,7 @@ def to_gn_args(args):
     if args.bitcode:
       if args.target_os != 'ios':
         raise Exception('Bitcode is only supported for iOS')
-      if runtime_mode == 'debug':
+      if runtime_mode != 'release':
         gn_args['bitcode_marker'] = True
 
     gn_args['enable_bitcode'] = args.bitcode


### PR DESCRIPTION
Bitcode vastly bloats the static library size - for profile:

```
dnfield@mbp:Flutter.framework$ xcrun bitcode_strip -r Flutter -o Flutter.nobitcode
dnfield@mbp:Flutter.framework$ du -hs Flutter Flutter.nobitcode 
413M    Flutter
 62M    Flutter.nobitcode
```

See also https://github.com/realm/realm-cocoa/issues/4450#issuecomment-267818165 for analysis of how similar issues impact Realm.

This PR changes the default behavior so that profile also gets `-fembed-bitcode-marker`, which results in just placeholders for Bitcode and a much smaller binary. It will mean that you cannot recompile from bitcode in profile mode, which would affect archiving your app for the app store in that mode - but we wouldn't really want users to ship profile mode binaries anyway, and if it's absolutely required they could do a local build with the GN args edited.
