### PR TITLE
Introduce an auto-deletable SkiaObject; make SkPaint a SkiaObject

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/canvas.dart
+++ b/lib/web_ui/lib/src/engine/compositor/canvas.dart
@@ -63,7 +63,7 @@ class SkCanvas {
       startAngle * toDegrees,
       sweepAngle * toDegrees,
       useCenter,
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
@@ -80,7 +80,7 @@ class SkCanvas {
       skAtlas.skImage,
       rects,
       rstTransforms,
-      paint.makeSkPaint(),
+      paint.skiaObject,
       makeSkBlendMode(blendMode),
       colors,
     ]);
@@ -91,7 +91,7 @@ class SkCanvas {
       c.dx,
       c.dy,
       radius,
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
@@ -106,7 +106,7 @@ class SkCanvas {
     skCanvas.callMethod('drawDRRect', <js.JsObject>[
       makeSkRRect(outer),
       makeSkRRect(inner),
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
@@ -116,7 +116,7 @@ class SkCanvas {
       skImage.skImage,
       offset.dx,
       offset.dy,
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
@@ -126,7 +126,7 @@ class SkCanvas {
       skImage.skImage,
       makeSkRect(src),
       makeSkRect(dst),
-      paint.makeSkPaint(),
+      paint.skiaObject,
       false,
     ]);
   }
@@ -138,7 +138,7 @@ class SkCanvas {
       skImage.skImage,
       makeSkRect(center),
       makeSkRect(dst),
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
@@ -148,19 +148,19 @@ class SkCanvas {
       p1.dy,
       p2.dx,
       p2.dy,
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
   void drawOval(ui.Rect rect, SkPaint paint) {
     skCanvas.callMethod('drawOval', <js.JsObject>[
       makeSkRect(rect),
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
   void drawPaint(SkPaint paint) {
-    skCanvas.callMethod('drawPaint', <js.JsObject>[paint.makeSkPaint()]);
+    skCanvas.callMethod('drawPaint', <js.JsObject>[paint.skiaObject]);
   }
 
   void drawParagraph(ui.Paragraph paragraph, ui.Offset offset) {
@@ -173,7 +173,7 @@ class SkCanvas {
   }
 
   void drawPath(ui.Path path, SkPaint paint) {
-    final js.JsObject skPaint = paint.makeSkPaint();
+    final js.JsObject skPaint = paint.skiaObject;
     final SkPath enginePath = path;
     final js.JsObject skPath = enginePath._skPath;
     skCanvas.callMethod('drawPath', <js.JsObject>[skPath, skPaint]);
@@ -188,20 +188,20 @@ class SkCanvas {
     skCanvas.callMethod('drawPoints', <dynamic>[
       makeSkPointMode(pointMode),
       points,
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
   void drawRRect(ui.RRect rrect, SkPaint paint) {
     skCanvas.callMethod('drawRRect', <js.JsObject>[
       makeSkRRect(rrect),
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
   void drawRect(ui.Rect rect, SkPaint paint) {
     final js.JsObject skRect = makeSkRect(rect);
-    final js.JsObject skPaint = paint.makeSkPaint();
+    final js.JsObject skPaint = paint.skiaObject;
     skCanvas.callMethod('drawRect', <js.JsObject>[skRect, skPaint]);
   }
 
@@ -217,7 +217,7 @@ class SkCanvas {
     skCanvas.callMethod('drawVertices', <js.JsObject>[
       skVertices.skVertices,
       makeSkBlendMode(blendMode),
-      paint.makeSkPaint()
+      paint.skiaObject
     ]);
   }
 
@@ -241,12 +241,12 @@ class SkCanvas {
   void saveLayer(ui.Rect bounds, SkPaint paint) {
     skCanvas.callMethod('saveLayer', <js.JsObject>[
       makeSkRect(bounds),
-      paint.makeSkPaint(),
+      paint.skiaObject,
     ]);
   }
 
   void saveLayerWithoutBounds(SkPaint paint) {
-    skCanvas.callMethod('saveLayer', <js.JsObject>[null, paint.makeSkPaint()]);
+    skCanvas.callMethod('saveLayer', <js.JsObject>[null, paint.skiaObject]);
   }
 
   void saveLayerWithFilter(ui.Rect bounds, ui.ImageFilter filter) {

--- a/lib/web_ui/lib/src/engine/compositor/painting.dart
+++ b/lib/web_ui/lib/src/engine/compositor/painting.dart
@@ -5,16 +5,23 @@
 part of engine;
 
 /// The implementation of [ui.Paint] used by the CanvasKit backend.
-class SkPaint implements ui.Paint {
+class SkPaint extends SkiaObject implements ui.Paint {
   SkPaint();
 
   static const ui.Color _defaultPaintColor = ui.Color(0xFF000000);
+  static final js.JsObject _skPaintStyleStroke = canvasKit['PaintStyle']['Stroke'];
+  static final js.JsObject _skPaintStyleFill = canvasKit['PaintStyle']['Fill'];
 
   @override
   ui.BlendMode get blendMode => _blendMode;
   @override
   set blendMode(ui.BlendMode value) {
     _blendMode = value;
+    _syncBlendMode();
+  }
+  void _syncBlendMode() {
+    final js.JsObject skBlendMode = makeSkBlendMode(_blendMode);
+    skiaObject.callMethod('setBlendMode', <js.JsObject>[skBlendMode]);
   }
   ui.BlendMode _blendMode = ui.BlendMode.srcOver;
 
@@ -23,6 +30,19 @@ class SkPaint implements ui.Paint {
   @override
   set style(ui.PaintingStyle value) {
     _style = value;
+    _syncStyle();
+  }
+  void _syncStyle() {
+    js.JsObject skPaintStyle;
+    switch (_style) {
+      case ui.PaintingStyle.stroke:
+        skPaintStyle = _skPaintStyleStroke;
+        break;
+      case ui.PaintingStyle.fill:
+        skPaintStyle = _skPaintStyleFill;
+        break;
+    }
+    skiaObject.callMethod('setStyle', <js.JsObject>[skPaintStyle]);
   }
   ui.PaintingStyle _style = ui.PaintingStyle.fill;
 
@@ -31,10 +51,15 @@ class SkPaint implements ui.Paint {
   @override
   set strokeWidth(double value) {
     _strokeWidth = value;
+    _syncStrokeWidth();
+  }
+  void _syncStrokeWidth() {
+    skiaObject.callMethod('setStrokeWidth', <double>[strokeWidth]);
   }
   double _strokeWidth = 0.0;
 
   @override
+  // TODO(yjbanov): implement
   ui.StrokeCap get strokeCap => _strokeCap;
   @override
   set strokeCap(ui.StrokeCap value) {
@@ -43,6 +68,7 @@ class SkPaint implements ui.Paint {
   ui.StrokeCap _strokeCap = ui.StrokeCap.butt;
 
   @override
+  // TODO(yjbanov): implement
   ui.StrokeJoin get strokeJoin => _strokeJoin;
   @override
   set strokeJoin(ui.StrokeJoin value) {
@@ -55,6 +81,10 @@ class SkPaint implements ui.Paint {
   @override
   set isAntiAlias(bool value) {
     _isAntiAlias = value;
+    _syncAntiAlias();
+  }
+  _syncAntiAlias() {
+    skiaObject.callMethod('setAntiAlias', <bool>[_isAntiAlias]);
   }
   bool _isAntiAlias = true;
 
@@ -63,10 +93,16 @@ class SkPaint implements ui.Paint {
   @override
   set color(ui.Color value) {
     _color = value;
+    int colorValue;
+    if (_color != null) {
+      colorValue = _color.value;
+    }
+    skiaObject.callMethod('setColor', <int>[colorValue]);
   }
   ui.Color _color = _defaultPaintColor;
 
   @override
+  // TODO(yjbanov): implement
   bool get invertColors => _invertColors;
   @override
   set invertColors(bool value) {
@@ -79,87 +115,22 @@ class SkPaint implements ui.Paint {
   @override
   set shader(ui.Shader value) {
     _shader = value;
+    js.JsObject skShader;
+    if (_shader != null) {
+      skShader = _shader.createSkiaShader();
+    }
+    skiaObject.callMethod('setShader', <js.JsObject>[skShader]);
   }
-  ui.Shader _shader;
+  EngineGradient _shader;
 
   @override
   ui.MaskFilter get maskFilter => _maskFilter;
   @override
   set maskFilter(ui.MaskFilter value) {
     _maskFilter = value;
-  }
-  ui.MaskFilter _maskFilter;
-
-  @override
-  ui.FilterQuality get filterQuality => _filterQuality;
-  @override
-  set filterQuality(ui.FilterQuality value) {
-    _filterQuality = value;
-  }
-  ui.FilterQuality _filterQuality = ui.FilterQuality.none;
-
-  @override
-  ui.ColorFilter get colorFilter => _colorFilter;
-  @override
-  set colorFilter(ui.ColorFilter value) {
-    _colorFilter = value;
-  }
-  ui.ColorFilter _colorFilter;
-
-  @override
-  double get strokeMiterLimit => _strokeMiterLimit;
-  @override
-  set strokeMiterLimit(double value) {
-    _strokeMiterLimit = value;
-  }
-  double _strokeMiterLimit = 0.0;
-
-  @override
-  ui.ImageFilter get imageFilter => _imageFilter;
-  @override
-  set imageFilter(ui.ImageFilter value) {
-    _imageFilter = value;
-  }
-  ui.ImageFilter _imageFilter;
-
-  js.JsObject makeSkPaint() {
-    final js.JsObject skPaint = js.JsObject(canvasKit['SkPaint']);
-
-    if (shader != null) {
-      final EngineGradient engineShader = shader;
-      skPaint.callMethod(
-          'setShader', <js.JsObject>[engineShader.createSkiaShader()]);
-    }
-
-    if (color != null) {
-      skPaint.callMethod('setColor', <int>[color.value]);
-    }
-
-    js.JsObject skPaintStyle;
-    switch (style) {
-      case ui.PaintingStyle.stroke:
-        skPaintStyle = canvasKit['PaintStyle']['Stroke'];
-        break;
-      case ui.PaintingStyle.fill:
-        skPaintStyle = canvasKit['PaintStyle']['Fill'];
-        break;
-    }
-    skPaint.callMethod('setStyle', <js.JsObject>[skPaintStyle]);
-
-    js.JsObject skBlendMode = makeSkBlendMode(blendMode);
-    if (skBlendMode != null) {
-      skPaint.callMethod('setBlendMode', <js.JsObject>[skBlendMode]);
-    }
-
-    skPaint.callMethod('setAntiAlias', <bool>[isAntiAlias]);
-
-    if (strokeWidth > 0.0) {
-      skPaint.callMethod('setStrokeWidth', <double>[strokeWidth]);
-    }
-
-    if (maskFilter != null) {
-      final ui.BlurStyle blurStyle = maskFilter.webOnlyBlurStyle;
-      final double sigma = maskFilter.webOnlySigma;
+    if (_maskFilter != null) {
+      final ui.BlurStyle blurStyle = _maskFilter.webOnlyBlurStyle;
+      final double sigma = _maskFilter.webOnlySigma;
 
       js.JsObject skBlurStyle;
       switch (blurStyle) {
@@ -179,21 +150,68 @@ class SkPaint implements ui.Paint {
 
       final js.JsObject skMaskFilter = canvasKit
           .callMethod('MakeBlurMaskFilter', <dynamic>[skBlurStyle, sigma, true]);
-      skPaint.callMethod('setMaskFilter', <js.JsObject>[skMaskFilter]);
+      skiaObject.callMethod('setMaskFilter', <js.JsObject>[skMaskFilter]);
+    } else {
+      skiaObject.callMethod('setMaskFilter', <js.JsObject>[null]);
     }
+  }
+  ui.MaskFilter _maskFilter;
 
-    if (imageFilter != null) {
-      final SkImageFilter skImageFilter = imageFilter;
-      skPaint.callMethod(
-          'setImageFilter', <js.JsObject>[skImageFilter.skImageFilter]);
-    }
+  @override
+  // TODO(yjbanov): implement
+  ui.FilterQuality get filterQuality => _filterQuality;
+  @override
+  set filterQuality(ui.FilterQuality value) {
+    _filterQuality = value;
+  }
+  ui.FilterQuality _filterQuality = ui.FilterQuality.none;
 
+  @override
+  ui.ColorFilter get colorFilter => _colorFilter;
+  @override
+  set colorFilter(ui.ColorFilter value) {
+    _colorFilter = value;
     if (colorFilter != null) {
       EngineColorFilter engineFilter = colorFilter;
       SkColorFilter skFilter = engineFilter._toSkColorFilter();
-      skPaint.callMethod('setColorFilter', <js.JsObject>[skFilter.skColorFilter]);
+      skiaObject.callMethod('setColorFilter', <js.JsObject>[skFilter.skColorFilter]);
     }
+  }
+  ui.ColorFilter _colorFilter;
 
-    return skPaint;
+  @override
+  // TODO(yjbanov): implement
+  double get strokeMiterLimit => _strokeMiterLimit;
+  @override
+  set strokeMiterLimit(double value) {
+    _strokeMiterLimit = value;
+  }
+  double _strokeMiterLimit = 0.0;
+
+  @override
+  ui.ImageFilter get imageFilter => _imageFilter;
+  @override
+  set imageFilter(ui.ImageFilter value) {
+    _imageFilter = value;
+    if (imageFilter != null) {
+      final SkImageFilter skImageFilter = imageFilter;
+      skiaObject.callMethod(
+          'setImageFilter', <js.JsObject>[skImageFilter.skImageFilter]);
+    }
+  }
+  ui.ImageFilter _imageFilter;
+
+  @override
+  js.JsObject createDefault() {
+    final obj = js.JsObject(canvasKit['SkPaint']);
+    _syncAntiAlias();
+    return obj;
+  }
+
+  @override
+  js.JsObject resurrect() {
+    final obj = js.JsObject(canvasKit['SkPaint']);
+    _syncAntiAlias();
+    return obj;
   }
 }

--- a/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
+++ b/lib/web_ui/lib/src/engine/compositor/rasterizer.dart
@@ -9,6 +9,7 @@ class Rasterizer {
   final Surface surface;
   final CompositorContext context = CompositorContext();
   final HtmlViewEmbedder viewEmbedder = HtmlViewEmbedder();
+  final List<ui.VoidCallback> _postFrameCallbacks = <ui.VoidCallback>[];
 
   Rasterizer(this.surface) {
     surface.viewEmbedder = viewEmbedder;
@@ -17,29 +18,44 @@ class Rasterizer {
   /// Creates a new frame from this rasterizer's surface, draws the given
   /// [LayerTree] into it, and then submits the frame.
   void draw(LayerTree layerTree) {
-    if (layerTree == null) {
-      return;
+    try {
+      if (layerTree == null) {
+        return;
+      }
+
+      final ui.Size physicalSize = ui.window.physicalSize;
+      final ui.Size frameSize = ui.Size(
+        physicalSize.width.truncate().toDouble(),
+        physicalSize.height.truncate().toDouble(),
+      );
+
+      if (frameSize.isEmpty) {
+        return;
+      }
+      layerTree.frameSize = frameSize;
+
+      final SurfaceFrame frame = surface.acquireFrame(layerTree.frameSize);
+      surface.viewEmbedder.frameSize = layerTree.frameSize;
+      final SkCanvas canvas = frame.skiaCanvas;
+      final Frame compositorFrame = context.acquireFrame(canvas, surface.viewEmbedder);
+
+      compositorFrame.raster(layerTree, ignoreRasterCache: true);
+      surface.addToScene();
+      frame.submit();
+      surface.viewEmbedder.submitFrame();
+    } finally {
+      _runPostFrameCallbacks();
     }
+  }
 
-    final ui.Size physicalSize = ui.window.physicalSize;
-    final ui.Size frameSize = ui.Size(
-      physicalSize.width.truncate().toDouble(),
-      physicalSize.height.truncate().toDouble(),
-    );
+  void addPostFrameCallback(ui.VoidCallback callback) {
+    _postFrameCallbacks.add(callback);
+  }
 
-    if (frameSize.isEmpty) {
-      return;
+  void _runPostFrameCallbacks() {
+    for (int i = 0; i < _postFrameCallbacks.length; i++) {
+      final ui.VoidCallback callback = _postFrameCallbacks[i];
+      callback();
     }
-    layerTree.frameSize = frameSize;
-
-    final SurfaceFrame frame = surface.acquireFrame(layerTree.frameSize);
-    surface.viewEmbedder.frameSize = layerTree.frameSize;
-    final SkCanvas canvas = frame.skiaCanvas;
-    final Frame compositorFrame = context.acquireFrame(canvas, surface.viewEmbedder);
-
-    compositorFrame.raster(layerTree, ignoreRasterCache: true);
-    surface.addToScene();
-    frame.submit();
-    surface.viewEmbedder.submitFrame();
   }
 }

--- a/lib/web_ui/lib/src/engine/compositor/text.dart
+++ b/lib/web_ui/lib/src/engine/compositor/text.dart
@@ -172,7 +172,7 @@ class SkTextStyle implements ui.TextStyle {
     final Map<String, dynamic> style = <String, dynamic>{};
 
     if (background != null) {
-      style['backgroundColor'] = background.makeSkPaint();
+      style['backgroundColor'] = background.skiaObject;
     }
 
     if (color != null) {
@@ -221,7 +221,7 @@ class SkTextStyle implements ui.TextStyle {
     }
 
     if (foreground != null) {
-      style['foreground'] = foreground.makeSkPaint();
+      style['foreground'] = foreground.skiaObject;
     }
 
     // TODO(hterkelsen): Add support for

--- a/lib/web_ui/lib/src/engine/compositor/util.dart
+++ b/lib/web_ui/lib/src/engine/compositor/util.dart
@@ -4,14 +4,41 @@
 
 part of engine;
 
-/// An object backed by a [js.JsObject] mapped onto a Skia C++ object in the WebAssembly heap.
+/// An object backed by a [js.JsObject] mapped onto a Skia C++ object in the
+/// WebAssembly heap.
 ///
 /// These objects are automatically deleted when no longer used.
+///
+/// Because there is no feedback from JavaScript's GC (no destructors or
+/// finalizers), we pessimistically delete the underlying C++ object before
+/// the Dart object is garbage-collected. The current algorithm deletes objects
+/// at the end of every frame. This allows reusing the C++ objects within the
+/// frame. In the future we may add smarter strategies that will allow us to
+/// reuse C++ objects across frames.
+///
+/// The lifecycle of a C++ object is as follows:
+///
+/// - Create default: when instantiating a C++ object for a Dart object for the
+///   first time, the C++ object is populated with default data (the defaults are
+///   defined by Flutter; Skia defaults are corrected if necessary). The
+///   default object is created by [createDefault].
+/// - Zero or more cycles of delete + resurrect: when a Dart object is reused
+///   after its C++ object is deleted we create a new C++ object populated with
+///   data from the current state of the Dart object. This is done using the
+///   [resurrect] method.
+/// - Final delete: if a Dart object is never reused, it is GC'd after its
+///   underlying C++ object is deleted. This is implemented by [SkiaObjects].
 abstract class SkiaObject {
+  SkiaObject() {
+    _skiaObject = createDefault();
+    SkiaObjects.manage(this);
+  }
+
   /// The JavaScript object that's mapped onto a Skia C++ object in the WebAssembly heap.
   js.JsObject get skiaObject {
     if (_skiaObject == null) {
-      _skiaObject = createDefault();
+      _skiaObject = resurrect();
+      SkiaObjects.manage(this);
     }
     return _skiaObject;
   }
@@ -19,35 +46,52 @@ abstract class SkiaObject {
   /// Do not use this field outside this class. Use [skiaObject] instead.
   js.JsObject _skiaObject;
 
-  /// Override this method to instantiate a new Skia-backed JavaScript object.
+  /// Instantiates a new Skia-backed JavaScript object containing default
+  /// values.
   ///
   /// The object is expected to represent Flutter's defaults. If Skia uses
   /// different defaults from those used by Flutter, this method is expected
   /// initialize the object to Flutter's defaults.
   js.JsObject createDefault();
 
+  /// Creates a new Skia-backed JavaScript object containing data representing
+  /// the current state of the Dart object.
   js.JsObject resurrect();
 }
 
+/// Singleton that manages the lifecycles of [SkiaObject] instances.
 class SkiaObjects {
-  static final List<SkiaObject> _objects = () {
-    window._rasterizer.addPostFrameCallback(_postFrameCleanUp);
+  // TODO(yjbanov): some sort of LRU strategy would allow us to reuse objects
+  //                beyond a single frame.
+  @visibleForTesting
+  static final List<SkiaObject> managedObjects = () {
+    window.rasterizer.addPostFrameCallback(postFrameCleanUp);
     return <SkiaObject>[];
   }();
 
-  static void _postFrameCleanUp() {
-    print('>>> Will clean up ${_objects.length} Skia objects.');
-    if (_objects.isEmpty) {
+  /// Starts managing the lifecycle of [object].
+  ///
+  /// The object's underlying WASM object is deleted by calling the
+  /// "delete" method when it goes out of scope.
+  ///
+  /// The current implementation deletes objects at the end of every frame.
+  static void manage(SkiaObject object) {
+    managedObjects.add(object);
+  }
+
+  /// Deletes all C++ objects created this frame.
+  static void postFrameCleanUp() {
+    if (managedObjects.isEmpty) {
       return;
     }
 
-    for (int i = 0; i < _objects.length; i++) {
-      final SkiaObject object = _objects[i];
+    for (int i = 0; i < managedObjects.length; i++) {
+      final SkiaObject object = managedObjects[i];
       object._skiaObject.callMethod('delete');
       object._skiaObject = null;
     }
 
-    _objects.clear();
+    managedObjects.clear();
   }
 }
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -160,7 +160,7 @@ class EngineWindow extends ui.Window {
 
       case 'flutter/platform_views':
         if (experimentalUseSkia) {
-          _rasterizer.viewEmbedder.handlePlatformViewCall(data, callback);
+          rasterizer.viewEmbedder.handlePlatformViewCall(data, callback);
         } else {
           handlePlatformViewCall(data, callback);
         }
@@ -279,15 +279,15 @@ class EngineWindow extends ui.Window {
   void render(ui.Scene scene) {
     if (experimentalUseSkia) {
       final LayerScene layerScene = scene;
-      _rasterizer.draw(layerScene.layerTree);
+      rasterizer.draw(layerScene.layerTree);
     } else {
       final SurfaceScene surfaceScene = scene;
       domRenderer.renderScene(surfaceScene.webOnlyRootElement);
     }
   }
 
-  final Rasterizer _rasterizer =
-      experimentalUseSkia ? Rasterizer(Surface()) : null;
+  @visibleForTesting
+  Rasterizer rasterizer = experimentalUseSkia ? Rasterizer(Surface()) : null;
 }
 
 /// The window singleton.

--- a/lib/web_ui/test/engine/compositor/util_test.dart
+++ b/lib/web_ui/test/engine/compositor/util_test.dart
@@ -1,0 +1,93 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'package:ui/src/engine.dart';
+
+void main() {
+  group(SkiaObject, () {
+    test('implements create, cache, delete, resurrect, delete lifecycle', () {
+      int addPostFrameCallbackCount = 0;
+
+      MockRasterizer mockRasterizer = MockRasterizer();
+      when(mockRasterizer.addPostFrameCallback(any)).thenAnswer((_) {
+        addPostFrameCallbackCount++;
+      });
+      window.rasterizer = mockRasterizer;
+
+      // Trigger first create
+      final TestSkiaObject testObject = TestSkiaObject();
+      expect(SkiaObjects.managedObjects.single, testObject);
+      expect(testObject.createDefaultCount, 1);
+      expect(testObject.resurrectCount, 0);
+      expect(testObject.deleteCount, 0);
+
+      // Check that the getter does not have side-effects
+      final JsObject skiaObject1 = testObject.skiaObject;
+      expect(skiaObject1, isNotNull);
+      expect(SkiaObjects.managedObjects.single, testObject);
+      expect(testObject.createDefaultCount, 1);
+      expect(testObject.resurrectCount, 0);
+      expect(testObject.deleteCount, 0);
+
+      // Trigger first delete
+      SkiaObjects.postFrameCleanUp();
+      expect(SkiaObjects.managedObjects, isEmpty);
+      expect(addPostFrameCallbackCount, 1);
+      expect(testObject.createDefaultCount, 1);
+      expect(testObject.resurrectCount, 0);
+      expect(testObject.deleteCount, 1);
+
+      // Trigger resurrect
+      final JsObject skiaObject2 = testObject.skiaObject;
+      expect(skiaObject2, isNotNull);
+      expect(skiaObject2, isNot(same(skiaObject1)));
+      expect(SkiaObjects.managedObjects.single, testObject);
+      expect(addPostFrameCallbackCount, 1);
+      expect(testObject.createDefaultCount, 1);
+      expect(testObject.resurrectCount, 1);
+      expect(testObject.deleteCount, 1);
+
+      // Trigger final delete
+      SkiaObjects.postFrameCleanUp();
+      expect(SkiaObjects.managedObjects, isEmpty);
+      expect(addPostFrameCallbackCount, 1);
+      expect(testObject.createDefaultCount, 1);
+      expect(testObject.resurrectCount, 1);
+      expect(testObject.deleteCount, 2);
+    });
+  });
+}
+
+class TestSkiaObject extends SkiaObject {
+  int createDefaultCount = 0;
+  int resurrectCount = 0;
+  int deleteCount = 0;
+
+  JsObject _makeJsObject() {
+    return JsObject.jsify({
+      'delete': allowInterop(() {
+        deleteCount++;
+      }),
+    });
+  }
+
+  @override
+  JsObject createDefault() {
+    createDefaultCount++;
+    return _makeJsObject();
+  }
+
+  @override
+  JsObject resurrect() {
+    resurrectCount++;
+    return _makeJsObject();
+  }
+}
+
+class MockRasterizer extends Mock implements Rasterizer {}


### PR DESCRIPTION
* Introduce `SkiaObject` an object that's backed by Skia C++ objects that need to be explicitly deleted.
* Automatically delete `SkiaObject`s at the end of frame.
* Make `SkPaint` a `SkiaObject`.

Because `SkiaObject`s are deleted at the end of the frame, the object can be reused as many times as necessary within the frame. `SkPaint` in particular is a fairly expensive object. Reusing this object, for example, on `drawRRect` drops the canvas paint time by 30%.