### PR TITLE
[fuchsia] change kMaxFramesInFlight to 3, add offset option

### DIFF
--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -94,7 +94,7 @@ class SessionConnection final {
   // The maximum number of frames Flutter sent to Scenic that it can have
   // outstanding at any time. This is equivalent to how many times it has
   // called Present2() before receiving an OnFramePresented() event.
-  static constexpr int kMaxFramesInFlight = 2;
+  static constexpr int kMaxFramesInFlight = 3;
   int frames_in_flight_ = 0;
 
   int frames_in_flight_allowed_ = 0;

--- a/shell/platform/fuchsia/flutter/vsync_waiter.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter.cc
@@ -131,6 +131,15 @@ void VsyncWaiter::AwaitVSync() {
       VsyncRecorder::GetInstance().GetLastPresentationTime();
   fml::TimePoint next_vsync = SnapToNextPhase(now, last_presentation_time,
                                               vsync_info.presentation_interval);
+
+  auto next_vsync_start_time = next_vsync - vsync_offset;
+
+  if (now >= next_vsync_start_time)
+    next_vsync_start_time =
+        next_vsync_start_time + vsync_info.presentation_interval;
+
+  fml::TimeDelta delta = next_vsync_start_time - now;
+
   task_runners_.GetUITaskRunner()->PostDelayedTask(
       [& weak_factory_ui = this->weak_factory_ui_] {
         if (!weak_factory_ui) {
@@ -143,7 +152,7 @@ void VsyncWaiter::AwaitVSync() {
           self->FireCallbackWhenSessionAvailable();
         }
       },
-      next_vsync - now);
+      delta);
 }
 
 void VsyncWaiter::FireCallbackWhenSessionAvailable() {

--- a/shell/platform/fuchsia/flutter/vsync_waiter.h
+++ b/shell/platform/fuchsia/flutter/vsync_waiter.h
@@ -34,6 +34,9 @@ class VsyncWaiter final : public flutter::VsyncWaiter {
   async::Wait session_wait_;
   fml::WeakPtrFactory<VsyncWaiter> weak_factory_;
 
+  static constexpr fml::TimeDelta vsync_offset =
+      fml::TimeDelta::FromNanoseconds(0);
+
   // For accessing the VsyncWaiter via the UI thread, necessary for the callback
   // for AwaitVSync()
   std::unique_ptr<fml::WeakPtrFactory<VsyncWaiter>> weak_factory_ui_;


### PR DESCRIPTION
To give more flexibiltiy in scheduling, we change the number of frames
in flight we can have at one time to 3. We also introduce an offset from
VSync that Flutter can use to begin its work at. It is currently set at
0ms, signalling no change from previous behavior.