### PR TITLE
Document dependencies and remove support-v13

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -232,7 +232,6 @@ action("flutter_shell_java") {
   sources += get_target_outputs(":gen_android_build_config_java")
 
   android_support_jars = [
-    "//third_party/android_support/android_support_v13.jar",
     "//third_party/android_support/android_support_compat.jar",
     "//third_party/android_support/android_support_annotations.jar",
     "//third_party/android_support/android_support_fragment.jar",

--- a/tools/android_support/files.json
+++ b/tools/android_support/files.json
@@ -2,41 +2,64 @@
   {
     "url": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/common/1.1.1/common-1.1.1.jar",
     "out_file_name": "android_arch_lifecycle_common.jar",
-    "maven_dependency": "android.arch.lifecycle:common:1.1.1"
+    "maven_dependency": "android.arch.lifecycle:common:1.1.1",
+    "provides": [
+      "android.arch.lifecycle.Lifecycle",
+      "android.arch.lifecycle.LifecycleObserver",
+      "android.arch.lifecycle.LifecycleOwner"
+    ]
   },
   {
     "url": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/common-java8/1.1.1/common-java8-1.1.1.jar",
     "out_file_name": "android_arch_lifecycle_common_java8.jar",
-    "maven_dependency": "android.arch.lifecycle:common-java8:1.1.1"
+    "maven_dependency": "android.arch.lifecycle:common-java8:1.1.1",
+    "provides": [
+      "android.arch.lifecycle.DefaultLifecycleObserver"
+    ]
   },
   {
     "url": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/runtime/1.1.1/runtime-1.1.1.aar",
     "out_file_name": "android_arch_lifecycle_runtime.jar",
-    "maven_dependency": "android.arch.lifecycle:runtime:1.1.1"
+    "maven_dependency": "android.arch.lifecycle:runtime:1.1.1",
+    "provides": [
+      "android.arch.lifecycle.LifecycleRegistry"
+    ]
   },
   {
     "url": "https://dl.google.com/dl/android/maven2/android/arch/lifecycle/viewmodel/1.1.1/viewmodel-1.1.1.aar",
     "out_file_name": "android_arch_lifecycle_viewmodel.jar",
-    "maven_dependency": "android.arch.lifecycle:viewmodel:1.1.1"
+    "maven_dependency": "android.arch.lifecycle:viewmodel:1.1.1",
+    "provides": []
   },
   {
     "url": "https://dl.google.com/dl/android/maven2/com/android/support/support-fragment/28.0.0/support-fragment-28.0.0.aar",
     "out_file_name": "android_support_fragment.jar",
-    "maven_dependency": "com.android.support:support-fragment:28.0.0"
-  },
-  {
-    "url": "https://dl.google.com/dl/android/maven2/com/android/support/support-v13/28.0.0/support-v13-28.0.0.aar",
-    "out_file_name": "android_support_v13.jar",
-    "maven_dependency": "com.android.support:support-v13:28.0.0"
+    "maven_dependency": "com.android.support:support-fragment:28.0.0",
+    "provides": [
+      "android.support.v4.app.Fragment",
+      "android.support.v4.app.FragmentActivity"
+    ]
   },
   {
     "url": "https://dl.google.com/dl/android/maven2/com/android/support/support-annotations/28.0.0/support-annotations-28.0.0.jar",
     "out_file_name": "android_support_annotations.jar",
-    "maven_dependency": "com.android.support:support-annotations:28.0.0"
+    "maven_dependency": "com.android.support:support-annotations:28.0.0",
+    "provides": [
+      "android.support.annotation.CallSuper",
+      "android.support.annotation.FloatRange",
+      "android.support.annotation.IntDef",
+      "android.support.annotation.Keep",
+      "android.support.annotation.NonNull",
+      "android.support.annotation.Nullable",
+      "android.support.annotation.RequiresApi",
+      "android.support.annotation.UiThread",
+      "android.support.annotation.VisibleForTesting"
+    ]
   },
   {
     "url": "https://dl.google.com/dl/android/maven2/com/android/support/support-compat/28.0.0/support-compat-28.0.0.aar",
     "out_file_name": "android_support_compat.jar",
-    "maven_dependency": "com.android.support:support-compat:28.0.0"
+    "maven_dependency": "com.android.support:support-compat:28.0.0",
+    "provides": []
   }
 ]

--- a/tools/android_support/generate_pom_file.py
+++ b/tools/android_support/generate_pom_file.py
@@ -57,6 +57,9 @@ def main():
   pom_dependencies = ''
   if args.include_embedding_dependencies:
     for dependency in dependencies:
+      if not dependency['provides']:
+        # Don't include transitive dependencies since they aren't used by the embedding.
+        continue
       group_id, artifact_id, version = dependency['maven_dependency'].split(':')
       pom_dependencies += POM_DEPENDENCY.format(group_id, artifact_id, version)
 

--- a/tools/gen_javadoc.py
+++ b/tools/gen_javadoc.py
@@ -30,7 +30,6 @@ def main():
     'third_party/android_support/android_support_annotations.jar',
     'third_party/android_support/android_support_compat.jar',
     'third_party/android_support/android_support_fragment.jar',
-    'third_party/android_support/android_support_v13.jar',
     'third_party/android_tools/sdk/platforms/android-29/android.jar',
     'base/android/java/src',
     'third_party/jsr-305/src/ri/src/main/java',


### PR DESCRIPTION
* Remove `android_support_v13.jar` since it's not needed.
* Document which dependencies are used by the embedding and which are added for compilation purposes only because they are transitive dependencies.
* Don't include dependencies that don't provide anything in the POM file.