### PR TITLE
Update formatting in web_ui scene bulder to match flutter style.

### DIFF
--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -680,12 +680,13 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
 
   /// (Fuchsia-only) Adds a scene rendered by another application to the scene
   /// for this application.
-  void addChildScene(
-      {Offset offset = Offset.zero,
-      double width = 0.0,
-      double height = 0.0,
-      SceneHost sceneHost,
-      bool hitTestable = true}) {
+  void addChildScene({
+    Offset offset = Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    SceneHost sceneHost,
+    bool hitTestable = true,
+  }) {
     _addChildScene(offset.dx, offset.dy, width, height, sceneHost, hitTestable);
   }
 

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -19,15 +19,11 @@ class Scene extends NativeFieldWrapperClass2 {
   @pragma('vm:entry-point')
   Scene._();
 
-
   /// Creates a raster image representation of the current state of the scene.
   /// This is a slow operation that is performed on a background thread.
   Future<Image> toImage(int width, int height) {
-    if (width <= 0 || height <= 0)
-      throw Exception('Invalid image dimensions.');
-    return _futurize(
-      (_Callback<Image> callback) => _toImage(width, height, callback)
-    );
+    if (width <= 0 || height <= 0) throw Exception('Invalid image dimensions.');
+    return _futurize((_Callback<Image> callback) => _toImage(width, height, callback));
   }
 
   String _toImage(int width, int height, _Callback<Image> callback) native 'Scene_toImage';
@@ -64,13 +60,12 @@ abstract class _EngineLayerWrapper implements EngineLayer {
 
   bool _debugCheckNotUsedAsOldLayer() {
     assert(
-      !_debugWasUsedAsOldLayer,
-      'Layer $runtimeType was previously used as oldLayer.\n'
-      'Once a layer is used as oldLayer, it may not be used again. Instead, '
-      'after calling one of the SceneBuilder.push* methods and passing an oldLayer '
-      'to it, use the layer returned by the method as oldLayer in subsequent '
-      'frames.'
-    );
+        !_debugWasUsedAsOldLayer,
+        'Layer $runtimeType was previously used as oldLayer.\n'
+        'Once a layer is used as oldLayer, it may not be used again. Instead, '
+        'after calling one of the SceneBuilder.push* methods and passing an oldLayer '
+        'to it, use the layer returned by the method as oldLayer in subsequent '
+        'frames.');
     return true;
   }
 }
@@ -179,7 +174,9 @@ class PhysicalShapeEngineLayer extends _EngineLayerWrapper {
 class SceneBuilder extends NativeFieldWrapperClass2 {
   /// Creates an empty [SceneBuilder] object.
   @pragma('vm:entry-point')
-  SceneBuilder() { _constructor(); }
+  SceneBuilder() {
+    _constructor();
+  }
   void _constructor() native 'SceneBuilder_constructor';
 
   // Layers used in this scene.
@@ -196,11 +193,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
       }
 
       assert(
-        !_usedLayers.containsKey(layer),
-        'Layer ${layer.runtimeType} already used.\n'
-        'The layer is already being used as ${_usedLayers[layer]} in this scene.\n'
-        'A layer may only be used once in a given scene.'
-      );
+          !_usedLayers.containsKey(layer),
+          'Layer ${layer.runtimeType} already used.\n'
+          'The layer is already being used as ${_usedLayers[layer]} in this scene.\n'
+          'A layer may only be used once in a given scene.');
 
       _usedLayers[layer] = usage;
       return true;
@@ -267,13 +263,17 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@endtemplate}
   ///
   /// See [pop] for details about the operation stack.
