### PR TITLE
Automatically destroy FlutterEngine when created by FlutterActivity or FlutterFragment.

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -674,9 +674,13 @@ public class FlutterActivity extends Activity
    */
   @Override
   public boolean shouldDestroyEngineWithHost() {
+    boolean explicitDestructionRequested = getIntent().getBooleanExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, false);
     if (getCachedEngineId() != null) {
-      return false;
+      // Only destroy a cached engine if explicitly requested by app developer.
+      return explicitDestructionRequested;
     } else {
+      // If this Activity created the FlutterEngine, destroy it by default unless
+      // explicitly requested not to.
       return getIntent().getBooleanExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, true);
     }
   }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -400,6 +400,7 @@ public class FlutterActivity extends Activity
    * write while exercising real lifecycle methods. At such a time, this method should be
    * removed.
    */
+  // TODO(mattcarroll): remove this when tests allow for it (https://github.com/flutter/flutter/issues/43798)
   @VisibleForTesting
   /* package */ void setDelegate(@NonNull FlutterActivityAndFragmentDelegate delegate) {
     this.delegate = delegate;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -674,7 +674,11 @@ public class FlutterActivity extends Activity
    */
   @Override
   public boolean shouldDestroyEngineWithHost() {
-    return getIntent().getBooleanExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, false);
+    if (getCachedEngineId() != null) {
+      return false;
+    } else {
+      return getIntent().getBooleanExtra(EXTRA_DESTROY_ENGINE_WITH_ACTIVITY, true);
+    }
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -13,6 +13,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -121,8 +122,16 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
    * or {@code Fragment}.
    */
   @Nullable
-  FlutterEngine getFlutterEngine() {
+  /* package */ FlutterEngine getFlutterEngine() {
     return flutterEngine;
+  }
+
+  /**
+   * Returns true if the host {@code Activity}/{@code Fragment} provided a
+   * {@code FlutterEngine}, as opposed to this delegate creating a new one.
+   */
+  /* package */ boolean isFlutterEngineFromHost() {
+    return isFlutterEngineFromHost;
   }
 
   /**
@@ -189,7 +198,8 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW;
    * If the {@code host} does not provide a {@link FlutterEngine}, then a new {@link FlutterEngine}
    * is instantiated.
    */
-  private void setupFlutterEngine() {
+  @VisibleForTesting
+  /* package */ void setupFlutterEngine() {
     Log.d(TAG, "Setting up FlutterEngine.");
 
     // First, check if the host wants to use a cached FlutterEngine.

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -766,7 +766,11 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
    */
   @Override
   public boolean shouldDestroyEngineWithHost() {
-    return getArguments().getBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, false);
+    if (getCachedEngineId() != null) {
+      return false;
+    } else {
+      return getArguments().getBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, true);
+    }
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.view.LayoutInflater;
@@ -565,12 +566,27 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
   // Delegate that runs all lifecycle and OS hook logic that is common between
   // FlutterActivity and FlutterFragment. See the FlutterActivityAndFragmentDelegate
   // implementation for details about why it exists.
-  private FlutterActivityAndFragmentDelegate delegate;
+  @VisibleForTesting
+  /* package */ FlutterActivityAndFragmentDelegate delegate;
 
   public FlutterFragment() {
     // Ensure that we at least have an empty Bundle of arguments so that we don't
     // need to continually check for null arguments before grabbing one.
     setArguments(new Bundle());
+  }
+
+  /**
+   * This method exists so that JVM tests can ensure that a delegate exists without
+   * putting this Fragment through any lifecycle events, because JVM tests cannot handle
+   * executing any lifecycle methods, at the time of writing this.
+   * <p>
+   * The testing infrastructure should be upgraded to make FlutterFragment tests easy to
+   * write while exercising real lifecycle methods. At such a time, this method should be
+   * removed.
+   */
+  @VisibleForTesting
+  /* package */ void setDelegate(@NonNull FlutterActivityAndFragmentDelegate delegate) {
+    this.delegate = delegate;
   }
 
   @Override
@@ -767,7 +783,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
   @Override
   public boolean shouldDestroyEngineWithHost() {
     boolean explicitDestructionRequested = getArguments().getBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, false);
-    if (getCachedEngineId() != null) {
+    if (getCachedEngineId() != null || delegate.isFlutterEngineFromHost()) {
       // Only destroy a cached engine if explicitly requested by app developer.
       return explicitDestructionRequested;
     } else {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -584,6 +584,7 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
    * write while exercising real lifecycle methods. At such a time, this method should be
    * removed.
    */
+  // TODO(mattcarroll): remove this when tests allow for it (https://github.com/flutter/flutter/issues/43798)
   @VisibleForTesting
   /* package */ void setDelegate(@NonNull FlutterActivityAndFragmentDelegate delegate) {
     this.delegate = delegate;

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -766,9 +766,13 @@ public class FlutterFragment extends Fragment implements FlutterActivityAndFragm
    */
   @Override
   public boolean shouldDestroyEngineWithHost() {
+    boolean explicitDestructionRequested = getArguments().getBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, false);
     if (getCachedEngineId() != null) {
-      return false;
+      // Only destroy a cached engine if explicitly requested by app developer.
+      return explicitDestructionRequested;
     } else {
+      // If this Fragment created the FlutterEngine, destroy it by default unless
+      // explicitly requested not to.
       return getArguments().getBoolean(ARG_DESTROY_ENGINE_WITH_FRAGMENT, true);
     }
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -39,6 +39,21 @@ public class FlutterActivityTest {
   }
 
   @Test
+  public void itDestroysNewEngineWhenIntentIsMissingParameter() {
+    // All clients should use the static members of FlutterActivity to construct an
+    // Intent. Missing extras is an error. However, Flutter has number of tests that
+    // don't seem to use the static members of FlutterActivity to construct the
+    // launching Intent, so this test explicitly verifies that even illegal Intents
+    // result in the automatic destruction of a non-cached FlutterEngine, which prevents
+    // the breakage of memory usage benchmark tests.
+    Intent intent = new Intent(RuntimeEnvironment.application, FlutterActivity.class);
+    ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
+    FlutterActivity flutterActivity = activityController.get();
+
+    assertTrue(flutterActivity.shouldDestroyEngineWithHost());
+  }
+
+  @Test
   public void itCreatesNewEngineIntentWithRequestedSettings() {
     Intent intent = FlutterActivity.withNewEngine()
         .initialRoute("/custom/route")

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterActivityTest.java
@@ -1,6 +1,10 @@
 package io.flutter.embedding.android;
 
+import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -10,13 +14,18 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.annotation.Config;
 
+import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.embedding.engine.loader.FlutterLoader;
+
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
-import io.flutter.embedding.android.FlutterActivityLaunchConfigs.BackgroundMode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @Config(manifest=Config.NONE)
 @RunWith(RobolectricTestRunner.class)
@@ -26,6 +35,7 @@ public class FlutterActivityTest {
     Intent intent = FlutterActivity.createDefaultIntent(RuntimeEnvironment.application);
     ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
+    flutterActivity.setDelegate(new FlutterActivityAndFragmentDelegate(flutterActivity));
 
     assertEquals("main", flutterActivity.getDartEntrypointFunctionName());
     assertEquals("/", flutterActivity.getInitialRoute());
@@ -49,8 +59,19 @@ public class FlutterActivityTest {
     Intent intent = new Intent(RuntimeEnvironment.application, FlutterActivity.class);
     ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
+    flutterActivity.setDelegate(new FlutterActivityAndFragmentDelegate(flutterActivity));
 
     assertTrue(flutterActivity.shouldDestroyEngineWithHost());
+  }
+
+  @Test
+  public void itDoesNotDestroyFlutterEngineWhenProvidedByHost() {
+    Intent intent = new Intent(RuntimeEnvironment.application, FlutterActivityWithProvidedEngine.class);
+    ActivityController<FlutterActivityWithProvidedEngine> activityController = Robolectric.buildActivity(FlutterActivityWithProvidedEngine.class, intent);
+    activityController.create();
+    FlutterActivityWithProvidedEngine flutterActivity = activityController.get();
+
+    assertFalse(flutterActivity.shouldDestroyEngineWithHost());
   }
 
   @Test
@@ -61,6 +82,7 @@ public class FlutterActivityTest {
         .build(RuntimeEnvironment.application);
     ActivityController<FlutterActivity> activityController = Robolectric.buildActivity(FlutterActivity.class, intent);
     FlutterActivity flutterActivity = activityController.get();
+    flutterActivity.setDelegate(new FlutterActivityAndFragmentDelegate(flutterActivity));
 
     assertEquals("/custom/route", flutterActivity.getInitialRoute());
     assertArrayEquals(new String[]{}, flutterActivity.getFlutterShellArgs().toArray());
@@ -98,5 +120,27 @@ public class FlutterActivityTest {
     assertTrue(flutterActivity.shouldAttachEngineToActivity());
     assertEquals("my_cached_engine", flutterActivity.getCachedEngineId());
     assertTrue(flutterActivity.shouldDestroyEngineWithHost());
+  }
+
+  static class FlutterActivityWithProvidedEngine extends FlutterActivity {
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+      super.delegate = new FlutterActivityAndFragmentDelegate(this);
+      super.delegate.setupFlutterEngine();
+    }
+
+    @Nullable
+    @Override
+    public FlutterEngine provideFlutterEngine(@NonNull Context context) {
+      FlutterJNI flutterJNI = mock(FlutterJNI.class);
+      when(flutterJNI.isAttached()).thenReturn(true);
+
+      return new FlutterEngine(
+          context,
+          mock(FlutterLoader.class),
+          flutterJNI,
+          new String[]{}
+        );
+    }
   }
 }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterFragmentTest.java
@@ -17,6 +17,7 @@ public class FlutterFragmentTest {
   @Test
   public void itCreatesDefaultFragmentWithExpectedDefaults() {
     FlutterFragment fragment = FlutterFragment.createDefault();
+    fragment.setDelegate(new FlutterActivityAndFragmentDelegate(fragment));
 
     assertEquals("main", fragment.getDartEntrypointFunctionName());
     assertEquals("/", fragment.getInitialRoute());
@@ -37,6 +38,7 @@ public class FlutterFragmentTest {
         .renderMode(FlutterView.RenderMode.texture)
         .transparencyMode(FlutterView.TransparencyMode.opaque)
         .build();
+    fragment.setDelegate(new FlutterActivityAndFragmentDelegate(fragment));
 
     assertEquals("custom_entrypoint", fragment.getDartEntrypointFunctionName());
     assertEquals("/custom/route", fragment.getInitialRoute());


### PR DESCRIPTION
Automatically destroy FlutterEngine when created by FlutterActivity or FlutterFragment.

I believe this resolves: https://github.com/flutter/flutter/issues/43688

I did a memory profile locally and got the following results:

Memory dump before, during, and after the gallery was opened using existing engine:
130,258
287,161
282,553

Memory dump before, during, and after the gallery was opened using changes in this PR:
118,115
282,177
52,930

I'm now attempting to reproduce these results by running the actual device lab test locally. I'm waiting for a local build of profile mode to finish so that I can execute the test, but so far the evidence looks pretty strong.