### PR TITLE
Make option to premultiply alpha when interpolating colors

### DIFF
--- a/lib/ui/painting/gradient.cc
+++ b/lib/ui/painting/gradient.cc
@@ -43,7 +43,8 @@ void CanvasGradient::initLinear(const tonic::Float32List& end_points,
                                 const tonic::Int32List& colors,
                                 const tonic::Float32List& color_stops,
                                 SkTileMode tile_mode,
-                                const tonic::Float64List& matrix4) {
+                                const tonic::Float64List& matrix4,
+                                bool interpolate_colors_in_premul) {
   FML_DCHECK(end_points.num_elements() == 4);
   FML_DCHECK(colors.num_elements() == color_stops.num_elements() ||
              color_stops.data() == nullptr);
@@ -62,7 +63,11 @@ void CanvasGradient::initLinear(const tonic::Float32List& end_points,
   set_shader(UIDartState::CreateGPUObject(SkGradientShader::MakeLinear(
       reinterpret_cast<const SkPoint*>(end_points.data()),
       reinterpret_cast<const SkColor*>(colors.data()), color_stops.data(),
-      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr)));
+      colors.num_elements(), tile_mode,
+      interpolate_colors_in_premul
+          ? SkGradientShader::Flags::kInterpolateColorsInPremul_Flag
+          : 0,
+      has_matrix ? &sk_matrix : nullptr)));
 }
 
 void CanvasGradient::initRadial(double center_x,
@@ -71,7 +76,8 @@ void CanvasGradient::initRadial(double center_x,
                                 const tonic::Int32List& colors,
                                 const tonic::Float32List& color_stops,
                                 SkTileMode tile_mode,
-                                const tonic::Float64List& matrix4) {
+                                const tonic::Float64List& matrix4,
+                                bool interpolate_colors_in_premul) {
   FML_DCHECK(colors.num_elements() == color_stops.num_elements() ||
              color_stops.data() == nullptr);
 
@@ -87,7 +93,11 @@ void CanvasGradient::initRadial(double center_x,
   set_shader(UIDartState::CreateGPUObject(SkGradientShader::MakeRadial(
       SkPoint::Make(center_x, center_y), radius,
       reinterpret_cast<const SkColor*>(colors.data()), color_stops.data(),
-      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr)));
+      colors.num_elements(), tile_mode,
+      interpolate_colors_in_premul
+          ? SkGradientShader::Flags::kInterpolateColorsInPremul_Flag
+          : 0,
+      has_matrix ? &sk_matrix : nullptr)));
 }
 
 void CanvasGradient::initSweep(double center_x,
@@ -97,7 +107,8 @@ void CanvasGradient::initSweep(double center_x,
                                SkTileMode tile_mode,
                                double start_angle,
                                double end_angle,
-                               const tonic::Float64List& matrix4) {
+                               const tonic::Float64List& matrix4,
+                               bool interpolate_colors_in_premul) {
   FML_DCHECK(colors.num_elements() == color_stops.num_elements() ||
              color_stops.data() == nullptr);
 
@@ -113,7 +124,10 @@ void CanvasGradient::initSweep(double center_x,
   set_shader(UIDartState::CreateGPUObject(SkGradientShader::MakeSweep(
       center_x, center_y, reinterpret_cast<const SkColor*>(colors.data()),
       color_stops.data(), colors.num_elements(), tile_mode,
-      start_angle * 180.0 / M_PI, end_angle * 180.0 / M_PI, 0,
+      start_angle * 180.0 / M_PI, end_angle * 180.0 / M_PI,
+      interpolate_colors_in_premul
+          ? SkGradientShader::Flags::kInterpolateColorsInPremul_Flag
+          : 0,
       has_matrix ? &sk_matrix : nullptr)));
 }
 
@@ -126,7 +140,8 @@ void CanvasGradient::initTwoPointConical(double start_x,
                                          const tonic::Int32List& colors,
                                          const tonic::Float32List& color_stops,
                                          SkTileMode tile_mode,
-                                         const tonic::Float64List& matrix4) {
+                                         const tonic::Float64List& matrix4,
+                                         bool interpolate_colors_in_premul) {
   FML_DCHECK(colors.num_elements() == color_stops.num_elements() ||
              color_stops.data() == nullptr);
 
@@ -143,7 +158,11 @@ void CanvasGradient::initTwoPointConical(double start_x,
       SkPoint::Make(start_x, start_y), start_radius,
       SkPoint::Make(end_x, end_y), end_radius,
       reinterpret_cast<const SkColor*>(colors.data()), color_stops.data(),
-      colors.num_elements(), tile_mode, 0, has_matrix ? &sk_matrix : nullptr)));
+      colors.num_elements(), tile_mode,
+      interpolate_colors_in_premul
+          ? SkGradientShader::Flags::kInterpolateColorsInPremul_Flag
+          : 0,
+      has_matrix ? &sk_matrix : nullptr)));
 }
 
 CanvasGradient::CanvasGradient() = default;

