### PR TITLE
Quote the font family name whenever setting the font-family property.

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -189,7 +189,7 @@ class _PolyfillFontManager extends _FontManager {
     html.document.body.append(paragraph);
     final int sansSerifWidth = paragraph.offsetWidth;
 
-    paragraph.style.fontFamily = '$family, sans-serif';
+    paragraph.style.fontFamily = "'$family', sans-serif";
 
     final Completer<void> completer = Completer<void>();
 

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1072,7 +1072,7 @@ void _applyParagraphStyleToElement({
           style._fontStyle == ui.FontStyle.normal ? 'normal' : 'italic';
     }
     if (style._effectiveFontFamily != null) {
-      cssStyle.fontFamily = style._effectiveFontFamily;
+      cssStyle.fontFamily = "'${style._effectiveFontFamily}'";
     }
   } else {
     if (style._textAlign != previousStyle._textAlign) {
@@ -1098,7 +1098,7 @@ void _applyParagraphStyleToElement({
           : null;
     }
     if (style._fontFamily != previousStyle._fontFamily) {
-      cssStyle.fontFamily = style._fontFamily;
+      cssStyle.fontFamily = "'${style._fontFamily}'";
     }
   }
 }
@@ -1138,11 +1138,11 @@ void _applyTextStyleToElement({
     // consistently use Ahem font.
     if (isSpan && !ui.debugEmulateFlutterTesterEnvironment) {
       if (style._fontFamily != null) {
-        cssStyle.fontFamily = style._fontFamily;
+        cssStyle.fontFamily = "'${style._fontFamily}'";
       }
     } else {
       if (style._effectiveFontFamily != null) {
-        cssStyle.fontFamily = style._effectiveFontFamily;
+        cssStyle.fontFamily = "'${style._effectiveFontFamily}'";
       }
     }
     if (style._letterSpacing != null) {
@@ -1176,7 +1176,7 @@ void _applyTextStyleToElement({
           : null;
     }
     if (style._fontFamily != previousStyle._fontFamily) {
-      cssStyle.fontFamily = style._fontFamily;
+      cssStyle.fontFamily = "'${style._fontFamily}'";
     }
     if (style._letterSpacing != previousStyle._letterSpacing) {
       cssStyle.letterSpacing = '${style._letterSpacing}px';

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -86,7 +86,7 @@ class ParagraphGeometricStyle {
       result.write(DomRenderer.defaultFontSize);
     }
     result.write(' ');
-    result.write(effectiveFontFamily);
+    result.write("'$effectiveFontFamily'");
 
     return result.toString();
   }
@@ -227,7 +227,7 @@ class TextDimensions {
   void applyStyle(ParagraphGeometricStyle style) {
     _element.style
       ..fontSize = style.fontSize != null ? '${style.fontSize.floor()}px' : null
-      ..fontFamily = style.effectiveFontFamily
+      ..fontFamily = "'${style.effectiveFontFamily}'"
       ..fontWeight =
           style.fontWeight != null ? fontWeightToCss(style.fontWeight) : null
       ..fontStyle = style.fontStyle != null


### PR DESCRIPTION
Browsers will only allow font names with spaces or '/' if they are
in quotes.

Fixes https://github.com/flutter/flutter/issues/39486