### PR TITLE
Add missing focusable testing info

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -536,6 +536,7 @@ class SemanticsFlag {
     _kHasImplicitScrollingIndex: hasImplicitScrolling,
     _kIsMultilineIndex: isMultiline,
     _kIsReadOnlyIndex: isReadOnly,
+    _kIsFocusableIndex: isFocusable,
     _kIsLinkIndex: isLink,
   };
 
@@ -584,6 +585,8 @@ class SemanticsFlag {
         return 'SemanticsFlag.isMultiline';
       case _kIsReadOnlyIndex:
         return 'SemanticsFlag.isReadOnly';
+      case _kIsFocusableIndex:
+        return 'SemanticsFlag.isFocusable';
       case _kIsLinkIndex:
         return 'SemanticsFlag.isLink';
     }

--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -34,6 +34,9 @@ class SemanticsAction {
   static const int _kDismissIndex = 1 << 18;
   static const int _kMoveCursorForwardByWordIndex = 1 << 19;
   static const int _kMoveCursorBackwardByWordIndex = 1 << 20;
+  // READ THIS: if you add an action here, you MUST update the
+  // numSemanticsActions value in testing/dart/semantics_test.dart, or tests
+  // will fail.
 
   /// The numerical value for this action.
   ///
@@ -292,6 +295,8 @@ class SemanticsFlag {
   static const int _kIsReadOnlyIndex = 1 << 20;
   static const int _kIsFocusableIndex = 1 << 21;
   static const int _kIsLinkIndex = 1 << 22;
+  // READ THIS: if you add a flag here, you MUST update the numSemanticsFlags
+  // value in testing/dart/semantics_test.dart, or tests will fail.
 
   const SemanticsFlag._(this.index);
 

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -1,0 +1,31 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+import 'package:test/test.dart' hide TypeMatcher, isInstanceOf;
+
+/// Verifies Semantics flags and actions.
+void main() {
+  // This must match the number of flags in lib/ui/semantics.dart
+  const int numSemanticsFlags = 23;
+  test('SemanticsFlag.values refers to all flags.', () async {
+    expect(SemanticsFlag.values.length, equals(numSemanticsFlags));
+    for (int index = 0; index < numSemanticsFlags; ++index) {
+      final int flag = 1 << index;
+      expect(SemanticsFlag.values[flag], isNotNull);
+      expect(SemanticsFlag.values[flag].toString(), startsWith('SemanticsFlag.'));
+    }
+  });
+
+  // This must match the number of actions in lib/ui/semantics.dart
+  const int numSemanticsActions = 21;
+  test('SemanticsAction.values refers to all actions.', () async {
+    expect(SemanticsAction.values.length, equals(numSemanticsActions));
+    for (int index = 0; index < numSemanticsActions; ++index) {
+      final int flag = 1 << index;
+      expect(SemanticsAction.values[flag], isNotNull);
+      expect(SemanticsAction.values[flag].toString(), startsWith('SemanticsAction.'));
+    }
+  });
+}


### PR DESCRIPTION
This adds a couple of instances of semantic node `isFocusable` info that were missing that the framework testing depends upon.