### PR TITLE
Add support for software text editing controls

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -406,7 +406,7 @@ action("pom_embedding") {
 }
 
 # To build and run:
-#   testing/run_tests.py [--type=java] [--filter=io.flutter.TestClassName]
+#   testing/run_tests.py [--type=java] [--java-filter=io.flutter.TestClassName]
 action("robolectric_tests") {
   script = "//build/android/gyp/javac.py"
   depfile = "$target_gen_dir/$target_name.d"

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -1,5 +1,8 @@
 package io.flutter.plugin.editing;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -7,9 +10,12 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import android.content.Context;
 import android.content.res.AssetManager;
 import android.text.Editable;
 import android.text.InputType;
+import android.text.Selection;
+import android.text.SpannableStringBuilder;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
@@ -22,8 +28,10 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
+import org.robolectric.shadow.api.Shadow;
+import org.robolectric.shadows.ShadowClipboardManager;
 
-@Config(manifest = Config.NONE, sdk = 27)
+@Config(manifest = Config.NONE, sdk = 27, shadows = ShadowClipboardManager.class)
 @RunWith(RobolectricTestRunner.class)
 public class InputConnectionAdaptorTest {
   @Test
@@ -46,5 +54,222 @@ public class InputConnectionAdaptorTest {
     FakeKeyEvent keyEvent = new FakeKeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER);
     inputConnectionAdaptor.sendKeyEvent(keyEvent);
     verify(spyEditable, times(1)).insert(eq(0), anyString());
+  }
+
+  @Test
+  public void testPerformContextMenuAction_selectAll() {
+    int selStart = 5;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    boolean didConsume = adaptor.performContextMenuAction(android.R.id.selectAll);
+
+    assertTrue(didConsume);
+    assertEquals(0, Selection.getSelectionStart(editable));
+    assertEquals(editable.length(), Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testPerformContextMenuAction_cut() {
+    ShadowClipboardManager clipboardManager =
+        Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE));
+    int selStart = 6;
+    int selEnd = 11;
+    Editable editable = sampleEditable(selStart, selEnd);
+    CharSequence textToBeCut = editable.subSequence(selStart, selEnd);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    boolean didConsume = adaptor.performContextMenuAction(android.R.id.cut);
+
+    assertTrue(didConsume);
+    assertTrue(clipboardManager.hasText());
+    assertEquals(textToBeCut, clipboardManager.getPrimaryClip().getItemAt(0).getText());
+    assertFalse(editable.toString().contains(textToBeCut));
+  }
+
+  @Test
+  public void testPerformContextMenuAction_copy() {
+    ShadowClipboardManager clipboardManager =
+        Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE));
+    int selStart = 6;
+    int selEnd = 11;
+    Editable editable = sampleEditable(selStart, selEnd);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    assertFalse(clipboardManager.hasText());
+
+    boolean didConsume = adaptor.performContextMenuAction(android.R.id.copy);
+
+    assertTrue(didConsume);
+    assertTrue(clipboardManager.hasText());
+    assertEquals(
+        editable.subSequence(selStart, selEnd),
+        clipboardManager.getPrimaryClip().getItemAt(0).getText());
+  }
+
+  @Test
+  public void testPerformContextMenuAction_paste() {
+    ShadowClipboardManager clipboardManager =
+        Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.CLIPBOARD_SERVICE));
+    String textToBePasted = "deadbeef";
+    clipboardManager.setText(textToBePasted);
+    Editable editable = sampleEditable(0, 0);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    boolean didConsume = adaptor.performContextMenuAction(android.R.id.paste);
+
+    assertTrue(didConsume);
+    assertTrue(editable.toString().startsWith(textToBePasted));
+  }
+
+  @Test
+  public void testSendKeyEvent_shiftKeyUpCancelsSelection() {
+    int selStart = 5;
+    int selEnd = 10;
+    Editable editable = sampleEditable(selStart, selEnd);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent shiftKeyUp = new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SHIFT_LEFT);
+    boolean didConsume = adaptor.sendKeyEvent(shiftKeyUp);
+
+    assertTrue(didConsume);
+    assertEquals(selEnd, Selection.getSelectionStart(editable));
+    assertEquals(selEnd, Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testSendKeyEvent_leftKeyMovesCaretLeft() {
+    int selStart = 5;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent leftKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT);
+    boolean didConsume = adaptor.sendKeyEvent(leftKeyDown);
+
+    assertTrue(didConsume);
+    assertEquals(selStart - 1, Selection.getSelectionStart(editable));
+    assertEquals(selStart - 1, Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testSendKeyEvent_leftKeyExtendsSelectionLeft() {
+    int selStart = 5;
+    int selEnd = 40;
+    Editable editable = sampleEditable(selStart, selEnd);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent leftKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT);
+    boolean didConsume = adaptor.sendKeyEvent(leftKeyDown);
+
+    assertTrue(didConsume);
+    assertEquals(selStart, Selection.getSelectionStart(editable));
+    assertEquals(selEnd - 1, Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testSendKeyEvent_shiftLeftKeyStartsSelectionLeft() {
+    int selStart = 5;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent shiftLeftKeyDown =
+        new KeyEvent(
+            0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT, 0, KeyEvent.META_SHIFT_ON);
+    boolean didConsume = adaptor.sendKeyEvent(shiftLeftKeyDown);
+
+    assertTrue(didConsume);
+    assertEquals(selStart, Selection.getSelectionStart(editable));
+    assertEquals(selStart - 1, Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testSendKeyEvent_rightKeyMovesCaretRight() {
+    int selStart = 5;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent rightKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
+    boolean didConsume = adaptor.sendKeyEvent(rightKeyDown);
+
+    assertTrue(didConsume);
+    assertEquals(selStart + 1, Selection.getSelectionStart(editable));
+    assertEquals(selStart + 1, Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testSendKeyEvent_rightKeyExtendsSelectionRight() {
+    int selStart = 5;
+    int selEnd = 40;
+    Editable editable = sampleEditable(selStart, selEnd);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent rightKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
+    boolean didConsume = adaptor.sendKeyEvent(rightKeyDown);
+
+    assertTrue(didConsume);
+    assertEquals(selStart, Selection.getSelectionStart(editable));
+    assertEquals(selEnd + 1, Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testSendKeyEvent_shiftRightKeyStartsSelectionRight() {
+    int selStart = 5;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent shiftRightKeyDown =
+        new KeyEvent(
+            0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT, 0, KeyEvent.META_SHIFT_ON);
+    boolean didConsume = adaptor.sendKeyEvent(shiftRightKeyDown);
+
+    assertTrue(didConsume);
+    assertEquals(selStart, Selection.getSelectionStart(editable));
+    assertEquals(selStart + 1, Selection.getSelectionEnd(editable));
+  }
+
+  @Test
+  public void testSendKeyEvent_upKeyMovesCaretUp() {
+    int selStart = SAMPLE_TEXT.indexOf('\n') + 4;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent upKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_UP);
+    boolean didConsume = adaptor.sendKeyEvent(upKeyDown);
+
+    assertTrue(didConsume);
+    // Checks the caret moved left (to some previous character). Selection.moveUp() behaves
+    // different in tests than on a real device, we can't verify the exact position.
+    assertTrue(Selection.getSelectionStart(editable) < selStart);
+  }
+
+  @Test
+  public void testSendKeyEvent_downKeyMovesCaretDown() {
+    int selStart = 4;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_DOWN);
+    boolean didConsume = adaptor.sendKeyEvent(downKeyDown);
+
+    assertTrue(didConsume);
+    // Checks the caret moved right (to some following character). Selection.moveDown() behaves
+    // different in tests than on a real device, we can't verify the exact position.
+    assertTrue(Selection.getSelectionStart(editable) > selStart);
+  }
+
+  private static final String SAMPLE_TEXT =
+      "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";
+
+  private static Editable sampleEditable(int selStart, int selEnd) {
+    SpannableStringBuilder sample = new SpannableStringBuilder(SAMPLE_TEXT);
+    Selection.setSelection(sample, selStart, selEnd);
+    return sample;
+  }
+
+  private static InputConnectionAdaptor sampleInputConnectionAdaptor(Editable editable) {
+    View testView = new View(RuntimeEnvironment.application);
+    int client = 0;
+    TextInputChannel textInputChannel = mock(TextInputChannel.class);
+    return new InputConnectionAdaptor(testView, client, textInputChannel, editable, null);
   }
 }


### PR DESCRIPTION
Includes selection, copy, cut, paste, as well as partial support for up
and down movement.

Text editing controls can be accessed in GBoard by:
  top-left arrow > three dots menu > text editing

Partial fix for flutter/flutter#9419 and flutter/flutter#37371.

## Before
<img src="https://user-images.githubusercontent.com/1776440/72293152-31911a80-3653-11ea-9826-d1e913afdc83.gif" width="300">

## After
<img src="https://user-images.githubusercontent.com/1776440/72293161-3786fb80-3653-11ea-93ce-1d64c089ed19.gif" width="300">

