### PR TITLE
Force the a11y focused node for a screen change notification on iOS.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -229,7 +229,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   // the NamesRoute flag with a non-nil semantic label. Otherwise
   // returns nil.
   if ([self node].HasFlag(flutter::SemanticsFlags::kNamesRoute)) {
-    NSString *label = [self accessibilityLabel];
+    NSString* label = [self accessibilityLabel];
     if (label != nil && [label length] > 0) {
       return self;
     }
@@ -734,7 +734,8 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
 
   layoutChanged = layoutChanged || [doomed_uids count] > 0;
   if (routeChanged) {
-    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, [lastAdded routeFocusObject]);
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification,
+                                    [lastAdded routeFocusObject]);
   } else if (layoutChanged) {
     // TODO(goderbauer): figure out which node to focus next.
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -224,20 +224,21 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   return YES;
 }
 
-- (NSString*)routeName {
-  // Returns the first non-null and non-empty semantic label of a child
-  // with an NamesRoute flag. Otherwise returns nil.
+- (id)routeFocusObject {
+  // Returns the first SemanticObject in this branch that has
+  // the NamesRoute flag with a non-nil semantic label. Otherwise
+  // returns nil.
   if ([self node].HasFlag(flutter::SemanticsFlags::kNamesRoute)) {
-    NSString* newName = [self accessibilityLabel];
-    if (newName != nil && [newName length] > 0) {
-      return newName;
+    NSString *label = [self accessibilityLabel];
+    if (label != nil && [label length] > 0) {
+      return self;
     }
   }
   if ([self hasChildren]) {
     for (SemanticsObject* child in self.children) {
-      NSString* newName = [child routeName];
-      if (newName != nil && [newName length] > 0) {
-        return newName;
+      SemanticsObject* labelObject = [child routeFocusObject];
+      if (labelObject != nil) {
+        return labelObject;
       }
     }
   }
@@ -733,8 +734,7 @@ void AccessibilityBridge::UpdateSemantics(flutter::SemanticsNodeUpdates nodes,
 
   layoutChanged = layoutChanged || [doomed_uids count] > 0;
   if (routeChanged) {
-    NSString* routeName = [lastAdded routeName];
-    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, routeName);
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, [lastAdded routeFocusObject]);
   } else if (layoutChanged) {
     // TODO(goderbauer): figure out which node to focus next.
     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil);


### PR DESCRIPTION
Currently on iOS, when a screen change has occurred (a route change), we pass the most recent route scope's label as the parameter to the `UIAccessibilityScreenChangedNotification`.  VoiceOver then picks a new node to move its a11y focus to. The way it does this is seems pretty random, depending on the structure of the SemanticObjects we present it, and doesn't give us a lot of control. However, the parameter to `UIAccessibilityScreenChangedNotification` can also be the `SemanticObject` that we want to have focus after the change.

This PR makes use of this and passes the new route's label node as the focus for the screen change.  This fixes a couple of issues: https://github.com/flutter/flutter/issues/46625, and https://github.com/flutter/flutter/issues/44001. 

This seems like a good fix to me, but I am not that familiar with how our semantic tree deals with scopes. Can anyone see any issue with using the label node for focus instead of just announcing the label and letting VoiceOver pick the focus for us?
 