### PR TITLE
Do not default to downstream affinity on iOS insertText

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -238,7 +238,6 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
     [self.inputDelegate selectionWillChange:self];
     [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
             updateEditingState:NO];
-
     _selectionAffinity = _kTextAffinityDownstream;
     if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
       _selectionAffinity = _kTextAffinityUpstream;
@@ -622,6 +621,9 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 }
 
 - (void)insertText:(NSString*)text {
+  // We do not know the affinity here. Set to "" so that Flutter interprets it
+  // as ambiguous and uses a fallback affinity.
+  _selectionAffinity = "";
   [self replaceRange:_selectedTextRange withText:text];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -621,7 +621,7 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 }
 
 - (void)insertText:(NSString*)text {
-  // We do not know the affinity here. Set to "" so that Flutter interprets it
+  // The affinity is unknown here. Set to "" so that Flutter interprets it
   // as ambiguous and uses a fallback affinity.
   _selectionAffinity = "";
   [self replaceRange:_selectedTextRange withText:text];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -238,6 +238,7 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
     [self.inputDelegate selectionWillChange:self];
     [self setSelectedTextRange:[FlutterTextRange rangeWithNSRange:selectedRange]
             updateEditingState:NO];
+
     _selectionAffinity = _kTextAffinityDownstream;
     if ([state[@"selectionAffinity"] isEqualToString:@(_kTextAffinityUpstream)])
       _selectionAffinity = _kTextAffinityUpstream;
@@ -621,7 +622,6 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 }
 
 - (void)insertText:(NSString*)text {
-  _selectionAffinity = _kTextAffinityDownstream;
   [self replaceRange:_selectedTextRange withText:text];
 }
 


### PR DESCRIPTION
This allows the framework to fall back on LibTxt metrics when the affinity is ambiguous.