### PR TITLE
Guard against orphaned semantic objects from referencing dead accessibility bridge on iOS

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -48,8 +48,8 @@ class AccessibilityBridge;
 /**
  * The accessibility bridge that this semantics object is attached to. This
  * object may use the bridge to access contextual application information. A weak
- * pointer is used because the platform view owns the accessibility bridge. 
- * If you are referencing this property from an iOS callback, be sure to 
+ * pointer is used because the platform view owns the accessibility bridge.
+ * If you are referencing this property from an iOS callback, be sure to
  * use `isAccessibilityBridgeActive` to protect against the case where this
  * node may be orphaned.
  */
@@ -60,8 +60,8 @@ class AccessibilityBridge;
  * there can be situations where the AccessibilityBridge is shutdown, but the SemanticObject
  * will still be alive. If VoiceOver is turned on again, it may try to access this orphaned
  * SemanticObject. Methods that are called from the accessiblity framework should use
- * this to guard against this case by just returning early if its bridge has been shutdown. 
- * 
+ * this to guard against this case by just returning early if its bridge has been shutdown.
+ *
  * See https://github.com/flutter/flutter/issues/43795 for more information.
  */
 - (BOOL)isAccessibilityBridgeAlive;
@@ -101,7 +101,6 @@ class AccessibilityBridge;
                            uid:(int32_t)uid NS_DESIGNATED_INITIALIZER;
 
 @end
-
 
 /**
  * An implementation of UIAccessibilityCustomAction which also contains the

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -47,10 +47,24 @@ class AccessibilityBridge;
 
 /**
  * The accessibility bridge that this semantics object is attached to. This
- * object may use the bridge to access contextual application information. A weak pointer is used
- * because the platform view owns the accessibility bridge.
+ * object may use the bridge to access contextual application information. A weak
+ * pointer is used because the platform view owns the accessibility bridge. 
+ * If you are referencing this property from an iOS callback, be sure to 
+ * use `isAccessibilityBridgeActive` to protect against the case where this
+ * node may be orphaned.
  */
 @property(nonatomic, readonly) fml::WeakPtr<flutter::AccessibilityBridge> bridge;
+
+/**
+ * Due to the fact that VoiceOver may hold onto SemanticObjects even after it shuts down,
+ * there can be situations where the AccessibilityBridge is shutdown, but the SemanticObject
+ * will still be alive. If VoiceOver is turned on again, it may try to access this orphaned
+ * SemanticObject. Methods that are called from the accessiblity framework should use
+ * this to guard against this case by just returning early if its bridge has been shutdown. 
+ * 
+ * See https://github.com/flutter/flutter/issues/43795 for more information.
+ */
+- (BOOL)isAccessibilityBridgeAlive;
 
 /**
  * The semantics node used to produce this semantics object.
@@ -88,16 +102,6 @@ class AccessibilityBridge;
 
 @end
 
-/**
- * Due to the fact that VoiceOver may hold onto SemanticObjects even after it shuts down,
- * there can be situations where the AccessibilityBridge is shutdown, but the SemanticObject
- * will still be alive. If VoiceOver is turned on again, it may try to access this orphaned
- * SemanticObject. Methods that are called from the accessiblity framework should use
- * this to guard against this case by just returning early if its bridge has been shutdown. 
- * 
- * See https://github.com/flutter/flutter/issues/43795 for more information.
- */
-#define RETURN_IF_ORPHANED(returnValue) if ([self bridge].get() == nil) return returnValue
 
 /**
  * An implementation of UIAccessibilityCustomAction which also contains the

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -89,6 +89,17 @@ class AccessibilityBridge;
 @end
 
 /**
+ * Due to the fact that VoiceOver may hold onto SemanticObjects even after it shuts down,
+ * there can be situations where the AccessibilityBridge is shutdown, but the SemanticObject
+ * will still be alive. If VoiceOver is turned on again, it may try to access this orphaned
+ * SemanticObject. Methods that are called from the accessiblity framework should use
+ * this to guard against this case by just returning early if its bridge has been shutdown. 
+ * 
+ * See https://github.com/flutter/flutter/issues/43795 for more information.
+ */
+#define RETURN_IF_ORPHANED(returnValue) if ([self bridge].get() == nil) return returnValue
+
+/**
  * An implementation of UIAccessibilityCustomAction which also contains the
  * Flutter uid.
  */

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -140,6 +140,10 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 
 #pragma mark - Semantic object methods
 
