### PR TITLE
Revert "Test child isolates are terminated when root is shutdown"

### DIFF
--- a/runtime/fixtures/runtime_test.dart
+++ b/runtime/fixtures/runtime_test.dart
@@ -60,18 +60,3 @@ void testCanLaunchSecondaryIsolate() {
 void testCanRecieveArguments(List<String> args) {
   notifyResult(args != null && args.length == 1 && args[0] == 'arg1');
 }
-
-@pragma('vm:entry-point')
-void testSecondaryIsolateShutdown() {
-  final onExit = RawReceivePort((_) { notifyNative(); });
-  Isolate.spawn(shutdownIsolateMain, 'You are isolate number 1', onExit: onExit.sendPort);
-  Isolate.spawn(shutdownIsolateMain, 'You are isolate number 2', onExit: onExit.sendPort);
-  Isolate.spawn(shutdownIsolateMain, 'You are isolate number 3', onExit: onExit.sendPort);
-  Isolate.spawn(shutdownIsolateMain, 'You are isolate number 4', onExit: onExit.sendPort);
-}
-
-void shutdownIsolateMain(String message) {
-  print('Secondary isolate got message: ' + message);
-  passMessage('In child Isolate.');
-  notifyNative();
-}


### PR DESCRIPTION
Reverts flutter/engine#13048 due to [LUCI failure on this test](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8899957187715978832/+/steps/Host_Tests_for_host_debug_unopt/0/stdout).