### PR TITLE
[flutter_runner] Remove usages of shared snapshots from CC sources

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -206,8 +206,7 @@ bool DartComponentController::SetupFromKernel() {
   }
 
   if (!CreateIsolate(isolate_snapshot_data_.address(),
-                     isolate_snapshot_instructions_.address(), nullptr,
-                     nullptr)) {
+                     isolate_snapshot_instructions_.address())) {
     return false;
   }
 
@@ -275,22 +274,8 @@ bool DartComponentController::SetupFromAppSnapshot() {
     return false;
   }
 
-  if (!MappedResource::LoadFromNamespace(
-          namespace_, data_path_ + "/shared_snapshot_data.bin",
-          shared_snapshot_data_)) {
-    return false;
-  }
-
-  if (!MappedResource::LoadFromNamespace(
-          namespace_, data_path_ + "/shared_snapshot_instructions.bin",
-          shared_snapshot_instructions_, true /* executable */)) {
-    return false;
-  }
-
   return CreateIsolate(isolate_snapshot_data_.address(),
-                       isolate_snapshot_instructions_.address(),
-                       shared_snapshot_data_.address(),
-                       shared_snapshot_instructions_.address());
+                       isolate_snapshot_instructions_.address());
 #endif  // defined(AOT_RUNTIME)
 }
 
