### PR TITLE
Add noexcept annotations to EnableValue moves

### DIFF
--- a/shell/platform/common/cpp/client_wrapper/include/flutter/encodable_value.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/encodable_value.h
@@ -204,7 +204,7 @@ class EncodableValue {
     }
   }
 
-  EncodableValue(EncodableValue&& other) { *this = std::move(other); }
+  EncodableValue(EncodableValue&& other) noexcept { *this = std::move(other); }
 
   EncodableValue& operator=(const EncodableValue& other) {
     if (&other == this) {
@@ -216,7 +216,7 @@ class EncodableValue {
     return *this;
   }
 
-  EncodableValue& operator=(EncodableValue&& other) {
+  EncodableValue& operator=(EncodableValue&& other) noexcept {
     if (&other == this) {
       return *this;
     }


### PR DESCRIPTION
Fixes a warning when compiling in Visual Studio on Windows.