### PR TITLE
Store fallback font names as a vector instead of a set.

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -165,14 +165,11 @@ FontCollection::GetMinikinFontCollectionForFamilies(
   if (enable_font_fallback_) {
     // Reverse iterate to prevent new fallback fonts changing how previously
     // resolved glyphs are rendered.
-    auto fallback_riter = fallback_fonts_for_locale_[locale].rbegin();
-    while (fallback_riter != fallback_fonts_for_locale_[locale].rend()) {
-      std::string fallback_family = *fallback_riter;
+    for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
       auto it = fallback_fonts_.find(fallback_family);
       if (it != fallback_fonts_.end()) {
         minikin_families.push_back(it->second);
       }
-      fallback_riter++;
     }
   }
   // Create the minikin font collection.
@@ -278,7 +275,17 @@ const std::shared_ptr<minikin::FontFamily>& FontCollection::DoMatchFallbackFont(
     typeface->getFamilyName(&sk_family_name);
     std::string family_name(sk_family_name.c_str());
 
-    fallback_fonts_for_locale_[locale].insert(family_name);
+    // Check if the fallback font already exists. Only insert if it does not
+    // exist.
+    bool contains_font = false;
+    for (std::string font : fallback_fonts_for_locale_[locale]) {
+      if (font == family_name) {
+        contains_font = true;
+        break;
+      }
+    }
+    if (!contains_font)
+      fallback_fonts_for_locale_[locale].push_back(family_name);
 
     return GetFallbackFontFamily(manager, family_name);
   }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -273,16 +273,9 @@ const std::shared_ptr<minikin::FontFamily>& FontCollection::DoMatchFallbackFont(
     typeface->getFamilyName(&sk_family_name);
     std::string family_name(sk_family_name.c_str());
 
-    // Check if the fallback font already exists. Only insert if it does not
-    // exist.
-    bool contains_font = false;
-    for (std::string font : fallback_fonts_for_locale_[locale]) {
-      if (font == family_name) {
-        contains_font = true;
-        break;
-      }
-    }
-    if (!contains_font)
+    if (std::find(fallback_fonts_for_locale_[locale].begin(),
+                  fallback_fonts_for_locale_[locale].end(),
+                  family_name) == fallback_fonts_for_locale_[locale].end())
       fallback_fonts_for_locale_[locale].push_back(family_name);
 
     return GetFallbackFontFamily(manager, family_name);

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -163,8 +163,6 @@ FontCollection::GetMinikinFontCollectionForFamilies(
     return nullptr;
   }
   if (enable_font_fallback_) {
-    // Reverse iterate to prevent new fallback fonts changing how previously
-    // resolved glyphs are rendered.
     for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
       auto it = fallback_fonts_.find(fallback_family);
       if (it != fallback_fonts_.end()) {

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -163,11 +163,16 @@ FontCollection::GetMinikinFontCollectionForFamilies(
     return nullptr;
   }
   if (enable_font_fallback_) {
-    for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
+    // Reverse iterate to prevent new fallback fonts changing how previously
+    // resolved glyphs are rendered.
+    auto fallback_riter = fallback_fonts_for_locale_[locale].rbegin();
+    while (fallback_riter != fallback_fonts_for_locale_[locale].rend()) {
+      std::string fallback_family = *fallback_riter;
       auto it = fallback_fonts_.find(fallback_family);
       if (it != fallback_fonts_.end()) {
         minikin_families.push_back(it->second);
       }
+      fallback_riter++;
     }
   }
   // Create the minikin font collection.

--- a/third_party/txt/src/txt/font_collection.h
+++ b/third_party/txt/src/txt/font_collection.h
@@ -103,7 +103,7 @@ class FontCollection : public std::enable_shared_from_this<FontCollection> {
       fallback_match_cache_;
   std::unordered_map<std::string, std::shared_ptr<minikin::FontFamily>>
       fallback_fonts_;
-  std::unordered_map<std::string, std::set<std::string>>
+  std::unordered_map<std::string, std::vector<std::string>>
       fallback_fonts_for_locale_;
   bool enable_font_fallback_;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/36527

Forward iterating the fallback set causes newly inserted fallback sets to take precedence over existing fonts. This manifests in issues where the glyph fallen back onto for existing characters changes after a new fallback is added in order to support another character.

Reverse iterating this makes sure the original/older fonts are used first before attempting to use fonts added later.