### PR TITLE
Suppress some deprecation warnings on Windows

### DIFF
--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -202,6 +202,9 @@ source_set("fml") {
       "platform/win/paths_win.cc",
       "platform/win/wstring_conversion.h",
     ]
+
+    # For wstring_conversion. See issue #50053.
+    defines = [ "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" ]
   } else {
     sources += [
       "platform/posix/file_posix.cc",

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -203,8 +203,10 @@ source_set("fml") {
       "platform/win/wstring_conversion.h",
     ]
 
-    # For wstring_conversion. See issue #50053.
-    defines = [ "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" ]
+    if (is_win) {
+      # For wstring_conversion. See issue #50053.
+      defines = [ "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" ]
+    }
   } else {
     sources += [
       "platform/posix/file_posix.cc",

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -53,6 +53,11 @@ source_set("common_cpp") {
   # won't have a JSON dependency.
   defines = [ "USE_RAPID_JSON" ]
   deps += [ "//third_party/rapidjson" ]
+
+  if (is_win) {
+    # For wstring_conversion. See issue #50053.
+    defines += [ "_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING" ]
+  }
 }
 
 copy("publish_headers") {

--- a/third_party/txt/BUILD.gn
+++ b/third_party/txt/BUILD.gn
@@ -28,6 +28,14 @@ config("txt_config") {
   include_dirs = [ "src" ]
 }
 
+config("allow_posix_names") {
+  if (is_win && is_clang) {
+    # POSIX names of many functions are marked deprecated by default;
+    # disable that since they are used for cross-platform compatibility.
+    defines = [ "_CRT_NONSTDC_NO_DEPRECATE" ]
+  }
+}
+
 source_set("txt") {
   defines = []
   if (flutter_use_fontconfig) {
@@ -295,6 +303,8 @@ executable("txt_unittests") {
       "tests/MinikinFontForTest.h",
     ]
   }
+
+  configs += [ ":allow_posix_names" ]
 
   deps = [
            ":txt",


### PR DESCRIPTION
Targeted suppression of some deprecation warnings that are build errors under
clang:
- Ignore the deprecation of codecvt's unicode conversion until we decide on
  a replacement strategy.
- Allow the deprecated posix names of functions in third_party/txt.

Part of https://github.com/flutter/flutter/issues/16256