### PR TITLE
add pointer data santizing in flutter web engine

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -405,6 +405,7 @@ FILE: ../../../flutter/lib/web_ui/lib/src/engine/picture.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/platform_views.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/plugins.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/pointer_binding.dart
+FILE: ../../../flutter/lib/web_ui/lib/src/engine/pointer_converter.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/recording_canvas.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/render_vertices.dart
 FILE: ../../../flutter/lib/web_ui/lib/src/engine/rrect_renderer.dart

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -62,6 +62,7 @@ part 'engine/picture.dart';
 part 'engine/platform_views.dart';
 part 'engine/plugins.dart';
 part 'engine/pointer_binding.dart';
+part 'engine/pointer_converter.dart';
 part 'engine/recording_canvas.dart';
 part 'engine/render_vertices.dart';
 part 'engine/rrect_renderer.dart';

--- a/lib/web_ui/lib/src/engine/pointer_binding.dart
+++ b/lib/web_ui/lib/src/engine/pointer_binding.dart
@@ -20,10 +20,12 @@ class PointerBinding {
       _instance = this;
       _detector = const PointerSupportDetector();
       _adapter = _createAdapter();
+      _pointerDataConverter = PointerDataConverter();
     }
     assert(() {
       registerHotRestartListener(() {
         _adapter?.clearListeners();
+        _pointerDataConverter?.clearPointerState();
       });
       return true;
     }());
@@ -32,7 +34,7 @@ class PointerBinding {
   final DomRenderer domRenderer;
   PointerSupportDetector _detector;
   BaseAdapter _adapter;
-
+  PointerDataConverter _pointerDataConverter;
   /// Should be used in tests to define custom detection of pointer support.
   ///
   /// ```dart
@@ -57,6 +59,7 @@ class PointerBinding {
       _detector = newDetector;
       _adapter?.clearListeners();
       _adapter = _createAdapter();
+      _pointerDataConverter?.clearPointerState();
     }
   }
 
