### PR TITLE
[frontend_server] Include bytecode generation in the training run.

### DIFF
--- a/flutter_frontend_server/lib/server.dart
+++ b/flutter_frontend_server/lib/server.dart
@@ -111,7 +111,7 @@ Future<int> starter(
     final Directory temp =
         Directory.systemTemp.createTempSync('train_frontend_server');
     try {
-      for (var i = 0; i < 3; i++) {
+      for (int i = 0; i < 3; i++) {
         final String outputTrainingDill = path.join(temp.path, 'app.dill');
         options = frontend.argParser.parse(<String>[
           '--incremental',

--- a/flutter_frontend_server/lib/server.dart
+++ b/flutter_frontend_server/lib/server.dart
@@ -111,25 +111,30 @@ Future<int> starter(
     final Directory temp =
         Directory.systemTemp.createTempSync('train_frontend_server');
     try {
-      final String outputTrainingDill = path.join(temp.path, 'app.dill');
-      options = frontend.argParser.parse(<String>[
-        '--incremental',
-        '--sdk-root=$sdkRoot',
-        '--output-dill=$outputTrainingDill',
-        '--target=flutter',
-        '--track-widget-creation',
-      ]);
-      compiler ??= _FlutterFrontendCompiler(output);
+      for (var i = 0; i < 3; i++) {
+        final String outputTrainingDill = path.join(temp.path, 'app.dill');
+        options = frontend.argParser.parse(<String>[
+          '--incremental',
+          '--sdk-root=$sdkRoot',
+          '--output-dill=$outputTrainingDill',
+          '--target=flutter',
+          '--track-widget-creation',
+          '--enable-asserts',
+          '--gen-bytecode',
+          '--bytecode-options=source-positions,local-var-info,debugger-stops,instance-field-initializers,keep-unreachable-code,avoid-closure-call-instructions',
+        ]);
+        compiler ??= _FlutterFrontendCompiler(output);
 
-      await compiler.compile(input, options);
-      compiler.acceptLastDelta();
-      await compiler.recompileDelta();
-      compiler.acceptLastDelta();
-      compiler.resetIncrementalCompiler();
-      await compiler.recompileDelta();
-      compiler.acceptLastDelta();
-      await compiler.recompileDelta();
-      compiler.acceptLastDelta();
+        await compiler.compile(input, options);
+        compiler.acceptLastDelta();
+        await compiler.recompileDelta();
+        compiler.acceptLastDelta();
+        compiler.resetIncrementalCompiler();
+        await compiler.recompileDelta();
+        compiler.acceptLastDelta();
+        await compiler.recompileDelta();
+        compiler.acceptLastDelta();
+      }
       return 0;
     } finally {
       temp.deleteSync(recursive: true);


### PR DESCRIPTION
../../bin/cache/dart-sdk/bin/dart ./bin/run.dart  -t flutter_test_performance --local-engine host_debug
AST-BEFORE
    "without_change_elapsed_time_ms": 2964,
    "implementation_change_elapsed_time_ms": 6650,
    "interface_change_elapsed_time_ms": 6449,
    "with_coverage_time_ms": 3021
AST-AFTER
    "without_change_elapsed_time_ms": 2785,
    "implementation_change_elapsed_time_ms": 6383,
    "interface_change_elapsed_time_ms": 6308,
    "with_coverage_time_ms": 2884
BYTECODE-BEFORE
    "without_change_elapsed_time_ms": 3982,
    "implementation_change_elapsed_time_ms": 9133,
    "interface_change_elapsed_time_ms": 9135,
    "with_coverage_time_ms": 4065
BYTECODE-AFTER
    "without_change_elapsed_time_ms": 3506,
    "implementation_change_elapsed_time_ms": 8027,
    "interface_change_elapsed_time_ms": 8066,
    "with_coverage_time_ms": 3703

