### PR TITLE
Started logging warnings if we drop platform messages.

### DIFF
--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -261,13 +261,21 @@ void Window::UpdateAccessibilityFeatures(int32_t values) {
 
 void Window::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
-  if (!dart_state)
+  if (!dart_state) {
+    FML_DLOG(WARNING)
+        << "Dropping platform message for lack of DartState on channel:"
+        << message->channel();
     return;
+  }
   tonic::DartState::Scope scope(dart_state);
   Dart_Handle data_handle =
       (message->hasData()) ? ToByteData(message->data()) : Dart_Null();
-  if (Dart_IsError(data_handle))
+  if (Dart_IsError(data_handle)) {
+    FML_DLOG(WARNING)
+        << "Dropping platform message because of a Dart error on channel:"
+        << message->channel();
     return;
+  }
 
   int response_id = 0;
   if (auto response = message->response()) {

--- a/lib/ui/window/window.cc
+++ b/lib/ui/window/window.cc
@@ -263,7 +263,7 @@ void Window::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
   std::shared_ptr<tonic::DartState> dart_state = library_.dart_state().lock();
   if (!dart_state) {
     FML_DLOG(WARNING)
-        << "Dropping platform message for lack of DartState on channel:"
+        << "Dropping platform message for lack of DartState on channel: "
         << message->channel();
     return;
   }
@@ -272,7 +272,7 @@ void Window::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
       (message->hasData()) ? ToByteData(message->data()) : Dart_Null();
   if (Dart_IsError(data_handle)) {
     FML_DLOG(WARNING)
-        << "Dropping platform message because of a Dart error on channel:"
+        << "Dropping platform message because of a Dart error on channel: "
         << message->channel();
     return;
   }

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -292,7 +292,7 @@ void Engine::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
     return;
   }
 
-  FML_DLOG(WARNING) << "Dropping platform message on channel:"
+  FML_DLOG(WARNING) << "Dropping platform message on channel: "
                     << message->channel();
 }
 

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -287,8 +287,13 @@ void Engine::DispatchPlatformMessage(fml::RefPtr<PlatformMessage> message) {
   }
 
   // If there's no runtime_, we may still need to set the initial route.
-  if (message->channel() == kNavigationChannel)
+  if (message->channel() == kNavigationChannel) {
     HandleNavigationPlatformMessage(std::move(message));
+    return;
+  }
+
+  FML_DLOG(WARNING) << "Dropping platform message on channel:"
+                    << message->channel();
 }
 
 bool Engine::HandleLifecyclePlatformMessage(PlatformMessage* message) {


### PR DESCRIPTION
Related issue: https://github.com/flutter/flutter/issues/38914

I plan to address the issue more thoroughly but at a minimum we should notify developers that their messages are getting dropped.  It is almost certainly an error to send a message that isn't received.