### PR TITLE
[web] Allow users to enable canvas text measurement

### DIFF
--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -184,7 +184,7 @@ abstract class TextMeasurementService {
   ///
   /// This is only used for testing at the moment. Once the implementation is
   /// complete and production-ready, we'll get rid of this flag.
-  static bool enableExperimentalCanvasImplementation = false;
+  static bool enableExperimentalCanvasImplementation = const bool.fromEnvironment('FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT', defaultValue: false);
 
   /// Gets the appropriate [TextMeasurementService] instance for the given
   /// [paragraph].


### PR DESCRIPTION
Now users can do:
```
flutter run -d web-server --release --dart-define=FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT=true
```
This flag enables the new experimental implementation of text measurement that's based on Canvas2d.