### PR TITLE
Release TextureView surface within FlutterTextureView when disconnected. (#48535)

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -38,6 +38,8 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
   private boolean isAttachedToFlutterRenderer = false;
   @Nullable
   private FlutterRenderer flutterRenderer;
+  @Nullable
+  private Surface renderSurface;
 
   // Connects the {@code SurfaceTexture} beneath this {@code TextureView} with Flutter's native code.
   // Callbacks are received by this Object and then those messages are forwarded to our
@@ -172,7 +174,8 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
       throw new IllegalStateException("connectSurfaceToRenderer() should only be called when flutterRenderer and getSurfaceTexture() are non-null.");
     }
 
-    flutterRenderer.startRenderingToSurface(new Surface(getSurfaceTexture()));
+    renderSurface = new Surface(getSurfaceTexture());
+    flutterRenderer.startRenderingToSurface(renderSurface);
   }
 
   // FlutterRenderer must be non-null.
@@ -192,5 +195,6 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
     }
 
     flutterRenderer.stopRenderingToSurface();
+    renderSurface.release();
   }
 }

--- a/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterTextureView.java
@@ -196,5 +196,6 @@ public class FlutterTextureView extends TextureView implements RenderSurface {
 
     flutterRenderer.stopRenderingToSurface();
     renderSurface.release();
+    renderSurface = null;
   }
 }


### PR DESCRIPTION
Release TextureView surface within FlutterTextureView when disconnected. (#48535)

**Note on testing:**
About a week ago I was able to reproduce the issue in question but I was unable to attempt a fix because I couldn't use a local engine with add-to-app. As of today, I can use a local engine with add-to-app, but I can no longer reproduce the problem. Even if I check out an older version of the framework and build with the associated engine version, the leak error no longer appears.

The fix seems like an obvious improvement, so we'll go ahead and merge without tests because it isn't clear how we would detect/measure the issue.