### PR TITLE
Remove TODO on embedder a11y unit tests

### DIFF
--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -21,9 +21,6 @@ namespace testing {
 
 using Embedder11yTest = testing::EmbedderTest;
 
-// TODO: This test has been disabled as it is flaky (more reproducible in
-// profile more). Multiple calls to a11y changed handler in Dart code is
-// suspected. https://github.com/flutter/flutter/issues/35218
 TEST_F(Embedder11yTest, A11yTreeIsConsistent) {
   auto& context = GetEmbedderContext();
 


### PR DESCRIPTION
Removes an out-of-date TODO stating that the embedder accessibility unittests are still disabled due to flakiness.

The tests were originally disabled in https://github.com/flutter/engine/pull/9482.

The issue tracking re-enabling the tests was https://github.com/flutter/flutter/issues/35218.

This issue was resolved, and the tests re-enabled, in https://github.com/flutter/engine/pull/9585.