### PR TITLE
Disable a11y on detach

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -701,6 +701,7 @@ public class FlutterView extends FrameLayout {
     isFlutterUiDisplayed = false;
     flutterRenderer.removeIsDisplayingFlutterUiListener(flutterUiDisplayListener);
     flutterRenderer.stopRenderingToSurface();
+    flutterRenderer.setSemanticsEnabled(false);
     renderSurface.detachFromRenderer();
     flutterEngine = null;
   }

--- a/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/android/FlutterViewTest.java
@@ -79,6 +79,19 @@ public class FlutterViewTest {
   }
 
   @Test
+  public void detachFromFlutterEngine_turnsOffA11y() {
+    FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
+    FlutterEngine flutterEngine = spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));
+    FlutterRenderer flutterRenderer = spy(new FlutterRenderer(mockFlutterJni));
+    when(flutterEngine.getRenderer()).thenReturn(flutterRenderer);
+
+    flutterView.attachToFlutterEngine(flutterEngine);
+    flutterView.detachFromFlutterEngine();
+
+    verify(flutterRenderer, times(1)).setSemanticsEnabled(false);
+  }
+
+  @Test
   public void onConfigurationChanged_fizzlesWhenNullEngine() {
     FlutterView flutterView = new FlutterView(RuntimeEnvironment.application);
     FlutterEngine flutterEngine = spy(new FlutterEngine(RuntimeEnvironment.application, mockFlutterLoader, mockFlutterJni));


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/46029
Fixes https://github.com/flutter/flutter/issues/31139
Fixes https://github.com/flutter/flutter/issues/33173
Fixes https://github.com/flutter/flutter/issues/45218

When we detach from the engine, we destroy the a11y bridge (which is right, it holds view refs that won't be valid when we reattach). We have to tell the framework that we're destroying all our a11y state on the native side - the only way to do that is to tell the framework that a11y is off.  Once we build the bridge again, it will tell the framework that a11y is back on.

The linked bugs are all cases where we get the bridge into a bad state because it thinks it has information it no longer does (because the framework thinks it already sent nodes the bridge knows nothing about, and really might not even be valid anymore because any native backing they have is gone).

Another reason to disable in this case: Even if a11y is enabled, we have no bridge. If the framework sends us a11y messages, they'll get missed by the bridge.