### PR TITLE
Add an initial macOS version of FlutterAppDelegate

### DIFF
--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -29,6 +29,7 @@ _flutter_framework_dir = "$root_out_dir/$_flutter_framework_filename"
 # The headers that will be copied to the framework and be accessed from outside
 # the Flutter engine source root.
 _flutter_framework_headers = [
+  "framework/Headers/FlutterAppDelegate.h",
   "framework/Headers/FlutterDartProject.h",
   "framework/Headers/FlutterEngine.h",
   "framework/Headers/FlutterMacOS.h",
@@ -46,6 +47,7 @@ shared_library("create_flutter_framework_dylib") {
   output_name = "$_flutter_framework_name"
 
   sources = [
+    "framework/Source/FlutterAppDelegate.mm",
     "framework/Source/FlutterDartProject.mm",
     "framework/Source/FlutterDartProject_Internal.h",
     "framework/Source/FlutterEngine.mm",

--- a/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h
@@ -1,0 +1,43 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FLUTTERAPPDELEGATE_H_
+#define FLUTTER_FLUTTERAPPDELEGATE_H_
+
+#import <Cocoa/Cocoa.h>
+
+#include "FlutterMacros.h"
+
+/**
+ * `NSApplicationDelegate` subclass for simple apps that want default behavior.
+ *
+ * This class implements the following behaviors:
+ *   * Updates the application name of items in the application menu to match the name in
+ *     the app's Info.plist, assuming it is set to APP_NAME initially. |applicationMenu| must be
+ *     set before the application finishes launching for this to take effect.
+ *   * Updates the main Flutter window's title to match the name in the app's Info.plist.
+ *     |mainFlutterWindow| must be set before the application finishes launching for this to take
+ *     effect.
+ *
+ * App delegates for Flutter applications are *not* required to inherit from
+ * this class. Developers of custom app delegate classes should copy and paste
+ * code as necessary from FlutterAppDelegate.mm.
+ */
+FLUTTER_EXPORT
+@interface FlutterAppDelegate : NSObject <NSApplicationDelegate>
+
+/**
+ * The application menu in the menu bar.
+ */
+@property(weak, nonatomic) IBOutlet NSMenu* applicationMenu;
+
+/**
+ * The primary application window containg a FlutterViewController. This is primarily intended
+ * for use in single-window applications.
+ */
+@property(weak, nonatomic) IBOutlet NSWindow* mainFlutterWindow;
+
+@end
+
+#endif  // FLUTTER_FLUTTERAPPDELEGATE_H_

--- a/shell/platform/darwin/macos/framework/Headers/FlutterMacOS.h
+++ b/shell/platform/darwin/macos/framework/Headers/FlutterMacOS.h
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#import "FlutterAppDelegate.h"
 #import "FlutterBinaryMessenger.h"
 #import "FlutterChannels.h"
 #import "FlutterCodecs.h"

--- a/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterAppDelegate.mm
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterAppDelegate.h"
+
+@interface FlutterAppDelegate ()
+
+/**
+ * Returns the display name of the application as set in the Info.plist.
+ */
+- (NSString*)applicationName;
+
+@end
+
+@implementation FlutterAppDelegate
+
+// TODO(stuartmorgan): Implement application lifecycle forwarding to plugins here, as is done
+// on iOS. Currently macOS plugins don't have access to lifecycle messages.
+
+- (void)applicationWillFinishLaunching:(NSNotification*)notification {
+  // Update UI elements to match the application name.
+  NSString* applicationName = [self applicationName];
+  _mainFlutterWindow.title = applicationName;
+  for (NSMenuItem* menuItem in _applicationMenu.itemArray) {
+    menuItem.title = [menuItem.title stringByReplacingOccurrencesOfString:@"APP_NAME"
+                                                               withString:applicationName];
+  }
+}
+
+#pragma mark Private Methods
+
+- (NSString*)applicationName {
+  NSString* applicationName =
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+  if (!applicationName) {
+    applicationName = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleName"];
+  }
+  return applicationName;
+}
+
+@end


### PR DESCRIPTION
Creates a starting point for an app delegate. For now it just
incorporates the menu and window renaming functionality that's currently
in the FDE example, but in the future this will also do forwarding of
application lifecycle events to plugins.

Fixes https://github.com/flutter/flutter/issues/32419