### PR TITLE
Allow embedders to post Dart objects on send ports from the native side.

### DIFF
--- a/fml/closure.h
+++ b/fml/closure.h
@@ -31,12 +31,20 @@ using closure = std::function<void()>;
 ///
 class ScopedCleanupClosure {
  public:
+  ScopedCleanupClosure() = default;
+
   ScopedCleanupClosure(const fml::closure& closure) : closure_(closure) {}
 
   ~ScopedCleanupClosure() {
     if (closure_) {
       closure_();
     }
+  }
+
+  fml::closure SetClosure(const fml::closure& closure) {
+    auto old_closure = closure_;
+    closure_ = closure;
+    return old_closure;
   }
 
   fml::closure Release() {

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1050,67 +1050,6 @@ TEST_F(ShellTest, Screenshot) {
   DestroyShell(std::move(shell));
 }
 
-enum class MemsetPatternOp {
-  kMemsetPatternOpSetBuffer,
-  kMemsetPatternOpCheckBuffer,
-};
-
-//------------------------------------------------------------------------------
-/// @brief      Depending on the operation, either scribbles a known pattern
-///             into the buffer or checks if that pattern is present in an
-///             existing buffer. This is a portable variant of the
-///             memset_pattern class of methods that also happen to do assert
-///             that the same pattern exists.
-///
-/// @param      buffer  The buffer
-/// @param[in]  size    The size
-/// @param[in]  op      The operation
-///
-/// @return     If the result of the operation was a success.
-///
-static bool MemsetPatternSetOrCheck(uint8_t* buffer,
-                                    size_t size,
-                                    MemsetPatternOp op) {
-  if (buffer == nullptr) {
-    return false;
-  }
-
-  auto pattern = reinterpret_cast<const uint8_t*>("dErP");
-  constexpr auto pattern_length = 4;
-
-  uint8_t* start = buffer;
-  uint8_t* p = buffer;
-
-  while ((start + size) - p >= pattern_length) {
-    switch (op) {
-      case MemsetPatternOp::kMemsetPatternOpSetBuffer:
-        memmove(p, pattern, pattern_length);
-        break;
-      case MemsetPatternOp::kMemsetPatternOpCheckBuffer:
-        if (memcmp(pattern, p, pattern_length) != 0) {
-          return false;
-        }
-        break;
-    };
-    p += pattern_length;
-  }
-
-  if ((start + size) - p != 0) {
-    switch (op) {
-      case MemsetPatternOp::kMemsetPatternOpSetBuffer:
-        memmove(p, pattern, (start + size) - p);
-        break;
-      case MemsetPatternOp::kMemsetPatternOpCheckBuffer:
-        if (memcmp(pattern, p, (start + size) - p) != 0) {
-          return false;
-        }
-        break;
-    }
-  }
-
-  return true;
-}
-
 TEST_F(ShellTest, CanConvertToAndFromMappings) {
   const size_t buffer_size = 2 << 20;
 

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -8,8 +8,10 @@
 #include <iostream>
 
 #include "flutter/fml/build_config.h"
+#include "flutter/fml/closure.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/native_library.h"
+#include "third_party/dart/runtime/include/dart_native_api.h"
 
 #if OS_WIN
 #define FLUTTER_EXPORT __declspec(dllexport)
@@ -1582,4 +1584,129 @@ FlutterEngineResult FlutterEngineUpdateLocales(FLUTTER_API_SYMBOL(FlutterEngine)
 
 bool FlutterEngineRunsAOTCompiledDartCode(void) {
   return flutter::DartVM::IsRunningPrecompiledCode();
+}
+
+FlutterEngineResult FlutterEnginePostDartObject(
+    FLUTTER_API_SYMBOL(FlutterEngine) engine,
+    FlutterEngineDartPort port,
+    const FlutterEngineDartObject* object) {
+  if (engine == nullptr) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments, "Invalid engine handle.");
+  }
+
+  if (!reinterpret_cast<flutter::EmbedderEngine*>(engine)->IsValid()) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments, "Engine not running.");
+  }
+
+  if (port == ILLEGAL_PORT) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                              "Attempted to post to an illegal port.");
+  }
+
+  if (object == nullptr) {
+    return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                              "Invalid Dart object to post.");
+  }
+
+  Dart_CObject dart_object = {};
+  fml::ScopedCleanupClosure typed_data_finalizer;
+
+  switch (object->type) {
+    case kFlutterEngineDartObjectTypeNull:
+      dart_object.type = Dart_CObject_kNull;
+      break;
+    case kFlutterEngineDartObjectTypeBool:
+      dart_object.type = Dart_CObject_kBool;
+      dart_object.value.as_bool = object->bool_value;
+      break;
+    case kFlutterEngineDartObjectTypeInt32:
+      dart_object.type = Dart_CObject_kInt32;
+      dart_object.value.as_int32 = object->int32_value;
+      break;
+    case kFlutterEngineDartObjectTypeInt64:
+      dart_object.type = Dart_CObject_kInt64;
+      dart_object.value.as_int64 = object->int64_value;
+      break;
+    case kFlutterEngineDartObjectTypeDouble:
+      dart_object.type = Dart_CObject_kDouble;
+      dart_object.value.as_double = object->double_value;
+      break;
+    case kFlutterEngineDartObjectTypeString:
+      if (object->string_value == nullptr) {
+        return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                                  "kFlutterEngineDartObjectTypeString must be "
+                                  "a null terminated string but was null.");
+      }
+      dart_object.type = Dart_CObject_kString;
+      dart_object.value.as_string = const_cast<char*>(object->string_value);
+      break;
+    case kFlutterEngineDartObjectTypeBuffer: {
+      auto* buffer = SAFE_ACCESS(object->buffer_value, buffer, nullptr);
+      if (buffer == nullptr) {
+        return LOG_EMBEDDER_ERROR(kInvalidArguments,
+                                  "kFlutterEngineDartObjectTypeBuffer must "
+                                  "specify a buffer but found nullptr.");
+      }
+      auto buffer_size = SAFE_ACCESS(object->buffer_value, buffer_size, 0);
+      auto callback =
+          SAFE_ACCESS(object->buffer_value, buffer_collect_callback, nullptr);
+      auto user_data = SAFE_ACCESS(object->buffer_value, user_data, nullptr);
+
+      // The the user has provided a callback, let them manage the lifecycle of
+      // the underlying data. If not, copy it out from the provided buffer.
+
+      if (callback == nullptr) {
+        dart_object.type = Dart_CObject_kTypedData;
+        dart_object.value.as_typed_data.type = Dart_TypedData_kUint8;
+        dart_object.value.as_typed_data.length = buffer_size;
+        dart_object.value.as_typed_data.values = buffer;
+      } else {
+        struct ExternalTypedDataPeer {
+          void* user_data = nullptr;
+          VoidCallback trampoline = nullptr;
+        };
+        auto peer = new ExternalTypedDataPeer();
+        peer->user_data = user_data;
+        peer->trampoline = callback;
+        // This finalizer is set so that in case of failure of the
+        // Dart_PostCObject below, we collect the peer. The embedder is still
+        // responsible for collecting the buffer in case of non-kSuccess returns
+        // from this method. This finalizer must be released in case of kSuccess
+        // returns from this method.
+        typed_data_finalizer.SetClosure([peer]() {
+          // This is the tiny object we use as the peer to the Dart call so that
+          // we can attach the a trampoline to the embedder supplied callback.
+          // In case of error, we need to collect this object lest we introduce
+          // a tiny leak.
+          delete peer;
+        });
+        dart_object.type = Dart_CObject_kExternalTypedData;
+        dart_object.value.as_external_typed_data.type = Dart_TypedData_kUint8;
+        dart_object.value.as_external_typed_data.length = buffer_size;
+        dart_object.value.as_external_typed_data.data = buffer;
+        dart_object.value.as_external_typed_data.peer = peer;
+        dart_object.value.as_external_typed_data.callback =
+            +[](void* unused_isolate_callback_data,
+                Dart_WeakPersistentHandle unused_handle, void* peer) {
+              auto typed_peer = reinterpret_cast<ExternalTypedDataPeer*>(peer);
+              typed_peer->trampoline(typed_peer->user_data);
+              delete typed_peer;
+            };
+      }
+    } break;
+    default:
+      return LOG_EMBEDDER_ERROR(
+          kInvalidArguments,
+          "Invalid FlutterEngineDartObjectType type specified.");
+  }
+
+  if (!Dart_PostCObject(port, &dart_object)) {
+    return LOG_EMBEDDER_ERROR(kInternalInconsistency,
+                              "Could not post the object to the Dart VM.");
+  }
+
+  // On a successful call, the VM takes ownership of and is responsible for
+  // invoking the finalizer.
+  typed_data_finalizer.Release();
+  return kSuccess;
 }

