### PR TITLE
Change IO thread shader cache strategy

### DIFF
--- a/shell/common/persistent_cache.cc
+++ b/shell/common/persistent_cache.cc
@@ -47,7 +47,7 @@ std::atomic<bool> PersistentCache::cache_sksl_ = false;
 std::atomic<bool> PersistentCache::strategy_set_ = false;
 
 void PersistentCache::SetCacheSkSL(bool value) {
-  if (strategy_set_) {
+  if (strategy_set_ && value != cache_sksl_) {
     FML_LOG(ERROR) << "Cache SkSL can only be set before the "
                       "GrContextOptions::fShaderCacheStrategy is set.";
     return;

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -19,6 +19,12 @@ sk_sp<GrContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
 
   GrContextOptions options = {};
 
+  if (PersistentCache::cache_sksl()) {
+    FML_LOG(INFO) << "Cache SkSL";
+    options.fShaderCacheStrategy = GrContextOptions::ShaderCacheStrategy::kSkSL;
+  }
+  PersistentCache::MarkStrategySet();
+
   options.fPersistentCache = PersistentCache::GetCacheForProcess();
 
   // There is currently a bug with doing GPU YUV to RGB conversions on the IO

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -50,8 +50,8 @@ GPUSurfaceGL::GPUSurfaceGL(GPUSurfaceGLDelegate* delegate,
   if (PersistentCache::cache_sksl()) {
     FML_LOG(INFO) << "Cache SkSL";
     options.fShaderCacheStrategy = GrContextOptions::ShaderCacheStrategy::kSkSL;
-    PersistentCache::MarkStrategySet();
   }
+  PersistentCache::MarkStrategySet();
   options.fPersistentCache = PersistentCache::GetCacheForProcess();
 
   options.fAvoidStencilBuffers = true;


### PR DESCRIPTION
So it's the same with the GPU thread.

Otherwise, some shaders may be cached in binary on the IO thread, and we will lose them when we do the SkSL precompile.