### PR TITLE
Remove buggy assertion in EmbedderTest::CanPostTaskToAllNativeThreads.

### DIFF
--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -3936,7 +3936,6 @@ TEST_F(EmbedderTest, CanPostTaskToAllNativeThreads) {
 
   sync_latch.Wait();
 
-  ASSERT_GT(worker_count, 4u /* three base threads plus workers */);
   const auto engine_threads_count = worker_count + 4u;
 
   struct Captures {


### PR DESCRIPTION
This was introduced in
https://github.com/flutter/engine/commit/c5329ef5c42a4b55b03ab7b84f1cbcecf43baf7d.

The assertion was originally written to check that more than 4 threads were
managed by the engine (UI, Platform, GPU, IO + ConcurrentWQWorkers). However,
the assertion actually only checked the count of workers in the ConcurrentWQ. As
written, this assertion would fail on all hosts with a hardware concurrency of
less than 4. Remove the assertion. The engine threads count and its assertions
already check callbacks on workers. So this check was incorrect and redundant.