### PR TITLE
Ensure GetFixturesPath works on Fuchsia

### DIFF
--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -230,7 +230,11 @@ template("test_fixtures") {
   # must always be known to tests.
   fixtures_location_target_name = "fixtures_location_$target_name"
   fixtures_location(fixtures_location_target_name) {
-    assets_dir = "$target_gen_dir/assets"
+    if (is_fuchsia) {
+      assets_dir = "/pkg/data/assets"
+    } else {
+      assets_dir = "$target_gen_dir/assets"
+    }
   }
   test_deps = [ ":$fixtures_location_target_name" ]
 


### PR DESCRIPTION
Right now GetFixturesPath() assumes that all tests are run on the build host, and so they return an absolute path to the build output directory for that particular build target.

On Fuchsia we will package these assets as part of the .far file in `data/assets`, which is accessible via `/pkg/data/assets`.