### PR TITLE
Enable shell_unittests on Fuchsia with Vulkan dependencies.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -136,6 +136,7 @@ if (is_fuchsia) {
       "//flutter/flow:flow_tests",
       "//flutter/fml:fml_tests",
       "//flutter/runtime:runtime_tests",
+      "//flutter/shell/common:shell_tests",
       "//flutter/shell/platform/fuchsia/flutter:flutter_runner_scenic_tests",
       "//flutter/shell/platform/fuchsia/flutter:flutter_runner_tests",
     ]

--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -578,6 +578,8 @@ FILE: ../../../flutter/shell/common/shell_test_platform_view.cc
 FILE: ../../../flutter/shell/common/shell_test_platform_view.h
 FILE: ../../../flutter/shell/common/shell_test_platform_view_gl.cc
 FILE: ../../../flutter/shell/common/shell_test_platform_view_gl.h
+FILE: ../../../flutter/shell/common/shell_test_platform_view_vulkan.cc
+FILE: ../../../flutter/shell/common/shell_test_platform_view_vulkan.h
 FILE: ../../../flutter/shell/common/shell_unittests.cc
 FILE: ../../../flutter/shell/common/skia_event_tracer_impl.cc
 FILE: ../../../flutter/shell/common/skia_event_tracer_impl.h

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -254,6 +254,7 @@ if (enable_unittests) {
 
       binary = "shell_unittests"
 
+      # TODO(gw280): https://github.com/flutter/flutter/issues/50294
       # Right now we need to manually specify all the fixtures that are
       # declared in the test_fixtures() call above.
       resources = [

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -2,8 +2,29 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
 import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/testing/testing.gni")
+
+if (is_fuchsia) {
+  import("//build/fuchsia/sdk.gni")
+  import("//flutter/tools/fuchsia/fuchsia_archive.gni")
+}
+
+config("vulkan_config") {
+  if (using_fuchsia_sdk) {
+    include_dirs = [ "$fuchsia_sdk_root/vulkan/include" ]
+  } else if (is_fuchsia) {
+    include_dirs =
+        [ "//third_party/vulkan_loader_and_validation_layers/include" ]
+  } else {
+    include_dirs = [ "//third_party/vulkan/src" ]
+  }
+
+  if (is_fuchsia) {
+    defines = [ "VK_USE_PLATFORM_FUCHSIA=1" ]
+  }
+}
 
 # Template to generate a dart embedder resource.cc file.
 # Required invoker inputs:
@@ -143,12 +164,19 @@ template("shell_host_executable") {
   }
 }
 
-if (current_toolchain == host_toolchain) {
+if (enable_unittests) {
+  declare_args() {
+    test_enable_vulkan = is_fuchsia
+    test_enable_gl = !is_fuchsia
+    test_enable_software = true
+    test_enable_metal = false
+  }
+
   shell_gpu_configuration("shell_unittests_gpu_configuration") {
-    enable_software = true
-    enable_vulkan = false
-    enable_gl = true
-    enable_metal = false
+    enable_software = test_enable_software
+    enable_vulkan = test_enable_vulkan
+    enable_gl = test_enable_gl
+    enable_metal = test_enable_metal
   }
 
   test_fixtures("shell_unittests_fixtures") {
@@ -168,8 +196,6 @@ if (current_toolchain == host_toolchain) {
       "shell_test.h",
       "shell_test_platform_view.cc",
       "shell_test_platform_view.h",
-      "shell_test_platform_view_gl.cc",
-      "shell_test_platform_view_gl.h",
       "shell_unittests.cc",
       "vsync_waiters_test.cc",
       "vsync_waiters_test.h",
@@ -184,8 +210,63 @@ if (current_toolchain == host_toolchain) {
       "//flutter/lib/ui:ui",
       "//flutter/shell",
       "//flutter/testing:dart",
-      "//flutter/testing:opengl",
     ]
+
+    if (!defined(defines)) {
+      defines = []
+    }
+
+    # SwiftShader only supports x86/x64_64
+    if (target_cpu == "x86" || target_cpu == "x64") {
+      if (test_enable_gl) {
+        sources += [
+          "shell_test_platform_view_gl.cc",
+          "shell_test_platform_view_gl.h",
+        ]
+
+        deps += [ "//flutter/testing:opengl" ]
+
+        defines += [ "SHELL_ENABLE_GL" ]
+      }
+
+      if (test_enable_vulkan) {
+        sources += [
+          "shell_test_platform_view_vulkan.cc",
+          "shell_test_platform_view_vulkan.h",
+        ]
+
+        deps += [
+          "//flutter/testing:vulkan",
+          "//flutter/vulkan",
+        ]
+
+        defines += [ "SHELL_ENABLE_VULKAN" ]
+      }
+    }
+  }
+
+  if (is_fuchsia) {
+    fuchsia_test_archive("shell_tests") {
+      deps = [
+        ":shell_unittests",
+        ":shell_unittests_fixtures",
+      ]
+
+      binary = "shell_unittests"
+
+      # Right now we need to manually specify all the fixtures that are
+      # declared in the test_fixtures() call above.
+      resources = [
+        {
+          path = "$target_gen_dir/assets/kernel_blob.bin"
+          dest = "assets/kernel_blob.bin"
+        },
+        {
+          path = "$target_gen_dir/assets/shelltest_screenshot.png"
+          dest = "assets/shelltest_screenshot.png"
+        },
+      ]
+    }
   }
 
   shell_host_executable("shell_benchmarks") {

--- a/shell/common/animator_unittests.cc
+++ b/shell/common/animator_unittests.cc
@@ -52,9 +52,10 @@ TEST_F(ShellTest, VSyncTargetTime) {
     shell = Shell::Create(
         task_runners, settings,
         [vsync_clock, &create_vsync_waiter](Shell& shell) {
-          return ShellTestPlatformView::Create(shell, shell.GetTaskRunners(),
-                                               vsync_clock,
-                                               std::move(create_vsync_waiter));
+          return ShellTestPlatformView::Create(
+              shell, shell.GetTaskRunners(), vsync_clock,
+              std::move(create_vsync_waiter),
+              ShellTestPlatformView::BackendType::kDefaultBackend);
         },
         [](Shell& shell) {
           return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -254,9 +254,10 @@ std::unique_ptr<Shell> ShellTest::CreateShell(Settings settings,
   return Shell::Create(
       task_runners, settings,
       [vsync_clock, &create_vsync_waiter](Shell& shell) {
-        return ShellTestPlatformView::Create(shell, shell.GetTaskRunners(),
-                                             vsync_clock,
-                                             std::move(create_vsync_waiter));
+        return ShellTestPlatformView::Create(
+            shell, shell.GetTaskRunners(), vsync_clock,
+            std::move(create_vsync_waiter),
+            ShellTestPlatformView::BackendType::kDefaultBackend);
       },
       [](Shell& shell) {
         return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());

--- a/shell/common/shell_test_platform_view.cc
+++ b/shell/common/shell_test_platform_view.cc
@@ -20,7 +20,8 @@ std::unique_ptr<ShellTestPlatformView> ShellTestPlatformView::Create(
     std::shared_ptr<ShellTestVsyncClock> vsync_clock,
     CreateVsyncWaiter create_vsync_waiter,
     BackendType backend) {
-  // TODO(gw280): Make this fully runtime configurable
+  // TODO(gw280): https://github.com/flutter/flutter/issues/50298
+  // Make this fully runtime configurable
   switch (backend) {
     case BackendType::kDefaultBackend:
 #ifdef SHELL_ENABLE_GL

--- a/shell/common/shell_test_platform_view.cc
+++ b/shell/common/shell_test_platform_view.cc
@@ -3,7 +3,13 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/common/shell_test_platform_view.h"
+
+#ifdef SHELL_ENABLE_GL
 #include "flutter/shell/common/shell_test_platform_view_gl.h"
+#endif  // SHELL_ENABLE_GL
+#ifdef SHELL_ENABLE_VULKAN
+#include "flutter/shell/common/shell_test_platform_view_vulkan.h"
+#endif  // SHELL_ENABLE_VULKAN
 
 namespace flutter {
 namespace testing {
@@ -12,9 +18,25 @@ std::unique_ptr<ShellTestPlatformView> ShellTestPlatformView::Create(
     PlatformView::Delegate& delegate,
     TaskRunners task_runners,
     std::shared_ptr<ShellTestVsyncClock> vsync_clock,
-    CreateVsyncWaiter create_vsync_waiter) {
-  return std::make_unique<ShellTestPlatformViewGL>(
-      delegate, task_runners, vsync_clock, create_vsync_waiter);
+    CreateVsyncWaiter create_vsync_waiter,
+    BackendType backend) {
+  // TODO(gw280): Make this fully runtime configurable
+  switch (backend) {
+    case BackendType::kDefaultBackend:
+#ifdef SHELL_ENABLE_GL
+    case BackendType::kGLBackend:
+      return std::make_unique<ShellTestPlatformViewGL>(
+          delegate, task_runners, vsync_clock, create_vsync_waiter);
+#endif  // SHELL_ENABLE_GL
+#ifdef SHELL_ENABLE_VULKAN
+    case BackendType::kVulkanBackend:
+      return std::make_unique<ShellTestPlatformViewVulkan>(
+          delegate, task_runners, vsync_clock, create_vsync_waiter);
+#endif  // SHELL_ENABLE_VULKAN
+    default:
+      FML_LOG(FATAL) << "No backends supported for ShellTestPlatformView";
+      return nullptr;
+  }
 }
 
 }  // namespace testing

--- a/shell/common/shell_test_platform_view.h
+++ b/shell/common/shell_test_platform_view.h
@@ -13,11 +13,18 @@ namespace testing {
 
 class ShellTestPlatformView : public PlatformView {
  public:
+  enum class BackendType {
+    kGLBackend,
+    kVulkanBackend,
+    kDefaultBackend,
+  };
+
   static std::unique_ptr<ShellTestPlatformView> Create(
       PlatformView::Delegate& delegate,
       TaskRunners task_runners,
       std::shared_ptr<ShellTestVsyncClock> vsync_clock,
-      CreateVsyncWaiter create_vsync_waiter);
+      CreateVsyncWaiter create_vsync_waiter,
+      BackendType backend);
 
   virtual void SimulateVSync() = 0;
 

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -1,0 +1,49 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/common/shell_test_platform_view_vulkan.h"
+#include "flutter/shell/gpu/gpu_surface_vulkan.h"
+
+namespace flutter {
+namespace testing {
+
+ShellTestPlatformViewVulkan::ShellTestPlatformViewVulkan(
+    PlatformView::Delegate& delegate,
+    TaskRunners task_runners,
+    std::shared_ptr<ShellTestVsyncClock> vsync_clock,
+    CreateVsyncWaiter create_vsync_waiter)
+    : ShellTestPlatformView(delegate, std::move(task_runners)),
+      create_vsync_waiter_(std::move(create_vsync_waiter)),
+      vsync_clock_(vsync_clock),
+      proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()) {}
+
+ShellTestPlatformViewVulkan::~ShellTestPlatformViewVulkan() = default;
+
+std::unique_ptr<VsyncWaiter> ShellTestPlatformViewVulkan::CreateVSyncWaiter() {
+  return create_vsync_waiter_();
+}
+
+void ShellTestPlatformViewVulkan::SimulateVSync() {
+  vsync_clock_->SimulateVSync();
+}
+
+// |PlatformView|
+std::unique_ptr<Surface> ShellTestPlatformViewVulkan::CreateRenderingSurface() {
+  return std::make_unique<GPUSurfaceVulkan>(this, nullptr, true);
+}
+
+// |PlatformView|
+PointerDataDispatcherMaker ShellTestPlatformViewVulkan::GetDispatcherMaker() {
+  return [](DefaultPointerDataDispatcher::Delegate& delegate) {
+    return std::make_unique<SmoothPointerDataDispatcher>(delegate);
+  };
+}
+
+// |GPUSurfaceVulkanDelegate|
+fml::RefPtr<vulkan::VulkanProcTable> ShellTestPlatformViewVulkan::vk() {
+  return proc_table_;
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/common/shell_test_platform_view_vulkan.h
+++ b/shell/common/shell_test_platform_view_vulkan.h
@@ -1,0 +1,51 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_VULKAN_H_
+#define FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_VULKAN_H_
+
+#include "flutter/shell/common/shell_test_platform_view.h"
+#include "flutter/shell/gpu/gpu_surface_vulkan_delegate.h"
+
+namespace flutter {
+namespace testing {
+
+class ShellTestPlatformViewVulkan : public ShellTestPlatformView,
+                                    public GPUSurfaceVulkanDelegate {
+ public:
+  ShellTestPlatformViewVulkan(PlatformView::Delegate& delegate,
+                              TaskRunners task_runners,
+                              std::shared_ptr<ShellTestVsyncClock> vsync_clock,
+                              CreateVsyncWaiter create_vsync_waiter);
+
+  ~ShellTestPlatformViewVulkan() override;
+
+  void SimulateVSync() override;
+
+ private:
+  CreateVsyncWaiter create_vsync_waiter_;
+
+  std::shared_ptr<ShellTestVsyncClock> vsync_clock_;
+
+  fml::RefPtr<vulkan::VulkanProcTable> proc_table_;
+
+  // |PlatformView|
+  std::unique_ptr<Surface> CreateRenderingSurface() override;
+
+  // |PlatformView|
+  std::unique_ptr<VsyncWaiter> CreateVSyncWaiter() override;
+
+  // |PlatformView|
+  PointerDataDispatcherMaker GetDispatcherMaker() override;
+
+  // |GPUSurfaceVulkanDelegate|
+  fml::RefPtr<vulkan::VulkanProcTable> vk() override;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(ShellTestPlatformViewVulkan);
+};
+
+}  // namespace testing
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_COMMON_SHELL_TEST_PLATFORM_VIEW_VULKAN_H_

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -135,7 +135,8 @@ TEST_F(ShellTest,
             [task_runners = shell.GetTaskRunners()]() {
               return static_cast<std::unique_ptr<VsyncWaiter>>(
                   std::make_unique<VsyncWaiterFallback>(task_runners));
-            });
+            },
+            ShellTestPlatformView::BackendType::kDefaultBackend);
       },
       [](Shell& shell) {
         return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());

--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -8,8 +8,6 @@ import("//flutter/tools/fuchsia/dart.gni")
 import("//flutter/tools/fuchsia/fuchsia_host_bundle.gni")
 
 if (using_fuchsia_sdk) {
-  testonly = true
-
   product_suffix = ""
   is_product = false
 

--- a/testing/BUILD.gn
+++ b/testing/BUILD.gn
@@ -75,73 +75,88 @@ source_set("skia") {
   ]
 }
 
-if (current_toolchain == host_toolchain) {
-  source_set("opengl") {
-    testonly = true
+if (enable_unittests) {
+  # SwiftShader only supports x86/x64_64
+  if (target_cpu == "x86" || target_cpu == "x64") {
+    source_set("opengl") {
+      testonly = true
 
-    configs += [ "//third_party/swiftshader_flutter:swiftshader_config" ]
+      configs += [ "//third_party/swiftshader_flutter:swiftshader_config" ]
 
-    sources = [
-      "test_gl_surface.cc",
-      "test_gl_surface.h",
-    ]
+      sources = [
+        "test_gl_surface.cc",
+        "test_gl_surface.h",
+      ]
 
-    deps = [
-      ":skia",
-      "//flutter/fml",
-      "//third_party/swiftshader_flutter:swiftshader",
-    ]
-  }
-
-  # All targets on all platforms should be able to use the Metal utilities. On
-  # platforms where Metal is not available, the tests must be skipped or
-  # implemented to use another available client rendering API. This is usually
-  # either OpenGL which is portably implemented via SwiftShader or the software
-  # backend. This way, all tests compile on all platforms but the Metal backend
-  # is exercised on platforms where Metal itself is available.
-  source_set("metal") {
-    testonly = true
-
-    sources = [
-      "test_metal_surface.cc",
-      "test_metal_surface.h",
-    ]
-
-    defines = []
-
-    if (shell_enable_metal) {
-      sources += [ "test_metal_surface_impl.mm" ]
-      defines += [ "TESTING_ENABLE_METAL" ]
+      deps = [
+        ":skia",
+        "//flutter/fml",
+        "//third_party/swiftshader_flutter:swiftshader_gl",
+      ]
     }
 
-    deps = [
-      ":skia",
-      "//flutter/fml",
-    ]
-  }
+    source_set("vulkan") {
+      testonly = true
 
-  test_fixtures("testing_fixtures") {
-    fixtures = []
-  }
+      configs += [ "//third_party/swiftshader_flutter:swiftshader_config" ]
 
-  # The //flutter/testing library provides utility methods to other test targets.
-  # This test target tests the testing utilities.
-  executable("testing_unittests") {
-    testonly = true
+      deps = [
+        ":skia",
+        "//flutter/fml",
+        "//third_party/swiftshader_flutter:swiftshader_vulkan",
+      ]
+    }
 
-    sources = [
-      "mock_canvas_unittests.cc",
-      "test_metal_surface_unittests.cc",
-    ]
+    # All targets on all platforms should be able to use the Metal utilities. On
+    # platforms where Metal is not available, the tests must be skipped or
+    # implemented to use another available client rendering API. This is usually
+    # either OpenGL which is portably implemented via SwiftShader or the software
+    # backend. This way, all tests compile on all platforms but the Metal backend
+    # is exercised on platforms where Metal itself is available.
+    source_set("metal") {
+      testonly = true
 
-    deps = [
-      ":dart",
-      ":metal",
-      ":opengl",
-      ":skia",
-      ":testing",
-      ":testing_fixtures",
-      ":testing_lib",
-    ]
+      sources = [
+        "test_metal_surface.cc",
+        "test_metal_surface.h",
+      ]
+
+      defines = []
+
+      if (shell_enable_metal) {
+        sources += [ "test_metal_surface_impl.mm" ]
+        defines += [ "TESTING_ENABLE_METAL" ]
+      }
+
+      deps = [
+        ":skia",
+        "//flutter/fml",
+      ]
+    }
+
+    test_fixtures("testing_fixtures") {
+      fixtures = []
+    }
+
+    # The //flutter/testing library provides utility methods to other test targets.
+    # This test target tests the testing utilities.
+    executable("testing_unittests") {
+      testonly = true
+
+      sources = [
+        "mock_canvas_unittests.cc",
+        "test_metal_surface_unittests.cc",
+      ]
+
+      deps = [
+        ":dart",
+        ":metal",
+        ":opengl",
+        ":skia",
+        ":testing",
+        ":testing_fixtures",
+        ":testing_lib",
+      ]
+    }
   }
 }

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -63,3 +63,8 @@ done
 ./fuchsia_ctl -d $device_name test \
     -f runtime_tests-0.far  \
     -t runtime_tests
+
+./fuchsia_ctl -d $device_name test \
+    -f shell_tests-0.far  \
+    -t shell_tests \
+    -a "--gtest_filter=-ShellTest.HandlesActualIphoneXsInputEvents:ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*:ShellTest.Screenshot"

--- a/testing/fuchsia/test_fars
+++ b/testing/fuchsia/test_fars
@@ -3,3 +3,4 @@ flutter_runner_scenic_tests-0.far
 fml_tests-0.far
 flow_tests-0.far
 runtime_tests-0.far
+shell_tests-0.far

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -9,6 +9,11 @@ import("//third_party/dart/build/dart/dart_action.gni")
 is_aot_test =
     flutter_runtime_mode == "profile" || flutter_runtime_mode == "release"
 
+# Unit tests targets are only enabled for host machines and Fuchsia right now
+declare_args() {
+  enable_unittests = current_toolchain == host_toolchain || is_fuchsia
+}
+
 # Creates a translation unit that defines the flutter::testing::GetFixturesPath
 # method that tests can use to locate their fixtures.
 #

--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -56,8 +56,7 @@ source_set("vulkan") {
       "vulkan_native_surface_android.h",
       "vulkan_swapchain.cc",
     ]
-  }
-  if (is_fuchsia) {
+  } else {
     sources += [ "vulkan_swapchain_stub.cc" ]
   }
 


### PR DESCRIPTION
I've added TODO for the final piece of the runtime configurable ShellTestPlatformView implementation. All the plumbing code exists and is wired up, this would just be to figure out how/what we want to test for each backend type.

Currently most of the ShellTests pass, but a few do not. I need to modify fuchsia_ctl to accept command line arguments, but a manual invocation with the parameters "--gtest_filter=-ShellTest.HandlesActualIphoneXsInputEvents:ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*:ShellTest.Screenshot" results in a passing test run on my test device.

This likely won't work in AOT builds. I'm leaning towards only enabling the shell_tests target in JIT builds for now, and figure out AOT later.