### PR TITLE
Pass LinearTextFlat to SkFont -  iOS13 letter spacing

### DIFF
--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -317,10 +317,8 @@ int Layout::findFace(const FakedFont& face, LayoutContext* ctx) {
   // corresponding hb_font object.
   if (ctx != NULL) {
     hb_font_t* font = getHbFontLocked(face.font);
-    // Temporarily removed to fix advance integer rounding.
-    // This is likely due to very old versions of harfbuzz and ICU.
-    // hb_font_set_funcs(font, getHbFontFuncs(isColorBitmapFont(font)),
-    // &ctx->paint, 0);
+    hb_font_set_funcs(font, getHbFontFuncs(isColorBitmapFont(font)),
+                      &ctx->paint, 0);
     ctx->hbFonts.push_back(font);
   }
   return ix;

--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -240,7 +240,7 @@ static hb_position_t harfbuzzGetGlyphHorizontalAdvance(hb_font_t* /* hbFont */,
                                                        void* /* userData */) {
   MinikinPaint* paint = reinterpret_cast<MinikinPaint*>(fontData);
   float advance = paint->font->GetHorizontalAdvance(glyph, *paint);
-  return 256 * advance + 0.5;
+  return 256 * advance;
 }
 
 static hb_bool_t harfbuzzGetGlyphHorizontalOrigin(hb_font_t* /* hbFont */,

--- a/third_party/txt/src/minikin/Layout.cpp
+++ b/third_party/txt/src/minikin/Layout.cpp
@@ -240,7 +240,7 @@ static hb_position_t harfbuzzGetGlyphHorizontalAdvance(hb_font_t* /* hbFont */,
                                                        void* /* userData */) {
   MinikinPaint* paint = reinterpret_cast<MinikinPaint*>(fontData);
   float advance = paint->font->GetHorizontalAdvance(glyph, *paint);
-  return 256 * advance;
+  return 256 * advance + 0.5;
 }
 
 static hb_bool_t harfbuzzGetGlyphHorizontalOrigin(hb_font_t* /* hbFont */,

--- a/third_party/txt/src/txt/font_skia.cc
+++ b/third_party/txt/src/txt/font_skia.cc
@@ -52,6 +52,7 @@ static void FontSkia_SetSkiaFont(sk_sp<SkTypeface> typeface,
                                  SkFont* skFont,
                                  const minikin::MinikinPaint& paint) {
   skFont->setTypeface(std::move(typeface));
+  skFont->setLinearMetrics((paint.paintFlags & minikin::LinearTextFlag) != 0);
   // TODO: set more paint parameters from Minikin
   skFont->setSize(paint.size);
 }

--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -129,6 +129,7 @@ class ParagraphTxt : public Paragraph {
  private:
   friend class ParagraphBuilderTxt;
   FRIEND_TEST(ParagraphTest, SimpleParagraph);
+  FRIEND_TEST(ParagraphTest, SimpleParagraphSmall);
   FRIEND_TEST(ParagraphTest, SimpleRedParagraph);
   FRIEND_TEST(ParagraphTest, RainbowParagraph);
   FRIEND_TEST(ParagraphTest, DefaultStyleParagraph);

--- a/third_party/txt/src/txt/styled_runs.h
+++ b/third_party/txt/src/txt/styled_runs.h
@@ -62,6 +62,7 @@ class StyledRuns {
 
  private:
   FRIEND_TEST(ParagraphTest, SimpleParagraph);
+  FRIEND_TEST(ParagraphTest, SimpleParagraphSmall);
   FRIEND_TEST(ParagraphTest, SimpleRedParagraph);
   FRIEND_TEST(ParagraphTest, RainbowParagraph);
   FRIEND_TEST(ParagraphTest, DefaultStyleParagraph);

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -211,7 +211,7 @@ TEST_F(ParagraphTest, LineMetricsParagraph1) {
   ASSERT_EQ(paragraph->GetLineMetrics()[0].hard_break, true);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].ascent, 12.988281);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].descent, 3.4179688);
-  ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].width, 149.67578);
+  ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].width, 149.72266);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].left, 0.0);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].baseline, 12.582031);
   ASSERT_EQ(paragraph->GetLineMetrics()[0].line_number, 0ull);
