### PR TITLE
Always set the pipeline depth to 2

### DIFF
--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -35,8 +35,7 @@ Animator::Animator(Delegate& delegate,
       frame_scheduled_(false),
       notify_idle_task_id_(0),
       dimension_change_pending_(false),
-      weak_factory_(this) {
-}
+      weak_factory_(this) {}
 
 Animator::~Animator() = default;
 

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -27,18 +27,7 @@ Animator::Animator(Delegate& delegate,
       waiter_(std::move(waiter)),
       last_begin_frame_time_(),
       dart_frame_deadline_(0),
-#if FLUTTER_SHELL_ENABLE_METAL
       layer_tree_pipeline_(fml::MakeRefCounted<LayerTreePipeline>(2)),
-#else   // FLUTTER_SHELL_ENABLE_METAL
-      // TODO(dnfield): We should remove this logic and set the pipeline depth
-      // back to 2 in this case. See
-      // https://github.com/flutter/engine/pull/9132 for discussion.
-      layer_tree_pipeline_(fml::MakeRefCounted<LayerTreePipeline>(
-          task_runners.GetPlatformTaskRunner() ==
-                  task_runners.GetGPUTaskRunner()
-              ? 1
-              : 2)),
-#endif  // FLUTTER_SHELL_ENABLE_METAL
       pending_frame_semaphore_(1),
       frame_number_(1),
       paused_(false),


### PR DESCRIPTION
https://github.com/flutter/engine/pull/9132 set the pipeline depth to 2 as a temporary workaround when the gpu and platform thread were the same (see more details on the PR description for https://github.com/flutter/engine/pull/9132).

We're now using a dynamic thread configuration for platform views on iOS, so this workaround essentially has no effect (as the pipeline depth is decided upon when the shell is created at which point the threads are always unmerged).

While we still don't fully understand the nature of the root issue, I believe dynamic thread merging ameliorates it as the threads are only kept merged while the composition of a platform view is animated. I'm also unaware of ios keyboard lags being reported since the release of v.1.12 which uses thread merging (which means the pipeline depth workaround is not active anyway).