### PR TITLE
Add "type" to getDisplayRefreshRate protocol

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -1268,6 +1268,7 @@ bool Shell::OnServiceProtocolGetDisplayRefreshRate(
     rapidjson::Document& response) {
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
   response.SetObject();
+  response.AddMember("type", "DisplayRefreshRate", response.GetAllocator());
   response.AddMember("fps", engine_->GetDisplayRefreshRate(),
                      response.GetAllocator());
   return true;


### PR DESCRIPTION
Per kenzieschmoll's request.

Will update https://github.com/flutter/flutter/wiki/Engine-specific-Service-Protocol-extensions once this is merged.