### PR TITLE
[dart_aot_runner] Generate vmservice aotsnapshots

### DIFF
--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -21,6 +21,7 @@ if (using_fuchsia_sdk) {
       "dart:kernel_compiler",
       "dart_runner:$dart_runner_target",
       "dart_runner/embedder:dart_aot_product_snapshot_cc",
+      "dart_runner/vmservice:vmservice",
       "flutter:flutter_aot_${product_suffix}runner",
       "flutter:flutter_jit_${product_suffix}runner",
       "flutter:flutter_runner_tests",

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -5,96 +5,18 @@
 import("//build/compiled_action.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
 import("$flutter_root/common/fuchsia_config.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
+import("$flutter_root/tools/fuchsia/dart_kernel.gni")
 
-template("dart_shim_kernel") {
-  prebuilt_dart_action(target_name) {
-    assert(defined(invoker.main_dart), "main_dart is a required parameter.")
-
-    main_dart = rebase_path(invoker.main_dart)
-
-    deps = [
-      "../kernel:kernel_platform_files",
-    ]
-
-    gen_kernel_script = "//third_party/dart/pkg/vm/bin/gen_kernel.dart"
-    platform_dill = "$root_out_dir/dart_runner_patched_sdk/platform_strong.dill"
-
-    dot_packages = rebase_path("//third_party/dart/.packages")
-
-    inputs = [
-      platform_dill,
-      gen_kernel_script,
-      main_dart,
-      dot_packages,
-    ]
-
-    output = "$target_gen_dir/$target_name.dill"
-    outputs = [
-      output,
-    ]
-
-    depfile = "$output.d"
-    abs_depfile = rebase_path(depfile)
-    rebased_output = rebase_path(output, root_build_dir)
-    vm_args = [
-      "--depfile=$abs_depfile",
-      "--depfile_output_filename=$rebased_output",
-    ]
-
-    script = gen_kernel_script
-
-    args = [
-      "--packages=" + rebase_path(dot_packages),
-      "--target=dart_runner",
-      "--platform=" + rebase_path(platform_dill),
-      "--no-link-platform",
-      "--output=" + rebase_path(output),
-    ]
-
-    if (is_debug) {
-      args += [ "--embed-sources" ]
-    } else {
-      args += [ "--no-embed-sources" ]
-    }
-
-    if (defined(invoker.aot) && invoker.aot) {
-      args += [
-        "--aot",
-        "--tfa",
-      ]
-    }
-
-    if (defined(invoker.product) && invoker.product) {
-      # Setting this flag in a non-product release build for AOT (a "profile"
-      # build) causes the vm service isolate code to be tree-shaken from an app.
-      # See the pragma on the entrypoint here:
-      #
-      # https://github.com/dart-lang/sdk/blob/master/runtime/bin/vmservice/vmservice_io.dart#L240
-      #
-      # Also, this define excludes debugging and profiling code from Flutter.
-      args += [ "-Ddart.vm.product=true" ]
-    } else {
-      if (!is_debug) {
-        # The following define excludes debugging code from Flutter.
-        args += [ "-Ddart.vm.profile=true" ]
-      }
-    }
-
-    visibility = [ ":*" ]
-
-    args += [ rebase_path(main_dart) ]
-  }
-}
-
-dart_shim_kernel("shim_kernel") {
+dart_kernel("shim_kernel") {
   main_dart = "shim.dart"
+  kernel_platform_files = "../kernel:kernel_platform_files"
   product = false
   aot = true
 }
 
-dart_shim_kernel("shim_product_kernel") {
+dart_kernel("shim_product_kernel") {
   main_dart = "shim.dart"
+  kernel_platform_files = "../kernel:kernel_platform_files"
   product = true
   aot = true
 }

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -2,22 +2,93 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//topaz/runtime/dart_runner/dart_app.gni")
+import("//build/compiled_action.gni")
+import("//build/fuchsia/sdk.gni")
+import("//third_party/dart/utils/compile_platform.gni")
+import("$flutter_root/common/config.gni")
+import("$flutter_root/tools/fuchsia/dart.gni")
+import("$flutter_root/tools/fuchsia/dart_kernel.gni")
 
-dart_aot_app("vmservice") {
+dart_kernel("vmservice_product_aot_kernel") {
+  kernel_platform_files = "../kernel:kernel_platform_files"
   main_dart = "empty.dart"
+  product = true
+  aot = true
+}
 
-  meta = [
-    {
-      path = rebase_path("meta/vmservice.cmx")
-      dest = "vmservice.cmx"
-    },
-  ]
-
-  source_dir = "."
-
+dart_kernel("vmservice_aot_kernel") {
+  kernel_platform_files = "../kernel:kernel_platform_files"
+  main_dart = "empty.dart"
   product = false
+  aot = true
+}
 
-  sources = []
-  deps = []
+template("aot_snapshot") {
+  compiled_action(target_name) {
+    kernel_name = target_name
+
+    product = defined(invoker.product) && invoker.product
+
+    product_suffix = ""
+    if (product) {
+      product_suffix = "_product"
+    }
+
+    shim_target = ":vmservice${product_suffix}_aot_kernel($host_toolchain)"
+    shim_kernel = get_label_info(shim_target, "target_gen_dir") +
+                  "/vmservice${product_suffix}_aot_kernel.dill"
+
+    deps = [
+      shim_target,
+    ]
+
+    vm_snapshot_data_path = "$target_gen_dir/${kernel_name}_vm_data.aotsnapshot"
+    vm_snapshot_instructions_path =
+        "$target_gen_dir/${kernel_name}_vm_instructions.aotsnapshot"
+    snapshot_data_path = "$target_gen_dir/${kernel_name}_data.aotsnapshot"
+    snapshot_instructions_path =
+        "$target_gen_dir/${kernel_name}_instructions.aotsnapshot"
+
+    inputs = [
+      shim_kernel,
+    ]
+
+    outputs = [
+      vm_snapshot_data_path,
+      vm_snapshot_instructions_path,
+      snapshot_data_path,
+      snapshot_instructions_path,
+    ]
+
+    if (product) {
+      tool = gen_snapshot_product
+    } else {
+      tool = gen_snapshot
+    }
+
+    args = [
+      "--no_causal_async_stacks",
+      "--deterministic",
+      "--snapshot_kind=app-aot-blobs",
+      "--vm_snapshot_data=" + rebase_path(vm_snapshot_data_path),
+      "--vm_snapshot_instructions=" +
+          rebase_path(vm_snapshot_instructions_path),
+      "--isolate_snapshot_data=" + rebase_path(snapshot_data_path),
+      "--isolate_snapshot_instructions=" +
+          rebase_path(snapshot_instructions_path),
+    ]
+
+    # No asserts in debug or release product.
+    # No asserts in release with flutter_profile=true (non-product)
+    # Yes asserts in non-product debug.
+    if (!product && (!(flutter_runtime_mode == "profile") || is_debug)) {
+      args += [ "--enable_asserts" ]
+    }
+
+    args += [ rebase_path(shim_kernel) ]
+  }
+}
+
+aot_snapshot("vmservice") {
+  product = false
 }

--- a/tools/fuchsia/dart_kernel.gni
+++ b/tools/fuchsia/dart_kernel.gni
@@ -1,0 +1,89 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+import("//third_party/dart/build/dart/dart_action.gni")
+import("$flutter_root/common/fuchsia_config.gni")
+import("$flutter_root/tools/fuchsia/dart.gni")
+
+template("dart_kernel") {
+  prebuilt_dart_action(target_name) {
+    assert(defined(invoker.main_dart), "main_dart is a required parameter.")
+    assert(defined(invoker.kernel_platform_files),
+           "kernel_platform_files target must be defined.")
+
+    main_dart = rebase_path(invoker.main_dart)
+
+    print(main_dart)
+
+    deps = [
+      invoker.kernel_platform_files,
+    ]
+
+    gen_kernel_script = "//third_party/dart/pkg/vm/bin/gen_kernel.dart"
+    platform_dill = "$root_out_dir/dart_runner_patched_sdk/platform_strong.dill"
+
+    dot_packages = rebase_path("//third_party/dart/.packages")
+
+    inputs = [
+      platform_dill,
+      gen_kernel_script,
+      main_dart,
+      dot_packages,
+    ]
+
+    output = "$target_gen_dir/$target_name.dill"
+    outputs = [
+      output,
+    ]
+
+    depfile = "$output.d"
+    abs_depfile = rebase_path(depfile)
+    rebased_output = rebase_path(output, root_build_dir)
+    vm_args = [
+      "--depfile=$abs_depfile",
+      "--depfile_output_filename=$rebased_output",
+    ]
+
+    script = gen_kernel_script
+
+    args = [
+      "--packages=" + rebase_path(dot_packages),
+      "--target=dart_runner",
+      "--platform=" + rebase_path(platform_dill),
+      "--no-link-platform",
+      "--output=" + rebase_path(output),
+    ]
+
+    if (is_debug) {
+      args += [ "--embed-sources" ]
+    } else {
+      args += [ "--no-embed-sources" ]
+    }
+
+    if (defined(invoker.aot) && invoker.aot) {
+      args += [
+        "--aot",
+        "--tfa",
+      ]
+    }
+
+    if (defined(invoker.product) && invoker.product) {
+      # Setting this flag in a non-product release build for AOT (a "profile"
+      # build) causes the vm service isolate code to be tree-shaken from an app.
+      # See the pragma on the entrypoint here:
+      #
+      # https://github.com/dart-lang/sdk/blob/master/runtime/bin/vmservice/vmservice_io.dart#L240
+      #
+      # Also, this define excludes debugging and profiling code from Flutter.
+      args += [ "-Ddart.vm.product=true" ]
+    } else {
+      if (!is_debug) {
+        # The following define excludes debugging code from Flutter.
+        args += [ "-Ddart.vm.profile=true" ]
+      }
+    }
+
+    args += [ rebase_path(main_dart) ]
+  }
+}

--- a/tools/fuchsia/dart_kernel.gni
+++ b/tools/fuchsia/dart_kernel.gni
@@ -14,8 +14,6 @@ template("dart_kernel") {
 
     main_dart = rebase_path(invoker.main_dart)
 
-    print(main_dart)
-
     deps = [
       invoker.kernel_platform_files,
     ]


### PR DESCRIPTION
This also refactors `dart_kernel` into its own template to be reused by `vmservice`