### PR TITLE
Fix Windows embedding issues caught by clang

### DIFF
--- a/shell/platform/windows/flutter_windows.cc
+++ b/shell/platform/windows/flutter_windows.cc
@@ -70,7 +70,7 @@ static std::unique_ptr<FlutterDesktopEngineState> RunFlutterEngine(
   config.open_gl.fbo_callback = [](void* user_data) -> uint32_t { return 0; };
   config.open_gl.gl_proc_resolver = [](void* user_data,
                                        const char* what) -> void* {
-    return eglGetProcAddress(what);
+    return reinterpret_cast<void*>(eglGetProcAddress(what));
   };
   config.open_gl.make_resource_current = [](void* user_data) -> bool {
     auto host = static_cast<flutter::Win32FlutterWindow*>(user_data);

--- a/shell/platform/windows/win32_flutter_window.cc
+++ b/shell/platform/windows/win32_flutter_window.cc
@@ -320,13 +320,6 @@ void Win32FlutterWindow::SendPointerEventWithData(
           std::chrono::high_resolution_clock::now().time_since_epoch())
           .count();
 
-  // Windows passes all input in either physical pixels (Per-monitor, System
-  // DPI) or pre-scaled to match bitmap scaling of output where process is
-  // running in DPI unaware more.  In either case, no need to manually scale
-  // input here.  For more information see DPIHelper.
-  event.scroll_delta_x;
-  event.scroll_delta_y;
-
   FlutterEngineSendPointerEvent(engine_, &event, 1);
 
   if (event_data.phase == FlutterPointerPhase::kAdd) {

--- a/shell/platform/windows/win32_flutter_window.h
+++ b/shell/platform/windows/win32_flutter_window.h
@@ -35,8 +35,8 @@ class Win32FlutterWindow : public Win32Window {
 
   ~Win32FlutterWindow();
 
-  static FlutterDesktopViewControllerRef
-  CreateWin32FlutterWindow(int width, int height);
+  static FlutterDesktopViewControllerRef CreateWin32FlutterWindow(int width,
+                                                                  int height);
 
   // |Win32Window|
   void OnDpiScale(unsigned int dpi) override;

--- a/shell/platform/windows/win32_flutter_window.h
+++ b/shell/platform/windows/win32_flutter_window.h
@@ -36,7 +36,7 @@ class Win32FlutterWindow : public Win32Window {
   ~Win32FlutterWindow();
 
   static FlutterDesktopViewControllerRef
-  Win32FlutterWindow::CreateWin32FlutterWindow(int width, int height);
+  CreateWin32FlutterWindow(int width, int height);
 
   // |Win32Window|
   void OnDpiScale(unsigned int dpi) override;
@@ -66,7 +66,7 @@ class Win32FlutterWindow : public Win32Window {
   void OnScroll(double delta_x, double delta_y) override;
 
   // |Win32Window|
-  void OnClose();
+  void OnClose() override;
 
   // |Win32Window|
   void OnFontChange() override;

--- a/shell/platform/windows/window_state.h
+++ b/shell/platform/windows/window_state.h
@@ -14,7 +14,9 @@
 #include "flutter/shell/platform/windows/text_input_plugin.h"
 #include "flutter/shell/platform/windows/win32_task_runner.h"
 
-struct flutter::Win32FlutterWindow;
+namespace flutter {
+struct Win32FlutterWindow;
+}
 
 // Struct for storing state within an instance of the windows native (HWND or
 // CoreWindow) Window.


### PR DESCRIPTION
Clang has different warning settings, so catches different issues than
the VS compile. This fixes various minor issues caught by clang.

Part of https://github.com/flutter/flutter/issues/16256