### PR TITLE
Revert "Build AOT and test targets, generate FARs when building Fuchsia"

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,6 +84,7 @@ task:
         cd $ENGINE_PATH/src
         ./flutter/tools/fuchsia/build_fuchsia_artifacts.py --engine-version HEAD --runtime-mode debug --no-lto --archs x64
         cd $ENGINE_PATH/src/flutter
+        ./ci/build_flutter_runner_tests.sh
 
 # WINDOWS
 task:

--- a/ci/build_flutter_runner_tests.sh
+++ b/ci/build_flutter_runner_tests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ex
+
+PATH="$HOME/depot_tools:$PATH"
+cd ..
+
+# Build the flutter runner tests far directory
+flutter/tools/gn --fuchsia --no-lto --runtime-mode debug
+ninja -C out/fuchsia_debug_x64 flutter/shell/platform/fuchsia/flutter:flutter_runner_tests
+
+# Generate the far package
+flutter/tools/fuchsia/gen_package.py\
+  --pm-bin $PWD/fuchsia/sdk/linux/tools/pm\
+  --package-dir $PWD/out/fuchsia_debug_x64/flutter_runner_tests_far\
+  --signing-key $PWD/flutter/tools/fuchsia/development.key\
+  --far-name flutter_runner_tests
+

--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -6,23 +6,20 @@ import("//build/fuchsia/sdk.gni")
 import("$flutter_root/common/config.gni")
 
 if (using_fuchsia_sdk) {
-  testonly = true
-
   product_suffix = ""
 
   if (flutter_runtime_mode == "release") {
     product_suffix = "product_"
   }
 
+  flutter_runner_target = "flutter_jit_${product_suffix}runner"
   dart_runner_target = "dart_jit_${product_suffix}runner"
 
   group("fuchsia") {
     deps = [
       "dart:kernel_compiler",
       "dart_runner:$dart_runner_target",
-      "flutter:flutter_aot_${product_suffix}runner",
-      "flutter:flutter_jit_${product_suffix}runner",
-      "flutter:flutter_runner_tests",
+      "flutter:$flutter_runner_target",
     ]
   }
 }

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -8,7 +8,7 @@ import("//build/fuchsia/sdk.gni")
 import("$flutter_root/common/fuchsia_config.gni")
 import("$flutter_root/tools/fuchsia/common_libs.gni")
 import("$flutter_root/tools/fuchsia/dart.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_archive.gni")
