### PR TITLE
Web PargraphStyle TextHeightBehavior integration

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1031,7 +1031,7 @@ class ParagraphStyle {
              'maxLines: ${      _encoded[0] & 0x020 == 0x020 ? _encoded[5]                       : "unspecified"}, '
              'textHeightBehavior: ${
                                 _encoded[0] & 0x040 == 0x040 ?
-                                  TextHeightBehavior.fromEncoded(_encoded[6]).toString() : "unspecified"}, '
+                                          TextHeightBehavior.fromEncoded(_encoded[6]).toString() : "unspecified"}, '
              'fontFamily: ${    _encoded[0] & 0x080 == 0x080 ? _fontFamily                       : "unspecified"}, '
              'fontSize: ${      _encoded[0] & 0x100 == 0x100 ? _fontSize                         : "unspecified"}, '
              'height: ${        _encoded[0] & 0x200 == 0x200 ? "${_height}x"                     : "unspecified"}, '

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -545,8 +545,21 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
   }
 
   @override
-  int get hashCode =>
-      ui.hashValues(_fontFamily, _fontSize, _height, _ellipsis, _locale);
+  int get hashCode {
+    return ui.hashValues(
+      _textAlign,
+      _textDirection,
+      _fontWeight,
+      _fontStyle,
+      _maxLines,
+      _fontFamily,
+      _fontSize,
+      _height,
+      _textHeightBehavior,
+      _ellipsis,
+      _locale
+    );
+  }
 
   @override
   String toString() {
@@ -557,6 +570,7 @@ class EngineParagraphStyle implements ui.ParagraphStyle {
           'fontWeight: ${_fontWeight ?? "unspecified"}, '
           'fontStyle: ${_fontStyle ?? "unspecified"}, '
           'maxLines: ${_maxLines ?? "unspecified"}, '
+          'textHeightBehavior: ${_textHeightBehavior ?? "unspecified"}, '
           'fontFamily: ${_fontFamily ?? "unspecified"}, '
           'fontSize: ${_fontSize != null ? _fontSize.toStringAsFixed(1) : "unspecified"}, '
           'height: ${_height != null ? "${_height.toStringAsFixed(1)}x" : "unspecified"}, '


### PR DESCRIPTION
Missed this part of the web-side implementation. This is needed to unblock the roller.

See https://github.com/flutter/engine/pull/15087 to see the main PR.