### PR TITLE
java imports/style

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivityDelegate.java
@@ -32,9 +32,7 @@ import io.flutter.view.FlutterMain;
 import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterRunArguments;
 import io.flutter.view.FlutterView;
-import org.json.JSONObject;
 
-import java.io.File;
 import java.util.ArrayList;
 
 /**
@@ -58,7 +56,8 @@ public final class FlutterActivityDelegate
         implements FlutterActivityEvents,
                    FlutterView.Provider,
                    PluginRegistry {
-    private static final String SPLASH_SCREEN_META_DATA_KEY = "io.flutter.app.android.SplashScreenUntilFirstFrame";
+    private static final String SPLASH_SCREEN_META_DATA_KEY =
+        "io.flutter.app.android.SplashScreenUntilFirstFrame";
     private static final String TAG = "FlutterActivityDelegate";
     private static final LayoutParams matchParent =
         new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);


### PR DESCRIPTION
Based on recommendations from the latest Google roll.  Unused imports, one line too long.

Is there any way we can add the same/similar cleaner to our presubmits?
