### PR TITLE
[dart_runner] Common libs need to exist for aot runner

### DIFF
--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -153,6 +153,8 @@ template("aot_runner_package") {
       },
     ]
 
+    libraries = common_libs
+
     resources = []
     if (!invoker.product) {
       vmservice_data = rebase_path(


### PR DESCRIPTION
This is to account for failures like:

```
00067.522] 13245:13247>
[00067.522] 13245:13247> ------------------------------------------------
[00067.522] 13245:13247> RUNNING TEST: /pkgfs/packages/goodbye_dart_test/0/test/goodbye_dart_test
[00067.522] 13245:13247>
[00067.754] 05775:06330> dlsvc: could not open 'ld.so.1'
[00067.758] 01149:01207> [component_manager] WARN: Failed to launch process 'dart_aot_runner.cmx' in job 163427: Failed to load dynamic linker from fuchsia.ldsvc.Loader: NOT_FOUND
[00067.759] 05775:05777> [ERROR:src/sys/appmgr/realm.cc(155)] Cannot run executable dart_aot_runner.cmx due to error -1 (ZX_ERR_INTERNAL): fuchsia.process.Launcher failed
[00067.759] 05775:05777> [ERROR:src/sys/appmgr/runner_holder.cc(41)] Runner (fuchsia-pkg://fuchsia.com/dart_aot_runner#meta/dart_aot_runner.cmx) terminating, reason: failed to create component (UNKNOWN)
[00067.760] 13245:13247> fuchsia-pkg://fuchsia.con/goodbye_dart_aot#meta/goodbye_dart_aot.cmx: failed to create component (UNKNOWN)
[00067.761] 13245:13247> goodbye_dart_aot --now failed
[00067.772] 13245:13247> FAILURE: /pkgfs/packages/goodbye_dart_test/0/test/goodbye_dart_test exited with nonzero status: 1
[00067.886] 13245:13247>
[00067.887] 13245:13247> ------------------------------------------------
```

logs: https://logs.chromium.org/logs/fuchsia/buildbucket/cr-buildbucket.appspot.com/8898242024940777936/+/steps/launch_collect/0/steps/1/0/steps/collect/0/logs/task_stdout_stderr:_QEMU/0