### PR TITLE
fix build_id logic for fuchsia symbols

### DIFF
--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -26,11 +26,13 @@ def Touch(fname):
 
 
 def GetBuildIdParts(exec_path, read_elf):
-  sha1_pattern = re.compile(r'[0-9a-zA-Z]{40}')
+  sha1_pattern = re.compile(r'[0-9a-zA-Z]+')
   file_out = subprocess.check_output([read_elf, '-n', exec_path])
   build_id_line = file_out.splitlines()[-1].split()
-  if build_id_line[0] != 'Build' or build_id_line[1] != 'ID:' or not sha1_pattern.match(build_id_line[-1]):
-    raise Exception('Expected the last line of llvm-readelf to match "Build ID <SHA-1>" Got: %s' % file_out)
+  if (build_id_line[0] != 'Build' or
+      build_id_line[1] != 'ID:' or
+      not sha1_pattern.match(build_id_line[-1]):
+    raise Exception('Expected the last line of llvm-readelf to match "Build ID <Hex String>" Got: %s' % file_out)
 
   build_id = build_id_line[-1]
   return {

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -26,7 +26,7 @@ def Touch(fname):
 
 
 def GetBuildIdParts(exec_path, read_elf):
-  sha1_pattern = re.compile(r'[0-9a-zA-Z]+')
+  sha1_pattern = re.compile(r'[0-9a-fA-F]+')
   file_out = subprocess.check_output([read_elf, '-n', exec_path])
   build_id_line = file_out.splitlines()[-1].split()
   if (build_id_line[0] != 'Build' or

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -26,7 +26,7 @@ def Touch(fname):
 
 
 def GetBuildIdParts(exec_path, read_elf):
-  sha1_pattern = re.compile(r'[0-9a-fA-F]+')
+  sha1_pattern = re.compile(r'[0-9a-fA-F\-]+')
   file_out = subprocess.check_output([read_elf, '-n', exec_path])
   build_id_line = file_out.splitlines()[-1].split()
   if (build_id_line[0] != 'Build' or

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -98,7 +98,7 @@ def main():
   try:
     os.makedirs(dbg_prefix_base)
   except OSError as e:
-    if e.errono != errno.EEXIST:
+    if e.errno != errno.EEXIST:
       raise
 
   if not os.path.exists(dbg_prefix_base):

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -30,8 +30,9 @@ def GetBuildIdParts(exec_path, read_elf):
   file_out = subprocess.check_output([read_elf, '-n', exec_path])
   build_id_line = file_out.splitlines()[-1].split()
   if (build_id_line[0] != 'Build' or
-      build_id_line[1] != 'ID:' or
-      not sha1_pattern.match(build_id_line[-1]):
+      build_id_line[1] != 'ID:' or not
+      sha1_pattern.match(build_id_line[-1]) or not
+      len(build_id_line[-1]) > 2):
     raise Exception('Expected the last line of llvm-readelf to match "Build ID <Hex String>" Got: %s' % file_out)
 
   build_id = build_id_line[-1]

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -92,7 +92,6 @@ def main():
   parts = GetBuildIdParts(args.exec_path, args.read_elf)
   dbg_prefix_base = os.path.join(args.dest, parts['prefix_dir'])
 
-  success = False
   # Multiple processes may be trying to create the same directory.
   # TODO(dnfield): use exist_ok when we upgrade to python 3, rather than try
   try:

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -11,6 +11,7 @@
 """
 
 import argparse
+import errno
 import json
 import os
 import re

--- a/tools/fuchsia/copy_debug_symbols.py
+++ b/tools/fuchsia/copy_debug_symbols.py
@@ -91,7 +91,7 @@ def main():
 
   success = False
   # Multiple processes may be trying to create the same directory.
-  #TODO(dnfield): use exist_ok when we upgrade to python 3, rather than try
+  # TODO(dnfield): use exist_ok when we upgrade to python 3, rather than try
   try:
     os.makedirs(dbg_prefix_base)
   except OSError as e:


### PR DESCRIPTION
`llvm-readelf  --hex-dump=.note.gnu.build-id` gives output like this:

```
Hex dump of section '.note.gnu.build-id':
0x000002e8 04000000 14000000 03000000 474e5500 ............GNU.
0x000002f8 e2911dbc 6820ea37 22d5bafa 9fee3db3 ....h .7".....=.
0x00000308 d6fcf810                            ....
```

We're then taking the last line (into a var named second_line!), including the string representation of the hex bytes, which sometimes results in getting a `/`.  This causes failures like https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8889296931334102496/+/steps/build_fuchsia_debug_x64_flutter_shell_platform_fuchsia:fuchsia_fuchsia_tests/0/stdout, because you can't have a file with a `/` in it on a POSIX file system.

This also isn't actually getting the right build id.  This patch uses `llvm-readelf -n` to get the nice buildID we want:

```
Displaying notes found at file offset 0x000002e8 with length 0x00000024:
  Owner                Data size 	Description
  GNU                  0x00000014	NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: 0a1ca5114c5c5548ee483781585f5e89228f9e66
```

I then still tried to keep the old logic, but I'm not 100% sure about the directory structure.  This will result in a file like:

`out/fuchsia_debug_x64/flutter-debug-symbols-debug-fuchsia-x64/e2/911dbc6820ea3722d5bafa9fee3db3d6fcf810.debug`, which I'm assuming is correct for a buildID of `e2911dbc6820ea3722d5bafa9fee3db3d6fcf810`.

I've also changed the retry logic so that it is just ok if the directory exists, and only fails if we failed to create the directory.  It fails sometimes because another process is also creating the directoyr we're trying to create and just got there first. This avoids the loop and the extraneous error messages during build.