@@ -264,7 +264,7 @@ TEST_F(ParagraphTest, LineMetricsParagraph1) {
   ASSERT_EQ(paragraph->GetLineMetrics()[1].hard_break, true);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[1].ascent, 12.988281);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[1].descent, 3.4179688);
-  ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[1].width, 72.039062);
+  ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[1].width, 72.0625);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[1].left, 0.0);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[1].baseline, 28.582031);
   ASSERT_EQ(paragraph->GetLineMetrics()[1].line_number, 1ull);
@@ -354,7 +354,7 @@ TEST_F(ParagraphTest, DISABLE_ON_MAC(LineMetricsParagraph2)) {
   ASSERT_EQ(paragraph->GetLineMetrics()[0].hard_break, false);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].ascent, 27.84);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].descent, 7.6799998);
-  ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].width, 349.21875);
+  ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].width, 349.26953);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].left, 0.0);
   ASSERT_FLOAT_EQ(paragraph->GetLineMetrics()[0].baseline, 28.32);
   ASSERT_EQ(paragraph->GetLineMetrics()[0].line_number, 0ull);
@@ -580,24 +580,24 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 7ull);
-  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[1].rect.top(), 50);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 140.92188);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 140.94531);
   EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 100);
 
-  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 231.34375);
+  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 231.39062);
   EXPECT_FLOAT_EQ(boxes[3].rect.top(), 50);
-  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 231.34375 + 50);
+  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 231.39062 + 50);
   EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 100);
 
-  EXPECT_FLOAT_EQ(boxes[4].rect.left(), 281.34375);
+  EXPECT_FLOAT_EQ(boxes[4].rect.left(), 281.39062);
   EXPECT_FLOAT_EQ(boxes[4].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 281.34375 + 5);
+  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 281.39062 + 5);
   EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 50);
 
-  EXPECT_FLOAT_EQ(boxes[6].rect.left(), 336.34375);
+  EXPECT_FLOAT_EQ(boxes[6].rect.left(), 336.39062);
   EXPECT_FLOAT_EQ(boxes[6].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[6].rect.right(), 336.34375 + 5);
+  EXPECT_FLOAT_EQ(boxes[6].rect.right(), 336.39062 + 5);
   EXPECT_FLOAT_EQ(boxes[6].rect.bottom(), 50);
 
   ASSERT_TRUE(Snapshot());
@@ -656,9 +656,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBaselineParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the box is in the right place
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 50);
 
   paint.setColor(SK_ColorBLUE);
@@ -669,9 +669,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBaselineParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the other text didn't just shift to accomodate it.
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.324219);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.34375);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 14.226246);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 44.694996);
 
   ASSERT_TRUE(Snapshot());
@@ -732,9 +732,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the box is in the right place
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.34765625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 49.652344);
 
   paint.setColor(SK_ColorBLUE);
@@ -745,9 +745,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the other text didn't just shift to accomodate it.
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.324219);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.34375);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 25.53125);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 56);
 
   ASSERT_TRUE(Snapshot());
@@ -808,9 +808,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the box is in the right place
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 24);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 74);
 
   paint.setColor(SK_ColorBLUE);
@@ -821,9 +821,9 @@ TEST_F(ParagraphTest,
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the other text didn't just shift to accomodate it.
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.324219);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.34375);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.12109375);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 30.347656);
 
   ASSERT_TRUE(Snapshot());
@@ -882,9 +882,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBottomParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the box is in the right place
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 50);
 
   paint.setColor(SK_ColorBLUE);
@@ -897,7 +897,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBottomParagraph)) {
   // Verify the other text didn't just shift to accomodate it.
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 19.53125);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 16.097656);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 16.101562);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 50);
 
   ASSERT_TRUE(Snapshot());
@@ -956,9 +956,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderTopParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the box is in the right place
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 50);
 
   paint.setColor(SK_ColorBLUE);
