### PR TITLE
Avoid NPE when no root semantics node available

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1144,7 +1144,12 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
             return false;
         }
 
-        SemanticsNode semanticsNodeUnderCursor = getRootSemanticsNode().hitTest(new float[] {event.getX(), event.getY(), 0, 1});
+        final SemanticsNode rootNode = getRootSemanticsNode();
+        if (rootNode == null) {
+            return false;
+        }
+
+        SemanticsNode semanticsNodeUnderCursor = rootNode.hitTest(new float[] {event.getX(), event.getY(), 0, 1});
         if (semanticsNodeUnderCursor.platformViewId != -1) {
             return accessibilityViewEmbedder.onAccessibilityHoverEvent(semanticsNodeUnderCursor.id, event);
         }
@@ -1187,7 +1192,12 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         if (flutterSemanticsTree.isEmpty()) {
             return;
         }
-        SemanticsNode semanticsNodeUnderCursor = getRootSemanticsNode().hitTest(new float[] {x, y, 0, 1});
+        final SemantisNode rootNode = getRootSemanticsNode();
+        if (rootNode == null) {
+            return;
+        }
+
+        SemanticsNode semanticsNodeUnderCursor = rootNode.hitTest(new float[] {x, y, 0, 1});
         if (semanticsNodeUnderCursor != hoveredObject) {
             // sending ENTER before EXIT is how Android wants it
             if (semanticsNodeUnderCursor != null) {


### PR DESCRIPTION
Fixes the crash part of https://github.com/flutter/flutter/issues/31139

Stack traces in that bug indicate that these methods are sometimes getting called in add-to-app type scenarios where no root node is yet present.  I am not able to reproduce locally, and not convinced this is a total fix for the issue, but it should at least prevent the crash.  My theory is that the OS is requesting these events sometimes before we've finished processing the semantic tree - but a more serious bug might be that we're not sending back the full semantic tree under some circumstances of the view lifecycle changing.  At the very least, this will allow execution to continue - but we really want to find a reproduction of this and make sure that a11y still works in these scenarios.

I'm not sure about whether the accessibility bridge has a good way to test at this point. I'm inclined to land this without a test to at least fix the crash, unless we have something in here that would let me test this that I'm missing.