### PR TITLE
[web] Update build_web_compilers to 2.7.1

### DIFF
--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -16,7 +16,7 @@ dev_dependencies:
   quiver: 2.0.5
   build_runner: 1.7.0
   build_test: 0.10.8
-  build_web_compilers: 2.1.5
+  build_web_compilers: 2.7.1
   yaml: 2.2.0
   watcher: 0.9.7+12
   web_engine_tester:

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   path: 1.6.4
   test: 1.6.5
   quiver: 2.0.5
-  build_runner: 1.7.0
+  build_runner: 1.7.2
   build_test: 0.10.8
   build_web_compilers: 2.7.1
   yaml: 2.2.0


### PR DESCRIPTION
This was causing problems with the dart compiler location
for web.

The compiler seems to be present in out/host_debug_unopt/dart-sdk/lib/dev_compiler/kernel/amd/dart_sdk.js as opposed to out/host_debug_unopt/dart-sdk/lib/dev_compiler/amd/dart_sdk.js