@@ -971,7 +971,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderTopParagraph)) {
   // Verify the other text didn't just shift to accomodate it.
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0.5);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 16.097656);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 16.101562);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 30.46875);
 
   ASSERT_TRUE(Snapshot());
@@ -1030,9 +1030,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderMiddleParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the box is in the right place
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 145.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 50);
 
   paint.setColor(SK_ColorBLUE);
@@ -1043,9 +1043,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderMiddleParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   // Verify the other text didn't just shift to accomodate it.
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.324219);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 75.34375);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 9.765625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 40.234375);
 
   ASSERT_TRUE(Snapshot());
@@ -1246,9 +1246,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBreakParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 31.695312);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 31.703125);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 218.53125);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 47.292969);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 47.304688);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 249);
 
   paint.setColor(SK_ColorRED);
@@ -1264,14 +1264,14 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderBreakParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 30ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 59.726562);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 59.742188);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 26.378906);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 56.847656);
 
-  EXPECT_FLOAT_EQ(boxes[11].rect.left(), 606.34375);
+  EXPECT_FLOAT_EQ(boxes[11].rect.left(), 606.39062);
   EXPECT_FLOAT_EQ(boxes[11].rect.top(), 38);
-  EXPECT_FLOAT_EQ(boxes[11].rect.right(), 631.34375);
+  EXPECT_FLOAT_EQ(boxes[11].rect.right(), 631.39062);
   EXPECT_FLOAT_EQ(boxes[11].rect.bottom(), 63);
 
   EXPECT_FLOAT_EQ(boxes[17].rect.left(), 0.5);
@@ -1378,19 +1378,19 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderGetRectsParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 34ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.921875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 90.945312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 140.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 140.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 50);
 
-  EXPECT_FLOAT_EQ(boxes[16].rect.left(), 800.92188);
+  EXPECT_FLOAT_EQ(boxes[16].rect.left(), 800.94531);
   EXPECT_FLOAT_EQ(boxes[16].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[16].rect.right(), 850.92188);
+  EXPECT_FLOAT_EQ(boxes[16].rect.right(), 850.94531);
   EXPECT_FLOAT_EQ(boxes[16].rect.bottom(), 50);
 
-  EXPECT_FLOAT_EQ(boxes[33].rect.left(), 503.38281);
+  EXPECT_FLOAT_EQ(boxes[33].rect.left(), 503.48438);
   EXPECT_FLOAT_EQ(boxes[33].rect.top(), 160);
-  EXPECT_FLOAT_EQ(boxes[33].rect.right(), 508.38281);
+  EXPECT_FLOAT_EQ(boxes[33].rect.right(), 508.48438);
   EXPECT_FLOAT_EQ(boxes[33].rect.bottom(), 180);
 
   Paragraph::RectHeightStyle rect_height_style =
@@ -1404,20 +1404,20 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(InlinePlaceholderGetRectsParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 8ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 216.09766);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 216.10156);
   // Top should be taller than "tight"
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 60);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 290.92188);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 290.94531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 120);
 
-  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 290.92188);
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 290.94531);
   EXPECT_FLOAT_EQ(boxes[1].rect.top(), 60);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 340.92188);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 340.94531);
   EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 120);
 
-  EXPECT_FLOAT_EQ(boxes[2].rect.left(), 340.92188);
+  EXPECT_FLOAT_EQ(boxes[2].rect.left(), 340.94531);
   EXPECT_FLOAT_EQ(boxes[2].rect.top(), 60);
-  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 345.92188);
+  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 345.94531);
   EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 120);
 
   ASSERT_TRUE(Snapshot());
@@ -1786,7 +1786,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(HeightOverrideParagraph)) {
   EXPECT_EQ(boxes.size(), 3ull);
   EXPECT_FLOAT_EQ(boxes[1].rect.left(), 0);
   EXPECT_NEAR(boxes[1].rect.top(), 92.805778503417969, 0.0001);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 43.84375);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 43.851562);
   EXPECT_NEAR(boxes[1].rect.bottom(), 165.49578857421875, 0.0001);
 
   ASSERT_TRUE(Snapshot());
