### PR TITLE
Revert "Roll fuchsia/sdk/core/linux-amd64 from xRgq0... to Jv4XM... (…

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -558,7 +558,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': 'Jv4XM2GT9-LLMLdAMTJt-TBY_1HvtHzZBFnQf0bWTX8C'
+        'version': 'xRgq0C_xL5zPZoXgqzV3IeDOkYwjq7tYjjmD0U8YxI4C'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: 020b33fa3a377e262341de6ca18e8977
+Signature: 2b67dee2e67cdd9a808ae7f3904ab47b
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
…#13135)"

This reverts commit a87067cfcdbe4f3d634baa643b4db140538021d9.

This seems to be breaking the roll https://github.com/flutter/flutter/pull/42748