### PR TITLE
Include firefox in check to quote font families

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -123,11 +123,11 @@ class _FontManager {
     String asset,
     Map<String, String> descriptors,
   ) {
-    // Safari crashes if you create a [html.FontFace] with a font family that
-    // is not correct CSS syntax. To ensure the font family is accepted on
-    // Safari, wrap it in quotes.
+    // Safari and Firefox crashes if you create a [html.FontFace] with a font
+    // family that is not correct CSS syntax. To ensure the font family is
+    // accepted on these browsers, wrap it in quotes.
     // See: https://drafts.csswg.org/css-fonts-3/#font-family-prop
-    if (browserEngine == BrowserEngine.webkit) {
+    if (browserEngine == BrowserEngine.webkit || browserEngine == BrowserEngine.firefox) {
       family = "'$family'";
     }
     // try/catch because `new FontFace` can crash with an improper font family.

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -123,7 +123,7 @@ class _FontManager {
     String asset,
     Map<String, String> descriptors,
   ) {
-    // Safari and Firefox crashes if you create a [html.FontFace] with a font
+    // Safari and Firefox crash if you create a [html.FontFace] with a font
     // family that is not correct CSS syntax. To ensure the font family is
     // accepted on these browsers, wrap it in quotes.
     // See: https://drafts.csswg.org/css-fonts-3/#font-family-prop

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1118,7 +1118,7 @@ class PluginUtilities {
 }
 
 // TODO(flutter_web): see https://github.com/flutter/flutter/issues/33616.
-class ImageShader {
+class ImageShader implements Shader {
   ImageShader(Image image, TileMode tmx, TileMode tmy, Float64List matrix4);
 }
 

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1118,7 +1118,7 @@ class PluginUtilities {
 }
 
 // TODO(flutter_web): see https://github.com/flutter/flutter/issues/33616.
-class ImageShader implements Shader {
+class ImageShader {
   ImageShader(Image image, TileMode tmx, TileMode tmy, Float64List matrix4);
 }
 


### PR DESCRIPTION
Both Firefox and Safari require quoted font families. Add a check to the browser detection here.

Fixes https://github.com/flutter/flutter/issues/40501