+- (BOOL)isAccessibilityBridgeAlive {
+  return [self bridge].get() != nil;
+}
+
 - (void)setSemanticsNode:(const flutter::SemanticsNode*)node {
   _node = *node;
 }
@@ -169,7 +173,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark - UIAccessibility overrides
 
 - (BOOL)isAccessibilityElement {
-  RETURN_IF_ORPHANED(false);
+  if (![self isAccessibilityBridgeAlive])
+    return false;
 
   // Note: hit detection will only apply to elements that report
   // -isAccessibilityElement of YES. The framework will continue scanning the
@@ -240,28 +245,35 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (NSString*)accessibilityLabel {
-  RETURN_IF_ORPHANED(nil);
+  if (![self isAccessibilityBridgeAlive])
+    return nil;
+
   if ([self node].label.empty())
     return nil;
   return @([self node].label.data());
 }
 
 - (NSString*)accessibilityHint {
-  RETURN_IF_ORPHANED(nil);
+  if (![self isAccessibilityBridgeAlive])
+    return nil;
+
   if ([self node].hint.empty())
     return nil;
   return @([self node].hint.data());
 }
 
 - (NSString*)accessibilityValue {
-  RETURN_IF_ORPHANED(nil);
+  if (![self isAccessibilityBridgeAlive])
+    return nil;
   if ([self node].value.empty())
     return nil;
   return @([self node].value.data());
 }
 
 - (CGRect)accessibilityFrame {
-  RETURN_IF_ORPHANED(CGRectMake(0, 0, 0, 0));
+  if (![self isAccessibilityBridgeAlive])
+    return CGRectMake(0, 0, 0, 0);
+
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden)) {
     return [super accessibilityFrame];
   }
