### PR TITLE
Started asserting the FlutterEngine is running before communicating over channels.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -533,7 +533,7 @@
 - (void)sendOnChannel:(NSString*)channel
               message:(NSData*)message
           binaryReply:(FlutterBinaryReply)callback {
-  NSAssert(channel, @"The channel must not be nil");
+  NSParameterAssert(channel);
   NSAssert(_shell && _shell->IsSetup(),
            @"Sending a message before the FlutterEngine has been run.");
   fml::RefPtr<flutter::PlatformMessageResponseDarwin> response =
@@ -553,7 +553,7 @@
 
 - (void)setMessageHandlerOnChannel:(NSString*)channel
               binaryMessageHandler:(FlutterBinaryMessageHandler)handler {
-  NSAssert(channel, @"The channel must not be null");
+  NSParameterAssert(channel);
   NSAssert(_shell && _shell->IsSetup(),
            @"Setting a message handler before the FlutterEngine has been run.");
   self.iosPlatformView->GetPlatformMessageRouter().SetMessageHandler(channel.UTF8String, handler);

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -533,7 +533,9 @@
 - (void)sendOnChannel:(NSString*)channel
               message:(NSData*)message
           binaryReply:(FlutterBinaryReply)callback {
-  NSAssert(channel, @"The channel must not be null");
+  NSAssert(channel, @"The channel must not be nil");
+  NSAssert(_shell && _shell->IsSetup(),
+           @"Sending a message before the FlutterEngine has been run.");
   fml::RefPtr<flutter::PlatformMessageResponseDarwin> response =
       (callback == nil) ? nullptr
                         : fml::MakeRefCounted<flutter::PlatformMessageResponseDarwin>(
@@ -552,7 +554,8 @@
 - (void)setMessageHandlerOnChannel:(NSString*)channel
               binaryMessageHandler:(FlutterBinaryMessageHandler)handler {
   NSAssert(channel, @"The channel must not be null");
-  FML_DCHECK(_shell && _shell->IsSetup());
+  NSAssert(_shell && _shell->IsSetup(),
+           @"Setting a message handler before the FlutterEngine has been run.");
   self.iosPlatformView->GetPlatformMessageRouter().SetMessageHandler(channel.UTF8String, handler);
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -14,7 +14,6 @@
 #error ARC must be enabled!
 #endif
 
-
 @interface FlutteEngineTest : XCTestCase
 @end
 
@@ -28,15 +27,13 @@
 
 - (void)testCreate {
   id project = OCMClassMock([FlutterDartProject class]);
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"
-                                                      project:project];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
   XCTAssertNotNil(engine);
 }
 
 - (void)testSendMessageBeforeRun {
   id project = OCMClassMock([FlutterDartProject class]);
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"
-                                                      project:project];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
   XCTAssertNotNil(engine);
   XCTAssertThrows([engine.binaryMessenger
       sendOnChannel:@"foo"
@@ -46,8 +43,7 @@
 
 - (void)testSetMessageHandlerBeforeRun {
   id project = OCMClassMock([FlutterDartProject class]);
-  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"
-                                                      project:project];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar" project:project];
   XCTAssertNotNil(engine);
   XCTAssertThrows([engine.binaryMessenger
       setMessageHandlerOnChannel:@"foo"

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -6,6 +6,15 @@
 #import <XCTest/XCTest.h>
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h"
 
+#ifndef __has_feature
+#define __has_feature(x) 0 /* for non-clang compilers */
+#endif
+
+#if !__has_feature(objc_arc)
+#error ARC must be enabled!
+#endif
+
+
 @interface FlutteEngineTest : XCTestCase
 @end
 
@@ -19,15 +28,15 @@
 
 - (void)testCreate {
   id project = OCMClassMock([FlutterDartProject class]);
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"foobar"
-                                                       project:project] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"
+                                                      project:project];
   XCTAssertNotNil(engine);
 }
 
 - (void)testSendMessageBeforeRun {
   id project = OCMClassMock([FlutterDartProject class]);
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"foobar"
-                                                       project:project] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"
+                                                      project:project];
   XCTAssertNotNil(engine);
   XCTAssertThrows([engine.binaryMessenger
       sendOnChannel:@"foo"
@@ -37,8 +46,8 @@
 
 - (void)testSetMessageHandlerBeforeRun {
   id project = OCMClassMock([FlutterDartProject class]);
-  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"foobar"
-                                                       project:project] autorelease];
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"foobar"
+                                                      project:project];
   XCTAssertNotNil(engine);
   XCTAssertThrows([engine.binaryMessenger
       setMessageHandlerOnChannel:@"foo"

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngineTest.mm
@@ -24,4 +24,27 @@
   XCTAssertNotNil(engine);
 }
 
+- (void)testSendMessageBeforeRun {
+  id project = OCMClassMock([FlutterDartProject class]);
+  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"foobar"
+                                                       project:project] autorelease];
+  XCTAssertNotNil(engine);
+  XCTAssertThrows([engine.binaryMessenger
+      sendOnChannel:@"foo"
+            message:[@"bar" dataUsingEncoding:NSUTF8StringEncoding]
+        binaryReply:nil]);
+}
+
+- (void)testSetMessageHandlerBeforeRun {
+  id project = OCMClassMock([FlutterDartProject class]);
+  FlutterEngine* engine = [[[FlutterEngine alloc] initWithName:@"foobar"
+                                                       project:project] autorelease];
+  XCTAssertNotNil(engine);
+  XCTAssertThrows([engine.binaryMessenger
+      setMessageHandlerOnChannel:@"foo"
+            binaryMessageHandler:^(NSData* _Nullable message, FlutterBinaryReply _Nonnull reply){
+
+            }]);
+}
+
 @end

--- a/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
+++ b/testing/ios/IosUnitTests/IosUnitTests.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		0D6AB6BE22BB05E200EEE540 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB6BD22BB05E200EEE540 /* Assets.xcassets */; };
 		0D6AB6C122BB05E200EEE540 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB6BF22BB05E200EEE540 /* LaunchScreen.storyboard */; };
 		0D6AB6C422BB05E200EEE540 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6C322BB05E200EEE540 /* main.m */; };
-		0D6AB6EB22BB40E700EEE540 /* FlutterEngineTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6E722BB40CF00EEE540 /* FlutterEngineTest.mm */; };
+		0D6AB6EB22BB40E700EEE540 /* FlutterEngineTest.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0D6AB6E722BB40CF00EEE540 /* FlutterEngineTest.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		0D6AB72C22BC339F00EEE540 /* libOCMock.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D6AB72522BC336100EEE540 /* libOCMock.a */; };
 		0D6AB73F22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0D6AB73E22BD8F0200EEE540 /* FlutterEngineConfig.xcconfig */; };
 /* End PBXBuildFile section */


### PR DESCRIPTION
This changes a null pointer exception to an NSException that will provide some meaningful data to clients incorrectly using the engine in an add-to-app situations.