### PR TITLE
Fix wrong fromRGBO alpha value calculation

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -129,17 +129,17 @@ class Color {
   /// * `r` is [red], from 0 to 255.
   /// * `g` is [green], from 0 to 255.
   /// * `b` is [blue], from 0 to 255.
-  /// * `opacity` is alpha channel of this color as a double, with 0.0 being
+  /// * `opacity` is the alpha channel of this color as a double, with 0.0 being
   ///   transparent and 1.0 being fully opaque.
   ///
   /// Out of range values are brought into range using modulo 255.
   ///
   /// See also [fromARGB], which takes the opacity as an integer value.
   const Color.fromRGBO(int r, int g, int b, double opacity) :
-    value = ((((opacity * 0xff ~/ 1) & 0xff) << 24) |
-              ((r                    & 0xff) << 16) |
-              ((g                    & 0xff) << 8)  |
-              ((b                    & 0xff) << 0)) & 0xFFFFFFFF;
+    value = (((((opacity * 0xff + 0.5) ~/ 1) & 0xff) << 24) | // Since colors are canonicalized we need to round the alpha value manually
+              ((r                            & 0xff) << 16) |
+              ((g                            & 0xff) << 8)  |
+              ((b                            & 0xff) << 0)) & 0xFFFFFFFF;
 
   /// A 32 bit value representing this color.
   ///

--- a/testing/dart/color_test.dart
+++ b/testing/dart/color_test.dart
@@ -55,6 +55,12 @@ void main() {
     expect(const NotAColor(123), equals(const NotAColor(123)));
   });
 
+  test('Color.fromRGBO', () {
+    expect(const Color.fromRGBO(0, 0, 0, 1.0), const Color(0xFF000000));
+    expect(const Color.fromRGBO(0, 0, 0, 0.5), const Color(0x80000000));
+    expect(const Color.fromRGBO(0, 0, 0, 0.0), const Color(0x00000000));
+  });
+
   test('Color.lerp', () {
     expect(
       Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 0.0),


### PR DESCRIPTION
Constructing colors using `fromRGBO` should return the same values as the CSS `rgba()` notation.

`rgba(0, 0, 255, 0.5)` is the same as `#0000ff80`

but `fromRGBO` sometimes creates a color with an off by one alpha value
```dart
expect(Color.fromRGBO(0, 0, 255, 0.5), Color(0x800000ff));
```
```
Expected: Color:<Color(0x800000ff)>
  Actual: Color:<Color(0x7f0000ff)>
```
if we use `withOpacity` to create the same color it returns the correct color:
```dart
expect(Color.fromRGBO(0, 0, 255, 1).withOpacity(0.5), Color(0x800000ff));
```
it should be changed in lib/web_ui/lib/src/ui/painting.dart too and I think it would break golden tests so I don't know where to go from here.