### PR TITLE
Fix analyzer warnings for frontend_server change

### DIFF
--- a/flutter_frontend_server/lib/server.dart
+++ b/flutter_frontend_server/lib/server.dart
@@ -70,12 +70,13 @@ class _FlutterFrontendCompiler implements frontend.CompilerInterface {
         expression, definitions, typeDefinitions, libraryUri, klass, isStatic);
   }
 
+  // ignore: annotate_overrides
   Future<Null> compileExpressionToJs(
       String libraryUri,
       int line,
       int column,
-      Map<String,String> jsModules,
-      Map<String,String> jsFrameValues,
+      Map<String, String> jsModules,
+      Map<String, String> jsFrameValues,
       String moduleName,
       String expression) {
     throw UnimplementedError('Compile expression to JS is not supported');
@@ -154,7 +155,8 @@ Future<int> starter(
 
   compiler ??= _FlutterFrontendCompiler(output,
       transformer: transformer,
-      unsafePackageSerialization: options['unsafe-package-serialization'] as bool);
+      unsafePackageSerialization:
+          options['unsafe-package-serialization'] as bool);
 
   if (options.rest.isNotEmpty) {
     return await compiler.compile(options.rest[0], options) ? 0 : 254;


### PR DESCRIPTION
- added temporary ignore for annotate_overrides analyzer warning,
  will remove the ignore in a follow-up PR after the SDK change
  https://dart-review.googlesource.com/c/sdk/+/134561 lands.
- run dartfmt