### PR TITLE
FlutterViewController notify will dealloc

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -171,13 +171,12 @@
   [self maybeSetupPlatformViewChannels];
 
   self.flutterViewControllerWillDeallocObserver =
-      [[NSNotificationCenter defaultCenter]
-          addObserverForName:FlutterViewControllerWillDealloc
-          object:viewController
-          queue:[NSOperationQueue mainQueue]
-          usingBlock:^(NSNotification *note) {
-            [self notifyViewControllerDeallocated];
-          }];
+      [[NSNotificationCenter defaultCenter] addObserverForName:FlutterViewControllerWillDealloc
+                                                        object:viewController
+                                                         queue:[NSOperationQueue mainQueue]
+                                                    usingBlock:^(NSNotification* note) {
+                                                      [self notifyViewControllerDeallocated];
+                                                    }];
 }
 
 - (void)notifyViewControllerDeallocated {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -33,6 +33,7 @@
 @property(nonatomic, readonly) NSMutableDictionary* pluginPublications;
 
 @property(nonatomic, readwrite, copy) NSString* isolateId;
+@property(nonatomic, retain) id<NSObject> flutterViewControllerWillDeallocObserver;
 @end
 
 @interface FlutterEngineRegistrar : NSObject <FlutterPluginRegistrar>
@@ -111,6 +112,7 @@
 
   NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
   [center removeObserver:self name:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+  [_flutterViewControllerWillDeallocObserver release];
 
   [super dealloc];
 }
@@ -167,12 +169,22 @@
   _viewController = [viewController getWeakPtr];
   self.iosPlatformView->SetOwnerViewController(_viewController);
   [self maybeSetupPlatformViewChannels];
+
+  self.flutterViewControllerWillDeallocObserver =
+      [[NSNotificationCenter defaultCenter]
+          addObserverForName:FlutterViewControllerWillDealloc
+          object:viewController
+          queue:[NSOperationQueue mainQueue]
+          usingBlock:^(NSNotification *note) {
+            [self notifyViewControllerDeallocated];
+          }];
 }
 
 - (void)notifyViewControllerDeallocated {
   if (!_allowHeadlessExecution) {
     [self destroyContext];
   }
+  _viewController.reset();
 }
 
 - (void)destroyContext {

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine_Internal.h
@@ -44,7 +44,6 @@
 - (FlutterTextInputPlugin*)textInputPlugin;
 - (void)launchEngine:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
 - (BOOL)createShell:(NSString*)entrypoint libraryURI:(NSString*)libraryOrNil;
-- (void)notifyViewControllerDeallocated;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -27,7 +27,6 @@ NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemantics
 
 NSNotificationName const FlutterViewControllerWillDealloc = @"FlutterViewControllerWillDealloc";
 
-
 // This is left a FlutterBinaryMessenger privately for now to give people a chance to notice the
 // change. Unfortunately unless you have Werror turned on, incompatible pointers as arguments are
 // just a warning.

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -25,6 +25,9 @@
 
 NSNotificationName const FlutterSemanticsUpdateNotification = @"FlutterSemanticsUpdate";
 
+NSNotificationName const FlutterViewControllerWillDealloc = @"FlutterViewControllerWillDealloc";
+
+
 // This is left a FlutterBinaryMessenger privately for now to give people a chance to notice the
 // change. Unfortunately unless you have Werror turned on, incompatible pointers as arguments are
 // just a warning.
@@ -521,7 +524,9 @@ typedef enum UIAccessibilityContrast : NSInteger {
 }
 
 - (void)dealloc {
-  [_engine.get() notifyViewControllerDeallocated];
+  [[NSNotificationCenter defaultCenter] postNotificationName:FlutterViewControllerWillDealloc
+                                                      object:self
+                                                    userInfo:nil];
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [_ongoingTouches release];
   [super dealloc];

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -258,19 +258,21 @@ typedef enum UIAccessibilityContrast : NSInteger {
 }
 
 - (void)testWillDeallocNotification {
-  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"notification called"];
+  XCTestExpectation* expectation =
+      [[XCTestExpectation alloc] initWithDescription:@"notification called"];
   id engine = [[MockEngine alloc] init];
   FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:engine
                                                                         nibName:nil
                                                                          bundle:nil];
-  id observer = [[NSNotificationCenter defaultCenter] addObserverForName:FlutterViewControllerWillDealloc
-                                                                  object:nil
-                                                                   queue:[NSOperationQueue mainQueue]
-                                                              usingBlock:^(NSNotification * _Nonnull note) {
-    [expectation fulfill];
-  }];
+  id observer =
+      [[NSNotificationCenter defaultCenter] addObserverForName:FlutterViewControllerWillDealloc
+                                                        object:nil
+                                                         queue:[NSOperationQueue mainQueue]
+                                                    usingBlock:^(NSNotification* _Nonnull note) {
+                                                      [expectation fulfill];
+                                                    }];
   realVC = nil;
-  [self waitForExpectations:@[expectation] timeout:1.0];
+  [self waitForExpectations:@[ expectation ] timeout:1.0];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -12,6 +12,19 @@
 #error ARC must be enabled!
 #endif
 
+extern NSNotificationName const FlutterViewControllerWillDealloc;
+
+/// OCMock can't be used for FlutterEngine sometimes because it retains arguments to invocations
+/// so it is impossible to test deleting of FluterViewControllers.
+@interface MockEngine : NSObject
+@end
+
+@implementation MockEngine
+- (void)setViewController:(FlutterViewController*)viewController {
+  // noop
+}
+@end
+
 @interface FlutterViewControllerTest : XCTestCase
 @end
 
@@ -242,6 +255,22 @@ typedef enum UIAccessibilityContrast : NSInteger {
   id mockTraitCollection = OCMClassMock([UITraitCollection class]);
   OCMStub([mockTraitCollection accessibilityContrast]).andReturn(contrast);
   return mockTraitCollection;
+}
+
+- (void)testWillDeallocNotification {
+  XCTestExpectation *expectation = [[XCTestExpectation alloc] initWithDescription:@"notification called"];
+  id engine = [[MockEngine alloc] init];
+  FlutterViewController* realVC = [[FlutterViewController alloc] initWithEngine:engine
+                                                                        nibName:nil
+                                                                         bundle:nil];
+  id observer = [[NSNotificationCenter defaultCenter] addObserverForName:FlutterViewControllerWillDealloc
+                                                                  object:nil
+                                                                   queue:[NSOperationQueue mainQueue]
+                                                              usingBlock:^(NSNotification * _Nonnull note) {
+    [expectation fulfill];
+  }];
+  realVC = nil;
+  [self waitForExpectations:@[expectation] timeout:1.0];
 }
 
 @end

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewControllerTest.m
@@ -14,8 +14,12 @@
 
 extern NSNotificationName const FlutterViewControllerWillDealloc;
 
-/// OCMock can't be used for FlutterEngine sometimes because it retains arguments to invocations
-/// so it is impossible to test deleting of FluterViewControllers.
+/// A simple mock class for FlutterEngine.
+///
+/// OCMockClass can't be used for FlutterEngine sometimes because OCMock retains arguments to
+/// invocations and since the init for FlutterViewController calls a method on the
+/// FlutterEngine it creates a retain cycle that stops us from testing behaviors related to
+/// deleting FlutterViewControllers.
 @interface MockEngine : NSObject
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController_Internal.h
@@ -12,6 +12,9 @@
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 
+FLUTTER_EXPORT
+extern NSNotificationName const FlutterViewControllerWillDealloc;
+
 @interface FlutterViewController ()
 
 - (fml::WeakPtr<FlutterViewController>)getWeakPtr;

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -52,6 +52,7 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;
   fml::closure firstFrameCallback_;
+  fml::scoped_nsprotocol<NSObject*> dealloc_view_controller_observer_;
 
   // |PlatformView|
   void HandlePlatformMessage(fml::RefPtr<flutter::PlatformMessage> message) override;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -52,16 +52,15 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
 
   // Add an observer that will clear out the owner_controller_ ivar and
   // the accessibility_bridge_ in case the view controller is deleted.
-  dealloc_view_controller_observer_.reset(
-    [[NSNotificationCenter defaultCenter]
-        addObserverForName:FlutterViewControllerWillDealloc
-        object:owner_controller_.get()
-        queue:[NSOperationQueue mainQueue]
-        usingBlock:^(NSNotification *note) {
-          // Implicit copy of 'this' is fine.
-          accessibility_bridge_.reset();
-          owner_controller_.reset();
-        }]);
+  dealloc_view_controller_observer_.reset([[NSNotificationCenter defaultCenter]
+      addObserverForName:FlutterViewControllerWillDealloc
+                  object:owner_controller_.get()
+                   queue:[NSOperationQueue mainQueue]
+              usingBlock:^(NSNotification* note) {
+                // Implicit copy of 'this' is fine.
+                accessibility_bridge_.reset();
+                owner_controller_.reset();
+              }]);
 
   if (owner_controller_) {
     ios_surface_ =

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -58,8 +58,9 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
         object:owner_controller_.get()
         queue:[NSOperationQueue mainQueue]
         usingBlock:^(NSNotification *note) {
+          // Implicit copy of 'this' is fine.
           accessibility_bridge_.reset();
-          this->owner_controller_.reset();
+          owner_controller_.reset();
         }]);
 
   if (owner_controller_) {

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -49,6 +49,19 @@ void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController>
     accessibility_bridge_.reset();
   }
   owner_controller_ = owner_controller;
+
+  // Add an observer that will clear out the owner_controller_ ivar and
+  // the accessibility_bridge_ in case the view controller is deleted.
+  dealloc_view_controller_observer_.reset(
+    [[NSNotificationCenter defaultCenter]
+        addObserverForName:FlutterViewControllerWillDealloc
+        object:owner_controller_.get()
+        queue:[NSOperationQueue mainQueue]
+        usingBlock:^(NSNotification *note) {
+          accessibility_bridge_.reset();
+          this->owner_controller_.reset();
+        }]);
+
   if (owner_controller_) {
     ios_surface_ =
         [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_context_];


### PR DESCRIPTION
Made the FlutterViewController's dealloc notification more generic and started turning off semantics when the view controller is remotely deleted.

Relevant issue: https://github.com/flutter/flutter/issues/33173