### PR TITLE
[web][felt] If full dart-sdk isn't available, install it

### DIFF
--- a/lib/web_ui/dev/felt
+++ b/lib/web_ui/dev/felt
@@ -31,25 +31,26 @@ HOST_DEBUG_UNOPT_DIR="${ENGINE_SRC_DIR}/out/host_debug_unopt"
 DART_SDK_DIR="${ENGINE_SRC_DIR}/out/host_debug_unopt/dart-sdk"
 GN="${FLUTTER_DIR}/tools/gn"
 DART_TOOL_DIR="${WEB_UI_DIR}/.dart_tool"
+PUB_PATH="$DART_SDK_DIR/bin/pub"
 SNAPSHOT_PATH="${DART_TOOL_DIR}/felt.snapshot"
 STAMP_PATH="${DART_TOOL_DIR}/felt.snapshot.stamp"
 SCRIPT_PATH="${DEV_DIR}/felt.dart"
 REVISION="$(cd "$FLUTTER_DIR"; git rev-parse HEAD)"
 
-if [ ! -d "${OUT_DIR}" ] || [ ! -d "${HOST_DEBUG_UNOPT_DIR}" ]
+if [ ! -f "${PUB_PATH}" ]
 then
   echo "Compiling the Dart SDK."
   gclient sync
   $GN --unoptimized --full-dart-sdk
-  ninja -C $HOST_DEBUG_UNOPT_DIR
+  ninja -C $HOST_DEBUG_UNOPT_DIR -j 100
 fi
 
 install_deps() {
   echo "Running \`pub get\` in 'engine/src/flutter/lib/web_ui'"
-  (cd "$WEB_UI_DIR"; $DART_SDK_DIR/bin/pub get)
+  (cd "$WEB_UI_DIR"; $PUB_PATH get)
 
   echo "Running \`pub get\` in 'engine/src/flutter/web_sdk/web_engine_tester'"
-  (cd "$FLUTTER_DIR/web_sdk/web_engine_tester"; $DART_SDK_DIR/bin/pub get)
+  (cd "$FLUTTER_DIR/web_sdk/web_engine_tester"; $PUB_PATH get)
 }
 
 if [[ "$FELT_USE_SNAPSHOT" == "false" || "$FELT_USE_SNAPSHOT" == "0" ]]; then


### PR DESCRIPTION
When the user gets a fresh copy of the engine repo, and have a non-full dart-sdk, the felt tool would crash because it tries to look for `pub` and it can't find it.

This PR fixes the issue by checking for `pub`'s existence. If `pub` doesn't exist, felt will install a full dart-sdk (which includes pub).