### PR TITLE
Move tonic into //flutter/third_party.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -145,9 +145,6 @@ deps = {
    # build. Eventually, we'll manage these dependencies together with Fuchsia
    # and not have to specific specific hashes.
 
-  'src/third_party/tonic':
-   Var('fuchsia_git') + '/tonic' + '@' + '1a8ed9be2e2b56b32e888266d6db465d36012df4',
-
   'src/third_party/benchmark':
    Var('fuchsia_git') + '/third_party/benchmark' + '@' + 'a779ffce872b4c811beef482e18bd0b63626aa42',
 

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -6,6 +6,7 @@ USED LICENSES:
 
 ====================================================================================================
 LIBRARY: engine
+LIBRARY: tonic
 LIBRARY: txt
 ORIGIN: ../../../flutter/LICENSE
 TYPE: LicenseType.bsd
@@ -1122,6 +1123,66 @@ FILE: ../../../flutter/shell/version/version.cc
 FILE: ../../../flutter/shell/version/version.h
 FILE: ../../../flutter/sky/packages/flutter_services/lib/empty.dart
 FILE: ../../../flutter/sky/tools/roll/patches/chromium/android_build.patch
+FILE: ../../../flutter/third_party/tonic/common/build_config.h
+FILE: ../../../flutter/third_party/tonic/common/log.cc
+FILE: ../../../flutter/third_party/tonic/common/log.h
+FILE: ../../../flutter/third_party/tonic/common/macros.h
+FILE: ../../../flutter/third_party/tonic/converter/dart_converter.cc
+FILE: ../../../flutter/third_party/tonic/converter/dart_converter.h
+FILE: ../../../flutter/third_party/tonic/dart_args.h
+FILE: ../../../flutter/third_party/tonic/dart_binding_macros.h
+FILE: ../../../flutter/third_party/tonic/dart_class_library.cc
+FILE: ../../../flutter/third_party/tonic/dart_class_library.h
+FILE: ../../../flutter/third_party/tonic/dart_class_provider.cc
+FILE: ../../../flutter/third_party/tonic/dart_class_provider.h
+FILE: ../../../flutter/third_party/tonic/dart_library_natives.cc
+FILE: ../../../flutter/third_party/tonic/dart_library_natives.h
+FILE: ../../../flutter/third_party/tonic/dart_list.cc
+FILE: ../../../flutter/third_party/tonic/dart_list.h
+FILE: ../../../flutter/third_party/tonic/dart_message_handler.cc
+FILE: ../../../flutter/third_party/tonic/dart_message_handler.h
+FILE: ../../../flutter/third_party/tonic/dart_microtask_queue.cc
+FILE: ../../../flutter/third_party/tonic/dart_microtask_queue.h
+FILE: ../../../flutter/third_party/tonic/dart_persistent_value.cc
+FILE: ../../../flutter/third_party/tonic/dart_persistent_value.h
+FILE: ../../../flutter/third_party/tonic/dart_state.cc
+FILE: ../../../flutter/third_party/tonic/dart_state.h
+FILE: ../../../flutter/third_party/tonic/dart_wrappable.cc
+FILE: ../../../flutter/third_party/tonic/dart_wrappable.h
+FILE: ../../../flutter/third_party/tonic/dart_wrapper_info.h
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader.cc
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader.h
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_fuchsia.cc
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_posix.cc
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_win.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/eintr_wrapper.h
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/file.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/file.h
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path.h
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path_posix.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path_win.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/portable_unistd.h
+FILE: ../../../flutter/third_party/tonic/logging/dart_error.cc
+FILE: ../../../flutter/third_party/tonic/logging/dart_error.h
+FILE: ../../../flutter/third_party/tonic/logging/dart_invoke.cc
+FILE: ../../../flutter/third_party/tonic/logging/dart_invoke.h
+FILE: ../../../flutter/third_party/tonic/parsers/packages_map.cc
+FILE: ../../../flutter/third_party/tonic/parsers/packages_map.h
+FILE: ../../../flutter/third_party/tonic/platform/platform_utils.h
+FILE: ../../../flutter/third_party/tonic/platform/platform_utils_posix.cc
+FILE: ../../../flutter/third_party/tonic/platform/platform_utils_win.cc
+FILE: ../../../flutter/third_party/tonic/scopes/dart_api_scope.h
+FILE: ../../../flutter/third_party/tonic/scopes/dart_isolate_scope.cc
+FILE: ../../../flutter/third_party/tonic/scopes/dart_isolate_scope.h
+FILE: ../../../flutter/third_party/tonic/typed_data/dart_byte_data.cc
+FILE: ../../../flutter/third_party/tonic/typed_data/dart_byte_data.h
+FILE: ../../../flutter/third_party/tonic/typed_data/float32_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/float64_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/int32_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/typed_list.cc
+FILE: ../../../flutter/third_party/tonic/typed_data/typed_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/uint16_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/uint8_list.h
 FILE: ../../../flutter/third_party/txt/src/txt/platform.cc
 FILE: ../../../flutter/third_party/txt/src/txt/platform.h
 FILE: ../../../flutter/third_party/txt/src/txt/platform_android.cc
@@ -1497,98 +1558,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../flutter/third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../flutter/third_party/tonic/common/build_config.h
-FILE: ../../../flutter/third_party/tonic/common/log.cc
-FILE: ../../../flutter/third_party/tonic/common/log.h
-FILE: ../../../flutter/third_party/tonic/common/macros.h
-FILE: ../../../flutter/third_party/tonic/converter/dart_converter.cc
-FILE: ../../../flutter/third_party/tonic/converter/dart_converter.h
-FILE: ../../../flutter/third_party/tonic/dart_args.h
-FILE: ../../../flutter/third_party/tonic/dart_binding_macros.h
-FILE: ../../../flutter/third_party/tonic/dart_class_library.cc
-FILE: ../../../flutter/third_party/tonic/dart_class_library.h
-FILE: ../../../flutter/third_party/tonic/dart_class_provider.cc
-FILE: ../../../flutter/third_party/tonic/dart_class_provider.h
-FILE: ../../../flutter/third_party/tonic/dart_library_natives.cc
-FILE: ../../../flutter/third_party/tonic/dart_library_natives.h
-FILE: ../../../flutter/third_party/tonic/dart_list.cc
-FILE: ../../../flutter/third_party/tonic/dart_list.h
-FILE: ../../../flutter/third_party/tonic/dart_message_handler.cc
-FILE: ../../../flutter/third_party/tonic/dart_message_handler.h
-FILE: ../../../flutter/third_party/tonic/dart_microtask_queue.cc
-FILE: ../../../flutter/third_party/tonic/dart_microtask_queue.h
-FILE: ../../../flutter/third_party/tonic/dart_persistent_value.cc
-FILE: ../../../flutter/third_party/tonic/dart_persistent_value.h
-FILE: ../../../flutter/third_party/tonic/dart_state.cc
-FILE: ../../../flutter/third_party/tonic/dart_state.h
-FILE: ../../../flutter/third_party/tonic/dart_wrappable.cc
-FILE: ../../../flutter/third_party/tonic/dart_wrappable.h
-FILE: ../../../flutter/third_party/tonic/dart_wrapper_info.h
-FILE: ../../../flutter/third_party/tonic/file_loader/file_loader.cc
-FILE: ../../../flutter/third_party/tonic/file_loader/file_loader.h
-FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_fuchsia.cc
-FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_posix.cc
-FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_win.cc
-FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/eintr_wrapper.h
-FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/file.cc
-FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/file.h
-FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path.h
-FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path_posix.cc
-FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path_win.cc
-FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/portable_unistd.h
-FILE: ../../../flutter/third_party/tonic/logging/dart_error.cc
-FILE: ../../../flutter/third_party/tonic/logging/dart_error.h
-FILE: ../../../flutter/third_party/tonic/logging/dart_invoke.cc
-FILE: ../../../flutter/third_party/tonic/logging/dart_invoke.h
-FILE: ../../../flutter/third_party/tonic/parsers/packages_map.cc
-FILE: ../../../flutter/third_party/tonic/parsers/packages_map.h
-FILE: ../../../flutter/third_party/tonic/platform/platform_utils.h
-FILE: ../../../flutter/third_party/tonic/platform/platform_utils_posix.cc
-FILE: ../../../flutter/third_party/tonic/platform/platform_utils_win.cc
-FILE: ../../../flutter/third_party/tonic/scopes/dart_api_scope.h
-FILE: ../../../flutter/third_party/tonic/scopes/dart_isolate_scope.cc
-FILE: ../../../flutter/third_party/tonic/scopes/dart_isolate_scope.h
-FILE: ../../../flutter/third_party/tonic/typed_data/dart_byte_data.cc
-FILE: ../../../flutter/third_party/tonic/typed_data/dart_byte_data.h
-FILE: ../../../flutter/third_party/tonic/typed_data/float32_list.h
-FILE: ../../../flutter/third_party/tonic/typed_data/float64_list.h
-FILE: ../../../flutter/third_party/tonic/typed_data/int32_list.h
-FILE: ../../../flutter/third_party/tonic/typed_data/typed_list.cc
-FILE: ../../../flutter/third_party/tonic/typed_data/typed_list.h
-FILE: ../../../flutter/third_party/tonic/typed_data/uint16_list.h
-FILE: ../../../flutter/third_party/tonic/typed_data/uint8_list.h
-----------------------------------------------------------------------------------------------------
-Copyright 2013 The Flutter Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-Total license count: 3
+Total license count: 2

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -1497,4 +1497,98 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ====================================================================================================
-Total license count: 2
+
+====================================================================================================
+LIBRARY: tonic
+ORIGIN: ../../../flutter/third_party/tonic/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../flutter/third_party/tonic/common/build_config.h
+FILE: ../../../flutter/third_party/tonic/common/log.cc
+FILE: ../../../flutter/third_party/tonic/common/log.h
+FILE: ../../../flutter/third_party/tonic/common/macros.h
+FILE: ../../../flutter/third_party/tonic/converter/dart_converter.cc
+FILE: ../../../flutter/third_party/tonic/converter/dart_converter.h
+FILE: ../../../flutter/third_party/tonic/dart_args.h
+FILE: ../../../flutter/third_party/tonic/dart_binding_macros.h
+FILE: ../../../flutter/third_party/tonic/dart_class_library.cc
+FILE: ../../../flutter/third_party/tonic/dart_class_library.h
+FILE: ../../../flutter/third_party/tonic/dart_class_provider.cc
+FILE: ../../../flutter/third_party/tonic/dart_class_provider.h
+FILE: ../../../flutter/third_party/tonic/dart_library_natives.cc
+FILE: ../../../flutter/third_party/tonic/dart_library_natives.h
+FILE: ../../../flutter/third_party/tonic/dart_list.cc
+FILE: ../../../flutter/third_party/tonic/dart_list.h
+FILE: ../../../flutter/third_party/tonic/dart_message_handler.cc
+FILE: ../../../flutter/third_party/tonic/dart_message_handler.h
+FILE: ../../../flutter/third_party/tonic/dart_microtask_queue.cc
+FILE: ../../../flutter/third_party/tonic/dart_microtask_queue.h
+FILE: ../../../flutter/third_party/tonic/dart_persistent_value.cc
+FILE: ../../../flutter/third_party/tonic/dart_persistent_value.h
+FILE: ../../../flutter/third_party/tonic/dart_state.cc
+FILE: ../../../flutter/third_party/tonic/dart_state.h
+FILE: ../../../flutter/third_party/tonic/dart_wrappable.cc
+FILE: ../../../flutter/third_party/tonic/dart_wrappable.h
+FILE: ../../../flutter/third_party/tonic/dart_wrapper_info.h
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader.cc
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader.h
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_fuchsia.cc
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_posix.cc
+FILE: ../../../flutter/third_party/tonic/file_loader/file_loader_win.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/eintr_wrapper.h
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/file.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/file.h
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path.h
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path_posix.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/path_win.cc
+FILE: ../../../flutter/third_party/tonic/filesystem/filesystem/portable_unistd.h
+FILE: ../../../flutter/third_party/tonic/logging/dart_error.cc
+FILE: ../../../flutter/third_party/tonic/logging/dart_error.h
+FILE: ../../../flutter/third_party/tonic/logging/dart_invoke.cc
+FILE: ../../../flutter/third_party/tonic/logging/dart_invoke.h
+FILE: ../../../flutter/third_party/tonic/parsers/packages_map.cc
+FILE: ../../../flutter/third_party/tonic/parsers/packages_map.h
+FILE: ../../../flutter/third_party/tonic/platform/platform_utils.h
+FILE: ../../../flutter/third_party/tonic/platform/platform_utils_posix.cc
+FILE: ../../../flutter/third_party/tonic/platform/platform_utils_win.cc
+FILE: ../../../flutter/third_party/tonic/scopes/dart_api_scope.h
+FILE: ../../../flutter/third_party/tonic/scopes/dart_isolate_scope.cc
+FILE: ../../../flutter/third_party/tonic/scopes/dart_isolate_scope.h
+FILE: ../../../flutter/third_party/tonic/typed_data/dart_byte_data.cc
+FILE: ../../../flutter/third_party/tonic/typed_data/dart_byte_data.h
+FILE: ../../../flutter/third_party/tonic/typed_data/float32_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/float64_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/int32_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/typed_list.cc
+FILE: ../../../flutter/third_party/tonic/typed_data/typed_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/uint16_list.h
+FILE: ../../../flutter/third_party/tonic/typed_data/uint8_list.h
+----------------------------------------------------------------------------------------------------
+Copyright 2013 The Flutter Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+Total license count: 3

--- a/ci/licenses_golden/licenses_fuchsia
+++ b/ci/licenses_golden/licenses_fuchsia
@@ -8,6 +8,150 @@ USED LICENSES:
 
 ====================================================================================================
 LIBRARY: fuchsia_sdk
+ORIGIN: ../../../flutter/third_party/tonic/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/boot/netboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/compiler.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/driver/binding.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/errors.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/i2c.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/audio.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/hid.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/hub.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/ums.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/listnode.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/pixelformat.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/processargs.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/status.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/debug.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/exception.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/log.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/object.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/pci.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/port.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/profile.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/resource.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/assert.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/boot/netboot.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/compiler.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/driver/binding.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/errors.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/i2c.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/audio.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/hid.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/hub.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/ums.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/listnode.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/pixelformat.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/processargs.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/status.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/debug.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/exception.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/log.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/object.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/pci.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/port.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/profile.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/resource.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/types.h
+FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/types.h
+FILE: ../../../fuchsia/sdk/linux/dart/fidl/lib/src/interface.dart
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/font_provider.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.math/math.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.playback/problem.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.playback/seeking_reader.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media/audio.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/basemgr/base_shell.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/basemgr/user_provider.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module/module_context.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module/module_controller.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/session/focus.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/session/session_shell.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_controller.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_info.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_provider.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.oldhttp/url_body.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/component_controller.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/environment.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/environment_controller.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/launcher.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/loader.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/runner.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.tracing.provider/provider.fidl
+FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.policy/presenter.fidl
+FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/fdio.h
+FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/io.h
+FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/vfs.h
+FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/watcher.h
+FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/include/lib/media/cpp/timeline_function.h
+FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/include/lib/media/cpp/timeline_rate.h
+FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/timeline_function.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/timeline_rate.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/sync/include/lib/sync/completion.h
+FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/include/lib/sys/cpp/termination_reason.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/channel.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/event.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/eventpair.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/channel.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/event.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/eventpair.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/job.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/object.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/object_traits.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/port.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/process.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/socket.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/task.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/thread.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/time.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/vmar.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/vmo.h
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/job.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/port.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/process.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/socket.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/thread.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/vmar.cc
+FILE: ../../../fuchsia/sdk/linux/pkg/zx/vmo.cc
+----------------------------------------------------------------------------------------------------
+Copyright 2016 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: fuchsia_sdk
 ORIGIN: ../../../fuchsia/sdk/linux/COPYRIGHT.musl
 TYPE: LicenseType.mit
 FILE: ../../../fuchsia/sdk/linux/.versions/core.cipd_version
@@ -3212,150 +3356,6 @@ FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/input_event_constants.fid
 FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.input/input_events.fidl
 ----------------------------------------------------------------------------------------------------
 Copyright 2014 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: fuchsia_sdk
-ORIGIN: ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/assert.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/boot/netboot.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/compiler.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/driver/binding.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/errors.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/i2c.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/audio.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/hid.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/hub.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/hw/usb/ums.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/listnode.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/pixelformat.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/processargs.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/status.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/debug.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/exception.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/log.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/object.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/pci.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/port.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/profile.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/resource.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/syscalls/types.h
-FILE: ../../../fuchsia/sdk/linux/arch/arm64/sysroot/include/zircon/types.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/assert.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/boot/netboot.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/compiler.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/driver/binding.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/errors.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/i2c.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/audio.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/hid.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/hub.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/hw/usb/ums.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/listnode.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/pixelformat.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/processargs.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/status.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/debug.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/exception.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/log.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/object.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/pci.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/port.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/profile.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/resource.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/syscalls/types.h
-FILE: ../../../fuchsia/sdk/linux/arch/x64/sysroot/include/zircon/types.h
-FILE: ../../../fuchsia/sdk/linux/dart/fidl/lib/src/interface.dart
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.fonts/font_provider.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.math/math.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.playback/problem.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media.playback/seeking_reader.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.media/audio.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/basemgr/base_shell.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/basemgr/user_provider.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module/module_context.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/module/module_controller.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/session/focus.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/session/session_shell.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_controller.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_info.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.modular/story/story_provider.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.net.oldhttp/url_body.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/component_controller.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/environment.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/environment_controller.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/launcher.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/loader.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.sys/runner.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.tracing.provider/provider.fidl
-FILE: ../../../fuchsia/sdk/linux/fidl/fuchsia.ui.policy/presenter.fidl
-FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/fdio.h
-FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/io.h
-FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/vfs.h
-FILE: ../../../fuchsia/sdk/linux/pkg/fdio/include/lib/fdio/watcher.h
-FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/include/lib/media/cpp/timeline_function.h
-FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/include/lib/media/cpp/timeline_rate.h
-FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/timeline_function.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/media_cpp_no_converters/timeline_rate.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/sync/include/lib/sync/completion.h
-FILE: ../../../fuchsia/sdk/linux/pkg/sys_cpp/include/lib/sys/cpp/termination_reason.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/channel.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/event.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/eventpair.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/channel.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/event.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/eventpair.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/job.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/object.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/object_traits.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/port.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/process.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/socket.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/task.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/thread.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/time.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/vmar.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/include/lib/zx/vmo.h
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/job.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/port.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/process.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/socket.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/thread.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/vmar.cc
-FILE: ../../../fuchsia/sdk/linux/pkg/zx/vmo.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2016 The Fuchsia Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are

--- a/ci/licenses_golden/licenses_third_party
+++ b/ci/licenses_golden/licenses_third_party
@@ -1,4 +1,4 @@
-Signature: d35b19eb9daf521e4c322dfe55a63a04
+Signature: e936724fefea8314b39c29cf43df4d3c
 
 UNUSED LICENSES:
 
@@ -1056,45 +1056,6 @@ limitations under the License.
 
 ====================================================================================================
 LIBRARY: angle
-LIBRARY: tonic
-ORIGIN: ../../../fuchsia/sdk/linux/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/angle/src/common/fuchsia_egl/fuchsia_egl.c
-FILE: ../../../third_party/angle/src/common/fuchsia_egl/fuchsia_egl.h
-FILE: ../../../third_party/angle/src/common/fuchsia_egl/fuchsia_egl_backend.h
-FILE: ../../../third_party/tonic/typed_data/typed_list.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2019 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: angle
 LIBRARY: vulkan-validation-layers
 ORIGIN: ../../../third_party/angle/android/AndroidManifest.xml.jinja2 + ../../../third_party/angle/LICENSE
 TYPE: LicenseType.bsd
@@ -1568,6 +1529,43 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
+====================================================================================================
+
+====================================================================================================
+LIBRARY: angle
+ORIGIN: ../../../fuchsia/sdk/linux/LICENSE
+TYPE: LicenseType.bsd
+FILE: ../../../third_party/angle/src/common/fuchsia_egl/fuchsia_egl.c
+FILE: ../../../third_party/angle/src/common/fuchsia_egl/fuchsia_egl.h
+FILE: ../../../third_party/angle/src/common/fuchsia_egl/fuchsia_egl_backend.h
+----------------------------------------------------------------------------------------------------
+Copyright 2019 The Fuchsia Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 
 ====================================================================================================
@@ -22312,201 +22310,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ====================================================================================================
 
 ====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/common/build_config.h
-FILE: ../../../third_party/tonic/converter/dart_converter.cc
-FILE: ../../../third_party/tonic/converter/dart_converter.h
-FILE: ../../../third_party/tonic/dart_message_handler.cc
-FILE: ../../../third_party/tonic/dart_message_handler.h
-FILE: ../../../third_party/tonic/dart_microtask_queue.cc
-FILE: ../../../third_party/tonic/dart_microtask_queue.h
-FILE: ../../../third_party/tonic/file_loader/file_loader.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader.h
-FILE: ../../../third_party/tonic/filesystem/filesystem/eintr_wrapper.h
-FILE: ../../../third_party/tonic/filesystem/filesystem/file.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/file.h
-FILE: ../../../third_party/tonic/filesystem/filesystem/path.h
-FILE: ../../../third_party/tonic/filesystem/filesystem/path_posix.cc
-FILE: ../../../third_party/tonic/logging/dart_error.cc
-FILE: ../../../third_party/tonic/logging/dart_error.h
-FILE: ../../../third_party/tonic/logging/dart_invoke.cc
-FILE: ../../../third_party/tonic/logging/dart_invoke.h
-FILE: ../../../third_party/tonic/parsers/packages_map.cc
-FILE: ../../../third_party/tonic/parsers/packages_map.h
-FILE: ../../../third_party/tonic/scopes/dart_api_scope.h
-FILE: ../../../third_party/tonic/scopes/dart_isolate_scope.cc
-FILE: ../../../third_party/tonic/scopes/dart_isolate_scope.h
-FILE: ../../../third_party/tonic/typed_data/dart_byte_data.h
-FILE: ../../../third_party/tonic/typed_data/int32_list.h
-FILE: ../../../third_party/tonic/typed_data/typed_list.h
-FILE: ../../../third_party/tonic/typed_data/uint16_list.h
-FILE: ../../../third_party/tonic/typed_data/uint8_list.h
-----------------------------------------------------------------------------------------------------
-Copyright 2016 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/common/log.cc + ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/common/log.cc
-FILE: ../../../third_party/tonic/common/log.h
-FILE: ../../../third_party/tonic/common/macros.h
-----------------------------------------------------------------------------------------------------
-Copyright 2018 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc + ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/dart_list.cc
-FILE: ../../../third_party/tonic/dart_list.h
-FILE: ../../../third_party/tonic/file_loader/file_loader_fuchsia.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_posix.cc
-FILE: ../../../third_party/tonic/file_loader/file_loader_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/path_win.cc
-FILE: ../../../third_party/tonic/filesystem/filesystem/portable_unistd.h
-FILE: ../../../third_party/tonic/platform/platform_utils.h
-FILE: ../../../third_party/tonic/platform/platform_utils_posix.cc
-FILE: ../../../third_party/tonic/platform/platform_utils_win.cc
-----------------------------------------------------------------------------------------------------
-Copyright 2017 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
-LIBRARY: tonic
-ORIGIN: ../../../third_party/tonic/typed_data/dart_byte_data.cc + ../../../third_party/tonic/LICENSE
-TYPE: LicenseType.bsd
-FILE: ../../../third_party/tonic/dart_args.h
-FILE: ../../../third_party/tonic/dart_binding_macros.h
-FILE: ../../../third_party/tonic/dart_class_library.cc
-FILE: ../../../third_party/tonic/dart_class_library.h
-FILE: ../../../third_party/tonic/dart_class_provider.cc
-FILE: ../../../third_party/tonic/dart_class_provider.h
-FILE: ../../../third_party/tonic/dart_library_natives.cc
-FILE: ../../../third_party/tonic/dart_library_natives.h
-FILE: ../../../third_party/tonic/dart_persistent_value.cc
-FILE: ../../../third_party/tonic/dart_persistent_value.h
-FILE: ../../../third_party/tonic/dart_state.cc
-FILE: ../../../third_party/tonic/dart_state.h
-FILE: ../../../third_party/tonic/dart_wrappable.cc
-FILE: ../../../third_party/tonic/dart_wrappable.h
-FILE: ../../../third_party/tonic/dart_wrapper_info.h
-FILE: ../../../third_party/tonic/typed_data/dart_byte_data.cc
-FILE: ../../../third_party/tonic/typed_data/float32_list.h
-FILE: ../../../third_party/tonic/typed_data/float64_list.h
-----------------------------------------------------------------------------------------------------
-Copyright 2015 The Fuchsia Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================================================
-
-====================================================================================================
 LIBRARY: trace_event
 ORIGIN: ../../../third_party/angle/src/third_party/trace_event/trace_event.h + ../../../LICENSE
 TYPE: LicenseType.bsd
