### PR TITLE
Remove extra shadows from ParagraphStyle

### DIFF
--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -18,7 +18,6 @@ class EngineParagraph implements ui.Paragraph {
     @required ui.TextAlign textAlign,
     @required ui.TextDirection textDirection,
     @required ui.Paint background,
-    @required List<ui.Shadow> shadows,
   })  : assert((plainText == null && paint == null) ||
             (plainText != null && paint != null)),
         _paragraphElement = paragraphElement,
@@ -27,8 +26,7 @@ class EngineParagraph implements ui.Paragraph {
         _textAlign = textAlign,
         _textDirection = textDirection,
         _paint = paint,
-        _background = background,
-        _shadows = shadows;
+        _background = background;
 
   final html.HtmlElement _paragraphElement;
   final ParagraphGeometricStyle _geometricStyle;
@@ -37,7 +35,6 @@ class EngineParagraph implements ui.Paragraph {
   final ui.TextAlign _textAlign;
   final ui.TextDirection _textDirection;
   final ui.Paint _background;
-  final List<ui.Shadow> _shadows;
 
   @visibleForTesting
   String get plainText => _plainText;
@@ -909,7 +906,6 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
           wordSpacing: wordSpacing,
           decoration: _textDecorationToCssString(decoration, decorationStyle),
           ellipsis: _paragraphStyle._ellipsis,
-          shadows: shadows,
         ),
         plainText: '',
         paint: paint,
@@ -963,7 +959,6 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
         wordSpacing: wordSpacing,
         decoration: _textDecorationToCssString(decoration, decorationStyle),
         ellipsis: _paragraphStyle._ellipsis,
-        shadows: shadows,
       ),
       plainText: plainText,
       paint: paint,
@@ -1007,7 +1002,6 @@ class EngineParagraphBuilder implements ui.ParagraphBuilder {
         lineHeight: _paragraphStyle._height,
         maxLines: _paragraphStyle._maxLines,
         ellipsis: _paragraphStyle._ellipsis,
-        shadows: _paragraphStyle._shadows,
       ),
       plainText: null,
       paint: null,

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -325,7 +325,6 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
     ui.StrutStyle strutStyle,
     String ellipsis,
     ui.Locale locale,
-    List<ui.Shadow> shadows,
   })  : _textAlign = textAlign,
         _textDirection = textDirection,
         _fontWeight = fontWeight,
@@ -337,8 +336,7 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
         // TODO(b/128317744): add support for strut style.
         _strutStyle = strutStyle,
         _ellipsis = ellipsis,
-        _locale = locale,
-        _shadows = shadows;
+        _locale = locale;
 
   final ui.TextAlign _textAlign;
   final ui.TextDirection _textDirection;
@@ -351,7 +349,6 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
   final EngineStrutStyle _strutStyle;
   final String _ellipsis;
   final ui.Locale _locale;
-  final List<ui.Shadow> _shadows;
 
   String get _effectiveFontFamily {
     if (assertionsEnabled) {
@@ -419,8 +416,7 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
           'fontSize: ${_fontSize != null ? _fontSize.toStringAsFixed(1) : "unspecified"}, '
           'height: ${_height != null ? "${_height.toStringAsFixed(1)}x" : "unspecified"}, '
           'ellipsis: ${_ellipsis != null ? "\"$_ellipsis\"" : "unspecified"}, '
-          'locale: ${_locale ?? "unspecified"}, '
-          'shadows: ${_shadows ?? "unspecified"}'
+          'locale: ${_locale ?? "unspecified"}'
           ')';
     } else {
       return super.toString();

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1114,9 +1114,6 @@ void _applyParagraphStyleToElement({
     if (style._fontFamily != previousStyle._fontFamily) {
       cssStyle.fontFamily = canonicalizeFontFamily(style._fontFamily);
     }
-    if (style._shadows != previousStyle._shadows) {
-      cssStyle.textShadow = _shadowListToCss(style._shadows);
-    }
   }
 }
 

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -1088,9 +1088,6 @@ void _applyParagraphStyleToElement({
     if (style._effectiveFontFamily != null) {
       cssStyle.fontFamily = canonicalizeFontFamily(style._effectiveFontFamily);
     }
-    if (style._shadows != null) {
-      cssStyle.textShadow = _shadowListToCss(style._shadows);
-    }
   } else {
     if (style._textAlign != previousStyle._textAlign) {
       cssStyle.textAlign = textAlignToCssValue(

--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -17,7 +17,6 @@ class ParagraphGeometricStyle {
     this.wordSpacing,
     this.decoration,
     this.ellipsis,
-    this.shadows,
   });
 
   final ui.FontWeight fontWeight;
@@ -30,7 +29,6 @@ class ParagraphGeometricStyle {
   final double wordSpacing;
   final String decoration;
   final String ellipsis;
-  final List<ui.Shadow> shadows;
 
   // Since all fields above are primitives, cache hashcode since ruler lookups
   // use this style as key.
@@ -111,8 +109,7 @@ class ParagraphGeometricStyle {
         letterSpacing == typedOther.letterSpacing &&
         wordSpacing == typedOther.wordSpacing &&
         decoration == typedOther.decoration &&
-        ellipsis == typedOther.ellipsis &&
-        shadows == typedOther.shadows;
+        ellipsis == typedOther.ellipsis;
   }
 
   @override
@@ -127,11 +124,7 @@ class ParagraphGeometricStyle {
         wordSpacing,
         decoration,
         ellipsis,
-        _hashShadows(shadows),
       );
-
-  int _hashShadows(List<ui.Shadow> shadows) =>
-      (shadows == null ? '' : _shadowListToCss(shadows)).hashCode;
 
   @override
   String toString() {
@@ -144,7 +137,6 @@ class ParagraphGeometricStyle {
           ' wordSpacing: $wordSpacing,'
           ' decoration: $decoration,'
           ' ellipsis: $ellipsis,'
-          ' shadows: $shadows,'
           ')';
     } else {
       return super.toString();
@@ -248,10 +240,6 @@ class TextDimensions {
       ..textDecoration = style.decoration;
     if (style.lineHeight != null) {
       _element.style.lineHeight = style.lineHeight.toString();
-    }
-    final List<ui.Shadow> shadowList = style.shadows;
-    if (shadowList != null) {
-      _element.style.textShadow = _shadowListToCss(shadowList);
     }
     _invalidateBoundsCache();
   }


### PR DESCRIPTION
ParagraphStyle does not have shadows. This should be removed.

For reference: https://github.com/flutter/engine/commit/db23a6cabfebaa9024d111af9cf3a3f743513f11