### PR TITLE
Made _printDebug only happen on debug builds of the engine for now.

### DIFF
--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -154,7 +154,7 @@ void DartRuntimeHooks::Install(bool is_ui_isolate,
 }
 
 void Logger_PrintDebugString(Dart_NativeArguments args) {
-#if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
+#ifndef NDEBUG
   Logger_PrintString(args);
 #endif
 }


### PR DESCRIPTION
This was the original intention of _printDebug.  We are getting red herring bug reports about channel overflows of the lifecycle channel since we spam it with messages on iOS right after launching the engine.