### PR TITLE
Fix an objc_overrelease_during_dealloc_error.

### DIFF
--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -46,6 +46,8 @@ class PlatformViewIOS final : public PlatformView {
 
   // |PlatformView|
   void SetSemanticsEnabled(bool enabled) override;
+  
+  void OnFlutterViewControllerDealloced();
 
  private:
   fml::WeakPtr<FlutterViewController> owner_controller_;
@@ -58,7 +60,6 @@ class PlatformViewIOS final : public PlatformView {
   std::unique_ptr<AccessibilityBridge> accessibility_bridge_;
   fml::scoped_nsprotocol<FlutterTextInputPlugin*> text_input_plugin_;
   fml::closure firstFrameCallback_;
-  fml::scoped_nsprotocol<NSObject*> dealloc_view_controller_observer_;
 
   // |PlatformView|
   void HandlePlatformMessage(fml::RefPtr<flutter::PlatformMessage> message) override;


### PR DESCRIPTION
Fix an objc_overrelease_during_dealloc_error, it is reported as below:
<img width="1429" alt="Screen Shot 2019-10-11 at 12 17 07 AM" src="https://user-images.githubusercontent.com/817851/66587645-69547600-ebbd-11e9-9aa4-922321290ab0.png">

This issue is introduced in: https://github.com/flutter/engine/commit/5075172fe