### PR TITLE
Fix crash occured when switch flutter view controller for flutter engine

### DIFF
--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -83,7 +83,9 @@ bool IOSGLRenderTarget::PresentRenderBuffer() const {
       GL_DEPTH_ATTACHMENT,
       GL_STENCIL_ATTACHMENT,
   };
-
+  [EAGLContext setCurrentContext:context_];
+  FML_DCHECK(glGetError() == GL_NO_ERROR);
+  
   glDiscardFramebufferEXT(GL_FRAMEBUFFER, sizeof(discards) / sizeof(GLenum), discards);
 
   glBindRenderbuffer(GL_RENDERBUFFER, colorbuffer_);

--- a/shell/platform/darwin/ios/ios_gl_render_target.mm
+++ b/shell/platform/darwin/ios/ios_gl_render_target.mm
@@ -85,7 +85,7 @@ bool IOSGLRenderTarget::PresentRenderBuffer() const {
   };
   [EAGLContext setCurrentContext:context_];
   FML_DCHECK(glGetError() == GL_NO_ERROR);
-  
+
   glDiscardFramebufferEXT(GL_FRAMEBUFFER, sizeof(discards) / sizeof(GLenum), discards);
 
   glBindRenderbuffer(GL_RENDERBUFFER, colorbuffer_);


