### PR TITLE
Remove use of the blobs snapshot format from unittests

### DIFF
--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -127,6 +127,7 @@ if (current_toolchain == host_toolchain) {
       "$flutter_root/testing:skia",
       "//third_party/skia",
       "//third_party/tonic",
+      "//third_party/dart/runtime/bin:elf_loader",
     ]
   }
 }

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -20,7 +20,7 @@ EmbedderTestContext::EmbedderTestContext(std::string assets_path)
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
     std::string filename(assets_path_);
-    filename += "/binary.so";
+    filename += "/app_elf_snapshot.so";
 
     const uint8_t *vm_snapshot_data = nullptr,
                   *vm_snapshot_instructions = nullptr,

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -28,9 +28,10 @@ EmbedderTestContext::EmbedderTestContext(std::string assets_path)
                   *isolate_snapshot_instructions = nullptr;
     const char* error = nullptr;
 
-    elf_library_handle_ = Dart_LoadELF(
-        filename.c_str(), &error, &vm_snapshot_data, &vm_snapshot_instructions,
-        &isolate_snapshot_data, &isolate_snapshot_instructions);
+    elf_library_handle_ =
+        Dart_LoadELF(filename.c_str(), /*file_offset=*/0, &error,
+                     &vm_snapshot_data, &vm_snapshot_instructions,
+                     &isolate_snapshot_data, &isolate_snapshot_instructions);
 
     if (elf_library_handle_ != nullptr) {
       vm_snapshot_data_.reset(new fml::NonOwnedMapping(vm_snapshot_data, 0));

--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -6,6 +6,7 @@
 
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/platform/embedder/tests/embedder_assertions.h"
+#include "third_party/dart/runtime/bin/elf_loader.h"
 #include "third_party/skia/include/core/SkSurface.h"
 
 namespace flutter {
@@ -16,16 +17,32 @@ EmbedderTestContext::EmbedderTestContext(std::string assets_path)
       native_resolver_(std::make_shared<TestDartNativeResolver>()) {
   auto assets_dir = fml::OpenDirectory(assets_path_.c_str(), false,
                                        fml::FilePermission::kRead);
-  vm_snapshot_data_ =
-      fml::FileMapping::CreateReadOnly(assets_dir, "vm_snapshot_data");
-  isolate_snapshot_data_ =
-      fml::FileMapping::CreateReadOnly(assets_dir, "isolate_snapshot_data");
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
-    vm_snapshot_instructions_ =
-        fml::FileMapping::CreateReadExecute(assets_dir, "vm_snapshot_instr");
-    isolate_snapshot_instructions_ = fml::FileMapping::CreateReadExecute(
-        assets_dir, "isolate_snapshot_instr");
+    std::string filename(assets_path_);
+    filename += "/binary.so";
+
+    const uint8_t *vm_snapshot_data = nullptr,
+                  *vm_snapshot_instructions = nullptr,
+                  *isolate_snapshot_data = nullptr,
+                  *isolate_snapshot_instructions = nullptr;
+    const char* error = nullptr;
+
+    elf_library_handle_ = Dart_LoadELF(
+        filename.c_str(), &error, &vm_snapshot_data, &vm_snapshot_instructions,
+        &isolate_snapshot_data, &isolate_snapshot_instructions);
+
+    if (elf_library_handle_ != nullptr) {
+      vm_snapshot_data_.reset(new fml::NonOwnedMapping(vm_snapshot_data, 0));
+      vm_snapshot_instructions_.reset(
+          new fml::NonOwnedMapping(vm_snapshot_instructions, 0));
+      isolate_snapshot_data_.reset(
+          new fml::NonOwnedMapping(isolate_snapshot_data, 0));
+      isolate_snapshot_instructions_.reset(
+          new fml::NonOwnedMapping(isolate_snapshot_instructions, 0));
+    } else {
+      FML_LOG(WARNING) << "Could not load snapshot: " << error;
+    }
   }
 
   isolate_create_callbacks_.push_back(
@@ -37,7 +54,11 @@ EmbedderTestContext::EmbedderTestContext(std::string assets_path)
       });
 }
 
