### PR TITLE
Added Semantic header support on Android.

### DIFF
--- a/shell/platform/android/AndroidManifest.xml
+++ b/shell/platform/android/AndroidManifest.xml
@@ -5,7 +5,7 @@
  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.flutter.app" android:versionCode="1" android:versionName="0.0.1">
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="29" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true" />

--- a/shell/platform/android/AndroidManifest.xml
+++ b/shell/platform/android/AndroidManifest.xml
@@ -5,7 +5,7 @@
  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="io.flutter.app" android:versionCode="1" android:versionName="0.0.1">
 
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="29" />
+    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="21" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="true" />

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -753,6 +753,11 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
 
         result.setSelected(semanticsNode.hasFlag(Flag.IS_SELECTED));
 
+        // Heading support
+        if (Build.VERSION.SDK_INT >= 28) {
+            result.setHeading(semanticsNode.hasFlag(Flag.IS_HEADER));
+        }
+
         // Accessibility Focus
         if (accessibilityFocusedSemanticsNode != null && accessibilityFocusedSemanticsNode.id == virtualViewId) {
             result.addAction(AccessibilityNodeInfo.ACTION_CLEAR_ACCESSIBILITY_FOCUS);

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -754,7 +754,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         result.setSelected(semanticsNode.hasFlag(Flag.IS_SELECTED));
 
         // Heading support
-        if (Build.VERSION.SDK_INT >= 28) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             result.setHeading(semanticsNode.hasFlag(Flag.IS_HEADER));
         }
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -4,6 +4,7 @@
 
 package io.flutter.view;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.database.ContentObserver;
@@ -489,6 +490,8 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
      */
     @Override
     @SuppressWarnings("deprecation")
+    // Supressing Lint warning for new API, as we are version guarding all calls to newer APIs
+    @SuppressLint("NewApi")
     public AccessibilityNodeInfo createAccessibilityNodeInfo(int virtualViewId) {
         if (virtualViewId >= MIN_ENGINE_GENERATED_NODE_ID) {
             // The node is in the engine generated range, and is provided by the accessibility view embedder.


### PR DESCRIPTION
Simple change to add support for the `Semantics.header` field on Android. Android P added a `AccessibilityNodeInfo.setHeading` function, so this just hooks that up to our Semantic tree.

Fixes: https://github.com/flutter/flutter/issues/41494
