### PR TITLE
Fizzle onConfigurationChanged if no FlutterView

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -269,9 +269,14 @@ public class FlutterView extends FrameLayout {
   @Override
   protected void onConfigurationChanged(@NonNull Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
-    Log.v(TAG, "Configuration changed. Sending locales and user settings to Flutter.");
-    sendLocalesToFlutter(newConfig);
-    sendUserSettingsToFlutter();
+    // We might get invoked here before attaching again when coming back from
+    // the app switcher. In that case, we'll call these methods when we get
+    // reattached to the engine.
+    if (flutterEngine != null) {
+      Log.v(TAG, "Configuration changed. Sending locales and user settings to Flutter.");
+      sendLocalesToFlutter(newConfig);
+      sendUserSettingsToFlutter();
+    }
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -269,9 +269,13 @@ public class FlutterView extends FrameLayout {
   @Override
   protected void onConfigurationChanged(@NonNull Configuration newConfig) {
     super.onConfigurationChanged(newConfig);
-    // We might get invoked here before attaching again when coming back from
-    // the app switcher. In that case, we'll call these methods when we get
-    // reattached to the engine.
+    // We've observed on Android Q that going to the background, changing
+    // orientation, and bringing the app back to foreground results in a sequence
+    // of detatch from flutterEngine, onConfigurationChanged, followed by attach
+    // to flutterEngine.
+    // No-op here so that we avoid NPE; these channels will get notified once
+    // the activity or fragment tell the view to attach to the Flutter engine
+    // again (e.g. in onStart).
     if (flutterEngine != null) {
       Log.v(TAG, "Configuration changed. Sending locales and user settings to Flutter.");
       sendLocalesToFlutter(newConfig);

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -78,6 +78,25 @@ public class FlutterViewTest {
     verify(platformViewsController, times(1)).detachFromView();
   }
 
+  @Test
+  public void onConfigurationChanged_fizzlesWhenNullEngine() {
+    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
+    FlutterEngine flutterEngine = spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+
+    Configuration configuration = RuntimeEnvironment.application.getResources().getConfiguration();
+    // 1 invocation of channels.
+    flutterView.attachToFlutterEngine(flutterEngine);
+    // 2 invocations of channels.
+    flutterView.onConfigurationChanged(configuration);
+    flutterView.detachFromFlutterEngine();
+
+    // Should fizzle.
+    flutterView.onConfigurationChanged(configuration);
+
+    verify(flutterEngine, times(2)).getLocalizationChannel();
+    verify(flutterEngine, times(2)).getSettingsChannel();
+  }
+
   // TODO(mattcarroll): turn this into an e2e test. GitHub #42990
   @Test
   public void itSendsLightPlatformBrightnessToFlutter() {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/43459

This can arise if the user rotates while the app is backgrounded in the app switcher.  We detach from the engine when going to background, but get called on this before re-attaching when foregrounded again (but we call the channels as soon as we reattach anyway).

/cc @dannyvalentesonos 