### PR TITLE
Use iOS 13 dark content status bar style

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -166,17 +166,22 @@ using namespace flutter;
 }
 
 - (void)setSystemChromeSystemUIOverlayStyle:(NSDictionary*)message {
-  NSString* style = message[@"statusBarBrightness"];
-  if (style == (id)[NSNull null])
+  NSString* brightness = message[@"statusBarBrightness"];
+  if (brightness == (id)[NSNull null])
     return;
 
   UIStatusBarStyle statusBarStyle;
-  if ([style isEqualToString:@"Brightness.dark"])
+  if ([brightness isEqualToString:@"Brightness.dark"]) {
     statusBarStyle = UIStatusBarStyleLightContent;
-  else if ([style isEqualToString:@"Brightness.light"])
-    statusBarStyle = UIStatusBarStyleDefault;
-  else
+  } else if ([brightness isEqualToString:@"Brightness.light"]) {
+    if (@available(iOS 13, *)) {
+      statusBarStyle = UIStatusBarStyleDarkContent;
+    } else {
+      statusBarStyle = UIStatusBarStyleDefault;
+    }
+  } else {
     return;
+  }
 
   NSNumber* infoValue = [[NSBundle mainBundle]
       objectForInfoDictionaryKey:@"UIViewControllerBasedStatusBarAppearance"];


### PR DESCRIPTION
On iOS 13 when Dark Mode is enabled, `UIStatusBarStyleDefault` uses light text for the status bar instead of dark text.

Since Flutter can only choose between `UIStatusBarStyleDefault` and `UIStatusBarStyleLightContent` (light text), the status bar is always white when in Dark Mode.

With this pull request, `UIStatusBarStyleDarkContent` is specified when dark text is needed.