### PR TITLE
Update --dart-vm-flags whitelist to include --write-service-info and --sample-buffer-duration

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -45,6 +45,8 @@ static const std::string gDartFlagsWhitelist[] = {
     "--profile_period",
     "--random_seed",
     "--enable_mirrors",
+    "--write-service-info",
+    "--sample-buffer-duration",
 };
 // clang-format on
 


### PR DESCRIPTION
These flags were recently added and are safe to pass through to the VM
for development.

FYI @kenzieschmoll, @jonahwilliams 