### PR TITLE
Ensure that message loop disposal acquires the mutex that guards access to the queue mutexes collection.

### DIFF
--- a/fml/message_loop_task_queues.cc
+++ b/fml/message_loop_task_queues.cc
@@ -50,6 +50,7 @@ MessageLoopTaskQueues::MessageLoopTaskQueues()
 MessageLoopTaskQueues::~MessageLoopTaskQueues() = default;
 
 void MessageLoopTaskQueues::Dispose(TaskQueueId queue_id) {
+  fml::UniqueLock lock(*queue_meta_mutex_);
   std::scoped_lock queue_lock(GetMutex(queue_id));
 
   const auto& queue_entry = queue_entries_.at(queue_id);
@@ -80,7 +81,7 @@ void MessageLoopTaskQueues::RegisterTask(TaskQueueId queue_id,
   std::scoped_lock queue_lock(GetMutex(queue_id));
 
   size_t order = order_++;
-  const auto& queue_entry = queue_entries_[queue_id];
+  const auto& queue_entry = queue_entries_.at(queue_id);
   queue_entry->delayed_tasks.push({order, std::move(task), target_time});
   TaskQueueId loop_to_wake = queue_id;
   if (queue_entry->subsumed_by != _kUnmerged) {
@@ -115,7 +116,7 @@ void MessageLoopTaskQueues::GetTasksToRunNow(
       break;
     }
     invocations.emplace_back(std::move(top.GetTask()));
-    queue_entries_[top_queue]->delayed_tasks.pop();
+    queue_entries_.at(top_queue)->delayed_tasks.pop();
     if (type == FlushType::kSingle) {
       break;
     }
@@ -161,14 +162,14 @@ void MessageLoopTaskQueues::AddTaskObserver(TaskQueueId queue_id,
   std::scoped_lock queue_lock(GetMutex(queue_id));
 
   FML_DCHECK(callback != nullptr) << "Observer callback must be non-null.";
-  queue_entries_[queue_id]->task_observers[key] = std::move(callback);
+  queue_entries_.at(queue_id)->task_observers[key] = std::move(callback);
 }
 
 void MessageLoopTaskQueues::RemoveTaskObserver(TaskQueueId queue_id,
                                                intptr_t key) {
   std::scoped_lock queue_lock(GetMutex(queue_id));
 
-  queue_entries_[queue_id]->task_observers.erase(key);
+  queue_entries_.at(queue_id)->task_observers.erase(key);
 }
 
 std::vector<fml::closure> MessageLoopTaskQueues::GetObserversToNotify(
@@ -199,7 +200,7 @@ void MessageLoopTaskQueues::SetWakeable(TaskQueueId queue_id,
                                         fml::Wakeable* wakeable) {
   std::scoped_lock queue_lock(GetMutex(queue_id));
 
-  FML_CHECK(!queue_entries_[queue_id]->wakeable)
+  FML_CHECK(!queue_entries_.at(queue_id)->wakeable)
       << "Wakeable can only be set once.";
   queue_entries_.at(queue_id)->wakeable = wakeable;
 }
@@ -244,13 +245,13 @@ bool MessageLoopTaskQueues::Merge(TaskQueueId owner, TaskQueueId subsumed) {
 bool MessageLoopTaskQueues::Unmerge(TaskQueueId owner) {
   std::scoped_lock owner_lock(GetMutex(owner));
 
-  auto& owner_entry = queue_entries_[owner];
+  auto& owner_entry = queue_entries_.at(owner);
   const TaskQueueId subsumed = owner_entry->owner_of;
   if (subsumed == _kUnmerged) {
     return false;
   }
 
-  queue_entries_[subsumed]->subsumed_by = _kUnmerged;
+  queue_entries_.at(subsumed)->subsumed_by = _kUnmerged;
   owner_entry->owner_of = _kUnmerged;
 
   if (HasPendingTasksUnlocked(owner)) {

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -13,6 +13,7 @@
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/task_runner.h"
+#include "flutter/fml/thread.h"
 #include "gtest/gtest.h"
 
 #define TIME_SENSITIVE(x) TimeSensitiveTest_##x
@@ -35,6 +36,7 @@ TEST(MessageLoop, DifferentThreadsHaveDifferentLoops) {
   fml::AutoResetWaitableEvent latch1;
   fml::AutoResetWaitableEvent term1;
   std::thread thread1([&loop1, &latch1, &term1]() {
+    fml::Thread::SetCurrentThreadName("thread1");
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     loop1 = &fml::MessageLoop::GetCurrent();
     latch1.Signal();
@@ -45,6 +47,7 @@ TEST(MessageLoop, DifferentThreadsHaveDifferentLoops) {
   fml::AutoResetWaitableEvent latch2;
   fml::AutoResetWaitableEvent term2;
   std::thread thread2([&loop2, &latch2, &term2]() {
+    fml::Thread::SetCurrentThreadName("thread2");
     fml::MessageLoop::EnsureInitializedForCurrentThread();
     loop2 = &fml::MessageLoop::GetCurrent();
     latch2.Signal();


### PR DESCRIPTION
Issues due to this unguarded access to the the queue_entries would only manifest
when the message loops were being torn down.

Also replaces `operator[]` access to entries with `at` where insertion is to be
explicitly avoided.

Fixes https://github.com/flutter/flutter/issues/44614 which was causing flaky failures on CI on test runs.