### PR TITLE
Run benchmarks in Cirrus

### DIFF
--- a/testing/run_tests.sh
+++ b/testing/run_tests.sh
@@ -5,4 +5,4 @@ set -o pipefail -e;
 BUILD_VARIANT="${1:-host_debug_unopt}"
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-python "${CURRENT_DIR}/run_tests.py" --variant="${BUILD_VARIANT}" --type=engine,dart
+python "${CURRENT_DIR}/run_tests.py" --variant="${BUILD_VARIANT}" --type=engine,dart,benchmarks


### PR DESCRIPTION
Although we don't collect metrics yet, this should at least ensure that
those benchmarks won't crash or get into a dead loop.