### PR TITLE
Try rasterizing each picture and layer at most once. Apply a consistent caching treshold to layers and pictures.

### DIFF
--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -84,7 +84,7 @@ class RasterCache {
                bool is_complex,
                bool will_change);
 
-  void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
+  bool Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
 
   RasterCacheResult Get(const SkPicture& picture, const SkMatrix& ctm) const;
 
@@ -101,6 +101,7 @@ class RasterCache {
  private:
   struct Entry {
     bool used_this_frame = false;
+    bool did_rasterize = false;
     size_t access_count = 0;
     RasterCacheResult image;
   };

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -4,6 +4,7 @@
 
 #include "flutter/flow/raster_cache.h"
 
+#include "flutter/flow/layers/container_layer.h"
 #include "gtest/gtest.h"
 #include "third_party/skia/include/core/SkPicture.h"
 #include "third_party/skia/include/core/SkPictureRecorder.h"
@@ -29,15 +30,13 @@ TEST(RasterCache, SimpleInitialization) {
   ASSERT_TRUE(true);
 }
 
-TEST(RasterCache, ThresholdIsRespected) {
+TEST(RasterCache, ThresholdIsRespectedForPictures) {
   size_t threshold = 2;
   flutter::RasterCache cache(threshold);
 
   SkMatrix matrix = SkMatrix::I();
 
   auto picture = GetSamplePicture();
-
-  sk_sp<SkImage> image;
 
   sk_sp<SkColorSpace> srgb = SkColorSpace::MakeSRGB();
   ASSERT_FALSE(
@@ -61,21 +60,28 @@ TEST(RasterCache, ThresholdIsRespected) {
   ASSERT_TRUE(cache.Get(*picture, matrix).is_valid());
 }
 
-TEST(RasterCache, AccessThresholdOfZeroDisablesCaching) {
-  size_t threshold = 0;
+TEST(RasterCache, ThresholdIsRespectedForLayers) {
+  size_t threshold = 2;
   flutter::RasterCache cache(threshold);
 
   SkMatrix matrix = SkMatrix::I();
 
-  auto picture = GetSamplePicture();
-
-  sk_sp<SkImage> image;
+  ContainerLayer layer;
 
   sk_sp<SkColorSpace> srgb = SkColorSpace::MakeSRGB();
-  ASSERT_FALSE(
-      cache.Prepare(NULL, picture.get(), matrix, srgb.get(), true, false));
+  ASSERT_FALSE(cache.Prepare(nullptr, &layer, matrix));
+  ASSERT_FALSE(cache.Prepare(nullptr, &layer, matrix));
+  ASSERT_FALSE(cache.Prepare(nullptr, &layer, matrix));
 
-  ASSERT_FALSE(cache.Get(*picture, matrix).is_valid());
+  // 1st access.
+  ASSERT_FALSE(cache.Get(&layer, matrix).is_valid());
+
+  ASSERT_FALSE(cache.Prepare(nullptr, &layer, matrix));
+
+  // 2st access.
+  ASSERT_FALSE(cache.Get(&layer, matrix).is_valid());
+
+  // Calling Prepare now would crash due to the nullptr.
 }
 
 TEST(RasterCache, PictureCacheLimitPerFrameIsRespectedWhenZero) {
@@ -85,8 +91,6 @@ TEST(RasterCache, PictureCacheLimitPerFrameIsRespectedWhenZero) {
   SkMatrix matrix = SkMatrix::I();
 
   auto picture = GetSamplePicture();
-
-  sk_sp<SkImage> image;
 
   sk_sp<SkColorSpace> srgb = SkColorSpace::MakeSRGB();
   ASSERT_FALSE(
@@ -103,8 +107,6 @@ TEST(RasterCache, SweepsRemoveUnusedFrames) {
 
   auto picture = GetSamplePicture();
 
-  sk_sp<SkImage> image;
-
   sk_sp<SkColorSpace> srgb = SkColorSpace::MakeSRGB();
   ASSERT_FALSE(cache.Prepare(NULL, picture.get(), matrix, srgb.get(), true,
                              false));  // 1
@@ -119,6 +121,30 @@ TEST(RasterCache, SweepsRemoveUnusedFrames) {
   cache.SweepAfterFrame();
   cache.SweepAfterFrame();  // Extra frame without a Get image access.
 
+  ASSERT_FALSE(cache.Get(*picture, matrix).is_valid());
+}
+
+TEST(RasterCache, TryRasterizngOnlyOnce) {
+  size_t threshold = 1;
+  flutter::RasterCache cache(threshold);
+
+  SkMatrix matrix = SkMatrix::I();
+  // Test picture too large to successfully rasterize.
+  auto picture = SkPicture::MakePlaceholder(SkRect::MakeWH(2e12, 2e12));
+
+  sk_sp<SkColorSpace> srgb = SkColorSpace::MakeSRGB();
+  ASSERT_FALSE(cache.Prepare(nullptr, picture.get(), matrix, srgb.get(), true,
+                             false));  // 1
+  ASSERT_FALSE(cache.Get(*picture, matrix).is_valid());
+
+  // Rasterization ran, though Get() below returns an invalid image.
+  ASSERT_TRUE(cache.Prepare(nullptr, picture.get(), matrix, srgb.get(), true,
+                            false));  // 2
+  ASSERT_FALSE(cache.Get(*picture, matrix).is_valid());
+
+  // This time we should not try again to rasterize.
+  ASSERT_FALSE(cache.Prepare(nullptr, picture.get(), matrix, srgb.get(), true,
+                             false));  // 2
   ASSERT_FALSE(cache.Get(*picture, matrix).is_valid());
 }
 


### PR DESCRIPTION
If Rasterization fails, i.e. image.is_valid() is false, the cache might try rasterizing the image again on the next frame. Not only is this wasteful put might also prevent other pictures to be cached within the current frame budget.

CC @cbracken 