### PR TITLE
Build gen_snapshot with a 64-bit host toolchain even if the target platform is 32-bit

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -136,7 +136,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + '01e923507b28e5d1d3fe7597d2db2b30b0a543e9',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '3b6ae6cbb7d891e637331faf689005fd6f302568',
 
    # Fuchsia compatibility
    #

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -20,7 +20,13 @@ copy("generate_dart_ui") {
 }
 
 compiled_action("generate_snapshot_bin") {
-  tool = "//third_party/dart/runtime/bin:gen_snapshot"
+  # By default Dart will create a 32-bit gen_snapshot host binary if the target
+  # platform is 32-bit.  Override this to create a 64-bit gen_snapshot for x86
+  # targets because some host platforms may not support 32-bit binaries.
+  tool = "//third_party/dart/runtime/bin:gen_snapshot_host_targeting_host"
+  if (target_cpu == "x86") {
+    toolchain = "//build/toolchain/$host_os:clang_x64"
+  }
 
   if ((is_fuchsia || is_fuchsia_host) && !using_fuchsia_sdk) {
     platform_kernel =


### PR DESCRIPTION
By default Dart will build a gen_snapshot for the host platform using a
toolchain matching the bit width of the target platform.  Some host platforms
no longer support 32-bit binaries, so gen_snapshot will now be built as a
64-bit host binary even if the target is 32-bit.