### PR TITLE
Cache computed window.physicalSize in a FrameReference

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -47,11 +47,24 @@ class EngineWindow extends ui.Window {
 
   @override
   ui.Size get physicalSize {
+    if (_physicalSize?.value == null) {
+      _computePhysicalSize();
+    }
+    assert(_physicalSize != null);
+    assert(_physicalSize.value != null);
+    return _physicalSize.value;
+  }
+
+  /// Computes the physical size of the screen from [html.window].
+  ///
+  /// This function is expensive. It triggers browser layout if there are
+  /// pending DOM writes.
+  void _computePhysicalSize() {
     bool override = false;
 
     assert(() {
       if (webOnlyDebugPhysicalSizeOverride != null) {
-        _physicalSize = webOnlyDebugPhysicalSizeOverride;
+        _physicalSize = FrameReference<ui.Size>(webOnlyDebugPhysicalSizeOverride);
         override = true;
       }
       return true;
@@ -68,23 +81,15 @@ class EngineWindow extends ui.Window {
         windowInnerWidth = html.window.innerWidth * devicePixelRatio;
         windowInnerHeight = html.window.innerHeight * devicePixelRatio;
       }
-      if (windowInnerWidth != _lastKnownWindowInnerWidth ||
-          windowInnerHeight != _lastKnownWindowInnerHeight) {
-        _lastKnownWindowInnerWidth = windowInnerWidth;
-        _lastKnownWindowInnerHeight = windowInnerHeight;
-        _physicalSize = ui.Size(
-          windowInnerWidth,
-          windowInnerHeight,
-        );
-      }
+      _physicalSize = FrameReference<ui.Size>(ui.Size(
+        windowInnerWidth,
+        windowInnerHeight,
+      ));
     }
-
-    return _physicalSize;
   }
 
-  ui.Size _physicalSize = ui.Size.zero;
-  double _lastKnownWindowInnerWidth = -1;
-  double _lastKnownWindowInnerHeight = -1;
+  /// Lazily populated and cleared at the end of the frame.
+  FrameReference<ui.Size> _physicalSize;
 
   /// Overrides the value of [physicalSize] in tests.
   ui.Size webOnlyDebugPhysicalSizeOverride;


### PR DESCRIPTION
Calling `html.window.physicalSize` with pending DOM writes triggers browser layout. This is particularly costly when we access physical size while painting (e.g. we do this when drawing text paragraphs). On some apps this costs up to 0.5ms each time it is called (e.g. once per paragraph).

This change caches a lazily-computed size in a `FrameReference` (which is cleared at the end of the frame). The first access that computes the initial value tends to be _before_ we write anything to the DOM and therefore costs us nothing. Subsequent accesses, even after DOM write, use the cached value, and, again, cost nothing.

In at least one of our customer apps, this significantly dropped the frame time, reducing total amount of browser layout time from 28% per frame down to 11% per frame, with overall frame times dropping by up to ~40%.

**Tests**: this is purely an optimization; there is no change in functionality, so existing tests should already cover this.