### PR TITLE
[fuchsia] Add diagnostics directory to the set of remote dirs

### DIFF
--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -232,7 +232,7 @@ Application::Application(
                          << "): " << zx_status_get_string(status);
           return;
         }
-        const char* other_dirs[] = {"debug", "ctrl"};
+        const char* other_dirs[] = {"debug", "ctrl", "diagnostics"};
         // add other directories as RemoteDirs.
         for (auto& dir_str : other_dirs) {
           fidl::InterfaceHandle<fuchsia::io::Directory> dir;


### PR DESCRIPTION
The Fuchsia component diagnostics team is changing the directory where inspect data lives to be in diagnostics.

As a side note, the proper fix of this I believe is to not hardcode these directories, but adding `diagnostics` for now to unblock ourselves. Should I open an issue for that?