### PR TITLE
Return a JSON value for the Skia channel

### DIFF
--- a/shell/common/fixtures/shell_test.dart
+++ b/shell/common/fixtures/shell_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert' show utf8;
+import 'dart:convert' show utf8, json;
 import 'dart:isolate';
 import 'dart:typed_data';
 import 'dart:ui';
@@ -66,15 +66,20 @@ void testSkiaResourceCacheSendsResponse() {
     if (data == null) {
       throw 'Response must not be null.';
     }
+    final String response = utf8.decode(data.buffer.asUint8List());
+    final List<bool> jsonResponse = json.decode(response).cast<bool>();
+    if (jsonResponse[0] != true) {
+      throw 'Response was not true';
+    }
     notifyNative();
   };
-  const String json = '''{
+  const String jsonRequest = '''{
                             "method": "Skia.setResourceCacheMaxBytes",
                             "args": 10000
                           }''';
   window.sendPlatformMessage(
     'flutter/skia',
-    Uint8List.fromList(utf8.encode(json)).buffer.asByteData(),
+    Uint8List.fromList(utf8.encode(jsonRequest)).buffer.asByteData(),
     callback,
   );
 }

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -959,7 +959,9 @@ void Shell::HandleEngineSkiaMessage(fml::RefPtr<PlatformMessage> message) {
                                                true);
         }
         if (response) {
-          std::vector<uint8_t> data = {1};
+          // The framework side expects this to be valid json encoded as a list.
+          // Return `[true]` to signal success.
+          std::vector<uint8_t> data = {'[', 't', 'r', 'u', 'e', ']'};
           response->Complete(
               std::make_unique<fml::DataMapping>(std::move(data)));
         }


### PR DESCRIPTION
Fixes flutter/flutter#39337 - for real this time.

The framework side expects responses to this to be valid JSON encoded as a list.  See https://github.com/flutter/flutter/blob/14cec30c18b5ada61e5cdb6a8fd3428ccc023e85/packages/flutter/lib/src/services/message_codecs.dart#L140

/cc @abhishekamit 