### PR TITLE
In the test harness, don’t attempt to load AOT snapshots from non-existent dylibs.

### DIFF
--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -81,7 +81,6 @@ class EmbedderTestContext {
   std::unique_ptr<fml::Mapping> vm_snapshot_instructions_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_data_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_instructions_;
-
   std::vector<fml::closure> isolate_create_callbacks_;
   std::shared_ptr<TestDartNativeResolver> native_resolver_;
   SemanticsNodeCallback update_semantics_node_callback_;
@@ -101,6 +100,8 @@ class EmbedderTestContext {
 
   static FlutterUpdateSemanticsCustomActionCallback
   GetUpdateSemanticsCustomActionCallbackHook();
+
+  void SetupAOTMappingsIfNecessary();
 
   void SetupCompositor();
 


### PR DESCRIPTION
This condition may arise when the embedder passes in a path to a non-existent
dylib. Instead of crashing, the embedder will now return an error response.

Fixes https://github.com/flutter/flutter/issues/49732