### PR TITLE
Retry CIPD upload in second place

### DIFF
--- a/tools/fuchsia/build_fuchsia_artifacts.py
+++ b/tools/fuchsia/build_fuchsia_artifacts.py
@@ -173,8 +173,18 @@ def ProcessCIPDPackage(upload, engine_version):
         os.path.join(_bucket_directory, 'fuchsia.cipd')
     ]
 
-  subprocess.check_call(command, cwd=_bucket_directory)
-
+  # Retry up to three times.  We've seen CIPD fail on verification in some
+  # instances. Normally verification takes slightly more than 1 minute when
+  # it succeeds.
+  num_tries = 3
+  for tries in range(num_tries):
+    try:
+      subprocess.check_call(command, cwd=_bucket_directory)
+      break
+    except subprocess.CalledProcessError:
+      print('Failed %s times' % tries + 1)
+      if tries == num_tries - 1:
+        raise
 
 def GetRunnerTarget(runner_type, product, aot):
   base = '%s/%s:' % (_fuchsia_base, runner_type)


### PR DESCRIPTION
See https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8890349592572894208/+/steps/Upload_Fuchsia_Artifacts/0/stdout where this failed because of a CIPD backend issue.

See also #15862 which applied this same fix to the other place we create CIPD packages.