### PR TITLE
Add test to ensure that concurrent message loops have at least one worker.

### DIFF
--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -284,6 +284,12 @@ TEST(MessageLoop, TaskObserverFire) {
   ASSERT_TRUE(terminated);
 }
 
+TEST(MessageLoop, ConcurrentMessageLoopHasNonZeroWorkers) {
+  auto loop = fml::ConcurrentMessageLoop::Create(
+      0u /* explicitly specify zero workers */);
+  ASSERT_GT(loop->GetWorkerCount(), 0u);
+}
+
 TEST(MessageLoop, CanCreateAndShutdownConcurrentMessageLoopsOverAndOver) {
   for (size_t i = 0; i < 10; ++i) {
     auto loop = fml::ConcurrentMessageLoop::Create(i + 1);


### PR DESCRIPTION
The current count is determined from std::thread::hardware_concurrency which can
return zero. Even in such cases, the implementation may not return a loop with
no workers. There are numerous components that depend on having non-zero workers
in the queue.