### PR TITLE
Don't launch the observatory by default on each embedder unit-test invocation.

### DIFF
--- a/shell/platform/embedder/tests/embedder_config_builder.h
+++ b/shell/platform/embedder/tests/embedder_config_builder.h
@@ -68,7 +68,7 @@ class EmbedderConfigBuilder {
 
   FlutterCompositor& GetCompositor();
 
-  UniqueEngine LaunchEngine();
+  UniqueEngine LaunchEngine() const;
 
  private:
   EmbedderTestContext& context_;


### PR DESCRIPTION
There is no test to assert this and it unnecessarily slows down the test
harness and opens tons of port on the host.