@@ -1965,7 +1965,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(RightAlignParagraph)) {
   // less than width_.
   ASSERT_DOUBLE_EQ(paragraph->width_, available_width);
   ASSERT_TRUE(paragraph->longest_line_ < available_width);
-  ASSERT_DOUBLE_EQ(paragraph->longest_line_, 880.765625);
+  ASSERT_DOUBLE_EQ(paragraph->longest_line_, 880.87109375);
 
   ASSERT_TRUE(paragraph->records_[2].style().equals(text_style));
   ASSERT_DOUBLE_EQ(paragraph->records_[2].offset().y(), expected_y);
@@ -2838,14 +2838,14 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(ArabicRectsParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 2ull);
 
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 556.54688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 556.48438);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.26855469);
   EXPECT_FLOAT_EQ(boxes[0].rect.right(), 900);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 44);
 
-  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 510.09375);
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 510.03125);
   EXPECT_FLOAT_EQ(boxes[1].rect.top(), -0.26855469);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 557.04688);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 556.98438);
   EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 44);
 
   ASSERT_EQ(paragraph_style.text_align,
@@ -2906,9 +2906,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(ArabicRectsLTRLeftAlignParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
 
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 89.40625);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 89.425781);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.26855469);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 121.87891);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 121.90625);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 44);
 
   ASSERT_EQ(paragraph_style.text_align,
@@ -2969,14 +2969,14 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(ArabicRectsLTRRightAlignParagraph)) {
   }
   EXPECT_EQ(boxes.size(), 2ull);
 
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 556.54688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 556.48438);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), -0.26855469);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 577.78125);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 577.72656);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 44);
 
-  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 545.30859);
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 545.24609);
   EXPECT_FLOAT_EQ(boxes[1].rect.top(), -0.26855469);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 557.04688);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 556.98438);
   EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 44);
 
   ASSERT_EQ(paragraph_style.text_align,
@@ -3125,7 +3125,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeParagraph)) {
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 56.835938);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 177.97266);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 177.98438);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 59);
 
   paint.setColor(SK_ColorGREEN);
@@ -3135,9 +3135,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 177.97266);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 177.98438);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 507.02344);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 507.03906);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 59);
 
   paint.setColor(SK_ColorRED);
@@ -3147,9 +3147,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 4ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 211.375);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 211.37891);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 59.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 463.61719);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 463.62891);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 118);
 
   // TODO(garyq): The following set of vals are definitely wrong and
@@ -3166,9 +3166,9 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeParagraph)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 450.1875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 450.20312);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 519.47266);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 519.49219);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 59);
 
   paint.setColor(SK_ColorRED);
@@ -3254,7 +3254,7 @@ TEST_F(ParagraphTest, LINUX_ONLY(GetRectsForRangeTight)) {
   }
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 264.09375);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 264.09766);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 74);
 
   paint.setColor(SK_ColorGREEN);
@@ -3264,9 +3264,9 @@ TEST_F(ParagraphTest, LINUX_ONLY(GetRectsForRangeTight)) {
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 2ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 264.09375);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 264.09766);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 595.08594);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 595.09375);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 74);
 
   ASSERT_TRUE(Snapshot());
@@ -3334,7 +3334,7 @@ TEST_F(ParagraphTest,
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.429688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.433594);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473305);
 
   paint.setColor(SK_ColorBLUE);
@@ -3344,9 +3344,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.429688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.433594);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473305);
 
   paint.setColor(SK_ColorGREEN);
@@ -3356,9 +3356,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.0625);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.09375);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473312);
 
   paint.setColor(SK_ColorRED);
@@ -3368,34 +3368,34 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 8ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 88.473312);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.6875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.72266);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 168.47331);
 
-  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.6875);
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.72266);
   EXPECT_FLOAT_EQ(boxes[1].rect.top(), 88.473312);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 168.4733);
 
   EXPECT_FLOAT_EQ(boxes[2].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[2].rect.top(), 168.4733);
-  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.57422);
+  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.60547);
   EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 248.47331);
 
-  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.57422);
+  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.60547);
   EXPECT_FLOAT_EQ(boxes[3].rect.top(), 168.4733);
