### PR TITLE
Add docs linking BoxHeightStyle and BoxWidthStyle.

### DIFF
--- a/lib/ui/text.dart
+++ b/lib/ui/text.dart
@@ -1620,6 +1620,8 @@ class ParagraphConstraints {
 
 /// Defines various ways to vertically bound the boxes returned by
 /// [Paragraph.getBoxesForRange].
+///
+/// See [BoxWidthStyle] for a similar property to control width.
 enum BoxHeightStyle {
   /// Provide tight bounding boxes that fit heights per run. This style may result
   /// in uneven bounding boxes that do not nicely connect with adjacent boxes.
@@ -1675,6 +1677,8 @@ enum BoxHeightStyle {
 
 /// Defines various ways to horizontally bound the boxes returned by
 /// [Paragraph.getBoxesForRange].
+///
+/// See [BoxHeightStyle] for a similar property to control height.
 enum BoxWidthStyle {
   /// Provide tight bounding boxes that fit widths to the runs of each line
   /// independently.


### PR DESCRIPTION
This makes the adjacent property far more discoverable from each other.

In preparation for https://github.com/flutter/flutter/pull/48917 which will make these enums far more visible and useful.