### PR TITLE
Revert "Disable setting a library tag handler."

### DIFF
--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -184,6 +184,11 @@ bool DartIsolate::Initialize(Dart_Isolate dart_isolate) {
 
   SetMessageHandlingTaskRunner(GetTaskRunners().GetUITaskRunner());
 
+  if (tonic::LogIfError(
+          Dart_SetLibraryTagHandler(tonic::DartState::HandleLibraryTag))) {
+    return false;
+  }
+
   if (!UpdateThreadPoolNames()) {
     return false;
   }
@@ -618,9 +623,10 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
 
   tonic::DartState::Scope scope(service_isolate);
   if (!DartServiceIsolate::Startup(
-          settings.observatory_host,  // server IP address
-          settings.observatory_port,  // server observatory port
-          false,                      //  disable websocket origin check
+          settings.observatory_host,           // server IP address
+          settings.observatory_port,           // server observatory port
+          tonic::DartState::HandleLibraryTag,  // embedder library tag handler
+          false,  //  disable websocket origin check
           settings.disable_service_auth_codes,  // disable VM service auth codes
           error                                 // error (out)
           )) {

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -30,6 +30,7 @@
 namespace flutter {
 namespace {
 
+static Dart_LibraryTagHandler g_embedder_tag_handler;
 static tonic::DartLibraryNatives* g_natives;
 static std::string g_observatory_uri;
 
@@ -126,11 +127,16 @@ void DartServiceIsolate::Shutdown(Dart_NativeArguments args) {
 
 bool DartServiceIsolate::Startup(std::string server_ip,
                                  intptr_t server_port,
+                                 Dart_LibraryTagHandler embedder_tag_handler,
                                  bool disable_origin_check,
                                  bool disable_service_auth_codes,
                                  char** error) {
   Dart_Isolate isolate = Dart_CurrentIsolate();
   FML_CHECK(isolate);
+
+  // Remember the embedder's library tag handler.
+  g_embedder_tag_handler = embedder_tag_handler;
+  FML_CHECK(g_embedder_tag_handler);
 
   // Setup native entries.
   if (!g_natives) {

--- a/runtime/dart_service_isolate.h
+++ b/runtime/dart_service_isolate.h
@@ -23,6 +23,7 @@ class DartServiceIsolate {
 
   static bool Startup(std::string server_ip,
                       intptr_t server_port,
+                      Dart_LibraryTagHandler embedder_tag_handler,
                       bool disable_origin_check,
                       bool disable_service_auth_codes,
                       char** error);


### PR DESCRIPTION
This reverts commit ef3aa0144c54ccd22efe014a4ee004aa6ba5b796. This address the use case of an internal customer. In a subsequent patch, I will add a test for this functionality. Instead of removing support for the same from tonic (along with the stuff surrounding filesystem access and package map handling), I’ll rework the same to use FML to avoid code duplication and maintainability.