### PR TITLE
Fix typo on channel buffer debug output.

### DIFF
--- a/lib/ui/channel_buffers.dart
+++ b/lib/ui/channel_buffers.dart
@@ -137,13 +137,13 @@ class ChannelBuffers {
     }
     final bool didOverflow = queue.push(_StoredMessage(data, callback));
     if (didOverflow) {
-      // TODO(aaclarke): Update this message to include instructions on how to resize
+      // TODO(gaaclarke): Update this message to include instructions on how to resize
       // the buffer once that is available to users and print in all engine builds
       // after we verify that dropping messages isn't part of normal execution.
-      _printDebug('Overflow on channel: $channel.  '
-                  'Messages on this channel are being discarded in FIFO fashion.  '
+      _printDebug('Overflow on channel: $channel. '
+                  'Messages on this channel are being discarded in FIFO fashion. '
                   'The engine may not be running or you need to adjust '
-                  'the buffer size if of the channel.');
+                  'the buffer size of the channel.');
     }
     return didOverflow;
   }


### PR DESCRIPTION
Before:
```Overflow on channel: plugins.flutter.io/firebase_messaging.  Messages on this channel are being discarded in FIFO fashion.  The engine may not be running or you need to adjust the buffer size if of the channel.```

After:
```Overflow on channel: plugins.flutter.io/firebase_messaging. Messages on this channel are being discarded in FIFO fashion. The engine may not be running or you need to adjust the buffer size of the channel.```

Also, @gaaclarke - I believe this is your TODO? :-)