### PR TITLE
Roll Skia to e678b79c489d (2 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -26,7 +26,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
-  'skia_revision': 'c5e528e15b1f2270714c5c19b4ba3fe922f64881',
+  'skia_revision': 'e678b79c489dcc98ce64643d2791c7f5b5835379',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: e2786ca638b91b01bb4302bb337a15ac
+Signature: 33653c8cbb61a7646d184419d7528d56
 
 UNUSED LICENSES:
 


### PR DESCRIPTION
https://skia.googlesource.com/skia.git/+log/c5e528e15b1f..e678b79c489d

e678b79 Remove use of kCTFontOpticalSizeAttribute by Ben Wagner
417d299 Fix windows DLL builds with shaper included by Brian Osman