### PR TITLE
Simplify task queues locking mechanism

### DIFF
--- a/fml/gpu_thread_merger_unittests.cc
+++ b/fml/gpu_thread_merger_unittests.cc
@@ -14,8 +14,7 @@
 #include "flutter/fml/task_runner.h"
 #include "gtest/gtest.h"
 
-// TODO(49007): Flaky. Investigate, fix and re-enable.
-TEST(GpuThreadMerger, DISABLED_RemainMergedTillLeaseExpires) {
+TEST(GpuThreadMerger, RemainMergedTillLeaseExpires) {
   fml::MessageLoop* loop1 = nullptr;
   fml::AutoResetWaitableEvent latch1;
   fml::AutoResetWaitableEvent term1;
@@ -62,8 +61,7 @@ TEST(GpuThreadMerger, DISABLED_RemainMergedTillLeaseExpires) {
   thread2.join();
 }
 
-// TODO(49007): Flaky. Investigate, fix and re-enable.
-TEST(GpuThreadMerger, DISABLED_IsNotOnRasterizingThread) {
+TEST(GpuThreadMerger, IsNotOnRasterizingThread) {
   fml::MessageLoop* loop1 = nullptr;
   fml::AutoResetWaitableEvent latch1;
   std::thread thread1([&loop1, &latch1]() {
@@ -148,8 +146,7 @@ TEST(GpuThreadMerger, DISABLED_IsNotOnRasterizingThread) {
   thread2.join();
 }
 
-// TODO(49007): Flaky. Investigate, fix and re-enable.
-TEST(GpuThreadMerger, DISABLED_LeaseExtension) {
+TEST(GpuThreadMerger, LeaseExtension) {
   fml::MessageLoop* loop1 = nullptr;
   fml::AutoResetWaitableEvent latch1;
   fml::AutoResetWaitableEvent term1;

--- a/fml/message_loop_task_queues.h
+++ b/fml/message_loop_task_queues.h
@@ -127,15 +127,11 @@ class MessageLoopTaskQueues
  private:
   class MergedQueuesRunner;
 
-  using Mutexes = std::vector<std::unique_ptr<std::mutex>>;
-
   MessageLoopTaskQueues();
 
   ~MessageLoopTaskQueues();
 
   void WakeUpUnlocked(TaskQueueId queue_id, fml::TimePoint time) const;
-
-  std::mutex& GetMutex(TaskQueueId queue_id) const;
 
   bool HasPendingTasksUnlocked(TaskQueueId queue_id) const;
 
@@ -147,9 +143,8 @@ class MessageLoopTaskQueues
   static std::mutex creation_mutex_;
   static fml::RefPtr<MessageLoopTaskQueues> instance_;
 
-  std::unique_ptr<fml::SharedMutex> queue_meta_mutex_;
+  mutable std::mutex queue_mutex_;
   std::map<TaskQueueId, std::unique_ptr<TaskQueueEntry>> queue_entries_;
-  std::map<TaskQueueId, std::unique_ptr<std::mutex>> queue_locks_;
 
   size_t task_queue_id_counter_;
 


### PR DESCRIPTION
We now have one mutex guarding all accesses to
the underlying task heaps. This simplifies the more granular
but bug prone mechanism of having striped locks.

This also re-enables GPUThreadMerger tests that are currently
disabled due to their flaky nature. The scenario that gets fixed by this
change is as follows:

1. Thread-1: We lock `queue_meta_mutex_` and grab locks on `queue_1` and release the meta mutex.
2. Thread-1: We add an Observer on `queues` object.
3. Thread-2: We lock `queue_meta_mutex_` and grab locks on `queue_2`.
4. Thread-2: We try to dispose all the pending tasks on `queue_2` which calls `erase` on `queues`.

The above situation is not thread safe without having 1 lock.

Note: This increases the contention on one lock and could potentially be bad for perf. We are
explicitly making this trade-off towards reducing the complexity.

Fixes: https://github.com/flutter/flutter/issues/49007