### PR TITLE
Add @Keep annotation

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -9,6 +9,7 @@ import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.SurfaceTexture;
 import android.os.Looper;
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
@@ -92,6 +93,7 @@ import io.flutter.view.FlutterCallbackInformation;
  *    bool enabled = FlutterJNI.nativeGetIsSoftwareRenderingEnabled();
  * }
  */
+@Keep
 public class FlutterJNI {
   private static final String TAG = "FlutterJNI";
 

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -12,6 +12,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.Keep;
 import android.util.Log;
 import android.view.*;
 import android.view.accessibility.AccessibilityEvent;
@@ -38,6 +39,7 @@ import static android.view.View.OnFocusChangeListener;
  *      |
  *   EmbeddedView
  */
+@Keep
 @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 class SingleViewPresentation extends Presentation {
 

--- a/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
@@ -10,6 +10,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -41,6 +42,7 @@ import java.util.Map;
  * for the virtual accessibility node IDs in the platform view's tree. Internally this class maintains a bidirectional
  * mapping between `flutterId`s and the corresponding platform view and `originId`.
  */
+@Keep
 final class AccessibilityViewEmbedder {
     private static final String TAG = "AccessibilityBridge";
 

--- a/shell/platform/android/io/flutter/view/FlutterCallbackInformation.java
+++ b/shell/platform/android/io/flutter/view/FlutterCallbackInformation.java
@@ -4,6 +4,7 @@
 
 package io.flutter.view;
 
+import android.support.annotation.Keep;
 import android.support.annotation.NonNull;
 
 import io.flutter.embedding.engine.FlutterJNI;
@@ -12,6 +13,7 @@ import io.flutter.embedding.engine.FlutterJNI;
  * A class representing information for a callback registered using
  * `PluginUtilities` from `dart:ui`.
  */
+@Keep
 public final class FlutterCallbackInformation {
   final public String callbackName;
   final public String callbackClassName;


### PR DESCRIPTION
The `keep` annotation is translated into Proguard rules by the Android Gradle plugin, so these classes aren't renamed or deleted.

Fixes: https://github.com/flutter/flutter/issues/39839