### PR TITLE
Bump third_party/wuffs DEPS to 0.2.0-alpha.47

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -403,7 +403,7 @@ deps = {
    Var('chromium_git') + '/webm/libwebp.git' + '@' + '0.6.0',
 
   'src/third_party/wuffs':
-   Var('skia_git') + '/external/github.com/google/wuffs.git' + '@' +  '6ad7d00a262e862549e4963b4a43d148a8285e50',
+   Var('skia_git') + '/external/github.com/google/wuffs.git' + '@' +  '65e7b2b6c98a4d35e26bc2fc437e2e00f1393dc2',
 
   'src/third_party/fontconfig/src':
    Var('chromium_git') + '/external/fontconfig.git' + '@' + 'c336b8471877371f0190ba06f7547c54e2b890ba',

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 049d68c084861a8c07c610aaf1f6cdd1
+Signature: be16e1ab5d1b6fd2f966428567b3cf39
 
 UNUSED LICENSES:
 
@@ -716,6 +716,8 @@ FILE: ../../../third_party/vulkan/include/vulkan/vulkan_xcb.h
 FILE: ../../../third_party/vulkan/include/vulkan/vulkan_xlib.h
 FILE: ../../../third_party/vulkan/include/vulkan/vulkan_xlib_xrandr.h
 FILE: ../../../third_party/wuffs/cmd/commonflags/commonflags.go
+FILE: ../../../third_party/wuffs/cmd/ractool/data.go
+FILE: ../../../third_party/wuffs/cmd/ractool/gen.go
 FILE: ../../../third_party/wuffs/cmd/ractool/main.go
 FILE: ../../../third_party/wuffs/cmd/wuffs-c/genlib.go
 FILE: ../../../third_party/wuffs/cmd/wuffs-c/main.go
@@ -778,17 +780,35 @@ FILE: ../../../third_party/wuffs/lang/token/token.go
 FILE: ../../../third_party/wuffs/lang/wuffsroot/wuffsroot.go
 FILE: ../../../third_party/wuffs/lib/base38/base38.go
 FILE: ../../../third_party/wuffs/lib/base38/base38_test.go
+FILE: ../../../third_party/wuffs/lib/cgozlib/cgozlib.go
+FILE: ../../../third_party/wuffs/lib/cgozlib/cgozlib_test.go
+FILE: ../../../third_party/wuffs/lib/cgozlib/notcgo.go
+FILE: ../../../third_party/wuffs/lib/cgozstd/cgozstd.go
+FILE: ../../../third_party/wuffs/lib/cgozstd/cgozstd_test.go
+FILE: ../../../third_party/wuffs/lib/cgozstd/notcgo.go
+FILE: ../../../third_party/wuffs/lib/compression/compression.go
+FILE: ../../../third_party/wuffs/lib/compression/compression_test.go
 FILE: ../../../third_party/wuffs/lib/flatecut/flatecut.go
 FILE: ../../../third_party/wuffs/lib/flatecut/flatecut_test.go
 FILE: ../../../third_party/wuffs/lib/interval/interval.go
 FILE: ../../../third_party/wuffs/lib/interval/interval_test.go
 FILE: ../../../third_party/wuffs/lib/interval/radial_test.go
+FILE: ../../../third_party/wuffs/lib/rac/chunk_reader.go
+FILE: ../../../third_party/wuffs/lib/rac/chunk_writer.go
+FILE: ../../../third_party/wuffs/lib/rac/conc_reader.go
 FILE: ../../../third_party/wuffs/lib/rac/example_test.go
 FILE: ../../../third_party/wuffs/lib/rac/rac.go
+FILE: ../../../third_party/wuffs/lib/rac/rac_test.go
+FILE: ../../../third_party/wuffs/lib/rac/reader.go
 FILE: ../../../third_party/wuffs/lib/rac/writer.go
-FILE: ../../../third_party/wuffs/lib/rac/writer_test.go
+FILE: ../../../third_party/wuffs/lib/raczlib/example_test.go
+FILE: ../../../third_party/wuffs/lib/raczlib/make_cgo.go
+FILE: ../../../third_party/wuffs/lib/raczlib/make_notcgo.go
 FILE: ../../../third_party/wuffs/lib/raczlib/raczlib.go
-FILE: ../../../third_party/wuffs/lib/raczlib/writer.go
+FILE: ../../../third_party/wuffs/lib/raczlib/raczlib_test.go
+FILE: ../../../third_party/wuffs/lib/raczstd/example_test.go
+FILE: ../../../third_party/wuffs/lib/raczstd/raczstd.go
+FILE: ../../../third_party/wuffs/lib/readerat/readerat.go
 FILE: ../../../third_party/wuffs/lib/zlibcut/example_test.go
 FILE: ../../../third_party/wuffs/lib/zlibcut/zlibcut.go
 FILE: ../../../third_party/wuffs/lib/zlibcut/zlibcut_test.go
@@ -813,6 +833,7 @@ FILE: ../../../third_party/wuffs/script/print-crc32-example.go
 FILE: ../../../third_party/wuffs/script/print-crc32-magic-numbers.go
 FILE: ../../../third_party/wuffs/script/print-deflate-magic-numbers.go
 FILE: ../../../third_party/wuffs/script/print-lzw-example.go
+FILE: ../../../third_party/wuffs/script/rac-random-seek-test.go
 FILE: ../../../third_party/wuffs/script/wuffs-deflate-decoder-decode-huffman.c
 FILE: ../../../third_party/wuffs/std/adler32/common_adler32.wuffs
 FILE: ../../../third_party/wuffs/std/crc32/common_crc32.wuffs


### PR DESCRIPTION
third_party/skia uses third_party/wuffs, and I would soon like to
upgrade upstream Skia's minimum Wuffs version. IIUC, bumping the flutter
DEPS first will avoid build breakage.