### PR TITLE
Add support for setting window size limits for glfw

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1031,6 +1031,7 @@ FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_objec
 FILE: ../../../flutter/shell/platform/fuchsia/runtime/dart/utils/vmservice_object.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_controller.cc
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_controller_unittests.cc
+FILE: ../../../flutter/shell/platform/glfw/client_wrapper/flutter_window_unittests.cc
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_window_controller.h
 FILE: ../../../flutter/shell/platform/glfw/client_wrapper/include/flutter/plugin_registrar_glfw.h

--- a/shell/platform/glfw/client_wrapper/BUILD.gn
+++ b/shell/platform/glfw/client_wrapper/BUILD.gn
@@ -75,6 +75,7 @@ executable("client_wrapper_glfw_unittests") {
   # TODO: Add more unit tests.
   sources = [
     "flutter_window_controller_unittests.cc",
+    "flutter_window_unittests.cc",
   ]
 
   deps = [

--- a/shell/platform/glfw/client_wrapper/flutter_window_unittests.cc
+++ b/shell/platform/glfw/client_wrapper/flutter_window_unittests.cc
@@ -1,0 +1,57 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h"
+
+#include <memory>
+#include <string>
+
+#include "flutter/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h"
+#include "gtest/gtest.h"
+
+namespace flutter {
+
+namespace {
+
+// Stub implementation to validate calls to the API.
+class TestGlfwApi : public testing::StubFlutterGlfwApi {
+ public:
+  // |flutter::testing::StubFlutterGlfwApi|
+  void SetSizeLimits(FlutterDesktopSize minimum_size,
+                     FlutterDesktopSize maximum_size) override {
+    set_size_limits_called_ = true;
+  }
+
+  bool set_size_limits_called() { return set_size_limits_called_; }
+
+ private:
+  bool set_size_limits_called_ = false;
+};
+
+}  // namespace
+
+TEST(FlutterWindowTest, SetSizeLimits) {
+  const std::string icu_data_path = "fake/path/to/icu";
+  testing::ScopedStubFlutterGlfwApi scoped_api_stub(
+      std::make_unique<TestGlfwApi>());
+  auto test_api = static_cast<TestGlfwApi*>(scoped_api_stub.stub());
+  // This is not actually used so any non-zero value works.
+  auto raw_window = reinterpret_cast<FlutterDesktopWindowRef>(1);
+
+  auto window = std::make_unique<FlutterWindow>(raw_window);
+
+  FlutterDesktopSize minimum_size = {};
+  minimum_size.width = 100;
+  minimum_size.height = 100;
+
+  FlutterDesktopSize maximum_size = {};
+  maximum_size.width = -1;
+  maximum_size.height = -1;
+
+  window->SetSizeLimits(minimum_size, maximum_size);
+
+  EXPECT_EQ(test_api->set_size_limits_called(), true);
+}
+
+}  // namespace flutter

--- a/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
+++ b/shell/platform/glfw/client_wrapper/include/flutter/flutter_window.h
@@ -88,6 +88,13 @@ class FlutterWindow {
     FlutterDesktopWindowSetPixelRatioOverride(window_, pixel_ratio);
   }
 
+  // Sets the min/max size of |flutter_window| in screen coordinates. Use
+  // kFlutterDesktopDontCare for any dimension you wish to leave unconstrained.
+  void SetSizeLimits(FlutterDesktopSize minimum_size,
+                     FlutterDesktopSize maximum_size) {
+    FlutterDesktopWindowSetSizeLimits(window_, minimum_size, maximum_size);
+  }
+
  private:
   // Handle for interacting with the C API's window.
   //

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.cc
@@ -107,6 +107,14 @@ void FlutterDesktopWindowSetFrame(FlutterDesktopWindowRef flutter_window,
   }
 }
 
+void FlutterDesktopWindowSetSizeLimits(FlutterDesktopWindowRef flutter_window,
+                                       FlutterDesktopSize minimum_size,
+                                       FlutterDesktopSize maximum_size) {
+  if (s_stub_implementation) {
+    s_stub_implementation->SetSizeLimits(minimum_size, maximum_size);
+  }
+}
+
 double FlutterDesktopWindowGetScaleFactor(
     FlutterDesktopWindowRef flutter_window) {
   if (s_stub_implementation) {

--- a/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
+++ b/shell/platform/glfw/client_wrapper/testing/stub_flutter_glfw_api.h
@@ -68,6 +68,10 @@ class StubFlutterGlfwApi {
   // Called for FlutterDesktopWindowSetPixelRatioOverride.
   virtual void SetPixelRatioOverride(double pixel_ratio) {}
 
+  // Called for FlutterDesktopWindowSetSizeLimits.
+  virtual void SetSizeLimits(FlutterDesktopSize minimum_size,
+                             FlutterDesktopSize maximum_size) {}
+
   // Called for FlutterDesktopRunWindowEventLoopWithTimeout.
   virtual bool RunWindowEventLoopWithTimeout(uint32_t millisecond_timeout) {
     return true;

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -34,6 +34,8 @@ using UniqueGLFWwindowPtr = std::unique_ptr<GLFWwindow, void (*)(GLFWwindow*)>;
 
 static_assert(FLUTTER_ENGINE_VERSION == 1, "");
 
+const int kFlutterDesktopDontCare = GLFW_DONT_CARE;
+
 static constexpr double kDpPerInch = 160.0;
 
 // Struct for storing state within an instance of the GLFW Window.
@@ -734,6 +736,14 @@ void FlutterDesktopWindowSetPixelRatioOverride(
     auto* state = GetSavedWindowState(flutter_window->window);
     SendWindowMetrics(state, width_px, height_px);
   }
+}
+
+void FlutterDesktopWindowSetSizeLimits(FlutterDesktopWindowRef flutter_window,
+                                       FlutterDesktopSize minimum_size,
+                                       FlutterDesktopSize maximum_size) {
+  glfwSetWindowSizeLimits(flutter_window->window, minimum_size.width,
+                          minimum_size.height, maximum_size.width,
+                          maximum_size.height);
 }
 
 bool FlutterDesktopRunWindowEventLoopWithTimeout(

--- a/shell/platform/glfw/public/flutter_glfw.h
+++ b/shell/platform/glfw/public/flutter_glfw.h
@@ -16,6 +16,9 @@
 extern "C" {
 #endif
 
+// Indicates that any value is acceptable for an otherwise required property.
+extern const int32_t kFlutterDesktopDontCare;
+
 // Opaque reference to a Flutter window controller.
 typedef struct FlutterDesktopWindowControllerState*
     FlutterDesktopWindowControllerRef;
@@ -25,6 +28,12 @@ typedef struct FlutterDesktopWindow* FlutterDesktopWindowRef;
 
 // Opaque reference to a Flutter engine instance.
 typedef struct FlutterDesktopEngineState* FlutterDesktopEngineRef;
+
+// Properties representing a generic rectangular size.
+typedef struct {
+  int32_t width;
+  int32_t height;
+} FlutterDesktopSize;
 
 // Properties for configuring a Flutter engine instance.
 typedef struct {
@@ -166,6 +175,13 @@ FLUTTER_EXPORT double FlutterDesktopWindowGetScaleFactor(
 FLUTTER_EXPORT void FlutterDesktopWindowSetPixelRatioOverride(
     FlutterDesktopWindowRef flutter_window,
     double pixel_ratio);
+
+// Sets the min/max size of |flutter_window| in screen coordinates. Use
+// kFlutterDesktopDontCare for any dimension you wish to leave unconstrained.
+FLUTTER_EXPORT void FlutterDesktopWindowSetSizeLimits(
+    FlutterDesktopWindowRef flutter_window,
+    FlutterDesktopSize minimum_size,
+    FlutterDesktopSize maximum_size);
 
 // Runs an instance of a headless Flutter engine.
 //


### PR DESCRIPTION
Add properties for speciying min/max width/height.

Pass those properties through to the window constructor.

Call glfwSetWindowSizeLimits with the values from those properties or
GLFW_DONT_CARE if they are set to zero which is the default implicit
initial value for integers.

glfwSetWindowSizeLimits must be called from the main thread, and I am
pretty sure we are on it given that we call other functions inside that
same function that must also only be called from the main thread.

I went with a nested struct rather than putting these at the same level as the other properties because they are logically related, but that is maybe a question of preference. I'd be happy to restructure that.