### PR TITLE
Reflect selection changes in Firefox for text editing

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -914,8 +914,8 @@ class _EditableSizeAndTransform {
 /// keys to move the text cursor.
 class SelectionChangeDetection {
   final html.HtmlElement _domElement;
-  int _start;
-  int _end;
+  int _start = -1;
+  int _end = -1;
 
   SelectionChangeDetection(this._domElement) {
     if (_domElement is html.InputElement) {

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -680,48 +680,50 @@ void main() {
   group('SelectionChangeDetection', () {
     SelectionChangeDetection _selectionChangeDetection;
 
-    setUp(() {
-      _selectionChangeDetection = SelectionChangeDetection();
-    });
-
     test('Change detected on an input field', () {
       final InputElement input = document.getElementsByTagName('input')[0];
+      _selectionChangeDetection = SelectionChangeDetection(input);
 
       input.value = 'foo\nbar';
       input.setSelectionRange(1, 3);
 
-      expect(_selectionChangeDetection.hasChangeDetected(input), true);
+      expect(_selectionChangeDetection.detectChange(), true);
+      expect(_selectionChangeDetection.detectChange(), false);
 
       input.setSelectionRange(1, 5);
 
-      expect(_selectionChangeDetection.hasChangeDetected(input), true);
+      expect(_selectionChangeDetection.detectChange(), true);
     });
 
     test('Change detected on an text area', () {
       final TextAreaElement textarea =
           document.getElementsByTagName('textarea')[0];
+      _selectionChangeDetection = SelectionChangeDetection(textarea);
 
       textarea.value = 'foo\nbar';
       textarea.setSelectionRange(4, 6);
 
-      expect(_selectionChangeDetection.hasChangeDetected(textarea), true);
+      expect(_selectionChangeDetection.detectChange(), true);
+      expect(_selectionChangeDetection.detectChange(), false);
 
       textarea.setSelectionRange(4, 5);
 
-      expect(_selectionChangeDetection.hasChangeDetected(textarea), true);
+      expect(_selectionChangeDetection.detectChange(), true);
     });
 
     test('No change if selection stayed the same', () {
       final InputElement input = document.getElementsByTagName('input')[0];
+      _selectionChangeDetection = SelectionChangeDetection(input);
 
       input.value = 'foo\nbar';
       input.setSelectionRange(1, 3);
 
-      expect(_selectionChangeDetection.hasChangeDetected(input), true);
+      expect(_selectionChangeDetection.detectChange(), true);
+      expect(_selectionChangeDetection.detectChange(), false);
 
       input.setSelectionRange(1, 3);
 
-      expect(_selectionChangeDetection.hasChangeDetected(input), false);
+      expect(_selectionChangeDetection.detectChange(), false);
     });
   });
 }

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -676,6 +676,54 @@ void main() {
       expect(spy.messages, isEmpty);
     });
   });
+
+  group('SelectionChangeDetection', () {
+    SelectionChangeDetection _selectionChangeDetection;
+
+    setUp(() {
+      _selectionChangeDetection = SelectionChangeDetection();
+    });
+
+    test('Change detected on an input field', () {
+      final InputElement input = document.getElementsByTagName('input')[0];
+
+      input.value = 'foo\nbar';
+      input.setSelectionRange(1, 3);
+
+      expect(_selectionChangeDetection.hasChangeDetected(input), true);
+
+      input.setSelectionRange(1, 5);
+
+      expect(_selectionChangeDetection.hasChangeDetected(input), true);
+    });
+
+    test('Change detected on an text area', () {
+      final TextAreaElement textarea =
+          document.getElementsByTagName('textarea')[0];
+
+      textarea.value = 'foo\nbar';
+      textarea.setSelectionRange(4, 6);
+
+      expect(_selectionChangeDetection.hasChangeDetected(textarea), true);
+
+      textarea.setSelectionRange(4, 5);
+
+      expect(_selectionChangeDetection.hasChangeDetected(textarea), true);
+    });
+
+    test('No change if selection stayed the same', () {
+      final InputElement input = document.getElementsByTagName('input')[0];
+
+      input.value = 'foo\nbar';
+      input.setSelectionRange(1, 3);
+
+      expect(_selectionChangeDetection.hasChangeDetected(input), true);
+
+      input.setSelectionRange(1, 3);
+
+      expect(_selectionChangeDetection.hasChangeDetected(input), false);
+    });
+  });
 }
 
 MethodCall configureSetStyleMethodCall(int fontSize, String fontFamily,


### PR DESCRIPTION
Reflect selection changes in Firefox. With this change if the keyboard arrow keys to move the cursor the selection change is synced to Flutter Framework

Fixing issue: https://github.com/flutter/flutter/issues/32225