-  TransformEngineLayer pushTransform(Float64List matrix4, { TransformEngineLayer oldLayer }) {
+  TransformEngineLayer pushTransform(
+    Float64List matrix4, {
+    TransformEngineLayer oldLayer,
+  }) {
     assert(_matrix4IsValid(matrix4));
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushTransform'));
     final TransformEngineLayer layer = TransformEngineLayer._(_pushTransform(matrix4));
     assert(_debugPushLayer(layer));
     return layer;
   }
+
   EngineLayer _pushTransform(Float64List matrix4) native 'SceneBuilder_pushTransform';
 
   /// Pushes an offset operation onto the operation stack.
@@ -285,12 +285,17 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  OffsetEngineLayer pushOffset(double dx, double dy, { OffsetEngineLayer oldLayer }) {
+  OffsetEngineLayer pushOffset(
+    double dx,
+    double dy, {
+    OffsetEngineLayer oldLayer,
+  }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushOffset'));
     final OffsetEngineLayer layer = OffsetEngineLayer._(_pushOffset(dx, dy));
     assert(_debugPushLayer(layer));
     return layer;
   }
+
   EngineLayer _pushOffset(double dx, double dy) native 'SceneBuilder_pushOffset';
 
   /// Pushes a rectangular clip operation onto the operation stack.
@@ -303,19 +308,22 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipRectEngineLayer pushClipRect(Rect rect, {Clip clipBehavior = Clip.antiAlias, ClipRectEngineLayer oldLayer }) {
+  ClipRectEngineLayer pushClipRect(
+    Rect rect, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipRectEngineLayer oldLayer,
+  }) {
     assert(clipBehavior != null);
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipRect'));
-    final ClipRectEngineLayer layer = ClipRectEngineLayer._(_pushClipRect(rect.left, rect.right, rect.top, rect.bottom, clipBehavior.index));
+    final ClipRectEngineLayer layer = ClipRectEngineLayer._(
+        _pushClipRect(rect.left, rect.right, rect.top, rect.bottom, clipBehavior.index));
     assert(_debugPushLayer(layer));
     return layer;
   }
-  EngineLayer _pushClipRect(double left,
-                            double right,
-                            double top,
-                            double bottom,
-                            int clipBehavior) native 'SceneBuilder_pushClipRect';
+
+  EngineLayer _pushClipRect(double left, double right, double top, double bottom, int clipBehavior)
+      native 'SceneBuilder_pushClipRect';
 
   /// Pushes a rounded-rectangular clip operation onto the operation stack.
   ///
@@ -327,15 +335,22 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipRRectEngineLayer pushClipRRect(RRect rrect, {Clip clipBehavior = Clip.antiAlias, ClipRRectEngineLayer oldLayer}) {
+  ClipRRectEngineLayer pushClipRRect(
+    RRect rrect, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipRRectEngineLayer oldLayer,
+  }) {
     assert(clipBehavior != null);
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipRRect'));
-    final ClipRRectEngineLayer layer = ClipRRectEngineLayer._(_pushClipRRect(rrect._value32, clipBehavior.index));
+    final ClipRRectEngineLayer layer =
+        ClipRRectEngineLayer._(_pushClipRRect(rrect._value32, clipBehavior.index));
     assert(_debugPushLayer(layer));
     return layer;
   }
-  EngineLayer _pushClipRRect(Float32List rrect, int clipBehavior) native 'SceneBuilder_pushClipRRect';
+
+  EngineLayer _pushClipRRect(Float32List rrect, int clipBehavior)
+      native 'SceneBuilder_pushClipRRect';
 
   /// Pushes a path clip operation onto the operation stack.
   ///
@@ -347,14 +362,20 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack. See [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipPathEngineLayer pushClipPath(Path path, {Clip clipBehavior = Clip.antiAlias, ClipPathEngineLayer oldLayer}) {
+  ClipPathEngineLayer pushClipPath(
+    Path path, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipPathEngineLayer oldLayer,
+  }) {
     assert(clipBehavior != null);
     assert(clipBehavior != Clip.none);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushClipPath'));
-    final ClipPathEngineLayer layer = ClipPathEngineLayer._(_pushClipPath(path, clipBehavior.index));
+    final ClipPathEngineLayer layer =
+        ClipPathEngineLayer._(_pushClipPath(path, clipBehavior.index));
     assert(_debugPushLayer(layer));
     return layer;
   }
+
   EngineLayer _pushClipPath(Path path, int clipBehavior) native 'SceneBuilder_pushClipPath';
 
   /// Pushes an opacity operation onto the operation stack.
@@ -369,12 +390,18 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  OpacityEngineLayer pushOpacity(int alpha, {Offset offset = Offset.zero, OpacityEngineLayer oldLayer}) {
+  OpacityEngineLayer pushOpacity(
+    int alpha, {
+    Offset offset = Offset.zero,
+    OpacityEngineLayer oldLayer,
+  }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushOpacity'));
-    final OpacityEngineLayer layer = OpacityEngineLayer._(_pushOpacity(alpha, offset.dx, offset.dy));
+    final OpacityEngineLayer layer =
+        OpacityEngineLayer._(_pushOpacity(alpha, offset.dx, offset.dy));
     assert(_debugPushLayer(layer));
     return layer;
   }
+
   EngineLayer _pushOpacity(int alpha, double dx, double dy) native 'SceneBuilder_pushOpacity';
 
   /// Pushes a color filter operation onto the operation stack.
@@ -387,7 +414,10 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  ColorFilterEngineLayer pushColorFilter(ColorFilter filter, { ColorFilterEngineLayer oldLayer }) {
+  ColorFilterEngineLayer pushColorFilter(
+    ColorFilter filter, {
+    ColorFilterEngineLayer oldLayer,
+  }) {
     assert(filter != null);
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushColorFilter'));
     final _ColorFilter nativeFilter = filter._toNativeColorFilter();
@@ -396,6 +426,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     assert(_debugPushLayer(layer));
     return layer;
   }
+
   EngineLayer _pushColorFilter(_ColorFilter filter) native 'SceneBuilder_pushColorFilter';
 
   /// Pushes a backdrop filter operation onto the operation stack.
@@ -408,12 +439,17 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  BackdropFilterEngineLayer pushBackdropFilter(ImageFilter filter, { BackdropFilterEngineLayer oldLayer }) {
+  BackdropFilterEngineLayer pushBackdropFilter(
+    ImageFilter filter, {
+    BackdropFilterEngineLayer oldLayer,
+  }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushBackdropFilter'));
-    final BackdropFilterEngineLayer layer = BackdropFilterEngineLayer._(_pushBackdropFilter(filter._toNativeImageFilter()));
+    final BackdropFilterEngineLayer layer =
+        BackdropFilterEngineLayer._(_pushBackdropFilter(filter._toNativeImageFilter()));
     assert(_debugPushLayer(layer));
     return layer;
   }
+
   EngineLayer _pushBackdropFilter(_ImageFilter filter) native 'SceneBuilder_pushBackdropFilter';
 
   /// Pushes a shader mask operation onto the operation stack.
@@ -426,23 +462,26 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  ShaderMaskEngineLayer pushShaderMask(Shader shader, Rect maskRect, BlendMode blendMode, { ShaderMaskEngineLayer oldLayer }) {
+  ShaderMaskEngineLayer pushShaderMask(
+    Shader shader,
+    Rect maskRect,
+    BlendMode blendMode, {
+    ShaderMaskEngineLayer oldLayer,
+  }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushShaderMask'));
-    final ShaderMaskEngineLayer layer = ShaderMaskEngineLayer._(_pushShaderMask(shader,
-                           maskRect.left,
-                           maskRect.right,
-                           maskRect.top,
-                           maskRect.bottom,
-                           blendMode.index));
+    final ShaderMaskEngineLayer layer = ShaderMaskEngineLayer._(_pushShaderMask(
+        shader, maskRect.left, maskRect.right, maskRect.top, maskRect.bottom, blendMode.index));
     assert(_debugPushLayer(layer));
     return layer;
   }
-  EngineLayer _pushShaderMask(Shader shader,
-                              double maskRectLeft,
-                              double maskRectRight,
-                              double maskRectTop,
-                              double maskRectBottom,
-                              int blendMode) native 'SceneBuilder_pushShaderMask';
+
+  EngineLayer _pushShaderMask(
+      Shader shader,
+      double maskRectLeft,
+      double maskRectRight,
+      double maskRectTop,
+      double maskRectBottom,
+      int blendMode) native 'SceneBuilder_pushShaderMask';
 
   /// Pushes a physical layer operation for an arbitrary shape onto the
   /// operation stack.
@@ -461,14 +500,23 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   // ignore: deprecated_member_use
-  PhysicalShapeEngineLayer pushPhysicalShape({ Path path, double elevation, Color color, Color shadowColor, Clip clipBehavior = Clip.none, PhysicalShapeEngineLayer oldLayer }) {
+  PhysicalShapeEngineLayer pushPhysicalShape({
+    Path path,
+    double elevation,
+    Color color,
+    Color shadowColor,
+    Clip clipBehavior = Clip.none,
+    PhysicalShapeEngineLayer oldLayer,
+  }) {
     assert(_debugCheckCanBeUsedAsOldLayer(oldLayer, 'pushPhysicalShape'));
-    final PhysicalShapeEngineLayer layer = PhysicalShapeEngineLayer._(_pushPhysicalShape(path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index));
+    final PhysicalShapeEngineLayer layer = PhysicalShapeEngineLayer._(_pushPhysicalShape(
+        path, elevation, color.value, shadowColor?.value ?? 0xFF000000, clipBehavior.index));
     assert(_debugPushLayer(layer));
     return layer;
   }
-  EngineLayer _pushPhysicalShape(Path path, double elevation, int color, int shadowColor, int clipBehavior) native
-    'SceneBuilder_pushPhysicalShape';
+
+  EngineLayer _pushPhysicalShape(Path path, double elevation, int color, int shadowColor,
+      int clipBehavior) native 'SceneBuilder_pushPhysicalShape';
 
   /// Ends the effect of the most recently pushed operation.
   ///
@@ -482,6 +530,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     }
     _pop();
   }
+
   void _pop() native 'SceneBuilder_pop';
 
   /// Add a retained engine layer subtree from previous frames.
@@ -518,6 +567,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     final _EngineLayerWrapper wrapper = retainedLayer;
     _addRetained(wrapper._nativeLayer);
   }
+
   void _addRetained(EngineLayer retainedLayer) native 'SceneBuilder_addRetained';
 
   /// Adds an object to the scene that displays performance statistics.
@@ -545,30 +595,34 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// for more details.
   // Values above must match constants in //engine/src/sky/compositor/performance_overlay_layer.h
   void addPerformanceOverlay(int enabledOptions, Rect bounds) {
-    _addPerformanceOverlay(enabledOptions,
-                           bounds.left,
-                           bounds.right,
-                           bounds.top,
-                           bounds.bottom);
+    _addPerformanceOverlay(enabledOptions, bounds.left, bounds.right, bounds.top, bounds.bottom);
   }
-  void _addPerformanceOverlay(int enabledOptions,
-                              double left,
-                              double right,
-                              double top,
-                              double bottom) native 'SceneBuilder_addPerformanceOverlay';
+
+  void _addPerformanceOverlay(
+    int enabledOptions,
+    double left,
+    double right,
+    double top,
+    double bottom,
+  ) native 'SceneBuilder_addPerformanceOverlay';
 
   /// Adds a [Picture] to the scene.
   ///
   /// The picture is rasterized at the given offset.
-  void addPicture(Offset offset, Picture picture, { bool isComplexHint = false, bool willChangeHint = false }) {
+  void addPicture(
+    Offset offset,
+    Picture picture, {
+    bool isComplexHint = false,
+    bool willChangeHint = false,
+  }) {
     int hints = 0;
-    if (isComplexHint)
-      hints |= 1;
-    if (willChangeHint)
-      hints |= 2;
+    if (isComplexHint) hints |= 1;
+    if (willChangeHint) hints |= 2;
     _addPicture(offset.dx, offset.dy, picture, hints);
   }
-  void _addPicture(double dx, double dy, Picture picture, int hints) native 'SceneBuilder_addPicture';
+
+  void _addPicture(double dx, double dy, Picture picture, int hints)
+      native 'SceneBuilder_addPicture';
 
   /// Adds a backend texture to the scene.
   ///
@@ -581,11 +635,19 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// previous or new size, to workaround this the framework "freezes" the
   /// texture just before resizing the Android view and un-freezes it when it is
   /// certain that a frame with the new size is ready.
-  void addTexture(int textureId, { Offset offset = Offset.zero, double width = 0.0, double height = 0.0 , bool freeze = false}) {
+  void addTexture(
+    int textureId, {
+    Offset offset = Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    bool freeze = false,
+  }) {
     assert(offset != null, 'Offset argument was null');
     _addTexture(offset.dx, offset.dy, width, height, textureId, freeze);
   }
-  void _addTexture(double dx, double dy, double width, double height, int textureId, bool freeze) native 'SceneBuilder_addTexture';
+
+  void _addTexture(double dx, double dy, double width, double height, int textureId, bool freeze)
+      native 'SceneBuilder_addTexture';
 
   /// Adds a platform view (e.g an iOS UIView) to the scene.
   ///
@@ -603,34 +665,32 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// With a platform view in the scene, Quartz has to composite the two Flutter surfaces and the
   /// embedded UIView. In addition to that, on iOS versions greater than 9, the Flutter frames are
   /// synchronized with the UIView frames adding additional performance overhead.
-  void addPlatformView(int viewId, { Offset offset = Offset.zero, double width = 0.0, double height = 0.0}) {
-    assert(offset != null, 'Offset argument was null');
-    _addPlatformView(offset.dx, offset.dy, width, height, viewId);
-  }
-  void _addPlatformView(double dx, double dy, double width, double height, int viewId) native 'SceneBuilder_addPlatformView';
-
-  /// (Fuchsia-only) Adds a scene rendered by another application to the scene
-  /// for this application.
-  void addChildScene({
+  void addPlatformView(
+    int viewId, {
     Offset offset = Offset.zero,
     double width = 0.0,
     double height = 0.0,
-    SceneHost sceneHost,
-    bool hitTestable = true
   }) {
-    _addChildScene(offset.dx,
-                   offset.dy,
-                   width,
-                   height,
-                   sceneHost,
-                   hitTestable);
+    assert(offset != null, 'Offset argument was null');
+    _addPlatformView(offset.dx, offset.dy, width, height, viewId);
   }
-  void _addChildScene(double dx,
-                      double dy,
-                      double width,
-                      double height,
-                      SceneHost sceneHost,
-                      bool hitTestable) native 'SceneBuilder_addChildScene';
+
+  void _addPlatformView(double dx, double dy, double width, double height, int viewId)
+      native 'SceneBuilder_addPlatformView';
+
+  /// (Fuchsia-only) Adds a scene rendered by another application to the scene
+  /// for this application.
+  void addChildScene(
+      {Offset offset = Offset.zero,
+      double width = 0.0,
+      double height = 0.0,
+      SceneHost sceneHost,
+      bool hitTestable = true}) {
+    _addChildScene(offset.dx, offset.dy, width, height, sceneHost, hitTestable);
+  }
+
+  void _addChildScene(double dx, double dy, double width, double height, SceneHost sceneHost,
+      bool hitTestable) native 'SceneBuilder_addChildScene';
 
   /// Sets a threshold after which additional debugging information should be recorded.
   ///
@@ -638,7 +698,8 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// interested in using this feature, please contact [flutter-dev](https://groups.google.com/forum/#!forum/flutter-dev).
   /// We'll hopefully be able to figure out how to make this feature more useful
   /// to you.
-  void setRasterizerTracingThreshold(int frameInterval) native 'SceneBuilder_setRasterizerTracingThreshold';
+  void setRasterizerTracingThreshold(int frameInterval)
+      native 'SceneBuilder_setRasterizerTracingThreshold';
 
   /// Sets whether the raster cache should checkerboard cached entries. This is
   /// only useful for debugging purposes.
@@ -655,13 +716,15 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   ///
   /// Currently this interface is difficult to use by end-developers. If you're
   /// interested in using this feature, please contact [flutter-dev](https://groups.google.com/forum/#!forum/flutter-dev).
-  void setCheckerboardRasterCacheImages(bool checkerboard) native 'SceneBuilder_setCheckerboardRasterCacheImages';
+  void setCheckerboardRasterCacheImages(bool checkerboard)
+      native 'SceneBuilder_setCheckerboardRasterCacheImages';
 
   /// Sets whether the compositor should checkerboard layers that are rendered
   /// to offscreen bitmaps.
   ///
   /// This is only useful for debugging purposes.
-  void setCheckerboardOffscreenLayers(bool checkerboard) native 'SceneBuilder_setCheckerboardOffscreenLayers';
+  void setCheckerboardOffscreenLayers(bool checkerboard)
+      native 'SceneBuilder_setCheckerboardOffscreenLayers';
 
   /// Finishes building the scene.
   ///
@@ -688,15 +751,21 @@ class SceneHost extends NativeFieldWrapperClass2 {
   ///
   /// The SceneHost takes ownership of the provided ViewHolder token.
   SceneHost(
-      dynamic viewHolderToken,
-      void Function() viewConnectedCallback,
-      void Function() viewDisconnectedCallback,
-      void Function(bool) viewStateChangedCallback) {
-    _constructor(viewHolderToken, viewConnectedCallback, viewDisconnectedCallback, viewStateChangedCallback);
+    dynamic viewHolderToken,
+    void Function() viewConnectedCallback,
+    void Function() viewDisconnectedCallback,
+    void Function(bool) viewStateChangedCallback,
+  ) {
+    _constructor(
+        viewHolderToken, viewConnectedCallback, viewDisconnectedCallback, viewStateChangedCallback);
   }
 
-  void _constructor(dynamic viewHolderToken, void Function() viewConnectedCallback, void Function() viewDisconnectedCallback, void Function(bool) viewStateChangedCallback)
-      native 'SceneHost_constructor';
+  void _constructor(
+    dynamic viewHolderToken,
+    void Function() viewConnectedCallback,
+    void Function() viewDisconnectedCallback,
+    void Function(bool) viewStateChangedCallbac,
+  ) native 'SceneHost_constructor';
 
   /// Releases the resources associated with the SceneHost.
   ///
@@ -706,11 +775,12 @@ class SceneHost extends NativeFieldWrapperClass2 {
   /// Set properties on the linked scene.  These properties include its bounds,
   /// as well as whether it can be the target of focus events or not.
   void setProperties(
-      double width,
-      double height,
-      double insetTop,
-      double insetRight,
-      double insetBottom,
-      double insetLeft,
-      bool focusable) native 'SceneHost_setProperties';
+    double width,
+    double height,
+    double insetTop,
+    double insetRight,
+    double insetBottom,
+    double insetLeft,
+    bool focusable,
+  ) native 'SceneHost_setProperties';
 }

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -22,7 +22,9 @@ class Scene extends NativeFieldWrapperClass2 {
   /// Creates a raster image representation of the current state of the scene.
   /// This is a slow operation that is performed on a background thread.
   Future<Image> toImage(int width, int height) {
-    if (width <= 0 || height <= 0) throw Exception('Invalid image dimensions.');
+    if (width <= 0 || height <= 0) {
+      throw Exception('Invalid image dimensions.');
+    }
     return _futurize((_Callback<Image> callback) => _toImage(width, height, callback));
   }
 
@@ -615,9 +617,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
     bool isComplexHint = false,
     bool willChangeHint = false,
   }) {
-    int hints = 0;
-    if (isComplexHint) hints |= 1;
-    if (willChangeHint) hints |= 2;
+    final int hints = (isComplexHint ? 1 : 0) | (willChangeHint ? 2 : 0);
     _addPicture(offset.dx, offset.dy, picture, hints);
   }
 

--- a/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/compositor/layer_scene_builder.dart
@@ -26,12 +26,13 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   ContainerLayer currentLayer;
 
   @override
-  void addChildScene(
-      {ui.Offset offset = ui.Offset.zero,
-      double width = 0.0,
-      double height = 0.0,
-      ui.SceneHost sceneHost,
-      bool hitTestable = true}) {
+  void addChildScene({
+    ui.Offset offset = ui.Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    ui.SceneHost sceneHost,
+    bool hitTestable = true,
+  }) {
     throw UnimplementedError();
   }
 
@@ -42,10 +43,13 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  void addPicture(ui.Offset offset, ui.Picture picture,
-      {bool isComplexHint = false, bool willChangeHint = false}) {
-    currentLayer
-        .add(PictureLayer(picture, offset, isComplexHint, willChangeHint));
+  void addPicture(
+    ui.Offset offset,
+    ui.Picture picture, {
+    bool isComplexHint = false,
+    bool willChangeHint = false,
+  }) {
+    currentLayer.add(PictureLayer(picture, offset, isComplexHint, willChangeHint));
   }
 
   @override
@@ -57,11 +61,13 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  void addTexture(int textureId,
-      {ui.Offset offset = ui.Offset.zero,
-      double width = 0.0,
-      double height = 0.0,
-      bool freeze = false}) {
+  void addTexture(
+    int textureId, {
+    ui.Offset offset = ui.Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    bool freeze = false,
+  }) {
     // TODO(b/128315641): implement addTexture.
   }
 
@@ -90,43 +96,59 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  ui.BackdropFilterEngineLayer pushBackdropFilter(ui.ImageFilter filter,
-      {ui.EngineLayer oldLayer}) {
+  ui.BackdropFilterEngineLayer pushBackdropFilter(
+    ui.ImageFilter filter, {
+    ui.EngineLayer oldLayer,
+  }) {
     pushLayer(BackdropFilterLayer(filter));
     return null;
   }
 
   @override
-  ui.ClipPathEngineLayer pushClipPath(ui.Path path,
-      {ui.Clip clipBehavior = ui.Clip.antiAlias, ui.EngineLayer oldLayer}) {
+  ui.ClipPathEngineLayer pushClipPath(
+    ui.Path path, {
+    ui.Clip clipBehavior = ui.Clip.antiAlias,
+    ui.EngineLayer oldLayer,
+  }) {
     pushLayer(ClipPathLayer(path, clipBehavior));
     return null;
   }
 
   @override
-  ui.ClipRRectEngineLayer pushClipRRect(ui.RRect rrect,
-      {ui.Clip clipBehavior, ui.EngineLayer oldLayer}) {
+  ui.ClipRRectEngineLayer pushClipRRect(
+    ui.RRect rrect, {
+    ui.Clip clipBehavior,
+    ui.EngineLayer oldLayer,
+  }) {
     pushLayer(ClipRRectLayer(rrect, clipBehavior));
     return null;
   }
 
   @override
-  ui.ClipRectEngineLayer pushClipRect(ui.Rect rect,
-      {ui.Clip clipBehavior = ui.Clip.antiAlias, ui.EngineLayer oldLayer}) {
+  ui.ClipRectEngineLayer pushClipRect(
+    ui.Rect rect, {
+    ui.Clip clipBehavior = ui.Clip.antiAlias,
+    ui.EngineLayer oldLayer,
+  }) {
     pushLayer(ClipRectLayer(rect, clipBehavior));
     return null;
   }
 
   @override
-  ui.ColorFilterEngineLayer pushColorFilter(ui.ColorFilter filter,
-      {ui.ColorFilterEngineLayer oldLayer}) {
+  ui.ColorFilterEngineLayer pushColorFilter(
+    ui.ColorFilter filter, {
+    ui.ColorFilterEngineLayer oldLayer,
+  }) {
     assert(filter != null);
     throw UnimplementedError();
   }
 
   @override
-  ui.OffsetEngineLayer pushOffset(double dx, double dy,
-      {ui.EngineLayer oldLayer}) {
+  ui.OffsetEngineLayer pushOffset(
+    double dx,
+    double dy, {
+    ui.EngineLayer oldLayer,
+  }) {
     final Matrix4 matrix = Matrix4.translationValues(dx, dy, 0.0);
     final TransformLayer layer = TransformLayer(matrix);
     pushLayer(layer);
@@ -134,8 +156,11 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  ui.OpacityEngineLayer pushOpacity(int alpha,
-      {ui.EngineLayer oldLayer, ui.Offset offset = ui.Offset.zero}) {
+  ui.OpacityEngineLayer pushOpacity(
+    int alpha, {
+    ui.EngineLayer oldLayer,
+    ui.Offset offset = ui.Offset.zero,
+  }) {
     final OpacityLayer layer = OpacityLayer(alpha, offset);
     pushLayer(layer);
     return layer;
@@ -158,14 +183,19 @@ class LayerSceneBuilder implements ui.SceneBuilder {
 
   @override
   ui.ShaderMaskEngineLayer pushShaderMask(
-      ui.Shader shader, ui.Rect maskRect, ui.BlendMode blendMode,
-      {ui.EngineLayer oldLayer}) {
+    ui.Shader shader,
+    ui.Rect maskRect,
+    ui.BlendMode blendMode, {
+    ui.EngineLayer oldLayer,
+  }) {
     throw UnimplementedError();
   }
 
   @override
-  ui.TransformEngineLayer pushTransform(Float64List matrix4,
-      {ui.EngineLayer oldLayer}) {
+  ui.TransformEngineLayer pushTransform(
+    Float64List matrix4, {
+    ui.EngineLayer oldLayer,
+  }) {
     final Matrix4 matrix = Matrix4.fromList(matrix4);
     pushLayer(TransformLayer(matrix));
     return null;
@@ -201,8 +231,15 @@ class LayerSceneBuilder implements ui.SceneBuilder {
   }
 
   @override
-  void setProperties(double width, double height, double insetTop,
-      double insetRight, double insetBottom, double insetLeft, bool focusable) {
+  void setProperties(
+    double width,
+    double height,
+    double insetTop,
+    double insetRight,
+    double insetBottom,
+    double insetLeft,
+    bool focusable,
+  ) {
     throw UnimplementedError();
   }
 }

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -9,8 +9,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     _surfaceStack.add(PersistedScene(_lastFrameScene));
   }
 
-  final List<PersistedContainerSurface> _surfaceStack =
-      <PersistedContainerSurface>[];
+  final List<PersistedContainerSurface> _surfaceStack = <PersistedContainerSurface>[];
 
   /// The scene built by this scene builder.
   ///
@@ -19,8 +18,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     assert(() {
       if (_surfaceStack.length != 1) {
         final String surfacePrintout = _surfaceStack
-            .map<Type>((PersistedContainerSurface surface) =>
-                surface.runtimeType)
+            .map<Type>((PersistedContainerSurface surface) => surface.runtimeType)
             .toList()
             .join(', ');
         throw Exception('Incorrect sequence of push/pop operations while '
@@ -65,7 +63,9 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.OffsetEngineLayer pushOffset(double dx, double dy, {
+  ui.OffsetEngineLayer pushOffset(
+    double dx,
+    double dy, {
     ui.OffsetEngineLayer oldLayer,
   }) {
     return _pushSurface(PersistedOffset(oldLayer, dx, dy));
@@ -77,7 +77,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.TransformEngineLayer pushTransform(Float64List matrix4, {
+  ui.TransformEngineLayer pushTransform(
+    Float64List matrix4, {
     ui.TransformEngineLayer oldLayer,
   }) {
     if (matrix4 == null) {
@@ -96,7 +97,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
   @override
-  ui.ClipRectEngineLayer pushClipRect(ui.Rect rect, {
+  ui.ClipRectEngineLayer pushClipRect(
+    ui.Rect rect, {
     ui.Clip clipBehavior = ui.Clip.antiAlias,
     ui.ClipRectEngineLayer oldLayer,
   }) {
@@ -111,7 +113,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.ClipRRectEngineLayer pushClipRRect(ui.RRect rrect, {
+  ui.ClipRRectEngineLayer pushClipRRect(
+    ui.RRect rrect, {
     ui.Clip clipBehavior,
     ui.ClipRRectEngineLayer oldLayer,
   }) {
@@ -124,7 +127,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.ClipPathEngineLayer pushClipPath(ui.Path path, {
+  ui.ClipPathEngineLayer pushClipPath(
+    ui.Path path, {
     ui.Clip clipBehavior = ui.Clip.antiAlias,
     ui.ClipPathEngineLayer oldLayer,
   }) {
@@ -142,7 +146,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.OpacityEngineLayer pushOpacity(int alpha, {
+  ui.OpacityEngineLayer pushOpacity(
+    int alpha, {
     ui.Offset offset = ui.Offset.zero,
     ui.OpacityEngineLayer oldLayer,
   }) {
@@ -160,7 +165,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.ColorFilterEngineLayer pushColorFilter(ui.ColorFilter filter, {
+  ui.ColorFilterEngineLayer pushColorFilter(
+    ui.ColorFilter filter, {
     ui.ColorFilterEngineLayer oldLayer,
   }) {
     assert(filter != null);
@@ -174,7 +180,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.BackdropFilterEngineLayer pushBackdropFilter(ui.ImageFilter filter, {
+  ui.BackdropFilterEngineLayer pushBackdropFilter(
+    ui.ImageFilter filter, {
     ui.BackdropFilterEngineLayer oldLayer,
   }) {
     return _pushSurface(PersistedBackdropFilter(oldLayer, filter));
@@ -280,8 +287,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// for more details.
   @override
   void addPerformanceOverlay(int enabledOptions, ui.Rect bounds) {
-    _addPerformanceOverlay(
-        enabledOptions, bounds.left, bounds.right, bounds.top, bounds.bottom);
+    _addPerformanceOverlay(enabledOptions, bounds.left, bounds.right, bounds.top, bounds.bottom);
   }
 
   /// Whether we've already warned the user about the lack of the performance
@@ -290,12 +296,16 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// We use this to avoid spamming the console with redundant warning messages.
   static bool _webOnlyDidWarnAboutPerformanceOverlay = false;
 
-  void _addPerformanceOverlay(int enabledOptions, double left, double right,
-      double top, double bottom) {
+  void _addPerformanceOverlay(
+    int enabledOptions,
+    double left,
+    double right,
+    double top,
+    double bottom,
+  ) {
     if (!_webOnlyDidWarnAboutPerformanceOverlay) {
       _webOnlyDidWarnAboutPerformanceOverlay = true;
-      html.window.console
-          .warn('The performance overlay isn\'t supported on the web');
+      html.window.console.warn('The performance overlay isn\'t supported on the web');
     }
   }
 
@@ -316,8 +326,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     if (willChangeHint) {
       hints |= 2;
     }
-    _addSurface(
-        persistedPictureFactory(offset.dx, offset.dy, picture, hints));
+    _addSurface(persistedPictureFactory(offset.dx, offset.dy, picture, hints));
   }
 
   /// Adds a backend texture to the scene.
@@ -325,17 +334,18 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// The texture is scaled to the given size and rasterized at the given
   /// offset.
   @override
-  void addTexture(int textureId,
-      {ui.Offset offset = ui.Offset.zero,
-      double width = 0.0,
-      double height = 0.0,
-      bool freeze = false}) {
+  void addTexture(
+    int textureId, {
+    ui.Offset offset = ui.Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    bool freeze = false,
+  }) {
     assert(offset != null, 'Offset argument was null');
     _addTexture(offset.dx, offset.dy, width, height, textureId);
   }
 
-  void _addTexture(
-      double dx, double dy, double width, double height, int textureId) {
+  void _addTexture(double dx, double dy, double width, double height, int textureId) {
     // In test mode, allow this to be a no-op.
     if (!ui.debugEmulateFlutterTesterEnvironment) {
       throw UnimplementedError('Textures are not supported in Flutter Web');
@@ -382,17 +392,24 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// (Fuchsia-only) Adds a scene rendered by another application to the scene
   /// for this application.
   @override
-  void addChildScene(
-      {ui.Offset offset = ui.Offset.zero,
-      double width = 0.0,
-      double height = 0.0,
-      ui.SceneHost sceneHost,
-      bool hitTestable = true}) {
+  void addChildScene({
+    ui.Offset offset = ui.Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    ui.SceneHost sceneHost,
+    bool hitTestable = true,
+  }) {
     _addChildScene(offset.dx, offset.dy, width, height, sceneHost, hitTestable);
   }
 
-  void _addChildScene(double dx, double dy, double width, double height,
-      ui.SceneHost sceneHost, bool hitTestable) {
+  void _addChildScene(
+    double dx,
+    double dy,
+    double width,
+    double height,
+    ui.SceneHost sceneHost,
+    bool hitTestable,
+  ) {
     throw UnimplementedError();
   }
 
@@ -489,8 +506,15 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// Set properties on the linked scene.  These properties include its bounds,
   /// as well as whether it can be the target of focus events or not.
   @override
-  void setProperties(double width, double height, double insetTop,
-      double insetRight, double insetBottom, double insetLeft, bool focusable) {
+  void setProperties(
+    double width,
+    double height,
+    double insetTop,
+    double insetRight,
+    double insetBottom,
+    double insetLeft,
+    bool focusable,
+  ) {
     throw UnimplementedError();
   }
 }

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -65,8 +65,9 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.OffsetEngineLayer pushOffset(double dx, double dy,
-      {ui.OffsetEngineLayer oldLayer}) {
+  ui.OffsetEngineLayer pushOffset(double dx, double dy, {
+    ui.OffsetEngineLayer oldLayer,
+  }) {
     return _pushSurface(PersistedOffset(oldLayer, dx, dy));
   }
 
@@ -76,8 +77,9 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.TransformEngineLayer pushTransform(Float64List matrix4,
-      {ui.TransformEngineLayer oldLayer}) {
+  ui.TransformEngineLayer pushTransform(Float64List matrix4, {
+    ui.TransformEngineLayer oldLayer,
+  }) {
     if (matrix4 == null) {
       throw ArgumentError('"matrix4" argument cannot be null');
     }
@@ -94,8 +96,10 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
   @override
-  ui.ClipRectEngineLayer pushClipRect(ui.Rect rect,
-      {ui.Clip clipBehavior = ui.Clip.antiAlias, ui.ClipRectEngineLayer oldLayer}) {
+  ui.ClipRectEngineLayer pushClipRect(ui.Rect rect, {
+    ui.Clip clipBehavior = ui.Clip.antiAlias,
+    ui.ClipRectEngineLayer oldLayer,
+  }) {
     assert(clipBehavior != null);
     assert(clipBehavior != ui.Clip.none);
     return _pushSurface(PersistedClipRect(oldLayer, rect));
@@ -107,10 +111,11 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.ClipRRectEngineLayer pushClipRRect(ui.RRect rrect,
-      {ui.Clip clipBehavior, ui.ClipRRectEngineLayer oldLayer}) {
-    return _pushSurface(
-        PersistedClipRRect(oldLayer, rrect, clipBehavior));
+  ui.ClipRRectEngineLayer pushClipRRect(ui.RRect rrect, {
+    ui.Clip clipBehavior,
+    ui.ClipRRectEngineLayer oldLayer,
+  }) {
+    return _pushSurface(PersistedClipRRect(oldLayer, rrect, clipBehavior));
   }
 
   /// Pushes a path clip operation onto the operation stack.
@@ -119,8 +124,10 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.ClipPathEngineLayer pushClipPath(ui.Path path,
-      {ui.Clip clipBehavior = ui.Clip.antiAlias, ui.ClipPathEngineLayer oldLayer}) {
+  ui.ClipPathEngineLayer pushClipPath(ui.Path path, {
+    ui.Clip clipBehavior = ui.Clip.antiAlias,
+    ui.ClipPathEngineLayer oldLayer,
+  }) {
     assert(clipBehavior != null);
     assert(clipBehavior != ui.Clip.none);
     return _pushSurface(PersistedClipPath(oldLayer, path, clipBehavior));
@@ -135,8 +142,10 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.OpacityEngineLayer pushOpacity(int alpha,
-      {ui.Offset offset = ui.Offset.zero, ui.OpacityEngineLayer oldLayer}) {
+  ui.OpacityEngineLayer pushOpacity(int alpha, {
+    ui.Offset offset = ui.Offset.zero,
+    ui.OpacityEngineLayer oldLayer,
+  }) {
     return _pushSurface(PersistedOpacity(oldLayer, alpha, offset));
   }
 
@@ -151,8 +160,9 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.ColorFilterEngineLayer pushColorFilter(ui.ColorFilter filter,
-      {ui.ColorFilterEngineLayer oldLayer}) {
+  ui.ColorFilterEngineLayer pushColorFilter(ui.ColorFilter filter, {
+    ui.ColorFilterEngineLayer oldLayer,
+  }) {
     assert(filter != null);
     throw UnimplementedError();
   }
@@ -164,8 +174,9 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   ///
   /// See [pop] for details about the operation stack.
   @override
-  ui.BackdropFilterEngineLayer pushBackdropFilter(ui.ImageFilter filter,
-      {ui.BackdropFilterEngineLayer oldLayer}) {
+  ui.BackdropFilterEngineLayer pushBackdropFilter(ui.ImageFilter filter, {
+    ui.BackdropFilterEngineLayer oldLayer,
+  }) {
     return _pushSurface(PersistedBackdropFilter(oldLayer, filter));
   }
 
@@ -177,8 +188,11 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// See [pop] for details about the operation stack.
   @override
   ui.ShaderMaskEngineLayer pushShaderMask(
-      ui.Shader shader, ui.Rect maskRect, ui.BlendMode blendMode,
-      {ui.ShaderMaskEngineLayer oldLayer}) {
+    ui.Shader shader,
+    ui.Rect maskRect,
+    ui.BlendMode blendMode, {
+    ui.ShaderMaskEngineLayer oldLayer,
+  }) {
     throw UnimplementedError();
   }
 

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -117,16 +117,18 @@ abstract class SceneBuilder {
   /// This is equivalent to [pushTransform] with a matrix with only translation.
   ///
   /// See [pop] for details about the operation stack.
-  OffsetEngineLayer pushOffset(double dx, double dy,
-      {OffsetEngineLayer oldLayer});
+  OffsetEngineLayer pushOffset(double dx, double dy, {
+    OffsetEngineLayer oldLayer,
+  });
 
   /// Pushes a transform operation onto the operation stack.
   ///
   /// The objects are transformed by the given matrix before rasterization.
   ///
   /// See [pop] for details about the operation stack.
-  TransformEngineLayer pushTransform(Float64List matrix4,
-      {TransformEngineLayer oldLayer});
+  TransformEngineLayer pushTransform(Float64List matrix4, {
+    TransformEngineLayer oldLayer,
+  });
 
   /// Pushes a rectangular clip operation onto the operation stack.
   ///
@@ -134,24 +136,30 @@ abstract class SceneBuilder {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipRectEngineLayer pushClipRect(Rect rect,
-      {Clip clipBehavior = Clip.antiAlias, ClipRectEngineLayer oldLayer});
+  ClipRectEngineLayer pushClipRect(Rect rect, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipRectEngineLayer oldLayer,
+  });
 
   /// Pushes a rounded-rectangular clip operation onto the operation stack.
   ///
   /// Rasterization outside the given rounded rectangle is discarded.
   ///
   /// See [pop] for details about the operation stack.
-  ClipRRectEngineLayer pushClipRRect(RRect rrect,
-      {Clip clipBehavior, ClipRRectEngineLayer oldLayer});
+  ClipRRectEngineLayer pushClipRRect(RRect rrect, {
+    Clip clipBehavior,
+    ClipRRectEngineLayer oldLayer,
+  });
 
   /// Pushes a path clip operation onto the operation stack.
   ///
   /// Rasterization outside the given path is discarded.
   ///
   /// See [pop] for details about the operation stack.
-  ClipPathEngineLayer pushClipPath(Path path,
-      {Clip clipBehavior = Clip.antiAlias, ClipPathEngineLayer oldLayer});
+  ClipPathEngineLayer pushClipPath(Path path, {
+    Clip clipBehavior = Clip.antiAlias,
+    ClipPathEngineLayer oldLayer,
+  });
 
   /// Pushes an opacity operation onto the operation stack.
   ///
@@ -161,8 +169,10 @@ abstract class SceneBuilder {
   /// opacity).
   ///
   /// See [pop] for details about the operation stack.
-  OpacityEngineLayer pushOpacity(int alpha,
-      {Offset offset = Offset.zero, OpacityEngineLayer oldLayer});
+  OpacityEngineLayer pushOpacity(int alpha, {
+    Offset offset = Offset.zero,
+    OpacityEngineLayer oldLayer,
+  });
 
   /// Pushes a color filter operation onto the operation stack.
   ///
@@ -174,8 +184,9 @@ abstract class SceneBuilder {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  ColorFilterEngineLayer pushColorFilter(ColorFilter filter,
-      {ColorFilterEngineLayer oldLayer});
+  ColorFilterEngineLayer pushColorFilter(ColorFilter filter, {
+    ColorFilterEngineLayer oldLayer,
+  });
 
   /// Pushes a backdrop filter operation onto the operation stack.
   ///
@@ -183,8 +194,9 @@ abstract class SceneBuilder {
   /// rasterizing the given objects.
   ///
   /// See [pop] for details about the operation stack.
-  BackdropFilterEngineLayer pushBackdropFilter(ImageFilter filter,
-      {BackdropFilterEngineLayer oldLayer});
+  BackdropFilterEngineLayer pushBackdropFilter(ImageFilter filter, {
+    BackdropFilterEngineLayer oldLayer,
+  });
 
   /// Pushes a shader mask operation onto the operation stack.
   ///
@@ -192,9 +204,9 @@ abstract class SceneBuilder {
   /// rectangle using the given blend mode.
   ///
   /// See [pop] for details about the operation stack.
-  ShaderMaskEngineLayer pushShaderMask(
-      Shader shader, Rect maskRect, BlendMode blendMode,
-      {ShaderMaskEngineLayer oldLayer});
+  ShaderMaskEngineLayer pushShaderMask(Shader shader, Rect maskRect, BlendMode blendMode, {
+    ShaderMaskEngineLayer oldLayer,
+  });
 
   /// Pushes a physical layer operation for an arbitrary shape onto the
   /// operation stack.

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -117,7 +117,9 @@ abstract class SceneBuilder {
   /// This is equivalent to [pushTransform] with a matrix with only translation.
   ///
   /// See [pop] for details about the operation stack.
-  OffsetEngineLayer pushOffset(double dx, double dy, {
+  OffsetEngineLayer pushOffset(
+    double dx,
+    double dy, {
     OffsetEngineLayer oldLayer,
   });
 
@@ -126,7 +128,8 @@ abstract class SceneBuilder {
   /// The objects are transformed by the given matrix before rasterization.
   ///
   /// See [pop] for details about the operation stack.
-  TransformEngineLayer pushTransform(Float64List matrix4, {
+  TransformEngineLayer pushTransform(
+    Float64List matrix4, {
     TransformEngineLayer oldLayer,
   });
 
@@ -136,7 +139,8 @@ abstract class SceneBuilder {
   ///
   /// See [pop] for details about the operation stack, and [Clip] for different clip modes.
   /// By default, the clip will be anti-aliased (clip = [Clip.antiAlias]).
-  ClipRectEngineLayer pushClipRect(Rect rect, {
+  ClipRectEngineLayer pushClipRect(
+    Rect rect, {
     Clip clipBehavior = Clip.antiAlias,
     ClipRectEngineLayer oldLayer,
   });
@@ -146,7 +150,8 @@ abstract class SceneBuilder {
   /// Rasterization outside the given rounded rectangle is discarded.
   ///
   /// See [pop] for details about the operation stack.
-  ClipRRectEngineLayer pushClipRRect(RRect rrect, {
+  ClipRRectEngineLayer pushClipRRect(
+    RRect rrect, {
     Clip clipBehavior,
     ClipRRectEngineLayer oldLayer,
   });
@@ -156,7 +161,8 @@ abstract class SceneBuilder {
   /// Rasterization outside the given path is discarded.
   ///
   /// See [pop] for details about the operation stack.
-  ClipPathEngineLayer pushClipPath(Path path, {
+  ClipPathEngineLayer pushClipPath(
+    Path path, {
     Clip clipBehavior = Clip.antiAlias,
     ClipPathEngineLayer oldLayer,
   });
@@ -169,7 +175,8 @@ abstract class SceneBuilder {
   /// opacity).
   ///
   /// See [pop] for details about the operation stack.
-  OpacityEngineLayer pushOpacity(int alpha, {
+  OpacityEngineLayer pushOpacity(
+    int alpha, {
     Offset offset = Offset.zero,
     OpacityEngineLayer oldLayer,
   });
@@ -184,7 +191,8 @@ abstract class SceneBuilder {
   /// {@macro dart.ui.sceneBuilder.oldLayerVsRetained}
   ///
   /// See [pop] for details about the operation stack.
-  ColorFilterEngineLayer pushColorFilter(ColorFilter filter, {
+  ColorFilterEngineLayer pushColorFilter(
+    ColorFilter filter, {
     ColorFilterEngineLayer oldLayer,
   });
 
@@ -194,7 +202,8 @@ abstract class SceneBuilder {
   /// rasterizing the given objects.
   ///
   /// See [pop] for details about the operation stack.
-  BackdropFilterEngineLayer pushBackdropFilter(ImageFilter filter, {
+  BackdropFilterEngineLayer pushBackdropFilter(
+    ImageFilter filter, {
     BackdropFilterEngineLayer oldLayer,
   });
 
@@ -204,7 +213,10 @@ abstract class SceneBuilder {
   /// rectangle using the given blend mode.
   ///
   /// See [pop] for details about the operation stack.
-  ShaderMaskEngineLayer pushShaderMask(Shader shader, Rect maskRect, BlendMode blendMode, {
+  ShaderMaskEngineLayer pushShaderMask(
+    Shader shader,
+    Rect maskRect,
+    BlendMode blendMode, {
     ShaderMaskEngineLayer oldLayer,
   });
 
@@ -286,11 +298,13 @@ abstract class SceneBuilder {
   ///
   /// The texture is scaled to the given size and rasterized at the given
   /// offset.
-  void addTexture(int textureId,
-      {Offset offset = Offset.zero,
-      double width = 0.0,
-      double height = 0.0,
-      bool freeze = false});
+  void addTexture(
+    int textureId, {
+    Offset offset = Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    bool freeze = false,
+  });
 
   /// Adds a platform view (e.g an iOS UIView) to the scene.
   ///
@@ -317,12 +331,13 @@ abstract class SceneBuilder {
 
   /// (Fuchsia-only) Adds a scene rendered by another application to the scene
   /// for this application.
-  void addChildScene(
-      {Offset offset = Offset.zero,
-      double width = 0.0,
-      double height = 0.0,
-      SceneHost sceneHost,
-      bool hitTestable = true});
+  void addChildScene({
+    Offset offset = Offset.zero,
+    double width = 0.0,
+    double height = 0.0,
+    SceneHost sceneHost,
+    bool hitTestable = true,
+  });
 
   /// Sets a threshold after which additional debugging information should be
   /// recorded.
@@ -369,8 +384,15 @@ abstract class SceneBuilder {
 
   /// Set properties on the linked scene.  These properties include its bounds,
   /// as well as whether it can be the target of focus events or not.
-  void setProperties(double width, double height, double insetTop,
-      double insetRight, double insetBottom, double insetLeft, bool focusable);
+  void setProperties(
+    double width,
+    double height,
+    double insetTop,
+    double insetRight,
+    double insetBottom,
+    double insetLeft,
+    bool focusable,
+  );
 }
 
 /// A handle for the framework to hold and retain an engine layer across frames.
@@ -390,10 +412,11 @@ class SceneHost {
   ///
   /// The SceneHost takes ownership of the provided ViewHolder token.
   SceneHost(
-      dynamic viewHolderToken,
-      void Function() viewConnectedCallback,
-      void Function() viewDisconnectedCallback,
-      void Function(bool) viewStateChangedCallback);
+    dynamic viewHolderToken,
+    void Function() viewConnectedCallback,
+    void Function() viewDisconnectedCallback,
+    void Function(bool) viewStateChangedCallback,
+  );
 
   /// Releases the resources associated with the SceneHost.
   ///
@@ -402,8 +425,15 @@ class SceneHost {
 
   /// Set properties on the linked scene.  These properties include its bounds,
   /// as well as whether it can be the target of focus events or not.
-  void setProperties(double width, double height, double insetTop,
-      double insetRight, double insetBottom, double insetLeft, bool focusable) {
+  void setProperties(
+    double width,
+    double height,
+    double insetTop,
+    double insetRight,
+    double insetBottom,
+    double insetLeft,
+    bool focusable,
+  ) {
     throw UnimplementedError();
   }
 }


### PR DESCRIPTION
In a [recent PR](https://github.com/flutter/engine/pull/14491) to add a new pushFooLayer() API to the SceneBuilder class in engine, the code format of the pushLayer methods was pointed out as not quite matching the flutter framework style. This PR is looking to find a suitable code style for these methods to embrace moving forward.

Most of the methods were formatted in this initial push to adopt the style [suggested](https://github.com/flutter/engine/pull/14491#discussion_r358576996) in the pushImageFilter PR, but it wasn't clear how to adapt the pushShaderMask() method to comply and I tried 2 variants here in the 2 different files for comparison and feedback.

dartfmt suggests that the fixed parameters be moved to separate lines as well, similar to pushPhysicalShape().  Note that the "one line per argument" style is not really embraced in the engine repo right now, so I hesitated on taking that suggestion to diverge even further.

The formatter built in to Android Studio with the Dart plugin also fights this style somewhat. If all of the arguments are moved to separate lines it insists on 4-space indentation which doesn't match the flutter style, but if only the named parameters (inside {}) are on their own lines then it seems perfectly happy with 2-space indentation.

Also, currently the main (non-web) SceneBuilder push...Layer() method code style seems to be universally "everything on one line regardless of how long the line is", which doesn't look very maintainable so that file should probably be consolidated with whatever format is deemed appropriate here for the web versions of that class.