### PR TITLE
[WIP] Fall-back to sans-serif on Flutter web

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/fonts.dart
+++ b/lib/web_ui/lib/src/engine/compositor/fonts.dart
@@ -41,11 +41,6 @@ class SkiaFontCollection {
           'There was a problem trying to load FontManifest.json');
     }
 
-    // Add Roboto to the bundled fonts since it is provided by default by
-    // Flutter.
-    _fontLoadingFutures
-        .add(_registerFont('Roboto', _robotoFontUrl, <String, String>{}));
-
     for (Map<String, dynamic> fontFamily in fontManifest) {
       final String family = fontFamily['family'];
       final List<dynamic> fontAssets = fontFamily['fonts'];

--- a/lib/web_ui/lib/src/engine/compositor/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/recording_canvas.dart
@@ -163,7 +163,7 @@ class SkRecordingCanvas implements RecordingCanvas {
     final EngineParagraph engineParagraph = paragraph;
     final ParagraphGeometricStyle style = engineParagraph.geometricStyle;
     final js.JsObject skFont =
-        skiaFontCollection.getFont(style.effectiveFontFamily, style.fontSize);
+        skiaFontCollection.getFont(style.effectiveFontFamilies[0], style.fontSize);
     final js.JsObject skShapedTextOpts = js.JsObject.jsify(<String, dynamic>{
       'font': skFont,
       'leftToRight': true,

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -54,13 +54,6 @@ class FontCollection {
       _assetFontManager = _PolyfillFontManager();
     }
 
-    // If not on Chrome, add Roboto to the bundled fonts since it is provided
-    // by default by Flutter.
-    if (browserEngine != BrowserEngine.blink) {
-      _assetFontManager
-          .registerAsset('Roboto', 'url($_robotoFontUrl)', <String, String>{});
-    }
-
     for (Map<String, dynamic> fontFamily in fontManifest) {
       final String family = fontFamily['family'];
       final List<dynamic> fontAssets = fontFamily['fonts'];

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -220,6 +220,31 @@ String _pathToSvgClipPath(ui.Path path,
   return sb.toString();
 }
 
+
+/// A list of font-family names that should never be wrapped in quotes.
+/// https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#Syntax
+const Set<String> nonQuotableFontFamilies = {
+  'serif',
+  'sans-serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'emoji',
+  'math',
+  'fangsong',
+  'inherit',
+  'initial',
+  'unset',
+};
+
+/// Converts a list of strings (containing font-families) into a valid CSS list.
+/// 
+/// Wraps each item of the list in quotes (except if it's contained in the
+/// nonQuotableFontFamilies set), then joins them with commas.
+String _listToCssFontFamily(List<String> fontFamilies, {bool skipDomRendererFallback = false}) => 
+  fontFamilies.map((family) => nonQuotableFontFamilies.contains(family) ? family : "'${family}'").join(",");
+
 /// Determines if the (dynamic) exception passed in is a NS_ERROR_FAILURE
 /// (from Firefox).
 ///


### PR DESCRIPTION
This CR implements something similar to option number 3 in https://github.com/flutter/flutter/issues/39994, and also implements initial support for fallbackFontFamily on https://github.com/flutter/flutter/issues/32233.

* Stop assuming that the Roboto asset is included somewhere in the app and auto-load it from the engine. Users need to bring their own Roboto font now, and set it up through the manifest, like any other font.
* Ensure rendering falls back to the intended [DomRenderer.defaultFontFamily](https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/dom_renderer.dart#L214).
* If additional fonts are passed on the fallbackFontFamily list of strings, they're passed along to the canvases, so the browser resolves the stack. I'm not sure this guarantees identical per-glyph behavior as documented [here](https://api.flutter.dev/flutter/painting/TextStyle/fontFamilyFallback.html), but it's a start.
* Avoids wrapping certain reserved font names in quotes, so they work as intended (TIL: `font-family: sans-serif` is not the same as `font-family: 'sans-serif'`).

I'm attempting to see all tests pass.