### PR TITLE
[fuchsia] Add LogSink to runners cmx files to route logs to fuchsia syslog

### DIFF
--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -17,6 +17,7 @@
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
       "fuchsia.intl.PropertyProvider",
+      "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",

--- a/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_jit_product_runner.cmx
@@ -17,6 +17,7 @@
       "fuchsia.feedback.CrashReporter",
       "fuchsia.fonts.Provider",
       "fuchsia.intl.PropertyProvider",
+      "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",


### PR DESCRIPTION
This removes logs such as and will route flutter logs to fuchsia syslog

```
[00040.970590][9280][9282][klog] INFO: [WARNING:src/sys/appmgr/service_provider_dir_impl.cc(120)] Component fuchsia-pk
g://fuchsia.com/flutter_jit_product_runner#meta/flutter_jit_product_runner.cmx is not allowed to connect to fuchsia.lo
gger.LogSink because this s                                                                                           
[00040.970592][9280][9282][klog] INFO: ervice is not present in the component's sandbox.                              
[00040.970594][9280][9282][klog] INFO: Refer to https://fuchsia.dev/fuchsia-src/concepts/framework/sandboxing#services
 for more information.   
```