### PR TITLE
Use snapshot symbol names from constants in dart_api.h.

### DIFF
--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -14,12 +14,6 @@
 
 namespace flutter {
 
-const char* DartSnapshot::kVMDataSymbol = "kDartVmSnapshotData";
-const char* DartSnapshot::kVMInstructionsSymbol = "kDartVmSnapshotInstructions";
-const char* DartSnapshot::kIsolateDataSymbol = "kDartIsolateSnapshotData";
-const char* DartSnapshot::kIsolateInstructionsSymbol =
-    "kDartIsolateSnapshotInstructions";
-
 // On Windows and Android (in debug mode) the engine finds the Dart snapshot
 // data through symbols that are statically linked into the executable.
 // On other platforms this data is obtained by a dynamic symbol lookup.
@@ -102,7 +96,7 @@ static std::shared_ptr<const fml::Mapping> ResolveVMData(
       settings.vm_snapshot_data,          // embedder_mapping_callback
       settings.vm_snapshot_data_path,     // file_path
       settings.application_library_path,  // native_library_path
-      DartSnapshot::kVMDataSymbol,        // native_library_symbol_name
+      kVmSnapshotDataCSymbol,             // native_library_symbol_name
       false                               // is_executable
   );
 #endif  // DART_SNAPSHOT_STATIC_LINK
@@ -114,11 +108,11 @@ static std::shared_ptr<const fml::Mapping> ResolveVMInstructions(
   return std::make_unique<fml::NonOwnedMapping>(kDartVmSnapshotInstructions, 0);
 #else   // DART_SNAPSHOT_STATIC_LINK
   return SearchMapping(
-      settings.vm_snapshot_instr,           // embedder_mapping_callback
-      settings.vm_snapshot_instr_path,      // file_path
-      settings.application_library_path,    // native_library_path
-      DartSnapshot::kVMInstructionsSymbol,  // native_library_symbol_name
-      true                                  // is_executable
+      settings.vm_snapshot_instr,         // embedder_mapping_callback
+      settings.vm_snapshot_instr_path,    // file_path
+      settings.application_library_path,  // native_library_path
+      kVmSnapshotInstructionsCSymbol,     // native_library_symbol_name
+      true                                // is_executable
   );
 #endif  // DART_SNAPSHOT_STATIC_LINK
 }
@@ -132,7 +126,7 @@ static std::shared_ptr<const fml::Mapping> ResolveIsolateData(
       settings.isolate_snapshot_data,       // embedder_mapping_callback
       settings.isolate_snapshot_data_path,  // file_path
       settings.application_library_path,    // native_library_path
-      DartSnapshot::kIsolateDataSymbol,     // native_library_symbol_name
+      kIsolateSnapshotDataCSymbol,          // native_library_symbol_name
       false                                 // is_executable
   );
 #endif  // DART_SNAPSHOT_STATIC_LINK
@@ -145,11 +139,11 @@ static std::shared_ptr<const fml::Mapping> ResolveIsolateInstructions(
       kDartIsolateSnapshotInstructions, 0);
 #else   // DART_SNAPSHOT_STATIC_LINK
   return SearchMapping(
-      settings.isolate_snapshot_instr,           // embedder_mapping_callback
-      settings.isolate_snapshot_instr_path,      // file_path
-      settings.application_library_path,         // native_library_path
-      DartSnapshot::kIsolateInstructionsSymbol,  // native_library_symbol_name
-      true                                       // is_executable
+      settings.isolate_snapshot_instr,       // embedder_mapping_callback
+      settings.isolate_snapshot_instr_path,  // file_path
+      settings.application_library_path,     // native_library_path
+      kIsolateSnapshotInstructionsCSymbol,   // native_library_symbol_name
+      true                                   // is_executable
   );
 #endif  // DART_SNAPSHOT_STATIC_LINK
 }

--- a/runtime/dart_snapshot.h
+++ b/runtime/dart_snapshot.h
@@ -42,27 +42,6 @@ namespace flutter {
 class DartSnapshot : public fml::RefCountedThreadSafe<DartSnapshot> {
  public:
   //----------------------------------------------------------------------------
-  /// The symbol name of the heap data of the core snapshot in a dynamic library
-  /// or currently loaded process.
-  ///
-  static const char* kVMDataSymbol;
-  //----------------------------------------------------------------------------
-  /// The symbol name of the instructions data of the core snapshot in a dynamic
-  /// library or currently loaded process.
-  ///
-  static const char* kVMInstructionsSymbol;
-  //----------------------------------------------------------------------------
-  /// The symbol name of the heap data of the isolate snapshot in a dynamic
-  /// library or currently loaded process.
-  ///
-  static const char* kIsolateDataSymbol;
-  //----------------------------------------------------------------------------
-  /// The symbol name of the instructions data of the isolate snapshot in a
-  /// dynamic library or currently loaded process.
-  ///
-  static const char* kIsolateInstructionsSymbol;
-
-  //----------------------------------------------------------------------------
   /// @brief      From the fields present in the given settings object, infer
   ///             the core snapshot.
   ///


### PR DESCRIPTION
We redefine these because dart_api.h didn’t have these constants when this class was written.