### PR TITLE
Add fuchsia.intl.PropertyProvider to our services on Fuchsia

### DIFF
--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -15,6 +15,7 @@
       "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -15,6 +15,7 @@
       "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.accessibility.semantics.SemanticsManager",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Launcher"
     ]
   }


### PR DESCRIPTION
This resolves the following error on Fuchsia: Component fuchsia-pkg://fuchsia.com/flutter_aot_product_runner#meta/flutter_aot_product_runner.cmx is not allowed to connect to fuchsia.intl.PropertyProvider because this service is not present in the component's sandbox.