### PR TITLE
Run Flutter framework tests against the web engine in Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,6 +80,10 @@ task:
       test_framework_script: |
         cd $FRAMEWORK_PATH/flutter/packages/flutter
         ../../bin/flutter test --local-engine=host_debug_unopt
+      # Run Flutter framework tests against the web engine.
+      test_framework_web_script: |
+        cd $FRAMEWORK_PATH/flutter/packages/flutter
+        ../../bin/flutter test --platform=chrome --local-engine=host_debug_unopt
     - name: build_and_test_web_linux_firefox
       compile_host_script: |
         cd $ENGINE_PATH/src

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -88,8 +88,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: web_tests-1-linux
       only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
@@ -97,8 +107,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: web_tests-2-linux
       only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
@@ -106,8 +126,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: web_tests-3-linux
       only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
@@ -115,8 +145,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: web_tests-4-linux
       only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
@@ -124,8 +164,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: web_tests-5-linux
       only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
@@ -133,8 +183,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: web_tests-6-linux
       only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
@@ -142,8 +202,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: web_tests-7_last-linux # last Web shard must end with _last
       only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
@@ -151,8 +221,18 @@ task:
         # As of October 2019, the Web shards needed more than 6G of RAM.
         CPU: 2
         MEMORY: 8G
+      compile_host_script: |
+        cd $ENGINE_PATH/src
+        ./flutter/tools/gn --unoptimized --full-dart-sdk
+        ninja -C out/host_debug_unopt
+      fetch_framework_script: |
+        mkdir -p $FRAMEWORK_PATH
+        cd $FRAMEWORK_PATH
+        git clone https://github.com/flutter/flutter.git
+        cd flutter
+        bin/flutter update-packages --local-engine=host_debug_unopt
       script:
-        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
 
     - name: build_and_test_web_linux_firefox
       compile_host_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,10 +80,80 @@ task:
       test_framework_script: |
         cd $FRAMEWORK_PATH/flutter/packages/flutter
         ../../bin/flutter test --local-engine=host_debug_unopt
-      # Run Flutter framework tests against the web engine.
-      test_framework_web_script: |
-        cd $FRAMEWORK_PATH/flutter/packages/flutter
-        ../../bin/flutter test --platform=chrome --local-engine=host_debug_unopt
+
+    # PLEASE KEEP THESE WEB TEST SHARDS IN SYNC WITH THEIR COUNTERPARTS IN flutter/flutter's CIRRUS CONFIG.
+    - name: web_tests-0-linux
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
+    - name: web_tests-1-linux
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
+    - name: web_tests-2-linux
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
+    - name: web_tests-3-linux
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
+    - name: web_tests-4-linux
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
+    - name: web_tests-5-linux
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
+    - name: web_tests-6-linux
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
+    - name: web_tests-7_last-linux # last Web shard must end with _last
+      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+      environment:
+        # As of October 2019, the Web shards needed more than 6G of RAM.
+        CPU: 2
+        MEMORY: 8G
+      script:
+        - dart --enable-asserts $FRAMEWORK_PATH/dev/bots/test.dart
+
     - name: build_and_test_web_linux_firefox
       compile_host_script: |
         cd $ENGINE_PATH/src

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,24 @@
 gcp_credentials: ENCRYPTED[987a78af29b91ce8489594c9ab3fec21845bbe5ba68294b8f6def3cf0d380830f06687a89ea69c87344c5ade369700fe]
 
+web_shard_template: &WEB_SHARD_TEMPLATE
+  only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
+  environment:
+    # As of October 2019, the Web shards needed more than 6G of RAM.
+    CPU: 2
+    MEMORY: 8G
+  compile_host_script: |
+    cd $ENGINE_PATH/src
+    ./flutter/tools/gn --unoptimized --full-dart-sdk
+    ninja -C out/host_debug_unopt
+  fetch_framework_script: |
+    mkdir -p $FRAMEWORK_PATH
+    cd $FRAMEWORK_PATH
+    git clone https://github.com/flutter/flutter.git
+    cd flutter
+    bin/flutter update-packages --local-engine=host_debug_unopt
+  script:
+    - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+
 # LINUX
 task:
   gke_container:
@@ -83,156 +102,28 @@ task:
 
     # PLEASE KEEP THESE WEB TEST SHARDS IN SYNC WITH THEIR COUNTERPARTS IN flutter/flutter's CIRRUS CONFIG.
     - name: web_tests-0-linux
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: web_tests-1-linux
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: web_tests-2-linux
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: web_tests-3-linux
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: web_tests-4-linux
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: web_tests-5-linux
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: web_tests-6-linux
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: web_tests-7_last-linux # last Web shard must end with _last
-      only_if: "changesInclude('.cirrus.yml', 'lib/web_ui/**', 'web_sdk/**') || $CIRRUS_PR == ''"
-      environment:
-        # As of October 2019, the Web shards needed more than 6G of RAM.
-        CPU: 2
-        MEMORY: 8G
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
-        cd flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - dart --enable-asserts $FRAMEWORK_PATH/flutter/dev/bots/test.dart --local-engine=host_debug_unopt
+      << : *WEB_SHARD_TEMPLATE
 
     - name: build_and_test_web_linux_firefox
       compile_host_script: |


### PR DESCRIPTION
I got bit multiple times because flutter tests currently don't run against the web engine in Cirrus (https://github.com/flutter/engine/pull/16268, https://github.com/flutter/engine/pull/14569).

These sort of mistakes could potentially be avoided too:
- https://github.com/flutter/engine/pull/16075
- https://github.com/flutter/engine/pull/15694