### PR TITLE
[webui] handle obscureText setting for single line TextField

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -330,7 +330,7 @@ class TextEditingElement {
     switch (inputConfig.inputType) {
       case InputType.text:
         domElement = owner.createInputElement();
-        // Setting the type to password seems to be only option to prevent the obscured text 
+        // Setting the type to password seems to be only option to prevent the obscured text
         // from being displayed as an suggestion / autocomplete option in mobile devices.
         if (inputConfig.obscureText) {
           domElement.setAttribute('type', 'password');

--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -330,6 +330,11 @@ class TextEditingElement {
     switch (inputConfig.inputType) {
       case InputType.text:
         domElement = owner.createInputElement();
+        // Setting the type to password seems to be only option to prevent the obscured text 
+        // from being displayed as an suggestion / autocomplete option in mobile devices.
+        if (inputConfig.obscureText) {
+          domElement.setAttribute('type', 'password');
+        }
         break;
 
       case InputType.multiline:


### PR DESCRIPTION
Though setting obscureText to true for TextField / TextFormField widgets will obscure the rendered  text content, it is still fully visible in the suggestion / autocomplete bar of soft keyboards (and touchbars of MacBooks). This PR changes this behaviour by setting the type of the input element corresponding to the TextField to 'password'. Unfortunately this works only for single line TextFields.