@@ -75,9 +78,8 @@ class PointerBinding {
 
   void _onPointerData(List<ui.PointerData> data) {
     final List<ui.PointerData> converted = List<ui.PointerData>.from(
-      PointerDataConverter.convert(data),
+      _pointerDataConverter.convert(data),
     );
-    print('from data ${data} to converted ${converted}');
     final ui.PointerDataPacket packet = ui.PointerDataPacket(data: converted);
     final ui.PointerDataPacketCallback callback = ui.window.onPointerDataPacket;
     if (callback != null) {

--- a/lib/web_ui/lib/src/engine/pointer_converter.dart
+++ b/lib/web_ui/lib/src/engine/pointer_converter.dart
@@ -7,7 +7,7 @@ part of engine;
 class _PointerState {
   _PointerState(this.x, this.y);
 
-  int get pointer => _pointer; // The identifier used in PointerEvent objects.
+  int get pointer => _pointer; // The identifier used in framework hit test.
   int _pointer;
   static int _pointerCount = 0;
   void startNewPointer() {
@@ -21,7 +21,8 @@ class _PointerState {
   double y;
 }
 
-/// Converter to convert web pointer data to a framework-compatible form.
+/// Converter to convert web pointer data into a form that framework can
+/// understand.
 ///
 /// This converter calculates pointer location delta and pointer identifier for
 /// each pointer. Both are required by framework to correctly trigger gesture
@@ -42,8 +43,7 @@ class _PointerState {
 class PointerDataConverter {
   PointerDataConverter();
 
-  // Map from platform pointer identifiers to PointerEvent pointer identifiers.
-  // Static to guarantee that pointers are unique.
+  // Map from browser pointer identifiers to PointerEvent pointer identifiers.
   final Map<int, _PointerState> _pointers = <int, _PointerState>{};
 
   /// Clears the existing pointer states.

--- a/lib/web_ui/lib/src/engine/pointer_converter.dart
+++ b/lib/web_ui/lib/src/engine/pointer_converter.dart
@@ -7,7 +7,8 @@ part of engine;
 class _PointerState {
   _PointerState(this.x, this.y);
 
-  int get pointer => _pointer; // The identifier used in framework hit test.
+  /// The identifier used in framework hit test.
+  int get pointer => _pointer;
   int _pointer;
   static int _pointerCount = 0;
   void startNewPointer() {
@@ -55,201 +56,585 @@ class PointerDataConverter {
     _PointerState._pointerCount = 0;
   }
 
-  _PointerState _ensureStateForPointer(ui.PointerData datum, double x, double y) {
+  _PointerState _ensureStateForPointer(int device, double x, double y) {
     return _pointers.putIfAbsent(
-      datum.device,
-        () => _PointerState(x, y),
+      device,
+      () => _PointerState(x, y),
     );
   }
 
-  ui.PointerData _generateCompletePointerData(ui.PointerData datum) {
-    assert(_pointers.containsKey(datum.device));
-    final _PointerState state = _pointers[datum.device];
-    final double deltaX = datum.physicalX - state.x;
-    final double deltaY = datum.physicalY - state.y;
-    state.x = datum.physicalX;
-    state.y = datum.physicalY;
+  ui.PointerData _generateCompletePointerData({
+    Duration timeStamp,
+    ui.PointerChange change,
+    ui.PointerDeviceKind kind,
+    ui.PointerSignalKind signalKind,
+    int device,
+    double physicalX,
+    double physicalY,
+    int buttons,
+    bool obscured,
+    double pressure,
+    double pressureMin,
+    double pressureMax,
+    double distance,
+    double distanceMax,
+    double size,
+    double radiusMajor,
+    double radiusMinor,
+    double radiusMin,
+    double radiusMax,
+    double orientation,
+    double tilt,
+    int platformData,
+    double scrollDeltaX,
+    double scrollDeltaY,
+  }) {
+    assert(_pointers.containsKey(device));
+    final _PointerState state = _pointers[device];
+    final double deltaX = physicalX - state.x;
+    final double deltaY = physicalY - state.y;
+    state.x = physicalX;
+    state.y = physicalY;
     return ui.PointerData(
-      timeStamp: datum.timeStamp,
-      change: datum.change,
-      kind: datum.kind,
-      signalKind: datum.signalKind,
-      device: datum.device,
+      timeStamp: timeStamp,
+      change: change,
+      kind: kind,
+      signalKind: signalKind,
+      device: device,
       pointerIdentifier: state.pointer ?? 0,
-      physicalX: datum.physicalX,
-      physicalY: datum.physicalY,
+      physicalX: physicalX,
+      physicalY: physicalY,
       physicalDeltaX: deltaX,
       physicalDeltaY: deltaY,
-      buttons: datum.buttons,
-      obscured: datum.obscured,
-      synthesized: datum.synthesized,
-      pressure: datum.pressure,
-      pressureMin: datum.pressureMin,
-      pressureMax: datum.pressureMax,
-      distance: datum.distance,
-      distanceMax: datum.distanceMax,
-      size: datum.size,
-      radiusMajor: datum.radiusMajor,
-      radiusMinor: datum.radiusMinor,
-      radiusMin: datum.radiusMin,
-      radiusMax: datum.radiusMax,
-      orientation: datum.orientation,
-      tilt: datum.tilt,
-      platformData: datum.platformData,
-      scrollDeltaX: datum.scrollDeltaX,
-      scrollDeltaY: datum.scrollDeltaY,
+      buttons: buttons,
+      obscured: obscured,
+      pressure: pressure,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      platformData: platformData,
+      scrollDeltaX: scrollDeltaX,
+      scrollDeltaY: scrollDeltaY,
     );
   }
 
-  bool _locationHasChanged(ui.PointerData datum) {
-    assert(_pointers.containsKey(datum.device));
-    final _PointerState state = _pointers[datum.device];
-    return state.x != datum.physicalX || state.y != datum.physicalY;
+  bool _locationHasChanged(int device, double physicalX, double physicalY) {
+    assert(_pointers.containsKey(device));
+    final _PointerState state = _pointers[device];
+    return state.x != physicalX || state.y != physicalY;
   }
 
-  ui.PointerData _synthesizeFrom(ui.PointerData datum, ui.PointerChange change) {
-    assert(_pointers.containsKey(datum.device));
-    final _PointerState state = _pointers[datum.device];
-    final double deltaX = datum.physicalX - state.x;
-    final double deltaY = datum.physicalY - state.y;
-    state.x = datum.physicalX;
-    state.y = datum.physicalY;
+  ui.PointerData _synthesizePointerData({
+    Duration timeStamp,
+    ui.PointerChange change,
+    ui.PointerDeviceKind kind,
+    int device,
+    double physicalX,
+    double physicalY,
+    int buttons,
+    bool obscured,
+    double pressure,
+    double pressureMin,
+    double pressureMax,
+    double distance,
+    double distanceMax,
+    double size,
+    double radiusMajor,
+    double radiusMinor,
+    double radiusMin,
+    double radiusMax,
+    double orientation,
+    double tilt,
+    int platformData,
+    double scrollDeltaX,
+    double scrollDeltaY,
+  }) {
+    assert(_pointers.containsKey(device));
+    final _PointerState state = _pointers[device];
+    final double deltaX = physicalX - state.x;
+    final double deltaY = physicalY - state.y;
+    state.x = physicalX;
+    state.y = physicalY;
     return ui.PointerData(
-      timeStamp: datum.timeStamp,
+      timeStamp: timeStamp,
       change: change,
-      kind: datum.kind,
+      kind: kind,
       // All the pointer data except scroll should not have a signal kind, and
       // there is no use case for synthetic scroll event. We should be
       // safe to default it to ui.PointerSignalKind.none.
       signalKind: ui.PointerSignalKind.none,
-      device: datum.device,
+      device: device,
       pointerIdentifier: state.pointer ?? 0,
-      physicalX: datum.physicalX,
-      physicalY: datum.physicalY,
+      physicalX: physicalX,
+      physicalY: physicalY,
       physicalDeltaX: deltaX,
       physicalDeltaY: deltaY,
-      buttons: datum.buttons,
-      obscured: datum.obscured,
+      buttons: buttons,
+      obscured: obscured,
       synthesized: true,
-      pressure: datum.pressure,
-      pressureMin: datum.pressureMin,
-      pressureMax: datum.pressureMax,
-      distance: datum.distance,
-      distanceMax: datum.distanceMax,
-      size: datum.size,
-      radiusMajor: datum.radiusMajor,
-      radiusMinor: datum.radiusMinor,
-      radiusMin: datum.radiusMin,
-      radiusMax: datum.radiusMax,
-      orientation: datum.orientation,
-      tilt: datum.tilt,
-      platformData: datum.platformData,
-      scrollDeltaX: datum.scrollDeltaX,
-      scrollDeltaY: datum.scrollDeltaY,
+      pressure: pressure,
+      pressureMin: pressureMin,
+      pressureMax: pressureMax,
+      distance: distance,
+      distanceMax: distanceMax,
+      size: size,
+      radiusMajor: radiusMajor,
+      radiusMinor: radiusMinor,
+      radiusMin: radiusMin,
+      radiusMax: radiusMax,
+      orientation: orientation,
+      tilt: tilt,
+      platformData: platformData,
+      scrollDeltaX: scrollDeltaX,
+      scrollDeltaY: scrollDeltaY,
     );
   }
 
-  /// Convert the given list pointer data into a sequence of framework-compatible
-  /// pointer data.
-  Iterable<ui.PointerData> convert(List<ui.PointerData> data) sync* {
-    for (ui.PointerData datum in data) {
-      assert(datum.change != null);
-      if (datum.signalKind == null ||
-        datum.signalKind == ui.PointerSignalKind.none) {
-        switch (datum.change) {
-          case ui.PointerChange.add:
-            assert(!_pointers.containsKey(datum.device));
-            _ensureStateForPointer(datum, datum.physicalX, datum.physicalY);
-            assert(!_locationHasChanged(datum));
-            yield _generateCompletePointerData(datum);
-            break;
-          case ui.PointerChange.hover:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(
-              datum, datum.physicalX, datum.physicalY);
-            assert(!state.down);
-            if (!alreadyAdded) {
-              // Synthesizes an add pointer data.
-              yield _synthesizeFrom(datum, ui.PointerChange.add);
+  /// Converts the given html pointer event metrics into a sequence of framework-compatible
+  /// pointer data and stores it into [result]
+  void convert(
+    List<ui.PointerData> result, {
+    Duration timeStamp = Duration.zero,
+    ui.PointerChange change = ui.PointerChange.cancel,
+    ui.PointerDeviceKind kind = ui.PointerDeviceKind.touch,
+    ui.PointerSignalKind signalKind,
+    int device = 0,
+    double physicalX = 0.0,
+    double physicalY = 0.0,
+    int buttons = 0,
+    bool obscured = false,
+    double pressure = 0.0,
+    double pressureMin = 0.0,
+    double pressureMax = 0.0,
+    double distance = 0.0,
+    double distanceMax = 0.0,
+    double size = 0.0,
+    double radiusMajor = 0.0,
+    double radiusMinor = 0.0,
+    double radiusMin = 0.0,
+    double radiusMax = 0.0,
+    double orientation = 0.0,
+    double tilt = 0.0,
+    int platformData = 0,
+    double scrollDeltaX = 0.0,
+    double scrollDeltaY = 0.0,
+  }) {
+    assert(change != null);
+    if (signalKind == null ||
+      signalKind == ui.PointerSignalKind.none) {
+      switch (change) {
+        case ui.PointerChange.add:
+          assert(!_pointers.containsKey(device));
+          _ensureStateForPointer(device, physicalX, physicalY);
+          assert(!_locationHasChanged(device, physicalX, physicalY));
+          result.add(
+            _generateCompletePointerData(
+              timeStamp: timeStamp,
+              change: change,
+              kind: kind,
+              signalKind: signalKind,
+              device: device,
+              physicalX: physicalX,
+              physicalY: physicalY,
+              buttons: buttons,
+              obscured: obscured,
+              pressure: pressure,
+              pressureMin: pressureMin,
+              pressureMax: pressureMax,
+              distance: distance,
+              distanceMax: distanceMax,
+              size: size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: orientation,
+              tilt: tilt,
+              platformData: platformData,
+              scrollDeltaX: scrollDeltaX,
+              scrollDeltaY: scrollDeltaY,
+            )
+          );
+          break;
+        case ui.PointerChange.hover:
+          final bool alreadyAdded = _pointers.containsKey(device);
+          final _PointerState state = _ensureStateForPointer(
+            device, physicalX, physicalY);
+          assert(!state.down);
+          if (!alreadyAdded) {
+            // Synthesizes an add pointer data.
+            result.add(
+              _synthesizePointerData(
+                timeStamp: timeStamp,
+                change: ui.PointerChange.add,
+                kind: kind,
+                device: device,
+                physicalX: physicalX,
+                physicalY: physicalY,
+                buttons: buttons,
+                obscured: obscured,
+                pressure: pressure,
+                pressureMin: pressureMin,
+                pressureMax: pressureMax,
+                distance: distance,
+                distanceMax: distanceMax,
+                size: size,
+                radiusMajor: radiusMajor,
+                radiusMinor: radiusMinor,
+                radiusMin: radiusMin,
+                radiusMax: radiusMax,
+                orientation: orientation,
+                tilt: tilt,
+                platformData: platformData,
+                scrollDeltaX: scrollDeltaX,
+                scrollDeltaY: scrollDeltaY,
+              )
+            );
+          }
+          result.add(
+            _generateCompletePointerData(
+              timeStamp: timeStamp,
+              change: change,
+              kind: kind,
+              signalKind: signalKind,
+              device: device,
+              physicalX: physicalX,
+              physicalY: physicalY,
+              buttons: buttons,
+              obscured: obscured,
+              pressure: pressure,
+              pressureMin: pressureMin,
+              pressureMax: pressureMax,
+              distance: distance,
+              distanceMax: distanceMax,
+              size: size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: orientation,
+              tilt: tilt,
+              platformData: platformData,
+              scrollDeltaX: scrollDeltaX,
+              scrollDeltaY: scrollDeltaY,
+            )
+          );
+          break;
+        case ui.PointerChange.down:
+          final bool alreadyAdded = _pointers.containsKey(device);
+          final _PointerState state = _ensureStateForPointer(
+            device, physicalX, physicalY);
+          assert(!state.down);
+          if (!alreadyAdded) {
+            // Synthesizes an add pointer data.
+            result.add(
+                _synthesizePointerData(
+                timeStamp: timeStamp,
+                change: ui.PointerChange.add,
+                kind: kind,
+                device: device,
+                physicalX: physicalX,
+                physicalY: physicalY,
+                buttons: buttons,
+                obscured: obscured,
+                pressure: pressure,
+                pressureMin: pressureMin,
+                pressureMax: pressureMax,
+                distance: distance,
+                distanceMax: distanceMax,
+                size: size,
+                radiusMajor: radiusMajor,
+                radiusMinor: radiusMinor,
+                radiusMin: radiusMin,
+                radiusMax: radiusMax,
+                orientation: orientation,
+                tilt: tilt,
+                platformData: platformData,
+                scrollDeltaX: scrollDeltaX,
+                scrollDeltaY: scrollDeltaY,
+              )
+            );
+          }
+          assert(!_locationHasChanged(device, physicalX, physicalY));
+          state.startNewPointer();
+          state.down = true;
+          result.add(
+            _generateCompletePointerData(
+              timeStamp: timeStamp,
+              change: change,
+              kind: kind,
+              signalKind: signalKind,
+              device: device,
+              physicalX: physicalX,
+              physicalY: physicalY,
+              buttons: buttons,
+              obscured: obscured,
+              pressure: pressure,
+              pressureMin: pressureMin,
+              pressureMax: pressureMax,
+              distance: distance,
+              distanceMax: distanceMax,
+              size: size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: orientation,
+              tilt: tilt,
+              platformData: platformData,
+              scrollDeltaX: scrollDeltaX,
+              scrollDeltaY: scrollDeltaY,
+            )
+          );
+          break;
+        case ui.PointerChange.move:
+          assert(_pointers.containsKey(device));
+          final _PointerState state = _pointers[device];
+          assert(state.down);
+          result.add(
+            _generateCompletePointerData(
+              timeStamp: timeStamp,
+              change: change,
+              kind: kind,
+              signalKind: signalKind,
+              device: device,
+              physicalX: physicalX,
+              physicalY: physicalY,
+              buttons: buttons,
+              obscured: obscured,
+              pressure: pressure,
+              pressureMin: pressureMin,
+              pressureMax: pressureMax,
+              distance: distance,
+              distanceMax: distanceMax,
+              size: size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: orientation,
+              tilt: tilt,
+              platformData: platformData,
+              scrollDeltaX: scrollDeltaX,
+              scrollDeltaY: scrollDeltaY,
+            )
+          );
+          break;
+        case ui.PointerChange.up:
+        case ui.PointerChange.cancel:
+          assert(_pointers.containsKey(device));
+          final _PointerState state = _pointers[device];
+          assert(state.down);
+          assert(!_locationHasChanged(device, physicalX, physicalY));
+          state.down = false;
+          result.add(
+            _generateCompletePointerData(
+              timeStamp: timeStamp,
+              change: change,
+              kind: kind,
+              signalKind: signalKind,
+              device: device,
+              physicalX: physicalX,
+              physicalY: physicalY,
+              buttons: buttons,
+              obscured: obscured,
+              pressure: pressure,
+              pressureMin: pressureMin,
+              pressureMax: pressureMax,
+              distance: distance,
+              distanceMax: distanceMax,
+              size: size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: orientation,
+              tilt: tilt,
+              platformData: platformData,
+              scrollDeltaX: scrollDeltaX,
+              scrollDeltaY: scrollDeltaY,
+            )
+          );
+          break;
+        case ui.PointerChange.remove:
+          assert(_pointers.containsKey(device));
+          final _PointerState state = _pointers[device];
+          assert(!state.down);
+          assert(!_locationHasChanged(device, physicalX, physicalY));
+          _pointers.remove(device);
+          result.add(
+            _generateCompletePointerData(
+              timeStamp: timeStamp,
+              change: change,
+              kind: kind,
+              signalKind: signalKind,
+              device: device,
+              physicalX: physicalX,
+              physicalY: physicalY,
+              buttons: buttons,
+              obscured: obscured,
+              pressure: pressure,
+              pressureMin: pressureMin,
+              pressureMax: pressureMax,
+              distance: distance,
+              distanceMax: distanceMax,
+              size: size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: orientation,
+              tilt: tilt,
+              platformData: platformData,
+              scrollDeltaX: scrollDeltaX,
+              scrollDeltaY: scrollDeltaY,
+            )
+          );
+          break;
+      }
+    } else {
+      switch (signalKind) {
+        case ui.PointerSignalKind.scroll:
+          final bool alreadyAdded = _pointers.containsKey(device);
+          final _PointerState state = _ensureStateForPointer(
+            device, physicalX, physicalY);
+          if (!alreadyAdded) {
+            // Synthesizes an add pointer data.
+            result.add(
+              _synthesizePointerData(
+                timeStamp: timeStamp,
+                change: ui.PointerChange.add,
+                kind: kind,
+                device: device,
+                physicalX: physicalX,
+                physicalY: physicalY,
+                buttons: buttons,
+                obscured: obscured,
+                pressure: pressure,
+                pressureMin: pressureMin,
+                pressureMax: pressureMax,
+                distance: distance,
+                distanceMax: distanceMax,
+                size: size,
+                radiusMajor: radiusMajor,
+                radiusMinor: radiusMinor,
+                radiusMin: radiusMin,
+                radiusMax: radiusMax,
+                orientation: orientation,
+                tilt: tilt,
+                platformData: platformData,
+                scrollDeltaX: scrollDeltaX,
+                scrollDeltaY: scrollDeltaY,
+              )
+            );
+          }
+          if (_locationHasChanged(device, physicalX, physicalY)) {
+            // Synthesize a hover/move of the pointer to the scroll location
+            // before sending the scroll event, if necessary, so that clients
+            // don't have to worry about native ordering of hover and scroll
+            // events.
+            if (state.down) {
+              result.add(
+                _synthesizePointerData(
+                  timeStamp: timeStamp,
+                  change: ui.PointerChange.move,
+                  kind: kind,
+                  device: device,
+                  physicalX: physicalX,
+                  physicalY: physicalY,
+                  buttons: buttons,
+                  obscured: obscured,
+                  pressure: pressure,
+                  pressureMin: pressureMin,
+                  pressureMax: pressureMax,
+                  distance: distance,
+                  distanceMax: distanceMax,
+                  size: size,
+                  radiusMajor: radiusMajor,
+                  radiusMinor: radiusMinor,
+                  radiusMin: radiusMin,
+                  radiusMax: radiusMax,
+                  orientation: orientation,
+                  tilt: tilt,
+                  platformData: platformData,
+                  scrollDeltaX: scrollDeltaX,
+                  scrollDeltaY: scrollDeltaY,
+                )
+              );
+            } else {
+              result.add(
+                _synthesizePointerData(
+                  timeStamp: timeStamp,
+                  change: ui.PointerChange.hover,
+                  kind: kind,
+                  device: device,
+                  physicalX: physicalX,
+                  physicalY: physicalY,
+                  buttons: buttons,
+                  obscured: obscured,
+                  pressure: pressure,
+                  pressureMin: pressureMin,
+                  pressureMax: pressureMax,
+                  distance: distance,
+                  distanceMax: distanceMax,
+                  size: size,
+                  radiusMajor: radiusMajor,
+                  radiusMinor: radiusMinor,
+                  radiusMin: radiusMin,
+                  radiusMax: radiusMax,
+                  orientation: orientation,
+                  tilt: tilt,
+                  platformData: platformData,
+                  scrollDeltaX: scrollDeltaX,
+                  scrollDeltaY: scrollDeltaY,
+                )
+              );
             }
-            yield _generateCompletePointerData(datum);
-            break;
-          case ui.PointerChange.down:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(
-              datum, datum.physicalX, datum.physicalY);
-            assert(!state.down);
-            if (!alreadyAdded) {
-              // Synthesizes an add pointer data.
-              yield _synthesizeFrom(datum, ui.PointerChange.add);
-            }
-            assert(!_locationHasChanged(datum));
-            state.startNewPointer();
-            state.down = true;
-            yield _generateCompletePointerData(datum);
-            break;
-          case ui.PointerChange.move:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(
-              datum, datum.physicalX, datum.physicalY);
-            if (!alreadyAdded) {
-              // Synthesizes an add pointer data and down pointer data.
-              yield _synthesizeFrom(datum, ui.PointerChange.add);
-              yield _synthesizeFrom(datum, ui.PointerChange.down);
-            }
-            assert(state.down);
-            yield _generateCompletePointerData(datum);
-            break;
-          case ui.PointerChange.up:
-          case ui.PointerChange.cancel:
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            assert(state.down);
-            assert(!_locationHasChanged(datum));
-            state.down = false;
-            yield _generateCompletePointerData(datum);
-            break;
-          case ui.PointerChange.remove:
-            assert(_pointers.containsKey(datum.device));
-            final _PointerState state = _pointers[datum.device];
-            assert(!state.down);
-            assert(!_locationHasChanged(datum));
-            _pointers.remove(datum.device);
-            yield _generateCompletePointerData(datum);
-            break;
-        }
-      } else {
-        switch (datum.signalKind) {
-          case ui.PointerSignalKind.scroll:
-            final bool alreadyAdded = _pointers.containsKey(datum.device);
-            final _PointerState state = _ensureStateForPointer(
-              datum, datum.physicalX, datum.physicalY);
-            if (!alreadyAdded) {
-              // Synthesizes an add pointer data.
-              yield _synthesizeFrom(datum, ui.PointerChange.add);
-            }
-            if (_locationHasChanged(datum)) {
-              // Synthesize a hover/move of the pointer to the scroll location
-              // before sending the scroll event, if necessary, so that clients
-              // don't have to worry about native ordering of hover and scroll
-              // events.
-              if (state.down) {
-                yield _synthesizeFrom(datum, ui.PointerChange.move);
-              } else {
-                yield _synthesizeFrom(datum, ui.PointerChange.hover);
-              }
-            }
-            yield _generateCompletePointerData(datum);
-            break;
-          case ui.PointerSignalKind.none:
-            assert(false); // This branch should already have 'none' filtered out.
-            break;
-          case ui.PointerSignalKind.unknown:
-          // Ignore unknown signals.
-            break;
-        }
+          }
+          result.add(
+            _generateCompletePointerData(
+              timeStamp: timeStamp,
+              change: change,
+              kind: kind,
+              signalKind: signalKind,
+              device: device,
+              physicalX: physicalX,
+              physicalY: physicalY,
+              buttons: buttons,
+              obscured: obscured,
+              pressure: pressure,
+              pressureMin: pressureMin,
+              pressureMax: pressureMax,
+              distance: distance,
+              distanceMax: distanceMax,
+              size: size,
+              radiusMajor: radiusMajor,
+              radiusMinor: radiusMinor,
+              radiusMin: radiusMin,
+              radiusMax: radiusMax,
+              orientation: orientation,
+              tilt: tilt,
+              platformData: platformData,
+              scrollDeltaX: scrollDeltaX,
+              scrollDeltaY: scrollDeltaY,
+            )
+          );
+          break;
+        case ui.PointerSignalKind.none:
+          assert(false); // This branch should already have 'none' filtered out.
+          break;
+        case ui.PointerSignalKind.unknown:
+        // Ignore unknown signals.
+          break;
       }
     }
   }
-
 }

--- a/lib/web_ui/lib/src/engine/pointer_converter.dart
+++ b/lib/web_ui/lib/src/engine/pointer_converter.dart
@@ -1,0 +1,246 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of engine;
+
+class _PointerState {
+  _PointerState(this.x, this.y);
+
+  int get pointer => _pointer; // The identifier used in PointerEvent objects.
+  int _pointer;
+  static int _pointerCount = 0;
+  void startNewPointer() {
+    _pointerCount += 1;
+    _pointer = _pointerCount;
+  }
+
+  bool down = false;
+
+  double x;
+  double y;
+}
+
+/// Converter to convert web pointer data to a framework-compatible form.
+///
+/// This converter calculates pointer location delta and pointer identifier for
+/// each pointer. Both are required by framework to correctly trigger gesture
+/// activity. It also attempts to sanitize pointer data input sequence by always
+/// synthesizing an add pointer data prior to hover or down if it the pointer is
+/// not previously added.
+///
+/// For example:
+///   before:
+///     hover -> down -> move -> up
+///   after:
+///     add(synthesize) -> hover -> down -> move -> up
+///
+///   before:
+///     down -> move -> up
+///   after:
+///     add(synthesize) -> down -> move -> up
+class PointerDataConverter {
+  PointerDataConverter._();
+
+  // Map from platform pointer identifiers to PointerEvent pointer identifiers.
+  // Static to guarantee that pointers are unique.
+  static final Map<int, _PointerState> _pointers = <int, _PointerState>{};
+
+  static _PointerState _ensureStateForPointer(ui.PointerData datum, double x, double y) {
+    return _pointers.putIfAbsent(
+      datum.device,
+        () => _PointerState(x, y),
+    );
+  }
+
+  static ui.PointerData _generateCompletePointerData(ui.PointerData datum) {
+    assert(_pointers.containsKey(datum.device));
+    final _PointerState state = _pointers[datum.device];
+    final double deltaX = datum.physicalX - state.x;
+    final double deltaY = datum.physicalY - state.y;
+    state.x = datum.physicalX;
+    state.y = datum.physicalY;
+    return ui.PointerData(
+      timeStamp: datum.timeStamp,
+      change: datum.change,
+      kind: datum.kind,
+      signalKind: datum.signalKind,
+      device: datum.device,
+      pointerIdentifier: state.pointer ?? 0,
+      physicalX: datum.physicalX,
+      physicalY: datum.physicalY,
+      physicalDeltaX: deltaX,
+      physicalDeltaY: deltaY,
+      buttons: datum.buttons,
+      obscured: datum.obscured,
+      synthesized: datum.synthesized,
+      pressure: datum.pressure,
+      pressureMin: datum.pressureMin,
+      pressureMax: datum.pressureMax,
+      distance: datum.distance,
+      distanceMax: datum.distanceMax,
+      size: datum.size,
+      radiusMajor: datum.radiusMajor,
+      radiusMinor: datum.radiusMinor,
+      radiusMin: datum.radiusMin,
+      radiusMax: datum.radiusMax,
+      orientation: datum.orientation,
+      tilt: datum.tilt,
+      platformData: datum.platformData,
+      scrollDeltaX: datum.scrollDeltaX,
+      scrollDeltaY: datum.scrollDeltaY,
+    );
+  }
+
+  static bool _locationHasChanged(ui.PointerData datum) {
+    assert(_pointers.containsKey(datum.device));
+    final _PointerState state = _pointers[datum.device];
+    return state.x != datum.physicalX || state.y != datum.physicalY;
+  }
+
+  static ui.PointerData _synthesizeFrom(ui.PointerData datum, ui.PointerChange change) {
+    assert(_pointers.containsKey(datum.device));
+    final _PointerState state = _pointers[datum.device];
+    final double deltaX = datum.physicalX - state.x;
+    final double deltaY = datum.physicalY - state.y;
+    state.x = datum.physicalX;
+    state.y = datum.physicalY;
+    return ui.PointerData(
+      timeStamp: datum.timeStamp,
+      change: change,
+      kind: datum.kind,
+      // All the pointer data except scroll should not have a signal kind, and
+      // there is no use case for synthetic scroll event. We should be
+      // safe to default it to ui.PointerSignalKind.none.
+      signalKind: ui.PointerSignalKind.none,
+      device: datum.device,
+      pointerIdentifier: state.pointer ?? 0,
+      physicalX: datum.physicalX,
+      physicalY: datum.physicalY,
+      physicalDeltaX: deltaX,
+      physicalDeltaY: deltaY,
+      buttons: datum.buttons,
+      obscured: datum.obscured,
+      synthesized: true,
+      pressure: datum.pressure,
+      pressureMin: datum.pressureMin,
+      pressureMax: datum.pressureMax,
+      distance: datum.distance,
+      distanceMax: datum.distanceMax,
+      size: datum.size,
+      radiusMajor: datum.radiusMajor,
+      radiusMinor: datum.radiusMinor,
+      radiusMin: datum.radiusMin,
+      radiusMax: datum.radiusMax,
+      orientation: datum.orientation,
+      tilt: datum.tilt,
+      platformData: datum.platformData,
+      scrollDeltaX: datum.scrollDeltaX,
+      scrollDeltaY: datum.scrollDeltaY,
+    );
+  }
+
+  /// Convert the given list pointer data into a sequence of framework-compatible
+  /// pointer data.
+  static Iterable<ui.PointerData> convert(List<ui.PointerData> data) sync* {
+    for (ui.PointerData datum in data) {
+      assert(datum.change != null);
+      if (datum.signalKind == null ||
+        datum.signalKind == ui.PointerSignalKind.none) {
+        switch (datum.change) {
+          case ui.PointerChange.add:
+            assert(!_pointers.containsKey(datum.device));
+            _ensureStateForPointer(datum, datum.physicalX, datum.physicalY);
+            assert(!_locationHasChanged(datum));
+            yield _generateCompletePointerData(datum);
+            break;
+          case ui.PointerChange.hover:
+            final bool alreadyAdded = _pointers.containsKey(datum.device);
+            final _PointerState state = _ensureStateForPointer(
+              datum, datum.physicalX, datum.physicalY);
+            assert(!state.down);
+            if (!alreadyAdded) {
+              // Synthesizes an add pointer data.
+              yield _synthesizeFrom(datum, ui.PointerChange.add);
+            }
+            yield _generateCompletePointerData(datum);
+            break;
+          case ui.PointerChange.down:
+            final bool alreadyAdded = _pointers.containsKey(datum.device);
+            final _PointerState state = _ensureStateForPointer(
+              datum, datum.physicalX, datum.physicalY);
+            assert(!state.down);
+            if (!alreadyAdded) {
+              // Synthesizes an add pointer data.
+              yield _synthesizeFrom(datum, ui.PointerChange.add);
+            }
+            assert(!_locationHasChanged(datum));
+            state.startNewPointer();
+            state.down = true;
+            yield _generateCompletePointerData(datum);
+            break;
+          case ui.PointerChange.move:
+            final bool alreadyAdded = _pointers.containsKey(datum.device);
+            final _PointerState state = _ensureStateForPointer(
+              datum, datum.physicalX, datum.physicalY);
+            if (!alreadyAdded) {
+              // Synthesizes an add pointer data and down pointer data.
+              yield _synthesizeFrom(datum, ui.PointerChange.add);
+              yield _synthesizeFrom(datum, ui.PointerChange.down);
+            }
+            assert(state.down);
+            yield _generateCompletePointerData(datum);
+            break;
+          case ui.PointerChange.up:
+          case ui.PointerChange.cancel:
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _pointers[datum.device];
+            assert(state.down);
+            assert(!_locationHasChanged(datum));
+            state.down = false;
+            yield _generateCompletePointerData(datum);
+            break;
+          case ui.PointerChange.remove:
+            assert(_pointers.containsKey(datum.device));
+            final _PointerState state = _pointers[datum.device];
+            assert(!state.down);
+            assert(!_locationHasChanged(datum));
+            _pointers.remove(datum.device);
+            yield _generateCompletePointerData(datum);
+            break;
+        }
+      } else {
+        switch (datum.signalKind) {
+          case ui.PointerSignalKind.scroll:
+            final bool alreadyAdded = _pointers.containsKey(datum.device);
+            final _PointerState state = _ensureStateForPointer(
+              datum, datum.physicalX, datum.physicalY);
+            if (!alreadyAdded) {
+              // Synthesizes an add pointer data.
+              yield _synthesizeFrom(datum, ui.PointerChange.add);
+            }
+            if (_locationHasChanged(datum)) {
+              // Synthesize a hover/move of the pointer to the scroll location
+              // before sending the scroll event, if necessary, so that clients
+              // don't have to worry about native ordering of hover and scroll
+              // events.
+              if (state.down) {
+                yield _synthesizeFrom(datum, ui.PointerChange.move);
+              } else {
+                yield _synthesizeFrom(datum, ui.PointerChange.hover);
+              }
+            }
+            yield _generateCompletePointerData(datum);
+            break;
+          case ui.PointerSignalKind.none:
+            assert(false); // This branch should already have 'none' filtered out.
+            break;
+          case ui.PointerSignalKind.unknown:
+          // Ignore unknown signals.
+            break;
+        }
+      }
+    }
+  }
+
+}

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -56,7 +56,11 @@ void main() {
       }));
 
       expect(packets, hasLength(3));
-      expect(packets[0].data[0].change, equals(ui.PointerChange.down));
+      // An add will be synthesized.
+      expect(packets[0].data, hasLength(2));
+      expect(packets[0].data[0].change, equals(ui.PointerChange.add));
+      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[1].change, equals(ui.PointerChange.down));
       expect(packets[1].data[0].change, equals(ui.PointerChange.up));
       expect(packets[2].data[0].change, equals(ui.PointerChange.down));
     });
@@ -78,10 +82,20 @@ void main() {
       }));
 
       expect(packets, hasLength(2));
-      expect(packets[0].data[0].change, equals(ui.PointerChange.down));
+      // An add will be synthesized.
+      expect(packets[0].data, hasLength(2));
+      expect(packets[0].data[0].change, equals(ui.PointerChange.add));
+      expect(packets[0].data[0].synthesized, equals(true));
       expect(packets[0].data[0].device, equals(1));
-      expect(packets[1].data[0].change, equals(ui.PointerChange.down));
+      expect(packets[0].data[1].change, equals(ui.PointerChange.down));
+      expect(packets[0].data[1].device, equals(1));
+      // An add will be synthesized.
+      expect(packets[1].data, hasLength(2));
+      expect(packets[1].data[0].change, equals(ui.PointerChange.add));
+      expect(packets[1].data[0].synthesized, equals(true));
       expect(packets[1].data[0].device, equals(2));
+      expect(packets[1].data[1].change, equals(ui.PointerChange.down));
+      expect(packets[1].data[1].device, equals(2));
     });
 
     test('creates an add event if the first pointer activity is a hover', () {
@@ -99,10 +113,11 @@ void main() {
       expect(packets.single.data, hasLength(2));
 
       expect(packets.single.data[0].change, equals(ui.PointerChange.add));
+      expect(packets.single.data[0].synthesized, equals(true));
       expect(packets.single.data[1].change, equals(ui.PointerChange.hover));
     });
 
-    test('does not create an add event if got a pointerdown', () {
+    test('does create an add event if got a pointerdown', () {
       List<ui.PointerDataPacket> packets = <ui.PointerDataPacket>[];
       ui.window.onPointerDataPacket = (ui.PointerDataPacket packet) {
         packets.add(packet);
@@ -114,9 +129,272 @@ void main() {
       }));
 
       expect(packets, hasLength(1));
-      expect(packets.single.data, hasLength(1));
+      expect(packets.single.data, hasLength(2));
 
-      expect(packets.single.data[0].change, equals(ui.PointerChange.down));
+      expect(packets.single.data[0].change, equals(ui.PointerChange.add));
+      expect(packets.single.data[1].change, equals(ui.PointerChange.down));
+    });
+
+    test('does calculate delta and pointer identifier correctly', () {
+      List<ui.PointerDataPacket> packets = <ui.PointerDataPacket>[];
+      ui.window.onPointerDataPacket = (ui.PointerDataPacket packet) {
+        packets.add(packet);
+      };
+
+      glassPane.dispatchEvent(html.PointerEvent('pointermove', {
+        'pointerId': 1,
+        'button': 1,
+        'clientX': 10.0,
+        'clientY': 10.0,
+      }));
+
+      glassPane.dispatchEvent(html.PointerEvent('pointermove', {
+        'pointerId': 1,
+        'button': 1,
+        'clientX': 20.0,
+        'clientY': 20.0,
+      }));
+
+      glassPane.dispatchEvent(html.PointerEvent('pointerdown', {
+        'pointerId': 1,
+        'button': 1,
+        'clientX': 20.0,
+        'clientY': 20.0,
+      }));
+
+      glassPane.dispatchEvent(html.PointerEvent('pointermove', {
+        'pointerId': 1,
+        'button': 1,
+        'clientX': 40.0,
+        'clientY': 30.0,
+      }));
+
+      glassPane.dispatchEvent(html.PointerEvent('pointerup', {
+        'pointerId': 1,
+        'button': 1,
+        'clientX': 40.0,
+        'clientY': 30.0,
+      }));
+
+      glassPane.dispatchEvent(html.PointerEvent('pointermove', {
+        'pointerId': 1,
+        'button': 1,
+        'clientX': 20.0,
+        'clientY': 10.0,
+      }));
+
+      glassPane.dispatchEvent(html.PointerEvent('pointerdown', {
+        'pointerId': 1,
+        'button': 1,
+        'clientX': 20.0,
+        'clientY': 10.0,
+      }));
+
+      expect(packets, hasLength(7));
+
+      expect(packets[0].data, hasLength(2));
+      expect(packets[0].data[0].change, equals(ui.PointerChange.add));
+      expect(packets[0].data[0].pointerIdentifier, equals(0));
+      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].physicalX, equals(10.0));
+      expect(packets[0].data[0].physicalY, equals(10.0));
+      expect(packets[0].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[0].data[0].physicalDeltaY, equals(0.0));
+
+      expect(packets[0].data[1].change, equals(ui.PointerChange.hover));
+      expect(packets[0].data[1].pointerIdentifier, equals(0));
+      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].physicalX, equals(10.0));
+      expect(packets[0].data[1].physicalY, equals(10.0));
+      expect(packets[0].data[1].physicalDeltaX, equals(0.0));
+      expect(packets[0].data[1].physicalDeltaY, equals(0.0));
+
+      expect(packets[1].data, hasLength(1));
+      expect(packets[1].data[0].change, equals(ui.PointerChange.hover));
+      expect(packets[1].data[0].pointerIdentifier, equals(0));
+      expect(packets[1].data[0].synthesized, equals(false));
+      expect(packets[1].data[0].physicalX, equals(20.0));
+      expect(packets[1].data[0].physicalY, equals(20.0));
+      expect(packets[1].data[0].physicalDeltaX, equals(10.0));
+      expect(packets[1].data[0].physicalDeltaY, equals(10.0));
+
+      expect(packets[2].data, hasLength(1));
+      expect(packets[2].data[0].change, equals(ui.PointerChange.down));
+      expect(packets[2].data[0].pointerIdentifier, equals(1));
+      expect(packets[2].data[0].synthesized, equals(false));
+      expect(packets[2].data[0].physicalX, equals(20.0));
+      expect(packets[2].data[0].physicalY, equals(20.0));
+      expect(packets[2].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[2].data[0].physicalDeltaY, equals(0.0));
+
+      expect(packets[3].data, hasLength(1));
+      expect(packets[3].data[0].change, equals(ui.PointerChange.move));
+      expect(packets[3].data[0].pointerIdentifier, equals(1));
+      expect(packets[3].data[0].synthesized, equals(false));
+      expect(packets[3].data[0].physicalX, equals(40.0));
+      expect(packets[3].data[0].physicalY, equals(30.0));
+      expect(packets[3].data[0].physicalDeltaX, equals(20.0));
+      expect(packets[3].data[0].physicalDeltaY, equals(10.0));
+
+      expect(packets[4].data, hasLength(1));
+      expect(packets[4].data[0].change, equals(ui.PointerChange.up));
+      expect(packets[4].data[0].pointerIdentifier, equals(1));
+      expect(packets[4].data[0].synthesized, equals(false));
+      expect(packets[4].data[0].physicalX, equals(40.0));
+      expect(packets[4].data[0].physicalY, equals(30.0));
+      expect(packets[4].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[4].data[0].physicalDeltaY, equals(0.0));
+
+      expect(packets[5].data, hasLength(1));
+      expect(packets[5].data[0].change, equals(ui.PointerChange.hover));
+      expect(packets[5].data[0].pointerIdentifier, equals(1));
+      expect(packets[5].data[0].synthesized, equals(false));
+      expect(packets[5].data[0].physicalX, equals(20.0));
+      expect(packets[5].data[0].physicalY, equals(10.0));
+      expect(packets[5].data[0].physicalDeltaX, equals(-20.0));
+      expect(packets[5].data[0].physicalDeltaY, equals(-20.0));
+
+      expect(packets[6].data, hasLength(1));
+      expect(packets[6].data[0].change, equals(ui.PointerChange.down));
+      expect(packets[6].data[0].pointerIdentifier, equals(2));
+      expect(packets[6].data[0].synthesized, equals(false));
+      expect(packets[6].data[0].physicalX, equals(20.0));
+      expect(packets[6].data[0].physicalY, equals(10.0));
+      expect(packets[6].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[6].data[0].physicalDeltaY, equals(0.0));
+    });
+
+    test('does synthesize add or hover or more for scroll', () {
+      List<ui.PointerDataPacket> packets = <ui.PointerDataPacket>[];
+      ui.window.onPointerDataPacket = (ui.PointerDataPacket packet) {
+        packets.add(packet);
+      };
+
+      glassPane.dispatchEvent(html.WheelEvent('wheel',
+        button: 1,
+        clientX: 10,
+        clientY: 10,
+        deltaX: 10,
+        deltaY: 10,
+      ));
+
+      glassPane.dispatchEvent(html.WheelEvent('wheel',
+        button: 1,
+        clientX: 20,
+        clientY: 50,
+        deltaX: 10,
+        deltaY: 10,
+      ));
+
+      glassPane.dispatchEvent(html.PointerEvent('pointerdown', {
+        'pointerId': -1,
+        'button': 1,
+        'clientX': 20.0,
+        'clientY': 50.0,
+      }));
+
+      glassPane.dispatchEvent(html.WheelEvent('wheel',
+        button: 1,
+        clientX: 30,
+        clientY: 60,
+        deltaX: 10,
+        deltaY: 10,
+      ));
+
+      expect(packets, hasLength(7));
+
+      // An add will be synthesized.
+      expect(packets[0].data, hasLength(2));
+      expect(packets[0].data[0].change, equals(ui.PointerChange.add));
+      expect(packets[0].data[0].pointerIdentifier, equals(0));
+      expect(packets[0].data[0].synthesized, equals(true));
+      expect(packets[0].data[0].physicalX, equals(10.0));
+      expect(packets[0].data[0].physicalY, equals(10.0));
+      expect(packets[0].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[0].data[0].physicalDeltaY, equals(0.0));
+
+      expect(packets[0].data[1].change, equals(ui.PointerChange.hover));
+      expect(packets[0].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[0].data[1].pointerIdentifier, equals(0));
+      expect(packets[0].data[1].synthesized, equals(false));
+      expect(packets[0].data[1].physicalX, equals(10.0));
+      expect(packets[0].data[1].physicalY, equals(10.0));
+      expect(packets[0].data[1].physicalDeltaX, equals(0.0));
+      expect(packets[0].data[1].physicalDeltaY, equals(0.0));
+      // Scroll event will fire twice
+      expect(packets[1].data[0].change, equals(ui.PointerChange.hover));
+      expect(packets[1].data[0].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[1].data[0].pointerIdentifier, equals(0));
+      expect(packets[1].data[0].synthesized, equals(false));
+      expect(packets[1].data[0].physicalX, equals(10.0));
+      expect(packets[1].data[0].physicalY, equals(10.0));
+      expect(packets[1].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[1].data[0].physicalDeltaY, equals(0.0));
+
+      // A hover will be synthesized.
+      expect(packets[2].data, hasLength(2));
+      expect(packets[2].data[0].change, equals(ui.PointerChange.hover));
+      expect(packets[2].data[0].pointerIdentifier, equals(0));
+      expect(packets[2].data[0].synthesized, equals(true));
+      expect(packets[2].data[0].physicalX, equals(20.0));
+      expect(packets[2].data[0].physicalY, equals(50.0));
+      expect(packets[2].data[0].physicalDeltaX, equals(10.0));
+      expect(packets[2].data[0].physicalDeltaY, equals(40.0));
+
+      expect(packets[2].data[1].change, equals(ui.PointerChange.hover));
+      expect(packets[2].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[2].data[1].pointerIdentifier, equals(0));
+      expect(packets[2].data[1].synthesized, equals(false));
+      expect(packets[2].data[1].physicalX, equals(20.0));
+      expect(packets[2].data[1].physicalY, equals(50.0));
+      expect(packets[2].data[1].physicalDeltaX, equals(0.0));
+      expect(packets[2].data[1].physicalDeltaY, equals(0.0));
+      // Scroll event will fire twice
+      expect(packets[3].data[0].change, equals(ui.PointerChange.hover));
+      expect(packets[3].data[0].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[3].data[0].pointerIdentifier, equals(0));
+      expect(packets[3].data[0].synthesized, equals(false));
+      expect(packets[3].data[0].physicalX, equals(20.0));
+      expect(packets[3].data[0].physicalY, equals(50.0));
+      expect(packets[3].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[3].data[0].physicalDeltaY, equals(0.0));
+
+      expect(packets[4].data[0].change, equals(ui.PointerChange.down));
+      expect(packets[4].data[0].signalKind, equals(null));
+      expect(packets[4].data[0].pointerIdentifier, equals(1));
+      expect(packets[4].data[0].synthesized, equals(false));
+      expect(packets[4].data[0].physicalX, equals(20.0));
+      expect(packets[4].data[0].physicalY, equals(50.0));
+      expect(packets[4].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[4].data[0].physicalDeltaY, equals(0.0));
+
+      // A move will be synthesized because the button is currently down.
+      expect(packets[5].data, hasLength(2));
+      expect(packets[5].data[0].change, equals(ui.PointerChange.move));
+      expect(packets[5].data[0].pointerIdentifier, equals(1));
+      expect(packets[5].data[0].synthesized, equals(true));
+      expect(packets[5].data[0].physicalX, equals(30.0));
+      expect(packets[5].data[0].physicalY, equals(60.0));
+      expect(packets[5].data[0].physicalDeltaX, equals(10.0));
+      expect(packets[5].data[0].physicalDeltaY, equals(10.0));
+
+      expect(packets[5].data[1].change, equals(ui.PointerChange.hover));
+      expect(packets[5].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[5].data[1].pointerIdentifier, equals(1));
+      expect(packets[5].data[1].synthesized, equals(false));
+      expect(packets[5].data[1].physicalX, equals(30.0));
+      expect(packets[5].data[1].physicalY, equals(60.0));
+      expect(packets[5].data[1].physicalDeltaX, equals(0.0));
+      expect(packets[5].data[1].physicalDeltaY, equals(0.0));
+      // Scroll event will fire twice
+      expect(packets[6].data[0].change, equals(ui.PointerChange.hover));
+      expect(packets[6].data[0].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[6].data[0].pointerIdentifier, equals(1));
+      expect(packets[6].data[0].synthesized, equals(false));
+      expect(packets[6].data[0].physicalX, equals(30.0));
+      expect(packets[6].data[0].physicalY, equals(60.0));
+      expect(packets[6].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[6].data[0].physicalDeltaY, equals(0.0));
     });
   });
 }

--- a/lib/web_ui/test/engine/pointer_binding_test.dart
+++ b/lib/web_ui/test/engine/pointer_binding_test.dart
@@ -301,7 +301,7 @@ void main() {
         deltaY: 10,
       ));
 
-      expect(packets, hasLength(7));
+      expect(packets, hasLength(4));
 
       // An add will be synthesized.
       expect(packets[0].data, hasLength(2));
@@ -321,80 +321,55 @@ void main() {
       expect(packets[0].data[1].physicalY, equals(10.0));
       expect(packets[0].data[1].physicalDeltaX, equals(0.0));
       expect(packets[0].data[1].physicalDeltaY, equals(0.0));
-      // Scroll event will fire twice
-      expect(packets[1].data[0].change, equals(ui.PointerChange.hover));
-      expect(packets[1].data[0].signalKind, equals(ui.PointerSignalKind.scroll));
-      expect(packets[1].data[0].pointerIdentifier, equals(0));
-      expect(packets[1].data[0].synthesized, equals(false));
-      expect(packets[1].data[0].physicalX, equals(10.0));
-      expect(packets[1].data[0].physicalY, equals(10.0));
-      expect(packets[1].data[0].physicalDeltaX, equals(0.0));
-      expect(packets[1].data[0].physicalDeltaY, equals(0.0));
 
       // A hover will be synthesized.
-      expect(packets[2].data, hasLength(2));
-      expect(packets[2].data[0].change, equals(ui.PointerChange.hover));
-      expect(packets[2].data[0].pointerIdentifier, equals(0));
-      expect(packets[2].data[0].synthesized, equals(true));
+      expect(packets[1].data, hasLength(2));
+      expect(packets[1].data[0].change, equals(ui.PointerChange.hover));
+      expect(packets[1].data[0].pointerIdentifier, equals(0));
+      expect(packets[1].data[0].synthesized, equals(true));
+      expect(packets[1].data[0].physicalX, equals(20.0));
+      expect(packets[1].data[0].physicalY, equals(50.0));
+      expect(packets[1].data[0].physicalDeltaX, equals(10.0));
+      expect(packets[1].data[0].physicalDeltaY, equals(40.0));
+
+      expect(packets[1].data[1].change, equals(ui.PointerChange.hover));
+      expect(packets[1].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[1].data[1].pointerIdentifier, equals(0));
+      expect(packets[1].data[1].synthesized, equals(false));
+      expect(packets[1].data[1].physicalX, equals(20.0));
+      expect(packets[1].data[1].physicalY, equals(50.0));
+      expect(packets[1].data[1].physicalDeltaX, equals(0.0));
+      expect(packets[1].data[1].physicalDeltaY, equals(0.0));
+
+      // No synthetic pointer data for down event.
+      expect(packets[2].data, hasLength(1));
+      expect(packets[2].data[0].change, equals(ui.PointerChange.down));
+      expect(packets[2].data[0].signalKind, equals(null));
+      expect(packets[2].data[0].pointerIdentifier, equals(1));
+      expect(packets[2].data[0].synthesized, equals(false));
       expect(packets[2].data[0].physicalX, equals(20.0));
       expect(packets[2].data[0].physicalY, equals(50.0));
-      expect(packets[2].data[0].physicalDeltaX, equals(10.0));
-      expect(packets[2].data[0].physicalDeltaY, equals(40.0));
+      expect(packets[2].data[0].physicalDeltaX, equals(0.0));
+      expect(packets[2].data[0].physicalDeltaY, equals(0.0));
 
-      expect(packets[2].data[1].change, equals(ui.PointerChange.hover));
-      expect(packets[2].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
-      expect(packets[2].data[1].pointerIdentifier, equals(0));
-      expect(packets[2].data[1].synthesized, equals(false));
-      expect(packets[2].data[1].physicalX, equals(20.0));
-      expect(packets[2].data[1].physicalY, equals(50.0));
-      expect(packets[2].data[1].physicalDeltaX, equals(0.0));
-      expect(packets[2].data[1].physicalDeltaY, equals(0.0));
-      // Scroll event will fire twice
-      expect(packets[3].data[0].change, equals(ui.PointerChange.hover));
-      expect(packets[3].data[0].signalKind, equals(ui.PointerSignalKind.scroll));
-      expect(packets[3].data[0].pointerIdentifier, equals(0));
-      expect(packets[3].data[0].synthesized, equals(false));
-      expect(packets[3].data[0].physicalX, equals(20.0));
-      expect(packets[3].data[0].physicalY, equals(50.0));
-      expect(packets[3].data[0].physicalDeltaX, equals(0.0));
-      expect(packets[3].data[0].physicalDeltaY, equals(0.0));
+      // A move will be synthesized instead of hover because the button is currently down.
+      expect(packets[3].data, hasLength(2));
+      expect(packets[3].data[0].change, equals(ui.PointerChange.move));
+      expect(packets[3].data[0].pointerIdentifier, equals(1));
+      expect(packets[3].data[0].synthesized, equals(true));
+      expect(packets[3].data[0].physicalX, equals(30.0));
+      expect(packets[3].data[0].physicalY, equals(60.0));
+      expect(packets[3].data[0].physicalDeltaX, equals(10.0));
+      expect(packets[3].data[0].physicalDeltaY, equals(10.0));
 
-      expect(packets[4].data[0].change, equals(ui.PointerChange.down));
-      expect(packets[4].data[0].signalKind, equals(null));
-      expect(packets[4].data[0].pointerIdentifier, equals(1));
-      expect(packets[4].data[0].synthesized, equals(false));
-      expect(packets[4].data[0].physicalX, equals(20.0));
-      expect(packets[4].data[0].physicalY, equals(50.0));
-      expect(packets[4].data[0].physicalDeltaX, equals(0.0));
-      expect(packets[4].data[0].physicalDeltaY, equals(0.0));
-
-      // A move will be synthesized because the button is currently down.
-      expect(packets[5].data, hasLength(2));
-      expect(packets[5].data[0].change, equals(ui.PointerChange.move));
-      expect(packets[5].data[0].pointerIdentifier, equals(1));
-      expect(packets[5].data[0].synthesized, equals(true));
-      expect(packets[5].data[0].physicalX, equals(30.0));
-      expect(packets[5].data[0].physicalY, equals(60.0));
-      expect(packets[5].data[0].physicalDeltaX, equals(10.0));
-      expect(packets[5].data[0].physicalDeltaY, equals(10.0));
-
-      expect(packets[5].data[1].change, equals(ui.PointerChange.hover));
-      expect(packets[5].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
-      expect(packets[5].data[1].pointerIdentifier, equals(1));
-      expect(packets[5].data[1].synthesized, equals(false));
-      expect(packets[5].data[1].physicalX, equals(30.0));
-      expect(packets[5].data[1].physicalY, equals(60.0));
-      expect(packets[5].data[1].physicalDeltaX, equals(0.0));
-      expect(packets[5].data[1].physicalDeltaY, equals(0.0));
-      // Scroll event will fire twice
-      expect(packets[6].data[0].change, equals(ui.PointerChange.hover));
-      expect(packets[6].data[0].signalKind, equals(ui.PointerSignalKind.scroll));
-      expect(packets[6].data[0].pointerIdentifier, equals(1));
-      expect(packets[6].data[0].synthesized, equals(false));
-      expect(packets[6].data[0].physicalX, equals(30.0));
-      expect(packets[6].data[0].physicalY, equals(60.0));
-      expect(packets[6].data[0].physicalDeltaX, equals(0.0));
-      expect(packets[6].data[0].physicalDeltaY, equals(0.0));
+      expect(packets[3].data[1].change, equals(ui.PointerChange.hover));
+      expect(packets[3].data[1].signalKind, equals(ui.PointerSignalKind.scroll));
+      expect(packets[3].data[1].pointerIdentifier, equals(1));
+      expect(packets[3].data[1].synthesized, equals(false));
+      expect(packets[3].data[1].physicalX, equals(30.0));
+      expect(packets[3].data[1].physicalY, equals(60.0));
+      expect(packets[3].data[1].physicalDeltaX, equals(0.0));
+      expect(packets[3].data[1].physicalDeltaY, equals(0.0));
     });
   });
 }


### PR DESCRIPTION
Framework moved the pointer data sanitization and metrics-related calculation to engine side.
It is now engine's responsibility to provide those metrics and clean pointer data stream.

This pr implements those calculation and sanitization in flutter web engine.
Fixes https://github.com/flutter/flutter/issues/45510