### PR TITLE
[web] filter test targets; cache host.dart compilation

### DIFF
--- a/lib/web_ui/dev/environment.dart
+++ b/lib/web_ui/dev/environment.dart
@@ -85,7 +85,7 @@ class Environment {
   ));
 
   /// Path to the "web_engine_tester" package.
-  io.Directory get goldenTesterRootDir => io.Directory(pathlib.join(
+  io.Directory get webEngineTesterRootDir => io.Directory(pathlib.join(
     webSdkRootDir.path,
     'web_engine_tester',
   ));

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -52,11 +52,10 @@ class TestsCommand extends Command<bool> {
 
     final List<FilePath> targets =
         this.targets.map((t) => FilePath.fromCwd(t)).toList();
+    await _buildTests(targets: targets);
     if (targets.isEmpty) {
-      await _buildTests();
       await _runAllTests();
     } else {
-      await _buildTests(targets: targets);
       await _runTargetTests(targets);
     }
     return true;

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -49,13 +49,14 @@ class TestsCommand extends Command<bool> {
 
     _copyAhemFontIntoWebUi();
     await _buildHostPage();
-    await _buildTests();
 
     final List<FilePath> targets =
         this.targets.map((t) => FilePath.fromCwd(t)).toList();
     if (targets.isEmpty) {
+      await _buildTests();
       await _runAllTests();
     } else {
+      await _buildTests(targets: targets);
       await _runTargetTests(targets);
     }
     return true;
@@ -143,27 +144,52 @@ class TestsCommand extends Command<bool> {
     }
   }
 
-  // TODO(yjbanov): skip rebuild if host.dart hasn't changed.
   Future<void> _buildHostPage() async {
+    final String hostDartPath = path.join('lib', 'static', 'host.dart');
+    final io.File hostDartFile = io.File(path.join(
+      environment.webEngineTesterRootDir.path,
+      hostDartPath,
+    ));
+    final io.File timestampFile = io.File(path.join(
+      environment.webEngineTesterRootDir.path,
+      '$hostDartPath.js.timestamp',
+    ));
+
+    final String timestamp = hostDartFile.statSync().modified.millisecondsSinceEpoch.toString();
+    if (timestampFile.existsSync()) {
+      final String lastBuildTimestamp = timestampFile.readAsStringSync();
+      if (lastBuildTimestamp == timestamp) {
+        // The file is still fresh. No need to rebuild.
+        return;
+      } else {
+        // Record new timestamp, but don't return. We need to rebuild.
+        print('${hostDartFile.path} timestamp changed. Rebuilding.');
+      }
+    } else {
+      print('Building ${hostDartFile.path}.');
+    }
+
     final int exitCode = await runProcess(
       environment.dart2jsExecutable,
       <String>[
-        'lib/static/host.dart',
+        hostDartPath,
         '-o',
-        'lib/static/host.dart.js',
+        '$hostDartPath.js',
       ],
-      workingDirectory: environment.goldenTesterRootDir.path,
+      workingDirectory: environment.webEngineTesterRootDir.path,
     );
 
     if (exitCode != 0) {
       io.stderr.writeln(
-          'Failed to compile tests. Compiler exited with exit code $exitCode');
+          'Failed to compile ${hostDartFile.path}. Compiler exited with exit code $exitCode');
       io.exit(1);
     }
+
+    // Record the timestamp to avoid rebuilding unless the file changes.
+    timestampFile.writeAsStringSync(timestamp);
   }
 
-  Future<void> _buildTests() async {
-    // TODO(yjbanov): learn to build only requested tests: https://github.com/flutter/flutter/issues/37810
+  Future<void> _buildTests({ List<FilePath> targets }) async {
     final int exitCode = await runProcess(
       environment.pubExecutable,
       <String>[
@@ -173,6 +199,12 @@ class TestsCommand extends Command<bool> {
         'test',
         '-o',
         'build',
+        if (targets != null)
+          for (FilePath path in targets)
+            ...[
+              '--build-filter=${path.relativeToWebUi}.js',
+              '--build-filter=${path.relativeToWebUi}.browser_test.dart.js',
+            ],
       ],
       workingDirectory: environment.webUiRootDir.path,
     );

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
   path: 1.6.4
   test: 1.6.5
   quiver: 2.0.5
-  build_runner: 1.6.5
+  build_runner: 1.7.0
   build_test: 0.10.8
   build_web_compilers: 2.1.5
   yaml: 2.2.0


### PR DESCRIPTION
This brings retest of a single test from minutes to seconds.

This is based on the new build_runner feature https://github.com/dart-lang/build/pull/2415 by @jakemac53 (Thank you @jakemac53 !!!)