### PR TITLE
Revert "Add support for on/off switch labels when built on iOS 13."

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -1213,7 +1213,6 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
-  static const int _kOnOffSwitchLabelsIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1241,11 +1240,6 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
-  /// The platform is requesting that on/off labels be added to switches.
-  ///
-  /// Only supported on iOS.
-  bool get onOffSwitchLabels => _kOnOffSwitchLabelsIndex & _index != 0;
-
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1259,8 +1253,6 @@ class AccessibilityFeatures {
       features.add('boldText');
     if (reduceMotion)
       features.add('reduceMotion');
-    if (onOffSwitchLabels)
-      features.add('onOffSwitchLabels');
     return 'AccessibilityFeatures$features';
   }
 

--- a/lib/ui/window/window.h
+++ b/lib/ui/window/window.h
@@ -44,7 +44,6 @@ enum class AccessibilityFeatureFlag : int32_t {
   kDisableAnimations = 1 << 2,
   kBoldText = 1 << 3,
   kReduceMotion = 1 << 4,
-  kOnOffSwitchLabels = 1 << 5,
 };
 
 class WindowClient {

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -995,7 +995,6 @@ class AccessibilityFeatures {
   static const int _kDisableAnimationsIndex = 1 << 2;
   static const int _kBoldTextIndex = 1 << 3;
   static const int _kReduceMotionIndex = 1 << 4;
-  static const int _kOnOffSwitchLabelsIndex = 1 << 5;
 
   // A bitfield which represents each enabled feature.
   final int _index;
@@ -1023,11 +1022,6 @@ class AccessibilityFeatures {
   /// Only supported on iOS.
   bool get reduceMotion => _kReduceMotionIndex & _index != 0;
 
-  /// The platform is requesting that on/off labels be added to switches.
-  ///
-  /// Only supported on iOS.
-  bool get onOffSwitchLabels => _kOnOffSwitchLabelsIndex & _index != 0;
-
   @override
   String toString() {
     final List<String> features = <String>[];
@@ -1045,9 +1039,6 @@ class AccessibilityFeatures {
     }
     if (reduceMotion) {
       features.add('reduceMotion');
-    }
-    if (onOffSwitchLabels) {
-      features.add('onOffSwitchLabels');
     }
     return 'AccessibilityFeatures$features';
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -238,13 +238,6 @@ typedef enum UIAccessibilityContrast : NSInteger {
              selector:@selector(onUserSettingsChanged:)
                  name:UIContentSizeCategoryDidChangeNotification
                object:nil];
-
-  if (@available(iOS 13, *)) {
-    [center addObserver:self
-               selector:@selector(onAccessibilityStatusChanged:)
-                   name:UIAccessibilityOnOffSwitchLabelsDidChangeNotification
-                 object:nil];
-  }
 }
 
 - (void)setInitialRoute:(NSString*)route {
@@ -896,10 +889,6 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kReduceMotion);
   if (UIAccessibilityIsBoldTextEnabled())
     flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kBoldText);
-  if (@available(iOS 13, *)) {
-    if (UIAccessibilityIsOnOffSwitchLabelsEnabled())
-      flags |= static_cast<int32_t>(flutter::AccessibilityFeatureFlag::kOnOffSwitchLabels);
-  }
 #if TARGET_OS_SIMULATOR
   // There doesn't appear to be any way to determine whether the accessibility
   // inspector is enabled on the simulator. We conservatively always turn on the


### PR DESCRIPTION
Broke a fake implementation of Accessibility features in the framework.
While this change is unlikely to break any users in the wild, this is a
breaking change by the standards set out in our documentation and
should follow the breaking change announcement process. Details can be
found at https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes.

The error in question:

    Missing concrete implementation of 'getter AccessibilityFeatures.onOffSwitchLabels' • packages/flutter_test/test/window_test.dart:252:7 • non_abstract_class_inherits_abstract_member

Original change: #12467
This reverts commit d12f2a609635d18ee89547131ff0a11eca59266c.