### PR TITLE
[libtxt] Assign a unique ID to each glyph cluster within a line

### DIFF
--- a/third_party/txt/src/txt/paragraph_txt.cc
+++ b/third_party/txt/src/txt/paragraph_txt.cc
@@ -796,6 +796,7 @@ void ParagraphTxt::Layout(double width) {
 
     double run_x_offset = 0;
     double justify_x_offset = 0;
+    size_t cluster_unique_id = 0;
     std::vector<PaintRecord> paint_records;
 
     for (auto line_run_it = line_runs.begin(); line_run_it != line_runs.end();
@@ -956,10 +957,10 @@ void ParagraphTxt::Layout(double width) {
           float grapheme_advance =
               glyph_advance / grapheme_code_unit_counts.size();
 
-          glyph_positions.emplace_back(run_x_offset + glyph_x_offset,
-                                       grapheme_advance,
-                                       run.start() + glyph_code_units.start,
-                                       grapheme_code_unit_counts[0], cluster);
+          glyph_positions.emplace_back(
+              run_x_offset + glyph_x_offset, grapheme_advance,
+              run.start() + glyph_code_units.start,
+              grapheme_code_unit_counts[0], cluster_unique_id);
 
           // Compute positions for the additional graphemes in the ligature.
           for (size_t i = 1; i < grapheme_code_unit_counts.size(); ++i) {
@@ -967,8 +968,9 @@ void ParagraphTxt::Layout(double width) {
                 glyph_positions.back().x_pos.end, grapheme_advance,
                 glyph_positions.back().code_units.start +
                     grapheme_code_unit_counts[i - 1],
-                grapheme_code_unit_counts[i], cluster);
+                grapheme_code_unit_counts[i], cluster_unique_id);
           }
+          cluster_unique_id++;
 
           bool at_word_start = false;
           bool at_word_end = false;

--- a/third_party/txt/tests/paragraph_unittests.cc
+++ b/third_party/txt/tests/paragraph_unittests.cc
@@ -175,6 +175,37 @@ TEST_F(ParagraphTest, GetGlyphPositionAtCoordinateSegfault) {
   ASSERT_TRUE(Snapshot());
 }
 
+// Check that GetGlyphPositionAtCoordinate computes correct text positions for
+// a paragraph containing multiple styled runs.
+TEST_F(ParagraphTest, GetGlyphPositionAtCoordinateMultiRun) {
+  txt::ParagraphStyle paragraph_style;
+  txt::ParagraphBuilderTxt builder(paragraph_style, GetTestFontCollection());
+
+  txt::TextStyle text_style;
+  text_style.font_families = std::vector<std::string>(1, "Ahem");
+  text_style.color = SK_ColorBLACK;
+  text_style.font_size = 10;
+  builder.PushStyle(text_style);
+  builder.AddText(u"A");
+  text_style.font_size = 20;
+  builder.PushStyle(text_style);
+  builder.AddText(u"B");
+  text_style.font_size = 30;
+  builder.PushStyle(text_style);
+  builder.AddText(u"C");
+
+  auto paragraph = BuildParagraph(builder);
+  paragraph->Layout(GetTestCanvasWidth());
+
+  paragraph->Paint(GetCanvas(), 10.0, 15.0);
+
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(2.0, 5.0).position, 0ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(12.0, 5.0).position, 1ull);
+  ASSERT_EQ(paragraph->GetGlyphPositionAtCoordinate(32.0, 5.0).position, 2ull);
+
+  ASSERT_TRUE(Snapshot());
+}
+
 TEST_F(ParagraphTest, LineMetricsParagraph1) {
   const char* text = "Hello! What is going on?\nSecond line \nthirdline";
   auto icu_text = icu::UnicodeString::fromUTF8(text);


### PR DESCRIPTION
Previously layout had been using the cluster index returned by Minikin,
which is only unique within each call to Minikin layout.  This can produce
duplicate cluster IDs within a line containing multiple text runs.
GetGlyphPositionAtCoordinate then returns incorrect results because it thinks
the affected glyphs are part of the same cluster.

Fixes https://github.com/flutter/flutter/issues/48231
Fixes https://github.com/flutter/flutter/issues/49044