### PR TITLE
[web_ui] PersistedPlatformView attribute update handling to enable resizing

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/surface/platform_view.dart
@@ -12,14 +12,13 @@ class PersistedPlatformView extends PersistedLeafSurface {
   final double width;
   final double height;
 
-  html.HtmlElement _hostElement;
   html.ShadowRoot _shadowRoot;
 
   PersistedPlatformView(this.viewId, this.dx, this.dy, this.width, this.height);
 
   @override
   html.Element createElement() {
-    _hostElement = defaultCreateElement('flt-platform-view');
+    html.Element element = defaultCreateElement('flt-platform-view');
 
     // Allow the platform view host element to receive pointer events.
     //
@@ -34,9 +33,9 @@ class PersistedPlatformView extends PersistedLeafSurface {
     // to enable accessibility, you must double tap the app *outside of a
     // platform view*. As a consequence, a full-screen platform view will make
     // it impossible to enable accessibility.
-    _hostElement.style.pointerEvents = 'auto';
+    element.style.pointerEvents = 'auto';
 
-    _shadowRoot = _hostElement.attachShadow(<String, String>{'mode': 'open'});
+    _shadowRoot = element.attachShadow(<String, String>{'mode': 'open'});
     final html.StyleElement _styleReset = html.StyleElement();
     _styleReset.innerHtml = '''
       :host {
@@ -50,7 +49,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
     } else {
       html.window.console.warn('No platform view created for id $viewId');
     }
-    return _hostElement;
+    return element;
   }
 
   @override
@@ -58,7 +57,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   void apply() {
-    _hostElement.style
+    rootElement.style
       ..transform = 'translate(${dx}px, ${dy}px)'
       ..width = '${width}px'
       ..height = '${height}px';
@@ -67,5 +66,17 @@ class PersistedPlatformView extends PersistedLeafSurface {
   @override
   double matchForUpdate(PersistedPlatformView existingSurface) {
     return existingSurface.viewId == viewId ? 0.0 : 1.0;
+  }
+
+  @override
+  void update(PersistedPlatformView oldSurface) {
+    super.update(oldSurface);
+    if (viewId != oldSurface.viewId) {
+      // the content of the surface has to be rebuild if the viewId is changed
+      build();
+    } else if (dx != oldSurface.dx || dy != oldSurface.dy || width != oldSurface.width || height != oldSurface.height) {
+      // a change in any of the dimensions is performed by calling apply
+      apply();
+    }
   }
 }

--- a/lib/web_ui/lib/src/engine/surface/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/surface/platform_view.dart
@@ -13,7 +13,6 @@ class PersistedPlatformView extends PersistedLeafSurface {
   final double height;
 
   html.ShadowRoot _shadowRoot;
-  html.Element _platformView;
 
   PersistedPlatformView(this.viewId, this.dx, this.dy, this.width, this.height);
 
@@ -43,9 +42,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
         all: initial;
       }''';
     _shadowRoot.append(_styleReset);
-    _platformView = platformViewRegistry.getCreatedView(viewId);
-    if (_platformView != null) {
-      _shadowRoot.append(_platformView);
+    final html.Element platformView =
+        platformViewRegistry.getCreatedView(viewId);
+    if (platformView != null) {
+      _shadowRoot.append(platformView);
     } else {
       html.window.console.warn('No platform view created for id $viewId');
     }
@@ -65,8 +65,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
       ..width = '${width}px'
       ..height = '${height}px';
     // Set size of the root element created by the PlatformView.
-    if (_platformView != null) {
-      _platformView.style
+    final html.Element platformView =
+        platformViewRegistry.getCreatedView(viewId);
+    if (platformView != null) {
+      platformView.style
         ..width = '${width}px'
         ..height = '${height}px';
     }

--- a/lib/web_ui/lib/src/engine/surface/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/surface/platform_view.dart
@@ -13,6 +13,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
   final double height;
 
   html.ShadowRoot _shadowRoot;
+  html.Element _platformView;
 
   PersistedPlatformView(this.viewId, this.dx, this.dy, this.width, this.height);
 
@@ -42,10 +43,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
         all: initial;
       }''';
     _shadowRoot.append(_styleReset);
-    final html.Element platformView =
+    _platformView =
         platformViewRegistry.getCreatedView(viewId);
-    if (platformView != null) {
-      _shadowRoot.append(platformView);
+    if (_platformView != null) {
+      _shadowRoot.append(_platformView);
     } else {
       html.window.console.warn('No platform view created for id $viewId');
     }
@@ -61,6 +62,12 @@ class PersistedPlatformView extends PersistedLeafSurface {
       ..transform = 'translate(${dx}px, ${dy}px)'
       ..width = '${width}px'
       ..height = '${height}px';
+    // Set size of the root element created by the PlatformView.
+    if (_platformView != null) {
+      _platformView.style
+        ..width = '${width}px'
+        ..height = '${height}px';
+  }
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/surface/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/surface/platform_view.dart
@@ -79,10 +79,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
   void update(PersistedPlatformView oldSurface) {
     super.update(oldSurface);
     if (viewId != oldSurface.viewId) {
-      // the content of the surface has to be rebuild if the viewId is changed
+      // The content of the surface has to be rebuild if the viewId is changed.
       build();
     } else if (dx != oldSurface.dx || dy != oldSurface.dy || width != oldSurface.width || height != oldSurface.height) {
-      // a change in any of the dimensions is performed by calling apply
+      // A change in any of the dimensions is performed by calling apply.
       apply();
     }
   }

--- a/lib/web_ui/lib/src/engine/surface/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/surface/platform_view.dart
@@ -58,7 +58,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   void apply() {
+    // The overflow property 'auto' enforces the effective size of the PlatformView
+    // and mimics the behaviour of WebView on mobile platforms.
     rootElement.style
+      ..overflow = 'auto'
       ..transform = 'translate(${dx}px, ${dy}px)'
       ..width = '${width}px'
       ..height = '${height}px';
@@ -67,7 +70,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
       _platformView.style
         ..width = '${width}px'
         ..height = '${height}px';
-  }
+    }
   }
 
   @override

--- a/lib/web_ui/lib/src/engine/surface/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/surface/platform_view.dart
@@ -35,6 +35,9 @@ class PersistedPlatformView extends PersistedLeafSurface {
     // it impossible to enable accessibility.
     element.style.pointerEvents = 'auto';
 
+    // Enforce the effective size of the PlatformView.
+    element.style.overflow = 'hidden';
+
     _shadowRoot = element.attachShadow(<String, String>{'mode': 'open'});
     final html.StyleElement _styleReset = html.StyleElement();
     _styleReset.innerHtml = '''
@@ -57,10 +60,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
 
   @override
   void apply() {
-    // The overflow property 'auto' enforces the effective size of the PlatformView
-    // and mimics the behaviour of WebView on mobile platforms.
     rootElement.style
-      ..overflow = 'auto'
       ..transform = 'translate(${dx}px, ${dy}px)'
       ..width = '${width}px'
       ..height = '${height}px';

--- a/lib/web_ui/lib/src/engine/surface/platform_view.dart
+++ b/lib/web_ui/lib/src/engine/surface/platform_view.dart
@@ -43,8 +43,7 @@ class PersistedPlatformView extends PersistedLeafSurface {
         all: initial;
       }''';
     _shadowRoot.append(_styleReset);
-    _platformView =
-        platformViewRegistry.getCreatedView(viewId);
+    _platformView = platformViewRegistry.getCreatedView(viewId);
     if (_platformView != null) {
       _shadowRoot.append(_platformView);
     } else {
@@ -84,7 +83,10 @@ class PersistedPlatformView extends PersistedLeafSurface {
     if (viewId != oldSurface.viewId) {
       // The content of the surface has to be rebuild if the viewId is changed.
       build();
-    } else if (dx != oldSurface.dx || dy != oldSurface.dy || width != oldSurface.width || height != oldSurface.height) {
+    } else if (dx != oldSurface.dx ||
+        dy != oldSurface.dy ||
+        width != oldSurface.width ||
+        height != oldSurface.height) {
       // A change in any of the dimensions is performed by calling apply.
       apply();
     }


### PR DESCRIPTION
PersistedPlatformView lacks handling of changes to attributes of retained surfaces. Consequently the size of a PlatformView is currently never adjusted after it has been created as the root HTML Element of the PlatformView is retained unaltered from frame to frame.

This PR fixes this problem by adding an update handler to PersistedPlatformView, which applys the new dimensions to a retained surface / root HTML Element in case they have been changed.