### PR TITLE
Convert images to raster on the GPU thread for Image.toByteData

### DIFF
--- a/lib/ui/snapshot_delegate.h
+++ b/lib/ui/snapshot_delegate.h
@@ -14,6 +14,8 @@ class SnapshotDelegate {
  public:
   virtual sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                             SkISize picture_size) = 0;
+
+  virtual sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) = 0;
 };
 
 }  // namespace flutter

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -426,6 +426,13 @@ class Rasterizer final : public SnapshotDelegate {
   sk_sp<SkImage> MakeRasterSnapshot(sk_sp<SkPicture> picture,
                                     SkISize picture_size) override;
 
+  // |SnapshotDelegate|
+  sk_sp<SkImage> ConvertToRasterImage(sk_sp<SkImage> image) override;
+
+  sk_sp<SkImage> DoMakeRasterSnapshot(
+      SkISize size,
+      std::function<void(SkCanvas*)> draw_callback);
+
   RasterStatus DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
 
   RasterStatus DrawToSurface(flutter::LayerTree& layer_tree);


### PR DESCRIPTION
If the image is a cross-context image that might be read from the GPU thread
during onscreen rendering, then it is not safe to read it concurrently from
the IO thread as part of Image.toByteData.

If the GPU thread does not have a graphics context, then fall back to
converting the image on the IO thread.

Fixes https://github.com/flutter/flutter/issues/30697