### PR TITLE
Relax timing restrictions on WakeUpTimersAreSingletons.

### DIFF
--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -331,8 +331,8 @@ TEST(MessageLoop, TIME_SENSITIVE(WakeUpTimersAreSingletons)) {
       [&]() {
         auto delta = fml::TimePoint::Now() - begin;
         auto ms = delta.ToMillisecondsF();
-        ASSERT_GE(ms, 18);
-        ASSERT_LE(ms, 22);
+        ASSERT_GE(ms, 10);
+        ASSERT_LE(ms, 25);
 
         loop_impl->Terminate();
       },


### PR DESCRIPTION
We don’t run this test on bots because we don’t want timeouts on any tests. This
only runs locally as a sanity check for timers.