### PR TITLE
Add support for on/off switch labels when built on iOS 13.

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -1194,6 +1194,7 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
+  static const int _kOnOffSwitchLabelsIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1221,6 +1222,11 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
+  /// The platform is requesting that on/off labels be added to switches.
+  ///
+  /// Only supported on iOS.
+  bool get onOffSwitchLabels => _kOnOffSwitchLabelsIndex & _index != 0;
+
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1234,6 +1240,8 @@ class AccessibilityFeatures {
       features.add('boldText');
     if (reduceMotion)
       features.add('reduceMotion');
+    if (onOffSwitchLabels)
+      features.add('onOffSwitchLabels');
     return 'AccessibilityFeatures$features';
   }
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -44,6 +44,7 @@ enum class AccessibilityFeatureFlag : int32_t {
   kDisableAnimations = 1 << 2,
   kBoldText = 1 << 3,
   kReduceMotion = 1 << 4,
+  kOnOffSwitchLabels = 1 << 5,
 };
 
 class WindowClient {

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1012,6 +1012,7 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
+  static const int _kOnOffSwitchLabelsIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1039,6 +1040,11 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
+  /// The platform is requesting that on/off labels be added to switches.
+  ///
+  /// Only supported on iOS.
+  bool get onOffSwitchLabels => _kOnOffSwitchLabelsIndex & _index != 0;
+
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1056,6 +1062,9 @@ class AccessibilityFeatures {
     }
     if (reduceMotion) {
       features.add('reduceMotion');
+    }
+    if (onOffSwitchLabels) {
+      features.add('onOffSwitchLabels');
     }
     return 'AccessibilityFeatures$features';
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -238,6 +238,13 @@ typedef enum UIAccessibilityContrast : NSInteger {
              selector:@selector(onUserSettingsChanged:)
                  name:UIContentSizeCategoryDidChangeNotification
                object:nil];
+
+  if (@available(iOS 13, *)) {
+    [center addObserver:self
+               selector:@selector(onAccessibilityStatusChanged:)
+                   name:UIAccessibilityOnOffSwitchLabelsDidChangeNotification
+                 object:nil];
+  }
 }
 
 - (void)setInitialRoute:(NSString*)route {
@@ -857,6 +864,10 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kReduceMotion);
   if (UIAccessibilityIsBoldTextEnabled())
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kBoldText);
+  if (@available(iOS 13, *)) {
+    if (UIAccessibilityIsOnOffSwitchLabelsEnabled())
+      flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kOnOffSwitchLabels);
+  }
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -34,10 +34,10 @@ source_set("utils") {
     "$fuchsia_sdk_root/pkg:async-loop-default",
     "$fuchsia_sdk_root/pkg:fdio",
     "$fuchsia_sdk_root/pkg:memfs",
-    "$fuchsia_sdk_root/pkg:syslog",
-    "$fuchsia_sdk_root/pkg:zx",
     "$fuchsia_sdk_root/pkg:sys_cpp",
+    "$fuchsia_sdk_root/pkg:syslog",
     "$fuchsia_sdk_root/pkg:vfs_cpp",
+    "$fuchsia_sdk_root/pkg:zx",
     "//third_party/tonic",
   ]
 


### PR DESCRIPTION
Same as #12404 but verifies platform is iOS 13. Shouldn't merge until build bots have been updated to support iOS 13.