### PR TITLE
Fix platform view offsets incorrectly taking into account device pixel ratios.

### DIFF
--- a/shell/platform/embedder/embedder_layers.cc
+++ b/shell/platform/embedder/embedder_layers.cc
@@ -184,16 +184,15 @@ void EmbedderLayers::PushPlatformViewLayer(
   layer.type = kFlutterLayerContentTypePlatformView;
   layer.platform_view = platform_views_referenced_.back().get();
 
-  const auto layer_bounds = SkRect::MakeXYWH(params.offsetPixels.x(),    //
-                                             params.offsetPixels.y(),    //
-                                             params.sizePoints.width(),  //
-                                             params.sizePoints.height()  //
-  );
+  const auto layer_bounds =
+      SkRect::MakeXYWH(params.offsetPixels.x(),                          //
+                       params.offsetPixels.y(),                          //
+                       params.sizePoints.width() * device_pixel_ratio_,  //
+                       params.sizePoints.height() * device_pixel_ratio_  //
+      );
 
   const auto transformed_layer_bounds =
-      SkMatrix::Concat(root_surface_transformation_,
-                       SkMatrix::MakeScale(device_pixel_ratio_))
-          .mapRect(layer_bounds);
+      root_surface_transformation_.mapRect(layer_bounds);
 
   layer.offset.x = transformed_layer_bounds.x();
   layer.offset.y = transformed_layer_bounds.y();

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -2803,7 +2803,7 @@ TEST_F(EmbedderTest,
           layer.type = kFlutterLayerContentTypePlatformView;
           layer.platform_view = &platform_view;
           layer.size = FlutterSizeMake(800.0, 560.0);
-          layer.offset = FlutterPointMake(0.0, 80.0);
+          layer.offset = FlutterPointMake(0.0, 40.0);
 
           ASSERT_EQ(*layers[1], layer);
         }
@@ -2902,7 +2902,7 @@ TEST_F(
           layer.type = kFlutterLayerContentTypePlatformView;
           layer.platform_view = &platform_view;
           layer.size = FlutterSizeMake(560.0, 800.0);
-          layer.offset = FlutterPointMake(80.0, 0.0);
+          layer.offset = FlutterPointMake(40.0, 0.0);
 
           ASSERT_EQ(*layers[1], layer);
         }


### PR DESCRIPTION
This issue was hidden by an incorrect test expectation that has been corrected.

Fixes b/144555069
Fixes https://github.com/flutter/flutter/issues/45991