### PR TITLE
Gets the DPI for all awareness mode and older Windows versions

### DIFF
--- a/shell/platform/windows/win32_dpi_helper.cc
+++ b/shell/platform/windows/win32_dpi_helper.cc
@@ -43,8 +43,6 @@ Win32DpiHelper::~Win32DpiHelper() {
   }
 }
 
-// SetAwareness
-// Check the available api. Start with v2, then fall back.
 void Win32DpiHelper::SetDpiAwerenessAllVersions() {
   if (permonitorv2_supported_) {
     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);

--- a/shell/platform/windows/win32_dpi_helper.cc
+++ b/shell/platform/windows/win32_dpi_helper.cc
@@ -1,7 +1,5 @@
 #include "flutter/shell/platform/windows/win32_dpi_helper.h"
 
-#include <iostream>
-
 namespace flutter {
 
 namespace {
@@ -43,17 +41,17 @@ Win32DpiHelper::~Win32DpiHelper() {
   }
 }
 
-void Win32DpiHelper::SetDpiAwerenessAllVersions() {
+BOOL Win32DpiHelper::SetDpiAwareness() {
   if (permonitorv2_supported_) {
-    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    return set_process_dpi_awareness_context_(
+        DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
   } else {
-    std::cerr << "Per Monitor V2 DPI awareness is not supported on this "
-                 "version of Windows. Setting System DPI awareness\n";
     AssignProcAddress(user32_module_, "GetDpiForSystem", get_dpi_for_system_);
     AssignProcAddress(user32_module_, "SetProcessDpiAware",
                       set_process_dpi_aware_);
 
-    SetProcessDPIAware();
+    return set_process_dpi_aware_();
   }
 }
 
@@ -68,27 +66,11 @@ BOOL Win32DpiHelper::EnableNonClientDpiScaling(HWND hwnd) {
   return enable_non_client_dpi_scaling_(hwnd);
 }
 
-UINT Win32DpiHelper::GetDpiForWindow(HWND hwnd) {
-  if (!permonitorv2_supported_) {
-    return false;
+UINT Win32DpiHelper::GetDpi(HWND hwnd) {
+  if (permonitorv2_supported_) {
+    return get_dpi_for_window_(hwnd);
   }
-  return get_dpi_for_window_(hwnd);
-}
-
-UINT Win32DpiHelper::GetDpiForSystem() {
   return get_dpi_for_system_();
-}
-
-BOOL Win32DpiHelper::SetProcessDpiAwarenessContext(
-    DPI_AWARENESS_CONTEXT context) {
-  if (!permonitorv2_supported_) {
-    return false;
-  }
-  return set_process_dpi_awareness_context_(context);
-}
-
-BOOL Win32DpiHelper::SetProcessDpiAware() {
-  return set_process_dpi_aware_();
 }
 
 }  // namespace flutter

--- a/shell/platform/windows/win32_dpi_helper.cc
+++ b/shell/platform/windows/win32_dpi_helper.cc
@@ -45,8 +45,8 @@ Win32DpiHelper::~Win32DpiHelper() {
 }
 
 UINT Win32DpiHelper::GetDpi(HWND hwnd) {
-  // GetDpiForWindow returns the DPI for any awareness mode. If not available, fallback to a
-  // per monitor, system, or default DPI.
+  // GetDpiForWindow returns the DPI for any awareness mode. If not available,
+  // fallback to a per monitor, system, or default DPI.
   if (dpi_for_window_supported_) {
     return get_dpi_for_window_(hwnd);
   } else if (dpi_for_monitor_supported_) {

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -38,7 +38,6 @@ class Win32DpiHelper {
   HMODULE shlib_module_ = nullptr;
   bool dpi_for_window_supported_ = false;
   bool dpi_for_monitor_supported_ = false;
-  UINT default_dpi_ = 96;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -10,16 +10,16 @@
 
 namespace flutter {
 
-// A helper class for abstracting various Windows DPI related functions across
-// Windows OS versions.
+/// A helper class for abstracting various Windows DPI related functions across
+/// Windows OS versions.
 class Win32DpiHelper {
  public:
   Win32DpiHelper();
 
   ~Win32DpiHelper();
 
-  // Returns the current DPI. Supports all DPI awareness modes, and is backward
-  // compatible down to Windows Vista.
+  /// Returns the current DPI. Supports all DPI awareness modes, and is backward
+  /// compatible down to Windows Vista.
   UINT GetDpi(HWND);
 
  private:

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -29,9 +29,6 @@ class Win32DpiHelper {
   // awareness has been set. Otherwise, returns the DPI for the System.
   UINT GetDpi(HWND);
 
-  // Sets the current process to System-level DPI awareness.
-  BOOL SetProcessDpiAware();
-
   // Sets the DPI awareness for the application. For versions >= Windows 1703,
   // use Per Monitor V2. For any older versions, use System.
   //

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -25,12 +25,9 @@ class Win32DpiHelper {
   // Wrapper for OS functionality to turn on automatic window non-client scaling
   BOOL EnableNonClientDpiScaling(HWND);
 
-  // Wrapper for OS functionality to return the DPI for |HWND|
-  UINT GetDpiForWindow(HWND);
-
-  // Wrapper for OS functionality to return the DPI for the System. Only used if
-  // Per Monitor V2 is not supported by the current Windows version.
-  UINT GetDpiForSystem();
+  // Wrapper for OS functionality to return the DPI for |HWND| if Per Monitor V2
+  // awareness has been set. Otherwise, returns the DPI for the System.
+  UINT GetDpi(HWND);
 
   // Sets the current process to a specified DPI awareness context.
   BOOL SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT);
@@ -43,7 +40,7 @@ class Win32DpiHelper {
   //
   // This call is overriden if DPI awareness is stated in the application
   // manifest.
-  void SetDpiAwerenessAllVersions();
+  BOOL SetDpiAwareness();
 
  private:
   using EnableNonClientDpiScaling_ = BOOL __stdcall(HWND);

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -28,17 +28,32 @@ class Win32DpiHelper {
   // Wrapper for OS functionality to return the DPI for |HWND|
   UINT GetDpiForWindow(HWND);
 
+  // Wrapper for OS functionality to return the DPI for the System. Only used if
+  // Per Monitor V2 is not supported by the current Windows version.
+  UINT GetDpiForSystem();
+
   // Sets the current process to a specified DPI awareness context.
   BOOL SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT);
+
+  // Sets the current process to System-level DPI awareness.
+  BOOL SetProcessDpiAware();
+
+  // Sets the DPI awareness for the application. For versions >= Windows 1703,
+  // use Per Monitor V2. For any older versions, use System.
+  void SetDpiAwerenessAllVersions();
 
  private:
   using EnableNonClientDpiScaling_ = BOOL __stdcall(HWND);
   using GetDpiForWindow_ = UINT __stdcall(HWND);
   using SetProcessDpiAwarenessContext_ = BOOL __stdcall(DPI_AWARENESS_CONTEXT);
+  using SetProcessDpiAware_ = BOOL __stdcall();
+  using GetDpiForSystem_ = UINT __stdcall();
 
   EnableNonClientDpiScaling_* enable_non_client_dpi_scaling_ = nullptr;
   GetDpiForWindow_* get_dpi_for_window_ = nullptr;
   SetProcessDpiAwarenessContext_* set_process_dpi_awareness_context_ = nullptr;
+  SetProcessDpiAware_* set_process_dpi_aware_ = nullptr;
+  GetDpiForSystem_* get_dpi_for_system_ = nullptr;
 
   HMODULE user32_module_ = nullptr;
   bool permonitorv2_supported_ = false;

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -40,6 +40,9 @@ class Win32DpiHelper {
 
   // Sets the DPI awareness for the application. For versions >= Windows 1703,
   // use Per Monitor V2. For any older versions, use System.
+  //
+  // This call is overriden if DPI awareness is stated in the application
+  // manifest.
   void SetDpiAwerenessAllVersions();
 
  private:

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -29,9 +29,6 @@ class Win32DpiHelper {
   // awareness has been set. Otherwise, returns the DPI for the System.
   UINT GetDpi(HWND);
 
-  // Sets the current process to a specified DPI awareness context.
-  BOOL SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT);
-
   // Sets the current process to System-level DPI awareness.
   BOOL SetProcessDpiAware();
 

--- a/shell/platform/windows/win32_dpi_helper.h
+++ b/shell/platform/windows/win32_dpi_helper.h
@@ -18,39 +18,27 @@ class Win32DpiHelper {
 
   ~Win32DpiHelper();
 
-  // Check if Windows Per Monitor V2 DPI scaling functionality is available on
-  // current system.
-  bool IsPerMonitorV2Available();
-
-  // Wrapper for OS functionality to turn on automatic window non-client scaling
-  BOOL EnableNonClientDpiScaling(HWND);
-
-  // Wrapper for OS functionality to return the DPI for |HWND| if Per Monitor V2
-  // awareness has been set. Otherwise, returns the DPI for the System.
+  // Returns the current DPI. Supports all DPI awareness modes, and is backward
+  // compatible down to Windows Vista.
   UINT GetDpi(HWND);
 
-  // Sets the DPI awareness for the application. For versions >= Windows 1703,
-  // use Per Monitor V2. For any older versions, use System.
-  //
-  // This call is overriden if DPI awareness is stated in the application
-  // manifest.
-  BOOL SetDpiAwareness();
-
  private:
-  using EnableNonClientDpiScaling_ = BOOL __stdcall(HWND);
   using GetDpiForWindow_ = UINT __stdcall(HWND);
-  using SetProcessDpiAwarenessContext_ = BOOL __stdcall(DPI_AWARENESS_CONTEXT);
-  using SetProcessDpiAware_ = BOOL __stdcall();
-  using GetDpiForSystem_ = UINT __stdcall();
+  using GetDpiForMonitor_ = HRESULT __stdcall(HMONITOR hmonitor,
+                                              MONITOR_DPI_TYPE dpiType,
+                                              UINT* dpiX,
+                                              UINT* dpiY);
+  using MonitorFromWindow_ = HMONITOR __stdcall(HWND hwnd, DWORD dwFlags);
 
-  EnableNonClientDpiScaling_* enable_non_client_dpi_scaling_ = nullptr;
   GetDpiForWindow_* get_dpi_for_window_ = nullptr;
-  SetProcessDpiAwarenessContext_* set_process_dpi_awareness_context_ = nullptr;
-  SetProcessDpiAware_* set_process_dpi_aware_ = nullptr;
-  GetDpiForSystem_* get_dpi_for_system_ = nullptr;
+  GetDpiForMonitor_* get_dpi_for_monitor_ = nullptr;
+  MonitorFromWindow_* monitor_from_window_ = nullptr;
 
   HMODULE user32_module_ = nullptr;
-  bool permonitorv2_supported_ = false;
+  HMODULE shlib_module_ = nullptr;
+  bool dpi_for_window_supported_ = false;
+  bool dpi_for_monitor_supported_ = false;
+  UINT default_dpi_ = 96;
 };
 
 }  // namespace flutter

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -20,7 +20,9 @@ void Win32Window::InitializeChild(const char* title,
 
   // Set DPI awareness for all Windows versions. This call has to be made before
   // the HWND is created.
-  dpi_helper_->SetDpiAwerenessAllVersions();
+  if (!dpi_helper_->SetDpiAwareness()) {
+    OutputDebugString(L"Failed to set DPI awareness");
+  }
 
   WNDCLASS window_class = RegisterWindowClass(converted_title);
 
@@ -86,10 +88,9 @@ LRESULT CALLBACK Win32Window::WndProc(HWND const window,
       if (result != TRUE) {
         OutputDebugString(L"Failed to enable non-client area autoscaling");
       }
-      that->current_dpi_ = that->dpi_helper_->GetDpiForWindow(window);
-    } else {
-      that->current_dpi_ = that->dpi_helper_->GetDpiForSystem();
     }
+    that->current_dpi_ = that->dpi_helper_->GetDpi(window);
+
     that->window_handle_ = window;
   } else if (Win32Window* that = GetThisFromHandle(window)) {
     return that->MessageHandler(window, message, wparam, lparam);
@@ -282,7 +283,7 @@ Win32Window::HandleDpiChange(HWND hwnd,
     // The DPI is only passed for DPI change messages on top level windows,
     // hence call function to get DPI if needed.
     if (uDpi == 0) {
-      uDpi = dpi_helper_->GetDpiForWindow(hwnd);
+      uDpi = dpi_helper_->GetDpi(hwnd);
     }
     current_dpi_ = uDpi;
     window->OnDpiScale(uDpi);

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -6,16 +6,8 @@
 
 namespace flutter {
 
-Win32Window::Win32Window() {
-  // Assume Windows 10 1703 or greater for DPI handling.  When running on a
-  // older release of Windows where this context doesn't exist, DPI calls will
-  // fail and Flutter rendering will be impacted until this is fixed.
-  // To handle downlevel correctly, dpi_helper must use the most recent DPI
-  // context available should be used: Windows 1703: Per-Monitor V2, 8.1:
-  // Per-Monitor V1, Windows 7: System See
-  // https://docs.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows
-  // for more information.
-}
+Win32Window::Win32Window() {}
+
 Win32Window::~Win32Window() {
   Destroy();
 }

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/windows/win32_window.h"
+#include <iostream>
 
 namespace flutter {
 
@@ -17,12 +18,6 @@ void Win32Window::InitializeChild(const char* title,
                                   unsigned int height) {
   Destroy();
   std::wstring converted_title = NarrowToWide(title);
-
-  // Set DPI awareness for all Windows versions. This call has to be made before
-  // the HWND is created.
-  if (!dpi_helper_->SetDpiAwareness()) {
-    OutputDebugString(L"Failed to set DPI awareness");
-  }
 
   WNDCLASS window_class = RegisterWindowClass(converted_title);
 
@@ -80,17 +75,7 @@ LRESULT CALLBACK Win32Window::WndProc(HWND const window,
                      reinterpret_cast<LONG_PTR>(cs->lpCreateParams));
 
     auto that = static_cast<Win32Window*>(cs->lpCreateParams);
-
-    if (that->dpi_helper_->IsPerMonitorV2Available()) {
-      // Since the application is running in Per-monitor V2 mode, turn on
-      // automatic titlebar scaling
-      BOOL result = that->dpi_helper_->EnableNonClientDpiScaling(window);
-      if (result != TRUE) {
-        OutputDebugString(L"Failed to enable non-client area autoscaling");
-      }
-    }
     that->current_dpi_ = that->dpi_helper_->GetDpi(window);
-
     that->window_handle_ = window;
   } else if (Win32Window* that = GetThisFromHandle(window)) {
     return that->MessageHandler(window, message, wparam, lparam);

--- a/shell/platform/windows/win32_window.cc
+++ b/shell/platform/windows/win32_window.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/platform/windows/win32_window.h"
-#include <iostream>
 
 namespace flutter {
 

--- a/shell/platform/windows/win32_window.h
+++ b/shell/platform/windows/win32_window.h
@@ -57,7 +57,7 @@ class Win32Window {
 
   // Registers a window class with default style attributes, cursor and
   // icon.
-  WNDCLASS ResgisterWindowClass(std::wstring& title);
+  WNDCLASS RegisterWindowClass(std::wstring& title);
 
   // OS callback called by message pump.  Handles the WM_NCCREATE message which
   // is passed when the non-client area is being created and enables automatic


### PR DESCRIPTION
A continuation of https://github.com/flutter/engine/pull/12735. 

Looks for the most modern API `GetDpiForWindow` first, but falls back to older APIs if not available. If none of the APIs are available, default to a 96 DPI.

Removed existing "`SetDpi*`" APIs since the DPI awareness should be set by the runner app. Also removed `EnableNonClientDpiScaling` since it should be called when the top-level window is created, which happens in the runner app.

Tested: Changed the runner's manifest to all awareness modes, and tried all possible APIs. Haven't tested in non-Windows 10 machines.

Related to https://github.com/google/flutter-desktop-embedding/issues/572