### PR TITLE
[dart_runner] Initialize logging and tracing

### DIFF
--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -4,6 +4,7 @@
 
 #include <lib/async-loop/cpp/loop.h>
 #include <lib/async-loop/default.h>
+#include <lib/syslog/global.h>
 #include <lib/trace-provider/provider.h>
 #include <lib/trace/event.h>
 
@@ -14,10 +15,6 @@
 #include "runtime/dart/utils/files.h"
 #include "runtime/dart/utils/tempfs.h"
 #include "third_party/dart/runtime/include/dart_api.h"
-
-#if !defined(FUCHSIA_SDK)
-#include <lib/syslog/cpp/logger.h>
-#endif  //  !defined(FUCHSIA_SDK)
 
 #if !defined(DART_PRODUCT)
 // Register native symbol information for the Dart VM's profiler.
@@ -34,20 +31,17 @@ static void RegisterProfilerSymbols(const char* symbols_path,
 #endif  // !defined(DART_PRODUCT)
 
 int main(int argc, const char** argv) {
+  fx_log_init();
   async::Loop loop(&kAsyncLoopConfigAttachToCurrentThread);
-
-#if !defined(FUCHSIA_SDK)
-  syslog::InitLogger();
 
   std::unique_ptr<trace::TraceProviderWithFdio> provider;
   {
-    TRACE_EVENT0("dart", "CreateTraceProvider");
+    TRACE_DURATION("dart", "CreateTraceProvider");
     bool already_started;
     // Use CreateSynchronously to prevent loss of early events.
     trace::TraceProviderWithFdio::CreateSynchronously(
         loop.dispatcher(), "dart_runner", &provider, &already_started);
   }
-#endif  //  !defined(FUCHSIA_SDK)
 
 #if !defined(DART_PRODUCT)
 #if defined(AOT_RUNTIME)


### PR DESCRIPTION
Remove `!defined(FUCHSIA_SDK)` bits to start using the SDK to initialize logging and trace events for dart runners.