### PR TITLE
Use Skia's matchStyleCSS3 to find bundled asset typefaces matching a font style

### DIFF
--- a/lib/ui/text/asset_manager_font_provider.h
+++ b/lib/ui/text/asset_manager_font_provider.h
@@ -20,7 +20,8 @@ namespace flutter {
 
 class AssetManagerFontStyleSet : public SkFontStyleSet {
  public:
-  AssetManagerFontStyleSet(std::shared_ptr<AssetManager> asset_manager);
+  AssetManagerFontStyleSet(std::shared_ptr<AssetManager> asset_manager,
+                           std::string family_name);
 
   ~AssetManagerFontStyleSet() override;
 
@@ -40,6 +41,7 @@ class AssetManagerFontStyleSet : public SkFontStyleSet {
 
  private:
   std::shared_ptr<AssetManager> asset_manager_;
+  std::string family_name_;
 
   struct TypefaceAsset {
     TypefaceAsset(std::string a);


### PR DESCRIPTION
This will improve font matching in SkParagraph for fonts that are bundled as assets within the app.  Libtxt was using Minikin's FontFamily class to select the closest matching font, but SkParagraph will rely on the matchStyle implementation in the asset font manager.
