### PR TITLE
Revert "[fuchsia] Temporarily disable intl provider (#13696)"

### DIFF
--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -41,6 +41,13 @@ static void UpdateNativeThreadLabelNames(const std::string& label,
   set_thread_name(runners.GetIOTaskRunner(), label, ".io");
 }
 
+static fml::RefPtr<flutter::PlatformMessage> MakeLocalizationPlatformMessage(
+    const fuchsia::intl::Profile& intl_profile) {
+  return fml::MakeRefCounted<flutter::PlatformMessage>(
+      "flutter/localization", MakeLocalizationPlatformMessageData(intl_profile),
+      nullptr);
+}
+
 Engine::Engine(Delegate& delegate,
                std::string thread_label,
                std::shared_ptr<sys::ServiceDirectory> svc,
@@ -255,6 +262,54 @@ Engine::Engine(Delegate& delegate,
   //  This platform does not get a separate surface platform view creation
   //  notification. Fire one eagerly.
   shell_->GetPlatformView()->NotifyCreated();
+
+  // Connect to the intl property provider.  If the connection fails, the
+  // initialization of the engine will simply proceed, printing a warning
+  // message.  The engine will be fully functional, except that the user's
+  // locale preferences would not be communicated to flutter engine.
+  {
+    intl_property_provider_.set_error_handler([](zx_status_t status) {
+      FML_LOG(WARNING) << "Failed to connect to "
+                       << fuchsia::intl::PropertyProvider::Name_ << ": "
+                       << zx_status_get_string(status)
+                       << " This is not a fatal error, but the user locale "
+                       << " preferences will not be forwarded to flutter apps";
+    });
+
+    // Note that we're using the runner's services, not the component's.
+    // Flutter locales should be updated regardless of whether the component has
+    // direct access to the fuchsia.intl.PropertyProvider service.
+    ZX_ASSERT(runner_services->Connect(intl_property_provider_.NewRequest()) ==
+              ZX_OK);
+
+    auto get_profile_callback = [flutter_runner_engine =
+                                     weak_factory_.GetWeakPtr()](
+                                    const fuchsia::intl::Profile& profile) {
+      if (!flutter_runner_engine) {
+        return;
+      }
+      if (!profile.has_locales()) {
+        FML_LOG(WARNING) << "Got intl Profile without locales";
+      }
+      auto message = MakeLocalizationPlatformMessage(profile);
+      FML_VLOG(-1) << "Sending LocalizationPlatformMessage";
+      flutter_runner_engine->shell_->GetPlatformView()->DispatchPlatformMessage(
+          message);
+    };
+
+    FML_VLOG(-1) << "Requesting intl Profile";
+
+    // Make the initial request
+    intl_property_provider_->GetProfile(get_profile_callback);
+
+    // And register for changes
+    intl_property_provider_.events().OnChange = [this, runner_services,
+                                                 get_profile_callback]() {
+      FML_VLOG(-1) << fuchsia::intl::PropertyProvider::Name_ << ": OnChange";
+      runner_services->Connect(intl_property_provider_.NewRequest());
+      intl_property_provider_->GetProfile(get_profile_callback);
+    };
+  }
 
   // Launch the engine in the appropriate configuration.
   auto run_configuration = flutter::RunConfiguration::InferFromSettings(

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -15,6 +15,7 @@
       "fuchsia.device.NameProvider",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -15,6 +15,7 @@
       "fuchsia.device.NameProvider",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_runner.cmx
@@ -15,6 +15,7 @@
       "fuchsia.device.NameProvider",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_runner_tests.cmx
@@ -9,6 +9,7 @@
     ],
     "services": [
       "fuchsia.accessibility.semantics.SemanticsManager",
+      "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Launcher"
     ]
   }


### PR DESCRIPTION
This reverts commit 6c763bb551cbc06da59b6a55b4c5ee0eccb6575f.

The reverted code was not the root cause of the issues with rolling
flutter into fuchsia, so adding it back.

In addition, lowering the severity of the connection error at the outset
to WARNING; since it is not a hard failure.