### PR TITLE
Fix message_loop_fuchsia and thus enable fml_tests and flow_tests for Fuchsia

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -129,9 +129,7 @@ if (is_fuchsia) {
 
     deps = [
       "$flutter_root/flow:flow_tests",
-
-      # TODO(gw280): Re-enable fml_tests on Fuchsia (https://github.com/flutter/flutter/issues/46122)
-      #     "$flutter_root/fml:fml_tests",
+      "$flutter_root/fml:fml_tests",
       "$flutter_root/shell/platform/fuchsia/flutter:flutter_runner_tests",
     ]
   }

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -225,7 +225,6 @@ executable("fml_unittests") {
     "memory/weak_ptr_unittest.cc",
     "message_loop_task_queues_merge_unmerge_unittests.cc",
     "message_loop_task_queues_unittests.cc",
-    "message_loop_unittests.cc",
     "message_unittests.cc",
     "paths_unittests.cc",
     "platform/darwin/string_range_sanitization_unittests.mm",
@@ -242,7 +241,10 @@ executable("fml_unittests") {
 
   # TODO(gw280): Figure out why these tests don't work currently on Fuchsia
   if (!is_fuchsia) {
-    sources += [ "file_unittest.cc" ]
+    sources += [
+      "file_unittest.cc",
+      "message_loop_unittests.cc",
+    ]
   }
 
   deps = [
@@ -252,6 +254,10 @@ executable("fml_unittests") {
     "$flutter_root/runtime:libdart",
     "$flutter_root/testing",
   ]
+
+  if (is_fuchsia && using_fuchsia_sdk) {
+    libs = [ "${fuchsia_sdk_path}/arch/${target_cpu}/sysroot/lib/libzircon.so" ]
+  }
 }
 
 if (is_fuchsia) {

--- a/fml/platform/fuchsia/message_loop_fuchsia.cc
+++ b/fml/platform/fuchsia/message_loop_fuchsia.cc
@@ -30,9 +30,10 @@ void MessageLoopFuchsia::WakeUp(fml::TimePoint time_point) {
     due_time = zx::nsec((time_point - now).ToNanoseconds());
   }
 
-  FML_DCHECK(async::PostDelayedTask(
+  auto status = async::PostDelayedTask(
                  loop_.dispatcher(), [this]() { RunExpiredTasksNow(); },
-                 due_time) == ZX_OK);
+                 due_time);
+  FML_DCHECK(status == ZX_OK);
 }
 
 }  // namespace fml

--- a/fml/platform/fuchsia/message_loop_fuchsia.cc
+++ b/fml/platform/fuchsia/message_loop_fuchsia.cc
@@ -31,8 +31,7 @@ void MessageLoopFuchsia::WakeUp(fml::TimePoint time_point) {
   }
 
   auto status = async::PostDelayedTask(
-                 loop_.dispatcher(), [this]() { RunExpiredTasksNow(); },
-                 due_time);
+      loop_.dispatcher(), [this]() { RunExpiredTasksNow(); }, due_time);
   FML_DCHECK(status == ZX_OK);
 }
 

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -29,8 +29,7 @@ group("libdart") {
   public_deps = []
 
   if (flutter_runtime_mode == "profile" || flutter_runtime_mode == "release") {
-    public_deps +=
-        [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
+    public_deps += [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
   } else {
     public_deps += [
       "$flutter_root/lib/snapshot",

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -28,17 +28,14 @@ source_set("test_font") {
 group("libdart") {
   public_deps = []
 
-  if (!(is_fuchsia && using_fuchsia_sdk)) {
-    if (flutter_runtime_mode == "profile" ||
-        flutter_runtime_mode == "release") {
-      public_deps +=
-          [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
-    } else {
-      public_deps += [
-        "$flutter_root/lib/snapshot",
-        "//third_party/dart/runtime:libdart_jit",
-      ]
-    }
+  if (flutter_runtime_mode == "profile" || flutter_runtime_mode == "release") {
+    public_deps +=
+        [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
+  } else {
+    public_deps += [
+      "$flutter_root/lib/snapshot",
+      "//third_party/dart/runtime:libdart_jit",
+    ]
   }
 }
 

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -53,7 +53,6 @@ template("runner") {
     deps = [
              "$flutter_root/common",
              "$flutter_root/fml",
-             "$flutter_root/runtime:libdart",
              "$flutter_root/shell/platform/fuchsia/dart-pkg/fuchsia",
              "$flutter_root/shell/platform/fuchsia/dart-pkg/zircon",
              "$fuchsia_sdk_root/pkg:async",

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -39,3 +39,11 @@ trap reboot EXIT
     -f flutter_runner_tests-0.far  \
     -t flutter_runner_tests
 
+./fuchsia_ctl -d $device_name test \
+    -f fml_tests-0.far  \
+    -t fml_tests
+
+./fuchsia_ctl -d $device_name test \
+    -f flow_tests-0.far  \
+    -t flow_tests
+

--- a/testing/fuchsia/test_fars
+++ b/testing/fuchsia/test_fars
@@ -1,1 +1,3 @@
 flutter_runner_tests-0.far
+fml_tests-0.far
+flow_tests-0.far


### PR DESCRIPTION
We had a bug in message_loop_fuchsia which meant that expired tasks were only ever drained in debug builds. I've fixed that and now we can re-enable fml_tests and flow_tests which were stuck in an indefinite wait before.

Some of the tests in message_loop_unittests.cc still don't pass, so they've been disabled for Fuchsia for now, but we can re-enable the rest.
