### PR TITLE
Stop setting the accessibility text if a node has SCOPES_ROUTE set.

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -519,6 +519,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         result.setClassName("android.view.View");
         result.setSource(rootAccessibilityView, virtualViewId);
         result.setFocusable(semanticsNode.isFocusable());
+        if (semanticsNode.isFocusable() && !semanticsNode.hasFlag(Flag.IS_FOCUSED)) {
+            result.addAction(AccessibilityNodeInfo.ACTION_FOCUS);
+        }
         if (inputFocusedSemanticsNode != null) {
             result.setFocused(inputFocusedSemanticsNode.id == virtualViewId);
         }

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1380,6 +1380,12 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 event.getText().add(object.label);
                 sendAccessibilityEvent(event);
             }
+
+            // If the object is the input-focused node, then tell the reader about it.
+            if (inputFocusedSemanticsNode != null && inputFocusedSemanticsNode.id == object.id) {
+                sendAccessibilityEvent(obtainAccessibilityEvent(object.id, AccessibilityEvent.TYPE_VIEW_FOCUSED));
+            }
+
             if (inputFocusedSemanticsNode != null && inputFocusedSemanticsNode.id == object.id
                     && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)
                     // If we have a TextField that has InputFocus, we should avoid announcing it if something

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -737,12 +737,10 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             result.setChecked(semanticsNode.hasFlag(Flag.IS_TOGGLED));
             result.setClassName("android.widget.Switch");
             result.setContentDescription(semanticsNode.getValueLabelHint());
-        } else {
+        } else if (!semanticsNode.hasFlag(Flag.SCOPES_ROUTE)) {
             // Setting the text directly instead of the content description
             // will replace the "checked" or "not-checked" label.
-            if (!semanticsNode.hasFlag(Flag.SCOPES_ROUTE)) {
-                result.setText(semanticsNode.getValueLabelHint());
-            }
+            result.setText(semanticsNode.getValueLabelHint());
         }
 
         result.setSelected(semanticsNode.hasFlag(Flag.IS_SELECTED));
@@ -1379,12 +1377,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
                 event.getText().add(object.label);
                 sendAccessibilityEvent(event);
             }
-
-            // If the object is the input-focused node, then tell the reader about it.
-            if (inputFocusedSemanticsNode != null && inputFocusedSemanticsNode.id == object.id) {
-                sendAccessibilityEvent(obtainAccessibilityEvent(object.id, AccessibilityEvent.TYPE_VIEW_FOCUSED));
-            }
-
             if (inputFocusedSemanticsNode != null && inputFocusedSemanticsNode.id == object.id
                     && object.hadFlag(Flag.IS_TEXT_FIELD) && object.hasFlag(Flag.IS_TEXT_FIELD)
                     // If we have a TextField that has InputFocus, we should avoid announcing it if something


### PR DESCRIPTION
This keeps us from setting the text on a node if it is a SCOPES_ROUTE node, and sends the "TYPE_VIEW_FOCUSED" event when we update the semantics information and a view has the input focus.
