### PR TITLE
Fix error: lambda capture 'iphone_xs_times' is not required

### DIFF
--- a/shell/common/input_events_unittests.cc
+++ b/shell/common/input_events_unittests.cc
@@ -280,7 +280,7 @@ TEST_F(ShellTest, HandlesActualIphoneXsInputEvents) {
     // TestSimulatedInputEvents.
     UnitlessTime base_latency =
         static_cast<UnitlessTime>(base_latency_f * frame_time);
-    Generator iphone_xs_generator = [frame_time, iphone_xs_times,
+    Generator iphone_xs_generator = [frame_time,
                                      base_latency](int i) {
       return base_latency +
              static_cast<UnitlessTime>(iphone_xs_times[i] * frame_time);


### PR DESCRIPTION
Fixes:
../../flutter/shell/common/input_events_unittests.cc:283:50: error: lambda capture 'iphone_xs_times' is not required to be captured for this use [-Werror,-Wunused-lambda-capture]
    Generator iphone_xs_generator = [frame_time, iphone_xs_times,
                                               ~~^~~~~~~~~~~~~~~

Signed-off-by: Damian Wrobel <dwrobel@ertelnet.rybnik.pl>