### PR TITLE
Add missing super.onNewIntent() call

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterFragmentActivity.java
@@ -101,7 +101,7 @@ public class FlutterFragmentActivity
             super.onBackPressed();
         }
     }
-        
+
     @Override
     protected void onStart() {
         super.onStart();
@@ -141,6 +141,7 @@ public class FlutterFragmentActivity
 
     @Override
     protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
         eventDelegate.onNewIntent(intent);
     }
 


### PR DESCRIPTION
From the onNewIntent docs:

    If you are handling new intents and may be making changes to the
    fragment state, you want to be sure to call through to the
    super-class here first. Otherwise, if your state is saved but the
    activity is not stopped, you could get an onNewIntent() call which
    happens before onResume() and trying to perform fragment operations
    at that point will throw IllegalStateException because the fragment
    manager thinks the state is still saved.