### PR TITLE
Roll ANGLE to ToT

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -423,7 +423,7 @@ deps = {
    Var('swiftshader_git') + '/SwiftShader.git' + '@' + '5d1e8540407c138f47028d64684f3da599430aa4',
 
    'src/third_party/angle':
-   Var('github_git') + '/google/angle.git' + '@' + '3ea90d609720b7b9b9d05ca094860382f2425294',
+   Var('github_git') + '/google/angle.git' + '@' + '13205b935d9ac29cd25b245fd1e8b7e67e5b8887',
 
   'src/third_party/pkg/when':
    Var('dart_git') + '/when.git' + '@' + '0.2.0',


### PR DESCRIPTION
Updates the ANGLE checkout to the latest master. Among other things, picks up fixes for errors when building under Visual Studio 2019.

Updates buildroot to for necessary changes, including a switch to VS 2019.