### PR TITLE
Add support for Increase Contrast on iOS

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -1211,6 +1211,7 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
+  static const int _kHighContrastIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1238,6 +1239,11 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
+  /// The platform is requesting that UI be rendered with darker colors.
+  ///
+  /// Only supported on iOS.
+  bool get highContrast => _kHighContrastIndex & _index != 0;
+
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1251,6 +1257,8 @@ class AccessibilityFeatures {
       features.add('boldText');
     if (reduceMotion)
       features.add('reduceMotion');
+    if (highContrast)
+      features.add('highContrast');
     return 'AccessibilityFeatures$features';
   }
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -44,6 +44,7 @@ enum class AccessibilityFeatureFlag : int32_t {
   kDisableAnimations = 1 << 2,
   kBoldText = 1 << 3,
   kReduceMotion = 1 << 4,
+  kHighContrast = 1 << 5,
 };
 
 class WindowClient {

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -995,6 +995,7 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
+  static const int _kHighContrastIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1022,6 +1023,11 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
+  /// The platform is requesting that UI be rendered with darker colors.
+  ///
+  /// Only supported on iOS.
+  bool get highContrast => _kHighContrastIndex & _index != 0;
+
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1039,6 +1045,9 @@ class AccessibilityFeatures {
     }
     if (reduceMotion) {
       features.add('reduceMotion');
+    }
+    if (highContrast) {
+      features.add('highContrast');
     }
     return 'AccessibilityFeatures$features';
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -297,7 +297,7 @@ typedef enum UIAccessibilityContrast : NSInteger {
              selector:@selector(onAccessibilityStatusChanged:)
                  name:UIAccessibilityBoldTextStatusDidChangeNotification
                object:nil];
-    
+
   [center addObserver:self
              selector:@selector(onAccessibilityStatusChanged:)
                  name:UIAccessibilityDarkerSystemColorsStatusDidChangeNotification

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -297,6 +297,11 @@ typedef enum UIAccessibilityContrast : NSInteger {
              selector:@selector(onAccessibilityStatusChanged:)
                  name:UIAccessibilityBoldTextStatusDidChangeNotification
                object:nil];
+    
+  [center addObserver:self
+             selector:@selector(onAccessibilityStatusChanged:)
+                 name:UIAccessibilityDarkerSystemColorsStatusDidChangeNotification
+               object:nil];
 
   [center addObserver:self
              selector:@selector(onUserSettingsChanged:)
@@ -962,6 +967,8 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kReduceMotion);
   if (UIAccessibilityIsBoldTextEnabled())
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kBoldText);
+  if (UIAccessibilityDarkerSystemColorsEnabled())
+    flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kHighContrast);
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the


### PR DESCRIPTION
Link to the design document: https://docs.google.com/document/d/1kePVlqWvJu5Ph0RL6wgg67F3SATmsJ8QY5N0S1MvaGg/edit?usp=sharing

## Description

Read the "Increase Contrast" setting from iOS accessibility settings and pass it together with the rest of accessibility flags.

According to the Apple documentation, the method `UIAccessibilityDarkerSystemColorsEnabled()` exposes the value of the "Increase Contrast" setting in the Accessibility settings.

https://developer.apple.com/documentation/uikit/1615087-uiaccessibilitydarkersystemcolor

From `UIInterface.h`:
```
/* The value of the "high contrast" Accessibility setting is available via `UIAccessibilityDarkerSystemColorsEnabled()`,
 * and is also expressed as the UIAccessibilityContrast trait.
 */
typedef NS_ENUM(NSInteger, UIAccessibilityContrast) {
    UIAccessibilityContrastUnspecified = -1,
    UIAccessibilityContrastNormal,
    UIAccessibilityContrastHigh,
} API_AVAILABLE(ios(13.0), tvos(13.0)) API_UNAVAILABLE(watchos);
```

The good thing about `UIAccessibilityDarkerSystemColorsEnabled` is that it is available from iOS 8.0, and it is not exclusive of iOS 13 like the `UIAccessibilityContrast` trait.

The value is passed as a flag together with the rest of accessibility
settings.

Later on, the flag is exposed in the `window.accessibilitySettings` and can be read from the `MediaQuery` class in Flutter (a PR on the Flutter project will be done as well)

## Related Issues

Reference ticket: https://github.com/flutter/flutter/issues/48418

Blocks PR on flutter/flutter: https://github.com/flutter/flutter/pull/48486

## Tests

I couldn't find any equivalent test for any of the other platform specific accessibility flags.

I tested this locally with an iOS simulator.
