### PR TITLE
Revert "Always make gpu thread different from platform thread regardless of platform view"

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -426,19 +426,43 @@ NSString* const FlutterDefaultDartEntrypoint = nil;
         return std::make_unique<flutter::Rasterizer>(shell, shell.GetTaskRunners());
       };
 
-  flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
-                                    fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                    _threadHost.gpu_thread->GetTaskRunner(),         // gpu
-                                    _threadHost.ui_thread->GetTaskRunner(),          // ui
-                                    _threadHost.io_thread->GetTaskRunner()           // io
-  );
-  // Create the shell. This is a blocking operation.
-  _shell = flutter::Shell::Create(std::move(task_runners),  // task runners
-                                  std::move(windowData),    // window data
-                                  std::move(settings),      // settings
-                                  on_create_platform_view,  // platform view creation
-                                  on_create_rasterizer      // rasterzier creation
-  );
+  if (flutter::IsIosEmbeddedViewsPreviewEnabled()) {
+    // Embedded views requires the gpu and the platform views to be the same.
+    // The plan is to eventually dynamically merge the threads when there's a
+    // platform view in the layer tree.
+    // For now we use a fixed thread configuration with the same thread used as the
+    // gpu and platform task runner.
+    // TODO(amirh/chinmaygarde): remove this, and dynamically change the thread configuration.
+    // https://github.com/flutter/flutter/issues/23975
+
+    flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // gpu
+                                      _threadHost.ui_thread->GetTaskRunner(),          // ui
+                                      _threadHost.io_thread->GetTaskRunner()           // io
+    );
+    // Create the shell. This is a blocking operation.
+    _shell = flutter::Shell::Create(std::move(task_runners),  // task runners
+                                    std::move(windowData),    // window data
+                                    std::move(settings),      // settings
+                                    on_create_platform_view,  // platform view creation
+                                    on_create_rasterizer      // rasterzier creation
+    );
+  } else {
+    flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
+                                      _threadHost.gpu_thread->GetTaskRunner(),         // gpu
+                                      _threadHost.ui_thread->GetTaskRunner(),          // ui
+                                      _threadHost.io_thread->GetTaskRunner()           // io
+    );
+    // Create the shell. This is a blocking operation.
+    _shell = flutter::Shell::Create(std::move(task_runners),  // task runners
+                                    std::move(windowData),    // window data
+                                    std::move(settings),      // settings
+                                    on_create_platform_view,  // platform view creation
+                                    on_create_rasterizer      // rasterzier creation
+    );
+  }
 
   if (_shell == nullptr) {
     FML_LOG(ERROR) << "Could not start a shell FlutterEngine with entrypoint: "


### PR DESCRIPTION
Reverts flutter/engine#16068

This caused a LUCI failure on the platform view scenario app fixes. Reverting for further investigation. 

https://ci.chromium.org/p/flutter/builders/prod/Mac%20iOS%20Engine/3784