### PR TITLE
Add support for FontLoader on the web

### DIFF
--- a/lib/web_ui/lib/src/ui/text.dart
+++ b/lib/web_ui/lib/src/ui/text.dart
@@ -1437,8 +1437,5 @@ abstract class ParagraphBuilder {
 /// * `fontFamily`: The family name used to identify the font in text styles.
 ///  If this is not provided, then the family name will be extracted from the font file.
 Future<void> loadFontFromList(Uint8List list, {String fontFamily}) {
-  if (engine.assertionsEnabled) {
-    throw UnsupportedError('loadFontFromList is not supported.');
-  }
-  return Future<void>.value(null);
+  return _fontCollection.loadFontFromList(list, fontFamily: fontFamily);
 }

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+
+Future<void> main() async {
+  await ui.webOnlyInitializeTestDomRenderer();
+  group('loadFontFromList', () {
+    const String _testFontUrl = 'packages/ui/assets/ahem.ttf';
+
+    tearDown(() {
+      html.document.fonts.clear();
+    });
+
+    test('surfaces error from invalid font buffer', () async {
+      await expectLater(
+          ui.loadFontFromList(Uint8List(0), fontFamily: 'test-font'),
+          throwsA(TypeMatcher<Exception>()));
+    });
+
+    test('loads Blehm font from buffer', () async {
+      expect(_containsFontFamily('Blehm'), false);
+
+      final html.HttpRequest response = await html.HttpRequest.request(
+          _testFontUrl,
+          responseType: 'arraybuffer');
+      await ui.loadFontFromList(Uint8List.view(response.response),
+          fontFamily: 'Blehm');
+
+      expect(_containsFontFamily('Blehm'), true);
+    });
+  });
+}
+
+bool _containsFontFamily(String family) {
+  bool found = false;
+  html.document.fonts.forEach((html.FontFace fontFace,
+      html.FontFace fontFaceAgain, html.FontFaceSet fontFaceSet) {
+    if (fontFace.family == family) {
+      found = true;
+    }
+  });
+  return found;
+}


### PR DESCRIPTION
I did a spot check in Chrome, Safari, and Firefox and it seems to support FontFace accepting a buffer. Unlike the other font loading path, I ensure that the errors are surfaced (in a non-dart:html type) so they can be caught and/or used for feature detection.

Fixes: https://github.com/flutter/flutter/issues/45459

TBD: does canvas kit have a different font loader?

<img width="1440" alt="Screen Shot 2019-11-23 at 2 04 07 PM" src="https://user-images.githubusercontent.com/8975114/69485901-4216d880-0dfa-11ea-9607-65fbfd7841f3.png">
