### PR TITLE
Add missing flag for embedder.

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -170,6 +170,8 @@ typedef enum {
   ///
   /// Only applicable when kFlutterSemanticsFlagIsTextField flag is on.
   kFlutterSemanticsFlagIsReadOnly = 1 << 20,
+  /// Whether the semantic node can hold the user's focus.
+  kFlutterSemanticsFlagIsFocusable = 1 << 21,
 } FlutterSemanticsFlag;
 
 typedef enum {


### PR DESCRIPTION
Adding missing flag for `IsFocusable` that I missed in https://github.com/flutter/engine/pull/12618