### PR TITLE
Fold the calls for FlutterMain into the FlutterEngine constructor

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -556,6 +556,7 @@ FILE: ../../../flutter/shell/platform/android/apk_asset_provider.cc
 FILE: ../../../flutter/shell/platform/android/apk_asset_provider.h
 FILE: ../../../flutter/shell/platform/android/flutter_main.cc
 FILE: ../../../flutter/shell/platform/android/flutter_main.h
+FILE: ../../../flutter/shell/platform/android/io/flutter/FlutterInjector.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/Log.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterActivity.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -588,6 +589,10 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/Flutte
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/dart/DartMessenger.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/dart/PlatformMessageHandler.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/loader/ResourceCleaner.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/loader/ResourceExtractor.java
+FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/loader/ResourcePaths.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/plugins/FlutterPlugin.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/plugins/PluginRegistry.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/embedding/engine/plugins/activity/ActivityAware.java
@@ -657,9 +662,6 @@ FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterMain.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterNativeView.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterRunArguments.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/FlutterView.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourceCleaner.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourceExtractor.java
-FILE: ../../../flutter/shell/platform/android/io/flutter/view/ResourcePaths.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/TextureRegistry.java
 FILE: ../../../flutter/shell/platform/android/io/flutter/view/VsyncWaiter.java
 FILE: ../../../flutter/shell/platform/android/library_loader.cc

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -410,6 +410,7 @@ action("robolectric_tests") {
   jar_path = "$root_out_dir/robolectric_tests.jar"
 
   sources = [
+    "test/io/flutter/FlutterInjectorTest.java",
     "test/io/flutter/FlutterTestSuite.java",
     "test/io/flutter/SmokeTest.java",
     "test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java",

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -123,6 +123,7 @@ action("flutter_shell_java") {
   source_jar_path = embedding_source_jar_path
 
   sources = [
+    "io/flutter/FlutterInjector.java",
     "io/flutter/Log.java",
     "io/flutter/app/FlutterActivity.java",
     "io/flutter/app/FlutterActivityDelegate.java",
@@ -155,6 +156,10 @@ action("flutter_shell_java") {
     "io/flutter/embedding/engine/dart/DartExecutor.java",
     "io/flutter/embedding/engine/dart/DartMessenger.java",
     "io/flutter/embedding/engine/dart/PlatformMessageHandler.java",
+    "io/flutter/embedding/engine/loader/FlutterLoader.java",
+    "io/flutter/embedding/engine/loader/ResourceCleaner.java",
+    "io/flutter/embedding/engine/loader/ResourceExtractor.java",
+    "io/flutter/embedding/engine/loader/ResourcePaths.java",
     "io/flutter/embedding/engine/plugins/FlutterPlugin.java",
     "io/flutter/embedding/engine/plugins/PluginRegistry.java",
     "io/flutter/embedding/engine/plugins/activity/ActivityAware.java",
@@ -224,9 +229,6 @@ action("flutter_shell_java") {
     "io/flutter/view/FlutterNativeView.java",
     "io/flutter/view/FlutterRunArguments.java",
     "io/flutter/view/FlutterView.java",
-    "io/flutter/view/ResourceCleaner.java",
-    "io/flutter/view/ResourceExtractor.java",
-    "io/flutter/view/ResourcePaths.java",
     "io/flutter/view/TextureRegistry.java",
     "io/flutter/view/VsyncWaiter.java",
   ]

--- a/shell/platform/android/io/flutter/FlutterInjector.java
+++ b/shell/platform/android/io/flutter/FlutterInjector.java
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/android/io/flutter/FlutterInjector.java
+++ b/shell/platform/android/io/flutter/FlutterInjector.java
@@ -90,13 +90,15 @@ public final class FlutterInjector {
   public static final class Builder {
 
     private boolean isRunningInRobolectricTest = false;
-    public void setIsRunningInRobolectricTest(boolean isRunningInRobolectricTest) {
+    public Builder setIsRunningInRobolectricTest(boolean isRunningInRobolectricTest) {
       this.isRunningInRobolectricTest = isRunningInRobolectricTest;
+      return this;
     }
 
     private FlutterLoader flutterLoader;
-    public void setFlutterLoader(@NonNull FlutterLoader flutterLoader) {
+    public Builder setFlutterLoader(@NonNull FlutterLoader flutterLoader) {
       this.flutterLoader = flutterLoader;
+      return this;
     }
 
     public FlutterInjector build() {

--- a/shell/platform/android/io/flutter/FlutterInjector.java
+++ b/shell/platform/android/io/flutter/FlutterInjector.java
@@ -1,0 +1,112 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
+
+import io.flutter.embedding.engine.loader.FlutterLoader;
+
+import java.lang.IllegalStateException;
+
+/*
+ * This class is a simple dependency injector for the Android part of the Flutter engine.
+ *
+ * This simple solution is used facilitate testability without bringing in heavier app-development
+ * centric dependency injection frameworks such as Guice or Dagger2.
+ */
+public final class FlutterInjector {
+
+  private static FlutterInjector instance;
+  private static boolean accessed;
+
+  /*
+   * Use {@link FlutterInjector.Builder} to specify members to be injected via the static
+   * {@code FlutterInjector}.
+   *
+   * This can only be called at the beginning of the program before the {@link #instance()} is
+   * accessed.
+   */
+  public static void setInstance(@NonNull FlutterInjector injector) {
+    if (accessed) {
+      throw new IllegalStateException("Cannot change the FlutterInjector instance once it's been " +
+          "read. If you're trying to dependency inject, be sure to do so at the beginning of " +
+          "the program");
+    }
+    instance = injector;
+  }
+
+  /*
+   * Retrieve the static instance of the {@code FlutterInjector} to use in your program.
+   *
+   * Once you access it, you can no longer change the values injected.
+   *
+   * If no override is provided for the injector, reasonable defaults are provided.
+   */
+  public static FlutterInjector instance() {
+    accessed = true;
+    if (instance == null) {
+      instance = new Builder().build();
+    }
+    return instance;
+  }
+
+  // This whole class is here to enable testing so to test the thing that lets you test, some degree
+  // of hack is needed.
+  @VisibleForTesting
+  /* Package default */ static void reset() {
+    accessed = false;
+    instance = null;
+  }
+
+  private FlutterInjector(
+    boolean isRunningInRobolectricTest,
+    @NonNull FlutterLoader flutterLoader
+  ) {
+    this.isRunningInRobolectricTest = isRunningInRobolectricTest;
+    this.flutterLoader = flutterLoader;
+  }
+
+  private boolean isRunningInRobolectricTest;
+  private FlutterLoader flutterLoader;
+
+  public boolean isRunningInRobolectricTest() {
+    return isRunningInRobolectricTest;
+  }
+
+  @NonNull
+  public FlutterLoader flutterLoader() {
+    return flutterLoader;
+  }
+
+  /*
+   * Builder used to supply a custom FlutterInjector instance to
+   * {@link FlutterInjector#setInstance(FlutterInjector)}.
+   *
+   * Non-overriden values have reasonable defaults.
+   */
+  public static final class Builder {
+
+    private boolean isRunningInRobolectricTest = false;
+    public void setIsRunningInRobolectricTest(boolean isRunningInRobolectricTest) {
+      this.isRunningInRobolectricTest = isRunningInRobolectricTest;
+    }
+
+    private FlutterLoader flutterLoader;
+    public void setFlutterLoader(@NonNull FlutterLoader flutterLoader) {
+      this.flutterLoader = flutterLoader;
+    }
+
+    public FlutterInjector build() {
+      if (flutterLoader == null) {
+        flutterLoader = new FlutterLoader();
+      }
+
+      return new FlutterInjector(isRunningInRobolectricTest, flutterLoader);
+    }
+
+  }
+
+}

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -31,39 +31,41 @@ import io.flutter.embedding.engine.systemchannels.SettingsChannel;
 import io.flutter.embedding.engine.systemchannels.SystemChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.platform.PlatformViewsController;
+import io.flutter.view.FlutterMain;
 
 /**
  * A single Flutter execution environment.
- *
- * WARNING: THIS CLASS IS EXPERIMENTAL. DO NOT SHIP A DEPENDENCY ON THIS CODE.
- * IF YOU USE IT, WE WILL BREAK YOU.
- *
+ * <p>
+ * WARNING: THIS CLASS IS CURRENTLY EXPERIMENTAL. USE AT YOUR OWN RISK.
+ * <p>
  * The {@code FlutterEngine} is the container through which Dart code can be run in an Android
  * application.
- *
+ * <p>
  * Dart code in a {@code FlutterEngine} can execute in the background, or it can be render to the
  * screen by using the accompanying {@link FlutterRenderer} and Dart code using the Flutter
  * framework on the Dart side. Rendering can be started and stopped, thus allowing a
- * {@code FlutterEngine} to move from UI interaction to data-only processing and then
- * back to UI interaction.
- *
+ * {@code FlutterEngine} to move from UI interaction to data-only processing and then back to UI
+ * interaction.
+ * <p>
  * Multiple {@code FlutterEngine}s may exist, execute Dart code, and render UIs within a single
  * Android app.
- *
+ * <p>
  * To start running Dart and/or Flutter within this {@code FlutterEngine}, get a reference to this
- * engine's {@link DartExecutor} and then use {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}.
- * The {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)} method must not be
+ * engine's {@link DartExecutor} and then use
+ * {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}. The
+ * {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)} method must not be
  * invoked twice on the same {@code FlutterEngine}.
- *
+ * <p>
  * To start rendering Flutter content to the screen, use {@link #getRenderer()} to obtain a
- * {@link FlutterRenderer} and then attach a {@link RenderSurface}.  Consider using
- * a {@link io.flutter.embedding.android.FlutterView} as a {@link RenderSurface}.
- *
+ * {@link FlutterRenderer} and then attach a {@link RenderSurface}.  Consider using a
+ * {@link io.flutter.embedding.android.FlutterView} as a {@link RenderSurface}.
+ * <p>
  * Instatiating the first {@code FlutterEngine} per process will also load the Flutter engine's
- * native library and start the Dart VM once. Subsequent {@code FlutterEngine}s will run on the same
- * VM instance but will have their own Dart <a href="https://api.dartlang.org/stable/dart-isolate/Isolate-class.html">Isolate</a>.
- * Each Isolate is a self-contained Dart environment and cannot communicate with each other except
- * via Isolate ports.
+ * native library and start the Dart VM. Subsequent {@code FlutterEngine}s will run on the same VM
+ * instance but will have their own Dart <a
+ * href="https://api.dartlang.org/stable/dart-isolate/Isolate-class.html">Isolate</a> when the
+ * {@link DartExecutor} is run. Each Isolate is a self-contained Dart environment and cannot
+ * communicate with each other except via Isolate ports.
  */
 public class FlutterEngine implements LifecycleOwner {
   private static final String TAG = "FlutterEngine";
@@ -119,24 +121,30 @@ public class FlutterEngine implements LifecycleOwner {
 
   /**
    * Constructs a new {@code FlutterEngine}.
-   *
-   * {@code FlutterMain.startInitialization} must be called before constructing a {@code FlutterEngine}
-   * to load the native libraries needed to attach to JNI.
-   *
+   * <p>
    * A new {@code FlutterEngine} does not execute any Dart code automatically. See
    * {@link #getDartExecutor()} and {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}
    * to begin executing Dart code within this {@code FlutterEngine}.
-   *
+   * <p>
    * A new {@code FlutterEngine} will not display any UI until a
    * {@link RenderSurface} is registered. See
    * {@link #getRenderer()} and {@link FlutterRenderer#startRenderingToSurface(RenderSurface)}.
-   *
+   * <p>
    * A new {@code FlutterEngine} does not come with any Flutter plugins attached. To attach plugins,
    * see {@link #getPlugins()}.
-   *
+   * <p>
    * A new {@code FlutterEngine} does come with all default system channels attached.
+   * <p>
+   * The first {@code FlutterEngine} instance constructed per process will also load the Flutter
+   * native library and start a Dart VM.
+   *
+   * In order to pass Dart VM initialization arguments (see {@link io.flutter.embedding.engine.FlutterShellArgs})
+   * when creating the VM, manually set the initialization arguments by calling {@link FlutterMain#startInitialization(io.flutter.view.Context)}
+   * and {@link FlutterMain#ensureInitializationComplete(io.flutter.view.Context, String[])}.
    */
   public FlutterEngine(@NonNull Context context) {
+    FlutterMain.startInitialization(context);
+    FlutterMain.ensureInitializationComplete(context, null);
     this.flutterJNI = new FlutterJNI();
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
     attachToJni();
@@ -183,9 +191,9 @@ public class FlutterEngine implements LifecycleOwner {
   }
 
   /**
-   * Cleans up all components within this {@code FlutterEngine} and then detaches from Flutter's
-   * native implementation.
-   *
+   * Cleans up all components within this {@code FlutterEngine} and destroys the associated Dart
+   * Isolate. All state held by the Dart Isolate, such as the Flutter Elements tree, is lost.
+   * <p>
    * This {@code FlutterEngine} instance should be discarded after invoking this method.
    */
   public void destroy() {
@@ -215,10 +223,10 @@ public class FlutterEngine implements LifecycleOwner {
 
   /**
    * The Dart execution context associated with this {@code FlutterEngine}.
-   *
+   * <p>
    * The {@link DartExecutor} can be used to start executing Dart code from a given entrypoint.
    * See {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}.
-   *
+   * <p>
    * Use the {@link DartExecutor} to connect any desired message channels and method channels
    * to facilitate communication between Android and Dart/Flutter.
    */
@@ -229,7 +237,7 @@ public class FlutterEngine implements LifecycleOwner {
 
   /**
    * The rendering system associated with this {@code FlutterEngine}.
-   *
+   * <p>
    * To render a Flutter UI that is produced by this {@code FlutterEngine}'s Dart code, attach
    * a {@link RenderSurface} to this
    * {@link FlutterRenderer}.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -137,7 +137,7 @@ public class FlutterEngine implements LifecycleOwner {
    * <p>
    * The first {@code FlutterEngine} instance constructed per process will also load the Flutter
    * native library and start a Dart VM.
-   *
+   * <p>
    * In order to pass Dart VM initialization arguments (see {@link io.flutter.embedding.engine.FlutterShellArgs})
    * when creating the VM, manually set the initialization arguments by calling {@link FlutterMain#startInitialization(io.flutter.view.Context)}
    * and {@link FlutterMain#ensureInitializationComplete(io.flutter.view.Context, String[])}.

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -12,8 +12,10 @@ import android.support.annotation.NonNull;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.flutter.FlutterInjector;
 import io.flutter.Log;
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.embedding.engine.plugins.PluginRegistry;
 import io.flutter.embedding.engine.plugins.activity.ActivityControlSurface;
 import io.flutter.embedding.engine.plugins.broadcastreceiver.BroadcastReceiverControlSurface;
@@ -31,7 +33,6 @@ import io.flutter.embedding.engine.systemchannels.SettingsChannel;
 import io.flutter.embedding.engine.systemchannels.SystemChannel;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
 import io.flutter.plugin.platform.PlatformViewsController;
-import io.flutter.view.FlutterMain;
 
 /**
  * A single Flutter execution environment.
@@ -143,8 +144,9 @@ public class FlutterEngine implements LifecycleOwner {
    * and {@link FlutterMain#ensureInitializationComplete(io.flutter.view.Context, String[])}.
    */
   public FlutterEngine(@NonNull Context context) {
-    FlutterMain.startInitialization(context);
-    FlutterMain.ensureInitializationComplete(context, null);
+    FlutterLoader flutterLoader = FlutterInjector.instance().flutterLoader();
+    flutterLoader.startInitialization(context);
+    FlutterLoader.ensureInitializationComplete(context, null);
     this.flutterJNI = new FlutterJNI();
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);
     attachToJni();

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -38,24 +38,33 @@ import io.flutter.plugin.platform.PlatformViewsController;
  * WARNING: THIS CLASS IS EXPERIMENTAL. DO NOT SHIP A DEPENDENCY ON THIS CODE.
  * IF YOU USE IT, WE WILL BREAK YOU.
  *
- * A {@code FlutterEngine} can execute in the background, or it can be rendered to the screen by
- * using the accompanying {@link FlutterRenderer}.  Rendering can be started and stopped, thus
- * allowing a {@code FlutterEngine} to move from UI interaction to data-only processing and then
+ * The {@code FlutterEngine} is the container through which Dart code can be run in an Android
+ * application.
+ *
+ * Dart code in a {@code FlutterEngine} can execute in the background, or it can be render to the
+ * screen by using the accompanying {@link FlutterRenderer} and Dart code using the Flutter
+ * framework on the Dart side. Rendering can be started and stopped, thus allowing a
+ * {@code FlutterEngine} to move from UI interaction to data-only processing and then
  * back to UI interaction.
  *
  * Multiple {@code FlutterEngine}s may exist, execute Dart code, and render UIs within a single
  * Android app.
  *
- * To start running Flutter within this {@code FlutterEngine}, get a reference to this engine's
- * {@link DartExecutor} and then use {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}.
+ * To start running Dart and/or Flutter within this {@code FlutterEngine}, get a reference to this
+ * engine's {@link DartExecutor} and then use {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)}.
  * The {@link DartExecutor#executeDartEntrypoint(DartExecutor.DartEntrypoint)} method must not be
  * invoked twice on the same {@code FlutterEngine}.
  *
  * To start rendering Flutter content to the screen, use {@link #getRenderer()} to obtain a
  * {@link FlutterRenderer} and then attach a {@link RenderSurface}.  Consider using
  * a {@link io.flutter.embedding.android.FlutterView} as a {@link RenderSurface}.
+ *
+ * Instatiating the first {@code FlutterEngine} per process will also load the Flutter engine's
+ * native library and start the Dart VM once. Subsequent {@code FlutterEngine}s will run on the same
+ * VM instance but will have their own Dart <a href="https://api.dartlang.org/stable/dart-isolate/Isolate-class.html">Isolate</a>.
+ * Each Isolate is a self-contained Dart environment and cannot communicate with each other except
+ * via Isolate ports.
  */
-// TODO(mattcarroll): re-evaluate system channel APIs - some are not well named or differentiated
 public class FlutterEngine implements LifecycleOwner {
   private static final String TAG = "FlutterEngine";
 

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -36,7 +36,7 @@ import io.flutter.view.FlutterMain;
  * <p>
  * Once started, a {@link DartExecutor} cannot be stopped. The associated Dart code will execute
  * until it completes, or until the {@link io.flutter.embedding.engine.FlutterEngine} that owns
- * this {@link DartExecutor} is destroyed via {@link io.flutter.embedding.engine.FlutterEngine#destroy()}.
+ * this {@link DartExecutor} is destroyed.
  */
 public class DartExecutor implements BinaryMessenger {
   private static final String TAG = "DartExecutor";

--- a/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/dart/DartExecutor.java
@@ -36,7 +36,7 @@ import io.flutter.view.FlutterMain;
  * <p>
  * Once started, a {@link DartExecutor} cannot be stopped. The associated Dart code will execute
  * until it completes, or until the {@link io.flutter.embedding.engine.FlutterEngine} that owns
- * this {@link DartExecutor} is destroyed.
+ * this {@link DartExecutor} is destroyed via {@link io.flutter.embedding.engine.FlutterEngine#destroy()}.
  */
 public class DartExecutor implements BinaryMessenger {
   private static final String TAG = "DartExecutor";

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -1,4 +1,4 @@
-// Copyright 2019 The Flutter Authors. All rights reserved.
+// Copyright 2013 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -1,0 +1,360 @@
+// Copyright 2019 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package io.flutter.embedding.engine.loader;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.res.AssetManager;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.SystemClock;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+import android.util.Log;
+import android.view.WindowManager;
+
+import io.flutter.FlutterInjector;
+import io.flutter.BuildConfig;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.util.PathUtils;
+import io.flutter.view.VsyncWaiter;
+
+import java.io.File;
+import java.util.*;
+
+/**
+ * This class finds Flutter resources in an application APK and also loads Flutter's native library.
+ */
+public class FlutterLoader {
+    private static final String TAG = "FlutterLoader";
+
+    // Must match values in flutter::switches
+    private static final String AOT_SHARED_LIBRARY_NAME = "aot-shared-library-name";
+    private static final String SNAPSHOT_ASSET_PATH_KEY = "snapshot-asset-path";
+    private static final String VM_SNAPSHOT_DATA_KEY = "vm-snapshot-data";
+    private static final String ISOLATE_SNAPSHOT_DATA_KEY = "isolate-snapshot-data";
+    private static final String FLUTTER_ASSETS_DIR_KEY = "flutter-assets-dir";
+
+    // XML Attribute keys supported in AndroidManifest.xml
+    public static final String PUBLIC_AOT_SHARED_LIBRARY_NAME =
+        FlutterLoader.class.getName() + '.' + AOT_SHARED_LIBRARY_NAME;
+    public static final String PUBLIC_VM_SNAPSHOT_DATA_KEY =
+        FlutterLoader.class.getName() + '.' + VM_SNAPSHOT_DATA_KEY;
+    public static final String PUBLIC_ISOLATE_SNAPSHOT_DATA_KEY =
+        FlutterLoader.class.getName() + '.' + ISOLATE_SNAPSHOT_DATA_KEY;
+    public static final String PUBLIC_FLUTTER_ASSETS_DIR_KEY =
+        FlutterLoader.class.getName() + '.' + FLUTTER_ASSETS_DIR_KEY;
+
+    // Resource names used for components of the precompiled snapshot.
+    private static final String DEFAULT_AOT_SHARED_LIBRARY_NAME = "libapp.so";
+    private static final String DEFAULT_VM_SNAPSHOT_DATA = "vm_snapshot_data";
+    private static final String DEFAULT_ISOLATE_SNAPSHOT_DATA = "isolate_snapshot_data";
+    private static final String DEFAULT_LIBRARY = "libflutter.so";
+    private static final String DEFAULT_KERNEL_BLOB = "kernel_blob.bin";
+    private static final String DEFAULT_FLUTTER_ASSETS_DIR = "flutter_assets";
+
+    @NonNull
+    private static String fromFlutterAssets(@NonNull String filePath) {
+        return sFlutterAssetsDir + File.separator + filePath;
+    }
+
+    // Mutable because default values can be overridden via config properties
+    private static String sAotSharedLibraryName = DEFAULT_AOT_SHARED_LIBRARY_NAME;
+    private static String sVmSnapshotData = DEFAULT_VM_SNAPSHOT_DATA;
+    private static String sIsolateSnapshotData = DEFAULT_ISOLATE_SNAPSHOT_DATA;
+    private static String sFlutterAssetsDir = DEFAULT_FLUTTER_ASSETS_DIR;
+
+    private static boolean sInitialized = false;
+
+    @Nullable
+    private static ResourceExtractor sResourceExtractor;
+    @Nullable
+    private static Settings sSettings;
+
+    public static class Settings {
+        private String logTag;
+
+        @Nullable
+        public String getLogTag() {
+            return logTag;
+        }
+
+        /**
+         * Set the tag associated with Flutter app log messages.
+         * @param tag Log tag.
+         */
+        public void setLogTag(String tag) {
+            logTag = tag;
+        }
+    }
+
+    /**
+     * Starts initialization of the native system.
+     * @param applicationContext The Android application context.
+     */
+    public static void startInitialization(@NonNull Context applicationContext) {
+        // Do nothing if we're running this in a Robolectric test.
+        if (FlutterInjector.instance().isRunningInRobolectricTest()) {
+            return;
+        }
+        startInitialization(applicationContext, new Settings());
+    }
+
+    /**
+     * Starts initialization of the native system.
+     * <p>
+     * This loads the Flutter engine's native library to enable subsequent JNI calls. This also
+     * starts locating and unpacking Dart resources packaged in the app's APK.
+     * <p>
+     * Calling this method multiple times has no effect.
+     *
+     * @param applicationContext The Android application context.
+     * @param settings Configuration settings.
+     */
+    public static void startInitialization(@NonNull Context applicationContext, @NonNull Settings settings) {
+        // Do nothing if we're running this in a Robolectric test.
+        if (FlutterInjector.instance().isRunningInRobolectricTest()) {
+            return;
+        }
+
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+          throw new IllegalStateException("startInitialization must be called on the main thread");
+        }
+        // Do not run startInitialization more than once.
+        if (sSettings != null) {
+          return;
+        }
+
+        sSettings = settings;
+
+        long initStartTimestampMillis = SystemClock.uptimeMillis();
+        initConfig(applicationContext);
+        initResources(applicationContext);
+
+        System.loadLibrary("flutter");
+
+        VsyncWaiter
+            .getInstance((WindowManager) applicationContext.getSystemService(Context.WINDOW_SERVICE))
+            .init();
+
+        // We record the initialization time using SystemClock because at the start of the
+        // initialization we have not yet loaded the native library to call into dart_tools_api.h.
+        // To get Timeline timestamp of the start of initialization we simply subtract the delta
+        // from the Timeline timestamp at the current moment (the assumption is that the overhead
+        // of the JNI call is negligible).
+        long initTimeMillis = SystemClock.uptimeMillis() - initStartTimestampMillis;
+        FlutterJNI.nativeRecordStartTimestamp(initTimeMillis);
+    }
+
+    /**
+     * Blocks until initialization of the native system has completed.
+     * <p>
+     * Calling this method multiple times has no effect.
+     *
+     * @param applicationContext The Android application context.
+     * @param args Flags sent to the Flutter runtime.
+     */
+    public static void ensureInitializationComplete(@NonNull Context applicationContext, @Nullable String[] args) {
+        // Do nothing if we're running this in a Robolectric test.
+        if (FlutterInjector.instance().isRunningInRobolectricTest()) {
+            return;
+        }
+
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+          throw new IllegalStateException("ensureInitializationComplete must be called on the main thread");
+        }
+        if (sSettings == null) {
+          throw new IllegalStateException("ensureInitializationComplete must be called after startInitialization");
+        }
+        if (sInitialized) {
+            return;
+        }
+        try {
+            if (sResourceExtractor != null) {
+                sResourceExtractor.waitForCompletion();
+            }
+
+            List<String> shellArgs = new ArrayList<>();
+            shellArgs.add("--icu-symbol-prefix=_binary_icudtl_dat");
+
+            ApplicationInfo applicationInfo = getApplicationInfo(applicationContext);
+            shellArgs.add("--icu-native-lib-path=" + applicationInfo.nativeLibraryDir + File.separator + DEFAULT_LIBRARY);
+
+            if (args != null) {
+                Collections.addAll(shellArgs, args);
+            }
+
+            String kernelPath = null;
+            if (BuildConfig.DEBUG) {
+                String snapshotAssetPath = PathUtils.getDataDirectory(applicationContext) + File.separator + sFlutterAssetsDir;
+                kernelPath = snapshotAssetPath + File.separator + DEFAULT_KERNEL_BLOB;
+                shellArgs.add("--" + SNAPSHOT_ASSET_PATH_KEY + "=" + snapshotAssetPath);
+                shellArgs.add("--" + VM_SNAPSHOT_DATA_KEY + "=" + sVmSnapshotData);
+                shellArgs.add("--" + ISOLATE_SNAPSHOT_DATA_KEY + "=" + sIsolateSnapshotData);
+            } else {
+                shellArgs.add("--" + AOT_SHARED_LIBRARY_NAME + "=" + sAotSharedLibraryName);
+
+                // Most devices can load the AOT shared library based on the library name
+                // with no directory path.  Provide a fully qualified path to the library
+                // as a workaround for devices where that fails.
+                shellArgs.add("--" + AOT_SHARED_LIBRARY_NAME + "=" + applicationInfo.nativeLibraryDir + File.separator + sAotSharedLibraryName);
+            }
+
+            shellArgs.add("--cache-dir-path=" + PathUtils.getCacheDirectory(applicationContext));
+            if (sSettings.getLogTag() != null) {
+                shellArgs.add("--log-tag=" + sSettings.getLogTag());
+            }
+
+            String appStoragePath = PathUtils.getFilesDir(applicationContext);
+            String engineCachesPath = PathUtils.getCacheDirectory(applicationContext);
+            FlutterJNI.nativeInit(applicationContext, shellArgs.toArray(new String[0]),
+                kernelPath, appStoragePath, engineCachesPath);
+
+            sInitialized = true;
+        } catch (Exception e) {
+            Log.e(TAG, "Flutter initialization failed.", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Same as {@link #ensureInitializationComplete(Context, String[])} but waiting on a background
+     * thread, then invoking {@code callback} on the {@code callbackHandler}.
+     */
+    public static void ensureInitializationCompleteAsync(
+        @NonNull Context applicationContext,
+        @Nullable String[] args,
+        @NonNull Handler callbackHandler,
+        @NonNull Runnable callback
+    ) {
+        // Do nothing if we're running this in a Robolectric test.
+        if (FlutterInjector.instance().isRunningInRobolectricTest()) {
+            return;
+        }
+
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            throw new IllegalStateException("ensureInitializationComplete must be called on the main thread");
+        }
+        if (sSettings == null) {
+            throw new IllegalStateException("ensureInitializationComplete must be called after startInitialization");
+        }
+        if (sInitialized) {
+            return;
+        }
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                if (sResourceExtractor != null) {
+                    sResourceExtractor.waitForCompletion();
+                }
+                new Handler(Looper.getMainLooper()).post(new Runnable() {
+                    @Override
+                    public void run() {
+                        ensureInitializationComplete(applicationContext.getApplicationContext(), args);
+                        callbackHandler.post(callback);
+                    }
+                });
+            }
+        }).start();
+    }
+
+    @NonNull
+    private static ApplicationInfo getApplicationInfo(@NonNull Context applicationContext) {
+        try {
+            return applicationContext
+                .getPackageManager()
+                .getApplicationInfo(applicationContext.getPackageName(), PackageManager.GET_META_DATA);
+        } catch (PackageManager.NameNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Initialize our Flutter config values by obtaining them from the
+     * manifest XML file, falling back to default values.
+     */
+    private static void initConfig(@NonNull Context applicationContext) {
+        Bundle metadata = getApplicationInfo(applicationContext).metaData;
+
+        // There isn't a `<meta-data>` tag as a direct child of `<application>` in
+        // `AndroidManifest.xml`.
+        if (metadata == null) {
+            return;
+        }
+
+        sAotSharedLibraryName = metadata.getString(PUBLIC_AOT_SHARED_LIBRARY_NAME, DEFAULT_AOT_SHARED_LIBRARY_NAME);
+        sFlutterAssetsDir = metadata.getString(PUBLIC_FLUTTER_ASSETS_DIR_KEY, DEFAULT_FLUTTER_ASSETS_DIR);
+
+        sVmSnapshotData = metadata.getString(PUBLIC_VM_SNAPSHOT_DATA_KEY, DEFAULT_VM_SNAPSHOT_DATA);
+        sIsolateSnapshotData = metadata.getString(PUBLIC_ISOLATE_SNAPSHOT_DATA_KEY, DEFAULT_ISOLATE_SNAPSHOT_DATA);
+    }
+
+    /**
+     * Extract assets out of the APK that need to be cached as uncompressed
+     * files on disk.
+     */
+    private static void initResources(@NonNull Context applicationContext) {
+        new ResourceCleaner(applicationContext).start();
+
+        if (BuildConfig.DEBUG) {
+            final String dataDirPath = PathUtils.getDataDirectory(applicationContext);
+            final String packageName = applicationContext.getPackageName();
+            final PackageManager packageManager = applicationContext.getPackageManager();
+            final AssetManager assetManager = applicationContext.getResources().getAssets();
+            sResourceExtractor = new ResourceExtractor(dataDirPath, packageName, packageManager, assetManager);
+
+            // In debug/JIT mode these assets will be written to disk and then
+            // mapped into memory so they can be provided to the Dart VM.
+            sResourceExtractor
+                .addResource(fromFlutterAssets(sVmSnapshotData))
+                .addResource(fromFlutterAssets(sIsolateSnapshotData))
+                .addResource(fromFlutterAssets(DEFAULT_KERNEL_BLOB));
+
+            sResourceExtractor.start();
+        }
+    }
+
+    @NonNull
+    public static String findAppBundlePath() {
+        return sFlutterAssetsDir;
+    }
+
+    @Deprecated
+    @Nullable
+    public static String findAppBundlePath(@NonNull Context applicationContext) {
+        return sFlutterAssetsDir;
+    }
+
+    /**
+     * Returns the file name for the given asset.
+     * The returned file name can be used to access the asset in the APK
+     * through the {@link android.content.res.AssetManager} API.
+     *
+     * @param asset the name of the asset. The name can be hierarchical
+     * @return      the filename to be used with {@link android.content.res.AssetManager}
+     */
+    @NonNull
+    public static String getLookupKeyForAsset(@NonNull String asset) {
+        return fromFlutterAssets(asset);
+    }
+
+    /**
+     * Returns the file name for the given asset which originates from the
+     * specified packageName. The returned file name can be used to access
+     * the asset in the APK through the {@link android.content.res.AssetManager} API.
+     *
+     * @param asset       the name of the asset. The name can be hierarchical
+     * @param packageName the name of the package from which the asset originates
+     * @return            the file name to be used with {@link android.content.res.AssetManager}
+     */
+    @NonNull
+    public static String getLookupKeyForAsset(@NonNull String asset, @NonNull String packageName) {
+        return getLookupKeyForAsset(
+            "packages" + File.separator + packageName + File.separator + asset);
+    }
+}

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ResourceCleaner.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ResourceCleaner.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package io.flutter.view;
+package io.flutter.embedding.engine.loader;
 
 import android.content.Context;
 import android.os.AsyncTask;

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ResourceExtractor.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ResourceExtractor.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package io.flutter.view;
+package io.flutter.embedding.engine.loader;
 
 import static java.util.Arrays.asList;
 

--- a/shell/platform/android/io/flutter/embedding/engine/loader/ResourcePaths.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/ResourcePaths.java
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-package io.flutter.view;
+package io.flutter.embedding.engine.loader;
 
 import android.content.Context;
 

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -112,10 +112,10 @@ public class FlutterMain {
 
     /**
      * Starts initialization of the native system.
-     *
+     * <p>
      * This loads the Flutter engine's native library to enable subsequent JNI calls. This also
      * starts locating and unpacking Dart resources packaged in the app's APK.
-     *
+     * <p>
      * Calling this method multiple times has no effect.
      *
      * @param applicationContext The Android application context.
@@ -158,7 +158,7 @@ public class FlutterMain {
 
     /**
      * Blocks until initialization of the native system has completed.
-     *
+     * <p>
      * Calling this method multiple times has no effect.
      *
      * @param applicationContext The Android application context.

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -19,7 +19,9 @@ import android.util.Log;
 import android.view.WindowManager;
 
 import io.flutter.BuildConfig;
+import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.util.PathUtils;
 
 import java.io.File;
@@ -29,57 +31,6 @@ import java.util.*;
  * A class to intialize the Flutter engine.
  */
 public class FlutterMain {
-    private static final String TAG = "FlutterMain";
-
-    // Must match values in sky::switches
-    private static final String AOT_SHARED_LIBRARY_NAME = "aot-shared-library-name";
-    private static final String SNAPSHOT_ASSET_PATH_KEY = "snapshot-asset-path";
-    private static final String VM_SNAPSHOT_DATA_KEY = "vm-snapshot-data";
-    private static final String ISOLATE_SNAPSHOT_DATA_KEY = "isolate-snapshot-data";
-    private static final String FLUTTER_ASSETS_DIR_KEY = "flutter-assets-dir";
-
-    // XML Attribute keys supported in AndroidManifest.xml
-    public static final String PUBLIC_AOT_SHARED_LIBRARY_NAME =
-        FlutterMain.class.getName() + '.' + AOT_SHARED_LIBRARY_NAME;
-    public static final String PUBLIC_VM_SNAPSHOT_DATA_KEY =
-        FlutterMain.class.getName() + '.' + VM_SNAPSHOT_DATA_KEY;
-    public static final String PUBLIC_ISOLATE_SNAPSHOT_DATA_KEY =
-        FlutterMain.class.getName() + '.' + ISOLATE_SNAPSHOT_DATA_KEY;
-    public static final String PUBLIC_FLUTTER_ASSETS_DIR_KEY =
-        FlutterMain.class.getName() + '.' + FLUTTER_ASSETS_DIR_KEY;
-
-    // Resource names used for components of the precompiled snapshot.
-    private static final String DEFAULT_AOT_SHARED_LIBRARY_NAME = "libapp.so";
-    private static final String DEFAULT_VM_SNAPSHOT_DATA = "vm_snapshot_data";
-    private static final String DEFAULT_ISOLATE_SNAPSHOT_DATA = "isolate_snapshot_data";
-    private static final String DEFAULT_LIBRARY = "libflutter.so";
-    private static final String DEFAULT_KERNEL_BLOB = "kernel_blob.bin";
-    private static final String DEFAULT_FLUTTER_ASSETS_DIR = "flutter_assets";
-
-    private static boolean isRunningInRobolectricTest = false;
-
-    @VisibleForTesting
-    public static void setIsRunningInRobolectricTest(boolean isRunningInRobolectricTest) {
-        FlutterMain.isRunningInRobolectricTest = isRunningInRobolectricTest;
-    }
-
-    @NonNull
-    private static String fromFlutterAssets(@NonNull String filePath) {
-        return sFlutterAssetsDir + File.separator + filePath;
-    }
-
-    // Mutable because default values can be overridden via config properties
-    private static String sAotSharedLibraryName = DEFAULT_AOT_SHARED_LIBRARY_NAME;
-    private static String sVmSnapshotData = DEFAULT_VM_SNAPSHOT_DATA;
-    private static String sIsolateSnapshotData = DEFAULT_ISOLATE_SNAPSHOT_DATA;
-    private static String sFlutterAssetsDir = DEFAULT_FLUTTER_ASSETS_DIR;
-
-    private static boolean sInitialized = false;
-
-    @Nullable
-    private static ResourceExtractor sResourceExtractor;
-    @Nullable
-    private static Settings sSettings;
 
     public static class Settings {
         private String logTag;
@@ -103,11 +54,7 @@ public class FlutterMain {
      * @param applicationContext The Android application context.
      */
     public static void startInitialization(@NonNull Context applicationContext) {
-        // Do nothing if we're running this in a Robolectric test.
-        if (isRunningInRobolectricTest) {
-            return;
-        }
-        startInitialization(applicationContext, new Settings());
+        FlutterInjector.instance().flutterLoader().startInitialization(applicationContext);
     }
 
     /**
@@ -122,38 +69,9 @@ public class FlutterMain {
      * @param settings Configuration settings.
      */
     public static void startInitialization(@NonNull Context applicationContext, @NonNull Settings settings) {
-        // Do nothing if we're running this in a Robolectric test.
-        if (isRunningInRobolectricTest) {
-            return;
-        }
-
-        if (Looper.myLooper() != Looper.getMainLooper()) {
-          throw new IllegalStateException("startInitialization must be called on the main thread");
-        }
-        // Do not run startInitialization more than once.
-        if (sSettings != null) {
-          return;
-        }
-
-        sSettings = settings;
-
-        long initStartTimestampMillis = SystemClock.uptimeMillis();
-        initConfig(applicationContext);
-        initResources(applicationContext);
-
-        System.loadLibrary("flutter");
-
-        VsyncWaiter
-            .getInstance((WindowManager) applicationContext.getSystemService(Context.WINDOW_SERVICE))
-            .init();
-
-        // We record the initialization time using SystemClock because at the start of the
-        // initialization we have not yet loaded the native library to call into dart_tools_api.h.
-        // To get Timeline timestamp of the start of initialization we simply subtract the delta
-        // from the Timeline timestamp at the current moment (the assumption is that the overhead
-        // of the JNI call is negligible).
-        long initTimeMillis = SystemClock.uptimeMillis() - initStartTimestampMillis;
-        FlutterJNI.nativeRecordStartTimestamp(initTimeMillis);
+        FlutterLoader.Settings newSettings = new FlutterLoader.Settings();
+        newSettings.setLogTag(settings.getLogTag());
+        FlutterInjector.instance().flutterLoader().startInitialization(applicationContext, newSettings);
     }
 
     /**
@@ -165,66 +83,7 @@ public class FlutterMain {
      * @param args Flags sent to the Flutter runtime.
      */
     public static void ensureInitializationComplete(@NonNull Context applicationContext, @Nullable String[] args) {
-        // Do nothing if we're running this in a Robolectric test.
-        if (isRunningInRobolectricTest) {
-            return;
-        }
-
-        if (Looper.myLooper() != Looper.getMainLooper()) {
-          throw new IllegalStateException("ensureInitializationComplete must be called on the main thread");
-        }
-        if (sSettings == null) {
-          throw new IllegalStateException("ensureInitializationComplete must be called after startInitialization");
-        }
-        if (sInitialized) {
-            return;
-        }
-        try {
-            if (sResourceExtractor != null) {
-                sResourceExtractor.waitForCompletion();
-            }
-
-            List<String> shellArgs = new ArrayList<>();
-            shellArgs.add("--icu-symbol-prefix=_binary_icudtl_dat");
-
-            ApplicationInfo applicationInfo = getApplicationInfo(applicationContext);
-            shellArgs.add("--icu-native-lib-path=" + applicationInfo.nativeLibraryDir + File.separator + DEFAULT_LIBRARY);
-
-            if (args != null) {
-                Collections.addAll(shellArgs, args);
-            }
-
-            String kernelPath = null;
-            if (BuildConfig.DEBUG) {
-                String snapshotAssetPath = PathUtils.getDataDirectory(applicationContext) + File.separator + sFlutterAssetsDir;
-                kernelPath = snapshotAssetPath + File.separator + DEFAULT_KERNEL_BLOB;
-                shellArgs.add("--" + SNAPSHOT_ASSET_PATH_KEY + "=" + snapshotAssetPath);
-                shellArgs.add("--" + VM_SNAPSHOT_DATA_KEY + "=" + sVmSnapshotData);
-                shellArgs.add("--" + ISOLATE_SNAPSHOT_DATA_KEY + "=" + sIsolateSnapshotData);
-            } else {
-                shellArgs.add("--" + AOT_SHARED_LIBRARY_NAME + "=" + sAotSharedLibraryName);
-
-                // Most devices can load the AOT shared library based on the library name
-                // with no directory path.  Provide a fully qualified path to the library
-                // as a workaround for devices where that fails.
-                shellArgs.add("--" + AOT_SHARED_LIBRARY_NAME + "=" + applicationInfo.nativeLibraryDir + File.separator + sAotSharedLibraryName);
-            }
-
-            shellArgs.add("--cache-dir-path=" + PathUtils.getCacheDirectory(applicationContext));
-            if (sSettings.getLogTag() != null) {
-                shellArgs.add("--log-tag=" + sSettings.getLogTag());
-            }
-
-            String appStoragePath = PathUtils.getFilesDir(applicationContext);
-            String engineCachesPath = PathUtils.getCacheDirectory(applicationContext);
-            FlutterJNI.nativeInit(applicationContext, shellArgs.toArray(new String[0]),
-                kernelPath, appStoragePath, engineCachesPath);
-
-            sInitialized = true;
-        } catch (Exception e) {
-            Log.e(TAG, "Flutter initialization failed.", e);
-            throw new RuntimeException(e);
-        }
+        FlutterInjector.instance().flutterLoader().ensureInitializationComplete(applicationContext, args);
     }
 
     /**
@@ -237,102 +96,19 @@ public class FlutterMain {
         @NonNull Handler callbackHandler,
         @NonNull Runnable callback
     ) {
-        // Do nothing if we're running this in a Robolectric test.
-        if (isRunningInRobolectricTest) {
-            return;
-        }
-
-        if (Looper.myLooper() != Looper.getMainLooper()) {
-            throw new IllegalStateException("ensureInitializationComplete must be called on the main thread");
-        }
-        if (sSettings == null) {
-            throw new IllegalStateException("ensureInitializationComplete must be called after startInitialization");
-        }
-        if (sInitialized) {
-            return;
-        }
-        new Thread(new Runnable() {
-            @Override
-            public void run() {
-                if (sResourceExtractor != null) {
-                    sResourceExtractor.waitForCompletion();
-                }
-                new Handler(Looper.getMainLooper()).post(new Runnable() {
-                    @Override
-                    public void run() {
-                        ensureInitializationComplete(applicationContext.getApplicationContext(), args);
-                        callbackHandler.post(callback);
-                    }
-                });
-            }
-        }).start();
-    }
-
-    @NonNull
-    private static ApplicationInfo getApplicationInfo(@NonNull Context applicationContext) {
-        try {
-            return applicationContext
-                .getPackageManager()
-                .getApplicationInfo(applicationContext.getPackageName(), PackageManager.GET_META_DATA);
-        } catch (PackageManager.NameNotFoundException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Initialize our Flutter config values by obtaining them from the
-     * manifest XML file, falling back to default values.
-     */
-    private static void initConfig(@NonNull Context applicationContext) {
-        Bundle metadata = getApplicationInfo(applicationContext).metaData;
-
-        // There isn't a `<meta-data>` tag as a direct child of `<application>` in
-        // `AndroidManifest.xml`.
-        if (metadata == null) {
-            return;
-        }
-
-        sAotSharedLibraryName = metadata.getString(PUBLIC_AOT_SHARED_LIBRARY_NAME, DEFAULT_AOT_SHARED_LIBRARY_NAME);
-        sFlutterAssetsDir = metadata.getString(PUBLIC_FLUTTER_ASSETS_DIR_KEY, DEFAULT_FLUTTER_ASSETS_DIR);
-
-        sVmSnapshotData = metadata.getString(PUBLIC_VM_SNAPSHOT_DATA_KEY, DEFAULT_VM_SNAPSHOT_DATA);
-        sIsolateSnapshotData = metadata.getString(PUBLIC_ISOLATE_SNAPSHOT_DATA_KEY, DEFAULT_ISOLATE_SNAPSHOT_DATA);
-    }
-
-    /**
-     * Extract assets out of the APK that need to be cached as uncompressed
-     * files on disk.
-     */
-    private static void initResources(@NonNull Context applicationContext) {
-        new ResourceCleaner(applicationContext).start();
-
-        if (BuildConfig.DEBUG) {
-            final String dataDirPath = PathUtils.getDataDirectory(applicationContext);
-            final String packageName = applicationContext.getPackageName();
-            final PackageManager packageManager = applicationContext.getPackageManager();
-            final AssetManager assetManager = applicationContext.getResources().getAssets();
-            sResourceExtractor = new ResourceExtractor(dataDirPath, packageName, packageManager, assetManager);
-
-            // In debug/JIT mode these assets will be written to disk and then
-            // mapped into memory so they can be provided to the Dart VM.
-            sResourceExtractor
-                .addResource(fromFlutterAssets(sVmSnapshotData))
-                .addResource(fromFlutterAssets(sIsolateSnapshotData))
-                .addResource(fromFlutterAssets(DEFAULT_KERNEL_BLOB));
-
-            sResourceExtractor.start();
-        }
+        FlutterInjector.instance().flutterLoader().ensureInitializationCompleteAsync(
+            applicationContext, args, callbackHandler, callback);
     }
 
     @NonNull
     public static String findAppBundlePath() {
-        return sFlutterAssetsDir;
+        return FlutterInjector.instance().flutterLoader().findAppBundlePath();
     }
 
     @Deprecated
     @Nullable
     public static String findAppBundlePath(@NonNull Context applicationContext) {
-        return sFlutterAssetsDir;
+        return FlutterInjector.instance().flutterLoader().findAppBundlePath(applicationContext);
     }
 
     /**
@@ -345,7 +121,7 @@ public class FlutterMain {
      */
     @NonNull
     public static String getLookupKeyForAsset(@NonNull String asset) {
-        return fromFlutterAssets(asset);
+        return FlutterInjector.instance().flutterLoader().getLookupKeyForAsset(asset);
     }
 
     /**
@@ -359,7 +135,6 @@ public class FlutterMain {
      */
     @NonNull
     public static String getLookupKeyForAsset(@NonNull String asset, @NonNull String packageName) {
-        return getLookupKeyForAsset(
-            "packages" + File.separator + packageName + File.separator + asset);
+        return FlutterInjector.instance().flutterLoader().getLookupKeyForAsset(asset, packageName);
     }
 }

--- a/shell/platform/android/io/flutter/view/FlutterMain.java
+++ b/shell/platform/android/io/flutter/view/FlutterMain.java
@@ -112,6 +112,12 @@ public class FlutterMain {
 
     /**
      * Starts initialization of the native system.
+     *
+     * This loads the Flutter engine's native library to enable subsequent JNI calls. This also
+     * starts locating and unpacking Dart resources packaged in the app's APK.
+     *
+     * Calling this method multiple times has no effect.
+     *
      * @param applicationContext The Android application context.
      * @param settings Configuration settings.
      */
@@ -152,6 +158,9 @@ public class FlutterMain {
 
     /**
      * Blocks until initialization of the native system has completed.
+     *
+     * Calling this method multiple times has no effect.
+     *
      * @param applicationContext The Android application context.
      * @param args Flags sent to the Flutter runtime.
      */

--- a/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
+++ b/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package io.flutter;
 
 import org.junit.Before;

--- a/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
+++ b/shell/platform/android/test/io/flutter/FlutterInjectorTest.java
@@ -1,0 +1,53 @@
+package io.flutter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
+
+import io.flutter.FlutterInjector;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.IllegalStateException;
+
+@Config(manifest=Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class FlutterInjectorTest {
+  @Before
+  public void setUp() {
+    FlutterInjector.reset();
+  }
+
+  @Test
+  public void itHasSomeReasonableDefaults() {
+    FlutterInjector injector = FlutterInjector.instance();
+    assertFalse(injector.isRunningInRobolectricTest());
+    assertNotNull(injector.flutterLoader());
+  }
+
+  @Test
+  public void canPartiallyOverride() {
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setIsRunningInRobolectricTest(true).build());
+    FlutterInjector injector = FlutterInjector.instance();
+    assertTrue(injector.isRunningInRobolectricTest());
+    assertNotNull(injector.flutterLoader());
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void cannotBeChangedOnceRead() {
+    FlutterInjector.instance();
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setIsRunningInRobolectricTest(true).build());
+  }
+}

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import io.flutter.FlutterInjectorTest;
 import io.flutter.embedding.android.FlutterActivityTest;
 import io.flutter.embedding.android.FlutterFragmentTest;
 import io.flutter.embedding.engine.FlutterEngineCacheTest;
@@ -25,6 +26,7 @@ import io.flutter.util.PreconditionsTest;
     FlutterActivityTest.class,
     FlutterEngineCacheTest.class,
     FlutterFragmentTest.class,
+    FlutterInjectorTest.class,
     FlutterJNITest.class,
     FlutterRendererTest.class,
     PlatformChannelTest.class,

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityAndFragmentDelegateTest.java
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -15,6 +16,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
+import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterEngineCache;
 import io.flutter.embedding.engine.FlutterShellArgs;
@@ -47,12 +49,16 @@ public class FlutterActivityAndFragmentDelegateTest {
   private FlutterEngine mockFlutterEngine;
   private FlutterActivityAndFragmentDelegate.Host mockHost;
 
+  @BeforeClass
+  public static void setupInjector() {
+    // FlutterLoader is utilized statically, therefore we need to inform it to behave differently
+    // for testing purposes.
+    FlutterInjector.setInstance(
+        new FlutterInjector.Builder().setIsRunningInRobolectricTest(true).build());
+  }
+
   @Before
   public void setup() {
-    // FlutterMain is utilized statically, therefore we need to inform it to behave differently
-    // for testing purposes.
-    FlutterMain.setIsRunningInRobolectricTest(true);
-
     // Create a mocked FlutterEngine for the various interactions required by the delegate
     // being tested.
     mockFlutterEngine = mockFlutterEngine();
@@ -71,12 +77,6 @@ public class FlutterActivityAndFragmentDelegateTest {
     when(mockHost.provideFlutterEngine(any(Context.class))).thenReturn(mockFlutterEngine);
     when(mockHost.shouldAttachEngineToActivity()).thenReturn(true);
     when(mockHost.shouldDestroyEngineWithHost()).thenReturn(true);
-  }
-
-  @After
-  public void teardown() {
-    // Return FlutterMain to normal.
-    FlutterMain.setIsRunningInRobolectricTest(false);
   }
 
   @Test

--- a/testing/scenario_app/README.md
+++ b/testing/scenario_app/README.md
@@ -45,3 +45,8 @@ the app in the `android/` folder. The app can be run by opening it in Android
 Studio and running it, or by running `./gradlew assemble` in the `android/`
 folder and installing the APK from the correct folder in
 `android/app/build/outputs/apk`.
+
+## Changing dart:ui code
+
+If you change the dart:ui interface, remember to point the sky_engine and
+sky_services clauses to your local engine's output path before compiling.

--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -30,5 +30,6 @@ dependencies {
     implementation 'android.arch.lifecycle:common-java8:1.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
 }

--- a/testing/scenario_app/android/app/build.gradle
+++ b/testing/scenario_app/android/app/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation 'com.android.support:design:28.0.0'
-    implementation 'android.arch.lifecycle:common-java8:1.1.0'
+    implementation 'android.arch.lifecycle:common-java8:1.1.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -20,9 +20,9 @@ import io.flutter.embedding.engine.dart.DartExecutor;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
-public class LaunchTest  {
+public class EngineLaunchE2ETest  {
     @Test
-    public void testEngineLaunch() throws Throwable {
+    public void smokeTestEngineLaunch() throws Throwable {
         Context applicationContext = InstrumentationRegistry.getTargetContext();
         // Specifically, create the engine without running FlutterMain first.
         final AtomicReference<FlutterEngine> engine = new AtomicReference<>();
@@ -35,11 +35,15 @@ public class LaunchTest  {
         );
         CompletableFuture<Boolean> statusReceived = new CompletableFuture<>();
 
+        // The default Dart main entrypoint sends back a platform message on the "scenario_status"
+        // channel. That will be our launch success assertion condition.
         engine.get().getDartExecutor().setMessageHandler(
             "scenario_status",
             (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE)
         );
 
+        // Launching the entrypoint will run the Dart code that sends the "scenario_status" platform
+        // message.
         UiThreadStatement.runOnUiThread(
             () -> engine.get().getDartExecutor().executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault())
         );

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/EngineLaunchE2ETest.java
@@ -1,3 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package dev.flutter.scenarios;
 
 import android.content.Context;

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/LaunchTest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/LaunchTest.java
@@ -2,59 +2,60 @@ package dev.flutter.scenarios;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
+import android.support.test.internal.runner.junit4.statement.UiThreadStatement;
 import android.support.test.runner.AndroidJUnit4;
 
-import org.junit.runner.Description;
+import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runner.Runner;
-import org.junit.runner.notification.Failure;
-import org.junit.runner.notification.RunNotifier;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 
-@RunWith(AndroidJUnit4.class)
-public class LaunchTest extends Runner {
-    @Override
-    public Description getDescription() {
-        return Description.createTestDescription(BlankActivity.class, "can launch engine");
-    }
+import static org.junit.Assert.fail;
 
-    @Override
-    public void run(RunNotifier notifier) {
-        notifier.fireTestStarted(getDescription());
+@RunWith(AndroidJUnit4.class)
+public class LaunchTest  {
+    @Test
+    public void testEngineLaunch() throws Throwable {
         Context applicationContext = InstrumentationRegistry.getTargetContext();
         // Specifically, create the engine without running FlutterMain first.
-        FlutterEngine engine = new FlutterEngine(applicationContext);
+        final AtomicReference<FlutterEngine> engine = new AtomicReference<>();
+
+        // Run the production under test on the UI thread instead of annotating the whole test
+        // as @UiThreadTest because having the message handler and the CompletableFuture both being
+        // on the same thread will create deadlocks.
+        UiThreadStatement.runOnUiThread(
+            () -> engine.set(new FlutterEngine(applicationContext))
+        );
         CompletableFuture<Boolean> statusReceived = new CompletableFuture<>();
 
-        engine.getDartExecutor().setMessageHandler(
+        engine.get().getDartExecutor().setMessageHandler(
             "scenario_status",
             (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE)
         );
 
-        engine.getDartExecutor().executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault());
+        UiThreadStatement.runOnUiThread(
+            () -> engine.get().getDartExecutor().executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault())
+        );
 
         try {
             Boolean result = statusReceived.get(10, TimeUnit.SECONDS);
             if (!result) {
-                notifier.fireTestFailure(
-                        new Failure(getDescription(),
-                        new Exception("expected message on scenario_status not received")));
+                fail("expected message on scenario_status not received");
             }
         } catch (ExecutionException e) {
-            notifier.fireTestFailure(new Failure(getDescription(), e));
+            fail(e.getMessage());
         } catch (InterruptedException e) {
-            notifier.fireTestFailure(new Failure(getDescription(), e));
+            fail(e.getMessage());
         } catch (TimeoutException e) {
-            notifier.fireTestFailure(
-                    new Failure(getDescription(),
-                    new Exception("timed out waiting for engine started signal")));
+            fail("timed out waiting for engine started signal");
         }
+        // If it gets to here, statusReceived is true.
     }
 }

--- a/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/LaunchTest.java
+++ b/testing/scenario_app/android/app/src/androidTest/java/dev/flutter/scenarios/LaunchTest.java
@@ -1,0 +1,60 @@
+package dev.flutter.scenarios;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.Runner;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.dart.DartExecutor;
+
+@RunWith(AndroidJUnit4.class)
+public class LaunchTest extends Runner {
+    @Override
+    public Description getDescription() {
+        return Description.createTestDescription(BlankActivity.class, "can launch engine");
+    }
+
+    @Override
+    public void run(RunNotifier notifier) {
+        notifier.fireTestStarted(getDescription());
+        Context applicationContext = InstrumentationRegistry.getTargetContext();
+        // Specifically, create the engine without running FlutterMain first.
+        FlutterEngine engine = new FlutterEngine(applicationContext);
+        CompletableFuture<Boolean> statusReceived = new CompletableFuture<>();
+
+        engine.getDartExecutor().setMessageHandler(
+            "scenario_status",
+            (byteBuffer, binaryReply) -> statusReceived.complete(Boolean.TRUE)
+        );
+
+        engine.getDartExecutor().executeDartEntrypoint(DartExecutor.DartEntrypoint.createDefault());
+
+        try {
+            Boolean result = statusReceived.get(10, TimeUnit.SECONDS);
+            if (!result) {
+                notifier.fireTestFailure(
+                        new Failure(getDescription(),
+                        new Exception("expected message on scenario_status not received")));
+            }
+        } catch (ExecutionException e) {
+            notifier.fireTestFailure(new Failure(getDescription(), e));
+        } catch (InterruptedException e) {
+            notifier.fireTestFailure(new Failure(getDescription(), e));
+        } catch (TimeoutException e) {
+            notifier.fireTestFailure(
+                    new Failure(getDescription(),
+                    new Exception("timed out waiting for engine started signal")));
+        }
+    }
+}

--- a/testing/scenario_app/android/app/src/main/AndroidManifest.xml
+++ b/testing/scenario_app/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="dev.flutter.scenarios">
-    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:allowBackup="true"
@@ -11,21 +11,32 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".MainActivity"
-            android:launchMode="singleTop"
+            android:name=".TextPlatformViewActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
+            android:launchMode="singleTop"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>
-                <action android:name="com.google.intent.action.TEST_LOOP"/>
-                <category android:name="android.intent.category.DEFAULT"/>
-                <data android:mimeType="application/javascript"/>
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="com.google.intent.action.TEST_LOOP" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="application/javascript" />
             </intent-filter>
         </activity>
+        <activity android:name=".BlankActivity"
+            android:launchMode="singleTop"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:hardwareAccelerated="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
     </application>
+
+    <uses-permission android:name="android.permission.INTERNET" />
 
 </manifest>

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/BlankActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/BlankActivity.java
@@ -1,0 +1,11 @@
+package dev.flutter.scenarios;
+
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class BlankActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewActivity.java
@@ -15,14 +15,12 @@ import java.nio.ByteBuffer;
 
 import io.flutter.Log;
 import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.android.FlutterFragment;
-import io.flutter.embedding.android.FlutterView;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.BinaryCodec;
 
-public class MainActivity extends FlutterActivity {
+public class TextPlatformViewActivity extends FlutterActivity {
   final static String TAG = "Scenarios";
 
   @Override

--- a/testing/scenario_app/android/build.gradle
+++ b/testing/scenario_app/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.5.0'
         
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/testing/scenario_app/run_android_tests.sh
+++ b/testing/scenario_app/run_android_tests.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 # Runs the Android scenario tests on a connected device.
 

--- a/testing/scenario_app/run_android_tests.sh
+++ b/testing/scenario_app/run_android_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Runs the Android scenario tests on a connected device.
+
+set -e
+
+FLUTTER_ENGINE=android_profile_unopt_arm64
+
+if [ $# -eq 1 ]; then
+  FLUTTER_ENGINE=$1
+fi
+
+cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd
+
+./compile_android_aot.sh ../../../out/host_profile_unopt_arm64 ../../../out/$FLUTTER_ENGINE/clang_x64
+
+pushd android
+
+set -o pipefail && ./gradlew assembleAndroidTest && ./gradlew connectedAndroidTest
+
+popd


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/32946
Fixes https://github.com/flutter/flutter/issues/33145
Fixes https://github.com/flutter/flutter/issues/37195

Partially alleviates https://github.com/flutter/flutter/issues/32987

Remove the call mainly because the extra granularity is error-prone boilerplate (https://github.com/flutter/flutter/issues/39675, https://github.com/flutter/flutter/issues/39384, https://github.com/flutter/flutter/issues/39108, https://github.com/flutter/flutter/issues/30332, https://github.com/flutter/flutter/issues/28439) and doesn't really add any degree of control. 

On a low end Android device, this means merging in the 40ms call to load the native library with the already 290ms call to create the VM. Controlling when that 40ms call happens isn't useful. 

Redundant calls will still work, as will the old embedding. This just allows new code using the new embedding to omit the FlutterMain calls. 

Add an AndroidJUnit in-process test in the scenario_app project. It makes sure the real engine boots on a device. Didn't hook into firebase in this PR yet. One step at a time. 

Also added some supplemental docs while going through this.