### PR TITLE
Revert "Support accessibility labels on iOS switches."

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -1194,7 +1194,6 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
-  static const int _kOnOffSwitchLabelsIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1222,11 +1221,6 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
-  /// The platform is requesting that on/off labels be added to switches.
-  ///
-  /// Only supported on iOS.
-  bool get onOffSwitchLabels => _kOnOffSwitchLabelsIndex & _index != 0;
-
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1240,8 +1234,6 @@ class AccessibilityFeatures {
       features.add('boldText');
     if (reduceMotion)
       features.add('reduceMotion');
-    if (onOffSwitchLabels)
-      features.add('onOffSwitchLabels');
     return 'AccessibilityFeatures$features';
   }
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -44,7 +44,6 @@ enum class AccessibilityFeatureFlag : int32_t {
   kDisableAnimations = 1 << 2,
   kBoldText = 1 << 3,
   kReduceMotion = 1 << 4,
-  kOnOffSwitchLabels = 1 << 5,
 };
 
 class WindowClient {

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1012,7 +1012,6 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
-  static const int _kOnOffSwitchLabelsIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1040,11 +1039,6 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
-  /// The platform is requesting that on/off labels be added to switches.
-  ///
-  /// Only supported on iOS.
-  bool get onOffSwitchLabels => _kOnOffSwitchLabelsIndex & _index != 0;
-
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1062,9 +1056,6 @@ class AccessibilityFeatures {
     }
     if (reduceMotion) {
       features.add('reduceMotion');
-    }
-    if (onOffSwitchLabels) {
-      features.add('onOffSwitchLabels');
     }
     return 'AccessibilityFeatures$features';
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -235,16 +235,6 @@ typedef enum UIAccessibilityContrast : NSInteger {
                object:nil];
 
   [center addObserver:self
-             selector:@selector(onAccessibilityStatusChanged:)
-                 name:UIAccessibilityOnOffSwitchLabelsDidChangeNotification
-               object:nil];
-
-  [center addObserver:self
-             selector:@selector(onAccessibilityStatusChanged:)
-                 name:UIAccessibilityOnOffSwitchLabelsDidChangeNotification
-               object:nil];
-
-  [center addObserver:self
              selector:@selector(onUserSettingsChanged:)
                  name:UIContentSizeCategoryDidChangeNotification
                object:nil];
@@ -867,8 +857,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kReduceMotion);
   if (UIAccessibilityIsBoldTextEnabled())
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kBoldText);
-  if (UIAccessibilityIsOnOffSwitchLabelsEnabled())
-    flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kOnOffSwitchLabels);
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the


### PR DESCRIPTION
Reverts flutter/engine#12404

Needs to be guarded by an availability flag

TBR @brandondiamond  @chinmaygarde 