### PR TITLE
[web] Proper support for text field's obscureText

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -369,6 +369,9 @@ class TextEditingElement {
   void _initDomElement(InputConfiguration inputConfig) {
     domElement = inputConfig.inputType.createDomElement();
     inputConfig.inputType.configureDomElement(domElement);
+    if (inputConfig.obscureText) {
+      domElement.setAttribute('type', 'password');
+    }
     _setStaticStyleAttributes(domElement);
     owner._setDynamicStyleAttributes(domElement);
     domRenderer.glassPaneElement.append(domElement);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -85,6 +85,7 @@ void main() {
       // Now the editing element should have focus.
       expect(document.activeElement, input);
       expect(editingElement.domElement, input);
+      expect(input.getAttribute('type'), null);
 
       // Input is appended to the glass pane.
       expect(domRenderer.glassPaneElement.contains(editingElement.domElement),
@@ -97,6 +98,25 @@ void main() {
       );
       // The focus is back to the body.
       expect(document.activeElement, document.body);
+    });
+
+    test('Knows how to create password fields', () {
+      final InputConfiguration config = InputConfiguration(
+        inputType: EngineInputType.text,
+        inputAction: 'TextInputAction.done',
+        obscureText: true,
+      );
+      editingElement.enable(
+        config,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+      expect(document.getElementsByTagName('input'), hasLength(1));
+      final InputElement input = document.getElementsByTagName('input')[0];
+      expect(editingElement.domElement, input);
+      expect(input.getAttribute('type'), 'password');
+
+      editingElement.disable();
     });
 
     test('Can read editing state correctly', () {


### PR DESCRIPTION
This PR adds support for `obscureText` by setting the `type` attribute to `"password"` on the DOM input element (`<input type="password" />`).

Fixes https://github.com/flutter/flutter/issues/44116