### PR TITLE
Create separate objects for isolate state and isolate group state

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -489,6 +489,8 @@ FILE: ../../../flutter/lib/web_ui/lib/ui.dart
 FILE: ../../../flutter/lib/web_ui/tool/unicode_sync_script.dart
 FILE: ../../../flutter/runtime/dart_isolate.cc
 FILE: ../../../flutter/runtime/dart_isolate.h
+FILE: ../../../flutter/runtime/dart_isolate_group_data.cc
+FILE: ../../../flutter/runtime/dart_isolate_group_data.h
 FILE: ../../../flutter/runtime/dart_isolate_unittests.cc
 FILE: ../../../flutter/runtime/dart_lifecycle_unittests.cc
 FILE: ../../../flutter/runtime/dart_service_isolate.cc

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -46,6 +46,8 @@ source_set("runtime") {
   sources = [
     "dart_isolate.cc",
     "dart_isolate.h",
+    "dart_isolate_group_data.cc",
+    "dart_isolate_group_data.h",
     "dart_service_isolate.cc",
     "dart_service_isolate.h",
     "dart_snapshot.cc",

--- a/runtime/dart_isolate_group_data.cc
+++ b/runtime/dart_isolate_group_data.cc
@@ -1,0 +1,65 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/runtime/dart_isolate_group_data.h"
+#include "flutter/runtime/dart_snapshot.h"
+
+namespace flutter {
+
+DartIsolateGroupData::DartIsolateGroupData(
+    const Settings& settings,
+    fml::RefPtr<const DartSnapshot> isolate_snapshot,
+    std::string advisory_script_uri,
+    std::string advisory_script_entrypoint,
+    const ChildIsolatePreparer& child_isolate_preparer,
+    const fml::closure& isolate_create_callback,
+    const fml::closure& isolate_shutdown_callback)
+    : settings_(settings),
+      isolate_snapshot_(isolate_snapshot),
+      advisory_script_uri_(advisory_script_uri),
+      advisory_script_entrypoint_(advisory_script_entrypoint),
+      child_isolate_preparer_(child_isolate_preparer),
+      isolate_create_callback_(isolate_create_callback),
+      isolate_shutdown_callback_(isolate_shutdown_callback) {
+  FML_DCHECK(isolate_snapshot_) << "Must contain a valid isolate snapshot.";
+}
+
+DartIsolateGroupData::~DartIsolateGroupData() = default;
+
+const Settings& DartIsolateGroupData::GetSettings() const {
+  return settings_;
+}
+
+fml::RefPtr<const DartSnapshot> DartIsolateGroupData::GetIsolateSnapshot()
+    const {
+  return isolate_snapshot_;
+}
+
+const std::string& DartIsolateGroupData::GetAdvisoryScriptURI() const {
+  return advisory_script_uri_;
+}
+
+const std::string& DartIsolateGroupData::GetAdvisoryScriptEntrypoint() const {
+  return advisory_script_entrypoint_;
+}
+
+const ChildIsolatePreparer& DartIsolateGroupData::GetChildIsolatePreparer()
+    const {
+  return child_isolate_preparer_;
+}
+
+const fml::closure& DartIsolateGroupData::GetIsolateCreateCallback() const {
+  return isolate_create_callback_;
+}
+
+const fml::closure& DartIsolateGroupData::GetIsolateShutdownCallback() const {
+  return isolate_shutdown_callback_;
+}
+
+void DartIsolateGroupData::SetChildIsolatePreparer(
+    const ChildIsolatePreparer& value) {
+  child_isolate_preparer_ = value;
+}
+
+}  // namespace flutter

--- a/runtime/dart_isolate_group_data.h
+++ b/runtime/dart_isolate_group_data.h
@@ -1,0 +1,63 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_RUNTIME_DART_ISOLATE_GROUP_DATA_H_
+#define FLUTTER_RUNTIME_DART_ISOLATE_GROUP_DATA_H_
+
+#include <string>
+
+#include "flutter/common/settings.h"
+#include "flutter/fml/closure.h"
+#include "flutter/fml/memory/ref_ptr.h"
+
+namespace flutter {
+
+class DartIsolate;
+class DartSnapshot;
+
+using ChildIsolatePreparer = std::function<bool(DartIsolate*)>;
+
+// Object holding state associated with a Dart isolate group.  An instance of
+// this class will be provided to Dart_CreateIsolateGroup as the
+// isolate_group_data.
+//
+// This object must be thread safe because the Dart VM can invoke the isolate
+// group cleanup callback on any thread.
+class DartIsolateGroupData {
+ public:
+  DartIsolateGroupData(const Settings& settings,
+                       fml::RefPtr<const DartSnapshot> isolate_snapshot,
+                       std::string advisory_script_uri,
+                       std::string advisory_script_entrypoint,
+                       const ChildIsolatePreparer& child_isolate_preparer,
+                       const fml::closure& isolate_create_callback,
+                       const fml::closure& isolate_shutdown_callback);
+
+  ~DartIsolateGroupData();
+
+  const Settings& GetSettings() const;
+  fml::RefPtr<const DartSnapshot> GetIsolateSnapshot() const;
+  const std::string& GetAdvisoryScriptURI() const;
+  const std::string& GetAdvisoryScriptEntrypoint() const;
+  const ChildIsolatePreparer& GetChildIsolatePreparer() const;
+  const fml::closure& GetIsolateCreateCallback() const;
+  const fml::closure& GetIsolateShutdownCallback() const;
+
+  void SetChildIsolatePreparer(const ChildIsolatePreparer& value);
+
+ private:
+  FML_DISALLOW_COPY_AND_ASSIGN(DartIsolateGroupData);
+
+  const Settings settings_;
+  const fml::RefPtr<const DartSnapshot> isolate_snapshot_;
+  const std::string advisory_script_uri_;
+  const std::string advisory_script_entrypoint_;
+  ChildIsolatePreparer child_isolate_preparer_;
+  const fml::closure isolate_create_callback_;
+  const fml::closure isolate_shutdown_callback_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_RUNTIME_DART_ISOLATE_GROUP_DATA_H_

--- a/runtime/dart_isolate_unittests.cc
+++ b/runtime/dart_isolate_unittests.cc
@@ -109,14 +109,15 @@ class AutoIsolateShutdown {
       return;
     }
     fml::AutoResetWaitableEvent latch;
-    fml::TaskRunner::RunNowOrPostTask(runner_, [isolate = isolate_, &latch]() {
-      FML_LOG(INFO) << "Shutting down isolate.";
-      if (!isolate->Shutdown()) {
-        FML_LOG(ERROR) << "Could not shutdown isolate.";
-        FML_CHECK(false);
-      }
-      latch.Signal();
-    });
+    fml::TaskRunner::RunNowOrPostTask(
+        runner_, [isolate = std::move(isolate_), &latch]() {
+          FML_LOG(INFO) << "Shutting down isolate.";
+          if (!isolate->Shutdown()) {
+            FML_LOG(ERROR) << "Could not shutdown isolate.";
+            FML_CHECK(false);
+          }
+          latch.Signal();
+        });
     latch.Wait();
   }
 


### PR DESCRIPTION
Isolate data may need to be deleted on the same thread where it was allocated.
In particular, the task observer set up in the UIDartState ctor must be removed
from the same message loop where it was added.

The engine had been using the same DartIsolate object as the root isolate data
and as the isolate group data.  This object would be deleted when the isolate
group was shut down.  However, group shutdown may occur on a thread associated
with a secondary isolate.  When this happens, cleanup of any state tied to the
root isolate's thread will fail.

This change adds a DartIsolateGroupData object holding state that is common
among all isolates in a group.  DartIsolateGroupData can be deleted on any
thread.

See https://github.com/flutter/flutter/issues/45578