### PR TITLE
Turn on caps/num lock mode in GLFW

### DIFF
--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -388,6 +388,7 @@ static void SetHoverCallbacksEnabled(GLFWwindow* window, bool enabled) {
 // Flushes event queue and then assigns default window callbacks.
 static void GLFWAssignEventCallbacks(GLFWwindow* window) {
   glfwPollEvents();
+  glfwSetInputMode(window, GLFW_LOCK_KEY_MODS, GLFW_TRUE);
   glfwSetKeyCallback(window, GLFWKeyCallback);
   glfwSetCharCallback(window, GLFWCharCallback);
   glfwSetMouseButtonCallback(window, GLFWMouseButtonCallback);


### PR DESCRIPTION
This turns on the mode in GLFW that shows the caps lock state in the modifiers flag instead of making us keep track of it.