### PR TITLE
Add --lazy_async_stacks to the set of whitelisted VM flags.

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -42,6 +42,7 @@ struct SwitchDesc {
 // clang-format off
 static const std::string gDartFlagsWhitelist[] = {
     "--no-causal_async_stacks",
+    "--lazy_async_stacks",
 };
 // clang-format on
 
@@ -56,6 +57,7 @@ static const std::string gDartFlagsWhitelist[] = {
     "--write-service-info",
     "--sample-buffer-duration",
     "--no-causal_async_stacks",
+    "--lazy_async_stacks",
     "--trace-reload",
     "--trace-reload-verbose",
 };


### PR DESCRIPTION
This flags was added in https://github.com/dart-lang/sdk/commit/d5dbf106726071a8c5be9b88c53d47b9485bc73c.