### PR TITLE
[flutter_runner] Enable Skia tracing by default on Fuchsia

### DIFF
--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -315,9 +315,8 @@ Application::Application(
   settings_.observatory_host = "127.0.0.1";
 #endif
 
-  // Set this to true to enable category "skia" trace events.
-  // TODO(PT-145): Explore enabling this by default.
-  settings_.trace_skia = false;
+  // Controls whether category "skia" trace events are enabled.
+  settings_.trace_skia = true;
 
   settings_.icu_data_path = "";
 


### PR DESCRIPTION
Since Flutter tracing is wired up to Fuchsia system level tracing (and
that includes Skia tracing within Flutter), it makes more sense to
enable Skia tracing by default on Fuchsia, and to control Flutter Skia
tracing, rely on whether Fuchsia system tracing is enabled, in progress,
and contains the "skia" category.