### PR TITLE
Started saving images of failed golden tests.

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewUITests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/PlatformViewUITests.m
@@ -106,6 +106,14 @@
   CGContextRelease(contextB);
 
   if (memcmp(rawA.mutableBytes, rawB.mutableBytes, size)) {
+    XCTAttachment* attachmentA = [XCTAttachment attachmentWithImage:a];
+    attachmentA.name = @"image-a";
+    attachmentA.lifetime = XCTAttachmentLifetimeKeepAlways;
+    [self addAttachment:attachmentA];
+    XCTAttachment* attachmentB = [XCTAttachment attachmentWithImage:b];
+    attachmentB.name = @"image-b";
+    attachmentB.lifetime = XCTAttachmentLifetimeKeepAlways;
+    [self addAttachment:attachmentB];
     return NO;
   }
 


### PR DESCRIPTION
This makes it easier to debug failed golden image compares since you can see the results in the xcresults directory now.