### PR TITLE
Change wordBoundary to take dynamic temporarily

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1871,7 +1871,17 @@ class Paragraph extends NativeFieldWrapperClass2 {
   /// on both sides. In such cases, this method will return [offset, offset+1].
   /// Word boundaries are defined more precisely in Unicode Standard Annex #29
   /// http://www.unicode.org/reports/tr29/#Word_Boundaries
-  List<int> getWordBoundary(int offset) native 'Paragraph_getWordBoundary';
+  List<int> getWordBoundary(dynamic position) {
+    // TODO(gspencergoog): have this take only a TextPosition once the framework
+    // code is calling it with that.
+    if (position is TextPosition) {
+      return _getWordBoundary(position.offset);
+    } else {
+      final int offset = position;
+      return _getWordBoundary(offset);
+    }
+  }
+  List<int> _getWordBoundary(int offset) native 'Paragraph_getWordBoundary';
 
   // Redirecting the paint function in this way solves some dependency problems
   // in the C++ code. If we straighten out the C++ dependencies, we can remove

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -281,26 +281,26 @@ class EngineParagraph implements ui.Paragraph {
   }
 
   @override
-  List<int> getWordBoundary(dynamic offset) {
+  List<int> getWordBoundary(dynamic position) {
     // TODO(gspencergoog): have this take only a TextPosition once the framework
     // code is calling it with that.
-    if (offset is ui.TextPosition) {
-      ui.TextPosition position = offset;
+    if (position is ui.TextPosition) {
+      ui.TextPosition textPosition = position;
       if (_plainText == null) {
-        return <int>[position.offset, position.offset];
+        return <int>[textPosition.offset, textPosition.offset];
       }
 
-      final int start = WordBreaker.prevBreakIndex(_plainText, position.offset);
-      final int end = WordBreaker.nextBreakIndex(_plainText, position.offset);
+      final int start = WordBreaker.prevBreakIndex(_plainText, textPosition.offset);
+      final int end = WordBreaker.nextBreakIndex(_plainText, textPosition.offset);
       return <int>[start, end];
     }
 
     if (_plainText == null) {
-      return <int>[offset, offset];
+      return <int>[position, position];
     }
 
-    final int start = WordBreaker.prevBreakIndex(_plainText, offset);
-    final int end = WordBreaker.nextBreakIndex(_plainText, offset);
+    final int start = WordBreaker.prevBreakIndex(_plainText, position);
+    final int end = WordBreaker.nextBreakIndex(_plainText, position);
     return <int>[start, end];
   }
 

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -281,7 +281,20 @@ class EngineParagraph implements ui.Paragraph {
   }
 
   @override
-  List<int> getWordBoundary(int offset) {
+  List<int> getWordBoundary(dynamic offset) {
+    // TODO(gspencergoog): have this take only a TextPosition once the framework
+    // code is calling it with that.
+    if (offset is ui.TextPosition) {
+      ui.TextPosition position = offset;
+      if (_plainText == null) {
+        return <int>[position.offset, position.offset];
+      }
+
+      final int start = WordBreaker.prevBreakIndex(_plainText, position.offset);
+      final int end = WordBreaker.nextBreakIndex(_plainText, position.offset);
+      return <int>[start, end];
+    }
+
     if (_plainText == null) {
       return <int>[offset, offset];
     }

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -1242,7 +1242,7 @@ abstract class Paragraph {
   /// on both sides. In such cases, this method will return [offset, offset+1].
   /// Word boundaries are defined more precisely in Unicode Standard Annex #29
   /// http://www.unicode.org/reports/tr29/#Word_Boundaries
-  List<int> getWordBoundary(dynamic offset);
+  List<int> getWordBoundary(dynamic position);
 
   /// Returns a list of text boxes that enclose all placeholders in the paragraph.
   ///

--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -1242,7 +1242,7 @@ abstract class Paragraph {
   /// on both sides. In such cases, this method will return [offset, offset+1].
   /// Word boundaries are defined more precisely in Unicode Standard Annex #29
   /// http://www.unicode.org/reports/tr29/#Word_Boundaries
-  List<int> getWordBoundary(int offset);
+  List<int> getWordBoundary(dynamic offset);
 
   /// Returns a list of text boxes that enclose all placeholders in the paragraph.
   ///


### PR DESCRIPTION
Converting the argument to `Paragraph.wordBoundary` to `dynamic` temporarily until the framework code is converted to send a `TextPosition` instead of an int.

I'll submit this, then update the framework side to send a `TextPosition`, and expect a `TextRange`
or a `List<int>`, and then submit that, then I'll change this code to send a `TextRange` and take a `TextPostion` only, removing the dynamic here. Once that's done, I'll remove the code in the framework that expects a `TextRange` or a `List<int>`, and have it just expect a `TextRange`.

This is so that we can change the API without breaking the builds.