### PR TITLE
Adjust iOS frame start times to match the platform info

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -114,7 +114,8 @@ float VsyncWaiterIOS::GetDisplayRefreshRate() const {
 }
 
 - (void)onDisplayLink:(CADisplayLink*)link {
-  fml::TimePoint frame_start_time = fml::TimePoint::Now();
+  CFTimeInterval delay = CACurrentMediaTime() - link.timestamp;
+  fml::TimePoint frame_start_time = fml::TimePoint::Now() - fml::TimeDelta::FromSecondsF(delay);
   fml::TimePoint frame_target_time = frame_start_time + fml::TimeDelta::FromSecondsF(link.duration);
 
   display_link_.get().paused = YES;


### PR DESCRIPTION
This simple commit adjusts the timestamps we report to the engine to match the platform timestamps provided for the actual vsync and target (next vsync) times.

This change makes the VsyncSchedulingOverhead bar in the Observatory more accurate.