### PR TITLE
Disable flaky test ShellTest_ReportTimingsIsCalled.

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -321,7 +321,8 @@ static void CheckFrameTimings(const std::vector<FrameTiming>& timings,
   }
 }
 
-TEST_F(ShellTest, ReportTimingsIsCalled) {
+// TODO(43192): This test is disable because of flakiness.
+TEST_F(ShellTest, DISABLED_ReportTimingsIsCalled) {
   fml::TimePoint start = fml::TimePoint::Now();
   auto settings = CreateSettingsForFixture();
   std::unique_ptr<Shell> shell = CreateShell(settings);


### PR DESCRIPTION
Investigation is tracked in https://github.com/flutter/flutter/issues/43192