### PR TITLE
Support empty strings and vectors in standard codec

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_codec.cc
@@ -128,9 +128,6 @@ EncodableValue StandardCodecSerializer::ReadValue(
     case EncodedType::kList: {
       size_t length = ReadSize(stream);
       EncodableList list_value;
-      if (length == 0) {
-        return EncodableValue(list_value);
-      }
       list_value.reserve(length);
       for (size_t i = 0; i < length; ++i) {
         list_value.push_back(ReadValue(stream));

--- a/shell/platform/common/cpp/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_codec.cc
@@ -111,10 +111,8 @@ EncodableValue StandardCodecSerializer::ReadValue(
     case EncodedType::kString: {
       size_t size = ReadSize(stream);
       std::string string_value;
-      if (size > 0) {
-        string_value.resize(size);
-        stream->ReadBytes(reinterpret_cast<uint8_t*>(&string_value[0]), size);
-      }
+      string_value.resize(size);
+      stream->ReadBytes(reinterpret_cast<uint8_t*>(&string_value[0]), size);
       return EncodableValue(string_value);
     }
     case EncodedType::kUInt8List:

--- a/shell/platform/common/cpp/client_wrapper/standard_message_codec_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_message_codec_unittests.cc
@@ -97,6 +97,11 @@ TEST(StandardMessageCodec, CanEncodeAndDecodeStringWithNonBMPCodePoint) {
   CheckEncodeDecode(EncodableValue(u8"h\U0001F602w"), bytes);
 }
 
+TEST(StandardMessageCodex, CanEncodeAndDecodeEmptyString) {
+  std::vector<uint8_t> bytes = {0x07, 0x00};
+  CheckEncodeDecode(EncodableValue(u8""), bytes);
+}
+
 TEST(StandardMessageCodec, CanEncodeAndDecodeList) {
   std::vector<uint8_t> bytes = {
       0x0c, 0x05, 0x00, 0x07, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x06,
@@ -115,6 +120,11 @@ TEST(StandardMessageCodec, CanEncodeAndDecodeList) {
       }),
   });
   CheckEncodeDecode(value, bytes);
+}
+
+TEST(StandardMessageCodec, CanEncodeAndDecodeEmptyList) {
+  std::vector<uint8_t> bytes = {0x0c, 0x00};
+  CheckEncodeDecode(EncodableValue(EncodableList{}), bytes);
 }
 
 TEST(StandardMessageCodec, CanEncodeAndDecodeMap) {

--- a/shell/platform/common/cpp/client_wrapper/standard_message_codec_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_message_codec_unittests.cc
@@ -97,7 +97,7 @@ TEST(StandardMessageCodec, CanEncodeAndDecodeStringWithNonBMPCodePoint) {
   CheckEncodeDecode(EncodableValue(u8"h\U0001F602w"), bytes);
 }
 
-TEST(StandardMessageCodex, CanEncodeAndDecodeEmptyString) {
+TEST(StandardMessageCodec, CanEncodeAndDecodeEmptyString) {
   std::vector<uint8_t> bytes = {0x07, 0x00};
   CheckEncodeDecode(EncodableValue(u8""), bytes);
 }


### PR DESCRIPTION
Fixes #41993

Currently an empty string or vector will call through to WriteBytes
which asserts that the number of bytes it is being asked to write is
strictly positive. Instead we should not call WriteBytes if the length
is zero.

Similarly, when we read, we don't need to call out if the length is
zero.