### PR TITLE
Catch exception for unit test failure and show output.

### DIFF
--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -24,7 +24,11 @@ dart_tests_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'dart',)
 fml_unittests_filter = '--gtest_filter=-*TimeSensitiveTest*:*GpuThreadMerger*'
 
 def RunCmd(cmd, **kwargs):
-  print(subprocess.check_output(cmd, **kwargs))
+  try:
+    print(subprocess.check_output(cmd, **kwargs))
+  except subprocess.CalledProcessError as cpe:
+    print(cpe.output)
+    raise cpe
 
 def IsMac():
   return sys.platform == 'darwin'


### PR DESCRIPTION
I found this change useful when creating and debugging some new unit tests. Without this change all you see if a unit test fails is a python stack trace for the testing framework.

The exception is still raised, so the test still halts, but now you can see exactly which test is failing.