### PR TITLE
[web] Long press fix on Safari on IOS

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -5,7 +5,7 @@
 part of engine;
 
 /// Make the content editable span visible to facilitate debugging.
-const bool _debugVisibleTextEditing = true;
+const bool _debugVisibleTextEditing = false;
 
 /// The `keyCode` of the "Enter" key.
 const int _kReturnKeyCode = 13;
@@ -552,21 +552,8 @@ class IOSTextEditingStrategy extends DefaultTextEditingStrategy {
       _positionInputElementTimer?.cancel();
       _positionInputElementTimer = Timer(_delayBeforePositioning, () {
         _canPosition = true;
-
-        _subscriptions.add(domElement.onClick.listen((_) {
-          if (_canPosition) {
-            // this means already positioned.
-            domElement.style.transform = 'translate(-9999px, -9999px)';
-            _canPosition = false;
-
-            _positionInputElementTimer?.cancel();
-            _positionInputElementTimer = Timer(_delayBeforePositioning, () {
-              _canPosition = true;
-              positionElement();
-            });
-          }
-        }));
         positionElement();
+        _addTapListener();
       });
     }));
 
@@ -593,6 +580,43 @@ class IOSTextEditingStrategy extends DefaultTextEditingStrategy {
     super.disable();
     _positionInputElementTimer?.cancel();
     _positionInputElementTimer = null;
+  }
+
+  /// On iOS long press works differently than a single tap.
+  ///
+  /// On a normal tap the virtual keyboard comes up and users can enter text
+  /// using the keyboard.
+  ///
+  /// The long press on the other hand focuses on the element without bringing
+  /// up the virtual keyboard. It allows the users to modify the field by using
+  /// copy/cut/select/paste etc.
+  ///
+  /// After a long press [domElement] is positioned to the correct place. If the
+  /// user later single-tap on the [domElement] the virtual keyboard will come
+  /// and might shift the page up.
+  ///
+  /// In order to prevent this shift, on a `click` event the position of the
+  /// element is again set somewhere outside of the page and
+  /// [_positionInputElementTimer] timer is restarted. The element will be
+  /// placed to its correct position after [_delayBeforePositioning].
+  void _addTapListener() {
+    _subscriptions.add(domElement.onClick.listen((_) {
+      // Check if the element is already positioned. If not this does not fall
+      // under `The user was using the long press, now they want to enter text
+      // via keyboard` journey.
+      if (_canPosition) {
+        // Re-place the element somewhere outside of the screen.
+        domElement.style.transform = 'translate(-9999px, -9999px)';
+        _canPosition = false;
+
+        // Re-configure the timer to place the element.
+        _positionInputElementTimer?.cancel();
+        _positionInputElementTimer = Timer(_delayBeforePositioning, () {
+          _canPosition = true;
+          positionElement();
+        });
+      }
+    }));
   }
 }
 

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -5,7 +5,7 @@
 part of engine;
 
 /// Make the content editable span visible to facilitate debugging.
-const bool _debugVisibleTextEditing = false;
+const bool _debugVisibleTextEditing = true;
 
 /// The `keyCode` of the "Enter" key.
 const int _kReturnKeyCode = 13;
@@ -552,6 +552,20 @@ class IOSTextEditingStrategy extends DefaultTextEditingStrategy {
       _positionInputElementTimer?.cancel();
       _positionInputElementTimer = Timer(_delayBeforePositioning, () {
         _canPosition = true;
+
+        _subscriptions.add(domElement.onClick.listen((_) {
+          if (_canPosition) {
+            // this means already positioned.
+            domElement.style.transform = 'translate(-9999px, -9999px)';
+            _canPosition = false;
+
+            _positionInputElementTimer?.cancel();
+            _positionInputElementTimer = Timer(_delayBeforePositioning, () {
+              _canPosition = true;
+              positionElement();
+            });
+          }
+        }));
         positionElement();
       });
     }));

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -549,13 +549,10 @@ class IOSTextEditingStrategy extends DefaultTextEditingStrategy {
     // Position the DOM element after it is focused.
     _subscriptions.add(domElement.onFocus.listen((_) {
       // Cancel previous timer if exists.
-      _positionInputElementTimer?.cancel();
-      _positionInputElementTimer = Timer(_delayBeforePositioning, () {
-        _canPosition = true;
-        positionElement();
-        _addTapListener();
-      });
+      _schedulePositioning();
     }));
+
+     _addTapListener();
 
     // On iOS, blur is trigerred if the virtual keyboard is closed or the
     // browser is sent to background or the browser tab is changed.
@@ -606,17 +603,20 @@ class IOSTextEditingStrategy extends DefaultTextEditingStrategy {
       // via keyboard` journey.
       if (_canPosition) {
         // Re-place the element somewhere outside of the screen.
-        domElement.style.transform = 'translate(-9999px, -9999px)';
-        _canPosition = false;
+        initializeElementPosition();
 
         // Re-configure the timer to place the element.
-        _positionInputElementTimer?.cancel();
-        _positionInputElementTimer = Timer(_delayBeforePositioning, () {
-          _canPosition = true;
-          positionElement();
-        });
+        _schedulePositioning();
       }
     }));
+  }
+
+  void _schedulePositioning() {
+    _positionInputElementTimer?.cancel();
+    _positionInputElementTimer = Timer(_delayBeforePositioning, () {
+      _canPosition = true;
+      positionElement();
+    });
   }
 }
 


### PR DESCRIPTION
The long press in IOS does not bring the virtual keyboard but still focus on the dom element. After this if a user taps on the input element the virtual keyboard will shift the page up. (the video I recorded turned out to be to big for github so I am not adding it here.)

in order to fix this, i added one more listener. this time for the click. this listener carries the input field temporarily out of the visible page to prevent shifting.

fixing eap issue: https://github.com/flutter/flutter/issues/41638
