### PR TITLE
[web_ui] add missing dispose handler for MethodCalls to flutter/platform_view

### DIFF
--- a/lib/web_ui/lib/src/engine/platform_views.dart
+++ b/lib/web_ui/lib/src/engine/platform_views.dart
@@ -50,6 +50,9 @@ void handlePlatformViewCall(
     case 'create':
       _createPlatformView(decoded, callback);
       return;
+    case 'dispose':
+      _disposePlatformView(decoded, callback);
+      return;
   }
   callback(null);
 }
@@ -74,5 +77,17 @@ void _createPlatformView(
       platformViewRegistry._registeredFactories[viewType](id);
 
   platformViewRegistry._createdViews[id] = element;
+  callback(codec.encodeSuccessEnvelope(null));
+}
+
+void _disposePlatformView(
+    MethodCall methodCall, ui.PlatformMessageResponseCallback callback) {
+  final int id = methodCall.arguments;
+  const MethodCodec codec = StandardMethodCodec();
+
+  // remove the root element of the view from the DOM
+  platformViewRegistry._createdViews[id]?.remove();
+  platformViewRegistry._createdViews.remove(id);
+
   callback(codec.encodeSuccessEnvelope(null));
 }

--- a/lib/web_ui/lib/src/engine/platform_views.dart
+++ b/lib/web_ui/lib/src/engine/platform_views.dart
@@ -85,7 +85,7 @@ void _disposePlatformView(
   final int id = methodCall.arguments;
   const MethodCodec codec = StandardMethodCodec();
 
-  // remove the root element of the view from the DOM
+  // Remove the root element of the view from the DOM.
   platformViewRegistry._createdViews[id]?.remove();
   platformViewRegistry._createdViews.remove(id);
 


### PR DESCRIPTION
This PR adds the missing handler for the 'dispose' MethodCall to the PlatformViewChannel ( flutter/platform_view ). This MethodCall is already invoked by _HtmlElementViewController in https://github.com/flutter/flutter/blob/2c94f2b4d9247965a32a873878cabfe6d2fb7a93/packages/flutter/lib/src/widgets/platform_view.dart#L412 and yields a MissingPluginException Error without the corresponding implementation. 

Fixes https://github.com/flutter/engine/pull/12226