### PR TITLE
Check if _semanticsPlaceholder is not null before calling remove

### DIFF
--- a/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
+++ b/lib/web_ui/lib/src/engine/semantics/semantics_helper.dart
@@ -127,7 +127,7 @@ class DesktopSemanticsEnabler extends SemanticsEnabler {
   @override
   bool tryEnableSemantics(html.Event event) {
     if (_schedulePlaceholderRemoval) {
-      _semanticsPlaceholder.remove();
+      if (_semanticsPlaceholder != null) _semanticsPlaceholder.remove();
       _semanticsPlaceholder = null;
       semanticsActivationTimer = null;
       return true;
@@ -258,7 +258,7 @@ class MobileSemanticsEnabler extends SemanticsEnabler {
       final bool removeNow =
           (browserEngine != BrowserEngine.webkit || event.type == 'touchend');
       if (removeNow) {
-        _semanticsPlaceholder.remove();
+        if (_semanticsPlaceholder != null) _semanticsPlaceholder.remove();
         _semanticsPlaceholder = null;
         semanticsActivationTimer = null;
       }


### PR DESCRIPTION
I was seeing the following error with our Flutter Web app, it would occur randomly after using the app for a short period of time.

`semantics_helper.dart:124 Uncaught TypeError: Cannot read property 'Symbol(dartx.remove)' of null
    at _engine.DesktopSemanticsEnabler.new.tryEnableSemantics (semantics_helper.dart:124)
    at _engine.SemanticsHelper.new.shouldEnableSemantics (semantics_helper.dart:43)
    at _engine.EngineSemanticsOwner.__.receiveGlobalEvent (semantics.dart:1349)
    at HTMLElement.<anonymous> (pointer_binding.dart:172)`

With @slightfoot's help we were able to track it down to this code/fix.