### PR TITLE
Manage resource and onscreen contexts using separate IOSGLContext objects

### DIFF
--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -45,8 +45,6 @@ class WeakPtr {
   // Copy constructor.
   WeakPtr(const WeakPtr<T>& r) = default;
 
-  WeakPtr(std::nullptr_t r) : ptr_(r) {}
-
   template <typename U>
   WeakPtr(const WeakPtr<U>& r)
       : ptr_(static_cast<T*>(r.ptr_)), flag_(r.flag_), checker_(r.checker_) {}

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -45,6 +45,8 @@ class WeakPtr {
   // Copy constructor.
   WeakPtr(const WeakPtr<T>& r) = default;
 
+  WeakPtr(std::nullptr_t r) : ptr_(r) {}
+
   template <typename U>
   WeakPtr(const WeakPtr<U>& r)
       : ptr_(static_cast<T*>(r.ptr_)), flag_(r.flag_), checker_(r.checker_) {}

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -36,6 +36,8 @@
 
 - (fml::WeakPtr<flutter::PlatformView>)platformView;
 
+- (flutter::PlatformViewIOS*)iosPlatformView;
+
 - (flutter::Rasterizer::Screenshot)screenshot:(flutter::Rasterizer::ScreenshotType)type
                                  base64Encode:(bool)base64Encode;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -25,8 +25,8 @@
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithContentsScale:(CGFloat)contentsScale;
 - (std::unique_ptr<flutter::IOSSurface>)
-    createSurfaceWithOnscreenContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreen_gl_context
-                     resourceContext:(fml::WeakPtr<flutter::IOSGLContext>)resource_gl_context;
+    createSurfaceWithOnscreenGLContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreenGLContext
+                     resourceGLContext:(fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -25,8 +25,8 @@
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithContentsScale:(CGFloat)contentsScale;
 - (std::unique_ptr<flutter::IOSSurface>)
-      createSurface:(std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
-    resourceContext:(std::shared_ptr<flutter::IOSGLContext>)resource_gl_context;
+    createSurfaceWithOnscreenContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreen_gl_context
+                     resourceContext:(fml::WeakPtr<flutter::IOSGLContext>)resource_gl_context;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -24,8 +24,8 @@
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithContentsScale:(CGFloat)contentsScale;
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
+- (std::unique_ptr<flutter::IOSSurface>)
+      createSurface:(std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
     resourceContext:(std::shared_ptr<flutter::IOSGLContext>)resource_gl_context;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -25,7 +25,8 @@
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithContentsScale:(CGFloat)contentsScale;
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)gl_context;
+    (std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
+    resourceContext:(std::shared_ptr<flutter::IOSGLContext>)resource_gl_context;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -78,8 +78,8 @@
 #endif  // TARGET_IPHONE_SIMULATOR
 }
 
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
+- (std::unique_ptr<flutter::IOSSurface>)
+      createSurface:(std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
     resourceContext:(std::shared_ptr<flutter::IOSGLContext>)resource_gl_context {
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
@@ -87,7 +87,8 @@
     if (@available(iOS 9.0, *)) {
       eagl_layer.get().presentsWithTransaction = YES;
     }
-    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), onscreen_gl_context, resource_gl_context);
+    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), onscreen_gl_context,
+                                                   resource_gl_context);
 #if FLUTTER_SHELL_ENABLE_METAL
   } else if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
     fml::scoped_nsobject<CAMetalLayer> metalLayer(

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -79,16 +79,16 @@
 }
 
 - (std::unique_ptr<flutter::IOSSurface>)
-    createSurfaceWithOnscreenContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreen_gl_context
-                     resourceContext:(fml::WeakPtr<flutter::IOSGLContext>)resource_gl_context {
+    createSurfaceWithOnscreenGLContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreenGLContext
+                     resourceGLContext:(fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext {
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
     if (@available(iOS 9.0, *)) {
       eagl_layer.get().presentsWithTransaction = YES;
     }
-    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), onscreen_gl_context,
-                                                   resource_gl_context);
+    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), onscreenGLContext,
+                                                   resourceGLContext);
 #if FLUTTER_SHELL_ENABLE_METAL
   } else if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
     fml::scoped_nsobject<CAMetalLayer> metalLayer(

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -79,14 +79,15 @@
 }
 
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)gl_context {
+    (std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
+    resourceContext:(std::shared_ptr<flutter::IOSGLContext>)resource_gl_context {
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
     if (@available(iOS 9.0, *)) {
       eagl_layer.get().presentsWithTransaction = YES;
     }
-    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), gl_context);
+    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), onscreen_gl_context, resource_gl_context);
 #if FLUTTER_SHELL_ENABLE_METAL
   } else if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
     fml::scoped_nsobject<CAMetalLayer> metalLayer(

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -79,8 +79,8 @@
 }
 
 - (std::unique_ptr<flutter::IOSSurface>)
