### PR TITLE
Implement Base32Decode

### DIFF
--- a/fml/base32.h
+++ b/fml/base32.h
@@ -15,19 +15,14 @@ namespace fml {
 template <int from_length, int to_length, int buffer_length>
 class BitConverter {
  public:
-  // Although member functions in headers are by default inline, we put extra
-  // "inline" keywords to strongly suggest the compiler to make these frequently
-  // called functions inline.
-  //
-  // TODO(liyuqian): Ask Chinmay "Can we use SK_WALWAYS_INLINE in fml?".
-  inline void Append(int bits) {
+  void Append(int bits) {
     FML_DCHECK(bits < (1 << from_length));
     FML_DCHECK(CanAppend());
     lower_free_bits_ -= from_length;
     buffer_ |= (bits << lower_free_bits_);
   }
 
-  inline int Extract() {
+  int Extract() {
     FML_DCHECK(CanExtract());
     int result = Peek();
     buffer_ = (buffer_ << to_length) & mask_;
@@ -35,10 +30,10 @@ class BitConverter {
     return result;
   }
 
-  inline int Peek() const { return (buffer_ >> (buffer_length - to_length)); }
-  inline int BitsAvailable() const { return buffer_length - lower_free_bits_; }
-  inline bool CanAppend() const { return lower_free_bits_ >= from_length; }
-  inline bool CanExtract() const { return BitsAvailable() >= to_length; }
+  int Peek() const { return (buffer_ >> (buffer_length - to_length)); }
+  int BitsAvailable() const { return buffer_length - lower_free_bits_; }
+  bool CanAppend() const { return lower_free_bits_ >= from_length; }
+  bool CanExtract() const { return BitsAvailable() >= to_length; }
 
  private:
   static_assert(buffer_length >= 2 * from_length);

--- a/fml/base32.h
+++ b/fml/base32.h
@@ -8,9 +8,54 @@
 #include <string_view>
 #include <utility>
 
+#include "flutter/fml/logging.h"
+
 namespace fml {
 
+template <int from_length, int to_length, int buffer_length>
+class BitConverter {
+ public:
+  // Although member functions in headers are by default inline, we put extra
+  // "inline" keywords to strongly suggest the compiler to make these frequently
+  // called functions inline.
+  //
+  // TODO(liyuqian): Ask Chinmay "Can we use SK_WALWAYS_INLINE in fml?".
+  inline void Append(int bits) {
+    FML_DCHECK(bits < (1 << from_length));
+    FML_DCHECK(CanAppend());
+    lower_free_bits_ -= from_length;
+    buffer_ |= (bits << lower_free_bits_);
+  }
+
+  inline int Extract() {
+    FML_DCHECK(CanExtract());
+    int result = Peek();
+    buffer_ = (buffer_ << to_length) & mask_;
+    lower_free_bits_ += to_length;
+    return result;
+  }
+
+  inline int Peek() const { return (buffer_ >> (buffer_length - to_length)); }
+  inline int BitsAvailable() const { return buffer_length - lower_free_bits_; }
+  inline bool CanAppend() const { return lower_free_bits_ >= from_length; }
+  inline bool CanExtract() const { return BitsAvailable() >= to_length; }
+
+ private:
+  static_assert(buffer_length >= 2 * from_length);
+  static_assert(buffer_length >= 2 * to_length);
+  static_assert(buffer_length < sizeof(int) * 8);
+
+  static constexpr int mask_ = (1 << buffer_length) - 1;
+
+  int buffer_ = 0;
+  int lower_free_bits_ = buffer_length;
+};
+
+using Base32DecodeConverter = BitConverter<5, 8, 16>;
+using Base32EncodeConverter = BitConverter<8, 5, 16>;
+
 std::pair<bool, std::string> Base32Encode(std::string_view input);
+std::pair<bool, std::string> Base32Decode(const std::string& input);
 
 }  // namespace fml
 

--- a/fml/base32_unittest.cc
+++ b/fml/base32_unittest.cc
@@ -5,6 +5,8 @@
 #include "flutter/fml/base32.h"
 #include "gtest/gtest.h"
 
+#include <iostream>
+
 TEST(Base32Test, CanEncode) {
   {
     auto result = fml::Base32Encode("hello");
@@ -34,5 +36,51 @@ TEST(Base32Test, CanEncode) {
     auto result = fml::Base32Encode("helLo");
     ASSERT_TRUE(result.first);
     ASSERT_EQ(result.second, "NBSWYTDP");
+  }
+}
+
+TEST(Base32Test, CanEncodeDecodeStrings) {
+  std::vector<std::string> strings = {"hello", "helLo", "", "1", "\0"};
+  for (size_t i = 0; i < strings.size(); i += 1) {
+    auto encode_result = fml::Base32Encode(strings[i]);
+    ASSERT_TRUE(encode_result.first);
+    auto decode_result = fml::Base32Decode(encode_result.second);
+    ASSERT_TRUE(decode_result.first);
+    const std::string& decoded = decode_result.second;
+    std::string decoded_string(decoded.data(), decoded.size());
+    ASSERT_EQ(strings[i], decoded_string);
+  }
+}
+
+TEST(Base32Test, DecodeReturnsFalseForInvalideInput) {
+  // "B" is invalid because it has a non-zero padding.
+  std::vector<std::string> invalid_inputs = {"a", "1", "9", "B"};
+  for (const std::string& input : invalid_inputs) {
+    auto decode_result = fml::Base32Decode(input);
+    if (decode_result.first) {
+      std::cout << "Base32Decode should return false on " << input << std::endl;
+    }
+    ASSERT_FALSE(decode_result.first);
+  }
+}
+
+TEST(Base32Test, CanDecodeSkSLKeys) {
+  std::vector<std::string> inputs = {
+      "CAZAAAACAAAAADQAAAABKAAAAAJQAAIA7777777777776EYAAEAP777777777777AAAAAABA"
+      "ABTAAAAAAAAAAAAAAABAAAAAGQAGGAA",
+      "CAZAAAICAAAAAAAAAAADOAAAAAJQAAIA777777Y4AAKAAEYAAEAP777777777777EAAGMAAA"
+      "AAAAAAAAAAACQACNAAAAAAAAAAAAAAACAAAAAPAAMMAA",
+      "CAZACAACAAAABAYACAAAAAAAAAJQAAIADQABIAH777777777777RQAAOAAAAAAAAAAAAAABE"
+      "AANQAAAAAAAAAAAAAAYAAJYAAAAAAAANAAAQAAAAAAAEAAAHAAAAAAAAAAAAAAANAAAQAAAA"
+      "AAAFIADKAAAAAAAAAAAAAAACAAAAAZAAMMAA"};
+  for (const std::string& input : inputs) {
+    auto decode_result = fml::Base32Decode(input);
+    if (!decode_result.first) {
+      std::cout << "Base32Decode should return true on " << input << std::endl;
+    }
+    ASSERT_TRUE(decode_result.first);
+    auto encode_result = fml::Base32Encode(decode_result.second);
+    ASSERT_TRUE(encode_result.first);
+    ASSERT_EQ(encode_result.second, input);
   }
 }


### PR DESCRIPTION
For https://github.com/flutter/flutter/issues/32170

This is to enable reading back SkSL persistent cache filenames
and decode them as SkData.