### PR TITLE
dart analysis of tests, cleanup

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -10,6 +10,9 @@
 #    private fields, especially on the Window object):
 
 analyzer:
+  # this test pretends to be part of dart:ui and results in lots of false
+  # positives.
+  exclude: [ testing/dart/window_hooks_integration_test.dart ]
   strong-mode:
     implicit-dynamic: false
   errors:

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -48,6 +48,8 @@ if [ -n "$RESULTS" ]; then
 fi
 
 echo "Analyzing testing/dart..."
+flutter/tools/gn --unoptimized
+ninja -C out/host_debug_unopt sky_engine sky_services
 (cd flutter/testing/dart && pub get)
 RESULTS=`dartanalyzer                                                          \
   --packages=flutter/testing/dart/.packages                                    \

--- a/ci/analyze.sh
+++ b/ci/analyze.sh
@@ -20,9 +20,9 @@ fi
 
 echo "Analyzing flutter_frontend_server..."
 RESULTS=`dartanalyzer                                                          \
-  --packages=flutter/flutter_frontend_server/.packages                                 \
+  --packages=flutter/flutter_frontend_server/.packages                         \
   --options flutter/analysis_options.yaml                                      \
-  flutter/flutter_frontend_server                                                      \
+  flutter/flutter_frontend_server                                              \
   2>&1                                                                         \
   | grep -Ev "No issues found!"                                                \
   | grep -Ev "Analyzing.+frontend_server"`
@@ -41,6 +41,36 @@ RESULTS=`dartanalyzer                                                          \
   2>&1                                                                         \
   | grep -Ev "No issues found!"                                                \
   | grep -Ev "Analyzing.+tools/licenses"`
+echo "$RESULTS"
+if [ -n "$RESULTS" ]; then
+  echo "Failed."
+  exit 1;
+fi
+
+echo "Analyzing testing/dart..."
+(cd flutter/testing/dart && pub get)
+RESULTS=`dartanalyzer                                                          \
+  --packages=flutter/testing/dart/.packages                                    \
+  --options flutter/analysis_options.yaml                                      \
+  flutter/testing/dart                                                         \
+  2>&1                                                                         \
+  | grep -Ev "No issues found!"                                                \
+  | grep -Ev "Analyzing.+testing/dart"`
+echo "$RESULTS"
+if [ -n "$RESULTS" ]; then
+  echo "Failed."
+  exit 1;
+fi
+
+echo "Analyzing testing/scenario_app..."
+(cd flutter/testing/scenario_app && pub get)
+RESULTS=`dartanalyzer                                                          \
+  --packages=flutter/testing/scenario_app/.packages                            \
+  --options flutter/analysis_options.yaml                                      \
+  flutter/testing/scenario_app                                                 \
+  2>&1                                                                         \
+  | grep -Ev "No issues found!"                                                \
+  | grep -Ev "Analyzing.+testing/scenario_app"`
 echo "$RESULTS"
 if [ -n "$RESULTS" ]; then
   echo "Failed."

--- a/testing/dart/canvas_test.dart
+++ b/testing/dart/canvas_test.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
 import 'dart:typed_data';
 import 'dart:ui';
-import 'dart:io';
 import 'package:image/image.dart' as dart_image;
 
 import 'package:path/path.dart' as path;

--- a/testing/dart/channel_buffers_test.dart
+++ b/testing/dart/channel_buffers_test.dart
@@ -1,73 +1,69 @@
-import 'dart:ui' as ui;
-import 'dart:typed_data';
 import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 
 import 'package:test/test.dart';
 
 void main() {
 
   ByteData _makeByteData(String str) {
-    var list = utf8.encode(str);
-    var buffer = list is Uint8List ? list.buffer : new Uint8List.fromList(list).buffer;
+    final Uint8List list = utf8.encode(str);
+    final ByteBuffer buffer = list is Uint8List ? list.buffer : Uint8List.fromList(list).buffer;
     return ByteData.view(buffer);
   }
 
-  String _getString(ByteData data) {
-    final buffer = data.buffer;
-    var list = buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
-    return utf8.decode(list);
-  }
-
   void _resize(ui.ChannelBuffers buffers, String name, int newSize) {
-    buffers.handleMessage(_makeByteData("resize\r$name\r$newSize"));
+    buffers.handleMessage(_makeByteData('resize\r$name\r$newSize'));
   }
 
   test('push drain', () async {
-    String channel = "foo";
-    ByteData data = _makeByteData('bar');
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
+    const String channel = 'foo';
+    final ByteData data = _makeByteData('bar');
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
+    final ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
     buffers.push(channel, data, callback);
     await buffers.drain(channel, (ByteData drainedData, ui.PlatformMessageResponseCallback drainedCallback) {
       expect(drainedData, equals(data));
       expect(drainedCallback, equals(callback));
+      return;
     });
   });
 
   test('push drain zero', () async {
-    String channel = "foo";
-    ByteData data = _makeByteData('bar');
+    const String channel = 'foo';
+    final ByteData data = _makeByteData('bar');
+    final
     ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
+    final ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
     _resize(buffers, channel, 0);
     buffers.push(channel, data, callback);
     bool didCall = false;
     await buffers.drain(channel, (ByteData drainedData, ui.PlatformMessageResponseCallback drainedCallback) {
       didCall = true;
+      return;
     });
     expect(didCall, equals(false));
   });
 
   test('empty', () async {
-    String channel = "foo";
-    ByteData data = _makeByteData('bar');
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
+    const String channel = 'foo';
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
     bool didCall = false;
     await buffers.drain(channel, (ByteData drainedData, ui.PlatformMessageResponseCallback drainedCallback) {
       didCall = true;
+      return;
     });
     expect(didCall, equals(false));
   });
 
   test('overflow', () async {
-    String channel = "foo";
-    ByteData one = _makeByteData('one');
-    ByteData two = _makeByteData('two');
-    ByteData three = _makeByteData('three');
-    ByteData four = _makeByteData('four');
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
+    const String channel = 'foo';
+    final ByteData one = _makeByteData('one');
+    final ByteData two = _makeByteData('two');
+    final ByteData three = _makeByteData('three');
+    final ByteData four = _makeByteData('four');
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
+    final ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
     _resize(buffers, channel, 3);
     expect(buffers.push(channel, one, callback), equals(false));
     expect(buffers.push(channel, two, callback), equals(false));
@@ -79,17 +75,18 @@ void main() {
         expect(drainedData, equals(two));
         expect(drainedCallback, equals(callback));
       }
+      return;
     });
     expect(counter, equals(3));
   });
 
   test('resize drop', () async {
-    String channel = "foo";
-    ByteData one = _makeByteData('one');
-    ByteData two = _makeByteData('two');
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
+    const String channel = 'foo';
+    final ByteData one = _makeByteData('one');
+    final ByteData two = _makeByteData('two');
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
     _resize(buffers, channel, 100);
-    ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
+    final ui.PlatformMessageResponseCallback callback = (ByteData responseData) {};
     expect(buffers.push(channel, one, callback), equals(false));
     expect(buffers.push(channel, two, callback), equals(false));
     _resize(buffers, channel, 1);
@@ -99,20 +96,21 @@ void main() {
         expect(drainedData, equals(two));
         expect(drainedCallback, equals(callback));
       }
+      return;
     });
     expect(counter, equals(1));
   });
 
   test('resize dropping calls callback', () async {
-    String channel = "foo";
-    ByteData one = _makeByteData('one');
-    ByteData two = _makeByteData('two');
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
+    const String channel = 'foo';
+    final ByteData one = _makeByteData('one');
+    final ByteData two = _makeByteData('two');
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
     bool didCallCallback = false;
-    ui.PlatformMessageResponseCallback oneCallback = (ByteData responseData) {
+    final ui.PlatformMessageResponseCallback oneCallback = (ByteData responseData) {
       didCallCallback = true;
     };
-    ui.PlatformMessageResponseCallback twoCallback = (ByteData responseData) {};
+    final ui.PlatformMessageResponseCallback twoCallback = (ByteData responseData) {};
     _resize(buffers, channel, 100);
     expect(buffers.push(channel, one, oneCallback), equals(false));
     expect(buffers.push(channel, two, twoCallback), equals(false));
@@ -121,15 +119,15 @@ void main() {
   });
 
   test('overflow calls callback', () async {
-    String channel = "foo";
-    ByteData one = _makeByteData('one');
-    ByteData two = _makeByteData('two');
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
+    const String channel = 'foo';
+    final ByteData one = _makeByteData('one');
+    final ByteData two = _makeByteData('two');
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
     bool didCallCallback = false;
-    ui.PlatformMessageResponseCallback oneCallback = (ByteData responseData) {
+    final ui.PlatformMessageResponseCallback oneCallback = (ByteData responseData) {
       didCallCallback = true;
     };
-    ui.PlatformMessageResponseCallback twoCallback = (ByteData responseData) {};
+    final ui.PlatformMessageResponseCallback twoCallback = (ByteData responseData) {};
     _resize(buffers, channel, 1);
     expect(buffers.push(channel, one, oneCallback), equals(false));
     expect(buffers.push(channel, two, twoCallback), equals(true));
@@ -137,14 +135,14 @@ void main() {
   });
 
   test('handle garbage', () async {
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    expect(() => buffers.handleMessage(_makeByteData("asdfasdf")),
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
+    expect(() => buffers.handleMessage(_makeByteData('asdfasdf')),
            throwsException);
   });
 
   test('handle resize garbage', () async {
-    ui.ChannelBuffers buffers = ui.ChannelBuffers();
-    expect(() => buffers.handleMessage(_makeByteData("resize\rfoo\rbar")),
+    final ui.ChannelBuffers buffers = ui.ChannelBuffers();
+    expect(() => buffers.handleMessage(_makeByteData('resize\rfoo\rbar')),
            throwsException);
   });
 }

--- a/testing/dart/color_filter_test.dart
+++ b/testing/dart/color_filter_test.dart
@@ -42,17 +42,17 @@ void main() {
   }
 
   test('ColorFilter - nulls', () async {
-    final Paint paint = Paint()..colorFilter = ColorFilter.mode(null, null);
+    final Paint paint = Paint()..colorFilter = const ColorFilter.mode(null, null);
     expect(paint.colorFilter, null);
 
-    paint.colorFilter = ColorFilter.matrix(null);
+    paint.colorFilter = const ColorFilter.matrix(null);
     expect(paint.colorFilter, null);
   });
 
   test('ColorFilter - mode', () async {
     final Paint paint = Paint()
       ..color = green
-      ..colorFilter = ColorFilter.mode(red, BlendMode.color);
+      ..colorFilter = const ColorFilter.mode(red, BlendMode.color);
 
     Uint32List bytes = await getBytesForPaint(paint);
     expect(bytes[0], greenRedColorBlend);
@@ -65,7 +65,7 @@ void main() {
   test('ColorFilter - matrix', () async {
     final Paint paint = Paint()
       ..color = green
-      ..colorFilter = ColorFilter.matrix(greyscaleColorMatrix);
+      ..colorFilter = const ColorFilter.matrix(greyscaleColorMatrix);
 
     Uint32List bytes = await getBytesForPaint(paint);
     expect(bytes[0], greenGreyscaled);
@@ -78,7 +78,7 @@ void main() {
   test('ColorFilter - linearToSrgbGamma', () async {
     final Paint paint = Paint()
       ..color = green
-      ..colorFilter = ColorFilter.linearToSrgbGamma();
+      ..colorFilter = const ColorFilter.linearToSrgbGamma();
 
     Uint32List bytes = await getBytesForPaint(paint);
     expect(bytes[0], greenLinearToSrgbGamma);
@@ -91,7 +91,7 @@ void main() {
   test('ColorFilter - srgbToLinearGamma', () async {
     final Paint paint = Paint()
       ..color = green
-      ..colorFilter = ColorFilter.srgbToLinearGamma();
+      ..colorFilter = const ColorFilter.srgbToLinearGamma();
 
     Uint32List bytes = await getBytesForPaint(paint);
     expect(bytes[0], greenSrgbToLinearGamma);

--- a/testing/dart/encoding_test.dart
+++ b/testing/dart/encoding_test.dart
@@ -13,8 +13,8 @@ import 'package:test/test.dart';
 const int _kWidth = 10;
 const int _kRadius = 2;
 
-const Color _kBlack = const Color.fromRGBO(0, 0, 0, 1.0);
-const Color _kGreen = const Color.fromRGBO(0, 255, 0, 1.0);
+const Color _kBlack = Color.fromRGBO(0, 0, 0, 1.0);
+const Color _kGreen = Color.fromRGBO(0, 255, 0, 1.0);
 
 void main() {
   group('Image.toByteData', () {

--- a/testing/dart/plugin_utilities_test.dart
+++ b/testing/dart/plugin_utilities_test.dart
@@ -14,7 +14,7 @@ class Foo {
   double getDouble() => 1.0;
 }
 
-const Foo foo = const Foo();
+const Foo foo = Foo();
 
 void main() {
   test('PluginUtilities Callback Handles', () {

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -339,13 +339,6 @@ void main() {
     });
 
     test('Window padding/insets/viewPadding/systemGestureInsets', () {
-      final double oldDPR = window.devicePixelRatio;
-      final Size oldSize = window.physicalSize;
-      final double oldPhysicalDepth = window.physicalDepth;
-      final WindowPadding oldPadding = window.viewPadding;
-      final WindowPadding oldInsets = window.viewInsets;
-      final WindowPadding oldSystemGestureInsets = window.systemGestureInsets;
-
       _updateWindowMetrics(
         1.0,   // DPR
         800.0, // width

--- a/testing/dart/window_test.dart
+++ b/testing/dart/window_test.dart
@@ -21,7 +21,7 @@ void main() {
   });
 
   test('FrameTiming.toString has the correct format', () {
-    FrameTiming timing = FrameTiming(<int>[1000, 8000, 9000, 19500]);
+    final FrameTiming timing = FrameTiming(<int>[1000, 8000, 9000, 19500]);
     expect(timing.toString(), 'FrameTiming(buildDuration: 7.0ms, rasterDuration: 10.5ms, totalSpan: 18.5ms)');
   });
 }

--- a/testing/scenario_app/lib/src/platform_view.dart
+++ b/testing/scenario_app/lib/src/platform_view.dart
@@ -27,8 +27,7 @@ List<int> _to64(num value) {
 }
 
 /// A simple platform view.
-class PlatformViewScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Creates the PlatformView scenario.
   ///
   /// The [window] parameter must not be null.
@@ -49,8 +48,7 @@ class PlatformViewScenario extends Scenario
 }
 
 /// Platform view with clip rect.
-class PlatformViewClipRectScenario extends Scenario
-    with _BasePlatformViewScenarioMixin {
+class PlatformViewClipRectScenario extends Scenario with _BasePlatformViewScenarioMixin {
   /// Constructs a platform view with clip rect scenario.
   PlatformViewClipRectScenario(Window window, String text, {int id = 0})
       : assert(window != null),
@@ -108,12 +106,12 @@ class PlatformViewClipPathScenario extends PlatformViewScenario {
     // Create a path of rectangle with width of 200 and height of 300, starting from (100, 100).
     //
     // Refer to "../../ios/Scenarios/Scenarios/ScenariosUITests/golden_platform_view_clippath_iPhone SE_simulator.png" for the exact path after clipping.
-    Path path = Path();
-    path.moveTo(100, 100);
-    path.quadraticBezierTo(50, 250, 100, 400);
-    path.lineTo(350, 400);
-    path.cubicTo(400, 300, 300, 200, 350, 100);
-    path.close();
+    final Path path = Path()
+      ..moveTo(100, 100)
+      ..quadraticBezierTo(50, 250, 100, 400)
+      ..lineTo(350, 400)
+      ..cubicTo(400, 300, 300, 200, 350, 100)
+      ..close();
     builder.pushClipPath(path);
 
     finishBuilderByAddingPlatformViewAndPicture(builder, 3);
@@ -234,11 +232,9 @@ mixin _BasePlatformViewScenarioMixin on Scenario {
     if (Platform.isIOS) {
       sceneBuilder.addPlatformView(viewId, width: 500, height: 500);
     } else if (Platform.isAndroid && _textureId != null) {
-      sceneBuilder.addTexture(_textureId,
-          offset: const Offset(150, 300), width: 500, height: 500);
+      sceneBuilder.addTexture(_textureId, offset: const Offset(150, 300), width: 500, height: 500);
     } else {
-      throw UnsupportedError(
-          'Platform ${Platform.operatingSystem} is not supported');
+      throw UnsupportedError('Platform ${Platform.operatingSystem} is not supported');
     }
     final PictureRecorder recorder = PictureRecorder();
     final Canvas canvas = Canvas(recorder);


### PR DESCRIPTION
Adds analysis of Dart files in the testing/ directory to the CI script

Cleans up issues so this should pass CI.

It excludes window_hooks becuase that test pulls in a bunch of stuff from dart:ui the analyze has no idea how to handle. Really we should rework all of that so that test is not accessing private details of dart:ui (https://github.com/flutter/flutter/issues/27628)