### PR TITLE
Fix runtime_unittest in AOT mode by loading AOT symbols from ELF loader.

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -147,6 +147,7 @@ source_set("runtime_unittests_common") {
     "$flutter_root/shell/common",
     "$flutter_root/testing:dart",
     "$flutter_root/third_party/tonic",
+    "//third_party/dart/runtime/bin:elf_loader",
     "//third_party/skia",
   ]
 }


### PR DESCRIPTION
This regressed when the symbols were no longer packed in discrete blobs but
instead moved to an ELF file.

Regressed in https://github.com/flutter/engine/commit/d9080029af4b917fd5813c1db7f96d509343e01e
Unnoticed because of https://github.com/flutter/flutter/issues/49733
Fixes https://github.com/flutter/flutter/issues/49763