### PR TITLE
[webui] Trigger TextInputAction.next/newline on tab/enter keypresses in single line text input elements.

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -45,6 +45,7 @@ void _setStaticStyleAttributes(html.HtmlElement domElement) {
 enum _InputAction {
   /// Procced to next enput element.
   next,
+
   /// Newline has been entered in current input element.
   newline,
 }
@@ -464,9 +465,9 @@ class TextEditingElement {
       if (event.which == 9) {
         _onAction(_InputAction.next);
         // The default action of the browser is to focus the next element.
-        // As the browser is not able to focus flutter widgets, it will 
+        // As the browser is not able to focus flutter widgets, it will
         // focus some part of its UI (e.g. the location bar).
-        // We prevent this action and leave it to the corresponding widget 
+        // We prevent this action and leave it to the corresponding widget
         // to change the focus.
         event.preventDefault();
       }
@@ -825,7 +826,7 @@ class HybridTextEditing {
     browserEngine == BrowserEngine.webkit &&
     operatingSystem == OperatingSystem.iOs;
   _InputActionToFlutter(_InputAction inputAction) {
-    switch(inputAction) {
+    switch (inputAction) {
       case _InputAction.next:
         return 'TextInputAction.next';
         break;

--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -42,6 +42,13 @@ void _setStaticStyleAttributes(html.HtmlElement domElement) {
   }
 }
 
+enum _InputAction {
+  /// Procced to next Input Element
+  next,
+  /// Newline entered in Input Element
+  newline,
+}
+
 /// The current text and selection state of a text field.
 class EditingState {
   EditingState({this.text, this.baseOffset = 0, this.extentOffset = 0});
@@ -162,6 +169,7 @@ class InputConfiguration {
 }
 
 typedef _OnChangeCallback = void Function(EditingState editingState);
+typedef _OnActionCallback = void Function(_InputAction inputAction);
 
 enum ElementType {
   /// The backing element is an `<input>`.
@@ -225,6 +233,7 @@ class TextEditingElement {
   html.HtmlElement domElement;
   EditingState _lastEditingState;
   _OnChangeCallback _onChange;
+  _OnActionCallback _onAction;
 
   final List<StreamSubscription<html.Event>> _subscriptions =
       <StreamSubscription<html.Event>>[];
@@ -268,12 +277,14 @@ class TextEditingElement {
   void enable(
     InputConfiguration inputConfig, {
     @required _OnChangeCallback onChange,
+    @required _OnActionCallback onAction,
   }) {
     assert(!_enabled);
 
     _initDomElement(inputConfig);
     _enabled = true;
     _onChange = onChange;
+    _onAction = onAction;
 
     // Chrome on Android will hide the onscreen keyboard when you tap outside
     // the text box. Instead, we want the framework to tell us to hide the
@@ -304,7 +315,8 @@ class TextEditingElement {
     // Subscribe to text and selection changes.
     _subscriptions
       ..add(html.document.onSelectionChange.listen(_handleChange))
-      ..add(domElement.onInput.listen(_handleChange));
+      ..add(domElement.onInput.listen(_handleChange))
+      ..add(domElement.onKeyDown.listen(_handleKeyDown));
   }
 
   /// Disables the element so it's no longer used for text editing.
@@ -438,6 +450,20 @@ class TextEditingElement {
   void _handleChange(html.Event event) {
     _lastEditingState = calculateEditingState();
     _onChange(_lastEditingState);
+  }
+
+  // Map KeyboardEvent to InputAction
+  void _handleKeyDown(html.KeyboardEvent event) {
+    // Trigger newline action if enter key was pressed
+    if (event.which == 13) {
+      _onAction(_InputAction.newline);
+    }
+    // Trigger next action if tab key was pressed
+    if (event.which == 9) {
+      _onAction(_InputAction.next);
+      // prevent default action to avoid input element losing focus
+      event.preventDefault();
+    }
   }
 
   @visibleForTesting
@@ -700,6 +726,7 @@ class HybridTextEditing {
     editingElement.enable(
       InputConfiguration.fromFlutter(_configuration),
       onChange: _syncEditingStateToFlutter,
+      onAction: _sendInputActionToFlutter,
     );
   }
 
@@ -790,6 +817,30 @@ class HybridTextEditing {
   bool get doesKeyboardShiftInput =>
     browserEngine == BrowserEngine.webkit &&
     operatingSystem == OperatingSystem.iOs;
+  _InputActionToFlutter(_InputAction inputAction) {
+    switch(inputAction) {
+      case _InputAction.next:
+        return 'TextInputAction.next';
+        break;
+      case _InputAction.newline:
+        return 'TextInputAction.newline';
+        break;
+    }
+    return 'TextInputAction.unspecified';
+  }
+
+  void _sendInputActionToFlutter(_InputAction inputAction) {
+    ui.window.onPlatformMessage(
+      'flutter/textinput',
+      const JSONMethodCodec().encodeMethodCall(
+        MethodCall('TextInputClient.performAction', <dynamic>[
+          _clientId,
+          _InputActionToFlutter(inputAction),
+        ]),
+      ),
+      _emptyCallback,
+    );
+  }
 
   /// These style attributes are dynamic throughout the life time of an input
   /// element.

--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -43,9 +43,9 @@ void _setStaticStyleAttributes(html.HtmlElement domElement) {
 }
 
 enum _InputAction {
-  /// Procced to next Input Element
+  /// Procced to next enput element.
   next,
-  /// Newline entered in Input Element
+  /// Newline has been entered in current input element.
   newline,
 }
 
@@ -452,17 +452,24 @@ class TextEditingElement {
     _onChange(_lastEditingState);
   }
 
-  // Map KeyboardEvent to InputAction
+  // Map KeyboardEvent to InputAction.
   void _handleKeyDown(html.KeyboardEvent event) {
-    // Trigger newline action if enter key was pressed
-    if (event.which == 13) {
-      _onAction(_InputAction.newline);
-    }
-    // Trigger next action if tab key was pressed
-    if (event.which == 9) {
-      _onAction(_InputAction.next);
-      // prevent default action to avoid input element losing focus
-      event.preventDefault();
+    // Tab and enter key can only be mapped to actions for single line inputs.
+    if (_elementType == ElementType.input) {
+      // Trigger newline action if enter key was pressed.
+      if (event.which == 13) {
+        _onAction(_InputAction.newline);
+      }
+      // Trigger next action if tab key was pressed.
+      if (event.which == 9) {
+        _onAction(_InputAction.next);
+        // The default action of the browser is to focus the next element.
+        // As the browser is not able to focus flutter widgets, it will 
+        // focus some part of its UI (e.g. the location bar).
+        // We prevent this action and leave it to the corresponding widget 
+        // to change the focus.
+        event.preventDefault();
+      }
     }
   }
 


### PR DESCRIPTION
On the web the expected behaviour of single line TextField / TextFormFields is that pressing tab will move the focus to the next input element. Switching focus between input elements is usually done in the onFieldSubmitted callback on mobile platforms (see also: [editable_text.dart#L854](https://github.com/flutter/flutter/blob/407668f4d51b5ecb4c12a434769954e293fc68dc/packages/flutter/lib/src/widgets/editable_text.dart#L854)) . Currently this is not possible on the web as TextEditingElement will never send a TextInputAction to flutter. This would in turn trigger the onFieldSubmitted callback ([editable_text.dart#L1210](https://github.com/flutter/flutter/blob/407668f4d51b5ecb4c12a434769954e293fc68dc/packages/flutter/lib/src/widgets/editable_text.dart#L1210)) .

This PR changes TextEditingElement so that it will send a TextInputAction.next to flutter if the user presses the tab key and TextInputAction.newline if the enter key was pressed. It is also possible to distinguish between both action in the onFieldSubmitted callback as the TextField will automatically lose focus for TextInputAction.newline but not for TextInputAction.next (as documented in [onEditingComplete](https://api.flutter.dev/flutter/material/TextField/onEditingComplete.html) ). Consequently the expected behaviour (tab -> next field, enter -> submit form) can be implemented in the onFieldSubmitted callback as in the following example:

```dart
TextFormField(
  focusNode: _focusNode,
  onFieldSubmitted: (String value) {
    if(_passFocusNode.hasPrimaryFocus) {
      // This field still has focus, therefore the callback was triggered by TextInputAction.next.
      _focusNode.nextFocus();
    } else {
      // This field has lost focus, therefore the callback was triggered by TextInputAction.newline.
      // Handle this case by e.g. submitting the form data.
    }
  }
)
```