### PR TITLE
Allow embedders to schedule a callback on all engine managed threads.

### DIFF
--- a/fml/concurrent_message_loop.cc
+++ b/fml/concurrent_message_loop.cc
@@ -26,6 +26,10 @@ ConcurrentMessageLoop::ConcurrentMessageLoop(size_t worker_count)
       WorkerMain();
     });
   }
+
+  for (const auto& worker : workers_) {
+    worker_thread_ids_.emplace_back(worker.get_id());
+  }
 }
 
 ConcurrentMessageLoop::~ConcurrentMessageLoop() {
@@ -73,25 +77,43 @@ void ConcurrentMessageLoop::PostTask(const fml::closure& task) {
 void ConcurrentMessageLoop::WorkerMain() {
   while (true) {
     std::unique_lock lock(tasks_mutex_);
-    tasks_condition_.wait(lock,
-                          [&]() { return tasks_.size() > 0 || shutdown_; });
+    tasks_condition_.wait(lock, [&]() {
+      return tasks_.size() > 0 || shutdown_ || HasThreadTasksLocked();
+    });
 
-    if (tasks_.size() == 0) {
-      // This can only be caused by shutdown.
-      FML_DCHECK(shutdown_);
-      break;
+    // Shutdown cannot be read with the task mutex unlocked.
+    bool shutdown_now = shutdown_;
+    fml::closure task;
+    std::vector<fml::closure> thread_tasks;
+
+    if (tasks_.size() != 0) {
+      task = tasks_.front();
+      tasks_.pop();
     }
 
-    auto task = tasks_.front();
-    tasks_.pop();
+    if (HasThreadTasksLocked()) {
+      thread_tasks = GetThreadTasksLocked();
+      FML_DCHECK(!HasThreadTasksLocked());
+    }
 
-    // Don't hold onto the mutex while the task is being executed as it could
-    // itself try to post another tasks to this message loop.
+    // Don't hold onto the mutex while tasks are being executed as they could
+    // themselves try to post more tasks to the message loop.
     lock.unlock();
 
     TRACE_EVENT0("flutter", "ConcurrentWorkerWake");
-    // Execute the one tasks we woke up for.
-    task();
+    // Execute the primary task we woke up for.
+    if (task) {
+      task();
+    }
+
+    // Execute any thread tasks.
+    for (const auto& thread_task : thread_tasks) {
+      thread_task();
+    }
+
+    if (shutdown_now) {
+      break;
+    }
   }
 }
 
@@ -99,6 +121,31 @@ void ConcurrentMessageLoop::Terminate() {
   std::scoped_lock lock(tasks_mutex_);
   shutdown_ = true;
   tasks_condition_.notify_all();
+}
+
+void ConcurrentMessageLoop::PostTaskToAllWorkers(fml::closure task) {
+  if (!task) {
+    return;
+  }
+
+  std::scoped_lock lock(tasks_mutex_);
+  for (const auto& worker_thread_id : worker_thread_ids_) {
+    thread_tasks_[worker_thread_id].emplace_back(task);
+  }
+  tasks_condition_.notify_all();
+}
+
+bool ConcurrentMessageLoop::HasThreadTasksLocked() const {
+  return thread_tasks_.count(std::this_thread::get_id()) > 0;
+}
+
+std::vector<fml::closure> ConcurrentMessageLoop::GetThreadTasksLocked() {
+  auto found = thread_tasks_.find(std::this_thread::get_id());
+  FML_DCHECK(found != thread_tasks_.end());
+  std::vector<fml::closure> pending_tasks;
+  std::swap(pending_tasks, found->second);
+  thread_tasks_.erase(found);
+  return pending_tasks;
 }
 
 ConcurrentTaskRunner::ConcurrentTaskRunner(

--- a/fml/concurrent_message_loop.h
+++ b/fml/concurrent_message_loop.h
@@ -6,6 +6,7 @@
 #define FLUTTER_FML_CONCURRENT_MESSAGE_LOOP_H_
 
 #include <condition_variable>
+#include <map>
 #include <queue>
 #include <thread>
 
@@ -30,6 +31,8 @@ class ConcurrentMessageLoop
 
   void Terminate();
 
+  void PostTaskToAllWorkers(fml::closure task);
+
  private:
   friend ConcurrentTaskRunner;
 
@@ -38,6 +41,8 @@ class ConcurrentMessageLoop
   std::mutex tasks_mutex_;
   std::condition_variable tasks_condition_;
   std::queue<fml::closure> tasks_;
+  std::vector<std::thread::id> worker_thread_ids_;
+  std::map<std::thread::id, std::vector<fml::closure>> thread_tasks_;
   bool shutdown_ = false;
 
   ConcurrentMessageLoop(size_t worker_count);
@@ -45,6 +50,10 @@ class ConcurrentMessageLoop
   void WorkerMain();
 
   void PostTask(const fml::closure& task);
+
+  bool HasThreadTasksLocked() const;
+
+  std::vector<fml::closure> GetThreadTasksLocked();
 
   FML_DISALLOW_COPY_AND_ASSIGN(ConcurrentMessageLoop);
 };

--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -504,4 +504,8 @@ DartVM::GetConcurrentWorkerTaskRunner() const {
   return concurrent_message_loop_->GetTaskRunner();
 }
 
+std::shared_ptr<fml::ConcurrentMessageLoop> DartVM::GetConcurrentMessageLoop() {
+  return concurrent_message_loop_;
+}
+
 }  // namespace flutter

--- a/runtime/dart_vm.h
+++ b/runtime/dart_vm.h
@@ -147,6 +147,19 @@ class DartVM {
   std::shared_ptr<fml::ConcurrentTaskRunner> GetConcurrentWorkerTaskRunner()
       const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      The concurrent message loop hosts threads that are used by the
+  ///             engine to perform tasks long running background tasks.
+  ///             Typically, to post tasks to this message loop, the
+  ///             `GetConcurrentWorkerTaskRunner` method may be used.
+  ///
+  /// @see        GetConcurrentWorkerTaskRunner
+  ///
+  /// @return     The concurrent message loop used by this running Dart VM
+  ///             instance.
+  ///
+  std::shared_ptr<fml::ConcurrentMessageLoop> GetConcurrentMessageLoop();
+
  private:
   const Settings settings_;
   std::shared_ptr<fml::ConcurrentMessageLoop> concurrent_message_loop_;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -352,6 +352,14 @@ class Shell final : public PlatformView::Delegate,
   /// @brief     Accessor for the disable GPU SyncSwitch
   std::shared_ptr<fml::SyncSwitch> GetIsGpuDisabledSyncSwitch() const;
 
+  //----------------------------------------------------------------------------
+  /// @brief      Get a pointer to the Dart VM used by this running shell
+  ///             instance.
+  ///
+  /// @return     The Dart VM pointer.
+  ///
+  DartVM* GetDartVM();
+
  private:
   using ServiceProtocolHandler =
       std::function<bool(const ServiceProtocol::Handler::ServiceProtocolMap&,
@@ -423,8 +431,6 @@ class Shell final : public PlatformView::Delegate,
              std::unique_ptr<Engine> engine,
              std::unique_ptr<Rasterizer> rasterizer,
              std::unique_ptr<ShellIOManager> io_manager);
-
-  DartVM* GetDartVM();
 
   void ReportTimings();
 

--- a/shell/platform/embedder/embedder_engine.h
+++ b/shell/platform/embedder/embedder_engine.h
@@ -80,7 +80,10 @@ class EmbedderEngine {
 
   bool RunTask(const FlutterTask* task);
 
-  const Shell& GetShell() const;
+  bool PostTaskOnEngineManagedNativeThreads(
+      std::function<void(FlutterNativeThreadType)> closure) const;
+
+  Shell& GetShell();
 
  private:
   const std::unique_ptr<EmbedderThreadHost> thread_host_;

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -4023,7 +4023,9 @@ TEST_F(EmbedderTest, CanPostTaskToAllNativeThreadsRecursively) {
                   if (engine.is_valid()) {
                     ASSERT_EQ(FlutterEnginePostCallbackOnAllNativeThreads(
                                   engine.get(),
-                                  [](auto, auto) { event.Signal(); }, nullptr),
+                                  [](FlutterNativeThreadType type,
+                                     void* baton) { event.Signal(); },
+                                  nullptr),
                               kSuccess);
                   }
                 },

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -3904,5 +3904,125 @@ TEST_F(EmbedderTest, CanSendLowMemoryNotification) {
   ASSERT_EQ(FlutterEngineNotifyLowMemoryWarning(engine.get()), kSuccess);
 }
 
+TEST_F(EmbedderTest, CanPostTaskToAllNativeThreads) {
+  UniqueEngine engine;
+  size_t worker_count = 0;
+  fml::AutoResetWaitableEvent sync_latch;
+
+  // One of the threads that the callback will be posted to is the platform
+  // thread. So we cannot wait for assertions to complete on the platform
+  // thread. Create a new thread to manage the engine instance and wait for
+  // assertions on the test thread.
+  auto platform_task_runner = CreateNewThread("platform_thread");
+
+  platform_task_runner->PostTask([&]() {
+    auto& context = GetEmbedderContext();
+
+    EmbedderConfigBuilder builder(context);
+    builder.SetSoftwareRendererConfig();
+
+    engine = builder.LaunchEngine();
+
+    ASSERT_TRUE(engine.is_valid());
+
+    worker_count = ToEmbedderEngine(engine.get())
+                       ->GetShell()
+                       .GetDartVM()
+                       ->GetConcurrentMessageLoop()
+                       ->GetWorkerCount();
+
+    sync_latch.Signal();
+  });
+
+  sync_latch.Wait();
+
+  ASSERT_GT(worker_count, 4u /* three base threads plus workers */);
+  const auto engine_threads_count = worker_count + 4u;
+
+  struct Captures {
+    // Waits the adequate number of callbacks to fire.
+    fml::CountDownLatch latch;
+
+    // Ensures that the expect number of distinct threads were serviced.
+    std::set<std::thread::id> thread_ids;
+
+    size_t platform_threads_count = 0;
+    size_t render_threads_count = 0;
+    size_t ui_threads_count = 0;
+    size_t worker_threads_count = 0;
+
+    Captures(size_t count) : latch(count) {}
+  };
+
+  Captures captures(engine_threads_count);
+
+  platform_task_runner->PostTask([&]() {
+    ASSERT_EQ(FlutterEnginePostCallbackOnAllNativeThreads(
+                  engine.get(),
+                  [](FlutterNativeThreadType type, void* baton) {
+                    auto captures = reinterpret_cast<Captures*>(baton);
+
+                    switch (type) {
+                      case kFlutterNativeThreadTypeRender:
+                        captures->render_threads_count++;
+                        break;
+                      case kFlutterNativeThreadTypeWorker:
+                        captures->worker_threads_count++;
+                        break;
+                      case kFlutterNativeThreadTypeUI:
+                        captures->ui_threads_count++;
+                        break;
+                      case kFlutterNativeThreadTypePlatform:
+                        captures->platform_threads_count++;
+                        break;
+                    }
+
+                    captures->thread_ids.insert(std::this_thread::get_id());
+                    captures->latch.CountDown();
+                  },
+                  &captures),
+              kSuccess);
+  });
+
+  captures.latch.Wait();
+  ASSERT_EQ(captures.thread_ids.size(), engine_threads_count);
+  ASSERT_EQ(captures.platform_threads_count, 1u);
+  ASSERT_EQ(captures.render_threads_count, 1u);
+  ASSERT_EQ(captures.ui_threads_count, 1u);
+  ASSERT_EQ(captures.worker_threads_count, worker_count + 1u /* for IO */);
+
+  platform_task_runner->PostTask([&]() {
+    engine.reset();
+    sync_latch.Signal();
+  });
+  sync_latch.Wait();
+
+  // The engine should have already been destroyed on the platform task runner.
+  ASSERT_FALSE(engine.is_valid());
+}
+
+TEST_F(EmbedderTest, CanPostTaskToAllNativeThreadsRecursively) {
+  EmbedderConfigBuilder builder(GetEmbedderContext());
+
+  builder.SetSoftwareRendererConfig();
+
+  auto engine = builder.LaunchEngine();
+
+  ASSERT_TRUE(engine.is_valid());
+
+  ASSERT_EQ(FlutterEnginePostCallbackOnAllNativeThreads(
+                engine.get(),
+                [](FlutterNativeThreadType type, void* baton) {
+                  // This should deadlock if the task mutex acquisition is
+                  // busted.
+                  ASSERT_EQ(FlutterEnginePostCallbackOnAllNativeThreads(
+                                reinterpret_cast<FlutterEngine>(baton),
+                                [](auto, auto) { /* dont care*/ }, nullptr),
+                            kSuccess);
+                },
+                engine.get()),
+            kSuccess);
+}
+
 }  // namespace testing
 }  // namespace flutter


### PR DESCRIPTION
`FlutterEnginePostCallbackOnAllNativeThreads` schedule a callback to be run on
all engine managed threads. The engine will attempt to service this callback the
next time the message loops for each managed thread is idle. Since the engine
manages the entire lifecycle of multiple threads, there is no opportunity for
the embedders to finely tune the priorities of threads directly, or, perform
other thread specific configuration (for example, setting thread names for
tracing). This callback gives embedders a chance to affect such tuning.

Fixes https://github.com/flutter/flutter/issues/49551
Fixes b/143774406
Fixes b/148278215
Fixes b/148278931