### PR TITLE
Update fallback to Roboto url to be HTTPS

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/fonts.dart
+++ b/lib/web_ui/lib/src/engine/compositor/fonts.dart
@@ -5,7 +5,7 @@
 part of engine;
 
 const String _robotoUrl =
-    'http://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf';
+    'https://fonts.gstatic.com/s/roboto/v20/KFOmCnqEu92Fr1Me5WZLCzYlKw.ttf';
 
 class SkiaFontCollection {
   final List<Future<ByteBuffer>> _loadingFontBuffers = <Future<ByteBuffer>>[];


### PR DESCRIPTION
Using CanvasKit on a HTTPS site fails with an unsecure error.

Demo: https://testchillers-dot-flutter-dashboard.appspot.com/build.html

The app is usable if you allow unsecure scripts. The issue is this script that is being loaded with HTTP instead of HTTPS.