### PR TITLE
[Fuchsia] Dump syslog output after tests have run

### DIFF
--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -68,3 +68,8 @@ done
     -f shell_tests-0.far  \
     -t shell_tests \
     -a "--gtest_filter=-ShellTest.HandlesActualIphoneXsInputEvents:ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*:ShellTest.Screenshot:ShellTest.WaitForFirstFrameTimeout"
+
+echo "Dumping system logs..."
+
+./fuchsia_ctl -d $device_name ssh \
+    -c "log_listener --dump_logs yes"


### PR DESCRIPTION
https://chromium-swarm.appspot.com/task?id=4a5409b6fe021710&w=true is an example run of this.