### PR TITLE
[fuchsia] [packaging] Layout debug symbols for Fuchsia

### DIFF
--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -111,7 +111,7 @@ def main():
   shutil.copyfile(args.exec_path, dbg_file_path)
 
   # Note this needs to be in sync with debug_symbols.gni
-  completion_file = os.path.join(args.dest, '%s_dbg_success' % args.exec_name)
+  completion_file = os.path.join(args.dest, '.%s_dbg_success' % args.exec_name)
   Touch(completion_file)
 
   return 0

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+""" Gather the build_id, prefix_dir, and exec_name given the path to executable
+    also copies to the specified destination.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+
+def Touch(fname):
+  with open(fname, 'a'):
+    os.utime(fname, None)
+
+
+def GetBuildIdParts(exec_path):
+  file_out = subprocess.check_output(['file', exec_path])
+  build_id = re.match('.*=(.*?),', file_out).groups()[0]
+  return {
+      'build_id': build_id,
+      'prefix_dir': build_id[:2],
+      'exec_name': build_id[2:]
+  }
+
+
+def main():
+  parser = argparse.ArgumentParser()
+
+  parser.add_argument(
+      '--executable-name', dest='exec_name', action='store', required=True)
+  parser.add_argument(
+      '--executable-path', dest='exec_path', action='store', required=True)
+  parser.add_argument(
+      '--destination-base', dest='dest', action='store', required=True)
+
+  parser.add_argument('--stripped', dest='stripped', action='store_true')
+  parser.add_argument('--unstripped', dest='stripped', action='store_false')
+  parser.set_defaults(stripped=True)
+
+  args = parser.parse_args()
+  assert os.path.exists(args.exec_path)
+  assert os.path.exists(args.dest)
+
+  parts = GetBuildIdParts(args.exec_path)
+  dbg_prefix_base = '%s/%s' % (args.dest, parts['prefix_dir'])
+
+  if not os.path.exists(dbg_prefix_base):
+    os.makedirs(dbg_prefix_base)
+
+  dbg_suffix = ''
+  if not args.stripped:
+    dbg_suffix = '.debug'
+  dbg_file_path = '%s/%s%s' % (dbg_prefix_base, parts['exec_name'], dbg_suffix)
+
+  shutil.copyfile(args.exec_path, dbg_file_path)
+
+  # Note this needs to be in sync with debug_symbols.gni
+  completion_file = '%s/.%s_dbg_success' % (args.dest, args.exec_name)
+  Touch(completion_file)
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 
 
 def Touch(fname):
@@ -52,8 +53,21 @@ def main():
   parts = GetBuildIdParts(args.exec_path)
   dbg_prefix_base = '%s/%s' % (args.dest, parts['prefix_dir'])
 
-  if not os.path.exists(dbg_prefix_base):
-    os.makedirs(dbg_prefix_base)
+  success = False
+  for _ in range(3):
+    try:
+      if not os.path.exists(dbg_prefix_base):
+        os.makedirs(dbg_prefix_base)
+      success = True
+      break
+    except OSError as error:
+      print 'Failed to create dir %s, error: %s. sleeping...' % (
+          dbg_prefix_base, error)
+      time.sleep(3)
+
+  if not success:
+    print 'Unable to create directory: %s.' % dbg_prefix_base
+    return 1
 
   dbg_suffix = ''
   if not args.stripped:

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -20,12 +20,33 @@ import sys
 import time
 
 
+def IsExecutable(fpath):
+  return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+
+def Which(program):
+  fpath, _ = os.path.split(program)
+  if fpath:
+    if IsExecutable(program):
+      return program
+  else:
+    for path in os.environ["PATH"].split(os.pathsep):
+      exe_file = os.path.join(path, program)
+      if IsExecutable(exe_file):
+        return exe_file
+
+  return None
+
+
 def Touch(fname):
   with open(fname, 'a'):
     os.utime(fname, None)
 
 
 def GetBuildIdParts(exec_path):
+  if not Which('file'):
+    print "'file' command is not present on PATH."
+    sys.exit(1)
   file_out = subprocess.check_output(['file', exec_path])
   build_id = re.match('.*=(.*?),', file_out).groups()[0]
   return {

--- a/tools/fuchsia/debug_symbols.gni
+++ b/tools/fuchsia/debug_symbols.gni
@@ -1,0 +1,82 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# The inputs to this template are 'binary_path' and a boolean 'unstripped'.
+# If 'unstripped' is specified, we append '.debug' to the symbols name.
+template("_copy_debug_symbols") {
+  assert(defined(invoker.binary_path), "'binary_path' needs to be defined.")
+
+  bin_path = invoker.binary_path
+
+  _args = []
+  if (defined(invoker.unstripped) && invoker.unstripped) {
+    _args += [ "--unstripped" ]
+  }
+
+  action(target_name) {
+    testonly = defined(invoker.testonly) && invoker.testonly
+
+    deps = []
+    if (defined(invoker.deps)) {
+      deps = invoker.deps
+    }
+
+    script = "$flutter_root/tools/fuchsia/copy_debug_symbols.py"
+
+    sources = [
+      bin_path,
+    ]
+
+    _dest_base =
+        "${root_out_dir}/flutter-debug-symbols-${target_os}-${target_cpu}"
+
+    args = _args + [
+             "--executable-name",
+             target_name,
+             "--executable-path",
+             rebase_path(bin_path),
+             "--destination-base",
+             rebase_path(_dest_base),
+           ]
+
+    outputs = [
+      "${_dest_base}/.${target_name}_success",
+    ]
+  }
+}
+
+# Takes a binary and generates its debug symbols following
+# the Fuchsia packaging convention.
+template("debug_symbols") {
+  assert(defined(invoker.binary), "'binary' needs to be defined.")
+  _testonly = defined(invoker.testonly) && invoker.testonly
+
+  _deps = []
+  if (defined(invoker.deps)) {
+    _deps = invoker.deps
+  }
+
+  bin = invoker.binary
+
+  _copy_debug_symbols("_${target_name}_stripped") {
+    testonly = _testonly
+    binary_path = rebase_path("${root_out_dir}/$bin")
+    deps = _deps
+  }
+
+  _copy_debug_symbols("_${target_name}_unstripped") {
+    testonly = _testonly
+    binary_path = "${root_out_dir}/exe.unstripped/$bin"
+    unstripped = true
+    deps = _deps
+  }
+
+  group(target_name) {
+    testonly = _testonly
+    deps = [
+      ":_${target_name}_stripped",
+      ":_${target_name}_unstripped",
+    ]
+  }
+}

--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/tools/fuchsia/debug_symbols.gni")
+import("$flutter_root/tools/fuchsia/fuchsia_debug_symbols.gni")
 
 # Creates a Fuchsia archive (.far) file using PM from the Fuchsia SDK.
 template("fuchsia_archive") {
@@ -75,7 +75,7 @@ template("fuchsia_archive") {
              "json")
 
   _dbg_symbols_target = "${target_name}_dbg_symbols"
-  debug_symbols(_dbg_symbols_target) {
+  fuchsia_debug_symbols(_dbg_symbols_target) {
     deps = pkg.deps
     testonly = pkg_testonly
     binary = invoker.binary

--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("$flutter_root/tools/fuchsia/debug_symbols.gni")
+
 # Creates a Fuchsia archive (.far) file using PM from the Fuchsia SDK.
 template("fuchsia_archive") {
   assert(defined(invoker.binary), "package must define binary")
@@ -72,6 +74,13 @@ template("fuchsia_archive") {
              },
              "json")
 
+  _dbg_symbols_target = "${target_name}_dbg_symbols"
+  debug_symbols(_dbg_symbols_target) {
+    deps = pkg.deps
+    testonly = pkg_testonly
+    binary = invoker.binary
+  }
+
   pkg_dir_deps = pkg.deps + [ ":$cmx_target" ]
 
   action("${target_name}_dir") {
@@ -86,7 +95,10 @@ template("fuchsia_archive") {
 
   action(target_name) {
     script = "$flutter_root/tools/fuchsia/gen_package.py"
-    deps = pkg_dir_deps + [ ":${target_name}_dir" ]
+    deps = pkg_dir_deps + [
+             ":${target_name}_dir",
+             ":${_dbg_symbols_target}",
+           ]
     sources = copy_outputs
 
     inputs = []

--- a/tools/fuchsia/fuchsia_debug_symbols.gni
+++ b/tools/fuchsia/fuchsia_debug_symbols.gni
@@ -6,39 +6,38 @@
 # If 'unstripped' is specified, we append '.debug' to the symbols name.
 template("_copy_debug_symbols") {
   assert(defined(invoker.binary_path), "'binary_path' needs to be defined.")
-
-  bin_path = invoker.binary_path
-
-  _args = []
-  if (defined(invoker.unstripped) && invoker.unstripped) {
-    _args += [ "--unstripped" ]
-  }
+  assert(defined(invoker.unstripped), "'unstripped' needs to be defined.")
 
   action(target_name) {
-    testonly = defined(invoker.testonly) && invoker.testonly
-
-    deps = []
-    if (defined(invoker.deps)) {
-      deps = invoker.deps
-    }
+    forward_variables_from(invoker,
+                           [
+                             "deps",
+                             "unstripped",
+                             "binary_path",
+                             "testonly",
+                           ])
 
     script = "$flutter_root/tools/fuchsia/copy_debug_symbols.py"
 
     sources = [
-      bin_path,
+      binary_path,
     ]
 
     _dest_base =
         "${root_out_dir}/flutter-debug-symbols-${target_os}-${target_cpu}"
 
-    args = _args + [
-             "--executable-name",
-             target_name,
-             "--executable-path",
-             rebase_path(bin_path),
-             "--destination-base",
-             rebase_path(_dest_base),
-           ]
+    args = [
+      "--executable-name",
+      target_name,
+      "--executable-path",
+      rebase_path(binary_path),
+      "--destination-base",
+      rebase_path(_dest_base),
+    ]
+
+    if (unstripped) {
+      args += [ "--unstripped" ]
+    }
 
     outputs = [
       "${_dest_base}/.${target_name}_success",
@@ -48,32 +47,23 @@ template("_copy_debug_symbols") {
 
 # Takes a binary and generates its debug symbols following
 # the Fuchsia packaging convention.
-template("debug_symbols") {
+template("fuchsia_debug_symbols") {
   assert(defined(invoker.binary), "'binary' needs to be defined.")
-  _testonly = defined(invoker.testonly) && invoker.testonly
-
-  _deps = []
-  if (defined(invoker.deps)) {
-    _deps = invoker.deps
-  }
-
-  bin = invoker.binary
 
   _copy_debug_symbols("_${target_name}_stripped") {
-    testonly = _testonly
-    binary_path = rebase_path("${root_out_dir}/$bin")
-    deps = _deps
+    forward_variables_from(invoker, "*")
+    binary_path = rebase_path("${root_out_dir}/$binary")
+    unstripped = false
   }
 
   _copy_debug_symbols("_${target_name}_unstripped") {
-    testonly = _testonly
-    binary_path = "${root_out_dir}/exe.unstripped/$bin"
+    forward_variables_from(invoker, "*")
+    binary_path = "${root_out_dir}/exe.unstripped/$binary"
     unstripped = true
-    deps = _deps
   }
 
   group(target_name) {
-    testonly = _testonly
+    forward_variables_from(invoker, [ "testonly" ])
     deps = [
       ":_${target_name}_stripped",
       ":_${target_name}_unstripped",

--- a/tools/fuchsia/fuchsia_debug_symbols.gni
+++ b/tools/fuchsia/fuchsia_debug_symbols.gni
@@ -33,6 +33,8 @@ template("_copy_debug_symbols") {
       rebase_path(binary_path),
       "--destination-base",
       rebase_path(_dest_base),
+      "--read-elf",
+      rebase_path("//fuchsia/toolchain/$host_os/bin/llvm-readelf"),
     ]
 
     if (unstripped) {


### PR DESCRIPTION
This packages and moves the relevant symbols to the right
locations in root_out_dir, but doesn't upload them to CIPD
yet. That will be done in a following change.

Refer: go/flutter-fuchsia-packaging for more information.