### PR TITLE
[glfw/windows] Stops keeping track of input models

### DIFF
--- a/shell/platform/glfw/text_input_plugin.cc
+++ b/shell/platform/glfw/text_input_plugin.cc
@@ -32,8 +32,6 @@ static constexpr char kBadArgumentError[] = "Bad Arguments";
 static constexpr char kInternalConsistencyError[] =
     "Internal Consistency Error";
 
-static constexpr uint32_t kInputModelLimit = 256;
-
 namespace flutter {
 
 void TextInputPlugin::CharHook(GLFWwindow* window, unsigned int code_point) {
@@ -83,7 +81,7 @@ void TextInputPlugin::KeyboardHook(GLFWwindow* window,
         }
         break;
       case GLFW_KEY_ENTER:
-        EnterPressed(active_model_);
+        EnterPressed(active_model_.get());
         break;
       default:
         break;
@@ -138,19 +136,7 @@ void TextInputPlugin::HandleMethodCall(
                       "Could not set client, missing arguments.");
       }
       int client_id = client_id_json.GetInt();
-      if (input_models_.find(client_id) == input_models_.end()) {
-        // Skips out on adding a new input model once over the limit.
-        if (input_models_.size() > kInputModelLimit) {
-          result->Error(
-              kInternalConsistencyError,
-              "Input models over limit. Aborting creation of new text model.");
-          return;
-        }
-        input_models_.insert(std::make_pair(
-            client_id,
-            std::make_unique<TextInputModel>(client_id, client_config)));
-      }
-      active_model_ = input_models_[client_id].get();
+      active_model_ = std::make_unique<TextInputModel>(client_id, client_config);
     } else if (method.compare(kSetEditingStateMethod) == 0) {
       if (active_model_ == nullptr) {
         result->Error(

--- a/shell/platform/glfw/text_input_plugin.h
+++ b/shell/platform/glfw/text_input_plugin.h
@@ -50,11 +50,8 @@ class TextInputPlugin : public KeyboardHookHandler {
   // The MethodChannel used for communication with the Flutter engine.
   std::unique_ptr<flutter::MethodChannel<rapidjson::Document>> channel_;
 
-  // Mapping of client IDs to text input models.
-  std::map<int, std::unique_ptr<TextInputModel>> input_models_;
-
   // The active model. nullptr if not set.
-  TextInputModel* active_model_;
+  std::unique_ptr<TextInputModel> active_model_;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/text_input_plugin.cc
+++ b/shell/platform/windows/text_input_plugin.cc
@@ -34,8 +34,6 @@ static constexpr char kBadArgumentError[] = "Bad Arguments";
 static constexpr char kInternalConsistencyError[] =
     "Internal Consistency Error";
 
-static constexpr uint32_t kInputModelLimit = 256;
-
 namespace flutter {
 
 void TextInputPlugin::CharHook(Win32FlutterWindow* window,
@@ -86,7 +84,7 @@ void TextInputPlugin::KeyboardHook(Win32FlutterWindow* window,
         }
         break;
       case VK_RETURN:
-        EnterPressed(active_model_);
+        EnterPressed(active_model_.get());
         break;
       default:
         break;
@@ -140,19 +138,7 @@ void TextInputPlugin::HandleMethodCall(
         return;
       }
       int client_id = client_id_json.GetInt();
-      if (input_models_.find(client_id) == input_models_.end()) {
-        // Skips out on adding a new input model once over the limit.
-        if (input_models_.size() > kInputModelLimit) {
-          result->Error(
-              kInternalConsistencyError,
-              "Input models over limit. Aborting creation of new text model.");
-          return;
-        }
-        input_models_.insert(std::make_pair(
-            client_id,
-            std::make_unique<TextInputModel>(client_id, client_config)));
-      }
-      active_model_ = input_models_[client_id].get();
+      active_model_ = std::make_unique<TextInputModel>(client_id, client_config);
     } else if (method.compare(kSetEditingStateMethod) == 0) {
       if (active_model_ == nullptr) {
         result->Error(

--- a/shell/platform/windows/text_input_plugin.h
+++ b/shell/platform/windows/text_input_plugin.h
@@ -52,11 +52,8 @@ class TextInputPlugin : public KeyboardHookHandler {
   // The MethodChannel used for communication with the Flutter engine.
   std::unique_ptr<flutter::MethodChannel<rapidjson::Document>> channel_;
 
-  // Mapping of client IDs to text input models.
-  std::map<int, std::unique_ptr<TextInputModel>> input_models_;
-
   // The active model. nullptr if not set.
-  TextInputModel* active_model_;
+  std::unique_ptr<TextInputModel> active_model_;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Keeping track of the input models doesn't actually work since the framework generates a new client ID on each new connection. 

fixes https://github.com/flutter/flutter/issues/30659