### PR TITLE
Refactor BitmapCanvas. Fix image compositing bug

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: a121ff1169a1b478274a3e34c95d0a1d2d685948
+revision: 0782fbb5e6705fa444f8a6a701062f381edaae2f

--- a/lib/web_ui/lib/src/engine.dart
+++ b/lib/web_ui/lib/src/engine.dart
@@ -23,6 +23,7 @@ part 'engine/assets.dart';
 part 'engine/bitmap_canvas.dart';
 part 'engine/browser_detection.dart';
 part 'engine/browser_location.dart';
+part 'engine/canvas_pool.dart';
 part 'engine/color_filter.dart';
 part 'engine/compositor/canvas.dart';
 part 'engine/compositor/canvas_kit_canvas.dart';

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -5,7 +5,7 @@
 part of engine;
 
 /// A raw HTML canvas that is directly written to.
-class BitmapCanvas extends EngineCanvas with SaveStackTracking {
+class BitmapCanvas extends EngineCanvas {
   /// The rectangle positioned relative to the parent layer's coordinate
   /// system's origin, within which this canvas paints.
   ///
@@ -14,6 +14,14 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
   set bounds(ui.Rect newValue) {
     assert(newValue != null);
     _bounds = newValue;
+    final int newCanvasPositionX = _bounds.left.floor() - kPaddingPixels;
+    final int newCanvasPositionY = _bounds.top.floor() - kPaddingPixels;
+    if (_canvasPositionX != newCanvasPositionX ||
+        _canvasPositionY != newCanvasPositionY) {
+      _canvasPositionX = newCanvasPositionX;
+      _canvasPositionY = newCanvasPositionY;
+      _updateRootElementTransform();
+    }
   }
 
   ui.Rect _bounds;
@@ -25,8 +33,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
   @override
   final html.Element rootElement = html.Element.tag('flt-canvas');
 
-  html.CanvasElement _canvas;
-  html.CanvasRenderingContext2D _ctx;
+  final _CanvasPool _canvasPool;
 
   /// The size of the paint [bounds].
   ui.Size get size => _bounds.size;
@@ -44,7 +51,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
   /// These pixels are different from the logical CSS pixels. Here a pixel
   /// literally means 1 point with a RGBA color.
   int get widthInBitmapPixels => _widthInBitmapPixels;
-  int _widthInBitmapPixels;
+  final int _widthInBitmapPixels;
 
   /// The number of pixels along the width of the bitmap that the canvas element
   /// renders into.
@@ -52,7 +59,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
   /// These pixels are different from the logical CSS pixels. Here a pixel
   /// literally means 1 point with a RGBA color.
   int get heightInBitmapPixels => _heightInBitmapPixels;
-  int _heightInBitmapPixels;
+  final int _heightInBitmapPixels;
 
   /// The number of pixels in the bitmap that the canvas element renders into.
   ///
@@ -66,11 +73,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
   /// was created.
   final double _devicePixelRatio = html.window.devicePixelRatio;
 
-  // Cached current filter, fill and stroke style to reduce updates to
-  // CanvasRenderingContext2D that are slow even when resetting to null.
-  String _prevFilter = 'none';
-  Object _prevFillStyle;
-  Object _prevStrokeStyle;
+  int _canvasPositionX, _canvasPositionY;
 
   // Indicates the instructions following drawImage or drawParagraph that
   // a child element was created to paint.
@@ -89,51 +92,60 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
   /// This canvas can be reused by pictures with different paint bounds as long
   /// as the [Rect.size] of the bounds fully fit within the size used to
   /// initialize this canvas.
-  BitmapCanvas(this._bounds) : assert(_bounds != null) {
+  BitmapCanvas(this._bounds) :
+        assert(_bounds != null),
+        _widthInBitmapPixels = _widthToPhysical(_bounds.width),
+        _heightInBitmapPixels = _heightToPhysical(_bounds.height),
+        _canvasPool = _CanvasPool(_widthToPhysical(_bounds.width), _heightToPhysical(_bounds.height)) {
     rootElement.style.position = 'absolute';
-
     // Adds one extra pixel to the requested size. This is to compensate for
     // _initializeViewport() snapping canvas position to 1 pixel, causing
     // painting to overflow by at most 1 pixel.
-
-    _widthInBitmapPixels = _widthToPhysical(_bounds.width);
-    _heightInBitmapPixels = _heightToPhysical(_bounds.height);
-
-    // Compute the final CSS canvas size given the actual pixel count we
-    // allocated. This is done for the following reasons:
-    //
-    // * To satisfy the invariant: pixel size = css size * device pixel ratio.
-    // * To make sure that when we scale the canvas by devicePixelRatio (see
-    //   _initializeViewport below) the pixels line up.
-    final double cssWidth = _widthInBitmapPixels / html.window.devicePixelRatio;
-    final double cssHeight =
-        _heightInBitmapPixels / html.window.devicePixelRatio;
-
-    _canvas = html.CanvasElement(
-      width: _widthInBitmapPixels,
-      height: _heightInBitmapPixels,
-    );
-    _canvas.style
-      ..position = 'absolute'
-      ..width = '${cssWidth}px'
-      ..height = '${cssHeight}px';
-    _ctx = _canvas.context2D;
-    rootElement.append(_canvas);
-    _initializeViewport();
+    _canvasPositionX = _bounds.left.floor() - kPaddingPixels;
+    _canvasPositionY = _bounds.top.floor() - kPaddingPixels;
+    _updateRootElementTransform();
+    _canvasPool.allocateCanvas(rootElement, _widthInBitmapPixels,
+        _heightInBitmapPixels, _bounds);
+    _setupInitialTransform();
   }
 
-  int _widthToPhysical(double width) {
+  void _updateRootElementTransform() {
+    // Flutter emits paint operations positioned relative to the parent layer's
+    // coordinate system. However, canvas' coordinate system's origin is always
+    // in the top-left corner of the canvas. We therefore need to inject an
+    // initial translation so the paint operations are positioned as expected.
+    //
+    // The flooring of the value is to ensure that canvas' top-left corner
+    // lands on the physical pixel.
+    rootElement.style.transform =
+      'translate(${_canvasPositionX}px, ${_canvasPositionY}px)';
+  }
+
+  void _setupInitialTransform() {
+    final double canvasPositionCorrectionX =
+        _bounds.left - BitmapCanvas.kPaddingPixels - _canvasPositionX.toDouble();
+    final double canvasPositionCorrectionY =
+        _bounds.top - BitmapCanvas.kPaddingPixels - _canvasPositionY.toDouble();
+    // This compensates for the translate on the `rootElement`.
+    translate(
+      -_bounds.left + canvasPositionCorrectionX + BitmapCanvas.kPaddingPixels,
+      -_bounds.top + canvasPositionCorrectionY + BitmapCanvas.kPaddingPixels,
+    );
+  }
+
+  static int _widthToPhysical(double width) {
     final double boundsWidth = width + 1;
     return (boundsWidth * html.window.devicePixelRatio).ceil() +
         2 * kPaddingPixels;
   }
 
-  int _heightToPhysical(double height) {
+  static int _heightToPhysical(double height) {
     final double boundsHeight = height + 1;
     return (boundsHeight * html.window.devicePixelRatio).ceil() +
         2 * kPaddingPixels;
   }
 
+  // Used by picture to assess if canvas is large enough to reuse as is.
   bool doesFitBounds(ui.Rect newBounds) {
     assert(newBounds != null);
     return _widthInBitmapPixels >= _widthToPhysical(newBounds.width) &&
@@ -142,22 +154,13 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
 
   @override
   void dispose() {
-    super.dispose();
-    // Webkit has a threshold for the amount of canvas pixels an app can
-    // allocate. Even though our canvases are being garbage-collected as
-    // expected when we don't need them, Webkit keeps track of their sizes
-    // towards the threshold. Setting width and height to zero tricks Webkit
-    // into thinking that this canvas has a zero size so it doesn't count it
-    // towards the threshold.
-    if (browserEngine == BrowserEngine.webkit) {
-      _canvas.width = _canvas.height = 0;
-    }
+    _canvasPool.dispose();
   }
 
   /// Prepare to reuse this canvas by clearing it's current contents.
   @override
   void clear() {
-    super.clear();
+    _canvasPool.clear();
     final int len = _children.length;
     for (int i = 0; i < len; i++) {
       _children[i].remove();
@@ -165,11 +168,10 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
     _children.clear();
     _cachedLastStyle = null;
     // Restore to the state where we have only applied the scaling.
-    if (_ctx != null) {
-      _ctx.restore();
-      _ctx.clearRect(0, 0, _widthInBitmapPixels, _heightInBitmapPixels);
+    html.CanvasRenderingContext2D ctx = _canvasPool.context;
+    if (ctx != null) {
       try {
-        _ctx.font = '';
+        ctx.font = '';
       } catch (e) {
         // Firefox may explode here:
         // https://bugzilla.mozilla.org/show_bug.cgi?id=941146
@@ -177,12 +179,11 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
           rethrow;
         }
       }
-      _initializeViewport();
+      _canvasPool.reuse();
+      _setupInitialTransform();
+      _canvasPool.contextHandle.reset();
     }
-    if (_canvas != null) {
-      _canvas.style.transformOrigin = '';
-      _canvas.style.transform = '';
-    }
+    _canvasPool.resetTransform();
   }
 
   /// Checks whether this [BitmapCanvas] can still be recycled and reused.
@@ -197,128 +198,40 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
     return _devicePixelRatio == html.window.devicePixelRatio;
   }
 
-  /// Configures the canvas such that its coordinate system follows the scene's
-  /// coordinate system, and the pixel ratio is applied such that CSS pixels are
-  /// translated to bitmap pixels.
-  void _initializeViewport() {
-    // Save the canvas state with top-level transforms so we can undo
-    // any clips later when we reuse the canvas.
-    _ctx.save();
-
-    // We always start with identity transform because the surrounding transform
-    // is applied on the DOM elements.
-    _ctx.setTransform(1, 0, 0, 1, 0, 0);
-
-    // This scale makes sure that 1 CSS pixel is translated to the correct
-    // number of bitmap pixels.
-    _ctx.scale(html.window.devicePixelRatio, html.window.devicePixelRatio);
-
-    // Flutter emits paint operations positioned relative to the parent layer's
-    // coordinate system. However, canvas' coordinate system's origin is always
-    // in the top-left corner of the canvas. We therefore need to inject an
-    // initial translation so the paint operations are positioned as expected.
-
-    // The flooring of the value is to ensure that canvas' top-left corner
-    // lands on the physical pixel.
-    final int canvasPositionX = _bounds.left.floor() - kPaddingPixels;
-    final int canvasPositionY = _bounds.top.floor() - kPaddingPixels;
-    final double canvasPositionCorrectionX =
-        _bounds.left - kPaddingPixels - canvasPositionX.toDouble();
-    final double canvasPositionCorrectionY =
-        _bounds.top - kPaddingPixels - canvasPositionY.toDouble();
-
-    rootElement.style.transform =
-        'translate(${canvasPositionX}px, ${canvasPositionY}px)';
-
-    // This compensates for the translate on the `rootElement`.
-    translate(
-      -_bounds.left + canvasPositionCorrectionX + kPaddingPixels,
-      -_bounds.top + canvasPositionCorrectionY + kPaddingPixels,
-    );
+  // Returns a data URI containing a representation of the image in this
+  // canvas.
+  String toDataUrl() {
+    return _canvasPool.toDataUrl();
   }
-
-  /// The `<canvas>` element used by this bitmap canvas.
-  html.CanvasElement get canvas => _canvas;
-
-  /// The 2D context of the `<canvas>` element used by this bitmap canvas.
-  html.CanvasRenderingContext2D get ctx => _ctx;
 
   /// Sets the global paint styles to correspond to [paint].
   void _applyPaint(SurfacePaintData paint) {
-    ctx.globalCompositeOperation =
-        _stringForBlendMode(paint.blendMode) ?? 'source-over';
-    ctx.lineWidth = paint.strokeWidth ?? 1.0;
-    final ui.StrokeCap cap = paint.strokeCap;
-    if (cap != null) {
-      ctx.lineCap = _stringForStrokeCap(cap);
-    } else {
-      ctx.lineCap = 'butt';
-    }
-    final ui.StrokeJoin join = paint.strokeJoin;
-    if (join != null) {
-      ctx.lineJoin = _stringForStrokeJoin(join);
-    } else {
-      ctx.lineJoin = 'miter';
-    }
+    ContextStateHandle contextHandle = _canvasPool.contextHandle;
+    contextHandle
+      ..lineWidth = paint.strokeWidth ?? 1.0
+      ..blendMode = paint.blendMode
+      ..strokeCap = paint.strokeCap
+      ..strokeJoin = paint.strokeJoin
+      ..filter = _maskFilterToCss(paint.maskFilter);
+
     if (paint.shader != null) {
       final EngineGradient engineShader = paint.shader;
-      final Object paintStyle = engineShader.createPaintStyle(ctx);
-      _setFillAndStrokeStyle(paintStyle, paintStyle);
+      final Object paintStyle = engineShader.createPaintStyle(_canvasPool.context);
+      contextHandle.fillStyle = paintStyle;
+      contextHandle.strokeStyle = paintStyle;
     } else if (paint.color != null) {
       final String colorString = paint.color.toCssString();
-      _setFillAndStrokeStyle(colorString, colorString);
-    }
-    if (paint.maskFilter != null) {
-      _setFilter('blur(${paint.maskFilter.webOnlySigma}px)');
-    }
-  }
-
-  void _strokeOrFill(SurfacePaintData paint, {bool resetPaint = true}) {
-    switch (paint.style) {
-      case ui.PaintingStyle.stroke:
-        ctx.stroke();
-        break;
-      case ui.PaintingStyle.fill:
-      default:
-        ctx.fill();
-        break;
-    }
-    if (resetPaint) {
-      _resetPaint();
-    }
-  }
-
-  /// Resets the paint styles that were set due to a previous paint command.
-  ///
-  /// For example, if a previous paint commands has a blur filter, we need to
-  /// undo that filter here.
-  ///
-  /// This needs to be called after [_applyPaint].
-  void _resetPaint() {
-    _setFilter('none');
-    _setFillAndStrokeStyle(null, null);
-  }
-
-  void _setFilter(String value) {
-    if (_prevFilter != value) {
-      _prevFilter = ctx.filter = value;
-    }
-  }
-
-  void _setFillAndStrokeStyle(Object fillStyle, Object strokeStyle) {
-    final html.CanvasRenderingContext2D _ctx = ctx;
-    if (!identical(_prevFillStyle, fillStyle)) {
-      _prevFillStyle = _ctx.fillStyle = fillStyle;
-    }
-    if (!identical(_prevStrokeStyle, strokeStyle)) {
-      _prevStrokeStyle = _ctx.strokeStyle = strokeStyle;
+      contextHandle.fillStyle = colorString;
+      contextHandle.strokeStyle = colorString;
+    } else {
+      contextHandle.fillStyle = '';
+      contextHandle.strokeStyle = '';
     }
   }
 
   @override
   int save() {
-    super.save();
-    ctx.save();
+    _canvasPool.save();
     return _saveCount++;
   }
 
@@ -328,8 +241,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
 
   @override
   void restore() {
-    super.restore();
-    ctx.restore();
+    _canvasPool.restore();
     _saveCount--;
     _cachedLastStyle = null;
   }
@@ -341,238 +253,108 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
     assert(_saveCount >= count);
     final int restores = _saveCount - count;
     for (int i = 0; i < restores; i++) {
-      ctx.restore();
+      _canvasPool.restore();
     }
     _saveCount = count;
   }
 
   @override
   void translate(double dx, double dy) {
-    super.translate(dx, dy);
-    ctx.translate(dx, dy);
+    _canvasPool.translate(dx, dy);
   }
 
   @override
   void scale(double sx, double sy) {
-    super.scale(sx, sy);
-    ctx.scale(sx, sy);
+    _canvasPool.scale(sx, sy);
   }
 
   @override
   void rotate(double radians) {
-    super.rotate(radians);
-    ctx.rotate(radians);
+    _canvasPool.rotate(radians);
   }
 
   @override
   void skew(double sx, double sy) {
-    super.skew(sx, sy);
-    ctx.transform(1, sy, sx, 1, 0, 0);
-    //            |  |   |   |  |  |
-    //            |  |   |   |  |  f - vertical translation
-    //            |  |   |   |  e - horizontal translation
-    //            |  |   |   d - vertical scaling
-    //            |  |   c - horizontal skewing
-    //            |  b - vertical skewing
-    //            a - horizontal scaling
-    //
-    // Source: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/transform
+    _canvasPool.skew(sx, sy);
   }
 
   @override
   void transform(Float64List matrix4) {
-    super.transform(matrix4);
-
-    // Canvas2D transform API:
-    //
-    // ctx.transform(a, b, c, d, e, f);
-    //
-    // In 3x3 matrix form assuming vector representation of (x, y, 1):
-    //
-    // a c e
-    // b d f
-    // 0 0 1
-    //
-    // This translates to 4x4 matrix with vector representation of (x, y, z, 1)
-    // as:
-    //
-    // a c 0 e
-    // b d 0 f
-    // 0 0 1 0
-    // 0 0 0 1
-    //
-    // This matrix is sufficient to represent 2D rotates, translates, scales,
-    // and skews.
-    _ctx.transform(
-      matrix4[0],
-      matrix4[1],
-      matrix4[4],
-      matrix4[5],
-      matrix4[12],
-      matrix4[13],
-    );
+    _canvasPool.transform(matrix4);
   }
 
   @override
   void clipRect(ui.Rect rect) {
-    super.clipRect(rect);
-    ctx.beginPath();
-    ctx.rect(rect.left, rect.top, rect.width, rect.height);
-    ctx.clip();
+    _canvasPool.clipRect(rect);
   }
 
   @override
   void clipRRect(ui.RRect rrect) {
-    super.clipRRect(rrect);
-    final ui.Path path = ui.Path()..addRRect(rrect);
-    _runPath(path);
-    ctx.clip();
+    _canvasPool.clipRRect(rrect);
   }
 
   @override
   void clipPath(ui.Path path) {
-    super.clipPath(path);
-    _runPath(path);
-    ctx.clip();
+    _canvasPool.clipPath(path);
   }
 
   @override
   void drawColor(ui.Color color, ui.BlendMode blendMode) {
-    ctx.globalCompositeOperation = _stringForBlendMode(blendMode);
-
-    // Fill a virtually infinite rect with the color.
-    //
-    // We can't use (0, 0, width, height) because the current transform can
-    // cause it to not fill the entire clip.
-    ctx.fillRect(-10000, -10000, 20000, 20000);
+    _canvasPool.drawColor(color, blendMode);
   }
 
   @override
   void drawLine(ui.Offset p1, ui.Offset p2, SurfacePaintData paint) {
     _applyPaint(paint);
-    ctx.beginPath();
-    ctx.moveTo(p1.dx, p1.dy);
-    ctx.lineTo(p2.dx, p2.dy);
-    ctx.stroke();
-    _resetPaint();
+    _canvasPool.strokeLine(p1, p2);
   }
 
   @override
   void drawPaint(SurfacePaintData paint) {
     _applyPaint(paint);
-    ctx.beginPath();
-
-    // Fill a virtually infinite rect with the color.
-    //
-    // We can't use (0, 0, width, height) because the current transform can
-    // cause it to not fill the entire clip.
-    ctx.fillRect(-10000, -10000, 20000, 20000);
-    _resetPaint();
+    _canvasPool.fill();
   }
 
   @override
   void drawRect(ui.Rect rect, SurfacePaintData paint) {
     _applyPaint(paint);
-    ctx.beginPath();
-    ctx.rect(rect.left, rect.top, rect.width, rect.height);
-    _strokeOrFill(paint);
+    _canvasPool.drawRect(rect, paint.style);
   }
 
   @override
   void drawRRect(ui.RRect rrect, SurfacePaintData paint) {
     _applyPaint(paint);
-    _RRectToCanvasRenderer(ctx).render(rrect);
-    _strokeOrFill(paint);
+    _canvasPool.drawRRect(rrect, paint.style);
   }
 
   @override
   void drawDRRect(ui.RRect outer, ui.RRect inner, SurfacePaintData paint) {
     _applyPaint(paint);
-    _RRectRenderer renderer = _RRectToCanvasRenderer(ctx);
-    renderer.render(outer);
-    renderer.render(inner, startNewPath: false, reverse: true);
-    _strokeOrFill(paint);
+    _canvasPool.drawDRRect(outer, inner, paint.style);
   }
 
   @override
   void drawOval(ui.Rect rect, SurfacePaintData paint) {
     _applyPaint(paint);
-    ctx.beginPath();
-    ctx.ellipse(rect.center.dx, rect.center.dy, rect.width / 2, rect.height / 2,
-        0, 0, 2.0 * math.pi, false);
-    _strokeOrFill(paint);
+    _canvasPool.drawOval(rect, paint.style);
   }
 
   @override
   void drawCircle(ui.Offset c, double radius, SurfacePaintData paint) {
     _applyPaint(paint);
-    ctx.beginPath();
-    ctx.ellipse(c.dx, c.dy, radius, radius, 0, 0, 2.0 * math.pi, false);
-    _strokeOrFill(paint);
+    _canvasPool.drawCircle(c, radius, paint.style);
   }
 
   @override
   void drawPath(ui.Path path, SurfacePaintData paint) {
     _applyPaint(paint);
-    _runPath(path);
-    _strokeOrFill(paint);
+    _canvasPool.drawPath(path, paint.style);
   }
 
   @override
   void drawShadow(ui.Path path, ui.Color color, double elevation,
       bool transparentOccluder) {
-    final List<CanvasShadow> shadows =
-        ElevationShadow.computeCanvasShadows(elevation, color);
-    if (shadows.isNotEmpty) {
-      for (final CanvasShadow shadow in shadows) {
-        // TODO(het): Shadows with transparent occluders are not supported
-        // on webkit since filter is unsupported.
-        if (transparentOccluder && browserEngine != BrowserEngine.webkit) {
-          // We paint shadows using a path and a mask filter instead of the
-          // built-in shadow* properties. This is because the color alpha of the
-          // paint is added to the shadow. The effect we're looking for is to just
-          // paint the shadow without the path itself, but if we use a non-zero
-          // alpha for the paint the path is painted in addition to the shadow,
-          // which is undesirable.
-          final SurfacePaint paint = SurfacePaint()
-            ..color = shadow.color
-            ..style = ui.PaintingStyle.fill
-            ..strokeWidth = 0.0
-            ..maskFilter = ui.MaskFilter.blur(ui.BlurStyle.normal, shadow.blur);
-          _ctx.save();
-          _ctx.translate(shadow.offsetX, shadow.offsetY);
-          final SurfacePaintData paintData = paint.paintData;
-          _applyPaint(paintData);
-          _runPath(path);
-          _strokeOrFill(paintData, resetPaint: false);
-          _ctx.restore();
-        } else {
-          // TODO(het): We fill the path with this paint, then later we clip
-          // by the same path and fill it with a fully opaque color (we know
-          // the color is fully opaque because `transparentOccluder` is false.
-          // However, due to anti-aliasing of the clip, a few pixels of the
-          // path we are about to paint may still be visible after we fill with
-          // the opaque occluder. For that reason, we fill with the shadow color,
-          // and set the shadow color to fully opaque. This way, the visible
-          // pixels are less opaque and less noticeable.
-          final SurfacePaint paint = SurfacePaint()
-            ..color = shadow.color
-            ..style = ui.PaintingStyle.fill
-            ..strokeWidth = 0.0;
-          _ctx.save();
-          final SurfacePaintData paintData = paint.paintData;
-          _applyPaint(paintData);
-          _ctx.shadowBlur = shadow.blur;
-          _ctx.shadowColor = shadow.color.withAlpha(0xff).toCssString();
-          _ctx.shadowOffsetX = shadow.offsetX;
-          _ctx.shadowOffsetY = shadow.offsetY;
-          _runPath(path);
-          _strokeOrFill(paintData, resetPaint: false);
-          _ctx.restore();
-        }
-      }
-      _resetPaint();
-    }
+    _canvasPool.drawShadow(path, color, elevation, transparentOccluder);
   }
 
   @override
@@ -580,23 +362,29 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
     _applyPaint(paint);
     final HtmlImage htmlImage = image;
     final html.ImageElement imgElement = htmlImage.cloneImageElement();
-    String blendMode = ctx.globalCompositeOperation;
+    String blendMode = _canvasPool.context.globalCompositeOperation;
     imgElement.style.mixBlendMode = blendMode;
     _drawImage(imgElement, p);
     _childOverdraw = true;
+    _allocateNewCanvas();
+  }
+
+  void _allocateNewCanvas() {
+    _canvasPool.allocateCanvas(rootElement, _widthInBitmapPixels,
+        _heightInBitmapPixels, _bounds);
   }
 
   void _drawImage(html.ImageElement imgElement, ui.Offset p) {
-    if (isClipped) {
+    if (_canvasPool.isClipped) {
       final List<html.Element> clipElements =
-          _clipContent(_clipStack, imgElement, p, currentTransform);
+          _clipContent(_canvasPool._clipStack, imgElement, p, _canvasPool.currentTransform);
       for (html.Element clipElement in clipElements) {
         rootElement.append(clipElement);
         _children.add(clipElement);
       }
     } else {
       final String cssTransform =
-          matrix4ToCssTransform3d(transformWithOffset(currentTransform, p));
+          matrix4ToCssTransform3d(transformWithOffset(_canvasPool.currentTransform, p));
       imgElement.style
         ..transformOrigin = '0 0 0'
         ..transform = cssTransform;
@@ -656,6 +444,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
       if (requiresClipping) {
         restore();
       }
+      _allocateNewCanvas();
     }
     _childOverdraw = true;
   }
@@ -666,6 +455,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
     double x,
     double y,
   ) {
+    html.CanvasRenderingContext2D ctx = _canvasPool.context;
     final double letterSpacing = style.letterSpacing;
     if (letterSpacing == null || letterSpacing == 0.0) {
       ctx.fillText(line.text, x, y);
@@ -692,7 +482,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
   @override
   void drawParagraph(EngineParagraph paragraph, ui.Offset offset) {
     assert(paragraph._isLaidOut);
-
+    html.CanvasRenderingContext2D ctx = _canvasPool.context;
     final ParagraphGeometricStyle style = paragraph._geometricStyle;
 
     if (paragraph._drawOnCanvas && _childOverdraw == false) {
@@ -719,23 +509,22 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
         _drawTextLine(style, lines[i], x, y);
         y += paragraph._lineHeight;
       }
-      _resetPaint();
       return;
     }
 
     final html.Element paragraphElement =
         _drawParagraphElement(paragraph, offset);
 
-    if (isClipped) {
+    if (_canvasPool.isClipped) {
       final List<html.Element> clipElements =
-          _clipContent(_clipStack, paragraphElement, offset, currentTransform);
+          _clipContent(_canvasPool._clipStack, paragraphElement, offset, _canvasPool.currentTransform);
       for (html.Element clipElement in clipElements) {
         rootElement.append(clipElement);
         _children.add(clipElement);
       }
     } else {
       final String cssTransform =
-          matrix4ToCssTransform3d(transformWithOffset(currentTransform, offset));
+          matrix4ToCssTransform3d(transformWithOffset(_canvasPool.currentTransform, offset));
       paragraphElement.style
         ..transformOrigin = '0 0 0'
         ..transform = cssTransform;
@@ -773,6 +562,7 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
         'Linear/Radial/SweepGradient and ImageShader not supported yet');
     final Int32List colors = vertices.colors;
     final ui.VertexMode mode = vertices.mode;
+    html.CanvasRenderingContext2D ctx = _canvasPool.context;
     if (colors == null) {
       final Float32List positions = mode == ui.VertexMode.triangles
           ? vertices.positions
@@ -780,69 +570,21 @@ class BitmapCanvas extends EngineCanvas with SaveStackTracking {
       // Draw hairline for vertices if no vertex colors are specified.
       save();
       final ui.Color color = paint.color ?? ui.Color(0xFF000000);
-      _setFillAndStrokeStyle('', color.toCssString());
-      _glRenderer.drawHairline(_ctx, positions);
+      _canvasPool.contextHandle
+        ..fillStyle = null
+        ..strokeStyle = color.toCssString();
+      _glRenderer.drawHairline(ctx, positions);
       restore();
       return;
     }
-    _glRenderer.drawVertices(_ctx, _widthInBitmapPixels, _heightInBitmapPixels,
-        currentTransform, vertices, blendMode, paint);
+    _glRenderer.drawVertices(ctx, _widthInBitmapPixels, _heightInBitmapPixels,
+        _canvasPool.currentTransform, vertices, blendMode, paint);
   }
 
-  /// 'Runs' the given [path] by applying all of its commands to the canvas.
-  void _runPath(SurfacePath path) {
-    ctx.beginPath();
-    for (Subpath subpath in path.subpaths) {
-      for (PathCommand command in subpath.commands) {
-        switch (command.type) {
-          case PathCommandTypes.bezierCurveTo:
-            final BezierCurveTo curve = command;
-            ctx.bezierCurveTo(
-                curve.x1, curve.y1, curve.x2, curve.y2, curve.x3, curve.y3);
-            break;
-          case PathCommandTypes.close:
-            ctx.closePath();
-            break;
-          case PathCommandTypes.ellipse:
-            final Ellipse ellipse = command;
-            ctx.ellipse(
-                ellipse.x,
-                ellipse.y,
-                ellipse.radiusX,
-                ellipse.radiusY,
-                ellipse.rotation,
-                ellipse.startAngle,
-                ellipse.endAngle,
-                ellipse.anticlockwise);
-            break;
-          case PathCommandTypes.lineTo:
-            final LineTo lineTo = command;
-            ctx.lineTo(lineTo.x, lineTo.y);
-            break;
-          case PathCommandTypes.moveTo:
-            final MoveTo moveTo = command;
-            ctx.moveTo(moveTo.x, moveTo.y);
-            break;
-          case PathCommandTypes.rRect:
-            final RRectCommand rrectCommand = command;
-            _RRectToCanvasRenderer(ctx)
-                .render(rrectCommand.rrect, startNewPath: false);
-            break;
-          case PathCommandTypes.rect:
-            final RectCommand rectCommand = command;
-            ctx.rect(rectCommand.x, rectCommand.y, rectCommand.width,
-                rectCommand.height);
-            break;
-          case PathCommandTypes.quadraticCurveTo:
-            final QuadraticCurveTo quadraticCurveTo = command;
-            ctx.quadraticCurveTo(quadraticCurveTo.x1, quadraticCurveTo.y1,
-                quadraticCurveTo.x2, quadraticCurveTo.y2);
-            break;
-          default:
-            throw UnimplementedError('Unknown path command $command');
-        }
-      }
-    }
+  @override
+  void endOfPaint() {
+    assert(_saveCount == 0);
+    _canvasPool.endOfPaint();
   }
 }
 
@@ -1026,4 +768,9 @@ String _cssTransformAtOffset(
     Matrix4 transform, double offsetX, double offsetY) {
   return matrix4ToCssTransform3d(
       transformWithOffset(transform, ui.Offset(offsetX, offsetY)));
+}
+
+String _maskFilterToCss(ui.MaskFilter maskFilter) {
+  if (maskFilter == null) return 'none';
+  return 'blur(${maskFilter.webOnlySigma}px)';
 }

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -105,7 +105,7 @@ class BitmapCanvas extends EngineCanvas {
     _canvasPositionY = _bounds.top.floor() - kPaddingPixels;
     _updateRootElementTransform();
     _canvasPool.allocateCanvas(rootElement, _widthInBitmapPixels,
-        _heightInBitmapPixels, _bounds);
+        _heightInBitmapPixels);
     _setupInitialTransform();
   }
 
@@ -366,12 +366,7 @@ class BitmapCanvas extends EngineCanvas {
     imgElement.style.mixBlendMode = blendMode;
     _drawImage(imgElement, p);
     _childOverdraw = true;
-    _allocateNewCanvas();
-  }
-
-  void _allocateNewCanvas() {
-    _canvasPool.allocateCanvas(rootElement, _widthInBitmapPixels,
-        _heightInBitmapPixels, _bounds);
+    _canvasPool.allocateExtraCanvas();
   }
 
   void _drawImage(html.ImageElement imgElement, ui.Offset p) {
@@ -444,7 +439,7 @@ class BitmapCanvas extends EngineCanvas {
       if (requiresClipping) {
         restore();
       }
-      _allocateNewCanvas();
+      _canvasPool.allocateExtraCanvas();
     }
     _childOverdraw = true;
   }

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -90,11 +90,12 @@ class BitmapCanvas extends EngineCanvas {
   /// This canvas can be reused by pictures with different paint bounds as long
   /// as the [Rect.size] of the bounds fully fit within the size used to
   /// initialize this canvas.
-  BitmapCanvas(this._bounds) :
-        assert(_bounds != null),
+  BitmapCanvas(this._bounds)
+      : assert(_bounds != null),
         widthInBitmapPixels = _widthToPhysical(_bounds.width),
         heightInBitmapPixels = _heightToPhysical(_bounds.height),
-        _canvasPool = _CanvasPool(_widthToPhysical(_bounds.width), _heightToPhysical(_bounds.height)) {
+        _canvasPool = _CanvasPool(_widthToPhysical(_bounds.width),
+            _heightToPhysical(_bounds.height)) {
     rootElement.style.position = 'absolute';
     // Adds one extra pixel to the requested size. This is to compensate for
     // _initializeViewport() snapping canvas position to 1 pixel, causing
@@ -102,8 +103,8 @@ class BitmapCanvas extends EngineCanvas {
     _canvasPositionX = _bounds.left.floor() - kPaddingPixels;
     _canvasPositionY = _bounds.top.floor() - kPaddingPixels;
     _updateRootElementTransform();
-    _canvasPool.allocateCanvas(rootElement, widthInBitmapPixels,
-        heightInBitmapPixels);
+    _canvasPool.allocateCanvas(
+        rootElement, widthInBitmapPixels, heightInBitmapPixels);
     _setupInitialTransform();
   }
 
@@ -118,12 +119,13 @@ class BitmapCanvas extends EngineCanvas {
     // transforms higher up in the stack. TODO: update for more accurate
     // positioning.
     rootElement.style.transform =
-      'translate(${_canvasPositionX}px, ${_canvasPositionY}px)';
+        'translate(${_canvasPositionX}px, ${_canvasPositionY}px)';
   }
 
   void _setupInitialTransform() {
-    final double canvasPositionCorrectionX =
-        _bounds.left - BitmapCanvas.kPaddingPixels - _canvasPositionX.toDouble();
+    final double canvasPositionCorrectionX = _bounds.left -
+        BitmapCanvas.kPaddingPixels -
+        _canvasPositionX.toDouble();
     final double canvasPositionCorrectionY =
         _bounds.top - BitmapCanvas.kPaddingPixels - _canvasPositionY.toDouble();
     // This compensates for the translate on the `rootElement`.
@@ -216,7 +218,8 @@ class BitmapCanvas extends EngineCanvas {
 
     if (paint.shader != null) {
       final EngineGradient engineShader = paint.shader;
-      final Object paintStyle = engineShader.createPaintStyle(_canvasPool.context);
+      final Object paintStyle =
+          engineShader.createPaintStyle(_canvasPool.context);
       contextHandle.fillStyle = paintStyle;
       contextHandle.strokeStyle = paintStyle;
     } else if (paint.color != null) {
@@ -371,15 +374,15 @@ class BitmapCanvas extends EngineCanvas {
 
   void _drawImage(html.ImageElement imgElement, ui.Offset p) {
     if (_canvasPool.isClipped) {
-      final List<html.Element> clipElements =
-          _clipContent(_canvasPool._clipStack, imgElement, p, _canvasPool.currentTransform);
+      final List<html.Element> clipElements = _clipContent(
+          _canvasPool._clipStack, imgElement, p, _canvasPool.currentTransform);
       for (html.Element clipElement in clipElements) {
         rootElement.append(clipElement);
         _children.add(clipElement);
       }
     } else {
-      final String cssTransform =
-          matrix4ToCssTransform3d(transformWithOffset(_canvasPool.currentTransform, p));
+      final String cssTransform = matrix4ToCssTransform3d(
+          transformWithOffset(_canvasPool.currentTransform, p));
       imgElement.style
         ..transformOrigin = '0 0 0'
         ..transform = cssTransform;
@@ -483,8 +486,7 @@ class BitmapCanvas extends EngineCanvas {
     if (paragraph._drawOnCanvas && _childOverdraw == false) {
       final List<EngineLineMetrics> lines = paragraph._measurementResult.lines;
 
-      final SurfacePaintData backgroundPaint =
-          paragraph._background?.paintData;
+      final SurfacePaintData backgroundPaint = paragraph._background?.paintData;
       if (backgroundPaint != null) {
         final ui.Rect rect = ui.Rect.fromLTWH(
             offset.dx, offset.dy, paragraph.width, paragraph.height);
@@ -511,15 +513,18 @@ class BitmapCanvas extends EngineCanvas {
         _drawParagraphElement(paragraph, offset);
 
     if (_canvasPool.isClipped) {
-      final List<html.Element> clipElements =
-          _clipContent(_canvasPool._clipStack, paragraphElement, offset, _canvasPool.currentTransform);
+      final List<html.Element> clipElements = _clipContent(
+          _canvasPool._clipStack,
+          paragraphElement,
+          offset,
+          _canvasPool.currentTransform);
       for (html.Element clipElement in clipElements) {
         rootElement.append(clipElement);
         _children.add(clipElement);
       }
     } else {
-      final String cssTransform =
-          matrix4ToCssTransform3d(transformWithOffset(_canvasPool.currentTransform, offset));
+      final String cssTransform = matrix4ToCssTransform3d(
+          transformWithOffset(_canvasPool.currentTransform, offset));
       paragraphElement.style
         ..transformOrigin = '0 0 0'
         ..transform = cssTransform;

--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -50,16 +50,14 @@ class BitmapCanvas extends EngineCanvas {
   ///
   /// These pixels are different from the logical CSS pixels. Here a pixel
   /// literally means 1 point with a RGBA color.
-  int get widthInBitmapPixels => _widthInBitmapPixels;
-  final int _widthInBitmapPixels;
+  final int widthInBitmapPixels;
 
   /// The number of pixels along the width of the bitmap that the canvas element
   /// renders into.
   ///
   /// These pixels are different from the logical CSS pixels. Here a pixel
   /// literally means 1 point with a RGBA color.
-  int get heightInBitmapPixels => _heightInBitmapPixels;
-  final int _heightInBitmapPixels;
+  final int heightInBitmapPixels;
 
   /// The number of pixels in the bitmap that the canvas element renders into.
   ///
@@ -94,8 +92,8 @@ class BitmapCanvas extends EngineCanvas {
   /// initialize this canvas.
   BitmapCanvas(this._bounds) :
         assert(_bounds != null),
-        _widthInBitmapPixels = _widthToPhysical(_bounds.width),
-        _heightInBitmapPixels = _heightToPhysical(_bounds.height),
+        widthInBitmapPixels = _widthToPhysical(_bounds.width),
+        heightInBitmapPixels = _heightToPhysical(_bounds.height),
         _canvasPool = _CanvasPool(_widthToPhysical(_bounds.width), _heightToPhysical(_bounds.height)) {
     rootElement.style.position = 'absolute';
     // Adds one extra pixel to the requested size. This is to compensate for
@@ -104,8 +102,8 @@ class BitmapCanvas extends EngineCanvas {
     _canvasPositionX = _bounds.left.floor() - kPaddingPixels;
     _canvasPositionY = _bounds.top.floor() - kPaddingPixels;
     _updateRootElementTransform();
-    _canvasPool.allocateCanvas(rootElement, _widthInBitmapPixels,
-        _heightInBitmapPixels);
+    _canvasPool.allocateCanvas(rootElement, widthInBitmapPixels,
+        heightInBitmapPixels);
     _setupInitialTransform();
   }
 
@@ -116,7 +114,9 @@ class BitmapCanvas extends EngineCanvas {
     // initial translation so the paint operations are positioned as expected.
     //
     // The flooring of the value is to ensure that canvas' top-left corner
-    // lands on the physical pixel.
+    // lands on the physical pixel. !This is not accurate if there are
+    // transforms higher up in the stack. TODO: update for more accurate
+    // positioning.
     rootElement.style.transform =
       'translate(${_canvasPositionX}px, ${_canvasPositionY}px)';
   }
@@ -148,8 +148,8 @@ class BitmapCanvas extends EngineCanvas {
   // Used by picture to assess if canvas is large enough to reuse as is.
   bool doesFitBounds(ui.Rect newBounds) {
     assert(newBounds != null);
-    return _widthInBitmapPixels >= _widthToPhysical(newBounds.width) &&
-        _heightInBitmapPixels >= _heightToPhysical(newBounds.height);
+    return widthInBitmapPixels >= _widthToPhysical(newBounds.width) &&
+        heightInBitmapPixels >= _heightToPhysical(newBounds.height);
   }
 
   @override
@@ -198,8 +198,8 @@ class BitmapCanvas extends EngineCanvas {
     return _devicePixelRatio == html.window.devicePixelRatio;
   }
 
-  // Returns a data URI containing a representation of the image in this
-  // canvas.
+  /// Returns a data URI containing a representation of the image in this
+  /// canvas.
   String toDataUrl() {
     return _canvasPool.toDataUrl();
   }
@@ -572,7 +572,7 @@ class BitmapCanvas extends EngineCanvas {
       restore();
       return;
     }
-    _glRenderer.drawVertices(ctx, _widthInBitmapPixels, _heightInBitmapPixels,
+    _glRenderer.drawVertices(ctx, widthInBitmapPixels, heightInBitmapPixels,
         _canvasPool.currentTransform, vertices, blendMode, paint);
   }
 

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -58,8 +58,8 @@ class _CanvasPool extends _SaveStackTracking {
     _replayClipStack();
   }
 
-  void allocateCanvas(html.HtmlElement rootElement,
-      int widthInBitmapPixels, int heightInBitmapPixels) {
+  void allocateCanvas(html.HtmlElement rootElement, int widthInBitmapPixels,
+      int heightInBitmapPixels) {
     bool requiresClearRect = false;
     if (_reusablePool != null && _reusablePool.isNotEmpty) {
       _canvas = _reusablePool.removeAt(0);
@@ -71,8 +71,8 @@ class _CanvasPool extends _SaveStackTracking {
       // * To satisfy the invariant: pixel size = css size * device pixel ratio.
       // * To make sure that when we scale the canvas by devicePixelRatio (see
       //   _initializeViewport below) the pixels line up.
-      final double cssWidth = widthInBitmapPixels /
-          html.window.devicePixelRatio;
+      final double cssWidth =
+          widthInBitmapPixels / html.window.devicePixelRatio;
       final double cssHeight =
           heightInBitmapPixels / html.window.devicePixelRatio;
       _canvas = html.CanvasElement(
@@ -101,8 +101,9 @@ class _CanvasPool extends _SaveStackTracking {
     // Replay save/clip stack on this canvas now.
     html.CanvasRenderingContext2D ctx = _context;
     int clipDepth = 0;
-    for (int saveStackIndex = 0, len = _saveStack.length; saveStackIndex < len;
-    saveStackIndex++) {
+    for (int saveStackIndex = 0, len = _saveStack.length;
+        saveStackIndex < len;
+        saveStackIndex++) {
       _SaveStackEntry saveEntry = _saveStack[saveStackIndex];
       Matrix4 matrix4 = saveEntry.transform;
       if (!matrix4.isIdentity()) {
@@ -111,7 +112,9 @@ class _CanvasPool extends _SaveStackTracking {
       }
       final List<_SaveClipEntry> clipStack = saveEntry.clipStack;
       if (clipStack != null) {
-        for (int clipCount = clipStack.length; clipDepth < clipCount; clipDepth++) {
+        for (int clipCount = clipStack.length;
+            clipDepth < clipCount;
+            clipDepth++) {
           _SaveClipEntry clipEntry = clipStack[clipDepth];
           if (clipEntry.rect != null) {
             _clipRect(ctx, clipEntry.rect);
@@ -127,11 +130,18 @@ class _CanvasPool extends _SaveStackTracking {
       ++_saveContextCount;
     }
     if (_currentTransform != null && !(_currentTransform.isIdentity())) {
-      ctx.setTransform(_currentTransform[0], _currentTransform[1], _currentTransform[4], _currentTransform[5],
-          _currentTransform[12], _currentTransform[13]);
+      ctx.setTransform(
+          _currentTransform[0],
+          _currentTransform[1],
+          _currentTransform[4],
+          _currentTransform[5],
+          _currentTransform[12],
+          _currentTransform[13]);
     }
     if (_clipStack != null && _clipStack.length > clipDepth) {
-      for (int clipCount = _clipStack.length; clipDepth < clipCount; clipDepth++) {
+      for (int clipCount = _clipStack.length;
+          clipDepth < clipCount;
+          clipDepth++) {
         _SaveClipEntry clipEntry = _clipStack[clipDepth];
         if (clipEntry.rect != null) {
           _clipRect(ctx, clipEntry.rect);
@@ -182,7 +192,6 @@ class _CanvasPool extends _SaveStackTracking {
       --_saveContextCount;
     }
   }
-
 
   /// Configures the canvas such that its coordinate system follows the scene's
   /// coordinate system, and the pixel ratio is applied such that CSS pixels are
@@ -260,7 +269,6 @@ class _CanvasPool extends _SaveStackTracking {
     //                a - horizontal scaling
     //
     // Source: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/transform
-
   }
 
   @override
@@ -424,8 +432,8 @@ class _CanvasPool extends _SaveStackTracking {
 
   void drawOval(ui.Rect rect, ui.PaintingStyle style) {
     context.beginPath();
-    context.ellipse(rect.center.dx, rect.center.dy, rect.width / 2, rect.height / 2,
-        0, 0, 2.0 * math.pi, false);
+    context.ellipse(rect.center.dx, rect.center.dy, rect.width / 2,
+        rect.height / 2, 0, 0, 2.0 * math.pi, false);
     contextHandle.paint(style);
   }
 
@@ -443,7 +451,7 @@ class _CanvasPool extends _SaveStackTracking {
   void drawShadow(ui.Path path, ui.Color color, double elevation,
       bool transparentOccluder) {
     final List<CanvasShadow> shadows =
-    ElevationShadow.computeCanvasShadows(elevation, color);
+        ElevationShadow.computeCanvasShadows(elevation, color);
     if (shadows.isNotEmpty) {
       for (final CanvasShadow shadow in shadows) {
         // TODO(het): Shadows with transparent occluders are not supported
@@ -457,7 +465,8 @@ class _CanvasPool extends _SaveStackTracking {
           // which is undesirable.
           context.save();
           context.translate(shadow.offsetX, shadow.offsetY);
-          context.filter = _maskFilterToCss(ui.MaskFilter.blur(ui.BlurStyle.normal, shadow.blur));
+          context.filter = _maskFilterToCss(
+              ui.MaskFilter.blur(ui.BlurStyle.normal, shadow.blur));
           context.strokeStyle = '';
           context.fillStyle = shadow.color.toCssString();
           _runPath(context, path);

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -20,10 +20,11 @@ part of engine;
 /// can be reused, [_CanvasPool] will move canvas(s) from pool to reusablePool
 /// to prevent reallocation.
 class _CanvasPool extends _SaveStackTracking {
-  html.CanvasElement _canvas;
   html.CanvasRenderingContext2D _context;
   ContextStateHandle _contextHandle;
   final int _widthInBitmapPixels, _heightInBitmapPixels;
+  // TODO(ferhat): Collapse _canvas,_pool,_reusablePool into single list.
+  html.CanvasElement _canvas;
   List<html.CanvasElement> _pool;
   List<html.CanvasElement> _reusablePool;
   int _saveContextCount = 0;

--- a/lib/web_ui/lib/src/engine/canvas_pool.dart
+++ b/lib/web_ui/lib/src/engine/canvas_pool.dart
@@ -1,0 +1,694 @@
+part of engine;
+
+class _CanvasPool extends _SaveStackTracking {
+  html.CanvasElement _canvas;
+  html.CanvasRenderingContext2D _context;
+  ContextStateHandle _contextHandle;
+  bool _contextSaved = false;
+  final int _widthInBitmapPixels, _heightInBitmapPixels;
+  List<html.CanvasElement> _pool;
+  List<html.CanvasElement> _reusablePool;
+
+  _CanvasPool(this._widthInBitmapPixels, this._heightInBitmapPixels);
+
+  html.CanvasRenderingContext2D get context {
+    if (_contextHandle == null) {
+      _context = _canvas.context2D;
+      _contextHandle = ContextStateHandle(_context);
+    }
+    return _context;
+  }
+
+  ContextStateHandle get contextHandle => _contextHandle;
+
+  void allocateCanvas(html.HtmlElement rootElement,
+      int widthInBitmapPixels, int heightInBitmapPixels,
+      ui.Rect bounds) {
+    // Allocating extra canvas items. Save current canvas so we can dispose
+    // and reply the clip/transform stack on top of new canvas.
+    bool requiresStackReplay = (_canvas != null);
+    if (requiresStackReplay){
+      _pool ??= [];
+      _pool.add(_canvas);
+      _canvas = null;
+      _context = null;
+      _contextHandle = null;
+    }
+    if (_reusablePool != null && _reusablePool.isNotEmpty) {
+      _canvas = _reusablePool[0];
+      _reusablePool.removeAt(0);
+    } else {
+      // Compute the final CSS canvas size given the actual pixel count we
+      // allocated. This is done for the following reasons:
+      //
+      // * To satisfy the invariant: pixel size = css size * device pixel ratio.
+      // * To make sure that when we scale the canvas by devicePixelRatio (see
+      //   _initializeViewport below) the pixels line up.
+      final double cssWidth = widthInBitmapPixels /
+          html.window.devicePixelRatio;
+      final double cssHeight =
+          heightInBitmapPixels / html.window.devicePixelRatio;
+      _canvas = html.CanvasElement(
+        width: widthInBitmapPixels,
+        height: heightInBitmapPixels,
+      );
+      _canvas.style
+        ..position = 'absolute'
+        ..width = '${cssWidth}px'
+        ..height = '${cssHeight}px';
+    }
+    rootElement.append(_canvas);
+    initializeViewport(widthInBitmapPixels, heightInBitmapPixels);
+    if (requiresStackReplay) {
+      _replayClipStack();
+    }
+  }
+
+  @override
+  void clear() {
+    super.clear();
+  }
+
+  void _replayClipStack() {
+    // Replay save/clip stack on this canvas now.
+    html.CanvasRenderingContext2D ctx = _context;
+    int clipDepth = 0;
+    for (int saveStackIndex = 0, len = _saveStack.length; saveStackIndex < len;
+    saveStackIndex++) {
+      _SaveStackEntry saveEntry = _saveStack[saveStackIndex];
+      Matrix4 matrix4 = saveEntry.transform;
+      if (!matrix4.isIdentity()) {
+        ctx.setTransform(matrix4[0], matrix4[1], matrix4[4], matrix4[5],
+            matrix4[12], matrix4[13]);
+      }
+      final List<_SaveClipEntry> clipStack = saveEntry.clipStack;
+      if (saveEntry.clipStack != null) {
+        for (int clipCount = clipStack.length; clipDepth < clipCount; clipDepth++) {
+          _SaveClipEntry clipEntry = clipStack[clipDepth];
+          if (clipEntry.rect != null) {
+            _clipRect(ctx, clipEntry.rect);
+          } else if (clipEntry.rrect != null) {
+            _clipRRect(ctx, clipEntry.rrect);
+          } else if (clipEntry.path != null) {
+            _runPath(ctx, clipEntry.path);
+            ctx.clip();
+          }
+        }
+      }
+      ctx.save();
+    }
+    if (_currentTransform != null && !(_currentTransform.isIdentity())) {
+      ctx.setTransform(_currentTransform[0], _currentTransform[1], _currentTransform[4], _currentTransform[5],
+          _currentTransform[12], _currentTransform[13]);
+    }
+    if (_clipStack != null && _clipStack.length > clipDepth) {
+      for (int clipCount = _clipStack.length; clipDepth < clipCount; clipDepth++) {
+        _SaveClipEntry clipEntry = _clipStack[clipDepth];
+        if (clipEntry.rect != null) {
+          _clipRect(ctx, clipEntry.rect);
+        } else if (clipEntry.rrect != null) {
+          _clipRRect(ctx, clipEntry.rrect);
+        } else if (clipEntry.path != null) {
+          _runPath(ctx, clipEntry.path);
+          ctx.clip();
+        }
+      }
+    }
+  }
+
+  // Marks this pool for reuse.
+  void reuse() {
+    if (_pool != null) {
+      _pool.add(_canvas);
+      _reusablePool = _pool;
+      _canvas = _reusablePool[0];
+      _reusablePool.removeAt(0);
+      _pool = null;
+      final html.HtmlElement rootElement = _canvas.parent;
+      rootElement.append(_canvas);
+    }
+    initializeViewport(_widthInBitmapPixels, _heightInBitmapPixels);
+  }
+
+  void endOfPaint() {
+    if (_reusablePool != null) {
+      for (html.CanvasElement e in _reusablePool) {
+        e.remove();
+      }
+      _reusablePool = null;
+    }
+  }
+
+  /// Configures the canvas such that its coordinate system follows the scene's
+  /// coordinate system, and the pixel ratio is applied such that CSS pixels are
+  /// translated to bitmap pixels.
+  void initializeViewport(int widthInBitmapPixels, int heightInBitmapPixels) {
+    html.CanvasRenderingContext2D ctx = context;
+    if (_contextSaved) {
+      ctx.restore();
+    }
+    // Save the canvas state with top-level transforms so we can undo
+    // any clips later when we reuse the canvas.
+    ctx.save();
+
+    // We always start with identity transform because the surrounding transform
+    // is applied on the DOM elements.
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+    // This scale makes sure that 1 CSS pixel is translated to the correct
+    // number of bitmap pixels.
+    ctx.scale(html.window.devicePixelRatio, html.window.devicePixelRatio);
+    // TODO: apply current clipstack if not first canvas.
+
+    if (_contextSaved) {
+      ctx.clearRect(0, 0, widthInBitmapPixels, heightInBitmapPixels);
+    }
+    _contextSaved = true;
+  }
+
+  void resetTransform() {
+    if (_canvas != null) {
+      _canvas.style.transformOrigin = '';
+      _canvas.style.transform = '';
+    }
+  }
+
+  // Returns a data URI containing a representation of the image in this
+  // canvas.
+  String toDataUrl() => _canvas.toDataUrl();
+
+  @override
+  void save() {
+    super.save();
+    context.save();
+  }
+
+  @override
+  void restore() {
+    super.restore();
+    context.restore();
+    contextHandle.reset();
+  }
+
+  @override
+  void translate(double dx, double dy) {
+    super.translate(dx, dy);
+    context.translate(dx, dy);
+  }
+
+  @override
+  void scale(double sx, double sy) {
+    super.scale(sx, sy);
+    context.scale(sx, sy);
+  }
+
+  @override
+  void rotate(double radians) {
+    super.rotate(radians);
+    context.rotate(radians);
+  }
+
+  @override
+  void skew(double sx, double sy) {
+    super.skew(sx, sy);
+    context.transform(1, sy, sx, 1, 0, 0);
+    //                |  |   |   |  |  |
+    //                |  |   |   |  |  f - vertical translation
+    //                |  |   |   |  e - horizontal translation
+    //                |  |   |   d - vertical scaling
+    //                |  |   c - horizontal skewing
+    //                |  b - vertical skewing
+    //                a - horizontal scaling
+    //
+    // Source: https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/transform
+
+  }
+
+  @override
+  void transform(Float64List matrix4) {
+    super.transform(matrix4);
+    // Canvas2D transform API:
+    //
+    // ctx.transform(a, b, c, d, e, f);
+    //
+    // In 3x3 matrix form assuming vector representation of (x, y, 1):
+    //
+    // a c e
+    // b d f
+    // 0 0 1
+    //
+    // This translates to 4x4 matrix with vector representation of (x, y, z, 1)
+    // as:
+    //
+    // a c 0 e
+    // b d 0 f
+    // 0 0 1 0
+    // 0 0 0 1
+    //
+    // This matrix is sufficient to represent 2D rotates, translates, scales,
+    // and skews.
+    context.transform(matrix4[0], matrix4[1], matrix4[4], matrix4[5],
+        matrix4[12], matrix4[13]);
+  }
+
+  void clipRect(ui.Rect rect) {
+    super.clipRect(rect);
+    _clipRect(context, rect);
+  }
+
+  void _clipRect(html.CanvasRenderingContext2D ctx, ui.Rect rect) {
+    ctx.beginPath();
+    ctx.rect(rect.left, rect.top, rect.width, rect.height);
+    ctx.clip();
+  }
+
+  void clipRRect(ui.RRect rrect) {
+    super.clipRRect(rrect);
+    _clipRRect(context, rrect);
+  }
+
+  void _clipRRect(html.CanvasRenderingContext2D ctx, ui.RRect rrect) {
+    final ui.Path path = ui.Path()..addRRect(rrect);
+    _runPath(ctx, path);
+    ctx.clip();
+  }
+
+  void clipPath(ui.Path path) {
+    super.clipPath(path);
+    html.CanvasRenderingContext2D ctx = context;
+    _runPath(ctx, path);
+    ctx.clip();
+  }
+
+  void drawColor(ui.Color color, ui.BlendMode blendMode) {
+    html.CanvasRenderingContext2D ctx = context;
+    contextHandle.blendMode = blendMode;
+    // Fill a virtually infinite rect with the color.
+    //
+    // We can't use (0, 0, width, height) because the current transform can
+    // cause it to not fill the entire clip.
+    contextHandle.fillStyle = color.toCssString();
+    contextHandle.strokeStyle = '';
+    ctx.fillRect(-10000, -10000, 20000, 20000);
+  }
+
+  // Fill a virtually infinite rect with the color.
+  void fill() {
+    html.CanvasRenderingContext2D ctx = context;
+    ctx.beginPath();
+    // We can't use (0, 0, width, height) because the current transform can
+    // cause it to not fill the entire clip.
+    ctx.fillRect(-10000, -10000, 20000, 20000);
+  }
+
+  void strokeLine(ui.Offset p1, ui.Offset p2) {
+    html.CanvasRenderingContext2D ctx = context;
+    ctx.beginPath();
+    ctx.moveTo(p1.dx, p1.dy);
+    ctx.lineTo(p2.dx, p2.dy);
+    ctx.stroke();
+  }
+
+  /// 'Runs' the given [path] by applying all of its commands to the canvas.
+  void _runPath(html.CanvasRenderingContext2D ctx, SurfacePath path) {
+    ctx.beginPath();
+    for (Subpath subpath in path.subpaths) {
+      for (PathCommand command in subpath.commands) {
+        switch (command.type) {
+          case PathCommandTypes.bezierCurveTo:
+            final BezierCurveTo curve = command;
+            ctx.bezierCurveTo(
+                curve.x1, curve.y1, curve.x2, curve.y2, curve.x3, curve.y3);
+            break;
+          case PathCommandTypes.close:
+            ctx.closePath();
+            break;
+          case PathCommandTypes.ellipse:
+            final Ellipse ellipse = command;
+            ctx.ellipse(
+                ellipse.x,
+                ellipse.y,
+                ellipse.radiusX,
+                ellipse.radiusY,
+                ellipse.rotation,
+                ellipse.startAngle,
+                ellipse.endAngle,
+                ellipse.anticlockwise);
+            break;
+          case PathCommandTypes.lineTo:
+            final LineTo lineTo = command;
+            ctx.lineTo(lineTo.x, lineTo.y);
+            break;
+          case PathCommandTypes.moveTo:
+            final MoveTo moveTo = command;
+            ctx.moveTo(moveTo.x, moveTo.y);
+            break;
+          case PathCommandTypes.rRect:
+            final RRectCommand rrectCommand = command;
+            _RRectToCanvasRenderer(ctx)
+                .render(rrectCommand.rrect, startNewPath: false);
+            break;
+          case PathCommandTypes.rect:
+            final RectCommand rectCommand = command;
+            ctx.rect(rectCommand.x, rectCommand.y, rectCommand.width,
+                rectCommand.height);
+            break;
+          case PathCommandTypes.quadraticCurveTo:
+            final QuadraticCurveTo quadraticCurveTo = command;
+            ctx.quadraticCurveTo(quadraticCurveTo.x1, quadraticCurveTo.y1,
+                quadraticCurveTo.x2, quadraticCurveTo.y2);
+            break;
+          default:
+            throw UnimplementedError('Unknown path command $command');
+        }
+      }
+    }
+  }
+
+  void drawRect(ui.Rect rect, ui.PaintingStyle style) {
+    context.beginPath();
+    context.rect(rect.left, rect.top, rect.width, rect.height);
+    contextHandle.paint(style);
+  }
+
+  void drawRRect(ui.RRect roundRect, ui.PaintingStyle style) {
+    _RRectToCanvasRenderer(context).render(roundRect);
+    contextHandle.paint(style);
+  }
+
+  void drawDRRect(ui.RRect outer, ui.RRect inner, ui.PaintingStyle style) {
+    _RRectRenderer renderer = _RRectToCanvasRenderer(context);
+    renderer.render(outer);
+    renderer.render(inner, startNewPath: false, reverse: true);
+    contextHandle.paint(style);
+  }
+
+  void drawOval(ui.Rect rect, ui.PaintingStyle style) {
+    context.beginPath();
+    context.ellipse(rect.center.dx, rect.center.dy, rect.width / 2, rect.height / 2,
+        0, 0, 2.0 * math.pi, false);
+    contextHandle.paint(style);
+  }
+
+  void drawCircle(ui.Offset c, double radius, ui.PaintingStyle style) {
+    context.beginPath();
+    context.ellipse(c.dx, c.dy, radius, radius, 0, 0, 2.0 * math.pi, false);
+    contextHandle.paint(style);
+  }
+
+  void drawPath(ui.Path path, ui.PaintingStyle style) {
+    _runPath(context, path);
+    contextHandle.paint(style);
+  }
+
+  void drawShadow(ui.Path path, ui.Color color, double elevation,
+      bool transparentOccluder) {
+    final List<CanvasShadow> shadows =
+    ElevationShadow.computeCanvasShadows(elevation, color);
+    if (shadows.isNotEmpty) {
+      for (final CanvasShadow shadow in shadows) {
+        // TODO(het): Shadows with transparent occluders are not supported
+        // on webkit since filter is unsupported.
+        if (transparentOccluder && browserEngine != BrowserEngine.webkit) {
+          // We paint shadows using a path and a mask filter instead of the
+          // built-in shadow* properties. This is because the color alpha of the
+          // paint is added to the shadow. The effect we're looking for is to just
+          // paint the shadow without the path itself, but if we use a non-zero
+          // alpha for the paint the path is painted in addition to the shadow,
+          // which is undesirable.
+          context.save();
+          context.translate(shadow.offsetX, shadow.offsetY);
+          context.filter = _maskFilterToCss(ui.MaskFilter.blur(ui.BlurStyle.normal, shadow.blur));
+          context.strokeStyle = '';
+          context.fillStyle = shadow.color.toCssString();
+          _runPath(context, path);
+          context.fill();
+          context.restore();
+        } else {
+          // TODO(het): We fill the path with this paint, then later we clip
+          // by the same path and fill it with a fully opaque color (we know
+          // the color is fully opaque because `transparentOccluder` is false.
+          // However, due to anti-aliasing of the clip, a few pixels of the
+          // path we are about to paint may still be visible after we fill with
+          // the opaque occluder. For that reason, we fill with the shadow color,
+          // and set the shadow color to fully opaque. This way, the visible
+          // pixels are less opaque and less noticeable.
+          context.save();
+          context.filter = 'none';
+          context.strokeStyle = '';
+          context.fillStyle = shadow.color.toCssString();
+          context.shadowBlur = shadow.blur;
+          context.shadowColor = shadow.color.withAlpha(0xff).toCssString();
+          context.shadowOffsetX = shadow.offsetX;
+          context.shadowOffsetY = shadow.offsetY;
+          _runPath(context, path);
+          context.fill();
+          context.restore();
+        }
+      }
+    }
+  }
+
+  void dispose() {
+    // Webkit has a threshold for the amount of canvas pixels an app can
+    // allocate. Even though our canvases are being garbage-collected as
+    // expected when we don't need them, Webkit keeps track of their sizes
+    // towards the threshold. Setting width and height to zero tricks Webkit
+    // into thinking that this canvas has a zero size so it doesn't count it
+    // towards the threshold.
+    if (browserEngine == BrowserEngine.webkit) {
+      _canvas.width = _canvas.height = 0;
+    }
+    _clearPool();
+  }
+
+  void _clearPool() {
+    if (_pool != null) {
+      for (html.CanvasElement c in _pool) {
+        if (browserEngine == BrowserEngine.webkit) {
+          c.width = c.height = 0;
+        }
+        c.remove();
+      }
+    }
+    _pool = null;
+  }
+}
+
+// Optimizes applying paint parameters to html canvas.
+//
+// See https://www.w3.org/TR/2dcontext/ for defaults used in this class
+// to initialize current values.
+//
+class ContextStateHandle {
+  html.CanvasRenderingContext2D context;
+  ContextStateHandle(this.context);
+  ui.BlendMode _currentBlendMode = ui.BlendMode.srcOver;
+  ui.StrokeCap _currentStrokeCap = ui.StrokeCap.butt;
+  ui.StrokeJoin _currentStrokeJoin = ui.StrokeJoin.miter;
+  Object _currentFillStyle;
+  Object _currentStrokeStyle;
+  double _currentLineWidth = 1.0;
+  String _currentFilter = 'none';
+  bool _secondaryAttributesDirty = false;
+
+  set blendMode(ui.BlendMode blendMode) {
+    if (blendMode != _currentBlendMode) {
+      _currentBlendMode = blendMode;
+      context.globalCompositeOperation =
+          _stringForBlendMode(blendMode) ?? 'source-over';
+      _secondaryAttributesDirty = true;
+    }
+  }
+
+  set strokeCap(ui.StrokeCap strokeCap) {
+    strokeCap ??= ui.StrokeCap.butt;
+    if (strokeCap != _currentStrokeCap) {
+      _currentStrokeCap = strokeCap;
+      context.lineCap = _stringForStrokeCap(strokeCap);
+      _secondaryAttributesDirty = true;
+    }
+  }
+
+  set lineWidth(double lineWidth) {
+    if (lineWidth != _currentLineWidth) {
+      _currentLineWidth = lineWidth;
+      context.lineWidth = lineWidth;
+      _secondaryAttributesDirty = true;
+    }
+  }
+
+  set strokeJoin(ui.StrokeJoin strokeJoin) {
+    strokeJoin ??= ui.StrokeJoin.miter;
+    if (strokeJoin != _currentStrokeJoin) {
+      _currentStrokeJoin = strokeJoin;
+      context.lineJoin = _stringForStrokeJoin(strokeJoin);
+      _secondaryAttributesDirty = true;
+    }
+  }
+
+  set fillStyle(Object colorOrGradient) {
+    if (!identical(colorOrGradient, _currentFillStyle)) {
+      _currentFillStyle = colorOrGradient;
+      context.fillStyle = colorOrGradient;
+      if (assertionsEnabled) {
+        _currentFillStyle = context.fillStyle;
+      }
+    }
+  }
+
+  set strokeStyle(Object colorOrGradient) {
+    if (!identical(colorOrGradient, _currentStrokeStyle)) {
+      _currentStrokeStyle = colorOrGradient;
+      context.strokeStyle = colorOrGradient;
+    }
+  }
+
+  set filter(String filter) {
+    if (_currentFilter != filter) {
+      _currentFilter = filter;
+      context.filter = filter;
+      _secondaryAttributesDirty = true;
+    }
+  }
+
+  void paint(ui.PaintingStyle style) {
+    if (style == ui.PaintingStyle.stroke) {
+      context.stroke();
+    } else {
+      context.fill();
+    }
+  }
+
+  void reset() {
+    context.fillStyle = '';
+    _currentFillStyle = context.fillStyle;
+    context.strokeStyle = '';
+    _currentStrokeStyle = context.strokeStyle;
+    context.filter = 'none';
+    _currentFilter = 'none';
+    context.globalCompositeOperation = 'source-over';
+    _currentBlendMode = ui.BlendMode.srcOver;
+    context.lineWidth = 1.0;
+    _currentLineWidth = 1.0;
+    context.lineCap = 'butt';
+    _currentStrokeCap = ui.StrokeCap.butt;
+    context.lineJoin = 'miter';
+    _currentStrokeJoin = ui.StrokeJoin.miter;
+  }
+}
+
+/// Provides save stack tracking functionality to implementations of
+/// [EngineCanvas].
+class _SaveStackTracking {
+  static final Vector3 _unitZ = Vector3(0.0, 0.0, 1.0);
+
+  final List<_SaveStackEntry> _saveStack = <_SaveStackEntry>[];
+
+  /// The stack that maintains clipping operations used when text is painted
+  /// onto bitmap canvas but is composited as separate element.
+  List<_SaveClipEntry> _clipStack;
+
+  /// Returns whether there are active clipping regions on the canvas.
+  bool get isClipped => _clipStack != null;
+
+  /// Empties the save stack and the element stack, and resets the transform
+  /// and clip parameters.
+  ///
+  /// Classes that override this method must call `super.clear()`.
+  void clear() {
+    _saveStack.clear();
+    _clipStack = null;
+    _currentTransform = Matrix4.identity();
+  }
+
+  /// The current transformation matrix.
+  Matrix4 get currentTransform => _currentTransform;
+  Matrix4 _currentTransform = Matrix4.identity();
+
+  /// Saves current clip and transform on the save stack.
+  ///
+  /// Classes that override this method must call `super.save()`.
+  void save() {
+    _saveStack.add(_SaveStackEntry(
+      transform: _currentTransform.clone(),
+      clipStack:
+          _clipStack == null ? null : List<_SaveClipEntry>.from(_clipStack),
+    ));
+  }
+
+  /// Restores current clip and transform from the save stack.
+  ///
+  /// Classes that override this method must call `super.restore()`.
+  void restore() {
+    if (_saveStack.isEmpty) {
+      return;
+    }
+    final _SaveStackEntry entry = _saveStack.removeLast();
+    _currentTransform = entry.transform;
+    _clipStack = entry.clipStack;
+  }
+
+  /// Multiplies the [currentTransform] matrix by a translation.
+  ///
+  /// Classes that override this method must call `super.translate()`.
+  void translate(double dx, double dy) {
+    _currentTransform.translate(dx, dy);
+  }
+
+  /// Scales the [currentTransform] matrix.
+  ///
+  /// Classes that override this method must call `super.scale()`.
+  void scale(double sx, double sy) {
+    _currentTransform.scale(sx, sy);
+  }
+
+  /// Rotates the [currentTransform] matrix.
+  ///
+  /// Classes that override this method must call `super.rotate()`.
+  void rotate(double radians) {
+    _currentTransform.rotate(_unitZ, radians);
+  }
+
+  /// Skews the [currentTransform] matrix.
+  ///
+  /// Classes that override this method must call `super.skew()`.
+  void skew(double sx, double sy) {
+    final Matrix4 skewMatrix = Matrix4.identity();
+    final Float64List storage = skewMatrix.storage;
+    storage[1] = sy;
+    storage[4] = sx;
+    _currentTransform.multiply(skewMatrix);
+  }
+
+  /// Multiplies the [currentTransform] matrix by another matrix.
+  ///
+  /// Classes that override this method must call `super.transform()`.
+  void transform(Float64List matrix4) {
+    _currentTransform.multiply(Matrix4.fromFloat64List(matrix4));
+  }
+
+  /// Adds a rectangle to clipping stack.
+  ///
+  /// Classes that override this method must call `super.clipRect()`.
+  void clipRect(ui.Rect rect) {
+    _clipStack ??= <_SaveClipEntry>[];
+    _clipStack.add(_SaveClipEntry.rect(rect, _currentTransform.clone()));
+  }
+
+  /// Adds a round rectangle to clipping stack.
+  ///
+  /// Classes that override this method must call `super.clipRRect()`.
+  void clipRRect(ui.RRect rrect) {
+    _clipStack ??= <_SaveClipEntry>[];
+    _clipStack.add(_SaveClipEntry.rrect(rrect, _currentTransform.clone()));
+  }
+
+  /// Adds a path to clipping stack.
+  ///
+  /// Classes that override this method must call `super.clipPath()`.
+  void clipPath(ui.Path path) {
+    _clipStack ??= <_SaveClipEntry>[];
+    _clipStack.add(_SaveClipEntry.path(path, _currentTransform.clone()));
+  }
+}

--- a/lib/web_ui/lib/src/engine/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/dom_canvas.dart
@@ -182,5 +182,6 @@ class DomCanvas extends EngineCanvas with SaveElementStackTracking {
 
   @override
   void endOfPaint() {
+    /// Instances are not re-used across paints yet. Noop for now.
   }
 }

--- a/lib/web_ui/lib/src/engine/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/dom_canvas.dart
@@ -175,8 +175,8 @@ class DomCanvas extends EngineCanvas with SaveElementStackTracking {
   }
 
   @override
-  void drawVertices(ui.Vertices vertices, ui.BlendMode blendMode,
-      SurfacePaintData paint) {
+  void drawVertices(
+      ui.Vertices vertices, ui.BlendMode blendMode, SurfacePaintData paint) {
     throw UnimplementedError();
   }
 

--- a/lib/web_ui/lib/src/engine/dom_canvas.dart
+++ b/lib/web_ui/lib/src/engine/dom_canvas.dart
@@ -179,4 +179,8 @@ class DomCanvas extends EngineCanvas with SaveElementStackTracking {
       SurfacePaintData paint) {
     throw UnimplementedError();
   }
+
+  @override
+  void endOfPaint() {
+  }
 }

--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -69,6 +69,8 @@ abstract class EngineCanvas {
   void drawVertices(ui.Vertices vertices, ui.BlendMode blendMode,
       SurfacePaintData paint);
 
+  /// Extension of Canvas API to mark the end of a stream of painting commands
+  /// to enable re-use/dispose optimizations.
   void endOfPaint();
 }
 

--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -66,8 +66,8 @@ abstract class EngineCanvas {
 
   void drawParagraph(EngineParagraph paragraph, ui.Offset offset);
 
-  void drawVertices(ui.Vertices vertices, ui.BlendMode blendMode,
-      SurfacePaintData paint);
+  void drawVertices(
+      ui.Vertices vertices, ui.BlendMode blendMode, SurfacePaintData paint);
 
   /// Extension of Canvas API to mark the end of a stream of painting commands
   /// to enable re-use/dispose optimizations.

--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -68,6 +68,8 @@ abstract class EngineCanvas {
 
   void drawVertices(ui.Vertices vertices, ui.BlendMode blendMode,
       SurfacePaintData paint);
+
+  void endOfPaint();
 }
 
 /// Adds an [offset] transformation to a [transform] matrix and returns the

--- a/lib/web_ui/lib/src/engine/houdini_canvas.dart
+++ b/lib/web_ui/lib/src/engine/houdini_canvas.dart
@@ -233,6 +233,10 @@ class HoudiniCanvas extends EngineCanvas with SaveElementStackTracking {
       SurfacePaintData paint) {
     // TODO(flutter_web): implement.
   }
+
+  @override
+  void endOfPaint() {
+  }
 }
 
 class _SaveElementStackEntry {

--- a/lib/web_ui/lib/src/engine/picture.dart
+++ b/lib/web_ui/lib/src/engine/picture.dart
@@ -47,7 +47,7 @@ class EnginePicture implements ui.Picture {
   Future<ui.Image> toImage(int width, int height) async {
     final BitmapCanvas canvas = BitmapCanvas(ui.Rect.fromLTRB(0, 0, width.toDouble(), height.toDouble()));
     recordingCanvas.apply(canvas);
-    final String imageDataUrl = canvas.canvas.toDataUrl();
+    final String imageDataUrl = canvas.toDataUrl();
     final html.ImageElement imageElement = html.ImageElement()
       ..src = imageDataUrl
       ..width = width

--- a/lib/web_ui/lib/src/engine/surface/painting.dart
+++ b/lib/web_ui/lib/src/engine/surface/painting.dart
@@ -900,7 +900,7 @@ class SurfacePath implements ui.Path {
         -BitmapCanvas.kPaddingPixels.toDouble());
     _rawRecorder.drawPath(
         this, (SurfacePaint()..color = const ui.Color(0xFF000000)).paintData);
-    final bool result = _rawRecorder.ctx.isPointInPath(pointX, pointY);
+    final bool result = _rawRecorder._canvasPool.context.isPointInPath(pointX, pointY);
     _rawRecorder.dispose();
     return result;
   }

--- a/lib/web_ui/lib/src/engine/surface/picture.dart
+++ b/lib/web_ui/lib/src/engine/surface/picture.dart
@@ -169,8 +169,8 @@ class PersistedStandardPicture extends PersistedPicture {
         // The canvas needs to be resized before painting.
         return 1.0;
       } else {
-        final int newPixelCount = oldCanvas._widthToPhysical(_exactLocalCullRect.width)
-             * oldCanvas._heightToPhysical(_exactLocalCullRect.height);
+        final int newPixelCount = BitmapCanvas._widthToPhysical(_exactLocalCullRect.width)
+             * BitmapCanvas._heightToPhysical(_exactLocalCullRect.height);
         final int oldPixelCount =
             oldCanvas.widthInBitmapPixels * oldCanvas.heightInBitmapPixels;
 

--- a/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
@@ -85,6 +85,7 @@ class RecordingCanvas {
         }
       }
     }
+    engineCanvas.endOfPaint();
   }
 
   /// Prints recorded commands.

--- a/lib/web_ui/test/canvas_test.dart
+++ b/lib/web_ui/test/canvas_test.dart
@@ -41,7 +41,7 @@ void main() {
       canvas.clear();
       recordingCanvas.apply(canvas);
     }, whenDone: () {
-      expect(mockCanvas.methodCallLog, hasLength(2));
+      expect(mockCanvas.methodCallLog, hasLength(3));
 
       MockCanvasCall call = mockCanvas.methodCallLog[0];
       expect(call.methodName, 'clear');
@@ -64,8 +64,9 @@ void main() {
       canvas.clear();
       recordingCanvas.apply(canvas);
     }, whenDone: () {
-      expect(mockCanvas.methodCallLog, hasLength(1));
+      expect(mockCanvas.methodCallLog, hasLength(2));
       expect(mockCanvas.methodCallLog[0].methodName, 'clear');
+      expect(mockCanvas.methodCallLog[1].methodName, 'endOfPaint');
     });
   });
 }

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -9,7 +9,6 @@ import 'package:test/test.dart';
 import '../mock_engine_canvas.dart';
 
 void main() {
-
   RecordingCanvas underTest;
   MockEngineCanvas mockCanvas;
 
@@ -20,17 +19,18 @@ void main() {
 
   group('drawDRRect', () {
     final RRect rrect = RRect.fromLTRBR(10, 10, 50, 50, Radius.circular(3));
-    final SurfacePaint somePaint = SurfacePaint()..color = const Color(0xFFFF0000);
+    final SurfacePaint somePaint = SurfacePaint()
+      ..color = const Color(0xFFFF0000);
 
     test('Happy case', () {
       underTest.drawDRRect(rrect, rrect.deflate(1), somePaint);
       underTest.apply(mockCanvas);
 
       _expectDrawCall(mockCanvas, {
-          'outer': rrect,
-          'inner': rrect.deflate(1),
-          'paint': somePaint.paintData,
-        });
+        'outer': rrect,
+        'inner': rrect.deflate(1),
+        'paint': somePaint.paintData,
+      });
     });
 
     test('Inner RRect > Outer RRect', () {
@@ -38,13 +38,16 @@ void main() {
       underTest.apply(mockCanvas);
       // Expect nothing to be called
       expect(mockCanvas.methodCallLog.length, equals(1));
+      expect(mockCanvas.methodCallLog.toString(), contains('endOfPaint'));
     });
 
     test('Inner RRect not completely inside Outer RRect', () {
-      underTest.drawDRRect(rrect, rrect.deflate(1).shift(const Offset(0.0, 10)), somePaint);
+      underTest.drawDRRect(
+          rrect, rrect.deflate(1).shift(const Offset(0.0, 10)), somePaint);
       underTest.apply(mockCanvas);
       // Expect nothing to be called
       expect(mockCanvas.methodCallLog.length, equals(1));
+      expect(mockCanvas.methodCallLog.toString(), contains('endOfPaint'));
     });
 
     test('Inner RRect same as Outer RRect', () {
@@ -52,12 +55,15 @@ void main() {
       underTest.apply(mockCanvas);
       // Expect nothing to be called
       expect(mockCanvas.methodCallLog.length, equals(1));
+      expect(mockCanvas.methodCallLog.toString(), contains('endOfPaint'));
     });
 
     test('negative corners in inner RRect get passed through to draw', () {
       // This comes from github issue #40728
-      final RRect outer = RRect.fromRectAndCorners(const Rect.fromLTWH(0, 0, 88, 48),
-        topLeft: Radius.circular(6), bottomLeft: Radius.circular(6));
+      final RRect outer = RRect.fromRectAndCorners(
+          const Rect.fromLTWH(0, 0, 88, 48),
+          topLeft: Radius.circular(6),
+          bottomLeft: Radius.circular(6));
       final RRect inner = outer.deflate(1);
 
       // If these assertions fail, check [_measureBorderRadius] in recording_canvas.dart
@@ -76,23 +82,26 @@ void main() {
     });
 
     test('preserve old scuba test behavior', () {
-      final RRect outer = RRect.fromRectAndCorners(const Rect.fromLTRB(10, 20, 30, 40));
-      final RRect inner = RRect.fromRectAndCorners(const Rect.fromLTRB(12, 22, 28, 38));
+      final RRect outer =
+          RRect.fromRectAndCorners(const Rect.fromLTRB(10, 20, 30, 40));
+      final RRect inner =
+          RRect.fromRectAndCorners(const Rect.fromLTRB(12, 22, 28, 38));
 
       underTest.drawDRRect(outer, inner, somePaint);
       underTest.apply(mockCanvas);
 
       _expectDrawCall(mockCanvas, {
-          'outer': outer,
-          'inner': inner,
-          'paint': somePaint.paintData,
-        });
+        'outer': outer,
+        'inner': inner,
+        'paint': somePaint.paintData,
+      });
     });
   });
 }
 
 // Expect a drawDRRect call to be registered in the mock call log, with the expectedArguments
-void _expectDrawCall(MockEngineCanvas mock, Map<String, dynamic> expectedArguments) {
+void _expectDrawCall(
+    MockEngineCanvas mock, Map<String, dynamic> expectedArguments) {
   expect(mock.methodCallLog.length, equals(2));
   MockCanvasCall mockCall = mock.methodCallLog[0];
   expect(mockCall.methodName, equals('drawDRRect'));

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -37,21 +37,21 @@ void main() {
       underTest.drawDRRect(rrect, rrect.inflate(1), somePaint);
       underTest.apply(mockCanvas);
       // Expect nothing to be called
-      expect(mockCanvas.methodCallLog.length, equals(0));
+      expect(mockCanvas.methodCallLog.length, equals(1));
     });
 
     test('Inner RRect not completely inside Outer RRect', () {
       underTest.drawDRRect(rrect, rrect.deflate(1).shift(const Offset(0.0, 10)), somePaint);
       underTest.apply(mockCanvas);
       // Expect nothing to be called
-      expect(mockCanvas.methodCallLog.length, equals(0));
+      expect(mockCanvas.methodCallLog.length, equals(1));
     });
 
     test('Inner RRect same as Outer RRect', () {
       underTest.drawDRRect(rrect, rrect, somePaint);
       underTest.apply(mockCanvas);
       // Expect nothing to be called
-      expect(mockCanvas.methodCallLog.length, equals(0));
+      expect(mockCanvas.methodCallLog.length, equals(1));
     });
 
     test('negative corners in inner RRect get passed through to draw', () {
@@ -93,7 +93,7 @@ void main() {
 
 // Expect a drawDRRect call to be registered in the mock call log, with the expectedArguments
 void _expectDrawCall(MockEngineCanvas mock, Map<String, dynamic> expectedArguments) {
-  expect(mock.methodCallLog.length, equals(1));
+  expect(mock.methodCallLog.length, equals(2));
   MockCanvasCall mockCall = mock.methodCallLog[0];
   expect(mockCall.methodName, equals('drawDRRect'));
   expect(mockCall.arguments, equals(expectedArguments));

--- a/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
@@ -19,8 +19,7 @@ void main() async {
 
   // Commit a recording canvas to a bitmap, and compare with the expected
   Future<void> _checkScreenshot(RecordingCanvas rc, String fileName,
-      { Rect region = const Rect.fromLTWH(0, 0, 500, 500) }) async {
-
+      {Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
 
     rc.apply(engineCanvas);
@@ -30,7 +29,7 @@ void main() async {
     try {
       sceneElement.append(engineCanvas.rootElement);
       html.document.body.append(sceneElement);
-      await matchGoldenFile('$fileName.png', region: region, maxDiffRate: 0.2);
+      await matchGoldenFile('$fileName.png', region: region, maxDiffRate: 0.2, write: true);
     } finally {
       // The page is reused across tests, so remove the element after taking the
       // Scuba screenshot.
@@ -47,7 +46,7 @@ void main() async {
 
   test('Paints image', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     rc.drawImage(createTestImage(), Offset(0, 0), new Paint());
     rc.restore();
@@ -56,7 +55,7 @@ void main() async {
 
   test('Paints image with transform', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     rc.translate(50.0, 100.0);
     rc.rotate(math.pi / 4.0);
@@ -67,7 +66,7 @@ void main() async {
 
   test('Paints image with transform and offset', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     rc.translate(50.0, 100.0);
     rc.rotate(math.pi / 4.0);
@@ -78,7 +77,7 @@ void main() async {
 
   test('Paints image with transform using destination', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     rc.translate(50.0, 100.0);
     rc.rotate(math.pi / 4.0);
@@ -93,42 +92,52 @@ void main() async {
 
   test('Paints image with source and destination', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
     double testHeight = testImage.height.toDouble();
-    rc.drawImageRect(testImage, Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
-        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.drawImageRect(
+        testImage,
+        Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight),
+        new Paint());
     rc.restore();
     await _checkScreenshot(rc, 'draw_image_rect_with_source');
   });
 
   test('Paints image with source and destination and round clip', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
     double testHeight = testImage.height.toDouble();
     rc.save();
-    rc.clipRRect(RRect.fromLTRBR(100, 30, 2 * testWidth, 2 * testHeight, Radius.circular(16)));
-    rc.drawImageRect(testImage, Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
-        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.clipRRect(RRect.fromLTRBR(
+        100, 30, 2 * testWidth, 2 * testHeight, Radius.circular(16)));
+    rc.drawImageRect(
+        testImage,
+        Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight),
+        new Paint());
     rc.restore();
     await _checkScreenshot(rc, 'draw_image_rect_with_source_and_clip');
   });
 
   test('Paints image with transform using source and destination', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     rc.translate(50.0, 100.0);
     rc.rotate(math.pi / 6.0);
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
     double testHeight = testImage.height.toDouble();
-    rc.drawImageRect(testImage, Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
-        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.drawImageRect(
+        testImage,
+        Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight),
+        new Paint());
     rc.restore();
     await _checkScreenshot(rc, 'draw_image_rect_with_transform_source');
   });
@@ -137,25 +146,49 @@ void main() async {
   // Circle should draw on top of image not below.
   test('Paints on top of image', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
     double testHeight = testImage.height.toDouble();
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
-    rc.drawCircle(Offset(100, 100), 50.0, Paint()
-      ..strokeWidth = 3
-      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.drawCircle(
+        Offset(100, 100),
+        50.0,
+        Paint()
+          ..strokeWidth = 3
+          ..color = Color.fromARGB(128, 0, 0, 0));
     rc.restore();
     await _checkScreenshot(rc, 'draw_circle_on_image');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/44845
+  // Circle should below image not on top.
+  test('Paints below image', () async {
+    final RecordingCanvas rc =
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage();
+    double testWidth = testImage.width.toDouble();
+    double testHeight = testImage.height.toDouble();
+    rc.drawCircle(
+        Offset(100, 100),
+        50.0,
+        Paint()
+          ..strokeWidth = 3
+          ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_circle_below_image');
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/44845
   // Circle should draw on top of image with clip rect.
   test('Paints on top of image with clip rect', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
@@ -163,9 +196,12 @@ void main() async {
     rc.clipRect(Rect.fromLTRB(75, 75, 160, 160));
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
-    rc.drawCircle(Offset(100, 100), 50.0, Paint()
-      ..strokeWidth = 3
-      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.drawCircle(
+        Offset(100, 100),
+        50.0,
+        Paint()
+          ..strokeWidth = 3
+          ..color = Color.fromARGB(128, 0, 0, 0));
     rc.restore();
     await _checkScreenshot(rc, 'draw_circle_on_image_clip_rect');
   });
@@ -174,7 +210,7 @@ void main() async {
   // Circle should draw on top of image with clip rect and transform.
   test('Paints on top of image with clip rect with transform', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
@@ -186,9 +222,12 @@ void main() async {
     rc.clipRect(Rect.fromLTRB(75, 75, 160, 160));
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
-    rc.drawCircle(Offset(100, 100), 50.0, Paint()
-      ..strokeWidth = 3
-      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.drawCircle(
+        Offset(100, 100),
+        50.0,
+        Paint()
+          ..strokeWidth = 3
+          ..color = Color.fromARGB(128, 0, 0, 0));
     rc.restore();
     await _checkScreenshot(rc, 'draw_circle_on_image_clip_rect_with_transform');
   });
@@ -197,7 +236,7 @@ void main() async {
   // Circle should draw on top of image with stack of clip rect and transforms.
   test('Paints on top of image with clip rect with stack', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
@@ -210,9 +249,12 @@ void main() async {
     rc.clipRect(Rect.fromLTRB(75, 75, 160, 160));
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
-    rc.drawCircle(Offset(100, 100), 50.0, Paint()
-      ..strokeWidth = 3
-      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.drawCircle(
+        Offset(100, 100),
+        50.0,
+        Paint()
+          ..strokeWidth = 3
+          ..color = Color.fromARGB(128, 0, 0, 0));
     rc.restore();
     rc.restore();
     await _checkScreenshot(rc, 'draw_circle_on_image_clip_rect_with_stack');
@@ -222,7 +264,7 @@ void main() async {
   // Circle should draw on top of image with clip rrect.
   test('Paints on top of image with clip rrect', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
@@ -230,9 +272,12 @@ void main() async {
     rc.clipRRect(RRect.fromLTRBR(75, 75, 160, 160, Radius.circular(5)));
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), Paint());
-    rc.drawCircle(Offset(100, 100), 50.0, Paint()
-      ..strokeWidth = 3
-      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.drawCircle(
+        Offset(100, 100),
+        50.0,
+        Paint()
+          ..strokeWidth = 3
+          ..color = Color.fromARGB(128, 0, 0, 0));
     rc.restore();
     await _checkScreenshot(rc, 'draw_circle_on_image_clip_rrect');
   });
@@ -241,7 +286,7 @@ void main() async {
   // Circle should draw on top of image with clip rrect.
   test('Paints on top of image with clip path', () async {
     final RecordingCanvas rc =
-    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+        RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     Image testImage = createTestImage();
     double testWidth = testImage.width.toDouble();
@@ -254,16 +299,20 @@ void main() async {
     rc.clipPath(path);
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), Paint());
-    rc.drawCircle(Offset(100, 100), 50.0, Paint()
-      ..strokeWidth = 3
-      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.drawCircle(
+        Offset(100, 100),
+        50.0,
+        Paint()
+          ..strokeWidth = 3
+          ..color = Color.fromARGB(128, 0, 0, 0));
     rc.restore();
     await _checkScreenshot(rc, 'draw_circle_on_image_clip_path');
   });
 }
 
 HtmlImage createTestImage({int width = 100, int height = 50}) {
-  html.CanvasElement canvas = new html.CanvasElement(width: width, height: height);
+  html.CanvasElement canvas =
+      new html.CanvasElement(width: width, height: height);
   html.CanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
   ctx.fillRect(0, 0, 33, 50);

--- a/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
@@ -50,6 +50,7 @@ void main() async {
     RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
     rc.save();
     rc.drawImage(createTestImage(), Offset(0, 0), new Paint());
+    rc.restore();
     await _checkScreenshot(rc, 'draw_image');
   });
 
@@ -60,6 +61,7 @@ void main() async {
     rc.translate(50.0, 100.0);
     rc.rotate(math.pi / 4.0);
     rc.drawImage(createTestImage(), Offset(0, 0), new Paint());
+    rc.restore();
     await _checkScreenshot(rc, 'draw_image_with_transform');
   });
 
@@ -70,6 +72,7 @@ void main() async {
     rc.translate(50.0, 100.0);
     rc.rotate(math.pi / 4.0);
     rc.drawImage(createTestImage(), Offset(30, 20), new Paint());
+    rc.restore();
     await _checkScreenshot(rc, 'draw_image_with_transform_and_offset');
   });
 
@@ -84,6 +87,7 @@ void main() async {
     double testHeight = testImage.height.toDouble();
     rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.restore();
     await _checkScreenshot(rc, 'draw_image_rect_with_transform');
   });
 
@@ -96,6 +100,7 @@ void main() async {
     double testHeight = testImage.height.toDouble();
     rc.drawImageRect(testImage, Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.restore();
     await _checkScreenshot(rc, 'draw_image_rect_with_source');
   });
 
@@ -109,6 +114,7 @@ void main() async {
     rc.clipRRect(RRect.fromLTRBR(100, 30, 2 * testWidth, 2 * testHeight, Radius.circular(16)));
     rc.drawImageRect(testImage, Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.restore();
     await _checkScreenshot(rc, 'draw_image_rect_with_source_and_clip');
   });
 
@@ -123,13 +129,140 @@ void main() async {
     double testHeight = testImage.height.toDouble();
     rc.drawImageRect(testImage, Rect.fromLTRB(testWidth / 2, 0, testWidth, testHeight),
         Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.restore();
     await _checkScreenshot(rc, 'draw_image_rect_with_transform_source');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/44845
+  // Circle should draw on top of image not below.
+  test('Paints on top of image', () async {
+    final RecordingCanvas rc =
+    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage();
+    double testWidth = testImage.width.toDouble();
+    double testHeight = testImage.height.toDouble();
+    rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.drawCircle(Offset(100, 100), 50.0, Paint()
+      ..strokeWidth = 3
+      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_circle_on_image');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/44845
+  // Circle should draw on top of image with clip rect.
+  test('Paints on top of image with clip rect', () async {
+    final RecordingCanvas rc =
+    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage();
+    double testWidth = testImage.width.toDouble();
+    double testHeight = testImage.height.toDouble();
+    rc.clipRect(Rect.fromLTRB(75, 75, 160, 160));
+    rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.drawCircle(Offset(100, 100), 50.0, Paint()
+      ..strokeWidth = 3
+      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_circle_on_image_clip_rect');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/44845
+  // Circle should draw on top of image with clip rect and transform.
+  test('Paints on top of image with clip rect with transform', () async {
+    final RecordingCanvas rc =
+    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage();
+    double testWidth = testImage.width.toDouble();
+    double testHeight = testImage.height.toDouble();
+    // Rotate around center of circle.
+    rc.translate(100, 100);
+    rc.rotate(math.pi / 4.0);
+    rc.translate(-100, -100);
+    rc.clipRect(Rect.fromLTRB(75, 75, 160, 160));
+    rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.drawCircle(Offset(100, 100), 50.0, Paint()
+      ..strokeWidth = 3
+      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_circle_on_image_clip_rect_with_transform');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/44845
+  // Circle should draw on top of image with stack of clip rect and transforms.
+  test('Paints on top of image with clip rect with stack', () async {
+    final RecordingCanvas rc =
+    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage();
+    double testWidth = testImage.width.toDouble();
+    double testHeight = testImage.height.toDouble();
+    // Rotate around center of circle.
+    rc.translate(100, 100);
+    rc.rotate(-math.pi / 4.0);
+    rc.save();
+    rc.translate(-100, -100);
+    rc.clipRect(Rect.fromLTRB(75, 75, 160, 160));
+    rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), new Paint());
+    rc.drawCircle(Offset(100, 100), 50.0, Paint()
+      ..strokeWidth = 3
+      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.restore();
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_circle_on_image_clip_rect_with_stack');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/44845
+  // Circle should draw on top of image with clip rrect.
+  test('Paints on top of image with clip rrect', () async {
+    final RecordingCanvas rc =
+    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage();
+    double testWidth = testImage.width.toDouble();
+    double testHeight = testImage.height.toDouble();
+    rc.clipRRect(RRect.fromLTRBR(75, 75, 160, 160, Radius.circular(5)));
+    rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), Paint());
+    rc.drawCircle(Offset(100, 100), 50.0, Paint()
+      ..strokeWidth = 3
+      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_circle_on_image_clip_rrect');
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/44845
+  // Circle should draw on top of image with clip rrect.
+  test('Paints on top of image with clip path', () async {
+    final RecordingCanvas rc =
+    RecordingCanvas(const Rect.fromLTRB(0, 0, 400, 300));
+    rc.save();
+    Image testImage = createTestImage();
+    double testWidth = testImage.width.toDouble();
+    double testHeight = testImage.height.toDouble();
+    final Path path = Path();
+    // Triangle.
+    path.moveTo(118, 57);
+    path.lineTo(75, 160);
+    path.lineTo(160, 160);
+    rc.clipPath(path);
+    rc.drawImageRect(testImage, Rect.fromLTRB(0, 0, testWidth, testHeight),
+        Rect.fromLTRB(100, 30, 2 * testWidth, 2 * testHeight), Paint());
+    rc.drawCircle(Offset(100, 100), 50.0, Paint()
+      ..strokeWidth = 3
+      ..color = Color.fromARGB(128, 0, 0, 0));
+    rc.restore();
+    await _checkScreenshot(rc, 'draw_circle_on_image_clip_path');
   });
 }
 
-HtmlImage createTestImage() {
-  const int width = 100;
-  const int height = 50;
+HtmlImage createTestImage({int width = 100, int height = 50}) {
   html.CanvasElement canvas = new html.CanvasElement(width: width, height: height);
   html.CanvasRenderingContext2D ctx = canvas.context2D;
   ctx.fillStyle = '#E04040';
@@ -145,4 +278,3 @@ HtmlImage createTestImage() {
   imageElement.src = js_util.callMethod(canvas, 'toDataURL', []);
   return HtmlImage(imageElement, width, height);
 }
-

--- a/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
@@ -29,7 +29,7 @@ void main() async {
     try {
       sceneElement.append(engineCanvas.rootElement);
       html.document.body.append(sceneElement);
-      await matchGoldenFile('$fileName.png', region: region, maxDiffRate: 0.2, write: true);
+      await matchGoldenFile('$fileName.png', region: region, maxDiffRate: 0.2);
     } finally {
       // The page is reused across tests, so remove the element after taking the
       // Scuba screenshot.

--- a/lib/web_ui/test/mock_engine_canvas.dart
+++ b/lib/web_ui/test/mock_engine_canvas.dart
@@ -228,4 +228,9 @@ class MockEngineCanvas implements EngineCanvas {
       'paint': paint,
     });
   }
+
+  @override
+  void endOfPaint() {
+    _called('endOfPaint', arguments: <String, dynamic>{});
+  }
 }


### PR DESCRIPTION
Added endOfPaint call on recording canvas to allow bitmap canvas to dispose after reuse.
Moved all immediate canvas calls from BitmapCanvas into CanvasPool.
Reduced context updates by creating ContextHandle class.
Added regression tests for drawing on top of image in a single Picture.

Fixes flutter/flutter#44845
Fixes flutter/flutter#48032