@@ -312,9 +297,7 @@ int DartComponentController::SetupFileDescriptor(
 
 bool DartComponentController::CreateIsolate(
     const uint8_t* isolate_snapshot_data,
-    const uint8_t* isolate_snapshot_instructions,
-    const uint8_t* shared_snapshot_data,
-    const uint8_t* shared_snapshot_instructions) {
+    const uint8_t* isolate_snapshot_instructions) {
   // Create the isolate from the snapshot.
   char* error = nullptr;
 
@@ -326,9 +309,9 @@ bool DartComponentController::CreateIsolate(
 
   isolate_ = Dart_CreateIsolateGroup(
       url_.c_str(), label_.c_str(), isolate_snapshot_data,
-      isolate_snapshot_instructions, shared_snapshot_data,
-      shared_snapshot_instructions, nullptr /* flags */,
-      state /* isolate_group_data */, state /* isolate_data */, &error);
+      isolate_snapshot_instructions, nullptr /* shared_snapshot_data */,
+      nullptr /* shared_snapshot_instructions */, nullptr /* flags */, state,
+      state, &error);
   if (!isolate_) {
     FX_LOGF(ERROR, LOG_TAG, "Dart_CreateIsolateGroup failed: %s", error);
     return false;

--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.h
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.h
@@ -42,9 +42,7 @@ class DartComponentController : public fuchsia::sys::ComponentController {
   bool SetupFromAppSnapshot();
 
   bool CreateIsolate(const uint8_t* isolate_snapshot_data,
-                     const uint8_t* isolate_snapshot_instructions,
-                     const uint8_t* shared_snapshot_data,
-                     const uint8_t* shared_snapshot_instructions);
+                     const uint8_t* isolate_snapshot_instructions);
 
   int SetupFileDescriptor(fuchsia::sys::FileDescriptorPtr fd);
 
@@ -76,8 +74,6 @@ class DartComponentController : public fuchsia::sys::ComponentController {
   int stderrfd_ = -1;
   MappedResource isolate_snapshot_data_;
   MappedResource isolate_snapshot_instructions_;
-  MappedResource shared_snapshot_data_;
-  MappedResource shared_snapshot_instructions_;
   std::vector<MappedResource> kernel_peices_;
 
   Dart_Isolate isolate_;

--- a/shell/platform/fuchsia/dart_runner/service_isolate.cc
+++ b/shell/platform/fuchsia/dart_runner/service_isolate.cc
@@ -21,8 +21,6 @@ namespace {
 
 MappedResource mapped_isolate_snapshot_data;
 MappedResource mapped_isolate_snapshot_instructions;
-MappedResource mapped_shared_snapshot_data;
-MappedResource mapped_shared_snapshot_instructions;
 tonic::DartLibraryNatives* service_natives = nullptr;
 
 Dart_NativeFunction GetNativeFunction(Dart_Handle name,
@@ -105,30 +103,13 @@ Dart_Isolate CreateServiceIsolate(const char* uri,
     return nullptr;
   }
 
-#if defined(AOT_RUNTIME)
-  if (!MappedResource::LoadFromNamespace(
-          nullptr, "pkg/data/vmservice_shared_snapshot_data.bin",
-          mapped_shared_snapshot_data)) {
-    *error = strdup("Failed to load snapshot for service isolate");
-    FX_LOG(ERROR, LOG_TAG, *error);
-    return nullptr;
-  }
-  if (!MappedResource::LoadFromNamespace(
-          nullptr, "pkg/data/vmservice_shared_snapshot_instructions.bin",
-          mapped_shared_snapshot_instructions, true /* executable */)) {
-    *error = strdup("Failed to load snapshot for service isolate");
-    FX_LOG(ERROR, LOG_TAG, *error);
-    return nullptr;
-  }
-#endif
-
   auto state = new std::shared_ptr<tonic::DartState>(new tonic::DartState());
   Dart_Isolate isolate = Dart_CreateIsolateGroup(
       uri, DART_VM_SERVICE_ISOLATE_NAME, mapped_isolate_snapshot_data.address(),
       mapped_isolate_snapshot_instructions.address(),
-      mapped_shared_snapshot_data.address(),
-      mapped_shared_snapshot_instructions.address(), nullptr /* flags */,
-      state /* isolate_group_data */, state /* isolate_data */, error);
+      nullptr /* shared_snapshot_data */,
+      nullptr /* shared_snapshot_instructions */, nullptr /* flags */, state,
+      state, error);
   if (!isolate) {
     FX_LOGF(ERROR, LOG_TAG, "Dart_CreateIsolateGroup failed: %s", *error);
     return nullptr;

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -455,18 +455,9 @@ void Application::AttemptVMLaunchWithCurrentSettings(
           application_assets_directory_.get() /* /pkg/data */,
           "isolate_snapshot_instructions.bin", true));
 
-  shared_snapshot_ = fml::MakeRefCounted<flutter::DartSnapshot>(
-      CreateWithContentsOfFile(
-          application_assets_directory_.get() /* /pkg/data */,
-          "shared_snapshot_data.bin", false),
-      CreateWithContentsOfFile(
-          application_assets_directory_.get() /* /pkg/data */,
-          "shared_snapshot_instructions.bin", true));
-
   auto vm = flutter::DartVMRef::Create(settings_,               //
                                        std::move(vm_snapshot),  //
-                                       isolate_snapshot_,       //
-                                       shared_snapshot_         //
+                                       isolate_snapshot_        //
   );
   FML_CHECK(vm) << "Mut be able to initialize the VM.";
 }
@@ -544,7 +535,6 @@ void Application::CreateView(
       runner_incoming_services_,     // Runner incoming services
       settings_,                     // settings
       std::move(isolate_snapshot_),  // isolate snapshot
-      std::move(shared_snapshot_),   // shared snapshot
       scenic::ToViewToken(std::move(view_token)),  // view token
       std::move(view_ref_control),                 // view ref control
       std::move(view_ref),                         // view ref

--- a/shell/platform/fuchsia/flutter/component.h
+++ b/shell/platform/fuchsia/flutter/component.h
@@ -76,7 +76,6 @@ class Application final : public Engine::Delegate,
   fidl::BindingSet<fuchsia::ui::app::ViewProvider> shells_bindings_;
 
   fml::RefPtr<flutter::DartSnapshot> isolate_snapshot_;
-  fml::RefPtr<flutter::DartSnapshot> shared_snapshot_;
   std::set<std::unique_ptr<Engine>> shell_holders_;
   std::pair<bool, uint32_t> last_return_code_;
   fml::WeakPtrFactory<Application> weak_factory_;

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -45,7 +45,6 @@ Engine::Engine(Delegate& delegate,
                std::shared_ptr<sys::ServiceDirectory> runner_services,
                flutter::Settings settings,
                fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
-               fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
                fuchsia::ui::views::ViewToken view_token,
                fuchsia::ui::views::ViewRefControl view_ref_control,
                fuchsia::ui::views::ViewRef view_ref,
@@ -222,20 +221,16 @@ Engine::Engine(Delegate& delegate,
     isolate_snapshot = vm->GetVMData()->GetIsolateSnapshot();
   }
 
-  if (!shared_snapshot) {
-    shared_snapshot = flutter::DartSnapshot::Empty();
-  }
-
   {
     TRACE_EVENT0("flutter", "CreateShell");
     shell_ = flutter::Shell::Create(
-        task_runners,                 // host task runners
-        settings_,                    // shell launch settings
-        std::move(isolate_snapshot),  // isolate snapshot
-        std::move(shared_snapshot),   // shared snapshot
-        on_create_platform_view,      // platform view create callback
-        on_create_rasterizer,         // rasterizer create callback
-        std::move(vm)                 // vm reference
+        task_runners,                    // host task runners
+        settings_,                       // shell launch settings
+        std::move(isolate_snapshot),     // isolate snapshot
+        flutter::DartSnapshot::Empty(),  // shared snapshot
+        on_create_platform_view,         // platform view create callback
+        on_create_rasterizer,            // rasterizer create callback
+        std::move(vm)                    // vm reference
     );
   }
 

--- a/shell/platform/fuchsia/flutter/engine.h
+++ b/shell/platform/fuchsia/flutter/engine.h
@@ -34,7 +34,6 @@ class Engine final {
          std::shared_ptr<sys::ServiceDirectory> runner_services,
          flutter::Settings settings,
          fml::RefPtr<const flutter::DartSnapshot> isolate_snapshot,
-         fml::RefPtr<const flutter::DartSnapshot> shared_snapshot,
          fuchsia::ui::views::ViewToken view_token,
          fuchsia::ui::views::ViewRefControl view_ref_control,
          fuchsia::ui::views::ViewRef view_ref,


### PR DESCRIPTION
Build rules still reference creating share snapshot data and instructions. This makes the engine to always pass them as empty to the dart vm. To be followed up with a change to alter the build rules to stop referencing the shared snapshots.

This is not being used currently and the fact that the runner will be built outside of the flutter tree means that the apps will not have much to gain via shared snapshots. The rationale behind this change is to partially make migrating the runner out of topaz tree easier.

Change-Id: Ibc4dd6a298d65082416af753522f5a17c88a750a