### PR TITLE
Ensure we export the various dart snapshot symbols on Fuchsia

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -109,7 +109,7 @@ config("config") {
 }
 
 config("export_dynamic_symbols") {
-  if (is_linux) {
+  if (is_linux || is_fuchsia) {
     inputs = [
       "$flutter_root/common/exported_symbols.sym",
     ]


### PR DESCRIPTION
When building in JIT mode, we package the dart isolate/vm snapshots in the binary and export the symbols for lookup using `dlsym`.

We need to ensure these symbols are exported correctly on Fuchsia so that `shell_unittests` can initalise properly.