### PR TITLE
Fix ensureInitializationCompleteAsync callback when already initialized. (#39675)

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -234,6 +234,7 @@ public class FlutterLoader {
           "ensureInitializationComplete must be called after startInitialization");
     }
     if (initialized) {
+      callbackHandler.post(callback);
       return;
     }
     new Thread(

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewActivity.java
@@ -9,13 +9,6 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
-
-import java.io.FileDescriptor;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import io.flutter.Log;
 import io.flutter.embedding.android.FlutterActivity;
 import io.flutter.embedding.engine.FlutterEngine;
@@ -23,6 +16,11 @@ import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.plugin.common.BasicMessageChannel;
 import io.flutter.plugin.common.BinaryCodec;
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class TextPlatformViewActivity extends FlutterActivity {
   static final String TAG = "Scenarios";

--- a/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewActivity.java
+++ b/testing/scenario_app/android/app/src/main/java/dev/flutter/scenarios/TextPlatformViewActivity.java
@@ -1,22 +1,28 @@
 package dev.flutter.scenarios;
 
 import android.Manifest;
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Looper;
 import android.support.annotation.NonNull;
-import io.flutter.Log;
-import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.embedding.engine.FlutterShellArgs;
-import io.flutter.plugin.common.BasicMessageChannel;
-import io.flutter.plugin.common.BinaryCodec;
+
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import io.flutter.Log;
+import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.FlutterShellArgs;
+import io.flutter.embedding.engine.loader.FlutterLoader;
+import io.flutter.plugin.common.BasicMessageChannel;
+import io.flutter.plugin.common.BinaryCodec;
 
 public class TextPlatformViewActivity extends FlutterActivity {
   static final String TAG = "Scenarios";
@@ -31,7 +37,19 @@ public class TextPlatformViewActivity extends FlutterActivity {
       }
       // Run for one minute, get the timeline data, write it, and finish.
       final Uri logFileUri = launchIntent.getData();
-      new Handler().postDelayed(() -> writeTimelineData(logFileUri), 20000);
+      new Handler()
+          .postDelayed(
+              new Runnable() {
+                @Override
+                public void run() {
+                  writeTimelineData(logFileUri);
+
+                  testFlutterLoaderCallbackWhenInitializedTwice();
+                }
+              },
+              20000);
+    } else {
+      testFlutterLoaderCallbackWhenInitializedTwice();
     }
   }
 
@@ -78,6 +96,48 @@ public class TextPlatformViewActivity extends FlutterActivity {
             Log.e(TAG, "Could not write timeline file: " + ex.toString());
           }
           finish();
+        });
+  }
+
+  /**
+   * This method verifies that {@link FlutterLoader#ensureInitializationCompleteAsync(Context,
+   * String[], Handler, Runnable)} invokes its callback when called after initialization.
+   */
+  private void testFlutterLoaderCallbackWhenInitializedTwice() {
+    FlutterLoader flutterLoader = new FlutterLoader();
+
+    // Flutter is probably already loaded in this app based on
+    // code that ran before this method. Nonetheless, invoke the
+    // blocking initialization here to ensure it's initialized.
+    flutterLoader.startInitialization(getApplicationContext());
+    flutterLoader.ensureInitializationComplete(getApplication(), new String[] {});
+
+    // Now that Flutter is loaded, invoke ensureInitializationCompleteAsync with
+    // a callback and verify that the callback is invoked.
+    Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    final AtomicBoolean didInvokeCallback = new AtomicBoolean(false);
+
+    flutterLoader.ensureInitializationCompleteAsync(
+        getApplication(),
+        new String[] {},
+        mainHandler,
+        new Runnable() {
+          @Override
+          public void run() {
+            didInvokeCallback.set(true);
+          }
+        });
+
+    mainHandler.post(
+        new Runnable() {
+          @Override
+          public void run() {
+            if (!didInvokeCallback.get()) {
+              throw new RuntimeException(
+                  "Failed test: FlutterLoader#ensureInitializationCompleteAsync() did not invoke its callback.");
+            }
+          }
         });
   }
 }


### PR DESCRIPTION
Fix ensureInitializationCompleteAsync callback when already initialized. (#39675)

The testing situation for this PR is as follows...

A JVM test cannot be used because this PR needs to test loading a native library.

A "scenario app" exists in the engine repo but it's unclear where or how to add new test code. The existing `Activity` in the scenario app should probably not be changed because it appears to include time tracking code that would be impacted by testing this PR.

It looks possible to add instrumentation tests to Firebase projects, but it will require the addition of an entirely new module and related configuration for Firebase.

It is also possible to add an entirely new Android project, but this again requires configuring Firebase.

I don't know that I'll have bandwidth to figure out Firebase configuration via LUCI so I'm putting up this PR either to merge without tests, or to let someone else take it over and add tests.