### PR TITLE
Add missing include in GLFW and Windows embeddings

### DIFF
--- a/shell/platform/glfw/glfw_event_loop.h
+++ b/shell/platform/glfw/glfw_event_loop.h
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <deque>
+#include <functional>
 #include <mutex>
 #include <queue>
 #include <thread>

--- a/shell/platform/windows/win32_task_runner.h
+++ b/shell/platform/windows/win32_task_runner.h
@@ -9,6 +9,7 @@
 
 #include <chrono>
 #include <deque>
+#include <functional>
 #include <mutex>
 #include <queue>
 #include <thread>


### PR DESCRIPTION
Fixes an error caught by VS 2019.

Needed for https://github.com/flutter/flutter/issues/48831