### PR TITLE
[fuchsia] SceneHostBindings are no longer thread locals

### DIFF
--- a/lib/ui/compositing/scene_host.cc
+++ b/lib/ui/compositing/scene_host.cc
@@ -25,8 +25,6 @@ struct SceneHostBindingKey {
                       const std::string isolate_service_id) {
     this->koid = koid;
     this->isolate_service_id = isolate_service_id;
-    FML_LOG(ERROR) << "SceneHostBindingKey koid:: " << koid
-                   << ", isolate: " << isolate_service_id;
   }
 
   bool operator==(const SceneHostBindingKey& other) const {

--- a/lib/ui/compositing/scene_host.cc
+++ b/lib/ui/compositing/scene_host.cc
@@ -21,9 +21,12 @@ struct SceneHostBindingKey {
   std::string isolate_service_id;
   zx_koid_t koid;
 
-  SceneHostBindingKey(const zx_koid_t koid) {
+  SceneHostBindingKey(const zx_koid_t koid,
+                      const std::string isolate_service_id) {
     this->koid = koid;
-    this->isolate_service_id = Dart_IsolateServiceId(Dart_CurrentIsolate());
+    this->isolate_service_id = isolate_service_id;
+    FML_LOG(ERROR) << "SceneHostBindingKey koid:: " << koid
+                   << ", isolate: " << isolate_service_id;
   }
 
   bool operator==(const SceneHostBindingKey& other) const {
@@ -49,13 +52,25 @@ void SceneHost_constructor(Dart_NativeArguments args) {
   tonic::DartCallConstructor(&flutter::SceneHost::Create, args);
 }
 
-flutter::SceneHost* GetSceneHost(scenic::ResourceId id) {
-  auto binding = scene_host_bindings.find(id);
-  if (binding != scene_host_bindings.end()) {
+flutter::SceneHost* GetSceneHost(scenic::ResourceId id,
+                                 std::string isolate_service_id) {
+  auto binding =
+      scene_host_bindings.find(SceneHostBindingKey(id, isolate_service_id));
+  if (binding == scene_host_bindings.end()) {
+    return nullptr;
+  } else {
     return binding->second;
   }
+}
 
-  return nullptr;
+flutter::SceneHost* GetSceneHostForCurrentIsolate(scenic::ResourceId id) {
+  auto isolate = Dart_CurrentIsolate();
+  if (!isolate) {
+    return nullptr;
+  } else {
+    std::string isolate_service_id = Dart_IsolateServiceId(isolate);
+    return GetSceneHost(id, isolate_service_id);
+  }
 }
 
 void InvokeDartClosure(const tonic::DartPersistentValue& closure) {
@@ -122,7 +137,7 @@ fml::RefPtr<SceneHost> SceneHost::Create(
 }
 
 void SceneHost::OnViewConnected(scenic::ResourceId id) {
-  auto* scene_host = GetSceneHost(id);
+  auto* scene_host = GetSceneHostForCurrentIsolate(id);
 
   if (scene_host && !scene_host->view_connected_callback_.is_empty()) {
     InvokeDartClosure(scene_host->view_connected_callback_);
@@ -130,7 +145,7 @@ void SceneHost::OnViewConnected(scenic::ResourceId id) {
 }
 
 void SceneHost::OnViewDisconnected(scenic::ResourceId id) {
-  auto* scene_host = GetSceneHost(id);
+  auto* scene_host = GetSceneHostForCurrentIsolate(id);
 
   if (scene_host && !scene_host->view_disconnected_callback_.is_empty()) {
     InvokeDartClosure(scene_host->view_disconnected_callback_);
@@ -138,7 +153,7 @@ void SceneHost::OnViewDisconnected(scenic::ResourceId id) {
 }
 
 void SceneHost::OnViewStateChanged(scenic::ResourceId id, bool state) {
-  auto* scene_host = GetSceneHost(id);
+  auto* scene_host = GetSceneHostForCurrentIsolate(id);
 
   if (scene_host && !scene_host->view_state_changed_callback_.is_empty()) {
     InvokeDartFunction(scene_host->view_state_changed_callback_, state);
@@ -153,6 +168,7 @@ SceneHost::SceneHost(fml::RefPtr<zircon::dart::Handle> viewHolderToken,
           UIDartState::Current()->GetTaskRunners().GetGPUTaskRunner()),
       koid_(GetKoid(viewHolderToken->handle())) {
   auto dart_state = UIDartState::Current();
+  isolate_service_id_ = Dart_IsolateServiceId(Dart_CurrentIsolate());
 
   // Initialize callbacks it they are non-null in Dart.
   if (!Dart_IsNull(viewConnectedCallback)) {
@@ -167,9 +183,10 @@ SceneHost::SceneHost(fml::RefPtr<zircon::dart::Handle> viewHolderToken,
 
   // This callback will be posted as a task  when the |scenic::ViewHolder|
   // resource is created and given an id by the GPU thread.
-  auto bind_callback = [scene_host = this](scenic::ResourceId id) {
-    FML_DCHECK(scene_host_bindings.find(id) == scene_host_bindings.end());
-    const auto key = SceneHostBindingKey(id);
+  auto bind_callback = [scene_host = this,
+                        isolate_service_id =
+                            isolate_service_id_](scenic::ResourceId id) {
+    const auto key = SceneHostBindingKey(id, isolate_service_id);
     scene_host_bindings.emplace(std::make_pair(key, scene_host));
   };
 
@@ -188,7 +205,7 @@ SceneHost::SceneHost(fml::RefPtr<zircon::dart::Handle> viewHolderToken,
 }
 
 SceneHost::~SceneHost() {
-  scene_host_bindings.erase(koid_);
+  scene_host_bindings.erase(SceneHostBindingKey(koid_, isolate_service_id_));
 
   gpu_task_runner_->PostTask(
       [id = koid_]() { flutter::ViewHolder::Destroy(id); });

--- a/lib/ui/compositing/scene_host.h
+++ b/lib/ui/compositing/scene_host.h
@@ -57,6 +57,7 @@ class SceneHost : public RefCountedDartWrappable<SceneHost> {
   tonic::DartPersistentValue view_connected_callback_;
   tonic::DartPersistentValue view_disconnected_callback_;
   tonic::DartPersistentValue view_state_changed_callback_;
+  std::string isolate_service_id_;
   zx_koid_t koid_ = ZX_KOID_INVALID;
 };
 


### PR DESCRIPTION
Prior to this change SceneHostBindinds was a ThreadLocal but the
intention was for it to be IsolateLocal. Given that dart
could collect this map on a non-UI thread this caused
use-after-free issues.

This change fixes it by making it keyed on isolate and koid
this is not the ideal solution, this would exist on
dart isolate group data struct. Given that Fuchsia is moving
to use the embedder API, the decision to use this temporary
work around was made.

fixes https://github.com/flutter/flutter/issues/49738