### PR TITLE
[web] test for edge launcher installation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -163,8 +163,6 @@ task:
         python flutter/tools/gn --runtime-mode debug --unoptimized
         ninja -C out/host_debug_unopt
       test_web_engine_edge_script: |
-        cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
-        pub --trace get
         cd %ENGINE_PATH%/src/flutter/lib/web_ui
         pub --trace get
         dart dev/edge_launcher_installation_test.dart

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -160,7 +160,7 @@ task:
     - name: build_and_test_web_windows_edge
       compile_host_script: |
         cd %ENGINE_PATH%/src
-        python.exe %ENGINE_PATH%/src/third_party/dart/tools/make_version.py --quiet
+        python %ENGINE_PATH%/src/third_party/dart/tools/make_version.py --quiet
       test_web_engine_edge_script: |
         cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
         %ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/pub get

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -164,7 +164,7 @@ task:
         ninja -C out/host_debug_unopt
       test_web_engine_edge_script: |
         cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
-        pub get
+        pub --trace get
         cd %ENGINE_PATH%/src/flutter/lib/web_ui
-        pub get
+        pub --trace get
         dart dev/edge_launcher_installation_test.dart

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -158,6 +158,10 @@ task:
         python flutter/tools/gn --runtime-mode debug
         ninja -C out/host_debug
     - name: build_and_test_web_windows_edge
+      compile_host_script: |
+        cd %ENGINE_PATH%/src
+        python flutter/tools/gn --runtime-mode debug --unoptimized
+        ninja -C out/host_debug_unopt
       test_web_engine_edge_script: |
         cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
         pub get

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -159,9 +159,9 @@ task:
     - name: build_and_test_web_windows_edge
       compile_host_script: |
         cd %ENGINE_PATH%/src
-        python flutter/tools/gn --unoptimized --full-dart-sdk
+        python flutter/tools/gn --runtime-mode debug --unoptimized --full-dart-sdk
         ninja -C out/host_debug_unopt
-      test_web_engine_firefox_script: |
+      test_web_engine_edge_script: |
         cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
         %ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/pub get
         cd %ENGINE_PATH%/src/flutter/lib/web_ui

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -136,6 +136,7 @@ task:
     DEPOT_TOOLS_WIN_TOOLCHAIN: 0
     GYP_MSVS_OVERRIDE_PATH: "c:/Program Files (x86)/Microsoft Visual Studio/2017/Community"
     ENGINE_PATH: "c:/flutter/engine"
+    GYP_MSVS_VERSION: 2017
   setup_script: |
     REM robocopy can return 1 for successful copy; suppress its error code.
     REM move somehow doesn't work as it complains that the file is being used by another process.
@@ -159,8 +160,7 @@ task:
     - name: build_and_test_web_windows_edge
       compile_host_script: |
         cd %ENGINE_PATH%/src
-        python flutter/tools/gn --runtime-mode debug --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
+        python.exe %ENGINE_PATH%/src/third_party/dart/tools/make_version.py --quiet
       test_web_engine_edge_script: |
         cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
         %ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/pub get

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -156,3 +156,15 @@ task:
         cd %ENGINE_PATH%/src
         python flutter/tools/gn --runtime-mode debug
         ninja -C out/host_debug
+    - name: build_and_test_web_windows_edge
+      compile_host_script: |
+        cd %ENGINE_PATH%/src
+        python flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      test_web_engine_firefox_script: |
+        cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
+        %ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/pub get
+        cd %ENGINE_PATH%/src/flutter/lib/web_ui
+        %ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/pub get
+        SET DART="%ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/dart"
+        %DART% dev/edge_launcher_installation_test.dart

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,7 +132,7 @@ task:
     disk: 50
   env:
     # Cirrus is somehow not picking up the environment variables set in the VM image.
-    PATH: "c:/depot_tools;c:/MinGit/cmd;$PATH"
+    PATH: "c:/depot_tools;c:/MinGit/cmd;c:/flutter/engine/src/out/host_debug_unopt/dart-sdk/bin/;$PATH"
     DEPOT_TOOLS_WIN_TOOLCHAIN: 0
     GYP_MSVS_OVERRIDE_PATH: "c:/Program Files (x86)/Microsoft Visual Studio/2017/Community"
     ENGINE_PATH: "c:/flutter/engine"
@@ -158,13 +158,9 @@ task:
         python flutter/tools/gn --runtime-mode debug
         ninja -C out/host_debug
     - name: build_and_test_web_windows_edge
-      compile_host_script: |
-        cd %ENGINE_PATH%/src
-        python %ENGINE_PATH%/src/third_party/dart/tools/make_version.py --quiet
       test_web_engine_edge_script: |
         cd %ENGINE_PATH%/src/flutter/web_sdk/web_engine_tester
-        %ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/pub get
+        pub get
         cd %ENGINE_PATH%/src/flutter/lib/web_ui
-        %ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/pub get
-        SET DART="%ENGINE_PATH%/src/out/host_debug_unopt/dart-sdk/bin/dart"
-        %DART% dev/edge_launcher_installation_test.dart
+        pub get
+        dart dev/edge_launcher_installation_test.dart

--- a/lib/web_ui/dev/edge_launcher_installation_test.dart
+++ b/lib/web_ui/dev/edge_launcher_installation_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm && windows')
+
+import 'dart:io' as io;
+
+import 'package:test/test.dart';
+
+import 'edge_installation.dart';
+
+void main() async {
+  void deleteEdgeInstallIfExists() {
+    final io.Directory installationDirectory =
+        EdgeLauncher().launcherInstallationDir;
+    if (installationDirectory.existsSync()) {
+      installationDirectory.deleteSync(recursive: true);
+    }
+  }
+
+  setUpAll(() {
+    deleteEdgeInstallIfExists();
+  });
+
+  tearDown(() {
+    deleteEdgeInstallIfExists();
+  });
+
+  test('installs a given version of Firefox', () async {
+    final EdgeLauncher edgeLauncher = EdgeLauncher();
+
+    expect(edgeLauncher.isInstalled, isFalse);
+
+    await getEdgeInstallation('system');
+
+    expect(EdgeLauncher().launcherInstallationDir.existsSync(), isTrue);
+    expect(edgeLauncher.isInstalled, isTrue);
+  });
+}


### PR DESCRIPTION
 test in cirrus for edge launcher installation. 

it will be removed from cirrus in a few weeks since we are moving to LUCI.

This also tests the web build in windows. I'll replace the build commands with "felt_windows.bat build" in the next PR.