### PR TITLE
Fix CGMutablePathRef memory leaks

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -132,10 +132,10 @@ void ResetAnchor(CALayer* layer) {
 }
 
 - (void)clipPath:(const SkPath&)path {
-  CGMutablePathRef pathRef = CGPathCreateMutable();
   if (!path.isValid()) {
     return;
   }
+  CGMutablePathRef pathRef = CGPathCreateMutable();
   if (path.isEmpty()) {
     CAShapeLayer* clip = [[CAShapeLayer alloc] init];
     clip.path = pathRef;

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -4,8 +4,8 @@
 
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 
-#include "flutter/shell/platform/darwin/ios/ios_surface.h"
 #include "flutter/fml/platform/darwin/cf_utils.h"
+#include "flutter/shell/platform/darwin/ios/ios_surface.h"
 
 static int kMaxPointsInVerb = 4;
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.mm
@@ -5,6 +5,7 @@
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPlatformViews_Internal.h"
 
 #include "flutter/shell/platform/darwin/ios/ios_surface.h"
+#include "flutter/fml/platform/darwin/cf_utils.h"
 
 static int kMaxPointsInVerb = 4;
 
@@ -135,12 +136,11 @@ void ResetAnchor(CALayer* layer) {
   if (!path.isValid()) {
     return;
   }
-  CGMutablePathRef pathRef = CGPathCreateMutable();
+  fml::CFRef<CGMutablePathRef> pathRef(CGPathCreateMutable());
   if (path.isEmpty()) {
     CAShapeLayer* clip = [[CAShapeLayer alloc] init];
     clip.path = pathRef;
     self.layer.mask = clip;
-    CGPathRelease(pathRef);
     return;
   }
 
@@ -198,7 +198,6 @@ void ResetAnchor(CALayer* layer) {
   CAShapeLayer* clip = [[CAShapeLayer alloc] init];
   clip.path = pathRef;
   self.layer.mask = clip;
-  CGPathRelease(pathRef);
 }
 
 - (void)setClip:(flutter::MutatorType)type


### PR DESCRIPTION
Fixes `pathRef` memory leaks if `path` is invalid.