### PR TITLE
Update test to verify that secondary isolate gets shutdown before root isolate exits.

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -774,6 +774,10 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
 void DartIsolate::DartIsolateShutdownCallback(
     std::shared_ptr<DartIsolate>* isolate_group_data,
     std::shared_ptr<DartIsolate>* isolate_data) {
+  TRACE_EVENT0("flutter", "DartIsolate::DartIsolateShutdownCallback");
+  FML_DLOG(INFO) << "DartIsolateShutdownCallback"
+                 << " isolate_group_data " << isolate_group_data
+                 << " isolate_data " << isolate_data;
   isolate_group_data->get()->OnShutdownCallback();
 }
 

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -381,8 +381,8 @@ TEST_F(DartIsolateTest, CanLaunchSecondaryIsolates) {
                                       "testCanLaunchSecondaryIsolate", {});
   ASSERT_TRUE(isolate);
   ASSERT_EQ(isolate->get()->GetPhase(), DartIsolate::Phase::Running);
-  child_shutdown_latch.Wait(); // wait for child isolate to shutdown first
-  latch.Wait(); // wait for last NotifyNative called by main isolate
+  child_shutdown_latch.Wait();  // wait for child isolate to shutdown first
+  latch.Wait();  // wait for last NotifyNative called by main isolate
   // root isolate will be auto-shutdown
 }
 

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -360,6 +360,7 @@ TEST_F(DartIsolateTest, CanSaveCompilationTrace) {
 
 TEST_F(DartIsolateTest, CanLaunchSecondaryIsolates) {
   fml::CountDownLatch latch(3);
+  fml::AutoResetWaitableEvent child_shutdown_latch;
   AddNativeCallback("NotifyNative",
                     CREATE_NATIVE_ENTRY(([&latch](Dart_NativeArguments args) {
                       latch.CountDown();
@@ -371,14 +372,18 @@ TEST_F(DartIsolateTest, CanLaunchSecondaryIsolates) {
         ASSERT_EQ("Hello from code is secondary isolate.", message);
         latch.CountDown();
       })));
-  const auto settings = CreateSettingsForFixture();
+  auto settings = CreateSettingsForFixture();
+  settings.isolate_shutdown_callback = [&child_shutdown_latch]() {
+    child_shutdown_latch.Signal();
+  };
   auto vm_ref = DartVMRef::Create(settings);
   auto isolate = RunDartCodeInIsolate(vm_ref, settings, CreateNewThread(),
                                       "testCanLaunchSecondaryIsolate", {});
   ASSERT_TRUE(isolate);
   ASSERT_EQ(isolate->get()->GetPhase(), DartIsolate::Phase::Running);
-
-  latch.Wait();
+  child_shutdown_latch.Wait(); // wait for child isolate to shutdown first
+  latch.Wait(); // wait for last NotifyNative called by main isolate
+  // root isolate will be auto-shutdown
 }
 
 TEST_F(DartIsolateTest, CanRecieveArguments) {

--- a/runtime/fixtures/runtime_test.dart
+++ b/runtime/fixtures/runtime_test.dart
@@ -52,8 +52,8 @@ void secondaryIsolateMain(String message) {
 
 @pragma('vm:entry-point')
 void testCanLaunchSecondaryIsolate() {
-  Isolate.spawn(secondaryIsolateMain, 'Hello from root isolate.');
-  notifyNative();
+  final onExit = RawReceivePort((_) { notifyNative(); });
+  Isolate.spawn(secondaryIsolateMain, 'Hello from root isolate.', onExit: onExit.sendPort);
 }
 
 @pragma('vm:entry-point')


### PR DESCRIPTION
Update CanLaunchSecondaryIsolates test so it waits for child isolate to get shutdown before exiting.

This test will help in context of https://github.com/flutter/engine/pull/12327. Updated test does pass with and without https://github.com/flutter/engine/commit/e6620ddb73280c5658e39b13d335aaae641c53e0