+import("$flutter_root/tools/fuchsia/package_dir.gni")
 
 template("runner") {
   assert(defined(invoker.product), "The parameter 'product' must be defined")
@@ -100,7 +100,7 @@ template("jit_runner_package") {
     product_suffix = "_product"
   }
 
-  fuchsia_archive(target_name) {
+  package_dir(target_name) {
     deps = [
       ":dart_jit${product_suffix}_runner_bin",
       "kernel:kernel_core_snapshot${product_suffix}",

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -9,7 +9,7 @@ import("$flutter_root/common/config.gni")
 import("$flutter_root/shell/gpu/gpu.gni")
 import("$flutter_root/tools/fuchsia/common_libs.gni")
 import("$flutter_root/tools/fuchsia/dart.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_archive.gni")
+import("$flutter_root/tools/fuchsia/package_dir.gni")
 import("engine_flutter_runner.gni")
 
 shell_gpu_configuration("fuchsia_gpu_configuration") {
@@ -89,7 +89,7 @@ template("jit_runner") {
     product_suffix = "_product"
   }
 
-  fuchsia_archive(target_name) {
+  package_dir(target_name) {
     snapshot_label = "kernel:kernel_core_snapshot${product_suffix}"
     snapshot_gen_dir = get_label_info(snapshot_label, "target_gen_dir")
 
@@ -174,7 +174,7 @@ template("aot_runner") {
     product_suffix = "_product"
   }
 
-  fuchsia_archive(target_name) {
+  package_dir(target_name) {
     deps = [
       ":aot${product_suffix}",
     ]
@@ -258,7 +258,7 @@ executable("flutter_runner_unittests") {
   ]
 }
 
-fuchsia_archive("flutter_runner_tests") {
+package_dir("flutter_runner_tests") {
   testonly = true
 
   deps = [
@@ -273,7 +273,7 @@ fuchsia_archive("flutter_runner_tests") {
 
   meta = [
     {
-      path = rebase_path("meta/$target_name.cmx")
+      path = "meta/$target_name.cmx"
       dest = "$target_name.cmx"
     },
   ]

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -15,13 +15,36 @@ import subprocess
 import sys
 import tempfile
 
-from gather_flutter_runner_artifacts import CopyPath
+from gather_flutter_runner_artifacts import CreateMetaPackage, CopyPath
+from gen_package import CreateFarPackage
 
 _script_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..'))
 _src_root_dir = os.path.join(_script_dir, '..', '..', '..')
 _out_dir = os.path.join(_src_root_dir, 'out')
 _bucket_directory = os.path.join(_out_dir, 'fuchsia_bucket')
 _fuchsia_base = 'flutter/shell/platform/fuchsia'
+
+
+def IsLinux():
+  return platform.system() == 'Linux'
+
+
+def IsMac():
+  return platform.system() == 'Darwin'
+
+
+def GetPMBinPath():
+  # host_os references the gn host_os
+  # https://gn.googlesource.com/gn/+/master/docs/reference.md#var_host_os
+  host_os = ''
+  if IsLinux():
+    host_os = 'linux'
+  elif IsMac():
+    host_os = 'mac'
+  else:
+    host_os = 'windows'
+
+  return os.path.join(_src_root_dir, 'fuchsia', 'sdk', host_os, 'tools', 'pm')
 
 
 def RunExecutable(command):
@@ -93,15 +116,18 @@ def CopyToBucketWithMode(source, destination, aot, product, runner_type):
   mode = 'aot' if aot else 'jit'
   product_suff = '_product' if product else ''
   runner_name = '%s_%s%s_runner' % (runner_type, mode, product_suff)
+  far_dir_name = '%s_far' % runner_name
   source_root = os.path.join(_out_dir, source)
+  far_base = os.path.join(source_root, far_dir_name)
+  CreateMetaPackage(far_base, runner_name)
+  pm_bin = GetPMBinPath()
+  key_path = os.path.join(_script_dir, 'development.key')
 
   destination = os.path.join(_bucket_directory, destination, mode)
+  CreateFarPackage(pm_bin, far_base, key_path, destination)
   patched_sdk_dirname = '%s_runner_patched_sdk' % runner_type
   patched_sdk_dir = os.path.join(source_root, patched_sdk_dirname)
   dest_sdk_path = os.path.join(destination, patched_sdk_dirname)
-  far_name = '%s-0.far' % runner_name
-  far_file = os.path.join(source_root, far_name)
-  CopyPath(far_file, os.path.join(destination, far_name))
   if not os.path.exists(dest_sdk_path):
     CopyPath(patched_sdk_dir, dest_sdk_path)
   CopyGenSnapshotIfExists(source_root, destination)

--- a/tools/fuchsia/gather_flutter_runner_artifacts.py
+++ b/tools/fuchsia/gather_flutter_runner_artifacts.py
@@ -40,7 +40,19 @@ def CopyPath(src, dst):
       raise
 
 
-def GatherArtifacts(src_root, dst_root):
+def CreateMetaPackage(dst_root, far_name):
+  meta = os.path.join(dst_root, 'meta')
+  if not os.path.isdir(meta):
+    os.makedirs(meta)
+  content = {}
+  content['name'] = far_name
+  content['version'] = '0'
+  package = os.path.join(meta, 'package')
+  with open(package, 'w') as out_file:
+    json.dump(content, out_file)
+
+
+def GatherArtifacts(src_root, dst_root, create_meta_package=True):
   if not os.path.exists(dst_root):
     os.makedirs(dst_root)
   else:
@@ -53,6 +65,9 @@ def GatherArtifacts(src_root, dst_root):
       print 'Unable to find artifact: ', str(src_full)
       sys.exit(1)
     CopyPath(src_full, dst_full)
+
+  if create_meta_package:
+    CreateMetaPackage(dst_root, 'flutter_runner')
 
 
 def main():

--- a/tools/fuchsia/gen_package.py
+++ b/tools/fuchsia/gen_package.py
@@ -13,6 +13,8 @@ import os
 import subprocess
 import sys
 
+from gather_flutter_runner_artifacts import CreateMetaPackage
+
 
 # Generates the manifest and returns the file.
 def GenerateManifest(package_dir):
@@ -40,18 +42,11 @@ def CreateFarPackage(pm_bin, package_dir, signing_key, dst_dir):
   ]
 
   # Build the package
-  try:
-    subprocess.check_output(pm_command_base + ['build'])
-  except subprocess.CalledProcessError as e:
-    print("pm output: " + e.output)
-    raise
+  subprocess.check_call(pm_command_base + ['build'])
 
   # Archive the package
-  try:
-    subprocess.check_output(pm_command_base + ['archive'])
-  except subprocess.CalledProcessError as e:
-    print("pm output: " + e.output)
-    raise
+  subprocess.check_call(pm_command_base + ['archive'])
+
   return 0
 
 
@@ -76,7 +71,7 @@ def main():
 
   pkg_dir = args.package_dir
   if not os.path.exists(os.path.join(pkg_dir, 'meta', 'package')):
-    raise Exception('Expected to find meta/package directory!')
+    CreateMetaPackage(pkg_dir, args.far_name)
 
   manifest_file = None
   if args.manifest_file is not None:

--- a/tools/fuchsia/package_dir.gni
+++ b/tools/fuchsia/package_dir.gni
@@ -2,8 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Creates a Fuchsia archive (.far) file using PM from the Fuchsia SDK.
-template("fuchsia_archive") {
+# Creates a package dir that we will them use pm to package.
+#
+# This currently ignores the CMX files and does minimal validation.
+template("package_dir") {
   assert(defined(invoker.binary), "package must define binary")
   assert(defined(invoker.meta_dir), "package must define meta_dir")
 
@@ -65,42 +67,12 @@ template("fuchsia_archive") {
     ]
   }
 
-  write_file("${far_base_dir}/meta/package",
-             {
-               name = pkg.package_name
-               version = pkg.package_version
-             },
-             "json")
-
-  pkg_dir_deps = pkg.deps + [ ":$cmx_target" ]
-
-  action("${target_name}_dir") {
+  action(target_name) {
     script = "$flutter_root/tools/fuchsia/copy_path.py"
     response_file_contents = rebase_path(copy_sources + copy_outputs)
-    deps = pkg_dir_deps
+    deps = pkg.deps + [ ":$cmx_target" ]
     args = [ "--file-list={{response_file_name}}" ]
     outputs = copy_outputs
-    testonly = pkg_testonly
-  }
-
-  action(target_name) {
-    script = "$flutter_root/tools/fuchsia/gen_package.py"
-    deps = pkg_dir_deps + [ ":${target_name}_dir" ]
-    sources = copy_outputs
-    args = [
-      "--pm-bin",
-      rebase_path("//fuchsia/sdk/$host_os/tools/pm"),
-      "--package-dir",
-      rebase_path(far_base_dir),
-      "--signing-key",
-      rebase_path("//flutter/tools/fuchsia/development.key"),
-      "--far-name",
-      target_name,
-    ]
-    outputs = [
-      "${far_base_dir}.manifest",
-      "$root_out_dir/${target_name}.far",
-    ]
     testonly = pkg_testonly
   }
 }


### PR DESCRIPTION
Reverts flutter/engine#12761

This broke CI.  I believe because of the python changes - we may have to leave that script as-is, update LUCI, and then reland the changes to the script.  For now, just will revert to unblock tree.

TBR @iskakaushik @chinmaygarde @gw280 