### PR TITLE
Disable flakey CountDownLatchTest.CanWait unit test on Fuchsia

### DIFF
--- a/fml/synchronization/count_down_latch_unittests.cc
+++ b/fml/synchronization/count_down_latch_unittests.cc
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <thread>
 
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/thread.h"
 #include "flutter/testing/testing.h"
@@ -16,6 +17,11 @@ TEST(CountDownLatchTest, CanWaitOnZero) {
   latch.Wait();
 }
 
+#if OS_FUCHSIA
+#define CanWait DISABLED_CanWait
+#else
+#define CanWait CanWait
+#endif
 TEST(CountDownLatchTest, CanWait) {
   fml::Thread thread("test_thread");
   const size_t count = 100;


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/49457