### PR TITLE
[flutter_runner] Kernel platform files can now be built in topaz

### DIFF
--- a/ci/check_gn_format.py
+++ b/ci/check_gn_format.py
@@ -25,7 +25,7 @@ def main():
   parser = argparse.ArgumentParser();
 
   parser.add_argument('--gn-binary', dest='gn_binary', required=True, type=str)
-  parser.add_argument('--dry-run', dest='dry_run', required=True, type=bool)
+  parser.add_argument('--dry-run', dest='dry_run', default=True, type=str)
   parser.add_argument('--root-directory', dest='root_directory', required=True, type=str)
 
   args = parser.parse_args()
@@ -35,7 +35,7 @@ def main():
 
   gn_command = [ gn_binary, 'format']
 
-  if args.dry_run:
+  if args.dry_run == 'false':
     gn_command.append('--dry-run')
 
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -22,7 +22,7 @@ copy("generate_dart_ui") {
 compiled_action("generate_snapshot_bin") {
   tool = "//third_party/dart/runtime/bin:gen_snapshot"
 
-  if ((is_fuchsia || is_fuchsia_host) && !using_fuchsia_sdk) {
+  if (is_fuchsia || is_fuchsia_host) {
     platform_kernel =
         "$root_out_dir/flutter_runner_patched_sdk/platform_strong.dill"
   } else {
@@ -208,7 +208,7 @@ bin_to_linkable("platform_strong_dill_linkable") {
   deps = [
     ":kernel_platform_files",
   ]
-  if ((is_fuchsia || is_fuchsia_host) && !using_fuchsia_sdk) {
+  if (is_fuchsia || is_fuchsia_host) {
     input = "$root_out_dir/flutter_runner_patched_sdk/platform_strong.dill"
   } else {
     input = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
@@ -273,10 +273,10 @@ compile_platform("strong_platform") {
 }
 
 # Fuchsia's snapshot requires a different platform with extra dart: libraries.
-if ((is_fuchsia || is_fuchsia_host) && !using_fuchsia_sdk) {
+if (is_fuchsia || is_fuchsia_host) {
   group("kernel_platform_files") {
     public_deps = [
-      "//topaz/runtime/flutter_runner/kernel:kernel_platform_files",
+      "$flutter_root/shell/platform/fuchsia/flutter/kernel:kernel_platform_files",
     ]
   }
 } else {

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -29,8 +29,7 @@ group("libdart") {
   public_deps = []
 
   if (!(is_fuchsia && using_fuchsia_sdk)) {
-    if (flutter_runtime_mode == "profile" ||
-        flutter_runtime_mode == "release") {
+    if (flutter_runtime_mode == "profile" || flutter_runtime_mode == "release") {
       public_deps +=
           [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
     } else {
@@ -103,8 +102,7 @@ source_set("runtime") {
   #  3. In the executable can enjoy the advantages of the windows preload
   #     mechanism, speed up I/O.
   if (is_win) {
-    if (flutter_runtime_mode == "profile" ||
-        flutter_runtime_mode == "release") {
+    if (flutter_runtime_mode == "profile" || flutter_runtime_mode == "release") {
       deps += [ "$flutter_root/lib/snapshot" ]
     }
   }

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -104,7 +104,7 @@ template("jit_runner_package") {
     ]
 
     if (!invoker.product) {
-      deps += [ observatory_target ]
+      deps += [ engine_observatory_target ]
     }
 
     binary = "dart_jit${product_suffix}_runner"
@@ -139,7 +139,7 @@ template("jit_runner_package") {
     if (!invoker.product) {
       resources += [
         {
-          path = rebase_path(observatory_archive_file)
+          path = rebase_path(engine_observatory_archive_file)
           dest = "observatory.tar"
         },
       ]

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -63,9 +63,9 @@ template("create_kernel_core_snapshot") {
       snapshot_profile,
     ]
 
-    gen_snapshot_to_use = gen_snapshot
+    gen_snapshot_to_use = engine_gen_snapshot
     if (invoker.product) {
-      gen_snapshot_to_use = gen_snapshot_product
+      gen_snapshot_to_use = engine_gen_snapshot_product
     }
 
     tool = gen_snapshot_to_use
@@ -94,8 +94,7 @@ template("create_kernel_core_snapshot") {
     # No asserts in debug or release product.
     # No asserts in release with flutter_profile=true (non-product)
     # Yes asserts in non-product debug.
-    if (!invoker.product &&
-        (is_debug || !(flutter_runtime_mode == "profile"))) {
+    if (!invoker.product && (is_debug || !(flutter_runtime_mode == "profile"))) {
       args += [ "--enable_asserts" ]
     }
     args += [ rebase_path(platform_dill) ]

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -217,7 +217,7 @@ template("jit_runner") {
     ]
 
     if (!product) {
-      deps += [ observatory_target ]
+      deps += [ engine_observatory_target ]
     }
 
     binary = "flutter_jit${product_suffix}_runner"
@@ -234,7 +234,7 @@ template("jit_runner") {
     if (!product) {
       resources += [
         {
-          path = rebase_path(observatory_archive_file)
+          path = rebase_path(engine_observatory_archive_file)
           dest = "observatory.tar"
         },
       ]
@@ -287,7 +287,7 @@ template("aot_runner") {
     ]
 
     if (!product) {
-      deps += [ observatory_target ]
+      deps += [ engine_observatory_target ]
     }
 
     meta_dir = "$flutter_root/shell/platform/fuchsia/flutter/meta"
@@ -304,7 +304,7 @@ template("aot_runner") {
     if (!product) {
       resources += [
         {
-          path = rebase_path(observatory_archive_file)
+          path = rebase_path(engine_observatory_archive_file)
           dest = "observatory.tar"
         },
       ]

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -67,9 +67,9 @@ template("core_snapshot") {
       snapshot_profile,
     ]
 
-    gen_snapshot_to_use = gen_snapshot
+    gen_snapshot_to_use = engine_gen_snapshot
     if (invoker.product) {
-      gen_snapshot_to_use = gen_snapshot_product
+      gen_snapshot_to_use = engine_gen_snapshot_product
     }
 
     tool = gen_snapshot_to_use
@@ -98,8 +98,7 @@ template("core_snapshot") {
     # No asserts in debug or release product.
     # No asserts in release with flutter_profile=true (non-product)
     # Yes asserts in non-product debug.
-    if (!invoker.product &&
-        (is_debug || !(flutter_runtime_mode == "profile"))) {
+    if (!invoker.product && (is_debug || !(flutter_runtime_mode == "profile"))) {
       args += [ "--enable_asserts" ]
     }
     args += [ rebase_path(platform_dill) ]

--- a/tools/fuchsia/dart.gni
+++ b/tools/fuchsia/dart.gni
@@ -1,13 +1,16 @@
-# Copyright 2018 The Fuchsia Authors. All rights reserved.
+# Copyright 2013 The Flutter Authors. All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-gen_snapshot = "//third_party/dart/runtime/bin:gen_snapshot"
-gen_snapshot_product = "//third_party/dart/runtime/bin:gen_snapshot_product"
+engine_gen_snapshot = "//third_party/dart/runtime/bin:gen_snapshot"
+engine_gen_snapshot_product =
+    "//third_party/dart/runtime/bin:gen_snapshot_product"
 
-observatory_target =
+engine_observatory_target =
     "//third_party/dart/runtime/observatory:observatory_archive"
-observatory_archive_dir = get_label_info(observatory_target, "target_gen_dir")
-observatory_archive_name = get_label_info(observatory_target, "name")
-observatory_archive_file =
-    "${observatory_archive_dir}/${observatory_archive_name}.tar"
+engine_observatory_archive_dir =
+    get_label_info(engine_observatory_target, "target_gen_dir")
+engine_observatory_archive_name =
+    get_label_info(engine_observatory_target, "name")
+engine_observatory_archive_file =
+    "${engine_observatory_archive_dir}/${engine_observatory_archive_name}.tar"


### PR DESCRIPTION
- Tested this compatibility in topaz repo. The build rules can now be
used to build kernel_platform_files in topaz tree, after this change we
can migrate the `platform*dill` and `vm*snapshot` files in topaz to use the
engine built artifacts.

- Also removes some namespace conflicts for dart configuration.