### PR TITLE
Fix forcing building the GLFW shell on all platforms

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -247,9 +247,8 @@ def to_gn_args(args):
       gn_args['dart_platform_sdk'] = not args.full_dart_sdk
     gn_args['full_dart_sdk'] = args.full_dart_sdk
 
-    if sys.platform == 'darwin':
-      if args.build_glfw_shell:
-        gn_args['build_glfw_shell'] = True
+    if args.build_glfw_shell:
+      gn_args['build_glfw_shell'] = True
 
     gn_args['stripped_symbols'] = args.stripped
 


### PR DESCRIPTION
Help says that using --build-glfw-shell should:
  "Force building the GLFW shell on desktop platforms..."

However, that seems to work only on the Darwin platform.
Let's make it working on all platforms as per documentation.

This is needed when you compile the GLFW shell on linux but
using custom toolchain.

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>