### PR TITLE
[flutter_runner] Port vulkan surface changes

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -32,8 +32,8 @@ bool CreateVulkanImage(vulkan::VulkanProvider& vulkan_provider,
   FML_DCHECK(out_vulkan_image != nullptr);
 
   // The image creation parameters need to be the same as those in scenic
-  // (garnet/lib/ui/gfx/resources/gpu_image.cc and
-  // garnet/public/lib/escher/util/image_utils.cc) or else the different vulkan
+  // (src/ui/scenic/lib/gfx/resources/gpu_image.cc and
+  // src/ui/lib/escher/util/image_utils.cc) or else the different vulkan
   // devices may interpret the bytes differently.
   // TODO(SCN-1369): Use API to coordinate this with scenic.
   out_vulkan_image->vk_external_image_create_info = {
@@ -235,9 +235,14 @@ bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrContext> context,
     }
   }
 
+  VkMemoryDedicatedAllocateInfo dedicated_allocate_info = {
+      .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO,
+      .pNext = nullptr,
+      .image = vulkan_image_.vk_image,
+      .buffer = VK_NULL_HANDLE};
   VkExportMemoryAllocateInfoKHR export_allocate_info = {
       .sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_KHR,
-      .pNext = nullptr,
+      .pNext = &dedicated_allocate_info,
       .handleTypes =
           VK_EXTERNAL_MEMORY_HANDLE_TYPE_TEMP_ZIRCON_VMO_BIT_FUCHSIA};
 


### PR DESCRIPTION
    [flutter_runner] use dedicated allocation info

    This informs the vulkan driver that we're allocating memory
    dedicated to a single image. This is required for aemu and
    might also allow future drivers to make optimizations currently
    not possible.

    No change in behavior. Existing tests (modular_tests,
    scenic_tests, etc.) are sufficient and regressions will be
    prevented by running these tests on aemu.

    DX-939 #comment

    Test: fx shell run fuchsia-pkg://fuchsia.com/basemgr#meta/basemgr.cmx --base_shell=fuchsia-pkg://fuchsia.com/spinning_cube#meta/spinning_cube.cmx
    Change-Id: If4ecd9aaa09f12f94654a68e8e9fe979748f44af

    [flutter_runner] use external image create info

    DX-939 #progress
    MA-394 #progress

    This informs the vulkan driver that we're creating an image
    that will be backed by external memory. The driver driver can
    decide to use different memory requirements based on the if
    memory for the image can be exported or not.

    No change in behavior. Existing tests (modular_tests,
    scenic_tests, etc.) are sufficient and regressions will be
    prevented by running these tests on aemu.

    Test: fx shell run fuchsia-pkg://fuchsia.com/basemgr#meta/basemgr.cmx --base_shell=fuchsia-pkg://fuchsia.com/spinning_cube#meta/spinning_cube.cmx
    Change-Id: I489318c2e31f752f76c80a81245e203861d44d94