### PR TITLE
Work around Fuchsia a11y / ICU name conflict

### DIFF
--- a/shell/platform/fuchsia/flutter/accessibility_bridge.h
+++ b/shell/platform/fuchsia/flutter/accessibility_bridge.h
@@ -5,6 +5,10 @@
 #ifndef FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_ACCESSIBILITY_BRIDGE_H_
 #define FLUTTER_SHELL_PLATFORM_FUCHSIA_FLUTTER_ACCESSIBILITY_BRIDGE_H_
 
+// Work around symbol conflicts with ICU.
+#undef TRUE
+#undef FALSE
+
 #include <fuchsia/accessibility/semantics/cpp/fidl.h>
 #include <fuchsia/sys/cpp/fidl.h>
 #include <fuchsia/ui/gfx/cpp/fidl.h>


### PR DESCRIPTION
ICU #defines TRUE and FALSE but these are used as enum member name by
the Fuchsia i18n FIDL library. This #undefs TRUE and FALSE before
including the generated FIDL header.

Fixes https://github.com/flutter/flutter/issues/44817