### PR TITLE
Change edge conditions of getLineBoundary

### DIFF
--- a/lib/ui/text/paragraph.cc
+++ b/lib/ui/text/paragraph.cc
@@ -140,7 +140,7 @@ Dart_Handle Paragraph::getLineBoundary(unsigned offset) {
   int line_start = -1;
   int line_end = -1;
   for (txt::LineMetrics& line : metrics) {
-    if (offset >= line.start_index && offset < line.end_index) {
+    if (offset >= line.start_index && offset <= line.end_index) {
       line_start = line.start_index;
       line_end = line.end_index;
       break;


### PR DESCRIPTION
<= instead of < for the end. Before, when requesting the line boundaries of the end of the line index, it would return (-1, -1). This causes the full range of offsets to have gaps of undefined boundaries at the ends of lines.

With this change, the full range of offsets return valid lines. This is relevant when selecting the last position in the line such as caret at end of line. For that position, the old version failed to produce a line boundary.

Related PR: https://github.com/flutter/engine/pull/13727