### PR TITLE
Always set mEditable values when different in TextPlugin

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -102,7 +102,6 @@ public class TextInputPlugin {
         return mImm;
     }
 
-    // public Editable getEditable() {
     @VisibleForTesting Editable getEditable() {
         return mEditable;
     }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -102,6 +102,15 @@ public class TextInputPlugin {
         return mImm;
     }
 
+    @VisibleForTesting Editable getEditable() {
+        return mEditable;
+    }
+
+    // @NonNull
+    // public Editable getEditable() {
+    //     return mEditable;
+    // }
+
     /***
      * Use the current platform view input connection until unlockPlatformViewInputConnection is called.
      *

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -106,11 +106,6 @@ public class TextInputPlugin {
         return mEditable;
     }
 
-    // @NonNull
-    // public Editable getEditable() {
-    //     return mEditable;
-    // }
-
     /***
      * Use the current platform view input connection until unlockPlatformViewInputConnection is called.
      *

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -102,6 +102,7 @@ public class TextInputPlugin {
         return mImm;
     }
 
+    // public Editable getEditable() {
     @VisibleForTesting Editable getEditable() {
         return mEditable;
     }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -306,15 +306,16 @@ public class TextInputPlugin {
     }
 
     @VisibleForTesting void setTextInputEditingState(View view, TextInputChannel.TextEditState state) {
-        if (!restartAlwaysRequired && !mRestartInputPending && state.text.equals(mEditable.toString())) {
-            applyStateToSelection(state);
+        if (!state.text.equals(mEditable.toString())) {
+            mEditable.replace(0, mEditable.length(), state.text);
+        }
+        applyStateToSelection(state);
+        if (!restartAlwaysRequired && !mRestartInputPending) {
             mImm.updateSelection(mView, Math.max(Selection.getSelectionStart(mEditable), 0),
                     Math.max(Selection.getSelectionEnd(mEditable), 0),
                     BaseInputConnection.getComposingSpanStart(mEditable),
                     BaseInputConnection.getComposingSpanEnd(mEditable));
         } else {
-            mEditable.replace(0, mEditable.length(), state.text);
-            applyStateToSelection(state);
             mImm.restartInput(view);
             mRestartInputPending = false;
         }

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -306,15 +306,20 @@ public class TextInputPlugin {
     }
 
     @VisibleForTesting void setTextInputEditingState(View view, TextInputChannel.TextEditState state) {
+        // Always replace the contents of mEditable if the text differs
         if (!state.text.equals(mEditable.toString())) {
             mEditable.replace(0, mEditable.length(), state.text);
         }
+        // Always apply state to selection which handles updating the selection if needed.
         applyStateToSelection(state);
+        // Use updateSelection to update imm on selection if it is not neccessary to restart.
         if (!restartAlwaysRequired && !mRestartInputPending) {
             mImm.updateSelection(mView, Math.max(Selection.getSelectionStart(mEditable), 0),
                     Math.max(Selection.getSelectionEnd(mEditable), 0),
                     BaseInputConnection.getComposingSpanStart(mEditable),
                     BaseInputConnection.getComposingSpanEnd(mEditable));
+        // Restart if there is a pending restart or the device requires a force restart
+        // (see isRestartAlwaysRequired). Restarting will also update the selection.
         } else {
             mImm.restartInput(view);
             mRestartInputPending = false;

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -73,26 +73,26 @@ public class TextInputPluginTest {
         assertEquals(1, testImm.getRestartCount(testView));
     }
 
-    // @Test
-    // public void setTextInputEditingState_alwaysSetEditableWhenDifferent() {
-    //     // Initialize a general TextInputPlugin.
-    //     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-    //     TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
-    //     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    //     View testView = new View(RuntimeEnvironment.application);
-    //     TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
-    //     textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, true, TextInputChannel.TextCapitalization.NONE, null, null, null));
-    //     // There's a pending restart since we initialized the text input client. Flush that now. With changed text, we should
-    //     // always set the Editable contents.
-    //     textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
-    //     assertEquals(1, testImm.getRestartCount(testView));
-    //     assertTrue(textInputPlugin.mEditable.text.equals("hello"));
+    @Test
+    public void setTextInputEditingState_alwaysSetEditableWhenDifferent() {
+        // Initialize a general TextInputPlugin.
+        InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
+        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+        testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
+        View testView = new View(RuntimeEnvironment.application);
+        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
+        textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, true, TextInputChannel.TextCapitalization.NONE, null, null, null));
+        // There's a pending restart since we initialized the text input client. Flush that now. With changed text, we should
+        // always set the Editable contents.
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
+        assertEquals(1, testImm.getRestartCount(testView));
+        assertTrue(textInputPlugin.getEditable().text.equals("hello"));
 
-    //     // No pending restart, set Editable contents anyways.
-    //     textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
-    //     assertEquals(1, testImm.getRestartCount(testView));
-    //     assertTrue(textInputPlugin.mEditable.text.equals("Shibuyawoo"));
-    // }
+        // No pending restart, set Editable contents anyways.
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
+        assertEquals(1, testImm.getRestartCount(testView));
+        assertTrue(textInputPlugin.getEditable().text.equals("Shibuyawoo"));
+    }
 
     // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512
     // All modern Samsung keybords are affected including non-korean languages and thus

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -86,12 +86,15 @@ public class TextInputPluginTest {
         // always set the Editable contents.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        assertTrue(textInputPlugin.getEditable().text.equals("hello"));
+        System.err.println("######################################################");
+        System.err.println(textInputPlugin);
+        assertTrue(true);
+        // assertTrue(textInputPlugin.getEditable().toString().equals("hello"));
 
         // No pending restart, set Editable contents anyways.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        assertTrue(textInputPlugin.getEditable().text.equals("Shibuyawoo"));
+        // assertTrue(textInputPlugin.getEditable().toString().equals("Shibuyawoo"));
     }
 
     // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -86,12 +86,12 @@ public class TextInputPluginTest {
         // always set the Editable contents.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        assertTrue(testImm.getEditale.text.equals("hello"));
+        // assertTrue(testImm.getEditale.text.equals("hello"));
 
         // No pending restart, set Editable contents anyways.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        assertTrue(testImm.getEditale.text.equals("Shibuyawoo"));
+        // assertTrue(testImm.getEditale.text.equals("Shibuyawoo"));
     }
 
     // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512
@@ -181,8 +181,8 @@ public class TextInputPluginTest {
             return restartCounter.get(view.hashCode(), /*defaultValue=*/0);
         }
 
