### PR TITLE
web: fix Paragraph.getBoxesForRange for zero-length ranges

### DIFF
--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -201,7 +201,7 @@ class EngineParagraph implements ui.Paragraph {
   }) {
     assert(boxHeightStyle != null);
     assert(boxWidthStyle != null);
-    if (_plainText == null) {
+    if (_plainText == null || start == end) {
       return <ui.TextBox>[];
     }
 

--- a/lib/web_ui/test/paragraph_test.dart
+++ b/lib/web_ui/test/paragraph_test.dart
@@ -96,4 +96,40 @@ void main() async {
     paragraph2.layout(ParagraphConstraints(width: fontSize * 5.0));
     expect(paragraph2.height, closeTo(fontSize, 0.001)); // because it wraps
   });
+
+  test('getBoxesForRange returns a box', () {
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'Ahem',
+      fontStyle: FontStyle.normal,
+      fontWeight: FontWeight.normal,
+      fontSize: 10,
+      textDirection: TextDirection.rtl,
+    ));
+    builder.addText('abcd');
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: 1000));
+    expect(
+      paragraph.getBoxesForRange(1, 2).single,
+      const TextBox.fromLTRBD(
+        10,
+        0,
+        20,
+        10,
+        TextDirection.rtl,
+      ),
+    );
+  });
+
+  test('getBoxesForRange return empty list for zero-length range', () {
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: 'Ahem',
+      fontStyle: FontStyle.normal,
+      fontWeight: FontWeight.normal,
+      fontSize: 10,
+    ));
+    builder.addText('abcd');
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(const ParagraphConstraints(width: 1000));
+    expect(paragraph.getBoxesForRange(0, 0), isEmpty);
+  });
 }


### PR DESCRIPTION
This will fix `text_test.dart` over on the framework side.