### PR TITLE
Move surface-based SceneBuilder implementation under surface/

### DIFF
--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -82,6 +82,7 @@ part 'engine/surface/opacity.dart';
 part 'engine/surface/picture.dart';
 part 'engine/surface/platform_view.dart';
 part 'engine/surface/scene.dart';
+part 'engine/surface/scene_builder.dart';
 part 'engine/surface/surface.dart';
 part 'engine/surface/transform.dart';
 part 'engine/test_embedding.dart';

--- a/lib/web_ui/lib/src/engine/surface/scene.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene.dart
@@ -4,6 +4,27 @@
 
 part of engine;
 
+class SurfaceScene implements ui.Scene {
+  /// This class is created by the engine, and should not be instantiated
+  /// or extended directly.
+  ///
+  /// To create a Scene object, use a [SceneBuilder].
+  SurfaceScene(this.webOnlyRootElement);
+
+  final html.Element webOnlyRootElement;
+
+  /// Creates a raster image representation of the current state of the scene.
+  /// This is a slow operation that is performed on a background thread.
+  Future<ui.Image> toImage(int width, int height) {
+    throw UnsupportedError('toImage is not supported on the Web');
+  }
+
+  /// Releases the resources used by this scene.
+  ///
+  /// After calling this function, the scene is cannot be used further.
+  void dispose() {}
+}
+
 /// A surface that creates a DOM element for whole app.
 class PersistedScene extends PersistedContainerSurface {
   PersistedScene(PersistedScene oldLayer) : super(oldLayer) {

--- a/lib/web_ui/lib/src/engine/surface/surface.dart
+++ b/lib/web_ui/lib/src/engine/surface/surface.dart
@@ -111,18 +111,6 @@ void commitScene(PersistedScene scene) {
   }());
 }
 
-/// Discards information about previously rendered frames, including DOM
-/// elements and cached canvases.
-///
-/// After calling this function new canvases will be created for the
-/// subsequent scene. This is useful when tests need predictable canvas
-/// sizes. If the cache is not cleared, then canvases allocated in one test
-/// may be reused in another test.
-void debugForgetFrameScene() {
-  _clipIdCounter = 0;
-  _recycledCanvases.clear();
-}
-
 /// Surfaces that were retained this frame.
 ///
 /// Surfaces should be added to this list directly. Instead, if a surface needs
