### PR TITLE
Remove unused _TypeNone enum field.

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2633,6 +2633,7 @@ class ColorFilter {
 
   // The type of SkColorFilter class to create for Skia.
   // These constants must be kept in sync with ColorFilterType in paint.cc.
+  // ignore:unused_field
   static const int _TypeNone = 0; // null
   static const int _TypeMode = 1; // MakeModeFilter
   static const int _TypeMatrix = 2; // MakeMatrixFilterRowMajor255

--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -2632,9 +2632,6 @@ class ColorFilter {
   final int _type;
 
   // The type of SkColorFilter class to create for Skia.
-  // These constants must be kept in sync with ColorFilterType in paint.cc.
-  // ignore:unused_field
-  static const int _TypeNone = 0; // null
   static const int _TypeMode = 1; // MakeModeFilter
   static const int _TypeMatrix = 2; // MakeMatrixFilterRowMajor255
   static const int _TypeLinearToSrgbGamma = 3; // MakeLinearToSRGBGamma

--- a/lib/web_ui/lib/src/engine/color_filter.dart
+++ b/lib/web_ui/lib/src/engine/color_filter.dart
@@ -114,8 +114,6 @@ class EngineColorFilter implements ui.ColorFilter {
   final int _type;
 
   // The type of SkColorFilter class to create for Skia.
-  // These constants must be kept in sync with ColorFilterType in paint.cc.
-  static const int _TypeNone = 0; // null
   static const int _TypeMode = 1; // MakeModeFilter
   static const int _TypeMatrix = 2; // MakeMatrixFilterRowMajor255
   static const int _TypeLinearToSrgbGamma = 3; // MakeLinearToSRGBGamma


### PR DESCRIPTION
_TypeNone is not used and that triggers hint in dart analyzer since dart 2.7.0