-        public Editable getEditable() {
-            return mEditable;
-        }
+        // public Editable getEditable() {
+        //     return mEditable;
+        // }
     }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -29,6 +29,7 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.platform.PlatformViewsController;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -86,15 +87,12 @@ public class TextInputPluginTest {
         // always set the Editable contents.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        System.err.println("######################################################");
-        // System.err.println(textInputPlugin);
-        // assertTrue(true);
-        // assertTrue(textInputPlugin.getEditable().toString().equals("hello"));
+        assertTrue(textInputPlugin.getEditable().toString().equals("hello"));
 
         // No pending restart, set Editable contents anyways.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        // assertTrue(textInputPlugin.getEditable().toString().equals("Shibuyawoo"));
+        assertTrue(textInputPlugin.getEditable().toString().equals("Shibuyawoo"));
     }
 
     // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -73,26 +73,26 @@ public class TextInputPluginTest {
         assertEquals(1, testImm.getRestartCount(testView));
     }
 
-    @Test
-    public void setTextInputEditingState_alwaysSetEditableWhenDifferent() {
-        // Initialize a general TextInputPlugin.
-        InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
-        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
-        testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-        View testView = new View(RuntimeEnvironment.application);
-        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
-        textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, true, TextInputChannel.TextCapitalization.NONE, null, null, null));
-        // There's a pending restart since we initialized the text input client. Flush that now. With changed text, we should
-        // always set the Editable contents.
-        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
-        assertEquals(1, testImm.getRestartCount(testView));
-        assertTrue(testImm.getEditale().text.equals("hello"));
+    // @Test
+    // public void setTextInputEditingState_alwaysSetEditableWhenDifferent() {
+    //     // Initialize a general TextInputPlugin.
+    //     InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
+    //     TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+    //     testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
+    //     View testView = new View(RuntimeEnvironment.application);
+    //     TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
+    //     textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, true, TextInputChannel.TextCapitalization.NONE, null, null, null));
+    //     // There's a pending restart since we initialized the text input client. Flush that now. With changed text, we should
+    //     // always set the Editable contents.
+    //     textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
+    //     assertEquals(1, testImm.getRestartCount(testView));
+    //     assertTrue(textInputPlugin.mEditable.text.equals("hello"));
 
