### PR TITLE
(WIP) Enable txt_unittests on mac

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -63,6 +63,42 @@ task:
       test_framework_script: |
         cd $FRAMEWORK_PATH/flutter/packages/flutter
         ../../bin/flutter test --local-engine=host_debug_unopt
+    - name: build_and_test_macos_unopt_debug
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      test_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/testing/run_tests.sh host_debug_unopt
+      test_web_engine_script: |
+        cd $ENGINE_PATH/src/flutter/web_sdk/web_engine_tester
+        $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/pub get
+        cd $ENGINE_PATH/src/flutter/lib/web_ui
+        $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/pub get
+        export FELT="$ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/dart dev/felt.dart"
+        $FELT check-licenses
+        CHROME_NO_SANDBOX=true $FELT test
+      always:
+        web_engine_test_artifacts:
+          path: test_results/*
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+      test_web_script: |
+        cd $FRAMEWORK_PATH/flutter/dev/integration_tests/web
+        ../../../bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web
+        ../../../bin/flutter --local-engine=host_debug_unopt build web -v
+      analyze_framework_script: |
+        cd $FRAMEWORK_PATH/flutter
+        rm -rf bin/cache/pkg/sky_engine
+        cp -r $ENGINE_PATH/src/out/host_debug_unopt/gen/dart-pkg/sky_engine bin/cache/pkg/
+        bin/flutter update-packages --local-engine=host_debug_unopt
+        bin/flutter analyze --dartdocs --flutter-repo --local-engine=host_debug_unopt
+      test_framework_script: |
+        cd $FRAMEWORK_PATH/flutter/packages/flutter
+        ../../bin/flutter test --local-engine=host_debug_unopt
     - name: build_and_test_android_unopt_debug
       env:
         USE_ANDROID: "True"

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -110,7 +110,7 @@ def RunCCTests(build_dir, filter):
     RunEngineExecutable(build_dir, 'flutter_channels_unittests', filter, shuffle_flags)
 
   # https://github.com/flutter/flutter/issues/36296
-  if IsLinux():
+  if IsLinux() or IsMac():
     RunEngineExecutable(build_dir, 'txt_unittests', filter, shuffle_flags)
 
 


### PR DESCRIPTION
The incompatible tests are disabled, so we can run this on mac now.

Fixes mac portion of https://github.com/flutter/flutter/issues/36296