### PR TITLE
Turn on RasterCache based on view hierarchy

### DIFF
--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -26,10 +26,16 @@ void ContainerLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 void ContainerLayer::PrerollChildren(PrerollContext* context,
                                      const SkMatrix& child_matrix,
                                      SkRect* child_paint_bounds) {
-  const bool had_platform_view = context->has_platform_view;
+  // Platform views have no children, so context->has_platform_view should
+  // always be false.
+  FML_DCHECK(!context->has_platform_view);
   bool child_has_platform_view = false;
   for (auto& layer : layers_) {
-    context->has_platform_view = had_platform_view;
+    // Reset context->has_platform_view to false so that layers aren't treated
+    // as if they have a platform view based on one being previously found in a
+    // sibling tree.
+    context->has_platform_view = false;
+
     layer->Preroll(context, child_matrix);
 
     if (layer->needs_system_composite()) {
@@ -41,7 +47,7 @@ void ContainerLayer::PrerollChildren(PrerollContext* context,
         child_has_platform_view || context->has_platform_view;
   }
 
-  context->has_platform_view = had_platform_view || child_has_platform_view;
+  context->has_platform_view = child_has_platform_view;
 }
 
 void ContainerLayer::PaintChildren(PaintContext& context) const {

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -26,14 +26,22 @@ void ContainerLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 void ContainerLayer::PrerollChildren(PrerollContext* context,
                                      const SkMatrix& child_matrix,
                                      SkRect* child_paint_bounds) {
+  const bool had_platform_view = context->has_platform_view;
+  bool child_has_platform_view = false;
   for (auto& layer : layers_) {
+    context->has_platform_view = had_platform_view;
     layer->Preroll(context, child_matrix);
 
     if (layer->needs_system_composite()) {
       set_needs_system_composite(true);
     }
     child_paint_bounds->join(layer->paint_bounds());
+
+    child_has_platform_view =
+        child_has_platform_view || context->has_platform_view;
   }
+
+  context->has_platform_view = had_platform_view || child_has_platform_view;
 }
 
 void ContainerLayer::PaintChildren(PaintContext& context) const {

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -58,6 +58,7 @@ struct PrerollContext {
   TextureRegistry& texture_registry;
   const bool checkerboard_offscreen_layers;
   float total_elevation = 0.0f;
+  bool has_platform_view = false;
 };
 
 // Represents a single composited layer. Created on the UI thread but then
@@ -89,6 +90,7 @@ class Layer {
     TextureRegistry& texture_registry;
     const RasterCache* raster_cache;
     const bool checkerboard_offscreen_layers;
+    bool has_platform_view;
   };
 
   // Calls SkCanvas::saveLayer and restores the layer upon destruction. Also

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -90,7 +90,6 @@ class Layer {
     TextureRegistry& texture_registry;
     const RasterCache* raster_cache;
     const bool checkerboard_offscreen_layers;
-    bool has_platform_view;
   };
 
   // Calls SkCanvas::saveLayer and restores the layer upon destruction. Also

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -152,6 +152,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
     root_layer_->Preroll(&preroll_context, root_surface_transformation);
     // The needs painting flag may be set after the preroll. So check it after.
     if (root_layer_->needs_painting()) {
+      paint_context.has_platform_view = preroll_context.has_platform_view;
       root_layer_->Paint(paint_context);
     }
   }

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -152,7 +152,6 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
     root_layer_->Preroll(&preroll_context, root_surface_transformation);
     // The needs painting flag may be set after the preroll. So check it after.
     if (root_layer_->needs_painting()) {
-      paint_context.has_platform_view = preroll_context.has_platform_view;
       root_layer_->Paint(paint_context);
     }
   }

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -75,9 +75,6 @@ void OpacityLayer::Paint(PaintContext& context) const {
   // See |EnsureSingleChild|.
   FML_DCHECK(layers().size() == 1);
 
-  // Embedded platform views are changing the canvas in the middle of the paint
-  // traversal. To make sure we paint on the right canvas, when there are
-  // platform views in the tree, we don't use the cache.
   if (context.raster_cache) {
     const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();
     RasterCacheResult child_cache =

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -78,7 +78,7 @@ void OpacityLayer::Paint(PaintContext& context) const {
   // Embedded platform views are changing the canvas in the middle of the paint
   // traversal. To make sure we paint on the right canvas, when there are
   // platform views in the tree, we don't use the cache.
-  if (!context.has_platform_view && context.raster_cache) {
+  if (context.raster_cache) {
     const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();
     RasterCacheResult child_cache =
         context.raster_cache->Get(layers()[0].get(), ctm);

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -46,7 +46,7 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   set_paint_bounds(paint_bounds().makeOffset(offset_.fX, offset_.fY));
   // See |EnsureSingleChild|.
   FML_DCHECK(layers().size() == 1);
-  if (context->view_embedder == nullptr && context->raster_cache &&
+  if (!context->has_platform_view && context->raster_cache &&
       SkRect::Intersects(context->cull_rect, paint_bounds())) {
     Layer* child = layers()[0].get();
     SkMatrix ctm = child_matrix;
@@ -76,10 +76,9 @@ void OpacityLayer::Paint(PaintContext& context) const {
   FML_DCHECK(layers().size() == 1);
 
   // Embedded platform views are changing the canvas in the middle of the paint
-  // traversal. To make sure we paint on the right canvas, when the embedded
-  // platform views preview is enabled (context.view_embedded is not null) we
-  // don't use the cache.
-  if (context.view_embedder == nullptr && context.raster_cache) {
+  // traversal. To make sure we paint on the right canvas, when there are
+  // platform views in the tree, we don't use the cache.
+  if (!context.has_platform_view && context.raster_cache) {
     const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();
     RasterCacheResult child_cache =
         context.raster_cache->Get(layers()[0].get(), ctm);

--- a/flow/layers/platform_view_layer.cc
+++ b/flow/layers/platform_view_layer.cc
@@ -23,6 +23,7 @@ void PlatformViewLayer::Preroll(PrerollContext* context,
                       "does not support embedding";
     return;
   }
+  context->has_platform_view = true;
   std::unique_ptr<EmbeddedViewParams> params =
       std::make_unique<EmbeddedViewParams>();
   params->offsetPixels =

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -158,28 +158,28 @@ void RasterCache::Prepare(PrerollContext* context,
   entry.access_count = ClampSize(entry.access_count + 1, 0, access_threshold_);
   entry.used_this_frame = true;
   if (!entry.image.is_valid()) {
-    entry.image = Rasterize(context->gr_context, ctm, context->dst_color_space,
-                            checkerboard_images_, layer->paint_bounds(),
-                            [layer, context](SkCanvas* canvas) {
-                              SkISize canvas_size = canvas->getBaseLayerSize();
-                              SkNWayCanvas internal_nodes_canvas(
-                                  canvas_size.width(), canvas_size.height());
-                              internal_nodes_canvas.addCanvas(canvas);
-                              Layer::PaintContext paintContext = {
-                                  (SkCanvas*)&internal_nodes_canvas,
-                                  canvas,
-                                  context->gr_context,
-                                  nullptr,
-                                  context->raster_time,
-                                  context->ui_time,
-                                  context->texture_registry,
-                                  context->raster_cache,
-                                  context->checkerboard_offscreen_layers,
-                                  context->has_platform_view};
-                              if (layer->needs_painting()) {
-                                layer->Paint(paintContext);
-                              }
-                            });
+    entry.image = Rasterize(
+        context->gr_context, ctm, context->dst_color_space,
+        checkerboard_images_, layer->paint_bounds(),
+        [layer, context](SkCanvas* canvas) {
+          SkISize canvas_size = canvas->getBaseLayerSize();
+          SkNWayCanvas internal_nodes_canvas(canvas_size.width(),
+                                             canvas_size.height());
+          internal_nodes_canvas.addCanvas(canvas);
+          Layer::PaintContext paintContext = {
+              (SkCanvas*)&internal_nodes_canvas,
+              canvas,
+              context->gr_context,
+              nullptr,
+              context->raster_time,
+              context->ui_time,
+              context->texture_registry,
+              context->has_platform_view ? nullptr : context->raster_cache,
+              context->checkerboard_offscreen_layers};
+          if (layer->needs_painting()) {
+            layer->Paint(paintContext);
+          }
+        });
   }
 }
 

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -174,7 +174,8 @@ void RasterCache::Prepare(PrerollContext* context,
                                   context->ui_time,
                                   context->texture_registry,
                                   context->raster_cache,
-                                  context->checkerboard_offscreen_layers};
+                                  context->checkerboard_offscreen_layers,
+                                  context->has_platform_view};
                               if (layer->needs_painting()) {
                                 layer->Paint(paintContext);
                               }
@@ -249,6 +250,10 @@ void RasterCache::SweepAfterFrame() {
 void RasterCache::Clear() {
   picture_cache_.clear();
   layer_cache_.clear();
+}
+
+bool RasterCache::empty() const {
+  return layer_cache_.empty() && picture_cache_.empty();
 }
 
 void RasterCache::SetCheckboardCacheImages(bool checkerboard) {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -252,8 +252,8 @@ void RasterCache::Clear() {
   layer_cache_.clear();
 }
 
-bool RasterCache::empty() const {
-  return layer_cache_.empty() && picture_cache_.empty();
+size_t RasterCache::size() const {
+  return layer_cache_.size() + picture_cache_.size();
 }
 
 void RasterCache::SetCheckboardCacheImages(bool checkerboard) {

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -252,7 +252,7 @@ void RasterCache::Clear() {
   layer_cache_.clear();
 }
 
-size_t RasterCache::size() const {
+size_t RasterCache::GetCachedEntriesCount() const {
   return layer_cache_.size() + picture_cache_.size();
 }
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -100,6 +100,8 @@ class RasterCache {
 
   void SetCheckboardCacheImages(bool checkerboard);
 
+  bool empty() const;
+
  private:
   struct Entry {
     bool used_this_frame = false;

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -100,7 +100,7 @@ class RasterCache {
 
   void SetCheckboardCacheImages(bool checkerboard);
 
-  bool empty() const;
+  size_t size() const;
 
  private:
   struct Entry {

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -100,7 +100,7 @@ class RasterCache {
 
   void SetCheckboardCacheImages(bool checkerboard);
 
-  size_t size() const;
+  size_t GetCachedEntriesCount() const;
 
  private:
   struct Entry {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -517,7 +517,7 @@ const TaskRunners& Shell::GetTaskRunners() const {
   return task_runners_;
 }
 
-fml::WeakPtr<Rasterizer> Shell::GetRasterizer() {
+fml::WeakPtr<Rasterizer> Shell::GetRasterizer() const {
   FML_DCHECK(is_setup_);
   return weak_rasterizer_;
 }

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -210,7 +210,7 @@ class Shell final : public PlatformView::Delegate,
   ///
   /// @return     A weak pointer to the rasterizer.
   ///
-  fml::WeakPtr<Rasterizer> GetRasterizer();
+  fml::WeakPtr<Rasterizer> GetRasterizer() const;
 
   //------------------------------------------------------------------------------
   /// @brief      Engines may only be accessed on the UI thread. This method is

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -122,6 +122,7 @@ if (current_toolchain == host_toolchain) {
       ":fixtures",
       "$flutter_root/lib/ui",
       "$flutter_root/runtime",
+      "$flutter_root/flow",
       "$flutter_root/testing:dart",
       "$flutter_root/testing:opengl",
       "$flutter_root/testing:skia",

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -247,4 +247,9 @@ bool EmbedderEngine::RunTask(const FlutterTask* task) {
                                 task->task);
 }
 
+const Shell& EmbedderEngine::shell() const {
+  FML_DCHECK(shell_);
+  return *shell_.get();
+}
+
 }  // namespace flutter

--- a/shell/platform/embedder/embedder_engine.cc
+++ b/shell/platform/embedder/embedder_engine.cc
@@ -247,7 +247,7 @@ bool EmbedderEngine::RunTask(const FlutterTask* task) {
                                 task->task);
 }
 
-const Shell& EmbedderEngine::shell() const {
+const Shell& EmbedderEngine::GetShell() const {
   FML_DCHECK(shell_);
   return *shell_.get();
 }

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -80,7 +80,7 @@ class EmbedderEngine {
 
   bool RunTask(const FlutterTask* task);
 
-  const Shell& shell() const;
+  const Shell& GetShell() const;
 
  private:
   const std::unique_ptr<EmbedderThreadHost> thread_host_;

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -80,6 +80,8 @@ class EmbedderEngine {
 
   bool RunTask(const FlutterTask* task);
 
+  const Shell& shell() const;
+
  private:
   const std::unique_ptr<EmbedderThreadHost> thread_host_;
   TaskRunners task_runners_;

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -210,12 +210,25 @@ void can_composite_platform_views() {
 void can_composite_platform_views_with_opacity() {
   window.onBeginFrame = (Duration duration) {
     SceneBuilder builder = SceneBuilder();
+
+    // Root node
+    builder.pushOffset(1.0, 2.0);
+
+    // First sibling layer (no platform view, should be cached)
     builder.pushOpacity(127);
     builder.addPicture(Offset(1.0, 1.0), CreateSimplePicture());
-    builder.pushOffset(1.0, 2.0);
+    builder.pop();
+
+    // Second sibling layer (platform view, should not be cached)
+    builder.pushOpacity(127);
     builder.addPlatformView(42, width: 123.0, height: 456.0);
-    builder.addPicture(Offset(1.0, 1.0), CreateSimplePicture());
-    builder.pop(); // offset
+    builder.pop();
+
+    // Third sibling layer (no platform view, should be cached)
+    builder.pushOpacity(127);
+    builder.addPicture(Offset(2.0, 1.0), CreateSimplePicture());
+    builder.pop();
+
     signalNativeTest(); // Signal 2
     window.render(builder.build());
   };

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -206,6 +206,37 @@ void can_composite_platform_views() {
   window.scheduleFrame();
 }
 
+@pragma('vm:entry-point')
+void can_composite_platform_views_with_opacity() {
+  window.onBeginFrame = (Duration duration) {
+    SceneBuilder builder = SceneBuilder();
+    builder.pushOpacity(127);
+    builder.addPicture(Offset(1.0, 1.0), CreateSimplePicture());
+    builder.pushOffset(1.0, 2.0);
+    builder.addPlatformView(42, width: 123.0, height: 456.0);
+    builder.addPicture(Offset(1.0, 1.0), CreateSimplePicture());
+    builder.pop(); // offset
+    signalNativeTest(); // Signal 2
+    window.render(builder.build());
+  };
+  signalNativeTest(); // Signal 1
+  window.scheduleFrame();
+}
+
+@pragma('vm:entry-point')
+void can_composite_with_opacity() {
+  window.onBeginFrame = (Duration duration) {
+    SceneBuilder builder = SceneBuilder();
+    builder.pushOpacity(127);
+    builder.addPicture(Offset(1.0, 1.0), CreateSimplePicture());
+    builder.pop(); // offset
+    signalNativeTest(); // Signal 2
+    window.render(builder.build());
+  };
+  signalNativeTest(); // Signal 1
+  window.scheduleFrame();
+}
+
 Picture CreateColoredBox(Color color, Size size) {
   Paint paint = Paint();
   paint.color = color;

--- a/shell/platform/embedder/tests/embedder_assertions.h
+++ b/shell/platform/embedder/tests/embedder_assertions.h
@@ -9,6 +9,7 @@
 
 #include "flutter/fml/logging.h"
 #include "flutter/shell/platform/embedder/embedder.h"
+#include "flutter/shell/platform/embedder/embedder_engine.h"
 #include "flutter/testing/assertions.h"
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkPoint.h"
@@ -259,6 +260,10 @@ inline FlutterTransformation FlutterTransformationMake(const SkMatrix& matrix) {
   transformation.pers1 = matrix[SkMatrix::kMPersp1];
   transformation.pers2 = matrix[SkMatrix::kMPersp2];
   return transformation;
+}
+
+inline flutter::EmbedderEngine* ToEmbedderEngine(const FlutterEngine& engine) {
+  return reinterpret_cast<flutter::EmbedderEngine*>(engine);
 }
 
 #endif  // FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_ASSERTIONS_H_

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -753,14 +753,13 @@ TEST_F(EmbedderTest, RasterCacheDisabledWithPlatformViews) {
   ASSERT_TRUE(engine.is_valid());
 
   setup.Wait();
-  const flutter::Shell& shell =
-      reinterpret_cast<flutter::EmbedderEngine*>(engine.get())->shell();
+  const flutter::Shell& shell = ToEmbedderEngine(engine.get())->GetShell();
   shell.GetTaskRunners().GetGPUTaskRunner()->PostTask([&] {
     const flutter::RasterCache& raster_cache =
         shell.GetRasterizer()->compositor_context()->raster_cache();
     // 3 layers total, but one of them had the platform view. So the cache
     // should only have 2 entries.
-    ASSERT_EQ(raster_cache.size(), 2u);
+    ASSERT_EQ(raster_cache.GetCachedEntriesCount(), 2u);
     verify.CountDown();
   });
 
@@ -826,12 +825,11 @@ TEST_F(EmbedderTest, RasterCacheEnabled) {
   ASSERT_TRUE(engine.is_valid());
 
   setup.Wait();
-  const flutter::Shell& shell =
-      reinterpret_cast<flutter::EmbedderEngine*>(engine.get())->shell();
+  const flutter::Shell& shell = ToEmbedderEngine(engine.get())->GetShell();
   shell.GetTaskRunners().GetGPUTaskRunner()->PostTask([&] {
     const flutter::RasterCache& raster_cache =
         shell.GetRasterizer()->compositor_context()->raster_cache();
-    ASSERT_EQ(raster_cache.size(), 1u);
+    ASSERT_EQ(raster_cache.GetCachedEntriesCount(), 1u);
     verify.CountDown();
   });
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -663,8 +663,8 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLFramebuffer) {
 }
 
 //------------------------------------------------------------------------------
-/// The RasterCache must be disabled with platform views in the hierarchy.
-///
+/// Layers in a hierarchy containing a platform view should not be cached. The
+/// other layers in the hierarchy should be, however.
 TEST_F(EmbedderTest, RasterCacheDisabledWithPlatformViews) {
   auto& context = GetEmbedderContext();
 
@@ -758,7 +758,9 @@ TEST_F(EmbedderTest, RasterCacheDisabledWithPlatformViews) {
   shell.GetTaskRunners().GetGPUTaskRunner()->PostTask([&] {
     const flutter::RasterCache& raster_cache =
         shell.GetRasterizer()->compositor_context()->raster_cache();
-    ASSERT_TRUE(raster_cache.empty());
+    // 3 layers total, but one of them had the platform view. So the cache
+    // should only have 2 entries.
+    ASSERT_EQ(raster_cache.size(), 2u);
     verify.CountDown();
   });
 
@@ -829,7 +831,7 @@ TEST_F(EmbedderTest, RasterCacheEnabled) {
   shell.GetTaskRunners().GetGPUTaskRunner()->PostTask([&] {
     const flutter::RasterCache& raster_cache =
         shell.GetRasterizer()->compositor_context()->raster_cache();
-    ASSERT_FALSE(raster_cache.empty());
+    ASSERT_EQ(raster_cache.size(), 1u);
     verify.CountDown();
   });
 

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -7,6 +7,8 @@
 #include <string>
 
 #include "embedder.h"
+#include "embedder_engine.h"
+#include "flutter/flow/raster_cache.h"
 #include "flutter/fml/file.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/mapping.h"
@@ -658,6 +660,180 @@ TEST_F(EmbedderTest, CompositorMustBeAbleToRenderToOpenGLFramebuffer) {
   ASSERT_TRUE(engine.is_valid());
 
   latch.Wait();
+}
+
+//------------------------------------------------------------------------------
+/// The RasterCache must be disabled with platform views in the hierarchy.
+///
+TEST_F(EmbedderTest, RasterCacheDisabledWithPlatformViews) {
+  auto& context = GetEmbedderContext();
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetOpenGLRendererConfig(SkISize::Make(800, 600));
+  builder.SetCompositor();
+  builder.SetDartEntrypoint("can_composite_platform_views_with_opacity");
+
+  context.GetCompositor().SetRenderTargetType(
+      EmbedderTestCompositor::RenderTargetType::kOpenGLFramebuffer);
+
+  fml::CountDownLatch setup(3);
+  fml::CountDownLatch verify(1);
+
+  context.GetCompositor().SetNextPresentCallback(
+      [&](const FlutterLayer** layers, size_t layers_count) {
+        ASSERT_EQ(layers_count, 3u);
+
+        {
+          FlutterBackingStore backing_store = *layers[0]->backing_store;
+          backing_store.struct_size = sizeof(backing_store);
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeFramebuffer;
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0, 0);
+
+          ASSERT_EQ(*layers[0], layer);
+        }
+
+        {
+          FlutterPlatformView platform_view = {};
+          platform_view.struct_size = sizeof(platform_view);
+          platform_view.identifier = 42;
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypePlatformView;
+          layer.platform_view = &platform_view;
+          layer.size = FlutterSizeMake(123.0, 456.0);
+          layer.offset = FlutterPointMake(1.0, 2.0);
+
+          ASSERT_EQ(*layers[1], layer);
+        }
+
+        {
+          FlutterBackingStore backing_store = *layers[2]->backing_store;
+          backing_store.struct_size = sizeof(backing_store);
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeFramebuffer;
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0.0, 0.0);
+
+          ASSERT_EQ(*layers[2], layer);
+        }
+
+        setup.CountDown();
+      });
+
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY(
+          [&setup](Dart_NativeArguments args) { setup.CountDown(); }));
+
+  UniqueEngine engine = builder.LaunchEngine();
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 800;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+  ASSERT_TRUE(engine.is_valid());
+
+  setup.Wait();
+  const flutter::Shell& shell =
+      reinterpret_cast<flutter::EmbedderEngine*>(engine.get())->shell();
+  shell.GetTaskRunners().GetGPUTaskRunner()->PostTask([&] {
+    const flutter::RasterCache& raster_cache =
+        shell.GetRasterizer()->compositor_context()->raster_cache();
+    ASSERT_TRUE(raster_cache.empty());
+    verify.CountDown();
+  });
+
+  verify.Wait();
+}
+
+//------------------------------------------------------------------------------
+/// The RasterCache should normally be enabled.
+///
+TEST_F(EmbedderTest, RasterCacheEnabled) {
+  auto& context = GetEmbedderContext();
+
+  EmbedderConfigBuilder builder(context);
+  builder.SetOpenGLRendererConfig(SkISize::Make(800, 600));
+  builder.SetCompositor();
+  builder.SetDartEntrypoint("can_composite_with_opacity");
+
+  context.GetCompositor().SetRenderTargetType(
+      EmbedderTestCompositor::RenderTargetType::kOpenGLFramebuffer);
+
+  fml::CountDownLatch setup(3);
+  fml::CountDownLatch verify(1);
+
+  context.GetCompositor().SetNextPresentCallback(
+      [&](const FlutterLayer** layers, size_t layers_count) {
+        ASSERT_EQ(layers_count, 1u);
+
+        {
+          FlutterBackingStore backing_store = *layers[0]->backing_store;
+          backing_store.struct_size = sizeof(backing_store);
+          backing_store.type = kFlutterBackingStoreTypeOpenGL;
+          backing_store.did_update = true;
+          backing_store.open_gl.type = kFlutterOpenGLTargetTypeFramebuffer;
+
+          FlutterLayer layer = {};
+          layer.struct_size = sizeof(layer);
+          layer.type = kFlutterLayerContentTypeBackingStore;
+          layer.backing_store = &backing_store;
+          layer.size = FlutterSizeMake(800.0, 600.0);
+          layer.offset = FlutterPointMake(0, 0);
+
+          ASSERT_EQ(*layers[0], layer);
+        }
+
+        setup.CountDown();
+      });
+
+  context.AddNativeCallback(
+      "SignalNativeTest",
+      CREATE_NATIVE_ENTRY(
+          [&setup](Dart_NativeArguments args) { setup.CountDown(); }));
+
+  UniqueEngine engine = builder.LaunchEngine();
+
+  // Send a window metrics events so frames may be scheduled.
+  FlutterWindowMetricsEvent event = {};
+  event.struct_size = sizeof(event);
+  event.width = 800;
+  event.height = 600;
+  event.pixel_ratio = 1.0;
+  ASSERT_EQ(FlutterEngineSendWindowMetricsEvent(engine.get(), &event),
+            kSuccess);
+  ASSERT_TRUE(engine.is_valid());
+
+  setup.Wait();
+  const flutter::Shell& shell =
+      reinterpret_cast<flutter::EmbedderEngine*>(engine.get())->shell();
+  shell.GetTaskRunners().GetGPUTaskRunner()->PostTask([&] {
+    const flutter::RasterCache& raster_cache =
+        shell.GetRasterizer()->compositor_context()->raster_cache();
+    ASSERT_FALSE(raster_cache.empty());
+    verify.CountDown();
+  });
+
+  verify.Wait();
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Previously the cache was disabled on whether or not PlatformViews were
globally enabled. Instead track their existence in the view hierarchy
and only disable RasterCache if a PlatformView is actually present.

Fixes flutter/flutter#38903