### PR TITLE
Re-land: Use os_log instead of syslog on Apple platforms

### DIFF
--- a/lib/ui/dart_runtime_hooks.cc
+++ b/lib/ui/dart_runtime_hooks.cc
@@ -30,7 +30,8 @@
 
 #if defined(OS_ANDROID)
 #include <android/log.h>
-#elif defined(OS_IOS)
+#elif defined(OS_MACOSX)
+#include <os/log.h>
 extern "C" {
 // Cannot import the syslog.h header directly because of macro collision.
 extern void syslog(int, const char*, ...);
@@ -199,19 +200,29 @@ void Logger_PrintString(Dart_NativeArguments args) {
     // Write to the logcat on Android.
     __android_log_print(ANDROID_LOG_INFO, logger_prefix.c_str(), "%.*s",
                         (int)length, chars);
-#elif defined(OS_IOS)
-    // Write to syslog on iOS.
-    //
+#elif defined(OS_MACOSX)
     // TODO(cbracken): replace with dedicated communication channel and bypass
     // iOS logging APIs altogether.
-    syslog(1 /* LOG_ALERT */, "%.*s", (int)length, chars);
+    //
+    // Unified logging (os_log) became available in iOS 9.0 and syslog stopped
+    // working in iOS 13.0. idevicesyslog made device syslog available on the
+    // connected host, but there is no known API to view device unified logging
+    // on the host. Flutter tool will continue to observe syslog on devices
+    // older than iOS 13.0 since it provides more logging context, particularly
+    // for application crashes.
+    if (__builtin_available(iOS 13.0, macOS 10.11, *)) {
+      os_log_t dart_log = os_log_create("io.flutter", "dart");
+      os_log(dart_log, "%.*s", static_cast<int>(length), chars);
+    } else {
+      syslog(1 /* LOG_ALERT */, "%.*s", static_cast<int>(length), chars);
+    }
 #else
     std::cout << log_string << std::endl;
 #endif
   }
 
   if (dart::bin::ShouldCaptureStdout()) {
-    // For now we report print output on the Stdout stream.
+    // Report print output on the Stdout stream.
     uint8_t newline[] = {'\n'};
     Dart_ServiceSendDataEvent("Stdout", "WriteEvent",
                               reinterpret_cast<const uint8_t*>(chars), length);


### PR DESCRIPTION
Migrates to using os_log for app logging on iOS 13 and above, macOS
10.11 and above. On older platform, fall back to syslog(), which is what
we used previously.

This re-lands commit 78a8909725bbaeec80870f498d01ea6e56932a3a with a fix.
That commit was reverted in a61dbf2f66b97e85f4d8bf0cfb29a8b3c2640c09.