### PR TITLE
[WIP] OnAnimatorBeginFrame will pass along target frame time

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -137,7 +137,7 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
   {
     TRACE_EVENT2("flutter", "Framework Workload", "mode", "basic", "frame",
                  FrameParity());
-    delegate_.OnAnimatorBeginFrame(last_begin_frame_time_);
+    delegate_.OnAnimatorBeginFrame(last_begin_frame_time_, frame_target_time);
   }
 
   if (!frame_scheduled_) {

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -30,7 +30,8 @@ class Animator final {
  public:
   class Delegate {
    public:
-    virtual void OnAnimatorBeginFrame(fml::TimePoint frame_time) = 0;
+    virtual void OnAnimatorBeginFrame(fml::TimePoint begin_frame_time,
+                                      fml::TimePoint target_frame_time) = 0;
 
     virtual void OnAnimatorNotifyIdle(int64_t deadline) = 0;
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -881,12 +881,13 @@ void Shell::OnPlatformViewSetNextFrameCallback(const fml::closure& closure) {
 }
 
 // |Animator::Delegate|
-void Shell::OnAnimatorBeginFrame(fml::TimePoint frame_time) {
+void Shell::OnAnimatorBeginFrame(fml::TimePoint begin_frame_time,
+                                 fml::TimePoint target_frame_time) {
   FML_DCHECK(is_setup_);
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
 
   if (engine_) {
-    engine_->BeginFrame(frame_time);
+    engine_->BeginFrame(begin_frame_time);
   }
 }
 

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -21,6 +21,7 @@
 #include "flutter/fml/synchronization/sync_switch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/thread.h"
+#include "flutter/fml/time/time_point.h"
 #include "flutter/lib/ui/semantics/custom_accessibility_action.h"
 #include "flutter/lib/ui/semantics/semantics_node.h"
 #include "flutter/lib/ui/window/platform_message.h"
@@ -429,7 +430,8 @@ class Shell final : public PlatformView::Delegate,
   void OnPlatformViewSetNextFrameCallback(const fml::closure& closure) override;
 
   // |Animator::Delegate|
-  void OnAnimatorBeginFrame(fml::TimePoint frame_time) override;
+  void OnAnimatorBeginFrame(fml::TimePoint begin_frame_time,
+                            fml::TimePoint target_frame_time) override;
 
   // |Animator::Delegate|
   void OnAnimatorNotifyIdle(int64_t deadline) override;


### PR DESCRIPTION
This is currently unused but will eventually be set
on the `SchedulerBinding` as the frame target time.