### PR TITLE
Only rasterize one layer tree per vsync frame

### DIFF
--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -21,8 +21,9 @@ LayerTree::LayerTree(const SkISize& frame_size,
       checkerboard_raster_cache_images_(false),
       checkerboard_offscreen_layers_(false) {}
 
-void LayerTree::RecordBuildTime(fml::TimePoint start) {
+void LayerTree::RecordBuildTime(fml::TimePoint start, fml::TimePoint target) {
   build_start_ = start;
+  build_target_ = target;
   build_finish_ = fml::TimePoint::Now();
 }
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -53,8 +53,9 @@ class LayerTree {
   float frame_physical_depth() const { return frame_physical_depth_; }
   float frame_device_pixel_ratio() const { return frame_device_pixel_ratio_; }
 
-  void RecordBuildTime(fml::TimePoint begin_start);
+  void RecordBuildTime(fml::TimePoint begin_start, fml::TimePoint begin_target);
   fml::TimePoint build_start() const { return build_start_; }
+  fml::TimePoint build_target() const { return build_target_; }
   fml::TimePoint build_finish() const { return build_finish_; }
   fml::TimeDelta build_time() const { return build_finish_ - build_start_; }
 
@@ -82,6 +83,7 @@ class LayerTree {
  private:
   std::shared_ptr<Layer> root_layer_;
   fml::TimePoint build_start_;
+  fml::TimePoint build_target_;
   fml::TimePoint build_finish_;
   SkISize frame_size_ = SkISize::MakeEmpty();  // Physical pixels.
   float frame_physical_depth_;

--- a/fml/message_loop_impl.cc
+++ b/fml/message_loop_impl.cc
@@ -57,7 +57,6 @@ MessageLoopImpl::~MessageLoopImpl() {
 void MessageLoopImpl::PostTask(const fml::closure& task,
                                fml::TimePoint target_time) {
   FML_DCHECK(task != nullptr);
-  FML_DCHECK(task != nullptr);
   if (terminated_) {
     // If the message loop has already been terminated, PostTask should destruct
     // |task| synchronously within this function.

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -26,6 +26,7 @@ Animator::Animator(Delegate& delegate,
       task_runners_(std::move(task_runners)),
       waiter_(std::move(waiter)),
       last_begin_frame_time_(),
+      last_begin_target_time_(),
       dart_frame_deadline_(0),
 #if FLUTTER_SHELL_ENABLE_METAL
       layer_tree_pipeline_(fml::MakeRefCounted<LayerTreePipeline>(2)),
@@ -133,6 +134,7 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
   FML_DCHECK(producer_continuation_);
 
   last_begin_frame_time_ = frame_start_time;
+  last_begin_target_time_ = frame_target_time;
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
   {
     TRACE_EVENT2("flutter", "Framework Workload", "mode", "basic", "frame",
@@ -178,7 +180,7 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
 
   if (layer_tree) {
     // Note the frame time for instrumentation.
-    layer_tree->RecordBuildTime(last_begin_frame_time_);
+    layer_tree->RecordBuildTime(last_begin_frame_time_, last_begin_target_time_);
   }
 
   // Commit the pending continuation.

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -97,6 +97,7 @@ class Animator final {
   std::shared_ptr<VsyncWaiter> waiter_;
 
   fml::TimePoint last_begin_frame_time_;
+  fml::TimePoint last_begin_target_time_;
   int64_t dart_frame_deadline_;
   fml::RefPtr<LayerTreePipeline> layer_tree_pipeline_;
   fml::Semaphore pending_frame_semaphore_;

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -412,10 +412,12 @@ class Rasterizer final : public SnapshotDelegate {
   std::unique_ptr<flutter::CompositorContext> compositor_context_;
   // This is the last successfully rasterized layer tree.
   std::unique_ptr<flutter::LayerTree> last_layer_tree_;
+  fml::TimePoint last_render_finish_;
   // Set when we need attempt to rasterize the layer tree again. This layer_tree
   // has not successfully rasterized. This can happen due to the change in the
   // thread configuration. This will be inserted to the front of the pipeline.
   std::unique_ptr<flutter::LayerTree> resubmitted_layer_tree_;
+  fml::TimePoint resubmitted_time_target_;
   fml::closure next_frame_callback_;
   bool user_override_resource_cache_bytes_;
   std::optional<size_t> max_cache_bytes_;
@@ -432,6 +434,8 @@ class Rasterizer final : public SnapshotDelegate {
   sk_sp<SkImage> DoMakeRasterSnapshot(
       SkISize size,
       std::function<void(SkCanvas*)> draw_callback);
+
+  fml::TimePoint DetermineRasterizationTime(LayerTree& layer_tree);
 
   RasterStatus DoDraw(std::unique_ptr<flutter::LayerTree> layer_tree);
 


### PR DESCRIPTION
These changes are attempting to avoid the condition we are having mainly on iOS where we will get hung up on one frame and then enter a period of time where all frames are blocked by OpenGL waiting for the next vsync. To avoid this, the changes here attempt to reschedule the render pass for a future vsync time interval (based on the last layer_tree generated or guessing on a delay if it has to - more work could be done to be more clever about that heuristic).

Issue: https://github.com/flutter/flutter/issues/75540

Before this change, the flutter_gallery_ios__transition_perf benchmark was posting 16+ms timings for the rasterization time of a lot of its frames.  For example:

```
    "average_frame_rasterizer_time_millis": 6.832514690982775,
    "90th_percentile_frame_rasterizer_time_millis": 16.652,
    "99th_percentile_frame_rasterizer_time_millis": 17.377,
    "worst_frame_rasterizer_time_millis": 19.322,
```

After the changes, the timings for average and 90% frames are much better. For example:

```
    "average_frame_rasterizer_time_millis": 2.412388779527557,
    "90th_percentile_frame_rasterizer_time_millis": 3.704,
    "99th_percentile_frame_rasterizer_time_millis": 16.282,
    "worst_frame_rasterizer_time_millis": 18.165,
```

With this fix, hopefully we can expect more consistent results from our benchmark output.

This is currently a WIP as much more testing is needed in many more cases, but I wanted to get the diffs out there to solicit feedback on the basic approach before I get too far with the testing.