### PR TITLE
Improve input method and Unicode character display(#30661)

### DIFF
--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -181,8 +181,9 @@ std::unique_ptr<rapidjson::Document> TextInputModel::GetState() const {
                           allocator);
   editing_state.AddMember(kSelectionIsDirectionalKey, false, allocator);
   std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> utf8conv;
-  editing_state.AddMember(kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
-                          allocator);
+  editing_state.AddMember(
+      kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
+      allocator);
   args->PushBack(editing_state, allocator);
   return args;
 }

--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -26,10 +26,16 @@ static constexpr char kTextInputAction[] = "inputAction";
 static constexpr char kTextInputType[] = "inputType";
 static constexpr char kTextInputTypeName[] = "name";
 
+#if defined(_MSC_VER)
+// TODO(naifu): This temporary code is to solve link error.(VS2015/2017)
+// https://social.msdn.microsoft.com/Forums/vstudio/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
+std::locale::id std::codecvt<char16_t, char, _Mbstatet>::id;
+#endif  // defined(_MSC_VER)
+
 namespace flutter {
 
 TextInputModel::TextInputModel(int client_id, const rapidjson::Value& config)
-    : text_(""),
+    : text_(std::u16string()),
       client_id_(client_id),
       selection_base_(text_.begin()),
       selection_extent_(text_.begin()) {
@@ -64,7 +70,8 @@ bool TextInputModel::SetEditingState(size_t selection_base,
   if (selection_extent > text.size()) {
     return false;
   }
-  text_ = std::string(text);
+  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> utf16conv;
+  text_ = utf16conv.from_bytes(text);
   selection_base_ = text_.begin() + selection_base;
   selection_extent_ = text_.begin() + selection_extent;
   return true;
@@ -76,7 +83,7 @@ void TextInputModel::DeleteSelected() {
   selection_extent_ = selection_base_;
 }
 
-void TextInputModel::AddCharacter(char c) {
+void TextInputModel::AddCharacter(unsigned int c) {
   if (selection_base_ != selection_extent_) {
     DeleteSelected();
   }
@@ -172,7 +179,8 @@ std::unique_ptr<rapidjson::Document> TextInputModel::GetState() const {
                           static_cast<int>(selection_extent_ - text_.begin()),
                           allocator);
   editing_state.AddMember(kSelectionIsDirectionalKey, false, allocator);
-  editing_state.AddMember(kTextKey, rapidjson::Value(text_, allocator).Move(),
+  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> utf8conv;
+  editing_state.AddMember(kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
                           allocator);
   args->PushBack(editing_state, allocator);
   return args;

--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -84,34 +84,11 @@ void TextInputModel::DeleteSelected() {
   selection_extent_ = selection_base_;
 }
 
-void TextInputModel::AddCharacter(uint32_t c) {
+void TextInputModel::AddCharacter(char32_t c) {
   if (selection_base_ != selection_extent_) {
     DeleteSelected();
   }
-  char32_t ch = c;
-  {
-    // I put this code (compatible processing logic for UTF-16) here for
-    // several reasons:
-    // 1. If I put it in win32/glfw 's message processing logic, there would
-    // be two sets of duplicate code.
-    // 2. Putting it here can still be guaranteed to be platform-independent
-    // and can handle more scenarios.
-    // Specific logic:
-    // What we expect to pass in is a Unicode, if it's UTF-32, it doesn't need
-    // any processing, and if it's UTF-16, it's converted to Unicode.
-    static char32_t lead_ch = 0;
-    // If ch is Lead Surrogate.
-    if ((ch & 0xFFFFFC00) == 0xD800) {
-      lead_ch = ch;
-      return;
-    }
-    // If ch is Trail Surrogate and pre-ch is Lead Surrogate.
-    if (lead_ch != 0 && (ch & 0xFFFFFC00) == 0xDC00) {
-      ch = 0x10000 + ((lead_ch & 0x000003FF) << 10) + (ch & 0x3FF);
-    }
-    lead_ch = 0;
-  }
-  selection_extent_ = text_.insert(selection_extent_, ch);
+  selection_extent_ = text_.insert(selection_extent_, c);
   selection_extent_++;
   selection_base_ = selection_extent_;
 }

--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -4,7 +4,9 @@
 
 #include "flutter/shell/platform/common/cpp/text_input_model.h"
 
+#include <codecvt>
 #include <iostream>
+#include <locale>
 
 // TODO(awdavies): Need to fix this regarding issue #47.
 static constexpr char kComposingBaseKey[] = "composingBase";
@@ -29,14 +31,13 @@ static constexpr char kTextInputTypeName[] = "name";
 #if defined(_MSC_VER)
 // TODO(naifu): This temporary code is to solve link error.(VS2015/2017)
 // https://social.msdn.microsoft.com/Forums/vstudio/en-US/8f40dcd8-c67f-4eba-9134-a19b9178e481/vs-2015-rc-linker-stdcodecvt-error
-std::locale::id std::codecvt<char16_t, char, _Mbstatet>::id;
+std::locale::id std::codecvt<char32_t, char, _Mbstatet>::id;
 #endif  // defined(_MSC_VER)
 
 namespace flutter {
 
 TextInputModel::TextInputModel(int client_id, const rapidjson::Value& config)
-    : text_(std::u16string()),
-      client_id_(client_id),
+    : client_id_(client_id),
       selection_base_(text_.begin()),
       selection_extent_(text_.begin()) {
   // TODO: Improve error handling during refactoring; this is just minimal
@@ -70,8 +71,8 @@ bool TextInputModel::SetEditingState(size_t selection_base,
   if (selection_extent > text.size()) {
     return false;
   }
-  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> utf16conv;
-  text_ = utf16conv.from_bytes(text);
+  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> utf32conv;
+  text_ = utf32conv.from_bytes(text);
   selection_base_ = text_.begin() + selection_base;
   selection_extent_ = text_.begin() + selection_extent;
   return true;
@@ -83,7 +84,7 @@ void TextInputModel::DeleteSelected() {
   selection_extent_ = selection_base_;
 }
 
-void TextInputModel::AddCharacter(unsigned int c) {
+void TextInputModel::AddCharacter(uint32_t c) {
   if (selection_base_ != selection_extent_) {
     DeleteSelected();
   }
@@ -179,10 +180,9 @@ std::unique_ptr<rapidjson::Document> TextInputModel::GetState() const {
                           static_cast<int>(selection_extent_ - text_.begin()),
                           allocator);
   editing_state.AddMember(kSelectionIsDirectionalKey, false, allocator);
-  std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> utf8conv;
-  editing_state.AddMember(
-      kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
-      allocator);
+  std::wstring_convert<std::codecvt_utf8<char32_t>, char32_t> utf8conv;
+  editing_state.AddMember(kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
+                          allocator);
   args->PushBack(editing_state, allocator);
   return args;
 }

--- a/shell/platform/common/cpp/text_input_model.cc
+++ b/shell/platform/common/cpp/text_input_model.cc
@@ -180,8 +180,9 @@ std::unique_ptr<rapidjson::Document> TextInputModel::GetState() const {
                           allocator);
   editing_state.AddMember(kSelectionIsDirectionalKey, false, allocator);
   std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> utf8conv;
-  editing_state.AddMember(kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
-                          allocator);
+  editing_state.AddMember(
+      kTextKey, rapidjson::Value(utf8conv.to_bytes(text_), allocator).Move(),
+      allocator);
   args->PushBack(editing_state, allocator);
   return args;
 }

--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -32,7 +32,7 @@ class TextInputModel {
   // Either appends after the cursor (when selection base and extent are the
   // same), or deletes the selected characters, replacing the text with the
   // character specified.
-  void AddCharacter(uint32_t c);
+  void AddCharacter(char32_t c);
 
   // Deletes either the selection, or one character ahead of the cursor.
   //

--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -7,6 +7,8 @@
 
 #include <memory>
 #include <string>
+#include <codecvt>
+#include <locale>
 
 #include "rapidjson/document.h"
 
@@ -32,7 +34,7 @@ class TextInputModel {
   // Either appends after the cursor (when selection base and extent are the
   // same), or deletes the selected characters, replacing the text with the
   // character specified.
-  void AddCharacter(char c);
+  void AddCharacter(unsigned int c);
 
   // Deletes either the selection, or one character ahead of the cursor.
   //
@@ -89,12 +91,12 @@ class TextInputModel {
  private:
   void DeleteSelected();
 
-  std::string text_;
+  std::u16string text_;
   int client_id_;
   std::string input_type_;
   std::string input_action_;
-  std::string::iterator selection_base_;
-  std::string::iterator selection_extent_;
+  std::u16string::iterator selection_base_;
+  std::u16string::iterator selection_extent_;
 };
 
 }  // namespace flutter

--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 #define FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 
-#include <memory>
-#include <string>
 #include <codecvt>
 #include <locale>
+#include <memory>
+#include <string>
 
 #include "rapidjson/document.h"
 

--- a/shell/platform/common/cpp/text_input_model.h
+++ b/shell/platform/common/cpp/text_input_model.h
@@ -5,8 +5,6 @@
 #ifndef FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 #define FLUTTER_SHELL_PLATFORM_CPP_TEXT_INPUT_MODEL_H_
 
-#include <codecvt>
-#include <locale>
 #include <memory>
 #include <string>
 
@@ -34,7 +32,7 @@ class TextInputModel {
   // Either appends after the cursor (when selection base and extent are the
   // same), or deletes the selected characters, replacing the text with the
   // character specified.
-  void AddCharacter(unsigned int c);
+  void AddCharacter(uint32_t c);
 
   // Deletes either the selection, or one character ahead of the cursor.
   //
@@ -91,12 +89,12 @@ class TextInputModel {
  private:
   void DeleteSelected();
 
-  std::u16string text_;
+  std::u32string text_;
   int client_id_;
   std::string input_type_;
   std::string input_action_;
-  std::u16string::iterator selection_base_;
-  std::u16string::iterator selection_extent_;
+  std::u32string::iterator selection_base_;
+  std::u32string::iterator selection_extent_;
 };
 
 }  // namespace flutter

--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -42,7 +42,7 @@ void TextInputPlugin::CharHook(GLFWwindow* window, unsigned int code_point) {
   }
   // TODO(awdavies): Actually handle potential unicode characters. Probably
   // requires some ICU data or something.
-  active_model_->AddCharacter(static_cast<char>(code_point));
+  active_model_->AddCharacter(code_point);
   SendStateUpdate(*active_model_);
 }
 

--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -36,12 +36,10 @@ static constexpr uint32_t kInputModelLimit = 256;
 
 namespace flutter {
 
-void TextInputPlugin::CharHook(GLFWwindow* window, unsigned int code_point) {
+void TextInputPlugin::CharHook(GLFWwindow* window, uint32_t code_point) {
   if (active_model_ == nullptr) {
     return;
   }
-  // TODO(awdavies): Actually handle potential unicode characters. Probably
-  // requires some ICU data or something.
   active_model_->AddCharacter(code_point);
   SendStateUpdate(*active_model_);
 }

--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -36,7 +36,7 @@ static constexpr uint32_t kInputModelLimit = 256;
 
 namespace flutter {
 
-void TextInputPlugin::CharHook(GLFWwindow* window, uint32_t code_point) {
+void TextInputPlugin::CharHook(GLFWwindow* window, unsigned int code_point) {
   if (active_model_ == nullptr) {
     return;
   }

--- a/shell/platform/glfw/text_input_plugin.h
+++ b/shell/platform/glfw/text_input_plugin.h
@@ -33,7 +33,7 @@ class TextInputPlugin : public KeyboardHookHandler {
                     int mods) override;
 
   // |KeyboardHookHandler|
-  void CharHook(GLFWwindow* window, uint32_t code_point) override;
+  void CharHook(GLFWwindow* window, unsigned int code_point) override;
 
  private:
   // Sends the current state of the given model to the Flutter engine.

--- a/shell/platform/glfw/text_input_plugin.h
+++ b/shell/platform/glfw/text_input_plugin.h
@@ -33,7 +33,7 @@ class TextInputPlugin : public KeyboardHookHandler {
                     int mods) override;
 
   // |KeyboardHookHandler|
-  void CharHook(GLFWwindow* window, unsigned int code_point) override;
+  void CharHook(GLFWwindow* window, uint32_t code_point) override;
 
  private:
   // Sends the current state of the given model to the Flutter engine.

--- a/shell/platform/windows/key_event_handler.cc
+++ b/shell/platform/windows/key_event_handler.cc
@@ -32,7 +32,7 @@ KeyEventHandler::KeyEventHandler(flutter::BinaryMessenger* messenger)
 KeyEventHandler::~KeyEventHandler() = default;
 
 void KeyEventHandler::CharHook(Win32FlutterWindow* window,
-                               unsigned int code_point) {}
+                               char32_t code_point) {}
 
 void KeyEventHandler::KeyboardHook(Win32FlutterWindow* window,
                                    int key,

--- a/shell/platform/windows/key_event_handler.h
+++ b/shell/platform/windows/key_event_handler.h
@@ -34,7 +34,7 @@ class KeyEventHandler : public KeyboardHookHandler {
                     int mods) override;
 
   // |KeyboardHookHandler|
-  void CharHook(Win32FlutterWindow* window, unsigned int code_point) override;
+  void CharHook(Win32FlutterWindow* window, char32_t code_point) override;
 
  private:
   // The Flutter system channel for key event messages.

--- a/shell/platform/windows/keyboard_hook_handler.h
+++ b/shell/platform/windows/keyboard_hook_handler.h
@@ -24,8 +24,7 @@ class KeyboardHookHandler {
                             int mods) = 0;
 
   // A function for hooking into unicode code point input.
-  virtual void CharHook(Win32FlutterWindow* window,
-                        char32_t code_point) = 0;
+  virtual void CharHook(Win32FlutterWindow* window, char32_t code_point) = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/keyboard_hook_handler.h
+++ b/shell/platform/windows/keyboard_hook_handler.h
@@ -25,7 +25,7 @@ class KeyboardHookHandler {
 
   // A function for hooking into unicode code point input.
   virtual void CharHook(Win32FlutterWindow* window,
-                        unsigned int code_point) = 0;
+                        char32_t code_point) = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -39,11 +39,10 @@ static constexpr uint32_t kInputModelLimit = 256;
 namespace flutter {
 
 void TextInputPlugin::CharHook(Win32FlutterWindow* window,
-                               unsigned int code_point) {
+                               uint32_t code_point) {
   if (active_model_ == nullptr) {
     return;
   }
-  // TODO bug 30661
   active_model_->AddCharacter(code_point);
   SendStateUpdate(*active_model_);
 }

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -44,7 +44,7 @@ void TextInputPlugin::CharHook(Win32FlutterWindow* window,
     return;
   }
   // TODO bug 30661
-  active_model_->AddCharacter(static_cast<char>(code_point));
+  active_model_->AddCharacter(code_point);
   SendStateUpdate(*active_model_);
 }
 

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -39,7 +39,7 @@ static constexpr uint32_t kInputModelLimit = 256;
 namespace flutter {
 
 void TextInputPlugin::CharHook(Win32FlutterWindow* window,
-                               uint32_t code_point) {
+                               unsigned int code_point) {
   if (active_model_ == nullptr) {
     return;
   }

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -39,7 +39,7 @@ static constexpr uint32_t kInputModelLimit = 256;
 namespace flutter {
 
 void TextInputPlugin::CharHook(Win32FlutterWindow* window,
-                               unsigned int code_point) {
+                               char32_t code_point) {
   if (active_model_ == nullptr) {
     return;
   }

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -35,7 +35,7 @@ class TextInputPlugin : public KeyboardHookHandler {
                     int mods) override;
 
   // |KeyboardHookHandler|
-  void CharHook(Win32FlutterWindow* window, unsigned int code_point) override;
+  void CharHook(Win32FlutterWindow* window, char32_t code_point) override;
 
  private:
   // Sends the current state of the given model to the Flutter engine.

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -35,7 +35,7 @@ class TextInputPlugin : public KeyboardHookHandler {
                     int mods) override;
 
   // |KeyboardHookHandler|
-  void CharHook(Win32FlutterWindow* window, unsigned int code_point) override;
+  void CharHook(Win32FlutterWindow* window, uint32_t code_point) override;
 
  private:
   // Sends the current state of the given model to the Flutter engine.

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -35,7 +35,7 @@ class TextInputPlugin : public KeyboardHookHandler {
                     int mods) override;
 
   // |KeyboardHookHandler|
-  void CharHook(Win32FlutterWindow* window, uint32_t code_point) override;
+  void CharHook(Win32FlutterWindow* window, unsigned int code_point) override;
 
  private:
   // Sends the current state of the given model to the Flutter engine.

--- a/shell/platform/windows/win32_flutter_window.cc
+++ b/shell/platform/windows/win32_flutter_window.cc
@@ -125,7 +125,7 @@ void Win32FlutterWindow::OnPointerUp(double x, double y) {
   }
 }
 
-void Win32FlutterWindow::OnChar(unsigned int code_point) {
+void Win32FlutterWindow::OnChar(char32_t code_point) {
   if (process_events_) {
     SendChar(code_point);
   }
@@ -207,7 +207,7 @@ void Win32FlutterWindow::SendPointerUp(double x, double y) {
   SendPointerEventWithData(event);
 }
 
-void Win32FlutterWindow::SendChar(unsigned int code_point) {
+void Win32FlutterWindow::SendChar(char32_t code_point) {
   for (const auto& handler : keyboard_hook_handlers_) {
     handler->CharHook(this, code_point);
   }

--- a/shell/platform/windows/win32_flutter_window.h
+++ b/shell/platform/windows/win32_flutter_window.h
@@ -54,7 +54,7 @@ class Win32FlutterWindow : public Win32Window {
   void OnPointerUp(double x, double y) override;
 
   // |Win32Window|
-  void OnChar(unsigned int code_point) override;
+  void OnChar(char32_t code_point) override;
 
   // |Win32Window|
   void OnKey(int key, int scancode, int action, int mods) override;
@@ -103,7 +103,7 @@ class Win32FlutterWindow : public Win32Window {
   void SendPointerUp(double x, double y);
 
   // Reports a keyboard character to Flutter engine.
-  void SendChar(unsigned int code_point);
+  void SendChar(char32_t code_point);
 
   // Reports a raw keyboard message to Flutter engine.
   void SendKey(int key, int scancode, int action, int mods);

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -153,17 +153,15 @@ Win32Window::MessageHandler(HWND hwnd,
         window->OnScroll(
             0.0, -(static_cast<short>(HIWORD(wparam)) / (double)WHEEL_DELTA));
         break;
-      case WM_UNICHAR:
-      {
-        // Tell thiary-pary app, we can support Unicode.
+      case WM_UNICHAR: {
+        // Tell third-pary app, we can support Unicode.
         if (wparam == UNICODE_NOCHAR)
           return TRUE;
         // DefWindowProc will send WM_CHAR for this WM_UNICHAR.
         break;
       }
       case WM_CHAR:
-      case WM_SYSCHAR:
-      {
+      case WM_SYSCHAR: {
         if (wparam == VK_BACK)
           break;
         char32_t ch = static_cast<char32_t>(wparam);

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -173,10 +173,8 @@ Win32Window::MessageHandler(HWND hwnd,
         }
         // Merge TrailSurrogate and LeadSurrogate.
         if (lead_surrogate != 0 && (code_point & 0xFFFFFC00) == 0xDC00) {
-          code_point =
-            0x10000
-            + ((lead_surrogate & 0x000003FF) << 10)
-            + (code_point & 0x3FF);
+          code_point = 0x10000 + ((lead_surrogate & 0x000003FF) << 10) +
+                       (code_point & 0x3FF);
         }
         lead_surrogate = 0;
         window->OnChar(code_point);

--- a/shell/platform/windows/win32_window.h
+++ b/shell/platform/windows/win32_window.h
@@ -89,7 +89,7 @@ class Win32Window {
   virtual void OnPointerUp(double x, double y) = 0;
 
   // Called when character input occurs.
-  virtual void OnChar(unsigned int code_point) = 0;
+  virtual void OnChar(char32_t code_point) = 0;
 
   // Called when raw keyboard input occurs.
   virtual void OnKey(int key, int scancode, int action, int mods) = 0;


### PR DESCRIPTION
We optimized the character handling so that it can accept and display Unicode characters well.

We use the standard library: codecvt, which is already used in flutter/fml. codecvt handles complex and error-prone character conversion logic that was previously handled separately on each platform. (Example: utf8/16/32, wchar_t(16/32)...)

ISSUE: https://github.com/flutter/flutter/issues/30661

![WXWorkCapture_15677038421072](https://user-images.githubusercontent.com/1241023/64364868-437c0480-d046-11e9-9e9c-e70ae682df46.png)
