### PR TITLE
[fuchsia] Timeline events in profile mode to observatory

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -380,7 +380,8 @@ DartVM::DartVM(std::shared_ptr<const DartVMData> vm_data,
     args.push_back(old_gen_heap_size_args.c_str());
   }
 
-#if defined(OS_FUCHSIA)
+#if defined(OS_FUCHSIA) && \
+    (FLUTTER_RUNTIME_MODE != FLUTTER_RUNTIME_MODE_PROFILE)
   PushBackAll(&args, kDartFuchsiaTraceArgs, fml::size(kDartFuchsiaTraceArgs));
   PushBackAll(&args, kDartTraceStreamsArgs, fml::size(kDartTraceStreamsArgs));
 #endif

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -39,7 +39,9 @@ const char* kDartVMArgs[] = {
     // addressed.
     "--no_causal_async_stacks",
 
+#if !defined(FLUTTER_PROFILE)
     "--systrace_timeline",
+#endif
     "--timeline_streams=Compiler,Dart,Debugger,Embedder,GC,Isolate,VM",
 
 #if defined(AOT_RUNTIME)


### PR DESCRIPTION
This is to address fxb/44063

In all the other modes they will be sent to the systrace