### PR TITLE
Make the Dart isolate constructor private.

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -55,7 +55,7 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
   // The child isolate preparer is null but will be set when the isolate is
   // being prepared to run.
   auto root_embedder_data = std::make_unique<std::shared_ptr<DartIsolate>>(
-      std::make_shared<DartIsolate>(
+      std::shared_ptr<DartIsolate>(new DartIsolate(
           settings,                     // settings
           std::move(isolate_snapshot),  // isolate snapshot
           std::move(shared_snapshot),   // shared snapshot
@@ -67,7 +67,7 @@ std::weak_ptr<DartIsolate> DartIsolate::CreateRootIsolate(
           nullptr,                      // child isolate preparer
           isolate_create_callback,      // isolate create callback
           isolate_shutdown_callback     // isolate shutdown callback
-          ));
+          )));
 
   std::tie(vm_isolate, embedder_isolate) = CreateDartVMAndEmbedderObjectPair(
       advisory_script_uri.c_str(),         // advisory script URI
@@ -702,7 +702,7 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
 
     // Copy most fields from the parent to the child.
     embedder_isolate = std::make_unique<std::shared_ptr<DartIsolate>>(
-        std::make_shared<DartIsolate>(
+        std::shared_ptr<DartIsolate>(new DartIsolate(
             (*raw_embedder_isolate)->GetSettings(),         // settings
             (*raw_embedder_isolate)->GetIsolateSnapshot(),  // isolate_snapshot
             (*raw_embedder_isolate)->GetSharedSnapshot(),   // shared_snapshot
@@ -714,7 +714,7 @@ DartIsolate::CreateDartVMAndEmbedderObjectPair(
             (*raw_embedder_isolate)->child_isolate_preparer_,    // preparer
             (*raw_embedder_isolate)->isolate_create_callback_,   // on create
             (*raw_embedder_isolate)->isolate_shutdown_callback_  // on shutdown
-            )
+            ))
 
     );
   }

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -54,18 +54,6 @@ class DartIsolate : public UIDartState {
       fml::closure isolate_create_callback,
       fml::closure isolate_shutdown_callback);
 
-  DartIsolate(const Settings& settings,
-              fml::RefPtr<const DartSnapshot> isolate_snapshot,
-              fml::RefPtr<const DartSnapshot> shared_snapshot,
-              TaskRunners task_runners,
-              fml::WeakPtr<IOManager> io_manager,
-              fml::WeakPtr<ImageDecoder> image_decoder,
-              std::string advisory_script_uri,
-              std::string advisory_script_entrypoint,
-              ChildIsolatePreparer child_isolate_preparer,
-              fml::closure isolate_create_callback,
-              fml::closure isolate_shutdown_callback);
-
   ~DartIsolate() override;
 
   const Settings& GetSettings() const;
@@ -138,6 +126,18 @@ class DartIsolate : public UIDartState {
   fml::RefPtr<fml::TaskRunner> message_handling_task_runner_;
   const fml::closure isolate_create_callback_;
   const fml::closure isolate_shutdown_callback_;
+
+  DartIsolate(const Settings& settings,
+              fml::RefPtr<const DartSnapshot> isolate_snapshot,
+              fml::RefPtr<const DartSnapshot> shared_snapshot,
+              TaskRunners task_runners,
+              fml::WeakPtr<IOManager> io_manager,
+              fml::WeakPtr<ImageDecoder> image_decoder,
+              std::string advisory_script_uri,
+              std::string advisory_script_entrypoint,
+              ChildIsolatePreparer child_isolate_preparer,
+              fml::closure isolate_create_callback,
+              fml::closure isolate_shutdown_callback);
 
   FML_WARN_UNUSED_RESULT bool Initialize(Dart_Isolate isolate,
                                          bool is_root_isolate);


### PR DESCRIPTION
Found this while attempting to document //flutter/runtime. The only reason this was public was because of the desire to use make_shared. Callers should never be able to create isolates directly because there is no thread safe mechanism for them to do so. I want the documentation changes to include no code updates. Hence this separate patch.