### PR TITLE
Roll fuchsia/clang/linux-amd64 from wGyr4... to -mnHl...

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -569,7 +569,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/clang/linux-amd64',
-        'version': 'wGyr4zXfvQ_jKBpPnE7vMbtaaHmuVtv04AKwiOrOezUC'
+        'version': '-mnHlaPaPgvt5sKjF7jhV88hKIn7NDHU6Bh4YZX7u_8C'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -218,8 +218,9 @@ void Engine::ReportTimings(std::vector<int64_t> timings) {
 }
 
 void Engine::NotifyIdle(int64_t deadline) {
+  auto trace_event = std::to_string(deadline - Dart_TimelineGetMicros());
   TRACE_EVENT1("flutter", "Engine::NotifyIdle", "deadline_now_delta",
-               std::to_string(deadline - Dart_TimelineGetMicros()).c_str());
+               trace_event.c_str());
   runtime_controller_->NotifyIdle(deadline);
 }
 


### PR DESCRIPTION
If this roll has caused a breakage, revert this CL and stop the roller
using the controls here:
https://autoroll.skia.org/r/fuchsia-linux-toolchain-flutter-engine
Please CC  on the revert to ensure that a human
is aware of the problem.

To report a problem with the AutoRoller itself, please file a bug:
https://bugs.chromium.org/p/skia/issues/entry?template=Autoroller+Bug

Documentation for the AutoRoller is here:
https://skia.googlesource.com/buildbot/+/master/autoroll/README.md