### PR TITLE
Listen to keyUp event on meta modified keys

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -310,8 +310,8 @@ static void CommonInit(FlutterViewController* controller) {
       addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp
                                    handler:^NSEvent*(NSEvent* event) {
                                      // Intercept keyUp only for events triggered on the current
-                                     // window.
-                                     if (([event window] == weakSelf.view.window) &&
+                                     // view.
+                                     if (([[event window] firstResponder] == weakSelf.view) &&
                                          ([event modifierFlags] & NSEventModifierFlagCommand) &&
                                          ([event type] == NSEventTypeKeyUp))
                                        [weakSelf keyUp:event];

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -304,7 +304,7 @@ static void CommonInit(FlutterViewController* controller) {
 // ViewController as a listener for a keyUp event before it's handled by NSApplication, and should
 // NOT modify the event to avoid any unexpected behavior.
 - (void)listenForMetaModifiedKeyUpEvents {
-  NSAssert(_keyUpMonitor == nil, @"_keyUpMonitor should not be created yet");
+  NSAssert(_keyUpMonitor == nil, @"_keyUpMonitor was already created");
   FlutterViewController* __weak weakSelf = self;
   _keyUpMonitor = [NSEvent
       addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -304,6 +304,7 @@ static void CommonInit(FlutterViewController* controller) {
 // ViewController as a listener for a keyUp event before it's handled by NSApplication, and should
 // NOT modify the event to avoid any unexpected behavior.
 - (void)listenForMetaModifiedKeyUpEvents {
+  NSAssert(_keyUpMonitor == nil, @"_keyUpMonitor should not be created yet");
   FlutterViewController* __weak weakSelf = self;
   _keyUpMonitor = [NSEvent
       addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -309,7 +309,10 @@ static void CommonInit(FlutterViewController* controller) {
   _keyUpMonitor = [NSEvent
       addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp
                                    handler:^NSEvent*(NSEvent* event) {
-                                     if (([event modifierFlags] & NSEventModifierFlagCommand) &&
+                                     // Intercept keyUp only for events triggered on the current
+                                     // window.
+                                     if (([event window] == weakSelf.view.window) &&
+                                         ([event modifierFlags] & NSEventModifierFlagCommand) &&
                                          ([event type] == NSEventTypeKeyUp))
                                        [weakSelf keyUp:event];
                                      return event;

--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -101,6 +101,11 @@ struct KeyboardState {
 @property(nonatomic) KeyboardState keyboardState;
 
 /**
+ * Event monitor for keyUp events.
+ */
+@property(nonatomic) id keyUpMonitor;
+
+/**
  * Starts running |engine|, including any initial setup.
  */
 - (BOOL)launchEngine;
@@ -244,9 +249,14 @@ static void CommonInit(FlutterViewController* controller) {
   }
 }
 
+- (void)viewWillDisappear {
+  // Per Apple's documentation, it is discouraged to call removeMonitor: in dealloc, and it's
+  // recommended to be called earlier in the lifecycle.
+  [NSEvent removeMonitor:_keyUpMonitor];
+}
+
 - (void)dealloc {
   _engine.viewController = nil;
-  [NSEvent removeMonitor:self];
 }
 
 #pragma mark - Public methods
@@ -295,7 +305,7 @@ static void CommonInit(FlutterViewController* controller) {
 // NOT modify the event to avoid any unexpected behavior.
 - (void)listenForMetaModifiedKeyUpEvents {
   FlutterViewController* __weak weakSelf = self;
-  [NSEvent
+  _keyUpMonitor = [NSEvent
       addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp
                                    handler:^NSEvent*(NSEvent* event) {
                                      if (([event modifierFlags] & NSEventModifierFlagCommand) &&


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/44135

Macos does not report a keyUp: event  when a meta-modified key is released while `command` is still pressed. This change listens to keyUp without modifying the NSEvent forwarded in the application.