### PR TITLE
[testing] Make vsync waiters pluggable in shell_unittests

### DIFF
--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -93,7 +93,8 @@ class ShellTestPlatformView : public PlatformView, public GPUSurfaceGLDelegate {
  public:
   ShellTestPlatformView(PlatformView::Delegate& delegate,
                         TaskRunners task_runners,
-                        bool simulate_vsync = false);
+                        std::shared_ptr<ShellTestVsyncClock> vsync_clock,
+                        CreateVsyncWaiter create_vsync_waiter);
 
   ~ShellTestPlatformView() override;
 
@@ -102,8 +103,9 @@ class ShellTestPlatformView : public PlatformView, public GPUSurfaceGLDelegate {
  private:
   TestGLSurface gl_surface_;
 
-  bool simulate_vsync_ = false;
-  ShellTestVsyncClock vsync_clock_;
+  CreateVsyncWaiter create_vsync_waiter_;
+
+  std::shared_ptr<ShellTestVsyncClock> vsync_clock_;
 
   // |PlatformView|
   std::unique_ptr<Surface> CreateRenderingSurface() override;

--- a/shell/common/test_vsync_waiters.cc
+++ b/shell/common/test_vsync_waiters.cc
@@ -35,7 +35,7 @@ std::future<int> ShellTestVsyncClock::NextVSync() {
 
 void ShellTestVsyncWaiter::AwaitVSync() {
   FML_DCHECK(task_runners_.GetUITaskRunner()->RunsTasksOnCurrentThread());
-  auto vsync_future = clock_.NextVSync();
+  auto vsync_future = clock_->NextVSync();
 
   auto async_wait = std::async([&vsync_future, this]() {
     vsync_future.wait();

--- a/shell/common/test_vsync_waiters.h
+++ b/shell/common/test_vsync_waiters.h
@@ -12,6 +12,8 @@
 namespace flutter {
 namespace testing {
 
+using CreateVsyncWaiter = std::function<std::unique_ptr<VsyncWaiter>()>;
+
 class ShellTestVsyncClock {
  public:
   /// Simulate that a vsync signal is triggered.
@@ -28,14 +30,15 @@ class ShellTestVsyncClock {
 
 class ShellTestVsyncWaiter : public VsyncWaiter {
  public:
-  ShellTestVsyncWaiter(TaskRunners task_runners, ShellTestVsyncClock& clock)
+  ShellTestVsyncWaiter(TaskRunners task_runners,
+                       std::shared_ptr<ShellTestVsyncClock> clock)
       : VsyncWaiter(std::move(task_runners)), clock_(clock) {}
 
  protected:
   void AwaitVSync() override;
 
  private:
-  ShellTestVsyncClock& clock_;
+  std::shared_ptr<ShellTestVsyncClock> clock_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
This makes it so that the platform views can be passed
an arbitraty CreateVsyncWaiter callback that lets us inject
a vsync waiter other than just the simulated monotonic vsync waiter
that currently exists.