### PR TITLE
Calling onConnectionClosed when the input element is blurred

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -857,6 +857,25 @@ class HybridTextEditing {
       _emptyCallback,
     );
   }
+
+  void sendTextConnectionClosedToFlutterIfAny() {
+    print('sendTextConnectionClosedToFlutter for client: $clientId');
+    if (isEditing) {
+      stopEditing();
+      ui.window.onPlatformMessage(
+        'flutter/textinput',
+        const JSONMethodCodec().encodeMethodCall(
+          MethodCall(
+            'TextInputClient.onConnectionClosed',
+            <dynamic>[
+              _clientId,
+            ],
+          ),
+        ),
+        _emptyCallback,
+      );
+    }
+  }
 }
 
 /// Information on the font and alignment of a text editing element.

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -623,8 +623,6 @@ void main() {
       // DOM element is blurred.
       textEditing.editingElement.domElement.blur();
 
-      await Future.delayed(const Duration(milliseconds: 100), (){});
-
       expect(spy.messages, hasLength(1));
       MethodCall call = spy.messages[0];
       spy.messages.clear();

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -598,6 +598,45 @@ void main() {
       expect(spy.messages, isEmpty);
     });
 
+    test('closeconnection on blur', () async {
+      final MethodCall setClient = MethodCall(
+          'TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);
+      textEditing.handleTextInput(codec.encodeMethodCall(setClient));
+
+      const MethodCall setEditingState =
+          MethodCall('TextInput.setEditingState', <String, dynamic>{
+        'text': 'abcd',
+        'selectionBase': 2,
+        'selectionExtent': 3,
+      });
+      textEditing.handleTextInput(codec.encodeMethodCall(setEditingState));
+
+      // Editing shouldn't have started yet.
+      expect(document.activeElement, document.body);
+
+      const MethodCall show = MethodCall('TextInput.show');
+      textEditing.handleTextInput(codec.encodeMethodCall(show));
+
+      checkInputEditingState(
+          textEditing.editingElement.domElement, 'abcd', 2, 3);
+
+      // DOM element is blurred.
+      textEditing.editingElement.domElement.blur();
+
+      await Future.delayed(const Duration(milliseconds: 100), (){});
+
+      expect(spy.messages, hasLength(1));
+      MethodCall call = spy.messages[0];
+      spy.messages.clear();
+      expect(call.method, 'TextInputClient.onConnectionClosed');
+      expect(
+        call.arguments,
+        <dynamic>[
+          123, // Client ID
+        ],
+      );
+    });
+
     test('setClient, setEditingState, show, setClient', () {
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -598,7 +598,7 @@ void main() {
       expect(spy.messages, isEmpty);
     });
 
-    test('closeconnection on blur', () async {
+    test('close connection on blur', () async {
       final MethodCall setClient = MethodCall(
           'TextInput.setClient', <dynamic>[123, flutterSinglelineConfig]);
       textEditing.handleTextInput(codec.encodeMethodCall(setClient));


### PR DESCRIPTION
Showing the usage of framework PR: flutter/flutter#43466

This is the same implementation in https://github.com/flutter/engine/pull/13344 Sent as a new PR since the class went through a major refactor.

Fixes flutter/flutter#43034

Tested manually for:

1. Chrome on Linux desktop
2. Chrome on Linux desktop a11y on with chromevox
3. Firefox on Linux desktop
4. Chrome on Android
5. Chrome on Android a11y on with talkback (**)
6. Safari on IOS
7. Safari on IOS a11y on with voiceover (**)
8. Safari on MacOS

(**): known issue since there is only one persistent mode now. The mobile browsers are also showing desktop optimized behavior. depending on the decision, will send a follow up PR which will also fix the known issue for wrong transform for input elements. 
