### PR TITLE
Enable verbose logging for shell unittests on Fuchsia

### DIFF
--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -9,6 +9,7 @@
 
 #include "flutter/flow/layers/layer_tree.h"
 #include "flutter/flow/layers/transform_layer.h"
+#include "flutter/fml/build_config.h"
 #include "flutter/fml/make_copyable.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/runtime/dart_vm.h"
@@ -218,6 +219,9 @@ Settings ShellTest::CreateSettingsForFixture() {
   settings.isolate_create_callback = [this]() {
     native_resolver_->SetNativeResolverForIsolate();
   };
+#if OS_FUCHSIA
+  settings.verbose_logging = true;
+#endif
   SetSnapshotsAndAssets(settings);
   return settings;
 }


### PR DESCRIPTION
shell_unittests is flaking on Fuchsia a lot right now, let's turn on verbose logging for Fuchsia only so that we can have a bit more information on what's going on.