### PR TITLE
Make internal cache vars private

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -483,8 +483,8 @@ class Locale {
   @override
   int get hashCode => hashValues(languageCode, scriptCode, countryCode);
 
-  static Locale cachedLocale;
-  static String cachedLocaleString;
+  static Locale _cachedLocale;
+  static String _cachedLocaleString;
 
   /// Returns a string representing the locale.
   ///
@@ -493,11 +493,11 @@ class Locale {
   /// purposes only. For parseable results, use [toLanguageTag] instead.
   @override
   String toString() {
-    if (!identical(cachedLocale, this)) {
-      cachedLocale = this;
-      cachedLocaleString = _rawToString('_');
+    if (!identical(_cachedLocale, this)) {
+      _cachedLocale = this;
+      _cachedLocaleString = _rawToString('_');
     }
-    return cachedLocaleString;
+    return _cachedLocaleString;
   }
 
   /// Returns a syntactically valid Unicode BCP47 Locale Identifier.


### PR DESCRIPTION
These variables seem like they shouldn't be public.  Noticed this when cleaning up stuff for https://github.com/flutter/engine/pull/15698

This doesn't seem to break any tests or have references in google3.