### PR TITLE
Use Skia's CSS3 style matcher for dynamically loaded font sets

### DIFF
--- a/third_party/txt/src/txt/typeface_font_asset_provider.cc
+++ b/third_party/txt/src/txt/typeface_font_asset_provider.cc
@@ -92,8 +92,16 @@ int TypefaceFontStyleSet::count() {
   return typefaces_.size();
 }
 
-void TypefaceFontStyleSet::getStyle(int index, SkFontStyle*, SkString* style) {
-  FML_DCHECK(false);
+void TypefaceFontStyleSet::getStyle(int index,
+                                    SkFontStyle* style,
+                                    SkString* name) {
+  FML_DCHECK(static_cast<size_t>(index) < typefaces_.size());
+  if (style) {
+    *style = typefaces_[index]->fontStyle();
+  }
+  if (name) {
+    name->reset();
+  }
 }
 
 SkTypeface* TypefaceFontStyleSet::createTypeface(int i) {
@@ -105,14 +113,7 @@ SkTypeface* TypefaceFontStyleSet::createTypeface(int i) {
 }
 
 SkTypeface* TypefaceFontStyleSet::matchStyle(const SkFontStyle& pattern) {
-  if (typefaces_.empty())
-    return nullptr;
-
-  for (const sk_sp<SkTypeface>& typeface : typefaces_)
-    if (typeface->fontStyle() == pattern)
-      return SkRef(typeface.get());
-
-  return SkRef(typefaces_[0].get());
+  return matchStyleCSS3(pattern);
 }
 
 }  // namespace txt

--- a/third_party/txt/src/txt/typeface_font_asset_provider.h
+++ b/third_party/txt/src/txt/typeface_font_asset_provider.h
@@ -39,7 +39,7 @@ class TypefaceFontStyleSet : public SkFontStyleSet {
   int count() override;
 
   // |SkFontStyleSet|
-  void getStyle(int index, SkFontStyle*, SkString* style) override;
+  void getStyle(int index, SkFontStyle* style, SkString* name) override;
 
   // |SkFontStyleSet|
   SkTypeface* createTypeface(int index) override;


### PR DESCRIPTION
This will improve font matching for SkParagraph, which relies on the
FontStyleSet's matchStyle implementation to find the closest match for a
FontStyle.