### PR TITLE
Revert "Reuse texture cache in ios_external_texture_gl. (#9806)"

### DIFF
--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -31,7 +31,6 @@ class IOSExternalTextureGL : public flutter::Texture {
 
   void EnsureTextureCacheExists();
 
-  bool new_frame_ready_ = false;
   NSObject<FlutterTexture>* external_texture_;
   fml::CFRef<CVOpenGLESTextureCacheRef> cache_ref_;
   fml::CFRef<CVOpenGLESTextureRef> texture_ref_;

--- a/shell/platform/darwin/ios/ios_external_texture_gl.mm
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.mm
@@ -53,24 +53,17 @@ void IOSExternalTextureGL::CreateTextureFromPixelBuffer() {
   }
 }
 
-bool IOSExternalTextureGL::NeedUpdateTexture(bool freeze) {
-  // Update texture if `texture_ref_` is reset to `nullptr` when GrContext
-  // is destroied or new frame is ready.
-  return (!freeze && new_frame_ready_) || !texture_ref_;
-}
-
 void IOSExternalTextureGL::Paint(SkCanvas& canvas,
                                  const SkRect& bounds,
                                  bool freeze,
                                  GrContext* context) {
   EnsureTextureCacheExists();
-  if (NeedUpdateTexture(freeze)) {
+  if (!freeze) {
     auto pixelBuffer = [external_texture_ copyPixelBuffer];
     if (pixelBuffer) {
       buffer_ref_.Reset(pixelBuffer);
     }
     CreateTextureFromPixelBuffer();
-    new_frame_ready_ = false;
   }
   if (!texture_ref_) {
     return;
@@ -100,8 +93,6 @@ void IOSExternalTextureGL::OnGrContextDestroyed() {
   cache_ref_.Reset(nullptr);
 }
 
-void IOSExternalTextureGL::MarkNewFrameAvailable() {
-  new_frame_ready_ = true;
-}
+void IOSExternalTextureGL::MarkNewFrameAvailable() {}
 
 }  // namespace flutter


### PR DESCRIPTION
Broke iOS builds:

    ../../flutter/shell/platform/darwin/ios/ios_external_texture_gl.mm:56:28: error: out-of-line definition of 'NeedUpdateTexture' does not match any declaration in 'flutter::IOSExternalTextureGL'
    bool IOSExternalTextureGL::NeedUpdateTexture(bool freeze) {
                           ^~~~~~~~~~~~~~~~~

This reverts commit 94b31749436e23bef0596f48bdf63e682670486c.