### PR TITLE
Fix hardware keyboard enter so it triggers an action.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -27,6 +27,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     private final int mClient;
     private final TextInputChannel textInputChannel;
     private final Editable mEditable;
+    private final EditorInfo mEditorInfo;
     private int mBatchCount;
     private InputMethodManager mImm;
     private final Layout mLayout;
@@ -36,13 +37,15 @@ class InputConnectionAdaptor extends BaseInputConnection {
         View view,
         int client,
         TextInputChannel textInputChannel,
-        Editable editable
+        Editable editable,
+        EditorInfo editorInfo
     ) {
         super(view, true);
         mFlutterView = view;
         mClient = client;
         this.textInputChannel = textInputChannel;
         mEditable = editable;
+        mEditorInfo = editorInfo;
         mBatchCount = 0;
         // We create a dummy Layout with max width so that the selection
         // shifting acts as if all text were in one line.
@@ -202,6 +205,10 @@ class InputConnectionAdaptor extends BaseInputConnection {
                 int selStart = Selection.getSelectionStart(mEditable);
                 int newSel = Math.min(selStart + 1, mEditable.length());
                 setSelection(newSel, newSel);
+                return true;
+            } else if (event.getKeyCode() == KeyEvent.KEYCODE_ENTER ||
+                       event.getKeyCode() == KeyEvent.KEYCODE_NUMPAD_ENTER) {
+                performEditorAction(mEditorInfo.imeOptions & EditorInfo.IME_MASK_ACTION);
                 return true;
             } else {
                 // Enter a character.

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -235,7 +235,8 @@ public class TextInputPlugin {
             view,
             inputTarget.id,
             textInputChannel,
-            mEditable
+            mEditable,
+            outAttrs
         );
         outAttrs.initialSelStart = Selection.getSelectionStart(mEditable);
         outAttrs.initialSelEnd = Selection.getSelectionEnd(mEditable);

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -4,11 +4,15 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.provider.Settings;
 import android.util.SparseIntArray;
+import android.view.KeyEvent;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
 
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +25,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowBuild;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
+import io.flutter.Log;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
@@ -154,6 +159,34 @@ public class TextInputPluginTest {
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
         assertEquals(1, testImm.getRestartCount(testView));
     }
+
+    @Test
+    public void inputConnection_createsActionFromEnter() {
+        Log.setLogLevel(android.util.Log.VERBOSE);
+        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+        FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
+        View testView = new View(RuntimeEnvironment.application);
+        DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
+        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, dartExecutor, mock(PlatformViewsController.class));
+        textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, true, TextInputChannel.TextCapitalization.NONE, new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false), null, null));
+        // There's a pending restart since we initialized the text input client. Flush that now.
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
+
+
+        ByteBuffer message = JSONMethodCodec.INSTANCE.encodeMethodCall(
+            new MethodCall("TextInputClient.performAction", Arrays.asList(0, "TextInputAction.done")));
+        verify(dartExecutor, times(1)).send("flutter/textinput", message, null);
+        InputConnection connection = textInputPlugin.createInputConnection(testView, new EditorInfo());
+
+        connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER));
+        verify(dartExecutor, times(2)).send("flutter/textinput", message, null);
+        connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER));
+
+        connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_NUMPAD_ENTER));
+        verify(dartExecutor, times(3)).send("flutter/textinput", message, null);
+        connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_NUMPAD_ENTER));
+    }
+
 
     @Implements(InputMethodManager.class)
     public static class TestImm extends ShadowInputMethodManager {

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -4,37 +4,44 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.provider.Settings;
 import android.util.SparseIntArray;
-import android.view.KeyEvent;
-import android.view.View;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
+import android.view.KeyEvent;
+import android.view.View;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
-import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
+import org.junit.Test;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowBuild;
 import org.robolectric.shadows.ShadowInputMethodManager;
 
-import io.flutter.Log;
-import io.flutter.embedding.engine.FlutterJNI;
+import org.mockito.ArgumentCaptor;
+
 import io.flutter.embedding.engine.dart.DartExecutor;
+import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
+import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.platform.PlatformViewsController;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -43,8 +50,22 @@ import static org.mockito.Mockito.verify;
 @Config(manifest = Config.NONE, shadows = TextInputPluginTest.TestImm.class, sdk = 27)
 @RunWith(RobolectricTestRunner.class)
 public class TextInputPluginTest {
+    // Verifies the method and arguments for a captured method call.
+    private void verifyMethodCall(ByteBuffer buffer, String methodName, String[] expectedArgs) throws JSONException {
+        buffer.rewind();
+        MethodCall methodCall = JSONMethodCodec.INSTANCE.decodeMethodCall(buffer);
+        assertEquals(methodName, methodCall.method);
+        if (expectedArgs != null) {
+            JSONArray args = methodCall.arguments();
+            assertEquals(expectedArgs.length, args.length());
+            for (int i = 0; i < args.length(); i++) {
+                assertEquals(expectedArgs[i], args.get(i).toString());
+            }
+        }
+    }
+
     @Test
-    public void textInputPlugin_RequestsReattachOnCreation() {
+    public void textInputPlugin_RequestsReattachOnCreation() throws JSONException {
         // Initialize a general TextInputPlugin.
         InputMethodSubtype inputMethodSubtype = mock(InputMethodSubtype.class);
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
@@ -55,8 +76,12 @@ public class TextInputPluginTest {
         DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, dartExecutor, mock(PlatformViewsController.class));
 
-        ByteBuffer message = JSONMethodCodec.INSTANCE.encodeMethodCall(new MethodCall("TextInputClient.requestExistingInputState", null));
-        verify(dartExecutor, times(1)).send("flutter/textinput", message, null);
+        ArgumentCaptor<String> channelCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+
+        verify(dartExecutor, times(1)).send(channelCaptor.capture(), bufferCaptor.capture(), any(BinaryMessenger.BinaryReply.class));
+        assertEquals("flutter/textinput", channelCaptor.getValue());
+        verifyMethodCall(bufferCaptor.getValue(), "TextInputClient.requestExistingInputState", null);
     }
 
     @Test
@@ -161,32 +186,39 @@ public class TextInputPluginTest {
     }
 
     @Test
-    public void inputConnection_createsActionFromEnter() {
-        Log.setLogLevel(android.util.Log.VERBOSE);
+    public void inputConnection_createsActionFromEnter() throws JSONException {
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
         View testView = new View(RuntimeEnvironment.application);
         DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
         TextInputPlugin textInputPlugin = new TextInputPlugin(testView, dartExecutor, mock(PlatformViewsController.class));
-        textInputPlugin.setTextInputClient(0, new TextInputChannel.Configuration(false, false, true, TextInputChannel.TextCapitalization.NONE, new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false), null, null));
+        textInputPlugin.setTextInputClient(
+            0,
+            new TextInputChannel.Configuration(
+                false, false, true, TextInputChannel.TextCapitalization.NONE,
+                new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false), null, null));
         // There's a pending restart since we initialized the text input client. Flush that now.
         textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
 
-
-        ByteBuffer message = JSONMethodCodec.INSTANCE.encodeMethodCall(
-            new MethodCall("TextInputClient.performAction", Arrays.asList(0, "TextInputAction.done")));
-        verify(dartExecutor, times(1)).send("flutter/textinput", message, null);
+        ArgumentCaptor<String> channelCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<ByteBuffer> bufferCaptor = ArgumentCaptor.forClass(ByteBuffer.class);
+        verify(dartExecutor, times(1)).send(channelCaptor.capture(), bufferCaptor.capture(), any(BinaryMessenger.BinaryReply.class));
+        assertEquals("flutter/textinput", channelCaptor.getValue());
+        verifyMethodCall(bufferCaptor.getValue(), "TextInputClient.requestExistingInputState", null);
         InputConnection connection = textInputPlugin.createInputConnection(testView, new EditorInfo());
 
         connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER));
-        verify(dartExecutor, times(2)).send("flutter/textinput", message, null);
+        verify(dartExecutor, times(2)).send(channelCaptor.capture(), bufferCaptor.capture(), any(BinaryMessenger.BinaryReply.class));
+        assertEquals("flutter/textinput", channelCaptor.getValue());
+        verifyMethodCall(bufferCaptor.getValue(), "TextInputClient.performAction", new String[] {"0", "TextInputAction.done"});
         connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER));
 
         connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_NUMPAD_ENTER));