--- a/lib/ui/painting/gradient.h
+++ b/lib/ui/painting/gradient.h
@@ -32,15 +32,16 @@ class CanvasGradient : public Shader {
                   const tonic::Int32List& colors,
                   const tonic::Float32List& color_stops,
                   SkTileMode tile_mode,
-                  const tonic::Float64List& matrix4);
-
+                  const tonic::Float64List& matrix4,
+                  bool interpolate_colors_in_premul);
   void initRadial(double center_x,
                   double center_y,
                   double radius,
                   const tonic::Int32List& colors,
                   const tonic::Float32List& color_stops,
                   SkTileMode tile_mode,
-                  const tonic::Float64List& matrix4);
+                  const tonic::Float64List& matrix4,
+                  bool interpolate_colors_in_premul);
 
   void initSweep(double center_x,
                  double center_y,
@@ -49,7 +50,8 @@ class CanvasGradient : public Shader {
                  SkTileMode tile_mode,
                  double start_angle,
                  double end_angle,
-                 const tonic::Float64List& matrix4);
+                 const tonic::Float64List& matrix4,
+                 bool interpolate_colors_in_premul);
 
   void initTwoPointConical(double start_x,
                            double start_y,
@@ -60,7 +62,8 @@ class CanvasGradient : public Shader {
                            const tonic::Int32List& colors,
                            const tonic::Float32List& color_stops,
                            SkTileMode tile_mode,
-                           const tonic::Float64List& matrix4);
+                           const tonic::Float64List& matrix4,
+                           bool interpolate_colors_in_premul);
 
   static void RegisterNatives(tonic::DartLibraryNatives* natives);
 

--- a/testing/dart/color_test.dart
+++ b/testing/dart/color_test.dart
@@ -55,7 +55,9 @@ void main() {
     expect(const NotAColor(123), equals(const NotAColor(123)));
   });
 
-  test('Color.lerp', () {
+  test('Color.lerp - no premul', () {
+    final bool previousValue = interpolateColorsInPremul;
+    interpolateColorsInPremul = false;
     expect(
       Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 0.0),
       const Color(0x00000000),
@@ -76,6 +78,33 @@ void main() {
       Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 1.1),
       const Color(0xFFFFFFFF),
     );
+    interpolateColorsInPremul = previousValue;
+  });
+
+  test('Color.lerp - premul', () {
+    final bool previousValue = interpolateColorsInPremul;
+    interpolateColorsInPremul = true;
+    expect(
+      Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 0.0),
+      const Color(0x00000000),
+    );
+    expect(
+      Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 0.5),
+      const Color(0x7FFFFFFF),
+    );
+    expect(
+      Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 1.0),
+      const Color(0xFFFFFFFF),
+    );
+    expect(
+      Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), -0.1),
+      const Color(0x00000000),
+    );
+    expect(
+      Color.lerp(const Color(0x00000000), const Color(0xFFFFFFFF), 1.1),
+      const Color(0xFFFFFFFF),
+    );
+    interpolateColorsInPremul = previousValue;
   });
 
   test('Color.alphaBlend', () {


### PR DESCRIPTION
This is the first step in fixing https://github.com/flutter/flutter/issues/48674 and https://github.com/flutter/flutter/issues/48534

Today, Flutter lerps colors (via Color.lerp and the various gradient) in unpremultiplied alpha space. This causes unexpected things for end users when they want to lerp to/from colors involving transparency. More details can be found at the linked bugs above, including DartPad gists which demonstrate the undesirable effects.

This adds a global flag to dart:ui to control whether we interpolate colors in premultiplied or unpremultiplied space. It applies the flag evenly to `Color.lerp` and `Gradient.*`.  The goal is to land this in a multi-stage process as a soft break:

1. This step.
2. Roll this to internal customers.
3. Enable this flag as true internally, fix all golden test failures.
4. Default the flag to true externally (the real breaking change).
5. Roll flag defaulted to true to internal customers.
6. Remove setters internally.
7. Remove flag externally.

These steps are tracked in https://github.com/flutter/flutter/issues/50070

To discourage people from using the flag, I'm marking it as deprecated from the start.