### PR DESCRIPTION
My app( Alibaba Xianyu App) need to manually reset the FlutterViewController for FlutterEngine, just like this demo: https://github.com/xujim/testaccessibility. After it has been deployed to our customer, we collected one crash log likes following:
![image](https://user-images.githubusercontent.com/3032016/71393618-5a238700-2648-11ea-8319-e8e2c4d01041.png)
After desymbolicatted for the Flutter framework( attached at the end), line #5(5   Flutter                         0x000000010a7387b0 0x000000010a70c000 + 182192)  actually invoked the last line in the following code snippet:
```c++
bool IOSGLRenderTarget::PresentRenderBuffer() const {
  const GLenum discards[] = {
      GL_DEPTH_ATTACHMENT,
      GL_STENCIL_ATTACHMENT,
  };
  glDiscardFramebufferEXT(GL_FRAMEBUFFER, sizeof(discards) / sizeof(GLenum), discards);

  glBindRenderbuffer(GL_RENDERBUFFER, colorbuffer_);
  return [[EAGLContext currentContext] presentRenderbuffer:GL_RENDERBUFFER];
}
```

> return [[EAGLContext currentContext] presentRenderbuffer:GL_RENDERBUFFER];

then calls to the OpenGL to render and crashed. Try To find why opengl crashed, I find GLEngine and AppleMetalGLRenderer 's binary here: https://github.com/Yonsm/MISC/tree/master/iOS10/arm64/System/Library/Frameworks/OpenGLES.framework/GLEngine.bundle
And use hopper disassembler to get following asm code:
```asm
__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_:  
000000024fc8b02c         stp        x28, x27, [sp, #-0x60]!
000000024fc8b030         stp        x26, x25, [sp, #0x10]
000000024fc8b034         stp        x24, x23, [sp, #0x20]
000000024fc8b038         stp        x22, x21, [sp, #0x30]
000000024fc8b03c         stp        x20, x19, [sp, #0x40]
000000024fc8b040         stp        x29, x30, [sp, #0x50]
000000024fc8b044         add        x29, sp, #0x50
000000024fc8b048         sub        sp, sp, #0x20
000000024fc8b04c         mov        x20, x7
000000024fc8b050         mov        x24, x6
000000024fc8b054         mov        x25, x5
000000024fc8b058         mov        x21, x4
000000024fc8b05c         mov        x23, x3
000000024fc8b060         mov        x22, x2
000000024fc8b064         mov        x19, x0
000000024fc8b068         ldr        x8, [x19, #0x188]
000000024fc8b06c         cbz        x8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+564

000000024fc8b070         movz       w9, #0x11db
000000024fc8b074         ldrb       w9, x19, x9
000000024fc8b078         cbnz       w9, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+1408

000000024fc8b07c         ldrb       w9, [x19, #0x178]
000000024fc8b080         and        w9, w9, #0x70
000000024fc8b084         cbz        w9, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+104

000000024fc8b088         movz       w9, #0x11d9
000000024fc8b08c         ldrb       w9, x19, x9
000000024fc8b090         cbnz       w9, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+1408

000000024fc8b094         movn       w26, #0xe800                                ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+88
000000024fc8b098         cbz        w1, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+176

000000024fc8b09c         orr        w9, w1, #0x2
000000024fc8b0a0         cmp        w9, #0x3
000000024fc8b0a4         b.ne       __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+564

000000024fc8b0a8         movz       w9, #0x1401
000000024fc8b0ac         cmp        w25, w9
000000024fc8b0b0         b.eq       __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+348

000000024fc8b0b4         ldrb       w9, [x8, #0x40]
000000024fc8b0b8         cbz        w9, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+348

000000024fc8b0bc         ldr        x8, [x8, #0x38]
000000024fc8b0c0         ldr        x27, [x8, #0x100]
000000024fc8b0c4         ldr        x8, [x27, #0x28]
000000024fc8b0c8         cbz        x8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+572

000000024fc8b0cc         ldr        x8, [x8, #0x18]
000000024fc8b0d0         cbz        x8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+572

000000024fc8b0d4         ldr        x23, [x8, #0x28]
000000024fc8b0d8         b          __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+576

000000024fc8b0dc         ldr        x8, [x19, #0x10]                            ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+108
000000024fc8b0e0         cbz        x8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+208

000000024fc8b0e4         ldr        w8, [x19, #0x7b0]
000000024fc8b0e8         cbz        w8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+216

000000024fc8b0ec         mov        x0, x19
000000024fc8b0f0         bl         __ZN13GLDContextRec13endRenderPassEv        ; GLDContextRec::endRenderPass()
000000024fc8b0f4         ldr        x8, [x19, #0x10]
000000024fc8b0f8         cbnz       x8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+216

000000024fc8b0fc         mov        x0, x19                                     ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+180
000000024fc8b100         bl         __ZN13GLDContextRec15beginRenderPassEv      ; GLDContextRec::beginRenderPass()

000000024fc8b104         movz       w8, #0x11da                                 ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+188, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+204
000000024fc8b108         add        x8, x19, x8
000000024fc8b10c         ldrb       w9, x8
000000024fc8b110         cmp        w9, #0x1
000000024fc8b114         b.eq       __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+256

000000024fc8b118         orr        w9, wzr, #0x1
000000024fc8b11c         strb       w9, x8
000000024fc8b120         ldr        w8, [x19, #0x7a8]
000000024fc8b124         orr        w8, w8, #0x8
000000024fc8b128         str        w8, [x19, #0x7a8]

000000024fc8b12c         mov        x0, x19                                     ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+232
000000024fc8b130         bl         __ZN13GLDContextRec25isTransformFeedbackActiveEv ; GLDContextRec::isTransformFeedbackActive()
000000024fc8b134         cbz        w0, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+1000

000000024fc8b138         orr        w8, wzr, #0x1
000000024fc8b13c         strb       w8, [x19, #0x85c]
000000024fc8b140         ldr        w8, [x19, #0x7a8]
000000024fc8b144         orr        w8, w8, #0x8
000000024fc8b148         str        w8, [x19, #0x7a8]
000000024fc8b14c         movz       w1, #0x1
000000024fc8b150         movk       w1, #0xfffd
000000024fc8b154         mov        x0, x19
000000024fc8b158         bl         __ZN13GLDContextRec14setRenderStateEj       ; GLDContextRec::setRenderState(unsigned int)
000000024fc8b15c         ldr        w8, [x19, #0x114]
000000024fc8b160         cbz        w8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+320

000000024fc8b164         mov        x0, x19
000000024fc8b168         bl         __ZN13GLDContextRec23setRenderVertexCurrentsEv ; GLDContextRec::setRenderVertexCurrents()

000000024fc8b16c         cbz        w22, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+764 ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+308

000000024fc8b170         cmp        w22, #0x4
000000024fc8b174         b.eq       __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+772

000000024fc8b178         cmp        w22, #0x1
000000024fc8b17c         b.ne       __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+1444

000000024fc8b180         orr        w8, wzr, #0x2
000000024fc8b184         b          __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+776

000000024fc8b188         ldr        x8, [x19, #0x10]                            ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+132, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+140
000000024fc8b18c         cbz        x8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+380

000000024fc8b190         ldr        w8, [x19, #0x7b0]
000000024fc8b194         cbz        w8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+388

000000024fc8b198         mov        x0, x19
000000024fc8b19c         bl         __ZN13GLDContextRec13endRenderPassEv        ; GLDContextRec::endRenderPass()
000000024fc8b1a0         ldr        x8, [x19, #0x10]
000000024fc8b1a4         cbnz       x8, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+388

000000024fc8b1a8         mov        x0, x19                                     ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+352
000000024fc8b1ac         bl         __ZN13GLDContextRec15beginRenderPassEv      ; GLDContextRec::beginRenderPass()

000000024fc8b1b0         add        x4, sp, #0x8                                ; CODE XREF=__ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+360, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+376
000000024fc8b1b4         add        x5, sp, #0x10
000000024fc8b1b8         mov        x1, x25
000000024fc8b1bc         mov        x2, x21
000000024fc8b1c0         mov        x0, x19
000000024fc8b1c4         mov        x3, x24
000000024fc8b1c8         bl         __ZN13GLDContextRec14getIndexBufferEjiPKvPmP12MTLIndexType ; GLDContextRec::getIndexBuffer(unsigned int, int, void const*, unsigned long*, MTLIndexType*)
000000024fc8b1cc         mov        x23, x0
000000024fc8b1d0         cbz        x23, __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+564

000000024fc8b1d4         movz       w8, #0x11da
000000024fc8b1d8         add        x8, x19, x8
000000024fc8b1dc         ldrb       w9, x8
000000024fc8b1e0         cmp        w9, #0x1
000000024fc8b1e4         b.eq       __ZL20gldRenderVertexArrayP13GLDContextRecjjiijPKviS2_+464

000000024fc8b1e8         orr        w9, wzr, #0x1
000000024fc8b1ec         strb       w9, x8
000000024fc8b1f0         ldr        w8, [x19, #0x7a8]
```
Obviously, the app crashed at address #000000024fc8b1e0, which try to access a field of GLDContextRec. Normally, the access of field won't fail except the object is null or wild pointer.
**So I concluded that GLDContextRec might be null or invalid and cause the accessing of its field illegal, and lead to crash/abort finally.**
Then when or why the GLDContextRec could be null? It might be caused by [EAGLContext setCurrentContext:nil] or the context switch of flutter.

Attached is the flutter.framework's binary compiled for my app.
[Flutter.zip](https://github.com/flutter/engine/files/3997503/Flutter.zip)
You can find the GLEngine and and AppleMetalGLRenderer 's binary here: https://github.com/Yonsm/MISC/tree/master/iOS10/arm64/System/Library/Frameworks/OpenGLES.framework/GLEngine.bundle
