### PR TITLE
Remove suprious warning

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1482,11 +1482,7 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         if (!accessibilityManager.isEnabled()) {
             return;
         }
-        if (viewId == ROOT_NODE_ID) {
-            rootAccessibilityView.sendAccessibilityEvent(eventType);
-        } else {
-            sendAccessibilityEvent(obtainAccessibilityEvent(viewId, eventType));
-        }
+        sendAccessibilityEvent(obtainAccessibilityEvent(viewId, eventType));
     }
 
     /**
@@ -1500,7 +1496,9 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
         if (!accessibilityManager.isEnabled()) {
             return;
         }
-        // TODO(mattcarroll): why are we explicitly talking to the root view's parent?
+        // See https://developer.android.com/reference/android/view/View.html#sendAccessibilityEvent(int)
+        // We just want the final part at this point, since the event parameter
+        // has already been correctly populated.
         rootAccessibilityView.getParent().requestSendAccessibilityEvent(rootAccessibilityView, event);
     }
 

--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -1551,9 +1551,6 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
      * invoked to create an {@link AccessibilityEvent} for the {@link #rootAccessibilityView}.
      */
     private AccessibilityEvent obtainAccessibilityEvent(int virtualViewId, int eventType) {
-        if (BuildConfig.DEBUG && virtualViewId == ROOT_NODE_ID) {
-            Log.e(TAG, "VirtualView node must not be the root node.");
-        }
         AccessibilityEvent event = AccessibilityEvent.obtain(eventType);
         event.setPackageName(rootAccessibilityView.getContext().getPackageName());
         event.setSource(rootAccessibilityView, virtualViewId);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/45928

At some point, this was only called on paths where that was valid.  That seems to no longer be the case.