-        verify(dartExecutor, times(3)).send("flutter/textinput", message, null);
+        verify(dartExecutor, times(3)).send(channelCaptor.capture(), bufferCaptor.capture(), any(BinaryMessenger.BinaryReply.class));
+        assertEquals("flutter/textinput", channelCaptor.getValue());
+        verifyMethodCall(bufferCaptor.getValue(), "TextInputClient.performAction", new String[] {"0", "TextInputAction.done"});
         connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_NUMPAD_ENTER));
     }
-
 
     @Implements(InputMethodManager.class)
     public static class TestImm extends ShadowInputMethodManager {

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -217,7 +217,6 @@ public class TextInputPluginTest {
         verify(dartExecutor, times(3)).send(channelCaptor.capture(), bufferCaptor.capture(), any(BinaryMessenger.BinaryReply.class));
         assertEquals("flutter/textinput", channelCaptor.getValue());
         verifyMethodCall(bufferCaptor.getValue(), "TextInputClient.performAction", new String[] {"0", "TextInputAction.done"});
-        connection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_NUMPAD_ENTER));
     }
 
     @Implements(InputMethodManager.class)


### PR DESCRIPTION
## Description

This changes the InputConnectionAdaptor so that it will execute an IME action when ENTER is pressed.  Prior to this, pressing ENTER on a hardware keyboard did nothing.

## Related Issues

- Fixes https://github.com/flutter/flutter/issues/19027

## Tests

- Added tests for method calls when keys are pressed, and fixed a test that thought it was checking the method call, but wasn't.