### PR TITLE
Move Fuchsia unit test runners into engine repo (#14092)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -128,8 +128,6 @@ if (is_fuchsia) {
     testonly = true
 
     deps = [
-      "$flutter_root/flow:flow_tests",
-
       # TODO(gw280): Re-enable fml_tests on Fuchsia (https://github.com/flutter/flutter/issues/46122)
       #     "$flutter_root/fml:fml_tests",
       "$flutter_root/shell/platform/fuchsia/flutter:flutter_runner_tests",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -92,11 +92,6 @@ group("flutter") {
       ]
     }
   }
-
-  # Fuchsia currently only supports a subset of our unit tests
-  if (is_fuchsia) {
-    public_deps += [ "$flutter_root/fml:fml_tests" ]
-  }
 }
 
 config("config") {
@@ -123,4 +118,21 @@ group("dist") {
   deps = [
     "$flutter_root/sky/dist",
   ]
+}
+
+# Fuchsia currently only supports a subset of our unit tests
+# When adding a new dep here, please also ensure the dep is added to
+# testing/fuchsia/run_tests.sh and testing/fuchsia/test_fars
+if (is_fuchsia) {
+  group("fuchsia_tests") {
+    testonly = true
+
+    deps = [
+      "$flutter_root/flow:flow_tests",
+
+      # TODO(gw280): Re-enable fml_tests on Fuchsia (https://github.com/flutter/flutter/issues/46122)
+      #     "$flutter_root/fml:fml_tests",
+      "$flutter_root/shell/platform/fuchsia/flutter:flutter_runner_tests",
+    ]
+  }
 }

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This expects the device to be in zedboot mode, with a zedboot that is
+# is compatible with the Fuchsia system image provided.
+#
+# The first and only parameter should be the path to the Fuchsia system image
+# tarball, e.g. `./fuchsia-test.sh generic-x64.tgz`.
+#
+# This script expects `pm`, `dev_finder`, and `fuchsia_ctl` to all be in the
+# same directory as the script, as well as the `flutter_aot_runner-0.far` and
+# the `flutter_runner_tests-0.far`. It is written to be run from its own
+# directory, and will fail if run from other directories or via sym-links.
+
+set -Ee
+
+# The nodes are named blah-blah--four-word-fuchsia-id
+device_name=${SWARMING_BOT_ID#*--}
+
+if [ -z "$device_name" ]
+then
+  echo "No device found. Aborting."
+  exit 1
+else
+  echo "Connecting to device $device_name"
+fi
+
+reboot() {
+  # note: this will set an exit code of 255, which we can ignore.
+  ./fuchsia_ctl -d $device_name ssh -c "dm reboot-recovery" || true
+}
+
+trap reboot EXIT
+
+./fuchsia_ctl -d $device_name pave  -i $1
+
+# TODO(gw280): Enable tests using JIT runner
+./fuchsia_ctl -d $device_name test \
+    -f flutter_aot_runner-0.far    \
+    -f flutter_runner_tests-0.far  \
+    -t flutter_runner_tests
+

--- a/testing/fuchsia/test_fars
+++ b/testing/fuchsia/test_fars
@@ -1,0 +1,1 @@
+flutter_runner_tests-0.far

--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -68,7 +68,7 @@ template("fuchsia_archive") {
       "$cmx_file",
     ]
     outputs = [
-      "$far_base_dir/meta/{{source_file_part}}",
+      "$far_base_dir/meta/${pkg_target_name}.cmx",
     ]
   }
 


### PR DESCRIPTION
- Copies fuchsia_test.sh into the testing/fuchsia directory
- Fixes a small issue with fuchsia_archive to ensure the cmx file is correctly named according to the target
- Add a list of fuchsia unittest fars to run on CI
- Add a GN build target to build all currently-enabled unittests for Fuchsia