### PR TITLE
Remove specificity on Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ Flutter Engine
 [![Build Status - Cirrus][]][Build status]
 
 Flutter is Google's mobile app SDK for crafting high-quality native interfaces
-on iOS and Android in record time. Flutter works with existing code, is used by
-developers and organizations around the world, and is free and open source.
+in record time. Flutter works with existing code, is used by developers and
+organizations around the world, and is free and open source.
 
 The Flutter Engine is a portable runtime for hosting
 [Flutter](https://flutter.dev) applications.  It implements Flutter's core


### PR DESCRIPTION
We run on more than two platforms these days.