### PR TITLE
Do not attempt to drain the SkiaUnrefQueue in the destructor

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -80,6 +80,7 @@ FILE: ../../../flutter/flow/scene_update_context.cc
 FILE: ../../../flutter/flow/scene_update_context.h
 FILE: ../../../flutter/flow/skia_gpu_object.cc
 FILE: ../../../flutter/flow/skia_gpu_object.h
+FILE: ../../../flutter/flow/skia_gpu_object_unittests.cc
 FILE: ../../../flutter/flow/texture.cc
 FILE: ../../../flutter/flow/texture.h
 FILE: ../../../flutter/flow/texture_unittests.cc

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -114,6 +114,7 @@ executable("flow_unittests") {
     "matrix_decomposition_unittests.cc",
     "mutators_stack_unittests.cc",
     "raster_cache_unittests.cc",
+    "skia_gpu_object_unittests.cc",
     "texture_unittests.cc",
   ]
 
@@ -121,6 +122,7 @@ executable("flow_unittests") {
     ":flow",
     ":flow_fixtures",
     "$flutter_root/fml",
+    "$flutter_root/testing:testing_lib",
     "//third_party/dart/runtime:libdart_jit",  # for tracing
     "//third_party/googletest:gtest",
     "//third_party/skia",

--- a/flow/skia_gpu_object.cc
+++ b/flow/skia_gpu_object.cc
@@ -15,7 +15,7 @@ SkiaUnrefQueue::SkiaUnrefQueue(fml::RefPtr<fml::TaskRunner> task_runner,
       drain_pending_(false) {}
 
 SkiaUnrefQueue::~SkiaUnrefQueue() {
-  Drain();
+  FML_DCHECK(objects_.empty());
 }
 
 void SkiaUnrefQueue::Unref(SkRefCnt* object) {

--- a/flow/skia_gpu_object_unittests.cc
+++ b/flow/skia_gpu_object_unittests.cc
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/flow/skia_gpu_object.h"
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/fml/task_runner.h"
+#include "flutter/testing/thread_test.h"
+#include "gtest/gtest.h"
+#include "third_party/skia/include/core/SkRefCnt.h"
+
+namespace flutter {
+namespace testing {
+
+using SkiaGpuObjectTest = flutter::testing::ThreadTest;
+
+class TestSkObject : public SkRefCnt {
+ public:
+  TestSkObject(std::shared_ptr<fml::AutoResetWaitableEvent> latch,
+               fml::TaskQueueId* dtor_task_queue_id)
+      : latch_(latch), dtor_task_queue_id_(dtor_task_queue_id) {}
+
+  ~TestSkObject() {
+    *dtor_task_queue_id_ = fml::MessageLoop::GetCurrentTaskQueueId();
+    latch_->Signal();
+  }
+
+ private:
+  std::shared_ptr<fml::AutoResetWaitableEvent> latch_;
+  fml::TaskQueueId* dtor_task_queue_id_;
+};
+
+TEST_F(SkiaGpuObjectTest, UnrefQueue) {
+  fml::RefPtr<fml::TaskRunner> task_runner = CreateNewThread();
+  fml::RefPtr<SkiaUnrefQueue> queue = fml::MakeRefCounted<SkiaUnrefQueue>(
+      task_runner, fml::TimeDelta::FromSeconds(0));
+
+  std::shared_ptr<fml::AutoResetWaitableEvent> latch =
+      std::make_shared<fml::AutoResetWaitableEvent>();
+  fml::TaskQueueId dtor_task_queue_id(0);
+  SkRefCnt* ref_object = new TestSkObject(latch, &dtor_task_queue_id);
+
+  queue->Unref(ref_object);
+  latch->Wait();
+  ASSERT_EQ(dtor_task_queue_id, task_runner->GetTaskQueueId());
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -9,6 +9,8 @@ source_set("testing_lib") {
     "$flutter_root/testing/assertions.h",
     "$flutter_root/testing/testing.cc",
     "$flutter_root/testing/testing.h",
+    "$flutter_root/testing/thread_test.cc",
+    "$flutter_root/testing/thread_test.h",
   ]
 
   public_deps = [
@@ -23,8 +25,6 @@ source_set("testing") {
 
   sources = [
     "$flutter_root/testing/run_all_unittests.cc",
-    "$flutter_root/testing/thread_test.cc",
-    "$flutter_root/testing/thread_test.h",
   ]
 
   public_deps = [


### PR DESCRIPTION
SkiaUnrefQueue should be empty at destruction time.  If the queue is nonempty,
then there will be a pending drain task that will hold a reference to the
queue.  The queue can only be destructed after the drain completes and the
reference is dropped.

Drains must only be done on the queue's task runner thread, which may not be
the thread where the queue is destructed.