### PR TITLE
Revert "Adding Link SemanticsFlag"

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -291,7 +291,6 @@ class SemanticsFlag {
   static const int _kIsMultilineIndex = 1 << 19;
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
-  static const int _kIsLinkIndex = 1 << 22;
 
   const SemanticsFlag._(this.index);
 
@@ -334,7 +333,7 @@ class SemanticsFlag {
 
   /// Whether the semantic node represents a button.
   ///
-  /// Platforms have special handling for buttons, for example Android's TalkBack
+  /// Platforms has special handling for buttons, for example Android's TalkBack
   /// and iOS's VoiceOver provides an additional hint when the focused object is
   /// a button.
   static const SemanticsFlag isButton = SemanticsFlag._(_kIsButtonIndex);
@@ -349,13 +348,6 @@ class SemanticsFlag {
   ///
   /// Only applicable when [isTextField] is true.
   static const SemanticsFlag isReadOnly = SemanticsFlag._(_kIsReadOnlyIndex);
-
-  /// Whether the semantic node is an interactive link.
-  ///
-  /// Platforms have special handling for links, for example iOS's VoiceOver
-  /// provides an additional hint when the focused object is a link, as well as
-  /// the ability to parse the links through another navigation menu.
-  static const SemanticsFlag isLink = SemanticsFlag._(_kIsLinkIndex);
 
   /// Whether the semantic node is able to hold the user's focus.
   ///
@@ -536,7 +528,6 @@ class SemanticsFlag {
     _kHasImplicitScrollingIndex: hasImplicitScrolling,
     _kIsMultilineIndex: isMultiline,
     _kIsReadOnlyIndex: isReadOnly,
-    _kIsLinkIndex: isLink,
   };
 
   @override
@@ -584,8 +575,6 @@ class SemanticsFlag {
         return 'SemanticsFlag.isMultiline';
       case _kIsReadOnlyIndex:
         return 'SemanticsFlag.isReadOnly';
-      case _kIsLinkIndex:
-        return 'SemanticsFlag.isLink';
     }
     return null;
   }

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -73,7 +73,6 @@ enum class SemanticsFlags : int32_t {
   // kIsMultiline = 1 << 19,
   kIsReadOnly = 1 << 20,
   kIsFocusable = 1 << 21,
-  kIsLink = 1 << 22,
 };
 
 const int kScrollableSemanticsFlags =

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -591,7 +591,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             }
         }
 
-        if (semanticsNode.hasFlag(Flag.IS_BUTTON) || semanticsNode.hasFlag(Flag.IS_LINK)) {
+        if (semanticsNode.hasFlag(Flag.IS_BUTTON)) {
             result.setClassName("android.widget.Button");
         }
         if (semanticsNode.hasFlag(Flag.IS_IMAGE)) {
@@ -1648,8 +1648,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         // The Dart API defines the following flag but it isn't used in Android.
         // IS_MULTILINE(1 << 19);
         IS_READ_ONLY(1 << 20),
-        IS_FOCUSABLE(1 << 21),
-        IS_LINK(1 << 22);
+        IS_FOCUSABLE(1 << 21);
 
         final int value;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -407,9 +407,6 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsLiveRegion)) {
     traits |= UIAccessibilityTraitUpdatesFrequently;
   }
-  if ([self node].HasFlag(flutter::SemanticsFlags::kIsLink)) {
-    traits |= UIAccessibilityTraitLink;
-  }
   return traits;
 }
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -63,7 +63,8 @@ typedef enum {
 /// Must match the `SemanticsAction` enum in semantics.dart.
 typedef enum {
   /// The equivalent of a user briefly tapping the screen with the finger
-  /// without moving it.
+  /// without
+  /// moving it.
   kFlutterSemanticsActionTap = 1 << 0,
   /// The equivalent of a user pressing and holding the screen with the finger
   /// for a few seconds without moving it.
@@ -171,8 +172,6 @@ typedef enum {
   kFlutterSemanticsFlagIsReadOnly = 1 << 20,
   /// Whether the semantic node can hold the user's focus.
   kFlutterSemanticsFlagIsFocusable = 1 << 21,
-  /// Whether the semantics node represents a link.
-  kFlutterSemanticsFlagIsLink = 1 << 22,
 } FlutterSemanticsFlag;
 
 typedef enum {


### PR DESCRIPTION
Reverts flutter/engine#12453

This breaks the framework and I cannot land a manual engine roll with the framework change right now due to the framework being already broken.
I will try again next week.