### PR TITLE
Fixing Link Semantics Typo

### DIFF
--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -346,7 +346,7 @@ class SemanticsFlag {
   ///
   /// Platforms have special handling for links, for example, iOS's VoiceOver
   /// provides an additional hint when the focused object is a link.
-  static const SemanticsFlag isLink = SemanticsFlag._(_kIsButtonIndex);
+  static const SemanticsFlag isLink = SemanticsFlag._(_kIsLinkIndex);
 
   /// Whether the semantic node represents a text field.
   ///


### PR DESCRIPTION
Causing framework breakage, will roll with https://github.com/flutter/flutter/pull/41327