### PR TITLE
fix text blurriness in HTML-rendered text

### DIFF
--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
-repository: https://github.com/yjbanov/goldens.git
-revision: 5e275fca21a956038cb9e07c64fe86e43a7dacfe
+repository: https://github.com/flutter/goldens.git
+revision: b20fee88d8917af269e8073910c31aa373f8a188

--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
 repository: https://github.com/flutter/goldens.git
-revision: c0032eeb9f9f064234991b8b5ddc15f714a53cf5
+revision: 5a7fcde183a7446088aa1cad14d06782cf36a530

--- a/lib/web_ui/dev/goldens_lock.yaml
+++ b/lib/web_ui/dev/goldens_lock.yaml
@@ -1,2 +1,2 @@
-repository: https://github.com/flutter/goldens.git
-revision: 5a7fcde183a7446088aa1cad14d06782cf36a530
+repository: https://github.com/yjbanov/goldens.git
+revision: 5e275fca21a956038cb9e07c64fe86e43a7dacfe

--- a/lib/web_ui/lib/src/engine/engine_canvas.dart
+++ b/lib/web_ui/lib/src/engine/engine_canvas.dart
@@ -262,10 +262,10 @@ html.Element _drawParagraphElement(
     ..width = '${paragraph.width}px';
 
   if (transform != null) {
-    paragraphStyle
-      ..transformOrigin = '0 0 0'
-      ..transform =
-          matrix4ToCssTransform3d(transformWithOffset(transform, offset));
+    setElementTransform(
+      paragraphElement,
+      transformWithOffset(transform, offset).storage,
+    );
   }
 
   final ParagraphGeometricStyle style = paragraph._geometricStyle;

--- a/lib/web_ui/lib/src/engine/surface/clip.dart
+++ b/lib/web_ui/lib/src/engine/surface/clip.dart
@@ -79,15 +79,17 @@ class PersistedClipRect extends PersistedContainerSurface
   @override
   void apply() {
     rootElement.style
-      ..transform = 'translate(${rect.left}px, ${rect.top}px)'
+      ..left = '${rect.left}px'
+      ..top = '${rect.top}px'
       ..width = '${rect.right - rect.left}px'
       ..height = '${rect.bottom - rect.top}px';
 
     // Translate the child container in the opposite direction to compensate for
     // the shift in the coordinate system introduced by the translation of the
     // rootElement. Clipping in Flutter has no effect on the coordinate system.
-    childContainer.style.transform =
-        'translate(${-rect.left}px, ${-rect.top}px)';
+    childContainer.style
+     ..left = '${-rect.left}px'
+     ..top = '${-rect.top}px';
   }
 
   @override
@@ -126,7 +128,8 @@ class PersistedClipRRect extends PersistedContainerSurface
   @override
   void apply() {
     rootElement.style
-      ..transform = 'translate(${rrect.left}px, ${rrect.top}px)'
+      ..left = '${rrect.left}px'
+      ..top = '${rrect.top}px'
       ..width = '${rrect.width}px'
       ..height = '${rrect.height}px'
       ..borderTopLeftRadius = '${rrect.tlRadiusX}px'
@@ -137,8 +140,9 @@ class PersistedClipRRect extends PersistedContainerSurface
     // Translate the child container in the opposite direction to compensate for
     // the shift in the coordinate system introduced by the translation of the
     // rootElement. Clipping in Flutter has no effect on the coordinate system.
-    childContainer.style.transform =
-        'translate(${-rrect.left}px, ${-rrect.top}px)';
+    childContainer.style
+     ..left = '${-rrect.left}px'
+     ..top = '${-rrect.top}px';
   }
 
   @override
@@ -218,12 +222,14 @@ class PersistedPhysicalShape extends PersistedContainerSurface
           '${roundRect.brRadiusX}px ${roundRect.blRadiusX}px';
       final html.CssStyleDeclaration style = rootElement.style;
       style
-        ..transform = 'translate(${roundRect.left}px, ${roundRect.top}px)'
+        ..left = '${roundRect.left}px'
+        ..top = '${roundRect.top}px'
         ..width = '${roundRect.width}px'
         ..height = '${roundRect.height}px'
         ..borderRadius = borderRadius;
-      childContainer.style.transform =
-          'translate(${-roundRect.left}px, ${-roundRect.top}px)';
+      childContainer.style
+        ..left = '${-roundRect.left}px'
+        ..top = '${-roundRect.top}px';
       if (clipBehavior != ui.Clip.none) {
         style.overflow = 'hidden';
       }
@@ -233,12 +239,14 @@ class PersistedPhysicalShape extends PersistedContainerSurface
       if (rect != null) {
         final html.CssStyleDeclaration style = rootElement.style;
         style
-          ..transform = 'translate(${rect.left}px, ${rect.top}px)'
+          ..left = '${rect.left}px'
+          ..top = '${rect.top}px'
           ..width = '${rect.width}px'
           ..height = '${rect.height}px'
           ..borderRadius = '';
-        childContainer.style.transform =
-            'translate(${-rect.left}px, ${-rect.top}px)';
+        childContainer.style
+          ..left = '${-rect.left}px'
+          ..top = '${-rect.top}px';
         if (clipBehavior != ui.Clip.none) {
           style.overflow = 'hidden';
         }
@@ -254,11 +262,14 @@ class PersistedPhysicalShape extends PersistedContainerSurface
           final double left = ellipse.x - rx;
           final double top = ellipse.y - ry;
           style
-            ..transform = 'translate(${left}px, ${top}px)'
+            ..left = '${left}px'
+            ..top = '${top}px'
             ..width = '${rx * 2}px'
             ..height = '${ry * 2}px'
             ..borderRadius = borderRadius;
-          childContainer.style.transform = 'translate(${-left}px, ${-top}px)';
+          childContainer.style
+            ..left = '${-left}px'
+            ..top = '${-top}px';
           if (clipBehavior != ui.Clip.none) {
             style.overflow = 'hidden';
           }
@@ -305,6 +316,8 @@ class PersistedPhysicalShape extends PersistedContainerSurface
       // rect/rrect and arbitrary path.
       final html.CssStyleDeclaration style = rootElement.style;
       style.transform = '';
+      style.left = '';
+      style.top = '';
       style.borderRadius = '';
       domRenderer.setElementStyle(rootElement, 'clip-path', '');
       domRenderer.setElementStyle(rootElement, '-webkit-clip-path', '');

--- a/lib/web_ui/lib/src/engine/surface/clip.dart
+++ b/lib/web_ui/lib/src/engine/surface/clip.dart
@@ -292,12 +292,14 @@ class PersistedPhysicalShape extends PersistedContainerSurface
     final html.CssStyleDeclaration rootElementStyle = rootElement.style;
     rootElementStyle
       ..overflow = ''
-      ..transform = 'translate(${bounds.left}px, ${bounds.top}px)'
+      ..left = '${bounds.left}px'
+      ..top = '${bounds.top}px'
       ..width = '${bounds.width}px'
       ..height = '${bounds.height}px'
       ..borderRadius = '';
-    childContainer.style.transform =
-        'translate(${-bounds.left}px, ${-bounds.top}px)';
+    childContainer.style
+      ..left = '-${bounds.left}px'
+      ..top = '-${bounds.top}px';
   }
 
   @override

--- a/lib/web_ui/test/engine/util_test.dart
+++ b/lib/web_ui/test/engine/util_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:typed_data';
+
+import 'package:ui/src/engine.dart';
+
+import 'package:test/test.dart';
+
+final Float64List identityTransform = Matrix4.identity().storage;
+final Float64List xTranslation = (Matrix4.identity()..translate(10)).storage;
+final Float64List yTranslation = (Matrix4.identity()..translate(0, 10)).storage;
+final Float64List zTranslation = (Matrix4.identity()..translate(0, 0, 10)).storage;
+
+void main() {
+  test('transformKindOf and isIdentityFloat64ListTransform identify matrix kind', () {
+    expect(transformKindOf(identityTransform), TransformKind.identity);
+    expect(isIdentityFloat64ListTransform(identityTransform), isTrue);
+
+    expect(transformKindOf(xTranslation), TransformKind.translation2d);
+    expect(isIdentityFloat64ListTransform(xTranslation), isFalse);
+
+    expect(transformKindOf(yTranslation), TransformKind.translation2d);
+    expect(isIdentityFloat64ListTransform(yTranslation), isFalse);
+
+    expect(transformKindOf(zTranslation), TransformKind.complex);
+    expect(isIdentityFloat64ListTransform(zTranslation), isFalse);
+  });
+}

--- a/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
@@ -22,8 +22,10 @@ void main() async {
     html.document.querySelector('flt-scene-host').append(testScene);
   }
 
-  setUp(() {
-    domRenderer;  // causes CSS reset to be applied to the page.
+  setUp(() async {
+    await webOnlyInitializePlatform();
+    webOnlyFontCollection.debugRegisterTestFonts();
+    await webOnlyFontCollection.ensureFontsLoaded();
   });
 
   tearDown(() {
@@ -134,7 +136,7 @@ void main() async {
   // More details: https://github.com/flutter/flutter/issues/32274
   test('renders clipped DOM text with high quality', () async {
     final Paragraph paragraph =
-        (ParagraphBuilder(ParagraphStyle())..addText('Am I blurry?')).build();
+        (ParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
     paragraph.layout(const ParagraphConstraints(width: 1000));
 
     final Rect canvasSize = Rect.fromLTRB(

--- a/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
@@ -11,17 +11,23 @@ import 'package:test/test.dart';
 import 'package:web_engine_tester/golden_tester.dart';
 
 void main() async {
-  final Rect region = Rect.fromLTWH(8, 8, 500, 100); // Compensate for old scuba tester padding
+  final Rect region = Rect.fromLTWH(0, 0, 500, 100);
 
   BitmapCanvas canvas;
 
+  void appendToScene() {
+    // Create a <flt-scene> element to make sure our CSS reset applies correctly.
+    final html.Element testScene = html.Element.tag('flt-scene');
+    testScene.append(canvas.rootElement);
+    html.document.querySelector('flt-scene-host').append(testScene);
+  }
+
   setUp(() {
-    html.document.body.style.transform = 'translate(10px, 10px)';
+    domRenderer;  // causes CSS reset to be applied to the page.
   });
 
   tearDown(() {
-    html.document.body.style.transform = 'none';
-    canvas.rootElement.remove();
+    html.document.querySelector('flt-scene').remove();
   });
 
   /// Draws several lines, some aligned precisely with the pixel grid, and some
@@ -39,6 +45,8 @@ void main() async {
 
     final SurfacePaintData fillPaint =
         (SurfacePaint()..style = PaintingStyle.fill).paintData;
+
+    canvas.translate(10, 10);
 
     canvas.drawRect(
       const Rect.fromLTWH(0, 0, 40, 40),
@@ -66,7 +74,7 @@ void main() async {
 
     drawMisalignedLines(canvas);
 
-    html.document.body.append(canvas.rootElement);
+    appendToScene();
 
     await matchGoldenFile('misaligned_pixels_in_canvas_test.png', region: region);
   }, timeout: const Timeout(Duration(seconds: 10)));
@@ -81,7 +89,7 @@ void main() async {
 
     drawMisalignedLines(canvas);
 
-    html.document.body.append(canvas.rootElement);
+    appendToScene();
 
     await matchGoldenFile('misaligned_canvas_test.png', region: region);
   }, timeout: const Timeout(Duration(seconds: 10)));
@@ -92,7 +100,7 @@ void main() async {
     canvas.translate(25, 25);
     canvas.drawColor(const Color.fromRGBO(0, 255, 0, 1.0), BlendMode.src);
 
-    html.document.body.append(canvas.rootElement);
+    appendToScene();
 
     await matchGoldenFile('bitmap_canvas_fills_color_when_transformed.png', region: region);
   }, timeout: const Timeout(Duration(seconds: 10)));
@@ -105,8 +113,61 @@ void main() async {
       ..color = const Color.fromRGBO(0, 255, 0, 1.0)
       ..style = PaintingStyle.fill);
 
-    html.document.body.append(canvas.rootElement);
+    appendToScene();
 
     await matchGoldenFile('bitmap_canvas_fills_paint_when_transformed.png', region: region);
   }, timeout: const Timeout(Duration(seconds: 10)));
+
+  // This test reproduces text blurriness when two pieces of text appear inside
+  // two nested clips:
+  //
+  //   ┌───────────────────────┐
+  //   │   text in outer clip  │
+  //   │ ┌────────────────────┐│
+  //   │ │ text in inner clip ││
+  //   │ └────────────────────┘│
+  //   └───────────────────────┘
+  //
+  // This test clips using canvas. See a similar test in `compositing_golden_test.dart`,
+  // which clips using layers.
+  //
+  // More details: https://github.com/flutter/flutter/issues/32274
+  test('renders clipped DOM text with high quality', () async {
+    final Paragraph paragraph =
+        (ParagraphBuilder(ParagraphStyle())..addText('Am I blurry?')).build();
+    paragraph.layout(const ParagraphConstraints(width: 1000));
+
+    final Rect canvasSize = Rect.fromLTRB(
+      0,
+      0,
+      paragraph.maxIntrinsicWidth + 16,
+      2 * paragraph.height + 32,
+    );
+    final Rect outerClip =
+        Rect.fromLTRB(0.5, 0.5, canvasSize.right, canvasSize.bottom);
+    final Rect innerClip = Rect.fromLTRB(0.5, canvasSize.bottom / 2 + 0.5,
+        canvasSize.right, canvasSize.bottom);
+
+    canvas = BitmapCanvas(canvasSize);
+    canvas.debugChildOverdraw = true;
+    canvas.clipRect(outerClip);
+    canvas.drawParagraph(paragraph, const Offset(8.5, 8.5));
+    canvas.clipRect(innerClip);
+    canvas.drawParagraph(paragraph, Offset(8.5, 8.5 + innerClip.top));
+
+    expect(
+      canvas.rootElement.querySelectorAll('p').map<String>((e) => e.innerText).toList(),
+      <String>['Am I blurry?', 'Am I blurry?'],
+      reason: 'Expected to render text using HTML',
+    );
+
+    appendToScene();
+
+    await matchGoldenFile(
+      'bitmap_canvas_draws_high_quality_text.png',
+      region: canvasSize,
+      maxDiffRate: 0.0,
+      pixelComparison: PixelComparison.precise,
+    );
+  }, timeout: const Timeout(Duration(seconds: 10)), testOn: 'chrome');
 }

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -15,12 +15,16 @@ import 'package:web_engine_tester/golden_tester.dart';
 final Rect region = Rect.fromLTWH(0, 0, 500, 100);
 
 void main() async {
-  setUp(() {
+  setUp(() async {
     debugShowClipLayers = true;
     SurfaceSceneBuilder.debugForgetFrameScene();
     for (html.Node scene in html.document.querySelectorAll('flt-scene')) {
       scene.remove();
     }
+
+    await webOnlyInitializePlatform();
+    webOnlyFontCollection.debugRegisterTestFonts();
+    await webOnlyFontCollection.ensureFontsLoaded();
   });
 
   test('pushClipRect', () async {
@@ -531,7 +535,7 @@ void _testCullRectComputation() {
       // To reproduce blurriness we need real clipping.
       debugShowClipLayers = false;
       final Paragraph paragraph =
-          (ParagraphBuilder(ParagraphStyle())..addText('Am I blurry?')).build();
+          (ParagraphBuilder(ParagraphStyle(fontFamily: 'Roboto'))..addText('Am I blurry?')).build();
       paragraph.layout(const ParagraphConstraints(width: 1000));
 
       final Rect canvasSize = Rect.fromLTRB(

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -15,9 +15,8 @@ import 'package:web_engine_tester/golden_tester.dart';
 final Rect region = Rect.fromLTWH(0, 0, 500, 100);
 
 void main() async {
-  debugShowClipLayers = true;
-
   setUp(() {
+    debugShowClipLayers = true;
     SurfaceSceneBuilder.debugForgetFrameScene();
     for (html.Node scene in html.document.querySelectorAll('flt-scene')) {
       scene.remove();
@@ -54,7 +53,8 @@ void main() async {
 
     html.document.body.append(builder.build().webOnlyRootElement);
 
-    await matchGoldenFile('compositing_clip_rect_with_offset_and_transform.png', region: region);
+    await matchGoldenFile('compositing_clip_rect_with_offset_and_transform.png',
+        region: region);
   }, timeout: const Timeout(Duration(seconds: 10)));
 
   test('pushClipRRect', () async {
@@ -95,7 +95,8 @@ void main() async {
 
     html.document.body.append(builder.build().webOnlyRootElement);
 
-    await matchGoldenFile('compositing_shifted_physical_shape_clip.png', region: region);
+    await matchGoldenFile('compositing_shifted_physical_shape_clip.png',
+        region: region);
   }, timeout: const Timeout(Duration(seconds: 10)));
 
   test('pushImageFilter', () async {
@@ -235,7 +236,8 @@ void _testCullRectComputation() {
     builder.pop(); // pushClipRect
     html.document.body.append(builder.build().webOnlyRootElement);
 
-    await matchGoldenFile('compositing_cull_rect_fills_layer_clip.png', region: region);
+    await matchGoldenFile('compositing_cull_rect_fills_layer_clip.png',
+        region: region);
 
     final PersistedStandardPicture picture = enumeratePictures().single;
     expect(picture.optimalLocalCullRect, const Rect.fromLTRB(40, 40, 70, 70));
@@ -263,7 +265,9 @@ void _testCullRectComputation() {
     builder.pop(); // pushClipRect
     html.document.body.append(builder.build().webOnlyRootElement);
 
-    await matchGoldenFile('compositing_cull_rect_intersects_clip_and_paint_bounds.png', region: region);
+    await matchGoldenFile(
+        'compositing_cull_rect_intersects_clip_and_paint_bounds.png',
+        region: region);
 
     final PersistedStandardPicture picture = enumeratePictures().single;
     expect(picture.optimalLocalCullRect, const Rect.fromLTRB(50, 40, 70, 70));
@@ -293,7 +297,8 @@ void _testCullRectComputation() {
     builder.pop(); // pushClipRect
     html.document.body.append(builder.build().webOnlyRootElement);
 
-    await matchGoldenFile('compositing_cull_rect_offset_inside_layer_clip.png', region: region);
+    await matchGoldenFile('compositing_cull_rect_offset_inside_layer_clip.png',
+        region: region);
 
     final PersistedStandardPicture picture = enumeratePictures().single;
     expect(picture.optimalLocalCullRect,
@@ -493,7 +498,8 @@ void _testCullRectComputation() {
 
     await matchGoldenFile('compositing_3d_rotate1.png', region: region);
 
-    final PersistedStandardPicture picture = enumeratePictures().single; // ignore: unused_local_variable
+    // ignore: unused_local_variable
+    final PersistedStandardPicture picture = enumeratePictures().single;
     // TODO(https://github.com/flutter/flutter/issues/40395):
     //   Needs ability to set iframe to 500,100 size. Current screen seems to be 500,500.
     // expect(
@@ -504,6 +510,91 @@ void _testCullRectComputation() {
     //           -140, -140, screenWidth - 360.0, screenHeight + 40.0)),
     // );
   }, timeout: const Timeout(Duration(seconds: 10)));
+
+  // This test reproduces text blurriness when two pieces of text appear inside
+  // two nested clips:
+  //
+  //   ┌───────────────────────┐
+  //   │   text in outer clip  │
+  //   │ ┌────────────────────┐│
+  //   │ │ text in inner clip ││
+  //   │ └────────────────────┘│
+  //   └───────────────────────┘
+  //
+  // This test clips using layers. See a similar test in `canvas_golden_test.dart`,
+  // which clips using canvas.
+  //
+  // More details: https://github.com/flutter/flutter/issues/32274
+  test(
+    'renders clipped text with high quality',
+    () async {
+      // To reproduce blurriness we need real clipping.
+      debugShowClipLayers = false;
+      final Paragraph paragraph =
+          (ParagraphBuilder(ParagraphStyle())..addText('Am I blurry?')).build();
+      paragraph.layout(const ParagraphConstraints(width: 1000));
+
+      final Rect canvasSize = Rect.fromLTRB(
+        0,
+        0,
+        paragraph.maxIntrinsicWidth + 16,
+        2 * paragraph.height + 32,
+      );
+      final Rect outerClip =
+          Rect.fromLTRB(0.5, 0.5, canvasSize.right, canvasSize.bottom);
+      final Rect innerClip = Rect.fromLTRB(0.5, canvasSize.bottom / 2 + 0.5,
+          canvasSize.right, canvasSize.bottom);
+      final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
+
+      builder.pushClipRect(outerClip);
+
+      {
+        final EnginePictureRecorder recorder = PictureRecorder();
+        final RecordingCanvas canvas = recorder.beginRecording(outerClip);
+        canvas.drawParagraph(paragraph, const Offset(8.5, 8.5));
+        final Picture picture = recorder.endRecording();
+        expect(canvas.hasArbitraryPaint, false);
+
+        builder.addPicture(
+          Offset.zero,
+          picture,
+        );
+      }
+
+      builder.pushClipRect(innerClip);
+      {
+        final EnginePictureRecorder recorder = PictureRecorder();
+        final RecordingCanvas canvas = recorder.beginRecording(innerClip);
+        canvas.drawParagraph(paragraph, Offset(8.5, 8.5 + innerClip.top));
+        final Picture picture = recorder.endRecording();
+        expect(canvas.hasArbitraryPaint, false);
+
+        builder.addPicture(
+          Offset.zero,
+          picture,
+        );
+      }
+      builder.pop(); // inner clip
+      builder.pop(); // outer clip
+
+      final html.Element sceneElement = builder.build().webOnlyRootElement;
+      expect(
+        sceneElement.querySelectorAll('p').map<String>((e) => e.innerText).toList(),
+        <String>['Am I blurry?', 'Am I blurry?'],
+        reason: 'Expected to render text using HTML',
+      );
+      html.document.body.append(sceneElement);
+
+      await matchGoldenFile(
+        'compositing_draw_high_quality_text.png',
+        region: canvasSize,
+        maxDiffRate: 0.0,
+        pixelComparison: PixelComparison.precise,
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 10)),
+    testOn: 'chrome',
+  );
 }
 
 void _drawTestPicture(SceneBuilder builder) {

--- a/web_sdk/web_engine_tester/lib/golden_tester.dart
+++ b/web_sdk/web_engine_tester/lib/golden_tester.dart
@@ -20,9 +20,36 @@ Future<dynamic> _callScreenshotServer(dynamic requestData) async {
   return json.decode(request.responseText);
 }
 
+/// How to compare pixels within the image.
+///
+/// Keep this enum in sync with the one defined in `goldens.dart`.
+enum PixelComparison {
+  /// Allows minor blur and anti-aliasing differences by comparing a 3x3 grid
+  /// surrounding the pixel rather than direct 1:1 comparison.
+  fuzzy,
+
+  /// Compares one pixel at a time.
+  ///
+  /// Anti-aliasing or blur will result in higher diff rate.
+  precise,
+}
+
 /// Attempts to match the current browser state with the screenshot [filename].
+///
+/// If [write] is true, will overwrite the golden file and fail the test. Use
+/// it to update golden files.
+///
+/// If [region] is not null, the golden will only include the part contained by
+/// the rectangle.
+///
+/// [maxDiffRate] specifies the tolerance to the number of non-matching pixels
+/// before the test is considered as failing. If [maxDiffRate] is null, applies
+/// a default value defined in `test_platform.dart`.
+///
+/// [pixelComparison] determines the algorithm used to compare pixels. Uses
+/// fuzzy comparison by default.
 Future<void> matchGoldenFile(String filename,
-    {bool write = false, Rect region = null, double maxDiffRate = null}) async {
+    {bool write = false, Rect region = null, double maxDiffRate = null, PixelComparison pixelComparison = PixelComparison.fuzzy}) async {
   Map<String, dynamic> serverParams = <String, dynamic>{
     'filename': filename,
     'write': write,
@@ -33,7 +60,8 @@ Future<void> matchGoldenFile(String filename,
             'y': region.top,
             'width': region.width,
             'height': region.height
-          }
+          },
+    'pixelComparison': pixelComparison.toString(),
   };
   if (maxDiffRate != null) {
     serverParams['maxdiffrate'] = maxDiffRate;


### PR DESCRIPTION
Prefer using `left` and `top` CSS properties instead of `transform` for 2D translation-only transforms on screens with low device-pixel ratios.

![text-blur-diff](https://user-images.githubusercontent.com/211513/72394129-00175e00-36ea-11ea-8bd1-15e2a50c5d65.png)

Fixes https://github.com/flutter/flutter/issues/32274
