### PR TITLE
Web: fix Color subclass handling

### DIFF
--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -1055,7 +1055,7 @@ class Paint {
       _paintData = _paintData.clone();
       _frozen = false;
     }
-    _paintData.color = value;
+   _paintData.color = value.runtimeType == Color ? value : Color(value.value);
   }
 
   /// Whether the colors of the image are inverted when drawn.

--- a/lib/web_ui/test/color_test.dart
+++ b/lib/web_ui/test/color_test.dart
@@ -146,6 +146,12 @@ void main() {
     // Call base class member, make sure it uses overridden value.
     expect(color.red, 0xE0);
   });
+
+  test('Paint converts Color subclasses to plain Color', () {
+    final DynamicColorClass color = DynamicColorClass(0xF0E0D0C0);
+    final Paint paint = Paint()..color = color;
+    expect(paint.color.runtimeType, Color);
+  });
 }
 
 class DynamicColorClass extends Color {


### PR DESCRIPTION
This is required for Cupertino widgets that pass `CupertinoDynamicColor` to `Paint`.