### PR TITLE
Unpublicize kDoNotResizeDimension

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1023,7 +1023,7 @@ enum Clip {
 ///
 /// Used by [instantiateImageCodec] as a magical value to disable resizing
 /// in the given dimension.
-const int kDoNotResizeDimension = -1;
+const int _kDoNotResizeDimension = -1;
 
 /// A description of the style to use when drawing on a [Canvas].
 ///
@@ -1665,7 +1665,7 @@ Future<Codec> instantiateImageCodec(Uint8List list, {
   int targetHeight,
 }) {
   return _futurize(
-    (_Callback<Codec> callback) => _instantiateImageCodec(list, callback, null, targetWidth ?? kDoNotResizeDimension, targetHeight ?? kDoNotResizeDimension)
+    (_Callback<Codec> callback) => _instantiateImageCodec(list, callback, null, targetWidth ?? _kDoNotResizeDimension, targetHeight ?? _kDoNotResizeDimension)
   );
 }
 
@@ -1675,9 +1675,9 @@ Future<Codec> instantiateImageCodec(Uint8List list, {
 /// image, in image pixels. Image in this context refers to image in every frame of the [Codec].
 /// If [targetWidth] and [targetHeight] are not equal to the intrinsic dimensions of the
 /// image, then the image will be scaled after being decoded. If exactly one of
-/// these two arguments is not equal to [kDoNotResizeDimension], then the aspect
+/// these two arguments is not equal to [_kDoNotResizeDimension], then the aspect
 /// ratio will be maintained while forcing the image to match the given dimension.
-/// If both are equal to [kDoNotResizeDimension], then the image maintains its real size.
+/// If both are equal to [_kDoNotResizeDimension], then the image maintains its real size.
 ///
 /// Returns an error message if the instantiation has failed, null otherwise.
 String _instantiateImageCodec(Uint8List list, _Callback<Codec> callback, _ImageInfo imageInfo, int targetWidth, int targetHeight)
@@ -1722,7 +1722,7 @@ void decodeImageFromPixels(
 ) {
   final _ImageInfo imageInfo = _ImageInfo(width, height, format.index, rowBytes);
   final Future<Codec> codecFuture = _futurize(
-    (_Callback<Codec> callback) => _instantiateImageCodec(pixels, callback, imageInfo, targetWidth ?? kDoNotResizeDimension, targetHeight ?? kDoNotResizeDimension)
+    (_Callback<Codec> callback) => _instantiateImageCodec(pixels, callback, imageInfo, targetWidth ?? _kDoNotResizeDimension, targetHeight ?? _kDoNotResizeDimension)
   );
   codecFuture.then((Codec codec) => codec.getNextFrame())
       .then((FrameInfo frameInfo) => callback(frameInfo.image));

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -1628,12 +1628,6 @@ enum PixelFormat {
   bgra8888,
 }
 
-/// Indicates that the image should not be resized in this dimension.
-///
-/// Used by [instantiateImageCodec] as a magical value to disable resizing
-/// in the given dimension.
-const int kDoNotResizeDimension = -1;
-
 class _ImageInfo {
   _ImageInfo(this.width, this.height, this.format, this.rowBytes) {
     rowBytes ??= width * 4;


### PR DESCRIPTION
This value turned out to be unnecessary. Hide it again!

Introduced in https://github.com/flutter/engine/pull/12448