### PR TITLE
Fix missing timeline event of flutter engine's startup time

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -417,7 +417,7 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     if (engine_main_enter_ts != 0) {
       Dart_TimelineEvent("FlutterEngineMainEnter",  // label
                          engine_main_enter_ts,      // timestamp0
-                         Dart_TimelineGetMicros(),      // timestamp1_or_async_id
+                         Dart_TimelineGetMicros(),  // timestamp1_or_async_id
                          Dart_Timeline_Event_Duration,  // event type
                          0,                             // argument_count
                          nullptr,                       // argument_names

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -417,7 +417,7 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     if (engine_main_enter_ts != 0) {
       Dart_TimelineEvent("FlutterEngineMainEnter",  // label
                          engine_main_enter_ts,      // timestamp0
-                         engine_main_enter_ts,      // timestamp1_or_async_id
+                         Dart_TimelineGetMicros(),      // timestamp1_or_async_id
                          Dart_Timeline_Event_Duration,  // event type
                          0,                             // argument_count
                          nullptr,                       // argument_names


### PR DESCRIPTION
The FlutterEngineMainEnter event's end point is incorrect and cannot be seen on the timeline.

1）Unable to record FlutterEngineMainEnter event when flutter engine is booting
![3-1-FlutterEngineMainEnter-origin](https://user-images.githubusercontent.com/4338041/70588203-effdf180-1c06-11ea-8828-576980609df5.png)

2）with this PR, we can see FlutterEngineMainEnter event in timeline
![3-2-FlutterEngineMainEnter-opt](https://user-images.githubusercontent.com/4338041/70588210-f7bd9600-1c06-11ea-9e08-9b66c2d2f5e5.png)
