### PR TITLE
A11y desktop fix the method call

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -40,7 +40,7 @@ class SemanticsHelper {
       isDesktop ? DesktopSemanticsEnabler() : MobileSemanticsEnabler();
 
   bool shouldEnableSemantics(html.Event event) {
-    return _enableSemantics.tryEnableSemantics(event);
+    return _enableSemantics.shouldEnableSemantics(event);
   }
 
   html.Element prepareAccesibilityPlaceholder() {


### PR DESCRIPTION
Wrong method was getting called, so it was bypassing the check to see if semantics were already enabled. If semantics is enabled the placeholder is null. This was the cause of null errors.

Fixing: https://github.com/flutter/flutter/issues/45709
