### PR TITLE
Fix text range logic for a11y

### DIFF
--- a/fml/platform/darwin/string_range_sanitization.mm
+++ b/fml/platform/darwin/string_range_sanitization.mm
@@ -7,7 +7,7 @@
 namespace fml {
 
 NSRange RangeForCharacterAtIndex(NSString* text, NSUInteger index) {
-  if (text == nil || index >= text.length) {
+  if (text == nil || index > text.length) {
     return NSMakeRange(NSNotFound, 0);
   }
   if (index < text.length)

--- a/fml/platform/darwin/string_range_sanitization_unittests.mm
+++ b/fml/platform/darwin/string_range_sanitization_unittests.mm
@@ -28,3 +28,7 @@ TEST(StringRangeSanitizationTest, CanHandleUnicodeRange) {
   EXPECT_EQ(result.location, 0UL);
   EXPECT_EQ(result.length, 0UL);
 }
+
+TEST(StringRangeSanitizationTest, HandlesEndOfRange) {
+  EXPECT_EQ(fml::RangeForCharacterAtIndex(@"1234", 4).location, 4UL);
+}

--- a/fml/platform/darwin/string_range_sanitization_unittests.mm
+++ b/fml/platform/darwin/string_range_sanitization_unittests.mm
@@ -31,4 +31,5 @@ TEST(StringRangeSanitizationTest, CanHandleUnicodeRange) {
 
 TEST(StringRangeSanitizationTest, HandlesEndOfRange) {
   EXPECT_EQ(fml::RangeForCharacterAtIndex(@"1234", 4).location, 4UL);
+  EXPECT_EQ(fml::RangeForCharacterAtIndex(@"1234", 4).length, 0UL);
 }

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -312,7 +312,12 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
 }
 
 - (NSString*)textInRange:(UITextRange*)range {
+  if (!range) {
+    return nil;
+  }
+  NSAssert([range isKindOfClass:[FlutterTextRange class]], @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
+  NSAssert(textRange.start != NSNotFound, @"Expected a valid text range.");
   return [self.text substringWithRange:textRange];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -315,7 +315,8 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
   if (!range) {
     return nil;
   }
-  NSAssert([range isKindOfClass:[FlutterTextRange class]], @"Expected a FlutterTextRange for range (got %@).", [range class]);
+  NSAssert([range isKindOfClass:[FlutterTextRange class]],
+           @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   NSAssert(textRange.start != NSNotFound, @"Expected a valid text range.");
   return [self.text substringWithRange:textRange];

--- a/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterTextInputPlugin.mm
@@ -318,7 +318,7 @@ static UIReturnKeyType ToUIReturnKeyType(NSString* inputType) {
   NSAssert([range isKindOfClass:[FlutterTextRange class]],
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
-  NSAssert(textRange.start != NSNotFound, @"Expected a valid text range.");
+  NSAssert(textRange.location != NSNotFound, @"Expected a valid text range.");
   return [self.text substringWithRange:textRange];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -29,7 +29,7 @@
   NSAssert([range isKindOfClass:[FlutterTextRange class]],
            @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
-  NSAssert(textRange.start != NSNotFound, @"Expected a valid text range.");
+  NSAssert(textRange.location != NSNotFound, @"Expected a valid text range.");
   return [self.text substringWithRange:textRange];
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -26,7 +26,8 @@
   if (!range) {
     return nil;
   }
-  NSAssert([range isKindOfClass:[FlutterTextRange class]], @"Expected a FlutterTextRange for range (got %@).", [range class]);
+  NSAssert([range isKindOfClass:[FlutterTextRange class]],
+           @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
   NSAssert(textRange.start != NSNotFound, @"Expected a valid text range.");
   return [self.text substringWithRange:textRange];

--- a/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_text_entry.mm
@@ -23,7 +23,12 @@
 }
 
 - (NSString*)textInRange:(UITextRange*)range {
+  if (!range) {
+    return nil;
+  }
+  NSAssert([range isKindOfClass:[FlutterTextRange class]], @"Expected a FlutterTextRange for range (got %@).", [range class]);
   NSRange textRange = ((FlutterTextRange*)range).range;
+  NSAssert(textRange.start != NSNotFound, @"Expected a valid text range.");
   return [self.text substringWithRange:textRange];
 }
 


### PR DESCRIPTION
see also: https://github.com/flutter/engine/pull/8747

The linked PR unintentionally introduced a bug in text range handling where we treated a text range with a location at the end of the string as invalid.  This should not be the case.

This resulted in a crash in a11y on iOS when you entered text, the cursor is at the end of the field, and you tap.  

This app can reproduce the issue with VoiceOver on:

```dart
import 'package:flutter/material.dart';

void main() => runApp(MyApp());

class MyApp extends StatelessWidget {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'VoiceOver Crash',
      home: Scaffold(
        body: Center(child: TextField()),
      ),
    );
  }
}
```

Fortunately, the FML change doesn't break any of the original tests - I think it was just an oversight at the time, the other FML method handles cases like this correctly.

/cc @jkurtw @mehmetf @chingjun  - this fixes b/149077991