### PR TITLE
Add style guide and formatting information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,16 @@ the Engine development environment][engine_dev_setup] on our wiki. Those
 instructions are part of the broader onboarding instructions described in the
 contributing guide.
 
+### Style
+
+The Flutter engine follows Google style for the languages it uses:
+- [C++](https://google.github.io/styleguide/cppguide.html)
+- [Objective-C](https://google.github.io/styleguide/objcguide.html) (including
+  [Objective-C++](https://google.github.io/styleguide/objcguide.html#objective-c))
+- [Java](https://google.github.io/styleguide/javaguide.html)
+
+C++ and Objective-C/C++ files are formatted with `clang-format`, and GN files with `gn format`.
+
 [build_status]: https://cirrus-ci.com/github/flutter/engine
 [code_of_conduct]: https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md
 [contrib_guide]: https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Updates CONTRIBUTING.md with style guide links for the engine languages, as well as a note about auto-formatting.

Addresses https://github.com/flutter/flutter/issues/39442