### PR TITLE
[web] Calling platform message callback after copy

### DIFF
--- a/lib/web_ui/lib/src/engine/clipboard.dart
+++ b/lib/web_ui/lib/src/engine/clipboard.dart
@@ -7,11 +7,10 @@ part of engine;
 /// Handles clipboard related platform messages.
 class ClipboardMessageHandler {
   /// Helper to handle copy to clipboard functionality.
-  final CopyToClipboardStrategy _copyToClipboardStrategy =
-      CopyToClipboardStrategy();
+  CopyToClipboardStrategy _copyToClipboardStrategy = CopyToClipboardStrategy();
 
   /// Helper to handle copy to clipboard functionality.
-  final PasteFromClipboardStrategy _pasteFromClipboardStrategy =
+  PasteFromClipboardStrategy _pasteFromClipboardStrategy =
       PasteFromClipboardStrategy();
 
   /// Handles the platform message which stores the given text to the clipboard.
@@ -44,6 +43,15 @@ class ClipboardMessageHandler {
       callback(codec.encodeErrorEnvelope(
           code: 'paste_fail', message: 'Clipboard.getData failed'));
     });
+  }
+
+  /// Methods used by tests.
+  set pasteFromClipboardStrategy(PasteFromClipboardStrategy strategy) {
+    _pasteFromClipboardStrategy = strategy;
+  }
+
+  set copyToClipboardStrategy(CopyToClipboardStrategy strategy) {
+    _copyToClipboardStrategy = strategy;
   }
 }
 

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -165,7 +165,7 @@ class EngineWindow extends ui.Window {
             // There are no default system sounds on web.
             return;
           case 'Clipboard.setData':
-            ClipboardMessageHandler().setDataMethodCall(decoded);
+            ClipboardMessageHandler().setDataMethodCall(decoded, callback);
             return;
           case 'Clipboard.getData':
             ClipboardMessageHandler().getDataMethodCall(callback);

--- a/lib/web_ui/test/clipboard_test.dart
+++ b/lib/web_ui/test/clipboard_test.dart
@@ -1,0 +1,97 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:ui/ui.dart' as ui;
+import 'package:ui/src/engine.dart';
+
+Future<void> main() async {
+  await ui.webOnlyInitializeTestDomRenderer();
+  group('message handler', () {
+    const String testText = 'test text';
+
+    final Future<bool> success = Future.value(true);
+    final Future<bool> failure = Future.value(false);
+    final Future<String> pasteTest = Future.value(testText);
+
+    ClipboardMessageHandler clipboardMessageHandler;
+    ClipboardAPICopyStrategy clipboardAPICopyStrategy =
+        MockClipboardAPICopyStrategy();
+    ClipboardAPIPasteStrategy clipboardAPIPasteStrategy =
+        MockClipboardAPIPasteStrategy();
+
+    setUp(() {
+      clipboardMessageHandler = new ClipboardMessageHandler();
+      clipboardAPICopyStrategy = MockClipboardAPICopyStrategy();
+      clipboardAPIPasteStrategy = MockClipboardAPIPasteStrategy();
+      clipboardMessageHandler.copyToClipboardStrategy =
+          clipboardAPICopyStrategy;
+      clipboardMessageHandler.pasteFromClipboardStrategy =
+          clipboardAPIPasteStrategy;
+    });
+
+    test('set data successful', () async {
+      when(clipboardAPICopyStrategy.setData(testText))
+          .thenAnswer((_) => success);
+      const MethodCodec codec = JSONMethodCodec();
+      bool result = false;
+      ui.PlatformMessageResponseCallback callback = (ByteData data) {
+        result = codec.decodeEnvelope(data);
+      };
+
+      await clipboardMessageHandler.setDataMethodCall(
+          const MethodCall('Clipboard.setData', <String, dynamic>{
+            'text': testText,
+          }),
+          callback);
+
+      await expectLater(result, true);
+    });
+
+    test('set data error', () async {
+      when(clipboardAPICopyStrategy.setData(testText))
+          .thenAnswer((_) => failure);
+      const MethodCodec codec = JSONMethodCodec();
+      ByteData result;
+      ui.PlatformMessageResponseCallback callback = (ByteData data) {
+        result = data;
+      };
+
+      await clipboardMessageHandler.setDataMethodCall(
+          const MethodCall('Clipboard.setData', <String, dynamic>{
+            'text': testText,
+          }),
+          callback);
+
+      expect(() async {
+        codec.decodeEnvelope(result);
+      }, throwsA(TypeMatcher<PlatformException>()
+          .having((e) => e.code, 'code', equals('copy_fail'))));
+    });
+
+    test('get data successful', () async {
+      when(clipboardAPIPasteStrategy.getData())
+          .thenAnswer((_) => pasteTest);
+      const MethodCodec codec = JSONMethodCodec();
+      Map<String, dynamic> result;
+      ui.PlatformMessageResponseCallback callback = (ByteData data) {
+        result = codec.decodeEnvelope(data);
+      };
+
+      await clipboardMessageHandler.getDataMethodCall(callback);
+
+      await expectLater(result['text'], testText);
+    });
+  });
+}
+
+class MockClipboardAPICopyStrategy extends Mock
+    implements ClipboardAPICopyStrategy {}
+
+class MockClipboardAPIPasteStrategy extends Mock
+    implements ClipboardAPIPasteStrategy {}


### PR DESCRIPTION
When implementing the copy operation, I forgot to call the message callback, which was giving a timeout for any operation waiting on the callback.

Example from user code: https://gist.github.com/perclasson/6863d899fbdbe670358da9b5c779c824

Fixes: https://github.com/flutter/flutter/issues/49349