### PR TITLE
Prevent default when Tab is clicked

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -50,6 +50,10 @@ class Keyboard {
   static const JSONMessageCodec _messageCodec = JSONMessageCodec();
 
   void _handleHtmlEvent(html.KeyboardEvent event) {
+    if (_shouldPreventDefault(event)) {
+      event.preventDefault();
+    }
+
     final Map<String, dynamic> eventData = <String, dynamic>{
       'type': event.type,
       'keymap': 'web',
@@ -60,6 +64,16 @@ class Keyboard {
 
     ui.window.onPlatformMessage('flutter/keyevent',
         _messageCodec.encodeMessage(eventData), _noopCallback);
+  }
+
+  bool _shouldPreventDefault(html.KeyboardEvent event) {
+    switch (event.key) {
+      case 'Tab':
+        return true;
+
+      default:
+        return false;
+    }
   }
 }
 


### PR DESCRIPTION
Hitting `Tab` inside a text field messes up the focus in the browser. We should prevent default and let Flutter handle it.

This PR also fixes a leak of `Keyboard` initialization across tests.

Issue: https://github.com/flutter/flutter/issues/41396