### PR TITLE
make engine, ui, and sdk rewriter inputs of dill construction

### DIFF
--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -103,9 +103,7 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk_outline") {
     "//third_party/dart/utils/dartdevc:dartdevc_sdk_patch_stamp",
   ]
 
-  inputs = [
-    "sdk_rewriter.dart"
-  ] + web_ui_sources + web_engine_sources
+  inputs = [ "sdk_rewriter.dart" ] + web_ui_sources + web_engine_sources
 
   outputs = [
     sdk_dill,
@@ -146,9 +144,7 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk") {
     "//third_party/dart/utils/dartdevc:dartdevc_sdk_patch_stamp",
   ]
 
-  inputs = [
-    "sdk_rewriter.dart"
-  ] + web_ui_sources + web_engine_sources
+  inputs = [ "sdk_rewriter.dart" ] + web_ui_sources + web_engine_sources
 
   packages = "//third_party/dart/.packages"
 


### PR DESCRIPTION
This fixes an error where updating the SDK script would not update the dill file produced from the SDK