### PR TITLE
Request a reattach when creating the text input plugin on Android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -119,7 +119,6 @@ public class TextInputChannel {
    */
   public void reattach() {
     channel.invokeMethod("TextInputClient.reattach", null);
-    Log.e("ASDF", "Sent reattach to flutter");
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -117,8 +117,8 @@ public class TextInputChannel {
    * to a {@link FlutterEngine}, as the engine may have kept alive a text
    * editing client on the Dart side.
    */
-  public void reattach() {
-    channel.invokeMethod("TextInputClient.reattach", null);
+  public void requestExistingInputState() {
+    channel.invokeMethod("TextInputClient.requestExistingInputState", null);
   }
 
   /**

--- a/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
+++ b/shell/platform/android/io/flutter/embedding/engine/systemchannels/TextInputChannel.java
@@ -111,6 +111,18 @@ public class TextInputChannel {
   }
 
   /**
+   * Instructs Flutter to reattach the last active text input client, if any.
+   *
+   * This is necessary when the view heirarchy has been detached and reattached
+   * to a {@link FlutterEngine}, as the engine may have kept alive a text
+   * editing client on the Dart side.
+   */
+  public void reattach() {
+    channel.invokeMethod("TextInputClient.reattach", null);
+    Log.e("ASDF", "Sent reattach to flutter");
+  }
+
+  /**
    * Instructs Flutter to update its text input editing state to reflect the given configuration.
    */
   public void updateEditingState(int inputClientId, String text, int selectionStart, int selectionEnd, int composingStart, int composingEnd) {

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -90,7 +90,7 @@ public class TextInputPlugin {
             }
         });
 
-        textInputChannel.reattach();
+        textInputChannel.requestExistingInputState();
 
         this.platformViewsController = platformViewsController;
         this.platformViewsController.attachTextInputPlugin(this);

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -90,6 +90,8 @@ public class TextInputPlugin {
             }
         });
 
+        textInputChannel.reattach();
+
         this.platformViewsController = platformViewsController;
         this.platformViewsController.attachTextInputPlugin(this);
         restartAlwaysRequired = isRestartAlwaysRequired();

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -49,7 +49,7 @@ public class TextInputPluginTest {
         DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, dartExecutor, mock(PlatformViewsController.class));
 
-        ByteBuffer message = JSONMethodCodec.INSTANCE.encodeMethodCall(new MethodCall("TextInputClient.reattach", null));
+        ByteBuffer message = JSONMethodCodec.INSTANCE.encodeMethodCall(new MethodCall("TextInputClient.requestExistingInputState", null));
         verify(dartExecutor, times(1)).send("flutter/textinput", message, null);
     }
 

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1,11 +1,14 @@
 package io.flutter.plugin.editing;
 
 import android.content.Context;
+import android.content.res.AssetManager;
 import android.provider.Settings;
 import android.util.SparseIntArray;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
+
+import java.nio.ByteBuffer;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,16 +21,38 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowBuild;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
+import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
+import io.flutter.plugin.common.JSONMethodCodec;
+import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.platform.PlatformViewsController;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @Config(manifest = Config.NONE, shadows = TextInputPluginTest.TestImm.class, sdk = 27)
 @RunWith(RobolectricTestRunner.class)
 public class TextInputPluginTest {
+    @Test
+    public void textInputPlugin_RequestsReattachOnCreation() {
+        // Initialize a general TextInputPlugin.
+        InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
+        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+        testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
+        View testView = new View(RuntimeEnvironment.application);
+
+        FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
+        DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
+        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, dartExecutor, mock(PlatformViewsController.class));
+
+        ByteBuffer message = JSONMethodCodec.INSTANCE.encodeMethodCall(new MethodCall("TextInputClient.reattach", null));
+        verify(dartExecutor, times(1)).send("flutter/textinput", message, null);
+    }
+
     @Test
     public void setTextInputEditingState_doesNotRestartWhenTextIsIdentical() {
         // Initialize a general TextInputPlugin.


### PR DESCRIPTION
Engine side of a fix for https://github.com/flutter/flutter/issues/35054

If the view heirarchy was torn down, for example because the app was backgrounded and detached from the FlutterEngine instance, the embedder loses all knowledge of text input clients from the framework.  However, the framework can maintain these client(s) if the engine is preserved.  When the view is reattached, it needs to be re-informed of such clients.  Another PR will be opened in the framework to respond to this message.

We can't use `AppLifecycleState.resumed`, because it comes too early (Dart code receives it before the FlutterView has re-attached to the engine, and has no way of knowing when it's safe to re-send the message).  @gaaclarke - I thought maybe the Channel Buffers stuff would handle that but apparently it's not.  We can discuss more if that's unexpected.

/cc @dannyvalentesonos