### PR TITLE
Revert "Remove use of the deprecated AccessibilityNodeInfo boundsInPa…

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
@@ -202,6 +202,10 @@ final class AccessibilityViewEmbedder {
             @NonNull Rect displayBounds,
             @NonNull AccessibilityNodeInfo resultNode
     ) {
+        Rect boundsInParent = new Rect();
+        originNode.getBoundsInParent(boundsInParent);
+        resultNode.setBoundsInParent(boundsInParent);
+
         Rect boundsInScreen = new Rect();
         originNode.getBoundsInScreen(boundsInScreen);
         boundsInScreen.offset(displayBounds.left, displayBounds.top);

--- a/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityViewEmbedder.java
@@ -197,6 +197,10 @@ final class AccessibilityViewEmbedder {
         flutterIdToOrigin.put(flutterId, origin);
     }
 
+    // Supressing deprecation warning for AccessibilityNodeInfo#getBoundsinParent and
+    // AccessibilityNodeInfo#getBoundsinParent as we are copying the platform view's
+    // accessibility node and we should not lose any available bounds information.
+    @SuppressWarnings("deprecation")
     private void setFlutterNodesTranslateBounds(
             @NonNull AccessibilityNodeInfo originNode,
             @NonNull Rect displayBounds,


### PR DESCRIPTION
…rent API (#10773)"

That PR broke webview a11y, as we were losing the bounds information on copy (see https://github.com/flutter/engine/pull/10773#issuecomment-581706339)

This PR adds a deprecation suppression for the deprecated `boundsInParent` methods on top of the revert.