### PR TITLE
Eliminate unused import in Android embedding

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -8,7 +8,6 @@ import android.app.Activity;
 import android.arch.lifecycle.Lifecycle;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;


### PR DESCRIPTION
Eliminates an unused dependency on android.os.build. The last remaining
use of this was eliminated in 0615f45623224bd99ee3ceb8ba4a0d4d04f58d54
with the removal of an unused method that contained an android version
check.