### PR TITLE
Fix missing API stream when record event in systrace

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -92,7 +92,7 @@ static const char* kDartDisableServiceAuthCodesArgs[]{
 };
 
 static const char* kDartTraceStartupArgs[]{
-    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",
+    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM,API",
 };
 
 static const char* kDartEndlessTraceBufferArgs[]{
@@ -108,7 +108,7 @@ static const char* kDartFuchsiaTraceArgs[] FML_ALLOW_UNUSED_TYPE = {
 };
 
 static const char* kDartTraceStreamsArgs[] = {
-    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",
+    "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM,API",
 };
 
 constexpr char kFileUriPrefix[] = "file://";


### PR DESCRIPTION
Fix missing API stream when record timeline event in systrace

For example,  third_party/dart/runtime/vm/dart_api_impl.cc
```
DART_EXPORT void Dart_NotifyIdle(int64_t deadline) {
  Thread* T = Thread::Current();
  CHECK_ISOLATE(T->isolate());
  API_TIMELINE_BEGIN_END(T);
  TransitionNativeToVM transition(T);
  T->isolate()->NotifyIdle(deadline);
}
```

1）API_TIMELINE_BEGIN_END does not appear in systrace
![4-1-systrace-No-API](https://user-images.githubusercontent.com/4338041/70592676-9ea92e80-1c15-11ea-8bd4-e1f66f6bcf2f.png)

2）with this PR, we can see Dart_NotifyIdle event in systrace
![4-2-systrace-add-API](https://user-images.githubusercontent.com/4338041/70592694-a7016980-1c15-11ea-933d-11b3cba546c9.png)
