### PR TITLE
Prevent long flash when switching to Flutter app. (#47903)

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -234,15 +234,16 @@ import java.util.Arrays;
   /**
    * Invoke this method from {@code Activity#onCreate(Bundle)} to create the content {@code View},
    * or from {@code Fragment#onCreateView(LayoutInflater, ViewGroup, Bundle)}.
-   * <p>
-   * {@code inflater} and {@code container} may be null when invoked from an {@code Activity}.
-   * <p>
-   * This method:
+   *
+   * <p>{@code inflater} and {@code container} may be null when invoked from an {@code Activity}.
+   *
+   * <p>This method:
+   *
    * <ol>
-   *   <li>creates a new {@link FlutterView} in a {@code View} hierarchy</li>
-   *   <li>adds a {@link FlutterUiDisplayListener} to it</li>
-   *   <li>attaches a {@link FlutterEngine} to the new {@link FlutterView}</li>
-   *   <li>returns the new {@code View} hierarchy</li>
+   *   <li>creates a new {@link FlutterView} in a {@code View} hierarchy
+   *   <li>adds a {@link FlutterUiDisplayListener} to it
+   *   <li>attaches a {@link FlutterEngine} to the new {@link FlutterView}
+   *   <li>returns the new {@code View} hierarchy
    * </ol>
    */
   @NonNull
@@ -288,7 +289,7 @@ import java.util.Arrays;
    * <p>
    *
    * <ol>
-   *   <li>Begins executing Dart code, if it is not already executing.</li>
+   *   <li>Begins executing Dart code, if it is not already executing.
    * </ol>
    */
   void onStart() {

--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivityAndFragmentDelegate.java
@@ -12,7 +12,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -235,11 +234,16 @@ import java.util.Arrays;
   /**
    * Invoke this method from {@code Activity#onCreate(Bundle)} to create the content {@code View},
    * or from {@code Fragment#onCreateView(LayoutInflater, ViewGroup, Bundle)}.
-   *
-   * <p>{@code inflater} and {@code container} may be null when invoked from an {@code Activity}.
-   *
-   * <p>This method creates a new {@link FlutterView}, adds a {@link FlutterUiDisplayListener} to
-   * it, and then returns it.
+   * <p>
+   * {@code inflater} and {@code container} may be null when invoked from an {@code Activity}.
+   * <p>
+   * This method:
+   * <ol>
+   *   <li>creates a new {@link FlutterView} in a {@code View} hierarchy</li>
+   *   <li>adds a {@link FlutterUiDisplayListener} to it</li>
+   *   <li>attaches a {@link FlutterEngine} to the new {@link FlutterView}</li>
+   *   <li>returns the new {@code View} hierarchy</li>
+   * </ol>
    */
   @NonNull
   View onCreateView(
@@ -261,6 +265,9 @@ import java.util.Arrays;
     }
     flutterSplashView.displayFlutterViewWithSplash(flutterView, host.provideSplashScreen());
 
+    Log.v(TAG, "Attaching FlutterEngine to FlutterView.");
+    flutterView.attachToFlutterEngine(flutterEngine);
+
     return flutterSplashView;
   }
 
@@ -281,31 +288,13 @@ import java.util.Arrays;
    * <p>
    *
    * <ol>
-   *   <li>Attaches the {@link FlutterEngine} owned by this delegate to the {@link FlutterView}
-   *       owned by this delegate.
-   *   <li>Begins executing Dart code, if it is not already executing.
+   *   <li>Begins executing Dart code, if it is not already executing.</li>
    * </ol>
    */
   void onStart() {
     Log.v(TAG, "onStart()");
     ensureAlive();
-
-    // We post() the code that attaches the FlutterEngine to our FlutterView because there is
-    // some kind of blocking logic on the native side when the surface is connected. That lag
-    // causes launching Activitys to wait a second or two before launching. By post()'ing this
-    // behavior we are able to move this blocking logic to after the Activity's launch.
-    // TODO(mattcarroll): figure out how to avoid blocking the MAIN thread when connecting a surface
-    new Handler()
-        .post(
-            new Runnable() {
-              @Override
-              public void run() {
-                Log.v(TAG, "Attaching FlutterEngine to FlutterView.");
-                flutterView.attachToFlutterEngine(flutterEngine);
-
-                doInitialFlutterViewRun();
-              }
-            });
+    doInitialFlutterViewRun();
   }
 
   /**
@@ -418,7 +407,6 @@ import java.util.Arrays;
     Log.v(TAG, "onStop()");
     ensureAlive();
     flutterEngine.getLifecycleChannel().appIsPaused();
-    flutterView.detachFromFlutterEngine();
   }
 
   /**
@@ -429,6 +417,8 @@ import java.util.Arrays;
   void onDestroyView() {
     Log.v(TAG, "onDestroyView()");
     ensureAlive();
+
+    flutterView.detachFromFlutterEngine();
     flutterView.removeOnFirstFrameRenderedListener(flutterUiDisplayListener);
   }
 


### PR DESCRIPTION
Prevent long flash when switching to Flutter app. (#47903)

@Hixie discovered a long black flash when switching to a Flutter app using the v2 embedding. It turns out that there was always a slight flash when selecting a Flutter app from the app switcher, but the v2 embedding made it much longer.

The root cause of the flash appears to be attaching/detaching the FlutterEngine to/from the FlutterView during non-destruction lifecycle methods. This decision wasn't inherently wrong, but since it created this visual artifact, this PR pushes attachment/detachment behavior to the creation/destruction lifecycle methods.

Testing for this behavior is likely impossible. I spoke with @Hixie a bit about it and we couldn't come up with any good ideas. @jason-simmons if you can think of anything worthwhile, please feel free to comment. The flash happens at the interface between the OS and the Flutter UI, and it is highly timing/processor dependent (flaky).

@mklim @jason-simmons it would be great if you two could carefully read through the changes in this PR to help find any likely issues that I may have missed with this change. The change seems to run fine so far on an emulator and physical device, but lifecycle methods have many implications throughout an app's life, so a couple more eyes on this wouldn't hurt.