### PR TITLE
Add wasm to sky_engine

### DIFF
--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -15,6 +15,7 @@ import("//third_party/dart/sdk/lib/io/io_sources.gni")
 import("//third_party/dart/sdk/lib/isolate/isolate_sources.gni")
 import("//third_party/dart/sdk/lib/math/math_sources.gni")
 import("//third_party/dart/sdk/lib/typed_data/typed_data_sources.gni")
+import("//third_party/dart/sdk/lib/wasm/wasm_sources.gni")
 import("$flutter_root/build/dart/rules.gni")
 import("$flutter_root/lib/ui/dart_ui.gni")
 
@@ -128,6 +129,14 @@ copy("typed_data") {
   ]
 }
 
+copy("wasm") {
+  lib_path = rebase_path("wasm", "", dart_sdk_lib_path)
+  sources = rebase_path(wasm_sdk_sources, "", lib_path)
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/wasm/{{source_file_part}}",
+  ]
+}
+
 copy("copy_dart_ui") {
   sources = dart_ui_files
 
@@ -150,6 +159,7 @@ group("copy_dart_sdk") {
     ":isolate",
     ":math",
     ":typed_data",
+    ":wasm",
   ]
 }
 


### PR DESCRIPTION
In https://github.com/flutter/engine/commit/74a3c73e3c77dc1fcddd98cf216d187ea830faf2, wasm was added to the set of embedder dart libraries but not to the sky_engine package. This causes dartdocs to crash when attempting to produce docs for the flutter dart sdk.

See; https://cirrus-ci.com/task/4755278756577280

Until we can land a fix I've disabled the autoroller.