### PR TITLE
Wrap the text in text editing to fix selections.

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -16,7 +16,7 @@ void _emptyCallback(dynamic _) {}
 void _setStaticStyleAttributes(html.HtmlElement domElement) {
   final html.CssStyleDeclaration elementStyle = domElement.style;
   elementStyle
-    ..whiteSpace = 'pre'
+    ..whiteSpace = 'pre-wrap'
     ..alignContent = 'center'
     ..position = 'absolute'
     ..top = '0'


### PR DESCRIPTION
This was causing a missalingment issue in textarea.

Easy steps to see the issue:
- In order to see it visiually: enable text selection for text area in dom renderer. Enable _debugVisibleTextEditing in text_editing.dart
- Paste a long text to a text area.
- Change the size of the window. 

The selection and text from Flutter Framework and the text/selection inside the dom element are misaligned. This can cause issue in selections, as well as copy paste locations.

Fixes https://github.com/flutter/flutter/issues/41701