### PR TITLE
modify test_runner.dart for windows to fix test build errors

### DIFF
--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -60,6 +60,10 @@ class TestCommand extends Command<bool> {
 
     _copyTestFontsIntoWebUi();
     await _buildHostPage();
+    if(io.Platform.isWindows) {
+      // Error on windows if not run.
+      await _runPubGet();
+    }
 
     final List<FilePath> targets =
         this.targets.map((t) => FilePath.fromCwd(t)).toList();
@@ -175,6 +179,22 @@ class TestCommand extends Command<bool> {
   void _checkExitCode() {
     if (io.exitCode != 0) {
       io.stderr.writeln('Process exited with exit code ${io.exitCode}.');
+      io.exit(1);
+    }
+  }
+
+  Future<void> _runPubGet() async {
+    final int exitCode = await runProcess(
+      environment.pubExecutable,
+      <String>[
+        'get',
+      ],
+      workingDirectory: environment.webUiRootDir.path,
+    );
+
+    if (exitCode != 0) {
+      io.stderr.writeln(
+          'Failed to run pub get. Exited with exit code $exitCode');
       io.exit(1);
     }
   }

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -60,8 +60,10 @@ class TestCommand extends Command<bool> {
 
     _copyTestFontsIntoWebUi();
     await _buildHostPage();
-    if(io.Platform.isWindows) {
-      // Error on windows if not run.
+    if (io.Platform.isWindows) {
+      // On Dart 2.7 or greater, it gives an error for not
+      // recognized "pub" version and asks for "pub" get.
+      // See: https://github.com/dart-lang/sdk/issues/39738
       await _runPubGet();
     }
 
@@ -166,7 +168,9 @@ class TestCommand extends Command<bool> {
           // Not a test file at all. Skip.
           continue;
         }
-        if(!path.split(testFilePath.relativeToWebUi).contains('golden_tests')) {
+        if (!path
+            .split(testFilePath.relativeToWebUi)
+            .contains('golden_tests')) {
           unitTestFiles.add(testFilePath);
         }
       }
@@ -193,8 +197,8 @@ class TestCommand extends Command<bool> {
     );
 
     if (exitCode != 0) {
-      io.stderr.writeln(
-          'Failed to run pub get. Exited with exit code $exitCode');
+      io.stderr
+          .writeln('Failed to run pub get. Exited with exit code $exitCode');
       io.exit(1);
     }
   }

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -43,6 +43,7 @@ Future<int> runProcess(
     executable,
     arguments,
     workingDirectory: workingDirectory,
+    runInShell: io.Platform.isWindows,
     mode: io.ProcessStartMode.inheritStdio,
   );
   final int exitCode = await process.exitCode;

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -43,6 +43,8 @@ Future<int> runProcess(
     executable,
     arguments,
     workingDirectory: workingDirectory,
+    // Running the process in a system shell for Windows. Otherwise 
+    // the process is not able to get Dart from path.
     runInShell: io.Platform.isWindows,
     mode: io.ProcessStartMode.inheritStdio,
   );

--- a/lib/web_ui/dev/utils.dart
+++ b/lib/web_ui/dev/utils.dart
@@ -43,7 +43,7 @@ Future<int> runProcess(
     executable,
     arguments,
     workingDirectory: workingDirectory,
-    // Running the process in a system shell for Windows. Otherwise 
+    // Running the process in a system shell for Windows. Otherwise
     // the process is not able to get Dart from path.
     runInShell: io.Platform.isWindows,
     mode: io.ProcessStartMode.inheritStdio,


### PR DESCRIPTION
Felt was not able to build tests on Windows.

The following changes fixes the problem:

1) Running the process in a system shell. (otherwise it is not able to get dart from path. I used this tool to track the error https://docs.microsoft.com/en-us/sysinternals/downloads/procmon)
2) Running pub get before starting pub run. My guess is it is related to the issue: https://github.com/dart-lang/pub/issues/2241 (there is also this issue reported for Dart 2.7+ https://github.com/dart-lang/sdk/issues/39738)

related: https://github.com/flutter/flutter/issues/48456