### PR TITLE
Ensure that the web image ImageShader implements Shader

### DIFF
--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1118,7 +1118,7 @@ class PluginUtilities {
 }
 
 // TODO(flutter_web): see https://github.com/flutter/flutter/issues/33616.
-class ImageShader {
+class ImageShader implements Shader {
   ImageShader(Image image, TileMode tmx, TileMode tmy, Float64List matrix4);
 }
 


### PR DESCRIPTION
This fixes a type error when manipulating Shader objects as in https://github.com/flutter/flutter/issues/39352. These are still not fully supported, but the error should be nicer