### PR TITLE
Apply transitions to snapshotted contents instead of showing invalid render targets on iOS as an orientation change is in progress.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -1208,12 +1208,12 @@ constexpr CGFloat kStandardStatusBarHeight = 20.0;
   // renderer is being torn down and recreated at the new size. Since Flutter won't generating
   // frames in transitionary state states, snpashotted contents have to interpolated instead.
   //
-  // iOS seems the layout the view in the final state after the transition, snapshot it, and animate
-  // to in reverse before discarding the snapshot. Flutter cannot do this because frame rendering is
-  // asynchronous and the viewport metrics update has not propagated to the framework yet (much less
-  // that a frame has been rendered). Instead, the current state of the Flutter view is snapshotted
-  // before a content transition is applied to the final state. At the final state, the snapshot is
-  // discarded.
+  // iOS seems to layout the view in the final state after the transition, snapshots it, and
+  // animates to it in reverse before discarding the snapshot. Flutter cannot do this because frame
+  // rendering is asynchronous and the viewport metrics update has not propagated to the framework
+  // yet (much less that a frame has been rendered). Instead, the current state of the Flutter view
+  // is snapshotted before a content transition is applied to the final state. At the final state,
+  // the snapshot is discarded.
   //
   // Flutter cannot render the scene in all intermediate states because of the asynchronous nature
   // of rendering where the backing store for the renderer is being torn down and recreated on one


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/16322.

It is extremely hard to make the transitions seamless across devices and simulators as the behavior is so different on both. I have attempted to find the most seamless solution on both. The transitions definitely look better on devices because of the content interpolation however. The black bars and other rendering artifacts (jumping between sizes and flashing) mentioned in the linked ticket are fixed on both variants however.