--- a/shell/platform/embedder/fixtures/main.dart
+++ b/shell/platform/embedder/fixtures/main.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui';
+import 'dart:isolate';
+import 'dart:ffi';
 import 'dart:core';
 import 'dart:convert';
 
@@ -659,3 +661,14 @@ void scene_builder_with_clips() {
   };
   window.scheduleFrame();
 }
+
+
+void sendObjectToNativeCode(dynamic object) native 'SendObjectToNativeCode';
+
+@pragma('vm:entry-point')
+void objects_can_be_posted() {
+  ReceivePort port = ReceivePort();
+  port.listen((dynamic message){ sendObjectToNativeCode(message); });
+  signalNativeCount(port.sendPort.nativePort);
+}
+

--- a/testing/testing.cc
+++ b/testing/testing.cc
@@ -53,5 +53,50 @@ std::unique_ptr<fml::Mapping> OpenFixtureAsMapping(std::string fixture_name) {
   return fml::FileMapping::CreateReadOnly(OpenFixture(fixture_name));
 }
 
+bool MemsetPatternSetOrCheck(uint8_t* buffer, size_t size, MemsetPatternOp op) {
+  if (buffer == nullptr) {
+    return false;
+  }
+
+  auto pattern = reinterpret_cast<const uint8_t*>("dErP");
+  constexpr auto pattern_length = 4;
+
+  uint8_t* start = buffer;
+  uint8_t* p = buffer;
+
+  while ((start + size) - p >= pattern_length) {
+    switch (op) {
+      case MemsetPatternOp::kMemsetPatternOpSetBuffer:
+        memmove(p, pattern, pattern_length);
+        break;
+      case MemsetPatternOp::kMemsetPatternOpCheckBuffer:
+        if (memcmp(pattern, p, pattern_length) != 0) {
+          return false;
+        }
+        break;
+    };
+    p += pattern_length;
+  }
+
+  if ((start + size) - p != 0) {
+    switch (op) {
+      case MemsetPatternOp::kMemsetPatternOpSetBuffer:
+        memmove(p, pattern, (start + size) - p);
+        break;
+      case MemsetPatternOp::kMemsetPatternOpCheckBuffer:
+        if (memcmp(pattern, p, (start + size) - p) != 0) {
+          return false;
+        }
+        break;
+    }
+  }
+
+  return true;
+}
+
+bool MemsetPatternSetOrCheck(std::vector<uint8_t>& buffer, MemsetPatternOp op) {
+  return MemsetPatternSetOrCheck(buffer.data(), buffer.size(), op);
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/testing/testing.h
+++ b/testing/testing.h
@@ -6,6 +6,7 @@
 #define TESTING_TESTING_H_
 
 #include <string>
+#include <vector>
 
 #include "flutter/fml/file.h"
 #include "flutter/fml/mapping.h"
@@ -61,6 +62,28 @@ std::unique_ptr<fml::Mapping> OpenFixtureAsMapping(std::string fixture_name);
 /// @return     The current test name.
 ///
 std::string GetCurrentTestName();
+
+enum class MemsetPatternOp {
+  kMemsetPatternOpSetBuffer,
+  kMemsetPatternOpCheckBuffer,
+};
+
+//------------------------------------------------------------------------------
+/// @brief      Depending on the operation, either scribbles a known pattern
+///             into the buffer or checks if that pattern is present in an
+///             existing buffer. This is a portable variant of the
+///             memset_pattern class of methods that also happen to do assert
+///             that the same pattern exists.
+///
+/// @param      buffer  The buffer
+/// @param[in]  size    The size
+/// @param[in]  op      The operation
+///
+/// @return     If the result of the operation was a success.
+///
+bool MemsetPatternSetOrCheck(uint8_t* buffer, size_t size, MemsetPatternOp op);
+
+bool MemsetPatternSetOrCheck(std::vector<uint8_t>& buffer, MemsetPatternOp op);
 
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
This is a non-breaking addition to the stable Flutter Embedder API and exposes a
subset of the functionality provided by `Dart_PostCObject` API in a stable and
tested manner to custom embedder implementations.

Send port acquisition can currently be done as described in the unit-test but
there may be opportunities to extend this API in the future to access ports more
easily or create ports from the native side.

The following capabilities of the the `Dart_PostCObject` API are explicitly NOT
exposed:
* Object arrays: This allows callers to create complex object graphs but only
  using the primitives specified in the native API. I could find no current use
  case for this and would have made the implementation a lot more complex. This
  is something we can add in the future if necessary however.
* Capabilities and ports: Again no use cases and I honestly I didn’t understand
  how to use capabilities. If needed, these can be added at a later point by
  appending to the union.

Fixes https://github.com/flutter/flutter/issues/46624
Fixes b/145982720