### PR TITLE
Create a new picture recorder even when the embedder supplied render target is recycled.

### DIFF
--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -100,10 +100,11 @@ void EmbedderExternalViewEmbedder::BeginFrame(SkISize frame_size,
   if (!root_render_target_) {
     root_render_target_ = create_render_target_callback_(
         context, MakeBackingStoreConfig(surface_size));
-    root_picture_recorder_ = std::make_unique<SkPictureRecorder>();
-    root_picture_recorder_->beginRecording(pending_frame_size_.width(),
-                                           pending_frame_size_.height());
   }
+
+  root_picture_recorder_ = std::make_unique<SkPictureRecorder>();
+  root_picture_recorder_->beginRecording(pending_frame_size_.width(),
+                                         pending_frame_size_.height());
 }
 
 // |ExternalViewEmbedder|

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -491,3 +491,20 @@ void verify_b143464703() {
   };
   window.scheduleFrame();
 }
+
+@pragma('vm:entry-point')
+void push_frames_over_and_over() {
+  window.onBeginFrame = (Duration duration) {
+    SceneBuilder builder = SceneBuilder();
+    builder.pushOffset(0.0, 0.0);
+    builder.addPicture(Offset(0.0, 0.0), CreateColoredBox(Color.fromARGB(255, 128, 128, 128), Size(1024.0, 600.0)));
+    builder.pushOpacity(128);
+    builder.addPlatformView(42, width: 1024.0, height: 540.0);
+    builder.pop();
+    builder.pop();
+    window.render(builder.build());
+    signalNativeTest();
+    window.scheduleFrame();
+  };
+  window.scheduleFrame();
+}


### PR DESCRIPTION
The earlier assumption was that the render target would be re-materialized per frame. The render target needs its own picture recorder to be create per frame as well. When render targets are cached in the registry, an existing target will be reused. But submitting the previous frame would have discarded the recorder already. The layer tree paint would then attempt to dererence a null canvas causing a crash at runtime.

Added tests to ensure that this does not happen both with and without a custom compositor specified by the embedder. I am going to rework this code so that the external view embedders thinks of render target access on a per frame basis but that is a larger change. This smaller patchset should unblock broken builds.

Fixes b/144093523