### PR TITLE
[embedder] Allow embedder to provide path to application library

### DIFF
--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -543,27 +543,43 @@ void PopulateSnapshotMappingCallbacks(const FlutterProjectArgs* args,
   };
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
+    bool provided_data_buffer = false;
     if (SAFE_ACCESS(args, vm_snapshot_data, nullptr) != nullptr) {
+      provided_data_buffer = true;
       settings.vm_snapshot_data = make_mapping_callback(
           args->vm_snapshot_data, SAFE_ACCESS(args, vm_snapshot_data_size, 0));
     }
 
     if (SAFE_ACCESS(args, vm_snapshot_instructions, nullptr) != nullptr) {
+      provided_data_buffer = true;
       settings.vm_snapshot_instr = make_mapping_callback(
           args->vm_snapshot_instructions,
           SAFE_ACCESS(args, vm_snapshot_instructions_size, 0));
     }
 
     if (SAFE_ACCESS(args, isolate_snapshot_data, nullptr) != nullptr) {
+      provided_data_buffer = true;
       settings.isolate_snapshot_data = make_mapping_callback(
           args->isolate_snapshot_data,
           SAFE_ACCESS(args, isolate_snapshot_data_size, 0));
     }
 
     if (SAFE_ACCESS(args, isolate_snapshot_instructions, nullptr) != nullptr) {
+      provided_data_buffer = true;
       settings.isolate_snapshot_instr = make_mapping_callback(
           args->isolate_snapshot_instructions,
           SAFE_ACCESS(args, isolate_snapshot_instructions_size, 0));
+    }
+
+    if (SAFE_ACCESS(args, application_library_path, nullptr) != nullptr) {
+      if (provided_data_buffer) {
+        LOG_EMBEDDER_ERROR(
+            kInvalidArguments,
+            "Cannot provide application_library_path and data buffer args.");
+      }
+      std::string application_library_path =
+          SAFE_ACCESS(args, application_library_path, nullptr);
+      settings.application_library_path.push_back(application_library_path);
     }
   }
 

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -1121,6 +1121,11 @@ typedef struct {
   /// See also:
   /// https://github.com/dart-lang/sdk/blob/ca64509108b3e7219c50d6c52877c85ab6a35ff2/runtime/vm/flag_list.h#L150
   int64_t dart_old_gen_heap_size;
+
+  /// Path to a library containing the application's compiled Dart code.
+  /// This may be provided as an alternative to the data buffers `vm_snapshot_data`,
+  /// `vm_snapshot_instructions`, `isolate_snapshot_data`, and `isolate_snapshot_instructions`.
+  const char* application_library_path;
 } FlutterProjectArgs;
 
 //------------------------------------------------------------------------------

--- a/shell/platform/glfw/flutter_glfw.cc
+++ b/shell/platform/glfw/flutter_glfw.cc
@@ -531,6 +531,14 @@ static FLUTTER_API_SYMBOL(FlutterEngine)
   args.command_line_argv = &argv[0];
   args.platform_message_callback = GLFWOnFlutterPlatformMessage;
   args.custom_task_runners = custom_task_runners;
+  // Provide path to .so in AOT configurations.
+  std::string shared_library_path = std::string();
+  shared_library_path.append(engine_properties.assets_path);
+  shared_library_path.append("/libapp.so");
+  if (FlutterEngineRunsAOTCompiledDartCode()) {
+    args.application_library_path = shared_library_path.c_str();
+  }
+
   FLUTTER_API_SYMBOL(FlutterEngine) engine = nullptr;
   auto result =
       FlutterEngineRun(FLUTTER_ENGINE_VERSION, &config, &args, window, &engine);


### PR DESCRIPTION
As an alternative to the 4 data buffers, a path to an ELF library can be provided to reuse the existing vm ELF loader. Work towards providing release mode for linux and windows.

Caveats:
- I don't have any tests yet
- I'm unsure whether we should expose the current settings which allows providing a vector of various search paths, currently it is just char*

Fixes https://github.com/flutter/flutter/issues/43454