### PR TITLE
add dart:html, dart:js, and dart:js_util to the copy of the Dart SDK used for analysis

### DIFF
--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -10,9 +10,12 @@ import("//third_party/dart/sdk/lib/convert/convert_sources.gni")
 import("//third_party/dart/sdk/lib/core/core_sources.gni")
 import("//third_party/dart/sdk/lib/developer/developer_sources.gni")
 import("//third_party/dart/sdk/lib/ffi/ffi_sources.gni")
+import("//third_party/dart/sdk/lib/html/html_sources.gni")
 import("//third_party/dart/sdk/lib/internal/internal_sources.gni")
 import("//third_party/dart/sdk/lib/io/io_sources.gni")
 import("//third_party/dart/sdk/lib/isolate/isolate_sources.gni")
+import("//third_party/dart/sdk/lib/js/js_sources.gni")
+import("//third_party/dart/sdk/lib/js_util/js_util_sources.gni")
 import("//third_party/dart/sdk/lib/math/math_sources.gni")
 import("//third_party/dart/sdk/lib/typed_data/typed_data_sources.gni")
 import("//third_party/dart/sdk/lib/wasm/wasm_sources.gni")
@@ -105,11 +108,35 @@ copy("ffi") {
   ]
 }
 
+copy("html") {
+  lib_path = rebase_path("html", "", dart_sdk_lib_path)
+  sources = rebase_path(html_sdk_sources, "", lib_path)
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/html/{{source_file_part}}",
+  ]
+}
+
 copy("isolate") {
   lib_path = rebase_path("isolate", "", dart_sdk_lib_path)
   sources = rebase_path(isolate_sdk_sources, "", lib_path)
   outputs = [
     "$root_gen_dir/dart-pkg/sky_engine/lib/isolate/{{source_file_part}}",
+  ]
+}
+
+copy("js") {
+  lib_path = rebase_path("js", "", dart_sdk_lib_path)
+  sources = rebase_path(js_sdk_sources, "", lib_path)
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/js/{{source_file_part}}",
+  ]
+}
+
+copy("js_util") {
+  lib_path = rebase_path("js_util", "", dart_sdk_lib_path)
+  sources = rebase_path(js_util_sdk_sources, "", lib_path)
+  outputs = [
+    "$root_gen_dir/dart-pkg/sky_engine/lib/js_util/{{source_file_part}}",
   ]
 }
 
@@ -154,9 +181,12 @@ group("copy_dart_sdk") {
     ":core",
     ":developer",
     ":ffi",
+    ":html",
     ":internal",
     ":io",
     ":isolate",
+    ":js",
+    ":js_util",
     ":math",
     ":typed_data",
     ":wasm",

--- a/sky/packages/sky_engine/lib/_embedder.yaml
+++ b/sky/packages/sky_engine/lib/_embedder.yaml
@@ -5,20 +5,19 @@ embedded_libs:
   "dart:core": "core/core.dart"
   "dart:developer": "developer/developer.dart"
   "dart:ffi": "ffi/ffi.dart"
-  "dart:wasm": "wasm/wasm.dart"
+  "dart:html": "html/html_dart2js.dart"
   "dart:io": "io/io.dart"
   "dart:isolate": "isolate/isolate.dart"
+  "dart:js": "js/js_dart2js.dart"
+  "dart:js_util": "js_util/js_util_dart2js.dart"
   "dart:math": "math/math.dart"
   "dart:typed_data": "typed_data/typed_data.dart"
   "dart:ui": "ui/ui.dart"
-  # The internal library is needed as some implementations bleed into the public
-  # API, e.g. List being Iterable by virtue of implementing
-  # EfficientLengthIterable.
-  # Not including this library yields analysis errors.
-  "dart:_http": "_http/http.dart"
-  "dart:_internal": "internal/internal.dart"
-  "dart:nativewrappers": "_empty.dart"
+  "dart:wasm": "wasm/wasm.dart"
 
-analyzer:
-  language:
-    enableSuperMixins: true
+  # The internal library is needed as some implementations bleed into the
+  # public API, e.g. List being Iterable by virtue of implementing
+  # EfficientLengthIterable. Not including this library yields analysis errors.
+  "dart:_internal": "internal/internal.dart"
+  "dart:_http": "_http/http.dart"
+  "dart:nativewrappers": "_empty.dart"


### PR DESCRIPTION
- add `dart:html`, `dart:js`, and `dart:js_util` to the copy of the Dart SDK used for analysis
- some work towards addressing https://github.com/flutter/flutter/issues/35588

This is a follow-up for the companion dart-lang/sdk CL https://dart-review.googlesource.com/c/sdk/+/118472.

@hterkelsen @jonahwilliams 