### PR TITLE
Temporarily switch to using SkShaper and SkParagraph instead of LibTx

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -331,7 +331,7 @@ def parse_args(args):
   parser.add_argument('--enable-vulkan', action='store_true', default=False)
 
   parser.add_argument('--enable-fontconfig', action='store_true', default=False)
-  parser.add_argument('--enable-skshaper', action='store_true', default=False)
+  parser.add_argument('--enable-skshaper', action='store_true', default=True)
   parser.add_argument('--enable-vulkan-validation-layers', action='store_true', default=False)
 
   parser.add_argument('--embedder-for-target', dest='embedder_for_target', action='store_true', default=False)


### PR DESCRIPTION
This bit-flip is meant to allow this to roll into framework and run Flutter framework devicelab benchmarks. This will be instantly reverted.