### PR TITLE
Revert "Add a deprecation javadoc note to the old FlutterActivity"

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/app/FlutterActivity.java
@@ -16,17 +16,12 @@ import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.view.FlutterNativeView;
 import io.flutter.view.FlutterView;
 
-// This uses a javadoc deprecation instead of a deprecation annotation because we don't want to show
-// a build-time warning yet. Revise once v2 embedding usage volume increases.
 /**
  * Base class for activities that use Flutter.
- *
- * @deprecated As of Flutter v1.12, this class is deprecated in favor of {@link io.flutter.embedding.android.FlutterActivity}.
- *             See https://flutter.dev/go/android-project-migration for migration details.
  */
 public class FlutterActivity extends Activity implements FlutterView.Provider, PluginRegistry, ViewFactory {
     private static final String TAG = "FlutterActivity";
-
+    
     private final FlutterActivityDelegate delegate = new FlutterActivityDelegate(this, this);
 
     // These aliases ensure that the methods we forward to the delegate adhere


### PR DESCRIPTION
Reverts flutter/engine#15156

Integration tests are using deprecated APIs, which is writing to stderr, which is a test failure.

[run_machine_concurrent_hot_reload_945f206_2.log](https://github.com/flutter/engine/files/4038212/run_machine_concurrent_hot_reload_945f206_2.log)

```
2020-01-08T15:23:22.242402: run:stderr: [+22729 ms] Note: /Users/flutter/.cocoon/flutter/dev/integration_tests/ui/android/app/src/main/java/com/yourcompany/integration_ui/MainActivity.java uses or overrides a deprecated API.2020-01-08T15:23:22.242974: 
```