### PR TITLE
instructions for running firefox/safari tests

### DIFF
--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -32,10 +32,12 @@ If you are a Google employee, you can use an internal instance of Goma to parall
 
 ## Running web engine tests
 To run all tests on Chrome:
+
 ```
 felt test
 ```
-To run tests on Firefox (this will work on a Linux device):
+
+To run tests on Firefox (this will work only on a Linux device):
 
 ```
 felt test --browser=firefox

--- a/lib/web_ui/dev/README.md
+++ b/lib/web_ui/dev/README.md
@@ -31,9 +31,26 @@ felt build [-w] -j 100
 If you are a Google employee, you can use an internal instance of Goma to parallelize your builds. Because Goma compiles code on remote servers, this option is effective even on low-powered laptops.
 
 ## Running web engine tests
-To run all tests:
+To run all tests on Chrome:
 ```
 felt test
+```
+To run tests on Firefox (this will work on a Linux device):
+
+```
+felt test --browser=firefox
+```
+
+For Chrome and Firefox, the tests run on a version locked on the [browser_lock.yaml](https://github.com/flutter/engine/blob/master/lib/web_ui/dev/browser_lock.yaml). In order to use another version, add the version argument:
+
+```
+felt test --browser=firefox --firefox-version=70.0.1
+```
+
+To run tests on Safari use the following command. It works on MacOS devices and it uses the Safari installed on the OS. Currently there is no option for using another Safari version.
+
+```
+felt test --browser=safari
 ```
 
 To run a single test:
@@ -41,7 +58,7 @@ To run a single test:
 felt test test/golden_tests/engine/canvas_golden_test.dart
 ```
 
-To debug a test:
+To debug a test on Chrome:
 ```
 felt test --debug test/golden_tests/engine/canvas_golden_test.dart
 ```


### PR DESCRIPTION
Adding instructions to felt documentation for running Flutter Web engine tests on  firefox and safari.