### PR TITLE
[fuchsia] Capture SkRRect in scene_update_context by value

### DIFF
--- a/flow/scene_update_context.h
+++ b/flow/scene_update_context.h
@@ -124,7 +124,7 @@ class SceneUpdateContext {
     void AddPaintLayer(Layer* layer);
 
    private:
-    const SkRRect& rrect_;
+    const SkRRect rrect_;
     SkColor const color_;
 
     std::vector<Layer*> paint_layers_;


### PR DESCRIPTION
This was leading to usage of the captured rect after the end
of the lifetime in descrutor of Frame.