### PR TITLE
Short-circuit font fallback after looking for fallback fonts.

### DIFF
--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -157,11 +157,6 @@ FontCollection::GetMinikinFontCollectionForFamilies(
       minikin_families.push_back(minikin_family);
     }
   }
-  // Default font family also not found. We fail to get a FontCollection.
-  if (minikin_families.empty()) {
-    font_collections_cache_[family_key] = nullptr;
-    return nullptr;
-  }
   if (enable_font_fallback_) {
     for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
       auto it = fallback_fonts_.find(fallback_family);
@@ -169,6 +164,12 @@ FontCollection::GetMinikinFontCollectionForFamilies(
         minikin_families.push_back(it->second);
       }
     }
+  }
+  // Default font family and fallbacks also not found. We fail to get a
+  // FontCollection.
+  if (minikin_families.empty()) {
+    font_collections_cache_[family_key] = nullptr;
+    return nullptr;
   }
   // Create the minikin font collection.
   auto font_collection =


### PR DESCRIPTION
This moves the "font not found" short circuit down so that fallback fonts are attempted before declaring failure.