### PR TITLE
Adds Support  for system dpi awareness for older versions of Windows

### DIFF
--- a/shell/platform/windows/win32_dpi_helper.cc
+++ b/shell/platform/windows/win32_dpi_helper.cc
@@ -43,8 +43,6 @@ Win32DpiHelper::~Win32DpiHelper() {
   }
 }
 
-// SetAwareness
-// Check the available api. Start with v2, then fall back.
 void Win32DpiHelper::SetDpiAwerenessAllVersions() {
   if (permonitorv2_supported_) {
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);

--- a/shell/platform/windows/win32_dpi_helper.cc
+++ b/shell/platform/windows/win32_dpi_helper.cc
@@ -1,7 +1,5 @@
 #include "flutter/shell/platform/windows/win32_dpi_helper.h"
 
-#include <iostream>
-
 namespace flutter {
 
 namespace {
@@ -43,17 +41,17 @@ Win32DpiHelper::~Win32DpiHelper() {
   }
 }
 
-void Win32DpiHelper::SetDpiAwerenessAllVersions() {
+BOOL Win32DpiHelper::SetDpiAwareness() {
   if (permonitorv2_supported_) {
-    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    return set_process_dpi_awareness_context_(
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
   } else {
-    std::cerr << "Per Monitor V2 DPI awareness is not supported on this "
-                 "version of Windows. Setting System DPI awareness\n";
     AssignProcAddress(user32_module_, "GetDpiForSystem", get_dpi_for_system_);
     AssignProcAddress(user32_module_, "SetProcessDpiAware",
                       set_process_dpi_aware_);
 
-    SetProcessDPIAware();
+    return set_process_dpi_aware_();
   }
 }
 
@@ -68,27 +66,11 @@ BOOL Win32DpiHelper::EnableNonClientDpiScaling(HWND hwnd) {
   return enable_non_client_dpi_scaling_(hwnd);
 }
 
-UINT Win32DpiHelper::GetDpiForWindow(HWND hwnd) {
-  if (!permonitorv2_supported_) {
-    return false;
+UINT Win32DpiHelper::GetDpi(HWND hwnd) {
+  if (permonitorv2_supported_) {
+    return get_dpi_for_window_(hwnd);
   }
-  return get_dpi_for_window_(hwnd);
-}
-
-UINT Win32DpiHelper::GetDpiForSystem() {
   return get_dpi_for_system_();
-}
-
-BOOL Win32DpiHelper::SetProcessDpiAwarenessContext(
-    DPI_AWARENESS_CONTEXT context) {
-  if (!permonitorv2_supported_) {
-    return false;
-  }
-  return set_process_dpi_awareness_context_(context);
-}
-
-BOOL Win32DpiHelper::SetProcessDpiAware() {
-  return set_process_dpi_aware_();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -29,9 +29,6 @@ class Win32DpiHelper {
   // awareness has been set. Otherwise, returns the DPI for the System.
   UINT GetDpi(HWND);
 
-  // Sets the current process to System-level DPI awareness.
-  BOOL SetProcessDpiAware();
-
   // Sets the DPI awareness for the application. For versions >= Windows 1703,
   // use Per Monitor V2. For any older versions, use System.
   //

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -25,12 +25,9 @@ class Win32DpiHelper {
   // Wrapper for OS functionality to turn on automatic window non-client scaling
   BOOL EnableNonClientDpiScaling(HWND);
 
-  // Wrapper for OS functionality to return the DPI for |HWND|
-  UINT GetDpiForWindow(HWND);
-
-  // Wrapper for OS functionality to return the DPI for the System. Only used if
-  // Per Monitor V2 is not supported by the current Windows version.
-  UINT GetDpiForSystem();
+  // Wrapper for OS functionality to return the DPI for |HWND| if Per Monitor V2
+  // awareness has been set. Otherwise, returns the DPI for the System.
+  UINT GetDpi(HWND);
 
   // Sets the current process to a specified DPI awareness context.
   BOOL SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT);
@@ -43,7 +40,7 @@ class Win32DpiHelper {
   //
   // This call is overriden if DPI awareness is stated in the application
   // manifest.
-  void SetDpiAwerenessAllVersions();
+  BOOL SetDpiAwareness();
 
  private:
   using EnableNonClientDpiScaling_ = BOOL __stdcall(HWND);

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -28,17 +28,32 @@ class Win32DpiHelper {
   // Wrapper for OS functionality to return the DPI for |HWND|
   UINT GetDpiForWindow(HWND);
 
+  // Wrapper for OS functionality to return the DPI for the System. Only used if
+  // Per Monitor V2 is not supported by the current Windows version.
+  UINT GetDpiForSystem();
+
   // Sets the current process to a specified DPI awareness context.
   BOOL SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT);
+
+  // Sets the current process to System-level DPI awareness.
+  BOOL SetProcessDpiAware();
+
+  // Sets the DPI awareness for the application. For versions >= Windows 1703,
+  // use Per Monitor V2. For any older versions, use System.
+  void SetDpiAwerenessAllVersions();
 
  private:
   using EnableNonClientDpiScaling_ = BOOL __stdcall(HWND);
   using GetDpiForWindow_ = UINT __stdcall(HWND);
   using SetProcessDpiAwarenessContext_ = BOOL __stdcall(DPI_AWARENESS_CONTEXT);
+  using SetProcessDpiAware_ = BOOL __stdcall();
+  using GetDpiForSystem_ = UINT __stdcall();
 
   EnableNonClientDpiScaling_* enable_non_client_dpi_scaling_ = nullptr;
   GetDpiForWindow_* get_dpi_for_window_ = nullptr;
   SetProcessDpiAwarenessContext_* set_process_dpi_awareness_context_ = nullptr;
+  SetProcessDpiAware_* set_process_dpi_aware_ = nullptr;
+  GetDpiForSystem_* get_dpi_for_system_ = nullptr;
 
   HMODULE user32_module_ = nullptr;
   bool permonitorv2_supported_ = false;

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -40,6 +40,9 @@ class Win32DpiHelper {
 
   // Sets the DPI awareness for the application. For versions >= Windows 1703,
   // use Per Monitor V2. For any older versions, use System.
+  //
+  // This call is overriden if DPI awareness is stated in the application
+  // manifest.
   void SetDpiAwerenessAllVersions();
 
  private:

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -29,9 +29,6 @@ class Win32DpiHelper {
   // awareness has been set. Otherwise, returns the DPI for the System.
   UINT GetDpi(HWND);
 
-  // Sets the current process to a specified DPI awareness context.
-  BOOL SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT);
-
   // Sets the current process to System-level DPI awareness.
   BOOL SetProcessDpiAware();
 

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -20,7 +20,9 @@ void Win32Window::InitializeChild(const char* title,
 
   // Set DPI awareness for all Windows versions. This call has to be made before
   // the HWND is created.
-  dpi_helper_->SetDpiAwerenessAllVersions();
+  if (!dpi_helper_->SetDpiAwareness()) {
+    OutputDebugString(L"Failed to set DPI awareness");
+  }
 
   WNDCLASS window_class = RegisterWindowClass(converted_title);
 
@@ -86,10 +88,9 @@ LRESULT CALLBACK Win32Window::WndProc(HWND const window,
       if (result != TRUE) {
         OutputDebugString(L"Failed to enable non-client area autoscaling");
       }
-      that->current_dpi_ = that->dpi_helper_->GetDpiForWindow(window);
-    } else {
-      that->current_dpi_ = that->dpi_helper_->GetDpiForSystem();
     }
+    that->current_dpi_ = that->dpi_helper_->GetDpi(window);
+
     that->window_handle_ = window;
   } else if (Win32Window* that = GetThisFromHandle(window)) {
     return that->MessageHandler(window, message, wparam, lparam);
@@ -282,7 +283,7 @@ Win32Window::HandleDpiChange(HWND hwnd,
     // The DPI is only passed for DPI change messages on top level windows,
     // hence call function to get DPI if needed.
     if (uDpi == 0) {
-      uDpi = dpi_helper_->GetDpiForWindow(hwnd);
+      uDpi = dpi_helper_->GetDpi(hwnd);
     }
     current_dpi_ = uDpi;
     window->OnDpiScale(uDpi);

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -6,16 +6,8 @@
 
 namespace flutter {
 
-Win32Window::Win32Window() {
-  // Assume Windows 10 1703 or greater for DPI handling.  When running on a
-  // older release of Windows where this context doesn't exist, DPI calls will
-  // fail and Flutter rendering will be impacted until this is fixed.
-  // To handle downlevel correctly, dpi_helper must use the most recent DPI
-  // context available should be used: Windows 1703: Per-Monitor V2, 8.1:
-  // Per-Monitor V1, Windows 7: System See
-  // https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows
-  // for more information.
-}
+Win32Window::Win32Window() {}
+
 Win32Window::~Win32Window() {
   Destroy();
 }

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/windows/win32_window.h"
-#include <iostream>
 
 namespace flutter {
 

--- a/shell/platform/windows/win32_window.h
+++ b/shell/platform/windows/win32_window.h
@@ -57,7 +57,7 @@ class Win32Window {
 
   // Registers a window class with default style attributes, cursor and
   // icon.
-  WNDCLASS ResgisterWindowClass(std::wstring& title);
+  WNDCLASS RegisterWindowClass(std::wstring& title);
 
   // OS callback called by message pump.  Handles the WM_NCCREATE message which
   // is passed when the non-client area is being created and enables automatic


### PR DESCRIPTION
Not supporting Per Monitor V1 since I wasn't able to get dpi_changed events from the Windows procedure. Will investigate this further, but this solution still covers most of our use cases. 

This change also sets dpi awareness programmatically, removing the need to state it in the application manifest. 

https://github.com/google/flutter-desktop-embedding/issues/572