### PR TITLE
Remove all uses of the redundant flutter_root variable.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/config.gni")
+import("//flutter/common/config.gni")
 
 if (is_fuchsia) {
   import("//build/fuchsia/sdk.gni")
@@ -21,41 +21,41 @@ group("flutter") {
 
   if (!(is_fuchsia && using_fuchsia_sdk)) {
     public_deps += [
-      "$flutter_root/lib/snapshot:generate_snapshot_bin",
-      "$flutter_root/lib/snapshot:kernel_platform_files",
+      "//flutter/lib/snapshot:generate_snapshot_bin",
+      "//flutter/lib/snapshot:kernel_platform_files",
     ]
   }
 
   public_deps += [
-    "$flutter_root/shell/platform/embedder:flutter_engine",
-    "$flutter_root/sky",
+    "//flutter/shell/platform/embedder:flutter_engine",
+    "//flutter/sky",
   ]
 
   if (current_toolchain == host_toolchain) {
-    public_deps += [ "$flutter_root/tools/font-subset" ]
+    public_deps += [ "//flutter/tools/font-subset" ]
   }
 
   if (current_toolchain == host_toolchain) {
-    public_deps += [ "$flutter_root/shell/testing" ]
+    public_deps += [ "//flutter/shell/testing" ]
     public_deps += [ "//flutter/tools/const_finder" ]
   }
 
   if (is_fuchsia && using_fuchsia_sdk) {
     public_deps += [
-      "$flutter_root/shell/platform/fuchsia",
-      "$flutter_root/shell/testing($host_toolchain)",
+      "//flutter/shell/platform/fuchsia",
+      "//flutter/shell/testing($host_toolchain)",
     ]
   }
 
   if (!is_fuchsia && !is_fuchsia_host) {
     if (current_toolchain == host_toolchain) {
       public_deps += [
-        "$flutter_root/flutter_frontend_server:frontend_server",
+        "//flutter/flutter_frontend_server:frontend_server",
         "//third_party/dart:create_sdk",
       ]
 
       if (full_dart_sdk) {
-        public_deps += [ "$flutter_root/web_sdk" ]
+        public_deps += [ "//flutter/web_sdk" ]
       }
     }
   }
@@ -64,36 +64,36 @@ group("flutter") {
   if (current_toolchain == host_toolchain) {
     if (is_mac) {
       public_deps += [
-        "$flutter_root/shell/platform/darwin:flutter_channels_unittests",
-        "$flutter_root/shell/platform/darwin/macos:flutter_desktop_darwin_unittests",
+        "//flutter/shell/platform/darwin:flutter_channels_unittests",
+        "//flutter/shell/platform/darwin/macos:flutter_desktop_darwin_unittests",
       ]
     }
 
     public_deps += [
-      "$flutter_root/flow:flow_unittests",
-      "$flutter_root/fml:fml_unittests",
-      "$flutter_root/lib/ui:ui_unittests",
-      "$flutter_root/runtime:runtime_unittests",
-      "$flutter_root/shell/common:shell_unittests",
-      "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper_unittests",
-      "$flutter_root/shell/platform/embedder:embedder_unittests",
-      "$flutter_root/shell/platform/glfw/client_wrapper:client_wrapper_glfw_unittests",
-      "$flutter_root/testing:testing_unittests",
-      "$flutter_root/third_party/txt:txt_unittests",
+      "//flutter/flow:flow_unittests",
+      "//flutter/fml:fml_unittests",
+      "//flutter/lib/ui:ui_unittests",
+      "//flutter/runtime:runtime_unittests",
+      "//flutter/shell/common:shell_unittests",
+      "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper_unittests",
+      "//flutter/shell/platform/embedder:embedder_unittests",
+      "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw_unittests",
+      "//flutter/testing:testing_unittests",
+      "//flutter/third_party/txt:txt_unittests",
     ]
 
     if (is_win) {
       public_deps += [
-        "$flutter_root/shell/platform/windows:flutter_windows_unittests",
-        "$flutter_root/shell/platform/windows/client_wrapper:client_wrapper_windows_unittests",
+        "//flutter/shell/platform/windows:flutter_windows_unittests",
+        "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows_unittests",
       ]
     }
 
     if (!is_win) {
       public_deps += [
-        "$flutter_root/fml:fml_benchmarks",
-        "$flutter_root/shell/common:shell_benchmarks",
-        "$flutter_root/third_party/txt:txt_benchmarks",
+        "//flutter/fml:fml_benchmarks",
+        "//flutter/shell/common:shell_benchmarks",
+        "//flutter/third_party/txt:txt_benchmarks",
       ]
     }
   }
@@ -111,7 +111,7 @@ config("config") {
 config("export_dynamic_symbols") {
   if (is_linux || is_fuchsia) {
     inputs = [
-      "$flutter_root/common/exported_symbols.sym",
+      "//flutter/common/exported_symbols.sym",
     ]
     ldflags = [ "-Wl,--dynamic-list=" + rebase_path(inputs[0], root_build_dir) ]
   }
@@ -121,7 +121,7 @@ group("dist") {
   testonly = true
 
   deps = [
-    "$flutter_root/sky/dist",
+    "//flutter/sky/dist",
   ]
 }
 
@@ -133,9 +133,9 @@ if (is_fuchsia) {
     testonly = true
 
     deps = [
-      "$flutter_root/flow:flow_tests",
-      "$flutter_root/fml:fml_tests",
-      "$flutter_root/shell/platform/fuchsia/flutter:flutter_runner_tests",
+      "//flutter/flow:flow_tests",
+      "//flutter/fml:fml_tests",
+      "//flutter/shell/platform/fuchsia/flutter:flutter_runner_tests",
     ]
   }
 }

--- a/assets/BUILD.gn
+++ b/assets/BUILD.gn
@@ -12,9 +12,9 @@ source_set("assets") {
   ]
 
   deps = [
-    "$flutter_root/common",
-    "$flutter_root/fml",
+    "//flutter/common",
+    "//flutter/fml",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }

--- a/benchmarking/BUILD.gn
+++ b/benchmarking/BUILD.gn
@@ -15,12 +15,12 @@ source_set("benchmarking") {
   ]
 
   public_deps = [
-    "$flutter_root/fml",
+    "//flutter/fml",
     "//third_party/benchmark",
   ]
 
   public_configs = [
-    "$flutter_root:config",
+    "//flutter:config",
     ":benchmark_config",
   ]
 }

--- a/build/dart/rules.gni
+++ b/build/dart/rules.gni
@@ -44,8 +44,7 @@ template("dart_pkg_helper") {
       sdk_ext_mappings += invoker.sdk_ext_mappings
     }
 
-    script =
-        rebase_path("$flutter_root/build/dart/tools/dart_pkg.py", ".", "//")
+    script = rebase_path("//flutter/build/dart/tools/dart_pkg.py", ".", "//")
 
     entrypoints = []
     if (defined(invoker.apps)) {
@@ -62,8 +61,7 @@ template("dart_pkg_helper") {
     if (defined(invoker.sources)) {
       sources += invoker.sources
     } else if (defined(invoker.pkg_dir)) {
-      list_script =
-          rebase_path("$flutter_root/build/dart/tools/ls.py", ".", "//")
+      list_script = rebase_path("//flutter/build/dart/tools/ls.py", ".", "//")
       extra_flags += [ "--read_only" ]
       ls_sources = exec_script(list_script,
                                [
@@ -115,9 +113,7 @@ template("dart_pkg") {
     pubspec_yaml_path = rebase_path("pubspec.yaml")
   }
   dart_package_name_script =
-      rebase_path("$flutter_root/build/dart/tools/dart_package_name.py",
-                  ".",
-                  "//")
+      rebase_path("//flutter/build/dart/tools/dart_package_name.py", ".", "//")
   dart_package_name = exec_script(dart_package_name_script,
                                   [
                                     "--pubspec",

--- a/common/BUILD.gn
+++ b/common/BUILD.gn
@@ -17,11 +17,11 @@ source_set("common") {
   ]
 
   deps = [
-    "$flutter_root/fml",
+    "//flutter/fml",
   ]
 
   public_configs = [
     ":flutter_config",
-    "$flutter_root:config",
+    "//flutter:config",
   ]
 }

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -4,9 +4,9 @@
 
 if (is_fuchsia) {
   import("//build/fuchsia/sdk.gni")
-  import("$flutter_root/tools/fuchsia/fuchsia_archive.gni")
+  import("//flutter/tools/fuchsia/fuchsia_archive.gni")
 }
-import("$flutter_root/testing/testing.gni")
+import("//flutter/testing/testing.gni")
 
 source_set("flow") {
   sources = [
@@ -64,13 +64,13 @@ source_set("flow") {
     "texture.h",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 
   public_deps = []
 
   deps = [
-    "$flutter_root/common",
-    "$flutter_root/fml",
+    "//flutter/common",
+    "//flutter/fml",
     "//third_party/skia",
   ]
 
@@ -119,7 +119,7 @@ source_set("flow_testing") {
 
   public_deps = [
     ":flow",
-    "$flutter_root/testing:skia",
+    "//flutter/testing:skia",
     "//third_party/googletest:gtest",
   ]
 }
@@ -160,9 +160,9 @@ executable("flow_unittests") {
     ":flow",
     ":flow_fixtures",
     ":flow_testing",
-    "$flutter_root/fml",
-    "$flutter_root/testing:skia",
-    "$flutter_root/testing:testing_lib",
+    "//flutter/fml",
+    "//flutter/testing:skia",
+    "//flutter/testing:testing_lib",
     "//third_party/dart/runtime:libdart_jit",  # for tracing
     "//third_party/googletest:gtest",
     "//third_party/skia",
@@ -181,23 +181,23 @@ if (is_fuchsia) {
 
     libraries = common_libs
 
-    meta_dir = "$flutter_root/testing/fuchsia/meta"
+    meta_dir = "//flutter/testing/fuchsia/meta"
     cmx_file = "$meta_dir/fuchsia_test.cmx"
 
     resources = [
       {
         path = rebase_path(
-                "$flutter_root/testing/resources/performance_overlay_gold_60fps.png")
+                "//flutter/testing/resources/performance_overlay_gold_60fps.png")
         dest = "flutter/testing/resources/performance_overlay_gold_60fps.png"
       },
       {
         path = rebase_path(
-                "$flutter_root/testing/resources/performance_overlay_gold_90fps.png")
+                "//flutter/testing/resources/performance_overlay_gold_90fps.png")
         dest = "flutter/testing/resources/performance_overlay_gold_90fps.png"
       },
       {
         path = rebase_path(
-                "$flutter_root/testing/resources/performance_overlay_gold_120fps.png")
+                "//flutter/testing/resources/performance_overlay_gold_120fps.png")
         dest = "flutter/testing/resources/performance_overlay_gold_120fps.png"
       },
     ]

--- a/flutter_frontend_server/BUILD.gn
+++ b/flutter_frontend_server/BUILD.gn
@@ -68,7 +68,7 @@ application_snapshot("frontend_server") {
   main_dart = "bin/starter.dart"
   deps = [
     ":package_incremental_compiler",
-    "$flutter_root/lib/snapshot:kernel_platform_files",
+    "//flutter/lib/snapshot:kernel_platform_files",
   ]
   dot_packages = rebase_path(".packages")
   flutter_patched_sdk = rebase_path("$root_out_dir/flutter_patched_sdk")
@@ -84,7 +84,7 @@ application_snapshot("frontend_server") {
 # For flutter/flutter#36738 we make the source files available so that
 # we can generate a local frontend_server snapshot in the tools cache.
 action("package_incremental_compiler") {
-  script = "$flutter_root/flutter_frontend_server/package_incremental.py"
+  script = "//flutter/flutter_frontend_server/package_incremental.py"
 
   inputs = frontend_server_files
 
@@ -101,6 +101,6 @@ action("package_incremental_compiler") {
   args = [
     "--input-root=" + rebase_path("//third_party/dart/pkg"),
     "--output-root=" + rebase_path("$root_gen_dir/dart-pkg"),
-    "--frontend-server=" + rebase_path("$flutter_root"),
+    "--frontend-server=" + rebase_path("//flutter"),
   ]
 }

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -4,9 +4,9 @@
 
 if (is_fuchsia) {
   import("//build/fuchsia/sdk.gni")
-  import("$flutter_root/tools/fuchsia/fuchsia_archive.gni")
+  import("//flutter/tools/fuchsia/fuchsia_archive.gni")
 }
-import("$flutter_root/testing/testing.gni")
+import("//flutter/testing/testing.gni")
 
 source_set("fml") {
   sources = [
@@ -96,8 +96,8 @@ source_set("fml") {
   configs += [ "//third_party/icu:icu_config" ]
 
   public_configs = [
-    "$flutter_root:config",
-    "$flutter_root/common:flutter_config",
+    "//flutter:config",
+    "//flutter/common:flutter_config",
   ]
 
   libs = []
@@ -249,10 +249,10 @@ executable("fml_unittests") {
 
   deps = [
     ":fml_fixtures",
-    "$flutter_root/fml",
-    "$flutter_root/fml/dart",
-    "$flutter_root/runtime:libdart",
-    "$flutter_root/testing",
+    "//flutter/fml",
+    "//flutter/fml/dart",
+    "//flutter/runtime:libdart",
+    "//flutter/testing",
   ]
 
   if (is_fuchsia && using_fuchsia_sdk) {
@@ -278,8 +278,8 @@ executable("fml_benchmarks") {
   ]
 
   deps = [
-    "$flutter_root/benchmarking",
-    "$flutter_root/fml",
-    "$flutter_root/runtime:libdart",
+    "//flutter/benchmarking",
+    "//flutter/fml",
+    "//flutter/runtime:libdart",
   ]
 }

--- a/fml/dart/BUILD.gn
+++ b/fml/dart/BUILD.gn
@@ -12,8 +12,8 @@ source_set("dart") {
   ]
 
   public_deps = [
-    "$flutter_root/fml",
-    "$flutter_root/runtime:libdart",
-    "$flutter_root/third_party/tonic",
+    "//flutter/fml",
+    "//flutter/runtime:libdart",
+    "//flutter/third_party/tonic",
   ]
 }

--- a/lib/io/BUILD.gn
+++ b/lib/io/BUILD.gn
@@ -9,12 +9,12 @@ source_set("io") {
   ]
 
   deps = [
-    "$flutter_root/third_party/tonic",
+    "//flutter/third_party/tonic",
     "//third_party/dart/runtime:dart_api",
     "//third_party/dart/runtime/bin:dart_io_api",
   ]
 
   configs += [ "//third_party/dart/runtime:dart_config" ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -4,9 +4,9 @@
 
 import("//build/compiled_action.gni")
 import("//build/fuchsia/sdk.gni")
+import("//flutter/common/config.gni")
+import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/utils/compile_platform.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/lib/ui/dart_ui.gni")
 
 bindings_output_dir = "$root_gen_dir/sky/bindings"
 

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -3,8 +3,8 @@
 # found in the LICENSE file.
 
 import("//build/fuchsia/sdk.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
 
 source_set("ui") {
   sources = [
@@ -109,22 +109,22 @@ source_set("ui") {
     "window/window.h",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 
   deps = [
-    "$flutter_root/assets",
-    "$flutter_root/common",
-    "$flutter_root/flow",
-    "$flutter_root/fml",
-    "$flutter_root/runtime:test_font",
-    "$flutter_root/third_party/tonic",
+    "//flutter/assets",
+    "//flutter/common",
+    "//flutter/flow",
+    "//flutter/fml",
+    "//flutter/runtime:test_font",
+    "//flutter/third_party/tonic",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/rapidjson",
     "//third_party/skia",
   ]
 
   public_deps = [
-    "$flutter_root/third_party/txt",
+    "//flutter/third_party/txt",
   ]
 
   if (flutter_enable_skshaper) {
@@ -139,9 +139,9 @@ source_set("ui") {
 
     if (using_fuchsia_sdk) {
       deps += [
-        "$flutter_root/shell/platform/fuchsia/dart-pkg/fuchsia",
-        "$flutter_root/shell/platform/fuchsia/dart-pkg/zircon",
         "$fuchsia_sdk_root/pkg:async-cpp",
+        "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
+        "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
       ]
     } else {
       deps += [ "//topaz/public/dart-pkg/zircon" ]
@@ -172,9 +172,9 @@ if (current_toolchain == host_toolchain) {
     deps = [
       ":ui",
       ":ui_unittests_fixtures",
-      "$flutter_root/common",
-      "$flutter_root/testing:dart",
-      "$flutter_root/testing:opengl",
+      "//flutter/common",
+      "//flutter/testing:dart",
+      "//flutter/testing:opengl",
     ]
   }
 }

--- a/lib/ui/dart_ui.gni
+++ b/lib/ui/dart_ui.gni
@@ -3,21 +3,21 @@
 # found in the LICENSE file.
 
 dart_ui_files = [
-  "$flutter_root/lib/ui/channel_buffers.dart",
-  "$flutter_root/lib/ui/compositing.dart",
-  "$flutter_root/lib/ui/geometry.dart",
-  "$flutter_root/lib/ui/hash_codes.dart",
-  "$flutter_root/lib/ui/hooks.dart",
-  "$flutter_root/lib/ui/isolate_name_server.dart",
-  "$flutter_root/lib/ui/lerp.dart",
-  "$flutter_root/lib/ui/natives.dart",
-  "$flutter_root/lib/ui/painting.dart",
-  "$flutter_root/lib/ui/plugins.dart",
-  "$flutter_root/lib/ui/pointer.dart",
-  "$flutter_root/lib/ui/semantics.dart",
-  "$flutter_root/lib/ui/text.dart",
-  "$flutter_root/lib/ui/ui.dart",
-  "$flutter_root/lib/ui/window.dart",
+  "//flutter/lib/ui/channel_buffers.dart",
+  "//flutter/lib/ui/compositing.dart",
+  "//flutter/lib/ui/geometry.dart",
+  "//flutter/lib/ui/hash_codes.dart",
+  "//flutter/lib/ui/hooks.dart",
+  "//flutter/lib/ui/isolate_name_server.dart",
+  "//flutter/lib/ui/lerp.dart",
+  "//flutter/lib/ui/natives.dart",
+  "//flutter/lib/ui/painting.dart",
+  "//flutter/lib/ui/plugins.dart",
+  "//flutter/lib/ui/pointer.dart",
+  "//flutter/lib/ui/semantics.dart",
+  "//flutter/lib/ui/text.dart",
+  "//flutter/lib/ui/ui.dart",
+  "//flutter/lib/ui/window.dart",
 ]
 
-dart_ui_path = "$flutter_root/lib/ui/ui.dart"
+dart_ui_path = "//flutter/lib/ui/ui.dart"

--- a/runtime/BUILD.gn
+++ b/runtime/BUILD.gn
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/config.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
 
 source_set("test_font") {
   sources = [
@@ -13,7 +13,7 @@ source_set("test_font") {
   deps = [
     "//third_party/skia",
   ]
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
   defines = []
   if (flutter_runtime_mode == "debug" || current_toolchain == host_toolchain) {
     # Though the test font data is small, we dont want to add to the binary size
@@ -31,7 +31,7 @@ group("libdart") {
     public_deps += [ "//third_party/dart/runtime:libdart_precompiled_runtime" ]
   } else {
     public_deps += [
-      "$flutter_root/lib/snapshot",
+      "//flutter/lib/snapshot",
       "//third_party/dart/runtime:libdart_jit",
     ]
   }
@@ -73,14 +73,14 @@ source_set("runtime") {
 
   deps = [
     ":test_font",
-    "$flutter_root/assets",
-    "$flutter_root/common",
-    "$flutter_root/flow",
-    "$flutter_root/fml",
-    "$flutter_root/lib/io",
-    "$flutter_root/lib/ui",
-    "$flutter_root/third_party/tonic",
-    "$flutter_root/third_party/txt",
+    "//flutter/assets",
+    "//flutter/common",
+    "//flutter/flow",
+    "//flutter/fml",
+    "//flutter/lib/io",
+    "//flutter/lib/ui",
+    "//flutter/third_party/tonic",
+    "//flutter/third_party/txt",
     "//third_party/dart/runtime:dart_api",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/skia",
@@ -104,7 +104,7 @@ source_set("runtime") {
   if (is_win) {
     if (flutter_runtime_mode == "profile" ||
         flutter_runtime_mode == "release") {
-      deps += [ "$flutter_root/lib/snapshot" ]
+      deps += [ "//flutter/lib/snapshot" ]
     }
   }
 
@@ -112,7 +112,7 @@ source_set("runtime") {
     "//third_party/rapidjson",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 
   if (flutter_runtime_mode != "release" && !is_fuchsia) {
     # Only link in Observatory in non-release modes on non-Fuchsia. Fuchsia
@@ -141,12 +141,13 @@ source_set("runtime_unittests_common") {
     ":libdart",
     ":runtime",
     ":runtime_fixtures",
-    "$flutter_root/common",
-    "$flutter_root/fml",
-    "$flutter_root/lib/snapshot",
-    "$flutter_root/shell/common",
-    "$flutter_root/testing:dart",
-    "$flutter_root/third_party/tonic",
+    "//flutter/common",
+    "//flutter/fml",
+    "//flutter/lib/snapshot",
+    "//flutter/shell/common",
+    "//flutter/testing:dart",
+    "//flutter/third_party/tonic",
+    "//third_party/dart/runtime/bin:elf_loader",
     "//third_party/skia",
   ]
 }
@@ -154,7 +155,7 @@ source_set("runtime_unittests_common") {
 executable("runtime_unittests") {
   testonly = true
 
-  configs += [ "$flutter_root:export_dynamic_symbols" ]
+  configs += [ "//flutter:export_dynamic_symbols" ]
 
   sources = [
     "dart_isolate_unittests.cc",

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/shell/gpu/gpu.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/shell/gpu/gpu.gni")
+import("//flutter/testing/testing.gni")
 
 # Template to generate a dart embedder resource.cc file.
 # Required invoker inputs:
@@ -99,24 +99,24 @@ source_set("common") {
   ]
 
   deps = [
-    "$flutter_root/assets",
-    "$flutter_root/common",
-    "$flutter_root/flow",
-    "$flutter_root/fml",
-    "$flutter_root/lib/ui",
-    "$flutter_root/runtime",
+    "//flutter/assets",
+    "//flutter/common",
+    "//flutter/flow",
+    "//flutter/fml",
+    "//flutter/lib/ui",
+    "//flutter/runtime",
     "//third_party/dart/runtime:dart_api",
     "//third_party/skia",
   ]
 
   public_deps = [
-    "$flutter_root/shell/version",
-    "$flutter_root/third_party/tonic",
-    "$flutter_root/third_party/txt",
+    "//flutter/shell/version",
+    "//flutter/third_party/tonic",
+    "//flutter/third_party/txt",
     "//third_party/rapidjson",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }
 
 template("shell_host_executable") {
@@ -131,15 +131,15 @@ template("shell_host_executable") {
 
     deps += [
       ":common",
-      "$flutter_root/fml",
-      "$flutter_root/lib/snapshot",
-      "$flutter_root/runtime",
-      "$flutter_root/runtime:libdart",
-      "$flutter_root/third_party/tonic",
+      "//flutter/fml",
+      "//flutter/lib/snapshot",
+      "//flutter/runtime",
+      "//flutter/runtime:libdart",
+      "//flutter/third_party/tonic",
       "//third_party/skia",
     ]
 
-    public_configs = [ "$flutter_root:export_dynamic_symbols" ]
+    public_configs = [ "//flutter:export_dynamic_symbols" ]
   }
 }
 
@@ -178,13 +178,13 @@ if (current_toolchain == host_toolchain) {
     deps = [
       ":shell_unittests_fixtures",
       ":shell_unittests_gpu_configuration",
-      "$flutter_root/common",
-      "$flutter_root/flow",
-      "$flutter_root/fml/dart",
-      "$flutter_root/lib/ui:ui",
-      "$flutter_root/shell",
-      "$flutter_root/testing:dart",
-      "$flutter_root/testing:opengl",
+      "//flutter/common",
+      "//flutter/flow",
+      "//flutter/fml/dart",
+      "//flutter/lib/ui:ui",
+      "//flutter/shell",
+      "//flutter/testing:dart",
+      "//flutter/testing:opengl",
     ]
   }
 
@@ -195,8 +195,8 @@ if (current_toolchain == host_toolchain) {
 
     deps = [
       ":shell_unittests_fixtures",
-      "$flutter_root/benchmarking",
-      "$flutter_root/testing:testing_lib",
+      "//flutter/benchmarking",
+      "//flutter/testing:testing_lib",
     ]
   }
 }

--- a/shell/gpu/BUILD.gn
+++ b/shell/gpu/BUILD.gn
@@ -2,15 +2,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/shell/config.gni")
+import("//flutter/shell/config.gni")
 
-gpu_dir = "$flutter_root/shell/gpu"
+gpu_dir = "//flutter/shell/gpu"
 
 gpu_common_deps = [
-  "$flutter_root/common",
-  "$flutter_root/flow",
-  "$flutter_root/fml",
-  "$flutter_root/shell/common",
+  "//flutter/common",
+  "//flutter/flow",
+  "//flutter/fml",
+  "//flutter/shell/common",
   "//third_party/skia",
 ]
 
@@ -45,7 +45,7 @@ source_set("gpu_surface_vulkan") {
 
   deps = gpu_common_deps + [
            "//third_party/skia",
-           "$flutter_root/vulkan",
+           "//flutter/vulkan",
          ]
 }
 

--- a/shell/gpu/gpu.gni
+++ b/shell/gpu/gpu.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/shell/config.gni")
+import("//flutter/shell/config.gni")
 
 template("shell_gpu_configuration") {
   assert(defined(invoker.enable_software),
@@ -18,19 +18,19 @@ template("shell_gpu_configuration") {
     public_deps = []
 
     if (invoker.enable_software) {
-      public_deps += [ "$flutter_root/shell/gpu:gpu_surface_software" ]
+      public_deps += [ "//flutter/shell/gpu:gpu_surface_software" ]
     }
 
     if (invoker.enable_gl) {
-      public_deps += [ "$flutter_root/shell/gpu:gpu_surface_gl" ]
+      public_deps += [ "//flutter/shell/gpu:gpu_surface_gl" ]
     }
 
     if (invoker.enable_vulkan) {
-      public_deps += [ "$flutter_root/shell/gpu:gpu_surface_vulkan" ]
+      public_deps += [ "//flutter/shell/gpu:gpu_surface_vulkan" ]
     }
 
     if (invoker.enable_metal) {
-      public_deps += [ "$flutter_root/shell/gpu:gpu_surface_metal" ]
+      public_deps += [ "//flutter/shell/gpu:gpu_surface_metal" ]
     }
   }
 }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -4,10 +4,10 @@
 
 import("//build/config/android/config.gni")
 import("//flutter/build/zip_bundle.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/shell/config.gni")
-import("$flutter_root/shell/gpu/gpu.gni")
-import("$flutter_root/shell/version/version.gni")
+import("//flutter/common/config.gni")
+import("//flutter/shell/config.gni")
+import("//flutter/shell/gpu/gpu.gni")
+import("//flutter/shell/version/version.gni")
 
 shell_gpu_configuration("android_gpu_configuration") {
   enable_software = true
@@ -57,18 +57,18 @@ shared_library("flutter_shell_native") {
   deps = [
     ":android_gpu_configuration",
     ":icudtl_object",
-    "$flutter_root/assets",
-    "$flutter_root/common",
-    "$flutter_root/flow",
-    "$flutter_root/fml",
-    "$flutter_root/lib/ui",
-    "$flutter_root/runtime",
-    "$flutter_root/runtime:libdart",
-    "$flutter_root/shell/common",
+    "//flutter/assets",
+    "//flutter/common",
+    "//flutter/flow",
+    "//flutter/fml",
+    "//flutter/lib/ui",
+    "//flutter/runtime",
+    "//flutter/runtime:libdart",
+    "//flutter/shell/common",
     "//third_party/skia",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 
   defines = []
 
@@ -78,7 +78,7 @@ shared_library("flutter_shell_native") {
       "android_surface_vulkan.h",
     ]
 
-    deps += [ "$flutter_root/vulkan" ]
+    deps += [ "//flutter/vulkan" ]
 
     defines += [ "SHELL_ENABLE_VULKAN" ]
   }
@@ -93,7 +93,7 @@ shared_library("flutter_shell_native") {
 }
 
 action("gen_android_build_config_java") {
-  script = "$flutter_root/tools/gen_android_buildconfig.py"
+  script = "//flutter/tools/gen_android_buildconfig.py"
 
   build_config_java = "$target_gen_dir/io/flutter/BuildConfig.java"
 
@@ -284,7 +284,7 @@ action("flutter_shell_java") {
 }
 
 action("icudtl_object") {
-  script = "$flutter_root/sky/tools/objcopy.py"
+  script = "//flutter/sky/tools/objcopy.py"
 
   icudtl_input = "//third_party/icu/flutter/icudtl.dat"
   icudtl_output = "$root_build_dir/flutter_icu/icudtl.o"
@@ -355,10 +355,10 @@ action("android_jar") {
 }
 
 action("pom_libflutter") {
-  script = "$flutter_root/tools/android_support/generate_pom_file.py"
+  script = "//flutter/tools/android_support/generate_pom_file.py"
 
   inputs = [
-    "$flutter_root/tools/android_support/files.json",
+    "//flutter/tools/android_support/files.json",
   ]
 
   artifact_id =
@@ -379,10 +379,10 @@ action("pom_libflutter") {
 }
 
 action("pom_embedding") {
-  script = "$flutter_root/tools/android_support/generate_pom_file.py"
+  script = "//flutter/tools/android_support/generate_pom_file.py"
 
   inputs = [
-    "$flutter_root/tools/android_support/files.json",
+    "//flutter/tools/android_support/files.json",
   ]
 
   artifact_id = "flutter_embedding_$flutter_runtime_mode"

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -45,8 +45,8 @@ source_set("common_cpp") {
 
   deps = [
     ":common_cpp_library_headers",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    "$flutter_root/shell/platform/embedder:embedder_with_symbol_prefix",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/embedder:embedder_with_symbol_prefix",
   ]
 
   # TODO: Remove once text input model refactor lands, at which point this code

--- a/shell/platform/common/cpp/client_wrapper/BUILD.gn
+++ b/shell/platform/common/cpp/client_wrapper/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/testing/testing.gni")
+import("//flutter/testing/testing.gni")
 import("core_wrapper_files.gni")
 
 # Client library build for internal use by the shell implementation.
@@ -11,19 +11,17 @@ source_set("client_wrapper") {
   public = core_cpp_client_wrapper_includes
 
   deps = [
-    "$flutter_root/shell/platform/common/cpp:common_cpp_library_headers",
+    "//flutter/shell/platform/common/cpp:common_cpp_library_headers",
     "//third_party/rapidjson",
   ]
 
   defines = [ "USE_RAPID_JSON" ]
 
-  configs += [
-    "$flutter_root/shell/platform/common/cpp:desktop_library_implementation",
-  ]
+  configs +=
+      [ "//flutter/shell/platform/common/cpp:desktop_library_implementation" ]
 
-  public_configs = [
-    "$flutter_root/shell/platform/common/cpp:relative_flutter_library_headers",
-  ]
+  public_configs =
+      [ "//flutter/shell/platform/common/cpp:relative_flutter_library_headers" ]
 }
 
 source_set("client_wrapper_library_stubs") {
@@ -35,7 +33,7 @@ source_set("client_wrapper_library_stubs") {
   defines = [ "FLUTTER_DESKTOP_LIBRARY" ]
 
   public_deps = [
-    "$flutter_root/shell/platform/common/cpp:common_cpp_library_headers",
+    "//flutter/shell/platform/common/cpp:common_cpp_library_headers",
   ]
 }
 
@@ -61,7 +59,7 @@ executable("client_wrapper_unittests") {
     ":client_wrapper",
     ":client_wrapper_fixtures",
     ":client_wrapper_library_stubs",
-    "$flutter_root/testing",
+    "//flutter/testing",
 
     # TODO(chunhtai): Consider refactoring flutter_root/testing so that there's a testing
     # target that doesn't require a Dart runtime to be linked in.

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -4,7 +4,7 @@
 
 assert(is_mac || is_ios)
 
-import("$flutter_root/testing/testing.gni")
+import("//flutter/testing/testing.gni")
 
 group("darwin") {
   if (is_ios) {
@@ -34,15 +34,15 @@ source_set("flutter_channels") {
   ]
 
   deps = [
-    "$flutter_root/common",
-    "$flutter_root/flow",
-    "$flutter_root/fml",
-    "$flutter_root/runtime",
-    "$flutter_root/shell/common",
+    "//flutter/common",
+    "//flutter/flow",
+    "//flutter/fml",
+    "//flutter/runtime",
+    "//flutter/shell/common",
     "//third_party/skia",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }
 
 test_fixtures("flutter_channels_fixtures") {
@@ -60,9 +60,9 @@ executable("flutter_channels_unittests") {
   deps = [
     ":flutter_channels",
     ":flutter_channels_fixtures",
-    "$flutter_root/testing",
+    "//flutter/testing",
     "//third_party/dart/runtime:libdart_jit",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -13,16 +13,16 @@ source_set("common") {
   ]
 
   deps = [
-    "$flutter_root/common",
-    "$flutter_root/flow",
-    "$flutter_root/fml",
-    "$flutter_root/runtime",
-    "$flutter_root/shell/common",
+    "//flutter/common",
+    "//flutter/flow",
+    "//flutter/fml",
+    "//flutter/runtime",
+    "//flutter/shell/common",
     "//third_party/dart/runtime:dart_api",
     "//third_party/skia",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }
 
 # Shared framework headers end up in the same folder as platform-specific
@@ -46,7 +46,7 @@ source_set("framework_shared") {
   defines = [ "FLUTTER_FRAMEWORK" ]
 
   public_configs = [
-    "$flutter_root:config",
+    "//flutter:config",
     ":framework_relative_headers",
   ]
 }

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -5,11 +5,11 @@
 assert(is_ios)
 
 import("//build/config/ios/ios_sdk.gni")
-import("$flutter_root/build/darwin/ios_app.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/shell/gpu/gpu.gni")
-import("$flutter_root/shell/platform/darwin/common/framework_shared.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/build/darwin/ios_app.gni")
+import("//flutter/common/config.gni")
+import("//flutter/shell/gpu/gpu.gni")
+import("//flutter/shell/platform/darwin/common/framework_shared.gni")
+import("//flutter/testing/testing.gni")
 
 _flutter_framework_dir = "$root_out_dir/Flutter.framework"
 
@@ -109,19 +109,19 @@ shared_library("create_flutter_framework_dylib") {
 
   deps = [
     ":ios_gpu_configuration",
-    "$flutter_root/common",
-    "$flutter_root/flow",
-    "$flutter_root/fml",
-    "$flutter_root/lib/ui",
-    "$flutter_root/runtime",
-    "$flutter_root/runtime:libdart",
-    "$flutter_root/shell/common",
-    "$flutter_root/shell/platform/darwin/common",
-    "$flutter_root/shell/platform/darwin/common:framework_shared",
+    "//flutter/common",
+    "//flutter/flow",
+    "//flutter/fml",
+    "//flutter/lib/ui",
+    "//flutter/runtime",
+    "//flutter/runtime:libdart",
+    "//flutter/shell/common",
+    "//flutter/shell/platform/darwin/common",
+    "//flutter/shell/platform/darwin/common:framework_shared",
     "//third_party/skia",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 
   defines = [ "FLUTTER_FRAMEWORK=1" ]
 
@@ -155,7 +155,7 @@ copy("copy_dylib") {
 }
 
 action("copy_framework_info_plist") {
-  script = "$flutter_root/build/copy_info_plist.py"
+  script = "//flutter/build/copy_info_plist.py"
   visibility = [ ":*" ]
   sources = [
     "framework/Info.plist",
@@ -181,7 +181,7 @@ copy("copy_framework_module_map") {
 }
 
 action("copy_framework_headers") {
-  script = "$flutter_root/sky/tools/install_framework_headers.py"
+  script = "//flutter/sky/tools/install_framework_headers.py"
   visibility = [ ":*" ]
   sources = get_path_info(_flutter_framework_headers, "abspath") +
             framework_shared_headers

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -5,10 +5,10 @@
 assert(is_mac)
 
 import("//build/config/mac/mac_sdk.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/shell/platform/darwin/common/framework_shared.gni")
-import("$flutter_root/shell/platform/glfw/config.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/common/config.gni")
+import("//flutter/shell/platform/darwin/common/framework_shared.gni")
+import("//flutter/shell/platform/glfw/config.gni")
+import("//flutter/testing/testing.gni")
 
 group("macos") {
   deps = [
@@ -17,8 +17,8 @@ group("macos") {
   if (build_glfw_shell) {
     deps += [
       ":flutter_macos_glfw",
-      "$flutter_root/shell/platform/glfw:publish_headers_glfw",
-      "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
+      "//flutter/shell/platform/glfw:publish_headers_glfw",
+      "//flutter/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
     ]
   }
 }
@@ -67,11 +67,11 @@ source_set("flutter_framework_source") {
   sources += _flutter_framework_headers
 
   deps = [
-    "$flutter_root/shell/platform/darwin/common:framework_shared",
-    "$flutter_root/shell/platform/embedder:embedder_with_symbol_prefix",
+    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/embedder:embedder_with_symbol_prefix",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 
   defines = [ "FLUTTER_FRAMEWORK" ]
 
@@ -112,12 +112,12 @@ executable("flutter_desktop_darwin_unittests") {
   deps = [
     ":flutter_desktop_darwin_fixtures",
     ":flutter_framework_source",
-    "$flutter_root/shell/platform/darwin/common:framework_shared",
-    "$flutter_root/shell/platform/embedder:embedder_with_symbol_prefix",
-    "$flutter_root/testing",
-    "$flutter_root/testing:dart",
-    "$flutter_root/testing:skia",
-    "$flutter_root/testing:testing_lib",
+    "//flutter/shell/platform/darwin/common:framework_shared",
+    "//flutter/shell/platform/embedder:embedder_with_symbol_prefix",
+    "//flutter/testing",
+    "//flutter/testing:dart",
+    "//flutter/testing:skia",
+    "//flutter/testing:testing_lib",
   ]
 }
 
@@ -157,7 +157,7 @@ copy("copy_framework_module_map") {
 }
 
 action("copy_framework_headers") {
-  script = "$flutter_root/sky/tools/install_framework_headers.py"
+  script = "//flutter/sky/tools/install_framework_headers.py"
   visibility = [ ":*" ]
   sources = get_path_info(_flutter_framework_headers, "abspath") +
             framework_shared_headers
@@ -242,9 +242,9 @@ group("flutter_framework") {
 if (build_glfw_shell) {
   shared_library("flutter_macos_glfw") {
     deps = [
-      "$flutter_root/shell/platform/glfw:flutter_glfw",
+      "//flutter/shell/platform/glfw:flutter_glfw",
     ]
 
-    public_configs = [ "$flutter_root:config" ]
+    public_configs = [ "//flutter:config" ]
   }
 }

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/config.gni")
-import("$flutter_root/shell/gpu/gpu.gni")
-import("$flutter_root/shell/platform/embedder/embedder.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/common/config.gni")
+import("//flutter/shell/gpu/gpu.gni")
+import("//flutter/shell/platform/embedder/embedder.gni")
+import("//flutter/testing/testing.gni")
 
 shell_gpu_configuration("embedder_gpu_configuration") {
   enable_software = true
@@ -57,19 +57,19 @@ template("embedder_source_set") {
 
     deps = [
       ":embedder_gpu_configuration",
-      "$flutter_root/assets",
-      "$flutter_root/common",
-      "$flutter_root/flow",
-      "$flutter_root/fml",
-      "$flutter_root/lib/ui",
-      "$flutter_root/runtime:libdart",
-      "$flutter_root/shell/common",
-      "$flutter_root/third_party/tonic",
+      "//flutter/assets",
+      "//flutter/common",
+      "//flutter/flow",
+      "//flutter/fml",
+      "//flutter/lib/ui",
+      "//flutter/runtime:libdart",
+      "//flutter/shell/common",
+      "//flutter/third_party/tonic",
       "//third_party/dart/runtime/bin:dart_io_api",
       "//third_party/skia",
     ]
 
-    public_configs += [ "$flutter_root:config" ]
+    public_configs += [ "//flutter:config" ]
   }
 }
 
@@ -109,7 +109,7 @@ if (current_toolchain == host_toolchain) {
   executable("embedder_unittests") {
     testonly = true
 
-    configs += [ "$flutter_root:export_dynamic_symbols" ]
+    configs += [ "//flutter:export_dynamic_symbols" ]
 
     include_dirs = [ "." ]
 
@@ -129,13 +129,14 @@ if (current_toolchain == host_toolchain) {
     deps = [
       ":embedder",
       ":fixtures",
-      "$flutter_root/flow",
-      "$flutter_root/lib/ui",
-      "$flutter_root/runtime",
-      "$flutter_root/testing:dart",
-      "$flutter_root/testing:opengl",
-      "$flutter_root/testing:skia",
-      "$flutter_root/third_party/tonic",
+      "//flutter/flow",
+      "//flutter/lib/ui",
+      "//flutter/runtime",
+      "//flutter/testing:dart",
+      "//flutter/testing:opengl",
+      "//flutter/testing:skia",
+      "//flutter/third_party/tonic",
+      "//third_party/dart/runtime/bin:elf_loader",
       "//third_party/skia",
     ]
   }
@@ -154,7 +155,7 @@ shared_library("flutter_engine_library") {
     ":embedder",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }
 
 copy("copy_headers") {
@@ -191,7 +192,7 @@ if (is_mac && !embedder_for_target) {
   }
 
   action("copy_info_plist") {
-    script = "$flutter_root/build/copy_info_plist.py"
+    script = "//flutter/build/copy_info_plist.py"
     visibility = [ ":*" ]
     sources = [
       "assets/EmbedderInfo.plist",

--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -3,9 +3,9 @@
 # found in the LICENSE file.
 
 import("//build/fuchsia/sdk.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_host_bundle.gni")
+import("//flutter/common/config.gni")
+import("//flutter/tools/fuchsia/dart.gni")
+import("//flutter/tools/fuchsia/fuchsia_host_bundle.gni")
 
 if (using_fuchsia_sdk) {
   testonly = true
@@ -46,7 +46,7 @@ if (using_fuchsia_sdk) {
 
     _kernel_compiler_label = "dart:kernel_compiler($host_toolchain)"
     _frontend_server_label =
-        "$flutter_root/flutter_frontend_server:frontend_server($host_toolchain)"
+        "//flutter/flutter_frontend_server:frontend_server($host_toolchain)"
 
     deps = [
       _frontend_server_label,

--- a/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/fuchsia/BUILD.gn
@@ -21,11 +21,11 @@ source_set("sdk_ext") {
   ]
 
   deps = [
-    "$flutter_root/fml",
-    "$flutter_root/third_party/tonic",
     "$fuchsia_sdk_root/fidl:fuchsia.sys",
     "$fuchsia_sdk_root/pkg:async-cpp",
     "../zircon",
+    "//flutter/fml",
+    "//flutter/third_party/tonic",
   ]
 
   public_configs = [ ":sdk_ext_config" ]

--- a/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
+++ b/shell/platform/fuchsia/dart-pkg/zircon/BUILD.gn
@@ -23,11 +23,11 @@ source_set("zircon") {
   ]
 
   deps = [
-    "$flutter_root/third_party/tonic",
     "$fuchsia_sdk_root/pkg:async-cpp",
     "$fuchsia_sdk_root/pkg:async-loop-cpp",
     "$fuchsia_sdk_root/pkg:fdio",
     "$fuchsia_sdk_root/pkg:zx",
     "//flutter/fml",
+    "//flutter/third_party/tonic",
   ]
 }

--- a/shell/platform/fuchsia/dart_runner/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/BUILD.gn
@@ -5,10 +5,10 @@
 assert(is_fuchsia)
 
 import("//build/fuchsia/sdk.gni")
-import("$flutter_root/common/fuchsia_config.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_archive.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_libs.gni")
+import("//flutter/common/fuchsia_config.gni")
+import("//flutter/tools/fuchsia/dart.gni")
+import("//flutter/tools/fuchsia/fuchsia_archive.gni")
+import("//flutter/tools/fuchsia/fuchsia_libs.gni")
 
 template("runner") {
   assert(defined(invoker.product), "The parameter 'product' must be defined")
@@ -41,20 +41,20 @@ template("runner") {
     if (!invoker.product) {
       dart_deps += [
         "//third_party/dart/runtime/bin:dart_io_api",
-        "$flutter_root/shell/platform/fuchsia/runtime/dart/utils:utils",
+        "//flutter/shell/platform/fuchsia/runtime/dart/utils:utils",
       ]
     } else {
       dart_deps += [
         "//third_party/dart/runtime/bin:dart_io_api_product",
-        "$flutter_root/shell/platform/fuchsia/runtime/dart/utils:utils_product",
+        "//flutter/shell/platform/fuchsia/runtime/dart/utils:utils_product",
       ]
     }
 
     deps = [
-             "$flutter_root/common",
-             "$flutter_root/fml",
-             "$flutter_root/shell/platform/fuchsia/dart-pkg/fuchsia",
-             "$flutter_root/shell/platform/fuchsia/dart-pkg/zircon",
+             "//flutter/common",
+             "//flutter/fml",
+             "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
+             "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
              "$fuchsia_sdk_root/pkg:async",
              "$fuchsia_sdk_root/pkg:async-cpp",
              "$fuchsia_sdk_root/pkg:async-default",
@@ -67,7 +67,7 @@ template("runner") {
              "$fuchsia_sdk_root/pkg:trace",
              "$fuchsia_sdk_root/pkg:trace-provider-so",
              "$fuchsia_sdk_root/pkg:vfs_cpp",
-             "$flutter_root/third_party/tonic",
+             "//flutter/third_party/tonic",
            ] + dart_deps + extra_deps
   }
 }
@@ -135,8 +135,8 @@ template("aot_runner_package") {
     ]
     if (!invoker.product) {
       deps += [
-        "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
         "vmservice:vmservice_snapshot",
+        "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
 
         # TODO(kaushikiska): Figure out how to get the profiler symbols for `libdart_precompiled_runtime`
         # "//topaz/runtime/dart/profiler_symbols:libdart_precompiled_runtime",
@@ -146,7 +146,7 @@ template("aot_runner_package") {
 
     binary = "dart_aot${product_suffix}_runner"
 
-    meta_dir = "$flutter_root/shell/platform/fuchsia/dart_runner/meta"
+    meta_dir = "//flutter/shell/platform/fuchsia/dart_runner/meta"
 
     meta = [
       {
@@ -164,7 +164,7 @@ template("aot_runner_package") {
               "/vmservice_snapshot.so")
       dart_profiler_symbols = rebase_path(
               get_label_info(
-                  "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
+                  "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_aot_runner",
                   "target_gen_dir") + "/dart_aot_runner.dartprofilersymbols")
 
       inputs = [
@@ -206,14 +206,14 @@ template("jit_runner_package") {
 
     if (!invoker.product) {
       deps += [
-        "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_jit_runner",
+        "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_jit_runner",
         observatory_target,
       ]
     }
 
     binary = "dart_jit${product_suffix}_runner"
 
-    meta_dir = "$flutter_root/shell/platform/fuchsia/dart_runner/meta"
+    meta_dir = "//flutter/shell/platform/fuchsia/dart_runner/meta"
 
     libraries = common_libs
 
@@ -249,7 +249,7 @@ template("jit_runner_package") {
         {
           path = rebase_path(
                   get_label_info(
-                      "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_jit_runner",
+                      "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:dart_jit_runner",
                       "target_gen_dir") + "/dart_jit_runner.dartprofilersymbols")
           dest = "dart_jit_runner.dartprofilersymbols"
         },

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -3,9 +3,9 @@
 # found in the LICENSE file.
 
 import("//build/compiled_action.gni")
+import("//flutter/common/fuchsia_config.gni")
+import("//flutter/tools/fuchsia/dart_kernel.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
-import("$flutter_root/common/fuchsia_config.gni")
-import("$flutter_root/tools/fuchsia/dart_kernel.gni")
 
 dart_kernel("shim_kernel") {
   main_dart = "shim.dart"

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -4,9 +4,9 @@
 
 import("//build/compiled_action.gni")
 import("//build/fuchsia/sdk.gni")
+import("//flutter/common/config.gni")
+import("//flutter/tools/fuchsia/dart.gni")
 import("//third_party/dart/utils/compile_platform.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
 
 compile_platform("kernel_platform_files") {
   single_root_scheme = "org-dartlang-sdk"
@@ -42,7 +42,7 @@ template("create_kernel_core_snapshot") {
 
     platform_dill = "$root_out_dir/dart_runner_patched_sdk/platform_strong.dill"
     compilation_trace =
-        "$flutter_root/shell/platform/fuchsia/flutter/compilation_trace.txt"
+        "//flutter/shell/platform/fuchsia/flutter/compilation_trace.txt"
     inputs = [
       platform_dill,
       compilation_trace,

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -4,10 +4,10 @@
 
 import("//build/compiled_action.gni")
 import("//build/fuchsia/sdk.gni")
+import("//flutter/common/config.gni")
+import("//flutter/tools/fuchsia/dart.gni")
+import("//flutter/tools/fuchsia/dart_kernel.gni")
 import("//third_party/dart/utils/compile_platform.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
-import("$flutter_root/tools/fuchsia/dart_kernel.gni")
 
 dart_kernel("vmservice_product_aot_kernel") {
   kernel_platform_files = "../kernel:kernel_platform_files"

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -5,13 +5,13 @@
 assert(is_fuchsia)
 
 import("//build/fuchsia/sdk.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/shell/gpu/gpu.gni")
-import("$flutter_root/testing/testing.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_archive.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_libs.gni")
-import("$flutter_root/vulkan/config.gni")
+import("//flutter/common/config.gni")
+import("//flutter/shell/gpu/gpu.gni")
+import("//flutter/testing/testing.gni")
+import("//flutter/tools/fuchsia/dart.gni")
+import("//flutter/tools/fuchsia/fuchsia_archive.gni")
+import("//flutter/tools/fuchsia/fuchsia_libs.gni")
+import("//flutter/vulkan/config.gni")
 import("engine_flutter_runner.gni")
 
 shell_gpu_configuration("fuchsia_gpu_configuration") {
@@ -126,14 +126,14 @@ template("jit_runner") {
 
     if (!product) {
       deps += [
-        "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_jit_runner",
+        "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_jit_runner",
         observatory_target,
       ]
     }
 
     binary = "flutter_jit${product_suffix}_runner"
 
-    meta_dir = "$flutter_root/shell/platform/fuchsia/flutter/meta"
+    meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
 
     resources = [
       {
@@ -151,7 +151,7 @@ template("jit_runner") {
         {
           path = rebase_path(
                   get_label_info(
-                      "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_jit_runner",
+                      "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_jit_runner",
                       "target_gen_dir") +
                   "/flutter_jit_runner.dartprofilersymbols")
           dest = "flutter_jit_runner.dartprofilersymbols"
@@ -216,12 +216,12 @@ template("aot_runner") {
 
     if (!product) {
       deps += [
-        "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_aot_runner",
+        "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_aot_runner",
         observatory_target,
       ]
     }
 
-    meta_dir = "$flutter_root/shell/platform/fuchsia/flutter/meta"
+    meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
 
     binary = "flutter_aot${product_suffix}_runner"
 
@@ -241,7 +241,7 @@ template("aot_runner") {
         {
           path = rebase_path(
                   get_label_info(
-                      "$flutter_root/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_aot_runner",
+                      "//flutter/shell/platform/fuchsia/runtime/dart/profiler_symbols:flutter_aot_runner",
                       "target_gen_dir") +
                   "/flutter_aot_runner.dartprofilersymbols")
           dest = "flutter_aot_runner.dartprofilersymbols"
@@ -398,22 +398,22 @@ fuchsia_archive("flutter_runner_tests") {
     },
     {
       path = rebase_path(
-              "$flutter_root/shell/platform/fuchsia/flutter/tests/tzdata/2019a/44/le/metaZones.res")
+              "//flutter/shell/platform/fuchsia/flutter/tests/tzdata/2019a/44/le/metaZones.res")
       dest = "tzdata/metaZones.res"
     },
     {
       path = rebase_path(
-              "$flutter_root/shell/platform/fuchsia/flutter/tests/tzdata/2019a/44/le/timezoneTypes.res")
+              "//flutter/shell/platform/fuchsia/flutter/tests/tzdata/2019a/44/le/timezoneTypes.res")
       dest = "tzdata/timezoneTypes.res"
     },
     {
       path = rebase_path(
-              "$flutter_root/shell/platform/fuchsia/flutter/tests/tzdata/2019a/44/le/zoneinfo64.res")
+              "//flutter/shell/platform/fuchsia/flutter/tests/tzdata/2019a/44/le/zoneinfo64.res")
       dest = "tzdata/zoneinfo64.res"
     },
   ]
 
-  meta_dir = "$flutter_root/shell/platform/fuchsia/flutter/meta"
+  meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
 
   libraries = common_libs
 
@@ -441,7 +441,7 @@ fuchsia_archive("flutter_runner_tzdata_tests") {
     },
   ]
 
-  meta_dir = "$flutter_root/shell/platform/fuchsia/flutter/meta"
+  meta_dir = "//flutter/shell/platform/fuchsia/flutter/meta"
 
   libraries = common_libs
 

--- a/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
+++ b/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
@@ -89,18 +89,18 @@ template("flutter_runner") {
     # embedder API.
     flutter_deps = [
       "../flutter:fuchsia_gpu_configuration",
-      "$flutter_root/assets",
-      "$flutter_root/common",
-      "$flutter_root/flow",
-      "$flutter_root/lib/ui",
-      "$flutter_root/runtime",
-      "$flutter_root/third_party/txt",
-      "$flutter_root/vulkan",
-      "$flutter_root/fml",
-      "$flutter_root/shell/common",
+      "//flutter/assets",
+      "//flutter/common",
+      "//flutter/flow",
+      "//flutter/lib/ui",
+      "//flutter/runtime",
+      "//flutter/third_party/txt",
+      "//flutter/vulkan",
+      "//flutter/fml",
+      "//flutter/shell/common",
     ]
 
-    _fuchsia_platform = "$flutter_root/shell/platform/fuchsia"
+    _fuchsia_platform = "//flutter/shell/platform/fuchsia"
 
     # TODO(kaushikiska) evaluate if all of these are needed.
     fuchsia_deps = [
@@ -133,7 +133,7 @@ template("flutter_runner") {
              "$fuchsia_sdk_root/pkg:vfs_cpp",
              "$fuchsia_sdk_root/pkg:zx",
              "//third_party/skia",
-             "$flutter_root/third_party/tonic",
+             "//flutter/third_party/tonic",
            ] + fuchsia_deps + flutter_deps + extra_deps
 
     # The flags below are needed so that Dart's CPU profiler can walk the

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -4,9 +4,9 @@
 
 import("//build/compiled_action.gni")
 import("//build/fuchsia/sdk.gni")
+import("//flutter/common/config.gni")
+import("//flutter/tools/fuchsia/dart.gni")
 import("//third_party/dart/utils/compile_platform.gni")
-import("$flutter_root/common/config.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
 
 compile_platform("kernel_platform_files") {
   single_root_scheme = "org-dartlang-sdk"
@@ -46,7 +46,7 @@ template("core_snapshot") {
     platform_dill =
         "$root_out_dir/flutter_runner_patched_sdk/platform_strong.dill"
     compilation_trace =
-        "$flutter_root/shell/platform/fuchsia/flutter/compilation_trace.txt"
+        "//flutter/shell/platform/fuchsia/flutter/compilation_trace.txt"
     inputs = [
       platform_dill,
       compilation_trace,

--- a/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/profiler_symbols/BUILD.gn
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/tools/fuchsia/clang.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
-import("$flutter_root/tools/fuchsia/clang.gni")
 
 template("generate_dart_profiler_symbols") {
   assert(defined(invoker.library_label), "Must define 'library_label'")
@@ -38,26 +38,26 @@ template("generate_dart_profiler_symbols") {
 
 generate_dart_profiler_symbols("dart_jit_runner") {
   library_label =
-      "$flutter_root/shell/platform/fuchsia/dart_runner:dart_jit_runner_bin"
+      "//flutter/shell/platform/fuchsia/dart_runner:dart_jit_runner_bin"
   library_path = "${root_out_dir}/exe.unstripped/dart_jit_runner"
   output = "${target_gen_dir}/dart_jit_runner.dartprofilersymbols"
 }
 
 generate_dart_profiler_symbols("dart_aot_runner") {
   library_label =
-      "$flutter_root/shell/platform/fuchsia/dart_runner:dart_aot_runner_bin"
+      "//flutter/shell/platform/fuchsia/dart_runner:dart_aot_runner_bin"
   library_path = "${root_out_dir}/exe.unstripped/dart_aot_runner"
   output = "${target_gen_dir}/dart_aot_runner.dartprofilersymbols"
 }
 
 generate_dart_profiler_symbols("flutter_jit_runner") {
-  library_label = "$flutter_root/shell/platform/fuchsia/flutter:jit"
+  library_label = "//flutter/shell/platform/fuchsia/flutter:jit"
   library_path = "${root_out_dir}/exe.unstripped/flutter_jit_runner"
   output = "${target_gen_dir}/flutter_jit_runner.dartprofilersymbols"
 }
 
 generate_dart_profiler_symbols("flutter_aot_runner") {
-  library_label = "$flutter_root/shell/platform/fuchsia/flutter:aot"
+  library_label = "//flutter/shell/platform/fuchsia/flutter:aot"
   library_path = "${root_out_dir}/exe.unstripped/flutter_aot_runner"
   output = "${target_gen_dir}/flutter_aot_runner.dartprofilersymbols"
 }

--- a/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
+++ b/shell/platform/fuchsia/runtime/dart/utils/BUILD.gn
@@ -5,7 +5,7 @@
 assert(is_fuchsia)
 
 import("//build/fuchsia/sdk.gni")
-import("$flutter_root/common/config.gni")
+import("//flutter/common/config.gni")
 
 config("utils_config") {
   include_dirs = [ "../../.." ]
@@ -43,7 +43,7 @@ template("make_utils") {
              "$fuchsia_sdk_root/pkg:trace",
              "$fuchsia_sdk_root/pkg:vfs_cpp",
              "$fuchsia_sdk_root/pkg:zx",
-             "$flutter_root/third_party/tonic",
+             "//flutter/third_party/tonic",
            ]
 
     public_configs = [ ":utils_config" ]

--- a/shell/platform/glfw/BUILD.gn
+++ b/shell/platform/glfw/BUILD.gn
@@ -18,16 +18,14 @@ source_set("flutter_glfw_headers") {
   public = _public_headers
 
   public_deps = [
-    "$flutter_root/shell/platform/common/cpp:common_cpp_library_headers",
+    "//flutter/shell/platform/common/cpp:common_cpp_library_headers",
   ]
 
-  configs += [
-    "$flutter_root/shell/platform/common/cpp:desktop_library_implementation",
-  ]
+  configs +=
+      [ "//flutter/shell/platform/common/cpp:desktop_library_implementation" ]
 
-  public_configs = [
-    "$flutter_root/shell/platform/common/cpp:relative_flutter_library_headers",
-  ]
+  public_configs =
+      [ "//flutter/shell/platform/common/cpp:relative_flutter_library_headers" ]
 }
 
 source_set("flutter_glfw") {
@@ -46,24 +44,23 @@ source_set("flutter_glfw") {
 
   defines = [ "USE_RAPID_JSON" ]
 
-  configs += [
-    "$flutter_root/shell/platform/common/cpp:desktop_library_implementation",
-  ]
+  configs +=
+      [ "//flutter/shell/platform/common/cpp:desktop_library_implementation" ]
 
   deps = [
     ":flutter_glfw_headers",
-    "$flutter_root/shell/platform/common/cpp:common_cpp",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    "$flutter_root/shell/platform/embedder:embedder_with_symbol_prefix",
-    "$flutter_root/shell/platform/glfw/client_wrapper:client_wrapper_glfw",
     "//build/secondary/third_party/glfw",
+    "//flutter/shell/platform/common/cpp:common_cpp",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/embedder:embedder_with_symbol_prefix",
+    "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw",
     "//third_party/rapidjson",
   ]
 
   if (is_linux) {
     libs = [ "GL" ]
 
-    configs += [ "$flutter_root/shell/platform/linux/config:x11" ]
+    configs += [ "//flutter/shell/platform/linux/config:x11" ]
   } else if (is_mac) {
     libs = [
       "CoreVideo.framework",
@@ -80,6 +77,6 @@ copy("publish_headers_glfw") {
 
   # The GLFW header assumes the presence of the common headers.
   deps = [
-    "$flutter_root/shell/platform/common/cpp:publish_headers",
+    "//flutter/shell/platform/common/cpp:publish_headers",
   ]
 }

--- a/shell/platform/glfw/client_wrapper/BUILD.gn
+++ b/shell/platform/glfw/client_wrapper/BUILD.gn
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/shell/platform/common/cpp/client_wrapper/publish.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/shell/platform/common/cpp/client_wrapper/publish.gni")
+import("//flutter/testing/testing.gni")
 
 _wrapper_includes = [
   "include/flutter/flutter_window.h",
@@ -17,9 +17,8 @@ _wrapper_sources = [ "flutter_window_controller.cc" ]
 # so uses header paths that assume the merged state. Include the header
 # header directory of the core wrapper files so these includes will work.
 config("relative_core_wrapper_headers") {
-  include_dirs = [
-    "$flutter_root/shell/platform/common/cpp/client_wrapper/include/flutter",
-  ]
+  include_dirs =
+      [ "//flutter/shell/platform/common/cpp/client_wrapper/include/flutter" ]
 }
 
 # GLFW client wrapper build for internal use by the shell implementation.
@@ -28,19 +27,18 @@ source_set("client_wrapper_glfw") {
   public = _wrapper_includes
 
   deps = [
-    "$flutter_root/shell/platform/common/cpp:common_cpp_library_headers",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    "$flutter_root/shell/platform/glfw:flutter_glfw_headers",
+    "//flutter/shell/platform/common/cpp:common_cpp_library_headers",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/glfw:flutter_glfw_headers",
   ]
 
-  configs += [
-    "$flutter_root/shell/platform/common/cpp:desktop_library_implementation",
-  ]
+  configs +=
+      [ "//flutter/shell/platform/common/cpp:desktop_library_implementation" ]
 
   public_configs = [
     ":relative_core_wrapper_headers",
-    "$flutter_root/shell/platform/common/cpp:relative_flutter_library_headers",
-    "$flutter_root/shell/platform/glfw:relative_flutter_glfw_headers",
+    "//flutter/shell/platform/common/cpp:relative_flutter_library_headers",
+    "//flutter/shell/platform/glfw:relative_flutter_glfw_headers",
   ]
 }
 
@@ -61,7 +59,7 @@ source_set("client_wrapper_library_stubs_glfw") {
   defines = [ "FLUTTER_DESKTOP_LIBRARY" ]
 
   public_deps = [
-    "$flutter_root/shell/platform/glfw:flutter_glfw_headers",
+    "//flutter/shell/platform/glfw:flutter_glfw_headers",
   ]
 }
 
@@ -82,8 +80,8 @@ executable("client_wrapper_glfw_unittests") {
     ":client_wrapper_glfw",
     ":client_wrapper_glfw_fixtures",
     ":client_wrapper_library_stubs_glfw",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper_library_stubs",
-    "$flutter_root/testing",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper_library_stubs",
+    "//flutter/testing",
 
     # TODO(chunhtai): Consider refactoring flutter_root/testing so that there's a testing
     # target that doesn't require a Dart runtime to be linked in.

--- a/shell/platform/linux/BUILD.gn
+++ b/shell/platform/linux/BUILD.gn
@@ -4,14 +4,14 @@
 
 assert(is_linux)
 
-import("$flutter_root/shell/platform/glfw/config.gni")
+import("//flutter/shell/platform/glfw/config.gni")
 
 group("linux") {
   if (build_glfw_shell) {
     deps = [
       ":flutter_linux_glfw",
-      "$flutter_root/shell/platform/glfw:publish_headers_glfw",
-      "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
+      "//flutter/shell/platform/glfw:publish_headers_glfw",
+      "//flutter/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
     ]
   }
 }
@@ -29,11 +29,11 @@ config("disable_fatal_link_warnings") {
 if (build_glfw_shell) {
   shared_library("flutter_linux_glfw") {
     deps = [
-      "$flutter_root/shell/platform/glfw:flutter_glfw",
+      "//flutter/shell/platform/glfw:flutter_glfw",
     ]
 
     configs += [ ":disable_fatal_link_warnings" ]
 
-    public_configs = [ "$flutter_root:config" ]
+    public_configs = [ "//flutter:config" ]
   }
 }

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -4,8 +4,8 @@
 
 assert(is_win)
 
-import("$flutter_root/shell/platform/glfw/config.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/shell/platform/glfw/config.gni")
+import("//flutter/testing/testing.gni")
 
 _public_headers = [ "public/flutter_windows.h" ]
 
@@ -27,16 +27,14 @@ source_set("flutter_windows_headers") {
   public = _public_headers
 
   public_deps = [
-    "$flutter_root/shell/platform/common/cpp:common_cpp_library_headers",
+    "//flutter/shell/platform/common/cpp:common_cpp_library_headers",
   ]
 
-  configs += [
-    "$flutter_root/shell/platform/common/cpp:desktop_library_implementation",
-  ]
+  configs +=
+      [ "//flutter/shell/platform/common/cpp:desktop_library_implementation" ]
 
-  public_configs = [
-    "$flutter_root/shell/platform/common/cpp:relative_flutter_library_headers",
-  ]
+  public_configs =
+      [ "//flutter/shell/platform/common/cpp:relative_flutter_library_headers" ]
 }
 
 source_set("flutter_windows_source") {
@@ -65,7 +63,7 @@ source_set("flutter_windows_source") {
   defines = [ "USE_RAPID_JSON" ]
 
   configs += [
-    "$flutter_root/shell/platform/common/cpp:desktop_library_implementation",
+    "//flutter/shell/platform/common/cpp:desktop_library_implementation",
     "//third_party/angle:gl_prototypes",
   ]
 
@@ -73,10 +71,10 @@ source_set("flutter_windows_source") {
 
   deps = [
     ":flutter_windows_headers",
-    "$flutter_root/shell/platform/common/cpp:common_cpp",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    "$flutter_root/shell/platform/embedder:embedder_with_symbol_prefix",
-    "$flutter_root/shell/platform/windows/client_wrapper:client_wrapper_windows",
+    "//flutter/shell/platform/common/cpp:common_cpp",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/embedder:embedder_with_symbol_prefix",
+    "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows",
     "//third_party/angle:libEGL_static",  # the order of libEGL_static and libGLESv2_static is important.. if reversed, will cause a linker error DllMain already defined in LIBCMTD.lib
     "//third_party/angle:libGLESv2_static",
     "//third_party/rapidjson",
@@ -91,7 +89,7 @@ copy("publish_headers_windows") {
 
   # The Windows header assumes the presence of the common headers.
   deps = [
-    "$flutter_root/shell/platform/common/cpp:publish_headers",
+    "//flutter/shell/platform/common/cpp:publish_headers",
   ]
 }
 
@@ -100,7 +98,7 @@ shared_library("flutter_windows") {
     ":flutter_windows_source",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }
 
 test_fixtures("flutter_windows_fixtures") {
@@ -116,13 +114,13 @@ executable("flutter_windows_unittests") {
     "win32_window_unittests.cc",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 
   deps = [
     ":flutter_windows_fixtures",
     ":flutter_windows_headers",
     ":flutter_windows_source",
-    "$flutter_root/testing",
+    "//flutter/testing",
 
     # TODO(chunhtai): Consider refactoring flutter_root/testing so that there's a testing
     # target that doesn't require a Dart runtime to be linked in.
@@ -134,18 +132,18 @@ executable("flutter_windows_unittests") {
 
 shared_library("flutter_windows_glfw") {
   deps = [
-    "$flutter_root/shell/platform/glfw:flutter_glfw",
+    "//flutter/shell/platform/glfw:flutter_glfw",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }
 
 group("windows_glfw") {
   deps = [
     ":flutter_windows",
     ":flutter_windows_glfw",
-    "$flutter_root/shell/platform/glfw:publish_headers_glfw",
-    "$flutter_root/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
+    "//flutter/shell/platform/glfw:publish_headers_glfw",
+    "//flutter/shell/platform/glfw/client_wrapper:publish_wrapper_glfw",
   ]
 }
 
@@ -153,7 +151,7 @@ group("windows") {
   deps = [
     ":flutter_windows",
     ":publish_headers_windows",
-    "$flutter_root/shell/platform/windows/client_wrapper:publish_wrapper_windows",
+    "//flutter/shell/platform/windows/client_wrapper:publish_wrapper_windows",
   ]
   if (build_glfw_shell) {
     deps += [ ":windows_glfw" ]

--- a/shell/platform/windows/client_wrapper/BUILD.gn
+++ b/shell/platform/windows/client_wrapper/BUILD.gn
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/shell/platform/common/cpp/client_wrapper/publish.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/shell/platform/common/cpp/client_wrapper/publish.gni")
+import("//flutter/testing/testing.gni")
 
 _wrapper_includes = [
   "include/flutter/flutter_view_controller.h",
@@ -17,9 +17,8 @@ _wrapper_sources = [ "flutter_view_controller.cc" ]
 # so uses header paths that assume the merged state. Include the header
 # header directory of the core wrapper files so these includes will work.
 config("relative_core_wrapper_headers") {
-  include_dirs = [
-    "$flutter_root/shell/platform/common/cpp/client_wrapper/include/flutter",
-  ]
+  include_dirs =
+      [ "//flutter/shell/platform/common/cpp/client_wrapper/include/flutter" ]
 }
 
 # Windows client wrapper build for internal use by the shell implementation.
@@ -28,19 +27,18 @@ source_set("client_wrapper_windows") {
   public = _wrapper_includes
 
   deps = [
-    "$flutter_root/shell/platform/common/cpp:common_cpp_library_headers",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper",
-    "$flutter_root/shell/platform/windows:flutter_windows_headers",
+    "//flutter/shell/platform/common/cpp:common_cpp_library_headers",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
+    "//flutter/shell/platform/windows:flutter_windows_headers",
   ]
 
-  configs += [
-    "$flutter_root/shell/platform/common/cpp:desktop_library_implementation",
-  ]
+  configs +=
+      [ "//flutter/shell/platform/common/cpp:desktop_library_implementation" ]
 
   public_configs = [
     ":relative_core_wrapper_headers",
-    "$flutter_root/shell/platform/common/cpp:relative_flutter_library_headers",
-    "$flutter_root/shell/platform/windows:relative_flutter_windows_headers",
+    "//flutter/shell/platform/common/cpp:relative_flutter_library_headers",
+    "//flutter/shell/platform/windows:relative_flutter_windows_headers",
   ]
 }
 
@@ -59,7 +57,7 @@ source_set("client_wrapper_library_stubs_windows") {
   defines = [ "FLUTTER_DESKTOP_LIBRARY" ]
 
   public_deps = [
-    "$flutter_root/shell/platform/windows:flutter_windows_headers",
+    "//flutter/shell/platform/windows:flutter_windows_headers",
   ]
 }
 
@@ -80,8 +78,8 @@ executable("client_wrapper_windows_unittests") {
     ":client_wrapper_library_stubs_windows",
     ":client_wrapper_windows",
     ":client_wrapper_windows_fixtures",
-    "$flutter_root/shell/platform/common/cpp/client_wrapper:client_wrapper_library_stubs",
-    "$flutter_root/testing",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper_library_stubs",
+    "//flutter/testing",
 
     # TODO(chunhtai): Consider refactoring flutter_root/testing so that there's a testing
     # target that doesn't require a Dart runtime to be linked in.

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -8,8 +8,8 @@ executable("testing") {
   output_name = "flutter_tester"
 
   public_configs = [
-    "$flutter_root:config",
-    "$flutter_root:export_dynamic_symbols",
+    "//flutter:config",
+    "//flutter:export_dynamic_symbols",
   ]
 
   sources = [
@@ -17,12 +17,12 @@ executable("testing") {
   ]
 
   deps = [
-    "$flutter_root/assets",
-    "$flutter_root/common",
-    "$flutter_root/fml",
-    "$flutter_root/lib/snapshot",
-    "$flutter_root/shell/common",
-    "$flutter_root/third_party/tonic",
+    "//flutter/assets",
+    "//flutter/common",
+    "//flutter/fml",
+    "//flutter/lib/snapshot",
+    "//flutter/shell/common",
+    "//flutter/third_party/tonic",
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/bin:dart_io_api",
     "//third_party/skia",

--- a/shell/version/BUILD.gn
+++ b/shell/version/BUILD.gn
@@ -16,5 +16,5 @@ source_set("version") {
     "DART_VERSION=\"$dart_version\"",
   ]
 
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }

--- a/shell/version/version.gni
+++ b/shell/version/version.gni
@@ -10,12 +10,14 @@ declare_args() {
   dart_version = ""
 }
 
+_flutter_root = "//flutter"
+
 if (engine_version == "") {
   engine_version_lines =
-      exec_script("$flutter_root/build/git_revision.py",
+      exec_script("//flutter/build/git_revision.py",
                   [
                     "--repository",
-                    rebase_path(flutter_root, "", flutter_root),
+                    rebase_path(_flutter_root, "", _flutter_root),
                   ],
                   "list lines")
   engine_version = engine_version_lines[0]
@@ -23,10 +25,10 @@ if (engine_version == "") {
 
 if (skia_version == "") {
   skia_version_lines =
-      exec_script("$flutter_root/build/git_revision.py",
+      exec_script("//flutter/build/git_revision.py",
                   [
                     "--repository",
-                    rebase_path("//third_party/skia", "", flutter_root),
+                    rebase_path("//third_party/skia", "", _flutter_root),
                   ],
                   "list lines")
   skia_version = skia_version_lines[0]
@@ -34,10 +36,10 @@ if (skia_version == "") {
 
 if (dart_version == "") {
   dart_version_lines =
-      exec_script("$flutter_root/build/git_revision.py",
+      exec_script("//flutter/build/git_revision.py",
                   [
                     "--repository",
-                    rebase_path("//third_party/dart", "", flutter_root),
+                    rebase_path("//third_party/dart", "", _flutter_root),
                   ],
                   "list lines")
   dart_version = dart_version_lines[0]

--- a/sky/BUILD.gn
+++ b/sky/BUILD.gn
@@ -6,10 +6,10 @@ group("sky") {
   testonly = true
 
   deps = [
-    "$flutter_root/sky/packages",
+    "//flutter/sky/packages",
   ]
 
   if (!is_fuchsia) {
-    deps += [ "$flutter_root/shell" ]
+    deps += [ "//flutter/shell" ]
   }
 }

--- a/sky/dist/BUILD.gn
+++ b/sky/dist/BUILD.gn
@@ -6,9 +6,9 @@ import("//flutter/build/zip_bundle.gni")
 
 if (is_android) {
   action("flutter_services") {
-    script = "$flutter_root/sky/tools/dist_dart_pkg.py"
+    script = "//flutter/sky/tools/dist_dart_pkg.py"
 
-    source = "$flutter_root/sky/packages/flutter_services"
+    source = "//flutter/sky/packages/flutter_services"
     dest = "$root_build_dir/dist/packages/flutter_services"
 
     inputs = [
@@ -26,11 +26,11 @@ if (is_android) {
     ]
 
     deps = [
-      "$flutter_root/sky/packages/flutter_services",
+      "//flutter/sky/packages/flutter_services",
     ]
   }
   action("sky_engine") {
-    script = "$flutter_root/sky/tools/dist_dart_pkg.py"
+    script = "//flutter/sky/tools/dist_dart_pkg.py"
 
     source = "$root_gen_dir/dart-pkg/sky_engine"
     dest = "$root_build_dir/dist/packages/sky_engine"
@@ -50,13 +50,13 @@ if (is_android) {
     ]
 
     deps = [
-      "$flutter_root/sky/packages/sky_engine",
-      "$flutter_root/sky/packages/sky_engine:sky_engine_pkg_helper",
+      "//flutter/sky/packages/sky_engine",
+      "//flutter/sky/packages/sky_engine:sky_engine_pkg_helper",
     ]
   }
 
   action("sky_services") {
-    script = "$flutter_root/sky/tools/dist_dart_pkg.py"
+    script = "//flutter/sky/tools/dist_dart_pkg.py"
 
     source = "$root_gen_dir/dart-pkg/sky_services"
     dest = "$root_build_dir/dist/packages/sky_services"
@@ -76,8 +76,8 @@ if (is_android) {
     ]
 
     deps = [
-      "$flutter_root/sky/packages/sky_services",
-      "$flutter_root/sky/packages/sky_services:sky_services_pkg_helper",
+      "//flutter/sky/packages/sky_services",
+      "//flutter/sky/packages/sky_services:sky_services_pkg_helper",
     ]
   }
 

--- a/sky/packages/BUILD.gn
+++ b/sky/packages/BUILD.gn
@@ -6,8 +6,8 @@ group("packages") {
   testonly = true
 
   deps = [
-    "$flutter_root/sky/packages/flutter_services",
-    "$flutter_root/sky/packages/sky_engine",
-    "$flutter_root/sky/packages/sky_services",
+    "//flutter/sky/packages/flutter_services",
+    "//flutter/sky/packages/sky_engine",
+    "//flutter/sky/packages/sky_services",
   ]
 }

--- a/sky/packages/flutter_services/BUILD.gn
+++ b/sky/packages/flutter_services/BUILD.gn
@@ -4,6 +4,6 @@
 
 group("flutter_services") {
   deps = [
-    "$flutter_root/sky/packages/sky_services",
+    "//flutter/sky/packages/sky_services",
   ]
 }

--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -3,6 +3,8 @@
 # found in the LICENSE file.
 
 import("//build/fuchsia/sdk.gni")
+import("//flutter/build/dart/rules.gni")
+import("//flutter/lib/ui/dart_ui.gni")
 import("//third_party/dart/sdk/lib/_http/http_sources.gni")
 import(
     "//third_party/dart/sdk/lib/_internal/js_runtime/interceptors_sources.gni")
@@ -21,8 +23,6 @@ import("//third_party/dart/sdk/lib/js_util/js_util_sources.gni")
 import("//third_party/dart/sdk/lib/math/math_sources.gni")
 import("//third_party/dart/sdk/lib/typed_data/typed_data_sources.gni")
 import("//third_party/dart/sdk/lib/wasm/wasm_sources.gni")
-import("$flutter_root/build/dart/rules.gni")
-import("$flutter_root/lib/ui/dart_ui.gni")
 
 if (!is_fuchsia) {
   copy("copy_sky_engine_authors") {

--- a/sky/packages/sky_services/BUILD.gn
+++ b/sky/packages/sky_services/BUILD.gn
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/build/dart/rules.gni")
+import("//flutter/build/dart/rules.gni")
 
 if (!is_fuchsia) {
   copy("copy_sky_services_license") {

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -3,7 +3,7 @@
 # found in the LICENSE file.
 
 import("//flutter/shell/config.gni")
-import("//flutter/testing/testing.gni")
+import("testing.gni")
 
 source_set("testing_lib") {
   testonly = true
@@ -17,10 +17,10 @@ source_set("testing_lib") {
   ]
 
   public_deps = [
-    "$flutter_root/fml",
+    "//flutter/fml",
     "//third_party/googletest:gtest",
   ]
-  public_configs = [ "$flutter_root:config" ]
+  public_configs = [ "//flutter:config" ]
 }
 
 source_set("testing") {
@@ -47,11 +47,10 @@ source_set("dart") {
 
   public_deps = [
     ":testing",
-    "$flutter_root/common",
-    "$flutter_root/fml",
-    "$flutter_root/runtime",
-    "$flutter_root/runtime:libdart",
-    "$flutter_root/third_party/tonic",
+    "//flutter/common",
+    "//flutter/runtime",
+    "//flutter/runtime:libdart",
+    "//flutter/third_party/tonic",
     "//third_party/dart/runtime/bin:elf_loader",
     "//third_party/skia",
   ]
@@ -87,7 +86,7 @@ if (current_toolchain == host_toolchain) {
 
     deps = [
       ":skia",
-      "$flutter_root/fml",
+      "//flutter/fml",
       "//third_party/swiftshader_flutter:swiftshader",
     ]
   }
@@ -115,7 +114,7 @@ if (current_toolchain == host_toolchain) {
 
     deps = [
       ":skia",
-      "$flutter_root/fml",
+      "//flutter/fml",
     ]
   }
 

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -3,8 +3,8 @@
 # found in the LICENSE file.
 
 import("//build/compiled_action.gni")
+import("//flutter/common/config.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
-import("$flutter_root/common/config.gni")
 
 is_aot_test =
     flutter_runtime_mode == "profile" || flutter_runtime_mode == "release"
@@ -60,7 +60,7 @@ template("dart_snapshot_kernel") {
     ]
 
     if (is_aot_test) {
-      deps += [ "$flutter_root/lib/snapshot:strong_platform" ]
+      deps += [ "//flutter/lib/snapshot:strong_platform" ]
     }
 
     script = "$root_out_dir/frontend_server.dart.snapshot"

--- a/third_party/tonic/BUILD.gn
+++ b/third_party/tonic/BUILD.gn
@@ -4,8 +4,8 @@
 
 config("config") {
   include_dirs = [
-    "$flutter_root/third_party",
-    "$flutter_root",
+    "//flutter/third_party",
+    "//flutter",
   ]
 }
 

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("$flutter_root/common/config.gni")
-import("$flutter_root/testing/testing.gni")
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
 
 declare_args() {
   flutter_use_fontconfig = false
@@ -129,7 +129,7 @@ source_set("txt") {
   public_configs = [ ":txt_config" ]
 
   public_deps = [
-    "$flutter_root/fml",
+    "//flutter/fml",
     "//third_party/harfbuzz",
     "//third_party/icu",
     "//third_party/skia",
@@ -156,7 +156,7 @@ source_set("txt") {
 
   if (is_mac || is_ios) {
     sources += [ "src/txt/platform_mac.mm" ]
-    deps += [ "$flutter_root/fml" ]
+    deps += [ "//flutter/fml" ]
   } else if (is_android) {
     sources += [ "src/txt/platform_android.cc" ]
   } else if (is_linux) {
@@ -172,7 +172,7 @@ source_set("txt") {
 
 txt_common_executable_deps = [
   "//third_party/dart/runtime:libdart_jit",  # For logging.
-  "$flutter_root/fml",  # For ICU initialization.
+  "//flutter/fml",  # For ICU initialization.
 ]
 
 source_set("txt_test_utils") {
@@ -183,7 +183,7 @@ source_set("txt_test_utils") {
 
   deps = [
     ":txt",
-    "$flutter_root/fml",
+    "//flutter/fml",
     "//third_party/skia",
   ]
 }
@@ -299,7 +299,7 @@ executable("txt_unittests") {
   deps = [
            ":txt",
            ":txt_test_utils",
-           "$flutter_root/testing:testing_lib",
+           "//flutter/testing:testing_lib",
            ":txt_fixtures",
          ] + txt_common_executable_deps
 }
@@ -318,7 +318,7 @@ executable("txt_benchmarks") {
   deps = [
            ":txt",
            ":txt_test_utils",
-           "$flutter_root/testing:testing_lib",
+           "//flutter/testing:testing_lib",
            "//third_party/benchmark",
            ":txt_fixtures",
          ] + txt_common_executable_deps

--- a/tools/fuchsia/clang.gni
+++ b/tools/fuchsia/clang.gni
@@ -27,7 +27,6 @@ if (is_fuchsia) {
 }
 
 clang_manifest = rebase_path("$clang_base/${clang_target}.manifest")
-clang_manifest_json =
-    exec_script("$flutter_root/tools/fuchsia/parse_manifest.py",
-                [ "--input=${clang_manifest}" ],
-                "json")
+clang_manifest_json = exec_script("//flutter/tools/fuchsia/parse_manifest.py",
+                                  [ "--input=${clang_manifest}" ],
+                                  "json")

--- a/tools/fuchsia/dart_kernel.gni
+++ b/tools/fuchsia/dart_kernel.gni
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/fuchsia_config.gni")
+import("//flutter/tools/fuchsia/dart.gni")
 import("//third_party/dart/build/dart/dart_action.gni")
-import("$flutter_root/common/fuchsia_config.gni")
-import("$flutter_root/tools/fuchsia/dart.gni")
 
 template("dart_kernel") {
   prebuilt_dart_action(target_name) {

--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/tools/fuchsia/fuchsia_debug_symbols.gni")
-import("$flutter_root/tools/fuchsia/fuchsia_libs.gni")
+import("//flutter/tools/fuchsia/fuchsia_debug_symbols.gni")
+import("//flutter/tools/fuchsia/fuchsia_libs.gni")
 
 # Creates a Fuchsia archive (.far) file using PM from the Fuchsia SDK.
 template("fuchsia_archive") {
@@ -89,7 +89,7 @@ template("fuchsia_archive") {
   pkg_dir_deps = pkg.deps + [ ":$cmx_target" ]
 
   action("${target_name}_dir") {
-    script = "$flutter_root/tools/fuchsia/copy_path.py"
+    script = "//flutter/tools/fuchsia/copy_path.py"
     sources = copy_sources
     response_file_contents = rebase_path(copy_sources + copy_outputs)
     deps = pkg_dir_deps
@@ -99,7 +99,7 @@ template("fuchsia_archive") {
   }
 
   action(target_name) {
-    script = "$flutter_root/tools/fuchsia/gen_package.py"
+    script = "//flutter/tools/fuchsia/gen_package.py"
     deps = pkg_dir_deps + [
              ":${target_name}_dir",
              ":${_dbg_symbols_target}",
@@ -143,7 +143,7 @@ template("fuchsia_test_archive") {
       resources = invoker.resources
     }
 
-    meta_dir = "$flutter_root/testing/fuchsia/meta"
+    meta_dir = "//flutter/testing/fuchsia/meta"
     cmx_file = "$meta_dir/fuchsia_test.cmx"
   }
 }

--- a/tools/fuchsia/fuchsia_debug_symbols.gni
+++ b/tools/fuchsia/fuchsia_debug_symbols.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/fuchsia_config.gni")
+import("//flutter/common/fuchsia_config.gni")
 
 # The inputs to this template are 'binary_path' and a boolean 'unstripped'.
 # If 'unstripped' is specified, we append '.debug' to the symbols name.
@@ -19,7 +19,7 @@ template("_copy_debug_symbols") {
                              "testonly",
                            ])
 
-    script = "$flutter_root/tools/fuchsia/copy_debug_symbols.py"
+    script = "//flutter/tools/fuchsia/copy_debug_symbols.py"
 
     sources = [
       binary_path,

--- a/tools/fuchsia/fuchsia_host_bundle.gni
+++ b/tools/fuchsia/fuchsia_host_bundle.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/common/fuchsia_config.gni")
+import("//flutter/common/fuchsia_config.gni")
 
 template("fuchsia_host_bundle") {
   assert(defined(invoker.name), "'name' must be defined for $target_name.")

--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("$flutter_root/tools/fuchsia/clang.gni")
+import("//flutter/tools/fuchsia/clang.gni")
 
 fuchsia_sdk_base = "//fuchsia/sdk/$host_os/arch/$target_cpu"
 fuchsia_sdk_dist = "$fuchsia_sdk_base/dist"

--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -62,12 +62,12 @@ source_set("vulkan") {
   }
 
   deps = [
-    "$flutter_root/fml",
+    "//flutter/fml",
     "//third_party/skia",
   ]
 
   public_configs = [
     ":vulkan_config",
-    "$flutter_root:config",
+    "//flutter:config",
   ]
 }

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -7,25 +7,24 @@ import("//third_party/dart/utils/compile_platform.gni")
 
 sdk_dill = "$root_out_dir/flutter_web_sdk/kernel/flutter_ddc_sdk.dill"
 
-web_ui_sources =
-    exec_script("//third_party/dart/tools/list_dart_files.py",
-                [
-                  "absolute",
-                  rebase_path("$flutter_root/lib/web_ui/lib/src/ui"),
-                ],
-                "list lines")
+web_ui_sources = exec_script("//third_party/dart/tools/list_dart_files.py",
+                             [
+                               "absolute",
+                               rebase_path("//flutter/lib/web_ui/lib/src/ui"),
+                             ],
+                             "list lines")
 
-web_ui_sources += [ "$flutter_root/lib/web_ui/lib/ui.dart" ]
+web_ui_sources += [ "//flutter/lib/web_ui/lib/ui.dart" ]
 
 web_engine_sources =
     exec_script("//third_party/dart/tools/list_dart_files.py",
                 [
                   "absolute",
-                  rebase_path("$flutter_root/lib/web_ui/lib/src/engine"),
+                  rebase_path("//flutter/lib/web_ui/lib/src/engine"),
                 ],
                 "list lines")
 
-web_engine_sources += [ "$flutter_root/lib/web_ui/lib/src/engine.dart" ]
+web_engine_sources += [ "//flutter/lib/web_ui/lib/src/engine.dart" ]
 
 group("web_sdk") {
   deps = [
@@ -43,7 +42,7 @@ prebuilt_dart_action("web_ui_sources") {
   packages = "//third_party/dart/.packages"
   script = "sdk_rewriter.dart"
   output_dir = rebase_path("$root_out_dir/flutter_web_sdk/lib/ui/")
-  input_dir = rebase_path("$flutter_root/lib/web_ui/lib/")
+  input_dir = rebase_path("//flutter/lib/web_ui/lib/")
 
   args = [
     "--output-dir=$output_dir",
@@ -67,7 +66,7 @@ prebuilt_dart_action("web_engine_sources") {
   packages = "//third_party/dart/.packages"
   script = "sdk_rewriter.dart"
   output_dir = rebase_path("$root_out_dir/flutter_web_sdk/lib/_engine/")
-  input_dir = rebase_path("$flutter_root/lib/web_ui/lib/src/")
+  input_dir = rebase_path("//flutter/lib/web_ui/lib/src/")
 
   args = [
     "--output-dir=$output_dir",
@@ -87,7 +86,7 @@ prebuilt_dart_action("web_engine_sources") {
 
 copy("web_ui_library") {
   sources = [
-    "$flutter_root/web_sdk/libraries.json",
+    "//flutter/web_sdk/libraries.json",
   ]
 
   outputs = [


### PR DESCRIPTION
This was only necessary when the Engine had to build in multiple buildroots
where the sources where checked out at different paths relative to the
buildroot. This is no longer the case and there are already cases GN rules
have been written that mix and match variable usage with the direct
specification of the path to the Flutter sources relative to the sole buildroot.