### PR TITLE
fix typo, update path metrics docs

### DIFF
--- a/lib/web_ui/lib/src/ui/path_metrics.dart
+++ b/lib/web_ui/lib/src/ui/path_metrics.dart
@@ -16,14 +16,16 @@ part of ui;
 /// another [Path.lineTo] will contain two contours and thus be represented by
 /// two [PathMetric] objects.
 ///
-/// When iterating across a [PathMetrics]' contours, the [PathMetric] objects
-/// are only valid until the next one is obtained.
+/// This iterable does not memoize. Callers who need to traverse the list
+/// multiple times, or who need to randomly access elements of the list, should
+/// use [toList] on this object.
 abstract class PathMetrics extends collection.IterableBase<PathMetric> {
   @override
   Iterator<PathMetric> get iterator;
 }
 
-/// Tracks iteration from one segment of a path to the next for measurement.
+/// Used by [PathMetrics] to track iteration from one segment of a path to the
+/// next for measurement.
 abstract class PathMetricIterator implements Iterator<PathMetric> {
   @override
   PathMetric get current;
@@ -32,14 +34,19 @@ abstract class PathMetricIterator implements Iterator<PathMetric> {
   bool moveNext();
 }
 
-/// Utilities for measuring a [Path] and extracting subpaths.
+/// Utilities for measuring a [Path] and extracting sub-paths.
 ///
 /// Iterate over the object returned by [Path.computeMetrics] to obtain
-/// [PathMetric] objects.
+/// [PathMetric] objects. Callers that want to randomly access elements or
+/// iterate multiple times should use `path.computeMetrics().toList()`, since
+/// [PathMetrics] does not memoize.
 ///
-/// Once created, metrics will only be valid while the iterator is at the given
-/// contour. When the next contour's [PathMetric] is obtained, this object
-/// becomes invalid.
+/// Once created, the metrics are only valid for the path as it was specified
+/// when [Path.computeMetrics] was called. If additional contours are added or
+/// any contours are updated, the metrics need to be recomputed. Previously
+/// created metrics will still refer to a snapshot of the path at the time they
+/// were computed, rather than to the actual metrics for the new mutations to
+/// the path.
 ///
 /// Implementation is based on
 /// https://github.com/google/skia/blob/master/src/core/SkContourMeasure.cpp


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/48980

Fixes a typo introduced in a recent PR by me as well.

Also updates the docs to align with the current state of Skia for this - they've made API changes we take advantage of now to make the methods accurate even after the iterator moves.

/cc @zbarryte-luminopia