### PR TITLE
Pass through invoker.resources in fuchsia_test_archive

### DIFF
--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -139,6 +139,10 @@ template("fuchsia_test_archive") {
     deps = invoker.deps
     binary = invoker.binary
 
+    if (defined(invoker.resources)) {
+      resources = invoker.resources
+    }
+
     meta_dir = "$flutter_root/testing/fuchsia/meta"
     cmx_file = "$meta_dir/fuchsia_test.cmx"
   }


### PR DESCRIPTION
This is required for us to be able to specify test fixtures that need to be copied as part of the .far file