### PR TITLE
Adding opacity -> alpha method to Color class

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -307,6 +307,16 @@ class Color {
     }
   }
 
+  /// Returns an alpha value representative of the provided [opacity] value.
+  ///
+  /// The [opacity] value may not be null, an must be between 0.0 and 1.0,
+  /// inclusive.
+  static int getAlphaFromOpacity(double opacity) {
+    assert(opacity != null);
+    final double clampedOpacity = opacity.clamp(0.0, 1.0);
+    return (clampedOpacity * 255).round();
+  }
+
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other))

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -309,8 +309,7 @@ class Color {
 
   /// Returns an alpha value representative of the provided [opacity] value.
   ///
-  /// The [opacity] value may not be null, an must be between 0.0 and 1.0,
-  /// inclusive.
+  /// The [opacity] value may not be null.
   static int getAlphaFromOpacity(double opacity) {
     assert(opacity != null);
     final double clampedOpacity = opacity.clamp(0.0, 1.0);

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -312,7 +312,6 @@ class Color {
   /// The [opacity] value may not be null.
   static int getAlphaFromOpacity(double opacity) {
     assert(opacity != null);
-    final double clampedOpacity = opacity.clamp(0.0, 1.0);
     return (opacity.clamp(0.0, 1.0) * 255).round();
   }
 

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -313,7 +313,7 @@ class Color {
   static int getAlphaFromOpacity(double opacity) {
     assert(opacity != null);
     final double clampedOpacity = opacity.clamp(0.0, 1.0);
-    return (clampedOpacity * 255).round();
+    return (opacity.clamp(0.0, 1.0) * 255).round();
   }
 
   @override

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -232,7 +232,7 @@ class Color {
   static int getAlphaFromOpacity(double opacity) {
     assert(opacity != null);
     final double clampedOpacity = opacity.clamp(0.0, 1.0);
-    return (clampedOpacity * 255).round();
+    return (opacity.clamp(0.0, 1.0) * 255).round();
   }
 
   @override

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -231,7 +231,6 @@ class Color {
   /// The [opacity] value may not be null.
   static int getAlphaFromOpacity(double opacity) {
     assert(opacity != null);
-    final double clampedOpacity = opacity.clamp(0.0, 1.0);
     return (opacity.clamp(0.0, 1.0) * 255).round();
   }
 

--- a/lib/web_ui/lib/src/ui/painting.dart
+++ b/lib/web_ui/lib/src/ui/painting.dart
@@ -226,6 +226,15 @@ class Color {
     }
   }
 
+  /// Returns an alpha value representative of the provided [opacity] value.
+  ///
+  /// The [opacity] value may not be null.
+  static int getAlphaFromOpacity(double opacity) {
+    assert(opacity != null);
+    final double clampedOpacity = opacity.clamp(0.0, 1.0);
+    return (clampedOpacity * 255).round();
+  }
+
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) {


### PR DESCRIPTION
This change stems from a suggestion made in https://github.com/flutter/flutter/pull/44289/files#r347058942

This simple method shows up a couple of times in the flutter framework. Adding it to dart:ui seems generally useful. :)