### PR TITLE
Make iOS FlutterViewController stop sending inactive/pause on app lifecycle events when not visible

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -537,23 +537,32 @@ typedef enum UIAccessibilityContrast : NSInteger {
   TRACE_EVENT0("flutter", "applicationBecameActive");
   if (_viewportMetrics.physical_width)
     [self surfaceUpdated:YES];
-  [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.resumed"];
+  [self goToApplicationLifecycle:@"AppLifecycleState.resumed"];
 }
 
 - (void)applicationWillResignActive:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillResignActive");
   [self surfaceUpdated:NO];
-  [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
+  [self goToApplicationLifecycle:@"AppLifecycleState.inactive"];
 }
 
 - (void)applicationDidEnterBackground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationDidEnterBackground");
-  [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.paused"];
+  [self goToApplicationLifecycle:@"AppLifecycleState.paused"];
 }
 
 - (void)applicationWillEnterForeground:(NSNotification*)notification {
   TRACE_EVENT0("flutter", "applicationWillEnterForeground");
-  [[_engine.get() lifecycleChannel] sendMessage:@"AppLifecycleState.inactive"];
+  [self goToApplicationLifecycle:@"AppLifecycleState.inactive"];
+}
+
+// Make this transition only while this current view controller is visible.
+- (void)goToApplicationLifecycle:(nonnull NSString*)state {
+  // Accessing self.view will create the view. Check whether the view is organically loaded
+  // first before checking whether the view is attached to window.
+  if (self.isViewLoaded && self.view.window) {
+    [[_engine.get() lifecycleChannel] sendMessage:state];
+  }
 }
 
 #pragma mark - Touch event handling

--- a/testing/scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.m
@@ -9,7 +9,6 @@
 
 @synthesize engine = _engine;
 
-
 - (id)initWithEngineRunCompletion:(void (^)(void))engineRunCompletion {
   self = [super init];
   _engine = [[FlutterEngine alloc] initWithScenario:@"poppable_screen"

--- a/testing/scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.m
+++ b/testing/scenario_app/ios/Scenarios/Scenarios/ScreenBeforeFlutter.m
@@ -7,7 +7,8 @@
 
 @implementation ScreenBeforeFlutter
 
-FlutterEngine* _engine;
+@synthesize engine = _engine;
+
 
 - (id)initWithEngineRunCompletion:(void (^)(void))engineRunCompletion {
   self = [super init];

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -42,6 +42,9 @@
                     initWithDescription:
                         @"A loading FlutterViewController goes through AppLifecycleState.resumed"]];
 
+  // Holding onto this FlutterViewController is consequential here. Since a released
+  // FlutterViewController wouldn't keep listening to the application lifecycle events and produce
+  // false positives.
   FlutterViewController* flutterVC = [rootVC showFlutter];
   [engine.lifecycleChannel setMessageHandler:^(id message, FlutterReply callback) {
     if (lifecycleExpectations.count == 0) {
@@ -82,33 +85,15 @@
   // checking that we aren't observing the UIApplication notifications and double registering
   // for AppLifecycleState events.
 
-  // However the production is temporarily wrong. https://github.com/flutter/flutter/issues/37226.
-  // It will be fixed in a next PR that removes the wrong asserts.
-  [lifecycleExpectations
-      addObject:
-          [[XCTestExpectation alloc]
-              initWithDescription:@"Current implementation sends another AppLifecycleState event"]];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationWillResignActiveNotification
                     object:nil];
-  [lifecycleExpectations
-      addObject:
-          [[XCTestExpectation alloc]
-              initWithDescription:@"Current implementation sends another AppLifecycleState event"]];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationDidEnterBackgroundNotification
                     object:nil];
-  [lifecycleExpectations
-      addObject:
-          [[XCTestExpectation alloc]
-              initWithDescription:@"Current implementation sends another AppLifecycleState event"]];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationWillEnterForegroundNotification
                     object:nil];
-  [lifecycleExpectations
-      addObject:
-          [[XCTestExpectation alloc]
-              initWithDescription:@"Current implementation sends another AppLifecycleState event"]];
   [[NSNotificationCenter defaultCenter]
       postNotificationName:UIApplicationDidBecomeActiveNotification
                     object:nil];

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -136,10 +136,7 @@
   // Dismantle.
   [engine.lifecycleChannel setMessageHandler:nil];
   [flutterVC dismissViewControllerAnimated:NO completion:nil];
-  flutterVC = nil;
   [engine setViewController:nil];
-  [rootVC dismissViewControllerAnimated:NO completion:nil];
-  rootVC = nil;
 }
 
 - (void)testVisibleFlutterViewControllerRespondsToApplicationLifecycle {
@@ -223,10 +220,7 @@
   // Dismantle.
   [engine.lifecycleChannel setMessageHandler:nil];
   [flutterVC dismissViewControllerAnimated:NO completion:nil];
-  flutterVC = nil;
   [engine setViewController:nil];
-  [rootVC dismissViewControllerAnimated:NO completion:nil];
-  rootVC = nil;
 }
 
 @end

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -21,7 +21,7 @@
   // synchronous with the executions in the test, so it's hard to find the cause in the test
   // otherwise.
   self = [super initWithDescription:[NSString stringWithFormat:@"Expected state %@ during step %@",
-                                                              expectedLifecycle, step]];
+                                                               expectedLifecycle, step]];
   _expectedLifecycle = [expectedLifecycle copy];
   return self;
 }

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/AppLifecycleTests.m
@@ -9,7 +9,7 @@
 @interface XCAppLifecycleTestExpectation : XCTestExpectation
 
 - (instancetype)initForLifecycle:(NSString*)expectedLifecycle forStep:(NSString*)step;
-@property(nonatomic, readonly) NSString* expectedLifecycle;
+@property(nonatomic, readonly, copy) NSString* expectedLifecycle;
 
 @end
 
@@ -20,9 +20,9 @@
   // The step is here because the callbacks into the handler which checks these expectations isn't
   // synchronous with the executions in the test, so it's hard to find the cause in the test
   // otherwise.
-  self = [self initWithDescription:[NSString stringWithFormat:@"Expected state %@ during step %@",
+  self = [super initWithDescription:[NSString stringWithFormat:@"Expected state %@ during step %@",
                                                               expectedLifecycle, step]];
-  _expectedLifecycle = expectedLifecycle;
+  _expectedLifecycle = [expectedLifecycle copy];
   return self;
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/37226

A non-dealloc'ed FlutterViewController is still observing the application lifecycle events and still forwarding events to Dart while it's not visible though it makes no sense that a showing, dismissing a FlutterViewController and then going to be the background and back will put Dart back into resumed state.