### PR TITLE
[web] adding firefox unit tests to font loading

### DIFF
--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -21,122 +21,192 @@ void main() {
       html.document.fonts.clear();
     });
 
-    test('Register Asset with no special characters', () async {
-      final String _testFontFamily = "Ahem";
-      final List<String> fontFamilyList = List<String>();
+    group('regular special characters', () {
+      test('Register Asset with no special characters', () async {
+        final String _testFontFamily = "Ahem";
+        final List<String> fontFamilyList = List<String>();
 
-      fontManager.registerAsset(
-          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
-      await fontManager.ensureFontsLoaded();
-      html.document.fonts
-          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
-        fontFamilyList.add(f.family);
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
+
+        expect(fontFamilyList.length, equals(1));
+        expect(fontFamilyList.first, 'Ahem');
       });
 
-      expect(fontFamilyList.length, equals(1));
-      expect(fontFamilyList.first, 'Ahem');
+      test('Register Asset with white space in the family name', () async {
+        final String _testFontFamily = "Ahem ahem ahem";
+        final List<String> fontFamilyList = List<String>();
+
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
+
+        expect(fontFamilyList.length, equals(1));
+        expect(fontFamilyList.first, 'Ahem ahem ahem');
+      });
+
+      test('Register Asset with capital case letters', () async {
+        final String _testFontFamily = "AhEm";
+        final List<String> fontFamilyList = List<String>();
+
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
+
+        expect(fontFamilyList.length, equals(1));
+        expect(fontFamilyList.first, 'AhEm');
+      });
     });
 
-    test('Register Asset with white space in the family name', () async {
-      final String _testFontFamily = "Ahem ahem ahem";
-      final List<String> fontFamilyList = List<String>();
+    group('special chracters Chrome, Safari 13, Edge', () {
+      test('Register Asset twice with special character slash', () async {
+        final String _testFontFamily = '/Ahem';
+        final List<String> fontFamilyList = List<String>();
 
-      fontManager.registerAsset(
-          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
-      await fontManager.ensureFontsLoaded();
-      html.document.fonts
-          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
-        fontFamilyList.add(f.family);
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
+
+        expect(fontFamilyList.length, equals(2));
+        expect(fontFamilyList, contains('\'/Ahem\''));
+        expect(fontFamilyList, contains('/Ahem'));
       });
 
-      expect(fontFamilyList.length, equals(1));
-      expect(fontFamilyList.first, 'Ahem ahem ahem');
-    });
+      test('Register Asset twice with exclamation mark', () async {
+        final String _testFontFamily = 'Ahem!!ahem';
+        final List<String> fontFamilyList = List<String>();
 
-    test('Register Asset with capital case letters', () async {
-      final String _testFontFamily = "AhEm";
-      final List<String> fontFamilyList = List<String>();
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
 
-      fontManager.registerAsset(
-          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
-      await fontManager.ensureFontsLoaded();
-      html.document.fonts
-          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
-        fontFamilyList.add(f.family);
+        expect(fontFamilyList.length, equals(2));
+        expect(fontFamilyList, contains('\'Ahem!!ahem\''));
+        expect(fontFamilyList, contains('Ahem!!ahem'));
       });
 
-      expect(fontFamilyList.length, equals(1));
-      expect(fontFamilyList.first, 'AhEm');
-    });
+      test('Register Asset twice with coma', () async {
+        final String _testFontFamily = 'Ahem ,ahem';
+        final List<String> fontFamilyList = List<String>();
 
-    test('Register Asset twice with special character slash', () async {
-      final String _testFontFamily = '/Ahem';
-      final List<String> fontFamilyList = List<String>();
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
 
-      fontManager.registerAsset(
-          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
-      await fontManager.ensureFontsLoaded();
-      html.document.fonts
-          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
-        fontFamilyList.add(f.family);
+        expect(fontFamilyList.length, equals(2));
+        expect(fontFamilyList, contains('\'Ahem ,ahem\''));
+        expect(fontFamilyList, contains('Ahem ,ahem'));
       });
 
-      expect(fontFamilyList.length, equals(2));
-      expect(fontFamilyList, contains('\'/Ahem\''));
-      expect(fontFamilyList, contains('/Ahem'));
+      test('Register Asset twice with a digit at the start of a token',
+          () async {
+        final String testFontFamily = 'Ahem 1998';
+        final List<String> fontFamilyList = List<String>();
+
+        fontManager.registerAsset(
+            testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
+
+        expect(fontFamilyList.length, equals(2));
+        expect(fontFamilyList, contains('Ahem 1998'));
+        expect(fontFamilyList, contains('\'Ahem 1998\''));
+      });
     }, skip: (browserEngine == BrowserEngine.firefox));
 
-    test('Register Asset twice with exclamation mark', () async {
-      final String _testFontFamily = 'Ahem!!ahem';
-      final List<String> fontFamilyList = List<String>();
+    group('special characters Firefox', () {
+      test('Register Asset with special character slash', () async {
+        final String _testFontFamily = '/Ahem';
+        final List<String> fontFamilyList = List<String>();
 
-      fontManager.registerAsset(
-          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
-      await fontManager.ensureFontsLoaded();
-      html.document.fonts
-          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
-        fontFamilyList.add(f.family);
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
+
+        expect(fontFamilyList.length, equals(1));
+        expect(fontFamilyList.first, '\"/Ahem\"');
       });
 
-      expect(fontFamilyList.length, equals(2));
-      expect(fontFamilyList, contains('\'Ahem!!ahem\''));
-      expect(fontFamilyList, contains('Ahem!!ahem'));
-    }, skip: (browserEngine == BrowserEngine.firefox));
+      test('Register Asset with exclamation mark', () async {
+        final String _testFontFamily = 'Ahem!!ahem';
+        final List<String> fontFamilyList = List<String>();
 
-    test('Register Asset twice with coma', () async {
-      final String _testFontFamily = 'Ahem ,ahem';
-      final List<String> fontFamilyList = List<String>();
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
 
-      fontManager.registerAsset(
-          _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
-      await fontManager.ensureFontsLoaded();
-      html.document.fonts
-          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
-        fontFamilyList.add(f.family);
+        expect(fontFamilyList.length, equals(1));
+        expect(fontFamilyList.first, '\"Ahem!!ahem\"');
       });
 
-      expect(fontFamilyList.length, equals(2));
-      expect(fontFamilyList, contains('\'Ahem ,ahem\''));
-      expect(fontFamilyList, contains('Ahem ,ahem'));
-    }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
-        skip: (browserEngine == BrowserEngine.firefox));
+      test('Register Asset with coma', () async {
+        final String _testFontFamily = 'Ahem ,ahem';
+        final List<String> fontFamilyList = List<String>();
 
-    test('Register Asset twice with a digit at the start of a token', () async {
-      final String testFontFamily = 'Ahem 1998';
-      final List<String> fontFamilyList = List<String>();
+        fontManager.registerAsset(
+            _testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
 
-      fontManager.registerAsset(
-          testFontFamily, 'url($_testFontUrl)', const <String, String>{});
-      await fontManager.ensureFontsLoaded();
-      html.document.fonts
-          .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
-        fontFamilyList.add(f.family);
+        expect(fontFamilyList.length, equals(1));
+        expect(fontFamilyList.first, '\"Ahem ,ahem\"');
       });
 
-      expect(fontFamilyList.length, equals(2));
-      expect(fontFamilyList, contains('Ahem 1998'));
-      expect(fontFamilyList, contains('\'Ahem 1998\''));
+      test('Register Asset with a digit at the start of a token',
+          () async {
+        final String testFontFamily = 'Ahem 1998';
+        final List<String> fontFamilyList = List<String>();
+
+        fontManager.registerAsset(
+            testFontFamily, 'url($_testFontUrl)', const <String, String>{});
+        await fontManager.ensureFontsLoaded();
+        html.document.fonts
+            .forEach((html.FontFace f, html.FontFace f2, html.FontFaceSet s) {
+          fontFamilyList.add(f.family);
+        });
+
+        expect(fontFamilyList.length, equals(1));
+        expect(fontFamilyList.first, '\"Ahem 1998\"');
+      });
     });
-  }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
-      skip: (browserEngine == BrowserEngine.firefox));
+  }, skip: (browserEngine != BrowserEngine.firefox));
 }

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -106,7 +106,7 @@ void main() {
         expect(fontFamilyList, contains('Ahem!!ahem'));
       });
 
-      test('Register Asset twice with coma', () async {
+      test('Register Asset twice with comma', () async {
         final String _testFontFamily = 'Ahem ,ahem';
         final List<String> fontFamilyList = List<String>();
 
@@ -175,7 +175,7 @@ void main() {
         expect(fontFamilyList.first, '\"Ahem!!ahem\"');
       });
 
-      test('Register Asset with coma', () async {
+      test('Register Asset with comma', () async {
         final String _testFontFamily = 'Ahem ,ahem';
         final List<String> fontFamilyList = List<String>();
 


### PR DESCRIPTION
flutter web engine unit tests is running on firefox (as an addition to chrome) with PR: flutter/engine#14267

The following tests were skipped on Firefox since they were failing:
test/text/font_collection_test.dart: FontManager Register Asset twice with special character slash
test/text/font_collection_test.dart: FontManager Register Asset twice with exclamation mark
test/text/font_collection_test.dart: FontManager Register Asset twice with coma
test/text/font_collection_test.dart: FontManager Register Asset twice with a digit at the start of a token

The failure was legitimate since the loading was handled differently for Firefox. Added a new group of tests to test Firefox and skipped the other group.

Related: https://github.com/flutter/flutter/issues/46638