### PR TITLE
v1.12.13+hotfix.7 cherry-picks

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -26,7 +26,7 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   # OCMock is for testing only so there is no google clone
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
-  'skia_revision': 'c3ff97a98b74554854b5822797c6b7b431f4d8d2',
+  'skia_revision': 'a640745ce52ea6ac9c1b958f40c1d28c98ad16fc',
 
   # When updating the Dart revision, ensure that all entries that are
   # dependencies of Dart are also updated to match the entries in the

--- a/ci/licenses_golden/licenses_skia
+++ b/ci/licenses_golden/licenses_skia
@@ -1,4 +1,4 @@
-Signature: d41f84acbe245ec2c36d88299851fa7d
+Signature: 860f6aef752d91219cb31a9ab4a8e625
 
 UNUSED LICENSES:
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -621,9 +621,7 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 }
 
 - (void)insertText:(NSString*)text {
-  // The affinity is unknown here. Set to "" so that Flutter interprets it
-  // as ambiguous and uses a fallback affinity.
-  _selectionAffinity = "";
+  _selectionAffinity = _kTextAffinityDownstream;
   [self replaceRange:_selectedTextRange withText:text];
 }
 


### PR DESCRIPTION
* google/skia@a640745 Disable QCOM_tiled_rendering while we wait for test devices
* bcb8267 Revert "Do not default to downstream affinity on iOS insertText"