### PR TITLE
[web_ui] Fixing invalid state bug for text editing

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -61,10 +61,20 @@ class EditingState {
   ///   "composingExtent": -1
   /// }
   /// ```
-  EditingState.fromFlutter(Map<String, dynamic> flutterEditingState)
-      : text = flutterEditingState['text'],
-        baseOffset = flutterEditingState['selectionBase'],
-        extentOffset = flutterEditingState['selectionExtent'];
+  ///
+  /// Flutter Framework can send the selectionBase and selectionExtent as -1,
+  /// if so 0 assigned to baseOffset and extentOffset. -1 is not a valid
+  /// selection range for input DOM elements.
+  factory EditingState.fromFlutter(Map<String, dynamic> flutterEditingState) {
+    final int selectionBase = flutterEditingState['selectionBase'];
+    final int selectionExtent = flutterEditingState['selectionExtent'];
+    final String text = flutterEditingState['text'];
+
+    return EditingState(
+        text: text,
+        baseOffset: (selectionBase >= 0) ? selectionBase : 0,
+        extentOffset: (selectionExtent >= 0) ? selectionExtent : 0);
+  }
 
   /// Creates an [EditingState] instance using values from the editing element
   /// in the DOM.

--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -62,9 +62,9 @@ class EditingState {
   /// }
   /// ```
   ///
-  /// Flutter Framework can send the selectionBase and selectionExtent as -1,
-  /// if so 0 assigned to baseOffset and extentOffset. -1 is not a valid
-  /// selection range for input DOM elements.
+  /// Flutter Framework can send the [selectionBase] and [selectionExtent] as
+  /// -1, if so 0 assigned to the [baseOffset] and [extentOffset]. -1 is not a
+  /// valid selection range for input DOM elements.
   factory EditingState.fromFlutter(Map<String, dynamic> flutterEditingState) {
     final int selectionBase = flutterEditingState['selectionBase'];
     final int selectionExtent = flutterEditingState['selectionExtent'];
@@ -72,8 +72,8 @@ class EditingState {
 
     return EditingState(
         text: text,
-        baseOffset: (selectionBase >= 0) ? selectionBase : 0,
-        extentOffset: (selectionExtent >= 0) ? selectionExtent : 0);
+        baseOffset: math.max(0, selectionBase),
+        extentOffset: math.max(0, selectionExtent));
   }
 
   /// Creates an [EditingState] instance using values from the editing element

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -549,6 +549,41 @@ void main() {
       expect(spy.messages, isEmpty);
     });
 
+    test('negative base and offset values in editing state is handled', () {
+      final MethodCall setClient = MethodCall(
+          'TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);
+      textEditing.handleTextInput(codec.encodeMethodCall(setClient));
+
+      const MethodCall setEditingState1 =
+          MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'abcd',
+        'selectionBase': 2,
+        'selectionExtent': 3,
+      });
+      textEditing.handleTextInput(codec.encodeMethodCall(setEditingState1));
+
+      const MethodCall show = MethodCall('TextInput.show');
+      textEditing.handleTextInput(codec.encodeMethodCall(show));
+
+      const MethodCall setEditingState2 =
+          MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'xyz',
+        'selectionBase': -1,
+        'selectionExtent': -1,
+      });
+      textEditing.handleTextInput(codec.encodeMethodCall(setEditingState2));
+
+      // The negative offset values are applied to the dom element as 0.
+      checkInputEditingState(
+          textEditing.editingElement.domElement, 'xyz', 0, 0);
+
+      const MethodCall clearClient = MethodCall('TextInput.clearClient');
+      textEditing.handleTextInput(codec.encodeMethodCall(clearClient));
+
+      // Confirm that [HybridTextEditing] didn't send any messages.
+      expect(spy.messages, isEmpty);
+    });
+
     test('Syncs the editing state back to Flutter', () {
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -549,21 +549,27 @@ void main() {
       expect(spy.messages, isEmpty);
     });
 
-    test('negative base and offset values in editing state is handled', () {
+    test(
+        'negative base offset and selection extent values in editing state is handled',
+        () {
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);
       textEditing.handleTextInput(codec.encodeMethodCall(setClient));
 
       const MethodCall setEditingState1 =
           MethodCall('TextInput.setEditingState', <String, dynamic>{
-        'text': 'abcd',
-        'selectionBase': 2,
-        'selectionExtent': 3,
+        'text': 'xyz',
+        'selectionBase': 1,
+        'selectionExtent': 2,
       });
       textEditing.handleTextInput(codec.encodeMethodCall(setEditingState1));
 
       const MethodCall show = MethodCall('TextInput.show');
       textEditing.handleTextInput(codec.encodeMethodCall(show));
+
+      // Check if the selection range is correct.
+      checkInputEditingState(
+          textEditing.editingElement.domElement, 'xyz', 1, 2);
 
       const MethodCall setEditingState2 =
           MethodCall('TextInput.setEditingState', <String, dynamic>{


### PR DESCRIPTION
Fixing invalid state bug for text editing.

Flutter Framework was sending editing state selection base and extent as -1. Since -1 is an invalid value for a dom element selection it was not applied to the last editing state. Now if the base or offset is sent as negative value, web engine will set 0 to the selection range.

## Related Issues

[#41376](https://github.com/flutter/flutter/issues/41376)
[#35438](https://github.com/flutter/flutter/issues/35438) 