### PR TITLE
Use futures to images used for comparison with fixtures in embedder unit-tests.

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_context.cc
+++ b/shell/platform/embedder/tests/embedder_test_context.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/shell/platform/embedder/tests/embedder_test_context.h"
 
+#include "flutter/fml/make_copyable.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/platform/embedder/tests/embedder_assertions.h"
 #include "third_party/dart/runtime/bin/elf_loader.h"
@@ -223,6 +224,16 @@ void EmbedderTestContext::SetNextSceneCallback(
     return;
   }
   next_scene_callback_ = next_scene_callback;
+}
+
+std::future<sk_sp<SkImage>> EmbedderTestContext::GetNextSceneImage() {
+  std::promise<sk_sp<SkImage>> promise;
+  auto future = promise.get_future();
+  SetNextSceneCallback(
+      fml::MakeCopyable([promise = std::move(promise)](auto image) mutable {
+        promise.set_value(image);
+      }));
+  return future;
 }
 
 bool EmbedderTestContext::SofwarePresent(sk_sp<SkImage> image) {

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -5,6 +5,7 @@
 #ifndef FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_CONTEXT_H_
 #define FLUTTER_SHELL_PLATFORM_EMBEDDER_TESTS_EMBEDDER_CONTEXT_H_
 
+#include <future>
 #include <map>
 #include <memory>
 #include <string>
@@ -60,8 +61,7 @@ class EmbedderTestContext {
 
   EmbedderTestCompositor& GetCompositor();
 
-  using NextSceneCallback = std::function<void(sk_sp<SkImage> image)>;
-  void SetNextSceneCallback(const NextSceneCallback& next_scene_callback);
+  std::future<sk_sp<SkImage>> GetNextSceneImage();
 
   size_t GetGLSurfacePresentCount() const;
 
@@ -70,6 +70,8 @@ class EmbedderTestContext {
  private:
   // This allows the builder to access the hooks.
   friend class EmbedderConfigBuilder;
+
+  using NextSceneCallback = std::function<void(sk_sp<SkImage> image)>;
 
   std::string assets_path_;
 
@@ -128,6 +130,8 @@ class EmbedderTestContext {
 
   void FireRootSurfacePresentCallbackIfPresent(
       const std::function<sk_sp<SkImage>(void)>& image_callback);
+
+  void SetNextSceneCallback(const NextSceneCallback& next_scene_callback);
 
   FML_DISALLOW_COPY_AND_ASSIGN(EmbedderTestContext);
 };


### PR DESCRIPTION
This earlier pattern was to use callbacks with latching. There are other calls that still use this pattern. I will work on removing them one by one.