### PR TITLE
Started making the accessibility bridge retain its view.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -570,6 +570,7 @@ AccessibilityBridge::AccessibilityBridge(UIView* view,
       weak_factory_(this),
       previous_route_id_(0),
       previous_routes_({}) {
+  [view_ retain];
   accessibility_channel_.reset([[FlutterBasicMessageChannel alloc]
          initWithName:@"flutter/accessibility"
       binaryMessenger:platform_view->GetOwnerViewController().get().engine.binaryMessenger
@@ -582,6 +583,7 @@ AccessibilityBridge::AccessibilityBridge(UIView* view,
 AccessibilityBridge::~AccessibilityBridge() {
   clearState();
   view_.accessibilityElements = nil;
+  [view_ release];
 }
 
 UIView<UITextInput>* AccessibilityBridge::textInputView() {


### PR DESCRIPTION
Related issue: https://github.com/flutter/flutter/issues/33173

The referenced issue mentions this crash, but I believe that the originally stated bug is something different since this is all related to iOS.

Why should we retain here?  Because the AccessibilityBridge can live longer than the view.  Imagine you have a UINavigationController and you push and pop a FlutterViewController.  There is no way for AccessibilityBridge to know that the view has been deleted and he is still referencing it.

This potentially means that the FlutterView can end up living in memory longer than we expected, the last one will be retained until a new one is presented to reset the AccessibilityBridge.  A potentially better relationship would to make FlutterView have an AccessibilityBridge instead of making PlatformViewIOS have one.  That would allow it to be deleted in lock-step with the FlutterView.  That would require a much more complicated reworking of the code though.