### PR TITLE
Change NSLog to FML_DLOG

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -6,7 +6,6 @@
 
 #import <objc/message.h>
 
-#import "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputModel.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
@@ -114,7 +113,6 @@ static NSString* const kMultilineInputType = @"TextInputType.multiline";
     [self updateEditState];
   } else {
     handled = NO;
-    FML_DLOG(WARNING) << "Unhandled text input method '" << method.UTF8String << "'";
   }
   result(handled ? nil : FlutterMethodNotImplemented);
 }

--- a/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterTextInputPlugin.mm
@@ -6,6 +6,7 @@
 
 #import <objc/message.h>
 
+#import "flutter/fml/logging.h"
 #import "flutter/shell/platform/darwin/common/framework/Headers/FlutterCodecs.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterTextInputModel.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterViewController_Internal.h"
@@ -113,7 +114,7 @@ static NSString* const kMultilineInputType = @"TextInputType.multiline";
     [self updateEditState];
   } else {
     handled = NO;
-    NSLog(@"Unhandled text input method '%@'", method);
+    FML_DLOG(WARNING) << "Unhandled text input method '" << method.UTF8String << "'";
   }
   result(handled ? nil : FlutterMethodNotImplemented);
 }


### PR DESCRIPTION
This log is confusing for users - the method channel is an optional one.  It may still be useful for people developing the engine if they're not sure which methods are and are not handled.

Fixes https://github.com/flutter/flutter/issues/49960