### PR TITLE
Adds missing comma in EngineParagraphStyle.toString()

### DIFF
--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -419,7 +419,7 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
           'fontSize: ${_fontSize != null ? _fontSize.toStringAsFixed(1) : "unspecified"}, '
           'height: ${_height != null ? "${_height.toStringAsFixed(1)}x" : "unspecified"}, '
           'ellipsis: ${_ellipsis != null ? "\"$_ellipsis\"" : "unspecified"}, '
-          'locale: ${_locale ?? "unspecified"}'
+          'locale: ${_locale ?? "unspecified"}, '
           'shadows: ${_shadows ?? "unspecified"}'
           ')';
     } else {


### PR DESCRIPTION
The string was added in https://github.com/flutter/engine/commit/679a4369b2e0a2ffb6fb18007f7517683d9dbf1a