### PR TITLE
Add isFocusable to SemanticsFlag

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -290,6 +290,7 @@ class SemanticsFlag {
   static const int _kHasImplicitScrollingIndex = 1 << 18;
   static const int _kIsMultilineIndex = 1 << 19;
   static const int _kIsReadOnlyIndex = 1 << 20;
+  static const int _kIsFocusableIndex = 1 << 21;
 
   const SemanticsFlag._(this.index);
 
@@ -347,6 +348,11 @@ class SemanticsFlag {
   ///
   /// Only applicable when [isTextField] is true.
   static const SemanticsFlag isReadOnly = SemanticsFlag._(_kIsReadOnlyIndex);
+
+  /// Whether the semantic node is able to hold the user's focus.
+  ///
+  /// The focused element is usually the current receiver of keyboard inputs.
+  static const SemanticsFlag isFocusable = SemanticsFlag._(_kIsFocusableIndex);
 
   /// Whether the semantic node currently holds the user's focus.
   ///

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -72,6 +72,7 @@ enum class SemanticsFlags : int32_t {
   // The Dart API defines the following flag but it isn't used in iOS.
   // kIsMultiline = 1 << 19,
   kIsReadOnly = 1 << 20,
+  kIsFocusable = 1 << 21,
 };
 
 const int kScrollableSemanticsFlags =

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -293,6 +293,7 @@ class SemanticsFlag {
   static const int _kHasImplicitScrollingIndex = 1 << 18;
   static const int _kIsMultilineIndex = 1 << 19;
   static const int _kIsReadOnlyIndex = 1 << 20;
+  static const int _kIsFocusableIndex = 1 << 21;
 
   const SemanticsFlag._(this.index);
 
@@ -350,6 +351,11 @@ class SemanticsFlag {
   ///
   /// Only applicable when [isTextField] is true.
   static const SemanticsFlag isReadOnly = SemanticsFlag._(_kIsReadOnlyIndex);
+
+  /// Whether the semantic node is able to hold the user's focus.
+  ///
+  /// The focused element is usually the current receiver of keyboard inputs.
+  static const SemanticsFlag isFocusable = SemanticsFlag._(_kIsFocusableIndex);
 
   /// Whether the semantic node currently holds the user's focus.
   ///
@@ -517,6 +523,7 @@ class SemanticsFlag {
     _kIsSelectedIndex: isSelected,
     _kIsButtonIndex: isButton,
     _kIsTextFieldIndex: isTextField,
+    _kIsFocusableIndex: isFocusable,
     _kIsFocusedIndex: isFocused,
     _kHasEnabledStateIndex: hasEnabledState,
     _kIsEnabledIndex: isEnabled,
@@ -548,6 +555,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isButton';
       case _kIsTextFieldIndex:
         return 'SemanticsFlag.isTextField';
+      case _kIsFocusableIndex:
+        return 'SemanticsFlag.isFocusable';
       case _kIsFocusedIndex:
         return 'SemanticsFlag.isFocused';
       case _kHasEnabledStateIndex:

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -519,10 +519,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         result.setClassName("android.view.View");
         result.setSource(rootAccessibilityView, virtualViewId);
         result.setFocusable(semanticsNode.isFocusable());
-        if (semanticsNode.isFocusable()) {
-           result.addAction(AccessibilityNodeInfo.ACTION_FOCUS);
-        }
-
         if (inputFocusedSemanticsNode != null) {
             result.setFocused(inputFocusedSemanticsNode.id == virtualViewId);
         }
@@ -1232,11 +1228,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             }
             if (semanticsNode.hasFlag(Flag.IS_FOCUSED)) {
                 inputFocusedSemanticsNode = semanticsNode;
-                AccessibilityEvent event = obtainAccessibilityEvent(
-                    inputFocusedSemanticsNode.id,
-                    AccessibilityEvent.TYPE_VIEW_FOCUSED
-                );
-                sendAccessibilityEvent(event);
             }
             if (semanticsNode.hadPreviousConfig) {
                 updated.add(semanticsNode);
@@ -1656,7 +1647,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         HAS_IMPLICIT_SCROLLING(1 << 18),
         // The Dart API defines the following flag but it isn't used in Android.
         // IS_MULTILINE(1 << 19);
-        IS_READ_ONLY(1 << 20);
+        IS_READ_ONLY(1 << 20),
+        IS_FOCUSABLE(1 << 21);
 
         final int value;
 
@@ -2030,6 +2022,12 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             if (hasFlag(Flag.SCOPES_ROUTE)) {
                 return false;
             }
+            if (hasFlag(Flag.IS_FOCUSABLE)) {
+                return true;
+            }
+            // If not explicitly set as focusable, then use our legacy
+            // algorithm. Once all focusable widgets have a Focus widget, then
+            // this won't be needed.
             int scrollableActions = Action.SCROLL_RIGHT.value | Action.SCROLL_LEFT.value
                     | Action.SCROLL_UP.value | Action.SCROLL_DOWN.value;
             return (actions & ~scrollableActions) != 0 || flags != 0


### PR DESCRIPTION
This adds an `isFocusable` to `SemanticsFlag` so that the framework can tell the engine what semantics nodes are allowed to be focused, which will affect what platform flags are applied to the semantics information.

This flag is not yet in use by the framework.