### PR TITLE
[flutter_runner] Port Expose ViewBound Wireframe Functionality

### DIFF
--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -83,6 +83,10 @@ void CompositorContext::OnSessionSizeChangeHint(float width_change_factor,
                                               height_change_factor);
 }
 
+void CompositorContext::OnWireframeEnabled(bool enabled) {
+  session_connection_.set_enable_wireframe(enabled);
+}
+
 CompositorContext::~CompositorContext() = default;
 
 std::unique_ptr<flutter::CompositorContext::ScopedFrame>

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -32,6 +32,8 @@ class CompositorContext final : public flutter::CompositorContext {
   void OnSessionSizeChangeHint(float width_change_factor,
                                float height_change_factor);
 
+  void OnWireframeEnabled(bool enabled);
+
  private:
   const std::string debug_label_;
   SessionConnection session_connection_;

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -67,6 +67,8 @@ class Engine final {
   void OnSessionSizeChangeHint(float width_change_factor,
                                float height_change_factor);
 
+  void OnDebugWireframeSettingsChanged(bool enabled);
+
   FML_DISALLOW_COPY_AND_ASSIGN(Engine);
 };
 

--- a/shell/platform/fuchsia/flutter/platform_view.h
+++ b/shell/platform/fuchsia/flutter/platform_view.h
@@ -27,6 +27,7 @@ namespace flutter_runner {
 using OnMetricsUpdate = fit::function<void(const fuchsia::ui::gfx::Metrics&)>;
 using OnSizeChangeHint =
     fit::function<void(float width_change_factor, float height_change_factor)>;
+using OnEnableWireframe = fit::function<void(bool)>;
 
 // The per engine component residing on the platform thread is responsible for
 // all platform specific integrations.
@@ -48,6 +49,7 @@ class PlatformView final : public flutter::PlatformView,
                fit::closure on_session_listener_error_callback,
                OnMetricsUpdate session_metrics_did_change_callback,
                OnSizeChangeHint session_size_change_hint_callback,
+               OnEnableWireframe wireframe_enabled_callback,
                zx_handle_t vsync_event_handle);
   PlatformView(PlatformView::Delegate& delegate,
                std::string debug_label,
@@ -67,6 +69,7 @@ class PlatformView final : public flutter::PlatformView,
   fit::closure session_listener_error_callback_;
   OnMetricsUpdate metrics_changed_callback_;
   OnSizeChangeHint size_change_hint_callback_;
+  OnEnableWireframe wireframe_enabled_callback_;
 
   int current_text_input_client_ = 0;
   fidl::Binding<fuchsia::ui::input::InputMethodEditorClient> ime_client_;
@@ -158,6 +161,10 @@ class PlatformView final : public flutter::PlatformView,
 
   // Channel handler for kTextInputChannel
   void HandleFlutterTextInputChannelPlatformMessage(
+      fml::RefPtr<flutter::PlatformMessage> message);
+
+  // Channel handler for kPlatformViewsChannel.
+  void HandleFlutterPlatformViewsChannelPlatformMessage(
       fml::RefPtr<flutter::PlatformMessage> message);
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformView);

--- a/shell/platform/fuchsia/flutter/session_connection.cc
+++ b/shell/platform/fuchsia/flutter/session_connection.cc
@@ -79,6 +79,11 @@ void SessionConnection::OnSessionSizeChangeHint(float width_change_factor,
                                              height_change_factor);
 }
 
+void SessionConnection::set_enable_wireframe(bool enable) {
+  session_wrapper_.Enqueue(
+      scenic::NewSetEnableDebugViewBoundsCmd(root_view_.id(), enable));
+}
+
 void SessionConnection::EnqueueClearOps() {
   // We are going to be sending down a fresh node hierarchy every frame. So just
   // enqueue a detach op on the imported root node.

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -48,6 +48,8 @@ class SessionConnection final {
         fidl::MakeOptional(std::move(metrics_copy)));
   }
 
+  void set_enable_wireframe(bool enable);
+
   flutter::SceneUpdateContext& scene_update_context() {
     return scene_update_context_;
   }


### PR DESCRIPTION
Expose scenic's ability to toggle wireframe debug
rendering of view bounds in flutter_runner. This is done
by registering a new function on the platform_views channel
with the PlatformView.

Note: Unittests have not been enabled, will enable once we
have sufficient infra.

SCN-1351 #done

Change-Id: Id4c8ef65cc39a967087d7fa6c9f595da8cfe5f01