### PR TITLE
Make Skia cache size channel respond with a value

### DIFF
--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -63,6 +63,9 @@ void testCanLaunchSecondaryIsolate() {
 @pragma('vm:entry-point')
 void testSkiaResourceCacheSendsResponse() {
   final PlatformMessageResponseCallback callback = (ByteData data) {
+    if (data == null) {
+      throw 'Response must not be null.';
+    }
     notifyNative();
   };
   const String json = '''{

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -959,7 +959,9 @@ void Shell::HandleEngineSkiaMessage(fml::RefPtr<PlatformMessage> message) {
                                                true);
         }
         if (response) {
-          response->CompleteEmpty();
+          std::vector<uint8_t> data = {1};
+          response->Complete(
+              std::make_unique<fml::DataMapping>(std::move(data)));
         }
       });
 }


### PR DESCRIPTION
`CompleteEmpty` causes an exception in the framework because it  thinks the null response means there's no plugin/channel listening. This was introduced a while back now to improve the API usage.

Fixes https://github.com/flutter/flutter/issues/39337

/cc @abhishekamit 