### PR TITLE
Expose enable-service-port-fallback switch

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -122,6 +122,10 @@ struct Settings {
   // the VM service.
   bool disable_service_auth_codes = true;
 
+  // Determine whether the vmservice should fallback to automatic port selection
+  // after failing to bind to a specified port.
+  bool enable_service_port_fallback = false;
+
   // Font settings
   bool use_test_fonts = false;
 

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -625,6 +625,7 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
           tonic::DartState::HandleLibraryTag,  // embedder library tag handler
           false,  //  disable websocket origin check
           settings.disable_service_auth_codes,  // disable VM service auth codes
+          settings.enable_service_port_fallback, // enable fallback to port 0 when bind fails.
           error                                 // error (out)
           )) {
     // Error is populated by call to startup.

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -625,8 +625,9 @@ Dart_Isolate DartIsolate::DartCreateAndStartServiceIsolate(
           tonic::DartState::HandleLibraryTag,  // embedder library tag handler
           false,  //  disable websocket origin check
           settings.disable_service_auth_codes,  // disable VM service auth codes
-          settings.enable_service_port_fallback, // enable fallback to port 0 when bind fails.
-          error                                 // error (out)
+          settings.enable_service_port_fallback,  // enable fallback to port 0
+                                                  // when bind fails.
+          error                                   // error (out)
           )) {
     // Error is populated by call to startup.
     FML_DLOG(ERROR) << *error;

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -197,9 +197,9 @@ bool DartServiceIsolate::Startup(std::string server_ip,
       Dart_SetField(library, Dart_NewStringFromCString("_authCodesDisabled"),
                     Dart_NewBoolean(disable_service_auth_codes));
   SHUTDOWN_ON_ERROR(result);
-  result =
-      Dart_SetField(library, Dart_NewStringFromCString("_enableServicePortFallback"),
-                    Dart_NewBoolean(enable_service_port_fallback));
+  result = Dart_SetField(
+      library, Dart_NewStringFromCString("_enableServicePortFallback"),
+      Dart_NewBoolean(enable_service_port_fallback));
   return true;
 }
 

--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -130,6 +130,7 @@ bool DartServiceIsolate::Startup(std::string server_ip,
                                  Dart_LibraryTagHandler embedder_tag_handler,
                                  bool disable_origin_check,
                                  bool disable_service_auth_codes,
+                                 bool enable_service_port_fallback,
                                  char** error) {
   Dart_Isolate isolate = Dart_CurrentIsolate();
   FML_CHECK(isolate);
@@ -196,6 +197,9 @@ bool DartServiceIsolate::Startup(std::string server_ip,
       Dart_SetField(library, Dart_NewStringFromCString("_authCodesDisabled"),
                     Dart_NewBoolean(disable_service_auth_codes));
   SHUTDOWN_ON_ERROR(result);
+  result =
+      Dart_SetField(library, Dart_NewStringFromCString("_enableServicePortFallback"),
+                    Dart_NewBoolean(enable_service_port_fallback));
   return true;
 }
 

--- a/runtime/dart_service_isolate.h
+++ b/runtime/dart_service_isolate.h
@@ -26,6 +26,7 @@ class DartServiceIsolate {
                       Dart_LibraryTagHandler embedder_tag_handler,
                       bool disable_origin_check,
                       bool disable_service_auth_codes,
+                      bool enable_service_port_fallback,
                       char** error);
 
   using CallbackHandle = ptrdiff_t;

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -242,6 +242,11 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   settings.disable_service_auth_codes =
       command_line.HasOption(FlagForSwitch(Switch::DisableServiceAuthCodes));
 
+  // Allow fallback to automatic port selection if binding to a specified port
+  // fails.
+  settings.enable_service_port_fallback =
+      command_line.HasOption(FlagForSwitch(Switch::EnableServicePortFallback));
+
   // Checked mode overrides.
   settings.disable_dart_asserts =
       command_line.HasOption(FlagForSwitch(Switch::DisableDartAsserts));

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -112,6 +112,10 @@ DEF_SWITCH(DisableServiceAuthCodes,
            "disable-service-auth-codes",
            "Disable the requirement for authentication codes for communicating"
            " with the VM service.")
+DEF_SWITCH(EnableServicePortFallback,
+           "enable-service-port-fallback",
+           "Allow the VM service to fallback to automatic port selection if"
+           " binding to a specified port fails.")
 DEF_SWITCH(StartPaused,
            "start-paused",
            "Start the application paused in the Dart debugger.")


### PR DESCRIPTION
TIL we setup the VM service isolate ourselves, so passing the --enable-service-port-fallback flag alone is not enough.  cc @zanderso 

For background, see https://github.com/flutter/flutter/issues/46724