### PR TITLE
Samsung fix duplication on punctuation: Update keyboard on finish compose.

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -14,6 +14,7 @@ import android.text.TextPaint;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 
@@ -132,6 +133,22 @@ class InputConnectionAdaptor extends BaseInputConnection {
         updateEditingState();
         return result;
     }
+
+    @Override
+    public boolean finishComposingText() {
+        boolean result = super.finishComposingText();
+
+        // Update the keyboard with a reset/empty composing region. Critical on
+        // Samsung keyboards to prevent punctuation duplication.
+        CursorAnchorInfo.Builder builder = new CursorAnchorInfo.Builder();
+        builder.setComposingText(-1, "");
+        CursorAnchorInfo anchorInfo = builder.build();
+        mImm.updateCursorAnchorInfo(mFlutterView, anchorInfo);
+        
+        updateEditingState();
+        return result;
+    }
+
 
     @Override
     public boolean setSelection(int start, int end) {

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -137,11 +137,10 @@ class InputConnectionAdaptor extends BaseInputConnection {
     }
 
     @Override
-    @TargetApi(21)
     public boolean finishComposingText() {
         boolean result = super.finishComposingText();
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= 21) {
             // Update the keyboard with a reset/empty composing region. Critical on
             // Samsung keyboards to prevent punctuation duplication.
             CursorAnchorInfo.Builder builder = new CursorAnchorInfo.Builder();

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -5,6 +5,7 @@
 package io.flutter.plugin.editing;
 
 import android.content.Context;
+import android.os.Build;
 import android.text.DynamicLayout;
 import android.text.Editable;
 import android.text.Layout;
@@ -138,13 +139,15 @@ class InputConnectionAdaptor extends BaseInputConnection {
     public boolean finishComposingText() {
         boolean result = super.finishComposingText();
 
-        // Update the keyboard with a reset/empty composing region. Critical on
-        // Samsung keyboards to prevent punctuation duplication.
-        CursorAnchorInfo.Builder builder = new CursorAnchorInfo.Builder();
-        builder.setComposingText(-1, "");
-        CursorAnchorInfo anchorInfo = builder.build();
-        mImm.updateCursorAnchorInfo(mFlutterView, anchorInfo);
-        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            // Update the keyboard with a reset/empty composing region. Critical on
+            // Samsung keyboards to prevent punctuation duplication.
+            CursorAnchorInfo.Builder builder = new CursorAnchorInfo.Builder();
+            builder.setComposingText(-1, "");
+            CursorAnchorInfo anchorInfo = builder.build();
+            mImm.updateCursorAnchorInfo(mFlutterView, anchorInfo);
+        }
+
         updateEditingState();
         return result;
     }

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -4,7 +4,6 @@
 
 package io.flutter.plugin.editing;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.text.DynamicLayout;

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -4,6 +4,7 @@
 
 package io.flutter.plugin.editing;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.text.DynamicLayout;

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -136,6 +136,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     }
 
     @Override
+    @TargetApi(21)
     public boolean finishComposingText() {
         boolean result = super.finishComposingText();
 

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -2,6 +2,7 @@ package io.flutter.plugin.editing;
 
 import android.content.Context;
 import android.content.res.AssetManager;
+import android.os.Build;
 import android.provider.Settings;
 import android.util.SparseIntArray;
 import android.view.inputmethod.CursorAnchorInfo;
@@ -238,10 +239,12 @@ public class TextInputPluginTest {
 
         connection.finishComposingText();
 
-        CursorAnchorInfo.Builder builder = new CursorAnchorInfo.Builder();
-        builder.setComposingText(-1, "");
-        CursorAnchorInfo anchorInfo = builder.build();
-        assertEquals(testImm.getLastCursorAnchorInfo(), anchorInfo);
+        if (Build.VERSION.SDK_INT >= 21) {
+            CursorAnchorInfo.Builder builder = new CursorAnchorInfo.Builder();
+            builder.setComposingText(-1, "");
+            CursorAnchorInfo anchorInfo = builder.build();
+            assertEquals(testImm.getLastCursorAnchorInfo(), anchorInfo);
+        }
     }
 
     @Implements(InputMethodManager.class)

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -222,7 +222,6 @@ public class TextInputPluginTest {
     }
 
     @Test
-    @TargetApi(21)
     public void inputConnection_finishComposingTextUpdatesIMM() throws JSONException {
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         FlutterJNI mockFlutterJni = mock(FlutterJNI.class);

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -272,7 +272,7 @@ public class TextInputPluginTest {
             return restartCounter.get(view.hashCode(), /*defaultValue=*/0);
         }
 
-        @Override
+        @Implementation
         public void updateCursorAnchorInfo(View view, CursorAnchorInfo cursorAnchorInfo) {
             this.cursorAnchorInfo = cursorAnchorInfo;
         }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -221,7 +221,7 @@ public class TextInputPluginTest {
     }
 
     @Test
-    public void inputConnection_createsActionFromEnter() throws JSONException {
+    public void inputConnection_finishComposingTextUpdatesIMM() throws JSONException {
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
         View testView = new View(RuntimeEnvironment.application);

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1,5 +1,6 @@
 package io.flutter.plugin.editing;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.provider.Settings;
@@ -221,6 +222,7 @@ public class TextInputPluginTest {
     }
 
     @Test
+    @TargetApi(21)
     public void inputConnection_finishComposingTextUpdatesIMM() throws JSONException {
         TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
         FlutterJNI mockFlutterJni = mock(FlutterJNI.class);

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -277,7 +277,7 @@ public class TextInputPluginTest {
             this.cursorAnchorInfo = cursorAnchorInfo;
         }
 
-        public getLastCursorAnchorInfo() {
+        public CursorAnchorInfo getLastCursorAnchorInfo() {
             return cursorAnchorInfo;
         }
     }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.AssetManager;
 import android.provider.Settings;
 import android.util.SparseIntArray;
+import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
@@ -219,10 +220,35 @@ public class TextInputPluginTest {
         verifyMethodCall(bufferCaptor.getValue(), "TextInputClient.performAction", new String[] {"0", "TextInputAction.done"});
     }
 
+    @Test
+    public void inputConnection_createsActionFromEnter() throws JSONException {
+        TestImm testImm = Shadow.extract(RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
+        FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
+        View testView = new View(RuntimeEnvironment.application);
+        DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
+        TextInputPlugin textInputPlugin = new TextInputPlugin(testView, dartExecutor, mock(PlatformViewsController.class));
+        textInputPlugin.setTextInputClient(
+            0,
+            new TextInputChannel.Configuration(
+                false, false, true, TextInputChannel.TextCapitalization.NONE,
+                new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false), null, null));
+        // There's a pending restart since we initialized the text input client. Flush that now.
+        textInputPlugin.setTextInputEditingState(testView, new TextInputChannel.TextEditState("", 0, 0));
+        InputConnection connection = textInputPlugin.createInputConnection(testView, new EditorInfo());
+
+        connection.finishComposingText();
+
+        CursorAnchorInfo.Builder builder = new CursorAnchorInfo.Builder();
+        builder.setComposingText(-1, "");
+        CursorAnchorInfo anchorInfo = builder.build();
+        assertEquals(testImm.getLastCursorAnchorInfo(), anchorInfo);
+    }
+
     @Implements(InputMethodManager.class)
     public static class TestImm extends ShadowInputMethodManager {
         private InputMethodSubtype currentInputMethodSubtype;
         private SparseIntArray restartCounter = new SparseIntArray();
+        private CursorAnchorInfo cursorAnchorInfo;
 
         public TestImm() {
         }
@@ -244,6 +270,15 @@ public class TextInputPluginTest {
 
         public int getRestartCount(View view) {
             return restartCounter.get(view.hashCode(), /*defaultValue=*/0);
+        }
+
+        @Override
+        public void updateCursorAnchorInfo(View view, CursorAnchorInfo cursorAnchorInfo) {
+            this.cursorAnchorInfo = cursorAnchorInfo;
+        }
+
+        public getLastCursorAnchorInfo() {
+            return cursorAnchorInfo;
         }
     }
 }

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -1,6 +1,5 @@
 package io.flutter.plugin.editing;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.AssetManager;
 import android.provider.Settings;


### PR DESCRIPTION
Partial fix for https://github.com/flutter/flutter/issues/31512

Resolves the duplication on punctuation.

The duplication when keyboard is hidden+re-shown is still there.

This overrides `finishComposingText` and force-updates the keyboard with an empty/clean composing region.