### PR TITLE
Add ambiguous affinity

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1343,6 +1343,15 @@ enum TextAffinity {
   /// just to the right of the "H". See the definition of [TextAffinity] for the
   /// full example.
   downstream,
+
+  /// The position is explicitly ambiguous. This indicates that at this point,
+  /// we are unable to distinguish between upstream and downstream affinity.
+  ///
+  /// Some platform APIs do not specify affinity.
+  ///
+  /// This is usually used to indicate that if a default or previous affinity is
+  /// known, we should use it instead.
+  ambiguous,
 }
 
 /// A position in a string of text.


### PR DESCRIPTION
Engine side PR for https://github.com/flutter/flutter/pull/44622

Add new affinity called `ambiguous` to handle cases where affinity is unknown.

This allows us to handle cases were we can supply more appropriate affinity than defaulting to `TextAffinity.downstream`.

Part of the fix for https://github.com/flutter/flutter/issues/40095