-        // No pending restart, set Editable contents anyways.
-        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
-        assertEquals(1, testImm.getRestartCount(testView));
-        assertTrue(testImm.getEditale().text.equals("Shibuyawoo"));
-    }
+    //     // No pending restart, set Editable contents anyways.
+    //     textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
+    //     assertEquals(1, testImm.getRestartCount(testView));
+    //     assertTrue(textInputPlugin.mEditable.text.equals("Shibuyawoo"));
+    // }
 
     // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512
     // All modern Samsung keybords are affected including non-korean languages and thus
@@ -179,10 +179,6 @@ public class TextInputPluginTest {
 
         public int getRestartCount(View view) {
             return restartCounter.get(view.hashCode(), /*defaultValue=*/0);
-        }
-
-        public Editable getEditable() {
-            return this.mEditable;
         }
     }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -88,7 +88,7 @@ public class TextInputPluginTest {
         assertEquals(1, testImm.getRestartCount(testView));
         System.err.println("######################################################");
         // System.err.println(textInputPlugin);
-        assertTrue(true);
+        // assertTrue(true);
         // assertTrue(textInputPlugin.getEditable().toString().equals("hello"));
 
         // No pending restart, set Editable contents anyways.

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -73,6 +73,27 @@ public class TextInputPluginTest {
         assertEquals(1, testImm.getRestartCount(testView));
     }
 
+    @Test
+    public void setTextInputEditingState_alwaysSetEditableWhenDifferent() {
+        // Initialize a general TextInputPlugin.
+        InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
+        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+        testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
+        View testView = new View(RuntimeEnvironment.application);
+        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, mock(DartExecutor.class), mock(PlatformViewsController.class));
+        textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, true, TextInputChannel.TextCapitalization.NONE, null, null, null));
+        // There's a pending restart since we initialized the text input client. Flush that now. With changed text, we should
+        // always set the Editable contents.
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
+        assertEquals(1, testImm.getRestartCount(testView));
+        assertTrue(testImm.getEditale.text.equals("hello"));
+
+        // No pending restart, set Editable contents anyways.
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
+        assertEquals(1, testImm.getRestartCount(testView));
+        assertTrue(testImm.getEditale.text.equals("Shibuyawoo"));
+    }
+
     // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512
     // All modern Samsung keybords are affected including non-korean languages and thus
     // need the restart.
@@ -158,6 +179,10 @@ public class TextInputPluginTest {
 
         public int getRestartCount(View view) {
             return restartCounter.get(view.hashCode(), /*defaultValue=*/0);
+        }
+
+        public Editable getEditable() {
+            return mEditable;
         }
     }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -86,12 +86,12 @@ public class TextInputPluginTest {
         // always set the Editable contents.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        // assertTrue(testImm.getEditale.text.equals("hello"));
+        assertTrue(testImm.getEditale().text.equals("hello"));
 
         // No pending restart, set Editable contents anyways.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("Shibuyawoo", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
-        // assertTrue(testImm.getEditale.text.equals("Shibuyawoo"));
+        assertTrue(testImm.getEditale().text.equals("Shibuyawoo"));
     }
 
     // See https://github.com/flutter/flutter/issues/29341 and https://github.com/flutter/flutter/issues/31512
@@ -182,7 +182,7 @@ public class TextInputPluginTest {
         }
 
         public Editable getEditable() {
-            return mEditable;
+            return this.mEditable;
         }
     }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -181,8 +181,8 @@ public class TextInputPluginTest {
             return restartCounter.get(view.hashCode(), /*defaultValue=*/0);
         }
 
-        // public Editable getEditable() {
-        //     return mEditable;
-        // }
+        public Editable getEditable() {
+            return mEditable;
+        }
     }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -87,7 +87,7 @@ public class TextInputPluginTest {
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("hello", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
         System.err.println("######################################################");
-        System.err.println(textInputPlugin);
+        // System.err.println(textInputPlugin);
         assertTrue(true);
         // assertTrue(textInputPlugin.getEditable().toString().equals("hello"));
 


### PR DESCRIPTION
Before, we would skip setting the value of mEditable in certain situations, causing the value to be lost.

This ensures that we always set mEditable if needed before doing anything else.

Should partially fix https://github.com/flutter/flutter/issues/44869 will need confirmation if this is enough. More work may be needed to resolve all symptoms.