### PR TITLE
Manage resource and onscreen contexts using separate IOSGLContext objects

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.h
@@ -24,8 +24,9 @@
 
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithContentsScale:(CGFloat)contentsScale;
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)gl_context;
+- (std::unique_ptr<flutter::IOSSurface>)
+    createSurfaceWithOnscreenGLContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreenGLContext
+                     resourceGLContext:(fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext;
 
 @end
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterOverlayView.mm
@@ -78,15 +78,17 @@
 #endif  // TARGET_IPHONE_SIMULATOR
 }
 
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)gl_context {
+- (std::unique_ptr<flutter::IOSSurface>)
+    createSurfaceWithOnscreenGLContext:(fml::WeakPtr<flutter::IOSGLContext>)onscreenGLContext
+                     resourceGLContext:(fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext {
   if ([self.layer isKindOfClass:[CAEAGLLayer class]]) {
     fml::scoped_nsobject<CAEAGLLayer> eagl_layer(
         reinterpret_cast<CAEAGLLayer*>([self.layer retain]));
     if (@available(iOS 9.0, *)) {
       eagl_layer.get().presentsWithTransaction = YES;
     }
-    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), gl_context);
+    return std::make_unique<flutter::IOSSurfaceGL>(std::move(eagl_layer), onscreenGLContext,
+                                                   resourceGLContext);
 #if FLUTTER_SHELL_ENABLE_METAL
   } else if ([self.layer isKindOfClass:[CAMetalLayer class]]) {
     fml::scoped_nsobject<CAMetalLayer> metalLayer(

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h
@@ -100,7 +100,9 @@ class FlutterPlatformViewsController {
   // Discards all platform views instances and auxiliary resources.
   void Reset();
 
-  bool SubmitFrame(GrContext* gr_context, std::shared_ptr<IOSGLContext> gl_context);
+  bool SubmitFrame(GrContext* gr_context,
+                   fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                   fml::WeakPtr<IOSGLContext> resource_gl_context);
 
   void OnMethodCall(FlutterMethodCall* call, FlutterResult& result);
 
@@ -162,7 +164,8 @@ class FlutterPlatformViewsController {
   // Dispose the views in `views_to_dispose_`.
   void DisposeViews();
   void EnsureOverlayInitialized(int64_t overlay_id,
-                                std::shared_ptr<IOSGLContext> gl_context,
+                                fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+                                fml::WeakPtr<IOSGLContext> resource_gl_context,
                                 GrContext* gr_context);
 
   // This will return true after pre-roll if any of the embedded views

--- a/shell/platform/darwin/ios/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/ios/framework/Source/FlutterView.h
@@ -33,8 +33,8 @@
 
 - (instancetype)initWithDelegate:(id<FlutterViewEngineDelegate>)delegate
                           opaque:(BOOL)opaque NS_DESIGNATED_INITIALIZER;
-- (std::unique_ptr<flutter::IOSSurface>)createSurface:
-    (std::shared_ptr<flutter::IOSGLContext>)context;
+- (std::unique_ptr<flutter::IOSSurface>)createSurfaceWithResourceGLContext:
+    (fml::WeakPtr<flutter::IOSGLContext>)resourceGLContext;
 
 @end
 

--- a/shell/platform/darwin/ios/ios_gl_context.h
+++ b/shell/platform/darwin/ios/ios_gl_context.h
@@ -13,29 +13,31 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/common/platform_view.h"
-#include "ios_gl_render_target.h"
 
 namespace flutter {
 
 class IOSGLContext {
  public:
   IOSGLContext();
+  IOSGLContext(EAGLSharegroup* sharegroup);
 
   ~IOSGLContext();
 
-  std::unique_ptr<IOSGLRenderTarget> CreateRenderTarget(
-      fml::scoped_nsobject<CAEAGLLayer> layer);
-
   bool MakeCurrent();
 
-  bool ResourceMakeCurrent();
+  bool BindRenderbufferStorage(fml::scoped_nsobject<CAEAGLLayer> layer);
 
   sk_sp<SkColorSpace> ColorSpace() const { return color_space_; }
 
+  std::unique_ptr<IOSGLContext> MakeSharedContext();
+
+  fml::WeakPtr<IOSGLContext> GetWeakPtr();
+
  private:
   fml::scoped_nsobject<EAGLContext> context_;
-  fml::scoped_nsobject<EAGLContext> resource_context_;
   sk_sp<SkColorSpace> color_space_;
+
+  std::unique_ptr<fml::WeakPtrFactory<IOSGLContext>> weak_factory_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSGLContext);
 };

--- a/shell/platform/darwin/ios/ios_gl_render_target.h
+++ b/shell/platform/darwin/ios/ios_gl_render_target.h
@@ -13,14 +13,15 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/shell/common/platform_view.h"
+#include "flutter/shell/platform/darwin/ios/ios_gl_context.h"
 
 namespace flutter {
 
 class IOSGLRenderTarget {
  public:
   IOSGLRenderTarget(fml::scoped_nsobject<CAEAGLLayer> layer,
-                    EAGLContext* context,
-                    EAGLContext* resource_context);
+                    fml::WeakPtr<IOSGLContext> onscreen_context,
+                    fml::WeakPtr<IOSGLContext> resource_context);
 
   ~IOSGLRenderTarget();
 
@@ -40,8 +41,8 @@ class IOSGLRenderTarget {
 
  private:
   fml::scoped_nsobject<CAEAGLLayer> layer_;
-  fml::scoped_nsobject<EAGLContext> context_;
-  fml::scoped_nsobject<EAGLContext> resource_context_;
+  fml::WeakPtr<IOSGLContext> onscreen_gl_context_;
+  fml::WeakPtr<IOSGLContext> resource_gl_context_;
   GLuint framebuffer_;
   GLuint colorbuffer_;
   GLint storage_size_width_;

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -20,11 +20,14 @@ class IOSSurfaceGL final : public IOSSurface,
                            public GPUSurfaceGLDelegate,
                            public ExternalViewEmbedder {
  public:
-  IOSSurfaceGL(std::shared_ptr<IOSGLContext> context,
+  IOSSurfaceGL(fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+               fml::WeakPtr<IOSGLContext> resource_gl_context,
                fml::scoped_nsobject<CAEAGLLayer> layer,
                FlutterPlatformViewsController* platform_views_controller);
 
-  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer, std::shared_ptr<IOSGLContext> context);
+  IOSSurfaceGL(fml::scoped_nsobject<CAEAGLLayer> layer,
+               fml::WeakPtr<IOSGLContext> onscreen_gl_context,
+               fml::WeakPtr<IOSGLContext> resource_gl_context);
 
   ~IOSSurfaceGL() override;
 
@@ -79,7 +82,10 @@ class IOSSurfaceGL final : public IOSSurface,
   bool SubmitFrame(GrContext* context) override;
 
  private:
-  std::shared_ptr<IOSGLContext> context_;
+  fml::WeakPtr<IOSGLContext> onscreen_gl_context_;
+
+  fml::WeakPtr<IOSGLContext> resource_gl_context_;
+
   std::unique_ptr<IOSGLRenderTarget> render_target_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSSurfaceGL);

--- a/shell/platform/darwin/ios/ios_surface_software.mm
+++ b/shell/platform/darwin/ios/ios_surface_software.mm
@@ -184,7 +184,8 @@ bool IOSSurfaceSoftware::SubmitFrame(GrContext* context) {
   if (platform_views_controller == nullptr) {
     return true;
   }
-  return platform_views_controller->SubmitFrame(nullptr, nullptr);
+  return platform_views_controller->SubmitFrame(nullptr, fml::WeakPtr<IOSGLContext>(),
+                                                fml::WeakPtr<IOSGLContext>());
 }
 
 }  // namespace flutter

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -75,7 +75,10 @@ class PlatformViewIOS final : public PlatformView {
   // |PlatformView|
   void OnPreEngineRestart() const override;
 
+  // |PlatformView|
   void NotifyDestroyed() override;
+
+  std::unique_ptr<IOSSurface> CreateIOSSurface() const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
 };

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -47,7 +47,7 @@ class PlatformViewIOS final : public PlatformView {
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;
   std::unique_ptr<IOSSurface> ios_surface_;
-  std::shared_ptr<IOSGLContext> gl_context_;
+  std::unique_ptr<IOSGLContext> resource_gl_context_;
   PlatformMessageRouter platform_message_router_;
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;
@@ -74,6 +74,8 @@ class PlatformViewIOS final : public PlatformView {
 
   // |PlatformView|
   void OnPreEngineRestart() const override;
+
+  void NotifyDestroyed() override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(PlatformViewIOS);
 };

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -44,9 +44,9 @@ fml::WeakPtr<FlutterViewController> PlatformViewIOS::GetOwnerViewController() co
 
 std::unique_ptr<IOSSurface> PlatformViewIOS::CreateIOSSurface() const {
   if (!owner_controller_) {
-      FML_DLOG(INFO) << "Could not CreateIOSSurface, this PlatformViewIOS "
-                        "has no ViewController.";
-      return nullptr;
+    FML_DLOG(INFO) << "Could not CreateIOSSurface, this PlatformViewIOS "
+                      "has no ViewController.";
+    return nullptr;
   }
 
   fml::WeakPtr<IOSGLContext> weak_gl_context;

--- a/shell/platform/darwin/ios/platform_view_ios.mm
+++ b/shell/platform/darwin/ios/platform_view_ios.mm
@@ -23,7 +23,7 @@ PlatformViewIOS::PlatformViewIOS(PlatformView::Delegate& delegate,
                                  flutter::TaskRunners task_runners)
     : PlatformView(delegate, std::move(task_runners)) {
 #if !TARGET_IPHONE_SIMULATOR
-  gl_context_ = std::make_shared<IOSGLContext>();
+  resource_gl_context_ = std::make_unique<IOSGLContext>();
 #endif  // !TARGET_IPHONE_SIMULATOR
 }
 
@@ -42,16 +42,24 @@ fml::WeakPtr<FlutterViewController> PlatformViewIOS::GetOwnerViewController() co
   return owner_controller_;
 }
 
+void PlatformViewIOS::NotifyDestroyed() {
+  PlatformView::NotifyDestroyed();
+  ios_surface_.reset();
+}
+
 void PlatformViewIOS::SetOwnerViewController(fml::WeakPtr<FlutterViewController> owner_controller) {
   if (ios_surface_ || !owner_controller) {
     NotifyDestroyed();
-    ios_surface_.reset();
     accessibility_bridge_.reset();
   }
   owner_controller_ = owner_controller;
   if (owner_controller_) {
-    ios_surface_ =
-        [static_cast<FlutterView*>(owner_controller.get().view) createSurface:gl_context_];
+    fml::WeakPtr<IOSGLContext> weak_gl_context;
+    if (resource_gl_context_) {
+      weak_gl_context = resource_gl_context_->GetWeakPtr();
+    }
+    ios_surface_ = [static_cast<FlutterView*>(owner_controller.get().view)
+        createSurfaceWithResourceGLContext:weak_gl_context];
     FML_DCHECK(ios_surface_ != nullptr);
 
     if (accessibility_bridge_) {
@@ -83,7 +91,7 @@ std::unique_ptr<Surface> PlatformViewIOS::CreateRenderingSurface() {
 
 // |PlatformView|
 sk_sp<GrContext> PlatformViewIOS::CreateResourceContext() const {
-  if (!gl_context_ || !gl_context_->ResourceMakeCurrent()) {
+  if (!resource_gl_context_ || !resource_gl_context_->MakeCurrent()) {
     FML_DLOG(INFO) << "Could not make resource context current on IO thread. "
                       "Async texture uploads will be disabled. On Simulators, "
                       "this is expected.";


### PR DESCRIPTION
Attempt 3. So the issue here was that with the change to WeakPtr for IOSGLContext we ended up with a nullptr deref on simulator where there is no GL context.

I've fixed that and verified it passes LUCI: 

https://chromium-swarm.appspot.com/task?id=4744ea5e1a2d3010#
https://chromium-swarm.appspot.com/task?id=4745214d8f1a6610

I am also going to file a follow up issue to clean up the logic surrounding `[FlutterView createSurfaceWithResourceGLContext]` as it's quite confusing right now with the way it deals with simulator and device.