### PR TITLE
Avoid generating VSYNC trace events when tracing to systrace.

### DIFF
--- a/shell/common/vsync_waiter.cc
+++ b/shell/common/vsync_waiter.cc
@@ -9,18 +9,6 @@
 
 namespace flutter {
 
-#if defined(OS_FUCHSIA)
-// In general, traces on Fuchsia are recorded across the whole system.
-// Because of this, emitting a "VSYNC" event per flutter process is
-// undesirable, as the events will collide with each other.  We
-// instead let another area of the system emit them.
-static constexpr const char* kVsyncTraceName = "vsync callback";
-#else   // defined(OS_FUCHSIA)
-// Note: The tag name must be "VSYNC" (it is special) so that the
-// "Highlight Vsync" checkbox in the timeline can be enabled.
-static constexpr const char* kVsyncTraceName = "VSYNC";
-#endif  // defined(OS_FUCHSIA)
-
 static constexpr const char* kVsyncFlowName = "VsyncFlow";
 
 VsyncWaiter::VsyncWaiter(TaskRunners task_runners)
@@ -114,7 +102,7 @@ void VsyncWaiter::FireCallback(fml::TimePoint frame_start_time,
 
     task_runners_.GetUITaskRunner()->PostTaskForTime(
         [callback, flow_identifier, frame_start_time, frame_target_time]() {
-          FML_TRACE_EVENT("flutter", kVsyncTraceName, "StartTime",
+          FML_TRACE_EVENT("flutter", "VsyncProcessCallback", "StartTime",
                           frame_start_time, "TargetTime", frame_target_time);
           fml::tracing::TraceEventAsyncComplete(
               "flutter", "VsyncSchedulingOverhead", fml::TimePoint::Now(),

--- a/shell/platform/android/vsync_waiter_android.cc
+++ b/shell/platform/android/vsync_waiter_android.cc
@@ -57,6 +57,8 @@ void VsyncWaiterAndroid::OnNativeVsync(JNIEnv* env,
                                        jlong frameTimeNanos,
                                        jlong frameTargetTimeNanos,
                                        jlong java_baton) {
+  TRACE_EVENT0("flutter", "VSYNC");
+
   auto frame_time = fml::TimePoint::FromEpochDelta(
       fml::TimeDelta::FromNanoseconds(frameTimeNanos));
   auto target_time = fml::TimePoint::FromEpochDelta(

--- a/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
+++ b/shell/platform/darwin/ios/framework/Source/vsync_waiter_ios.mm
@@ -114,6 +114,8 @@ float VsyncWaiterIOS::GetDisplayRefreshRate() const {
 }
 
 - (void)onDisplayLink:(CADisplayLink*)link {
+  TRACE_EVENT0("flutter", "VSYNC");
+
   CFTimeInterval delay = CACurrentMediaTime() - link.timestamp;
   fml::TimePoint frame_start_time = fml::TimePoint::Now() - fml::TimeDelta::FromSecondsF(delay);
   fml::TimePoint frame_target_time = frame_start_time + fml::TimeDelta::FromSecondsF(link.duration);


### PR DESCRIPTION
Chrome Trace viewer treats events labeled "VSYNC" as special and highlights them (when the "Highlight Vsync" checkbox is enabled). This is the only VSYNC reference existing when debugging a single Flutter app through Observatory.

However when tracing to Systrace there is usually a more authoritative system-wide VSYNC event source. So we avoid sending Flutter VSYNC events which make/ debugging multiple applications running in the system at once.