### PR TITLE
Disable GPUThreadMerger tests inline instead of via harness flags.

### DIFF
--- a/fml/gpu_thread_merger_unittests.cc
+++ b/fml/gpu_thread_merger_unittests.cc
@@ -14,7 +14,8 @@
 #include "flutter/fml/task_runner.h"
 #include "gtest/gtest.h"
 
-TEST(GpuThreadMerger, RemainMergedTillLeaseExpires) {
+// TODO(49007): Flaky. Investigate, fix and re-enable.
+TEST(GpuThreadMerger, DISABLED_RemainMergedTillLeaseExpires) {
   fml::MessageLoop* loop1 = nullptr;
   fml::AutoResetWaitableEvent latch1;
   fml::AutoResetWaitableEvent term1;
@@ -61,7 +62,8 @@ TEST(GpuThreadMerger, RemainMergedTillLeaseExpires) {
   thread2.join();
 }
 
-TEST(GpuThreadMerger, IsNotOnRasterizingThread) {
+// TODO(49007): Flaky. Investigate, fix and re-enable.
+TEST(GpuThreadMerger, DISABLED_IsNotOnRasterizingThread) {
   fml::MessageLoop* loop1 = nullptr;
   fml::AutoResetWaitableEvent latch1;
   std::thread thread1([&loop1, &latch1]() {
@@ -146,7 +148,8 @@ TEST(GpuThreadMerger, IsNotOnRasterizingThread) {
   thread2.join();
 }
 
-TEST(GpuThreadMerger, LeaseExtension) {
+// TODO(49007): Flaky. Investigate, fix and re-enable.
+TEST(GpuThreadMerger, DISABLED_LeaseExtension) {
   fml::MessageLoop* loop1 = nullptr;
   fml::AutoResetWaitableEvent latch1;
   fml::AutoResetWaitableEvent term1;

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -22,7 +22,7 @@ roboto_font_path = os.path.join(fonts_dir, 'Roboto-Regular.ttf')
 dart_tests_dir = os.path.join(buildroot_dir, 'flutter', 'testing', 'dart',)
 font_subset_dir = os.path.join(buildroot_dir, 'flutter', 'tools', 'font-subset')
 
-fml_unittests_filter = '--gtest_filter=-*TimeSensitiveTest*:*GpuThreadMerger*'
+fml_unittests_filter = '--gtest_filter=-*TimeSensitiveTest*'
 
 def RunCmd(cmd, **kwargs):
   try:


### PR DESCRIPTION
Fixes https://bugs.fuchsia.dev/p/fuchsia/issues/detail?id=44238