### PR TITLE
Add plugin_registrar_windows.h to published wrapper

### DIFF
--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -5,7 +5,10 @@
 import("$flutter_root/shell/platform/common/cpp/client_wrapper/publish.gni")
 import("$flutter_root/testing/testing.gni")
 
-_wrapper_includes = [ "include/flutter/flutter_view_controller.h" ]
+_wrapper_includes = [
+  "include/flutter/flutter_view_controller.h",
+  "include/flutter/plugin_registrar_windows.h",
+]
 
 _wrapper_sources = [ "flutter_view_controller.cc" ]
 


### PR DESCRIPTION
This file was missed in the wrapper publishing during the switch to the
Win32 embedding, so it's not part of the wrapper package that is
available to clients. This adds it to the published wrapper, as
originally intended.