@@ -23521,4 +23324,4 @@ freely, subject to the following restrictions:
    misrepresented as being the original software.
 3. This notice may not be removed or altered from any source distribution.
 ====================================================================================================
-Total license count: 369
+Total license count: 365

--- a/fml/dart/BUILD.gn
+++ b/fml/dart/BUILD.gn
@@ -14,6 +14,6 @@ source_set("dart") {
   public_deps = [
     "$flutter_root/fml",
     "$flutter_root/runtime:libdart",
-    "//third_party/tonic",
+    "$flutter_root/third_party/tonic",
   ]
 }

--- a/lib/io/BUILD.gn
+++ b/lib/io/BUILD.gn
@@ -9,9 +9,9 @@ source_set("io") {
   ]
 
   deps = [
+    "$flutter_root/third_party/tonic",
     "//third_party/dart/runtime:dart_api",
     "//third_party/dart/runtime/bin:dart_io_api",
-    "//third_party/tonic",
   ]
 
   configs += [ "//third_party/dart/runtime:dart_config" ]

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -117,10 +117,10 @@ source_set("ui") {
     "$flutter_root/flow",
     "$flutter_root/fml",
     "$flutter_root/runtime:test_font",
+    "$flutter_root/third_party/tonic",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/rapidjson",
     "//third_party/skia",
-    "//third_party/tonic",
   ]
 
   public_deps = [

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -79,11 +79,11 @@ source_set("runtime") {
     "$flutter_root/fml",
     "$flutter_root/lib/io",
     "$flutter_root/lib/ui",
+    "$flutter_root/third_party/tonic",
     "$flutter_root/third_party/txt",
     "//third_party/dart/runtime:dart_api",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/skia",
-    "//third_party/tonic",
   ]
 
   # On Windows the engine finds the Dart snapshot data through symbols
@@ -146,8 +146,8 @@ source_set("runtime_unittests_common") {
     "$flutter_root/lib/snapshot",
     "$flutter_root/shell/common",
     "$flutter_root/testing:dart",
+    "$flutter_root/third_party/tonic",
     "//third_party/skia",
-    "//third_party/tonic",
   ]
 }
 

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -111,9 +111,9 @@ source_set("common") {
 
   public_deps = [
     "$flutter_root/shell/version",
+    "$flutter_root/third_party/tonic",
     "$flutter_root/third_party/txt",
     "//third_party/rapidjson",
-    "//third_party/tonic",
   ]
 
   public_configs = [ "$flutter_root:config" ]
@@ -135,8 +135,8 @@ template("shell_host_executable") {
       "$flutter_root/lib/snapshot",
       "$flutter_root/runtime",
       "$flutter_root/runtime:libdart",
+      "$flutter_root/third_party/tonic",
       "//third_party/skia",
-      "//third_party/tonic",
     ]
 
     public_configs = [ "$flutter_root:export_dynamic_symbols" ]

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -64,9 +64,9 @@ template("embedder_source_set") {
       "$flutter_root/lib/ui",
       "$flutter_root/runtime:libdart",
       "$flutter_root/shell/common",
+      "$flutter_root/third_party/tonic",
       "//third_party/dart/runtime/bin:dart_io_api",
       "//third_party/skia",
-      "//third_party/tonic",
     ]
 
     public_configs += [ "$flutter_root:config" ]
@@ -135,9 +135,9 @@ if (current_toolchain == host_toolchain) {
       "$flutter_root/testing:dart",
       "$flutter_root/testing:opengl",
       "$flutter_root/testing:skia",
+      "$flutter_root/third_party/tonic",
       "//third_party/dart/runtime/bin:elf_loader",
       "//third_party/skia",
-      "//third_party/tonic",
     ]
   }
 }

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
@@ -22,10 +22,10 @@ source_set("sdk_ext") {
 
   deps = [
     "$flutter_root/fml",
+    "$flutter_root/third_party/tonic",
     "$fuchsia_sdk_root/fidl:fuchsia.sys",
     "$fuchsia_sdk_root/pkg:async-cpp",
     "../zircon",
-    "//third_party/tonic",
   ]
 
   public_configs = [ ":sdk_ext_config" ]

--- a/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
@@ -23,11 +23,11 @@ source_set("zircon") {
   ]
 
   deps = [
+    "$flutter_root/third_party/tonic",
     "$fuchsia_sdk_root/pkg:async-cpp",
     "$fuchsia_sdk_root/pkg:async-loop-cpp",
     "$fuchsia_sdk_root/pkg:fdio",
     "$fuchsia_sdk_root/pkg:zx",
     "//flutter/fml",
-    "//third_party/tonic",
   ]
 }

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -67,7 +67,7 @@ template("runner") {
              "$fuchsia_sdk_root/pkg:trace",
              "$fuchsia_sdk_root/pkg:trace-provider-so",
              "$fuchsia_sdk_root/pkg:vfs_cpp",
-             "//third_party/tonic",
+             "$flutter_root/third_party/tonic",
            ] + dart_deps + extra_deps
   }
 }

--- a/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
+++ b/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
@@ -125,7 +125,7 @@ template("flutter_runner") {
              "$fuchsia_sdk_root/pkg:vfs_cpp",
              "$fuchsia_sdk_root/pkg:zx",
              "//third_party/skia",
-             "//third_party/tonic",
+             "$flutter_root/third_party/tonic",
            ] + fuchsia_deps + flutter_deps + extra_deps
 
     # The flags below are needed so that Dart's CPU profiler can walk the

--- a/shell/platform/fuchsia/flutter/platform_view_unittest.cc
+++ b/shell/platform/fuchsia/flutter/platform_view_unittest.cc
@@ -17,7 +17,7 @@
 #include "flutter/lib/ui/window/platform_message.h"
 #include "flutter/lib/ui/window/window.h"
 #include "fuchsia/ui/views/cpp/fidl.h"
