### PR TITLE
Fix picture raster cache throttling

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -218,8 +218,8 @@ bool RasterCache::Prepare(GrContext* context,
   if (!entry.image.is_valid()) {
     entry.image = RasterizePicture(picture, context, transformation_matrix,
                                    dst_color_space, checkerboard_images_);
+    picture_cached_this_frame_++;
   }
-  picture_cached_this_frame_++;
   return true;
 }
 


### PR DESCRIPTION
Previously, we're also counting the pictures that are already raster
cached.

This fixes https://github.com/flutter/flutter/issues/44252 and helps
solving the GPU thread issue of https://github.com/flutter/flutter/issues/43083

https://github.com/flutter/flutter/pull/45050 is a performance test in the framework repo to reveal this bug.