### PR TITLE
remove references to package:_chrome

### DIFF
--- a/web_sdk/libraries.json
+++ b/web_sdk/libraries.json
@@ -42,9 +42,6 @@
       "_js_helper": {
         "uri": "../dart-sdk/lib/_internal/js_runtime/lib/js_helper.dart"
       },
-      "_chrome": {
-        "uri": "../dart-sdk/lib/_chrome/dart2js/chrome_dart2js.dart"
-      },
       "html_common": {
         "uri": "../dart-sdk/lib/html/html_common/html_common_dart2js.dart"
       },

--- a/web_sdk/libraries.yaml
+++ b/web_sdk/libraries.yaml
@@ -140,9 +140,6 @@ dart2js:
       uri: "../dart-sdk/lib/async/async.dart"
       patches: "../dart-sdk/lib/_internal/js_runtime/lib/async_patch.dart"
 
-    _chrome:
-      uri: "../dart-sdk/lib/_chrome/dart2js/chrome_dart2js.dart"
-
     collection:
       uri: "../dart-sdk/lib/collection/collection.dart"
       patches: "../dart-sdk/lib/_internal/js_runtime/lib/collection_patch.dart"


### PR DESCRIPTION
- remove references to `package:_chrome`

This package hasn't been actively used for several years, and is not part of the public API of the SDK. The library was removed from the SDK in https://dart-review.googlesource.com/c/sdk/+/120005.