### PR TITLE
Make kDoNotResizeDimension public so framework can use it directly

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1019,12 +1019,10 @@ enum Clip {
   antiAliasWithSaveLayer,
 }
 
-// Indicates that the image should not be resized in this dimension.
-//
-// Used by [instantiateImageCodec] as a magical value to disable resizing
-// in the given dimension.
-//
-// This needs to be kept in sync with "kDoNotResizeDimension" in codec.cc
+/// Indicates that the image should not be resized in this dimension.
+///
+/// Used by [instantiateImageCodec] as a magical value to disable resizing
+/// in the given dimension.
 const int kDoNotResizeDimension = -1;
 
 /// A description of the style to use when drawing on a [Canvas].

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1025,7 +1025,7 @@ enum Clip {
 // in the given dimension.
 //
 // This needs to be kept in sync with "kDoNotResizeDimension" in codec.cc
-const int _kDoNotResizeDimension = -1;
+const int kDoNotResizeDimension = -1;
 
 /// A description of the style to use when drawing on a [Canvas].
 ///
@@ -1667,7 +1667,7 @@ Future<Codec> instantiateImageCodec(Uint8List list, {
   int targetHeight,
 }) {
   return _futurize(
-    (_Callback<Codec> callback) => _instantiateImageCodec(list, callback, null, targetWidth ?? _kDoNotResizeDimension, targetHeight ?? _kDoNotResizeDimension)
+    (_Callback<Codec> callback) => _instantiateImageCodec(list, callback, null, targetWidth ?? kDoNotResizeDimension, targetHeight ?? kDoNotResizeDimension)
   );
 }
 
@@ -1677,9 +1677,9 @@ Future<Codec> instantiateImageCodec(Uint8List list, {
 /// image, in image pixels. Image in this context refers to image in every frame of the [Codec].
 /// If [targetWidth] and [targetHeight] are not equal to the intrinsic dimensions of the
 /// image, then the image will be scaled after being decoded. If exactly one of
-/// these two arguments is not equal to [_kDoNotResizeDimension], then the aspect
+/// these two arguments is not equal to [kDoNotResizeDimension], then the aspect
 /// ratio will be maintained while forcing the image to match the given dimension.
-/// If both are equal to [_kDoNotResizeDimension], then the image maintains its real size.
+/// If both are equal to [kDoNotResizeDimension], then the image maintains its real size.
 ///
 /// Returns an error message if the instantiation has failed, null otherwise.
 String _instantiateImageCodec(Uint8List list, _Callback<Codec> callback, _ImageInfo imageInfo, int targetWidth, int targetHeight)
@@ -1724,7 +1724,7 @@ void decodeImageFromPixels(
 ) {
   final _ImageInfo imageInfo = _ImageInfo(width, height, format.index, rowBytes);
   final Future<Codec> codecFuture = _futurize(
-    (_Callback<Codec> callback) => _instantiateImageCodec(pixels, callback, imageInfo, targetWidth ?? _kDoNotResizeDimension, targetHeight ?? _kDoNotResizeDimension)
+    (_Callback<Codec> callback) => _instantiateImageCodec(pixels, callback, imageInfo, targetWidth ?? kDoNotResizeDimension, targetHeight ?? kDoNotResizeDimension)
   );
   codecFuture.then((Codec codec) => codec.getNextFrame())
       .then((FrameInfo frameInfo) => callback(frameInfo.image));

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -33,9 +33,6 @@ namespace flutter {
 
 namespace {
 
-// This needs to be kept in sync with _kDoNotResizeDimension in painting.dart
-const int kDoNotResizeDimension = -1;
-
 // This must be kept in sync with the enum in painting.dart
 enum PixelFormat {
   kRGBA8888,
@@ -217,10 +214,10 @@ static void InstantiateImageCodec(Dart_NativeArguments args) {
     ImageDecoder::ImageDescriptor descriptor;
     descriptor.decompressed_image_info = image_info;
 
-    if (targetWidth > kDoNotResizeDimension) {
+    if (targetWidth > 0) {
       descriptor.target_width = targetWidth;
     }
-    if (targetHeight > kDoNotResizeDimension) {
+    if (targetHeight > 0) {
       descriptor.target_height = targetHeight;
     }
     descriptor.data = std::move(buffer);

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -33,7 +33,7 @@ namespace flutter {
 
 namespace {
 
-// This needs to be kept in sync with _kDoNotResizeDimension in painting.dart
+// This needs to be kept in sync with kDoNotResizeDimension in painting.dart
 const int kDoNotResizeDimension = -1;
 
 // This must be kept in sync with the enum in painting.dart

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -33,6 +33,9 @@ namespace flutter {
 
 namespace {
 
+// This needs to be kept in sync with _kDoNotResizeDimension in painting.dart
+const int kDoNotResizeDimension = -1;
+
 // This must be kept in sync with the enum in painting.dart
 enum PixelFormat {
   kRGBA8888,
@@ -214,10 +217,10 @@ static void InstantiateImageCodec(Dart_NativeArguments args) {
     ImageDecoder::ImageDescriptor descriptor;
     descriptor.decompressed_image_info = image_info;
 
-    if (targetWidth >= 0 && targetWidth < image_info->sk_info.width()) {
+    if (targetWidth > kDoNotResizeDimension) {
       descriptor.target_width = targetWidth;
     }
-    if (targetHeight >= 0 && targetHeight < image_info->sk_info.height()) {
+    if (targetHeight > kDoNotResizeDimension) {
       descriptor.target_height = targetHeight;
     }
     descriptor.data = std::move(buffer);

--- a/lib/ui/painting/codec.cc
+++ b/lib/ui/painting/codec.cc
@@ -33,9 +33,6 @@ namespace flutter {
 
 namespace {
 
-// This needs to be kept in sync with kDoNotResizeDimension in painting.dart
-const int kDoNotResizeDimension = -1;
-
 // This must be kept in sync with the enum in painting.dart
 enum PixelFormat {
   kRGBA8888,
@@ -217,10 +214,10 @@ static void InstantiateImageCodec(Dart_NativeArguments args) {
     ImageDecoder::ImageDescriptor descriptor;
     descriptor.decompressed_image_info = image_info;
 
-    if (targetWidth != kDoNotResizeDimension) {
+    if (targetWidth >= 0 && targetWidth < image_info->sk_info.width()) {
       descriptor.target_width = targetWidth;
     }
-    if (targetHeight != kDoNotResizeDimension) {
+    if (targetHeight >= 0 && targetHeight < image_info->sk_info.height()) {
       descriptor.target_height = targetHeight;
     }
     descriptor.data = std::move(buffer);

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -1628,6 +1628,14 @@ enum PixelFormat {
   bgra8888,
 }
 
+// Indicates that the image should not be resized in this dimension.
+//
+// Used by [instantiateImageCodec] as a magical value to disable resizing
+// in the given dimension.
+//
+// This needs to be kept in sync with "kDoNotResizeDimension" in codec.cc
+const int kDoNotResizeDimension = -1;
+
 class _ImageInfo {
   _ImageInfo(this.width, this.height, this.format, this.rowBytes) {
     rowBytes ??= width * 4;
@@ -1705,9 +1713,13 @@ class Codec {
 ///
 /// The returned future can complete with an error if the image decoding has
 /// failed.
-Future<Codec> instantiateImageCodec(Uint8List list,
-    {double decodedCacheRatioCap = double.infinity}) {
+Future<Codec> instantiateImageCodec(Uint8List list, {
+  double decodedCacheRatioCap = double.infinity
+  int targetWidth,
+  int targetHeight,
+}) {
   return engine.futurize((engine.Callback<Codec> callback) =>
+      // TODO: Implement targetWidth and targetHeight support.
       _instantiateImageCodec(list, callback, null));
 }
 

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -1714,7 +1714,6 @@ class Codec {
 /// The returned future can complete with an error if the image decoding has
 /// failed.
 Future<Codec> instantiateImageCodec(Uint8List list, {
-  double decodedCacheRatioCap = double.infinity
   int targetWidth,
   int targetHeight,
 }) {

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -1628,12 +1628,10 @@ enum PixelFormat {
   bgra8888,
 }
 
-// Indicates that the image should not be resized in this dimension.
-//
-// Used by [instantiateImageCodec] as a magical value to disable resizing
-// in the given dimension.
-//
-// This needs to be kept in sync with "kDoNotResizeDimension" in codec.cc
+/// Indicates that the image should not be resized in this dimension.
+///
+/// Used by [instantiateImageCodec] as a magical value to disable resizing
+/// in the given dimension.
 const int kDoNotResizeDimension = -1;
 
 class _ImageInfo {

--- a/testing/dart/image_resize_test.dart
+++ b/testing/dart/image_resize_test.dart
@@ -97,6 +97,14 @@ void main() {
     expect(resized.height, 1);
     expect(resized.width, 10);
   });
+
+  test('pixels: large negative dimensions', () async {
+    final BlackSquare blackSquare = BlackSquare.create();
+    final Image resized =
+        await blackSquare.resize(targetHeight: -100, targetWidth: -99999);
+    expect(resized.height, 2);
+    expect(resized.width, 2);
+  });
 }
 
 class BlackSquare {


### PR DESCRIPTION
Otherwise, framework would have to keep in sync with dart:ui and maintain its own copy.

For another attempt at landing https://github.com/flutter/flutter/pull/31164