### PR TITLE
Handle new navigation platform messages

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -77,7 +77,7 @@ class EngineWindow extends ui.Window {
   /// Setting this member will automatically update [_browserHistory].
   ///
   /// By setting this to null, the browser history will be disabled.
-  set webOnlyLocationStrategy(LocationStrategy strategy) {
+  set locationStrategy(LocationStrategy strategy) {
     _browserHistory.locationStrategy = strategy;
   }
 
@@ -146,6 +146,20 @@ class EngineWindow extends ui.Window {
       case 'flutter/accessibility':
         // In widget tests we want to bypass processing of platform messages.
         accessibilityAnnouncements.handleMessage(data);
+        return;
+
+      case 'flutter/navigation':
+        const MethodCodec codec = JSONMethodCodec();
+        final MethodCall decoded = codec.decodeMethodCall(data);
+        final Map<String, dynamic> message = decoded.arguments;
+        switch (decoded.method) {
+          case 'routePushed':
+            _browserHistory.setRouteName(message['routeName']);
+            break;
+          case 'routePopped':
+            _browserHistory.setRouteName(message['previousRouteName']);
+            break;
+        }
         return;
     }
 

--- a/lib/web_ui/lib/src/ui/initialization.dart
+++ b/lib/web_ui/lib/src/ui/initialization.dart
@@ -9,7 +9,7 @@ Future<void> webOnlyInitializePlatform({
   engine.AssetManager assetManager,
 }) async {
   if (!debugEmulateFlutterTesterEnvironment) {
-    engine.window.webOnlyLocationStrategy = const engine.HashLocationStrategy();
+    engine.window.locationStrategy = const engine.HashLocationStrategy();
   }
 
   engine.webOnlyInitializeEngine();

--- a/lib/web_ui/lib/src/ui/test_embedding.dart
+++ b/lib/web_ui/lib/src/ui/test_embedding.dart
@@ -24,12 +24,6 @@ Future<dynamic> ensureTestPlatformInitializedThenRunTest(
   return _testPlatformInitializedFuture.then<dynamic>((_) => body());
 }
 
-/// This setter is used by [WebNavigatorObserver] to update the url to
-/// reflect the [Navigator]'s current route name.
-set webOnlyRouteName(String routeName) {
-  engine.window.webOnlyRouteName = routeName;
-}
-
 /// Used to track when the platform is initialized. This ensures the test fonts
 /// are available.
 Future<void> _platformInitializedFuture;

--- a/lib/web_ui/test/engine/navigation_test.dart
+++ b/lib/web_ui/test/engine/navigation_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart' as engine;
+
+engine.TestLocationStrategy _strategy;
+
+const engine.MethodCodec codec = engine.JSONMethodCodec();
+
+void emptyCallback(ByteData date) {}
+
+void main() {
+  setUp(() {
+    engine.window.locationStrategy = _strategy = engine.TestLocationStrategy();
+  });
+
+  tearDown(() {
+    engine.window.locationStrategy = _strategy = null;
+  });
+
+  test('Tracks pushed and popped routes', () {
+    engine.window.sendPlatformMessage(
+      'flutter/navigation',
+      codec.encodeMethodCall(const engine.MethodCall(
+        'routePushed',
+        <String, dynamic>{'previousRouteName': '/', 'routeName': '/foo'},
+      )),
+      emptyCallback,
+    );
+    expect(_strategy.path, '/foo');
+
+    engine.window.sendPlatformMessage(
+      'flutter/navigation',
+      codec.encodeMethodCall(const engine.MethodCall(
+        'routePushed',
+        <String, dynamic>{'previousRouteName': '/foo', 'routeName': '/bar'},
+      )),
+      emptyCallback,
+    );
+    expect(_strategy.path, '/bar');
+
+    engine.window.sendPlatformMessage(
+      'flutter/navigation',
+      codec.encodeMethodCall(const engine.MethodCall(
+        'routePopped',
+        <String, dynamic>{'previousRouteName': '/foo', 'routeName': '/bar'},
+      )),
+      emptyCallback,
+    );
+    expect(_strategy.path, '/foo');
+
+    engine.window.sendPlatformMessage(
+      'flutter/navigation',
+      codec.encodeMethodCall(const engine.MethodCall(
+        'routePushed',
+        <String, dynamic>{'previousRouteName': '/foo', 'routeName': '/bar/baz'},
+      )),
+      emptyCallback,
+    );
+    expect(_strategy.path, '/bar/baz');
+  });
+}


### PR DESCRIPTION
The way route names are sent to the engine changed after the unfork. The new implementation uses platform messages (see https://github.com/flutter/flutter/pull/39344). This PR handles those platform messages in the engine side so that text editing works as expected, end-to-end.