### PR TITLE
[flutter_runner] Explicitly set |trace_skia| to false

### DIFF
--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -261,6 +261,10 @@ Application::Application(
   settings_.observatory_host = "127.0.0.1";
 #endif
 
+  // Set this to true to enable category "skia" trace events.
+  // TODO(PT-145): Explore enabling this by default.
+  settings_.trace_skia = false;
+
   settings_.icu_data_path = "";
 
   settings_.assets_dir = application_assets_directory_.get();


### PR DESCRIPTION
Explicitly set |Application|'s |flutter::Settings| |trace_skia| field to
false (it currently defaults to false), in order to slightly simplify
the enabling skia trace events workflow.

PT-145 #comment-patch

Change-Id: Ib40f9ed3dc6f824056465db2cd45309c78b7e3b4