### PR TITLE
Adds PluginRegistry to the C++ client wrapper API

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -684,6 +684,7 @@ FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_codec.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h
+FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_message_codec.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/json_message_codec.cc

--- a/shell/platform/common/cpp/client_wrapper/core_wrapper_files.gni
+++ b/shell/platform/common/cpp/client_wrapper/core_wrapper_files.gni
@@ -17,6 +17,7 @@ core_cpp_client_wrapper_includes =
                     "include/flutter/method_codec.h",
                     "include/flutter/method_result.h",
                     "include/flutter/plugin_registrar.h",
+                    "include/flutter/plugin_registry.h",
                     "include/flutter/standard_message_codec.h",
                     "include/flutter/standard_method_codec.h",
                   ],

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
@@ -17,6 +17,7 @@ namespace flutter {
 // plugin's main class.
 class PluginRegistry {
  public:
+  PluginRegistry() = default;
   virtual ~PluginRegistry() = default;
 
   // Returns the FlutterDesktopPluginRegistrarRef to register a plugin with the

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_COMMON_CPP_CLIENT_WRAPPER_INCLUDE_FLUTTER_PLUGIN_REGISTRY_H_
+#define FLUTTER_SHELL_PLATFORM_COMMON_CPP_CLIENT_WRAPPER_INCLUDE_FLUTTER_PLUGIN_REGISTRY_H_
+
+#include <string>
+
+#include <flutter_plugin_registrar.h>
+
+namespace flutter {
+
+// Vends PluginRegistrars for named plugins.
+//
+// Plugins are identified by unique string keys, typically the name of the
+// plugin's main class.
+class PluginRegistry {
+ public:
+  virtual ~PluginRegistry() = default;
+
+  // Returns the FlutterDesktopPluginRegistrarRef to register a plugin with the
+  // given name.
+  //
+  // The name must be unique across the application.
+  virtual FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
+      const std::string& plugin_name);
+
+  // Prevent copying.
+  PluginRegistry(PluginRegistry const&) = delete;
+  PluginRegistry& operator=(PluginRegistry const&) = delete;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_COMMON_CPP_CLIENT_WRAPPER_INCLUDE_FLUTTER_PLUGIN_REGISTRY_H_

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
@@ -20,16 +20,16 @@ class PluginRegistry {
   PluginRegistry() = default;
   virtual ~PluginRegistry() = default;
 
+  // Prevent copying.
+  PluginRegistry(PluginRegistry const&) = delete;
+  PluginRegistry& operator=(PluginRegistry const&) = delete;
+
   // Returns the FlutterDesktopPluginRegistrarRef to register a plugin with the
   // given name.
   //
   // The name must be unique across the application.
   virtual FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
-      const std::string& plugin_name);
-
-  // Prevent copying.
-  PluginRegistry(PluginRegistry const&) = delete;
-  PluginRegistry& operator=(PluginRegistry const&) = delete;
+      const std::string& plugin_name) = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
@@ -41,14 +41,14 @@ struct WindowProperties {
 // requires control of the application's event loop, and is thus useful
 // primarily for building a simple one-window shell hosting a Flutter
 // application. The final implementation and API will be very different.
-class FlutterWindowController {
+class FlutterWindowController : public PluginRegistry {
  public:
   // There must be only one instance of this class in an application at any
   // given time, as Flutter does not support multiple engines in one process,
   // or multiple views in one engine.
   explicit FlutterWindowController(const std::string& icu_data_path);
 
-  ~FlutterWindowController();
+  virtual ~FlutterWindowController();
 
   // Prevent copying.
   FlutterWindowController(FlutterWindowController const&) = delete;

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
@@ -14,6 +14,7 @@
 
 #include "flutter_window.h"
 #include "plugin_registrar.h"
+#include "plugin_registry.h"
 
 namespace flutter {
 
@@ -68,13 +69,6 @@ class FlutterWindowController {
                     const std::string& assets_path,
                     const std::vector<std::string>& arguments);
 
-  // Returns the FlutterDesktopPluginRegistrarRef to register a plugin with the
-  // given name.
-  //
-  // The name must be unique across the application.
-  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
-      const std::string& plugin_name);
-
   // The FlutterWindow managed by this controller, if any. Returns nullptr
   // before CreateWindow is called, and after RunEventLoop returns;
   FlutterWindow* window() { return window_.get(); }
@@ -88,6 +82,10 @@ class FlutterWindowController {
 
   // Deprecated. Use RunEventLoopWithTimeout.
   void RunEventLoop();
+
+  // flutter::PluginRegistry:
+  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
+      const std::string& plugin_name) override;
 
  private:
   // The path to the ICU data file. Set at creation time since it is the same

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "plugin_registrar.h"
+#include "plugin_registry.h"
 
 namespace flutter {
 
@@ -47,19 +48,16 @@ class FlutterViewController {
   FlutterViewController(FlutterViewController const&) = delete;
   FlutterViewController& operator=(FlutterViewController const&) = delete;
 
-  // Returns the FlutterDesktopPluginRegistrarRef to register a plugin with the
-  // given name.
-  //
-  // The name must be unique across the application.
-  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
-      const std::string& plugin_name);
-
   // Return backing HWND for manipulation in host application.
   HWND GetNativeWindow();
 
   // Must be called in run loop to enable the view to do work on each tick of
   // loop.
   void ProcessMessages();
+
+  // flutter::PluginRegistry:
+  FlutterDesktopPluginRegistrarRef GetRegistrarForPlugin(
+      const std::string& plugin_name) override;
 
  private:
   // The path to the ICU data file. Set at creation time since it is the same

--- a/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
+++ b/shell/platform/windows/client_wrapper/include/flutter/flutter_view_controller.h
@@ -20,7 +20,7 @@ namespace flutter {
 // This is the primary wrapper class for the desktop C API.
 // If you use this class, you should not call any of the setup or teardown
 // methods in the C API directly, as this class will do that internally.
-class FlutterViewController {
+class FlutterViewController : public PluginRegistry {
  public:
   // There must be only one instance of this class in an application at any
   // given time, as Flutter does not support multiple engines in one process,
@@ -42,7 +42,7 @@ class FlutterViewController {
                                  const std::string& assets_path,
                                  const std::vector<std::string>& arguments);
 
-  ~FlutterViewController();
+  virtual ~FlutterViewController();
 
   // Prevent copying.
   FlutterViewController(FlutterViewController const&) = delete;


### PR DESCRIPTION
Makes the plugin registration structure consistent with macOS. This will
be used in generated plugin registrant files rather than a specific
implemenation class, so this helps unblock the creation of generated
registrants on Windows and Linux.