### PR TITLE
Add fuchsia.intl.PropertyProvider to our services on Fuchsia

### DIFF
--- a/shell/platform/fuchsia/dart_runner/examples/goodbye_dart/meta/goodbye_dart_aot.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/goodbye_dart/meta/goodbye_dart_aot.cmx
@@ -7,6 +7,7 @@
       "deprecated-ambient-replace-as-executable"
     ],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/goodbye_dart/meta/goodbye_dart_jit.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/goodbye_dart/meta/goodbye_dart_jit.cmx
@@ -7,6 +7,7 @@
       "deprecated-ambient-replace-as-executable"
     ],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/hello_app_dart/meta/hello_app_dart_aot.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/hello_app_dart/meta/hello_app_dart_aot.cmx
@@ -5,6 +5,7 @@
   "sandbox": {
     "features": [],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/hello_app_dart/meta/hello_app_dart_jit.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/hello_app_dart/meta/hello_app_dart_jit.cmx
@@ -7,6 +7,7 @@
       "deprecated-ambient-replace-as-executable"
     ],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_aot.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_aot.cmx
@@ -5,6 +5,7 @@
   "sandbox": {
     "features": [],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_aot_product.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_aot_product.cmx
@@ -5,6 +5,7 @@
   "sandbox": {
     "features": [],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_debug.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_debug.cmx
@@ -5,6 +5,7 @@
   "sandbox": {
     "features": [],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_jit.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_jit.cmx
@@ -7,6 +7,7 @@
       "deprecated-ambient-replace-as-executable"
     ],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_jit_product.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/hello_dart/meta/hello_dart_jit_product.cmx
@@ -7,6 +7,7 @@
       "deprecated-ambient-replace-as-executable"
     ],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/integration/meta/dart_aot_runner_test.cmx
+++ b/shell/platform/fuchsia/dart_runner/integration/meta/dart_aot_runner_test.cmx
@@ -6,6 +6,7 @@
     "services": [
       "fuchsia.cobalt.LoggerFactory",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.modular.Clipboard",
       "fuchsia.modular.ContextWriter",

--- a/shell/platform/fuchsia/dart_runner/integration/meta/dart_jit_runner_test.cmx
+++ b/shell/platform/fuchsia/dart_runner/integration/meta/dart_jit_runner_test.cmx
@@ -9,6 +9,7 @@
     "services": [
       "fuchsia.cobalt.LoggerFactory",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.modular.Clipboard",
       "fuchsia.modular.ContextWriter",

--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.feedback.CrashReporter",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",

--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.feedback.CrashReporter",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.feedback.CrashReporter",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.feedback.CrashReporter",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",

--- a/shell/platform/fuchsia/dart_runner/meta/dart_zircon_test.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_zircon_test.cmx
@@ -8,6 +8,7 @@
       "root-ssl-certificates"
     ],
     "services": [
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/vmservice/meta/vmservice.cmx
+++ b/shell/platform/fuchsia/dart_runner/vmservice/meta/vmservice.cmx
@@ -6,6 +6,7 @@
     "services": [
       "fuchsia.cobalt.LoggerFactory",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.modular.Clipboard",
       "fuchsia.modular.ContextWriter",

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -15,6 +15,7 @@
       "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -15,6 +15,7 @@
       "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.accessibility.semantics.SemanticsManager",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Launcher"
     ]
   }


### PR DESCRIPTION
This resolves the following error on Fuchsia: Component fuchsia-pkg://fuchsia.com/flutter_aot_product_runner#meta/flutter_aot_product_runner.cmx is not allowed to connect to fuchsia.intl.PropertyProvider because this service is not present in the component's sandbox.