### PR TITLE
Expose platform view ID on embedder semantics node

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -737,6 +737,7 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
                 &node.childrenInHitTestOrder[0],
                 node.customAccessibilityActions.size(),
                 &node.customAccessibilityActions[0],
+                node.platformViewId,
             };
             ptr(&embedder_node, user_data);
           }

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -458,6 +458,11 @@ typedef struct {
   double bottom;
 } FlutterRect;
 
+/// The identifier of the platform view. This identifier is specified by the
+/// application when a platform view is added to the scene via the
+/// `SceneBuilder.addPlatformView` call.
+typedef int64_t FlutterPlatformViewIdentifier;
+
 /// `FlutterSemanticsNode` ID used as a sentinel to signal the end of a batch of
 /// semantics node updates.
 FLUTTER_EXPORT
@@ -529,6 +534,9 @@ typedef struct {
   /// Array of `FlutterSemanticsCustomAction` IDs associated with this node.
   /// Has length `custom_accessibility_actions_count`.
   const int32_t* custom_accessibility_actions;
+  /// Identifier of the platform view associated with this semantics node, or
+  /// zero if none.
+  FlutterPlatformViewIdentifier platform_view_id;
 } FlutterSemanticsNode;
 
 /// `FlutterSemanticsCustomAction` ID used as a sentinel to signal the end of a
@@ -652,11 +660,6 @@ typedef struct {
   /// store.
   VoidCallback destruction_callback;
 } FlutterSoftwareBackingStore;
-
-/// The identifier of the platform view. This identifier is specified by the
-/// application when a platform view is added to the scene via the
-/// `SceneBuilder.addPlatformView` call.
-typedef int64_t FlutterPlatformViewIdentifier;
 
 typedef struct {
   /// The size of this struct. Must be sizeof(FlutterPlatformView).

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -130,6 +130,7 @@ void a11y_main() async { // ignore: non_constant_identifier_names
       rect: Rect.fromLTRB(40.0, 40.0, 80.0, 80.0),
       transform: kTestTransform,
       additionalActions: Int32List.fromList(<int>[21]),
+      platformViewId: 0x3f3,
     )
     ..updateCustomAction(
       id: 21,

--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -137,6 +137,12 @@ TEST_F(Embedder11yTest, A11yTreeIsConsistent) {
           ASSERT_EQ(7.0, node->transform.pers0);
           ASSERT_EQ(8.0, node->transform.pers1);
           ASSERT_EQ(9.0, node->transform.pers2);
+
+          if (node->id == 128) {
+            ASSERT_EQ(0x3f3, node->platform_view_id);
+          } else {
+            ASSERT_EQ(0, node->platform_view_id);
+          }
         }
       });
 


### PR DESCRIPTION
This exposes platform_view_id on the embedder API's FlutterSemanticNode.

In bd0f9085e5bdbac74cc6e611f758768f15ad5415 (#8055), platformViewId was added to SemanticsNode. This field is non-zero when the SemanticsNode represents a platform view and is typically used by embedders as a means of identifying locations where a platform view's 'native' accessibility tree should be injected into the platform-specific accessibility tree constructed by the embedder.

Due to the intended use of this field, the Flutter framework is meant to enforce that this node has a child count of zero.

Resolves the embedder API aspect of https://github.com/flutter/flutter/issues/37400.