### PR TITLE
Re-enable ThreadChecker and fix associated failures

### DIFF
--- a/fml/memory/thread_checker.h
+++ b/fml/memory/thread_checker.h
@@ -55,8 +55,6 @@ class ThreadChecker final {
 #endif
 };
 
-// TODO(chinmaygarde): Re-enable this after auditing all new users of
-// fml::WeakPtr.
 #if !defined(NDEBUG)
 #define FML_DECLARE_THREAD_CHECKER(c) fml::ThreadChecker c
 #define FML_DCHECK_CREATION_THREAD_IS_CURRENT(c) \

--- a/fml/memory/thread_checker.h
+++ b/fml/memory/thread_checker.h
@@ -57,7 +57,7 @@ class ThreadChecker final {
 
 // TODO(chinmaygarde): Re-enable this after auditing all new users of
 // fml::WeakPtr.
-#if !defined(NDEBUG) && false
+#if !defined(NDEBUG)
 #define FML_DECLARE_THREAD_CHECKER(c) fml::ThreadChecker c
 #define FML_DCHECK_CREATION_THREAD_IS_CURRENT(c) \
   FML_DCHECK((c).IsCreationThreadCurrent())

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -84,6 +84,9 @@ class WeakPtr {
     return *this ? ptr_ : nullptr;
   }
 
+  // TODO(gw280): Remove all remaining usages of getUnsafe()
+  //
+  // https://github.com/flutter/flutter/issues/42949
   T* getUnsafe() const {
     // This is an unsafe method to get access to the raw pointer.
     // We still check the flag_ to determine if the pointer is valid

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -84,7 +84,13 @@ class WeakPtr {
     return *this ? ptr_ : nullptr;
   }
 
-  T* getUnsafe() const { return *this ? ptr_ : nullptr; }
+  T* getUnsafe() const {
+    // This is an unsafe method to get access to the raw pointer.
+    // We still check the flag_ to determine if the pointer is valid
+    // but callees should note that this WeakPtr could have been
+    // invalidated on another thread.
+    return flag_ && flag_->is_valid() ? ptr_ : nullptr;
+  }
 
   T& operator*() const {
     FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker_.checker);

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -84,7 +84,8 @@ class WeakPtr {
     return *this ? ptr_ : nullptr;
   }
 
-  // TODO(gw280): Remove all remaining usages of getUnsafe()
+  // TODO(gw280): Remove all remaining usages of getUnsafe().
+  // No new usages of getUnsafe() are allowed.
   //
   // https://github.com/flutter/flutter/issues/42949
   T* getUnsafe() const {

--- a/fml/memory/weak_ptr.h
+++ b/fml/memory/weak_ptr.h
@@ -84,6 +84,8 @@ class WeakPtr {
     return *this ? ptr_ : nullptr;
   }
 
+  T* getUnsafe() const { return *this ? ptr_ : nullptr; }
+
   T& operator*() const {
     FML_DCHECK_CREATION_THREAD_IS_CURRENT(checker_.checker);
     FML_DCHECK(*this);

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -168,10 +168,13 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
   fml::AutoResetWaitableEvent latch;
 
   std::unique_ptr<IOManager> io_manager;
-  std::unique_ptr<ImageDecoder> image_decoder;
 
+  auto release_io_manager = [&]() {
+    io_manager.reset();
+    latch.Signal();
+  };
   auto decode_image = [&]() {
-    image_decoder = std::make_unique<ImageDecoder>(
+    std::unique_ptr<ImageDecoder> image_decoder = std::make_unique<ImageDecoder>(
         runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
 
     ImageDecoder::ImageDescriptor image_descriptor;
@@ -183,7 +186,7 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
     ImageDecoder::ImageResult callback = [&](SkiaGPUObject<SkImage> image) {
       ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
       ASSERT_TRUE(image.get());
-      latch.Signal();
+      runners.GetIOTaskRunner()->PostTask(release_io_manager);
     };
     image_decoder->Decode(std::move(image_descriptor), callback);
   };
@@ -210,11 +213,15 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
   fml::AutoResetWaitableEvent latch;
 
   std::unique_ptr<IOManager> io_manager;
-  std::unique_ptr<ImageDecoder> image_decoder;
+
+  auto release_io_manager = [&]() {
+    io_manager.reset();
+    latch.Signal();
+  };
 
   SkISize decoded_size = SkISize::MakeEmpty();
   auto decode_image = [&]() {
-    image_decoder = std::make_unique<ImageDecoder>(
+    std::unique_ptr<ImageDecoder> image_decoder = std::make_unique<ImageDecoder>(
         runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
 
     ImageDecoder::ImageDescriptor image_descriptor;
@@ -227,7 +234,7 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
       ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
       ASSERT_TRUE(image.get());
       decoded_size = image.get()->dimensions();
-      latch.Signal();
+      runners.GetIOTaskRunner()->PostTask(release_io_manager);
     };
     image_decoder->Decode(std::move(image_descriptor), callback);
   };
@@ -257,10 +264,14 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
   fml::AutoResetWaitableEvent latch;
 
   std::unique_ptr<IOManager> io_manager;
-  std::unique_ptr<ImageDecoder> image_decoder;
+
+  auto release_io_manager = [&]() {
+    io_manager.reset();
+    latch.Signal();
+  };
 
   auto decode_image = [&]() {
-    image_decoder = std::make_unique<ImageDecoder>(
+    std::unique_ptr<ImageDecoder> image_decoder = std::make_unique<ImageDecoder>(
         runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
 
     ImageDecoder::ImageDescriptor image_descriptor;
@@ -272,7 +283,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
     ImageDecoder::ImageResult callback = [&](SkiaGPUObject<SkImage> image) {
       ASSERT_TRUE(runners.GetUITaskRunner()->RunsTasksOnCurrentThread());
       ASSERT_TRUE(image.get());
-      latch.Signal();
+      runners.GetIOTaskRunner()->PostTask(release_io_manager);
     };
     image_decoder->Decode(std::move(image_descriptor), callback);
   };
@@ -355,6 +366,20 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   ASSERT_EQ(decoded_size(100, {}), SkISize::Make(100, 133));
   ASSERT_EQ(decoded_size({}, 100), SkISize::Make(75, 100));
   ASSERT_EQ(decoded_size(100, 100), SkISize::Make(100, 100));
+
+  // Destroy the IO manager
+  runners.GetIOTaskRunner()->PostTask([&]() {
+    io_manager.reset();
+    latch.Signal();
+  });
+  latch.Wait();
+
+  // Destroy the image decoder
+  runners.GetUITaskRunner()->PostTask([&]() {
+    image_decoder.reset();
+    latch.Signal();
+  });
+  latch.Wait();
 }
 
 TEST_F(ImageDecoderFixtureTest, CanResizeWithoutDecode) {
@@ -441,6 +466,20 @@ TEST_F(ImageDecoderFixtureTest, CanResizeWithoutDecode) {
   ASSERT_EQ(decoded_size(100, {}), SkISize::Make(100, 133));
   ASSERT_EQ(decoded_size({}, 100), SkISize::Make(75, 100));
   ASSERT_EQ(decoded_size(100, 100), SkISize::Make(100, 100));
+
+    // Destroy the IO manager
+  runners.GetIOTaskRunner()->PostTask([&]() {
+    io_manager.reset();
+    latch.Signal();
+  });
+  latch.Wait();
+
+  // Destroy the image decoder
+  runners.GetUITaskRunner()->PostTask([&]() {
+    image_decoder.reset();
+    latch.Signal();
+  });
+  latch.Wait();
 }
 
 }  // namespace testing

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -174,8 +174,9 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
     latch.Signal();
   };
   auto decode_image = [&]() {
-    std::unique_ptr<ImageDecoder> image_decoder = std::make_unique<ImageDecoder>(
-        runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
+    std::unique_ptr<ImageDecoder> image_decoder =
+        std::make_unique<ImageDecoder>(runners, loop->GetTaskRunner(),
+                                       io_manager->GetWeakIOManager());
 
     ImageDecoder::ImageDescriptor image_descriptor;
     image_descriptor.data = OpenFixtureAsSkData("DashInNooglerHat.jpg");
@@ -221,8 +222,9 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
 
   SkISize decoded_size = SkISize::MakeEmpty();
   auto decode_image = [&]() {
-    std::unique_ptr<ImageDecoder> image_decoder = std::make_unique<ImageDecoder>(
-        runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
+    std::unique_ptr<ImageDecoder> image_decoder =
+        std::make_unique<ImageDecoder>(runners, loop->GetTaskRunner(),
+                                       io_manager->GetWeakIOManager());
 
     ImageDecoder::ImageDescriptor image_descriptor;
     image_descriptor.data = OpenFixtureAsSkData("Horizontal.jpg");
@@ -271,8 +273,9 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
   };
 
   auto decode_image = [&]() {
-    std::unique_ptr<ImageDecoder> image_decoder = std::make_unique<ImageDecoder>(
-        runners, loop->GetTaskRunner(), io_manager->GetWeakIOManager());
+    std::unique_ptr<ImageDecoder> image_decoder =
+        std::make_unique<ImageDecoder>(runners, loop->GetTaskRunner(),
+                                       io_manager->GetWeakIOManager());
 
     ImageDecoder::ImageDescriptor image_descriptor;
     image_descriptor.data = OpenFixtureAsSkData("DashInNooglerHat.jpg");
@@ -467,7 +470,7 @@ TEST_F(ImageDecoderFixtureTest, CanResizeWithoutDecode) {
   ASSERT_EQ(decoded_size({}, 100), SkISize::Make(75, 100));
   ASSERT_EQ(decoded_size(100, 100), SkISize::Make(100, 100));
 
-    // Destroy the IO manager
+  // Destroy the IO manager
   runners.GetIOTaskRunner()->PostTask([&]() {
     io_manager.reset();
     latch.Signal();

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -79,7 +79,12 @@ const TaskRunners& UIDartState::GetTaskRunners() const {
 }
 
 fml::RefPtr<flutter::SkiaUnrefQueue> UIDartState::GetSkiaUnrefQueue() const {
-  // TODO(gw280): Remove this usage of getUnsafe()
+  // TODO(gw280): The WeakPtr here asserts that we are derefing it on the
+  // same thread as it was created on. As we can't guarantee that currently
+  // we're being called from the IO thread (construction thread), we need
+  // to use getUnsafe() here to avoid failing the assertion.
+  //
+  // https://github.com/flutter/flutter/issues/42946
   if (!io_manager_.getUnsafe()) {
     return nullptr;
   }

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -79,11 +79,10 @@ const TaskRunners& UIDartState::GetTaskRunners() const {
 }
 
 fml::RefPtr<flutter::SkiaUnrefQueue> UIDartState::GetSkiaUnrefQueue() const {
-  FML_DCHECK(task_runners_.GetIOTaskRunner()->RunsTasksOnCurrentThread());
   if (!io_manager_) {
     return nullptr;
   }
-  return io_manager_->GetSkiaUnrefQueue();
+  return io_manager_.getUnsafe()->GetSkiaUnrefQueue();
 }
 
 void UIDartState::ScheduleMicrotask(Dart_Handle closure) {

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -79,7 +79,7 @@ const TaskRunners& UIDartState::GetTaskRunners() const {
 }
 
 fml::RefPtr<flutter::SkiaUnrefQueue> UIDartState::GetSkiaUnrefQueue() const {
-  if (!io_manager_) {
+  if (!io_manager_.getUnsafe()) {
     return nullptr;
   }
   return io_manager_.getUnsafe()->GetSkiaUnrefQueue();

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -79,6 +79,7 @@ const TaskRunners& UIDartState::GetTaskRunners() const {
 }
 
 fml::RefPtr<flutter::SkiaUnrefQueue> UIDartState::GetSkiaUnrefQueue() const {
+  // TODO(gw280): Remove this usage of getUnsafe()
   if (!io_manager_.getUnsafe()) {
     return nullptr;
   }

--- a/lib/ui/ui_dart_state.cc
+++ b/lib/ui/ui_dart_state.cc
@@ -79,6 +79,7 @@ const TaskRunners& UIDartState::GetTaskRunners() const {
 }
 
 fml::RefPtr<flutter::SkiaUnrefQueue> UIDartState::GetSkiaUnrefQueue() const {
+  FML_DCHECK(task_runners_.GetIOTaskRunner()->RunsTasksOnCurrentThread());
   if (!io_manager_) {
     return nullptr;
   }
@@ -114,6 +115,7 @@ void UIDartState::AddOrRemoveTaskObserver(bool add) {
 }
 
 fml::WeakPtr<GrContext> UIDartState::GetResourceContext() const {
+  FML_DCHECK(task_runners_.GetIOTaskRunner()->RunsTasksOnCurrentThread());
   if (!io_manager_) {
     return {};
   }

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -67,19 +67,8 @@ class UIDartState : public tonic::DartState {
       return {};
     }
     auto* state = UIDartState::Current();
-    auto io_task_runner = state->GetTaskRunners().GetIOTaskRunner();
-
     FML_DCHECK(state);
-
-    fml::RefPtr<flutter::SkiaUnrefQueue> queue;
-    fml::AutoResetWaitableEvent latch;
-
-    auto io_task = [&state, &queue, &latch]() {
-      queue = state->GetSkiaUnrefQueue();
-      latch.Signal();
-    };
-    fml::TaskRunner::RunNowOrPostTask(io_task_runner, io_task);
-    latch.Wait();
+    auto queue = state->GetSkiaUnrefQueue();
 
     return {std::move(object), std::move(queue)};
   };

--- a/lib/ui/ui_dart_state.h
+++ b/lib/ui/ui_dart_state.h
@@ -69,7 +69,6 @@ class UIDartState : public tonic::DartState {
     auto* state = UIDartState::Current();
     FML_DCHECK(state);
     auto queue = state->GetSkiaUnrefQueue();
-
     return {std::move(object), std::move(queue)};
   };
 

--- a/shell/common/input_events_unittests.cc
+++ b/shell/common/input_events_unittests.cc
@@ -127,7 +127,14 @@ static void TestSimulatedInputEvents(
   });
 
   simulation.wait();
-  shell.reset();
+
+  TaskRunners task_runners = fixture->GetTaskRunnersForFixture();
+  fml::AutoResetWaitableEvent latch;
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+  latch.Wait();
 
   // Make sure that all events have been consumed so
   // https://github.com/flutter/flutter/issues/40863 won't happen again.

--- a/shell/common/persistent_cache_unittests.cc
+++ b/shell/common/persistent_cache_unittests.cc
@@ -87,7 +87,7 @@ TEST_F(ShellTest, CacheSkSLWorks) {
   settings.dump_skp_on_shader_compilation = true;
   auto normal_config = RunConfiguration::InferFromSettings(settings);
   normal_config.SetEntrypoint("emptyMain");
-  shell.reset();
+  DestroyShell(std::move(shell));
   shell = CreateShell(settings);
   PlatformViewNotifyCreated(shell.get());
   RunEngine(shell.get(), std::move(normal_config));
@@ -120,6 +120,7 @@ TEST_F(ShellTest, CacheSkSLWorks) {
     return true;
   };
   fml::VisitFiles(dir.fd(), remove_visitor);
+  DestroyShell(std::move(shell));
 }
 
 }  // namespace testing

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -283,15 +283,14 @@ Shell::Shell(DartVMRef vm, TaskRunners task_runners, Settings settings)
   FML_DCHECK(task_runners_.IsValid());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
-  // Generate a WeakPtrFactory for use with the GPU thread. This does not need to wait
-  // on a latch because it can only ever be used from the GPU thread from this class,
-  // so we have ordering guarantees.
+  // Generate a WeakPtrFactory for use with the GPU thread. This does not need
+  // to wait on a latch because it can only ever be used from the GPU thread
+  // from this class, so we have ordering guarantees.
   fml::TaskRunner::RunNowOrPostTask(
-      task_runners_.GetGPUTaskRunner(),
-      fml::MakeCopyable(
-          [this]() mutable {
-            this->weak_factory_gpu_ = std::make_unique<fml::WeakPtrFactory<Shell>>(this);
-          }));
+      task_runners_.GetGPUTaskRunner(), fml::MakeCopyable([this]() mutable {
+        this->weak_factory_gpu_ =
+            std::make_unique<fml::WeakPtrFactory<Shell>>(this);
+      }));
 
   // Install service protocol handlers.
 
@@ -342,12 +341,13 @@ Shell::~Shell() {
 
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetGPUTaskRunner(),
-      fml::MakeCopyable(
-          [rasterizer = std::move(rasterizer_), weak_factory_gpu = std::move(weak_factory_gpu_), &gpu_latch]() mutable {
-            rasterizer.reset();
-            weak_factory_gpu.reset();
-            gpu_latch.Signal();
-          }));
+      fml::MakeCopyable([rasterizer = std::move(rasterizer_),
+                         weak_factory_gpu = std::move(weak_factory_gpu_),
+                         &gpu_latch]() mutable {
+        rasterizer.reset();
+        weak_factory_gpu.reset();
+        gpu_latch.Signal();
+      }));
   gpu_latch.Wait();
 
   fml::TaskRunner::RunNowOrPostTask(
@@ -499,10 +499,12 @@ bool Shell::Setup(std::unique_ptr<PlatformView> platform_view,
 
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetUITaskRunner(),
-      fml::MakeCopyable([engine = weak_engine_, &ui_latch, &display_refresh_rate = this->display_refresh_rate_]() mutable {
-        display_refresh_rate = engine->GetDisplayRefreshRate();
-        ui_latch.Signal();
-      }));
+      fml::MakeCopyable(
+          [engine = weak_engine_, &ui_latch,
+           &display_refresh_rate = this->display_refresh_rate_]() mutable {
+            display_refresh_rate = engine->GetDisplayRefreshRate();
+            ui_latch.Signal();
+          }));
   ui_latch.Wait();
 
   return true;

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1090,7 +1090,6 @@ void Shell::OnFrameRasterized(const FrameTiming& timing) {
     // Also make sure that frame times get reported with a max latency of 1
     // second. Otherwise, the timings of last few frames of an animation may
     // never be reported until the next animation starts.
-
     frame_timings_report_scheduled_ = true;
     task_runners_.GetGPUTaskRunner()->PostDelayedTask(
         [self = weak_factory_gpu_->GetWeakPtr()]() {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -97,10 +97,10 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
   // when calling Shell::Setup() when resolving the io_manager_future.
   fml::TaskRunner::RunNowOrPostTask(
       io_task_runner,
-      [&io_manager_promise,                          //
-       &weak_io_manager_promise,                     //
-       platform_view = platform_view.get(),          //
-       io_task_runner                                //
+      [&io_manager_promise,                  //
+       &weak_io_manager_promise,             //
+       platform_view = platform_view.get(),  //
+       io_task_runner                        //
   ]() {
         TRACE_EVENT0("flutter", "ShellSetupIOSubsystem");
         auto io_manager = std::make_unique<ShellIOManager>(

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -518,7 +518,7 @@ class Shell final : public PlatformView::Delegate,
   fml::WeakPtrFactory<Shell> weak_factory_;
 
   // For accessing the Shell via the GPU thread, necessary for various
-  // rasterizer callbacks
+  // rasterizer callbacks.
   std::unique_ptr<fml::WeakPtrFactory<Shell>> weak_factory_gpu_;
 
   friend class testing::ShellTest;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -517,7 +517,8 @@ class Shell final : public PlatformView::Delegate,
 
   fml::WeakPtrFactory<Shell> weak_factory_;
 
-  // For accessing the Shell via the GPU thread, necessary for various rasterizer callbacks
+  // For accessing the Shell via the GPU thread, necessary for various
+  // rasterizer callbacks
   std::unique_ptr<fml::WeakPtrFactory<Shell>> weak_factory_gpu_;
 
   friend class testing::ShellTest;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -74,7 +74,8 @@ enum class DartErrorCode {
 /// platform task runner. In case the embedder wants to directly access a shell
 /// subcomponent, it is the embedder's responsibility to acquire a weak pointer
 /// to that component and post a task to the task runner used by the component
-/// to access its methods.
+/// to access its methods. The shell must also be destroyed on the platform
+/// task runner.
 ///
 /// There is no explicit API to bootstrap and shutdown the Dart VM. The first
 /// instance of the shell in the process bootstraps the Dart VM and the

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -517,6 +517,9 @@ class Shell final : public PlatformView::Delegate,
 
   fml::WeakPtrFactory<Shell> weak_factory_;
 
+  // For accessing the Shell via the GPU thread, necessary for various rasterizer callbacks
+  std::unique_ptr<fml::WeakPtrFactory<Shell>> weak_factory_gpu_;
+
   friend class testing::ShellTest;
 
   FML_DISALLOW_COPY_AND_ASSIGN(Shell);

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -252,10 +252,11 @@ void ShellTest::DestroyShell(std::unique_ptr<Shell> shell) {
 void ShellTest::DestroyShell(std::unique_ptr<Shell> shell,
                              TaskRunners task_runners) {
   fml::AutoResetWaitableEvent latch;
-  fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(), [&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
+  fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(),
+                                    [&shell, &latch]() mutable {
+                                      shell.reset();
+                                      latch.Signal();
+                                    });
   latch.Wait();
 }
 

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -245,6 +245,20 @@ std::unique_ptr<Shell> ShellTest::CreateShell(Settings settings,
       });
 }
 
+void ShellTest::DestroyShell(std::unique_ptr<Shell> shell) {
+  DestroyShell(std::move(shell), GetTaskRunnersForFixture());
+}
+
+void ShellTest::DestroyShell(std::unique_ptr<Shell> shell,
+                             TaskRunners task_runners) {
+  fml::AutoResetWaitableEvent latch;
+  fml::TaskRunner::RunNowOrPostTask(task_runners.GetPlatformTaskRunner(), [&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+  latch.Wait();
+}
+
 // |testing::ThreadTest|
 void ShellTest::SetUp() {
   ThreadTest::SetUp();

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -34,6 +34,9 @@ class ShellTest : public ThreadTest {
   std::unique_ptr<Shell> CreateShell(Settings settings,
                                      TaskRunners task_runners,
                                      bool simulate_vsync = false);
+  void DestroyShell(std::unique_ptr<Shell> shell);
+  void DestroyShell(std::unique_ptr<Shell> shell,
+                    TaskRunners task_runners);
   TaskRunners GetTaskRunnersForFixture();
 
   void SendEnginePlatformMessage(Shell* shell,

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -35,8 +35,7 @@ class ShellTest : public ThreadTest {
                                      TaskRunners task_runners,
                                      bool simulate_vsync = false);
   void DestroyShell(std::unique_ptr<Shell> shell);
-  void DestroyShell(std::unique_ptr<Shell> shell,
-                    TaskRunners task_runners);
+  void DestroyShell(std::unique_ptr<Shell> shell, TaskRunners task_runners);
   TaskRunners GetTaskRunnersForFixture();
 
   void SendEnginePlatformMessage(Shell* shell,

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -883,6 +883,7 @@ TEST_F(ShellTest, TextureFrameMarkedAvailableAndUnregister) {
   latch->Wait();
 
   EXPECT_EQ(mockTexture->unregistered(), true);
+  DestroyShell(std::move(shell), std::move(task_runners));
 }
 
 TEST_F(ShellTest, IsolateCanAccessPersistentIsolateData) {
@@ -921,6 +922,7 @@ TEST_F(ShellTest, IsolateCanAccessPersistentIsolateData) {
   });
 
   message_latch.Wait();
+  DestroyShell(std::move(shell), std::move(task_runners));
 }
 
 }  // namespace testing

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -75,7 +75,16 @@ TEST_F(ShellTest, InitializeWithDifferentThreads) {
   auto shell = CreateShell(std::move(settings), std::move(task_runners));
   ASSERT_TRUE(ValidateShell(shell.get()));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
+
+  fml::AutoResetWaitableEvent latch;
+
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+
+  latch.Wait();
+
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -90,7 +99,14 @@ TEST_F(ShellTest, InitializeWithSingleThread) {
   auto shell = CreateShell(std::move(settings), std::move(task_runners));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
-  shell.reset();
+  fml::AutoResetWaitableEvent latch;
+
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+
+  latch.Wait();
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -104,7 +120,14 @@ TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
   auto shell = CreateShell(std::move(settings), std::move(task_runners));
   ASSERT_TRUE(ValidateShell(shell.get()));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
+  fml::AutoResetWaitableEvent latch;
+
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+
+  latch.Wait();
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -132,7 +155,14 @@ TEST_F(ShellTest,
       });
   ASSERT_TRUE(ValidateShell(shell.get()));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
+  fml::AutoResetWaitableEvent latch;
+
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+
+  latch.Wait();
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -152,7 +182,14 @@ TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
   auto shell = CreateShell(std::move(settings), std::move(task_runners));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
-  shell.reset();
+  fml::AutoResetWaitableEvent latch;
+
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+
+  latch.Wait();
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -174,7 +211,14 @@ TEST_F(ShellTest, FixturesAreFunctional) {
   RunEngine(shell.get(), std::move(configuration));
   main_latch.Wait();
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
+  fml::AutoResetWaitableEvent latch;
+
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+
+  latch.Wait();
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -198,7 +242,12 @@ TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
   latch.Wait();
 
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  shell.reset();
+  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
+    shell.reset();
+    latch.Signal();
+  });
+
+  latch.Wait();
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -75,16 +75,7 @@ TEST_F(ShellTest, InitializeWithDifferentThreads) {
   auto shell = CreateShell(std::move(settings), std::move(task_runners));
   ASSERT_TRUE(ValidateShell(shell.get()));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-
-  fml::AutoResetWaitableEvent latch;
-
-  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
-
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -96,17 +87,10 @@ TEST_F(ShellTest, InitializeWithSingleThread) {
   auto task_runner = thread_host.platform_thread->GetTaskRunner();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
-  auto shell = CreateShell(std::move(settings), std::move(task_runners));
+  auto shell = CreateShell(std::move(settings), task_runners);
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
-  fml::AutoResetWaitableEvent latch;
-
-  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -117,17 +101,10 @@ TEST_F(ShellTest, InitializeWithSingleThreadWhichIsTheCallingThread) {
   auto task_runner = fml::MessageLoop::GetCurrent().GetTaskRunner();
   TaskRunners task_runners("test", task_runner, task_runner, task_runner,
                            task_runner);
-  auto shell = CreateShell(std::move(settings), std::move(task_runners));
+  auto shell = CreateShell(std::move(settings), task_runners);
   ASSERT_TRUE(ValidateShell(shell.get()));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  fml::AutoResetWaitableEvent latch;
-
-  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -155,14 +132,7 @@ TEST_F(ShellTest,
       });
   ASSERT_TRUE(ValidateShell(shell.get()));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  fml::AutoResetWaitableEvent latch;
-
-  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -182,14 +152,7 @@ TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
   auto shell = CreateShell(std::move(settings), std::move(task_runners));
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
   ASSERT_TRUE(ValidateShell(shell.get()));
-  fml::AutoResetWaitableEvent latch;
-
-  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
+  DestroyShell(std::move(shell), std::move(task_runners));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -211,14 +174,7 @@ TEST_F(ShellTest, FixturesAreFunctional) {
   RunEngine(shell.get(), std::move(configuration));
   main_latch.Wait();
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  fml::AutoResetWaitableEvent latch;
-
-  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
+  DestroyShell(std::move(shell));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -242,12 +198,7 @@ TEST_F(ShellTest, SecondaryIsolateBindingsAreSetupViaShellSettings) {
   latch.Wait();
 
   ASSERT_TRUE(DartVMRef::IsInstanceRunning());
-  task_runners.GetPlatformTaskRunner()->PostTask([&shell, &latch]() mutable {
-    shell.reset();
-    latch.Signal();
-  });
-
-  latch.Wait();
+  DestroyShell(std::move(shell));
   ASSERT_FALSE(DartVMRef::IsInstanceRunning());
 }
 
@@ -330,6 +281,7 @@ TEST_F(ShellTest, NoNeedToReportTimingsByDefault) {
   // positive in any tests. Otherwise those tests will be flaky as the clearing
   // of unreported timings is unpredictive.
   ASSERT_EQ(UnreportedTimingsCount(shell.get()), 0);
+  DestroyShell(std::move(shell));
 }
 
 TEST_F(ShellTest, NeedsReportTimingsIsSetWithCallback) {
@@ -345,6 +297,7 @@ TEST_F(ShellTest, NeedsReportTimingsIsSetWithCallback) {
   RunEngine(shell.get(), std::move(configuration));
   PumpOneFrame(shell.get());
   ASSERT_TRUE(GetNeedsReportTimings(shell.get()));
+  DestroyShell(std::move(shell));
 }
 
 static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
@@ -399,7 +352,7 @@ TEST_F(ShellTest, ReportTimingsIsCalled) {
   }
 
   reportLatch.Wait();
-  shell.reset();
+  DestroyShell(std::move(shell));
 
   fml::TimePoint finish = fml::TimePoint::Now();
   ASSERT_TRUE(timestamps.size() > 0);
@@ -469,6 +422,7 @@ TEST_F(ShellTest, FrameRasterizedCallbackIsCalled) {
   int64_t build_start =
       timing.Get(FrameTiming::kBuildStart).ToEpochDelta().ToMicroseconds();
   ASSERT_EQ(build_start, begin_frame);
+  DestroyShell(std::move(shell));
 }
 
 TEST(SettingsTest, FrameTimingSetsAndGetsProperly) {
@@ -523,7 +477,7 @@ TEST_F(ShellTest, ReportTimingsIsCalledSoonerInNonReleaseMode) {
   PumpOneFrame(shell.get());
 
   reportLatch.Wait();
-  shell.reset();
+  DestroyShell(std::move(shell));
 
   fml::TimePoint finish = fml::TimePoint::Now();
   fml::TimeDelta ellapsed = finish - start;
@@ -567,7 +521,7 @@ TEST_F(ShellTest, ReportTimingsIsCalledImmediatelyAfterTheFirstFrame) {
   }
 
   reportLatch.Wait();
-  shell.reset();
+  DestroyShell(std::move(shell));
 
   // Check for the immediate callback of the first frame that doesn't wait for
   // the other 9 frames to be rasterized.
@@ -619,6 +573,7 @@ TEST_F(ShellTest, WaitForFirstFrame) {
   fml::Status result =
       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1000));
   ASSERT_TRUE(result.ok());
+  DestroyShell(std::move(shell));
 }
 
 TEST_F(ShellTest, WaitForFirstFrameTimeout) {
@@ -635,6 +590,7 @@ TEST_F(ShellTest, WaitForFirstFrameTimeout) {
   fml::Status result =
       shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(10));
   ASSERT_EQ(result.code(), fml::StatusCode::kDeadlineExceeded);
+  DestroyShell(std::move(shell));
 }
 
 TEST_F(ShellTest, WaitForFirstFrameMultiple) {
@@ -656,6 +612,7 @@ TEST_F(ShellTest, WaitForFirstFrameMultiple) {
     result = shell->WaitForFirstFrame(fml::TimeDelta::FromMilliseconds(1));
     ASSERT_TRUE(result.ok());
   }
+  DestroyShell(std::move(shell));
 }
 
 /// Makes sure that WaitForFirstFrame works if we rendered a frame with the
@@ -684,6 +641,7 @@ TEST_F(ShellTest, WaitForFirstFrameInlined) {
     event.Signal();
   });
   ASSERT_FALSE(event.WaitWithTimeout(fml::TimeDelta::FromMilliseconds(1000)));
+  DestroyShell(std::move(shell), std::move(task_runners));
 }
 
 static size_t GetRasterizerResourceCacheBytesSync(Shell& shell) {
@@ -748,6 +706,7 @@ TEST_F(ShellTest, SetResourceCacheSize) {
   PumpOneFrame(shell.get());
 
   EXPECT_EQ(GetRasterizerResourceCacheBytesSync(*shell), 10000U);
+  DestroyShell(std::move(shell), std::move(task_runners));
 }
 
 TEST_F(ShellTest, SetResourceCacheSizeEarly) {
@@ -776,6 +735,7 @@ TEST_F(ShellTest, SetResourceCacheSizeEarly) {
 
   EXPECT_EQ(GetRasterizerResourceCacheBytesSync(*shell),
             static_cast<size_t>(3840000U));
+  DestroyShell(std::move(shell), std::move(task_runners));
 }
 
 TEST_F(ShellTest, SetResourceCacheSizeNotifiesDart) {
@@ -814,6 +774,7 @@ TEST_F(ShellTest, SetResourceCacheSizeNotifiesDart) {
 
   EXPECT_EQ(GetRasterizerResourceCacheBytesSync(*shell),
             static_cast<size_t>(10000U));
+  DestroyShell(std::move(shell), std::move(task_runners));
 }
 
 TEST_F(ShellTest, CanCreateImagefromDecompressedBytes) {
@@ -847,6 +808,7 @@ TEST_F(ShellTest, CanCreateImagefromDecompressedBytes) {
   RunEngine(shell.get(), std::move(configuration));
 
   latch.Wait();
+  DestroyShell(std::move(shell), std::move(task_runners));
 }
 
 class MockTexture : public Texture {


### PR DESCRIPTION
This patch re-enables the disabled ThreadChecker which is used by the WeakPtrFactory to ensure we access it on the correct threads. This highlighted a bunch of threading issues surrounding Shell.

This patch is not final, I'm creating the PR to:

- Run CI and see where we're at
- Solicit initial feedback on the fixes I've implemented.

In particular:

- Grabbing the display refresh rate adds a blocking task runner call to the constructor for Shell. Ideally I'd like to be able to do this in the existing blocking task runner call in the CreateShell factory, but because that's a static it'd require some special plumbing to get the value into the class. I'm still undecided if I like this or not.
- The rasterizer uses callbacks on the Shell which must be called from the GPU thread. The `OnFrameRasterized` callback uses a delayed task to grab the unreported frames count, by way of calling the method on a WeakPtr to the Shell. I've added a WeakPtrFactory that lives on the GPU thread which is held inside a `unique_ptr`, but I'm not sure if it's the way we want to go.