### PR TITLE
Guard availability of user notification related methods to iOS 10.0

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -83,11 +83,14 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
 - (void)userNotificationCenter:(UNUserNotificationCenter*)center
        willPresentNotification:(UNNotification*)notification
          withCompletionHandler:
-             (void (^)(UNNotificationPresentationOptions options))completionHandler {
-  if ([_lifeCycleDelegate respondsToSelector:_cmd]) {
-    [_lifeCycleDelegate userNotificationCenter:center
-                       willPresentNotification:notification
-                         withCompletionHandler:completionHandler];
+             (void (^)(UNNotificationPresentationOptions options))completionHandler
+    NS_AVAILABLE_IOS(10_0) {
+  if (@available(iOS 10.0, *)) {
+    if ([_lifeCycleDelegate respondsToSelector:_cmd]) {
+      [_lifeCycleDelegate userNotificationCenter:center
+                         willPresentNotification:notification
+                           withCompletionHandler:completionHandler];
+    }
   }
 }
 
@@ -96,11 +99,13 @@ static NSString* kBackgroundFetchCapatibility = @"fetch";
  */
 - (void)userNotificationCenter:(UNUserNotificationCenter*)center
     didReceiveNotificationResponse:(UNNotificationResponse*)response
-             withCompletionHandler:(void (^)(void))completionHandler {
-  if ([_lifeCycleDelegate respondsToSelector:_cmd]) {
-    [_lifeCycleDelegate userNotificationCenter:center
-                didReceiveNotificationResponse:response
-                         withCompletionHandler:completionHandler];
+             withCompletionHandler:(void (^)(void))completionHandler NS_AVAILABLE_IOS(10_0) {
+  if (@available(iOS 10.0, *)) {
+    if ([_lifeCycleDelegate respondsToSelector:_cmd]) {
+      [_lifeCycleDelegate userNotificationCenter:center
+                  didReceiveNotificationResponse:response
+                           withCompletionHandler:completionHandler];
+    }
   }
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate.mm
@@ -275,24 +275,29 @@ static BOOL isPowerOfTwo(NSUInteger x) {
 - (void)userNotificationCenter:(UNUserNotificationCenter*)center
        willPresentNotification:(UNNotification*)notification
          withCompletionHandler:
-             (void (^)(UNNotificationPresentationOptions options))completionHandler {
-  for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
-    if ([delegate respondsToSelector:_cmd]) {
-      [delegate userNotificationCenter:center
-               willPresentNotification:notification
-                 withCompletionHandler:completionHandler];
+             (void (^)(UNNotificationPresentationOptions options))completionHandler
+    NS_AVAILABLE_IOS(10_0) {
+  if (@available(iOS 10.0, *)) {
+    for (NSObject<FlutterApplicationLifeCycleDelegate>* delegate in _delegates) {
+      if ([delegate respondsToSelector:_cmd]) {
+        [delegate userNotificationCenter:center
+                 willPresentNotification:notification
+                   withCompletionHandler:completionHandler];
+      }
     }
   }
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter*)center
     didReceiveNotificationResponse:(UNNotificationResponse*)response
-             withCompletionHandler:(void (^)(void))completionHandler {
-  for (id<FlutterApplicationLifeCycleDelegate> delegate in _delegates) {
-    if ([delegate respondsToSelector:_cmd]) {
-      [delegate userNotificationCenter:center
-          didReceiveNotificationResponse:response
-                   withCompletionHandler:completionHandler];
+             withCompletionHandler:(void (^)(void))completionHandler NS_AVAILABLE_IOS(10_0) {
+  if (@available(iOS 10.0, *)) {
+    for (id<FlutterApplicationLifeCycleDelegate> delegate in _delegates) {
+      if ([delegate respondsToSelector:_cmd]) {
+        [delegate userNotificationCenter:center
+            didReceiveNotificationResponse:response
+                     withCompletionHandler:completionHandler];
+      }
     }
   }
 }


### PR DESCRIPTION
* `NS_AVAILABLE_IOS(10_0)` makes us tell our compiler that the method needs
  to be stamped into the TU but we promise to do stuff in it only on iOS 10.0
  and above.
* `@availability` ensures that if those methods are called on iOS versions less
  than 10.0, we will do nothing with it. This guards us against the case where
  iOS introduced the functionality privately in older versions of iOS.