### PR TITLE
Fix double subscription to on/off label accessibility notification.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -240,11 +240,6 @@ typedef enum UIAccessibilityContrast : NSInteger {
                object:nil];
 
   [center addObserver:self
-             selector:@selector(onAccessibilityStatusChanged:)
-                 name:UIAccessibilityOnOffSwitchLabelsDidChangeNotification
-               object:nil];
-
-  [center addObserver:self
              selector:@selector(onUserSettingsChanged:)
                  name:UIContentSizeCategoryDidChangeNotification
                object:nil];


### PR DESCRIPTION
An extra subscription was accidentally added in #12404. This will cause onAccessibilityStatusChanged to be invoked an extra time (it isn't an error to subscribe twice, but this is nonetheless suboptimal).

This removes the extraneous subscription.