@@ -639,6 +627,14 @@ abstract class PersistedSurface implements ui.EngineLayer {
   @protected
   @mustCallSuper
   void build() {
+    if (rootElement != null) {
+      try {
+        throw null;
+      } catch(_, stack) {
+        print('Attempted to build a $runtimeType, but it already has an HTML element ${rootElement.tagName}.');
+        print(stack.toString().split('\n').take(20).join('\n'));
+      }
+    }
     assert(rootElement == null);
     assert(isCreated);
     rootElement = createElement();

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -248,12 +248,23 @@ class EngineWindow extends ui.Window {
     _brightnessMediaQueryListener = null;
   }
 
-
   @override
-  void dispose() {
-    _removeBrightnessMediaQueryListener();
+  void render(ui.Scene scene) {
+    if (experimentalUseSkia) {
+      final LayerScene layerScene = scene;
+      _rasterizer.draw(layerScene.layerTree);
+    } else {
+      final SurfaceScene surfaceScene = scene;
+      domRenderer.renderScene(surfaceScene.webOnlyRootElement);
+    }
   }
 
+  final Rasterizer _rasterizer = experimentalUseSkia
+      ? Rasterizer(Surface((SkCanvas canvas) {
+          domRenderer.renderScene(canvas.htmlCanvas);
+          canvas.skSurface.callMethod('flush');
+        }))
+      : null;
 }
 
 /// The window singleton.

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -974,21 +974,7 @@ abstract class Window {
   ///    scheduling of frames.
   ///  * [RendererBinding], the Flutter framework class which manages layout and
   ///    painting.
-  void render(Scene scene) {
-    if (engine.experimentalUseSkia) {
-      final engine.LayerScene layerScene = scene;
-      _rasterizer.draw(layerScene.layerTree);
-    } else {
-      engine.domRenderer.renderScene(scene.webOnlyRootElement);
-    }
-  }
-
-  final engine.Rasterizer _rasterizer = engine.experimentalUseSkia
-      ? engine.Rasterizer(engine.Surface((engine.SkCanvas canvas) {
-          engine.domRenderer.renderScene(canvas.htmlCanvas);
-          canvas.skSurface.callMethod('flush');
-        }))
-      : null;
+  void render(Scene scene);
 
   String get initialLifecycleState => _initialLifecycleState;
 

--- a/lib/web_ui/test/compositing_test.dart
+++ b/lib/web_ui/test/compositing_test.dart
@@ -185,7 +185,7 @@ void testLayerLifeCycle(
     TestLayerBuilder layerBuilder, ExpectedHtmlGetter expectedHtmlGetter) {
   // Force scene builder to start from scratch. This guarantees that the first
   // scene starts from the "build" phase.
-  SceneBuilder.debugForgetFrameScene();
+  SurfaceSceneBuilder.debugForgetFrameScene();
 
   // Build: builds a brand new layer.
   SceneBuilder sceneBuilder = SceneBuilder();

--- a/lib/web_ui/test/engine/surface/surface_test.dart
+++ b/lib/web_ui/test/engine/surface/surface_test.dart
@@ -12,7 +12,7 @@ import 'package:test/test.dart';
 void main() {
   group('Surface', () {
     setUp(() {
-      SceneBuilder.debugForgetFrameScene();
+      SurfaceSceneBuilder.debugForgetFrameScene();
     });
 
     test('is created', () {

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -18,14 +18,14 @@ void main() async {
   debugShowClipLayers = true;
 
   setUp(() {
-    SceneBuilder.debugForgetFrameScene();
+    SurfaceSceneBuilder.debugForgetFrameScene();
     for (html.Node scene in html.document.querySelectorAll('flt-scene')) {
       scene.remove();
     }
   });
 
   test('pushClipRect', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     builder.pushClipRect(
       const Rect.fromLTRB(10, 10, 60, 60),
     );
@@ -38,7 +38,7 @@ void main() async {
   }, timeout: const Timeout(Duration(seconds: 10)));
 
   test('pushClipRect with offset and transform', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
 
     builder.pushOffset(0, 60);
     builder.pushTransform(
@@ -58,7 +58,7 @@ void main() async {
   }, timeout: const Timeout(Duration(seconds: 10)));
 
   test('pushClipRRect', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     builder.pushClipRRect(
       RRect.fromLTRBR(10, 10, 60, 60, const Radius.circular(5)),
     );
@@ -71,7 +71,7 @@ void main() async {
   }, timeout: const Timeout(Duration(seconds: 10)));
 
   test('pushPhysicalShape', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     builder.pushPhysicalShape(
       path: Path()..addRect(const Rect.fromLTRB(10, 10, 60, 60)),
       clipBehavior: Clip.hardEdge,
@@ -204,7 +204,7 @@ void _testCullRectComputation() {
   // Draw a picture inside a layer clip but fill all available space inside it.
   // Verify that the cull rect is equal to the layer clip.
   test('fills layer clip rect', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     builder.pushClipRect(
       const Rect.fromLTWH(10, 10, 60, 60),
     );
@@ -232,7 +232,7 @@ void _testCullRectComputation() {
   // paint bounds overflow the layer clip. Verify that the cull rect is the
   // intersection between the layer clip and paint bounds.
   test('intersects layer clip rect and paint bounds', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     builder.pushClipRect(
       const Rect.fromLTWH(10, 10, 60, 60),
     );
@@ -260,7 +260,7 @@ void _testCullRectComputation() {
   // an offset layer. Verify that the cull rect is the intersection between the
   // layer clip and the offset paint bounds.
   test('offsets picture inside layer clip rect', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     builder.pushClipRect(
       const Rect.fromLTWH(10, 10, 60, 60),
     );
@@ -320,7 +320,7 @@ void _testCullRectComputation() {
   // Draw a picture inside a rotated clip. Verify that the cull rect is big
   // enough to fit the rotated clip.
   test('rotates clip and the picture', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     builder.pushOffset(80, 50);
 
     builder.pushTransform(
@@ -364,7 +364,7 @@ void _testCullRectComputation() {
   }, timeout: const Timeout(Duration(seconds: 10)));
 
   test('pushClipPath', () async {
-    final SceneBuilder builder = SceneBuilder();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
     final Path path = Path();
     path..addRect(const Rect.fromLTRB(10, 10, 60, 60));
     builder.pushClipPath(
@@ -381,9 +381,10 @@ void _testCullRectComputation() {
   // Draw a picture inside a rotated clip. Verify that the cull rect is big
   // enough to fit the rotated clip.
   test('clips correctly when using 3d transforms', () async {
-    final SceneBuilder builder = SceneBuilder();
-    final double screenWidth = html.window.innerWidth.toDouble();
-    final double screenHeight = html.window.innerHeight.toDouble();
+    final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
+    // TODO(yjbanov): see the TODO below.
+    // final double screenWidth = html.window.innerWidth.toDouble();
+    // final double screenHeight = html.window.innerHeight.toDouble();
 
     final Matrix4 scaleTransform = Matrix4.identity().scaled(0.5, 0.2);
     builder.pushTransform(

--- a/lib/web_ui/test/matchers.dart
+++ b/lib/web_ui/test/matchers.dart
@@ -23,7 +23,7 @@ import 'package:ui/src/engine.dart';
 ///
 /// Surfaces are returned in a depth-first order.
 Iterable<PersistedSurface> enumerateSurfaces([PersistedSurface root]) {
-  root ??= SceneBuilder.debugLastFrameScene;
+  root ??= SurfaceSceneBuilder.debugLastFrameScene;
   final List<PersistedSurface> surfaces = <PersistedSurface>[root];
 
   root.visitChildren((PersistedSurface surface) {
@@ -37,7 +37,7 @@ Iterable<PersistedSurface> enumerateSurfaces([PersistedSurface root]) {
 ///
 /// If [root] is `null` returns all pictures from the last rendered scene.
 Iterable<PersistedPicture> enumeratePictures([PersistedSurface root]) {
-  root ??= SceneBuilder.debugLastFrameScene;
+  root ??= SurfaceSceneBuilder.debugLastFrameScene;
   return enumerateSurfaces(root).whereType<PersistedPicture>();
 }
 
@@ -45,7 +45,7 @@ Iterable<PersistedPicture> enumeratePictures([PersistedSurface root]) {
 ///
 /// If [root] is `null` returns all pictures from the last rendered scene.
 Iterable<PersistedOffset> enumerateOffsets([PersistedSurface root]) {
-  root ??= SceneBuilder.debugLastFrameScene;
+  root ??= SurfaceSceneBuilder.debugLastFrameScene;
   return enumerateSurfaces(root).whereType<PersistedOffset>();
 }
 
@@ -459,7 +459,7 @@ String get currentHtml {
 class SceneTester {
   SceneTester(this.scene);
 
-  final Scene scene;
+  final SurfaceScene scene;
 
   void expectSceneHtml(String expectedHtml) {
     expectHtml(scene.webOnlyRootElement, expectedHtml,


### PR DESCRIPTION
This creates a consistent directory structure across DOM- (a.k.a. "surface") and CanvasKit-based backends. The immediate benefit is that I can add much more instrumentation to surfaces without polluting the `ui` namespace.