-      createSurface:(std::shared_ptr<flutter::IOSGLContext>)onscreen_gl_context
-    resourceContext:(std::shared_ptr<flutter::IOSGLContext>)resource_gl_context {
+    createSurfaceWithOnscreenContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreen_gl_context
+                     resourceContext:(fml::WeakPtr<flutter::IOSGLContext>)resource_gl_context {
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -361,14 +361,16 @@ void FlutterPlatformViewsController::Reset() {
   views_to_recomposite_.clear();
 }
 
-bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
-                                                 std::shared_ptr<IOSGLContext> onscreen_gl_context,
-                                                 std::shared_ptr<IOSGLContext> resource_gl_context) {
+bool FlutterPlatformViewsController::SubmitFrame(
+    GrContext* gr_context,
+    std::shared_ptr<IOSGLContext> onscreen_gl_context,
+    std::shared_ptr<IOSGLContext> resource_gl_context) {
   DisposeViews();
 
   bool did_submit = true;
   for (int64_t view_id : composition_order_) {
-    EnsureOverlayInitialized(view_id, std::move(onscreen_gl_context), std::move(resource_gl_context), gr_context);
+    EnsureOverlayInitialized(view_id, std::move(onscreen_gl_context),
+                             std::move(resource_gl_context), gr_context);
     auto frame = overlays_[view_id]->surface->AcquireFrame(frame_size_);
     SkCanvas* canvas = frame->SkiaCanvas();
     canvas->drawPicture(picture_recorders_[view_id]->finishRecordingAsPicture());
@@ -469,7 +471,8 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
     overlay_view.get().frame = flutter_view_.get().bounds;
     overlay_view.get().autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-    std::unique_ptr<IOSSurface> ios_surface = [overlay_view.get() createSurface:nil resourceContext:nil];
+    std::unique_ptr<IOSSurface> ios_surface = [overlay_view.get() createSurface:nil
+                                                                resourceContext:nil];
     std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface();
     overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
         std::move(overlay_view), std::move(ios_surface), std::move(surface));
@@ -494,7 +497,8 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
   overlay_view.get().autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   std::unique_ptr<IOSSurface> ios_surface =
-      [overlay_view.get() createSurface:std::move(onscreen_gl_context) resourceContext:std::move(resource_gl_context)];
+      [overlay_view.get() createSurface:std::move(onscreen_gl_context)
+                        resourceContext:std::move(resource_gl_context)];
   std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface(gr_context);
   overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
       std::move(overlay_view), std::move(ios_surface), std::move(surface));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -361,16 +361,14 @@ void FlutterPlatformViewsController::Reset() {
   views_to_recomposite_.clear();
 }
 
-bool FlutterPlatformViewsController::SubmitFrame(
-    GrContext* gr_context,
-    std::shared_ptr<IOSGLContext> onscreen_gl_context,
-    std::shared_ptr<IOSGLContext> resource_gl_context) {
+bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
+                                                 fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                                                 fml::WeakPtr<IOSGLContext> resource_gl_context) {
   DisposeViews();
 
   bool did_submit = true;
   for (int64_t view_id : composition_order_) {
-    EnsureOverlayInitialized(view_id, std::move(onscreen_gl_context),
-                             std::move(resource_gl_context), gr_context);
+    EnsureOverlayInitialized(view_id, onscreen_gl_context, resource_gl_context, gr_context);
     auto frame = overlays_[view_id]->surface->AcquireFrame(frame_size_);
     SkCanvas* canvas = frame->SkiaCanvas();
     canvas->drawPicture(picture_recorders_[view_id]->finishRecordingAsPicture());
@@ -454,8 +452,8 @@ void FlutterPlatformViewsController::DisposeViews() {
 
 void FlutterPlatformViewsController::EnsureOverlayInitialized(
     int64_t overlay_id,
-    std::shared_ptr<IOSGLContext> onscreen_gl_context,
-    std::shared_ptr<IOSGLContext> resource_gl_context,
+    fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+    fml::WeakPtr<IOSGLContext> resource_gl_context,
     GrContext* gr_context) {
   FML_DCHECK(flutter_view_);
 
@@ -471,8 +469,8 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
     overlay_view.get().frame = flutter_view_.get().bounds;
     overlay_view.get().autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-    std::unique_ptr<IOSSurface> ios_surface = [overlay_view.get() createSurface:nil
-                                                                resourceContext:nil];
+    std::unique_ptr<IOSSurface> ios_surface =
+        [overlay_view.get() createSurfaceWithOnscreenContext:nil resourceContext:nil];
     std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface();
     overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
         std::move(overlay_view), std::move(ios_surface), std::move(surface));
@@ -497,8 +495,8 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
   overlay_view.get().autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   std::unique_ptr<IOSSurface> ios_surface =
-      [overlay_view.get() createSurface:std::move(onscreen_gl_context)
-                        resourceContext:std::move(resource_gl_context)];
+      [overlay_view.get() createSurfaceWithOnscreenContext:std::move(onscreen_gl_context)
+                                           resourceContext:std::move(resource_gl_context)];
   std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface(gr_context);
   overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
       std::move(overlay_view), std::move(ios_surface), std::move(surface));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -469,9 +469,9 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
     overlay_view.get().frame = flutter_view_.get().bounds;
     overlay_view.get().autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-    std::unique_ptr<IOSSurface> ios_surface =
-        [overlay_view.get() createSurfaceWithOnscreenGLContext:fml::WeakPtr<flutter::IOSGLContext>()
-                                             resourceGLContext:fml::WeakPtr<flutter::IOSGLContext>()];
+    std::unique_ptr<IOSSurface> ios_surface = [overlay_view.get()
+        createSurfaceWithOnscreenGLContext:fml::WeakPtr<flutter::IOSGLContext>()
+                         resourceGLContext:fml::WeakPtr<flutter::IOSGLContext>()];
     std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface();
     overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
         std::move(overlay_view), std::move(ios_surface), std::move(surface));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -470,8 +470,8 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
     overlay_view.get().autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     std::unique_ptr<IOSSurface> ios_surface =
-        [overlay_view.get() createSurfaceWithOnscreenContext:fml::WeakPtr<flutter::IOSGLContext>()
-                                             resourceContext:fml::WeakPtr<flutter::IOSGLContext>()];
+        [overlay_view.get() createSurfaceWithOnscreenGLContext:fml::WeakPtr<flutter::IOSGLContext>()
+                                             resourceGLContext:fml::WeakPtr<flutter::IOSGLContext>()];
     std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface();
     overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
         std::move(overlay_view), std::move(ios_surface), std::move(surface));
@@ -496,8 +496,8 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
   overlay_view.get().autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   std::unique_ptr<IOSSurface> ios_surface =
-      [overlay_view.get() createSurfaceWithOnscreenContext:std::move(onscreen_gl_context)
-                                           resourceContext:std::move(resource_gl_context)];
+      [overlay_view.get() createSurfaceWithOnscreenGLContext:std::move(onscreen_gl_context)
+                                           resourceGLContext:std::move(resource_gl_context)];
   std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface(gr_context);
   overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
       std::move(overlay_view), std::move(ios_surface), std::move(surface));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -362,12 +362,13 @@ void FlutterPlatformViewsController::Reset() {
 }
 
 bool FlutterPlatformViewsController::SubmitFrame(GrContext* gr_context,
-                                                 std::shared_ptr<IOSGLContext> gl_context) {
+                                                 std::shared_ptr<IOSGLContext> onscreen_gl_context,
+                                                 std::shared_ptr<IOSGLContext> resource_gl_context) {
   DisposeViews();
 
   bool did_submit = true;
   for (int64_t view_id : composition_order_) {
-    EnsureOverlayInitialized(view_id, std::move(gl_context), gr_context);
+    EnsureOverlayInitialized(view_id, std::move(onscreen_gl_context), std::move(resource_gl_context), gr_context);
     auto frame = overlays_[view_id]->surface->AcquireFrame(frame_size_);
     SkCanvas* canvas = frame->SkiaCanvas();
     canvas->drawPicture(picture_recorders_[view_id]->finishRecordingAsPicture());
@@ -451,7 +452,8 @@ void FlutterPlatformViewsController::DisposeViews() {
 
 void FlutterPlatformViewsController::EnsureOverlayInitialized(
     int64_t overlay_id,
-    std::shared_ptr<IOSGLContext> gl_context,
+    std::shared_ptr<IOSGLContext> onscreen_gl_context,
+    std::shared_ptr<IOSGLContext> resource_gl_context,
     GrContext* gr_context) {
   FML_DCHECK(flutter_view_);
 
@@ -467,7 +469,7 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
     overlay_view.get().frame = flutter_view_.get().bounds;
     overlay_view.get().autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-    std::unique_ptr<IOSSurface> ios_surface = [overlay_view.get() createSurface:nil];
+    std::unique_ptr<IOSSurface> ios_surface = [overlay_view.get() createSurface:nil resourceContext:nil];
     std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface();
     overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
         std::move(overlay_view), std::move(ios_surface), std::move(surface));
@@ -492,7 +494,7 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
   overlay_view.get().autoresizingMask =
       (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
   std::unique_ptr<IOSSurface> ios_surface =
-      [overlay_view.get() createSurface:std::move(gl_context)];
+      [overlay_view.get() createSurface:std::move(onscreen_gl_context) resourceContext:std::move(resource_gl_context)];
   std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface(gr_context);
   overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
       std::move(overlay_view), std::move(ios_surface), std::move(surface));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews.mm
@@ -470,7 +470,8 @@ void FlutterPlatformViewsController::EnsureOverlayInitialized(
     overlay_view.get().autoresizingMask =
         (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     std::unique_ptr<IOSSurface> ios_surface =
-        [overlay_view.get() createSurfaceWithOnscreenContext:nil resourceContext:nil];
+        [overlay_view.get() createSurfaceWithOnscreenContext:fml::WeakPtr<flutter::IOSGLContext>()
+                                             resourceContext:fml::WeakPtr<flutter::IOSGLContext>()];
     std::unique_ptr<Surface> surface = ios_surface->CreateGPUSurface();
     overlays_[overlay_id] = std::make_unique<FlutterPlatformViewLayer>(
         std::move(overlay_view), std::move(ios_surface), std::move(surface));

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -101,8 +101,8 @@ class FlutterPlatformViewsController {
   void Reset();
 
   bool SubmitFrame(GrContext* gr_context,
-                   std::shared_ptr<IOSGLContext> onscreen_gl_context,
-                   std::shared_ptr<IOSGLContext> resource_gl_context);
+                   fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                   fml::WeakPtr<IOSGLContext> resource_gl_context);
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
@@ -164,8 +164,8 @@ class FlutterPlatformViewsController {
   // Dispose the views in `views_to_dispose_`.
   void DisposeViews();
   void EnsureOverlayInitialized(int64_t overlay_id,
-                                std::shared_ptr<IOSGLContext> onscreen_gl_context,
-                                std::shared_ptr<IOSGLContext> resource_gl_context,
+                                fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                                fml::WeakPtr<IOSGLContext> resource_gl_context,
                                 GrContext* gr_context);
 
   // This will return true after pre-roll if any of the embedded views

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -100,7 +100,7 @@ class FlutterPlatformViewsController {
   // Discards all platform views instances and auxiliary resources.
   void Reset();
 
-  bool SubmitFrame(GrContext* gr_context, std::shared_ptr<IOSGLContext> gl_context);
+  bool SubmitFrame(GrContext* gr_context, std::shared_ptr<IOSGLContext> onscreen_gl_context, std::shared_ptr<IOSGLContext> resource_gl_context);
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
@@ -162,7 +162,8 @@ class FlutterPlatformViewsController {
   // Dispose the views in `views_to_dispose_`.
   void DisposeViews();
   void EnsureOverlayInitialized(int64_t overlay_id,
-                                std::shared_ptr<IOSGLContext> gl_context,
+                                std::shared_ptr<IOSGLContext> onscreen_gl_context,
+                                std::shared_ptr<IOSGLContext> resource_gl_context,
                                 GrContext* gr_context);
 
   // This will return true after pre-roll if any of the embedded views

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -100,7 +100,9 @@ class FlutterPlatformViewsController {
   // Discards all platform views instances and auxiliary resources.
   void Reset();
 
-  bool SubmitFrame(GrContext* gr_context, std::shared_ptr<IOSGLContext> onscreen_gl_context, std::shared_ptr<IOSGLContext> resource_gl_context);
+  bool SubmitFrame(GrContext* gr_context,
+                   std::shared_ptr<IOSGLContext> onscreen_gl_context,
+                   std::shared_ptr<IOSGLContext> resource_gl_context);
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -34,7 +34,7 @@
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)context;
+    (std::shared_ptr<flutter::IOSGLContext>)resourceContext;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -33,7 +33,7 @@
 
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
+- (std::unique_ptr<flutter::IOSSurface>)createSurfaceWithResourceGLContext:
     (fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext;
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -34,7 +34,7 @@
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)resourceContext;
+    (fml::WeakPtr<flutter::IOSGLContext>)resourceContext;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -34,7 +34,7 @@
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (fml::WeakPtr<flutter::IOSGLContext>)resourceContext;
+    (fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -95,7 +95,7 @@
 #endif  // TARGET_IPHONE_SIMULATOR
 }
 
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
+- (std::unique_ptr<flutter::IOSSurface>)createSurfaceWithResourceGLContext:
     (fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext {
 #if !TARGET_IPHONE_SIMULATOR
   if (!_onscreenGLContext) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -101,9 +101,9 @@ std::shared_ptr<flutter::IOSGLContext> _onscreenContext;
 }
 
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)resource_context {
+    (std::shared_ptr<flutter::IOSGLContext>)resourceContext {
 #if !TARGET_IPHONE_SIMULATOR
-  _onscreenContext = std::make_shared<flutter::IOSGLContext>(resource_context->Sharegroup());
+  _onscreenContext = resourceContext->MakeSharedContext();
 #endif  // !TARGET_IPHONE_SIMULATOR
 
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
@@ -116,7 +116,7 @@ std::shared_ptr<flutter::IOSGLContext> _onscreenContext;
         eagl_layer.get().presentsWithTransaction = YES;
       }
     }
-    return std::make_unique<flutter::IOSSurfaceGL>(_onscreenContext, resource_context,
+    return std::make_unique<flutter::IOSSurfaceGL>(_onscreenContext, resourceContext,
                                                    std::move(eagl_layer),
                                                    [_delegate platformViewsController]);
 #if FLUTTER_SHELL_ENABLE_METAL

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -111,7 +111,8 @@ std::shared_ptr<flutter::IOSGLContext> _onscreen_context;
         eagl_layer.get().presentsWithTransaction = YES;
       }
     }
-    return std::make_unique<flutter::IOSSurfaceGL>(_onscreen_context, resource_context, std::move(eagl_layer),
+    return std::make_unique<flutter::IOSSurfaceGL>(_onscreen_context, resource_context,
+                                                   std::move(eagl_layer),
                                                    [_delegate platformViewsController]);
 #if FLUTTER_SHELL_ENABLE_METAL
   } else if ([self.layer isKindOfClass:[CAMetalLayer class]]) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -114,7 +114,7 @@
       }
     }
     return std::make_unique<flutter::IOSSurfaceGL>(
-        _onscreenContext->WeakPtr(), std::move(resourceContext), std::move(eagl_layer),
+        _onscreenContext->GetWeakPtr(), std::move(resourceContext), std::move(eagl_layer),
         [_delegate platformViewsController]);
 #if FLUTTER_SHELL_ENABLE_METAL
   } else if ([self.layer isKindOfClass:[CAMetalLayer class]]) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -24,7 +24,7 @@
 
 @implementation FlutterView {
   id<FlutterViewEngineDelegate> _delegate;
-  std::unique_ptr<flutter::IOSGLContext> _onscreenContext;
+  std::unique_ptr<flutter::IOSGLContext> _onscreenGLContext;
 }
 
 - (instancetype)init {
@@ -96,10 +96,10 @@
 }
 
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (fml::WeakPtr<flutter::IOSGLContext>)resourceContext {
+    (fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext {
 #if !TARGET_IPHONE_SIMULATOR
-  if (!_onscreenContext) {
-    _onscreenContext = resourceContext->MakeSharedContext();
+  if (!_onscreenGLContext) {
+    _onscreenGLContext = resourceGLContext->MakeSharedContext();
   }
 #endif  // !TARGET_IPHONE_SIMULATOR
 
@@ -114,7 +114,7 @@
       }
     }
     return std::make_unique<flutter::IOSSurfaceGL>(
-        _onscreenContext->GetWeakPtr(), std::move(resourceContext), std::move(eagl_layer),
+        _onscreenGLContext->GetWeakPtr(), std::move(resourceGLContext), std::move(eagl_layer),
         [_delegate platformViewsController]);
 #if FLUTTER_SHELL_ENABLE_METAL
   } else if ([self.layer isKindOfClass:[CAMetalLayer class]]) {

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.mm
@@ -46,7 +46,7 @@ std::shared_ptr<flutter::IOSGLContext> _onscreenContext;
 }
 
 - (void)dealloc {
-  _onscreenContext = nullptr;
+  _onscreenContext.reset();
   [super dealloc];
 }
 
@@ -103,7 +103,9 @@ std::shared_ptr<flutter::IOSGLContext> _onscreenContext;
 - (std::unique_ptr<flutter::IOSSurface>)createSurface:
     (std::shared_ptr<flutter::IOSGLContext>)resourceContext {
 #if !TARGET_IPHONE_SIMULATOR
-  _onscreenContext = resourceContext->MakeSharedContext();
+  if (!_onscreenContext) {
+    _onscreenContext = resourceContext->MakeSharedContext();
+  }
 #endif  // !TARGET_IPHONE_SIMULATOR
 
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
@@ -116,7 +118,7 @@ std::shared_ptr<flutter::IOSGLContext> _onscreenContext;
         eagl_layer.get().presentsWithTransaction = YES;
       }
     }
-    return std::make_unique<flutter::IOSSurfaceGL>(_onscreenContext, resourceContext,
+    return std::make_unique<flutter::IOSSurfaceGL>(_onscreenContext, std::move(resourceContext),
                                                    std::move(eagl_layer),
                                                    [_delegate platformViewsController]);
 #if FLUTTER_SHELL_ENABLE_METAL

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1153,7 +1153,7 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
 }
 
 - (BOOL)hasOnscreenSurface {
-    return [_engine.get() iosPlatformView] -> HasOnscreenSurface();
+  return [_engine.get() iosPlatformView] -> HasOnscreenSurface();
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1152,4 +1152,8 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
   return [_engine.get() valuePublishedByPlugin:pluginKey];
 }
 
+- (BOOL)hasOnscreenSurface {
+    return [_engine.get() iosPlatformView] -> HasOnscreenSurface();
+}
+
 @end

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -19,6 +19,7 @@ namespace flutter {
 class IOSGLContext {
  public:
   IOSGLContext();
+  IOSGLContext(EAGLSharegroup* sharegroup);
 
   ~IOSGLContext();
 
@@ -31,7 +32,6 @@ class IOSGLContext {
   std::shared_ptr<IOSGLContext> MakeSharedContext();
 
  private:
-  IOSGLContext(EAGLSharegroup* sharegroup);
 
   fml::scoped_nsobject<EAGLContext> context_;
   sk_sp<SkColorSpace> color_space_;

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -29,11 +29,15 @@ class IOSGLContext {
 
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 
-  std::shared_ptr<IOSGLContext> MakeSharedContext();
+  std::unique_ptr<IOSGLContext> MakeSharedContext();
+
+  fml::WeakPtr<IOSGLContext> WeakPtr();
 
  private:
   fml::scoped_nsobject<EAGLContext> context_;
   sk_sp<SkColorSpace> color_space_;
+
+  std::unique_ptr<fml::WeakPtrFactory<IOSGLContext>> weak_factory_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSGLContext);
 };

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -13,7 +13,6 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/common/platform_view.h"
-#include "ios_gl_render_target.h"
 
 namespace flutter {
 
@@ -23,18 +22,13 @@ class IOSGLContext {
 
   ~IOSGLContext();
 
-  std::unique_ptr<IOSGLRenderTarget> CreateRenderTarget(
-      fml::scoped_nsobject<CAEAGLLayer> layer);
-
   bool MakeCurrent();
 
-  bool ResourceMakeCurrent();
-
+  bool BindRenderbufferStorage(NSUInteger target, fml::scoped_nsobject<CAEAGLLayer> layer);
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 
  private:
   fml::scoped_nsobject<EAGLContext> context_;
-  fml::scoped_nsobject<EAGLContext> resource_context_;
   sk_sp<SkColorSpace> color_space_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSGLContext);

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -18,13 +18,16 @@ namespace flutter {
 
 class IOSGLContext {
  public:
-  IOSGLContext();
+  IOSGLContext(fml::scoped_nsobject<EAGLSharegroup> sharegroup);
 
   ~IOSGLContext();
 
   bool MakeCurrent();
 
   bool BindRenderbufferStorage(NSUInteger target, fml::scoped_nsobject<CAEAGLLayer> layer);
+
+  fml::scoped_nsobject<EAGLSharegroup> Sharegroup();
+
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 
  private:

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -25,7 +25,7 @@ class IOSGLContext {
 
   bool MakeCurrent();
 
-  bool BindRenderbufferStorage(NSUInteger target, fml::scoped_nsobject<CAEAGLLayer> layer);
+  bool BindRenderbufferStorage(fml::scoped_nsobject<CAEAGLLayer> layer);
 
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -18,7 +18,7 @@ namespace flutter {
 
 class IOSGLContext {
  public:
-  IOSGLContext(fml::scoped_nsobject<EAGLSharegroup> sharegroup);
+  IOSGLContext();
 
   ~IOSGLContext();
 
@@ -26,11 +26,13 @@ class IOSGLContext {
 
   bool BindRenderbufferStorage(NSUInteger target, fml::scoped_nsobject<CAEAGLLayer> layer);
 
-  fml::scoped_nsobject<EAGLSharegroup> Sharegroup();
-
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 
+  std::shared_ptr<IOSGLContext> MakeSharedContext();
+
  private:
+  IOSGLContext(EAGLSharegroup* sharegroup);
+
   fml::scoped_nsobject<EAGLContext> context_;
   sk_sp<SkColorSpace> color_space_;
 

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -32,7 +32,6 @@ class IOSGLContext {
   std::shared_ptr<IOSGLContext> MakeSharedContext();
 
  private:
-
   fml::scoped_nsobject<EAGLContext> context_;
   sk_sp<SkColorSpace> color_space_;
 

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -31,7 +31,7 @@ class IOSGLContext {
 
   std::unique_ptr<IOSGLContext> MakeSharedContext();
 
-  fml::WeakPtr<IOSGLContext> WeakPtr();
+  fml::WeakPtr<IOSGLContext> GetWeakPtr();
 
  private:
   fml::scoped_nsobject<EAGLContext> context_;

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -48,7 +48,8 @@ IOSGLContext::IOSGLContext() {
   }
 }
 
-bool IOSGLContext::BindRenderbufferStorage(NSUInteger target, fml::scoped_nsobject<CAEAGLLayer> layer) {
+bool IOSGLContext::BindRenderbufferStorage(NSUInteger target,
+                                           fml::scoped_nsobject<CAEAGLLayer> layer) {
   return [context_.get() renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer.get()];
 }
 

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -45,7 +45,7 @@ IOSGLContext::IOSGLContext(EAGLSharegroup* sharegroup)
   }
 }
 
-fml::WeakPtr<IOSGLContext> IOSGLContext::WeakPtr() {
+fml::WeakPtr<IOSGLContext> IOSGLContext::GetWeakPtr() {
   return weak_factory_->GetWeakPtr();
 }
 

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -49,8 +49,7 @@ fml::WeakPtr<IOSGLContext> IOSGLContext::GetWeakPtr() {
   return weak_factory_->GetWeakPtr();
 }
 
-bool IOSGLContext::BindRenderbufferStorage(NSUInteger target,
-                                           fml::scoped_nsobject<CAEAGLLayer> layer) {
+bool IOSGLContext::BindRenderbufferStorage(fml::scoped_nsobject<CAEAGLLayer> layer) {
   return [context_.get() renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer.get()];
 }
 

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -12,13 +12,15 @@
 
 namespace flutter {
 
-IOSGLContext::IOSGLContext(fml::scoped_nsobject<EAGLSharegroup> sharegroup) {
+IOSGLContext::IOSGLContext() : IOSGLContext(nullptr) {}
+
+IOSGLContext::IOSGLContext(EAGLSharegroup* sharegroup) {
   context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
-                                       sharegroup:sharegroup.get()]);
+                                       sharegroup:sharegroup]);
 
   if (!context_) {
     context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
-                                         sharegroup:sharegroup.get()]);
+                                         sharegroup:sharegroup]);
   }
 
   // TODO:
@@ -42,10 +44,6 @@ IOSGLContext::IOSGLContext(fml::scoped_nsobject<EAGLSharegroup> sharegroup) {
   }
 }
 
-fml::scoped_nsobject<EAGLSharegroup> IOSGLContext::Sharegroup() {
-  return fml::scoped_nsobject<EAGLSharegroup>(context_.get().sharegroup);
-}
-
 bool IOSGLContext::BindRenderbufferStorage(NSUInteger target,
                                            fml::scoped_nsobject<CAEAGLLayer> layer) {
   return [context_.get() renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer.get()];
@@ -55,6 +53,10 @@ IOSGLContext::~IOSGLContext() = default;
 
 bool IOSGLContext::MakeCurrent() {
   return [EAGLContext setCurrentContext:context_.get()];
+}
+
+std::shared_ptr<IOSGLContext> IOSGLContext::MakeSharedContext() {
+  return std::shared_ptr<IOSGLContext>(new IOSGLContext(context_.get().sharegroup));
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -12,19 +12,13 @@
 
 namespace flutter {
 
-static fml::scoped_nsobject<EAGLSharegroup> sharegroup_;
-
-IOSGLContext::IOSGLContext() {
+IOSGLContext::IOSGLContext(fml::scoped_nsobject<EAGLSharegroup> sharegroup) {
   context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
-                                       sharegroup:sharegroup_.get()]);
+                                       sharegroup:sharegroup.get()]);
 
   if (!context_) {
     context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
-                                         sharegroup:sharegroup_.get()]);
-  }
-
-  if (sharegroup_ == nullptr) {
-    sharegroup_.reset(context_.get().sharegroup);
+                                         sharegroup:sharegroup.get()]);
   }
 
   // TODO:
@@ -46,6 +40,10 @@ IOSGLContext::IOSGLContext() {
         break;
     }
   }
+}
+
+fml::scoped_nsobject<EAGLSharegroup> IOSGLContext::Sharegroup() {
+  return fml::scoped_nsobject<EAGLSharegroup>(context_.get().sharegroup);
 }
 
 bool IOSGLContext::BindRenderbufferStorage(NSUInteger target,

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -56,7 +56,7 @@ bool IOSGLContext::MakeCurrent() {
 }
 
 std::shared_ptr<IOSGLContext> IOSGLContext::MakeSharedContext() {
-  return std::shared_ptr<IOSGLContext>(new IOSGLContext(context_.get().sharegroup));
+  return std::make_shared<IOSGLContext>(context_.get().sharegroup);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -14,7 +14,8 @@ namespace flutter {
 
 IOSGLContext::IOSGLContext() : IOSGLContext(nullptr) {}
 
-IOSGLContext::IOSGLContext(EAGLSharegroup* sharegroup) {
+IOSGLContext::IOSGLContext(EAGLSharegroup* sharegroup)
+    : weak_factory_(std::make_unique<fml::WeakPtrFactory<IOSGLContext>>(this)) {
   context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
                                        sharegroup:sharegroup]);
 
@@ -44,6 +45,10 @@ IOSGLContext::IOSGLContext(EAGLSharegroup* sharegroup) {
   }
 }
 
+fml::WeakPtr<IOSGLContext> IOSGLContext::WeakPtr() {
+  return weak_factory_->GetWeakPtr();
+}
+
 bool IOSGLContext::BindRenderbufferStorage(NSUInteger target,
                                            fml::scoped_nsobject<CAEAGLLayer> layer) {
   return [context_.get() renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer.get()];
@@ -55,8 +60,8 @@ bool IOSGLContext::MakeCurrent() {
   return [EAGLContext setCurrentContext:context_.get()];
 }
 
-std::shared_ptr<IOSGLContext> IOSGLContext::MakeSharedContext() {
-  return std::make_shared<IOSGLContext>(context_.get().sharegroup);
+std::unique_ptr<IOSGLContext> IOSGLContext::MakeSharedContext() {
+  return std::make_unique<IOSGLContext>(context_.get().sharegroup);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_gl_context.mm
+++ b/shell/platform/darwin/ios/ios_gl_context.mm
@@ -12,15 +12,19 @@
 
 namespace flutter {
 
+static fml::scoped_nsobject<EAGLSharegroup> sharegroup_;
+
 IOSGLContext::IOSGLContext() {
-  resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3]);
-  if (resource_context_ != nullptr) {
-    context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
-                                         sharegroup:resource_context_.get().sharegroup]);
-  } else {
-    resource_context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2]);
+  context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3
+                                       sharegroup:sharegroup_.get()]);
+
+  if (!context_) {
     context_.reset([[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2
-                                         sharegroup:resource_context_.get().sharegroup]);
+                                         sharegroup:sharegroup_.get()]);
+  }
+
+  if (sharegroup_ == nullptr) {
+    sharegroup_.reset(context_.get().sharegroup);
   }
 
   // TODO:
@@ -44,20 +48,14 @@ IOSGLContext::IOSGLContext() {
   }
 }
 
-IOSGLContext::~IOSGLContext() = default;
-
-std::unique_ptr<IOSGLRenderTarget> IOSGLContext::CreateRenderTarget(
-    fml::scoped_nsobject<CAEAGLLayer> layer) {
-  return std::make_unique<IOSGLRenderTarget>(std::move(layer), context_.get(),
-                                             resource_context_.get());
+bool IOSGLContext::BindRenderbufferStorage(NSUInteger target, fml::scoped_nsobject<CAEAGLLayer> layer) {
+  return [context_.get() renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer.get()];
 }
+
+IOSGLContext::~IOSGLContext() = default;
 
 bool IOSGLContext::MakeCurrent() {
   return [EAGLContext setCurrentContext:context_.get()];
-}
-
-bool IOSGLContext::ResourceMakeCurrent() {
-  return [EAGLContext setCurrentContext:resource_context_.get()];
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_gl_render_target.h
+++ b/shell/platform/darwin/ios/ios_gl_render_target.h
@@ -20,8 +20,8 @@ namespace flutter {
 class IOSGLRenderTarget {
  public:
   IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
-                    std::shared_ptr<IOSGLContext> onscreen_context,
-                    std::shared_ptr<IOSGLContext> resource_context);
+                    fml::WeakPtr<IOSGLContext> onscreen_context,
+                    fml::WeakPtr<IOSGLContext> resource_context);
 
   ~IOSGLRenderTarget();
 
@@ -41,8 +41,8 @@ class IOSGLRenderTarget {
 
  private:
   fml::scoped_nsobject<CAEAGLLayer> layer_;
-  std::shared_ptr<IOSGLContext> onscreen_context_;
-  std::shared_ptr<IOSGLContext> resource_context_;
+  fml::WeakPtr<IOSGLContext> onscreen_context_;
+  fml::WeakPtr<IOSGLContext> resource_context_;
   GLuint framebuffer_;
   GLuint colorbuffer_;
   GLint storage_size_width_;

--- a/shell/platform/darwin/ios/ios_gl_render_target.h
+++ b/shell/platform/darwin/ios/ios_gl_render_target.h
@@ -13,14 +13,15 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/platform/darwin/ios/ios_gl_context.h"
 
 namespace flutter {
 
 class IOSGLRenderTarget {
  public:
   IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
-                    EAGLContext* context,
-                    EAGLContext* resource_context);
+                    std::shared_ptr<IOSGLContext> onscreen_context,
+                    std::shared_ptr<IOSGLContext> resource_context);
 
   ~IOSGLRenderTarget();
 
@@ -40,8 +41,8 @@ class IOSGLRenderTarget {
 
  private:
   fml::scoped_nsobject<CAEAGLLayer> layer_;
-  fml::scoped_nsobject<EAGLContext> context_;
-  fml::scoped_nsobject<EAGLContext> resource_context_;
+  std::shared_ptr<IOSGLContext> onscreen_context_;
+  std::shared_ptr<IOSGLContext> resource_context_;
   GLuint framebuffer_;
   GLuint colorbuffer_;
   GLint storage_size_width_;

--- a/shell/platform/darwin/ios/ios_gl_render_target.h
+++ b/shell/platform/darwin/ios/ios_gl_render_target.h
@@ -41,8 +41,8 @@ class IOSGLRenderTarget {
 
  private:
   fml::scoped_nsobject<CAEAGLLayer> layer_;
-  fml::WeakPtr<IOSGLContext> onscreen_context_;
-  fml::WeakPtr<IOSGLContext> resource_context_;
+  fml::WeakPtr<IOSGLContext> onscreen_gl_context_;
+  fml::WeakPtr<IOSGLContext> resource_gl_context_;
   GLuint framebuffer_;
   GLuint colorbuffer_;
   GLint storage_size_width_;

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -11,23 +11,22 @@
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
 
 namespace flutter {
-
 IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
-                                     EAGLContext* context,
-                                     EAGLContext* resource_context)
+                                     std::shared_ptr<IOSGLContext> onscreen_context,
+                                     std::shared_ptr<IOSGLContext> resource_context)
     : layer_(std::move(layer)),
-      context_([context retain]),
-      resource_context_([resource_context retain]),
+      onscreen_context_(onscreen_context.get()),
+      resource_context_(resource_context.get()),
       framebuffer_(GL_NONE),
       colorbuffer_(GL_NONE),
       storage_size_width_(0),
       storage_size_height_(0),
       valid_(false) {
   FML_DCHECK(layer_ != nullptr);
-  FML_DCHECK(context_ != nullptr);
+  FML_DCHECK(onscreen_context_ != nullptr);
   FML_DCHECK(resource_context_ != nullptr);
 
-  bool context_current = [EAGLContext setCurrentContext:context_];
+  bool context_current = onscreen_context_->MakeCurrent();
 
   FML_DCHECK(context_current);
   FML_DCHECK(glGetError() == GL_NO_ERROR);
@@ -63,7 +62,7 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
 
 IOSGLRenderTarget::~IOSGLRenderTarget() {
   EAGLContext* context = EAGLContext.currentContext;
-  [EAGLContext setCurrentContext:context_];
+  onscreen_context_->MakeCurrent();
   FML_DCHECK(glGetError() == GL_NO_ERROR);
 
   // Deletes on GL_NONEs are ignored
@@ -105,7 +104,7 @@ bool IOSGLRenderTarget::UpdateStorageSizeIfNecessary() {
 
   FML_DCHECK(glGetError() == GL_NO_ERROR);
 
-  if (![EAGLContext setCurrentContext:context_]) {
+  if (!onscreen_context_->MakeCurrent()) {
     return false;
   }
 
@@ -116,7 +115,7 @@ bool IOSGLRenderTarget::UpdateStorageSizeIfNecessary() {
   glBindRenderbuffer(GL_RENDERBUFFER, colorbuffer_);
   FML_DCHECK(glGetError() == GL_NO_ERROR);
 
-  if (![context_.get() renderbufferStorage:GL_RENDERBUFFER fromDrawable:layer_.get()]) {
+  if (!onscreen_context_->BindRenderbufferStorage(GL_RENDERBUFFER, std::move(layer_))) {
     return false;
   }
 
@@ -133,11 +132,11 @@ bool IOSGLRenderTarget::UpdateStorageSizeIfNecessary() {
 }
 
 bool IOSGLRenderTarget::MakeCurrent() {
-  return UpdateStorageSizeIfNecessary() && [EAGLContext setCurrentContext:context_.get()];
+  return UpdateStorageSizeIfNecessary() && onscreen_context_->MakeCurrent();
 }
 
 bool IOSGLRenderTarget::ResourceMakeCurrent() {
-  return [EAGLContext setCurrentContext:resource_context_.get()];
+  return resource_context_->MakeCurrent();
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -12,21 +12,21 @@
 
 namespace flutter {
 IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
-                                     fml::WeakPtr<IOSGLContext> onscreen_context,
-                                     fml::WeakPtr<IOSGLContext> resource_context)
+                                     fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                                     fml::WeakPtr<IOSGLContext> resource_gl_context)
     : layer_(std::move(layer)),
-      onscreen_context_(std::move(onscreen_context)),
-      resource_context_(std::move(resource_context)),
+      onscreen_gl_context_(std::move(onscreen_gl_context)),
+      resource_gl_context_(std::move(resource_gl_context)),
       framebuffer_(GL_NONE),
       colorbuffer_(GL_NONE),
       storage_size_width_(0),
       storage_size_height_(0),
       valid_(false) {
   FML_DCHECK(layer_ != nullptr);
-  FML_DCHECK(onscreen_context_);
-  FML_DCHECK(resource_context_);
+  FML_DCHECK(onscreen_gl_context_);
+  FML_DCHECK(resource_gl_context_);
 
-  bool context_current = onscreen_context_->MakeCurrent();
+  bool context_current = onscreen_gl_context_->MakeCurrent();
 
   FML_DCHECK(context_current);
   FML_DCHECK(glGetError() == GL_NO_ERROR);
@@ -62,7 +62,7 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
 
 IOSGLRenderTarget::~IOSGLRenderTarget() {
   EAGLContext* context = EAGLContext.currentContext;
-  onscreen_context_->MakeCurrent();
+  onscreen_gl_context_->MakeCurrent();
   FML_DCHECK(glGetError() == GL_NO_ERROR);
 
   // Deletes on GL_NONEs are ignored
@@ -104,7 +104,7 @@ bool IOSGLRenderTarget::UpdateStorageSizeIfNecessary() {
 
   FML_DCHECK(glGetError() == GL_NO_ERROR);
 
-  if (!onscreen_context_->MakeCurrent()) {
+  if (!onscreen_gl_context_->MakeCurrent()) {
     return false;
   }
 
@@ -115,7 +115,7 @@ bool IOSGLRenderTarget::UpdateStorageSizeIfNecessary() {
   glBindRenderbuffer(GL_RENDERBUFFER, colorbuffer_);
   FML_DCHECK(glGetError() == GL_NO_ERROR);
 
-  if (!onscreen_context_->BindRenderbufferStorage(GL_RENDERBUFFER, std::move(layer_))) {
+  if (!onscreen_gl_context_->BindRenderbufferStorage(layer_)) {
     return false;
   }
 
@@ -132,11 +132,11 @@ bool IOSGLRenderTarget::UpdateStorageSizeIfNecessary() {
 }
 
 bool IOSGLRenderTarget::MakeCurrent() {
-  return UpdateStorageSizeIfNecessary() && onscreen_context_->MakeCurrent();
+  return UpdateStorageSizeIfNecessary() && onscreen_gl_context_->MakeCurrent();
 }
 
 bool IOSGLRenderTarget::ResourceMakeCurrent() {
-  return resource_context_->MakeCurrent();
+  return resource_gl_context_->MakeCurrent();
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -15,16 +15,16 @@ IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
                                      std::shared_ptr<IOSGLContext> onscreen_context,
                                      std::shared_ptr<IOSGLContext> resource_context)
     : layer_(std::move(layer)),
-      onscreen_context_(onscreen_context.get()),
-      resource_context_(resource_context.get()),
+      onscreen_context_(std::move(onscreen_context)),
+      resource_context_(std::move(resource_context)),
       framebuffer_(GL_NONE),
       colorbuffer_(GL_NONE),
       storage_size_width_(0),
       storage_size_height_(0),
       valid_(false) {
   FML_DCHECK(layer_ != nullptr);
-  FML_DCHECK(onscreen_context_ != nullptr);
-  FML_DCHECK(resource_context_ != nullptr);
+  FML_DCHECK(onscreen_context_);
+  FML_DCHECK(resource_context_);
 
   bool context_current = onscreen_context_->MakeCurrent();
 

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -12,8 +12,8 @@
 
 namespace flutter {
 IOSGLRenderTarget::IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
-                                     std::shared_ptr<IOSGLContext> onscreen_context,
-                                     std::shared_ptr<IOSGLContext> resource_context)
+                                     fml::WeakPtr<IOSGLContext> onscreen_context,
+                                     fml::WeakPtr<IOSGLContext> resource_context)
     : layer_(std::move(layer)),
       onscreen_context_(std::move(onscreen_context)),
       resource_context_(std::move(resource_context)),

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -20,14 +20,14 @@ class IOSSurfaceGL final : public IOSSurface,
                            public GPUSurfaceGLDelegate,
                            public ExternalViewEmbedder {
  public:
-  IOSSurfaceGL(fml::WeakPtr<IOSGLContext> onscreen_context,
-               fml::WeakPtr<IOSGLContext> resource_context,
+  IOSSurfaceGL(fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+               fml::WeakPtr<IOSGLContext> resource_gl_context,
                fml::scoped_nsobject<CAEAGLLayer> layer,
                FlutterPlatformViewsController* platform_views_controller);
 
   IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-               fml::WeakPtr<IOSGLContext> onscreen_context,
-               fml::WeakPtr<IOSGLContext> resource_context);
+               fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+               fml::WeakPtr<IOSGLContext> resource_gl_context);
 
   ~IOSSurfaceGL() override;
 
@@ -82,9 +82,9 @@ class IOSSurfaceGL final : public IOSSurface,
   bool SubmitFrame(GrContext* context) override;
 
  private:
-  fml::WeakPtr<IOSGLContext> onscreen_context_;
+  fml::WeakPtr<IOSGLContext> onscreen_gl_context_;
 
-  fml::WeakPtr<IOSGLContext> resource_context_;
+  fml::WeakPtr<IOSGLContext> resource_gl_context_;
 
   std::unique_ptr<IOSGLRenderTarget> render_target_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -20,11 +20,14 @@ class IOSSurfaceGL final : public IOSSurface,
                            public GPUSurfaceGLDelegate,
                            public ExternalViewEmbedder {
  public:
-  IOSSurfaceGL(std::shared_ptr<IOSGLContext> context,
+  IOSSurfaceGL(std::shared_ptr<IOSGLContext> onscreen_context,
+               std::shared_ptr<IOSGLContext> resource_context,
                fml::scoped_nsobject<CAEAGLLayer> layer,
                FlutterPlatformViewsController* platform_views_controller);
 
-  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer, std::shared_ptr<IOSGLContext> context);
+  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+               std::shared_ptr<IOSGLContext> onscreen_context,
+               std::shared_ptr<IOSGLContext> resource_context);
 
   ~IOSSurfaceGL() override;
 
@@ -79,7 +82,10 @@ class IOSSurfaceGL final : public IOSSurface,
   bool SubmitFrame(GrContext* context) override;
 
  private:
-  std::shared_ptr<IOSGLContext> context_;
+  std::shared_ptr<IOSGLContext> onscreen_context_;
+
+  std::shared_ptr<IOSGLContext> resource_context_;
+
   std::unique_ptr<IOSGLRenderTarget> render_target_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceGL);

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -20,14 +20,14 @@ class IOSSurfaceGL final : public IOSSurface,
                            public GPUSurfaceGLDelegate,
                            public ExternalViewEmbedder {
  public:
-  IOSSurfaceGL(std::shared_ptr<IOSGLContext> onscreen_context,
-               std::shared_ptr<IOSGLContext> resource_context,
+  IOSSurfaceGL(fml::WeakPtr<IOSGLContext> onscreen_context,
+               fml::WeakPtr<IOSGLContext> resource_context,
                fml::scoped_nsobject<CAEAGLLayer> layer,
                FlutterPlatformViewsController* platform_views_controller);
 
   IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-               std::shared_ptr<IOSGLContext> onscreen_context,
-               std::shared_ptr<IOSGLContext> resource_context);
+               fml::WeakPtr<IOSGLContext> onscreen_context,
+               fml::WeakPtr<IOSGLContext> resource_context);
 
   ~IOSSurfaceGL() override;
 
@@ -82,9 +82,9 @@ class IOSSurfaceGL final : public IOSSurface,
   bool SubmitFrame(GrContext* context) override;
 
  private:
-  std::shared_ptr<IOSGLContext> onscreen_context_;
+  fml::WeakPtr<IOSGLContext> onscreen_context_;
 
-  std::shared_ptr<IOSGLContext> resource_context_;
+  fml::WeakPtr<IOSGLContext> resource_context_;
 
   std::unique_ptr<IOSGLRenderTarget> render_target_;
 

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -14,8 +14,8 @@ IOSSurfaceGL::IOSSurfaceGL(std::shared_ptr<IOSGLContext> onscreen_context,
                            fml::scoped_nsobject<CAEAGLLayer> layer,
                            FlutterPlatformViewsController* platform_views_controller)
     : IOSSurface(platform_views_controller),
-      onscreen_context_(onscreen_context),
-      resource_context_(resource_context) {
+      onscreen_context_(std::move(onscreen_context)),
+      resource_context_(std::move(resource_context)) {
   render_target_ =
       std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
 }
@@ -24,8 +24,8 @@ IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
                            std::shared_ptr<IOSGLContext> onscreen_context,
                            std::shared_ptr<IOSGLContext> resource_context)
     : IOSSurface(nullptr),
-      onscreen_context_(onscreen_context),
-      resource_context_(resource_context) {
+      onscreen_context_(std::move(onscreen_context)),
+      resource_context_(std::move(resource_context)) {
   render_target_ =
       std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
 }

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -9,25 +9,25 @@
 
 namespace flutter {
 
-IOSSurfaceGL::IOSSurfaceGL(fml::WeakPtr<IOSGLContext> onscreen_context,
-                           fml::WeakPtr<IOSGLContext> resource_context,
+IOSSurfaceGL::IOSSurfaceGL(fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                           fml::WeakPtr<IOSGLContext> resource_gl_context,
                            fml::scoped_nsobject<CAEAGLLayer> layer,
                            FlutterPlatformViewsController* platform_views_controller)
     : IOSSurface(platform_views_controller),
-      onscreen_context_(std::move(onscreen_context)),
-      resource_context_(std::move(resource_context)) {
-  render_target_ =
-      std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
+      onscreen_gl_context_(std::move(onscreen_gl_context)),
+      resource_gl_context_(std::move(resource_gl_context)) {
+  render_target_ = std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_gl_context_,
+                                                       resource_gl_context_);
 }
 
 IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-                           fml::WeakPtr<IOSGLContext> onscreen_context,
-                           fml::WeakPtr<IOSGLContext> resource_context)
+                           fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                           fml::WeakPtr<IOSGLContext> resource_gl_context)
     : IOSSurface(nullptr),
-      onscreen_context_(std::move(onscreen_context)),
-      resource_context_(std::move(resource_context)) {
-  render_target_ =
-      std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
+      onscreen_gl_context_(std::move(onscreen_gl_context)),
+      resource_gl_context_(std::move(resource_gl_context)) {
+  render_target_ = std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_gl_context_,
+                                                       resource_gl_context_);
 }
 
 IOSSurfaceGL::~IOSSurfaceGL() = default;
@@ -37,7 +37,7 @@ bool IOSSurfaceGL::IsValid() const {
 }
 
 bool IOSSurfaceGL::ResourceContextMakeCurrent() {
-  return resource_context_->MakeCurrent();
+  return resource_gl_context_->MakeCurrent();
 }
 
 void IOSSurfaceGL::UpdateStorageSizeIfNecessary() {
@@ -68,7 +68,7 @@ bool IOSSurfaceGL::GLContextMakeCurrent() {
   if (!IsValid()) {
     return false;
   }
-  return render_target_->UpdateStorageSizeIfNecessary() && onscreen_context_->MakeCurrent();
+  return render_target_->UpdateStorageSizeIfNecessary() && onscreen_gl_context_->MakeCurrent();
 }
 
 bool IOSSurfaceGL::GLContextClearCurrent() {
@@ -153,8 +153,8 @@ bool IOSSurfaceGL::SubmitFrame(GrContext* context) {
     return true;
   }
 
-  bool submitted = platform_views_controller->SubmitFrame(std::move(context), onscreen_context_,
-                                                          resource_context_);
+  bool submitted = platform_views_controller->SubmitFrame(std::move(context), onscreen_gl_context_,
+                                                          resource_gl_context_);
   [CATransaction commit];
   return submitted;
 }

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -13,15 +13,21 @@ IOSSurfaceGL::IOSSurfaceGL(std::shared_ptr<IOSGLContext> onscreen_context,
                            std::shared_ptr<IOSGLContext> resource_context,
                            fml::scoped_nsobject<CAEAGLLayer> layer,
                            FlutterPlatformViewsController* platform_views_controller)
-    : IOSSurface(platform_views_controller), onscreen_context_(onscreen_context), resource_context_(resource_context) {
-  render_target_ = std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
+    : IOSSurface(platform_views_controller),
+      onscreen_context_(onscreen_context),
+      resource_context_(resource_context) {
+  render_target_ =
+      std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
 }
 
 IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
                            std::shared_ptr<IOSGLContext> onscreen_context,
                            std::shared_ptr<IOSGLContext> resource_context)
-    : IOSSurface(nullptr), onscreen_context_(onscreen_context), resource_context_(resource_context) {
-  render_target_ = std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
+    : IOSSurface(nullptr),
+      onscreen_context_(onscreen_context),
+      resource_context_(resource_context) {
+  render_target_ =
+      std::make_unique<IOSGLRenderTarget>(std::move(layer), onscreen_context_, resource_context_);
 }
 
 IOSSurfaceGL::~IOSSurfaceGL() = default;
@@ -147,7 +153,8 @@ bool IOSSurfaceGL::SubmitFrame(GrContext* context) {
     return true;
   }
 
-  bool submitted = platform_views_controller->SubmitFrame(std::move(context), onscreen_context_, resource_context_);
+  bool submitted = platform_views_controller->SubmitFrame(std::move(context), onscreen_context_,
+                                                          resource_context_);
   [CATransaction commit];
   return submitted;
 }

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -9,8 +9,8 @@
 
 namespace flutter {
 
-IOSSurfaceGL::IOSSurfaceGL(std::shared_ptr<IOSGLContext> onscreen_context,
-                           std::shared_ptr<IOSGLContext> resource_context,
+IOSSurfaceGL::IOSSurfaceGL(fml::WeakPtr<IOSGLContext> onscreen_context,
+                           fml::WeakPtr<IOSGLContext> resource_context,
                            fml::scoped_nsobject<CAEAGLLayer> layer,
                            FlutterPlatformViewsController* platform_views_controller)
     : IOSSurface(platform_views_controller),
@@ -21,8 +21,8 @@ IOSSurfaceGL::IOSSurfaceGL(std::shared_ptr<IOSGLContext> onscreen_context,
 }
 
 IOSSurfaceGL::IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
-                           std::shared_ptr<IOSGLContext> onscreen_context,
-                           std::shared_ptr<IOSGLContext> resource_context)
+                           fml::WeakPtr<IOSGLContext> onscreen_context,
+                           fml::WeakPtr<IOSGLContext> resource_context)
     : IOSSurface(nullptr),
       onscreen_context_(std::move(onscreen_context)),
       resource_context_(std::move(resource_context)) {

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -184,7 +184,8 @@ bool IOSSurfaceSoftware::SubmitFrame(GrContext* context) {
   if (platform_views_controller == nullptr) {
     return true;
   }
-  return platform_views_controller->SubmitFrame(nullptr, nullptr, nullptr);
+  return platform_views_controller->SubmitFrame(nullptr, fml::WeakPtr<IOSGLContext>(),
+                                                fml::WeakPtr<IOSGLContext>());
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -184,7 +184,7 @@ bool IOSSurfaceSoftware::SubmitFrame(GrContext* context) {
   if (platform_views_controller == nullptr) {
     return true;
   }
-  return platform_views_controller->SubmitFrame(nullptr, nullptr);
+  return platform_views_controller->SubmitFrame(nullptr, nullptr, nullptr);
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -47,7 +47,7 @@ class PlatformViewIOS final : public PlatformView {
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;
   std::unique_ptr<IOSSurface> ios_surface_;
-  std::shared_ptr<IOSGLContext> gl_resource_context_;
+  std::unique_ptr<IOSGLContext> gl_resource_context_;
   PlatformMessageRouter platform_message_router_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -75,6 +75,8 @@ class PlatformViewIOS final : public PlatformView {
   // |PlatformView|
   void OnPreEngineRestart() const override;
 
+  void NotifyDestroyed() override;
+
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
 };
 

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -47,7 +47,7 @@ class PlatformViewIOS final : public PlatformView {
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;
   std::unique_ptr<IOSSurface> ios_surface_;
-  std::unique_ptr<IOSGLContext> gl_resource_context_;
+  std::unique_ptr<IOSGLContext> resource_gl_context_;
   PlatformMessageRouter platform_message_router_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -47,7 +47,7 @@ class PlatformViewIOS final : public PlatformView {
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;
   std::unique_ptr<IOSSurface> ios_surface_;
-  std::shared_ptr<IOSGLContext> gl_context_;
+  std::shared_ptr<IOSGLContext> gl_resource_context_;
   PlatformMessageRouter platform_message_router_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -44,6 +44,8 @@ class PlatformViewIOS final : public PlatformView {
   // |PlatformView|
   void SetSemanticsEnabled(bool enabled) override;
 
+  bool HasOnscreenSurface() const;
+
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;
   std::unique_ptr<IOSSurface> ios_surface_;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -23,7 +23,7 @@ PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
                                  flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
-  gl_context_ = std::make_shared<IOSGLContext>();
+  gl_resource_context_ = std::make_shared<IOSGLContext>();
 #endif  // !TARGET_IPHONE_SIMULATOR
 }
 
@@ -51,7 +51,7 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
   owner_controller_ = owner_controller;
   if (owner_controller_) {
     ios_surface_ =
-        [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_context_];
+        [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_resource_context_];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {
@@ -83,7 +83,7 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
 
 // |PlatformView|
 sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
-  if (!gl_context_ || !gl_context_->ResourceMakeCurrent()) {
+  if (!gl_resource_context_ || !gl_resource_context_->MakeCurrent()) {
     FML_DLOG(INFO) << "Could not make resource context current on IO thread. "
                       "Async texture uploads will be disabled. On Simulators, "
                       "this is expected.";

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -46,6 +46,11 @@ void PlatformViewIOS::NotifyDestroyed() {
   PlatformView::NotifyDestroyed();
   ios_surface_.reset();
 }
+
+bool PlatformViewIOS::HasOnscreenSurface() const {
+  return !!ios_surface_;
+}
+
 void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController> owner_controller) {
   if (ios_surface_ || !owner_controller) {
     NotifyDestroyed();

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -23,7 +23,7 @@ PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
                                  flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
-  gl_resource_context_ = std::make_unique<IOSGLContext>();
+  resource_gl_context_ = std::make_unique<IOSGLContext>();
 #endif  // !TARGET_IPHONE_SIMULATOR
 }
 
@@ -54,7 +54,7 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
   owner_controller_ = owner_controller;
   if (owner_controller_) {
     ios_surface_ = [static_cast<FlutterView*>(owner_controller.get().view)
-        createSurface:gl_resource_context_->GetWeakPtr()];
+        createSurface:resource_gl_context_->GetWeakPtr()];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {
@@ -86,7 +86,7 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
 
 // |PlatformView|
 sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
-  if (!gl_resource_context_ || !gl_resource_context_->MakeCurrent()) {
+  if (!resource_gl_context_ || !resource_gl_context_->MakeCurrent()) {
     FML_DLOG(INFO) << "Could not make resource context current on IO thread. "
                       "Async texture uploads will be disabled. On Simulators, "
                       "this is expected.";

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -23,7 +23,7 @@ PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
                                  flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
-  gl_resource_context_ = std::make_shared<IOSGLContext>(nullptr);
+  gl_resource_context_ = std::make_shared<IOSGLContext>();
 #endif  // !TARGET_IPHONE_SIMULATOR
 }
 

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -54,7 +54,7 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
   owner_controller_ = owner_controller;
   if (owner_controller_) {
     ios_surface_ = [static_cast<FlutterView*>(owner_controller.get().view)
-        createSurface:resource_gl_context_->GetWeakPtr()];
+        createSurfaceWithResourceGLContext:resource_gl_context_->GetWeakPtr()];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -54,7 +54,7 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
   owner_controller_ = owner_controller;
   if (owner_controller_) {
     ios_surface_ = [static_cast<FlutterView*>(owner_controller.get().view)
-        createSurface:gl_resource_context_->WeakPtr()];
+        createSurface:gl_resource_context_->GetWeakPtr()];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -42,10 +42,13 @@ fml::WeakPtr<FlutterViewController> PlatformViewIOS::GetOwnerViewController() co
   return owner_controller_;
 }
 
+void PlatformViewIOS::NotifyDestroyed() {
+  PlatformView::NotifyDestroyed();
+  ios_surface_.reset();
+}
 void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController> owner_controller) {
   if (ios_surface_ || !owner_controller) {
     NotifyDestroyed();
-    ios_surface_.reset();
     accessibility_bridge_.reset();
   }
   owner_controller_ = owner_controller;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -23,7 +23,7 @@ PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
                                  flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
-  gl_resource_context_ = std::make_shared<IOSGLContext>();
+  gl_resource_context_ = std::make_unique<IOSGLContext>();
 #endif  // !TARGET_IPHONE_SIMULATOR
 }
 
@@ -53,8 +53,8 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
   }
   owner_controller_ = owner_controller;
   if (owner_controller_) {
-    ios_surface_ =
-        [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_resource_context_];
+    ios_surface_ = [static_cast<FlutterView*>(owner_controller.get().view)
+        createSurface:gl_resource_context_->WeakPtr()];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -23,7 +23,7 @@ PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
                                  flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
-  gl_resource_context_ = std::make_shared<IOSGLContext>();
+  gl_resource_context_ = std::make_shared<IOSGLContext>(nullptr);
 #endif  // !TARGET_IPHONE_SIMULATOR
 }
 

--- a/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/project.pbxproj
+++ b/testing/scenario_app/ios/Scenarios/Scenarios.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		24D47D1B230C79840069DD5E /* golden_platform_view_D211AP.png in Resources */ = {isa = PBXBuildFile; fileRef = 24D47D1A230C79840069DD5E /* golden_platform_view_D211AP.png */; };
 		24D47D1D230CA2700069DD5E /* golden_platform_view_iPhone SE_simulator.png in Resources */ = {isa = PBXBuildFile; fileRef = 24D47D1C230CA2700069DD5E /* golden_platform_view_iPhone SE_simulator.png */; };
 		24F1FB89230B4579005ACE7C /* TextPlatformView.m in Sources */ = {isa = PBXBuildFile; fileRef = 24F1FB87230B4579005ACE7C /* TextPlatformView.m */; };
+		D678B7C82322EFDA00792FDC /* FlutterViewTest.m in Sources */ = {isa = PBXBuildFile; fileRef = D678B7C72322EFDA00792FDC /* FlutterViewTest.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -105,6 +106,7 @@
 		24D47D1E230CA4480069DD5E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		24F1FB87230B4579005ACE7C /* TextPlatformView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TextPlatformView.m; sourceTree = "<group>"; };
 		24F1FB88230B4579005ACE7C /* TextPlatformView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextPlatformView.h; sourceTree = "<group>"; };
+		D678B7C72322EFDA00792FDC /* FlutterViewTest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FlutterViewTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -176,6 +178,7 @@
 			children = (
 				248FDFC322FE7CD0009CC7CD /* FlutterEngineTest.m */,
 				0DB781FC22EA2C0300E9B371 /* FlutterViewControllerTest.m */,
+				D678B7C72322EFDA00792FDC /* FlutterViewTest.m */,
 				248D76E522E388380012F0C1 /* Info.plist */,
 			);
 			path = ScenariosTests;
@@ -349,6 +352,7 @@
 			files = (
 				0DB7820222EA493B00E9B371 /* FlutterViewControllerTest.m in Sources */,
 				248FDFC422FE7CD0009CC7CD /* FlutterEngineTest.m in Sources */,
+				D678B7C82322EFDA00792FDC /* FlutterViewTest.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
@@ -39,18 +39,23 @@
   [rootVC presentViewController:self.flutterViewController animated:NO completion:nil];
 
   // TODO: refactor this to not rely on private test-only APIs
-  __weak id flutterView = [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
+  __weak id flutterView =
+      [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
   XCTAssertNotNil(flutterView);
-  XCTAssertTrue([self.flutterViewController performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
+  XCTAssertTrue(
+      [self.flutterViewController performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
 
-  [self.flutterViewController dismissViewControllerAnimated:NO completion:^{
-      __weak id flutterView = [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
-      XCTAssertNil(flutterView);
-      XCTAssertFalse([self.flutterViewController performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
-  }];
+  [self.flutterViewController
+      dismissViewControllerAnimated:NO
+                         completion:^{
+                           __weak id flutterView = [self.flutterViewController
+                               performSelector:NSSelectorFromString(@"flutterView")];
+                           XCTAssertNil(flutterView);
+                           XCTAssertFalse([self.flutterViewController
+                               performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
+                         }];
 }
 
 @end
 
 #pragma clang diagnostic pop
-

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
@@ -8,6 +8,7 @@
 
 @interface FlutterViewGLContextTest : XCTestCase
 @property(nonatomic, strong) FlutterViewController* flutterViewController;
+@property(nonatomic, strong) FlutterEngine* flutterEngine;
 @end
 
 @implementation FlutterViewGLContextTest
@@ -20,14 +21,18 @@
 - (void)tearDown {
   if (self.flutterViewController) {
     [self.flutterViewController removeFromParentViewController];
+    [self.flutterViewController release];
+  }
+  if (self.flutterEngine) {
+    [self.flutterEngine release];
   }
   [super tearDown];
 }
 
 - (void)testFlutterViewDestroyed {
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"testGL" project:nil];
-  [engine runWithEntrypoint:nil];
-  self.flutterViewController = [[FlutterViewController alloc] initWithEngine:engine
+  self.flutterEngine = [[FlutterEngine alloc] initWithName:@"testGL" project:nil];
+  [self.flutterEngine runWithEntrypoint:nil];
+  self.flutterViewController = [[FlutterViewController alloc] initWithEngine:self.flutterEngine
                                                                      nibName:nil
                                                                       bundle:nil];
 

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
@@ -27,11 +27,6 @@
   [super tearDown];
 }
 
-// Ideally we want to also test that the IOSurface backed by a FlutterView is
-// destroyed as well. Unfortunately due to test harness limitations we can't
-// check that without adding test-only APIs to get access to internal objects.
-//
-// TODO: Test for the IOSurface destruction as well.
 - (void)testFlutterViewDestroyed {
   FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"testGL" project:nil];
   [engine runWithEntrypoint:nil];
@@ -43,12 +38,15 @@
   UIViewController* rootVC = appDelegate.window.rootViewController;
   [rootVC presentViewController:self.flutterViewController animated:NO completion:nil];
 
+  // TODO: refactor this to not rely on private test-only APIs
   __weak id flutterView = [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
   XCTAssertNotNil(flutterView);
-    
+  XCTAssertTrue([self.flutterViewController performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
+
   [self.flutterViewController dismissViewControllerAnimated:NO completion:^{
       __weak id flutterView = [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
       XCTAssertNil(flutterView);
+      XCTAssertFalse([self.flutterViewController performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
   }];
 }
 

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
@@ -1,0 +1,58 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <Flutter/Flutter.h>
+#import <XCTest/XCTest.h>
+#import "AppDelegate.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+
+@interface FlutterViewGLContextTest : XCTestCase
+@property(nonatomic, strong) FlutterViewController* flutterViewController;
+@end
+
+@implementation FlutterViewGLContextTest
+
+- (void)setUp {
+  [super setUp];
+  self.continueAfterFailure = NO;
+}
+
+- (void)tearDown {
+  if (self.flutterViewController) {
+    [self.flutterViewController removeFromParentViewController];
+  }
+  [super tearDown];
+}
+
+// Ideally we want to also test that the IOSurface backed by a FlutterView is
+// destroyed as well. Unfortunately due to test harness limitations we can't
+// check that without adding test-only APIs to get access to internal objects.
+//
+// TODO: Test for the IOSurface destruction as well.
+- (void)testFlutterViewDestroyed {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"testGL" project:nil];
+  [engine runWithEntrypoint:nil];
+  self.flutterViewController = [[FlutterViewController alloc] initWithEngine:engine
+                                                                     nibName:nil
+                                                                      bundle:nil];
+
+  AppDelegate* appDelegate = (AppDelegate*)UIApplication.sharedApplication.delegate;
+  UIViewController* rootVC = appDelegate.window.rootViewController;
+  [rootVC presentViewController:self.flutterViewController animated:NO completion:nil];
+
+  __weak id flutterView = [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
+  XCTAssertNotNil(flutterView);
+    
+  [self.flutterViewController dismissViewControllerAnimated:NO completion:^{
+      __weak id flutterView = [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
+      XCTAssertNil(flutterView);
+  }];
+}
+
+@end
+
+#pragma clang diagnostic pop
+

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterViewTest.m
@@ -6,9 +6,6 @@
 #import <XCTest/XCTest.h>
 #import "AppDelegate.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wundeclared-selector"
-
 @interface FlutterViewGLContextTest : XCTestCase
 @property(nonatomic, strong) FlutterViewController* flutterViewController;
 @end
@@ -39,23 +36,17 @@
   [rootVC presentViewController:self.flutterViewController animated:NO completion:nil];
 
   // TODO: refactor this to not rely on private test-only APIs
-  __weak id flutterView =
-      [self.flutterViewController performSelector:NSSelectorFromString(@"flutterView")];
+  __weak id flutterView = [self.flutterViewController flutterView];
   XCTAssertNotNil(flutterView);
-  XCTAssertTrue(
-      [self.flutterViewController performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
+  XCTAssertTrue([self.flutterViewController hasOnscreenSurface]);
 
   [self.flutterViewController
       dismissViewControllerAnimated:NO
                          completion:^{
-                           __weak id flutterView = [self.flutterViewController
-                               performSelector:NSSelectorFromString(@"flutterView")];
+                           __weak id flutterView = [self.flutterViewController flutterView];
                            XCTAssertNil(flutterView);
-                           XCTAssertFalse([self.flutterViewController
-                               performSelector:NSSelectorFromString(@"hasOnscreenSurface")]);
+                           XCTAssertFalse([self.flutterViewController hasOnscreenSurface]);
                          }];
 }
 
 @end
-
-#pragma clang diagnostic pop


### PR DESCRIPTION
Initial attempt at managing the onscreen and resource GL contexts on iOS using separate IOSGLContext objects.

I still need to work out when to destroy the objects, but this seemed like a good place to get initial feedback.

My biggest concern with this patch is the static where I store the sharegroup to allow for the same sharegroup to be used to generate the contexts.