### PR TITLE
Fixing selection issues in Firefox

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -341,6 +341,9 @@ class TextEditingElement {
       _subscriptions.add(domElement.onKeyUp.listen((event) {
         _handleChange(event);
       }));
+      /// In Firefox the context menu item "Select All" does not work without
+      /// listening onSelect. On the other browersers onSelectionChange is
+      /// enough for covering "Select All" functionality.
       _subscriptions.add(domElement.onSelect.listen(_handleChange));
     } else {
       _subscriptions.add(html.document.onSelectionChange.listen(_handleChange));

--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -341,6 +341,7 @@ class TextEditingElement {
       _subscriptions.add(domElement.onKeyUp.listen((event) {
         _handleChange(event);
       }));
+      _subscriptions.add(domElement.onSelect.listen(_handleChange));
     } else {
       _subscriptions.add(html.document.onSelectionChange.listen(_handleChange));
     }
@@ -379,7 +380,7 @@ class TextEditingElement {
         throw UnsupportedError(
             'Unsupported input type: ${inputConfig.inputType}');
     }
-    html.document.body.append(domElement);
+    domRenderer.glassPaneElement.append(domElement);
   }
 
   void _removeDomElement() {

--- a/lib/web_ui/lib/src/engine/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing.dart
@@ -342,7 +342,7 @@ class TextEditingElement {
         _handleChange(event);
       }));
       /// In Firefox the context menu item "Select All" does not work without
-      /// listening onSelect. On the other browersers onSelectionChange is
+      /// listening to onSelect. On the other browsers onSelectionChange is
       /// enough for covering "Select All" functionality.
       _subscriptions.add(domElement.onSelect.listen(_handleChange));
     } else {

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -76,7 +76,8 @@ void main() {
       expect(editingElement.domElement, input);
 
       // Input is appended to the glass pane.
-      expect('${editingElement.domElement.parent.tagName}', 'FLT-GLASS-PANE');
+      expect(domRenderer.glassPaneElement.contains(editingElement.domElement),
+          isTrue);
 
       editingElement.disable();
       expect(

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -75,6 +75,9 @@ void main() {
       expect(document.activeElement, input);
       expect(editingElement.domElement, input);
 
+      // Input is appended to the glass pane.
+      expect('${editingElement.domElement.parent.tagName}', 'FLT-GLASS-PANE');
+
       editingElement.disable();
       expect(
         document.getElementsByTagName('input'),


### PR DESCRIPTION
This fixes 2 issues:

1) On the context menu select all was not working for firefox. All the other events are using onselectionchange (https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onselectionchange) For firefox,  onSelect listener is added.

2) Moving the cursor by mouse selection was not working since the input/textarea element was not a child of glass pane. This PR moves the dom element under glass pane.

Fixing issue https://github.com/flutter/flutter/issues/41633
This is also a good first step for: https://github.com/flutter/flutter/issues/32213 since the gestures on the text field will be sync'ed to Flutter Framework now.
Fixing issue https://github.com/flutter/flutter/issues/41643 Since the touch gestures are sync'ed to Flutter Framework