-EmbedderTestContext::~EmbedderTestContext() = default;
+EmbedderTestContext::~EmbedderTestContext() {
+  if (elf_library_handle_ != nullptr) {
+    Dart_UnloadELF(elf_library_handle_);
+  }
+}
 
 const std::string& EmbedderTestContext::GetAssetsPath() const {
   return assets_path_;

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -73,7 +73,7 @@ class EmbedderTestContext {
   std::string assets_path_;
 
   // Pieces of the Dart snapshot in ELF form, loaded by Dart's ELF library.
-  LoadedElfLibrary elf_library_handle_ = nullptr;
+  Dart_LoadedElf* elf_library_handle_ = nullptr;
   std::unique_ptr<fml::Mapping> vm_snapshot_data_;
   std::unique_ptr<fml::Mapping> vm_snapshot_instructions_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_data_;

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -17,6 +17,7 @@
 #include "flutter/shell/platform/embedder/tests/embedder_test_compositor.h"
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/test_gl_surface.h"
+#include "third_party/dart/runtime/bin/elf_loader.h"
 #include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {
@@ -70,10 +71,14 @@ class EmbedderTestContext {
   friend class EmbedderConfigBuilder;
 
   std::string assets_path_;
+
+  // Pieces of the Dart snapshot in ELF form, loaded by Dart's ELF library.
+  LoadedElfLibrary elf_library_handle_ = nullptr;
   std::unique_ptr<fml::Mapping> vm_snapshot_data_;
   std::unique_ptr<fml::Mapping> vm_snapshot_instructions_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_data_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_instructions_;
+
   std::vector<fml::closure> isolate_create_callbacks_;
   std::shared_ptr<TestDartNativeResolver> native_resolver_;
   SemanticsNodeCallback update_semantics_node_callback_;

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -125,7 +125,8 @@ template("dart_snapshot_aot") {
       invoker.dart_kernel,
     ]
 
-    elf_object = "$target_gen_dir/assets/binary.so"
+    # Custom ELF loader is used for Mac and Windows.
+    elf_object = "$target_gen_dir/assets/app_elf_snapshot.so"
 
     outputs = [elf_object]
 

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -125,26 +125,15 @@ template("dart_snapshot_aot") {
       invoker.dart_kernel,
     ]
 
-    vm_snapshot_data = "$target_gen_dir/assets/vm_snapshot_data"
-    vm_snapshot_instr = "$target_gen_dir/assets/vm_snapshot_instr"
-    isolate_snapshot_data = "$target_gen_dir/assets/isolate_snapshot_data"
-    isolate_snapshot_instr = "$target_gen_dir/assets/isolate_snapshot_instr"
+    elf_object = "$target_gen_dir/assets/binary.so"
 
-    outputs = [
-      vm_snapshot_data,
-      vm_snapshot_instr,
-      isolate_snapshot_data,
-      isolate_snapshot_instr,
-    ]
+    outputs = [elf_object]
 
     args = [
       "--causal_async_stacks",
       "--deterministic",
-      "--snapshot_kind=app-aot-blobs",
-      "--vm_snapshot_data=" + rebase_path(vm_snapshot_data),
-      "--vm_snapshot_instructions=" + rebase_path(vm_snapshot_instr),
-      "--isolate_snapshot_data=" + rebase_path(isolate_snapshot_data),
-      "--isolate_snapshot_instructions=" + rebase_path(isolate_snapshot_instr),
+      "--snapshot_kind=app-aot-elf",
+      "--elf=" + rebase_path(elf_object),
       rebase_path(invoker.dart_kernel),
     ]
 

--- a/tools/gn
+++ b/tools/gn
@@ -281,7 +281,7 @@ def parse_args(args):
 
   parser.add_argument('--runtime-mode', type=str, choices=['debug', 'profile', 'release', 'jit_release'], default='debug')
   parser.add_argument('--interpreter', default=False, action='store_true')
-  parser.add_argument('--dart-debug', default=False, action='store_true', help='Enables assertsion in the Dart VM. ' +
+  parser.add_argument('--dart-debug', default=False, action='store_true', help='Enables assertions in the Dart VM. ' +
       'Does not affect optimization levels. If you need to disable optimizations in Dart, use --full-dart-debug')
   parser.add_argument('--full-dart-debug', default=False, action='store_true', help='Implies --dart-debug ' +
       'and also disables optimizations in the Dart VM making it easier to step through VM code in the debugger.')


### PR DESCRIPTION
The blobs snapshot format is deprecated for AOT snapshots.

We supply a cross-platform ELF loader which can be used to load ELF snapshots on all platforms, and may be used as a drop-in replacement for all existing (AOT) blobs uses.

I deleted the previous (identical) PR thinking that we would want to move the ELF loader behind the third-party embedder API (`embedder.h`). However, I realized that none of the third-party embedders need to use it yet, and there are use cases which are not easy to handle if the embedder API requires passing a path the Dart snapshot instead of the snapshots pieces. For example, one can statically link an Assembly snapshot into the main app executable.

So, this PR follows the policy that a Flutter embedder should use the ELF loader directly if it needs it.

/cc @mraleph @mkustermann 