### PR TITLE
Fix subprocess error in Windows build

### DIFF
--- a/build/git_revision.py
+++ b/build/git_revision.py
@@ -25,7 +25,7 @@ def GetRepositoryVersion(repository):
     repository,
     'rev-parse',
     'HEAD',
-  ])
+  ], shell=True)
 
   return version.strip()
 


### PR DESCRIPTION
Not sure why Cirrus doesn't encounter this, but I did while building in a VM and it seems like a few others have as well:  https://github.com/flutter/flutter/issues/28720