### PR TITLE
Allow embedders to update preferrred locales.

### DIFF
--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -779,6 +779,30 @@ typedef struct {
 } FlutterCompositor;
 
 typedef struct {
+  /// This size of this struct. Must be sizeof(FlutterLocale).
+  size_t struct_size;
+  /// The language code of the locale. For example, "en". This is a required
+  /// field. The string must be null terminated. It may be collected after the
+  /// call the `FlutterEngineUpdateLocales`.
+  const char* language_code;
+  /// The country code of the locale. For example, "US". This is a an optional
+  /// field. The string must be null terminated if present. It may be collected
+  /// after the call the `FlutterEngineUpdateLocales`. If not present, a
+  /// `nullptr` may be specified.
+  const char* country_code;
+  /// The script code of the locale. This is a an optional field. The string
+  /// must be null terminated if present. It may be collected after the call the
+  /// `FlutterEngineUpdateLocales`. If not present, a `nullptr` may be
+  /// specified.
+  const char* script_code;
+  /// The variant code of the locale. This is a an optional field. The string
+  /// must be null terminated if present. It may be collected after the call the
+  /// `FlutterEngineUpdateLocales`. If not present, a `nullptr` may be
+  /// specified.
+  const char* variant_code;
+} FlutterLocale;
+
+typedef struct {
   /// The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
   /// The path to the Flutter assets directory containing project assets. The
@@ -1404,7 +1428,7 @@ uint64_t FlutterEngineGetCurrentTime();
 ///             must only be made at the target time specified in that callback.
 ///             Running the task before that time is undefined behavior.
 ///
-/// @param[in]  engine     a running instance.
+/// @param[in]  engine     A running engine instance.
 /// @param[in]  task       the task handle.
 ///
 /// @return     The result of the call.
@@ -1413,6 +1437,24 @@ FLUTTER_EXPORT
 FlutterEngineResult FlutterEngineRunTask(FLUTTER_API_SYMBOL(FlutterEngine)
                                              engine,
                                          const FlutterTask* task);
+
+//------------------------------------------------------------------------------
+/// @brief      Notify a running engine instance that the locale has been
+///             updated. The preferred locale must be the first item in the list
+///             of locales supplied. The other entries will be used as a
+///             fallback.
+///
+/// @param[in]  engine         A running engine instance.
+/// @param[in]  locales        The updates locales in the order of preference.
+/// @param[in]  locales_count  The count of locales supplied.
+///
+/// @return     Whether the locale updates were applied.
+///
+FLUTTER_EXPORT
+FlutterEngineResult FlutterEngineUpdateLocales(FLUTTER_API_SYMBOL(FlutterEngine)
+                                                   engine,
+                                               const FlutterLocale** locales,
+                                               size_t locales_count);
 
 #if defined(__cplusplus)
 }  // extern "C"

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1445,7 +1445,7 @@ FlutterEngineResult FlutterEngineRunTask(FLUTTER_API_SYMBOL(FlutterEngine)
 ///             fallback.
 ///
 /// @param[in]  engine         A running engine instance.
-/// @param[in]  locales        The updates locales in the order of preference.
+/// @param[in]  locales        The updated locales in the order of preference.
 /// @param[in]  locales_count  The count of locales supplied.
 ///
 /// @return     Whether the locale updates were applied.

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -783,20 +783,20 @@ typedef struct {
   size_t struct_size;
   /// The language code of the locale. For example, "en". This is a required
   /// field. The string must be null terminated. It may be collected after the
-  /// call the `FlutterEngineUpdateLocales`.
+  /// call to `FlutterEngineUpdateLocales`.
   const char* language_code;
   /// The country code of the locale. For example, "US". This is a an optional
   /// field. The string must be null terminated if present. It may be collected
-  /// after the call the `FlutterEngineUpdateLocales`. If not present, a
+  /// after the call to `FlutterEngineUpdateLocales`. If not present, a
   /// `nullptr` may be specified.
   const char* country_code;
   /// The script code of the locale. This is a an optional field. The string
-  /// must be null terminated if present. It may be collected after the call the
+  /// must be null terminated if present. It may be collected after the call to
   /// `FlutterEngineUpdateLocales`. If not present, a `nullptr` may be
   /// specified.
   const char* script_code;
   /// The variant code of the locale. This is a an optional field. The string
-  /// must be null terminated if present. It may be collected after the call the
+  /// must be null terminated if present. It may be collected after the call to
   /// `FlutterEngineUpdateLocales`. If not present, a `nullptr` may be
   /// specified.
   const char* variant_code;

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -47,6 +47,7 @@ Float64List kTestTransform = () {
 }();
 
 void signalNativeTest() native 'SignalNativeTest';
+void signalNativeCount(int count) native 'SignalNativeCount';
 void signalNativeMessage(String message) native 'SignalNativeMessage';
 void notifySemanticsEnabled(bool enabled) native 'NotifySemanticsEnabled';
 void notifyAccessibilityFeatures(bool reduceMotion) native 'NotifyAccessibilityFeatures';
@@ -442,4 +443,12 @@ void can_display_platform_view_with_pixel_ratio() {
     window.render(builder.build());
   };
   window.scheduleFrame();
+}
+
+@pragma('vm:entry-point')
+void can_receive_locale_updates() {
+  window.onLocaleChanged = (){
+    signalNativeCount(window.locales.length);
+  };
+  signalNativeTest();
 }

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2779,7 +2779,7 @@ TEST_F(EmbedderTest, CanUpdateLocales) {
   locale2.struct_size = sizeof(locale2);
   locale2.language_code = "zh";
   locale2.country_code = "CN";
-  locale2.script_code = "";
+  locale2.script_code = "Hans";
   locale2.variant_code = nullptr;
 
   std::vector<const FlutterLocale*> locales;

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2751,5 +2751,63 @@ TEST_F(
   latch.Wait();
 }
 
+TEST_F(EmbedderTest, CanUpdateLocales) {
+  auto& context = GetEmbedderContext();
+  EmbedderConfigBuilder builder(context);
+  builder.SetSoftwareRendererConfig();
+  builder.SetDartEntrypoint("can_receive_locale_updates");
+  fml::AutoResetWaitableEvent latch;
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY(
+          [&latch](Dart_NativeArguments args) { latch.Signal(); }));
+
+  auto engine = builder.LaunchEngine();
+  ASSERT_TRUE(engine.is_valid());
+
+  // Wait for the application to attach the listener.
+  latch.Wait();
+
+  FlutterLocale locale1 = {};
+  locale1.struct_size = sizeof(locale1);
+  locale1.language_code = "";  // invalid
+  locale1.country_code = "US";
+  locale1.script_code = "";
+  locale1.variant_code = nullptr;
+
+  FlutterLocale locale2 = {};
+  locale2.struct_size = sizeof(locale2);
+  locale2.language_code = "zh";
+  locale2.country_code = "CN";
+  locale2.script_code = "";
+  locale2.variant_code = nullptr;
+
+  std::vector<const FlutterLocale*> locales;
+  locales.push_back(&locale1);
+  locales.push_back(&locale2);
+
+  ASSERT_EQ(
+      FlutterEngineUpdateLocales(engine.get(), locales.data(), locales.size()),
+      kInvalidArguments);
+
+  // Fix the invalid code.
+  locale1.language_code = "en";
+
+  ASSERT_EQ(
+      FlutterEngineUpdateLocales(engine.get(), locales.data(), locales.size()),
+      kSuccess);
+
+  fml::AutoResetWaitableEvent check_latch;
+  context.AddNativeCallback(
+      "SignalNativeCount",
+      CREATE_NATIVE_ENTRY([&check_latch](Dart_NativeArguments args) {
+        ASSERT_EQ(tonic::DartConverter<int>::FromDart(
+                      Dart_GetNativeArgument(args, 0)),
+                  2);
+        check_latch.Signal();
+      }));
+  check_latch.Wait();
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
This was previously only possible by sending an undocumented payload over an engine managed channel.