### PR TITLE
do not wrap font family name

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -122,7 +122,7 @@ class _FontManager {
     // family that is not correct CSS syntax. To ensure the font family is
     // accepted on these browsers, wrap it in quotes.
     // See: https://drafts.csswg.org/css-fonts-3/#font-family-prop
-    if (browserEngine == BrowserEngine.webkit || browserEngine == BrowserEngine.firefox) {
+    if (browserEngine == BrowserEngine.firefox) {
       family = "'$family'";
     }
     // try/catch because `new FontFace` can crash with an improper font family.

--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -103,9 +103,11 @@ class FontCollection {
 class FontManager {
   final List<Future<void>> _fontLoadingFutures = <Future<void>>[];
 
-  // Regular expression to detect punctuations. For example font family
-  // 'Ahem!' falls into this category.
-  static final RegExp punctuations = RegExp(r"[.,:;!`\/#\$\%\^&~\*=\-_(){}]");
+  // Regular expression to detect a string with no punctuations.
+  // For example font family 'Ahem!' does not fall into this category
+  // so the family name will be wrapped in quotes.
+  static final RegExp notPunctuation =
+      RegExp(r"[a-z0-9\s]+", caseSensitive: false);
   // Regular expression to detect tokens starting with a digit.
   // For example font family 'Goudy Bookletter 1911' falls into this
   // category.
@@ -144,8 +146,8 @@ class FontManager {
   ///
   /// In order to avoid all these browser compatibility issues this method:
   /// * Detects the family names that might cause a conflict.
-  /// * Loads it with quotes.
-  /// * Loads it again without quotes.
+  /// * Loads it with the quotes.
+  /// * Loads it again without the quotes.
   /// * For all the other family names [html.FontFace] is loaded only once.
   ///
   /// See also:
@@ -157,16 +159,13 @@ class FontManager {
     String asset,
     Map<String, String> descriptors,
   ) {
-    // Fonts names when a package dependency is added has '/' in the family
-    // names such as 'package/material_design_icons_flutter/...'
-    if (family.contains('/') ||
-        punctuations.hasMatch(family) ||
-        startWithDigit.hasMatch(family)) {
-      // Load a font family name with special chracters once here wrapped in
+    if (startWithDigit.hasMatch(family) ||
+        notPunctuation.stringMatch(family) != family) {
+      // Load a font family name with special characters once here wrapped in
       // quotes.
-      _loadFontFace("'$family'", asset, descriptors);
+      _loadFontFace('\'$family\'', asset, descriptors);
     }
-    // Load all font fonts, without quoted family names.
+    // Load all fonts, without quoted family names.
     _loadFontFace(family, asset, descriptors);
   }
 

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -37,6 +37,38 @@ void main() {
       expect(fontFamilyList.first, 'Ahem');
     });
 
+    test('Register Asset with white space in the family name', () async {
+      final String _testFontFamily = "Ahem ahem ahem";
+      final List<String> fontFamilyList = List<String>();
+
+      fontManager.registerAsset(
+          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+      await fontManager.ensureFontsLoaded();
+      html.document.fonts
+          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        fontFamilyList.add(f.family);
+      });
+
+      expect(fontFamilyList.length, equals(1));
+      expect(fontFamilyList.first, 'Ahem ahem ahem');
+    });
+
+    test('Register Asset with capital case letters', () async {
+      final String _testFontFamily = "AhEm";
+      final List<String> fontFamilyList = List<String>();
+
+      fontManager.registerAsset(
+          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+      await fontManager.ensureFontsLoaded();
+      html.document.fonts
+          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        fontFamilyList.add(f.family);
+      });
+
+      expect(fontFamilyList.length, equals(1));
+      expect(fontFamilyList.first, 'AhEm');
+    });
+
     test('Register Asset twice with special character slash', () async {
       final String _testFontFamily = '/Ahem';
       final List<String> fontFamilyList = List<String>();

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -1,0 +1,108 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+
+import 'package:ui/src/engine.dart';
+
+import 'package:test/test.dart';
+
+void main() {
+  group('$FontManager', () {
+    FontManager fontManager;
+    const String _testFontUrl = 'packages/ui/assets/ahem.ttf';
+
+    setUp(() {
+      fontManager = FontManager();
+    });
+
+    tearDown(() {
+      html.document.fonts.clear();
+    });
+
+    test('Register Asset with no special characters', () async {
+      final String _testFontFamily = "Ahem";
+      final List<String> fontFamilyList = List<String>();
+
+      fontManager.registerAsset(
+          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+      await fontManager.ensureFontsLoaded();
+      html.document.fonts
+          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        fontFamilyList.add(f.family);
+      });
+
+      expect(fontFamilyList.length, equals(1));
+      expect(fontFamilyList.first, 'Ahem');
+    });
+
+    test('Register Asset twice with special character slash', () async {
+      final String _testFontFamily = '/Ahem';
+      final List<String> fontFamilyList = List<String>();
+
+      fontManager.registerAsset(
+          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+      await fontManager.ensureFontsLoaded();
+      html.document.fonts
+          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        fontFamilyList.add(f.family);
+      });
+
+      expect(fontFamilyList.length, equals(2));
+      expect(fontFamilyList, contains('\'/Ahem\''));
+      expect(fontFamilyList, contains('/Ahem'));
+    });
+
+    test('Register Asset twice with exclamation mark', () async {
+      final String _testFontFamily = 'Ahem!!ahem';
+      final List<String> fontFamilyList = List<String>();
+
+      fontManager.registerAsset(
+          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+      await fontManager.ensureFontsLoaded();
+      html.document.fonts
+          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        fontFamilyList.add(f.family);
+      });
+
+      expect(fontFamilyList.length, equals(2));
+      expect(fontFamilyList, contains('\'Ahem!!ahem\''));
+      expect(fontFamilyList, contains('Ahem!!ahem'));
+    });
+
+    test('Register Asset twice with coma', () async {
+      final String _testFontFamily = 'Ahem ,ahem';
+      final List<String> fontFamilyList = List<String>();
+
+      fontManager.registerAsset(
+          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+      await fontManager.ensureFontsLoaded();
+      html.document.fonts
+          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        fontFamilyList.add(f.family);
+      });
+
+      expect(fontFamilyList.length, equals(2));
+      expect(fontFamilyList, contains('\'Ahem ,ahem\''));
+      expect(fontFamilyList, contains('Ahem ,ahem'));
+    });
+
+    test('Register Asset twice with a digit at the start of a token', () async {
+      final String testFontFamily = 'Ahem 1998';
+      final List<String> fontFamilyList = List<String>();
+
+      fontManager.registerAsset(
+          testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+      await fontManager.ensureFontsLoaded();
+      html.document.fonts
+          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+        fontFamilyList.add(f.family);
+      });
+
+      expect(fontFamilyList.length, equals(2));
+      expect(fontFamilyList, contains('Ahem 1998'));
+      expect(fontFamilyList, contains('\'Ahem 1998\''));
+    });
+  });
+}


### PR DESCRIPTION
do not wrap font family name in webkit otherwise icons not show on safari 13 (both IOS and desktop)

Manually tested using Flutter Gallery app and other additions:

- Iphone with safari 12
- Iphone with safari 13
- Desktop with safari 13
- Firefox Desktop
- Chrome Desktop
- Chrome on Android

Additional fonts/icons tested:
"MdiIcons" (package:material_design_icons_flutter/material_design_icons_flutter.dart)
"Lucida" Grande

Fixes the issue: https://github.com/flutter/flutter/issues/41218
Fixes the issue: https://github.com/flutter/flutter/issues/41483