### PR TITLE
[web] [tests] Changing configurations for firefox

### DIFF
--- a/lib/web_ui/dart_test_chrome.yaml
+++ b/lib/web_ui/dart_test_chrome.yaml
@@ -1,7 +1,6 @@
-# Sources of inspiration for this file:
+# For more information on test and runner configurations:
 #
-# * https://github.com/dart-lang/angular/blob/master/dev/tool/test/dart_test_repo.yaml
-# * https://github.com/dart-lang/angular/blob/master/_tests/dart_test.yaml
+# * https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#platforms
 
 platforms:
   - chrome

--- a/lib/web_ui/dart_test_chrome.yaml
+++ b/lib/web_ui/dart_test_chrome.yaml
@@ -6,6 +6,7 @@
 platforms:
   - chrome
   - vm
+
 presets:
   cirrus:
     override_platforms:

--- a/lib/web_ui/dart_test_firefox.yaml
+++ b/lib/web_ui/dart_test_firefox.yaml
@@ -1,7 +1,6 @@
-# Sources of inspiration for this file:
+# For more information on test and runner configurations:
 #
-# * https://github.com/dart-lang/angular/blob/master/dev/tool/test/dart_test_repo.yaml
-# * https://github.com/dart-lang/angular/blob/master/_tests/dart_test.yaml
+# * https://github.com/dart-lang/test/blob/master/pkgs/test/doc/configuration.md#platforms
 
 platforms:
   - firefox

--- a/lib/web_ui/dart_test_firefox.yaml
+++ b/lib/web_ui/dart_test_firefox.yaml
@@ -1,0 +1,8 @@
+# Sources of inspiration for this file:
+#
+# * https://github.com/dart-lang/angular/blob/master/dev/tool/test/dart_test_repo.yaml
+# * https://github.com/dart-lang/angular/blob/master/_tests/dart_test.yaml
+
+platforms:
+  - firefox
+  - vm

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -52,7 +52,6 @@ class Firefox extends Browser {
         '-width $kMaxScreenshotWidth',
         '-height $kMaxScreenshotHeight',
         '-new-window',
-        '-headless',
         '-new-instance',
         '-prefs { "dom.disable_beforeunload" = true, "toolkit.startup.max_resumed_crashes"=999999 } ',
         '--start-debugger-server $kDevtoolsPort',

--- a/lib/web_ui/dev/firefox.dart
+++ b/lib/web_ui/dev/firefox.dart
@@ -49,17 +49,20 @@ class Firefox extends Browser {
       var args = [
         url.toString(),
         if (!debug) '--headless',
-        '-width $kMaxScreenshotWidth'
+        '-width $kMaxScreenshotWidth',
         '-height $kMaxScreenshotHeight',
         '-new-window',
+        '-headless',
         '-new-instance',
+        '-prefs { "dom.disable_beforeunload" = true, "toolkit.startup.max_resumed_crashes"=999999 } ',
         '--start-debugger-server $kDevtoolsPort',
       ];
 
-      final Process process = await Process.start(installation.executable, args);
+      final Process process =
+          await Process.start(installation.executable, args);
 
-      remoteDebuggerCompleter.complete(getRemoteDebuggerUrl(
-          Uri.parse('http://localhost:$kDevtoolsPort')));
+      remoteDebuggerCompleter.complete(
+          getRemoteDebuggerUrl(Uri.parse('http://localhost:$kDevtoolsPort')));
 
       unawaited(process.exitCode
           .then((_) => Directory(dir).deleteSync(recursive: true)));

--- a/lib/web_ui/dev/supported_browsers.dart
+++ b/lib/web_ui/dev/supported_browsers.dart
@@ -8,6 +8,7 @@ import 'browser.dart';
 import 'chrome.dart';
 import 'chrome_installer.dart';
 import 'common.dart';
+import 'environment.dart';
 import 'firefox.dart';
 import 'firefox_installer.dart'; // ignore: implementation_imports
 
@@ -28,6 +29,11 @@ class SupportedBrowsers {
   final Map<String, Runtime> supportedBrowsersToRuntimes = {
     'chrome': Runtime.chrome,
     'firefox': Runtime.firefox
+  };
+
+  final Map<String, String> browserToConfiguration = {
+    'chrome': '--configuration=${environment.webUiRootDir.path}/dart_test_chrome.yaml',
+    'firefox': '--configuration=${environment.webUiRootDir.path}/dart_test_firefox.yaml',
   };
 
   static final SupportedBrowsers _singletonInstance = SupportedBrowsers._();

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -83,6 +83,8 @@ class TestCommand extends Command<bool> {
 
   String get browser => argResults['browser'];
 
+  bool get isChrome => argResults['browser'] == 'chrome';
+
   /// When running screenshot tests writes them to the file system into
   /// ".dart_tool/goldens".
   bool get doUpdateScreenshotGoldens => argResults['update-screenshot-goldens'];
@@ -243,6 +245,7 @@ class TestCommand extends Command<bool> {
       if (isDebug) '--pause-after-load',
       '--platform=$browser',
       '--precompiled=${environment.webUiRootDir.path}/build',
+      SupportedBrowsers.instance.browserToConfiguration[browser],
       '--',
       ...testFiles.map((f) => f.relativeToWebUi).toList(),
     ];

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -83,8 +83,6 @@ class TestCommand extends Command<bool> {
 
   String get browser => argResults['browser'];
 
-  bool get isChrome => argResults['browser'] == 'chrome';
-
   /// When running screenshot tests writes them to the file system into
   /// ".dart_tool/goldens".
   bool get doUpdateScreenshotGoldens => argResults['update-screenshot-goldens'];


### PR DESCRIPTION
The configurations for firefox is added. Previously only chrome related conf. was loaded this was causing firefox to break on "felt test browser=firefox"

New prefs are added to firefox:

- dom.disable_beforeunload=true: firefox does not show a popup for default browser
- toolkit.startup.max_resumed_crashes=999999:  firefox does not show a popup after browser crash

related to issue: https://github.com/flutter/flutter/issues/44959