### PR TITLE
Fix editing selection and deletion on macOS

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -107,6 +107,10 @@ static NSString* const kMultilineInputType = @"TextInputType.multiline";
   } else if ([method isEqualToString:kSetEditingStateMethod]) {
     NSDictionary* state = call.arguments;
     self.activeModel.state = state;
+    // Close the loop, since the framework state could have been updated by the
+    // engine since it sent this update, and needs to now be made to match the
+    // engine's version of the state.
+    [self updateEditState];
   } else {
     handled = NO;
     NSLog(@"Unhandled text input method '%@'", method);
@@ -121,7 +125,6 @@ static NSString* const kMultilineInputType = @"TextInputType.multiline";
   if (self.activeModel == nil) {
     return;
   }
-
   [_channel invokeMethod:kUpdateEditStateResponseMethod
                arguments:@[ self.activeModel.clientID, self.activeModel.state ]];
 }
@@ -200,12 +203,28 @@ static NSString* const kMultilineInputType = @"TextInputType.multiline";
       // Use selection
       range = self.activeModel.selectedRange;
     }
-    if (range.location > self.activeModel.text.length)
-      range.location = self.activeModel.text.length;
-    if (range.length > (self.activeModel.text.length - range.location))
-      range.length = self.activeModel.text.length - range.location;
-    [self.activeModel.text replaceCharactersInRange:range withString:string];
-    self.activeModel.selectedRange = NSMakeRange(range.location + ((NSString*)string).length, 0);
+    // The selected range can actually have negative numbers, since it can start
+    // at the end of the range if the user selected the text going backwards.
+    // NSRange uses NSUIntegers, however, so we have to cast them to know if the
+    // selection is reversed or not.
+    long signedLength = static_cast<long>(range.length);
+
+    NSUInteger length;
+    NSUInteger location;
+    if (signedLength >= 0) {
+      location = range.location;
+      length = range.length;
+    } else {
+      location = range.location + range.length;
+      length = ABS(signedLength);
+    }
+    if (location > self.activeModel.text.length)
+      location = self.activeModel.text.length;
+    if (length > (self.activeModel.text.length - location))
+      length = self.activeModel.text.length - location;
+    [self.activeModel.text replaceCharactersInRange:NSMakeRange(location, length)
+                                         withString:string];
+    self.activeModel.selectedRange = NSMakeRange(location + ((NSString*)string).length, 0);
     [self updateEditState];
   }
 }


### PR DESCRIPTION
This fixes the selection and deletion during text editing on macOS so that it can handle selections that have a base (selection start) that is after the extent (selection end) in the string.

Apparently the [insertText:replacementRange](https://developer.apple.com/documentation/appkit/nstextinputclient/1438258-inserttext?language=objc) on macOS can supply an `NSRange` object that has negative values for the length (even though the length is an unsigned NSUInteger). This change checks for that case, and fixes the range of characters replaced in the text to have the right bounds.

Also, I added an additional `updateEditState` after the state is set from the framework, since there is a timing problem: when the delete key is pressed, it sends an `insertText` message, which updates the framework state *after* the framework has already sent its state update to delete the selected region.  This additional `updateEditState` puts the engine and framework back in sync again. Ideally, we would just avoid sending the `insertText` message, but there's really no way for the engine to know if the pressed key is part of an edit sequence or not.