### PR TITLE
Disabled GPUThreadMerger tests.

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -21,8 +21,7 @@ fonts_dir = os.path.join(buildroot_dir, 'flutter', 'third_party', 'txt', 'third_
 roboto_font_path = os.path.join(fonts_dir, 'Roboto-Regular.ttf')
 dart_tests_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'dart',)
 
-time_sensitve_test_flag = '--gtest_filter=-*TimeSensitiveTest*'
-gpu_thread_merger_test_flag = '--gtest_filter=-*GpuThreadMerger*'
+fml_unittests_filter = '--gtest_filter=-*TimeSensitiveTest*:*GpuThreadMerger*'
 
 def IsMac():
   return sys.platform == 'darwin'
@@ -96,7 +95,7 @@ def RunCCTests(build_dir, filter):
     ]
   RunEngineExecutable(build_dir, 'flow_unittests', filter, flow_flags + shuffle_flags)
 
-  RunEngineExecutable(build_dir, 'fml_unittests', filter, [ time_sensitve_test_flag, gpu_thread_merger_test_flag ] + shuffle_flags)
+  RunEngineExecutable(build_dir, 'fml_unittests', filter, [ fml_unittests_filter ] + shuffle_flags)
 
   RunEngineExecutable(build_dir, 'runtime_unittests', filter, shuffle_flags)
 

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -22,6 +22,7 @@ roboto_font_path = os.path.join(fonts_dir, 'Roboto-Regular.ttf')
 dart_tests_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'dart',)
 
 time_sensitve_test_flag = '--gtest_filter=-*TimeSensitiveTest*'
+gpu_thread_merger_test_flag = '--gtest_filter=-*GpuThreadMerger*'
 
 def IsMac():
   return sys.platform == 'darwin'
@@ -95,7 +96,7 @@ def RunCCTests(build_dir, filter):
     ]
   RunEngineExecutable(build_dir, 'flow_unittests', filter, flow_flags + shuffle_flags)
 
-  RunEngineExecutable(build_dir, 'fml_unittests', filter, [ time_sensitve_test_flag ] + shuffle_flags)
+  RunEngineExecutable(build_dir, 'fml_unittests', filter, [ time_sensitve_test_flag, gpu_thread_merger_test_flag ] + shuffle_flags)
 
   RunEngineExecutable(build_dir, 'runtime_unittests', filter, shuffle_flags)
 


### PR DESCRIPTION
The GPUThreadMerger tests are flakey so I'm disabling them.

Running them locally I've seen them sometimes fail in LeaseExtension and sometimes in GpuThreadMerger.

They started showing up in LUCI at commit 1eb15c12fb1ffb2ef8e09aba98e26f3dad066e25 but that PR is unrelated.  Maybe they were always flakey, maybe something shortly before 1eb15c12fb1ffb2ef8e09aba98e26f3dad066e25 made them flakey.

```
[ RUN      ] GpuThreadMerger.LeaseExtension
[FATAL:flutter/fml/message_loop_task_queues.cc(275)] Check failed: queue_locks_.count(queue_id) && queue_entries_.count(queue_id). Trying to acquire a lock on an invalid queue_id: 32

[----------] 3 tests from GpuThreadMerger
[ RUN      ] GpuThreadMerger.IsNotOnRasterizingThread
[FATAL:flutter/fml/message_loop_task_queues.cc(275)] Check failed: queue_locks_.count(queue_id) && queue_entries_.count(queue_id). Trying to acquire a lock on an invalid queue_id: 26
Abort trap: 6
```