### PR TITLE
Fix continuous event polling in the GLFW event loop

### DIFF
--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -739,9 +739,10 @@ void FlutterDesktopWindowSetPixelRatioOverride(
 bool FlutterDesktopRunWindowEventLoopWithTimeout(
     FlutterDesktopWindowControllerRef controller,
     uint32_t timeout_milliseconds) {
-  auto wait_duration = timeout_milliseconds == 0
-                           ? std::chrono::milliseconds::max()
-                           : std::chrono::milliseconds(timeout_milliseconds);
+  std::chrono::nanoseconds wait_duration =
+      timeout_milliseconds == 0
+          ? std::chrono::nanoseconds::max()
+          : std::chrono::milliseconds(timeout_milliseconds);
   controller->event_loop->WaitForEvents(wait_duration);
 
   return !glfwWindowShouldClose(controller->window.get());


### PR DESCRIPTION
* Do not pass a milliseconds::max() timeout that will overflow when converted
  to nanoseconds
* Avoid holding the task_queue_mutex_ while calling glfwWaitEventsTimeout
* Use a signed type to hold the difference between a task's timestamp and
  the current engine time

Fixes https://github.com/flutter/flutter/issues/40281