-  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 248.47331);
 
   EXPECT_FLOAT_EQ(boxes[4].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[4].rect.top(), 248.47331);
-  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 328.4733);
 
   EXPECT_FLOAT_EQ(boxes[5].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[5].rect.top(), 328.47333);
-  EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 408.4733);
 
   paint.setColor(SK_ColorBLUE);
@@ -3405,9 +3405,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.72656);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.75781);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.23047);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.26172);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 88.473305);
 
   paint.setColor(SK_ColorRED);
@@ -3483,7 +3483,7 @@ TEST_F(ParagraphTest,
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.429688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.433594);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorBLUE);
@@ -3493,9 +3493,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.429688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.433594);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorGREEN);
@@ -3505,9 +3505,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.0625);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.09375);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorRED);
@@ -3517,34 +3517,34 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 8ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 80);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.6875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.72266);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 160);
 
-  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.6875);
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.72266);
   EXPECT_FLOAT_EQ(boxes[1].rect.top(), 80);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 160);
 
   EXPECT_FLOAT_EQ(boxes[2].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[2].rect.top(), 160);
-  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.57422);
+  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.60547);
   EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 240);
 
-  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.57422);
+  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.60547);
   EXPECT_FLOAT_EQ(boxes[3].rect.top(), 160);
-  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 240);
 
   EXPECT_FLOAT_EQ(boxes[4].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[4].rect.top(), 240);
-  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 320);
 
   EXPECT_FLOAT_EQ(boxes[5].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[5].rect.top(), 320);
-  EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 400);
 
   paint.setColor(SK_ColorBLUE);
@@ -3554,9 +3554,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.72656);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.75781);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.23047);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.26172);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 80);
 
   paint.setColor(SK_ColorRED);
@@ -3632,7 +3632,7 @@ TEST_F(ParagraphTest,
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.429688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 17.433594);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorBLUE);
@@ -3642,9 +3642,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.429688);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 67.433594);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorGREEN);
@@ -3654,9 +3654,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.0625);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 508.09375);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorRED);
@@ -3666,34 +3666,34 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 8ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.00781);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 190.01953);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 96.946617);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.6875);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 525.72266);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 176.94661);
 
-  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.6875);
+  EXPECT_FLOAT_EQ(boxes[1].rect.left(), 525.72266);
   EXPECT_FLOAT_EQ(boxes[1].rect.top(), 96.946617);
-  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[1].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[1].rect.bottom(), 176.94661);
 
   EXPECT_FLOAT_EQ(boxes[2].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[2].rect.top(), 176.94661);
-  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.57422);
+  EXPECT_FLOAT_EQ(boxes[2].rect.right(), 531.60547);
   EXPECT_FLOAT_EQ(boxes[2].rect.bottom(), 256.94662);
 
-  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.57422);
+  EXPECT_FLOAT_EQ(boxes[3].rect.left(), 531.60547);
   EXPECT_FLOAT_EQ(boxes[3].rect.top(), 176.94661);
-  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[3].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[3].rect.bottom(), 256.94662);
 
   EXPECT_FLOAT_EQ(boxes[4].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[4].rect.top(), 256.94662);
-  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[4].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[4].rect.bottom(), 336.94662);
 
   EXPECT_FLOAT_EQ(boxes[5].rect.left(), 0);
   EXPECT_FLOAT_EQ(boxes[5].rect.top(), 336.94662);
-  EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.02344);
+  EXPECT_FLOAT_EQ(boxes[5].rect.right(), 570.05859);
   EXPECT_FLOAT_EQ(boxes[5].rect.bottom(), 416.94662);
 
   paint.setColor(SK_ColorBLUE);
@@ -3703,9 +3703,9 @@ TEST_F(ParagraphTest,
     GetCanvas()->drawRect(boxes[i].rect, paint);
   }
   EXPECT_EQ(boxes.size(), 1ull);
-  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.72656);
+  EXPECT_FLOAT_EQ(boxes[0].rect.left(), 463.75781);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 16.946615);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.23047);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 530.26172);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 96.946609);
 
   paint.setColor(SK_ColorRED);
