### PR TITLE
Added new lifecycle enum

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -171,18 +171,16 @@ enum AppLifecycleState {
   ///
   /// When the application is in this state, the engine will not call the
   /// [Window.onBeginFrame] and [Window.onDrawFrame] callbacks.
-  ///
-  /// Android apps in this state should assume that they may enter the
-  /// [suspending] state at any time.
   paused,
 
-  /// The application will be suspended momentarily.
+  /// The application is still hosted on a flutter engine but is detached from
+  /// any host views.
   ///
-  /// When the application is in this state, the engine will not call the
-  /// [Window.onBeginFrame] and [Window.onDrawFrame] callbacks.
-  ///
-  /// On iOS, this state is currently unused.
-  suspending,
+  /// When the application is in this state, the engine is running without
+  /// a view. It can either be in the progress of attaching a view when engine
+  /// was first initializes, or after the view being destroyed due to a Navigator
+  /// pop.
+  detached,
 }
 
 /// A representation of distances for each of the four edges of a rectangle,

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -73,18 +73,13 @@ enum AppLifecycleState {
   ///
   /// When the application is in this state, the engine will not call the
   /// [Window.onBeginFrame] and [Window.onDrawFrame] callbacks.
-  ///
-  /// Android apps in this state should assume that they may enter the
-  /// [suspending] state at any time.
   paused,
 
-  /// The application will be suspended momentarily.
+  /// The application is detached from view.
   ///
-  /// When the application is in this state, the engine will not call the
-  /// [Window.onBeginFrame] and [Window.onDrawFrame] callbacks.
-  ///
-  /// On iOS, this state is currently unused.
-  suspending,
+  /// When the application is in this state, the engine is running without
+  /// a platform UI.
+  detached,
 }
 
 /// A representation of distances for each of the four edges of a rectangle,

--- a/runtime/runtime_controller.h
+++ b/runtime/runtime_controller.h
@@ -120,7 +120,7 @@ class RuntimeController final : public WindowClient {
     std::string variant_code;
     std::vector<std::string> locale_data;
     std::string user_settings_data = "{}";
-    std::string lifecycle_state;
+    std::string lifecycle_state = "AppLifecycleState.detached";
     bool semantics_enabled = false;
     bool assistive_technology_enabled = false;
     int32_t accessibility_feature_flags_ = 0;

--- a/shell/common/engine.cc
+++ b/shell/common/engine.cc
@@ -311,7 +311,7 @@ bool Engine::HandleLifecyclePlatformMessage(PlatformMessage* message) {
   const auto& data = message->data();
   std::string state(reinterpret_cast<const char*>(data.data()), data.size());
   if (state == "AppLifecycleState.paused" ||
-      state == "AppLifecycleState.suspending") {
+      state == "AppLifecycleState.detached") {
     activity_running_ = false;
     StopAnimator();
   } else if (state == "AppLifecycleState.resumed" ||

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -461,6 +461,8 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
       platformPlugin = null;
     }
 
+    flutterEngine.getLifecycleChannel().appIsDetached();
+
     // Destroy our FlutterEngine if we're not set to retain it.
     if (host.shouldDestroyEngineWithHost()) {
       flutterEngine.destroy();

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/LifecycleChannel.java
@@ -39,4 +39,8 @@ public class LifecycleChannel {
     channel.send("AppLifecycleState.paused");
   }
 
+  public void appIsDetached() {
+    Log.v(TAG, "Sending AppLifecycleState.detached message.");
+    channel.send("AppLifecycleState.detached");
+  }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -85,18 +85,21 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsResumed();
     verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsPaused();
     verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsInactive();
+    verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsDetached();
 
     // When the Activity/Fragment is resumed, a resumed message should have been sent to Flutter.
     delegate.onResume();
     verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsResumed();
     verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsInactive();
     verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsPaused();
+    verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsDetached();
 
     // When the Activity/Fragment is paused, an inactive message should have been sent to Flutter.
     delegate.onPause();
     verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsResumed();
     verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsInactive();
     verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsPaused();
+    verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsDetached();
 
     // When the Activity/Fragment is stopped, a paused message should have been sent to Flutter.
     // Notice that Flutter uses the term "paused" in a different way, and at a different time
@@ -105,6 +108,14 @@ public class FlutterActivityAndFragmentDelegateTest {
     verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsResumed();
     verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsInactive();
     verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsPaused();
+    verify(mockFlutterEngine.getLifecycleChannel(), never()).appIsDetached();
+
+    // When activity detaches, a detached message should have been sent to Flutter.
+    delegate.onDetach();
+    verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsResumed();
+    verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsInactive();
+    verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsPaused();
+    verify(mockFlutterEngine.getLifecycleChannel(), times(1)).appIsDetached();
   }
 
   @Test

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -180,6 +180,8 @@ NSString* const FlutterDefaultDartEntrypoint = nil;
   [self maybeSetupPlatformViewChannels];
 
   __block FlutterEngine* blockSelf = self;
+  [_flutterViewControllerWillDeallocObserver release];
+
   self.flutterViewControllerWillDeallocObserver =
       [[NSNotificationCenter defaultCenter] addObserverForName:FlutterViewControllerWillDealloc
                                                         object:viewController
@@ -201,6 +203,7 @@ NSString* const FlutterDefaultDartEntrypoint = nil;
 }
 
 - (void)notifyViewControllerDeallocated {
+  [[self lifecycleChannel] sendMessage:@"AppLifecycleState.detached"];
   if (!_allowHeadlessExecution) {
     [self destroyContext];
   } else {


### PR DESCRIPTION
This is one of the step toward fixing add to app warm up issue
[design doc](https://docs.google.com/document/d/1FNuq5-3rEB1n1fChdEde6gzZG9QOiw7HtM2jb12Ecv4/edit?ts=5d703a01#heading=h.9ao3rfi8jsub)

This pr adds a new AppLifecycleState.detached, and make sure flutter embedder sends out the correct signal when engine is initialized.

This pr also includes removes AppLifecycleState.suspend, It seems it is not longer used

This will be a breaking change and require manual engine roll.
framework pr https://github.com/flutter/flutter/pull/39945/files

https://github.com/flutter/flutter/issues/39832

Here is the breaking change [email draft](https://docs.google.com/document/d/1NkDosubQ9Ti2O0J3_8n9W1xg6GfIGmDHMRkTH0-UCXI/edit#)