### PR TITLE
Revert "Started taking advantage of Skia's new copyTableData to avoid (#10154)"

### DIFF
--- a/third_party/txt/src/txt/font_skia.cc
+++ b/third_party/txt/src/txt/font_skia.cc
@@ -15,7 +15,6 @@
  */
 
 #include "font_skia.h"
-#include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkFont.h"
 
 #include <minikin/MinikinFont.h>
@@ -25,14 +24,21 @@ namespace {
 
 hb_blob_t* GetTable(hb_face_t* face, hb_tag_t tag, void* context) {
   SkTypeface* typeface = reinterpret_cast<SkTypeface*>(context);
-  sk_sp<SkData> data = typeface->copyTableData(tag);
-  if (!data) {
+
+  const size_t table_size = typeface->getTableSize(tag);
+  if (table_size == 0)
+    return nullptr;
+  void* buffer = malloc(table_size);
+  if (buffer == nullptr)
+    return nullptr;
+
+  size_t actual_size = typeface->getTableData(tag, 0, table_size, buffer);
+  if (table_size != actual_size) {
+    free(buffer);
     return nullptr;
   }
-  SkData* rawData = data.release();
-  return hb_blob_create(reinterpret_cast<char*>(rawData->writable_data()),
-                        rawData->size(), HB_MEMORY_MODE_WRITABLE, rawData,
-                        [](void* ctx) { ((SkData*)ctx)->unref(); });
+  return hb_blob_create(reinterpret_cast<char*>(buffer), table_size,
+                        HB_MEMORY_MODE_WRITABLE, buffer, free);
 }
 
 }  // namespace


### PR DESCRIPTION
This reverts commit 6beba539af8f4480e233f76f7820b0169467c67b as it breaks flutter on ios 32-bit devices.