### PR TITLE
Fix for tab not working

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -67,7 +67,6 @@ class Keyboard {
   static const JSONMessageCodec _messageCodec = JSONMessageCodec();
 
   void _handleHtmlEvent(html.KeyboardEvent event) {
-    print('event: ${event.type}');
     if (_shouldIgnoreEvent(event)) {
       return;
     }
@@ -134,7 +133,7 @@ int _getMetaState(html.KeyboardEvent event) {
   if (event.getModifierState('Meta')) {
     metaState |= _modifierMeta;
   }
-  // TODO: Reenable lock key modifiers one there is support on Flutter
+  // TODO: Re-enable lock key modifiers once there is support on Flutter
   // Framework. https://github.com/flutter/flutter/issues/46718
   return metaState;
 }

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -118,13 +118,6 @@ const int _modifierShift = 0x01;
 const int _modifierAlt = 0x02;
 const int _modifierControl = 0x04;
 const int _modifierMeta = 0x08;
-const int _modifierNumLock = 0x10;
-const int _modifierCapsLock = 0x20;
-const int _modifierScrollLock = 0x40;
-
-const int _kNumLockKeyCode = 0;
-const int _kScroolLockKeyCode = 0;
-const int _kCapsLockKeyCode = 0;
 
 /// Creates a bitmask representing the meta state of the [event].
 int _getMetaState(html.KeyboardEvent event) {
@@ -141,17 +134,8 @@ int _getMetaState(html.KeyboardEvent event) {
   if (event.getModifierState('Meta')) {
     metaState |= _modifierMeta;
   }
-  if (event.keyCode == _kNumLockKeyCode && event.getModifierState('NumLock')) {
-    metaState |= _modifierNumLock;
-  }
-  if (event.keyCode == _kCapsLockKeyCode &&
-      event.getModifierState('CapsLock')) {
-    metaState |= _modifierCapsLock;
-  }
-  if (event.keyCode == _kScroolLockKeyCode &&
-      event.getModifierState('ScrollLock')) {
-    metaState |= _modifierScrollLock;
-  }
+  // TODO: Reenable lock key modifiers one there is support on Flutter
+  // Framework. https://github.com/flutter/flutter/issues/46718
   return metaState;
 }
 

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -69,12 +69,10 @@ class Keyboard {
   void _handleHtmlEvent(html.KeyboardEvent event) {
     print('event: ${event.type}');
     if (_shouldIgnoreEvent(event)) {
-      print('event:IGNORE');
       return;
     }
 
     if (_shouldPreventDefault(event)) {
-      print('event:PREVENT');
       event.preventDefault();
     }
 
@@ -124,6 +122,10 @@ const int _modifierNumLock = 0x10;
 const int _modifierCapsLock = 0x20;
 const int _modifierScrollLock = 0x40;
 
+const int _kNumLockKeyCode = 0;
+const int _kScroolLockKeyCode = 0;
+const int _kCapsLockKeyCode = 0;
+
 /// Creates a bitmask representing the meta state of the [event].
 int _getMetaState(html.KeyboardEvent event) {
   int metaState = _modifierNone;
@@ -139,13 +141,15 @@ int _getMetaState(html.KeyboardEvent event) {
   if (event.getModifierState('Meta')) {
     metaState |= _modifierMeta;
   }
-  if (event.getModifierState('NumLock')) {
+  if (event.keyCode == _kNumLockKeyCode && event.getModifierState('NumLock')) {
     metaState |= _modifierNumLock;
   }
-  if (event.getModifierState('CapsLock')) {
+  if (event.keyCode == _kCapsLockKeyCode &&
+      event.getModifierState('CapsLock')) {
     metaState |= _modifierCapsLock;
   }
-  if (event.getModifierState('ScrollLock')) {
+  if (event.keyCode == _kScroolLockKeyCode &&
+      event.getModifierState('ScrollLock')) {
     metaState |= _modifierScrollLock;
   }
   return metaState;

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -67,11 +67,14 @@ class Keyboard {
   static const JSONMessageCodec _messageCodec = JSONMessageCodec();
 
   void _handleHtmlEvent(html.KeyboardEvent event) {
+    print('event: ${event.type}');
     if (_shouldIgnoreEvent(event)) {
+      print('event:IGNORE');
       return;
     }
 
     if (_shouldPreventDefault(event)) {
+      print('event:PREVENT');
       event.preventDefault();
     }
 


### PR DESCRIPTION
Masking modifier state for lock keys if the key code is not the same as the modifier. this fixes tab issue happening when numlock/capslock is on.

Fixes: https://github.com/flutter/flutter/issues/45250