### PR TITLE
Raise API level for reportFullyDrawn

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -938,7 +938,9 @@ public class FlutterActivity extends Activity
   public void onFlutterUiDisplayed() {
     // Notifies Android that we're fully drawn so that performance metrics can be collected by
     // Flutter performance tests.
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+    // This was supported in KitKat (API 19), but has a bug around requiring
+    // permissions. See https://github.com/flutter/flutter/issues/46172
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
       reportFullyDrawn();
     }
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/46172

I'm not sure how we could really test this, short of adding API 19 specifically to the devicelab.