### PR TITLE
[flutter_runner] Make sure that SocketBase::ListInterfaces works

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -962,6 +962,7 @@ FILE: ../../../flutter/shell/platform/fuchsia/flutter/runner.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/runner.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/session_connection.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/session_connection.h
+FILE: ../../../flutter/shell/platform/fuchsia/flutter/socket_base_fuchsia_unittest.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/surface.cc
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/surface.h
 FILE: ../../../flutter/shell/platform/fuchsia/flutter/task_observers.cc

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -251,6 +251,10 @@ executable("flutter_runner_unittests") {
 
   output_name = "flutter_runner_tests"
 
+  # This is needed by dart/runtime/platform it expects either DEBUG
+  # or NDEBUG to be defined.
+  defines = [ "NDEBUG" ]
+
   sources = [
     "accessibility_bridge.cc",
     "accessibility_bridge.h",
@@ -260,6 +264,7 @@ executable("flutter_runner_unittests") {
     "platform_view.cc",
     "platform_view.h",
     "platform_view_unittest.cc",
+    "socket_base_fuchsia_unittest.cc",
     "surface.cc",
     "surface.h",
     "vsync_recorder.cc",

--- a/shell/platform/fuchsia/flutter/socket_base_fuchsia_unittest.cc
+++ b/shell/platform/fuchsia/flutter/socket_base_fuchsia_unittest.cc
@@ -1,0 +1,19 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <dart/runtime/bin/socket_base.h>
+#include <gtest/gtest.h>
+
+namespace flutter_runner_test::socket_base_test {
+
+TEST(SocketBaseTest, TestGetInterfaces) {
+  dart::bin::SocketBase::Initialize();
+  dart::bin::OSError* os_error = NULL;
+  const int type_any = dart::bin::SocketAddress::TYPE_ANY;
+  auto interfaces = dart::bin::SocketBase::ListInterfaces(type_any, &os_error);
+  ASSERT_FALSE(os_error);
+  ASSERT_TRUE(interfaces->count() > 0);
+}
+
+}  // namespace flutter_runner_test::socket_base_test


### PR DESCRIPTION
This is to prevent regressions like: b/142123619

Currently dart doesn't have the capacity to run Fuchsia unittests.
This is a temporary home for this test while https://github.com/dart-lang/sdk/issues/38752
gets addressed.