@@ -3898,7 +3898,7 @@ TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(GetRectsForRangeCenterParagraph)) {
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 346.04492);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 358.49414);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 358.49805);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 59);
 
   paint.setColor(SK_ColorRED);
@@ -4083,7 +4083,7 @@ TEST_F(ParagraphTest,
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 346.04492);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 0.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 358.49414);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 358.49805);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 59);
 
   paint.setColor(SK_ColorBLACK);
@@ -4107,7 +4107,7 @@ TEST_F(ParagraphTest,
   EXPECT_EQ(boxes.size(), 1ull);
   EXPECT_FLOAT_EQ(boxes[0].rect.left(), 331.83594);
   EXPECT_FLOAT_EQ(boxes[0].rect.top(), 59.40625);
-  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 419.18359);
+  EXPECT_FLOAT_EQ(boxes[0].rect.right(), 419.19531);
   EXPECT_FLOAT_EQ(boxes[0].rect.bottom(), 118);
 
   paint.setColor(SK_ColorRED);
@@ -4172,7 +4172,7 @@ TEST_F(ParagraphTest, LINUX_ONLY(GetRectsForRangeStrut)) {
 
   EXPECT_FLOAT_EQ(strut_rect.left(), 0);
   EXPECT_FLOAT_EQ(strut_rect.top(), 10.611719);
-  EXPECT_FLOAT_EQ(strut_rect.right(), 118.60547);
+  EXPECT_FLOAT_EQ(strut_rect.right(), 118.61719);
   EXPECT_FLOAT_EQ(strut_rect.bottom(), 27.017969);
 
   ASSERT_TRUE(tight_rect.contains(strut_rect));
@@ -4498,9 +4498,9 @@ TEST_F(ParagraphTest, KernScaleParagraph) {
 
   EXPECT_DOUBLE_EQ(paragraph->records_[0].offset().x(), 0);
   EXPECT_DOUBLE_EQ(paragraph->records_[1].offset().x(), 0);
-  EXPECT_DOUBLE_EQ(paragraph->records_[2].offset().x(), 207.36328125f);
-  EXPECT_DOUBLE_EQ(paragraph->records_[3].offset().x(), 230.86328125f);
-  EXPECT_DOUBLE_EQ(paragraph->records_[4].offset().x(), 253.35546875f);
+  EXPECT_DOUBLE_EQ(paragraph->records_[2].offset().x(), 207.359375f);
+  EXPECT_DOUBLE_EQ(paragraph->records_[3].offset().x(), 230.859375f);
+  EXPECT_DOUBLE_EQ(paragraph->records_[4].offset().x(), 253.34765625f);
 }
 
 TEST_F(ParagraphTest, DISABLE_ON_WINDOWS(NewlineParagraph)) {
@@ -5153,10 +5153,10 @@ TEST_F(ParagraphTest, FontFallbackParagraph) {
   ASSERT_TRUE(Snapshot());
 
   ASSERT_EQ(paragraph->records_.size(), 5ull);
-  ASSERT_DOUBLE_EQ(paragraph->records_[0].GetRunWidth(), 64.19921875);
-  ASSERT_DOUBLE_EQ(paragraph->records_[1].GetRunWidth(), 139.1171875);
+  ASSERT_DOUBLE_EQ(paragraph->records_[0].GetRunWidth(), 64.2109375);
+  ASSERT_DOUBLE_EQ(paragraph->records_[1].GetRunWidth(), 139.1328125);
   ASSERT_DOUBLE_EQ(paragraph->records_[2].GetRunWidth(), 28);
-  ASSERT_DOUBLE_EQ(paragraph->records_[3].GetRunWidth(), 62.24609375);
+  ASSERT_DOUBLE_EQ(paragraph->records_[3].GetRunWidth(), 62.25);
   ASSERT_DOUBLE_EQ(paragraph->records_[4].GetRunWidth(), 28);
   // When a different font is resolved, then the metrics are different.
   ASSERT_TRUE(paragraph->records_[2].metrics().fTop -


### PR DESCRIPTION
Call hb_font_set_funcs again since harfbuzz is now modern.

This fixes https://github.com/flutter/flutter/issues/41101