### PR TITLE
Revert "Roll fuchsia/sdk/core/linux-amd64 from UdfLO... to 9wKTl... (…

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -562,7 +562,7 @@ deps = {
      'packages': [
        {
         'package': 'fuchsia/sdk/core/linux-amd64',
-        'version': '9wKTl6OgTwPYnwLcHBYA9ok18H58VaFkxF1cP_zA3fAC'
+        'version': 'UdfLOwiV3CK9deXMATb19JxetGTwtSaTZXX5b8g4Wb4C'
        }
      ],
      'condition': 'host_os == "linux"',

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -1,4 +1,4 @@
-Signature: f4db1350a58dc05423f556cfae14d815
+Signature: 485b280b9c5de95a2c846d670269f43b
 
 UNUSED LICENSES:
 
@@ -501,6 +501,7 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.recovery.ui/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.recovery/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.scenic.scheduling/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.settings/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysinfo/meta.json
@@ -1439,6 +1440,7 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.settings/privacy.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.settings/settings.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.settings/setup.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.settings/system.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/types.fidl
@@ -2175,6 +2177,7 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.recovery.ui/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.recovery/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.scenic.scheduling/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.settings/meta.json
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys.test/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/meta.json
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysinfo/meta.json
@@ -2610,6 +2613,7 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net/connectivity.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net/net.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.process/launcher.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.process/resolver.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.simplecamera/simple_camera.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/job_provider.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysinfo/sysinfo.fidl
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sysmem/allocator.fidl

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -333,7 +333,6 @@ executable("flutter_runner_unittests") {
     ":aot",
     ":flutter_runner_fixtures",
     "//build/fuchsia/fidl:fuchsia.accessibility.semantics",
-    "//build/fuchsia/pkg:async-default",
     "//build/fuchsia/pkg:async-loop-cpp",
     "//build/fuchsia/pkg:async-loop-default",
     "//build/fuchsia/pkg:scenic_cpp",

--- a/shell/platform/fuchsia/flutter/thread.cc
+++ b/shell/platform/fuchsia/flutter/thread.cc
@@ -10,7 +10,6 @@
 #include <algorithm>
 
 #include <lib/async-loop/cpp/loop.h>
-#include <lib/async/default.h>
 
 #include "flutter/fml/logging.h"
 #include "loop.h"


### PR DESCRIPTION
…#14342)"

This reverts commit 18519e916919439132e5b3db7c40a6cb7082eae3.

This broke build_fuchsia_debug_x64
https://ci.chromium.org/p/flutter/builders/prod/Linux%20Fuchsia/1852:

```
[1492/6347] CXX obj/flutter/shell/platform/fuchsia/flutter/flutter_runner_tests.vsync_waiter_unittests.o
FAILED: obj/flutter/shell/platform/fuchsia/flutter/flutter_runner_tests.vsync_waiter_unittests.o
/b/s/w/ir/cache/goma/client/gomacc  ../../fuchsia/toolchain/linux/bin//clang++ -MD -MF obj/flutter/shell/platform/fuchsia/flutter/flutter_runner_tests.vsync_waiter_unittests.o.d --target=x86_64-fuchsia --sysroot ../../fuchsia/sdk/linux/arch/x64/sysroot  -DUSE_OPENSSL=1 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D_FORTIFY_SOURCE=2 -D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS -D_LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS -DNDEBUG -DNVALGRIND -DDYNAMIC_ANNOTATIONS_ENABLED=0 -DSK_VULKAN -DSK_HAS_JPEG_LIBRARY -DSK_HAS_PNG_LIBRARY -DSK_HAS_WEBP_LIBRARY -DSK_HAS_WUFFS_LIBRARY -DFLUTTER_RUNTIME_MODE_DEBUG=1 -DFLUTTER_RUNTIME_MODE_PROFILE=2 -DFLUTTER_RUNTIME_MODE_RELEASE=3 -DFLUTTER_RUNTIME_MODE_JIT_RELEASE=4 -DFLUTTER_RUNTIME_MODE=1 -DFLUTTER_JIT_RUNTIME=1 -DFUCHSIA_SDK=1 -DU_USING_ICU_NAMESPACE=0 -DU_ENABLE_DYLOAD=0 -DUSE_CHROMIUM_ICU=1 -DU_STATIC_IMPLEMENTATION -DICU_UTIL_DATA_IMPL=ICU_UTIL_DATA_FILE -DUCHAR_TYPE=uint16_t -DSK_R32_SHIFT=16 -DSK_DISABLE_REDUCE_OPLIST_SPLITTING -DSK_LEGACY_SKCODEC_NONE_ENUM -DSK_ENABLE_DUMP_GPU -DSK_DISABLE_AAA -DSK_DISABLE_READBUFFER -DSK_DISABLE_EFFECT_DESERIALIZATION -DSK_DISABLE_LEGACY_SHADERCONTEXT -DSK_DISABLE_LOWP_RASTER_PIPELINE -DSK_FORCE_RASTER_PIPELINE_BLITTER -DRAPIDJSON_HAS_STDSTRING -DRAPIDJSON_HAS_CXX11_RANGE_FOR -DRAPIDJSON_HAS_CXX11_RVALUE_REFS -DRAPIDJSON_HAS_CXX11_TYPETRAITS -DRAPIDJSON_HAS_CXX11_NOEXCEPT -I../.. -Igen -Igen/build/fuchsia/fidl -I../../fuchsia/sdk/linux/pkg/fidl_cpp/include -I../../fuchsia/sdk/linux/pkg/fidl_cpp_sync/include -I../../fuchsia/sdk/linux/pkg/fidl_cpp_base/include -I../../fuchsia/sdk/linux/pkg/fidl_base/include -I../../fuchsia/sdk/linux/pkg/fit/include -I../../fuchsia/sdk/linux/pkg/fidl-async/include -I../../fuchsia/sdk/linux/pkg/async/include -I../../fuchsia/sdk/linux/pkg/fidl/include -I../../fuchsia/sdk/linux/pkg/zx/include -I../../fuchsia/sdk/linux/pkg/async-default/include -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -I../../fuchsia/sdk/linux/pkg/async-loop-cpp/include -I../../fuchsia/sdk/linux/pkg/async-loop/include -I../../fuchsia/sdk/linux/pkg/async-loop-default/include -I../../fuchsia/sdk/linux/pkg/scenic_cpp/include -I../../fuchsia/sdk/linux/pkg/images_cpp/include -I../../fuchsia/sdk/linux/pkg/syslog/include -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -Igen/build/fuchsia/fidl -I../../fuchsia/sdk/linux/pkg/sys_cpp_testing/include -I../../fuchsia/sdk/linux/pkg/sys_cpp/include -I../../fuchsia/sdk/linux/pkg/sys_service_cpp/include -I../../fuchsia/sdk/linux/pkg/vfs_cpp/include -I../../fuchsia/sdk/linux/pkg/fdio/include -Igen/build/fuchsia/fidl -I../../fuchsia/sdk/linux/pkg/async-cpp/include -Igen/build/fuchsia/fidl -I../.. -I../../flutter/third_party/txt/src -I../../fuchsia/sdk/linux/pkg/trace/include -I../../fuchsia/sdk/linux/pkg/trace-engine/include -I../../third_party/harfbuzz/src -I../../third_party/icu/source/common -I../../third_party/icu/source/i18n -I../../third_party/skia -I../../fuchsia/sdk/linux/pkg/vulkan/include -I../../build/fuchsia/vulkan/include -I../../third_party/rapidjson -I../../third_party/rapidjson/include -I../../third_party -I../../third_party/dart/runtime -I../../third_party/dart/runtime/include -I../../flutter/shell/platform/fuchsia -I../../third_party/googletest/googletest/include -fno-strict-aliasing -m64 -march=x86-64 -fcolor-diagnostics -Wall -Wextra -Wendif-labels -Werror -Wno-missing-field-initializers -Wno-unused-parameter -Wno-c99-designator -fvisibility=hidden -Wstring-conversion -Wnewline-eof -Wno-implicit-int-float-conversion -O2 -fno-ident -fdata-sections -ffunction-sections -g2 -fvisibility-inlines-hidden -std=c++17 -fno-rtti -fno-exceptions -c ../../flutter/shell/platform/fuchsia/flutter/vsync_waiter_unittests.cc -o obj/flutter/shell/platform/fuchsia/flutter/flutter_runner_tests.vsync_waiter_unittests.o
../../flutter/shell/platform/fuchsia/flutter/vsync_waiter_unittests.cc:64:11: error: use of undeclared identifier 'async_get_default_dispatcher'; did you mean 'async_loop_get_default_dispatcher_t'?
          async_get_default_dispatcher()),  // platform
          ^
../../fuchsia/sdk/linux/pkg/async-loop/include/lib/async-loop/loop.h:31:29: note: 'async_loop_get_default_dispatcher_t' declared here
typedef async_dispatcher_t*(async_loop_get_default_dispatcher_t)(void);
                            ^
1 error generated.
```