### PR TITLE
Strip bitcode from gen_snapshot

### DIFF
--- a/sky/tools/create_macos_gen_snapshots.py
+++ b/sky/tools/create_macos_gen_snapshots.py
@@ -30,9 +30,9 @@ def main():
     return 1
 
   subprocess.check_call(['xcrun', 'bitcode_strip', '-r', armv7_gen_snapshot,
-      '-o', os.path.join(args.dst, 'gen_snapshot_armv7'])
+      '-o', os.path.join(args.dst, 'gen_snapshot_armv7')])
   subprocess.check_call(['xcrun', 'bitcode_strip', '-r', arm64_gen_snapshot,
-      '-o', os.path.join(args.dst, 'gen_snapshot_arm64'])
+      '-o', os.path.join(args.dst, 'gen_snapshot_arm64')])
 
 if __name__ == '__main__':
   sys.exit(main())


### PR DESCRIPTION
We don't need bitcode in gen_snapshot - it vastly bloats the binary and we're not linking against this/recompiling it from bitcode.