### PR TITLE
Fix runtime type errors when running with canvaskit

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/fonts.dart
+++ b/lib/web_ui/lib/src/engine/compositor/fonts.dart
@@ -58,7 +58,7 @@ class SkiaFontCollection {
         final String asset = fontAsset['asset'];
         _loadingFontBuffers.add(html.window
             .fetch(assetManager.getAssetUrl(asset))
-            .then((dynamic fetchResult) => fetchResult.arrayBuffer()));
+            .then(_getArrayBuffer));
       }
     }
 
@@ -69,9 +69,13 @@ class SkiaFontCollection {
       // Download Roboto and add it to the font buffers.
       _loadingFontBuffers.add(html.window
           .fetch(_robotoUrl)
-          .then((dynamic fetchResult) => fetchResult.arrayBuffer()));
+          .then(_getArrayBuffer));
     }
   }
 
+  Future<ByteBuffer> _getArrayBuffer(dynamic fetchResult) {
+    return fetchResult.arrayBuffer().then<ByteBuffer>((x) => x as ByteBuffer);
+  }
+  
   js.JsObject skFontMgr;
 }

--- a/lib/web_ui/lib/src/engine/compositor/fonts.dart
+++ b/lib/web_ui/lib/src/engine/compositor/fonts.dart
@@ -76,6 +76,6 @@ class SkiaFontCollection {
   Future<ByteBuffer> _getArrayBuffer(dynamic fetchResult) {
     return fetchResult.arrayBuffer().then<ByteBuffer>((x) => x as ByteBuffer);
   }
-  
+
   js.JsObject skFontMgr;
 }

--- a/lib/web_ui/lib/src/engine/compositor/initialization.dart
+++ b/lib/web_ui/lib/src/engine/compositor/initialization.dart
@@ -6,7 +6,7 @@ part of engine;
 
 /// EXPERIMENTAL: Enable the Skia-based rendering backend.
 const bool experimentalUseSkia =
-    bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: false);
+    bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: true);
 
 /// The URL to use when downloading the CanvasKit script and associated wasm.
 const String canvasKitBaseUrl = 'https://unpkg.com/canvaskit-wasm@0.11.0/bin/';

--- a/lib/web_ui/lib/src/engine/compositor/initialization.dart
+++ b/lib/web_ui/lib/src/engine/compositor/initialization.dart
@@ -6,7 +6,7 @@ part of engine;
 
 /// EXPERIMENTAL: Enable the Skia-based rendering backend.
 const bool experimentalUseSkia =
-    bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: true);
+    bool.fromEnvironment('FLUTTER_WEB_USE_SKIA', defaultValue: false);
 
 /// The URL to use when downloading the CanvasKit script and associated wasm.
 const String canvasKitBaseUrl = 'https://unpkg.com/canvaskit-wasm@0.11.0/bin/';

--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -110,10 +110,10 @@ class Surface {
       ..position = 'absolute'
       ..width = '${logicalSize.width.ceil()}px'
       ..height = '${logicalSize.height.ceil()}px';
-    final js.JsObject glContext = canvasKit
+    final int glContext = canvasKit
         .callMethod('GetWebGLContext', <html.CanvasElement>[htmlCanvas]);
     final js.JsObject grContext =
-        canvasKit.callMethod('MakeGrContext', <js.JsObject>[glContext]);
+        canvasKit.callMethod('MakeGrContext', [glContext]);
     final js.JsObject skSurface =
         canvasKit.callMethod('MakeOnScreenGLSurface', <dynamic>[
       grContext,
@@ -135,7 +135,7 @@ class Surface {
       return false;
     }
 
-    canvasKit.callMethod('setCurrentContext', <js.JsObject>[_surface.context]);
+    canvasKit.callMethod('setCurrentContext', [_surface.context]);
     _surface.getCanvas().flush();
     return true;
   }
@@ -144,7 +144,7 @@ class Surface {
 /// A Dart wrapper around Skia's SkSurface.
 class SkSurface {
   final js.JsObject _surface;
-  final js.JsObject _glContext;
+  final int _glContext;
 
   SkSurface(this._surface, this._glContext);
 
@@ -153,7 +153,7 @@ class SkSurface {
     return SkCanvas(skCanvas);
   }
 
-  js.JsObject get context => _glContext;
+  int get context => _glContext;
 
   int width() => _surface.callMethod('width');
   int height() => _surface.callMethod('height');


### PR DESCRIPTION
This  lets gallery load under ddc (and presumably dart2js in default mode) under canvaskit.