### PR TITLE
Expanded channel buffer resize to method channels.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/BasicMessageChannel.java
@@ -112,8 +112,13 @@ public final class BasicMessageChannel<T> {
      * yet or the channel's message handler isn't setup on the Dart side yet.
      */
     public void resizeChannelBuffer(int newSize) {
+        resizeChannelBuffer(messenger, name, newSize);
+    }
+
+    static void resizeChannelBuffer(
+            @NonNull BinaryMessenger messenger, @NonNull String channel, int newSize) {
         Charset charset = Charset.forName("UTF-8");
-        String messageString = String.format(Locale.US, "resize\r%s\r%d", name, newSize);
+        String messageString = String.format(Locale.US, "resize\r%s\r%d", channel, newSize);
         ByteBuffer message = ByteBuffer.wrap(messageString.getBytes(charset));
         messenger.send(CHANNEL_BUFFERS_CHANNEL, message);
     }

--- a/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
+++ b/shell/platform/android/io/flutter/plugin/common/MethodChannel.java
@@ -120,6 +120,15 @@ public final class MethodChannel {
     }
 
     /**
+     * Adjusts the number of messages that will get buffered when sending messages to
+     * channels that aren't fully setup yet.  For example, the engine isn't running
+     * yet or the channel's message handler isn't setup on the Dart side yet.
+     */
+    public void resizeChannelBuffer(int newSize) {
+        BasicMessageChannel.resizeChannelBuffer(messenger, name, newSize);
+    }
+
+    /**
      * A handler of incoming method calls.
      */
     public interface MethodCallHandler {

--- a/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterChannels.h
@@ -252,6 +252,14 @@ FLUTTER_EXPORT
  * @param handler The method call handler.
  */
 - (void)setMethodCallHandler:(FlutterMethodCallHandler _Nullable)handler;
+
+/**
+ * Adjusts the number of messages that will get buffered when sending messages to
+ * channels that aren't fully setup yet.  For example, the engine isn't running
+ * yet or the channel's message handler isn't setup on the Dart side yet.
+ */
+- (void)resizeChannelBuffer:(NSInteger)newSize;
+
 @end
 
 /**

--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -8,6 +8,14 @@
 
 static NSString* const FlutterChannelBuffersChannel = @"dev.flutter/channel-buffers";
 
+static void resizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenger,
+                                NSString* channel,
+                                NSInteger newSize) {
+  NSString* messageString = [NSString stringWithFormat:@"resize\r%@\r%@", channel, @(newSize)];
+  NSData* message = [messageString dataUsingEncoding:NSUTF8StringEncoding];
+  [binaryMessenger sendOnChannel:FlutterChannelBuffersChannel message:message];
+}
+
 @implementation FlutterBasicMessageChannel {
   NSObject<FlutterBinaryMessenger>* _messenger;
   NSString* _name;
@@ -74,9 +82,7 @@ static NSString* const FlutterChannelBuffersChannel = @"dev.flutter/channel-buff
 }
 
 - (void)resizeChannelBuffer:(NSInteger)newSize {
-  NSString* messageString = [NSString stringWithFormat:@"resize\r%@\r%@", _name, @(newSize)];
-  NSData* message = [messageString dataUsingEncoding:NSUTF8StringEncoding];
-  [_messenger sendOnChannel:FlutterChannelBuffersChannel message:message];
+  resizeChannelBuffer(_messenger, _name, newSize);
 }
 
 @end
@@ -234,6 +240,11 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
   };
   [_messenger setMessageHandlerOnChannel:_name binaryMessageHandler:messageHandler];
 }
+
+- (void)resizeChannelBuffer:(NSInteger)newSize {
+  resizeChannelBuffer(_messenger, _name, newSize);
+}
+
 @end
 
 #pragma mark - Event channel

--- a/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterChannels.mm
@@ -8,7 +8,7 @@
 
 static NSString* const FlutterChannelBuffersChannel = @"dev.flutter/channel-buffers";
 
-static void resizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenger,
+static void ResizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenger,
                                 NSString* channel,
                                 NSInteger newSize) {
   NSString* messageString = [NSString stringWithFormat:@"resize\r%@\r%@", channel, @(newSize)];
@@ -82,7 +82,7 @@ static void resizeChannelBuffer(NSObject<FlutterBinaryMessenger>* binaryMessenge
 }
 
 - (void)resizeChannelBuffer:(NSInteger)newSize {
-  resizeChannelBuffer(_messenger, _name, newSize);
+  ResizeChannelBuffer(_messenger, _name, newSize);
 }
 
 @end
@@ -242,7 +242,7 @@ NSObject const* FlutterMethodNotImplemented = [NSObject new];
 }
 
 - (void)resizeChannelBuffer:(NSInteger)newSize {
-  resizeChannelBuffer(_messenger, _name, newSize);
+  ResizeChannelBuffer(_messenger, _name, newSize);
 }
 
 @end


### PR DESCRIPTION
There was talk of trying to make this logic more complicated but I've opted for the simple solution of having a pool dedicated to a whole method channel.  If clients want more control over the channel buffers they can split out multiple channels.