### PR TITLE
Disable EmbedderTest::CanLaunchAndShutdownMultipleTimes.

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -50,7 +50,8 @@ TEST_F(EmbedderTest, CanLaunchAndShutdownWithValidProjectArgs) {
   engine.reset();
 }
 
-TEST_F(EmbedderTest, CanLaunchAndShutdownMultipleTimes) {
+// TODO(41999): Disabled because flaky.
+TEST_F(EmbedderTest, DISABLED_CanLaunchAndShutdownMultipleTimes) {
   EmbedderConfigBuilder builder(GetEmbedderContext());
   builder.SetSoftwareRendererConfig();
   for (size_t i = 0; i < 3; ++i) {


### PR DESCRIPTION
Re-enabling this is tracked in https://github.com/flutter/flutter/issues/41999. Will land on red to fix LUCI errors.