@@ -314,7 +326,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark - UIAccessibilityAction overrides
 
 - (BOOL)accessibilityActivate {
-  RETURN_IF_ORPHANED(NO);
+  if (![self isAccessibilityBridgeAlive]) 
+    return NO;
   if (![self node].HasAction(flutter::SemanticsAction::kTap))
     return NO;
   [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kTap);
@@ -322,7 +335,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityIncrement {
-  RETURN_IF_ORPHANED();
+  if (![self isAccessibilityBridgeAlive]) 
+    return;
   if ([self node].HasAction(flutter::SemanticsAction::kIncrease)) {
     [self node].value = [self node].increasedValue;
     [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kIncrease);
@@ -330,7 +344,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityDecrement {
-  RETURN_IF_ORPHANED();
+  if (![self isAccessibilityBridgeAlive]) 
+    return;
   if ([self node].HasAction(flutter::SemanticsAction::kDecrease)) {
     [self node].value = [self node].decreasedValue;
     [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kDecrease);
@@ -338,7 +353,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
-  RETURN_IF_ORPHANED(NO);
+  if (![self isAccessibilityBridgeAlive]) 
+    return NO;
   flutter::SemanticsAction action = GetSemanticsActionForScrollDirection(direction);
   if (![self node].HasAction(action))
     return NO;
@@ -347,7 +363,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (BOOL)accessibilityPerformEscape {
-  RETURN_IF_ORPHANED(NO);
+  if (![self isAccessibilityBridgeAlive]) 
+    return NO;
   if (![self node].HasAction(flutter::SemanticsAction::kDismiss))
     return NO;
   [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kDismiss);
@@ -357,7 +374,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark UIAccessibilityFocus overrides
 
 - (void)accessibilityElementDidBecomeFocused {
-  RETURN_IF_ORPHANED();
+  if (![self isAccessibilityBridgeAlive]) 
+    return;
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden)) {
     [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
   }
@@ -368,7 +386,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  RETURN_IF_ORPHANED();
+  if (![self isAccessibilityBridgeAlive]) 
+    return;
   if ([self node].HasAction(flutter::SemanticsAction::kDidLoseAccessibilityFocus)) {
     [self bridge] -> DispatchSemanticsAction([self uid],
                                              flutter::SemanticsAction::kDidLoseAccessibilityFocus);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -169,6 +169,8 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark - UIAccessibility overrides
 
 - (BOOL)isAccessibilityElement {
+  RETURN_IF_ORPHANED(false);
+
   // Note: hit detection will only apply to elements that report
   // -isAccessibilityElement of YES. The framework will continue scanning the
   // entire element tree looking for such a hit.
@@ -238,24 +240,28 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (NSString*)accessibilityLabel {
+  RETURN_IF_ORPHANED(nil);
   if ([self node].label.empty())
     return nil;
   return @([self node].label.data());
 }
 
 - (NSString*)accessibilityHint {
+  RETURN_IF_ORPHANED(nil);
   if ([self node].hint.empty())
     return nil;
   return @([self node].hint.data());
 }
 
 - (NSString*)accessibilityValue {
+  RETURN_IF_ORPHANED(nil);
   if ([self node].value.empty())
     return nil;
   return @([self node].value.data());
 }
 
 - (CGRect)accessibilityFrame {
+  RETURN_IF_ORPHANED(CGRectMake(0, 0, 0, 0));
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden)) {
     return [super accessibilityFrame];
   }
@@ -308,6 +314,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark - UIAccessibilityAction overrides
 
 - (BOOL)accessibilityActivate {
+  RETURN_IF_ORPHANED(NO);
   if (![self node].HasAction(flutter::SemanticsAction::kTap))
     return NO;
   [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kTap);
@@ -315,6 +322,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityIncrement {
+  RETURN_IF_ORPHANED();
   if ([self node].HasAction(flutter::SemanticsAction::kIncrease)) {
     [self node].value = [self node].increasedValue;
     [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kIncrease);
@@ -322,6 +330,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityDecrement {
+  RETURN_IF_ORPHANED();
   if ([self node].HasAction(flutter::SemanticsAction::kDecrease)) {
     [self node].value = [self node].decreasedValue;
     [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kDecrease);
@@ -329,6 +338,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
+  RETURN_IF_ORPHANED(NO);
   flutter::SemanticsAction action = GetSemanticsActionForScrollDirection(direction);
   if (![self node].HasAction(action))
     return NO;
@@ -337,6 +347,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (BOOL)accessibilityPerformEscape {
+  RETURN_IF_ORPHANED(NO);
   if (![self node].HasAction(flutter::SemanticsAction::kDismiss))
     return NO;
   [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kDismiss);
@@ -346,6 +357,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark UIAccessibilityFocus overrides
 
 - (void)accessibilityElementDidBecomeFocused {
+  RETURN_IF_ORPHANED();
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden)) {
     [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
   }
@@ -356,6 +368,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityElementDidLoseFocus {
+  RETURN_IF_ORPHANED();
   if ([self node].HasAction(flutter::SemanticsAction::kDidLoseAccessibilityFocus)) {
     [self bridge] -> DispatchSemanticsAction([self uid],
                                              flutter::SemanticsAction::kDidLoseAccessibilityFocus);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -326,7 +326,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark - UIAccessibilityAction overrides
 
 - (BOOL)accessibilityActivate {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return NO;
   if (![self node].HasAction(flutter::SemanticsAction::kTap))
     return NO;
@@ -335,7 +335,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityIncrement {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return;
   if ([self node].HasAction(flutter::SemanticsAction::kIncrease)) {
     [self node].value = [self node].increasedValue;
@@ -344,7 +344,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityDecrement {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return;
   if ([self node].HasAction(flutter::SemanticsAction::kDecrease)) {
     [self node].value = [self node].decreasedValue;
@@ -353,7 +353,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (BOOL)accessibilityScroll:(UIAccessibilityScrollDirection)direction {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return NO;
   flutter::SemanticsAction action = GetSemanticsActionForScrollDirection(direction);
   if (![self node].HasAction(action))
@@ -363,7 +363,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (BOOL)accessibilityPerformEscape {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return NO;
   if (![self node].HasAction(flutter::SemanticsAction::kDismiss))
     return NO;
@@ -374,7 +374,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 #pragma mark UIAccessibilityFocus overrides
 
 - (void)accessibilityElementDidBecomeFocused {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return;
   if ([self node].HasFlag(flutter::SemanticsFlags::kIsHidden)) {
     [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kShowOnScreen);
@@ -386,7 +386,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return;
   if ([self node].HasAction(flutter::SemanticsAction::kDidLoseAccessibilityFocus)) {
     [self bridge] -> DispatchSemanticsAction([self uid],

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -219,33 +219,33 @@
 }
 
 - (void)accessibilityElementDidBecomeFocused {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return;
   [[self textInputSurrogate] accessibilityElementDidBecomeFocused];
   [super accessibilityElementDidBecomeFocused];
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return;
   [[self textInputSurrogate] accessibilityElementDidLoseFocus];
   [super accessibilityElementDidLoseFocus];
 }
 
 - (BOOL)accessibilityElementIsFocused {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return false;
   return [self node].HasFlag(flutter::SemanticsFlags::kIsFocused);
 }
 
 - (BOOL)accessibilityActivate {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return false;
   return [[self textInputSurrogate] accessibilityActivate];
 }
 
 - (NSString*)accessibilityLabel {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return nil;
 
   NSString* label = [super accessibilityLabel];
@@ -255,7 +255,7 @@
 }
 
 - (NSString*)accessibilityHint {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return nil;
   NSString* hint = [super accessibilityHint];
   if (hint != nil)
@@ -264,7 +264,7 @@
 }
 
 - (NSString*)accessibilityValue {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return nil;
   NSString* value = [super accessibilityValue];
   if (value != nil)
@@ -273,7 +273,7 @@
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {
-  if (![self isAccessibilityBridgeAlive]) 
+  if (![self isAccessibilityBridgeAlive])
     return 0;
   // Adding UIAccessibilityTraitKeyboardKey to the trait list so that iOS treats it like
   // a keyboard entry control, thus adding support for text editing features, such as

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -219,29 +219,35 @@
 }
 
 - (void)accessibilityElementDidBecomeFocused {
-  RETURN_IF_ORPHANED();
+  if (![self isAccessibilityBridgeAlive]) 
+    return;
   [[self textInputSurrogate] accessibilityElementDidBecomeFocused];
   [super accessibilityElementDidBecomeFocused];
 }
 
 - (void)accessibilityElementDidLoseFocus {
-  RETURN_IF_ORPHANED();
+  if (![self isAccessibilityBridgeAlive]) 
+    return;
   [[self textInputSurrogate] accessibilityElementDidLoseFocus];
   [super accessibilityElementDidLoseFocus];
 }
 
 - (BOOL)accessibilityElementIsFocused {
-  RETURN_IF_ORPHANED(false);
+  if (![self isAccessibilityBridgeAlive]) 
+    return false;
   return [self node].HasFlag(flutter::SemanticsFlags::kIsFocused);
 }
 
 - (BOOL)accessibilityActivate {
-  RETURN_IF_ORPHANED(false);
+  if (![self isAccessibilityBridgeAlive]) 
+    return false;
   return [[self textInputSurrogate] accessibilityActivate];
 }
 
 - (NSString*)accessibilityLabel {
-  RETURN_IF_ORPHANED(nil);
+  if (![self isAccessibilityBridgeAlive]) 
+    return nil;
+
   NSString* label = [super accessibilityLabel];
   if (label != nil)
     return label;
@@ -249,7 +255,8 @@
 }
 
 - (NSString*)accessibilityHint {
-  RETURN_IF_ORPHANED(nil);
+  if (![self isAccessibilityBridgeAlive]) 
+    return nil;
   NSString* hint = [super accessibilityHint];
   if (hint != nil)
     return hint;
@@ -257,7 +264,8 @@
 }
 
 - (NSString*)accessibilityValue {
-  RETURN_IF_ORPHANED(nil);
+  if (![self isAccessibilityBridgeAlive]) 
+    return nil;
   NSString* value = [super accessibilityValue];
   if (value != nil)
     return value;
@@ -265,7 +273,8 @@
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {
-  RETURN_IF_ORPHANED(0);
+  if (![self isAccessibilityBridgeAlive]) 
+    return 0;
   // Adding UIAccessibilityTraitKeyboardKey to the trait list so that iOS treats it like
   // a keyboard entry control, thus adding support for text editing features, such as
   // pinch to select text, and up/down fling to move cursor.

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -219,24 +219,29 @@
 }
 
 - (void)accessibilityElementDidBecomeFocused {
+  RETURN_IF_ORPHANED();
   [[self textInputSurrogate] accessibilityElementDidBecomeFocused];
   [super accessibilityElementDidBecomeFocused];
 }
 
 - (void)accessibilityElementDidLoseFocus {
+  RETURN_IF_ORPHANED();
   [[self textInputSurrogate] accessibilityElementDidLoseFocus];
   [super accessibilityElementDidLoseFocus];
 }
 
 - (BOOL)accessibilityElementIsFocused {
+  RETURN_IF_ORPHANED(false);
   return [self node].HasFlag(flutter::SemanticsFlags::kIsFocused);
 }
 
 - (BOOL)accessibilityActivate {
+  RETURN_IF_ORPHANED(false);
   return [[self textInputSurrogate] accessibilityActivate];
 }
 
 - (NSString*)accessibilityLabel {
+  RETURN_IF_ORPHANED(nil);
   NSString* label = [super accessibilityLabel];
   if (label != nil)
     return label;
@@ -244,6 +249,7 @@
 }
 
 - (NSString*)accessibilityHint {
+  RETURN_IF_ORPHANED(nil);
   NSString* hint = [super accessibilityHint];
   if (hint != nil)
     return hint;
@@ -251,6 +257,7 @@
 }
 
 - (NSString*)accessibilityValue {
+  RETURN_IF_ORPHANED(nil);
   NSString* value = [super accessibilityValue];
   if (value != nil)
     return value;
@@ -258,6 +265,7 @@
 }
 
 - (UIAccessibilityTraits)accessibilityTraits {
+  RETURN_IF_ORPHANED(0);
   // Adding UIAccessibilityTraitKeyboardKey to the trait list so that iOS treats it like
   // a keyboard entry control, thus adding support for text editing features, such as
   // pinch to select text, and up/down fling to move cursor.


### PR DESCRIPTION
The core issue causing https://github.com/flutter/flutter/issues/43795 is that when VoiceOver is turned off, it will still hang onto our `SemanticObjects` for the focused node. In response to VoiceOver shutting down (via the `UIAccessibilityVoiceOverStatusChanged` message handler), we tear down the `AccessibilityBridge`. When this happens we release all of our SemanticsObjects and delete the bridge. However, because iOS will hold onto (at least in this case) the focused semantics object, when VoiceOver is turned back on it will notify the the semantic object that it no longer has focus. If the node tries to do anything that involves the bridge, it will try to dereference a dead weak pointer, so it crashes.

I attempted several approaches to see if there was a way to get iOS to release the node (reseting the semantics tree to empty, sending various `UIAccessibilityPostNotification` messages), but nothing would cause it to release the now defunct SemanticsObject.

I looked into wrapping each of the `SemanticsObjects` with a safe guarding object that would only delegate to the real semantics object if the bridge were still active. This would be way more boilerplate than it would be worth (in addition to adding to taking up more memory for each node).

So the solution I came up with is this. I added a new macro `RETURN_IF_ORPHANED` that can be used at the top of any accessibility message handler in a `SemanticsObject`. It will check if the node's bridge is still active and if not, then just return immediately. This will guard against any references to a dead bridge. Not the most elegant solution, and I am open to better suggestions. Are there any similar patterns in use in the engine?

Fixes: https://github.com/flutter/flutter/issues/43795

