### PR TITLE
Add size parameters to Vulkan surface functions

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface.cc
@@ -254,7 +254,8 @@ bool VulkanSurface::AllocateDeviceMemory(sk_sp<GrContext> context,
   };
 
   {
-    TRACE_EVENT0("flutter", "vkAllocateMemory");
+    TRACE_EVENT1("flutter", "vkAllocateMemory", "allocationSize",
+                 alloc_info.allocationSize);
     VkDeviceMemory vk_memory = VK_NULL_HANDLE;
     if (VK_CALL_LOG_ERROR(vulkan_provider_.vk().AllocateMemory(
             vulkan_provider_.vk_device(), &alloc_info, NULL, &vk_memory)) !=

--- a/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_pool.cc
@@ -49,7 +49,8 @@ std::unique_ptr<VulkanSurface> VulkanSurfacePool::AcquireSurface(
 
 std::unique_ptr<VulkanSurface> VulkanSurfacePool::GetCachedOrCreateSurface(
     const SkISize& size) {
-  TRACE_EVENT0("flutter", "VulkanSurfacePool::GetCachedOrCreateSurface");
+  TRACE_EVENT2("flutter", "VulkanSurfacePool::GetCachedOrCreateSurface",
+               "width", size.width(), "height", size.height());
   // First try to find a surface that exactly matches |size|.
   {
     auto exact_match_it =
@@ -163,7 +164,8 @@ void VulkanSurfacePool::SubmitSurface(
 
 std::unique_ptr<VulkanSurface> VulkanSurfacePool::CreateSurface(
     const SkISize& size) {
-  TRACE_EVENT0("flutter", "VulkanSurfacePool::CreateSurface");
+  TRACE_EVENT2("flutter", "VulkanSurfacePool::CreateSurface", "width",
+               size.width(), "height", size.height());
   auto surface = std::make_unique<VulkanSurface>(vulkan_provider_, context_,
                                                  scenic_session_, size);
   if (!surface->IsValid()) {


### PR DESCRIPTION
Add "width" and "height" trace parameters to
|VulkanSurfacePool::GetCachedOrCreateSurface| and
|VulkanSurfacePool::CreateSurface|.  Also add an "allocationSize"
parameter to the "vkAllocateMemory" event.