### PR TITLE
[web] Don't require felt to be in PATH

### DIFF
--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -11,7 +11,7 @@
 You could also run `felt help` or `felt help <command>` to get more information about the available commands and arguments.
 
 ## How can I use `felt`?
-Once you have your local copy of the engine [setup](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment), you'll need to add `/path/to/engine/src/flutter/lib/web_ui/dev` to your `PATH`.
+Once you have your local copy of the engine [setup](https://github.com/flutter/flutter/wiki/Setting-up-the-Engine-development-environment), it's recommended that you add `/path/to/engine/src/flutter/lib/web_ui/dev` to your `PATH`.
 Then you would be able to use the `felt` tool from anywhere:
 ```
 felt check-licenses
@@ -20,6 +20,8 @@ or:
 ```
 felt build --watch
 ```
+
+If you don't want to add `felt` to your path, you can still invoke it using a relative path like `./web_ui/dev/felt <command>`
 
 ## Configuration files
 

--- a/lib/web_ui/dev/felt
+++ b/lib/web_ui/dev/felt
@@ -4,31 +4,25 @@ set -e
 # felt: a command-line utility for building and testing Flutter web engine.
 #       It stands for Flutter Engine Local Tester.
 
-FELT_PATH=`which felt`
-if [ -z "$FELT_PATH" ]
-then
-  echo "ERROR: felt is not in your PATH"
-  echo "Fix: add lib/web_ui/dev to your PATH"
-  exit 1
-fi
+FELT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-GCLIENT_PATH=`which gclient`
-if [ -z "$GCLIENT_PATH" ]
+if [ -z "`which gclient`" ]
 then
   echo "ERROR: gclient is not in your PATH"
   echo "Fix: add the path to your installation of depot_tools to your PATH"
   exit 1
 fi
+GCLIENT_PATH=`which gclient`
 
-NINJA_PATH=`which ninja`
-if [ -z "$NINJA_PATH" ]
+if [ -z "`which ninja`" ]
 then
   echo "ERROR: ninja is not in your PATH"
   echo "Fix: add the path to your installation of depot_tools to your PATH"
   exit 1
 fi
+NINJA_PATH=`which ninja`
 
-ENGINE_SRC_DIR="$(dirname $(dirname $(dirname $(dirname $(dirname ${FELT_PATH})))))"
+ENGINE_SRC_DIR="$(dirname $(dirname $(dirname $(dirname ${FELT_DIR}))))"
 FLUTTER_DIR="${ENGINE_SRC_DIR}/flutter"
 WEB_UI_DIR="${FLUTTER_DIR}/lib/web_ui"
 DEV_DIR="${WEB_UI_DIR}/dev"


### PR DESCRIPTION
This PR also makes the checks for the existence of `gclient` and `ninja` work as expected.