### PR TITLE
[web] Freeze window.defaultRouteName

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -99,8 +99,10 @@ class EngineWindow extends ui.Window {
   /// Simulates clicking the browser's back button.
   Future<void> webOnlyBack() => _browserHistory.back();
 
+  String _defaultRouteName;
+
   @override
-  String get defaultRouteName => _browserHistory.currentPath;
+  String get defaultRouteName => _defaultRouteName ??= _browserHistory.currentPath;
 
   /// Change the strategy to use for handling browser history location.
   /// Setting this member will automatically update [_browserHistory].

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -99,6 +99,10 @@ class EngineWindow extends ui.Window {
   /// Simulates clicking the browser's back button.
   Future<void> webOnlyBack() => _browserHistory.back();
 
+  /// Lazily initialized when the `defaultRouteName` getter is invoked.
+  ///
+  /// The reason for the lazy initialization is to give enough time for the app to set [locationStrategy]
+  /// in `lib/src/ui/initialization.dart`. 
   String _defaultRouteName;
 
   @override

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -102,7 +102,7 @@ class EngineWindow extends ui.Window {
   /// Lazily initialized when the `defaultRouteName` getter is invoked.
   ///
   /// The reason for the lazy initialization is to give enough time for the app to set [locationStrategy]
-  /// in `lib/src/ui/initialization.dart`. 
+  /// in `lib/src/ui/initialization.dart`.
   String _defaultRouteName;
 
   @override

--- a/lib/web_ui/test/window_test.dart
+++ b/lib/web_ui/test/window_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+import 'package:ui/src/engine.dart';
+
+TestLocationStrategy _strategy;
+TestLocationStrategy get strategy => _strategy;
+set strategy(TestLocationStrategy newStrategy) {
+  window.locationStrategy = _strategy = newStrategy;
+}
+
+void main() {
+  test('window.defaultRouteName should not change', () {
+    strategy = TestLocationStrategy.fromEntry(TestHistoryEntry('initial state', null, '/initial'));
+    expect(window.defaultRouteName, '/initial');
+
+    strategy.replaceState(null, null, '/newpath');
+    expect(window.defaultRouteName, '/initial');
+  });
+}


### PR DESCRIPTION
Helps with some routing-related issues in Flutter Gallery's Shrine and other apps (https://github.com/flutter/flutter/issues/43982#issuecomment-571267096).