### PR TITLE
[flow][fuchsia] Add more tracing to layers and Fuchsia surface pool

### DIFF
--- a/flow/layers/child_scene_layer.cc
+++ b/flow/layers/child_scene_layer.cc
@@ -18,6 +18,7 @@ ChildSceneLayer::ChildSceneLayer(zx_koid_t layer_id,
       hit_testable_(hit_testable) {}
 
 void ChildSceneLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  TRACE_EVENT0("flutter", "ChildSceneLayer::Preroll");
   set_needs_system_composite(true);
 }
 

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -34,6 +34,7 @@ void OpacityLayer::EnsureSingleChild() {
 }
 
 void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  TRACE_EVENT0("flutter", "OpacityLayer::Preroll");
   EnsureSingleChild();
   SkMatrix child_matrix = matrix;
   child_matrix.postTranslate(offset_.fX, offset_.fY);

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -52,6 +52,7 @@ PhysicalShapeLayer::~PhysicalShapeLayer() = default;
 
 void PhysicalShapeLayer::Preroll(PrerollContext* context,
                                  const SkMatrix& matrix) {
+  TRACE_EVENT0("flutter", "PhysicalShapeLayer::Preroll");
   context->total_elevation += elevation_;
   total_elevation_ = context->total_elevation;
   SkRect child_paint_bounds;
@@ -115,12 +116,14 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
 
 void PhysicalShapeLayer::UpdateScene(SceneUpdateContext& context) {
   FML_DCHECK(needs_system_composite());
+  TRACE_EVENT0("flutter", "PhysicalShapeLayer::UpdateScene");
 
   // Retained rendering: speedup by reusing a retained entity node if possible.
   // When an entity node is reused, no paint layer is added to the frame so we
   // won't call PhysicalShapeLayer::Paint.
   LayerRasterCacheKey key(unique_id(), context.Matrix());
   if (context.HasRetainedNode(key)) {
+    TRACE_EVENT_INSTANT0("flutter", "retained layer cache hit");
     const scenic::EntityNode& retained_node = context.GetRetainedNode(key);
     FML_DCHECK(context.top_entity());
     FML_DCHECK(retained_node.session() == context.session());
@@ -128,6 +131,7 @@ void PhysicalShapeLayer::UpdateScene(SceneUpdateContext& context) {
     return;
   }
 
+  TRACE_EVENT_INSTANT0("flutter", "cache miss, creating");
   // If we can't find an existing retained surface, create one.
   SceneUpdateContext::Frame frame(context, frameRRect_, color_, elevation_,
                                   total_elevation_, viewport_depth_, this);


### PR DESCRIPTION
This adds more trace events to more layer operations and enhances the
trace counters for the Fuchsia vulkan surface pool to include retained
surface counts, emit stats on recycle events that might change the
surface count, and by separating counters which measure bytes from
counters which measure counts to make analysis simpler.