### PR TITLE
Reuse texture cache in ios_external_texture_gl

### DIFF
--- a/shell/platform/darwin/ios/ios_external_texture_gl.h
+++ b/shell/platform/darwin/ios/ios_external_texture_gl.h
@@ -30,7 +30,9 @@ class IOSExternalTextureGL : public flutter::Texture {
   void CreateTextureFromPixelBuffer();
 
   void EnsureTextureCacheExists();
+  bool NeedUpdateTexture(bool freeze);
 
+  bool new_frame_ready_ = false;
   NSObject<FlutterTexture>* external_texture_;
   fml::CFRef<CVOpenGLESTextureCacheRef> cache_ref_;
   fml::CFRef<CVOpenGLESTextureRef> texture_ref_;


### PR DESCRIPTION
In current implementation, external texture data flow is a
producer-consumer model. When painting external texture, it always asks
registered external texture object to produce new CVPixelBuffer, then
transforms it to texture. `MarkNewFrameAvailable` function is ignored.
This commit changes the dataflow. Now ios_external_texture_gl caches
previous opengl texture, if no new frame are available, it do not
`copyPixelBuffer` method, just uses cached opengl texture to draw.

This is a re-land of flutter/engine#9806, which was previously reverted
in flutter/engine#11522.