### PR TITLE
Fix prebuilt dart sdk at 2.6.0.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -494,6 +494,16 @@ deps = {
      'dep_type': 'cipd',
    },
 
+   'src/third_party/dart/tools/sdks': {
+     'packages': [
+       {
+         'package': 'dart/dart-sdk/${{platform}}',
+         'version': 'version:2.6.0'
+       }
+     ],
+     'dep_type': 'cipd',
+   },
+
    'src/third_party/dart/pkg/analysis_server/language_model': {
      'packages': [
        {


### PR DESCRIPTION
This is to work around an issue with analyzer at 2.7.0 and above complaining about unused enum values https://github.com/flutter/engine/runs/344747526.
