### PR TITLE
Fix test to account for pixel ratio transformations being framework responsibility.

### DIFF
--- a/shell/platform/embedder/embedder_external_view_embedder.cc
+++ b/shell/platform/embedder/embedder_external_view_embedder.cc
@@ -211,6 +211,33 @@ static FlutterLayer MakePlatformViewLayer(
   return layer;
 }
 
+bool EmbedderExternalViewEmbedder::RenderPictureToRenderTarget(
+    sk_sp<SkPicture> picture,
+    const EmbedderRenderTarget* render_target) const {
+  if (!picture || render_target == nullptr) {
+    return false;
+  }
+
+  auto render_surface = render_target->GetRenderSurface();
+
+  if (!render_surface) {
+    return false;
+  }
+
+  auto render_canvas = render_surface->getCanvas();
+
+  if (render_canvas == nullptr) {
+    return false;
+  }
+
+  render_canvas->setMatrix(pending_surface_transformation_);
+  render_canvas->clear(SK_ColorTRANSPARENT);
+  render_canvas->drawPicture(picture);
+  render_canvas->flush();
+
+  return true;
+}
+
 // |ExternalViewEmbedder|
 bool EmbedderExternalViewEmbedder::SubmitFrame(GrContext* context) {
   std::map<FlutterPlatformViewIdentifier, FlutterPlatformView>
@@ -225,18 +252,15 @@ bool EmbedderExternalViewEmbedder::SubmitFrame(GrContext* context) {
     return false;
   }
 
-  // Copy the contents of the root picture recorder onto the root surface
-  // while making sure to take into account any surface transformations.
-  if (auto root_canvas = root_render_target_->GetRenderSurface()->getCanvas()) {
-    root_canvas->setMatrix(pending_surface_transformation_);
-    root_canvas->scale(pending_device_pixel_ratio_,
-                       pending_device_pixel_ratio_);
-    root_canvas->clear(SK_ColorTRANSPARENT);
-    root_canvas->drawPicture(
-        root_picture_recorder_->finishRecordingAsPicture());
-    root_canvas->flush();
-    root_picture_recorder_.reset();
+  // Copy the contents of the root picture recorder onto the root surface.
+  if (!RenderPictureToRenderTarget(
+          root_picture_recorder_->finishRecordingAsPicture(),
+          root_render_target_.get())) {
+    FML_LOG(ERROR) << "Could not render into the the root render target.";
+    return false;
   }
+  // The root picture recorder will be reset when a new frame begins.
+  root_picture_recorder_.reset();
 
   {
     // The root surface is expressed as a layer.
@@ -307,21 +331,13 @@ bool EmbedderExternalViewEmbedder::SubmitFrame(GrContext* context) {
 
     render_targets_used[registry_key] = render_target;
 
-    auto render_surface = render_target->GetRenderSurface();
-    auto render_canvas = render_surface ? render_surface->getCanvas() : nullptr;
-
-    if (!render_canvas) {
-      FML_LOG(ERROR)
-          << "Could not acquire render canvas for on-screen rendering.";
+    if (!RenderPictureToRenderTarget(picture, render_target.get())) {
+      FML_LOG(ERROR) << "Could not render into the render target for platform "
+                        "view of identifier "
+                     << view_id;
       return false;
     }
 
-    render_canvas->setMatrix(pending_surface_transformation_);
-    render_canvas->scale(pending_device_pixel_ratio_,
-                         pending_device_pixel_ratio_);
-    render_canvas->clear(SK_ColorTRANSPARENT);
-    render_canvas->drawPicture(picture);
-    render_canvas->flush();
     // Indicate a layer for the backing store containing contents rendered by
     // Flutter.
     presented_layers.push_back(MakeBackingStoreLayer(

--- a/shell/platform/embedder/embedder_external_view_embedder.h
+++ b/shell/platform/embedder/embedder_external_view_embedder.h
@@ -144,6 +144,10 @@ class EmbedderExternalViewEmbedder final : public ExternalViewEmbedder {
 
   SkMatrix GetSurfaceTransformation() const;
 
+  bool RenderPictureToRenderTarget(
+      sk_sp<SkPicture> picture,
+      const EmbedderRenderTarget* render_target) const;
+
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderExternalViewEmbedder);
 };
 

--- a/shell/platform/embedder/embedder_render_target.cc
+++ b/shell/platform/embedder/embedder_render_target.cc
@@ -30,7 +30,7 @@ const FlutterBackingStore* EmbedderRenderTarget::GetBackingStore() const {
   return &backing_store_;
 }
 
-sk_sp<SkSurface> EmbedderRenderTarget::GetRenderSurface() {
+sk_sp<SkSurface> EmbedderRenderTarget::GetRenderSurface() const {
   return render_surface_;
 }
 

--- a/shell/platform/embedder/embedder_render_target.h
+++ b/shell/platform/embedder/embedder_render_target.h
@@ -51,7 +51,7 @@ class EmbedderRenderTarget {
   ///
   /// @return     The render surface.
   ///
-  sk_sp<SkSurface> GetRenderSurface();
+  sk_sp<SkSurface> GetRenderSurface() const;
 
   //----------------------------------------------------------------------------
   /// @brief      The embedder backing store descriptor. This is the descriptor

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -481,7 +481,12 @@ void verify_b141980393() {
 void can_display_platform_view_with_pixel_ratio() {
   window.onBeginFrame = (Duration duration) {
     SceneBuilder builder = SceneBuilder();
-    builder.pushOffset(0.0, 0.0); // base
+    builder.pushTransform(Float64List.fromList([
+      2.0, 0.0, 0.0, 0.0,
+      0.0, 2.0, 0.0, 0.0,
+      0.0, 0.0, 1.0, 0.0,
+      0.0, 0.0, 0.0, 1.0
+    ])); // base
     builder.addPicture(Offset(0.0, 0.0), CreateGradientBox(Size(400.0, 300.0)));
     builder.pushOffset(0.0, 20.0); // offset
     builder.addPlatformView(42, width: 400.0, height: 280.0);

--- a/shell/platform/embedder/tests/embedder_test_compositor.cc
+++ b/shell/platform/embedder/tests/embedder_test_compositor.cc
@@ -112,15 +112,22 @@ bool EmbedderTestCompositor::UpdateOffscrenComposition(
         break;
     };
 
+    // If the layer is not a platform view but the engine did not specify an
+    // image for the backing store, it is an error.
     if (!layer_image && layer->type != kFlutterLayerContentTypePlatformView) {
       FML_LOG(ERROR) << "Could not snapshot layer in test compositor: "
                      << *layer;
       return false;
     }
 
-    // The image rendered by Flutter already has the correct offset and
-    // transformation applied. The layers offset is meant for the platform.
-    canvas->drawImage(layer_image.get(), canvas_offset.x(), canvas_offset.y());
+    // The test could have just specified no contents to be rendered in place of
+    // a platform view. This is not an error.
+    if (layer_image) {
+      // The image rendered by Flutter already has the correct offset and
+      // transformation applied. The layers offset is meant for the platform.
+      canvas->drawImage(layer_image.get(), canvas_offset.x(),
+                        canvas_offset.y());
+    }
   }
 
   last_composition_ = surface->makeImageSnapshot();

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2803,7 +2803,7 @@ TEST_F(EmbedderTest,
           layer.type = kFlutterLayerContentTypePlatformView;
           layer.platform_view = &platform_view;
           layer.size = FlutterSizeMake(800.0, 560.0);
-          layer.offset = FlutterPointMake(0.0, 40.0);
+          layer.offset = FlutterPointMake(0.0, 80.0);
 
           ASSERT_EQ(*layers[1], layer);
         }
@@ -2902,7 +2902,7 @@ TEST_F(
           layer.type = kFlutterLayerContentTypePlatformView;
           layer.platform_view = &platform_view;
           layer.size = FlutterSizeMake(560.0, 800.0);
-          layer.offset = FlutterPointMake(40.0, 0.0);
+          layer.offset = FlutterPointMake(80.0, 0.0);
 
           ASSERT_EQ(*layers[1], layer);
         }


### PR DESCRIPTION
This incorrect assumption led to the introduction of a failure on an external embedder. Also dries up the section that copies the picture to the embedder managed render targets.

Fixes https://github.com/flutter/flutter/issues/43906
Fixes https://b.corp.google.com/issues/143529469