### PR TITLE
Updating text field location in IOS as a pre-work for spellcheck

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -316,22 +316,7 @@ flt-glass-pane * {
     // apps fully specifies their text styles.
     setElementStyle(bodyElement, 'font', defaultCssFont);
     setElementStyle(bodyElement, 'color', 'red');
-
-    // TODO(flutter_web): send the location during the scroll for more frequent
-    // location updates from the framework. Remove spellcheck=false property.
-    /// The spell check is being disabled for now.
-    ///
-    /// Flutter web is positioning the input box on top of editable widget.
-    /// This location is updated only in the paint phase of the widget.
-    /// It is wrong during the scroll. It is not important for text editing
-    /// since the content is already invisible. On the other hand, the red
-    /// indicator for spellcheck gets confusing due to the wrong positioning.
-    /// We are disabling spellcheck until the location starts getting updated
-    /// via scroll. This is possible since we can listen to the scroll on
-    /// Flutter.
-    /// See [HybridTextEditing].
-    bodyElement.spellcheck = false;
-
+    
     for (html.Element viewportMeta
         in html.document.head.querySelectorAll('meta[name="viewport"]')) {
       if (assertionsEnabled) {

--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -316,7 +316,11 @@ flt-glass-pane * {
     // apps fully specifies their text styles.
     setElementStyle(bodyElement, 'font', defaultCssFont);
     setElementStyle(bodyElement, 'color', 'red');
-    
+
+    // TODO(flutter_web): Disable spellcheck until changes in the framework and
+    // engine are complete.
+    bodyElement.spellcheck = false;
+
     for (html.Element viewportMeta
         in html.document.head.querySelectorAll('meta[name="viewport"]')) {
       if (assertionsEnabled) {

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -323,11 +323,6 @@ class TouchAdapter extends BaseAdapter {
       event.preventDefault();
       _updateButtonDownState(_kPrimaryMouseButton, false);
       _callback(_convertEventToPointerData(ui.PointerChange.up, event));
-      if (textEditing.needsKeyboard &&
-          browserEngine == BrowserEngine.webkit &&
-          operatingSystem == OperatingSystem.iOs) {
-        textEditing.editingElement.configureInputElementForIOS();
-      }
     });
 
     _addEventListener('touchcancel', (html.Event event) {

--- a/lib/web_ui/lib/src/engine/semantics/text_field.dart
+++ b/lib/web_ui/lib/src/engine/semantics/text_field.dart
@@ -38,7 +38,6 @@ class TextField extends RoleManager {
     // and autocorrect suggestion. To disable that, we have to do the following:
     _textFieldElement
       ..spellcheck = false
-      ..setAttribute('spellcheck', 'false')
       ..setAttribute('autocorrect', 'off')
       ..setAttribute('autocomplete', 'off')
       ..setAttribute('data-semantics-role', 'text-field');

--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -857,8 +857,6 @@ class _EditingStyle {
 ///
 /// This information is received via "TextInput.setEditableSizeAndTransform"
 /// message. Framework currently sends this information on paint.
-// TODO(flutter_web): send the location during the scroll for more frequent
-// updates from the framework.
 class _EditableSizeAndTransform {
   _EditableSizeAndTransform({
     @required this.width,


### PR DESCRIPTION
The location/transform of the text input is updated at post frame for all the browsers except IOS (with Webkit engine). 

In IOS this update was only on touch end. When spellcheck is enabled the red underling was static and were not moving with scroll.

This PR changes the location updates which is pre-work for enabling spellcheck.
