### PR TITLE
[dart_aot_runner] Complete the port of dart_aot_runner

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -36,7 +36,10 @@ group("flutter") {
   }
 
   if (is_fuchsia && using_fuchsia_sdk) {
-    public_deps += [ "$flutter_root/shell/platform/fuchsia" ]
+    public_deps += [
+      "$flutter_root/shell/platform/fuchsia",
+      "$flutter_root/shell/testing($host_toolchain)",
+    ]
   }
 
   if (!is_fuchsia && !is_fuchsia_host) {

--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -14,14 +14,11 @@ if (using_fuchsia_sdk) {
     product_suffix = "product_"
   }
 
-  dart_runner_target = "dart_jit_${product_suffix}runner"
-
   group("fuchsia") {
     deps = [
       "dart:kernel_compiler",
-      "dart_runner:$dart_runner_target",
-      "dart_runner/embedder:dart_aot_product_snapshot_cc",
-      "dart_runner/vmservice:vmservice",
+      "dart_runner:dart_aot_${product_suffix}runner",
+      "dart_runner:dart_jit_${product_suffix}runner",
       "flutter:flutter_aot_${product_suffix}runner",
       "flutter:flutter_jit_${product_suffix}runner",
       "flutter:flutter_runner_tests",

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -155,17 +155,31 @@ template("aot_runner_package") {
 
     resources = []
     if (!invoker.product) {
+      vmservice_data = rebase_path(
+              get_label_info("vmservice:vmservice_snapshot", "target_gen_dir") +
+              "/vmservice_data.aotsnapshot")
+      vmservice_instr = rebase_path(
+              get_label_info("vmservice:vmservice_snapshot", "target_gen_dir") +
+              "/vmservice_instructions.aotsnapshot")
+      dart_profiler_symbols = rebase_path(
+              get_label_info(
+                  "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
+                  "target_gen_dir") + "/dart_aot_runner.dartprofilersymbols")
+
+      inputs = [
+        vmservice_data,
+        vmservice_instr,
+        observatory_archive_file,
+        dart_profiler_symbols,
+      ]
+
       resources += [
         {
-          path = rebase_path(get_label_info("vmservice:vmservice_snapshot",
-                                            "target_gen_dir") +
-                             "/vmservice_data.aotsnapshot")
+          path = vmservice_data
           dest = "vmservice_isolate_snapshot_data.bin"
         },
         {
-          path = rebase_path(get_label_info("vmservice:vmservice_snapshot",
-                                            "target_gen_dir") +
-                             "/vmservice_instructions.aotsnapshot")
+          path = vmservice_instr
           dest = "vmservice_isolate_snapshot_instructions.bin"
         },
         {
@@ -173,10 +187,7 @@ template("aot_runner_package") {
           dest = "observatory.tar"
         },
         {
-          path = rebase_path(
-                  get_label_info(
-                      "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
-                      "target_gen_dir") + "/dart_aot_runner.dartprofilersymbols")
+          path = dart_profiler_symbols
           dest = "dart_aot_runner.dartprofilersymbols"
         },
       ]

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -121,6 +121,69 @@ runner("dart_aot_product_runner_bin") {
   ]
 }
 
+template("aot_runner_package") {
+  assert(defined(invoker.product), "The parameter 'product' must be defined")
+  product_suffix = ""
+  if (invoker.product) {
+    product_suffix = "_product"
+  }
+  fuchsia_archive(target_name) {
+    deps = [
+      ":dart_aot${product_suffix}_runner_bin",
+    ]
+    if (!invoker.product) {
+      deps += [
+        "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
+        "vmservice:vmservice_snapshot",
+
+        # TODO(kaushikiska): Figure out how to get the profiler symbols for `libdart_precompiled_runtime`
+        # "//topaz/runtime/dart/profiler_symbols:libdart_precompiled_runtime",
+        observatory_target,
+      ]
+    }
+
+    binary = "dart_aot${product_suffix}_runner"
+
+    meta_dir = "$flutter_root/shell/platform/fuchsia/dart_runner/meta"
+
+    meta = [
+      {
+        path = rebase_path("meta/dart_aot${product_suffix}_runner.cmx")
+        dest = "dart_aot${product_suffix}_runner.cmx"
+      },
+    ]
+
+    resources = []
+    if (!invoker.product) {
+      resources += [
+        {
+          path = rebase_path(get_label_info("vmservice:vmservice_snapshot",
+                                            "target_gen_dir") +
+                             "/vmservice_data.aotsnapshot")
+          dest = "vmservice_isolate_snapshot_data.bin"
+        },
+        {
+          path = rebase_path(get_label_info("vmservice:vmservice_snapshot",
+                                            "target_gen_dir") +
+                             "/vmservice_instructions.aotsnapshot")
+          dest = "vmservice_isolate_snapshot_instructions.bin"
+        },
+        {
+          path = rebase_path(observatory_archive_file)
+          dest = "observatory.tar"
+        },
+        {
+          path = rebase_path(
+                  get_label_info(
+                      "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
+                      "target_gen_dir") + "/dart_aot_runner.dartprofilersymbols")
+          dest = "dart_aot_runner.dartprofilersymbols"
+        },
+      ]
+    }
+  }
+}
+
 template("jit_runner_package") {
   assert(defined(invoker.product), "The parameter 'product' must be defined")
   product_suffix = ""
@@ -135,7 +198,10 @@ template("jit_runner_package") {
     ]
 
     if (!invoker.product) {
-      deps += [ observatory_target ]
+      deps += [
+        "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_jit_runner",
+        observatory_target,
+      ]
     }
 
     binary = "dart_jit${product_suffix}_runner"
@@ -173,6 +239,13 @@ template("jit_runner_package") {
           path = rebase_path(observatory_archive_file)
           dest = "observatory.tar"
         },
+        {
+          path = rebase_path(
+                  get_label_info(
+                      "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_jit_runner",
+                      "target_gen_dir") + "/dart_jit_runner.dartprofilersymbols")
+          dest = "dart_jit_runner.dartprofilersymbols"
+        },
       ]
     }
 
@@ -183,6 +256,14 @@ template("jit_runner_package") {
       },
     ]
   }
+}
+
+aot_runner_package("dart_aot_runner") {
+  product = false
+}
+
+aot_runner_package("dart_aot_product_runner") {
+  product = true
 }
 
 jit_runner_package("dart_jit_runner") {

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -27,6 +27,10 @@ template("aot_snapshot") {
   compiled_action(target_name) {
     kernel_name = target_name
 
+    if (defined(invoker.kernel_name)) {
+      kernel_name = invoker.kernel_name
+    }
+
     product = defined(invoker.product) && invoker.product
 
     product_suffix = ""
@@ -90,5 +94,6 @@ template("aot_snapshot") {
 }
 
 aot_snapshot("vmservice_snapshot") {
+  kernel_name = "vmservice"
   product = false
 }

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -89,6 +89,6 @@ template("aot_snapshot") {
   }
 }
 
-aot_snapshot("vmservice") {
+aot_snapshot("vmservice_snapshot") {
   product = false
 }

--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
@@ -43,6 +43,13 @@ generate_dart_profiler_symbols("dart_jit_runner") {
   output = "${target_gen_dir}/dart_jit_runner.dartprofilersymbols"
 }
 
+generate_dart_profiler_symbols("dart_aot_runner") {
+  library_label =
+      "$flutter_root/shell/platform/fuchsia/dart_runner:dart_aot_runner_bin"
+  library_path = "${root_out_dir}/exe.unstripped/dart_aot_runner"
+  output = "${target_gen_dir}/dart_aot_runner.dartprofilersymbols"
+}
+
 generate_dart_profiler_symbols("flutter_jit_runner") {
   library_label = "$flutter_root/shell/platform/fuchsia/flutter:jit"
   library_path = "${root_out_dir}/exe.unstripped/flutter_jit_runner"

--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -52,8 +52,8 @@ def RunExecutable(command):
 
 
 def RunGN(variant_dir, flags):
-  print('Running gn for variant "%s" with flags: %s' % (variant_dir,
-      ','.join(flags)))
+  print('Running gn for variant "%s" with flags: %s' %
+        (variant_dir, ','.join(flags)))
   RunExecutable([
       os.path.join('flutter', 'tools', 'gn'),
   ] + flags)
@@ -137,6 +137,7 @@ def CopyToBucket(src, dst, product=False):
   CopyToBucketWithMode(src, dst, False, product, 'flutter')
   CopyToBucketWithMode(src, dst, True, product, 'flutter')
   CopyToBucketWithMode(src, dst, False, product, 'dart')
+  CopyToBucketWithMode(src, dst, True, product, 'dart')
 
 
 def BuildBucket(runtime_mode, arch, product):
@@ -189,6 +190,7 @@ def GetTargetsToBuild(product=False):
       GetRunnerTarget('flutter', product, True),
       # The Dart Runner.
       GetRunnerTarget('dart_runner', product, False),
+      GetRunnerTarget('dart_runner', product, True),
       '%s/dart:kernel_compiler' % _fuchsia_base,
   ]
   return targets_to_build
@@ -234,10 +236,7 @@ def main():
       default='all')
 
   parser.add_argument(
-      '--archs',
-      type=str,
-      choices=['x64', 'arm64', 'all'],
-      default='all')
+      '--archs', type=str, choices=['x64', 'arm64', 'all'], default='all')
 
   parser.add_argument(
       '--no-lto',
@@ -246,10 +245,10 @@ def main():
       help='If set, disables LTO for the build.')
 
   parser.add_argument(
-    '--skip-build',
-    action='store_true',
-    default=False,
-    help='If set, skips building and just creates packages.')
+      '--skip-build',
+      action='store_true',
+      default=False,
+      help='If set, skips building and just creates packages.')
 
   args = parser.parse_args()
   RemoveDirectoryIfExists(_bucket_directory)

--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -87,6 +87,10 @@ template("fuchsia_archive") {
     script = "$flutter_root/tools/fuchsia/gen_package.py"
     deps = pkg_dir_deps + [ ":${target_name}_dir" ]
     sources = copy_outputs
+    inputs = []
+    if (defined(invoker.inputs)) {
+      inputs = invoker.inputs
+    }
     args = [
       "--pm-bin",
       rebase_path("//fuchsia/sdk/$host_os/tools/pm"),


### PR DESCRIPTION
- also adds the previously missing profiler symbols for dart_jit_runner
- CIPD package will contain both the JIT and AOT dart runners