### PR TITLE
Avoid accessing the Cocoa view on the GPU or IO task runners.

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterView.h
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.h
@@ -35,14 +35,4 @@
 - (nullable instancetype)initWithCoder:(nonnull NSCoder*)coder NS_UNAVAILABLE;
 - (nonnull instancetype)init NS_UNAVAILABLE;
 
-/**
- * Sets this view as the current context object for OpenGL drawing.
- */
-- (void)makeCurrentContext;
-
-/**
- * Called when the OpenGL display should be updated.
- */
-- (void)onPresent;
-
 @end

--- a/shell/platform/darwin/macos/framework/Source/FlutterView.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterView.mm
@@ -26,14 +26,6 @@
   return self;
 }
 
-- (void)makeCurrentContext {
-  [self.openGLContext makeCurrentContext];
-}
-
-- (void)onPresent {
-  [self.openGLContext flushBuffer];
-}
-
 #pragma mark - NSView overrides
 
 /**


### PR DESCRIPTION
The view was being accessed from a background thread so its OpenGL context could be accessed. This tripped thread safety assertions in Cocoa. Now the OpenGL context is stashed in the FlutterEngine instance itself.