### PR TITLE
Update ui.instantiateImageCodec docs to reflect what it does.

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1654,8 +1654,8 @@ class Codec extends NativeFieldWrapperClass2 {
 /// The [targetWidth] and [targetHeight] arguments specify the size of the output
 /// image, in image pixels. If they are not equal to the intrinsic dimensions of the
 /// image, then the image will be scaled after being decoded. If only one dimension
-/// specified, the omitted dimension will remain its original size. If both are not
-/// specified, then the image maintains its real size.
+/// is specified, the omitted dimension will remain its original size. If both are
+/// not specified, then the image maintains its real size.
 ///
 /// The returned future can complete with an error if the image decoding has
 /// failed.

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1653,9 +1653,8 @@ class Codec extends NativeFieldWrapperClass2 {
 ///
 /// The [targetWidth] and [targetHeight] arguments specify the size of the output
 /// image, in image pixels. If they are not equal to the intrinsic dimensions of the
-/// image, then the image will be scaled after being decoded. If exactly one of
-/// these two arguments is specified, then the aspect ratio will be maintained
-/// while forcing the image to match the specified dimension. If both are not
+/// image, then the image will be scaled after being decoded. If only one dimension
+/// specified, the omitted dimension will remain its original size. If both are not
 /// specified, then the image maintains its real size.
 ///
 /// The returned future can complete with an error if the image decoding has


### PR DESCRIPTION
The previous docs claimed it would maintain aspect ratio in the case of an omitted dimension, but that does not seem to be the case.