### PR TITLE
Added FunctionRef to fml.

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -25,6 +25,7 @@ source_set("fml") {
     "eintr_wrapper.h",
     "file.cc",
     "file.h",
+    "functional/function_ref.h",
     "gpu_thread_merger.cc",
     "gpu_thread_merger.h",
     "icu_util.cc",
@@ -203,6 +204,7 @@ executable("fml_unittests") {
   sources = [
     "base32_unittest.cc",
     "command_line_unittest.cc",
+    "functional/function_ref_unittest.cc",
     "memory/ref_counted_unittest.cc",
     "memory/weak_ptr_unittest.cc",
     "message_loop_task_queues_merge_unmerge_unittests.cc",
@@ -246,6 +248,20 @@ if (is_fuchsia) {
     binary = "fml_unittests"
   }
 }
+
+executable("fml_function_ref_benchmarks") {
+  testonly = true
+
+  sources = [
+    "functional/function_ref_benchmarks.cc",
+  ]
+
+  deps = [
+    "$flutter_root/fml",
+    "$flutter_root/runtime:libdart",
+  ]
+}
+
 
 executable("fml_benchmarks") {
   testonly = true

--- a/fml/file.h
+++ b/fml/file.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "flutter/fml/functional/function_ref.h"
 #include "flutter/fml/macros.h"
 #include "flutter/fml/unique_fd.h"
 
@@ -94,8 +95,8 @@ bool WriteAtomically(const fml::UniqueFD& base_directory,
 /// to `directory`). The returned bool should be false if and only if further
 /// traversal should be stopped. For example, a file-search visitor may return
 /// false when the file is found so no more visiting is needed.
-using FileVisitor = std::function<bool(const fml::UniqueFD& directory,
-                                       const std::string& filename)>;
+using FileVisitor = fml::FunctionRef<bool(const fml::UniqueFD& directory,
+                                          const std::string& filename)>;
 
 /// Call `visitor` on all files inside the `directory` non-recursively. The
 /// trivial file "." and ".." will not be visited.

--- a/fml/functional/function_ref.h
+++ b/fml/functional/function_ref.h
@@ -1,0 +1,61 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_FML_FUNCTIONAL_FUNCTION_REF_H_
+#define FLUTTER_FML_FUNCTIONAL_FUNCTION_REF_H_
+
+#include <cassert>
+
+#include <functional>
+#include <type_traits>
+
+#include "flutter/fml/logging.h"
+
+namespace fml {
+
+/// A drop in replacement for std::function that doesn't own the underlying
+/// memory.  This is similar to absl::FunctionRef.
+///
+/// This is roughly 2x-15x faster than using std::function, pass-by-value is
+/// faster since the copy is so cheap.
+///
+/// References:
+///  - https://vittorioromeo.info/index/blog/passing_functions_to_functions.html#function_view
+///
+/// @todo Implement constructor for function pointers, just works with
+/// std::function right now.
+
+template <typename Signature>
+class FunctionRef;
+
+template <typename R, typename... Args>
+class FunctionRef<R(Args...)> final {
+ public:
+  /// Constructor for std::functions.
+  template <typename T,
+            typename = std::enable_if_t<
+                // Asserting for std::functions
+                std::is_function<T&(Args...)>{} &&
+                // Not for function pointers
+                !std::is_same<std::decay_t<T>, FunctionRef>{}>>
+  FunctionRef(T&& x) : ptr_{(void*)std::addressof(x)} {
+    call_ = [](void* ptr, Args... xs) -> R {
+      return (*reinterpret_cast<std::add_pointer_t<T>>(ptr))(
+          std::forward<Args>(xs)...);
+    };
+  }
+
+  decltype(auto) operator()(Args... xs) const {
+    FML_DCHECK(call_);
+    return call_(ptr_, std::forward<Args>(xs)...);
+  }
+
+ private:
+  void* ptr_;
+  R (*call_)(void*, Args...);
+};
+
+}  // namespace fml
+
+#endif  // FLUTTER_FML_FUNCTIONAL_FUNCTION_REF_H_

--- a/fml/functional/function_ref_benchmarks.cc
+++ b/fml/functional/function_ref_benchmarks.cc
@@ -1,0 +1,76 @@
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include "function_ref.h"
+
+namespace {
+uint64_t measureTime(const std::string& name,
+                     fml::FunctionRef<void(void)> func) {
+  auto start = std::chrono::system_clock::now();
+  func();
+  auto end = std::chrono::system_clock::now();
+
+  uint64_t elapsed_time =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+  std::cout << name << ": elapsed time:" << elapsed_time << "ns" << std::endl;
+  return elapsed_time;
+}
+
+void fibonacciFunc(uint64_t count,
+                   uint64_t start0,
+                   uint64_t start1,
+                   std::function<void(uint64_t)> func) {
+  if (start1 < count) {
+    func(start0);
+    fibonacciFunc(count, start1, start1 + start0, func);
+  } else {
+    func(start1);
+  }
+}
+
+void fibonacciRef(uint64_t count,
+                  uint64_t start0,
+                  uint64_t start1,
+                  fml::FunctionRef<void(uint64_t)> func) {
+  if (start1 < count) {
+    func(start0);
+    fibonacciFunc(count, start1, start1 + start0, func);
+  } else {
+    func(start1);
+  }
+}
+
+void fibonacciConstRef(uint64_t count,
+                       uint64_t start0,
+                       uint64_t start1,
+                       const std::function<void(uint64_t)>& func) {
+  if (start1 < count) {
+    func(start0);
+    fibonacciFunc(count, start1, start1 + start0, func);
+  } else {
+    func(start1);
+  }
+}
+
+}  // namespace
+
+int main() {
+  int count = 10000;
+  uint64_t func_time = measureTime("std::function", [&] {
+    bool is_greater = false;
+    fibonacciFunc(count, 0, 1, [&](uint64_t x) { is_greater = (x > 1000LL); });
+    std::cout << "is_greater: " << is_greater << std::endl;
+  });
+  uint64_t ref_time = measureTime("fml::FunctionRef", [&] {
+    bool is_greater = false;
+    fibonacciRef(count, 0, 1, [&](uint64_t x) { is_greater = (x > 1000LL); });
+    std::cout << "is_greater: " << is_greater << std::endl;
+  });
+  std::cout << "faster: " << static_cast<double>(func_time) / ref_time << "x"
+            << std::endl;
+  measureTime("const std::function&", [&] {
+    bool is_greater = false;
+    fibonacciConstRef(count, 0, 1, [&](uint64_t x) { is_greater = (x > 1000LL); });
+    std::cout << "is_greater: " << is_greater << std::endl;
+  });
+}

--- a/fml/functional/function_ref_unittest.cc
+++ b/fml/functional/function_ref_unittest.cc
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Fork of webrtc function_view_unittest:
+// https://github.com/webrtc-uwp/webrtc/blob/master/api/function_view_unittest.cc
+
+#include <memory>
+#include <utility>
+
+#include <functional>
+#include "function_ref.h"
+#include "gtest/gtest.h"
+
+namespace fml {
+
+namespace {
+
+void exec(FunctionRef<void(void)> func) {
+  func();
+}
+
+TEST(FunctionRefTest, Simple) {
+  int x = 0;
+  std::function<void(void)> func = [&] { x++; };
+  exec(func);
+  EXPECT_EQ(1, x);
+}
+
+}  // namespace
+}  // namespace fml


### PR DESCRIPTION
Made an implementation of absl::FunctionRef.

This runs faster than std::function in cases that use it and documents semantics better about memory management,

Output from benchmarks:
```
aaclarke-macbookpro2:src aaclarke$ ./out/host_release/fml_function_ref_benchmarks
is_greater: 1
std::function: elapsed time:35000ns
is_greater: 1
fml::FunctionRef: elapsed time:2000ns
faster: 17.5x
is_greater: 1
const std::function&: elapsed time:2000ns
```
In this case FunctionRef is 17.5x faster than std::function and no faster than const refs.