### PR TITLE
Upgrades the ICU version to 64.2

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -136,7 +136,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'edd0f2d19604a7d63deb20e9c19c1412acb8a9bd',
+  'src': 'https://github.com/flutter/buildroot.git' + '@' + '9c893948fd2413b32669b5a9261a1b6a487b8f9b',
 
    # Fuchsia compatibility
    #
@@ -177,7 +177,7 @@ deps = {
    Var('chromium_git') + '/chromium/src/ios.git' + '@' + Var('ios_tools_revision'),
 
   'src/third_party/icu':
-   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + 'c56c671998902fcc4fc9ace88c83daa99f980793',
+   Var('chromium_git') + '/chromium/deps/icu.git' + '@' + '5005010d694e16571b8dfbf07d70817841f80a69',
 
   'src/third_party/boringssl':
    Var('github_git') + '/dart-lang/boringssl_gen.git' + '@' + Var('dart_boringssl_gen_rev'),

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: 15ade88b2fb3afa2b3f4934384f9c9a5
+Signature: a70217e9b4f8fce1f7235c21378cffa6
 
 UNUSED LICENSES:
 
@@ -13992,10 +13992,12 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 LIBRARY: icu
 ORIGIN: ../../../third_party/dart/runtime/third_party/double-conversion/COPYING
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14006,24 +14008,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14032,11 +14046,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14070,9 +14083,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -14085,7 +14095,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright 2006-2011, the V8 project authors. All rights reserved.
 Redistribution and use in source and binary forms, with or without
@@ -14119,10 +14131,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14133,24 +14147,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14159,11 +14185,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14197,9 +14222,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -14212,7 +14234,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 1999 Computer Systems and Communication Lab,
                    Institute of Information Science, Academia
@@ -14251,10 +14275,12 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14265,24 +14291,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14291,11 +14329,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14329,9 +14366,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -14344,7 +14378,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 1999 TaBE Project.
 Copyright (c) 1999 Pai-Hsiang Hsiao.
@@ -14382,10 +14418,12 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14396,24 +14434,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14422,11 +14472,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14460,9 +14509,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -14475,7 +14521,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2013 International Business Machines Corporation
 and others. All Rights Reserved.
@@ -14519,10 +14567,12 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14533,24 +14583,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14559,11 +14621,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14597,9 +14658,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -14612,7 +14670,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 2014 International Business Machines Corporation
 and others. All Rights Reserved.
@@ -14655,10 +14715,12 @@ SUCH DAMAGE.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.bsd
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14669,24 +14731,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14695,11 +14769,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14733,9 +14806,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -14748,7 +14818,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 The BSD License
 http://opensource.org/licenses/bsd-license.php
@@ -14787,10 +14859,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.icu
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14801,24 +14875,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14827,11 +14913,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14865,9 +14950,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -14880,7 +14962,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright (c) 1995-2016 International Business Machines Corporation and others
 All rights reserved.
@@ -14918,10 +15002,12 @@ property of their respective owners.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -14932,24 +15018,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -14958,11 +15056,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -14996,9 +15093,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -15011,7 +15105,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright 1996 Chih-Hao Tsai @ Beckman Institute,
     University of Illinois
@@ -15022,10 +15118,12 @@ c-tsai4@uiuc.edu  http://casper.beckman.uiuc.edu/~c-tsai4
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -15036,24 +15134,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -15062,11 +15172,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -15100,9 +15209,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -15115,7 +15221,9 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
 Copyright 2000, 2001, 2002, 2003 Nara Institute of Science
 and Technology.  All Rights Reserved.
@@ -15193,10 +15301,12 @@ above as far as the program is concerned.
 LIBRARY: icu
 ORIGIN: ../../../third_party/icu/LICENSE
 TYPE: LicenseType.unknown
-FILE: ../../../third_party/icu/android/brkitr.patch
-FILE: ../../../third_party/icu/android/currencies.list
 FILE: ../../../third_party/icu/android/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl.dat
+FILE: ../../../third_party/icu/android_small/icudtl_extra.dat
+FILE: ../../../third_party/icu/cast/brkitr.patch
 FILE: ../../../third_party/icu/cast/icudtl.dat
+FILE: ../../../third_party/icu/chromeos/icudtl.dat
 FILE: ../../../third_party/icu/common/icudtb.dat
 FILE: ../../../third_party/icu/common/icudtl.dat
 FILE: ../../../third_party/icu/flutter/brkitr.patch
@@ -15207,24 +15317,36 @@ FILE: ../../../third_party/icu/fuzzers/icu_break_iterator_utf32_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_number_format_fuzzer.cc
 FILE: ../../../third_party/icu/fuzzers/icu_ucasemap_fuzzer.cc
 FILE: ../../../third_party/icu/ios/icudtl.dat
+FILE: ../../../third_party/icu/patches/DateIntervalInfo.patch
+FILE: ../../../third_party/icu/patches/bidiunshift.patch
+FILE: ../../../third_party/icu/patches/buildtool.patch
+FILE: ../../../third_party/icu/patches/calendarToAdopt.patch
 FILE: ../../../third_party/icu/patches/cjdict.patch
+FILE: ../../../third_party/icu/patches/clang_builtins.patch
+FILE: ../../../third_party/icu/patches/configure.patch
 FILE: ../../../third_party/icu/patches/data.build.patch
-FILE: ../../../third_party/icu/patches/data.build.win.patch
 FILE: ../../../third_party/icu/patches/data_symb.patch
-FILE: ../../../third_party/icu/patches/decimalformat_align.patch
 FILE: ../../../third_party/icu/patches/double_conversion.patch
 FILE: ../../../third_party/icu/patches/gb_table.patch
-FILE: ../../../third_party/icu/patches/greek_lowercase.patch
+FILE: ../../../third_party/icu/patches/hu_minimumGroupingDigits.patch
+FILE: ../../../third_party/icu/patches/icupkg.patch
+FILE: ../../../third_party/icu/patches/iso2022jp.patch
 FILE: ../../../third_party/icu/patches/isvalidenum.patch
 FILE: ../../../third_party/icu/patches/khmer-dictbe.patch
 FILE: ../../../third_party/icu/patches/locale1.patch
 FILE: ../../../third_party/icu/patches/locale_google.patch
-FILE: ../../../third_party/icu/patches/locid_map.patch
-FILE: ../../../third_party/icu/patches/nf_maxsig.patch
-FILE: ../../../third_party/icu/patches/vscomp.patch
+FILE: ../../../third_party/icu/patches/localematcher.patch
+FILE: ../../../third_party/icu/patches/regexp.patch
+FILE: ../../../third_party/icu/patches/regexp2.patch
+FILE: ../../../third_party/icu/patches/remove_atomics_macros.patch
+FILE: ../../../third_party/icu/patches/staticmutex.patch
+FILE: ../../../third_party/icu/patches/this_hour_minute.patch
+FILE: ../../../third_party/icu/patches/timezone.patch
+FILE: ../../../third_party/icu/patches/tracing.patch
+FILE: ../../../third_party/icu/patches/trie.patch
+FILE: ../../../third_party/icu/patches/usePool.patch
 FILE: ../../../third_party/icu/patches/wordbrk.patch
 FILE: ../../../third_party/icu/patches/wpo.patch
-FILE: ../../../third_party/icu/source/data/curr/pool.res
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-implicithan.icu
 FILE: ../../../third_party/icu/source/data/in/coll/ucadata-unihan.icu
 FILE: ../../../third_party/icu/source/data/in/nfc.nrm
@@ -15233,11 +15355,10 @@ FILE: ../../../third_party/icu/source/data/in/nfkc_cf.nrm
 FILE: ../../../third_party/icu/source/data/in/pnames.icu
 FILE: ../../../third_party/icu/source/data/in/ubidi.icu
 FILE: ../../../third_party/icu/source/data/in/ucase.icu
+FILE: ../../../third_party/icu/source/data/in/ulayout.icu
 FILE: ../../../third_party/icu/source/data/in/unames.icu
 FILE: ../../../third_party/icu/source/data/in/uprops.icu
 FILE: ../../../third_party/icu/source/data/in/uts46.nrm
-FILE: ../../../third_party/icu/source/data/lang/pool.res
-FILE: ../../../third_party/icu/source/data/locales/pool.res
 FILE: ../../../third_party/icu/source/data/mappings/big5-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-jp-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/euc-kr-html.ucm
@@ -15271,9 +15392,6 @@ FILE: ../../../third_party/icu/source/data/mappings/windows-1258-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-874-html.ucm
 FILE: ../../../third_party/icu/source/data/mappings/windows-936-2000.ucm
 FILE: ../../../third_party/icu/source/data/mappings/x-mac-cyrillic-html.ucm
-FILE: ../../../third_party/icu/source/data/region/pool.res
-FILE: ../../../third_party/icu/source/data/unit/pool.res
-FILE: ../../../third_party/icu/source/data/zone/pool.res
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsp
 FILE: ../../../third_party/icu/source/extra/scrptrun/srtest.dsw
 FILE: ../../../third_party/icu/source/samples/ucnv/data02.bin
@@ -15286,10 +15404,12 @@ FILE: ../../../third_party/icu/source/tools/tzcode/tzfile.h
 FILE: ../../../third_party/icu/source/tools/tzcode/tzselect.ksh
 FILE: ../../../third_party/icu/source/tools/tzcode/zdump.c
 FILE: ../../../third_party/icu/source/tools/tzcode/zic.c
-FILE: ../../../third_party/icu/windows/icudt.dll
+FILE: ../../../third_party/icu/tzres/metaZones.res
+FILE: ../../../third_party/icu/tzres/timezoneTypes.res
+FILE: ../../../third_party/icu/tzres/zoneinfo64.res
 ----------------------------------------------------------------------------------------------------
-Copyright © 1991-2018 Unicode, Inc. All rights reserved.
-Distributed under the Terms of Use in http://www.unicode.org/copyright.html.
+Copyright © 1991-2019 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of the Unicode data files and any associated documentation
@@ -15319,6 +15439,48 @@ Except as contained in this notice, the name of a copyright holder
 shall not be used in advertising or otherwise to promote the sale,
 use or other dealings in these Data Files or Software without prior
 written authorization of the copyright holder.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: icu
+ORIGIN: ../../../third_party/icu/filters/android.json + ../../../third_party/dart/runtime/third_party/double-conversion/COPYING
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/icu/filters/android.json
+FILE: ../../../third_party/icu/filters/android_extra.json
+FILE: ../../../third_party/icu/filters/android_small.json
+FILE: ../../../third_party/icu/filters/cast.json
+FILE: ../../../third_party/icu/filters/chromeos.json
+FILE: ../../../third_party/icu/filters/common.json
+FILE: ../../../third_party/icu/filters/flutter.json
+FILE: ../../../third_party/icu/filters/ios.json
+----------------------------------------------------------------------------------------------------
+Copyright 2019 the V8 project authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+    * Neither the name of Google Inc. nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 
 ====================================================================================================
@@ -15415,6 +15577,8 @@ FILE: ../../../third_party/icu/source/common/bytestrie.cpp
 FILE: ../../../third_party/icu/source/common/bytestriebuilder.cpp
 FILE: ../../../third_party/icu/source/common/bytestrieiterator.cpp
 FILE: ../../../third_party/icu/source/common/caniter.cpp
+FILE: ../../../third_party/icu/source/common/capi_helper.h
+FILE: ../../../third_party/icu/source/common/characterproperties.cpp
 FILE: ../../../third_party/icu/source/common/chariter.cpp
 FILE: ../../../third_party/icu/source/common/charstr.cpp
 FILE: ../../../third_party/icu/source/common/charstr.h
@@ -15441,21 +15605,30 @@ FILE: ../../../third_party/icu/source/common/hash.h
 FILE: ../../../third_party/icu/source/common/icudataver.cpp
 FILE: ../../../third_party/icu/source/common/icuplug.cpp
 FILE: ../../../third_party/icu/source/common/icuplugimp.h
-FILE: ../../../third_party/icu/source/common/listformatter.cpp
 FILE: ../../../third_party/icu/source/common/loadednormalizer2impl.cpp
+FILE: ../../../third_party/icu/source/common/localebuilder.cpp
+FILE: ../../../third_party/icu/source/common/localematcher.cpp
+FILE: ../../../third_party/icu/source/common/localeprioritylist.cpp
+FILE: ../../../third_party/icu/source/common/localeprioritylist.h
 FILE: ../../../third_party/icu/source/common/localsvc.h
 FILE: ../../../third_party/icu/source/common/locavailable.cpp
 FILE: ../../../third_party/icu/source/common/locbased.cpp
 FILE: ../../../third_party/icu/source/common/locbased.h
 FILE: ../../../third_party/icu/source/common/locdispnames.cpp
+FILE: ../../../third_party/icu/source/common/locdistance.cpp
+FILE: ../../../third_party/icu/source/common/locdistance.h
 FILE: ../../../third_party/icu/source/common/locdspnm.cpp
 FILE: ../../../third_party/icu/source/common/locid.cpp
 FILE: ../../../third_party/icu/source/common/loclikely.cpp
+FILE: ../../../third_party/icu/source/common/loclikelysubtags.cpp
+FILE: ../../../third_party/icu/source/common/loclikelysubtags.h
 FILE: ../../../third_party/icu/source/common/locmap.cpp
 FILE: ../../../third_party/icu/source/common/locmap.h
 FILE: ../../../third_party/icu/source/common/locresdata.cpp
 FILE: ../../../third_party/icu/source/common/locutil.cpp
 FILE: ../../../third_party/icu/source/common/locutil.h
+FILE: ../../../third_party/icu/source/common/lsr.cpp
+FILE: ../../../third_party/icu/source/common/lsr.h
 FILE: ../../../third_party/icu/source/common/messageimpl.h
 FILE: ../../../third_party/icu/source/common/messagepattern.cpp
 FILE: ../../../third_party/icu/source/common/msvcres.h
@@ -15501,6 +15674,8 @@ FILE: ../../../third_party/icu/source/common/resbund.cpp
 FILE: ../../../third_party/icu/source/common/resbund_cnv.cpp
 FILE: ../../../third_party/icu/source/common/resource.cpp
 FILE: ../../../third_party/icu/source/common/resource.h
+FILE: ../../../third_party/icu/source/common/restrace.cpp
+FILE: ../../../third_party/icu/source/common/restrace.h
 FILE: ../../../third_party/icu/source/common/ruleiter.cpp
 FILE: ../../../third_party/icu/source/common/ruleiter.h
 FILE: ../../../third_party/icu/source/common/schriter.cpp
@@ -15586,6 +15761,8 @@ FILE: ../../../third_party/icu/source/common/ucnvsel.cpp
 FILE: ../../../third_party/icu/source/common/ucol_data.h
 FILE: ../../../third_party/icu/source/common/ucol_swp.cpp
 FILE: ../../../third_party/icu/source/common/ucol_swp.h
+FILE: ../../../third_party/icu/source/common/ucptrie.cpp
+FILE: ../../../third_party/icu/source/common/ucptrie_impl.h
 FILE: ../../../third_party/icu/source/common/ucurr.cpp
 FILE: ../../../third_party/icu/source/common/ucurrimp.h
 FILE: ../../../third_party/icu/source/common/udata.cpp
@@ -15604,9 +15781,9 @@ FILE: ../../../third_party/icu/source/common/uinit.cpp
 FILE: ../../../third_party/icu/source/common/uinvchar.cpp
 FILE: ../../../third_party/icu/source/common/uinvchar.h
 FILE: ../../../third_party/icu/source/common/uiter.cpp
+FILE: ../../../third_party/icu/source/common/ulayout_props.h
 FILE: ../../../third_party/icu/source/common/ulist.cpp
 FILE: ../../../third_party/icu/source/common/ulist.h
-FILE: ../../../third_party/icu/source/common/ulistformatter.cpp
 FILE: ../../../third_party/icu/source/common/uloc.cpp
 FILE: ../../../third_party/icu/source/common/uloc_keytype.cpp
 FILE: ../../../third_party/icu/source/common/uloc_tag.cpp
@@ -15614,6 +15791,7 @@ FILE: ../../../third_party/icu/source/common/ulocimp.h
 FILE: ../../../third_party/icu/source/common/umapfile.cpp
 FILE: ../../../third_party/icu/source/common/umapfile.h
 FILE: ../../../third_party/icu/source/common/umath.cpp
+FILE: ../../../third_party/icu/source/common/umutablecptrie.cpp
 FILE: ../../../third_party/icu/source/common/umutex.cpp
 FILE: ../../../third_party/icu/source/common/umutex.h
 FILE: ../../../third_party/icu/source/common/unames.cpp
@@ -15636,7 +15814,8 @@ FILE: ../../../third_party/icu/source/common/unicode/filteredbrk.h
 FILE: ../../../third_party/icu/source/common/unicode/icudataver.h
 FILE: ../../../third_party/icu/source/common/unicode/icuplug.h
 FILE: ../../../third_party/icu/source/common/unicode/idna.h
-FILE: ../../../third_party/icu/source/common/unicode/listformatter.h
+FILE: ../../../third_party/icu/source/common/unicode/localebuilder.h
+FILE: ../../../third_party/icu/source/common/unicode/localematcher.h
 FILE: ../../../third_party/icu/source/common/unicode/localpointer.h
 FILE: ../../../third_party/icu/source/common/unicode/locdspnm.h
 FILE: ../../../third_party/icu/source/common/unicode/locid.h
@@ -15674,6 +15853,8 @@ FILE: ../../../third_party/icu/source/common/unicode/ucnv_cb.h
 FILE: ../../../third_party/icu/source/common/unicode/ucnv_err.h
 FILE: ../../../third_party/icu/source/common/unicode/ucnvsel.h
 FILE: ../../../third_party/icu/source/common/unicode/uconfig.h
+FILE: ../../../third_party/icu/source/common/unicode/ucpmap.h
+FILE: ../../../third_party/icu/source/common/unicode/ucptrie.h
 FILE: ../../../third_party/icu/source/common/unicode/ucurr.h
 FILE: ../../../third_party/icu/source/common/unicode/udata.h
 FILE: ../../../third_party/icu/source/common/unicode/udisplaycontext.h
@@ -15681,10 +15862,10 @@ FILE: ../../../third_party/icu/source/common/unicode/uenum.h
 FILE: ../../../third_party/icu/source/common/unicode/uidna.h
 FILE: ../../../third_party/icu/source/common/unicode/uiter.h
 FILE: ../../../third_party/icu/source/common/unicode/uldnames.h
-FILE: ../../../third_party/icu/source/common/unicode/ulistformatter.h
 FILE: ../../../third_party/icu/source/common/unicode/uloc.h
 FILE: ../../../third_party/icu/source/common/unicode/umachine.h
 FILE: ../../../third_party/icu/source/common/unicode/umisc.h
+FILE: ../../../third_party/icu/source/common/unicode/umutablecptrie.h
 FILE: ../../../third_party/icu/source/common/unicode/unifilt.h
 FILE: ../../../third_party/icu/source/common/unicode/unifunct.h
 FILE: ../../../third_party/icu/source/common/unicode/unimatch.h
@@ -15779,6 +15960,7 @@ FILE: ../../../third_party/icu/source/common/utrie2.cpp
 FILE: ../../../third_party/icu/source/common/utrie2.h
 FILE: ../../../third_party/icu/source/common/utrie2_builder.cpp
 FILE: ../../../third_party/icu/source/common/utrie2_impl.h
+FILE: ../../../third_party/icu/source/common/utrie_swap.cpp
 FILE: ../../../third_party/icu/source/common/uts46.cpp
 FILE: ../../../third_party/icu/source/common/utypeinfo.h
 FILE: ../../../third_party/icu/source/common/utypes.cpp
@@ -15823,6 +16005,7 @@ FILE: ../../../third_party/icu/source/config/mh-solaris-gcc
 FILE: ../../../third_party/icu/source/config/mh-unknown
 FILE: ../../../third_party/icu/source/config/windows-update.sed.in
 FILE: ../../../third_party/icu/source/data/build.xml
+FILE: ../../../third_party/icu/source/data/buildtool/filtration_schema.json
 FILE: ../../../third_party/icu/source/data/icu-coll-deprecates.xml
 FILE: ../../../third_party/icu/source/data/icu-config.xml
 FILE: ../../../third_party/icu/source/data/icu-locale-deprecates.xml
@@ -16150,6 +16333,8 @@ FILE: ../../../third_party/icu/source/i18n/dtitvinf.cpp
 FILE: ../../../third_party/icu/source/i18n/dtptngen.cpp
 FILE: ../../../third_party/icu/source/i18n/dtptngen_impl.h
 FILE: ../../../third_party/icu/source/i18n/dtrule.cpp
+FILE: ../../../third_party/icu/source/i18n/erarules.cpp
+FILE: ../../../third_party/icu/source/i18n/erarules.h
 FILE: ../../../third_party/icu/source/i18n/esctrn.cpp
 FILE: ../../../third_party/icu/source/i18n/esctrn.h
 FILE: ../../../third_party/icu/source/i18n/ethpccal.cpp
@@ -16158,6 +16343,10 @@ FILE: ../../../third_party/icu/source/i18n/fmtable.cpp
 FILE: ../../../third_party/icu/source/i18n/fmtable_cnv.cpp
 FILE: ../../../third_party/icu/source/i18n/fmtableimp.h
 FILE: ../../../third_party/icu/source/i18n/format.cpp
+FILE: ../../../third_party/icu/source/i18n/formattedval_impl.h
+FILE: ../../../third_party/icu/source/i18n/formattedval_iterimpl.cpp
+FILE: ../../../third_party/icu/source/i18n/formattedval_sbimpl.cpp
+FILE: ../../../third_party/icu/source/i18n/formattedvalue.cpp
 FILE: ../../../third_party/icu/source/i18n/fphdlimp.cpp
 FILE: ../../../third_party/icu/source/i18n/fphdlimp.h
 FILE: ../../../third_party/icu/source/i18n/fpositer.cpp
@@ -16178,6 +16367,7 @@ FILE: ../../../third_party/icu/source/i18n/islamcal.cpp
 FILE: ../../../third_party/icu/source/i18n/islamcal.h
 FILE: ../../../third_party/icu/source/i18n/japancal.cpp
 FILE: ../../../third_party/icu/source/i18n/japancal.h
+FILE: ../../../third_party/icu/source/i18n/listformatter.cpp
 FILE: ../../../third_party/icu/source/i18n/measfmt.cpp
 FILE: ../../../third_party/icu/source/i18n/measunit.cpp
 FILE: ../../../third_party/icu/source/i18n/measure.cpp
@@ -16226,6 +16416,7 @@ FILE: ../../../third_party/icu/source/i18n/number_modifiers.h
 FILE: ../../../third_party/icu/source/i18n/number_multiplier.cpp
 FILE: ../../../third_party/icu/source/i18n/number_multiplier.h
 FILE: ../../../third_party/icu/source/i18n/number_notation.cpp
+FILE: ../../../third_party/icu/source/i18n/number_output.cpp
 FILE: ../../../third_party/icu/source/i18n/number_padding.cpp
 FILE: ../../../third_party/icu/source/i18n/number_patternmodifier.cpp
 FILE: ../../../third_party/icu/source/i18n/number_patternmodifier.h
@@ -16265,6 +16456,9 @@ FILE: ../../../third_party/icu/source/i18n/numparse_types.h
 FILE: ../../../third_party/icu/source/i18n/numparse_utils.h
 FILE: ../../../third_party/icu/source/i18n/numparse_validators.cpp
 FILE: ../../../third_party/icu/source/i18n/numparse_validators.h
+FILE: ../../../third_party/icu/source/i18n/numrange_fluent.cpp
+FILE: ../../../third_party/icu/source/i18n/numrange_impl.cpp
+FILE: ../../../third_party/icu/source/i18n/numrange_impl.h
 FILE: ../../../third_party/icu/source/i18n/numsys.cpp
 FILE: ../../../third_party/icu/source/i18n/numsys_impl.h
 FILE: ../../../third_party/icu/source/i18n/olsontz.cpp
@@ -16373,6 +16567,7 @@ FILE: ../../../third_party/icu/source/i18n/udatpg.cpp
 FILE: ../../../third_party/icu/source/i18n/ufieldpositer.cpp
 FILE: ../../../third_party/icu/source/i18n/uitercollationiterator.cpp
 FILE: ../../../third_party/icu/source/i18n/uitercollationiterator.h
+FILE: ../../../third_party/icu/source/i18n/ulistformatter.cpp
 FILE: ../../../third_party/icu/source/i18n/ulocdata.cpp
 FILE: ../../../third_party/icu/source/i18n/umsg.cpp
 FILE: ../../../third_party/icu/source/i18n/umsg_imp.h
@@ -16401,15 +16596,18 @@ FILE: ../../../third_party/icu/source/i18n/unicode/dtrule.h
 FILE: ../../../third_party/icu/source/i18n/unicode/fieldpos.h
 FILE: ../../../third_party/icu/source/i18n/unicode/fmtable.h
 FILE: ../../../third_party/icu/source/i18n/unicode/format.h
+FILE: ../../../third_party/icu/source/i18n/unicode/formattedvalue.h
 FILE: ../../../third_party/icu/source/i18n/unicode/fpositer.h
 FILE: ../../../third_party/icu/source/i18n/unicode/gender.h
 FILE: ../../../third_party/icu/source/i18n/unicode/gregocal.h
+FILE: ../../../third_party/icu/source/i18n/unicode/listformatter.h
 FILE: ../../../third_party/icu/source/i18n/unicode/measfmt.h
 FILE: ../../../third_party/icu/source/i18n/unicode/measunit.h
 FILE: ../../../third_party/icu/source/i18n/unicode/measure.h
 FILE: ../../../third_party/icu/source/i18n/unicode/msgfmt.h
 FILE: ../../../third_party/icu/source/i18n/unicode/nounit.h
 FILE: ../../../third_party/icu/source/i18n/unicode/numberformatter.h
+FILE: ../../../third_party/icu/source/i18n/unicode/numberrangeformatter.h
 FILE: ../../../third_party/icu/source/i18n/unicode/numfmt.h
 FILE: ../../../third_party/icu/source/i18n/unicode/numsys.h
 FILE: ../../../third_party/icu/source/i18n/unicode/plurfmt.h
@@ -16445,7 +16643,9 @@ FILE: ../../../third_party/icu/source/i18n/unicode/udateintervalformat.h
 FILE: ../../../third_party/icu/source/i18n/unicode/udatpg.h
 FILE: ../../../third_party/icu/source/i18n/unicode/ufieldpositer.h
 FILE: ../../../third_party/icu/source/i18n/unicode/uformattable.h
+FILE: ../../../third_party/icu/source/i18n/unicode/uformattedvalue.h
 FILE: ../../../third_party/icu/source/i18n/unicode/ugender.h
+FILE: ../../../third_party/icu/source/i18n/unicode/ulistformatter.h
 FILE: ../../../third_party/icu/source/i18n/unicode/ulocdata.h
 FILE: ../../../third_party/icu/source/i18n/unicode/umsg.h
 FILE: ../../../third_party/icu/source/i18n/unicode/unirepl.h
@@ -16679,6 +16879,8 @@ FILE: ../../../third_party/icu/source/tools/genrb/derb.1.in
 FILE: ../../../third_party/icu/source/tools/genrb/derb.cpp
 FILE: ../../../third_party/icu/source/tools/genrb/errmsg.c
 FILE: ../../../third_party/icu/source/tools/genrb/errmsg.h
+FILE: ../../../third_party/icu/source/tools/genrb/filterrb.cpp
+FILE: ../../../third_party/icu/source/tools/genrb/filterrb.h
 FILE: ../../../third_party/icu/source/tools/genrb/genrb.1.in
 FILE: ../../../third_party/icu/source/tools/genrb/genrb.cpp
 FILE: ../../../third_party/icu/source/tools/genrb/genrb.h
@@ -23005,4 +23207,4 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 ====================================================================================================
-Total license count: 360
+Total license count: 361


### PR DESCRIPTION
The current version is 62.1, which is a now 3 major releases behind,
given that ICU 65 was released on Oct 3, 2019.

The version bump required an update to buildroot to fix too strict compilation
of ICU.

Previous update was here:
#6097

I was advised to upgrade in the code review for this PR:
#13045

This change brings in the function `icu::Locale::forLanguageTag(...)`
which is directly relevant to the work in the PR, but also updates
the library considerably.

Tested:

```bash

set -x

readonly FLUTTER_ENGINE_DIR="${FLUTTER_ENGINE_DIR:-$HOME/fx/flutter/engine/src}"
readonly OUT_DIR="${FLUTTER_ENGINE_DIR}/out"

(
  cd ${FLUTTER_ENGINE_DIR}

  ./flutter/tools/gn --unoptimized
  ninja -j 100 -C "${OUT_DIR}/host_debug_unopt"
  ./flutter/testing/run_tests.py --type engine
)
```