### PR TITLE
[dart] Makes the intl services available

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.feedback.CrashReporter",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.feedback.CrashReporter",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -11,10 +11,11 @@
     "services": [
       "fuchsia.accessibility.SettingsManager",
       "fuchsia.accessibility.semantics.SemanticsManager",
-      "fuchsia.device.NameProvider",
       "fuchsia.deprecatedtimezone.Timezone",
+      "fuchsia.device.NameProvider",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",


### PR DESCRIPTION
This registers that the dart runner requires
`fuchsia.intl.PropertyProvider` service.  It is a way for the runner
to discover the system locale.