### PR TITLE
Restart all modern Samsung keyboard IMM

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -324,13 +324,14 @@ public class TextInputPlugin {
     @SuppressWarnings("deprecation")
     private boolean isRestartAlwaysRequired() {
         InputMethodSubtype subtype = mImm.getCurrentInputMethodSubtype();
-        if (subtype == null) {
+        // Impacted devices all shipped with Android Lollipop or newer.
+        if (subtype == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.L) {
             return false;
         }
         String language = (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
                 ? subtype.getLanguageTag()
                 : subtype.getLocale();
-        return Build.MANUFACTURER.equals("samsung") && language.equals("ko");
+        return Build.MANUFACTURER.equals("samsung");
     }
 
     private void clearTextInputClient() {

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -334,7 +334,7 @@ public class TextInputPlugin {
         String keyboardName = Settings.Secure.getString(mView.getContext().getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
         // The Samsung keyboard is called "com.sec.android.inputmethod/.SamsungKeypad" but look
         // for "Samsung" just in case Samsung changes the name of the keyboard.
-        return Build.MANUFACTURER.equals("samsung") && keyboardName.contains("Samsung");
+        return Build.MANUFACTURER.equals("samsung") && keyboardName.toLowerCase().contains("samsung");
     }
 
     private void clearTextInputClient() {

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -334,7 +334,6 @@ public class TextInputPlugin {
         String keyboardName = Settings.Secure.getString(mView.getContext().getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
         // The Samsung keyboard is called "com.sec.android.inputmethod/.SamsungKeypad" but look
         // for "Samsung" just in case Samsung changes the name of the keyboard.
-        System.err.println("KEYBOARD::::: " + keyboardName);
         return keyboardName.contains("Samsung");
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -334,7 +334,7 @@ public class TextInputPlugin {
         String keyboardName = Settings.Secure.getString(mView.getContext().getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
         // The Samsung keyboard is called "com.sec.android.inputmethod/.SamsungKeypad" but look
         // for "Samsung" just in case Samsung changes the name of the keyboard.
-        return Build.MANUFACTURER.equals("samsung") && keyboardName.toLowerCase().contains("samsung");
+        return Build.MANUFACTURER.equals("samsung") && keyboardName.contains("Samsung");
     }
 
     private void clearTextInputClient() {

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -328,13 +328,14 @@ public class TextInputPlugin {
     private boolean isRestartAlwaysRequired() {
         InputMethodSubtype subtype = mImm.getCurrentInputMethodSubtype();
         // Impacted devices all shipped with Android Lollipop or newer.
-        if (subtype == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        if (subtype == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP || !Build.MANUFACTURER.equals("samsung")) {
             return false;
         }
         String keyboardName = Settings.Secure.getString(mView.getContext().getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD);
         // The Samsung keyboard is called "com.sec.android.inputmethod/.SamsungKeypad" but look
         // for "Samsung" just in case Samsung changes the name of the keyboard.
-        return Build.MANUFACTURER.equals("samsung") && keyboardName.contains("Samsung");
+        System.err.println("KEYBOARD::::: " + keyboardName);
+        return keyboardName.contains("Samsung");
     }
 
     private void clearTextInputClient() {

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1,6 +1,7 @@
 package io.flutter.plugin.editing;
 
 import android.content.Context;
+import android.provider.Settings;
 import android.util.SparseIntArray;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
@@ -96,7 +97,7 @@ public class TextInputPluginTest {
     }
 
     @Test
-    public void setTextInputEditingState_doesNotRestartsOnUnaffectedDevices() {
+    public void setTextInputEditingState_doesNotRestartOnUnaffectedDevices() {
         // Initialize a TextInputPlugin that needs to be always restarted.
         ShadowBuild.setManufacturer("samsung");
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"en", "", "", false, false);

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -56,9 +56,9 @@ public class TextInputPluginTest {
         // Initialize a TextInputPlugin that needs to be always restarted.
         ShadowBuild.setManufacturer("samsung");
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"en", "", "", false, false);
+        Settings.Secure.putString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-        Settings.Secure.putString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
         View testView = new View(RuntimeEnvironment.application);
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
         textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, TextInputChannel.TextCapitalization.NONE, null, null, null));
@@ -78,6 +78,7 @@ public class TextInputPluginTest {
         // Initialize a TextInputPlugin that needs to be always restarted.
         ShadowBuild.setManufacturer("samsung");
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"en", "", "", false, false);
+        Settings.Secure.putString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.fake.test.blah/.NotTheRightKeyboard");
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
         View testView = new View(RuntimeEnvironment.application);

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -56,7 +56,7 @@ public class TextInputPluginTest {
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"ko", "", "", false, false);
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-        Settings.Secure.getString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
+        Settings.Secure.putString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
         View testView = new View(RuntimeEnvironment.application);
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
         textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, TextInputChannel.TextCapitalization.NONE, null, null, null));
@@ -81,7 +81,7 @@ public class TextInputPluginTest {
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"en", "", "", false, false);
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-        Settings.Secure.getString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
+        Settings.Secure.putString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
         View testView = new View(RuntimeEnvironment.application);
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
         textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, TextInputChannel.TextCapitalization.NONE, null, null, null));

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -25,7 +25,7 @@ import io.flutter.plugin.platform.PlatformViewsController;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 
-@Config(manifest = Config.NONE, shadows = TextInputPluginTest.TestImm.class)
+@Config(manifest = Config.NONE, shadows = TextInputPluginTest.TestImm.class, sdk = 27)
 @RunWith(RobolectricTestRunner.class)
 public class TextInputPluginTest {
     @Test
@@ -48,30 +48,7 @@ public class TextInputPluginTest {
         assertEquals(1, testImm.getRestartCount(testView));
     }
 
-    // See https://github.com/flutter/flutter/issues/29341
-    @Test
-    public void setTextInputEditingState_alwaysRestartsOnAffectedDevices() {
-        // Initialize a TextInputPlugin that needs to be always restarted.
-        ShadowBuild.setManufacturer("samsung");
-        InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"ko", "", "", false, false);
-        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
-        testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-        Settings.Secure.putString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
-        View testView = new View(RuntimeEnvironment.application);
-        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
-        textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, TextInputChannel.TextCapitalization.NONE, null, null, null));
-        // There's a pending restart since we initialized the text input client. Flush that now.
-        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
-
-        // Move the cursor.
-        assertEquals(1, testImm.getRestartCount(testView));
-        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
-
-        // Verify that we've restarted the input.
-        assertEquals(2, testImm.getRestartCount(testView));
-    }
-
-    // See https://github.com/flutter/flutter/issues/31512
+    // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512
     // All modern Samsung keybords are affected including non-korean languages and thus
     // need the restart.
     @Test

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -55,6 +55,7 @@ public class TextInputPluginTest {
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"ko", "", "", false, false);
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
+        Settings.Secure.getString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
         View testView = new View(RuntimeEnvironment.application);
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
         textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, TextInputChannel.TextCapitalization.NONE, null, null, null));
@@ -79,6 +80,7 @@ public class TextInputPluginTest {
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"en", "", "", false, false);
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
+        Settings.Secure.getString(RuntimeEnvironment.application.getContentResolver(), Settings.Secure.DEFAULT_INPUT_METHOD, "com.sec.android.inputmethod/.SamsungKeypad");
         View testView = new View(RuntimeEnvironment.application);
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
         textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, TextInputChannel.TextCapitalization.NONE, null, null, null));
@@ -91,6 +93,27 @@ public class TextInputPluginTest {
 
         // Verify that we've restarted the input.
         assertEquals(2, testImm.getRestartCount(testView));
+    }
+
+    @Test
+    public void setTextInputEditingState_doesNotRestartsOnUnaffectedDevices() {
+        // Initialize a TextInputPlugin that needs to be always restarted.
+        ShadowBuild.setManufacturer("samsung");
+        InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"en", "", "", false, false);
+        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+        testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
+        View testView = new View(RuntimeEnvironment.application);
+        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
+        textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, TextInputChannel.TextCapitalization.NONE, null, null, null));
+        // There's a pending restart since we initialized the text input client. Flush that now.
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
+
+        // Move the cursor.
+        assertEquals(1, testImm.getRestartCount(testView));
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
+
+        // Verify that we've restarted the input.
+        assertEquals(1, testImm.getRestartCount(testView));
     }
 
     @Test

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -73,7 +73,7 @@ public class TextInputPluginTest {
     // All modern Samsung keybords are affected including non-korean languages and thus
     // need the restart.
     @Test
-    public void setTextInputEditingState_alwaysRestartsOnAffectedDevices() {
+    public void setTextInputEditingState_alwaysRestartsOnAffectedDevices2() {
         // Initialize a TextInputPlugin that needs to be always restarted.
         ShadowBuild.setManufacturer("samsung");
         InputMethodSubtype inputMethodSubtype = new InputMethodSubtype(0, 0, /*locale=*/"en", "", "", false, false);


### PR DESCRIPTION
Turns out the restart workaround introduced in https://github.com/flutter/engine/pull/12432 is applicable to all languages in the Samsung keyboard.

This PR enables the workaround on all Samsung devices using Samsung keyboard with Android Lollipop and newer as the oldest affected device shipped with Lollipop.

Fixes https://github.com/flutter/flutter/issues/31512 (workaround)