### PR TITLE
Fix FontLoader does not remove the cache in web engine

### DIFF
--- a/lib/web_ui/lib/src/engine/text/font_collection.dart
+++ b/lib/web_ui/lib/src/engine/text/font_collection.dart
@@ -200,6 +200,10 @@ class FontManager {
     final html.FontFace fontFace = html.FontFace(family, list);
     return fontFace.load().then((_) {
       html.document.fonts.add(fontFace);
+      // There might be paragraph measurements for this new font before it is
+      // loaded. They were measured using fallback font, so we should clear the
+      // cache.
+      TextMeasurementService.clearCache();
     }, onError: (dynamic exception) {
       // Failures here will throw an html.DomException which confusingly
       // does not implement Exception or Error. Rethrow an Exception so it can

--- a/lib/web_ui/lib/src/engine/text/measurement.dart
+++ b/lib/web_ui/lib/src/engine/text/measurement.dart
@@ -168,7 +168,8 @@ abstract class TextMeasurementService {
   /// Initializes the text measurement service with a specific
   /// [rulerCacheCapacity] that gets passed to the [RulerManager].
   static void initialize({@required int rulerCacheCapacity}) {
-    clearCache();
+    rulerManager?.dispose();
+    rulerManager = null;
     rulerManager = RulerManager(rulerCacheCapacity: rulerCacheCapacity);
   }
 
@@ -211,11 +212,10 @@ abstract class TextMeasurementService {
     return domInstance;
   }
 
-  /// Clears the cache of paragraph rulers.
-  @visibleForTesting
+  /// Clears the cache of paragraph rulers that are used for measuring paragraph
+  /// metrics.
   static void clearCache() {
-    rulerManager?.dispose();
-    rulerManager = null;
+    rulerManager?._evictAllRulers();
   }
 
   static bool _canUseCanvasMeasurement(EngineParagraph paragraph) {


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/47236
This pr makes sure loadFontFromList in web engine clears the rulerManager's cache