### PR TITLE
[web] Don't send keyboard events from text fields to flutter

### DIFF
--- a/lib/web_ui/dev/chrome.dart
+++ b/lib/web_ui/dev/chrome.dart
@@ -60,6 +60,7 @@ class Chrome extends Browser {
         '--window-size=$kMaxScreenshotWidth,$kMaxScreenshotHeight', // When headless, this is the actual size of the viewport
         '--disable-extensions',
         '--disable-popup-blocking',
+        // Indicates that the browser is in "browse without sign-in" (Guest session) mode.
         '--bwsi',
         '--no-first-run',
         '--no-default-browser-check',

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -4,7 +4,15 @@
 
 part of engine;
 
-/// These keys should always be sent to Flutter, even when triggered in a text field.
+/// Contains a whitelist of keys that must be sent to Flutter under all
+/// circumstances.
+///
+/// When keys are pressed in a text field, we generally don't want to send them
+/// to Flutter. This list of keys is the exception to that rule. Keys in this
+/// list will be sent to Flutter even if pressed in a text field.
+///
+/// A good example is the "Tab" and "Shift" keys which are used by the framework
+/// to move focus between text fields.
 const List<String> _alwaysSentKeys = <String>[
   'Alt',
   'Control',

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -17,6 +17,8 @@ void _emptyCallback(dynamic _) {}
 ///
 /// They are assigned once during the creation of the DOM element.
 void _setStaticStyleAttributes(html.HtmlElement domElement) {
+  domElement.classes.add(HybridTextEditing.textEditingClass);
+
   final html.CssStyleDeclaration elementStyle = domElement.style;
   elementStyle
     ..whiteSpace = 'pre-wrap'
@@ -531,6 +533,14 @@ class HybridTextEditing {
       return _customEditingElement;
     }
     return _defaultEditingElement;
+  }
+
+  /// A CSS class name used to identify all elements used for text editing.
+  @visibleForTesting
+  static const String textEditingClass = 'flt-text-editing';
+
+  static bool isEditingElement(html.Element element) {
+    return element.classes.contains(textEditingClass);
   }
 
   /// Requests that [customEditingElement] is used for managing text editing state


### PR DESCRIPTION
The solution in this PR is to stop sending keyboard events to flutter if they were triggered on a text field. There are exceptions listed in the whitelist `_alwaysSentKeys`. e.g. modifier keys and `Tab` that are used by the framework to move the focus to next/previous text field.

Fixes https://github.com/flutter/flutter/issues/44133