### PR TITLE
Fix DOM-based ParagraphRuler.hitTest()

### DIFF
--- a/lib/web_ui/lib/src/engine/text/ruler.dart
+++ b/lib/web_ui/lib/src/engine/text/ruler.dart
@@ -629,30 +629,45 @@ class ParagraphRuler {
       final double dx = offset.dx;
       final double dy = offset.dy;
       if (dx >= bounds.left &&
-          dy < bounds.right &&
+          dx < bounds.right &&
           dy >= bounds.top &&
           dy < bounds.bottom) {
         // We found the element bounds that contains offset.
         // Calculate text position for this node.
-        int textPosition = 0;
-        for (int nodeIndex = 0; nodeIndex < i; nodeIndex++) {
-          textPosition += textNodes[nodeIndex].text.length;
-        }
-        return textPosition;
+        return _countTextPosition(el.childNodes, textNodes[i]);
       }
     }
     return 0;
   }
 
   void _collectTextNodes(Iterable<html.Node> nodes, List<html.Node> textNodes) {
+    if (nodes.isEmpty) {
+      return;
+    }
+    final List<html.Node> childNodes = [];
     for (html.Node node in nodes) {
       if (node.nodeType == html.Node.TEXT_NODE) {
         textNodes.add(node);
       }
-      if (node.hasChildNodes()) {
-        _collectTextNodes(node.childNodes, textNodes);
+      childNodes.addAll(node.childNodes);
+    }
+    _collectTextNodes(childNodes, textNodes);
+  }
+
+  int _countTextPosition(List<html.Node> nodes, html.Node endNode) {
+    int position = 0;
+    final List<html.Node> stack = nodes.reversed.toList();
+    while (true) {
+      var node = stack.removeLast();
+      stack.addAll(node.childNodes.reversed);
+      if (node == endNode) {
+        break;
+      }
+      if (node.nodeType == html.Node.TEXT_NODE) {
+        position += node.text.length;
       }
     }
+    return position;
   }
 
   /// Performs clean-up after a measurement is done, preparing this ruler for

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -238,7 +238,7 @@ void main() async {
 
     /* Logical arrangement: Tree
 
-    Root TextSpan: 0 
+    Root TextSpan: 0
     */
     builder.pushStyle(style);
     {
@@ -291,10 +291,10 @@ void main() async {
 
     /* Display arrangement: Visible texts
 
-    Because `const fontSize = 20.0`, the width of each character is 20 and the 
-    height is 20. `Display arrangement` squashes `Logical arrangement` to the 
+    Because `const fontSize = 20.0`, the width of each character is 20 and the
+    height is 20. `Display arrangement` squashes `Logical arrangement` to the
     (x, y) plane. That means `Display arrangement` only shows the visible texts.
-    The order of texts is text00 --> text010 --> text02 --> text030 --> text04 
+    The order of texts is text00 --> text010 --> text02 --> text030 --> text04
     --> text050.
 
     The output is like that.

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -228,13 +228,12 @@ void main() async {
       fontSize: fontSize,
     ));
 
-    const text00 =
-        'test test test test test test test test test test test te00';
-    const text010 = ' test010 ';
-    const text02 = 'test test test test test test test test test test te02';
-    const text030 = ' test030 ';
-    const text04 = 'test test test test test test test test test test te04';
-    const text050 = ' test050 ';
+    const text00 = 'test test test test test te00 ';
+    const text010 = 'test010 ';
+    const text02 = 'test test test test te02 ';
+    const text030 = 'test030 ';
+    const text04 = 'test test test test test test test test test test te04 ';
+    const text050 = 'test050 ';
 
     /* Logical arrangement: Tree
 
@@ -299,20 +298,20 @@ void main() async {
 
     The output is like that.
 
-     |- 180 -| End of test030
-     |------ 380 ------| Begin of test010
-     |-------- 480 ---------| Begin of test050
-     |--------- 560 -----------| End of test010
-     |------------ 660 -------------| End of test050
+     |------------ 600 ------------| Begin of test010
+     |--------------- 760 ----------------| End of test010
+     |---------- 500 ---------| Begin of test030
+     |------------- 660 -------------| End of test030
+     |-- 180 --| Begin of test050
+     |------ 360 -----| End of test050
+    'test test test test test te00 test010 '
+    'test test test test te02 test030 test '
     'test test test test test test test test '
-    'test test test te00 test010 test test tes'
-    't test test test test test test test te02'
-    ' test030 test test test test test test '
-    'test test test test te04 test050 '
+    'test te04 test050 '
     */
 
-    final EngineParagraph paragraph = builder.build();
-    paragraph.layout(ParagraphConstraints(width: 840));
+    final Paragraph paragraph = builder.build();
+    paragraph.layout(ParagraphConstraints(width: 800));
 
     // Reference the offsets with the output of `Display arrangement`.
     const offset010 = text00.length;
@@ -320,22 +319,22 @@ void main() async {
     const offset04 = offset030 + text030.length;
     const offset050 = offset04 + text04.length;
     // Tap text010.
-    expect(paragraph.getPositionForOffset(Offset(400, 30)).offset, offset010);
+    expect(paragraph.getPositionForOffset(Offset(700, 10)).offset, offset010);
     // Tap text030
-    expect(paragraph.getPositionForOffset(Offset(100, 70)).offset, offset030);
+    expect(paragraph.getPositionForOffset(Offset(600, 30)).offset, offset030);
     // Tap text050
-    expect(paragraph.getPositionForOffset(Offset(500, 90)).offset, offset050);
+    expect(paragraph.getPositionForOffset(Offset(220, 70)).offset, offset050);
     // Tap the left neighbor of text050
-    expect(paragraph.getPositionForOffset(Offset(479, 90)).offset, offset04);
+    expect(paragraph.getPositionForOffset(Offset(199, 70)).offset, offset04);
     // Tap the right neighbor of text050. No matter who the right neighbor of
     // text0505 is, it must not be text050 itself.
-    expect(paragraph.getPositionForOffset(Offset(660, 90)).offset,
+    expect(paragraph.getPositionForOffset(Offset(360, 70)).offset,
         isNot(offset050));
     // Tap the neighbor above text050
-    expect(paragraph.getPositionForOffset(Offset(480, 79)).offset, offset04);
+    expect(paragraph.getPositionForOffset(Offset(220, 59)).offset, offset04);
     // Tap the neighbor below text050. No matter who the neighbor above text050,
     // it must not be text050 itself.
-    expect(paragraph.getPositionForOffset(Offset(480, 100)).offset,
+    expect(paragraph.getPositionForOffset(Offset(220, 80)).offset,
         isNot(offset050));
   });
 

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -299,16 +299,16 @@ void main() async {
 
     The output is like that.
 
-    |- 180 -| End of test030
-    |------ 380 ------| Begin of test010
-    |-------- 480 ---------| Begin of test050
-    |--------- 560 -----------| End of test010
-    |------------ 660 -------------| End of test050
-    test test test test test test test test 
-    test test test te00 test010 test test tes
-    t test test test test test test test te02
-     test030 test test test test test test 
-    test test test test te04 test050 
+     |- 180 -| End of test030
+     |------ 380 ------| Begin of test010
+     |-------- 480 ---------| Begin of test050
+     |--------- 560 -----------| End of test010
+     |------------ 660 -------------| End of test050
+    'test test test test test test test test '
+    'test test test te00 test010 test test tes'
+    't test test test test test test test te02'
+    ' test030 test test test test test test '
+    'test test test test te04 test050 '
     */
 
     final EngineParagraph paragraph = builder.build();

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -219,6 +219,126 @@ void main() async {
         thirdSpanStartPosition);
   });
 
+  test('hit test on the nested text span and returns correct span offset', () {
+    const fontFamily = 'sans-serif';
+    const fontSize = 20.0;
+    final style = TextStyle(fontFamily: fontFamily, fontSize: fontSize);
+    final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
+      fontFamily: fontFamily,
+      fontSize: fontSize,
+    ));
+
+    const text00 =
+        'test test test test test test test test test test test te00';
+    const text010 = ' test010 ';
+    const text02 = 'test test test test test test test test test test te02';
+    const text030 = ' test030 ';
+    const text04 = 'test test test test test test test test test test te04';
+    const text050 = ' test050 ';
+
+    /* Logical arrangement: Tree
+
+    Root TextSpan: 0 
+    */
+    builder.pushStyle(style);
+    {
+      // 1st child TextSpan of Root: 0.0
+      builder.pushStyle(style);
+      builder.addText(text00);
+      builder.pop();
+
+      // 2nd child TextSpan of Root: 0.1
+      builder.pushStyle(style);
+      {
+        // 1st child TextSpan of 0.1: 0.1.0
+        builder.pushStyle(style);
+        builder.addText(text010);
+        builder.pop();
+      }
+      builder.pop();
+
+      // 3rd child TextSpan of Root: 0.2
+      builder.pushStyle(style);
+      builder.addText(text02);
+      builder.pop();
+
+      // 4th child TextSpan of Root: 0.3
+      builder.pushStyle(style);
+      {
+        // 1st child TextSpan of 0.3: 0.3.0
+        builder.pushStyle(style);
+        builder.addText(text030);
+        builder.pop();
+      }
+      builder.pop();
+
+      // 5th child TextSpan of Root: 0.4
+      builder.pushStyle(style);
+      builder.addText(text04);
+      builder.pop();
+
+      // 6th child TextSpan of Root: 0.5
+      builder.pushStyle(style);
+      {
+        // 1st child TextSpan of 0.5: 0.5.0
+        builder.pushStyle(style);
+        builder.addText(text050);
+        builder.pop();
+      }
+      builder.pop();
+    }
+    builder.pop();
+
+    /* Display arrangement: Visible texts
+
+    Because `const fontSize = 20.0`, the width of each character is 20 and the 
+    height is 20. `Display arrangement` squashes `Logical arrangement` to the 
+    (x, y) plane. That means `Display arrangement` only shows the visible texts.
+    The order of texts is text00 --> text010 --> text02 --> text030 --> text04 
+    --> text050.
+
+    The output is like that.
+
+    |- 180 -| End of test030
+    |------ 380 ------| Begin of test010
+    |-------- 480 ---------| Begin of test050
+    |--------- 560 -----------| End of test010
+    |------------ 660 -------------| End of test050
+    test test test test test test test test 
+    test test test te00 test010 test test tes
+    t test test test test test test test te02
+     test030 test test test test test test 
+    test test test test te04 test050 
+    */
+
+    final EngineParagraph paragraph = builder.build();
+    paragraph.layout(ParagraphConstraints(width: 840));
+
+    // Reference the offsets with the output of `Display arrangement`.
+    const offset010 = text00.length;
+    const offset030 = offset010 + text010.length + text02.length;
+    const offset04 = offset030 + text030.length;
+    const offset050 = offset04 + text04.length;
+    // Tap text010.
+    expect(paragraph.getPositionForOffset(Offset(400, 30)).offset, offset010);
+    // Tap text030
+    expect(paragraph.getPositionForOffset(Offset(100, 70)).offset, offset030);
+    // Tap text050
+    expect(paragraph.getPositionForOffset(Offset(500, 90)).offset, offset050);
+    // Tap the left neighbor of text050
+    expect(paragraph.getPositionForOffset(Offset(479, 90)).offset, offset04);
+    // Tap the right neighbor of text050. No matter who the right neighbor of
+    // text0505 is, it must not be text050 itself.
+    expect(paragraph.getPositionForOffset(Offset(660, 90)).offset,
+        isNot(offset050));
+    // Tap the neighbor above text050
+    expect(paragraph.getPositionForOffset(Offset(480, 79)).offset, offset04);
+    // Tap the neighbor below text050. No matter who the neighbor above text050,
+    // it must not be text050 itself.
+    expect(paragraph.getPositionForOffset(Offset(480, 100)).offset,
+        isNot(offset050));
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/38972
   test(
       'should not set fontFamily to effectiveFontFamily for spans in rich text',


### PR DESCRIPTION
## Description
If you tap the **nested** `TextSpan`, it doesn't received the tap event by `TapGestureRecognizer`. That's because `DOM-based` implementation of `ParagraphRuler.hitTest()` doesn't pick the **inner-most** `TextSpan` up. I fixed it by arranging the search path with breadth-first traversal. There are more explanations in the comments of test-case.

## Issues
Fixed: flutter/flutter#46975
Related: flutter/flutter#33523

## Tests
I added a test-case for general implementation and that covers both cases of `DOM-based` and `Canvas-based` implementation.