### PR TITLE
Set the Cirrus badge to only display status of the master branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ Flutter is a fully open source project, and we welcome contributions.
 Information on how to get started can be found at our
 [contributor guide](CONTRIBUTING.md).
 
-[Build Status - Cirrus]: https://api.cirrus-ci.com/github/flutter/engine.svg
+[Build Status - Cirrus]: https://api.cirrus-ci.com/github/flutter/engine.svg?branch=master
 [Build status]: https://cirrus-ci.com/github/flutter/engine


### PR DESCRIPTION
The badge used to query the last build which may be a pull request (or an aborted run).