-#include "googletest/googletest/include/gtest/gtest.h"
+#include "gtest/gtest.h"
 
 namespace flutter_runner_test::flutter_runner_a11y_test {
 

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -43,7 +43,7 @@ template("make_utils") {
              "$fuchsia_sdk_root/pkg:trace",
              "$fuchsia_sdk_root/pkg:vfs_cpp",
              "$fuchsia_sdk_root/pkg:zx",
-             "//third_party/tonic",
+             "$flutter_root/third_party/tonic",
            ]
 
     public_configs = [ ":utils_config" ]

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -22,10 +22,10 @@ executable("testing") {
     "$flutter_root/fml",
     "$flutter_root/lib/snapshot",
     "$flutter_root/shell/common",
+    "$flutter_root/third_party/tonic",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/skia",
-    "//third_party/tonic",
   ]
 
   if (is_fuchsia) {

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -46,7 +46,7 @@ source_set("dart") {
   public_deps = [
     ":testing",
     "$flutter_root/runtime:libdart",
-    "//third_party/tonic",
+    "$flutter_root/third_party/tonic",
   ]
 }
 

--- a/third_party/tonic/.clang-format
+++ b/third_party/tonic/.clang-format
@@ -1,0 +1,8 @@
+# Defines the Chromium style for automatic reformatting.
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+BasedOnStyle: Chromium
+# This defaults to 'Auto'. Explicitly set it for a while, so that
+# 'vector<vector<int> >' in existing files gets formatted to
+# 'vector<vector<int>>'. ('Auto' means that clang-format will only use
+# 'int>>' if the file already contains at least one such instance.)
+Standard: Cpp11

--- a/third_party/tonic/AUTHORS
+++ b/third_party/tonic/AUTHORS
@@ -1,0 +1,9 @@
+# This is the list of Fuchsia Authors.
+
+# Names should be added to this file as one of
+#     Organization's name
+#     Individual's name <submission email address>
+#     Individual's name <submission email address> <email2> <emailN>
+
+Google Inc.
+The Chromium Authors

--- a/third_party/tonic/BUILD.gn
+++ b/third_party/tonic/BUILD.gn
@@ -1,0 +1,49 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+config("config") {
+  include_dirs = [
+    "$flutter_root/third_party",
+    "$flutter_root",
+  ]
+}
+
+source_set("tonic") {
+  sources = [
+    "dart_args.h",
+    "dart_binding_macros.h",
+    "dart_class_library.cc",
+    "dart_class_library.h",
+    "dart_class_provider.cc",
+    "dart_class_provider.h",
+    "dart_library_natives.cc",
+    "dart_library_natives.h",
+    "dart_list.cc",
+    "dart_list.h",
+    "dart_message_handler.cc",
+    "dart_message_handler.h",
+    "dart_microtask_queue.cc",
+    "dart_microtask_queue.h",
+    "dart_persistent_value.cc",
+    "dart_persistent_value.h",
+    "dart_state.cc",
+    "dart_state.h",
+    "dart_wrappable.cc",
+    "dart_wrappable.h",
+    "dart_wrapper_info.h",
+  ]
+
+  public_deps = [
+    "common",
+    "converter",
+    "file_loader",
+    "logging",
+    "platform",
+    "scopes",
+    "typed_data",
+    "//third_party/dart/runtime:dart_api",
+  ]
+
+  public_configs = [ ":config" ]
+}

--- a/third_party/tonic/PATENTS
+++ b/third_party/tonic/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Fuchsia project.
+
+Google hereby grants to you a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell,
+import, transfer, and otherwise run, modify and propagate the contents
+of this implementation of Fuchsia, where such license applies only to
+those patent claims, both currently owned by Google and acquired in
+the future, licensable by Google that are necessarily infringed by
+this implementation. This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation. If you or your agent or exclusive licensee institute
+or order or agree to the institution of patent litigation or any other
+patent enforcement activity against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that this
+implementation of Fuchsia constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of
+Fuchsia shall terminate as of the date such litigation is filed.

--- a/third_party/tonic/README.md
+++ b/third_party/tonic/README.md
@@ -1,0 +1,3 @@
+# Tonic
+
+A collection of C++ utilities for working with the DartVM API.

--- a/third_party/tonic/common/BUILD.gn
+++ b/third_party/tonic/common/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("common") {
+  visibility = [ "../*" ]
+
+  public_configs = [ "../:config" ]
+
+  sources = [
+    "build_config.h",
+    "log.cc",
+    "log.h",
+    "macros.h",
+  ]
+}

--- a/third_party/tonic/common/build_config.h
+++ b/third_party/tonic/common/build_config.h
@@ -1,0 +1,110 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file adds defines about the platform we're currently building on.
+//  Operating System:
+//    OS_WIN / OS_MACOSX / OS_LINUX / OS_POSIX (MACOSX or LINUX) /
+//    OS_NACL (NACL_SFI or NACL_NONSFI) / OS_NACL_SFI / OS_NACL_NONSFI
+//  Compiler:
+//    COMPILER_MSVC / COMPILER_GCC
+//  Processor:
+//    ARCH_CPU_X86 / ARCH_CPU_X86_64 / ARCH_CPU_X86_FAMILY (X86 or X86_64)
+//    ARCH_CPU_32_BITS / ARCH_CPU_64_BITS
+
+#ifndef TONIC_COMMON_BUILD_CONFIG_H_
+#define TONIC_COMMON_BUILD_CONFIG_H_
+
+#if defined(__Fuchsia__)
+#define OS_FUCHSIA 1
+#elif defined(ANDROID)
+#define OS_ANDROID 1
+#elif defined(__APPLE__)
+// only include TargetConditions after testing ANDROID as some android builds
+// on mac don't have this header available and it's not needed unless the target
+// is really mac/ios.
+#include <TargetConditionals.h>
+#define OS_MACOSX 1
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#define OS_IOS 1
+#endif  // defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+#elif defined(__linux__)
+#define OS_LINUX 1
+// include a system header to pull in features.h for glibc/uclibc macros.
+#include <unistd.h>
+#if defined(__GLIBC__) && !defined(__UCLIBC__)
+// we really are using glibc, not uClibc pretending to be glibc
+#define LIBC_GLIBC 1
+#endif
+#elif defined(_WIN32)
+#define OS_WIN 1
+#elif defined(__FreeBSD__)
+#define OS_FREEBSD 1
+#elif defined(__OpenBSD__)
+#define OS_OPENBSD 1
+#elif defined(__sun)
+#define OS_SOLARIS 1
+#elif defined(__QNXNTO__)
+#define OS_QNX 1
+#else
+#error Please add support for your platform in tonic/common/build_config.h
+#endif
+
+// For access to standard BSD features, use OS_BSD instead of a
+// more specific macro.
+#if defined(OS_FREEBSD) || defined(OS_OPENBSD)
+#define OS_BSD 1
+#endif
+
+// For access to standard POSIXish features, use OS_POSIX instead of a
+// more specific macro.
+#if defined(OS_MACOSX) || defined(OS_LINUX) || defined(OS_FREEBSD) ||    \
+    defined(OS_OPENBSD) || defined(OS_SOLARIS) || defined(OS_ANDROID) || \
+    defined(OS_NACL) || defined(OS_QNX)
+#define OS_POSIX 1
+#endif
+
+// Processor architecture detection.  For more info on what's defined, see:
+//   http://msdn.microsoft.com/en-us/library/b0084kay.aspx
+//   http://www.agner.org/optimize/calling_conventions.pdf
+//   or with gcc, run: "echo | gcc -E -dM -"
+#if defined(_M_X64) || defined(__x86_64__)
+#define ARCH_CPU_X86_FAMILY 1
+#define ARCH_CPU_X86_64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(_M_IX86) || defined(__i386__)
+#define ARCH_CPU_X86_FAMILY 1
+#define ARCH_CPU_X86 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__ARMEL__)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARMEL 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__aarch64__)
+#define ARCH_CPU_ARM_FAMILY 1
+#define ARCH_CPU_ARM64 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__pnacl__)
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#elif defined(__MIPSEL__)
+#if defined(__LP64__)
+#define ARCH_CPU_MIPS64_FAMILY 1
+#define ARCH_CPU_MIPS64EL 1
+#define ARCH_CPU_64_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#else
+#define ARCH_CPU_MIPS_FAMILY 1
+#define ARCH_CPU_MIPSEL 1
+#define ARCH_CPU_32_BITS 1
+#define ARCH_CPU_LITTLE_ENDIAN 1
+#endif
+#else
+#error Please add support for your architecture in build/build_config.h
+#endif
+
+#endif  // TONIC_COMMON_BUILD_CONFIG_H_

--- a/third_party/tonic/common/log.cc
+++ b/third_party/tonic/common/log.cc
@@ -1,0 +1,48 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/common/log.h"
+
+#include <cstdarg>
+#include <cstdio>
+#include <memory>
+
+namespace tonic {
+
+namespace {
+
+std::function<void(const char*)> log_handler;
+
+}  // namespace
+
+void Log(const char* format, ...) {
+  va_list ap;
+  va_start(ap, format);
+  int result = vsnprintf(nullptr, 0, format, ap);
+  va_end(ap);
+
+  if (result < 0)
+    return;
+
+  int size = result + 1;
+  std::unique_ptr<char[]> message(new char[size]);
+  va_start(ap, format);
+  result = vsnprintf(message.get(), size, format, ap);
+  va_end(ap);
+
+  if (result < 0)
+    return;
+
+  if (log_handler) {
+    log_handler(message.get());
+  } else {
+    printf("%s\n", message.get());
+  }
+}
+
+void SetLogHandler(std::function<void(const char*)> handler) {
+  log_handler = handler;
+}
+
+}  // namespace tonic

--- a/third_party/tonic/common/log.h
+++ b/third_party/tonic/common/log.h
@@ -1,0 +1,18 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TONIC_COMMON_LOG_H_
+#define TONIC_COMMON_LOG_H_
+
+#include <functional>
+
+namespace tonic {
+
+void Log(const char* format, ...);
+
+void SetLogHandler(std::function<void(const char*)> handler);
+
+}  // namespace tonic
+
+#endif  // TONIC_COMMON_LOG_H_

--- a/third_party/tonic/common/macros.h
+++ b/third_party/tonic/common/macros.h
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TONIC_COMMON_MACROS_H_
+#define TONIC_COMMON_MACROS_H_
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+
+#include "tonic/common/log.h"
+
+#define TONIC_DISALLOW_COPY(TypeName) TypeName(const TypeName&) = delete;
+
+#define TONIC_DISALLOW_ASSIGN(TypeName) \
+  void operator=(const TypeName&) = delete;
+
+#define TONIC_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  TONIC_DISALLOW_COPY(TypeName)                  \
+  TONIC_DISALLOW_ASSIGN(TypeName)
+
+#define TONIC_CHECK(condition)                    \
+  {                                               \
+    if (!(condition)) {                           \
+      tonic::Log("assertion failed " #condition); \
+      abort();                                    \
+    }                                             \
+  }
+
+#ifndef NDEBUG
+#define TONIC_DCHECK TONIC_CHECK
+#else  // NDEBUG
+#define TONIC_DCHECK (void)
+#endif  // NDEBUG
+
+#endif  // TONIC_COMMON_MACROS_H_

--- a/third_party/tonic/converter/BUILD.gn
+++ b/third_party/tonic/converter/BUILD.gn
@@ -1,0 +1,22 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("converter") {
+  visibility = [ "../*" ]
+
+  configs += [ "../:config" ]
+
+  sources = [
+    "dart_converter.cc",
+    "dart_converter.h",
+  ]
+
+  deps = [
+    "../common",
+  ]
+
+  public_deps = [
+    "//third_party/dart/runtime:dart_api",
+  ]
+}

--- a/third_party/tonic/converter/dart_converter.cc
+++ b/third_party/tonic/converter/dart_converter.cc
@@ -1,0 +1,7 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/converter/dart_converter.h"
+
+// This file exists to ensure dart_converter.h doesn't miss any dependencies.

--- a/third_party/tonic/converter/dart_converter.h
+++ b/third_party/tonic/converter/dart_converter.h
@@ -1,0 +1,396 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_CONVERTER_TONIC_DART_CONVERTER_H_
+#define LIB_CONVERTER_TONIC_DART_CONVERTER_H_
+
+#include <string>
+#include <vector>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+
+namespace tonic {
+
+// DartConvert converts types back and forth from Sky to Dart. The template
+// parameter |T| determines what kind of type conversion to perform.
+template <typename T, typename Enable = void>
+struct DartConverter {};
+
+// This is to work around the fact that typedefs do not create new types. If you
+// have a typedef, and want it to use a different converter, specialize this
+// template and override the types here.
+// Ex:
+//   typedef int ColorType;  // Want to use a different converter.
+//   class ColorConverterType {};  // Dummy type.
+//   template<> struct DartConvertType<ColorConverterType> {
+//     using ConverterType = ColorConverterType;
+//     using ValueType = ColorType;
+//   };
+template <typename T>
+struct DartConverterTypes {
+  using ConverterType = T;
+  using ValueType = T;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Boolean
+
+template <>
+struct DartConverter<bool> {
+  static Dart_Handle ToDart(bool val) { return Dart_NewBoolean(val); }
+
+  static void SetReturnValue(Dart_NativeArguments args, bool val) {
+    Dart_SetBooleanReturnValue(args, val);
+  }
+
+  static bool FromDart(Dart_Handle handle) {
+    bool result = 0;
+    Dart_BooleanValue(handle, &result);
+    return result;
+  }
+
+  static bool FromArguments(Dart_NativeArguments args,
+                            int index,
+                            Dart_Handle& exception) {
+    bool result = false;
+    Dart_GetNativeBooleanArgument(args, index, &result);
+    return result;
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Numbers
+
+template <typename T>
+struct DartConverterInteger {
+  static Dart_Handle ToDart(T val) { return Dart_NewInteger(val); }
+
+  static void SetReturnValue(Dart_NativeArguments args, T val) {
+    Dart_SetIntegerReturnValue(args, val);
+  }
+
+  static T FromDart(Dart_Handle handle) {
+    int64_t result = 0;
+    Dart_IntegerToInt64(handle, &result);
+    return static_cast<T>(result);
+  }
+
+  static T FromArguments(Dart_NativeArguments args,
+                         int index,
+                         Dart_Handle& exception) {
+    int64_t result = 0;
+    Dart_GetNativeIntegerArgument(args, index, &result);
+    return static_cast<T>(result);
+  }
+};
+
+template <>
+struct DartConverter<int> : public DartConverterInteger<int> {};
+
+template <>
+struct DartConverter<long int> : public DartConverterInteger<long int> {};
+
+template <>
+struct DartConverter<unsigned> : public DartConverterInteger<unsigned> {};
+
+template <>
+struct DartConverter<long long> : public DartConverterInteger<long long> {};
+
+template <>
+struct DartConverter<unsigned long>
+    : public DartConverterInteger<unsigned long> {};
+
+template <>
+struct DartConverter<unsigned long long> {
+  // TODO(abarth): The Dart VM API doesn't yet have an entry-point for
+  // an unsigned 64-bit type. We will need to add a Dart API for
+  // constructing an integer from uint64_t.
+  //
+  // (In the meantime, we have asserts below to check that we're never
+  // converting values that have the 64th bit set.)
+
+  static Dart_Handle ToDart(unsigned long long val) {
+    TONIC_DCHECK(val <= 0x7fffffffffffffffLL);
+    return Dart_NewInteger(static_cast<int64_t>(val));
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args,
+                             unsigned long long val) {
+    TONIC_DCHECK(val <= 0x7fffffffffffffffLL);
+    Dart_SetIntegerReturnValue(args, val);
+  }
+
+  static unsigned long long FromDart(Dart_Handle handle) {
+    int64_t result = 0;
+    Dart_IntegerToInt64(handle, &result);
+    return result;
+  }
+
+  static unsigned long long FromArguments(Dart_NativeArguments args,
+                                          int index,
+                                          Dart_Handle& exception) {
+    int64_t result = 0;
+    Dart_GetNativeIntegerArgument(args, index, &result);
+    return result;
+  }
+};
+
+template <typename T>
+struct DartConverterFloatingPoint {
+  static Dart_Handle ToDart(T val) { return Dart_NewDouble(val); }
+
+  static void SetReturnValue(Dart_NativeArguments args, T val) {
+    Dart_SetDoubleReturnValue(args, val);
+  }
+
+  static T FromDart(Dart_Handle handle) {
+    double result = 0;
+    Dart_DoubleValue(handle, &result);
+    return result;
+  }
+
+  static T FromArguments(Dart_NativeArguments args,
+                         int index,
+                         Dart_Handle& exception) {
+    double result = 0;
+    Dart_GetNativeDoubleArgument(args, index, &result);
+    return result;
+  }
+};
+
+template <>
+struct DartConverter<float> : public DartConverterFloatingPoint<float> {};
+
+template <>
+struct DartConverter<double> : public DartConverterFloatingPoint<double> {};
+
+////////////////////////////////////////////////////////////////////////////////
+// Enum Classes
+
+template <typename T>
+struct DartConverter<T, typename std::enable_if<std::is_enum<T>::value>::type> {
+  static Dart_Handle ToDart(T val) {
+    return Dart_NewInteger(
+        static_cast<typename std::underlying_type<T>::type>(val));
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args, T val) {
+    Dart_SetIntegerReturnValue(
+        args, static_cast<typename std::underlying_type<T>::type>(val));
+  }
+
+  static T FromDart(Dart_Handle handle) {
+    int64_t result = 0;
+    Dart_IntegerToInt64(handle, &result);
+    return static_cast<T>(result);
+  }
+
+  static T FromArguments(Dart_NativeArguments args,
+                         int index,
+                         Dart_Handle& exception) {
+    int64_t result = 0;
+    Dart_GetNativeIntegerArgument(args, index, &result);
+    return static_cast<T>(result);
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Strings
+
+template <>
+struct DartConverter<std::string> {
+  static Dart_Handle ToDart(const std::string& val) {
+    return Dart_NewStringFromUTF8(reinterpret_cast<const uint8_t*>(val.data()),
+                                  val.length());
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args,
+                             const std::string& val) {
+    Dart_SetReturnValue(args, ToDart(val));
+  }
+
+  static std::string FromDart(Dart_Handle handle) {
+    uint8_t* data = nullptr;
+    intptr_t length = 0;
+    if (Dart_IsError(Dart_StringToUTF8(handle, &data, &length)))
+      return std::string();
+    return std::string(reinterpret_cast<char*>(data), length);
+  }
+
+  static std::string FromArguments(Dart_NativeArguments args,
+                                   int index,
+                                   Dart_Handle& exception) {
+    return FromDart(Dart_GetNativeArgument(args, index));
+  }
+};
+
+template <>
+struct DartConverter<std::u16string> {
+  static Dart_Handle ToDart(const std::u16string& val) {
+    return Dart_NewStringFromUTF16(
+        reinterpret_cast<const uint16_t*>(val.data()), val.length());
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args,
+                             const std::u16string& val) {
+    Dart_SetReturnValue(args, ToDart(val));
+  }
+
+  static std::u16string FromDart(Dart_Handle handle) {
+    intptr_t length = 0;
+    Dart_StringLength(handle, &length);
+    std::vector<uint16_t> data(length);
+    Dart_StringToUTF16(handle, data.data(), &length);
+    return std::u16string(reinterpret_cast<char16_t*>(data.data()), length);
+  }
+
+  static std::u16string FromArguments(Dart_NativeArguments args,
+                                      int index,
+                                      Dart_Handle& exception) {
+    return FromDart(Dart_GetNativeArgument(args, index));
+  }
+};
+
+template <>
+struct DartConverter<const char*> {
+  static Dart_Handle ToDart(const char* val) {
+    return Dart_NewStringFromCString(val);
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args, const char* val) {
+    Dart_SetReturnValue(args, ToDart(val));
+  }
+
+  static const char* FromDart(Dart_Handle handle) {
+    const char* result = nullptr;
+    Dart_StringToCString(handle, &result);
+    return result;
+  }
+
+  static const char* FromArguments(Dart_NativeArguments args,
+                                   int index,
+                                   Dart_Handle& exception) {
+    return FromDart(Dart_GetNativeArgument(args, index));
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Collections
+
+template <typename T, typename Enable = void>
+struct DartListFactory {
+  static Dart_Handle NewList(intptr_t length) { return Dart_NewList(length); }
+};
+
+template <>
+struct DartListFactory<std::string> {
+  static Dart_Handle NewList(intptr_t length) {
+    return Dart_NewListOf(Dart_CoreType_String, length);
+  }
+};
+
+template <typename T>
+struct DartConverter<std::vector<T>> {
+  using ValueType = typename DartConverterTypes<T>::ValueType;
+  using ConverterType = typename DartConverterTypes<T>::ConverterType;
+
+  static Dart_Handle ToDart(const std::vector<ValueType>& val) {
+    Dart_Handle list = DartListFactory<ValueType>::NewList(val.size());
+    if (Dart_IsError(list))
+      return list;
+    for (size_t i = 0; i < val.size(); i++) {
+      Dart_Handle result =
+          Dart_ListSetAt(list, i, DartConverter<ConverterType>::ToDart(val[i]));
+      if (Dart_IsError(result))
+        return result;
+    }
+    return list;
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args,
+                             const std::vector<ValueType>& val) {
+    Dart_SetReturnValue(args, ToDart(val));
+  }
+
+  static std::vector<ValueType> FromDart(Dart_Handle handle) {
+    std::vector<ValueType> result;
+
+    if (!Dart_IsList(handle))
+      return result;
+
+    intptr_t length = 0;
+    Dart_ListLength(handle, &length);
+
+    if (length == 0)
+      return result;
+
+    result.reserve(length);
+
+    std::vector<Dart_Handle> items(length);
+    Dart_Handle items_result =
+        Dart_ListGetRange(handle, 0, length, items.data());
+    TONIC_DCHECK(!Dart_IsError(items_result));
+
+    for (intptr_t i = 0; i < length; ++i) {
+      TONIC_DCHECK(items[i]);
+      result.push_back(DartConverter<ConverterType>::FromDart(items[i]));
+    }
+    return result;
+  }
+
+  static std::vector<ValueType> FromArguments(Dart_NativeArguments args,
+                                              int index,
+                                              Dart_Handle& exception) {
+    return FromDart(Dart_GetNativeArgument(args, index));
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Dart_Handle
+
+template <>
+struct DartConverter<Dart_Handle> {
+  static Dart_Handle ToDart(Dart_Handle val) { return val; }
+
+  static void SetReturnValue(Dart_NativeArguments args, Dart_Handle val) {
+    Dart_SetReturnValue(args, val);
+  }
+
+  static Dart_Handle FromDart(Dart_Handle handle) { return handle; }
+
+  static Dart_Handle FromArguments(Dart_NativeArguments args,
+                                   int index,
+                                   Dart_Handle& exception) {
+    return Dart_GetNativeArgument(args, index);
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Convience wrappers using type inference
+
+template <typename T>
+Dart_Handle ToDart(const T& object) {
+  return DartConverter<T>::ToDart(object);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// std::string support
+
+inline Dart_Handle StdStringToDart(const std::string& val) {
+  return DartConverter<std::string>::ToDart(val);
+}
+
+inline std::string StdStringFromDart(Dart_Handle handle) {
+  return DartConverter<std::string>::FromDart(handle);
+}
+
+// Alias Dart_NewStringFromCString for less typing.
+inline Dart_Handle ToDart(const char* val) {
+  return Dart_NewStringFromCString(val);
+}
+
+}  // namespace tonic
+
+#endif  // LIB_CONVERTER_TONIC_DART_CONVERTER_H_

--- a/third_party/tonic/dart_args.h
+++ b/third_party/tonic/dart_args.h
@@ -1,0 +1,234 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_ARGS_H_
+#define LIB_TONIC_DART_ARGS_H_
+
+#include <type_traits>
+#include <utility>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/converter/dart_converter.h"
+#include "tonic/dart_wrappable.h"
+
+namespace tonic {
+
+class DartArgIterator {
+ public:
+  DartArgIterator(Dart_NativeArguments args, int start_index = 1)
+      : args_(args), index_(start_index), had_exception_(false) {}
+
+  template <typename T>
+  T GetNext() {
+    if (had_exception_)
+      return T();
+    Dart_Handle exception = nullptr;
+    T arg = DartConverter<T>::FromArguments(args_, index_++, exception);
+    if (exception) {
+      had_exception_ = true;
+      Dart_ThrowException(exception);
+    }
+    return arg;
+  }
+
+  bool had_exception() const { return had_exception_; }
+
+  Dart_NativeArguments args() const { return args_; }
+
+ private:
+  Dart_NativeArguments args_;
+  int index_;
+  bool had_exception_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartArgIterator);
+};
+
+// Classes for generating and storing an argument pack of integer indices
+// (based on well-known "indices trick", see: http://goo.gl/bKKojn):
+template <size_t... indices>
+struct IndicesHolder {};
+
+template <size_t requested_index, size_t... indices>
+struct IndicesGenerator {
+  using type = typename IndicesGenerator<requested_index - 1,
+                                         requested_index - 1,
+                                         indices...>::type;
+};
+
+template <size_t... indices>
+struct IndicesGenerator<0, indices...> {
+  using type = IndicesHolder<indices...>;
+};
+
+template <typename T>
+class IndicesForSignature {};
+
+template <typename ResultType, typename... ArgTypes>
+struct IndicesForSignature<ResultType (*)(ArgTypes...)> {
+  static const size_t count = sizeof...(ArgTypes);
+  using type = typename IndicesGenerator<count>::type;
+};
+
+template <typename C, typename ResultType, typename... ArgTypes>
+struct IndicesForSignature<ResultType (C::*)(ArgTypes...)> {
+  static const size_t count = sizeof...(ArgTypes);
+  using type = typename IndicesGenerator<count>::type;
+};
+
+template <typename C, typename ResultType, typename... ArgTypes>
+struct IndicesForSignature<ResultType (C::*)(ArgTypes...) const> {
+  static const size_t count = sizeof...(ArgTypes);
+  using type = typename IndicesGenerator<count>::type;
+};
+
+template <size_t index, typename ArgType>
+struct DartArgHolder {
+  using ValueType = typename std::remove_const<
+      typename std::remove_reference<ArgType>::type>::type;
+
+  ValueType value;
+
+  explicit DartArgHolder(DartArgIterator* it)
+      : value(it->GetNext<ValueType>()) {}
+};
+
+template <typename T>
+void DartReturn(T result, Dart_NativeArguments args) {
+  DartConverter<T>::SetReturnValue(args, std::move(result));
+}
+
+template <typename IndicesType, typename T>
+class DartDispatcher {};
+
+template <size_t... indices, typename... ArgTypes>
+struct DartDispatcher<IndicesHolder<indices...>, void (*)(ArgTypes...)>
+    : public DartArgHolder<indices, ArgTypes>... {
+  using FunctionPtr = void (*)(ArgTypes...);
+
+  DartArgIterator* it_;
+
+  explicit DartDispatcher(DartArgIterator* it)
+      : DartArgHolder<indices, ArgTypes>(it)..., it_(it) {}
+
+  void Dispatch(FunctionPtr func) {
+    (*func)(DartArgHolder<indices, ArgTypes>::value...);
+  }
+};
+
+template <size_t... indices, typename ResultType, typename... ArgTypes>
+struct DartDispatcher<IndicesHolder<indices...>, ResultType (*)(ArgTypes...)>
+    : public DartArgHolder<indices, ArgTypes>... {
+  using FunctionPtr = ResultType (*)(ArgTypes...);
+  using CtorResultType = ResultType;
+
+  DartArgIterator* it_;
+
+  explicit DartDispatcher(DartArgIterator* it)
+      : DartArgHolder<indices, ArgTypes>(it)..., it_(it) {}
+
+  void Dispatch(FunctionPtr func) {
+    DartReturn((*func)(DartArgHolder<indices, ArgTypes>::value...),
+               it_->args());
+  }
+
+  ResultType DispatchCtor(FunctionPtr func) {
+    return (*func)(DartArgHolder<indices, ArgTypes>::value...);
+  }
+};
+
+template <size_t... indices, typename C, typename... ArgTypes>
+struct DartDispatcher<IndicesHolder<indices...>, void (C::*)(ArgTypes...)>
+    : public DartArgHolder<indices, ArgTypes>... {
+  using FunctionPtr = void (C::*)(ArgTypes...);
+
+  DartArgIterator* it_;
+
+  explicit DartDispatcher(DartArgIterator* it)
+      : DartArgHolder<indices, ArgTypes>(it)..., it_(it) {}
+
+  void Dispatch(FunctionPtr func) {
+    (GetReceiver<C>(it_->args())->*func)(
+        DartArgHolder<indices, ArgTypes>::value...);
+  }
+};
+
+template <size_t... indices,
+          typename C,
+          typename ReturnType,
+          typename... ArgTypes>
+struct DartDispatcher<IndicesHolder<indices...>,
+                      ReturnType (C::*)(ArgTypes...) const>
+    : public DartArgHolder<indices, ArgTypes>... {
+  using FunctionPtr = ReturnType (C::*)(ArgTypes...) const;
+
+  DartArgIterator* it_;
+
+  explicit DartDispatcher(DartArgIterator* it)
+      : DartArgHolder<indices, ArgTypes>(it)..., it_(it) {}
+
+  void Dispatch(FunctionPtr func) {
+    DartReturn((GetReceiver<C>(it_->args())->*func)(
+                   DartArgHolder<indices, ArgTypes>::value...),
+               it_->args());
+  }
+};
+
+template <size_t... indices,
+          typename C,
+          typename ResultType,
+          typename... ArgTypes>
+struct DartDispatcher<IndicesHolder<indices...>, ResultType (C::*)(ArgTypes...)>
+    : public DartArgHolder<indices, ArgTypes>... {
+  using FunctionPtr = ResultType (C::*)(ArgTypes...);
+
+  DartArgIterator* it_;
+
+  explicit DartDispatcher(DartArgIterator* it)
+      : DartArgHolder<indices, ArgTypes>(it)..., it_(it) {}
+
+  void Dispatch(FunctionPtr func) {
+    DartReturn((GetReceiver<C>(it_->args())->*func)(
+                   DartArgHolder<indices, ArgTypes>::value...),
+               it_->args());
+  }
+};
+
+template <typename Sig>
+void DartCall(Sig func, Dart_NativeArguments args) {
+  DartArgIterator it(args);
+  using Indices = typename IndicesForSignature<Sig>::type;
+  DartDispatcher<Indices, Sig> decoder(&it);
+  if (it.had_exception())
+    return;
+  decoder.Dispatch(func);
+}
+
+template <typename Sig>
+void DartCallStatic(Sig func, Dart_NativeArguments args) {
+  DartArgIterator it(args, 0);
+  using Indices = typename IndicesForSignature<Sig>::type;
+  DartDispatcher<Indices, Sig> decoder(&it);
+  if (it.had_exception())
+    return;
+  decoder.Dispatch(func);
+}
+
+template <typename Sig>
+void DartCallConstructor(Sig func, Dart_NativeArguments args) {
+  DartArgIterator it(args);
+  using Indices = typename IndicesForSignature<Sig>::type;
+  using Wrappable = typename DartDispatcher<Indices, Sig>::CtorResultType;
+  Wrappable wrappable;
+  {
+    DartDispatcher<Indices, Sig> decoder(&it);
+    if (it.had_exception())
+      return;
+    wrappable = decoder.DispatchCtor(func);
+  }
+  wrappable->AssociateWithDartWrapper(args);
+}
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_ARGS_H_

--- a/third_party/tonic/dart_binding_macros.h
+++ b/third_party/tonic/dart_binding_macros.h
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_BINDING_MACROS_H_
+#define LIB_TONIC_DART_BINDING_MACROS_H_
+
+#include "tonic/dart_args.h"
+
+#define DART_NATIVE_CALLBACK(CLASS, METHOD)                 \
+  static void CLASS##_##METHOD(Dart_NativeArguments args) { \
+    tonic::DartCall(&CLASS::METHOD, args);                  \
+  }
+
+#define DART_NATIVE_CALLBACK_STATIC(CLASS, METHOD)          \
+  static void CLASS##_##METHOD(Dart_NativeArguments args) { \
+    tonic::DartCallStatic(&CLASS::METHOD, args);            \
+  }
+
+#define DART_REGISTER_NATIVE(CLASS, METHOD) \
+  {#CLASS "_" #METHOD, CLASS##_##METHOD,    \
+   tonic::IndicesForSignature<decltype(&CLASS::METHOD)>::count + 1, true},
+
+#define DART_REGISTER_NATIVE_STATIC(CLASS, METHOD)                           \
+  {                                                                          \
+#CLASS "_" #METHOD, CLASS##_##METHOD,                                    \
+        tonic::IndicesForSignature < decltype(&CLASS::METHOD)> ::count, true \
+  }
+
+#define DART_BIND_ALL(CLASS, FOR_EACH)                              \
+  FOR_EACH(DART_NATIVE_CALLBACK)                                    \
+  void CLASS::RegisterNatives(tonic::DartLibraryNatives* natives) { \
+    natives->Register({FOR_EACH(DART_REGISTER_NATIVE)});            \
+  }
+
+#endif  // LIB_TONIC_DART_BINDING_MACROS_H_

--- a/third_party/tonic/dart_class_library.cc
+++ b/third_party/tonic/dart_class_library.cc
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_class_library.h"
+
+#include "tonic/common/macros.h"
+#include "tonic/dart_wrapper_info.h"
+
+namespace tonic {
+
+DartClassLibrary::DartClassLibrary() {}
+
+DartClassLibrary::~DartClassLibrary() {
+  // Note that we don't need to delete these persistent handles because this
+  // object lives as long as the isolate. The handles will get deleted when the
+  // isolate dies.
+}
+
+Dart_PersistentHandle DartClassLibrary::GetClass(const DartWrapperInfo& info) {
+  const auto& result = info_cache_.insert(std::make_pair(&info, nullptr));
+  if (!result.second) {
+    // Already present, return value.
+    return result.first->second;
+  }
+  return GetAndCacheClass(info.library_name, info.interface_name,
+                          &result.first->second);
+}
+
+Dart_PersistentHandle DartClassLibrary::GetClass(
+    const std::string& library_name,
+    const std::string& interface_name) {
+  auto key = std::make_pair(library_name, interface_name);
+  const auto& result = name_cache_.insert(std::make_pair(key, nullptr));
+  if (!result.second) {
+    // Already present, return value.
+    return result.first->second;
+  }
+  return GetAndCacheClass(library_name.c_str(), interface_name.c_str(),
+                          &result.first->second);
+}
+
+Dart_PersistentHandle DartClassLibrary::GetAndCacheClass(
+    const char* library_name,
+    const char* interface_name,
+    Dart_PersistentHandle* cache_slot) {
+  auto it = providers_.find(library_name);
+  TONIC_DCHECK(it != providers_.end());
+
+  Dart_Handle class_handle = it->second->GetClassByName(interface_name);
+  *cache_slot = Dart_NewPersistentHandle(class_handle);
+  return *cache_slot;
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_class_library.h
+++ b/third_party/tonic/dart_class_library.h
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_CLASS_LIBRARY_H_
+#define LIB_TONIC_DART_CLASS_LIBRARY_H_
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/dart_class_provider.h"
+
+namespace tonic {
+struct DartWrapperInfo;
+
+class DartClassLibrary {
+ public:
+  explicit DartClassLibrary();
+  ~DartClassLibrary();
+
+  void add_provider(const std::string& library_name,
+                    std::unique_ptr<DartClassProvider> provider) {
+    providers_.insert(std::make_pair(library_name, std::move(provider)));
+  }
+
+  Dart_PersistentHandle GetClass(const DartWrapperInfo& info);
+  Dart_PersistentHandle GetClass(const std::string& library_name,
+                                 const std::string& interface_name);
+
+ private:
+  Dart_PersistentHandle GetAndCacheClass(const char* library_name,
+                                         const char* interface_name,
+                                         Dart_PersistentHandle* cache_slot);
+
+  // TODO(abarth): Move this class somewhere more general.
+  // We should also use a more reasonable hash function, such as described in
+  // http://www.boost.org/doc/libs/1_35_0/doc/html/boost/hash_combine_id241013.html
+  struct PairHasher {
+    template <typename T, typename U>
+    std::size_t operator()(const std::pair<T, U>& pair) const {
+      return std::hash<T>()(pair.first) + 37 * std::hash<U>()(pair.second);
+    }
+  };
+
+  std::unordered_map<std::string, std::unique_ptr<DartClassProvider>>
+      providers_;
+  std::unordered_map<const DartWrapperInfo*, Dart_PersistentHandle> info_cache_;
+  std::unordered_map<std::pair<std::string, std::string>,
+                     Dart_PersistentHandle,
+                     PairHasher>
+      name_cache_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartClassLibrary);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_CLASS_LIBRARY_H_

--- a/third_party/tonic/dart_class_provider.cc
+++ b/third_party/tonic/dart_class_provider.cc
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_class_provider.h"
+
+#include "tonic/converter/dart_converter.h"
+#include "tonic/dart_state.h"
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+DartClassProvider::DartClassProvider(DartState* dart_state,
+                                     const char* class_name) {
+  library_.Set(dart_state, Dart_LookupLibrary(ToDart(class_name)));
+}
+
+DartClassProvider::~DartClassProvider() {}
+
+Dart_Handle DartClassProvider::GetClassByName(const char* class_name) {
+  Dart_Handle name_handle = ToDart(class_name);
+  Dart_Handle class_handle =
+      Dart_GetType(library_.value(), name_handle, 0, nullptr);
+  TONIC_DCHECK(!Dart_IsError(class_handle));
+  return class_handle;
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_class_provider.h
+++ b/third_party/tonic/dart_class_provider.h
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_CLASS_PROVIDER_H_
+#define LIB_TONIC_DART_CLASS_PROVIDER_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/dart_persistent_value.h"
+
+namespace tonic {
+class DartState;
+
+class DartClassProvider {
+ public:
+  DartClassProvider(DartState* dart_state, const char* library_name);
+  ~DartClassProvider();
+
+  Dart_Handle GetClassByName(const char* class_name);
+
+ private:
+  DartPersistentValue library_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartClassProvider);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_CLASS_PROVIDER_H_

--- a/third_party/tonic/dart_library_natives.cc
+++ b/third_party/tonic/dart_library_natives.cc
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_library_natives.h"
+
+#include "tonic/converter/dart_converter.h"
+
+namespace tonic {
+
+DartLibraryNatives::DartLibraryNatives() {}
+
+DartLibraryNatives::~DartLibraryNatives() {}
+
+void DartLibraryNatives::Register(std::initializer_list<Entry> entries) {
+  for (const Entry& entry : entries) {
+    symbols_.emplace(entry.native_function, entry.symbol);
+    entries_.emplace(entry.symbol, entry);
+  }
+}
+
+Dart_NativeFunction DartLibraryNatives::GetNativeFunction(
+    Dart_Handle name,
+    int argument_count,
+    bool* auto_setup_scope) {
+  std::string name_string = StdStringFromDart(name);
+  auto it = entries_.find(name_string);
+  if (it == entries_.end())
+    return nullptr;
+  const Entry& entry = it->second;
+  if (entry.argument_count != argument_count)
+    return nullptr;
+  *auto_setup_scope = entry.auto_setup_scope;
+  return entry.native_function;
+}
+
+const uint8_t* DartLibraryNatives::GetSymbol(
+    Dart_NativeFunction native_function) {
+  auto it = symbols_.find(native_function);
+  if (it == symbols_.end())
+    return nullptr;
+  return reinterpret_cast<const uint8_t*>(it->second);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_library_natives.h
+++ b/third_party/tonic/dart_library_natives.h
@@ -1,0 +1,45 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_LIBRARY_NATIVES_H_
+#define LIB_TONIC_DART_LIBRARY_NATIVES_H_
+
+#include <initializer_list>
+#include <string>
+#include <unordered_map>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+
+namespace tonic {
+
+class DartLibraryNatives {
+ public:
+  DartLibraryNatives();
+  ~DartLibraryNatives();
+
+  struct Entry {
+    const char* symbol;
+    Dart_NativeFunction native_function;
+    int argument_count;
+    bool auto_setup_scope;
+  };
+
+  void Register(std::initializer_list<Entry> entries);
+
+  Dart_NativeFunction GetNativeFunction(Dart_Handle name,
+                                        int argument_count,
+                                        bool* auto_setup_scope);
+  const uint8_t* GetSymbol(Dart_NativeFunction native_function);
+
+ private:
+  std::unordered_map<std::string, Entry> entries_;
+  std::unordered_map<Dart_NativeFunction, const char*> symbols_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartLibraryNatives);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_LIBRARY_NATIVES_H_

--- a/third_party/tonic/dart_list.cc
+++ b/third_party/tonic/dart_list.cc
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_list.h"
+
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+DartList::DartList(Dart_Handle dart_handle) : dart_handle_(dart_handle) {
+  TONIC_DCHECK(Dart_IsList(dart_handle_));
+
+  intptr_t length;
+  is_valid_ = !LogIfError(Dart_ListLength(dart_handle_, &length));
+  size_ = length;
+}
+
+DartList::DartList() {
+  dart_handle_ = Dart_Null();
+  size_ = 0;
+  is_valid_ = false;
+}
+
+DartList::DartList(DartList&& other)
+    : dart_handle_(other.dart_handle_),
+      size_(other.size_),
+      is_valid_(other.is_valid_) {
+  other.dart_handle_ = nullptr;
+  other.size_ = 0;
+  other.is_valid_ = false;
+}
+
+void DartList::Set(size_t index, Dart_Handle value) {
+  LogIfError(Dart_ListSetAt(dart_handle_, index, value));
+}
+
+DartList DartConverter<DartList>::FromArguments(Dart_NativeArguments args,
+                                                int index,
+                                                Dart_Handle& exception) {
+  Dart_Handle list = Dart_GetNativeArgument(args, index);
+  if (LogIfError(list) || !Dart_IsList(list)) {
+    exception = Dart_NewApiError("Invalid Argument");
+    return DartList();
+  }
+
+  return DartList(list);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_list.h
+++ b/third_party/tonic/dart_list.h
@@ -1,0 +1,59 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_LIST_H_
+#define LIB_TONIC_DART_LIST_H_
+
+#include <stddef.h>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/converter/dart_converter.h"
+
+namespace tonic {
+
+class DartList {
+ public:
+  DartList(DartList&& other);
+
+  void Set(size_t index, Dart_Handle value);
+  Dart_Handle Get(size_t index);
+
+  template <class T>
+  void Set(size_t index, T value) {
+    Set(index, DartConverter<T>::ToDart(value));
+  }
+
+  template <class T>
+  T Get(size_t index) {
+    return DartConverter<T>::FromDart(Get(index));
+  }
+
+  Dart_Handle dart_handle() const { return dart_handle_; }
+  size_t size() const { return size_; }
+  bool is_valid() const { return is_valid_; }
+
+  explicit operator bool() const { return is_valid_; }
+
+ private:
+  explicit DartList(Dart_Handle list);
+  friend struct DartConverter<DartList>;
+
+  DartList();
+  Dart_Handle dart_handle_;
+  size_t size_;
+  bool is_valid_;
+
+  DartList(const DartList& other) = delete;
+};
+
+template <>
+struct DartConverter<DartList> {
+  static DartList FromArguments(Dart_NativeArguments args,
+                                int index,
+                                Dart_Handle& exception);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_LIST_H_

--- a/third_party/tonic/dart_message_handler.cc
+++ b/third_party/tonic/dart_message_handler.cc
@@ -1,0 +1,149 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_message_handler.h"
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "third_party/dart/runtime/include/dart_native_api.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
+#include "tonic/common/macros.h"
+#include "tonic/dart_state.h"
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+DartMessageHandler::DartMessageHandler()
+    : handled_first_message_(false),
+      isolate_exited_(false),
+      isolate_had_uncaught_exception_error_(false),
+      isolate_had_fatal_error_(false),
+      isolate_last_error_(kNoError),
+      task_dispatcher_(nullptr) {}
+
+DartMessageHandler::~DartMessageHandler() {
+  task_dispatcher_ = nullptr;
+}
+
+void DartMessageHandler::Initialize(TaskDispatcher dispatcher) {
+  // Only can be called once.
+  TONIC_CHECK(!task_dispatcher_ && dispatcher);
+  task_dispatcher_ = dispatcher;
+  Dart_SetMessageNotifyCallback(MessageNotifyCallback);
+}
+
+void DartMessageHandler::OnMessage(DartState* dart_state) {
+  auto task_dispatcher_ = dart_state->message_handler().task_dispatcher_;
+
+  // Schedule a task to run on the message loop thread.
+  auto weak_dart_state = dart_state->GetWeakPtr();
+  task_dispatcher_([weak_dart_state]() {
+    if (auto dart_state = weak_dart_state.lock()) {
+      dart_state->message_handler().OnHandleMessage(dart_state.get());
+    }
+  });
+}
+
+void DartMessageHandler::UnhandledError(Dart_Handle error) {
+  TONIC_DCHECK(Dart_CurrentIsolate());
+  TONIC_DCHECK(Dart_IsError(error));
+
+  isolate_last_error_ = GetErrorHandleType(error);
+  // Remember that we had an uncaught exception error.
+  isolate_had_uncaught_exception_error_ = true;
+  if (Dart_IsFatalError(error)) {
+    isolate_had_fatal_error_ = true;
+    // Stop handling messages.
+    Dart_SetMessageNotifyCallback(nullptr);
+    // Shut down the isolate.
+    Dart_ShutdownIsolate();
+  }
+}
+
+void DartMessageHandler::OnHandleMessage(DartState* dart_state) {
+  if (isolate_had_fatal_error_) {
+    // Don't handle any more messages.
+    return;
+  }
+
+  DartIsolateScope scope(dart_state->isolate());
+  DartApiScope dart_api_scope;
+  Dart_Handle result = Dart_Null();
+  bool error = false;
+
+  // On the first message, check if we should pause on isolate start.
+  if (!handled_first_message()) {
+    set_handled_first_message(true);
+    if (Dart_ShouldPauseOnStart()) {
+      // Mark that we are paused on isolate start.
+      Dart_SetPausedOnStart(true);
+    }
+  }
+
+  if (Dart_IsPausedOnStart()) {
+    // We are paused on isolate start. Only handle service messages until we are
+    // requested to resume.
+    if (Dart_HasServiceMessages()) {
+      bool resume = Dart_HandleServiceMessages();
+      if (!resume) {
+        return;
+      }
+      Dart_SetPausedOnStart(false);
+      // We've resumed, handle normal messages that are in the queue.
+      result = Dart_HandleMessage();
+      error = LogIfError(result);
+      dart_state->MessageEpilogue(result);
+      if (!Dart_CurrentIsolate()) {
+        isolate_exited_ = true;
+        return;
+      }
+    }
+  } else if (Dart_IsPausedOnExit()) {
+    // We are paused on isolate exit. Only handle service messages until we are
+    // requested to resume.
+    if (Dart_HasServiceMessages()) {
+      bool resume = Dart_HandleServiceMessages();
+      if (!resume) {
+        return;
+      }
+      Dart_SetPausedOnExit(false);
+    }
+  } else {
+    // We are processing messages normally.
+    result = Dart_HandleMessage();
+    // If the Dart program has set a return code, then it is intending to shut
+    // down by way of a fatal error, and so there is no need to emit a log
+    // message.
+    if (dart_state->has_set_return_code() && Dart_IsError(result) &&
+        Dart_IsFatalError(result)) {
+      error = true;
+    } else {
+      error = LogIfError(result);
+    }
+    dart_state->MessageEpilogue(result);
+    if (!Dart_CurrentIsolate()) {
+      isolate_exited_ = true;
+      return;
+    }
+  }
+
+  if (error) {
+    UnhandledError(result);
+  } else if (!Dart_HasLivePorts()) {
+    // The isolate has no live ports and would like to exit.
+    if (!Dart_IsPausedOnExit() && Dart_ShouldPauseOnExit()) {
+      // Mark that we are paused on exit.
+      Dart_SetPausedOnExit(true);
+    } else {
+      isolate_exited_ = true;
+    }
+  }
+}
+
+void DartMessageHandler::MessageNotifyCallback(Dart_Isolate dest_isolate) {
+  auto dart_state = DartState::From(dest_isolate);
+  TONIC_CHECK(dart_state);
+  dart_state->message_handler().OnMessage(dart_state);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_message_handler.h
+++ b/third_party/tonic/dart_message_handler.h
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_MESSAGE_HANDLER_H_
+#define LIB_TONIC_DART_MESSAGE_HANDLER_H_
+
+#include <functional>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+class DartState;
+
+class DartMessageHandler {
+ public:
+  using TaskDispatcher = std::function<void(std::function<void(void)>)>;
+
+  DartMessageHandler();
+
+  ~DartMessageHandler();
+
+  // Messages for the current isolate will be scheduled on |runner|.
+  void Initialize(TaskDispatcher dispatcher);
+
+  // Handle an unhandled error. If the error is fatal then shut down the
+  // isolate. The message handler's isolate must be the current isolate.
+  void UnhandledError(Dart_Handle error);
+
+  // Did the isolate exit?
+  bool isolate_exited() const { return isolate_exited_; }
+
+  // Did the isolate have an uncaught exception error?
+  bool isolate_had_uncaught_exception_error() const {
+    return isolate_had_uncaught_exception_error_;
+  }
+
+  DartErrorHandleType isolate_last_error() const { return isolate_last_error_; }
+
+ protected:
+  // Called from an unknown thread for each message.
+  void OnMessage(DartState* dart_state);
+  // By default, called on the task runner's thread for each message.
+  void OnHandleMessage(DartState* dart_state);
+
+  bool handled_first_message() const { return handled_first_message_; }
+
+  void set_handled_first_message(bool handled_first_message) {
+    handled_first_message_ = handled_first_message;
+  }
+
+  bool handled_first_message_;
+  bool isolate_exited_;
+  bool isolate_had_uncaught_exception_error_;
+  bool isolate_had_fatal_error_;
+  DartErrorHandleType isolate_last_error_;
+  TaskDispatcher task_dispatcher_;
+
+ private:
+  static void MessageNotifyCallback(Dart_Isolate dest_isolate);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_MESSAGE_HANDLER_H_

--- a/third_party/tonic/dart_microtask_queue.cc
+++ b/third_party/tonic/dart_microtask_queue.cc
@@ -1,0 +1,107 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_microtask_queue.h"
+
+#include "tonic/common/build_config.h"
+#include "tonic/dart_state.h"
+#include "tonic/logging/dart_invoke.h"
+
+#ifdef OS_IOS
+#include <pthread.h>
+#endif
+
+namespace tonic {
+namespace {
+
+#ifdef OS_IOS
+// iOS doesn't support the thread_local keyword.
+
+pthread_key_t g_queue_key;
+pthread_once_t g_queue_key_once = PTHREAD_ONCE_INIT;
+
+void MakeKey() {
+  pthread_key_create(&g_queue_key, nullptr);
+}
+
+void SetQueue(DartMicrotaskQueue* queue) {
+  pthread_once(&g_queue_key_once, MakeKey);
+  pthread_setspecific(g_queue_key, queue);
+}
+
+DartMicrotaskQueue* GetQueue() {
+  return static_cast<tonic::DartMicrotaskQueue*>(
+      pthread_getspecific(g_queue_key));
+}
+
+#else
+
+thread_local DartMicrotaskQueue* g_queue = nullptr;
+
+void SetQueue(DartMicrotaskQueue* queue) {
+  g_queue = queue;
+}
+
+DartMicrotaskQueue* GetQueue() {
+  return g_queue;
+}
+
+#endif
+
+}  // namespace
+
+DartMicrotaskQueue::DartMicrotaskQueue() : last_error_(kNoError) {}
+
+DartMicrotaskQueue::~DartMicrotaskQueue() = default;
+
+void DartMicrotaskQueue::StartForCurrentThread() {
+  SetQueue(new DartMicrotaskQueue());
+}
+
+DartMicrotaskQueue* DartMicrotaskQueue::GetForCurrentThread() {
+  return GetQueue();
+}
+
+void DartMicrotaskQueue::ScheduleMicrotask(Dart_Handle callback) {
+  queue_.emplace_back(DartState::Current(), callback);
+}
+
+void DartMicrotaskQueue::RunMicrotasks() {
+  while (!queue_.empty()) {
+    MicrotaskQueue local;
+    std::swap(queue_, local);
+    for (const auto& callback : local) {
+      if (auto dart_state = callback.dart_state().lock()) {
+        DartState::Scope dart_scope(dart_state.get());
+        Dart_Handle result = Dart_InvokeClosure(callback.value(), 0, nullptr);
+        // If the Dart program has set a return code, then it is intending to
+        // shut down by way of a fatal error, and so there is no need to emit a
+        // log message.
+        if (!dart_state->has_set_return_code() || !Dart_IsError(result) ||
+            !Dart_IsFatalError(result)) {
+          LogIfError(result);
+        }
+        DartErrorHandleType error = GetErrorHandleType(result);
+        if (error != kNoError) {
+          last_error_ = error;
+        }
+        dart_state->MessageEpilogue(result);
+        if (!Dart_CurrentIsolate())
+          return;
+      }
+    }
+  }
+}
+
+void DartMicrotaskQueue::Destroy() {
+  TONIC_DCHECK(this == GetForCurrentThread());
+  SetQueue(nullptr);
+  delete this;
+}
+
+DartErrorHandleType DartMicrotaskQueue::GetLastError() {
+  return last_error_;
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_microtask_queue.h
+++ b/third_party/tonic/dart_microtask_queue.h
@@ -1,0 +1,42 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_MICROTASK_QUEUE_H_
+#define LIB_TONIC_DART_MICROTASK_QUEUE_H_
+
+#include <vector>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/dart_persistent_value.h"
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+class DartMicrotaskQueue {
+ public:
+  DartMicrotaskQueue();
+  ~DartMicrotaskQueue();
+
+  static void StartForCurrentThread();
+
+  static DartMicrotaskQueue* GetForCurrentThread();
+
+  void ScheduleMicrotask(Dart_Handle callback);
+  void RunMicrotasks();
+  void Destroy();
+
+  bool HasMicrotasks() const { return !queue_.empty(); }
+
+  DartErrorHandleType GetLastError();
+
+ private:
+  typedef std::vector<DartPersistentValue> MicrotaskQueue;
+
+  DartErrorHandleType last_error_;
+  MicrotaskQueue queue_;
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_MICROTASK_QUEUE_H_

--- a/third_party/tonic/dart_persistent_value.cc
+++ b/third_party/tonic/dart_persistent_value.cc
@@ -1,0 +1,63 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_persistent_value.h"
+
+#include "tonic/dart_state.h"
+#include "tonic/scopes/dart_isolate_scope.h"
+
+namespace tonic {
+
+DartPersistentValue::DartPersistentValue() : value_(nullptr) {}
+
+DartPersistentValue::DartPersistentValue(DartPersistentValue&& other)
+    : dart_state_(other.dart_state_), value_(other.value_) {
+  other.dart_state_.reset();
+  other.value_ = nullptr;
+}
+
+DartPersistentValue::DartPersistentValue(DartState* dart_state,
+                                         Dart_Handle value)
+    : value_(nullptr) {
+  Set(dart_state, value);
+}
+
+DartPersistentValue::~DartPersistentValue() {
+  Clear();
+}
+
+void DartPersistentValue::Set(DartState* dart_state, Dart_Handle value) {
+  TONIC_DCHECK(is_empty());
+  dart_state_ = dart_state->GetWeakPtr();
+  value_ = Dart_NewPersistentHandle(value);
+}
+
+void DartPersistentValue::Clear() {
+  if (!value_) {
+    return;
+  }
+
+  auto dart_state = dart_state_.lock();
+  if (!dart_state) {
+    return;
+  }
+
+  DartIsolateScope scope(dart_state->isolate());
+  Dart_DeletePersistentHandle(value_);
+  dart_state_.reset();
+  value_ = nullptr;
+}
+
+Dart_Handle DartPersistentValue::Get() {
+  if (!value_)
+    return nullptr;
+  return Dart_HandleFromPersistent(value_);
+}
+
+Dart_Handle DartPersistentValue::Release() {
+  Dart_Handle local = Get();
+  Clear();
+  return local;
+}
+}  // namespace tonic

--- a/third_party/tonic/dart_persistent_value.h
+++ b/third_party/tonic/dart_persistent_value.h
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_PERSISTENT_VALUE_H_
+#define LIB_TONIC_DART_PERSISTENT_VALUE_H_
+
+#include <memory>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+
+namespace tonic {
+class DartState;
+
+// DartPersistentValue is a bookkeeping class to help pair calls to
+// Dart_NewPersistentHandle with Dart_DeletePersistentHandle. Consider using
+// this class instead of holding a Dart_PersistentHandle directly so that you
+// don't leak the Dart_PersistentHandle.
+class DartPersistentValue {
+ public:
+  DartPersistentValue();
+  DartPersistentValue(DartPersistentValue&& other);
+  DartPersistentValue(DartState* dart_state, Dart_Handle value);
+  ~DartPersistentValue();
+
+  Dart_PersistentHandle value() const { return value_; }
+  bool is_empty() const { return !value_; }
+
+  void Set(DartState* dart_state, Dart_Handle value);
+  void Clear();
+  Dart_Handle Get();
+  Dart_Handle Release();
+
+  const std::weak_ptr<DartState>& dart_state() const { return dart_state_; }
+
+ private:
+  std::weak_ptr<DartState> dart_state_;
+  Dart_PersistentHandle value_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartPersistentValue);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_PERSISTENT_VALUE_H_

--- a/third_party/tonic/dart_state.cc
+++ b/third_party/tonic/dart_state.cc
@@ -1,0 +1,75 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_state.h"
+
+#include "tonic/converter/dart_converter.h"
+#include "tonic/dart_class_library.h"
+#include "tonic/dart_message_handler.h"
+#include "tonic/file_loader/file_loader.h"
+
+namespace tonic {
+
+DartState::Scope::Scope(DartState* dart_state)
+    : scope_(dart_state->isolate()) {}
+
+DartState::Scope::Scope(std::shared_ptr<DartState> dart_state)
+    : scope_(dart_state->isolate()) {}
+
+DartState::Scope::~Scope() {}
+
+DartState::DartState(int dirfd,
+                     std::function<void(Dart_Handle)> message_epilogue)
+    : isolate_(nullptr),
+      class_library_(new DartClassLibrary),
+      message_handler_(new DartMessageHandler()),
+      file_loader_(new FileLoader(dirfd)),
+      message_epilogue_(message_epilogue),
+      has_set_return_code_(false) {}
+
+DartState::~DartState() {}
+
+void DartState::SetIsolate(Dart_Isolate isolate) {
+  isolate_ = isolate;
+  if (!isolate_)
+    return;
+  DidSetIsolate();
+}
+
+DartState* DartState::From(Dart_Isolate isolate) {
+  auto isolate_data =
+      static_cast<std::shared_ptr<DartState>*>(Dart_IsolateData(isolate));
+  return isolate_data->get();
+}
+
+DartState* DartState::Current() {
+  auto isolate_data =
+      static_cast<std::shared_ptr<DartState>*>(Dart_CurrentIsolateData());
+  return isolate_data->get();
+}
+
+std::weak_ptr<DartState> DartState::GetWeakPtr() {
+  return shared_from_this();
+}
+
+void DartState::SetReturnCode(uint32_t return_code) {
+  if (set_return_code_callback_) {
+    set_return_code_callback_(return_code);
+  }
+  has_set_return_code_ = true;
+}
+
+void DartState::SetReturnCodeCallback(std::function<void(uint32_t)> callback) {
+  set_return_code_callback_ = callback;
+}
+
+void DartState::DidSetIsolate() {}
+
+Dart_Handle DartState::HandleLibraryTag(Dart_LibraryTag tag,
+                                        Dart_Handle library,
+                                        Dart_Handle url) {
+  return Current()->file_loader().HandleLibraryTag(tag, library, url);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_state.h
+++ b/third_party/tonic/dart_state.h
@@ -1,0 +1,86 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_STATE_H_
+#define LIB_TONIC_DART_STATE_H_
+
+#include <functional>
+#include <memory>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+#include "tonic/dart_persistent_value.h"
+#include "tonic/scopes/dart_api_scope.h"
+#include "tonic/scopes/dart_isolate_scope.h"
+
+namespace tonic {
+class DartClassLibrary;
+class DartMessageHandler;
+class FileLoader;
+
+// DartState represents the state associated with a given Dart isolate. The
+// lifetime of this object is controlled by the DartVM. If you want to hold a
+// reference to a DartState instance, please hold a std::weak_ptr<DartState>.
+//
+// DartState is analogous to gin::PerIsolateData and JSC::ExecState.
+class DartState : public std::enable_shared_from_this<DartState> {
+ public:
+  class Scope {
+   public:
+    explicit Scope(DartState* dart_state);
+    explicit Scope(std::shared_ptr<DartState> dart_state);
+    ~Scope();
+
+   private:
+    DartIsolateScope scope_;
+    DartApiScope api_scope_;
+  };
+
+  DartState(int dirfd = -1,
+            std::function<void(Dart_Handle)> message_epilogue = nullptr);
+  virtual ~DartState();
+
+  static DartState* From(Dart_Isolate isolate);
+  static DartState* Current();
+
+  std::weak_ptr<DartState> GetWeakPtr();
+
+  Dart_Isolate isolate() { return isolate_; }
+  void SetIsolate(Dart_Isolate isolate);
+
+  DartClassLibrary& class_library() { return *class_library_; }
+  DartMessageHandler& message_handler() { return *message_handler_; }
+  FileLoader& file_loader() { return *file_loader_; }
+
+  void MessageEpilogue(Dart_Handle message_result) {
+    if (message_epilogue_) {
+      message_epilogue_(message_result);
+    }
+  }
+  void SetReturnCode(uint32_t return_code);
+  void SetReturnCodeCallback(std::function<void(uint32_t)> callback);
+  bool has_set_return_code() const { return has_set_return_code_; }
+
+  virtual void DidSetIsolate();
+
+  static Dart_Handle HandleLibraryTag(Dart_LibraryTag tag,
+                                      Dart_Handle library,
+                                      Dart_Handle url);
+
+ private:
+  Dart_Isolate isolate_;
+  std::unique_ptr<DartClassLibrary> class_library_;
+  std::unique_ptr<DartMessageHandler> message_handler_;
+  std::unique_ptr<FileLoader> file_loader_;
+  std::function<void(Dart_Handle)> message_epilogue_;
+  std::function<void(uint32_t)> set_return_code_callback_;
+  bool has_set_return_code_;
+
+ protected:
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartState);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_STATE_H_

--- a/third_party/tonic/dart_wrappable.cc
+++ b/third_party/tonic/dart_wrappable.cc
@@ -1,0 +1,116 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/dart_wrappable.h"
+
+#include "tonic/dart_class_library.h"
+#include "tonic/dart_state.h"
+#include "tonic/dart_wrapper_info.h"
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+DartWrappable::~DartWrappable() {
+  TONIC_CHECK(!dart_wrapper_);
+}
+
+Dart_Handle DartWrappable::CreateDartWrapper(DartState* dart_state) {
+  TONIC_DCHECK(!dart_wrapper_);
+  const DartWrapperInfo& info = GetDartWrapperInfo();
+
+  Dart_PersistentHandle type = dart_state->class_library().GetClass(info);
+  TONIC_DCHECK(!LogIfError(type));
+
+  intptr_t native_fields[kNumberOfNativeFields];
+  native_fields[kPeerIndex] = reinterpret_cast<intptr_t>(this);
+  native_fields[kWrapperInfoIndex] = reinterpret_cast<intptr_t>(&info);
+  Dart_Handle wrapper =
+      Dart_AllocateWithNativeFields(type, kNumberOfNativeFields, native_fields);
+  TONIC_DCHECK(!LogIfError(wrapper));
+
+  this->RetainDartWrappableReference();  // Balanced in FinalizeDartWrapper.
+  dart_wrapper_ = Dart_NewWeakPersistentHandle(
+      wrapper, this, GetAllocationSize(), &FinalizeDartWrapper);
+
+  return wrapper;
+}
+
+void DartWrappable::AssociateWithDartWrapper(Dart_NativeArguments args) {
+  TONIC_DCHECK(!dart_wrapper_);
+
+  Dart_Handle wrapper = Dart_GetNativeArgument(args, 0);
+  TONIC_CHECK(!LogIfError(wrapper));
+
+  intptr_t native_fields[kNumberOfNativeFields];
+  TONIC_CHECK(!LogIfError(Dart_GetNativeFieldsOfArgument(
+      args, 0, kNumberOfNativeFields, native_fields)));
+  TONIC_CHECK(!native_fields[kPeerIndex]);
+  TONIC_CHECK(!native_fields[kWrapperInfoIndex]);
+
+  const DartWrapperInfo& info = GetDartWrapperInfo();
+  TONIC_CHECK(!LogIfError(Dart_SetNativeInstanceField(
+      wrapper, kPeerIndex, reinterpret_cast<intptr_t>(this))));
+  TONIC_CHECK(!LogIfError(Dart_SetNativeInstanceField(
+      wrapper, kWrapperInfoIndex, reinterpret_cast<intptr_t>(&info))));
+
+  this->RetainDartWrappableReference();  // Balanced in FinalizeDartWrapper.
+  dart_wrapper_ = Dart_NewWeakPersistentHandle(
+      wrapper, this, GetAllocationSize(), &FinalizeDartWrapper);
+}
+
+void DartWrappable::ClearDartWrapper() {
+  TONIC_DCHECK(dart_wrapper_);
+  Dart_Handle wrapper = Dart_HandleFromWeakPersistent(dart_wrapper_);
+  TONIC_CHECK(!LogIfError(Dart_SetNativeInstanceField(wrapper, kPeerIndex, 0)));
+  TONIC_CHECK(
+      !LogIfError(Dart_SetNativeInstanceField(wrapper, kWrapperInfoIndex, 0)));
+  Dart_DeleteWeakPersistentHandle(Dart_CurrentIsolate(), dart_wrapper_);
+  dart_wrapper_ = nullptr;
+  this->ReleaseDartWrappableReference();
+}
+
+void DartWrappable::FinalizeDartWrapper(void* isolate_callback_data,
+                                        Dart_WeakPersistentHandle wrapper,
+                                        void* peer) {
+  DartWrappable* wrappable = reinterpret_cast<DartWrappable*>(peer);
+  wrappable->dart_wrapper_ = nullptr;
+  wrappable->ReleaseDartWrappableReference();  // Balanced in CreateDartWrapper.
+}
+
+size_t DartWrappable::GetAllocationSize() {
+  return GetDartWrapperInfo().size_in_bytes;
+}
+
+Dart_PersistentHandle DartWrappable::GetTypeForWrapper(
+    tonic::DartState* dart_state,
+    const tonic::DartWrapperInfo& wrapper_info) {
+  return dart_state->class_library().GetClass(wrapper_info);
+}
+
+DartWrappable* DartConverterWrappable::FromDart(Dart_Handle handle) {
+  intptr_t peer = 0;
+  Dart_Handle result =
+      Dart_GetNativeInstanceField(handle, DartWrappable::kPeerIndex, &peer);
+  if (Dart_IsError(result))
+    return nullptr;
+  return reinterpret_cast<DartWrappable*>(peer);
+}
+
+DartWrappable* DartConverterWrappable::FromArguments(Dart_NativeArguments args,
+                                                     int index,
+                                                     Dart_Handle& exception) {
+  intptr_t native_fields[DartWrappable::kNumberOfNativeFields];
+  Dart_Handle result = Dart_GetNativeFieldsOfArgument(
+      args, index, DartWrappable::kNumberOfNativeFields, native_fields);
+  if (Dart_IsError(result)) {
+    exception = Dart_NewStringFromCString(DartError::kInvalidArgument);
+    return nullptr;
+  }
+  if (!native_fields[DartWrappable::kPeerIndex])
+    return nullptr;
+  return reinterpret_cast<DartWrappable*>(
+      native_fields[DartWrappable::kPeerIndex]);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/dart_wrappable.h
+++ b/third_party/tonic/dart_wrappable.h
@@ -1,0 +1,190 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_WRAPPABLE_H_
+#define LIB_TONIC_DART_WRAPPABLE_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+#include "tonic/converter/dart_converter.h"
+#include "tonic/dart_state.h"
+#include "tonic/dart_wrapper_info.h"
+#include "tonic/logging/dart_error.h"
+
+#include <type_traits>
+
+namespace tonic {
+
+// DartWrappable is a base class that you can inherit from in order to be
+// exposed to Dart code as an interface.
+class DartWrappable {
+ public:
+  enum DartNativeFields {
+    kPeerIndex,  // Must be first to work with Dart_GetNativeReceiver.
+    kWrapperInfoIndex,
+    kNumberOfNativeFields,
+  };
+
+  DartWrappable() : dart_wrapper_(nullptr) {}
+
+  // Subclasses that wish to expose a new interface must override this function
+  // and provide information about their wrapper. There is no need to call your
+  // base class's implementation of this function.
+  // Implement using IMPLEMENT_WRAPPERTYPEINFO macro
+  virtual const DartWrapperInfo& GetDartWrapperInfo() const = 0;
+
+  // Override this to customize the object size reported to the Dart garbage
+  // collector.
+  // Implement using IMPLEMENT_WRAPPERTYPEINFO macro
+  virtual size_t GetAllocationSize();
+
+  virtual void RetainDartWrappableReference() const = 0;
+
+  virtual void ReleaseDartWrappableReference() const = 0;
+
+  Dart_Handle CreateDartWrapper(DartState* dart_state);
+  void AssociateWithDartWrapper(Dart_NativeArguments args);
+  void ClearDartWrapper();  // Warning: Might delete this.
+  Dart_WeakPersistentHandle dart_wrapper() const { return dart_wrapper_; }
+
+ protected:
+  virtual ~DartWrappable();
+
+  static Dart_PersistentHandle GetTypeForWrapper(
+      tonic::DartState* dart_state,
+      const tonic::DartWrapperInfo& wrapper_info);
+
+ private:
+  static void FinalizeDartWrapper(void* isolate_callback_data,
+                                  Dart_WeakPersistentHandle wrapper,
+                                  void* peer);
+
+  Dart_WeakPersistentHandle dart_wrapper_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartWrappable);
+};
+
+#define DEFINE_WRAPPERTYPEINFO()                                           \
+ public:                                                                   \
+  const tonic::DartWrapperInfo& GetDartWrapperInfo() const override {      \
+    return dart_wrapper_info_;                                             \
+  }                                                                        \
+  static Dart_PersistentHandle GetDartType(tonic::DartState* dart_state) { \
+    return GetTypeForWrapper(dart_state, dart_wrapper_info_);              \
+  }                                                                        \
+                                                                           \
+ private:                                                                  \
+  static const tonic::DartWrapperInfo& dart_wrapper_info_
+
+#define IMPLEMENT_WRAPPERTYPEINFO(LibraryName, ClassName)       \
+  static const tonic::DartWrapperInfo                           \
+      kDartWrapperInfo_##LibraryName_##ClassName = {            \
+          #LibraryName,                                         \
+          #ClassName,                                           \
+          sizeof(ClassName),                                    \
+  };                                                            \
+  const tonic::DartWrapperInfo& ClassName::dart_wrapper_info_ = \
+      kDartWrapperInfo_##LibraryName_##ClassName;
+
+struct DartConverterWrappable {
+  static DartWrappable* FromDart(Dart_Handle handle);
+  static DartWrappable* FromArguments(Dart_NativeArguments args,
+                                      int index,
+                                      Dart_Handle& exception);
+};
+
+template <typename T>
+struct DartConverter<
+    T*,
+    typename std::enable_if<
+        std::is_convertible<T*, const DartWrappable*>::value>::type> {
+  static Dart_Handle ToDart(DartWrappable* val) {
+    if (!val)
+      return Dart_Null();
+    if (Dart_WeakPersistentHandle wrapper = val->dart_wrapper())
+      return Dart_HandleFromWeakPersistent(wrapper);
+    return val->CreateDartWrapper(DartState::Current());
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args,
+                             DartWrappable* val,
+                             bool auto_scope = true) {
+    if (!val)
+      Dart_SetReturnValue(args, Dart_Null());
+    else if (Dart_WeakPersistentHandle wrapper = val->dart_wrapper())
+      Dart_SetWeakHandleReturnValue(args, wrapper);
+    else
+      Dart_SetReturnValue(args, val->CreateDartWrapper(DartState::Current()));
+  }
+
+  static T* FromDart(Dart_Handle handle) {
+    // TODO(abarth): We're missing a type check.
+    return static_cast<T*>(DartConverterWrappable::FromDart(handle));
+  }
+
+  static T* FromArguments(Dart_NativeArguments args,
+                          int index,
+                          Dart_Handle& exception,
+                          bool auto_scope = true) {
+    // TODO(abarth): We're missing a type check.
+    return static_cast<T*>(
+        DartConverterWrappable::FromArguments(args, index, exception));
+  }
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Support for generic smart pointers that have a "get" method that returns a
+// pointer to a type that is Dart convertible as well as a constructor that
+// adopts a raw pointer to that type.
+
+template <template <typename T> class PTR, typename T>
+struct DartConverter<PTR<T>> {
+  static Dart_Handle ToDart(const PTR<T>& val) {
+    return DartConverter<T*>::ToDart(val.get());
+  }
+
+  static PTR<T> FromDart(Dart_Handle handle) {
+    return DartConverter<T*>::FromDart(handle);
+  }
+
+  static PTR<T> FromArguments(Dart_NativeArguments args,
+                              int index,
+                              Dart_Handle& exception,
+                              bool auto_scope = true) {
+    return PTR<T>(
+        DartConverter<T*>::FromArguments(args, index, exception, auto_scope));
+  }
+
+  static void SetReturnValue(Dart_NativeArguments args,
+                             const PTR<T>& val,
+                             bool auto_scope = true) {
+    DartConverter<T*>::SetReturnValue(args, val.get());
+  }
+};
+
+template <template <typename T> class PTR, typename T>
+struct DartListFactory<
+    PTR<T>,
+    typename std::enable_if<
+        std::is_convertible<T*, const DartWrappable*>::value>::type> {
+  static Dart_Handle NewList(intptr_t length) {
+    Dart_PersistentHandle type = T::GetDartType(DartState::Current());
+    TONIC_DCHECK(!LogIfError(type));
+    return Dart_NewListOfType(Dart_HandleFromPersistent(type), length);
+  }
+};
+
+template <typename T>
+inline T* GetReceiver(Dart_NativeArguments args) {
+  intptr_t receiver;
+  Dart_Handle result = Dart_GetNativeReceiver(args, &receiver);
+  TONIC_DCHECK(!Dart_IsError(result));
+  if (!receiver)
+    Dart_ThrowException(ToDart("Object has been disposed."));
+  return static_cast<T*>(reinterpret_cast<DartWrappable*>(receiver));
+}
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_WRAPPABLE_H_

--- a/third_party/tonic/dart_wrapper_info.h
+++ b/third_party/tonic/dart_wrapper_info.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_DART_WRAPPER_INFO_H_
+#define LIB_TONIC_DART_WRAPPER_INFO_H_
+
+#include <cstddef>
+
+namespace tonic {
+class DartWrappable;
+
+typedef void (*DartWrappableAccepter)(DartWrappable*);
+
+struct DartWrapperInfo {
+  const char* library_name;
+  const char* interface_name;
+  const size_t size_in_bytes;
+
+ private:
+  DartWrapperInfo(const DartWrapperInfo&) = delete;
+  DartWrapperInfo& operator=(const DartWrapperInfo&) = delete;
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_WRAPPER_INFO_H_

--- a/third_party/tonic/file_loader/BUILD.gn
+++ b/third_party/tonic/file_loader/BUILD.gn
@@ -1,0 +1,31 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("file_loader") {
+  visibility = [ "../*" ]
+
+  configs += [ "../:config" ]
+
+  sources = [
+    "file_loader.cc",
+    "file_loader.h",
+  ]
+
+  if (is_win) {
+    sources += [ "file_loader_win.cc" ]
+  } else if (is_fuchsia) {
+    sources += [ "file_loader_fuchsia.cc" ]
+  } else {
+    sources += [ "file_loader_posix.cc" ]
+  }
+
+  deps = [
+    "../common",
+    "../converter",
+    "../filesystem",
+    "../parsers",
+    "../platform",
+    "//third_party/dart/runtime:dart_api",
+  ]
+}

--- a/third_party/tonic/file_loader/file_loader.cc
+++ b/third_party/tonic/file_loader/file_loader.cc
@@ -1,0 +1,240 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/file_loader/file_loader.h"
+
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include "filesystem/file.h"
+#include "filesystem/path.h"
+#include "filesystem/portable_unistd.h"
+#include "tonic/common/macros.h"
+#include "tonic/converter/dart_converter.h"
+#include "tonic/parsers/packages_map.h"
+#include "tonic/platform/platform_utils.h"
+
+namespace tonic {
+namespace {
+
+constexpr char kDartScheme[] = "dart:";
+
+constexpr char kFileScheme[] = "file:";
+constexpr size_t kFileSchemeLength = sizeof(kFileScheme) - 1;
+
+constexpr char kPackageScheme[] = "package:";
+constexpr size_t kPackageSchemeLength = sizeof(kPackageScheme) - 1;
+
+// Extract the scheme prefix ('package:' or 'file:' from )
+std::string ExtractSchemePrefix(std::string url) {
+  if (url.find(kPackageScheme) == 0u)
+    return kPackageScheme;
+  if (url.find(kFileScheme) == 0u)
+    return kFileScheme;
+  return std::string();
+}
+
+// Extract the path from a package: or file: url.
+std::string ExtractPath(std::string url) {
+  if (url.find(kPackageScheme) == 0u)
+    return url.substr(kPackageSchemeLength);
+  if (url.find(kFileScheme) == 0u)
+    return url.substr(kFileSchemeLength);
+  return url;
+}
+
+}  // namespace
+
+FileLoader::FileLoader(int dirfd) : dirfd_(dirfd) {}
+
+FileLoader::~FileLoader() {
+  for (auto kernel_buffer : kernel_buffers_)
+    free(kernel_buffer);
+
+  if (dirfd_ >= 0)
+    close(dirfd_);
+}
+
+std::string FileLoader::SanitizeURIEscapedCharacters(const std::string& str) {
+  std::string result;
+  result.reserve(str.size());
+  for (std::string::size_type i = 0; i < str.size(); ++i) {
+    if (str[i] == '%') {
+      if (i > str.size() - 3 || !isxdigit(str[i + 1]) || !isxdigit(str[i + 2]))
+        return "";
+      const std::string hex = str.substr(i + 1, 2);
+      const unsigned char c = strtoul(hex.c_str(), nullptr, 16);
+      if (!c)
+        return "";
+      result += c;
+      i += 2;
+    } else {
+      result += str[i];
+    }
+  }
+  return result;
+}
+
+bool FileLoader::LoadPackagesMap(const std::string& packages) {
+  packages_ = packages;
+  std::string packages_source;
+  if (!ReadFileToString(packages_, &packages_source)) {
+    tonic::Log("error: Unable to load .packages file '%s'.", packages_.c_str());
+    return false;
+  }
+  packages_map_.reset(new PackagesMap());
+  std::string error;
+  if (!packages_map_->Parse(packages_source, &error)) {
+    tonic::Log("error: Unable to parse .packages file '%s'. %s",
+               packages_.c_str(), error.c_str());
+    return false;
+  }
+  return true;
+}
+
+std::string FileLoader::GetFilePathForPackageURL(std::string url) {
+  if (!packages_map_)
+    return std::string();
+  TONIC_DCHECK(url.find(kPackageScheme) == 0u);
+  url = url.substr(kPackageSchemeLength);
+
+  size_t slash = url.find(FileLoader::kPathSeparator);
+  if (slash == std::string::npos)
+    return std::string();
+  std::string package = url.substr(0, slash);
+  std::string library_path = url.substr(slash + 1);
+  std::string package_path = packages_map_->Resolve(package);
+  if (package_path.empty())
+    return std::string();
+  if (package_path.find(FileLoader::kFileURLPrefix) == 0u)
+    return SanitizePath(package_path.substr(FileLoader::kFileURLPrefixLength) +
+                        library_path);
+  return filesystem::GetDirectoryName(filesystem::AbsolutePath(packages_)) +
+         FileLoader::kPathSeparator + package_path +
+         FileLoader::kPathSeparator + library_path;
+}
+
+Dart_Handle FileLoader::HandleLibraryTag(Dart_LibraryTag tag,
+                                         Dart_Handle library,
+                                         Dart_Handle url) {
+  TONIC_DCHECK(Dart_IsNull(library) || Dart_IsLibrary(library) ||
+               Dart_IsString(library));
+  TONIC_DCHECK(Dart_IsString(url));
+  if (tag == Dart_kCanonicalizeUrl)
+    return CanonicalizeURL(library, url);
+  if (tag == Dart_kKernelTag)
+    return Kernel(url);
+  if (tag == Dart_kImportTag)
+    return Import(url);
+  return Dart_NewApiError("Unknown library tag.");
+}
+
+Dart_Handle FileLoader::CanonicalizeURL(Dart_Handle library, Dart_Handle url) {
+  std::string string = StdStringFromDart(url);
+  if (string.find(kDartScheme) == 0u)
+    return url;
+  if (string.find(kPackageScheme) == 0u)
+    return StdStringToDart(SanitizePath(string));
+  if (string.find(kFileScheme) == 0u)
+    return StdStringToDart(SanitizePath(CanonicalizeFileURL(string)));
+
+  std::string library_url = StdStringFromDart(Dart_LibraryUrl(library));
+  std::string prefix = ExtractSchemePrefix(library_url);
+  std::string base_path = ExtractPath(library_url);
+  std::string simplified_path =
+      filesystem::SimplifyPath(filesystem::GetDirectoryName(base_path) +
+                               FileLoader::kPathSeparator + string);
+  return StdStringToDart(SanitizePath(prefix + simplified_path));
+}
+
+std::string FileLoader::GetFilePathForURL(std::string url) {
+  if (url.find(kPackageScheme) == 0u)
+    return GetFilePathForPackageURL(std::move(url));
+  if (url.find(kFileScheme) == 0u)
+    return GetFilePathForFileURL(std::move(url));
+  return url;
+}
+
+Dart_Handle FileLoader::FetchBytes(const std::string& url,
+                                   uint8_t*& buffer,
+                                   intptr_t& buffer_size) {
+  buffer = nullptr;
+  buffer_size = -1;
+
+  std::string path = filesystem::SimplifyPath(GetFilePathForURL(url));
+  if (path.empty()) {
+    std::string error_message = "error: Unable to read '" + url + "'.";
+    return Dart_NewUnhandledExceptionError(
+        Dart_NewStringFromCString(error_message.c_str()));
+  }
+  std::string absolute_path = filesystem::GetAbsoluteFilePath(path);
+  auto result = filesystem::ReadFileToBytes(absolute_path);
+  if (result.first == nullptr) {
+    std::string error_message =
+        "error: Unable to read '" + absolute_path + "'.";
+    return Dart_NewUnhandledExceptionError(
+        Dart_NewStringFromCString(error_message.c_str()));
+  }
+  buffer = result.first;
+  buffer_size = result.second;
+  return Dart_True();
+}
+
+Dart_Handle FileLoader::Import(Dart_Handle url) {
+  std::string url_string = StdStringFromDart(url);
+  uint8_t* buffer = nullptr;
+  intptr_t buffer_size = -1;
+  Dart_Handle result = FetchBytes(url_string, buffer, buffer_size);
+  if (Dart_IsError(result)) {
+    return result;
+  }
+  // The embedder must keep the buffer alive until isolate shutdown.
+  kernel_buffers_.push_back(buffer);
+  return Dart_LoadLibraryFromKernel(buffer, buffer_size);
+}
+
+namespace {
+void MallocFinalizer(void* isolate_callback_data,
+                     Dart_WeakPersistentHandle handle,
+                     void* peer) {
+  free(peer);
+}
+}  // namespace
+
+Dart_Handle FileLoader::Kernel(Dart_Handle url) {
+  std::string url_string = StdStringFromDart(url);
+  uint8_t* buffer = nullptr;
+  intptr_t buffer_size = -1;
+  Dart_Handle result = FetchBytes(url_string, buffer, buffer_size);
+  if (Dart_IsError(result)) {
+    return result;
+  }
+  result =
+      Dart_NewExternalTypedData(Dart_TypedData_kUint8, buffer, buffer_size);
+  Dart_NewWeakPersistentHandle(result, buffer, buffer_size, MallocFinalizer);
+  return result;
+}
+
+// This is invoked upon a reload request.
+void FileLoader::SetPackagesUrl(Dart_Handle url) {
+  if (url == Dart_Null()) {
+    // No packages url specified.
+    LoadPackagesMap(packages());
+    return;
+  }
+  const std::string& packages_url = StdStringFromDart(url);
+  LoadPackagesMap(packages_url);
+}
+
+std::string FileLoader::GetFilePathForFileURL(std::string url) {
+  TONIC_DCHECK(url.find(FileLoader::kFileURLPrefix) == 0u);
+  return SanitizePath(url.substr(FileLoader::kFileURLPrefixLength));
+}
+
+std::string FileLoader::GetFileURLForPath(const std::string& path) {
+  return std::string(FileLoader::kFileURLPrefix) + path;
+}
+
+}  // namespace tonic

--- a/third_party/tonic/file_loader/file_loader.h
+++ b/third_party/tonic/file_loader/file_loader.h
@@ -1,0 +1,70 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_FILE_LOADER_FILE_LOADER_H_
+#define LIB_TONIC_FILE_LOADER_FILE_LOADER_H_
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+#include "tonic/parsers/packages_map.h"
+
+namespace tonic {
+
+class FileLoader {
+ public:
+  FileLoader(int dirfd = -1);
+  ~FileLoader();
+
+  bool LoadPackagesMap(const std::string& packages);
+
+  // The path to the `.packages` file the packages map was loaded from.
+  const std::string& packages() const { return packages_; }
+
+  Dart_Handle HandleLibraryTag(Dart_LibraryTag tag,
+                               Dart_Handle library,
+                               Dart_Handle url);
+
+  Dart_Handle CanonicalizeURL(Dart_Handle library, Dart_Handle url);
+  Dart_Handle Import(Dart_Handle url);
+  Dart_Handle Kernel(Dart_Handle url);
+  void SetPackagesUrl(Dart_Handle url);
+
+  Dart_Handle FetchBytes(const std::string& url,
+                         uint8_t*& buffer,
+                         intptr_t& buffer_size);
+
+  static const char kFileURLPrefix[];
+  static const size_t kFileURLPrefixLength;
+  static const std::string kPathSeparator;
+
+ private:
+  static std::string SanitizeURIEscapedCharacters(const std::string& str);
+  static std::string SanitizePath(const std::string& path);
+  static std::string CanonicalizeFileURL(const std::string& url);
+
+  std::string GetFilePathForURL(std::string url);
+  std::string GetFilePathForPackageURL(std::string url);
+  std::string GetFilePathForFileURL(std::string url);
+
+  std::string GetFileURLForPath(const std::string& path);
+
+  bool ReadFileToString(const std::string& path, std::string* result);
+  std::pair<uint8_t*, intptr_t> ReadFileToBytes(const std::string& path);
+
+  int dirfd_;
+  std::string packages_;
+  std::unique_ptr<PackagesMap> packages_map_;
+  std::vector<uint8_t*> kernel_buffers_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(FileLoader);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_FILE_LOADER_FILE_LOADER_H_

--- a/third_party/tonic/file_loader/file_loader_fuchsia.cc
+++ b/third_party/tonic/file_loader/file_loader_fuchsia.cc
@@ -1,0 +1,63 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/file_loader/file_loader.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/types.h>
+
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include "filesystem/file.h"
+#include "filesystem/path.h"
+#include "tonic/common/macros.h"
+#include "tonic/converter/dart_converter.h"
+#include "tonic/parsers/packages_map.h"
+
+namespace tonic {
+
+const std::string FileLoader::kPathSeparator = "/";
+const char FileLoader::kFileURLPrefix[] = "file://";
+const size_t FileLoader::kFileURLPrefixLength =
+    sizeof(FileLoader::kFileURLPrefix) - 1;
+
+namespace {
+
+const size_t kFileSchemeLength = FileLoader::kFileURLPrefixLength - 2;
+
+}  // namespace
+
+std::string FileLoader::SanitizePath(const std::string& url) {
+  return SanitizeURIEscapedCharacters(url);
+}
+
+std::string FileLoader::CanonicalizeFileURL(const std::string& url) {
+  return url.substr(kFileSchemeLength);
+}
+
+bool FileLoader::ReadFileToString(const std::string& path,
+                                  std::string* result) {
+  if (dirfd_ == -1)
+    return filesystem::ReadFileToString(path, result);
+  const char* cpath = path.c_str();
+  const int offset = (cpath[0] == '/') ? 1 : 0;
+  filesystem::Descriptor fd(openat(dirfd_, &cpath[offset], O_RDONLY));
+  return filesystem::ReadFileDescriptorToString(fd.get(), result);
+}
+
+std::pair<uint8_t*, intptr_t> FileLoader::ReadFileToBytes(
+    const std::string& path) {
+  if (dirfd_ == -1)
+    return filesystem::ReadFileToBytes(path);
+  const char* cpath = path.c_str();
+  const int offset = (cpath[0] == '/') ? 1 : 0;
+  filesystem::Descriptor fd(openat(dirfd_, &cpath[offset], O_RDONLY));
+  return filesystem::ReadFileDescriptorToBytes(fd.get());
+}
+
+}  // namespace tonic

--- a/third_party/tonic/file_loader/file_loader_posix.cc
+++ b/third_party/tonic/file_loader/file_loader_posix.cc
@@ -1,0 +1,50 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/file_loader/file_loader.h"
+
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include "filesystem/file.h"
+#include "filesystem/path.h"
+#include "tonic/common/macros.h"
+#include "tonic/converter/dart_converter.h"
+#include "tonic/parsers/packages_map.h"
+
+namespace tonic {
+
+const std::string FileLoader::kPathSeparator = "/";
+const char FileLoader::kFileURLPrefix[] = "file://";
+const size_t FileLoader::kFileURLPrefixLength =
+    sizeof(FileLoader::kFileURLPrefix) - 1;
+
+namespace {
+
+const size_t kFileSchemeLength = FileLoader::kFileURLPrefixLength - 2;
+
+}  // namespace
+
+std::string FileLoader::SanitizePath(const std::string& url) {
+  return SanitizeURIEscapedCharacters(url);
+}
+
+std::string FileLoader::CanonicalizeFileURL(const std::string& url) {
+  return url.substr(kFileSchemeLength);
+}
+
+bool FileLoader::ReadFileToString(const std::string& path,
+                                  std::string* result) {
+  TONIC_DCHECK(dirfd_ == -1);
+  return filesystem::ReadFileToString(path, result);
+}
+
+std::pair<uint8_t*, intptr_t> FileLoader::ReadFileToBytes(
+    const std::string& path) {
+  TONIC_DCHECK(dirfd_ == -1);
+  return filesystem::ReadFileToBytes(path);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/file_loader/file_loader_win.cc
+++ b/third_party/tonic/file_loader/file_loader_win.cc
@@ -1,0 +1,58 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/file_loader/file_loader.h"
+
+#include <iostream>
+#include <memory>
+#include <utility>
+
+#include "filesystem/file.h"
+#include "filesystem/path.h"
+#include "tonic/common/macros.h"
+#include "tonic/parsers/packages_map.h"
+
+namespace tonic {
+namespace {
+
+void FindAndReplaceInPlace(std::string& str,
+                           const std::string& findStr,
+                           const std::string& replaceStr) {
+  size_t pos = 0;
+  while ((pos = str.find(findStr, pos)) != std::string::npos) {
+    str.replace(pos, findStr.length(), replaceStr);
+    pos += replaceStr.length();
+  }
+}
+
+}  // namespace
+
+const char FileLoader::kFileURLPrefix[] = "file:///";
+const size_t FileLoader::kFileURLPrefixLength =
+    sizeof(FileLoader::kFileURLPrefix) - 1;
+const std::string FileLoader::kPathSeparator = "\\";
+
+std::string FileLoader::SanitizePath(const std::string& url) {
+  std::string sanitized = url;
+  FindAndReplaceInPlace(sanitized, "/", FileLoader::kPathSeparator);
+  return SanitizeURIEscapedCharacters(sanitized);
+}
+
+std::string FileLoader::CanonicalizeFileURL(const std::string& url) {
+  return SanitizePath(url.substr(FileLoader::kFileURLPrefixLength));
+}
+
+bool FileLoader::ReadFileToString(const std::string& path,
+                                  std::string* result) {
+  TONIC_DCHECK(dirfd_ == -1);
+  return filesystem::ReadFileToString(path, result);
+}
+
+std::pair<uint8_t*, intptr_t> FileLoader::ReadFileToBytes(
+    const std::string& path) {
+  TONIC_DCHECK(dirfd_ == -1);
+  return filesystem::ReadFileToBytes(path);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/filesystem/BUILD.gn
+++ b/third_party/tonic/filesystem/BUILD.gn
@@ -1,0 +1,9 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+group("filesystem") {
+  public_deps = [
+    "filesystem",
+  ]
+}

--- a/third_party/tonic/filesystem/README.md
+++ b/third_party/tonic/filesystem/README.md
@@ -1,0 +1,4 @@
+Files
+=====
+
+A simple cross-platform library with minimal dependencies to work with files and paths.

--- a/third_party/tonic/filesystem/filesystem/BUILD.gn
+++ b/third_party/tonic/filesystem/filesystem/BUILD.gn
@@ -1,0 +1,37 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+config("filesystem_config") {
+  visibility = [ ":*" ]
+
+  # We want callers to refer to headers in this folders using the "files"
+  # prefix.
+  include_dirs = [ ".." ]
+}
+
+source_set("filesystem") {
+  visibility = [ "../*" ]
+
+  configs += [ "../../:config" ]
+
+  sources = [
+    "eintr_wrapper.h",
+    "file.cc",
+    "file.h",
+    "path.h",
+    "portable_unistd.h",
+  ]
+
+  if (is_win) {
+    sources += [ "path_win.cc" ]
+  } else {
+    sources += [ "path_posix.cc" ]
+  }
+
+  deps = [
+    "../../common",
+  ]
+
+  public_configs = [ ":filesystem_config" ]
+}

--- a/third_party/tonic/filesystem/filesystem/eintr_wrapper.h
+++ b/third_party/tonic/filesystem/filesystem/eintr_wrapper.h
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FILESYSTEM_EINTR_WRAPPER_H_
+#define FILESYSTEM_EINTR_WRAPPER_H_
+
+#include <errno.h>
+
+#include "tonic/common/build_config.h"
+
+#if defined(OS_WIN)
+
+// Windows has no concept of EINTR.
+#define HANDLE_EINTR(x) (x)
+#define IGNORE_EINTR(x) (x)
+
+#else
+
+#if defined(NDEBUG)
+
+#define HANDLE_EINTR(x)                                     \
+  ({                                                        \
+    decltype(x) eintr_wrapper_result;                       \
+    do {                                                    \
+      eintr_wrapper_result = (x);                           \
+    } while (eintr_wrapper_result == -1 && errno == EINTR); \
+    eintr_wrapper_result;                                   \
+  })
+
+#else
+
+#define HANDLE_EINTR(x)                                      \
+  ({                                                         \
+    int eintr_wrapper_counter = 0;                           \
+    decltype(x) eintr_wrapper_result;                        \
+    do {                                                     \
+      eintr_wrapper_result = (x);                            \
+    } while (eintr_wrapper_result == -1 && errno == EINTR && \
+             eintr_wrapper_counter++ < 100);                 \
+    eintr_wrapper_result;                                    \
+  })
+
+#endif  // NDEBUG
+
+#define IGNORE_EINTR(x)                                   \
+  ({                                                      \
+    decltype(x) eintr_wrapper_result;                     \
+    do {                                                  \
+      eintr_wrapper_result = (x);                         \
+      if (eintr_wrapper_result == -1 && errno == EINTR) { \
+        eintr_wrapper_result = 0;                         \
+      }                                                   \
+    } while (0);                                          \
+    eintr_wrapper_result;                                 \
+  })
+
+#endif  // defined(OS_WIN)
+
+#endif  // FILESYSTEM_EINTR_WRAPPER_H_

--- a/third_party/tonic/filesystem/filesystem/file.cc
+++ b/third_party/tonic/filesystem/filesystem/file.cc
@@ -1,0 +1,101 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filesystem/file.h"
+
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <sys/stat.h>
+
+#include "tonic/common/build_config.h"
+
+#if defined(OS_WIN)
+#define BINARY_MODE _O_BINARY
+#else
+#define BINARY_MODE 0
+#endif
+
+#if defined(OS_WIN)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
+#include "filesystem/eintr_wrapper.h"
+#include "filesystem/portable_unistd.h"
+
+namespace filesystem {
+namespace {
+
+template <typename T>
+bool ReadFileDescriptor(int fd, T* result) {
+  if (!result) {
+    return false;
+  }
+
+  result->clear();
+
+  if (fd < 0)
+    return false;
+
+  constexpr size_t kBufferSize = 1 << 16;
+  size_t offset = 0;
+  ssize_t bytes_read = 0;
+  do {
+    offset += bytes_read;
+    result->resize(offset + kBufferSize);
+    bytes_read = HANDLE_EINTR(read(fd, &(*result)[offset], kBufferSize));
+  } while (bytes_read > 0);
+
+  if (bytes_read < 0) {
+    result->clear();
+    return false;
+  }
+
+  result->resize(offset + bytes_read);
+  return true;
+}
+
+}  // namespace
+
+std::pair<uint8_t*, intptr_t> ReadFileDescriptorToBytes(int fd) {
+  std::pair<uint8_t*, intptr_t> failure_pair{nullptr, -1};
+  struct stat st;
+  if (fstat(fd, &st) != 0) {
+    return failure_pair;
+  }
+  intptr_t file_size = st.st_size;
+  uint8_t* ptr = (uint8_t*)malloc(file_size);
+
+  size_t bytes_left = file_size;
+  size_t offset = 0;
+  while (bytes_left > 0) {
+    ssize_t bytes_read = HANDLE_EINTR(read(fd, &ptr[offset], bytes_left));
+    if (bytes_read < 0) {
+      return failure_pair;
+    }
+    offset += bytes_read;
+    bytes_left -= bytes_read;
+  }
+  return std::pair<uint8_t*, intptr_t>(ptr, file_size);
+}
+
+bool ReadFileToString(const std::string& path, std::string* result) {
+  Descriptor fd(open(path.c_str(), O_RDONLY));
+  return ReadFileDescriptor(fd.get(), result);
+}
+
+bool ReadFileDescriptorToString(int fd, std::string* result) {
+  return ReadFileDescriptor(fd, result);
+}
+
+std::pair<uint8_t*, intptr_t> ReadFileToBytes(const std::string& path) {
+  std::pair<uint8_t*, intptr_t> failure_pair{nullptr, -1};
+  Descriptor fd(open(path.c_str(), O_RDONLY | BINARY_MODE));
+  if (!fd.is_valid())
+    return failure_pair;
+  return ReadFileDescriptorToBytes(fd.get());
+}
+
+}  // namespace filesystem

--- a/third_party/tonic/filesystem/filesystem/file.h
+++ b/third_party/tonic/filesystem/filesystem/file.h
@@ -1,0 +1,55 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FILESYSTEM_FILE_H_
+#define FILESYSTEM_FILE_H_
+
+#include <string>
+#include <vector>
+
+#include "filesystem/eintr_wrapper.h"
+#include "filesystem/portable_unistd.h"
+
+namespace filesystem {
+
+class Descriptor {
+ public:
+  using Handle = int;
+
+  Descriptor(Handle handle) : handle_(handle) {}
+
+  ~Descriptor() {
+    if (is_valid()) {
+      IGNORE_EINTR(::close(handle_));
+    }
+  }
+
+  bool is_valid() { return handle_ >= 0; }
+
+  Handle get() { return handle_; }
+
+ private:
+  Handle handle_ = -1;
+
+  Descriptor(Descriptor&) = delete;
+
+  void operator=(const Descriptor&) = delete;
+};
+
+// Reads the contents of the file at the given path or file descriptor and
+// stores the data in result. Returns true if the file was read successfully,
+// otherwise returns false. If this function returns false, |result| will be
+// the empty string.
+bool ReadFileToString(const std::string& path, std::string* result);
+bool ReadFileDescriptorToString(int fd, std::string* result);
+
+// Reads the contents of the file at the given path and if successful, returns
+// pair of read allocated bytes with data and size of the data if succesful.
+// pair of <nullptr, -1> if read failed.
+std::pair<uint8_t*, intptr_t> ReadFileToBytes(const std::string& path);
+std::pair<uint8_t*, intptr_t> ReadFileDescriptorToBytes(int fd);
+
+}  // namespace filesystem
+
+#endif  // FILESYSTEM_FILE_H_

--- a/third_party/tonic/filesystem/filesystem/path.h
+++ b/third_party/tonic/filesystem/filesystem/path.h
@@ -1,0 +1,33 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FILESYSTEM_PATH_H_
+#define FILESYSTEM_PATH_H_
+
+#include <string>
+
+namespace filesystem {
+
+// Resolves ".." and "." components of the path syntactically without consulting
+// the file system.
+std::string SimplifyPath(std::string path);
+
+// Returns the absolute path of a possibly relative path.
+// It doesn't consult the filesystem or simplify the path.
+std::string AbsolutePath(const std::string& path);
+
+// Returns the directory name component of the given path.
+std::string GetDirectoryName(const std::string& path);
+
+// Returns the basename component of the given path by stripping everything up
+// to and including the last slash.
+std::string GetBaseName(const std::string& path);
+
+// Returns the real path for the given path by unwinding symbolic links and
+// directory traversals.
+std::string GetAbsoluteFilePath(const std::string& path);
+
+}  // namespace filesystem
+
+#endif  // FILESYSTEM_PATH_H_

--- a/third_party/tonic/filesystem/filesystem/path_posix.cc
+++ b/third_party/tonic/filesystem/filesystem/path_posix.cc
@@ -1,0 +1,188 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filesystem/path.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <functional>
+#include <list>
+#include <memory>
+
+#include "filesystem/portable_unistd.h"
+#include "tonic/common/build_config.h"
+
+namespace filesystem {
+namespace {
+
+size_t ResolveParentDirectoryTraversal(const std::string& path, size_t put) {
+  if (put >= 2) {
+    size_t previous_separator = path.rfind('/', put - 2);
+    if (previous_separator != std::string::npos)
+      return previous_separator + 1;
+  }
+  if (put == 1 && path[0] == '/') {
+    return put;
+  }
+  return 0;
+}
+
+std::string GetCurrentDirectory() {
+  char buffer[PATH_MAX];
+  if (getcwd(buffer, sizeof(buffer)) == NULL) {
+    return {};
+  }
+  return std::string(buffer);
+}
+
+}  // namespace
+
+std::string SimplifyPath(std::string path) {
+  if (path.empty())
+    return ".";
+
+  size_t put = 0;
+  size_t get = 0;
+  size_t traversal_root = 0;
+  size_t component_start = 0;
+
+  if (path[0] == '/') {
+    put = 1;
+    get = 1;
+    component_start = 1;
+  }
+
+  while (get < path.size()) {
+    char c = path[get];
+
+    if (c == '.' && (get == component_start || get == component_start + 1)) {
+      // We've seen "." or ".." so far in this component. We need to continue
+      // searching.
+      ++get;
+      continue;
+    }
+
+    if (c == '/') {
+      if (get == component_start || get == component_start + 1) {
+        // We've found a "/" or a "./", which we can elide.
+        ++get;
+        component_start = get;
+        continue;
+      }
+      if (get == component_start + 2) {
+        // We've found a "../", which means we need to remove the previous
+        // component.
+        if (put == traversal_root) {
+          path[put++] = '.';
+          path[put++] = '.';
+          path[put++] = '/';
+          traversal_root = put;
+        } else {
+          put = ResolveParentDirectoryTraversal(path, put);
+        }
+        ++get;
+        component_start = get;
+        continue;
+      }
+    }
+
+    size_t next_separator = path.find('/', get);
+    if (next_separator == std::string::npos) {
+      // We've reached the last component.
+      break;
+    }
+    size_t next_component_start = next_separator + 1;
+    ++next_separator;
+    size_t component_size = next_component_start - component_start;
+    if (put != component_start && component_size > 0) {
+      path.replace(put, component_size,
+                   path.substr(component_start, component_size));
+    }
+    put += component_size;
+    get = next_component_start;
+    component_start = next_component_start;
+  }
+
+  size_t last_component_size = path.size() - component_start;
+  if (last_component_size == 1 && path[component_start] == '.') {
+    // The last component is ".", which we can elide.
+  } else if (last_component_size == 2 && path[component_start] == '.' &&
+             path[component_start + 1] == '.') {
+    // The last component is "..", which means we need to remove the previous
+    // component.
+    if (put == traversal_root) {
+      path[put++] = '.';
+      path[put++] = '.';
+      path[put++] = '/';
+      traversal_root = put;
+    } else {
+      put = ResolveParentDirectoryTraversal(path, put);
+    }
+  } else {
+    // Otherwise, we need to copy over the last component.
+    if (put != component_start && last_component_size > 0) {
+      path.replace(put, last_component_size,
+                   path.substr(component_start, last_component_size));
+    }
+    put += last_component_size;
+  }
+
+  if (put >= 2 && path[put - 1] == '/')
+    --put;  // Trim trailing /
+  else if (put == 0)
+    return ".";  // Use . for otherwise empty paths to treat them as relative.
+
+  path.resize(put);
+  return path;
+}
+
+std::string AbsolutePath(const std::string& path) {
+  if (path.size() > 0) {
+    if (path[0] == '/') {
+      // Path is already absolute.
+      return path;
+    }
+    return GetCurrentDirectory() + "/" + path;
+  } else {
+    // Path is empty.
+    return GetCurrentDirectory();
+  }
+}
+
+std::string GetDirectoryName(const std::string& path) {
+  size_t separator = path.rfind('/');
+  if (separator == 0u)
+    return "/";
+  if (separator == std::string::npos)
+    return std::string();
+  return path.substr(0, separator);
+}
+
+std::string GetBaseName(const std::string& path) {
+  size_t separator = path.rfind('/');
+  if (separator == std::string::npos)
+    return path;
+  return path.substr(separator + 1);
+}
+
+std::string GetAbsoluteFilePath(const std::string& path) {
+#if defined(OS_FUCHSIA)
+  // realpath() isn't supported by Fuchsia. See MG-425.
+  return SimplifyPath(AbsolutePath(path));
+#else
+  char buffer[PATH_MAX];
+  if (realpath(path.c_str(), buffer) == nullptr)
+    return std::string();
+  return buffer;
+#endif  // defined(OS_FUCHSIA)
+}
+
+}  // namespace filesystem

--- a/third_party/tonic/filesystem/filesystem/path_win.cc
+++ b/third_party/tonic/filesystem/filesystem/path_win.cc
@@ -1,0 +1,227 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filesystem/path.h"
+
+#include <windows.h>
+
+#include <direct.h>
+#include <errno.h>
+#include <shellapi.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <algorithm>
+#include <functional>
+#include <list>
+#include <memory>
+
+namespace filesystem {
+namespace {
+
+size_t RootLength(const std::string& path) {
+  if (path.size() == 0)
+    return 0;
+  if (path[0] == '/')
+    return 1;
+  if (path[0] == '\\') {
+    if (path.size() < 2 || path[1] != '\\')
+      return 1;
+    // The path is a network share. Search for up to two '\'s, as they are
+    // the server and share - and part of the root part.
+    size_t index = path.find('\\', 2);
+    if (index > 0) {
+      index = path.find('\\', index + 1);
+      if (index > 0)
+        return index;
+    }
+    return path.size();
+  }
+  // If the path is of the form 'C:/' or 'C:\', with C being any letter, it's
+  // a root part.
+  if (path.length() >= 2 && path[1] == ':' &&
+      (path[2] == '/' || path[2] == '\\') &&
+      ((path[0] >= 'A' && path[0] <= 'Z') ||
+       (path[0] >= 'a' && path[0] <= 'z'))) {
+    return 3;
+  }
+  return 0;
+}
+
+size_t IsSeparator(const char sep) {
+  return sep == '/' || sep == '\\';
+}
+
+size_t LastSeparator(const std::string& path) {
+  return path.find_last_of("/\\");
+}
+
+size_t LastSeparator(const std::string& path, size_t pos) {
+  return path.find_last_of("/\\", pos);
+}
+
+size_t FirstSeparator(const std::string& path, size_t pos) {
+  return path.find_first_of("/\\", pos);
+}
+
+size_t ResolveParentDirectoryTraversal(const std::string& path,
+                                       size_t put,
+                                       size_t root_length) {
+  if (put <= root_length) {
+    return root_length;
+  }
+  size_t previous_separator = LastSeparator(path, put - 2);
+  if (previous_separator != std::string::npos)
+    return previous_separator + 1;
+  return 0;
+}
+}  // namespace
+
+std::string SimplifyPath(std::string path) {
+  if (path.empty())
+    return ".";
+
+  size_t put = 0;
+  size_t get = 0;
+  size_t traversal_root = 0;
+  size_t component_start = 0;
+
+  size_t rootLength = RootLength(path);
+  if (rootLength > 0) {
+    put = rootLength;
+    get = rootLength;
+    component_start = rootLength;
+  }
+
+  while (get < path.size()) {
+    char c = path[get];
+
+    if (c == '.' && (get == component_start || get == component_start + 1)) {
+      // We've seen "." or ".." so far in this component. We need to continue
+      // searching.
+      ++get;
+      continue;
+    }
+
+    if (IsSeparator(c)) {
+      if (get == component_start || get == component_start + 1) {
+        // We've found a "/" or a "./", which we can elide.
+        ++get;
+        component_start = get;
+        continue;
+      }
+      if (get == component_start + 2) {
+        // We've found a "../", which means we need to remove the previous
+        // component.
+        if (put == traversal_root) {
+          path[put++] = '.';
+          path[put++] = '.';
+          path[put++] = '\\';
+          traversal_root = put;
+        } else {
+          put = ResolveParentDirectoryTraversal(path, put, rootLength);
+        }
+        ++get;
+        component_start = get;
+        continue;
+      }
+    }
+
+    size_t next_separator = FirstSeparator(path, get);
+    if (next_separator == std::string::npos) {
+      // We've reached the last component.
+      break;
+    }
+    size_t next_component_start = next_separator + 1;
+    ++next_separator;
+    size_t component_size = next_component_start - component_start;
+    if (put != component_start && component_size > 0) {
+      path.replace(put, component_size,
+                   path.substr(component_start, component_size));
+    }
+    put += component_size;
+    get = next_component_start;
+    component_start = next_component_start;
+  }
+
+  size_t last_component_size = path.size() - component_start;
+  if (last_component_size == 1 && path[component_start] == '.') {
+    // The last component is ".", which we can elide.
+  } else if (last_component_size == 2 && path[component_start] == '.' &&
+             path[component_start + 1] == '.') {
+    // The last component is "..", which means we need to remove the previous
+    // component.
+    if (put == traversal_root) {
+      path[put++] = '.';
+      path[put++] = '.';
+      path[put++] = '\\';
+      traversal_root = put;
+    } else {
+      put = ResolveParentDirectoryTraversal(path, put, rootLength);
+    }
+  } else {
+    // Otherwise, we need to copy over the last component.
+    if (put != component_start && last_component_size > 0) {
+      path.replace(put, last_component_size,
+                   path.substr(component_start, last_component_size));
+    }
+    put += last_component_size;
+  }
+
+  if (put >= 2 && IsSeparator(path[put - 1]))
+    --put;  // Trim trailing /
+  else if (put == 0)
+    return ".";  // Use . for otherwise empty paths to treat them as relative.
+
+  path.resize(put);
+  std::replace(path.begin(), path.end(), '/', '\\');
+  return path;
+}
+
+std::string AbsolutePath(const std::string& path) {
+  char absPath[MAX_PATH];
+  _fullpath(absPath, path.c_str(), MAX_PATH);
+  return std::string(absPath);
+}
+
+std::string GetDirectoryName(const std::string& path) {
+  size_t rootLength = RootLength(path);
+  size_t separator = LastSeparator(path);
+  if (separator < rootLength)
+    separator = rootLength;
+  if (separator == std::string::npos)
+    return std::string();
+  return path.substr(0, separator);
+}
+
+std::string GetBaseName(const std::string& path) {
+  size_t separator = LastSeparator(path);
+  if (separator == std::string::npos)
+    return path;
+  return path.substr(separator + 1);
+}
+
+std::string GetAbsoluteFilePath(const std::string& path) {
+  HANDLE file =
+      CreateFileA(path.c_str(), FILE_READ_ATTRIBUTES,
+                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
+                  OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+  if (file == INVALID_HANDLE_VALUE) {
+    return std::string();
+  }
+  char buffer[MAX_PATH];
+  DWORD ret =
+      GetFinalPathNameByHandleA(file, buffer, MAX_PATH, FILE_NAME_NORMALIZED);
+  if (ret == 0 || ret > MAX_PATH) {
+    CloseHandle(file);
+    return std::string();
+  }
+  std::string result(buffer);
+  result.erase(0, strlen("\\\\?\\"));
+  CloseHandle(file);
+  return result;
+}
+
+}  // namespace filesystem

--- a/third_party/tonic/filesystem/filesystem/portable_unistd.h
+++ b/third_party/tonic/filesystem/filesystem/portable_unistd.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FILESYSTEM_PORTABLE_UNISTD_H_
+#define FILESYSTEM_PORTABLE_UNISTD_H_
+
+#include "tonic/common/build_config.h"
+
+#if defined(OS_WIN)
+#include <direct.h>
+#include <io.h>
+#include <stdlib.h>
+
+#define STDERR_FILENO _fileno(stderr)
+#define PATH_MAX _MAX_PATH
+
+#define S_ISDIR(m) (((m)&S_IFMT) == S_IFDIR)
+#define S_ISREG(m) (((m)&S_IFMT) == S_IFREG)
+#define R_OK 4
+
+#define mkdir(path, mode) _mkdir(path)
+
+#else
+#include <unistd.h>
+#endif
+
+#endif  // FILESYSTEM_PORTABLE_UNISTD_H_

--- a/third_party/tonic/filesystem/tests/BUILD.gn
+++ b/third_party/tonic/filesystem/tests/BUILD.gn
@@ -1,0 +1,20 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+executable("files_unittests") {
+  testonly = true
+
+  sources = [
+    "directory_unittest.cc",
+    "file_descriptor_unittest.cc",
+    "file_unittest.cc",
+    "files_unittest_main.cc",
+    "path_unittest.cc",
+    "scoped_temp_dir_unittest.cc",
+  ]
+
+  deps = [
+    ":../:filesystem",
+  ]
+}

--- a/third_party/tonic/filesystem/tests/directory_unittest.cc
+++ b/third_party/tonic/filesystem/tests/directory_unittest.cc
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filesystem/directory.h"
+#include "filesystem/path.h"
+#include "filesystem/scoped_temp_dir.h"
+#include "gtest/gtest.h"
+
+namespace filesystem {
+
+TEST(Directory, CreateDirectory) {
+  std::string cwd = GetCurrentDirectory();
+
+  ScopedTempDir dir;
+  EXPECT_TRUE(IsDirectory(dir.path()));
+  EXPECT_EQ(0, chdir(dir.path().c_str()));
+
+  EXPECT_TRUE(CreateDirectory("foo/bar"));
+  EXPECT_TRUE(IsDirectory("foo"));
+  EXPECT_TRUE(IsDirectory("foo/bar"));
+  EXPECT_FALSE(IsDirectory("foo/bar/baz"));
+
+  EXPECT_TRUE(CreateDirectory("foo/bar/baz"));
+  EXPECT_TRUE(IsDirectory("foo/bar/baz"));
+
+  EXPECT_TRUE(CreateDirectory("qux"));
+  EXPECT_TRUE(IsDirectory("qux"));
+
+  EXPECT_EQ(0, chdir(cwd.c_str()));
+
+  std::string abs_path = dir.path() + "/another/one";
+  EXPECT_TRUE(CreateDirectory(abs_path));
+  EXPECT_TRUE(IsDirectory(abs_path));
+}
+
+}  // namespace filesystem

--- a/third_party/tonic/filesystem/tests/file_descriptor_unittest.cc
+++ b/third_party/tonic/filesystem/tests/file_descriptor_unittest.cc
@@ -1,0 +1,36 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <fcntl.h>
+#include <sys/types.h>
+
+#include <string>
+#include <vector>
+
+#include "filesystem/scoped_temp_dir.h"
+#include "filesystem/unique_fd.h"
+#include "gtest/gtest.h"
+
+namespace filesystem {
+
+TEST(FileDescriptor, WriteAndRead) {
+  files::ScopedTempDir temp_dir;
+  std::string path;
+  ASSERT_TRUE(temp_dir.NewTempFile(&path));
+
+  fxl::UniqueFD fd(open(path.c_str(), O_RDWR));
+  ASSERT_TRUE(fd.is_valid());
+
+  std::string string = "one, two, three";
+  EXPECT_TRUE(WriteFileDescriptor(fd.get(), string.data(), string.size()));
+  EXPECT_EQ(0, lseek(fd.get(), 0, SEEK_SET));
+
+  std::vector<char> buffer;
+  buffer.resize(1024);
+  ssize_t read = ReadFileDescriptor(fd.get(), buffer.data(), 1024);
+  EXPECT_EQ(static_cast<ssize_t>(string.size()), read);
+  EXPECT_EQ(string, buffer.data());
+}
+
+}  // namespace filesystem

--- a/third_party/tonic/filesystem/tests/file_unittest.cc
+++ b/third_party/tonic/filesystem/tests/file_unittest.cc
@@ -1,0 +1,57 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filesystem/file.h"
+
+#include <fcntl.h>
+
+#include "filesystem/path.h"
+#include "filesystem/scoped_temp_dir.h"
+#include "gtest/gtest.h"
+
+namespace filesystem {
+namespace {
+
+TEST(File, GetFileSize) {
+  ScopedTempDir dir;
+  std::string path;
+
+  ASSERT_TRUE(dir.NewTempFile(&path));
+
+  uint64_t size;
+  EXPECT_TRUE(GetFileSize(path, &size));
+  EXPECT_EQ(0u, size);
+
+  std::string content = "Hello World";
+  ASSERT_TRUE(WriteFile(path, content.data(), content.size()));
+  EXPECT_TRUE(GetFileSize(path, &size));
+  EXPECT_EQ(content.size(), size);
+}
+
+TEST(File, WriteFileInTwoPhases) {
+  ScopedTempDir dir;
+  std::string path = dir.path() + "/destination";
+
+  std::string content = "Hello World";
+  ASSERT_TRUE(WriteFileInTwoPhases(path, content, dir.path()));
+  std::string read_content;
+  ASSERT_TRUE(ReadFileToString(path, &read_content));
+  EXPECT_EQ(read_content, content);
+}
+
+#if defined(OS_LINUX) || defined(OS_FUCHSIA)
+TEST(File, IsFileAt) {
+  ScopedTempDir dir;
+  std::string path;
+
+  ASSERT_TRUE(dir.NewTempFile(&path));
+
+  fxl::UniqueFD dirfd(open(dir.path().c_str(), O_RDONLY));
+  ASSERT_TRUE(dirfd.get() != -1);
+  EXPECT_TRUE(IsFileAt(dirfd.get(), GetBaseName(path)));
+}
+#endif
+
+}  // namespace
+}  // namespace filesystem

--- a/third_party/tonic/filesystem/tests/files_unittest_main.cc
+++ b/third_party/tonic/filesystem/tests/files_unittest_main.cc
@@ -1,0 +1,5 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "gtest/gtest.h"

--- a/third_party/tonic/filesystem/tests/path_unittest.cc
+++ b/third_party/tonic/filesystem/tests/path_unittest.cc
@@ -1,0 +1,234 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filesystem/path.h"
+#include "filesystem/directory.h"
+#include "filesystem/scoped_temp_dir.h"
+#include "gtest/gtest.h"
+#include "tonic/common/build_config.h"
+
+namespace filesystem {
+
+void ExpectPlatformPath(std::string expected, std::string actual) {
+#if defined(OS_WIN)
+  std::replace(expected.begin(), expected.end(), '/', '\\');
+#endif
+  EXPECT_EQ(expected, actual);
+}
+
+TEST(Path, SimplifyPath) {
+  ExpectPlatformPath(".", SimplifyPath(""));
+  ExpectPlatformPath(".", SimplifyPath("."));
+  ExpectPlatformPath("..", SimplifyPath(".."));
+  ExpectPlatformPath("...", SimplifyPath("..."));
+
+  ExpectPlatformPath("/", SimplifyPath("/"));
+  ExpectPlatformPath("/", SimplifyPath("/."));
+  ExpectPlatformPath("/", SimplifyPath("/.."));
+  ExpectPlatformPath("/...", SimplifyPath("/..."));
+
+  ExpectPlatformPath("foo", SimplifyPath("foo"));
+  ExpectPlatformPath("foo", SimplifyPath("foo/"));
+  ExpectPlatformPath("foo", SimplifyPath("foo/."));
+  ExpectPlatformPath("foo", SimplifyPath("foo/./"));
+  ExpectPlatformPath(".", SimplifyPath("foo/.."));
+  ExpectPlatformPath(".", SimplifyPath("foo/../"));
+  ExpectPlatformPath("foo/...", SimplifyPath("foo/..."));
+  ExpectPlatformPath("foo/...", SimplifyPath("foo/.../"));
+  ExpectPlatformPath("foo/.b", SimplifyPath("foo/.b"));
+  ExpectPlatformPath("foo/.b", SimplifyPath("foo/.b/"));
+
+  ExpectPlatformPath("/foo", SimplifyPath("/foo"));
+  ExpectPlatformPath("/foo", SimplifyPath("/foo/"));
+  ExpectPlatformPath("/foo", SimplifyPath("/foo/."));
+  ExpectPlatformPath("/foo", SimplifyPath("/foo/./"));
+  ExpectPlatformPath("/", SimplifyPath("/foo/.."));
+  ExpectPlatformPath("/", SimplifyPath("/foo/../"));
+  ExpectPlatformPath("/foo/...", SimplifyPath("/foo/..."));
+  ExpectPlatformPath("/foo/...", SimplifyPath("/foo/.../"));
+  ExpectPlatformPath("/foo/.b", SimplifyPath("/foo/.b"));
+  ExpectPlatformPath("/foo/.b", SimplifyPath("/foo/.b/"));
+
+  ExpectPlatformPath("foo/bar", SimplifyPath("foo/bar"));
+  ExpectPlatformPath("foo/bar", SimplifyPath("foo/bar/"));
+  ExpectPlatformPath("foo/bar", SimplifyPath("foo/./bar"));
+  ExpectPlatformPath("foo/bar", SimplifyPath("foo/./bar/"));
+  ExpectPlatformPath("bar", SimplifyPath("foo/../bar"));
+  ExpectPlatformPath("bar", SimplifyPath("foo/baz/../../bar"));
+  ExpectPlatformPath("bar", SimplifyPath("foo/../bar/"));
+  ExpectPlatformPath("foo/.../bar", SimplifyPath("foo/.../bar"));
+  ExpectPlatformPath("foo/.../bar", SimplifyPath("foo/.../bar/"));
+  ExpectPlatformPath("foo/.b/bar", SimplifyPath("foo/.b/bar"));
+  ExpectPlatformPath("foo/.b/bar", SimplifyPath("foo/.b/bar/"));
+
+  ExpectPlatformPath("/foo/bar", SimplifyPath("/foo/bar"));
+  ExpectPlatformPath("/foo/bar", SimplifyPath("/foo/bar/"));
+  ExpectPlatformPath("/foo/bar", SimplifyPath("/foo/./bar"));
+  ExpectPlatformPath("/foo/bar", SimplifyPath("/foo/./bar/"));
+  ExpectPlatformPath("/bar", SimplifyPath("/foo/../bar"));
+  ExpectPlatformPath("/bar", SimplifyPath("/foo/../bar/"));
+  ExpectPlatformPath("/foo/.../bar", SimplifyPath("/foo/.../bar"));
+  ExpectPlatformPath("/foo/.../bar", SimplifyPath("/foo/.../bar/"));
+  ExpectPlatformPath("/foo/.b/bar", SimplifyPath("/foo/.b/bar"));
+  ExpectPlatformPath("/foo/.b/bar", SimplifyPath("/foo/.b/bar/"));
+
+  ExpectPlatformPath("../foo", SimplifyPath("../foo"));
+  ExpectPlatformPath("../../bar", SimplifyPath("../foo/../../bar"));
+  ExpectPlatformPath("/bar", SimplifyPath("/foo/../../bar"));
+
+  // Already clean
+  ExpectPlatformPath(".", SimplifyPath(""));
+  ExpectPlatformPath("abc", SimplifyPath("abc"));
+  ExpectPlatformPath("abc/def", SimplifyPath("abc/def"));
+  ExpectPlatformPath("a/b/c", SimplifyPath("a/b/c"));
+  ExpectPlatformPath(".", SimplifyPath("."));
+  ExpectPlatformPath("..", SimplifyPath(".."));
+  ExpectPlatformPath("../..", SimplifyPath("../.."));
+  ExpectPlatformPath("../../abc", SimplifyPath("../../abc"));
+  ExpectPlatformPath("/abc", SimplifyPath("/abc"));
+  ExpectPlatformPath("/", SimplifyPath("/"));
+
+  // Remove trailing slash
+  ExpectPlatformPath("abc", SimplifyPath("abc/"));
+  ExpectPlatformPath("abc/def", SimplifyPath("abc/def/"));
+  ExpectPlatformPath("a/b/c", SimplifyPath("a/b/c/"));
+  ExpectPlatformPath(".", SimplifyPath("./"));
+  ExpectPlatformPath("..", SimplifyPath("../"));
+  ExpectPlatformPath("../..", SimplifyPath("../../"));
+  ExpectPlatformPath("/abc", SimplifyPath("/abc/"));
+
+  // Remove doubled slash
+  ExpectPlatformPath("abc/def/ghi", SimplifyPath("abc//def//ghi"));
+  ExpectPlatformPath("/abc", SimplifyPath("//abc"));
+  ExpectPlatformPath("/abc", SimplifyPath("///abc"));
+  ExpectPlatformPath("/abc", SimplifyPath("//abc//"));
+  ExpectPlatformPath("abc", SimplifyPath("abc//"));
+
+  // Remove . elements
+  ExpectPlatformPath("abc/def", SimplifyPath("abc/./def"));
+  ExpectPlatformPath("/abc/def", SimplifyPath("/./abc/def"));
+  ExpectPlatformPath("abc", SimplifyPath("abc/."));
+
+  // Remove .. elements
+  ExpectPlatformPath("abc/def/jkl", SimplifyPath("abc/def/ghi/../jkl"));
+  ExpectPlatformPath("abc/jkl", SimplifyPath("abc/def/../ghi/../jkl"));
+  ExpectPlatformPath("abc", SimplifyPath("abc/def/.."));
+  ExpectPlatformPath(".", SimplifyPath("abc/def/../.."));
+  ExpectPlatformPath("/", SimplifyPath("/abc/def/../.."));
+  ExpectPlatformPath("..", SimplifyPath("abc/def/../../.."));
+  ExpectPlatformPath("/", SimplifyPath("/abc/def/../../.."));
+  ExpectPlatformPath("../../mno",
+                     SimplifyPath("abc/def/../../../ghi/jkl/../../../mno"));
+  ExpectPlatformPath("/mno", SimplifyPath("/../mno"));
+
+  // Combinations
+  ExpectPlatformPath("def", SimplifyPath("abc/./../def"));
+  ExpectPlatformPath("def", SimplifyPath("abc//./../def"));
+  ExpectPlatformPath("../../def", SimplifyPath("abc/../../././../def"));
+
+#if defined(OS_WIN)
+  ExpectPlatformPath("a\\c", SimplifyPath("a\\b\\..\\c"));
+  ExpectPlatformPath("X:\\a\\c", SimplifyPath("X:/a/b/../c"));
+  ExpectPlatformPath("X:\\a\\b\\c", SimplifyPath("X:/a/b/./c"));
+  ExpectPlatformPath("X:\\c", SimplifyPath("X:/../../c"));
+#endif
+}
+
+TEST(Path, AbsolutePath) {
+#if defined(OS_WIN)
+  // We cut out the drive letter as it can be different on every system.
+  EXPECT_EQ(":\\foo\\bar", AbsolutePath("\\foo\\bar").substr(1));
+  EXPECT_EQ(":\\foo\\bar", AbsolutePath("/foo/bar").substr(1));
+  EXPECT_EQ(":\\foo\\bar\\", AbsolutePath("\\foo\\bar\\").substr(1));
+  EXPECT_EQ(":\\foo\\bar\\", AbsolutePath("/foo/bar/").substr(1));
+  EXPECT_EQ("C:\\foo\\bar\\", AbsolutePath("C:\\foo\\bar\\"));
+  EXPECT_EQ(GetCurrentDirectory() + "\\foo", AbsolutePath("foo"));
+#else
+  EXPECT_EQ("/foo/bar", AbsolutePath("/foo/bar"));
+  EXPECT_EQ("/foo/bar/", AbsolutePath("/foo/bar/"));
+  EXPECT_EQ(GetCurrentDirectory() + "/foo", AbsolutePath("foo"));
+#endif
+  EXPECT_EQ(GetCurrentDirectory(), AbsolutePath(""));
+}
+
+TEST(Path, GetDirectoryName) {
+  EXPECT_EQ("foo", GetDirectoryName("foo/"));
+  EXPECT_EQ("foo/bar", GetDirectoryName("foo/bar/"));
+  EXPECT_EQ("foo", GetDirectoryName("foo/bar"));
+  EXPECT_EQ("foo/bar", GetDirectoryName("foo/bar/.."));
+  EXPECT_EQ("foo/bar/..", GetDirectoryName("foo/bar/../.."));
+  EXPECT_EQ("", GetDirectoryName("foo"));
+  EXPECT_EQ("/", GetDirectoryName("/"));
+  EXPECT_EQ("", GetDirectoryName("a"));
+  EXPECT_EQ("/", GetDirectoryName("/a"));
+  EXPECT_EQ("/a", GetDirectoryName("/a/"));
+  EXPECT_EQ("a", GetDirectoryName("a/"));
+#if defined(OS_WIN)
+  EXPECT_EQ("C:\\", GetDirectoryName("C:\\"));
+  EXPECT_EQ("C:\\foo", GetDirectoryName("C:\\foo\\"));
+  EXPECT_EQ("C:\\foo", GetDirectoryName("C:\\foo\\bar"));
+  EXPECT_EQ("foo\\bar", GetDirectoryName("foo\\bar\\"));
+  EXPECT_EQ("foo", GetDirectoryName("foo\\bar"));
+  EXPECT_EQ("\\", GetDirectoryName("\\"));
+  EXPECT_EQ("\\", GetDirectoryName("\\a"));
+#endif
+}
+
+TEST(Path, GetBaseName) {
+  EXPECT_EQ("", GetBaseName("foo/"));
+  EXPECT_EQ("", GetBaseName("foo/bar/"));
+  EXPECT_EQ("bar", GetBaseName("foo/bar"));
+  EXPECT_EQ("..", GetBaseName("foo/bar/.."));
+  EXPECT_EQ("..", GetBaseName("foo/bar/../.."));
+  EXPECT_EQ("foo", GetBaseName("foo"));
+  EXPECT_EQ("", GetBaseName("/"));
+  EXPECT_EQ("a", GetBaseName("a"));
+  EXPECT_EQ("a", GetBaseName("/a"));
+  EXPECT_EQ("", GetBaseName("/a/"));
+  EXPECT_EQ("", GetBaseName("a/"));
+#if defined(OS_WIN)
+  EXPECT_EQ("", GetBaseName("C:\\"));
+  EXPECT_EQ("", GetBaseName("C:\\foo\\"));
+  EXPECT_EQ("bar", GetBaseName("C:\\foo\\bar"));
+  EXPECT_EQ("", GetBaseName("foo\\bar\\"));
+  EXPECT_EQ("bar", GetBaseName("foo\\bar"));
+  EXPECT_EQ("", GetBaseName("\\"));
+  EXPECT_EQ("a", GetBaseName("\\a"));
+#endif
+}
+
+TEST(Path, DeletePath) {
+  ScopedTempDir dir;
+
+  std::string sub_dir = dir.path() + "/dir";
+  CreateDirectory(sub_dir);
+  EXPECT_TRUE(IsDirectory(sub_dir));
+  EXPECT_TRUE(DeletePath(sub_dir, false));
+  EXPECT_FALSE(IsDirectory(sub_dir));
+}
+
+TEST(Path, DeletePathRecursively) {
+  ScopedTempDir dir;
+
+  std::string sub_dir = dir.path() + "/dir";
+  CreateDirectory(sub_dir);
+  EXPECT_TRUE(IsDirectory(sub_dir));
+
+  std::string sub_sub_dir1 = sub_dir + "/dir1";
+  CreateDirectory(sub_sub_dir1);
+  EXPECT_TRUE(IsDirectory(sub_sub_dir1));
+  std::string sub_sub_dir2 = sub_dir + "/dir2";
+  CreateDirectory(sub_sub_dir2);
+  EXPECT_TRUE(IsDirectory(sub_sub_dir2));
+
+  EXPECT_FALSE(DeletePath(sub_dir, false));
+  EXPECT_TRUE(IsDirectory(sub_dir));
+  EXPECT_TRUE(IsDirectory(sub_sub_dir1));
+
+  EXPECT_TRUE(DeletePath(sub_dir, true));
+  EXPECT_FALSE(IsDirectory(sub_dir));
+  EXPECT_FALSE(IsDirectory(sub_sub_dir1));
+}
+
+}  // namespace filesystem

--- a/third_party/tonic/filesystem/tests/scoped_temp_dir_unittest.cc
+++ b/third_party/tonic/filesystem/tests/scoped_temp_dir_unittest.cc
@@ -1,0 +1,56 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "filesystem/scoped_temp_dir.h"
+#include "filesystem/directory.h"
+#include "filesystem/path.h"
+#include "gtest/gtest.h"
+
+namespace filesystem {
+
+TEST(ScopedTempDir, Creation) {
+  ScopedTempDir dir;
+
+  EXPECT_TRUE(IsDirectory(dir.path()));
+}
+
+TEST(ScopedTempDir, Deletion) {
+  std::string path;
+  {
+    ScopedTempDir dir;
+    path = dir.path();
+  }
+
+  EXPECT_FALSE(IsDirectory(path));
+}
+
+TEST(ScopedTempDir, NewTempFile) {
+  ScopedTempDir dir;
+  std::string path;
+  EXPECT_TRUE(dir.NewTempFile(&path));
+  EXPECT_FALSE(path.empty());
+}
+
+TEST(ScopedTempDir, CustomParent) {
+  ScopedTempDir root_dir;
+  std::string parent = root_dir.path() + "/a/b/c";
+  std::string path;
+  {
+    ScopedTempDir dir(parent);
+    path = dir.path();
+    EXPECT_TRUE(IsDirectory(path));
+    EXPECT_EQ(path.substr(0, parent.size()), parent);
+    EXPECT_NE("temp_dir_XXXXXX", GetBaseName(path));
+
+    // Regression test - don't create temp_dir_XXXXXX dir next to the temp one.
+    EXPECT_FALSE(
+        files::IsDirectory(GetDirectoryName(path) + "/temp_dir_XXXXXX"));
+  }
+
+  // Verify that the tmp directory itself was deleted, but not the parent.
+  EXPECT_FALSE(IsDirectory(path));
+  EXPECT_TRUE(IsDirectory(parent));
+}
+
+}  // namespace filesystem

--- a/third_party/tonic/logging/BUILD.gn
+++ b/third_party/tonic/logging/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("logging") {
+  visibility = [ "../*" ]
+
+  configs += [ "../:config" ]
+
+  sources = [
+    "dart_error.cc",
+    "dart_error.h",
+    "dart_invoke.cc",
+    "dart_invoke.h",
+  ]
+
+  deps = [
+    "../common",
+  ]
+
+  public_deps = [
+    "//third_party/dart/runtime:dart_api",
+  ]
+}

--- a/third_party/tonic/logging/dart_error.cc
+++ b/third_party/tonic/logging/dart_error.cc
@@ -1,0 +1,46 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/logging/dart_error.h"
+
+#include "tonic/common/macros.h"
+
+namespace tonic {
+namespace DartError {
+const char kInvalidArgument[] = "Invalid argument.";
+}  // namespace DartError
+
+bool LogIfError(Dart_Handle handle) {
+  if (Dart_IsError(handle)) {
+    tonic::Log("Dart Error: %s", Dart_GetError(handle));
+    return true;
+  }
+  return false;
+}
+
+DartErrorHandleType GetErrorHandleType(Dart_Handle handle) {
+  if (Dart_IsCompilationError(handle)) {
+    return kCompilationErrorType;
+  } else if (Dart_IsApiError(handle)) {
+    return kApiErrorType;
+  } else if (Dart_IsError(handle)) {
+    return kUnknownErrorType;
+  } else {
+    return kNoError;
+  }
+}
+
+int GetErrorExitCode(Dart_Handle handle) {
+  if (Dart_IsCompilationError(handle)) {
+    return 254;  // dart::bin::kCompilationErrorExitCode
+  } else if (Dart_IsApiError(handle)) {
+    return 253;  // dart::bin::kApiErrorExitCode
+  } else if (Dart_IsError(handle)) {
+    return 255;  // dart::bin::kErrorExitCode
+  } else {
+    return 0;
+  }
+}
+
+}  // namespace tonic

--- a/third_party/tonic/logging/dart_error.h
+++ b/third_party/tonic/logging/dart_error.h
@@ -1,0 +1,31 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_LOGGING_DART_ERROR_H_
+#define LIB_TONIC_LOGGING_DART_ERROR_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+
+namespace tonic {
+
+namespace DartError {
+extern const char kInvalidArgument[];
+}  // namespace DartError
+
+bool LogIfError(Dart_Handle handle);
+
+enum DartErrorHandleType {
+  kNoError,
+  kUnknownErrorType,
+  kApiErrorType,
+  kCompilationErrorType,
+};
+
+DartErrorHandleType GetErrorHandleType(Dart_Handle handle);
+
+int GetErrorExitCode(Dart_Handle handle);
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_DART_ERROR_H_

--- a/third_party/tonic/logging/dart_invoke.cc
+++ b/third_party/tonic/logging/dart_invoke.cc
@@ -1,0 +1,35 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/logging/dart_invoke.h"
+
+#include "tonic/common/macros.h"
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+Dart_Handle DartInvokeField(Dart_Handle target,
+                            const char* name,
+                            std::initializer_list<Dart_Handle> args) {
+  Dart_Handle field = Dart_NewStringFromCString(name);
+  return Dart_Invoke(target, field, args.size(),
+                     const_cast<Dart_Handle*>(args.begin()));
+}
+
+Dart_Handle DartInvoke(Dart_Handle closure,
+                       std::initializer_list<Dart_Handle> args) {
+  int argc = args.size();
+  Dart_Handle* argv = const_cast<Dart_Handle*>(args.begin());
+  Dart_Handle handle = Dart_InvokeClosure(closure, argc, argv);
+  LogIfError(handle);
+  return handle;
+}
+
+Dart_Handle DartInvokeVoid(Dart_Handle closure) {
+  Dart_Handle handle = Dart_InvokeClosure(closure, 0, nullptr);
+  LogIfError(handle);
+  return handle;
+}
+
+}  // namespace tonic

--- a/third_party/tonic/logging/dart_invoke.h
+++ b/third_party/tonic/logging/dart_invoke.h
@@ -1,0 +1,24 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_LOGGING_DART_INVOKE_H_
+#define LIB_TONIC_LOGGING_DART_INVOKE_H_
+
+#include <initializer_list>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+
+namespace tonic {
+
+Dart_Handle DartInvokeField(Dart_Handle target,
+                            const char* name,
+                            std::initializer_list<Dart_Handle> args);
+
+Dart_Handle DartInvoke(Dart_Handle closure,
+                       std::initializer_list<Dart_Handle> args);
+Dart_Handle DartInvokeVoid(Dart_Handle closure);
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_LOGGING_DART_INVOKE_H_

--- a/third_party/tonic/parsers/BUILD.gn
+++ b/third_party/tonic/parsers/BUILD.gn
@@ -1,0 +1,18 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("parsers") {
+  visibility = [ "../*" ]
+
+  configs += [ "../:config" ]
+
+  deps = [
+    "../common",
+  ]
+
+  sources = [
+    "packages_map.cc",
+    "packages_map.h",
+  ]
+}

--- a/third_party/tonic/parsers/packages_map.cc
+++ b/third_party/tonic/parsers/packages_map.cc
@@ -1,0 +1,87 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Spec: https://github.com/lrhn/dep-pkgspec/blob/master/DEP-pkgspec.md
+
+#include "tonic/parsers/packages_map.h"
+
+#include <memory>
+
+namespace tonic {
+namespace {
+
+bool isLineBreak(char c) {
+  return c == '\r' || c == '\n';
+}
+
+}  // namespace
+
+PackagesMap::PackagesMap() {}
+
+PackagesMap::~PackagesMap() {}
+
+bool PackagesMap::Parse(const std::string& source, std::string* error) {
+  map_.clear();
+  const auto end = source.end();
+  for (auto it = source.begin(); it != end; ++it) {
+    const char c = *it;
+
+    // Skip blank lines.
+    if (isLineBreak(c))
+      continue;
+
+    // Skip comments.
+    if (c == '#') {
+      while (it != end && !isLineBreak(*it))
+        ++it;
+      continue;
+    }
+
+    if (c == ':') {
+      map_.clear();
+      *error = "Packages file contains a line that begins with ':'.";
+      return false;
+    }
+
+    auto package_name_begin = it;
+    auto package_name_end = end;
+    bool found_separator = false;
+    for (; it != end; ++it) {
+      const char c = *it;
+      if (c == ':' && !found_separator) {
+        found_separator = true;
+        package_name_end = it;
+        continue;
+      }
+      if (isLineBreak(c))
+        break;
+    }
+
+    if (!found_separator) {
+      map_.clear();
+      *error = "Packages file contains non-comment line that lacks a ':'.";
+      return false;
+    }
+
+    std::string package_name(package_name_begin, package_name_end);
+    std::string package_path(package_name_end + 1, it);
+
+    auto result = map_.emplace(package_name, package_path);
+    if (!result.second) {
+      map_.clear();
+      *error =
+          std::string("Packages file contains multiple entries for package '") +
+          package_name + "'.";
+      return false;
+    }
+  }
+
+  return true;
+}
+
+std::string PackagesMap::Resolve(const std::string& package_name) {
+  return map_[package_name];
+}
+
+}  // namespace tonic

--- a/third_party/tonic/parsers/packages_map.h
+++ b/third_party/tonic/parsers/packages_map.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_PARSERS_PACKAGES_MAP_H_
+#define LIB_TONIC_PARSERS_PACKAGES_MAP_H_
+
+#include <string>
+#include <unordered_map>
+
+namespace tonic {
+
+class PackagesMap {
+ public:
+  PackagesMap();
+  ~PackagesMap();
+
+  bool Parse(const std::string& source, std::string* error);
+  std::string Resolve(const std::string& package_name);
+
+ private:
+  std::unordered_map<std::string, std::string> map_;
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_PARSERS_PACKAGES_MAP_H_

--- a/third_party/tonic/platform/BUILD.gn
+++ b/third_party/tonic/platform/BUILD.gn
@@ -1,0 +1,25 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("platform") {
+  visibility = [ "../*" ]
+
+  configs += [ "../:config" ]
+
+  if (is_win) {
+    set_sources_assignment_filter([ "*_posix.cc" ])
+  } else {
+    set_sources_assignment_filter([ "*_win.cc" ])
+  }
+
+  deps = [
+    "../common",
+  ]
+
+  sources = [
+    "platform_utils.h",
+    "platform_utils_posix.cc",
+    "platform_utils_win.cc",
+  ]
+}

--- a/third_party/tonic/platform/platform_utils.h
+++ b/third_party/tonic/platform/platform_utils.h
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_PLATFORM_UTILS_H_
+#define LIB_TONIC_PLATFORM_UTILS_H_
+
+namespace tonic {
+
+// Calls the equivalent of exit(status) for a given platform.
+void PlatformExit(int status);
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_PLATFORM_UTILS_H_

--- a/third_party/tonic/platform/platform_utils_posix.cc
+++ b/third_party/tonic/platform/platform_utils_posix.cc
@@ -1,0 +1,14 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <cstdlib>
+#include "platform_utils.h"
+
+namespace tonic {
+
+void PlatformExit(int status) {
+  exit(status);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/platform/platform_utils_win.cc
+++ b/third_party/tonic/platform/platform_utils_win.cc
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "platform_utils.h"
+
+#include <windows.h>
+
+namespace tonic {
+
+void PlatformExit(int status) {
+  ::ExitProcess(status);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/scopes/BUILD.gn
+++ b/third_party/tonic/scopes/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("scopes") {
+  visibility = [ "../*" ]
+
+  configs += [ "../:config" ]
+
+  sources = [
+    "dart_api_scope.h",
+    "dart_isolate_scope.cc",
+    "dart_isolate_scope.h",
+  ]
+
+  deps = [
+    "../common",
+  ]
+
+  public_deps = [
+    "//third_party/dart/runtime:dart_api",
+  ]
+}

--- a/third_party/tonic/scopes/dart_api_scope.h
+++ b/third_party/tonic/scopes/dart_api_scope.h
@@ -1,0 +1,27 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_SCOPES_DART_API_SCOPE_H_
+#define LIB_TONIC_SCOPES_DART_API_SCOPE_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+
+namespace tonic {
+
+class DartApiScope {
+ public:
+  DartApiScope() { Dart_EnterScope(); }
+  ~DartApiScope() {
+    if (Dart_CurrentIsolate())
+      Dart_ExitScope();
+  }
+
+ private:
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartApiScope);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_SCOPES_DART_API_SCOPE_H_

--- a/third_party/tonic/scopes/dart_isolate_scope.cc
+++ b/third_party/tonic/scopes/dart_isolate_scope.cc
@@ -1,0 +1,30 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/scopes/dart_isolate_scope.h"
+
+namespace tonic {
+
+DartIsolateScope::DartIsolateScope(Dart_Isolate isolate) {
+  isolate_ = isolate;
+  previous_ = Dart_CurrentIsolate();
+  if (previous_ == isolate_)
+    return;
+  if (previous_)
+    Dart_ExitIsolate();
+  Dart_EnterIsolate(isolate_);
+}
+
+DartIsolateScope::~DartIsolateScope() {
+  Dart_Isolate current = Dart_CurrentIsolate();
+  TONIC_DCHECK(!current || current == isolate_);
+  if (previous_ == isolate_)
+    return;
+  if (current)
+    Dart_ExitIsolate();
+  if (previous_)
+    Dart_EnterIsolate(previous_);
+}
+
+}  // namespace tonic

--- a/third_party/tonic/scopes/dart_isolate_scope.h
+++ b/third_party/tonic/scopes/dart_isolate_scope.h
@@ -1,0 +1,28 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_SCOPES_DART_ISOLATE_SCOPE_H_
+#define LIB_TONIC_SCOPES_DART_ISOLATE_SCOPE_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/common/macros.h"
+
+namespace tonic {
+
+// DartIsolateScope is a helper class for entering and exiting a given isolate.
+class DartIsolateScope {
+ public:
+  explicit DartIsolateScope(Dart_Isolate isolate);
+  ~DartIsolateScope();
+
+ private:
+  Dart_Isolate isolate_;
+  Dart_Isolate previous_;
+
+  TONIC_DISALLOW_COPY_AND_ASSIGN(DartIsolateScope);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_SCOPES_DART_ISOLATE_SCOPE_H_

--- a/third_party/tonic/typed_data/BUILD.gn
+++ b/third_party/tonic/typed_data/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source_set("typed_data") {
+  visibility = [ "../*" ]
+
+  configs += [ "../:config" ]
+
+  sources = [
+    "dart_byte_data.cc",
+    "dart_byte_data.h",
+    "typed_list.cc",
+    "typed_list.h",
+
+    # Deprecated.
+    "float32_list.h",
+    "float64_list.h",
+    "int32_list.h",
+    "uint16_list.h",
+    "uint8_list.h",
+  ]
+
+  deps = [
+    "../common",
+  ]
+
+  public_deps = [
+    "../converter",
+    "../logging",
+    "//third_party/dart/runtime:dart_api",
+  ]
+}

--- a/third_party/tonic/typed_data/dart_byte_data.cc
+++ b/third_party/tonic/typed_data/dart_byte_data.cc
@@ -1,0 +1,85 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/typed_data/dart_byte_data.h"
+
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+Dart_Handle DartByteData::Create(const void* data, size_t length) {
+  auto handle = DartByteData{data, length}.dart_handle();
+  // The destructor should release the typed data.
+  return handle;
+}
+
+DartByteData::DartByteData()
+    : data_(nullptr), length_in_bytes_(0), dart_handle_(nullptr) {}
+
+DartByteData::DartByteData(const void* data, size_t length)
+    : data_(nullptr),
+      length_in_bytes_(0),
+      dart_handle_(Dart_NewTypedData(Dart_TypedData_kByteData, length)) {
+  if (!Dart_IsError(dart_handle_)) {
+    Dart_TypedData_Type type;
+    auto acquire_result = Dart_TypedDataAcquireData(dart_handle_, &type, &data_,
+                                                    &length_in_bytes_);
+
+    if (!Dart_IsError(acquire_result)) {
+      ::memcpy(data_, data, length_in_bytes_);
+    }
+  }
+}
+
+DartByteData::DartByteData(Dart_Handle list)
+    : data_(nullptr), length_in_bytes_(0), dart_handle_(list) {
+  if (Dart_IsNull(list))
+    return;
+
+  Dart_TypedData_Type type;
+  Dart_TypedDataAcquireData(list, &type, &data_, &length_in_bytes_);
+  TONIC_DCHECK(!LogIfError(list));
+  if (type != Dart_TypedData_kByteData)
+    Dart_ThrowException(ToDart("Non-genuine ByteData passed to engine."));
+}
+
+DartByteData::DartByteData(DartByteData&& other)
+    : data_(other.data_),
+      length_in_bytes_(other.length_in_bytes_),
+      dart_handle_(other.dart_handle_) {
+  other.data_ = nullptr;
+  other.dart_handle_ = nullptr;
+}
+
+DartByteData::~DartByteData() {
+  Release();
+}
+
+std::vector<char> DartByteData::Copy() const {
+  const char* ptr = static_cast<const char*>(data_);
+  return std::vector<char>(ptr, ptr + length_in_bytes_);
+}
+
+void DartByteData::Release() const {
+  if (data_) {
+    Dart_TypedDataReleaseData(dart_handle_);
+    data_ = nullptr;
+  }
+}
+
+DartByteData DartConverter<DartByteData>::FromArguments(
+    Dart_NativeArguments args,
+    int index,
+    Dart_Handle& exception) {
+  Dart_Handle data = Dart_GetNativeArgument(args, index);
+  TONIC_DCHECK(!LogIfError(data));
+  return DartByteData(data);
+}
+
+void DartConverter<DartByteData>::SetReturnValue(Dart_NativeArguments args,
+                                                 DartByteData val) {
+  Dart_SetReturnValue(args, val.dart_handle());
+}
+
+}  // namespace tonic

--- a/third_party/tonic/typed_data/dart_byte_data.h
+++ b/third_party/tonic/typed_data/dart_byte_data.h
@@ -1,0 +1,53 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_TYPED_DATA_DART_BYTE_DATA_H_
+#define LIB_TONIC_TYPED_DATA_DART_BYTE_DATA_H_
+
+#include <vector>
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/converter/dart_converter.h"
+
+namespace tonic {
+
+class DartByteData {
+ public:
+  static Dart_Handle Create(const void* data, size_t length);
+
+  explicit DartByteData(Dart_Handle list);
+  DartByteData(DartByteData&& other);
+  DartByteData();
+  ~DartByteData();
+
+  const void* data() const { return data_; }
+  void* data() { return data_; }
+  size_t length_in_bytes() const { return length_in_bytes_; }
+  Dart_Handle dart_handle() const { return dart_handle_; }
+
+  std::vector<char> Copy() const;
+  void Release() const;
+
+  explicit operator bool() const { return data_ != nullptr; }
+
+ private:
+  mutable void* data_;
+  intptr_t length_in_bytes_;
+  Dart_Handle dart_handle_;
+
+  DartByteData(const DartByteData& other) = delete;
+  DartByteData(const void* data, size_t length);
+};
+
+template <>
+struct DartConverter<DartByteData> {
+  static void SetReturnValue(Dart_NativeArguments args, DartByteData val);
+  static DartByteData FromArguments(Dart_NativeArguments args,
+                                    int index,
+                                    Dart_Handle& exception);
+};
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_TYPED_DATA_DART_BYTE_DATA_H_

--- a/third_party/tonic/typed_data/float32_list.h
+++ b/third_party/tonic/typed_data/float32_list.h
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_TYPED_DATA_FLOAT32_LIST_H_
+#define LIB_TONIC_TYPED_DATA_FLOAT32_LIST_H_
+
+#warning float32_list.h is deprecated; use typed_list.h instead.
+
+#include "tonic/typed_data/typed_list.h"
+
+#endif  // LIB_TONIC_TYPED_DATA_FLOAT32_LIST_H_

--- a/third_party/tonic/typed_data/float64_list.h
+++ b/third_party/tonic/typed_data/float64_list.h
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_TYPED_DATA_FLOAT64_LIST_H_
+#define LIB_TONIC_TYPED_DATA_FLOAT64_LIST_H_
+
+#warning float64_list.h is deprecated; use typed_list.h instead.
+
+#include "tonic/typed_data/typed_list.h"
+
+#endif  // LIB_TONIC_TYPED_DATA_FLOAT64_LIST_H_

--- a/third_party/tonic/typed_data/int32_list.h
+++ b/third_party/tonic/typed_data/int32_list.h
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_TYPED_DATA_INT32_LIST_H_
+#define LIB_TONIC_TYPED_DATA_INT32_LIST_H_
+
+#warning int32_list.h is deprecated; use typed_list.h instead.
+
+#include "tonic/typed_data/typed_list.h"
+
+#endif  // LIB_TONIC_TYPED_DATA_INT32_LIST_H_

--- a/third_party/tonic/typed_data/typed_list.cc
+++ b/third_party/tonic/typed_data/typed_list.cc
@@ -1,0 +1,104 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "tonic/typed_data/typed_list.h"
+
+#include <cstring>
+
+#include "tonic/logging/dart_error.h"
+
+namespace tonic {
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+TypedList<kTypeName, ElemType>::TypedList()
+    : data_(nullptr), num_elements_(0), dart_handle_(nullptr) {}
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+TypedList<kTypeName, ElemType>::TypedList(Dart_Handle list)
+    : data_(nullptr), num_elements_(0), dart_handle_(list) {
+  if (Dart_IsNull(list))
+    return;
+
+  Dart_TypedData_Type type;
+  Dart_TypedDataAcquireData(list, &type, reinterpret_cast<void**>(&data_),
+                            &num_elements_);
+  TONIC_DCHECK(!LogIfError(list));
+  if (type != kTypeName)
+    Dart_ThrowException(ToDart("Non-genuine TypedData passed to engine."));
+}
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+TypedList<kTypeName, ElemType>::TypedList(
+    TypedList<kTypeName, ElemType>&& other)
+    : data_(other.data_),
+      num_elements_(other.num_elements_),
+      dart_handle_(other.dart_handle_) {
+  other.data_ = nullptr;
+  other.num_elements_ = 0;
+  other.dart_handle_ = nullptr;
+}
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+TypedList<kTypeName, ElemType>::~TypedList() {
+  Release();
+}
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+void TypedList<kTypeName, ElemType>::Release() {
+  if (data_) {
+    Dart_TypedDataReleaseData(dart_handle_);
+    data_ = nullptr;
+    num_elements_ = 0;
+    dart_handle_ = nullptr;
+  }
+}
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+TypedList<kTypeName, ElemType>
+DartConverter<TypedList<kTypeName, ElemType>>::FromArguments(
+    Dart_NativeArguments args,
+    int index,
+    Dart_Handle& exception) {
+  Dart_Handle list = Dart_GetNativeArgument(args, index);
+  TONIC_DCHECK(!LogIfError(list));
+  return TypedList<kTypeName, ElemType>(list);
+}
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+void DartConverter<TypedList<kTypeName, ElemType>>::SetReturnValue(
+    Dart_NativeArguments args,
+    TypedList<kTypeName, ElemType> val) {
+  Dart_SetReturnValue(args, val.dart_handle());
+}
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+Dart_Handle DartConverter<TypedList<kTypeName, ElemType>>::ToDart(
+    const ElemType* buffer,
+    unsigned int length) {
+  const intptr_t buffer_length = static_cast<intptr_t>(length);
+  Dart_Handle array = Dart_NewTypedData(kTypeName, buffer_length);
+  TONIC_DCHECK(!LogIfError(array));
+  {
+    Dart_TypedData_Type type;
+    void* data = nullptr;
+    intptr_t data_length = 0;
+    Dart_TypedDataAcquireData(array, &type, &data, &data_length);
+    TONIC_CHECK(type == kTypeName);
+    TONIC_CHECK(data);
+    TONIC_CHECK(data_length == buffer_length);
+    std::memmove(data, buffer, data_length * sizeof(ElemType));
+    Dart_TypedDataReleaseData(array);
+  }
+  return array;
+}
+
+#define TONIC_TYPED_DATA_DEFINE(name, type)               \
+  template class TypedList<Dart_TypedData_k##name, type>; \
+  template struct DartConverter<name##List>;
+
+TONIC_TYPED_DATA_FOREACH(TONIC_TYPED_DATA_DEFINE)
+
+#undef TONIC_TYPED_DATA_DEFINE
+
+}  // namespace tonic

--- a/third_party/tonic/typed_data/typed_list.h
+++ b/third_party/tonic/typed_data/typed_list.h
@@ -1,0 +1,85 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_TYPED_DATA_TYPED_LIST_H_
+#define LIB_TONIC_TYPED_DATA_TYPED_LIST_H_
+
+#include "third_party/dart/runtime/include/dart_api.h"
+#include "tonic/converter/dart_converter.h"
+
+namespace tonic {
+
+// A simple wrapper around Dart TypedData objects. It uses
+// Dart_TypedDataAcquireData to obtain a raw pointer to the data, which is
+// released when this object is destroyed.
+//
+// This is designed to be used with DartConverter only.
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+class TypedList {
+ public:
+  explicit TypedList(Dart_Handle list);
+  TypedList(TypedList<kTypeName, ElemType>&& other);
+  TypedList();
+  ~TypedList();
+
+  ElemType& at(intptr_t i) {
+    TONIC_CHECK(0 <= i);
+    TONIC_CHECK(i < num_elements_);
+    return data_[i];
+  }
+  const ElemType& at(intptr_t i) const {
+    TONIC_CHECK(0 <= i);
+    TONIC_CHECK(i < num_elements_);
+    return data_[i];
+  }
+
+  ElemType& operator[](intptr_t i) { return at(i); }
+  const ElemType& operator[](intptr_t i) const { return at(i); }
+
+  const ElemType* data() const { return data_; }
+  intptr_t num_elements() const { return num_elements_; }
+  Dart_Handle dart_handle() const { return dart_handle_; }
+
+  void Release();
+
+ private:
+  ElemType* data_;
+  intptr_t num_elements_;
+  Dart_Handle dart_handle_;
+};
+
+template <Dart_TypedData_Type kTypeName, typename ElemType>
+struct DartConverter<TypedList<kTypeName, ElemType>> {
+  static void SetReturnValue(Dart_NativeArguments args,
+                             TypedList<kTypeName, ElemType> val);
+  static TypedList<kTypeName, ElemType> FromArguments(Dart_NativeArguments args,
+                                                      int index,
+                                                      Dart_Handle& exception);
+  static Dart_Handle ToDart(const ElemType* buffer, unsigned int length);
+};
+
+#define TONIC_TYPED_DATA_FOREACH(F) \
+  F(Int8, int8_t)                   \
+  F(Uint8, uint8_t)                 \
+  F(Int16, int16_t)                 \
+  F(Uint16, uint16_t)               \
+  F(Int32, int32_t)                 \
+  F(Uint32, uint32_t)               \
+  F(Int64, int64_t)                 \
+  F(Uint64, uint64_t)               \
+  F(Float32, float)                 \
+  F(Float64, double)
+
+#define TONIC_TYPED_DATA_DECLARE(name, type)                     \
+  using name##List = TypedList<Dart_TypedData_k##name, type>;    \
+  extern template class TypedList<Dart_TypedData_k##name, type>; \
+  extern template struct DartConverter<name##List>;
+
+TONIC_TYPED_DATA_FOREACH(TONIC_TYPED_DATA_DECLARE)
+
+#undef TONIC_TYPED_DATA_DECLARE
+
+}  // namespace tonic
+
+#endif  // LIB_TONIC_TYPED_DATA_TYPED_LIST_H_

--- a/third_party/tonic/typed_data/uint16_list.h
+++ b/third_party/tonic/typed_data/uint16_list.h
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_TYPED_DATA_UINT16_LIST_H_
+#define LIB_TONIC_TYPED_DATA_UINT16_LIST_H_
+
+#warning uint16_list.h is deprecated; use typed_list.h instead.
+
+#include "tonic/typed_data/typed_list.h"
+
+#endif  // LIB_TONIC_TYPED_DATA_UINT16_LIST_H_

--- a/third_party/tonic/typed_data/uint8_list.h
+++ b/third_party/tonic/typed_data/uint8_list.h
@@ -1,0 +1,12 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef LIB_TONIC_TYPED_DATA_UINT8_LIST_H_
+#define LIB_TONIC_TYPED_DATA_UINT8_LIST_H_
+
+#warning uint8_list.h is deprecated; use typed_list.h instead.
+
+#include "tonic/typed_data/typed_list.h"
+
+#endif  // LIB_TONIC_TYPED_DATA_UINT8_LIST_H_


### PR DESCRIPTION
Tonic used to be used by multiple consumers outside of Flutter Engine. Due to this, it has an unnecessary abstraction layer as well as utilities duplicated in FML and other engine subsystems. The sole user of Tonic is now the Flutter Engine. It is intended that the Flutter Engine team now owns this subsystem, removes unnecessary utilities and documents the headers. This is the first step in the transition. No history is being imported as the initial history was already lost in the transition of this component to fuchsia.googlesource. As this component was unmaintained there, I could see no additional value in importing the history of the patches there.

No functional change. Just moved the repo from //third_party to //flutter/third_party and updates GN refs.