### PR TITLE
Avoid GL calls when compiling for Fuchsia.

### DIFF
--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/common/shell_io_manager.h"
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/message_loop.h"
 #include "flutter/shell/common/persistent_cache.h"
 #include "third_party/skia/include/gpu/gl/GrGLInterface.h"
@@ -38,7 +39,7 @@ sk_sp<GrContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
   // ES2 shading language when the ES3 external image extension is missing.
   options.fPreferExternalImagesOverES3 = true;
 
-#if !defined(OS_FUCHSIA)
+#if !OS_FUCHSIA
   if (auto context = GrContext::MakeGL(gl_interface, options)) {
     // Do not cache textures created by the image decoder.  These textures
     // should be deleted when they are no longer referenced by an SkImage.

--- a/shell/common/shell_io_manager.cc
+++ b/shell/common/shell_io_manager.cc
@@ -38,12 +38,14 @@ sk_sp<GrContext> ShellIOManager::CreateCompatibleResourceLoadingContext(
   // ES2 shading language when the ES3 external image extension is missing.
   options.fPreferExternalImagesOverES3 = true;
 
+#if !defined(OS_FUCHSIA)
   if (auto context = GrContext::MakeGL(gl_interface, options)) {
     // Do not cache textures created by the image decoder.  These textures
     // should be deleted when they are no longer referenced by an SkImage.
     context->setResourceCacheLimits(0, 0);
     return context;
   }
+#endif
 
   return nullptr;
 }


### PR DESCRIPTION
Skia is going to be eliding all GL interfaces when they compile for Fuchsia soon so we need to avoid making any calls. This change was test compiled against a future (un-rolled) Skia to make sure we will continue to compile.