### PR TITLE
Fix opacity regression due to PR#11322

### DIFF
--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -31,19 +31,17 @@ ContainerLayer::ContainerLayer(bool force_single_child) {
   // Place all "child" layers under a single child if requested.
   if (force_single_child) {
     single_child_ = std::make_shared<TransformLayer>(SkMatrix::I());
-    single_child_->set_parent(this);
     layers_.push_back(single_child_);
   }
 }
+
 void ContainerLayer::Add(std::shared_ptr<Layer> layer) {
   // Place all "child" layers under a single child if requested.
   if (single_child_) {
     single_child_->Add(std::move(layer));
-    return;
+  } else {
+    layers_.push_back(std::move(layer));
   }
-
-  layer->set_parent(this);
-  layers_.push_back(std::move(layer));
 }
 
 void ContainerLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -23,8 +23,7 @@ uint64_t NextUniqueID() {
 namespace flutter {
 
 Layer::Layer()
-    : parent_(nullptr),
-      paint_bounds_(SkRect::MakeEmpty()),
+    : paint_bounds_(SkRect::MakeEmpty()),
       unique_id_(NextUniqueID()),
       needs_system_composite_(false) {}
 

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -133,9 +133,6 @@ class Layer {
   // Updates the system composited scene.
   virtual void UpdateScene(SceneUpdateContext& context) {}
 
-  ContainerLayer* parent() const { return parent_; }
-  void set_parent(ContainerLayer* parent) { parent_ = parent; }
-
   bool needs_system_composite() const { return needs_system_composite_; }
   void set_needs_system_composite(bool value) {
     needs_system_composite_ = value;
@@ -151,7 +148,6 @@ class Layer {
   uint64_t unique_id() const { return unique_id_; }
 
  private:
-  ContainerLayer* parent_;
   SkRect paint_bounds_;
   uint64_t unique_id_;
   bool needs_system_composite_;

--- a/lib/ui/compositing/scene_builder.cc
+++ b/lib/ui/compositing/scene_builder.cc
@@ -78,8 +78,11 @@ void SceneBuilder::RegisterNatives(tonic::DartLibraryNatives* natives) {
   });
 }
 
-SceneBuilder::SceneBuilder() = default;
-SceneBuilder::~SceneBuilder() = default;
+SceneBuilder::SceneBuilder() {
+  // Add a ContainerLayer as the root layer, so that AddLayer operations are
+  // always valid.
+  PushLayer(std::make_shared<flutter::ContainerLayer>());
+}
 
 fml::RefPtr<EngineLayer> SceneBuilder::pushTransform(
     tonic::Float64List& matrix4) {
@@ -180,34 +183,37 @@ fml::RefPtr<EngineLayer> SceneBuilder::pushPhysicalShape(const CanvasPath* path,
   return EngineLayer::MakeRetained(layer);
 }
 
-void SceneBuilder::addRetained(fml::RefPtr<EngineLayer> retainedLayer) {
-  if (!current_layer_) {
-    return;
-  }
-  current_layer_->Add(retainedLayer->Layer());
+void SceneBuilder::pop() {
+  PopLayer();
 }
 
-void SceneBuilder::pop() {
-  if (!current_layer_) {
-    return;
-  }
-  current_layer_ = current_layer_->parent();
+void SceneBuilder::addRetained(fml::RefPtr<EngineLayer> retainedLayer) {
+  AddLayer(retainedLayer->Layer());
+}
+
+void SceneBuilder::addPerformanceOverlay(uint64_t enabledOptions,
+                                         double left,
+                                         double right,
+                                         double top,
+                                         double bottom) {
+  SkRect rect = SkRect::MakeLTRB(left, top, right, bottom);
+  auto layer =
+      std::make_unique<flutter::PerformanceOverlayLayer>(enabledOptions);
+  layer->set_paint_bounds(rect);
+  AddLayer(std::move(layer));
 }
 
 void SceneBuilder::addPicture(double dx,
                               double dy,
                               Picture* picture,
                               int hints) {
-  if (!current_layer_) {
-    return;
-  }
   SkPoint offset = SkPoint::Make(dx, dy);
   SkRect pictureRect = picture->picture()->cullRect();
   pictureRect.offset(offset.x(), offset.y());
   auto layer = std::make_unique<flutter::PictureLayer>(
       offset, UIDartState::CreateGPUObject(picture->picture()), !!(hints & 1),
       !!(hints & 2));
-  current_layer_->Add(std::move(layer));
+  AddLayer(std::move(layer));
 }
 
 void SceneBuilder::addTexture(double dx,
@@ -216,12 +222,9 @@ void SceneBuilder::addTexture(double dx,
                               double height,
                               int64_t textureId,
                               bool freeze) {
-  if (!current_layer_) {
-    return;
-  }
   auto layer = std::make_unique<flutter::TextureLayer>(
       SkPoint::Make(dx, dy), SkSize::Make(width, height), textureId, freeze);
-  current_layer_->Add(std::move(layer));
+  AddLayer(std::move(layer));
 }
 
 void SceneBuilder::addPlatformView(double dx,
@@ -229,12 +232,9 @@ void SceneBuilder::addPlatformView(double dx,
                                    double width,
                                    double height,
                                    int64_t viewId) {
-  if (!current_layer_) {
-    return;
-  }
   auto layer = std::make_unique<flutter::PlatformViewLayer>(
       SkPoint::Make(dx, dy), SkSize::Make(width, height), viewId);
-  current_layer_->Add(std::move(layer));
+  AddLayer(std::move(layer));
 }
 
 #if defined(OS_FUCHSIA)
@@ -244,30 +244,12 @@ void SceneBuilder::addChildScene(double dx,
                                  double height,
                                  SceneHost* sceneHost,
                                  bool hitTestable) {
-  if (!current_layer_) {
-    return;
-  }
   auto layer = std::make_unique<flutter::ChildSceneLayer>(
       sceneHost->id(), SkPoint::Make(dx, dy), SkSize::Make(width, height),
       hitTestable);
-  current_layer_->Add(std::move(layer));
+  AddLayer(std::move(layer));
 }
 #endif  // defined(OS_FUCHSIA)
-
-void SceneBuilder::addPerformanceOverlay(uint64_t enabledOptions,
-                                         double left,
-                                         double right,
-                                         double top,
-                                         double bottom) {
-  if (!current_layer_) {
-    return;
-  }
-  SkRect rect = SkRect::MakeLTRB(left, top, right, bottom);
-  auto layer =
-      std::make_unique<flutter::PerformanceOverlayLayer>(enabledOptions);
-  layer->set_paint_bounds(rect);
-  current_layer_->Add(std::move(layer));
-}
 
 void SceneBuilder::setRasterizerTracingThreshold(uint32_t frameInterval) {
   rasterizer_tracing_threshold_ = frameInterval;
@@ -282,29 +264,33 @@ void SceneBuilder::setCheckerboardOffscreenLayers(bool checkerboard) {
 }
 
 fml::RefPtr<Scene> SceneBuilder::build() {
+  FML_DCHECK(layer_stack_.size() >= 1);
+
   fml::RefPtr<Scene> scene = Scene::create(
-      std::move(root_layer_), rasterizer_tracing_threshold_,
+      layer_stack_[0], rasterizer_tracing_threshold_,
       checkerboard_raster_cache_images_, checkerboard_offscreen_layers_);
-  ClearDartWrapper();
+  ClearDartWrapper();  // may delete this object.
   return scene;
 }
 
-void SceneBuilder::PushLayer(std::shared_ptr<flutter::ContainerLayer> layer) {
+void SceneBuilder::AddLayer(std::shared_ptr<Layer> layer) {
   FML_DCHECK(layer);
 
-  if (!root_layer_) {
-    root_layer_ = std::move(layer);
-    current_layer_ = root_layer_.get();
-    return;
+  if (!layer_stack_.empty()) {
+    layer_stack_.back()->Add(std::move(layer));
   }
+}
 
-  if (!current_layer_) {
-    return;
+void SceneBuilder::PushLayer(std::shared_ptr<ContainerLayer> layer) {
+  AddLayer(layer);
+  layer_stack_.push_back(std::move(layer));
+}
+
+void SceneBuilder::PopLayer() {
+  // We never pop the root layer, so that AddLayer operations are always valid.
+  if (layer_stack_.size() > 1) {
+    layer_stack_.pop_back();
   }
-
-  flutter::ContainerLayer* newLayer = layer.get();
-  current_layer_->Add(std::move(layer));
-  current_layer_ = newLayer;
 }
 
 }  // namespace flutter

--- a/lib/ui/window/viewport_metrics.cc
+++ b/lib/ui/window/viewport_metrics.cc
@@ -4,8 +4,9 @@
 
 #include "flutter/lib/ui/window/viewport_metrics.h"
 
+#include "flutter/fml/logging.h"
+
 namespace flutter {
-ViewportMetrics::ViewportMetrics() = default;
 
 ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
                                  double p_physical_width,
@@ -40,8 +41,9 @@ ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
           p_physical_system_gesture_inset_bottom),
       physical_system_gesture_inset_left(p_physical_system_gesture_inset_left) {
   // Ensure we don't have nonsensical dimensions.
-  FML_DCHECK(physical_width > 0);
-  FML_DCHECK(physical_height > 0);
+  FML_DCHECK(physical_width >= 0);
+  FML_DCHECK(physical_height >= 0);
+  FML_DCHECK(physical_depth >= 0);
   FML_DCHECK(device_pixel_ratio > 0);
 }
 
@@ -74,11 +76,10 @@ ViewportMetrics::ViewportMetrics(double p_device_pixel_ratio,
       physical_view_inset_front(p_physical_view_inset_front),
       physical_view_inset_back(p_physical_view_inset_back) {
   // Ensure we don't have nonsensical dimensions.
-  FML_DCHECK(physical_width > 0);
-  FML_DCHECK(physical_height > 0);
+  FML_DCHECK(physical_width >= 0);
+  FML_DCHECK(physical_height >= 0);
+  FML_DCHECK(physical_depth >= 0);
   FML_DCHECK(device_pixel_ratio > 0);
 }
-
-ViewportMetrics::ViewportMetrics(const ViewportMetrics& other) = default;
 
 }  // namespace flutter

--- a/lib/ui/window/viewport_metrics.h
+++ b/lib/ui/window/viewport_metrics.h
@@ -7,8 +7,6 @@
 
 #include <stdint.h>
 
-#include "flutter/fml/logging.h"
-
 namespace flutter {
 
 // This is the value of double.maxFinite from dart:core.
@@ -18,7 +16,8 @@ namespace flutter {
 static const double kUnsetDepth = 1.7976931348623157e+308;
 
 struct ViewportMetrics {
-  ViewportMetrics();
+  ViewportMetrics() = default;
+  ViewportMetrics(const ViewportMetrics& other) = default;
 
   // Create a 2D ViewportMetrics instance.
   ViewportMetrics(double p_device_pixel_ratio,
@@ -52,8 +51,6 @@ struct ViewportMetrics {
                   double p_physical_view_inset_right,
                   double p_physical_view_inset_bottom,
                   double p_physical_view_inset_left);
-
-  ViewportMetrics(const ViewportMetrics& other);
 
   double device_pixel_ratio = 1.0;
   double physical_width = 0;

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -34,10 +34,10 @@ source_set("utils") {
     "$fuchsia_sdk_root/pkg:async-loop-default",
     "$fuchsia_sdk_root/pkg:fdio",
     "$fuchsia_sdk_root/pkg:memfs",
-    "$fuchsia_sdk_root/pkg:syslog",
-    "$fuchsia_sdk_root/pkg:zx",
     "$fuchsia_sdk_root/pkg:sys_cpp",
+    "$fuchsia_sdk_root/pkg:syslog",
     "$fuchsia_sdk_root/pkg:vfs_cpp",
+    "$fuchsia_sdk_root/pkg:zx",
     "//third_party/tonic",
   ]
 


### PR DESCRIPTION
To do so, this CL removes the parent pointer from Layer, and the
SceneBuilder maintains a stack locally instead.  This has the benefit of
shrinking the byte size of Layer, while also reducing complexity.

To ensure the stack state remains consistent, a ContainerLayer is added
to the top of the stack to serve as a root layer.  It is never popped
off, and Dart code has no way of manipulating it.

This has the nice side effect of allowing add*() operations to succeed,
even if no push*() was performed yet.  It also allows sequences like these
to generate a valid LayerTree:  push(); push(); add(); pop(); pop();
push(); add(); (the push and add at the end were invalid before).  Before,
these edge cases would just silently fail.

Test:  Ran cull_opacity_perf__timeline_summary locally

Fixes: https://github.com/flutter/flutter/issues/41394