### PR TITLE
[flutter_runner] Remove the checks for libdart profiler symbols

### DIFF
--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -51,13 +51,8 @@ int main(int argc, const char** argv) {
 
 #if !defined(DART_PRODUCT)
 #if defined(AOT_RUNTIME)
-  RegisterProfilerSymbols(
-      "pkg/data/libdart_precompiled_runtime.dartprofilersymbols",
-      "libdart_precompiled_runtime.so");
   RegisterProfilerSymbols("pkg/data/dart_aot_runner.dartprofilersymbols", "");
 #else
-  RegisterProfilerSymbols("pkg/data/libdart_jit.dartprofilersymbols",
-                          "libdart_jit.so");
   RegisterProfilerSymbols("pkg/data/dart_jit_runner.dartprofilersymbols", "");
 #endif  // defined(AOT_RUNTIME)
 #endif  // !defined(DART_PRODUCT)


### PR DESCRIPTION
Since the runner binaries are statically linked, we do not need
to look for the libdart profiler symbols separately.