### PR TITLE
Ensure that Android embedding initialization always uses an application context

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -215,7 +215,7 @@ public class FlutterEngine {
       boolean automaticallyRegisterPlugins
   ) {
     this.flutterJNI = flutterJNI;
-    flutterLoader.startInitialization(context);
+    flutterLoader.startInitialization(context.getApplicationContext());
     flutterLoader.ensureInitializationComplete(context, dartVmArgs);
 
     flutterJNI.addEngineLifecycleListener(engineLifecycleListener);

--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -113,6 +113,9 @@ public class FlutterLoader {
           throw new IllegalStateException("startInitialization must be called on the main thread");
         }
 
+        // Ensure that the context is actually the application context.
+        applicationContext = applicationContext.getApplicationContext();
+
         this.settings = settings;
 
         long initStartTimestampMillis = SystemClock.uptimeMillis();

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -1,5 +1,6 @@
 package test.io.flutter.embedding.engine;
 
+import android.content.Context;
 import io.flutter.plugin.platform.PlatformViewsController;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 import java.util.List;
@@ -21,6 +22,7 @@ import io.flutter.embedding.engine.loader.FlutterLoader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -101,5 +103,20 @@ public class FlutterEngineTest {
     // Verify that FlutterEngine notified PlatformViewsController of the pre-engine restart,
     // AKA hot restart.
     verify(platformViewsController, times(1)).onPreEngineRestart();
+  }
+
+  @Test
+  public void itUsesApplicationContext() {
+    Context context = mock(Context.class);
+
+    new FlutterEngine(
+        context,
+        mock(FlutterLoader.class),
+        flutterJNI,
+        /*dartVmArgs=*/new String[] {},
+        /*automaticallyRegisterPlugins=*/false
+    );
+
+    verify(context, atLeast(1)).getApplicationContext();
   }
 }


### PR DESCRIPTION
Some parts of the embedding (e.g. VsyncWaiter) may hold global references to
system services obtained through the context used during initialization.
These must not be associated with an activity or other non-application context.

Fixes https://github.com/flutter/flutter/issues/49612