### PR TITLE
Rework simpler conditional offscreen for screen readback support.

### DIFF
--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -36,10 +36,11 @@ std::unique_ptr<CompositorContext::ScopedFrame> CompositorContext::AcquireFrame(
     ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,
     bool instrumentation_enabled,
+    bool surface_supports_readback,
     fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger) {
   return std::make_unique<ScopedFrame>(
       *this, gr_context, canvas, view_embedder, root_surface_transformation,
-      instrumentation_enabled, gpu_thread_merger);
+      instrumentation_enabled, surface_supports_readback, gpu_thread_merger);
 }
 
 CompositorContext::ScopedFrame::ScopedFrame(
@@ -49,6 +50,7 @@ CompositorContext::ScopedFrame::ScopedFrame(
     ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,
     bool instrumentation_enabled,
+    bool surface_supports_readback,
     fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger)
     : context_(context),
       gr_context_(gr_context),
@@ -56,6 +58,7 @@ CompositorContext::ScopedFrame::ScopedFrame(
       view_embedder_(view_embedder),
       root_surface_transformation_(root_surface_transformation),
       instrumentation_enabled_(instrumentation_enabled),
+      surface_supports_readback_(surface_supports_readback),
       gpu_thread_merger_(gpu_thread_merger) {
   context_.BeginFrame(*this, instrumentation_enabled_);
 }
@@ -67,7 +70,8 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 RasterStatus CompositorContext::ScopedFrame::Raster(
     flutter::LayerTree& layer_tree,
     bool ignore_raster_cache) {
-  layer_tree.Preroll(*this, ignore_raster_cache);
+  bool tree_needs_readback = layer_tree.Preroll(*this, ignore_raster_cache);
+  bool needs_save_layer = tree_needs_readback && !surface_supports_readback();
   PostPrerollResult post_preroll_result = PostPrerollResult::kSuccess;
   if (view_embedder_ && gpu_thread_merger_) {
     post_preroll_result = view_embedder_->PostPrerollAction(gpu_thread_merger_);
@@ -79,9 +83,18 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
   // Clearing canvas after preroll reduces one render target switch when preroll
   // paints some raster cache.
   if (canvas()) {
+    if (needs_save_layer) {
+      FML_LOG(INFO) << "Using SaveLayer to protect non-readback surface";
+      SkRect bounds = SkRect::MakeIWH(layer_tree.frame_size().width(),
+                                      layer_tree.frame_size().height());
+      canvas()->saveLayer(&bounds, nullptr);
+    }
     canvas()->clear(SK_ColorTRANSPARENT);
   }
   layer_tree.Paint(*this, ignore_raster_cache);
+  if (canvas() && needs_save_layer) {
+    canvas()->restore();
+  }
   return RasterStatus::kSuccess;
 }
 

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -85,9 +85,10 @@ RasterStatus CompositorContext::ScopedFrame::Raster(
   if (canvas()) {
     if (needs_save_layer) {
       FML_LOG(INFO) << "Using SaveLayer to protect non-readback surface";
-      SkRect bounds = SkRect::MakeIWH(layer_tree.frame_size().width(),
-                                      layer_tree.frame_size().height());
-      canvas()->saveLayer(&bounds, nullptr);
+      SkRect bounds = SkRect::Make(layer_tree.frame_size());
+      SkPaint paint;
+      paint.setBlendMode(SkBlendMode::kSrc);
+      canvas()->saveLayer(&bounds, &paint);
     }
     canvas()->clear(SK_ColorTRANSPARENT);
   }

--- a/flow/compositor_context.cc
+++ b/flow/compositor_context.cc
@@ -70,8 +70,8 @@ CompositorContext::ScopedFrame::~ScopedFrame() {
 RasterStatus CompositorContext::ScopedFrame::Raster(
     flutter::LayerTree& layer_tree,
     bool ignore_raster_cache) {
-  bool tree_needs_readback = layer_tree.Preroll(*this, ignore_raster_cache);
-  bool needs_save_layer = tree_needs_readback && !surface_supports_readback();
+  bool root_needs_readback = layer_tree.Preroll(*this, ignore_raster_cache);
+  bool needs_save_layer = root_needs_readback && !surface_supports_readback();
   PostPrerollResult post_preroll_result = PostPrerollResult::kSuccess;
   if (view_embedder_ && gpu_thread_merger_) {
     post_preroll_result = view_embedder_->PostPrerollAction(gpu_thread_merger_);

--- a/flow/compositor_context.h
+++ b/flow/compositor_context.h
@@ -45,6 +45,7 @@ class CompositorContext {
                 ExternalViewEmbedder* view_embedder,
                 const SkMatrix& root_surface_transformation,
                 bool instrumentation_enabled,
+                bool surface_supports_readback,
                 fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger);
 
     virtual ~ScopedFrame();
@@ -59,6 +60,8 @@ class CompositorContext {
       return root_surface_transformation_;
     }
 
+    bool surface_supports_readback() { return surface_supports_readback_; }
+
     GrContext* gr_context() const { return gr_context_; }
 
     virtual RasterStatus Raster(LayerTree& layer_tree,
@@ -71,6 +74,7 @@ class CompositorContext {
     ExternalViewEmbedder* view_embedder_;
     const SkMatrix& root_surface_transformation_;
     const bool instrumentation_enabled_;
+    const bool surface_supports_readback_;
     fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger_;
 
     FML_DISALLOW_COPY_AND_ASSIGN(ScopedFrame);
@@ -86,6 +90,7 @@ class CompositorContext {
       ExternalViewEmbedder* view_embedder,
       const SkMatrix& root_surface_transformation,
       bool instrumentation_enabled,
+      bool surface_supports_readback,
       fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger);
 
   void OnGrContextCreated();

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -11,8 +11,8 @@ BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
 
 void BackdropFilterLayer::Preroll(PrerollContext* context,
                                   const SkMatrix& matrix) {
-  Layer::AutoPrerollSaveLayer save =
-      Layer::AutoPrerollSaveLayer::Create(context, true, bool(filter_));
+  Layer::AutoPrerollSaveLayerState save =
+      Layer::AutoPrerollSaveLayerState::Create(context, true, bool(filter_));
   ContainerLayer::Preroll(context, matrix);
 }
 

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -11,13 +11,10 @@ BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
 
 void BackdropFilterLayer::Preroll(PrerollContext* context,
                                   const SkMatrix& matrix) {
-  // We will not be restoring the previous read flag (see below).
-  // bool prev_read = context->layer_reads_from_surface;
+  bool prev_read = context->layer_reads_from_surface;
   context->layer_reads_from_surface = false;
   ContainerLayer::Preroll(context, matrix);
-  // Normally we would reset the flag to the previous value since we protected
-  // the children but the BackdropFilterLayer itself performs a readback
-  context->layer_reads_from_surface = true;
+  context->layer_reads_from_surface = prev_read || filter_.get() != nullptr;
 }
 
 void BackdropFilterLayer::Paint(PaintContext& context) const {

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -11,10 +11,9 @@ BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
 
 void BackdropFilterLayer::Preroll(PrerollContext* context,
                                   const SkMatrix& matrix) {
-  bool prev_read = context->layer_reads_from_surface;
-  context->layer_reads_from_surface = false;
+  Layer::AutoPrerollSaveLayer save =
+      Layer::AutoPrerollSaveLayer::Create(context, true, bool(filter_));
   ContainerLayer::Preroll(context, matrix);
-  context->layer_reads_from_surface = prev_read || filter_.get() != nullptr;
 }
 
 void BackdropFilterLayer::Paint(PaintContext& context) const {

--- a/flow/layers/backdrop_filter_layer.cc
+++ b/flow/layers/backdrop_filter_layer.cc
@@ -9,6 +9,17 @@ namespace flutter {
 BackdropFilterLayer::BackdropFilterLayer(sk_sp<SkImageFilter> filter)
     : filter_(std::move(filter)) {}
 
+void BackdropFilterLayer::Preroll(PrerollContext* context,
+                                  const SkMatrix& matrix) {
+  // We will not be restoring the previous read flag (see below).
+  // bool prev_read = context->layer_reads_from_surface;
+  context->layer_reads_from_surface = false;
+  ContainerLayer::Preroll(context, matrix);
+  // Normally we would reset the flag to the previous value since we protected
+  // the children but the BackdropFilterLayer itself performs a readback
+  context->layer_reads_from_surface = true;
+}
+
 void BackdropFilterLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "BackdropFilterLayer::Paint");
   FML_DCHECK(needs_painting());

--- a/flow/layers/backdrop_filter_layer.h
+++ b/flow/layers/backdrop_filter_layer.h
@@ -15,6 +15,8 @@ class BackdropFilterLayer : public ContainerLayer {
  public:
   BackdropFilterLayer(sk_sp<SkImageFilter> filter);
 
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+
   void Paint(PaintContext& context) const override;
 
  private:

--- a/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/flow/layers/backdrop_filter_layer_unittests.cc
@@ -183,34 +183,34 @@ TEST_F(BackdropFilterLayerTest, Nested) {
 }
 
 TEST_F(BackdropFilterLayerTest, Readback) {
+  sk_sp<SkImageFilter> no_filter;
   auto layer_filter = SkImageFilters::Paint(SkPaint(SkColors::kMagenta));
   auto initial_transform = SkMatrix();
 
   // BDF with filter always reads from surface
   auto layer1 = std::make_shared<BackdropFilterLayer>(layer_filter);
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer1->Preroll(preroll_context(), initial_transform);
-  EXPECT_TRUE(preroll_context()->layer_reads_from_surface);
+  EXPECT_TRUE(preroll_context()->subtree_performs_readback_operation);
 
   // BDF with no filter does not read from surface itself
-  layer_filter.reset();
-  auto layer2 = std::make_shared<BackdropFilterLayer>(layer_filter);
-  preroll_context()->layer_reads_from_surface = false;
+  auto layer2 = std::make_shared<BackdropFilterLayer>(no_filter);
+  preroll_context()->subtree_performs_readback_operation = false;
   layer2->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 
   // BDF with no filter does not block prior readback value
-  preroll_context()->layer_reads_from_surface = true;
+  preroll_context()->subtree_performs_readback_operation = true;
   layer2->Preroll(preroll_context(), initial_transform);
-  EXPECT_TRUE(preroll_context()->layer_reads_from_surface);
+  EXPECT_TRUE(preroll_context()->subtree_performs_readback_operation);
 
   // BDF with no filter blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer2->Add(mock_layer);
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer2->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 }
 
 }  // namespace testing

--- a/flow/layers/backdrop_filter_layer_unittests.cc
+++ b/flow/layers/backdrop_filter_layer_unittests.cc
@@ -189,28 +189,28 @@ TEST_F(BackdropFilterLayerTest, Readback) {
 
   // BDF with filter always reads from surface
   auto layer1 = std::make_shared<BackdropFilterLayer>(layer_filter);
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer1->Preroll(preroll_context(), initial_transform);
-  EXPECT_TRUE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_TRUE(preroll_context()->surface_needs_readback);
 
   // BDF with no filter does not read from surface itself
   auto layer2 = std::make_shared<BackdropFilterLayer>(no_filter);
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer2->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 
   // BDF with no filter does not block prior readback value
-  preroll_context()->subtree_performs_readback_operation = true;
+  preroll_context()->surface_needs_readback = true;
   layer2->Preroll(preroll_context(), initial_transform);
-  EXPECT_TRUE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_TRUE(preroll_context()->surface_needs_readback);
 
   // BDF with no filter blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer2->Add(mock_layer);
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer2->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 }
 
 }  // namespace testing

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -22,16 +22,12 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect clip_path_bounds = clip_path_.getBounds();
   children_inside_clip_ = context->cull_rect.intersect(clip_path_bounds);
   if (children_inside_clip_) {
+    Layer::AutoPrerollSaveLayer save =
+        Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
     context->mutators_stack.PushClipPath(clip_path_);
-    bool prev_read = context->layer_reads_from_surface;
-    if (uses_save_layer()) {
-      context->layer_reads_from_surface = false;
-    }
+
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
-    if (uses_save_layer()) {
-      context->layer_reads_from_surface = prev_read;
-    }
 
     if (child_paint_bounds.intersect(clip_path_bounds)) {
       set_paint_bounds(child_paint_bounds);

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -23,8 +23,15 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   children_inside_clip_ = context->cull_rect.intersect(clip_path_bounds);
   if (children_inside_clip_) {
     context->mutators_stack.PushClipPath(clip_path_);
+    bool prev_read = context->layer_reads_from_surface;
+    if (uses_save_layer()) {
+      context->layer_reads_from_surface = false;
+    }
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
+    if (uses_save_layer()) {
+      context->layer_reads_from_surface = prev_read;
+    }
 
     if (child_paint_bounds.intersect(clip_path_bounds)) {
       set_paint_bounds(child_paint_bounds);
@@ -57,11 +64,11 @@ void ClipPathLayer::Paint(PaintContext& context) const {
   context.internal_nodes_canvas->clipPath(clip_path_,
                                           clip_behavior_ != Clip::hardEdge);
 
-  if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
+  if (uses_save_layer()) {
     context.internal_nodes_canvas->saveLayer(paint_bounds(), nullptr);
   }
   PaintChildren(context);
-  if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
+  if (uses_save_layer()) {
     context.internal_nodes_canvas->restore();
   }
 }

--- a/flow/layers/clip_path_layer.cc
+++ b/flow/layers/clip_path_layer.cc
@@ -22,10 +22,9 @@ void ClipPathLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect clip_path_bounds = clip_path_.getBounds();
   children_inside_clip_ = context->cull_rect.intersect(clip_path_bounds);
   if (children_inside_clip_) {
-    Layer::AutoPrerollSaveLayer save =
-        Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
+    Layer::AutoPrerollSaveLayerState save =
+        Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
     context->mutators_stack.PushClipPath(clip_path_);
-
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
 
@@ -60,11 +59,11 @@ void ClipPathLayer::Paint(PaintContext& context) const {
   context.internal_nodes_canvas->clipPath(clip_path_,
                                           clip_behavior_ != Clip::hardEdge);
 
-  if (uses_save_layer()) {
+  if (UsesSaveLayer()) {
     context.internal_nodes_canvas->saveLayer(paint_bounds(), nullptr);
   }
   PaintChildren(context);
-  if (uses_save_layer()) {
+  if (UsesSaveLayer()) {
     context.internal_nodes_canvas->restore();
   }
 }

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -17,6 +17,10 @@ class ClipPathLayer : public ContainerLayer {
 
   void Paint(PaintContext& context) const override;
 
+  bool uses_save_layer() const {
+    return clip_behavior_ == Clip::antiAliasWithSaveLayer;
+  }
+
 #if defined(OS_FUCHSIA)
   void UpdateScene(SceneUpdateContext& context) override;
 #endif  // defined(OS_FUCHSIA)

--- a/flow/layers/clip_path_layer.h
+++ b/flow/layers/clip_path_layer.h
@@ -17,7 +17,7 @@ class ClipPathLayer : public ContainerLayer {
 
   void Paint(PaintContext& context) const override;
 
-  bool uses_save_layer() const {
+  bool UsesSaveLayer() const {
     return clip_behavior_ == Clip::antiAliasWithSaveLayer;
   }
 

--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -203,9 +203,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->subtree_performs_readback_operation = before;
+  context->surface_needs_readback = before;
   layer->Preroll(context, initial_matrix);
-  return context->subtree_performs_readback_operation;
+  return context->surface_needs_readback;
 }
 
 TEST_F(ClipPathLayerTest, Readback) {

--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -192,5 +192,69 @@ TEST_F(ClipPathLayerTest, PartiallyContainedChild) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
+#define CHECK_READBACK(layer, before, after)                       \
+  do {                                                             \
+    preroll_context()->layer_reads_from_surface = before;          \
+    layer->Preroll(preroll_context(), initial_matrix);             \
+    EXPECT_EQ(preroll_context()->layer_reads_from_surface, after); \
+  } while (0)
+
+#define CLIP_RECT_CHECK_READBACK(clip, before, after)               \
+  do {                                                              \
+    auto layer = std::make_shared<ClipPathLayer>(layer_path, clip); \
+    CHECK_READBACK(layer, before, after);                           \
+  } while (0)
+
+#define CLIP_RECT_CHILD_CHECK_READBACK(clip, child, before, after)  \
+  do {                                                              \
+    auto layer = std::make_shared<ClipPathLayer>(layer_path, clip); \
+    layer->Add(child);                                              \
+    CHECK_READBACK(layer, before, after);                           \
+  } while (0)
+
+TEST_F(ClipPathLayerTest, Readback) {
+  const SkMatrix initial_matrix = SkMatrix();
+  const SkRect layer_bounds = SkRect::MakeXYWH(0.5, 1.0, 5.0, 6.0);
+  const SkPath layer_path = SkPath().addRect(layer_bounds);
+
+  const Clip hard = Clip::hardEdge;
+  const Clip soft = Clip::antiAlias;
+  const Clip save_layer = Clip::antiAliasWithSaveLayer;
+
+  auto mock_read_layer =
+      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
+  auto mock_no_read_layer = std::make_shared<MockLayer>(SkPath(), SkPaint());
+
+  // No children, no prior readback -> no readback after
+  CLIP_RECT_CHECK_READBACK(hard, false, false);
+  CLIP_RECT_CHECK_READBACK(soft, false, false);
+  CLIP_RECT_CHECK_READBACK(save_layer, false, false);
+
+  // No children, prior readback -> readback after
+  CLIP_RECT_CHECK_READBACK(hard, true, true);
+  CLIP_RECT_CHECK_READBACK(soft, true, true);
+  CLIP_RECT_CHECK_READBACK(save_layer, true, true);
+
+  // Non readback child, no prior readback -> no readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, false, false);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, false, false);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, false, false);
+
+  // Non readback child, prior readback -> readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, true, true);
+
+  // Readback child, no prior readback -> readback after unless SaveLayer
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, false, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, false, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, false, false);
+
+  // Readback child, prior readback -> readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, true, true);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -203,9 +203,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->layer_reads_from_surface = before;
+  context->subtree_performs_readback_operation = before;
   layer->Preroll(context, initial_matrix);
-  return context->layer_reads_from_surface;
+  return context->subtree_performs_readback_operation;
 }
 
 TEST_F(ClipPathLayerTest, Readback) {

--- a/flow/layers/clip_path_layer_unittests.cc
+++ b/flow/layers/clip_path_layer_unittests.cc
@@ -192,68 +192,64 @@ TEST_F(ClipPathLayerTest, PartiallyContainedChild) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
-#define CHECK_READBACK(layer, before, after)                       \
-  do {                                                             \
-    preroll_context()->layer_reads_from_surface = before;          \
-    layer->Preroll(preroll_context(), initial_matrix);             \
-    EXPECT_EQ(preroll_context()->layer_reads_from_surface, after); \
-  } while (0)
-
-#define CLIP_RECT_CHECK_READBACK(clip, before, after)               \
-  do {                                                              \
-    auto layer = std::make_shared<ClipPathLayer>(layer_path, clip); \
-    CHECK_READBACK(layer, before, after);                           \
-  } while (0)
-
-#define CLIP_RECT_CHILD_CHECK_READBACK(clip, child, before, after)  \
-  do {                                                              \
-    auto layer = std::make_shared<ClipPathLayer>(layer_path, clip); \
-    layer->Add(child);                                              \
-    CHECK_READBACK(layer, before, after);                           \
-  } while (0)
-
-TEST_F(ClipPathLayerTest, Readback) {
+static bool ReadbackResult(PrerollContext* context,
+                           Clip clip_behavior,
+                           std::shared_ptr<Layer> child,
+                           bool before) {
   const SkMatrix initial_matrix = SkMatrix();
   const SkRect layer_bounds = SkRect::MakeXYWH(0.5, 1.0, 5.0, 6.0);
   const SkPath layer_path = SkPath().addRect(layer_bounds);
+  auto layer = std::make_shared<ClipPathLayer>(layer_path, clip_behavior);
+  if (child != nullptr) {
+    layer->Add(child);
+  }
+  context->layer_reads_from_surface = before;
+  layer->Preroll(context, initial_matrix);
+  return context->layer_reads_from_surface;
+}
+
+TEST_F(ClipPathLayerTest, Readback) {
+  PrerollContext* context = preroll_context();
+  SkPath path;
+  SkPaint paint;
 
   const Clip hard = Clip::hardEdge;
   const Clip soft = Clip::antiAlias;
   const Clip save_layer = Clip::antiAliasWithSaveLayer;
 
-  auto mock_read_layer =
-      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
-  auto mock_no_read_layer = std::make_shared<MockLayer>(SkPath(), SkPaint());
+  std::shared_ptr<MockLayer> nochild;
+  auto reader = std::make_shared<MockLayer>(path, paint, false, false, true);
+  auto nonreader = std::make_shared<MockLayer>(path, paint);
 
   // No children, no prior readback -> no readback after
-  CLIP_RECT_CHECK_READBACK(hard, false, false);
-  CLIP_RECT_CHECK_READBACK(soft, false, false);
-  CLIP_RECT_CHECK_READBACK(save_layer, false, false);
+  EXPECT_FALSE(ReadbackResult(context, hard, nochild, false));
+  EXPECT_FALSE(ReadbackResult(context, soft, nochild, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, nochild, false));
 
   // No children, prior readback -> readback after
-  CLIP_RECT_CHECK_READBACK(hard, true, true);
-  CLIP_RECT_CHECK_READBACK(soft, true, true);
-  CLIP_RECT_CHECK_READBACK(save_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, nochild, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, nochild, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, nochild, true));
 
   // Non readback child, no prior readback -> no readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, false, false);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, false, false);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, false, false);
+  EXPECT_FALSE(ReadbackResult(context, hard, nonreader, false));
+  EXPECT_FALSE(ReadbackResult(context, soft, nonreader, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, nonreader, false));
 
   // Non readback child, prior readback -> readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, nonreader, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, nonreader, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, nonreader, true));
 
   // Readback child, no prior readback -> readback after unless SaveLayer
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, false, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, false, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, false, false);
+  EXPECT_TRUE(ReadbackResult(context, hard, reader, false));
+  EXPECT_TRUE(ReadbackResult(context, soft, reader, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, reader, false));
 
   // Readback child, prior readback -> readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, reader, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, reader, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, reader, true));
 }
 
 }  // namespace testing

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -15,16 +15,12 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect previous_cull_rect = context->cull_rect;
   children_inside_clip_ = context->cull_rect.intersect(clip_rect_);
   if (children_inside_clip_) {
+    Layer::AutoPrerollSaveLayer save =
+        Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
     context->mutators_stack.PushClipRect(clip_rect_);
-    bool prev_read = context->layer_reads_from_surface;
-    if (uses_save_layer()) {
-      context->layer_reads_from_surface = false;
-    }
+
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
-    if (uses_save_layer()) {
-      context->layer_reads_from_surface = prev_read;
-    }
 
     if (child_paint_bounds.intersect(clip_rect_)) {
       set_paint_bounds(child_paint_bounds);

--- a/flow/layers/clip_rect_layer.cc
+++ b/flow/layers/clip_rect_layer.cc
@@ -15,10 +15,9 @@ void ClipRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect previous_cull_rect = context->cull_rect;
   children_inside_clip_ = context->cull_rect.intersect(clip_rect_);
   if (children_inside_clip_) {
-    Layer::AutoPrerollSaveLayer save =
-        Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
+    Layer::AutoPrerollSaveLayerState save =
+        Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
     context->mutators_stack.PushClipRect(clip_rect_);
-
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
 
@@ -53,11 +52,11 @@ void ClipRectLayer::Paint(PaintContext& context) const {
   context.internal_nodes_canvas->clipRect(clip_rect_,
                                           clip_behavior_ != Clip::hardEdge);
 
-  if (uses_save_layer()) {
+  if (UsesSaveLayer()) {
     context.internal_nodes_canvas->saveLayer(clip_rect_, nullptr);
   }
   PaintChildren(context);
-  if (uses_save_layer()) {
+  if (UsesSaveLayer()) {
     context.internal_nodes_canvas->restore();
   }
 }

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -16,6 +16,10 @@ class ClipRectLayer : public ContainerLayer {
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
 
+  bool uses_save_layer() const {
+    return clip_behavior_ == Clip::antiAliasWithSaveLayer;
+  }
+
 #if defined(OS_FUCHSIA)
   void UpdateScene(SceneUpdateContext& context) override;
 #endif  // defined(OS_FUCHSIA)

--- a/flow/layers/clip_rect_layer.h
+++ b/flow/layers/clip_rect_layer.h
@@ -16,7 +16,7 @@ class ClipRectLayer : public ContainerLayer {
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
 
-  bool uses_save_layer() const {
+  bool UsesSaveLayer() const {
     return clip_behavior_ == Clip::antiAliasWithSaveLayer;
   }
 

--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -190,67 +190,63 @@ TEST_F(ClipRectLayerTest, PartiallyContainedChild) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
-#define CHECK_READBACK(layer, before, after)                       \
-  do {                                                             \
-    preroll_context()->layer_reads_from_surface = before;          \
-    layer->Preroll(preroll_context(), initial_matrix);             \
-    EXPECT_EQ(preroll_context()->layer_reads_from_surface, after); \
-  } while (0)
-
-#define CLIP_RECT_CHECK_READBACK(clip, before, after)                 \
-  do {                                                                \
-    auto layer = std::make_shared<ClipRectLayer>(layer_bounds, clip); \
-    CHECK_READBACK(layer, before, after);                             \
-  } while (0)
-
-#define CLIP_RECT_CHILD_CHECK_READBACK(clip, child, before, after)    \
-  do {                                                                \
-    auto layer = std::make_shared<ClipRectLayer>(layer_bounds, clip); \
-    layer->Add(child);                                                \
-    CHECK_READBACK(layer, before, after);                             \
-  } while (0)
-
-TEST_F(ClipRectLayerTest, Readback) {
+static bool ReadbackResult(PrerollContext* context,
+                           Clip clip_behavior,
+                           std::shared_ptr<Layer> child,
+                           bool before) {
   const SkMatrix initial_matrix = SkMatrix();
   const SkRect layer_bounds = SkRect::MakeXYWH(0.5, 1.0, 5.0, 6.0);
+  auto layer = std::make_shared<ClipRectLayer>(layer_bounds, clip_behavior);
+  if (child != nullptr) {
+    layer->Add(child);
+  }
+  context->layer_reads_from_surface = before;
+  layer->Preroll(context, initial_matrix);
+  return context->layer_reads_from_surface;
+}
+
+TEST_F(ClipRectLayerTest, Readback) {
+  PrerollContext* context = preroll_context();
+  SkPath path;
+  SkPaint paint;
 
   const Clip hard = Clip::hardEdge;
   const Clip soft = Clip::antiAlias;
   const Clip save_layer = Clip::antiAliasWithSaveLayer;
 
-  auto mock_read_layer =
-      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
-  auto mock_no_read_layer = std::make_shared<MockLayer>(SkPath(), SkPaint());
+  std::shared_ptr<MockLayer> nochild;
+  auto reader = std::make_shared<MockLayer>(path, paint, false, false, true);
+  auto nonreader = std::make_shared<MockLayer>(path, paint);
 
   // No children, no prior readback -> no readback after
-  CLIP_RECT_CHECK_READBACK(hard, false, false);
-  CLIP_RECT_CHECK_READBACK(soft, false, false);
-  CLIP_RECT_CHECK_READBACK(save_layer, false, false);
+  EXPECT_FALSE(ReadbackResult(context, hard, nochild, false));
+  EXPECT_FALSE(ReadbackResult(context, soft, nochild, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, nochild, false));
 
   // No children, prior readback -> readback after
-  CLIP_RECT_CHECK_READBACK(hard, true, true);
-  CLIP_RECT_CHECK_READBACK(soft, true, true);
-  CLIP_RECT_CHECK_READBACK(save_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, nochild, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, nochild, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, nochild, true));
 
   // Non readback child, no prior readback -> no readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, false, false);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, false, false);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, false, false);
+  EXPECT_FALSE(ReadbackResult(context, hard, nonreader, false));
+  EXPECT_FALSE(ReadbackResult(context, soft, nonreader, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, nonreader, false));
 
   // Non readback child, prior readback -> readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, nonreader, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, nonreader, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, nonreader, true));
 
   // Readback child, no prior readback -> readback after unless SaveLayer
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, false, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, false, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, false, false);
+  EXPECT_TRUE(ReadbackResult(context, hard, reader, false));
+  EXPECT_TRUE(ReadbackResult(context, soft, reader, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, reader, false));
 
   // Readback child, prior readback -> readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, reader, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, reader, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, reader, true));
 }
 
 }  // namespace testing

--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -200,9 +200,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->subtree_performs_readback_operation = before;
+  context->surface_needs_readback = before;
   layer->Preroll(context, initial_matrix);
-  return context->subtree_performs_readback_operation;
+  return context->surface_needs_readback;
 }
 
 TEST_F(ClipRectLayerTest, Readback) {

--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -190,5 +190,68 @@ TEST_F(ClipRectLayerTest, PartiallyContainedChild) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
+#define CHECK_READBACK(layer, before, after)                       \
+  do {                                                             \
+    preroll_context()->layer_reads_from_surface = before;          \
+    layer->Preroll(preroll_context(), initial_matrix);             \
+    EXPECT_EQ(preroll_context()->layer_reads_from_surface, after); \
+  } while (0)
+
+#define CLIP_RECT_CHECK_READBACK(clip, before, after)                 \
+  do {                                                                \
+    auto layer = std::make_shared<ClipRectLayer>(layer_bounds, clip); \
+    CHECK_READBACK(layer, before, after);                             \
+  } while (0)
+
+#define CLIP_RECT_CHILD_CHECK_READBACK(clip, child, before, after)    \
+  do {                                                                \
+    auto layer = std::make_shared<ClipRectLayer>(layer_bounds, clip); \
+    layer->Add(child);                                                \
+    CHECK_READBACK(layer, before, after);                             \
+  } while (0)
+
+TEST_F(ClipRectLayerTest, Readback) {
+  const SkMatrix initial_matrix = SkMatrix();
+  const SkRect layer_bounds = SkRect::MakeXYWH(0.5, 1.0, 5.0, 6.0);
+
+  const Clip hard = Clip::hardEdge;
+  const Clip soft = Clip::antiAlias;
+  const Clip save_layer = Clip::antiAliasWithSaveLayer;
+
+  auto mock_read_layer =
+      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
+  auto mock_no_read_layer = std::make_shared<MockLayer>(SkPath(), SkPaint());
+
+  // No children, no prior readback -> no readback after
+  CLIP_RECT_CHECK_READBACK(hard, false, false);
+  CLIP_RECT_CHECK_READBACK(soft, false, false);
+  CLIP_RECT_CHECK_READBACK(save_layer, false, false);
+
+  // No children, prior readback -> readback after
+  CLIP_RECT_CHECK_READBACK(hard, true, true);
+  CLIP_RECT_CHECK_READBACK(soft, true, true);
+  CLIP_RECT_CHECK_READBACK(save_layer, true, true);
+
+  // Non readback child, no prior readback -> no readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, false, false);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, false, false);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, false, false);
+
+  // Non readback child, prior readback -> readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, true, true);
+
+  // Readback child, no prior readback -> readback after unless SaveLayer
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, false, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, false, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, false, false);
+
+  // Readback child, prior readback -> readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, true, true);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/clip_rect_layer_unittests.cc
+++ b/flow/layers/clip_rect_layer_unittests.cc
@@ -200,9 +200,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->layer_reads_from_surface = before;
+  context->subtree_performs_readback_operation = before;
   layer->Preroll(context, initial_matrix);
-  return context->layer_reads_from_surface;
+  return context->subtree_performs_readback_operation;
 }
 
 TEST_F(ClipRectLayerTest, Readback) {

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -16,16 +16,12 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect clip_rrect_bounds = clip_rrect_.getBounds();
   children_inside_clip_ = context->cull_rect.intersect(clip_rrect_bounds);
   if (children_inside_clip_) {
+    Layer::AutoPrerollSaveLayer save =
+        Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
     context->mutators_stack.PushClipRRect(clip_rrect_);
-    bool prev_read = context->layer_reads_from_surface;
-    if (uses_save_layer()) {
-      context->layer_reads_from_surface = false;
-    }
+
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
-    if (uses_save_layer()) {
-      context->layer_reads_from_surface = prev_read;
-    }
 
     if (child_paint_bounds.intersect(clip_rrect_bounds)) {
       set_paint_bounds(child_paint_bounds);

--- a/flow/layers/clip_rrect_layer.cc
+++ b/flow/layers/clip_rrect_layer.cc
@@ -16,10 +16,9 @@ void ClipRRectLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   SkRect clip_rrect_bounds = clip_rrect_.getBounds();
   children_inside_clip_ = context->cull_rect.intersect(clip_rrect_bounds);
   if (children_inside_clip_) {
-    Layer::AutoPrerollSaveLayer save =
-        Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
+    Layer::AutoPrerollSaveLayerState save =
+        Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
     context->mutators_stack.PushClipRRect(clip_rrect_);
-
     SkRect child_paint_bounds = SkRect::MakeEmpty();
     PrerollChildren(context, matrix, &child_paint_bounds);
 
@@ -54,11 +53,11 @@ void ClipRRectLayer::Paint(PaintContext& context) const {
   context.internal_nodes_canvas->clipRRect(clip_rrect_,
                                            clip_behavior_ != Clip::hardEdge);
 
-  if (uses_save_layer()) {
+  if (UsesSaveLayer()) {
     context.internal_nodes_canvas->saveLayer(paint_bounds(), nullptr);
   }
   PaintChildren(context);
-  if (uses_save_layer()) {
+  if (UsesSaveLayer()) {
     context.internal_nodes_canvas->restore();
   }
 }

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -17,7 +17,7 @@ class ClipRRectLayer : public ContainerLayer {
 
   void Paint(PaintContext& context) const override;
 
-  bool uses_save_layer() const {
+  bool UsesSaveLayer() const {
     return clip_behavior_ == Clip::antiAliasWithSaveLayer;
   }
 

--- a/flow/layers/clip_rrect_layer.h
+++ b/flow/layers/clip_rrect_layer.h
@@ -17,6 +17,10 @@ class ClipRRectLayer : public ContainerLayer {
 
   void Paint(PaintContext& context) const override;
 
+  bool uses_save_layer() const {
+    return clip_behavior_ == Clip::antiAliasWithSaveLayer;
+  }
+
 #if defined(OS_FUCHSIA)
   void UpdateScene(SceneUpdateContext& context) override;
 #endif  // defined(OS_FUCHSIA)

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -206,9 +206,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->layer_reads_from_surface = before;
+  context->subtree_performs_readback_operation = before;
   layer->Preroll(context, initial_matrix);
-  return context->layer_reads_from_surface;
+  return context->subtree_performs_readback_operation;
 }
 
 TEST_F(ClipRRectLayerTest, Readback) {

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -206,9 +206,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->subtree_performs_readback_operation = before;
+  context->surface_needs_readback = before;
   layer->Preroll(context, initial_matrix);
-  return context->subtree_performs_readback_operation;
+  return context->surface_needs_readback;
 }
 
 TEST_F(ClipRRectLayerTest, Readback) {

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -195,68 +195,64 @@ TEST_F(ClipRRectLayerTest, PartiallyContainedChild) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
-#define CHECK_READBACK(layer, before, after)                       \
-  do {                                                             \
-    preroll_context()->layer_reads_from_surface = before;          \
-    layer->Preroll(preroll_context(), initial_matrix);             \
-    EXPECT_EQ(preroll_context()->layer_reads_from_surface, after); \
-  } while (0)
-
-#define CLIP_RECT_CHECK_READBACK(clip, before, after)                 \
-  do {                                                                \
-    auto layer = std::make_shared<ClipRRectLayer>(layer_rrect, clip); \
-    CHECK_READBACK(layer, before, after);                             \
-  } while (0)
-
-#define CLIP_RECT_CHILD_CHECK_READBACK(clip, child, before, after)    \
-  do {                                                                \
-    auto layer = std::make_shared<ClipRRectLayer>(layer_rrect, clip); \
-    layer->Add(child);                                                \
-    CHECK_READBACK(layer, before, after);                             \
-  } while (0)
-
-TEST_F(ClipRRectLayerTest, Readback) {
+static bool ReadbackResult(PrerollContext* context,
+                           Clip clip_behavior,
+                           std::shared_ptr<Layer> child,
+                           bool before) {
   const SkMatrix initial_matrix = SkMatrix();
   const SkRect layer_bounds = SkRect::MakeXYWH(0.5, 1.0, 5.0, 6.0);
   const SkRRect layer_rrect = SkRRect::MakeRect(layer_bounds);
+  auto layer = std::make_shared<ClipRRectLayer>(layer_rrect, clip_behavior);
+  if (child != nullptr) {
+    layer->Add(child);
+  }
+  context->layer_reads_from_surface = before;
+  layer->Preroll(context, initial_matrix);
+  return context->layer_reads_from_surface;
+}
+
+TEST_F(ClipRRectLayerTest, Readback) {
+  PrerollContext* context = preroll_context();
+  SkPath path;
+  SkPaint paint;
 
   const Clip hard = Clip::hardEdge;
   const Clip soft = Clip::antiAlias;
   const Clip save_layer = Clip::antiAliasWithSaveLayer;
 
-  auto mock_read_layer =
-      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
-  auto mock_no_read_layer = std::make_shared<MockLayer>(SkPath(), SkPaint());
+  std::shared_ptr<MockLayer> nochild;
+  auto reader = std::make_shared<MockLayer>(path, paint, false, false, true);
+  auto nonreader = std::make_shared<MockLayer>(path, paint);
 
   // No children, no prior readback -> no readback after
-  CLIP_RECT_CHECK_READBACK(hard, false, false);
-  CLIP_RECT_CHECK_READBACK(soft, false, false);
-  CLIP_RECT_CHECK_READBACK(save_layer, false, false);
+  EXPECT_FALSE(ReadbackResult(context, hard, nochild, false));
+  EXPECT_FALSE(ReadbackResult(context, soft, nochild, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, nochild, false));
 
   // No children, prior readback -> readback after
-  CLIP_RECT_CHECK_READBACK(hard, true, true);
-  CLIP_RECT_CHECK_READBACK(soft, true, true);
-  CLIP_RECT_CHECK_READBACK(save_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, nochild, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, nochild, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, nochild, true));
 
   // Non readback child, no prior readback -> no readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, false, false);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, false, false);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, false, false);
+  EXPECT_FALSE(ReadbackResult(context, hard, nonreader, false));
+  EXPECT_FALSE(ReadbackResult(context, soft, nonreader, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, nonreader, false));
 
   // Non readback child, prior readback -> readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, nonreader, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, nonreader, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, nonreader, true));
 
   // Readback child, no prior readback -> readback after unless SaveLayer
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, false, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, false, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, false, false);
+  EXPECT_TRUE(ReadbackResult(context, hard, reader, false));
+  EXPECT_TRUE(ReadbackResult(context, soft, reader, false));
+  EXPECT_FALSE(ReadbackResult(context, save_layer, reader, false));
 
   // Readback child, prior readback -> readback after
-  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, true, true);
-  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, true, true);
+  EXPECT_TRUE(ReadbackResult(context, hard, reader, true));
+  EXPECT_TRUE(ReadbackResult(context, soft, reader, true));
+  EXPECT_TRUE(ReadbackResult(context, save_layer, reader, true));
 }
 
 }  // namespace testing

--- a/flow/layers/clip_rrect_layer_unittests.cc
+++ b/flow/layers/clip_rrect_layer_unittests.cc
@@ -195,5 +195,69 @@ TEST_F(ClipRRectLayerTest, PartiallyContainedChild) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
+#define CHECK_READBACK(layer, before, after)                       \
+  do {                                                             \
+    preroll_context()->layer_reads_from_surface = before;          \
+    layer->Preroll(preroll_context(), initial_matrix);             \
+    EXPECT_EQ(preroll_context()->layer_reads_from_surface, after); \
+  } while (0)
+
+#define CLIP_RECT_CHECK_READBACK(clip, before, after)                 \
+  do {                                                                \
+    auto layer = std::make_shared<ClipRRectLayer>(layer_rrect, clip); \
+    CHECK_READBACK(layer, before, after);                             \
+  } while (0)
+
+#define CLIP_RECT_CHILD_CHECK_READBACK(clip, child, before, after)    \
+  do {                                                                \
+    auto layer = std::make_shared<ClipRRectLayer>(layer_rrect, clip); \
+    layer->Add(child);                                                \
+    CHECK_READBACK(layer, before, after);                             \
+  } while (0)
+
+TEST_F(ClipRRectLayerTest, Readback) {
+  const SkMatrix initial_matrix = SkMatrix();
+  const SkRect layer_bounds = SkRect::MakeXYWH(0.5, 1.0, 5.0, 6.0);
+  const SkRRect layer_rrect = SkRRect::MakeRect(layer_bounds);
+
+  const Clip hard = Clip::hardEdge;
+  const Clip soft = Clip::antiAlias;
+  const Clip save_layer = Clip::antiAliasWithSaveLayer;
+
+  auto mock_read_layer =
+      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
+  auto mock_no_read_layer = std::make_shared<MockLayer>(SkPath(), SkPaint());
+
+  // No children, no prior readback -> no readback after
+  CLIP_RECT_CHECK_READBACK(hard, false, false);
+  CLIP_RECT_CHECK_READBACK(soft, false, false);
+  CLIP_RECT_CHECK_READBACK(save_layer, false, false);
+
+  // No children, prior readback -> readback after
+  CLIP_RECT_CHECK_READBACK(hard, true, true);
+  CLIP_RECT_CHECK_READBACK(soft, true, true);
+  CLIP_RECT_CHECK_READBACK(save_layer, true, true);
+
+  // Non readback child, no prior readback -> no readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, false, false);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, false, false);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, false, false);
+
+  // Non readback child, prior readback -> readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_no_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_no_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_no_read_layer, true, true);
+
+  // Readback child, no prior readback -> readback after unless SaveLayer
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, false, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, false, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, false, false);
+
+  // Readback child, prior readback -> readback after
+  CLIP_RECT_CHILD_CHECK_READBACK(hard, mock_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(soft, mock_read_layer, true, true);
+  CLIP_RECT_CHILD_CHECK_READBACK(save_layer, mock_read_layer, true, true);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -11,8 +11,8 @@ ColorFilterLayer::ColorFilterLayer(sk_sp<SkColorFilter> filter)
 
 void ColorFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
-  Layer::AutoPrerollSaveLayer save =
-      Layer::AutoPrerollSaveLayer::Create(context);
+  Layer::AutoPrerollSaveLayerState save =
+      Layer::AutoPrerollSaveLayerState::Create(context);
   ContainerLayer::Preroll(context, matrix);
 }
 

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -11,10 +11,9 @@ ColorFilterLayer::ColorFilterLayer(sk_sp<SkColorFilter> filter)
 
 void ColorFilterLayer::Preroll(PrerollContext* context,
                                const SkMatrix& matrix) {
-  bool prev_read = context->layer_reads_from_surface;
-  context->layer_reads_from_surface = false;
+  Layer::AutoPrerollSaveLayer save =
+      Layer::AutoPrerollSaveLayer::Create(context);
   ContainerLayer::Preroll(context, matrix);
-  context->layer_reads_from_surface = prev_read;
 }
 
 void ColorFilterLayer::Paint(PaintContext& context) const {

--- a/flow/layers/color_filter_layer.cc
+++ b/flow/layers/color_filter_layer.cc
@@ -9,6 +9,14 @@ namespace flutter {
 ColorFilterLayer::ColorFilterLayer(sk_sp<SkColorFilter> filter)
     : filter_(std::move(filter)) {}
 
+void ColorFilterLayer::Preroll(PrerollContext* context,
+                               const SkMatrix& matrix) {
+  bool prev_read = context->layer_reads_from_surface;
+  context->layer_reads_from_surface = false;
+  ContainerLayer::Preroll(context, matrix);
+  context->layer_reads_from_surface = prev_read;
+}
+
 void ColorFilterLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ColorFilterLayer::Paint");
   FML_DCHECK(needs_painting());

--- a/flow/layers/color_filter_layer.h
+++ b/flow/layers/color_filter_layer.h
@@ -15,6 +15,8 @@ class ColorFilterLayer : public ContainerLayer {
  public:
   ColorFilterLayer(sk_sp<SkColorFilter> filter);
 
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+
   void Paint(PaintContext& context) const override;
 
  private:

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -195,5 +195,24 @@ TEST_F(ColorFilterLayerTest, Nested) {
                    MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
+TEST_F(ColorFilterLayerTest, Readback) {
+  auto layer_filter = SkColorFilters::LinearToSRGBGamma();
+  auto initial_transform = SkMatrix();
+
+  // ColorFilterLayer does not read from surface
+  auto layer = std::make_shared<ColorFilterLayer>(layer_filter);
+  preroll_context()->layer_reads_from_surface = false;
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+
+  // ColorFilterLayer blocks child with readback
+  auto mock_layer =
+      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
+  layer->Add(mock_layer);
+  preroll_context()->layer_reads_from_surface = false;
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -201,17 +201,17 @@ TEST_F(ColorFilterLayerTest, Readback) {
 
   // ColorFilterLayer does not read from surface
   auto layer = std::make_shared<ColorFilterLayer>(layer_filter);
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 
   // ColorFilterLayer blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer->Add(mock_layer);
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 }
 
 }  // namespace testing

--- a/flow/layers/color_filter_layer_unittests.cc
+++ b/flow/layers/color_filter_layer_unittests.cc
@@ -201,17 +201,17 @@ TEST_F(ColorFilterLayerTest, Readback) {
 
   // ColorFilterLayer does not read from surface
   auto layer = std::make_shared<ColorFilterLayer>(layer_filter);
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 
   // ColorFilterLayer blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer->Add(mock_layer);
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 }
 
 }  // namespace testing

--- a/flow/layers/layer.cc
+++ b/flow/layers/layer.cc
@@ -27,7 +27,7 @@ uint64_t Layer::NextUniqueID() {
 
 void Layer::Preroll(PrerollContext* context, const SkMatrix& matrix) {}
 
-Layer::AutoPrerollSaveLayer::AutoPrerollSaveLayer(
+Layer::AutoPrerollSaveLayerState::AutoPrerollSaveLayerState(
     PrerollContext* preroll_context,
     bool save_layer_is_active,
     bool layer_itself_performs_readback)
@@ -35,25 +35,23 @@ Layer::AutoPrerollSaveLayer::AutoPrerollSaveLayer(
       save_layer_is_active_(save_layer_is_active),
       layer_itself_performs_readback_(layer_itself_performs_readback) {
   if (save_layer_is_active_) {
-    prev_subtree_performs_readback_operation_ =
-        preroll_context_->subtree_performs_readback_operation;
-    preroll_context_->subtree_performs_readback_operation = false;
+    prev_surface_needs_readback_ = preroll_context_->surface_needs_readback;
+    preroll_context_->surface_needs_readback = false;
   }
 }
 
-Layer::AutoPrerollSaveLayer Layer::AutoPrerollSaveLayer::Create(
+Layer::AutoPrerollSaveLayerState Layer::AutoPrerollSaveLayerState::Create(
     PrerollContext* preroll_context,
     bool save_layer_is_active,
     bool layer_itself_performs_readback) {
-  return Layer::AutoPrerollSaveLayer(preroll_context, save_layer_is_active,
-                                     layer_itself_performs_readback);
+  return Layer::AutoPrerollSaveLayerState(preroll_context, save_layer_is_active,
+                                          layer_itself_performs_readback);
 }
 
-Layer::AutoPrerollSaveLayer::~AutoPrerollSaveLayer() {
+Layer::AutoPrerollSaveLayerState::~AutoPrerollSaveLayerState() {
   if (save_layer_is_active_) {
-    preroll_context_->subtree_performs_readback_operation =
-        (prev_subtree_performs_readback_operation_ ||
-         layer_itself_performs_readback_);
+    preroll_context_->surface_needs_readback =
+        (prev_surface_needs_readback_ || layer_itself_performs_readback_);
   }
 }
 

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -49,7 +49,7 @@ struct PrerollContext {
   MutatorsStack& mutators_stack;
   SkColorSpace* dst_color_space;
   SkRect cull_rect;
-  bool layer_reads_from_surface;
+  bool subtree_performs_readback_operation;
 
   // These allow us to paint in the end of subtree Preroll.
   const Stopwatch& raster_time;
@@ -76,6 +76,32 @@ class Layer {
   virtual ~Layer();
 
   virtual void Preroll(PrerollContext* context, const SkMatrix& matrix);
+
+  // Used during Preroll by layers that employ a saveLayer to manage the
+  // PrerollContext settings with values affected by the saveLayer mechanism.
+  // This object must be created before calling Preroll on the children to
+  // set up the state for the children and then restore the state upon
+  // destruction.
+  class AutoPrerollSaveLayer {
+   public:
+    FML_WARN_UNUSED_RESULT static AutoPrerollSaveLayer Create(
+        PrerollContext* preroll_context,
+        bool save_layer_is_active = true,
+        bool layer_itself_performs_readback = false);
+
+    ~AutoPrerollSaveLayer();
+
+   private:
+    AutoPrerollSaveLayer(PrerollContext* preroll_context,
+                         bool save_layer_is_active,
+                         bool layer_itself_performs_readback);
+
+    PrerollContext* preroll_context_;
+    bool save_layer_is_active_;
+    bool layer_itself_performs_readback_;
+
+    bool prev_subtree_performs_readback_operation_;
+  };
 
   struct PaintContext {
     // When splitting the scene into multiple canvases (e.g when embedding

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -49,7 +49,7 @@ struct PrerollContext {
   MutatorsStack& mutators_stack;
   SkColorSpace* dst_color_space;
   SkRect cull_rect;
-  bool subtree_performs_readback_operation;
+  bool surface_needs_readback;
 
   // These allow us to paint in the end of subtree Preroll.
   const Stopwatch& raster_time;
@@ -82,25 +82,25 @@ class Layer {
   // This object must be created before calling Preroll on the children to
   // set up the state for the children and then restore the state upon
   // destruction.
-  class AutoPrerollSaveLayer {
+  class AutoPrerollSaveLayerState {
    public:
-    FML_WARN_UNUSED_RESULT static AutoPrerollSaveLayer Create(
+    FML_WARN_UNUSED_RESULT static AutoPrerollSaveLayerState Create(
         PrerollContext* preroll_context,
         bool save_layer_is_active = true,
         bool layer_itself_performs_readback = false);
 
-    ~AutoPrerollSaveLayer();
+    ~AutoPrerollSaveLayerState();
 
    private:
-    AutoPrerollSaveLayer(PrerollContext* preroll_context,
-                         bool save_layer_is_active,
-                         bool layer_itself_performs_readback);
+    AutoPrerollSaveLayerState(PrerollContext* preroll_context,
+                              bool save_layer_is_active,
+                              bool layer_itself_performs_readback);
 
     PrerollContext* preroll_context_;
     bool save_layer_is_active_;
     bool layer_itself_performs_readback_;
 
-    bool prev_subtree_performs_readback_operation_;
+    bool prev_surface_needs_readback_;
   };
 
   struct PaintContext {

--- a/flow/layers/layer.h
+++ b/flow/layers/layer.h
@@ -49,6 +49,7 @@ struct PrerollContext {
   MutatorsStack& mutators_stack;
   SkColorSpace* dst_color_space;
   SkRect cull_rect;
+  bool layer_reads_from_surface;
 
   // These allow us to paint in the end of subtree Preroll.
   const Stopwatch& raster_time;

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -56,7 +56,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       frame_device_pixel_ratio_};
 
   root_layer_->Preroll(&context, frame.root_surface_transformation());
-  return context.subtree_performs_readback_operation;
+  return context.surface_needs_readback;
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -56,7 +56,7 @@ bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       frame_device_pixel_ratio_};
 
   root_layer_->Preroll(&context, frame.root_surface_transformation());
-  return context.layer_reads_from_surface;
+  return context.subtree_performs_readback_operation;
 }
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -26,13 +26,13 @@ void LayerTree::RecordBuildTime(fml::TimePoint start) {
   build_finish_ = fml::TimePoint::Now();
 }
 
-void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
+bool LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
                         bool ignore_raster_cache) {
   TRACE_EVENT0("flutter", "LayerTree::Preroll");
 
   if (!root_layer_) {
     FML_LOG(ERROR) << "The scene did not specify any layers.";
-    return;
+    return false;
   }
 
   SkColorSpace* color_space =
@@ -47,6 +47,7 @@ void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       stack,
       color_space,
       kGiantRect,
+      false,
       frame.context().raster_time(),
       frame.context().ui_time(),
       frame.context().texture_registry(),
@@ -55,6 +56,7 @@ void LayerTree::Preroll(CompositorContext::ScopedFrame& frame,
       frame_device_pixel_ratio_};
 
   root_layer_->Preroll(&context, frame.root_surface_transformation());
+  return context.layer_reads_from_surface;
 }
 
 #if defined(OS_FUCHSIA)
@@ -152,6 +154,7 @@ sk_sp<SkPicture> LayerTree::Flatten(const SkRect& bounds) {
       unused_stack,              // mutator stack
       nullptr,                   // SkColorSpace* dst_color_space
       kGiantRect,                // SkRect cull_rect
+      false,                     // layer reads from surface
       unused_stopwatch,          // frame time (dont care)
       unused_stopwatch,          // engine time (dont care)
       unused_texture_registry,   // texture registry (not supported)

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -23,6 +23,13 @@ class LayerTree {
             float frame_physical_depth,
             float frame_device_pixel_ratio);
 
+  // Perform a preroll pass on the tree and return information about
+  // the tree that affects rendering this frame.
+  //
+  // Returns:
+  // - a boolean indicating whether or not the top level of the
+  //   layer tree performs any operations that require readback
+  //   from the root surface.
   bool Preroll(CompositorContext::ScopedFrame& frame,
                bool ignore_raster_cache = false);
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -23,7 +23,7 @@ class LayerTree {
             float frame_physical_depth,
             float frame_device_pixel_ratio);
 
-  void Preroll(CompositorContext::ScopedFrame& frame,
+  bool Preroll(CompositorContext::ScopedFrame& frame,
                bool ignore_raster_cache = false);
 
 #if defined(OS_FUCHSIA)

--- a/flow/layers/layer_tree_unittests.cc
+++ b/flow/layers/layer_tree_unittests.cc
@@ -26,6 +26,7 @@ class LayerTreeTest : public CanvasTest {
                                                        nullptr,
                                                        root_transform_,
                                                        false,
+                                                       true,
                                                        nullptr)) {}
 
   LayerTree& layer_tree() { return layer_tree_; }

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -58,7 +58,10 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   child_matrix.postTranslate(offset_.fX, offset_.fY);
   context->mutators_stack.PushTransform(
       SkMatrix::MakeTrans(offset_.fX, offset_.fY));
+  bool prev_read = context->layer_reads_from_surface;
+  context->layer_reads_from_surface = false;
   OpacityLayerBase::Preroll(context, child_matrix);
+  context->layer_reads_from_surface = prev_read;
   context->mutators_stack.Pop();
 
   // When using the system compositor, do not include the offset since we are

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -58,8 +58,8 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   child_matrix.postTranslate(offset_.fX, offset_.fY);
   context->mutators_stack.PushTransform(
       SkMatrix::MakeTrans(offset_.fX, offset_.fY));
-  Layer::AutoPrerollSaveLayer save =
-      Layer::AutoPrerollSaveLayer::Create(context);
+  Layer::AutoPrerollSaveLayerState save =
+      Layer::AutoPrerollSaveLayerState::Create(context);
   OpacityLayerBase::Preroll(context, child_matrix);
   context->mutators_stack.Pop();
 

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -58,10 +58,9 @@ void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   child_matrix.postTranslate(offset_.fX, offset_.fY);
   context->mutators_stack.PushTransform(
       SkMatrix::MakeTrans(offset_.fX, offset_.fY));
-  bool prev_read = context->layer_reads_from_surface;
-  context->layer_reads_from_surface = false;
+  Layer::AutoPrerollSaveLayer save =
+      Layer::AutoPrerollSaveLayer::Create(context);
   OpacityLayerBase::Preroll(context, child_matrix);
-  context->layer_reads_from_surface = prev_read;
   context->mutators_stack.Pop();
 
   // When using the system compositor, do not include the offset since we are

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -314,17 +314,17 @@ TEST_F(OpacityLayerTest, Readback) {
   layer->Add(std::make_shared<MockLayer>(SkPath()));
 
   // OpacityLayer does not read from surface
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 
   // OpacityLayer blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer->Add(mock_layer);
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 }
 
 }  // namespace testing

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -314,17 +314,17 @@ TEST_F(OpacityLayerTest, Readback) {
   layer->Add(std::make_shared<MockLayer>(SkPath()));
 
   // OpacityLayer does not read from surface
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 
   // OpacityLayer blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer->Add(mock_layer);
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 }
 
 }  // namespace testing

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -308,5 +308,24 @@ TEST_F(OpacityLayerTest, Nested) {
   EXPECT_EQ(mock_canvas().draw_calls(), expected_draw_calls);
 }
 
+TEST_F(OpacityLayerTest, Readback) {
+  auto initial_transform = SkMatrix();
+  auto layer = std::make_shared<OpacityLayer>(kOpaque_SkAlphaType, SkPoint());
+  layer->Add(std::make_shared<MockLayer>(SkPath()));
+
+  // OpacityLayer does not read from surface
+  preroll_context()->layer_reads_from_surface = false;
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+
+  // OpacityLayer blocks child with readback
+  auto mock_layer =
+      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
+  layer->Add(mock_layer);
+  preroll_context()->layer_reads_from_surface = false;
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -49,8 +49,8 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
                                  const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "PhysicalShapeLayer::Preroll");
 
-  Layer::AutoPrerollSaveLayer save =
-      Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
+  Layer::AutoPrerollSaveLayerState save =
+      Layer::AutoPrerollSaveLayerState::Create(context, UsesSaveLayer());
   PhysicalShapeLayerBase::Preroll(context, matrix);
 
   if (elevation() == 0) {
@@ -102,7 +102,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
       break;
   }
 
-  if (uses_save_layer()) {
+  if (UsesSaveLayer()) {
     // If we want to avoid the bleeding edge artifact
     // (https://github.com/flutter/flutter/issues/18057#issue-328003931)
     // using saveLayer, we have to call drawPaint instead of drawPath as

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -49,14 +49,9 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
                                  const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "PhysicalShapeLayer::Preroll");
 
-  bool prev_read = context->layer_reads_from_surface;
-  if (uses_save_layer()) {
-    context->layer_reads_from_surface = false;
-  }
+  Layer::AutoPrerollSaveLayer save =
+      Layer::AutoPrerollSaveLayer::Create(context, uses_save_layer());
   PhysicalShapeLayerBase::Preroll(context, matrix);
-  if (uses_save_layer()) {
-    context->layer_reads_from_surface = prev_read;
-  }
 
   if (elevation() == 0) {
     set_paint_bounds(path_.getBounds());

--- a/flow/layers/physical_shape_layer.cc
+++ b/flow/layers/physical_shape_layer.cc
@@ -49,7 +49,14 @@ void PhysicalShapeLayer::Preroll(PrerollContext* context,
                                  const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "PhysicalShapeLayer::Preroll");
 
+  bool prev_read = context->layer_reads_from_surface;
+  if (uses_save_layer()) {
+    context->layer_reads_from_surface = false;
+  }
   PhysicalShapeLayerBase::Preroll(context, matrix);
+  if (uses_save_layer()) {
+    context->layer_reads_from_surface = prev_read;
+  }
 
   if (elevation() == 0) {
     set_paint_bounds(path_.getBounds());
@@ -100,7 +107,7 @@ void PhysicalShapeLayer::Paint(PaintContext& context) const {
       break;
   }
 
-  if (clip_behavior_ == Clip::antiAliasWithSaveLayer) {
+  if (uses_save_layer()) {
     // If we want to avoid the bleeding edge artifact
     // (https://github.com/flutter/flutter/issues/18057#issue-328003931)
     // using saveLayer, we have to call drawPaint instead of drawPath as

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -46,6 +46,10 @@ class PhysicalShapeLayer : public PhysicalShapeLayerBase {
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
 
+  bool uses_save_layer() const {
+    return clip_behavior_ == Clip::antiAliasWithSaveLayer;
+  }
+
  private:
   SkColor shadow_color_;
   SkPath path_;

--- a/flow/layers/physical_shape_layer.h
+++ b/flow/layers/physical_shape_layer.h
@@ -46,7 +46,7 @@ class PhysicalShapeLayer : public PhysicalShapeLayerBase {
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
 
-  bool uses_save_layer() const {
+  bool UsesSaveLayer() const {
     return clip_behavior_ == Clip::antiAliasWithSaveLayer;
   }
 

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -216,9 +216,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->subtree_performs_readback_operation = before;
+  context->surface_needs_readback = before;
   layer->Preroll(context, initial_matrix);
-  return context->subtree_performs_readback_operation;
+  return context->surface_needs_readback;
 }
 
 TEST_F(PhysicalShapeLayerTest, Readback) {

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -204,8 +204,6 @@ TEST_F(PhysicalShapeLayerTest, ElevationComplex) {
 
 #define MAKE_PHYSICAL_SHAPE_LAYER(clip)                              \
   std::make_shared<PhysicalShapeLayer>(SK_ColorGREEN, SK_ColorBLACK, \
-                                       1.0f, /* pixel ratio */       \
-                                       1.0f, /* depth */             \
                                        0.0f, /* elevation */         \
                                        layer_path, clip)
 

--- a/flow/layers/physical_shape_layer_unittests.cc
+++ b/flow/layers/physical_shape_layer_unittests.cc
@@ -216,9 +216,9 @@ static bool ReadbackResult(PrerollContext* context,
   if (child != nullptr) {
     layer->Add(child);
   }
-  context->layer_reads_from_surface = before;
+  context->subtree_performs_readback_operation = before;
   layer->Preroll(context, initial_matrix);
-  return context->layer_reads_from_surface;
+  return context->subtree_performs_readback_operation;
 }
 
 TEST_F(PhysicalShapeLayerTest, Readback) {

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -12,8 +12,8 @@ ShaderMaskLayer::ShaderMaskLayer(sk_sp<SkShader> shader,
     : shader_(shader), mask_rect_(mask_rect), blend_mode_(blend_mode) {}
 
 void ShaderMaskLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  Layer::AutoPrerollSaveLayer save =
-      Layer::AutoPrerollSaveLayer::Create(context);
+  Layer::AutoPrerollSaveLayerState save =
+      Layer::AutoPrerollSaveLayerState::Create(context);
   ContainerLayer::Preroll(context, matrix);
 }
 

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -12,10 +12,9 @@ ShaderMaskLayer::ShaderMaskLayer(sk_sp<SkShader> shader,
     : shader_(shader), mask_rect_(mask_rect), blend_mode_(blend_mode) {}
 
 void ShaderMaskLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
-  bool prev_read = context->layer_reads_from_surface;
-  context->layer_reads_from_surface = false;
+  Layer::AutoPrerollSaveLayer save =
+      Layer::AutoPrerollSaveLayer::Create(context);
   ContainerLayer::Preroll(context, matrix);
-  context->layer_reads_from_surface = prev_read;
 }
 
 void ShaderMaskLayer::Paint(PaintContext& context) const {

--- a/flow/layers/shader_mask_layer.cc
+++ b/flow/layers/shader_mask_layer.cc
@@ -11,6 +11,13 @@ ShaderMaskLayer::ShaderMaskLayer(sk_sp<SkShader> shader,
                                  SkBlendMode blend_mode)
     : shader_(shader), mask_rect_(mask_rect), blend_mode_(blend_mode) {}
 
+void ShaderMaskLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
+  bool prev_read = context->layer_reads_from_surface;
+  context->layer_reads_from_surface = false;
+  ContainerLayer::Preroll(context, matrix);
+  context->layer_reads_from_surface = prev_read;
+}
+
 void ShaderMaskLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ShaderMaskLayer::Paint");
   FML_DCHECK(needs_painting());

--- a/flow/layers/shader_mask_layer.h
+++ b/flow/layers/shader_mask_layer.h
@@ -17,6 +17,8 @@ class ShaderMaskLayer : public ContainerLayer {
                   const SkRect& mask_rect,
                   SkBlendMode blend_mode);
 
+  void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
+
   void Paint(PaintContext& context) const override;
 
  private:

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -253,5 +253,27 @@ TEST_F(ShaderMaskLayerTest, Nested) {
            MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
+TEST_F(ShaderMaskLayerTest, Readback) {
+  auto initial_transform = SkMatrix();
+  const SkRect layer_bounds = SkRect::MakeLTRB(2.0f, 4.0f, 20.5f, 20.5f);
+  auto layer_filter =
+      SkPerlinNoiseShader::MakeImprovedNoise(1.0f, 1.0f, 1, 1.0f);
+  auto layer = std::make_shared<ShaderMaskLayer>(layer_filter, layer_bounds,
+                                                 SkBlendMode::kSrc);
+
+  // ShaderMaskLayer does not read from surface
+  preroll_context()->layer_reads_from_surface = false;
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+
+  // ShaderMaskLayer blocks child with readback
+  auto mock_layer =
+      std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
+  layer->Add(mock_layer);
+  preroll_context()->layer_reads_from_surface = false;
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -262,17 +262,17 @@ TEST_F(ShaderMaskLayerTest, Readback) {
                                                  SkBlendMode::kSrc);
 
   // ShaderMaskLayer does not read from surface
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 
   // ShaderMaskLayer blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer->Add(mock_layer);
-  preroll_context()->subtree_performs_readback_operation = false;
+  preroll_context()->surface_needs_readback = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
+  EXPECT_FALSE(preroll_context()->surface_needs_readback);
 }
 
 }  // namespace testing

--- a/flow/layers/shader_mask_layer_unittests.cc
+++ b/flow/layers/shader_mask_layer_unittests.cc
@@ -262,17 +262,17 @@ TEST_F(ShaderMaskLayerTest, Readback) {
                                                  SkBlendMode::kSrc);
 
   // ShaderMaskLayer does not read from surface
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 
   // ShaderMaskLayer blocks child with readback
   auto mock_layer =
       std::make_shared<MockLayer>(SkPath(), SkPaint(), false, false, true);
   layer->Add(mock_layer);
-  preroll_context()->layer_reads_from_surface = false;
+  preroll_context()->subtree_performs_readback_operation = false;
   layer->Preroll(preroll_context(), initial_transform);
-  EXPECT_FALSE(preroll_context()->layer_reads_from_surface);
+  EXPECT_FALSE(preroll_context()->subtree_performs_readback_operation);
 }
 
 }  // namespace testing

--- a/flow/testing/layer_test.h
+++ b/flow/testing/layer_test.h
@@ -37,6 +37,7 @@ class LayerTestBase : public CanvasTestBase<BaseT> {
             nullptr, /* external_view_embedder */
             mutators_stack_, TestT::mock_canvas().imageInfo().colorSpace(),
             kGiantRect, /* cull_rect */
+            false,      /* layer reads from surface */
             raster_time_, ui_time_, texture_registry_,
             false,  /* checkerboard_offscreen_layers */
             100.0f, /* frame_physical_depth */

--- a/flow/testing/mock_layer.cc
+++ b/flow/testing/mock_layer.cc
@@ -10,11 +10,13 @@ namespace testing {
 MockLayer::MockLayer(SkPath path,
                      SkPaint paint,
                      bool fake_has_platform_view,
-                     bool fake_needs_system_composite)
+                     bool fake_needs_system_composite,
+                     bool fake_reads_surface)
     : fake_paint_path_(path),
       fake_paint_(paint),
       fake_has_platform_view_(fake_has_platform_view),
-      fake_needs_system_composite_(fake_needs_system_composite) {}
+      fake_needs_system_composite_(fake_needs_system_composite),
+      fake_reads_surface_(fake_reads_surface) {}
 
 void MockLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   parent_mutators_ = context->mutators_stack;
@@ -26,6 +28,9 @@ void MockLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   context->has_platform_view = fake_has_platform_view_;
   set_paint_bounds(fake_paint_path_.getBounds());
   set_needs_system_composite(fake_needs_system_composite_);
+  if (fake_reads_surface_) {
+    context->layer_reads_from_surface = true;
+  }
 }
 
 void MockLayer::Paint(PaintContext& context) const {

--- a/flow/testing/mock_layer.cc
+++ b/flow/testing/mock_layer.cc
@@ -29,7 +29,7 @@ void MockLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   set_paint_bounds(fake_paint_path_.getBounds());
   set_needs_system_composite(fake_needs_system_composite_);
   if (fake_reads_surface_) {
-    context->subtree_performs_readback_operation = true;
+    context->surface_needs_readback = true;
   }
 }
 

--- a/flow/testing/mock_layer.cc
+++ b/flow/testing/mock_layer.cc
@@ -29,7 +29,7 @@ void MockLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   set_paint_bounds(fake_paint_path_.getBounds());
   set_needs_system_composite(fake_needs_system_composite_);
   if (fake_reads_surface_) {
-    context->layer_reads_from_surface = true;
+    context->subtree_performs_readback_operation = true;
   }
 }
 

--- a/flow/testing/mock_layer.h
+++ b/flow/testing/mock_layer.h
@@ -19,7 +19,8 @@ class MockLayer : public Layer {
   MockLayer(SkPath path,
             SkPaint paint = SkPaint(),
             bool fake_has_platform_view = false,
-            bool fake_needs_system_composite = false);
+            bool fake_needs_system_composite = false,
+            bool fake_reads_surface = false);
 
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
   void Paint(PaintContext& context) const override;
@@ -40,6 +41,7 @@ class MockLayer : public Layer {
   bool parent_has_platform_view_ = false;
   bool fake_has_platform_view_ = false;
   bool fake_needs_system_composite_ = false;
+  bool fake_reads_surface_ = false;
 
   FML_DISALLOW_COPY_AND_ASSIGN(MockLayer);
 };

--- a/shell/common/rasterizer.cc
+++ b/shell/common/rasterizer.cc
@@ -333,6 +333,7 @@ RasterStatus Rasterizer::DrawToSurface(flutter::LayerTree& layer_tree) {
       external_view_embedder,       // external view embedder
       root_surface_transformation,  // root surface transformation
       true,                         // instrumentation enabled
+      frame->supports_readback(),   // surface supports pixel reads
       gpu_thread_merger_            // thread merger
   );
 
@@ -377,7 +378,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsPicture(
   // https://github.com/flutter/flutter/issues/23435
   auto frame = compositor_context.AcquireFrame(
       nullptr, recorder.getRecordingCanvas(), nullptr,
-      root_surface_transformation, false, nullptr);
+      root_surface_transformation, false, true, nullptr);
 
   frame->Raster(*tree, true);
 
@@ -434,7 +435,7 @@ static sk_sp<SkData> ScreenshotLayerTreeAsImage(
   // surface if we don't call the base method.
   auto frame = compositor_context.flutter::CompositorContext::AcquireFrame(
       surface_context, canvas, nullptr, root_surface_transformation, false,
-      nullptr);
+      true, nullptr);
   canvas->clear(SK_ColorTRANSPARENT);
   frame->Raster(*tree, true);
   canvas->flush();

--- a/shell/common/surface.cc
+++ b/shell/common/surface.cc
@@ -10,8 +10,12 @@
 namespace flutter {
 
 SurfaceFrame::SurfaceFrame(sk_sp<SkSurface> surface,
+                           bool supports_readback,
                            const SubmitCallback& submit_callback)
-    : submitted_(false), surface_(surface), submit_callback_(submit_callback) {
+    : submitted_(false),
+      surface_(surface),
+      supports_readback_(supports_readback),
+      submit_callback_(submit_callback) {
   FML_DCHECK(submit_callback_);
 }
 

--- a/shell/common/surface.h
+++ b/shell/common/surface.h
@@ -21,7 +21,9 @@ class SurfaceFrame {
   using SubmitCallback =
       std::function<bool(const SurfaceFrame& surface_frame, SkCanvas* canvas)>;
 
-  SurfaceFrame(sk_sp<SkSurface> surface, const SubmitCallback& submit_callback);
+  SurfaceFrame(sk_sp<SkSurface> surface,
+               bool supports_readback,
+               const SubmitCallback& submit_callback);
 
   ~SurfaceFrame();
 
@@ -31,9 +33,12 @@ class SurfaceFrame {
 
   sk_sp<SkSurface> SkiaSurface() const;
 
+  bool supports_readback() { return supports_readback_; }
+
  private:
   bool submitted_;
   sk_sp<SkSurface> surface_;
+  bool supports_readback_;
   SubmitCallback submit_callback_;
 
   bool PerformSubmit();

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -228,7 +228,7 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
     return false;
   }
 
-  if (delegate_->UseOffscreenSurface()) {
+  if (false && delegate_->UseOffscreenSurface()) {
     offscreen_surface = CreateOffscreenSurface(context_.get(), size);
     if (offscreen_surface == nullptr) {
       FML_LOG(ERROR) << "Could not create offscreen surface.";
@@ -263,7 +263,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
   // external view embedder may want to render to the root surface.
   if (!render_to_surface_) {
     return std::make_unique<SurfaceFrame>(
-        nullptr, [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
+        nullptr, true, [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
           return true;
         });
   }
@@ -285,7 +285,8 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
         return weak ? weak->PresentSurface(canvas) : false;
       };
 
-  return std::make_unique<SurfaceFrame>(surface, submit_callback);
+  return std::make_unique<SurfaceFrame>(
+      surface, !delegate_->UseOffscreenSurface(), submit_callback);
 }
 
 bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {

--- a/shell/gpu/gpu_surface_gl.cc
+++ b/shell/gpu/gpu_surface_gl.cc
@@ -180,19 +180,6 @@ static sk_sp<SkSurface> WrapOnscreenSurface(GrContext* context,
   );
 }
 
-static sk_sp<SkSurface> CreateOffscreenSurface(GrContext* context,
-                                               const SkISize& size) {
-  const SkImageInfo image_info = SkImageInfo::MakeN32(
-      size.fWidth, size.fHeight, kOpaque_SkAlphaType, SkColorSpace::MakeSRGB());
-
-  const SkSurfaceProps surface_props(
-      SkSurfaceProps::InitType::kLegacyFontHost_InitType);
-
-  return SkSurface::MakeRenderTarget(context, SkBudgeted::kNo, image_info, 0,
-                                     kBottomLeft_GrSurfaceOrigin,
-                                     &surface_props);
-}
-
 bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
   if (onscreen_surface_ != nullptr &&
       size == SkISize::Make(onscreen_surface_->width(),
@@ -206,14 +193,13 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
 
   // Either way, we need to get rid of previous surface.
   onscreen_surface_ = nullptr;
-  offscreen_surface_ = nullptr;
 
   if (size.isEmpty()) {
     FML_LOG(ERROR) << "Cannot create surfaces of empty size.";
     return false;
   }
 
-  sk_sp<SkSurface> onscreen_surface, offscreen_surface;
+  sk_sp<SkSurface> onscreen_surface;
 
   onscreen_surface =
       WrapOnscreenSurface(context_.get(),            // GL context
@@ -228,16 +214,7 @@ bool GPUSurfaceGL::CreateOrUpdateSurfaces(const SkISize& size) {
     return false;
   }
 
-  if (false && delegate_->UseOffscreenSurface()) {
-    offscreen_surface = CreateOffscreenSurface(context_.get(), size);
-    if (offscreen_surface == nullptr) {
-      FML_LOG(ERROR) << "Could not create offscreen surface.";
-      return false;
-    }
-  }
-
   onscreen_surface_ = std::move(onscreen_surface);
-  offscreen_surface_ = std::move(offscreen_surface);
 
   return true;
 }
@@ -286,21 +263,12 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceGL::AcquireFrame(const SkISize& size) {
       };
 
   return std::make_unique<SurfaceFrame>(
-      surface, !delegate_->UseOffscreenSurface(), submit_callback);
+      surface, delegate_->SurfaceSupportsReadback(), submit_callback);
 }
 
 bool GPUSurfaceGL::PresentSurface(SkCanvas* canvas) {
   if (delegate_ == nullptr || canvas == nullptr || context_ == nullptr) {
     return false;
-  }
-
-  if (offscreen_surface_ != nullptr) {
-    TRACE_EVENT0("flutter", "CopyTextureOnscreen");
-    SkPaint paint;
-    SkCanvas* onscreen_canvas = onscreen_surface_->getCanvas();
-    onscreen_canvas->clear(SK_ColorTRANSPARENT);
-    onscreen_canvas->drawImage(offscreen_surface_->makeImageSnapshot(), 0, 0,
-                               &paint);
   }
 
   {
@@ -347,7 +315,7 @@ sk_sp<SkSurface> GPUSurfaceGL::AcquireRenderSurface(
     return nullptr;
   }
 
-  return offscreen_surface_ != nullptr ? offscreen_surface_ : onscreen_surface_;
+  return onscreen_surface_;
 }
 
 // |Surface|

--- a/shell/gpu/gpu_surface_gl.h
+++ b/shell/gpu/gpu_surface_gl.h
@@ -50,7 +50,6 @@ class GPUSurfaceGL : public Surface {
   GPUSurfaceGLDelegate* delegate_;
   sk_sp<GrContext> context_;
   sk_sp<SkSurface> onscreen_surface_;
-  sk_sp<SkSurface> offscreen_surface_;
   bool context_owner_;
   // TODO(38466): Refactor GPU surface APIs take into account the fact that an
   // external view embedder may want to render to the root surface. This is a

--- a/shell/gpu/gpu_surface_gl_delegate.cc
+++ b/shell/gpu/gpu_surface_gl_delegate.cc
@@ -12,8 +12,8 @@ bool GPUSurfaceGLDelegate::GLContextFBOResetAfterPresent() const {
   return false;
 }
 
-bool GPUSurfaceGLDelegate::UseOffscreenSurface() const {
-  return false;
+bool GPUSurfaceGLDelegate::SurfaceSupportsReadback() const {
+  return true;
 }
 
 SkMatrix GPUSurfaceGLDelegate::GLContextSurfaceTransformation() const {

--- a/shell/gpu/gpu_surface_gl_delegate.h
+++ b/shell/gpu/gpu_surface_gl_delegate.h
@@ -36,8 +36,9 @@ class GPUSurfaceGLDelegate : public GPUSurfaceDelegate {
   // subsequent frames.
   virtual bool GLContextFBOResetAfterPresent() const;
 
-  // Create an offscreen surface to render into before onscreen composition.
-  virtual bool UseOffscreenSurface() const;
+  // Indicates whether or not the surface supports pixel readback as used in
+  // circumstances such as a BackdropFilter.
+  virtual bool SurfaceSupportsReadback() const;
 
   // A transformation applied to the onscreen surface before the canvas is
   // flushed.

--- a/shell/gpu/gpu_surface_metal.mm
+++ b/shell/gpu/gpu_surface_metal.mm
@@ -152,7 +152,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceMetal::AcquireFrame(const SkISize& size)
     return true;
   };
 
-  return std::make_unique<SurfaceFrame>(std::move(surface), submit_callback);
+  return std::make_unique<SurfaceFrame>(std::move(surface), true, submit_callback);
 }
 
 // |Surface|

--- a/shell/gpu/gpu_surface_software.cc
+++ b/shell/gpu/gpu_surface_software.cc
@@ -29,7 +29,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceSoftware::AcquireFrame(
   // external view embedder may want to render to the root surface.
   if (!render_to_surface_) {
     return std::make_unique<SurfaceFrame>(
-        nullptr, [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
+        nullptr, true, [](const SurfaceFrame& surface_frame, SkCanvas* canvas) {
           return true;
         });
   }
@@ -69,7 +69,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceSoftware::AcquireFrame(
     return self->delegate_->PresentBackingStore(surface_frame.SkiaSurface());
   };
 
-  return std::make_unique<SurfaceFrame>(backing_store, on_submit);
+  return std::make_unique<SurfaceFrame>(backing_store, true, on_submit);
 }
 
 // |Surface|

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -40,7 +40,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkan::AcquireFrame(
     }
     return weak_this->window_.SwapBuffers();
   };
-  return std::make_unique<SurfaceFrame>(std::move(surface),
+  return std::make_unique<SurfaceFrame>(std::move(surface), true,
                                         std::move(callback));
 }
 

--- a/shell/platform/darwin/ios/ios_surface_gl.h
+++ b/shell/platform/darwin/ios/ios_surface_gl.h
@@ -48,7 +48,7 @@ class IOSSurfaceGL final : public IOSSurface,
 
   intptr_t GLContextFBO() const override;
 
-  bool UseOffscreenSurface() const override;
+  bool SurfaceSupportsReadback() const override;
 
   // |GPUSurfaceGLDelegate|
   ExternalViewEmbedder* GetExternalViewEmbedder() override;

--- a/shell/platform/darwin/ios/ios_surface_gl.mm
+++ b/shell/platform/darwin/ios/ios_surface_gl.mm
@@ -49,11 +49,13 @@ intptr_t IOSSurfaceGL::GLContextFBO() const {
   return IsValid() ? render_target_->framebuffer() : GL_NONE;
 }
 
-bool IOSSurfaceGL::UseOffscreenSurface() const {
-  // The onscreen surface wraps a GL renderbuffer, which is extremely slow to read.
-  // Certain filter effects require making a copy of the current destination, so we
-  // always render to an offscreen surface, which will be much quicker to read/copy.
-  return true;
+bool IOSSurfaceGL::SurfaceSupportsReadback() const {
+  // The onscreen surface wraps a GL renderbuffer, which is extremely slow to read on iOS.
+  // Certain filter effects, in particular BackdropFilter, require making a copy of
+  // the current destination. For performance, the iOS surface will specify that it
+  // does not support readback so that the engine compositor can implement a workaround
+  // such as rendering the scene to an offscreen surface or Skia saveLayer.
+  return false;
 }
 
 bool IOSSurfaceGL::GLContextMakeCurrent() {

--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -20,6 +20,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
                                                 nullptr,
                                                 root_surface_transformation,
                                                 instrumentation_enabled,
+                                                true,
                                                 nullptr),
         session_connection_(session_connection) {}
 
@@ -96,6 +97,7 @@ CompositorContext::AcquireFrame(
     flutter::ExternalViewEmbedder* view_embedder,
     const SkMatrix& root_surface_transformation,
     bool instrumentation_enabled,
+    bool surface_supports_readback,
     fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger) {
   // TODO: The AcquireFrame interface is too broad and must be refactored to get
   // rid of the context and canvas arguments as those seem to be only used for

--- a/shell/platform/fuchsia/flutter/compositor_context.h
+++ b/shell/platform/fuchsia/flutter/compositor_context.h
@@ -45,6 +45,7 @@ class CompositorContext final : public flutter::CompositorContext {
       flutter::ExternalViewEmbedder* view_embedder,
       const SkMatrix& root_surface_transformation,
       bool instrumentation_enabled,
+      bool surface_supports_readback,
       fml::RefPtr<fml::GpuThreadMerger> gpu_thread_merger) override;
 
   FML_DISALLOW_COPY_AND_ASSIGN(CompositorContext);

--- a/shell/platform/fuchsia/flutter/surface.cc
+++ b/shell/platform/fuchsia/flutter/surface.cc
@@ -26,8 +26,10 @@ bool Surface::IsValid() {
 std::unique_ptr<flutter::SurfaceFrame> Surface::AcquireFrame(
     const SkISize& size) {
   return std::make_unique<flutter::SurfaceFrame>(
-      nullptr, [](const flutter::SurfaceFrame& surface_frame,
-                  SkCanvas* canvas) { return true; });
+      nullptr, true,
+      [](const flutter::SurfaceFrame& surface_frame, SkCanvas* canvas) {
+        return true;
+      });
 }
 
 // |flutter::Surface|


### PR DESCRIPTION
This solution for the conditional offscreen allows us to check for layers that read from the surface in Preroll instead of in the constructors. There are no longer any flags propagating to parents or any other potentially quadratic recursions compared to the previous solution.

I have an FML_LOG(INFO) in the code that lets you check on the status of when we use an offscreen by running an app with `flutter run --verbose-system-logs`

Things TBD:
- run more tests (apps and examples to make sure they render correctly)

Former TBD things completed:
- specifically run the [BackdropFilter devicelab benchmark](https://github.com/flutter/flutter/blob/master/dev/benchmarks/macrobenchmarks/lib/src/backdrop_filter.dart) before/after to verify no loss of performance
- specifically run the LinearProgressApp and check its energy usage in Xcode and CPU/GPU usage with [the gauge in flutter-packages](https://github.com/flutter/packages/tree/master/packages/gauge)
- write (and then run) unit tests
- remove offscreen support from gpu_surface_gl (currently it is just bypassed, but it can be deleted)
- my Fuchsia build seems to be broken now so I can only marginally claim that it still compiles