### PR TITLE
Remove duplicate and outdated src/third_party/dart/tools/sdks entry from DEPS.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -494,16 +494,6 @@ deps = {
      'dep_type': 'cipd',
    },
 
-   'src/third_party/dart/tools/sdks': {
-     'packages': [
-       {
-         'package': 'dart/dart-sdk/${{platform}}',
-         'version': 'version:2.6.0'
-       }
-     ],
-     'dep_type': 'cipd',
-   },
-
    'src/third_party/dart/pkg/analysis_server/language_model': {
      'packages': [
        {

--- a/DEPS
+++ b/DEPS
@@ -498,7 +498,7 @@ deps = {
      'packages': [
        {
          'package': 'dart/dart-sdk/${{platform}}',
-         'version': 'version:2.4.0'
+         'version': 'version:2.6.0'
        }
      ],
      'dep_type': 'cipd',


### PR DESCRIPTION
This PR removes outdated src/third_party/dart/tools/sdks entry from DEPS file.
Example of a breakage caused by outdated version of dart sdk pulled in is https://ci.chromium.org/p/dart/builders/ci.sandbox/flutter-engine-linux/9577.