### PR TITLE
[fuchsia] [packaging] Prettify parent folder name

### DIFF
--- a/tools/fuchsia/merge_and_upload_debug_symbols.py
+++ b/tools/fuchsia/merge_and_upload_debug_symbols.py
@@ -97,7 +97,9 @@ def main():
   for symbol_dir in symbol_dirs:
     assert os.path.exists(symbol_dir) and os.path.isdir(symbol_dir)
 
-  out_dir = NormalizeDirPathForRsync(args.out_dir)
+  arch = args.target_arch
+  out_dir = NormalizeDirPathForRsync(
+      os.path.join(args.out_dir, 'flutter-fuchsia-debug-symbols-%s' % arch))
   if os.path.exists(out_dir):
     print 'Directory: %s is not empty, deleting it.' % out_dir
     shutil.rmtree(out_dir)
@@ -108,9 +110,8 @@ def main():
         ['rsync', '--recursive',
          NormalizeDirPathForRsync(symbol_dir), out_dir])
 
-  cipd_def = WriteCIPDDefinition(args.target_arch, out_dir)
-  ProcessCIPDPackage(args.upload, cipd_def, args.engine_version, out_dir,
-                     args.target_arch)
+  cipd_def = WriteCIPDDefinition(arch, out_dir)
+  ProcessCIPDPackage(args.upload, cipd_def, args.engine_version, out_dir, arch)
   return 0
 
 


### PR DESCRIPTION
Currently they are held in a folder with names like tmpXasY6
e.g. https://chrome-infra-packages.appspot.com/p/flutter/fuchsia-debug-symbols-x64/+/3HEz_9w6dBWxZX0oPwDKRRRAbE-60Ub38Yp9TFyvCaIC

This should name them well.