### PR TITLE
Fix RTL justification with newline by passing in full justify tracking  var

### DIFF
--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -1065,7 +1065,7 @@ void ParagraphTxt::Layout(double width) {
 
     // Adjust the glyph positions based on the alignment of the line.
     double line_x_offset =
-        GetLineXOffset(run_x_offset, line_number, line_limit);
+        GetLineXOffset(run_x_offset, line_number, justify_line);
     if (line_x_offset) {
       for (CodeUnitRun& code_unit_run : line_code_unit_runs) {
         code_unit_run.Shift(line_x_offset);
@@ -1192,7 +1192,7 @@ void ParagraphTxt::Layout(double width) {
 
 double ParagraphTxt::GetLineXOffset(double line_total_advance,
                                     size_t line_number,
-                                    size_t line_limit) {
+                                    bool justify_line) {
   if (isinf(width_))
     return 0;
 
@@ -1201,7 +1201,7 @@ double ParagraphTxt::GetLineXOffset(double line_total_advance,
   if (align == TextAlign::right ||
       (align == TextAlign::justify &&
        paragraph_style_.text_direction == TextDirection::rtl &&
-       line_number == line_limit - 1)) {
+       !justify_line)) {
     return width_ - line_total_advance;
   } else if (align == TextAlign::center) {
     return (width_ - line_total_advance) / 2;

--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -136,6 +136,7 @@ class ParagraphTxt : public Paragraph {
   FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, CenterAlignParagraph);
   FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, JustifyAlignParagraph);
   FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, JustifyRTL);
+  FRIEND_TEST_WINDOWS_DISABLED(ParagraphTest, JustifyRTLNewLine);
   FRIEND_TEST(ParagraphTest, DecorationsParagraph);
   FRIEND_TEST(ParagraphTest, ItalicsParagraph);
   FRIEND_TEST(ParagraphTest, ChineseParagraph);
@@ -362,7 +363,7 @@ class ParagraphTxt : public Paragraph {
   // alignment.
   double GetLineXOffset(double line_total_advance,
                         size_t line_number,
-                        size_t line_limit);
+                        bool justify_line);
 
   // Creates and draws the decorations onto the canvas.
   void PaintDecorations(SkCanvas* canvas,


### PR DESCRIPTION
Fixes newline justification when using RTL text.

Previously, we recalculated what alignment based off of only partial info. Now, we pass the precomputed `justify_line` bool and use that to decide our justification.

This allows hard break lines to justify to the appropriate side for the language.

Fixes: https://github.com/flutter/flutter/issues/28700