### PR TITLE
Remove device independent mask

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -522,14 +522,12 @@ static void CommonInit(FlutterViewController* controller) {
 }
 
 - (void)flagsChanged:(NSEvent*)event {
-  NSUInteger currentlyPressedFlags =
-      event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
-  if (currentlyPressedFlags < _keyboardState.previously_pressed_flags) {
+  if (event.modifierFlags < _keyboardState.previously_pressed_flags) {
     [self keyUp:event];
   } else {
     [self keyDown:event];
   }
-  _keyboardState.previously_pressed_flags = currentlyPressedFlags;
+  _keyboardState.previously_pressed_flags = event.modifierFlags;
 }
 
 - (void)mouseEntered:(NSEvent*)event {


### PR DESCRIPTION
The current implementation doesn't differentiate between modifiers of the same kind but different side. For example, releasing Shift Right, while holding Shift Left, will result in a keyDown event.