### PR TITLE
Isolate and move common portable ELF loading from fixtures into //flutter/testing.

### DIFF
--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -147,7 +147,6 @@ source_set("runtime_unittests_common") {
     "$flutter_root/shell/common",
     "$flutter_root/testing:dart",
     "$flutter_root/third_party/tonic",
-    "//third_party/dart/runtime/bin:elf_loader",
     "//third_party/skia",
   ]
 }

--- a/runtime/runtime_test.cc
+++ b/runtime/runtime_test.cc
@@ -4,65 +4,18 @@
 
 #include "flutter/runtime/runtime_test.h"
 
-#include "flutter/fml/file.h"
-#include "flutter/fml/native_library.h"
-#include "flutter/fml/paths.h"
-#include "flutter/runtime/dart_snapshot.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/testing/testing.h"
 
 namespace flutter {
 namespace testing {
 
-static constexpr const char* kAOTAppELFFileName = "app_elf_snapshot.so";
-
-static ELFAOTSymbols LoadELFIfNecessary() {
-  if (!DartVM::IsRunningPrecompiledCode()) {
-    return {};
-  }
-
-  const auto elf_path =
-      fml::paths::JoinPaths({GetFixturesPath(), kAOTAppELFFileName});
-
-  if (!fml::IsFile(elf_path)) {
-    FML_LOG(ERROR) << "App AOT file does not exist for this fixture. Attempts "
-                      "to launch the Dart VM will fail.";
-    return {};
-  }
-
-  ELFAOTSymbols symbols;
-
-  // Must not be freed.
-  const char* error = nullptr;
-
-  auto loaded_elf =
-      Dart_LoadELF(elf_path.c_str(),             // file path
-                   0,                            // file offset
-                   &error,                       // error (out)
-                   &symbols.vm_snapshot_data,    // vm snapshot data (out)
-                   &symbols.vm_snapshot_instrs,  // vm snapshot instrs (out)
-                   &symbols.vm_isolate_data,     // vm isolate data (out)
-                   &symbols.vm_isolate_instrs    // vm isolate instr (out)
-      );
-
-  if (loaded_elf == nullptr) {
-    FML_LOG(ERROR) << "Could not fetch AOT symbols from loaded ELF. Attempts "
-                      "to launch the Dart VM will fail. Error: "
-                   << error;
-    return {};
-  }
-
-  symbols.loaded_elf.reset(loaded_elf);
-
-  return symbols;
-}
-
 RuntimeTest::RuntimeTest()
     : native_resolver_(std::make_shared<TestDartNativeResolver>()),
       assets_dir_(fml::OpenDirectory(GetFixturesPath(),
                                      false,
                                      fml::FilePermission::kRead)),
-      aot_symbols_(LoadELFIfNecessary()) {}
+      aot_symbols_(LoadELFSymbolFromFixturesIfNeccessary()) {}
 
 void RuntimeTest::SetSnapshotsAndAssets(Settings& settings) {
   if (!assets_dir_.is_valid()) {
@@ -75,22 +28,7 @@ void RuntimeTest::SetSnapshotsAndAssets(Settings& settings) {
   // don't need to be explicitly supplied by the embedder. In AOT, these
   // snapshots will be present in the application AOT dylib.
   if (DartVM::IsRunningPrecompiledCode()) {
-    settings.vm_snapshot_data = [&]() {
-      return std::make_unique<fml::NonOwnedMapping>(
-          aot_symbols_.vm_snapshot_data, 0u);
-    };
-    settings.isolate_snapshot_data = [&]() {
-      return std::make_unique<fml::NonOwnedMapping>(
-          aot_symbols_.vm_isolate_data, 0u);
-    };
-    settings.vm_snapshot_instr = [&]() {
-      return std::make_unique<fml::NonOwnedMapping>(
-          aot_symbols_.vm_snapshot_instrs, 0u);
-    };
-    settings.isolate_snapshot_instr = [&]() {
-      return std::make_unique<fml::NonOwnedMapping>(
-          aot_symbols_.vm_isolate_instrs, 0u);
-    };
+    PrepareSettingsForAOTWithSymbols(settings, aot_symbols_);
   } else {
     settings.application_kernels = [this]() {
       std::vector<std::unique_ptr<const fml::Mapping>> kernel_mappings;

--- a/runtime/runtime_test.h
+++ b/runtime/runtime_test.h
@@ -9,26 +9,12 @@
 
 #include "flutter/common/settings.h"
 #include "flutter/fml/macros.h"
+#include "flutter/testing/elf_loader.h"
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/thread_test.h"
-#include "third_party/dart/runtime/bin/elf_loader.h"
 
 namespace flutter {
 namespace testing {
-
-struct LoadedELFDeleter {
-  void operator()(Dart_LoadedElf* elf) { Dart_UnloadELF(elf); }
-};
-
-using UniqueLoadedELF = std::unique_ptr<Dart_LoadedElf, LoadedELFDeleter>;
-
-struct ELFAOTSymbols {
-  UniqueLoadedELF loaded_elf;
-  const uint8_t* vm_snapshot_data = nullptr;
-  const uint8_t* vm_snapshot_instrs = nullptr;
-  const uint8_t* vm_isolate_data = nullptr;
-  const uint8_t* vm_isolate_instrs = nullptr;
-};
 
 class RuntimeTest : public ThreadTest {
  public:

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -25,7 +25,8 @@ ShellTest::ShellTest()
                        ThreadHost::Type::UI | ThreadHost::Type::GPU),
       assets_dir_(fml::OpenDirectory(GetFixturesPath(),
                                      false,
-                                     fml::FilePermission::kRead)) {}
+                                     fml::FilePermission::kRead)),
+      aot_symbols_(LoadELFSymbolFromFixturesIfNeccessary()) {}
 
 void ShellTest::SendEnginePlatformMessage(
     Shell* shell,
@@ -52,26 +53,7 @@ void ShellTest::SetSnapshotsAndAssets(Settings& settings) {
   // In JIT execution, all snapshots are present within the binary itself and
   // don't need to be explicitly suppiled by the embedder.
   if (DartVM::IsRunningPrecompiledCode()) {
-    settings.vm_snapshot_data = [this]() {
-      return fml::FileMapping::CreateReadOnly(assets_dir_, "vm_snapshot_data");
-    };
-
-    settings.isolate_snapshot_data = [this]() {
-      return fml::FileMapping::CreateReadOnly(assets_dir_,
-                                              "isolate_snapshot_data");
-    };
-
-    if (DartVM::IsRunningPrecompiledCode()) {
-      settings.vm_snapshot_instr = [this]() {
-        return fml::FileMapping::CreateReadExecute(assets_dir_,
-                                                   "vm_snapshot_instr");
-      };
-
-      settings.isolate_snapshot_instr = [this]() {
-        return fml::FileMapping::CreateReadExecute(assets_dir_,
-                                                   "isolate_snapshot_instr");
-      };
-    }
+    PrepareSettingsForAOTWithSymbols(settings, aot_symbols_);
   } else {
     settings.application_kernels = [this]() {
       std::vector<std::unique_ptr<const fml::Mapping>> kernel_mappings;

--- a/shell/common/shell_test.h
+++ b/shell/common/shell_test.h
@@ -16,6 +16,7 @@
 #include "flutter/shell/common/shell.h"
 #include "flutter/shell/common/thread_host.h"
 #include "flutter/shell/common/vsync_waiters_test.h"
+#include "flutter/testing/elf_loader.h"
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/thread_test.h"
 
@@ -84,6 +85,7 @@ class ShellTest : public ThreadTest {
   std::shared_ptr<TestDartNativeResolver> native_resolver_;
   ThreadHost thread_host_;
   fml::UniqueFD assets_dir_;
+  ELFAOTSymbols aot_symbols_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ShellTest);
 };

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -136,7 +136,6 @@ if (current_toolchain == host_toolchain) {
       "$flutter_root/testing:opengl",
       "$flutter_root/testing:skia",
       "$flutter_root/third_party/tonic",
-      "//third_party/dart/runtime/bin:elf_loader",
       "//third_party/skia",
     ]
   }

--- a/shell/platform/embedder/tests/embedder_test_context.h
+++ b/shell/platform/embedder/tests/embedder_test_context.h
@@ -16,9 +16,9 @@
 #include "flutter/fml/mapping.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/tests/embedder_test_compositor.h"
+#include "flutter/testing/elf_loader.h"
 #include "flutter/testing/test_dart_native_resolver.h"
 #include "flutter/testing/test_gl_surface.h"
-#include "third_party/dart/runtime/bin/elf_loader.h"
 #include "third_party/skia/include/core/SkImage.h"
 
 namespace flutter {
@@ -74,9 +74,7 @@ class EmbedderTestContext {
   using NextSceneCallback = std::function<void(sk_sp<SkImage> image)>;
 
   std::string assets_path_;
-
-  // Pieces of the Dart snapshot in ELF form, loaded by Dart's ELF library.
-  Dart_LoadedElf* elf_library_handle_ = nullptr;
+  ELFAOTSymbols aot_symbols_;
   std::unique_ptr<fml::Mapping> vm_snapshot_data_;
   std::unique_ptr<fml::Mapping> vm_snapshot_instructions_;
   std::unique_ptr<fml::Mapping> isolate_snapshot_data_;

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -9,11 +9,11 @@ source_set("testing_lib") {
   testonly = true
 
   sources = [
-    "$flutter_root/testing/assertions.h",
-    "$flutter_root/testing/testing.cc",
-    "$flutter_root/testing/testing.h",
-    "$flutter_root/testing/thread_test.cc",
-    "$flutter_root/testing/thread_test.h",
+    "assertions.h",
+    "testing.cc",
+    "testing.h",
+    "thread_test.cc",
+    "thread_test.h",
   ]
 
   public_deps = [
@@ -27,7 +27,7 @@ source_set("testing") {
   testonly = true
 
   sources = [
-    "$flutter_root/testing/run_all_unittests.cc",
+    "run_all_unittests.cc",
   ]
 
   public_deps = [
@@ -39,14 +39,21 @@ source_set("dart") {
   testonly = true
 
   sources = [
-    "$flutter_root/testing/test_dart_native_resolver.cc",
-    "$flutter_root/testing/test_dart_native_resolver.h",
+    "elf_loader.cc",
+    "elf_loader.h",
+    "test_dart_native_resolver.cc",
+    "test_dart_native_resolver.h",
   ]
 
   public_deps = [
     ":testing",
+    "$flutter_root/common",
+    "$flutter_root/fml",
+    "$flutter_root/runtime",
     "$flutter_root/runtime:libdart",
     "$flutter_root/third_party/tonic",
+    "//third_party/dart/runtime/bin:elf_loader",
+    "//third_party/skia",
   ]
 }
 
@@ -54,11 +61,11 @@ source_set("skia") {
   testonly = true
 
   sources = [
-    "$flutter_root/testing/assertions_skia.cc",
-    "$flutter_root/testing/assertions_skia.h",
-    "$flutter_root/testing/canvas_test.h",
-    "$flutter_root/testing/mock_canvas.cc",
-    "$flutter_root/testing/mock_canvas.h",
+    "assertions_skia.cc",
+    "assertions_skia.h",
+    "canvas_test.h",
+    "mock_canvas.cc",
+    "mock_canvas.h",
   ]
 
   public_deps = [
@@ -74,8 +81,8 @@ if (current_toolchain == host_toolchain) {
     configs += [ "//third_party/swiftshader_flutter:swiftshader_config" ]
 
     sources = [
-      "$flutter_root/testing/test_gl_surface.cc",
-      "$flutter_root/testing/test_gl_surface.h",
+      "test_gl_surface.cc",
+      "test_gl_surface.h",
     ]
 
     deps = [
@@ -95,14 +102,14 @@ if (current_toolchain == host_toolchain) {
     testonly = true
 
     sources = [
-      "$flutter_root/testing/test_metal_surface.cc",
-      "$flutter_root/testing/test_metal_surface.h",
+      "test_metal_surface.cc",
+      "test_metal_surface.h",
     ]
 
     defines = []
 
     if (shell_enable_metal) {
-      sources += [ "$flutter_root/testing/test_metal_surface_impl.mm" ]
+      sources += [ "test_metal_surface_impl.mm" ]
       defines += [ "TESTING_ENABLE_METAL" ]
     }
 

--- a/testing/elf_loader.cc
+++ b/testing/elf_loader.cc
@@ -1,0 +1,82 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/testing/elf_loader.h"
+
+#include "flutter/fml/file.h"
+#include "flutter/fml/paths.h"
+#include "flutter/runtime/dart_vm.h"
+#include "flutter/testing/testing.h"
+
+namespace flutter {
+namespace testing {
+
+static constexpr const char* kAOTAppELFFileName = "app_elf_snapshot.so";
+
+ELFAOTSymbols LoadELFSymbolFromFixturesIfNeccessary() {
+  if (!DartVM::IsRunningPrecompiledCode()) {
+    return {};
+  }
+
+  const auto elf_path =
+      fml::paths::JoinPaths({GetFixturesPath(), kAOTAppELFFileName});
+
+  if (!fml::IsFile(elf_path)) {
+    FML_LOG(ERROR) << "App AOT file does not exist for this fixture. Attempts "
+                      "to launch the Dart VM with these AOT symbols will fail.";
+    return {};
+  }
+
+  ELFAOTSymbols symbols;
+
+  // Must not be freed.
+  const char* error = nullptr;
+
+  auto loaded_elf =
+      Dart_LoadELF(elf_path.c_str(),             // file path
+                   0,                            // file offset
+                   &error,                       // error (out)
+                   &symbols.vm_snapshot_data,    // vm snapshot data (out)
+                   &symbols.vm_snapshot_instrs,  // vm snapshot instrs (out)
+                   &symbols.vm_isolate_data,     // vm isolate data (out)
+                   &symbols.vm_isolate_instrs    // vm isolate instr (out)
+      );
+
+  if (loaded_elf == nullptr) {
+    FML_LOG(ERROR)
+        << "Could not fetch AOT symbols from loaded ELF. Attempts "
+           "to launch the Dart VM with these AOT symbols  will fail. Error: "
+        << error;
+    return {};
+  }
+
+  symbols.loaded_elf.reset(loaded_elf);
+
+  return symbols;
+}
+
+bool PrepareSettingsForAOTWithSymbols(Settings& settings,
+                                      const ELFAOTSymbols& symbols) {
+  if (!DartVM::IsRunningPrecompiledCode()) {
+    return false;
+  }
+  settings.vm_snapshot_data = [&]() {
+    return std::make_unique<fml::NonOwnedMapping>(symbols.vm_snapshot_data, 0u);
+  };
+  settings.isolate_snapshot_data = [&]() {
+    return std::make_unique<fml::NonOwnedMapping>(symbols.vm_isolate_data, 0u);
+  };
+  settings.vm_snapshot_instr = [&]() {
+    return std::make_unique<fml::NonOwnedMapping>(symbols.vm_snapshot_instrs,
+                                                  0u);
+  };
+  settings.isolate_snapshot_instr = [&]() {
+    return std::make_unique<fml::NonOwnedMapping>(symbols.vm_isolate_instrs,
+                                                  0u);
+  };
+  return true;
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/testing/elf_loader.h
+++ b/testing/elf_loader.h
@@ -1,0 +1,60 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_TESTING_ELF_LOADER_H_
+#define FLUTTER_TESTING_ELF_LOADER_H_
+
+#include <memory>
+
+#include "flutter/common/settings.h"
+#include "flutter/fml/macros.h"
+#include "third_party/dart/runtime/bin/elf_loader.h"
+
+namespace flutter {
+namespace testing {
+
+struct LoadedELFDeleter {
+  void operator()(Dart_LoadedElf* elf) { ::Dart_UnloadELF(elf); }
+};
+
+using UniqueLoadedELF = std::unique_ptr<Dart_LoadedElf, LoadedELFDeleter>;
+
+struct ELFAOTSymbols {
+  UniqueLoadedELF loaded_elf;
+  const uint8_t* vm_snapshot_data = nullptr;
+  const uint8_t* vm_snapshot_instrs = nullptr;
+  const uint8_t* vm_isolate_data = nullptr;
+  const uint8_t* vm_isolate_instrs = nullptr;
+};
+
+//------------------------------------------------------------------------------
+/// @brief      Attempts to resolve AOT symbols from the portable ELF loader.
+///             This location is automatically resolved from the fixtures
+///             generator. This only returns valid symbols when the VM is
+///             configured for AOT.
+///
+/// @return     The loaded ELF symbols.
+///
+ELFAOTSymbols LoadELFSymbolFromFixturesIfNeccessary();
+
+//------------------------------------------------------------------------------
+/// @brief      Prepare the settings objects various AOT mappings resolvers with
+///             the symbols already loaded. This method does nothing in non-AOT
+///             runtime modes.
+///
+/// @warning    The symbols must not be collected till all shell instantiations
+///             made using the settings object are collected.
+///
+/// @param[in/out] settings  The settings whose AOT resolvers to populate.
+/// @param[in]     symbols   The symbols used to populate the settings object.
+///
+/// @return     If the settings object was correctly updated.
+///
+bool PrepareSettingsForAOTWithSymbols(Settings& settings,
+                                      const ELFAOTSymbols& symbols);
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_TESTING_ELF_LOADER_H_


### PR DESCRIPTION
Also update all known test harnesses to use this and fixes the broken shell_unittests harness.

Fixes https://github.com/flutter/flutter/issues/49853