### PR TITLE
Ensure DRRects without corners also draw.

### DIFF
--- a/lib/web_ui/lib/src/engine/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/recording_canvas.dart
@@ -234,7 +234,8 @@ class RecordingCanvas {
     // Ensure inner is fully contained within outer, by comparing its
     // defining points (including its border radius)
     ui.Rect innerRect = inner.outerRect;
-    if (outer.outerRect.intersect(innerRect) != innerRect) {
+    ui.Rect outerRect = outer.outerRect;
+    if (outerRect == innerRect || outerRect.intersect(innerRect) != innerRect) {
       return; // inner is not fully contained within outer
     }
 
@@ -252,7 +253,7 @@ class RecordingCanvas {
     final double innerBl = _getDistance(scaledInner.blRadiusX, scaledInner.blRadiusY);
     final double innerBr = _getDistance(scaledInner.brRadiusX, scaledInner.brRadiusY);
 
-    if (innerTl >= outerTl || innerTr >= outerTr || innerBl >= outerBl || innerBr >= outerBr) {
+    if (innerTl > outerTl || innerTr > outerTr || innerBl > outerBl || innerBr > outerBr) {
       return; // Some inner radius is overlapping some outer radius
     }
 

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -25,15 +25,12 @@ void main() {
     test('Happy case', () {
       underTest.drawDRRect(rrect, rrect.deflate(1), somePaint);
       underTest.apply(mockCanvas);
-      // Expect drawDRRect to be called
-      expect(mockCanvas.methodCallLog.length, equals(1));
-      MockCanvasCall mockCall = mockCanvas.methodCallLog[0];
-      expect(mockCall.methodName, equals('drawDRRect'));
-      expect(mockCall.arguments, equals({
+
+      _expectDrawCall(mockCanvas, {
           'outer': rrect,
           'inner': rrect.deflate(1),
           'paint': somePaint.webOnlyPaintData,
-        }));
+        });
     });
 
     test('Inner RRect > Outer RRect', () {
@@ -56,5 +53,27 @@ void main() {
       // Expect nothing to be called
       expect(mockCanvas.methodCallLog.length, equals(0));
     });
+
+    test('preserve old scuba test behavior', () {
+      final RRect outer = RRect.fromRectAndCorners(const Rect.fromLTRB(10, 20, 30, 40));
+      final RRect inner = RRect.fromRectAndCorners(const Rect.fromLTRB(12, 22, 28, 38));
+
+      underTest.drawDRRect(outer, inner, somePaint);
+      underTest.apply(mockCanvas);
+
+      _expectDrawCall(mockCanvas, {
+          'outer': outer,
+          'inner': inner,
+          'paint': somePaint.webOnlyPaintData,
+        });
+    });
   });
+}
+
+// Expect a drawDRRect call to be registered in the mock call log, with the expectedArguments
+void _expectDrawCall(MockEngineCanvas mock, Map<String, dynamic> expectedArguments) {
+  expect(mock.methodCallLog.length, equals(1));
+  MockCanvasCall mockCall = mock.methodCallLog[0];
+  expect(mockCall.methodName, equals('drawDRRect'));
+  expect(mockCall.arguments, equals(expectedArguments));
 }


### PR DESCRIPTION
Uncovered this bug running some additional engine tests. 

Backported the affected test, and fixed the recording_canvas code to behave as expected.