### PR TITLE
Ensure that the CAMetalLayer FBO attachments can be read from.

### DIFF
--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -23,6 +23,9 @@ GPUSurfaceMetal::GPUSurfaceMetal(GPUSurfaceDelegate* delegate,
   }
 
   layer.get().pixelFormat = MTLPixelFormatBGRA8Unorm;
+  // Flutter needs to read from the color attachment in cases where there are effects such as
+  // backdrop filters.
+  layer.get().framebufferOnly = NO;
 
   auto metal_device = fml::scoped_nsprotocol<id<MTLDevice>>([layer_.get().device retain]);
   auto metal_queue = fml::scoped_nsprotocol<id<MTLCommandQueue>>([metal_device newCommandQueue]);


### PR DESCRIPTION
By default, the CAMetalLayer backing store is a framebuffer attachment that is
only optimized for display. However, effects such as backdrop filters require
renderbuffer readback. Making these calls will result in exceptions. Disable the
write only optimization on such backing stores.

Fixes https://github.com/flutter/flutter/issues/43555
Fixes https://github.com/flutter/flutter/issues/43789