### PR TITLE
Deprecated DartExecutor as BinaryMessenger and added a getBinaryMessenger() method. (#43202)

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -419,6 +419,7 @@ action("robolectric_tests") {
     "test/io/flutter/embedding/android/FlutterAndroidComponentTest.java",
     "test/io/flutter/embedding/android/FlutterFragmentTest.java",
     "test/io/flutter/embedding/android/FlutterViewTest.java",
+    "test/io/flutter/embedding/engine/dart/DartExecutorTest.java",
     "test/io/flutter/embedding/engine/FlutterEngineCacheTest.java",
     "test/io/flutter/embedding/engine/FlutterJNITest.java",
     "test/io/flutter/embedding/engine/RenderingComponentTest.java",

--- a/shell/platform/android/test/io/flutter/FlutterTestSuite.java
+++ b/shell/platform/android/test/io/flutter/FlutterTestSuite.java
@@ -21,10 +21,12 @@ import io.flutter.plugin.common.StandardMessageCodecTest;
 import io.flutter.plugin.editing.TextInputPluginTest;
 import io.flutter.plugin.platform.SingleViewPresentationTest;
 import io.flutter.util.PreconditionsTest;
+import test.io.flutter.embedding.engine.dart.DartExecutorTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
     //FlutterActivityAndFragmentDelegateTest.class, //TODO(mklim): Fix and re-enable this
+    DartExecutorTest.class,
     FlutterActivityTest.class,
     FlutterAndroidComponentTest.class,
     FlutterEngineCacheTest.class,

--- a/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/dart/DartExecutorTest.java
@@ -1,0 +1,48 @@
+package test.io.flutter.embedding.engine.dart;
+
+import android.content.res.AssetManager;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.nio.ByteBuffer;
+
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.dart.DartExecutor;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@Config(manifest=Config.NONE)
+@RunWith(RobolectricTestRunner.class)
+public class DartExecutorTest {
+  @Test
+  public void itSendsBinaryMessages() {
+    // Setup test.
+    FlutterJNI fakeFlutterJni = mock(FlutterJNI.class);
+
+    // Create object under test.
+    DartExecutor dartExecutor = new DartExecutor(fakeFlutterJni, mock(AssetManager.class));
+
+    // Verify a BinaryMessenger exists.
+    assertNotNull(dartExecutor.getBinaryMessenger());
+
+    // Execute the behavior under test.
+    ByteBuffer fakeMessage = mock(ByteBuffer.class);
+    dartExecutor.getBinaryMessenger().send("fake_channel", fakeMessage);
+
+    // Verify that DartExecutor sent our message to FlutterJNI.
+    verify(fakeFlutterJni, times(1)).dispatchPlatformMessage(
+        eq("fake_channel"),
+        eq(fakeMessage),
+        anyInt(),
+        anyInt()
+    );
+  }
+}


### PR DESCRIPTION
Deprecated DartExecutor as BinaryMessenger and added a getBinaryMessenger() method. (#43202)

The stated goal of this change is to make it easier for developers to figure out where they can get a `BinaryMessenger`.