### PR TITLE
[web] Flutter for web autocorrect support

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -179,13 +179,15 @@ class InputConfiguration {
     @required this.inputType,
     @required this.inputAction,
     @required this.obscureText,
+    @required this.autocorrect,
   });
 
   InputConfiguration.fromFlutter(Map<String, dynamic> flutterInputConfiguration)
       : inputType = EngineInputType.fromName(
             flutterInputConfiguration['inputType']['name']),
         inputAction = flutterInputConfiguration['inputAction'],
-        obscureText = flutterInputConfiguration['obscureText'];
+        obscureText = flutterInputConfiguration['obscureText'],
+        autocorrect = flutterInputConfiguration['autocorrect'];
 
   /// The type of information being edited in the input control.
   final EngineInputType inputType;
@@ -195,6 +197,9 @@ class InputConfiguration {
 
   /// Whether to hide the text being edited.
   final bool obscureText;
+
+  /// Whether to  to enable autocorrection. Only available on Webkit.
+  final bool autocorrect;
 }
 
 typedef _OnChangeCallback = void Function(EditingState editingState);
@@ -371,6 +376,10 @@ class TextEditingElement {
     inputConfig.inputType.configureDomElement(domElement);
     if (inputConfig.obscureText) {
       domElement.setAttribute('type', 'password');
+    }
+    if (browserEngine == BrowserEngine.webkit && inputConfig.autocorrect) {
+      final String autocorrectValue = inputConfig.autocorrect ? 'on' : 'off';
+      domElement.setAttribute('autocorrect', autocorrectValue);
     }
     _setStaticStyleAttributes(domElement);
     owner._setDynamicStyleAttributes(domElement);

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -198,7 +198,13 @@ class InputConfiguration {
   /// Whether to hide the text being edited.
   final bool obscureText;
 
-  /// Whether to  to enable autocorrection. Only available on Webkit.
+  /// Whether to  to enable autocorrection.
+  ///
+  /// Definition of autocorrect can be found in:
+  /// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
+  ///
+  /// For future manual tests, note that autocorrect is an attribute only
+  /// supported by Safari.
   final bool autocorrect;
 }
 
@@ -377,10 +383,10 @@ class TextEditingElement {
     if (inputConfig.obscureText) {
       domElement.setAttribute('type', 'password');
     }
-    if (browserEngine == BrowserEngine.webkit && inputConfig.autocorrect) {
-      final String autocorrectValue = inputConfig.autocorrect ? 'on' : 'off';
-      domElement.setAttribute('autocorrect', autocorrectValue);
-    }
+
+    final String autocorrectValue = inputConfig.autocorrect ? 'on' : 'off';
+    domElement.setAttribute('autocorrect', autocorrectValue);
+
     _setStaticStyleAttributes(domElement);
     owner._setDynamicStyleAttributes(domElement);
     domRenderer.glassPaneElement.append(domElement);

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -198,7 +198,7 @@ class InputConfiguration {
   /// Whether to hide the text being edited.
   final bool obscureText;
 
-  /// Whether to  to enable autocorrection.
+  /// Whether to enable autocorrection.
   ///
   /// Definition of autocorrect can be found in:
   /// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -26,6 +26,7 @@ final InputConfiguration singlelineConfig = InputConfiguration(
   inputType: EngineInputType.text,
   obscureText: false,
   inputAction: 'TextInputAction.done',
+  autocorrect: true,
 );
 final Map<String, dynamic> flutterSinglelineConfig =
     createFlutterConfig('text');
@@ -34,6 +35,7 @@ final InputConfiguration multilineConfig = InputConfiguration(
   inputType: EngineInputType.multiline,
   obscureText: false,
   inputAction: 'TextInputAction.newline',
+  autocorrect: true,
 );
 final Map<String, dynamic> flutterMultilineConfig =
     createFlutterConfig('multiline');
@@ -105,6 +107,7 @@ void main() {
         inputType: EngineInputType.text,
         inputAction: 'TextInputAction.done',
         obscureText: true,
+        autocorrect: true,
       );
       editingElement.enable(
         config,
@@ -263,6 +266,7 @@ void main() {
         inputType: EngineInputType.text,
         obscureText: false,
         inputAction: 'TextInputAction.done',
+        autocorrect: true,
       );
       editingElement.enable(
         config,
@@ -286,6 +290,7 @@ void main() {
         inputType: EngineInputType.multiline,
         obscureText: false,
         inputAction: 'TextInputAction.done',
+        autocorrect: true,
       );
       editingElement.enable(
         config,

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -122,6 +122,46 @@ void main() {
       editingElement.disable();
     });
 
+    test('Knows to turn autocorrect off', () {
+      final InputConfiguration config = InputConfiguration(
+        inputType: EngineInputType.text,
+        inputAction: 'TextInputAction.done',
+        obscureText: false,
+        autocorrect: false,
+      );
+      editingElement.enable(
+        config,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+      expect(document.getElementsByTagName('input'), hasLength(1));
+      final InputElement input = document.getElementsByTagName('input')[0];
+      expect(editingElement.domElement, input);
+      expect(input.getAttribute('autocorrect'), 'off');
+
+      editingElement.disable();
+    });
+
+    test('Knows to turn autocorrect on', () {
+      final InputConfiguration config = InputConfiguration(
+        inputType: EngineInputType.text,
+        inputAction: 'TextInputAction.done',
+        obscureText: false,
+        autocorrect: true,
+      );
+      editingElement.enable(
+        config,
+        onChange: trackEditingState,
+        onAction: trackInputAction,
+      );
+      expect(document.getElementsByTagName('input'), hasLength(1));
+      final InputElement input = document.getElementsByTagName('input')[0];
+      expect(editingElement.domElement, input);
+      expect(input.getAttribute('autocorrect'), 'on');
+
+      editingElement.disable();
+    });
+
     test('Can read editing state correctly', () {
       editingElement.enable(
         singlelineConfig,
@@ -1134,6 +1174,7 @@ class PlatformMessagesSpy {
 Map<String, dynamic> createFlutterConfig(
   String inputType, {
   bool obscureText = false,
+  bool autocorrect = true,
   String inputAction,
 }) {
   return <String, dynamic>{
@@ -1141,6 +1182,7 @@ Map<String, dynamic> createFlutterConfig(
       'name': 'TextInputType.$inputType',
     },
     'obscureText': obscureText,
+    'autocorrect': autocorrect,
     'inputAction': inputAction ?? 'TextInputAction.done',
   };
 }


### PR DESCRIPTION
Using autocorrect value in the InputConfiguration in the web engine.

This attribute is only supported in webkit for now. there is an open issue for chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=901839

Note: no unit test support since unit tests does not run on webkit for now.

fixes: https://github.com/flutter/flutter/issues/45195