### PR TITLE
Fix multi-line Javadoc code blocks

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterActivity.java
@@ -107,12 +107,14 @@ import java.lang.reflect.Method;
  *
  * <p>The following illustrates how to pre-warm and cache a {@link FlutterEngine}:
  *
- * <p>{@code // Create and pre-warm a FlutterEngine. FlutterEngine flutterEngine = new
- * FlutterEngine(context); flutterEngine .getDartExecutor()
- * .executeDartEntrypoint(DartEntrypoint.createDefault());
+ * <pre>{@code
+ * // Create and pre-warm a FlutterEngine.
+ * FlutterEngine flutterEngine = new FlutterEngine(context);
+ * flutterEngine.getDartExecutor().executeDartEntrypoint(DartEntrypoint.createDefault());
  *
- * <p>// Cache the pre-warmed FlutterEngine in the FlutterEngineCache.
- * FlutterEngineCache.getInstance().put("my_engine", flutterEngine); }
+ * // Cache the pre-warmed FlutterEngine in the FlutterEngineCache.
+ * FlutterEngineCache.getInstance().put("my_engine", flutterEngine);
+ * }</pre>
  *
  * <p><strong>Alternatives to FlutterActivity</strong>
  *

--- a/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterFragment.java
@@ -67,12 +67,14 @@ import io.flutter.view.FlutterMain;
  *
  * <p>The following illustrates how to pre-warm and cache a {@link FlutterEngine}:
  *
- * <p>{@code // Create and pre-warm a FlutterEngine. FlutterEngine flutterEngine = new
- * FlutterEngine(context); flutterEngine .getDartExecutor()
- * .executeDartEntrypoint(DartEntrypoint.createDefault());
+ * <pre>{@code
+ * // Create and pre-warm a FlutterEngine. FlutterEngine flutterEngine = new
+ * FlutterEngine(context);
+ * flutterEngine.getDartExecutor().executeDartEntrypoint(DartEntrypoint.createDefault());
  *
- * <p>// Cache the pre-warmed FlutterEngine in the FlutterEngineCache.
- * FlutterEngineCache.getInstance().put("my_engine", flutterEngine); }
+ * // Cache the pre-warmed FlutterEngine in the FlutterEngineCache.
+ * FlutterEngineCache.getInstance().put("my_engine", flutterEngine);
+ * }</pre>
  *
  * <p>If Flutter is needed in a location that can only use a {@code View}, consider using a {@link
  * FlutterView}. Using a {@link FlutterView} requires forwarding some calls from an {@code

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -56,13 +56,16 @@ import java.util.concurrent.CopyOnWriteArraySet;
  * <p>To connect part of an Android app to Flutter's C/C++ engine, instantiate a {@code FlutterJNI}
  * and then attach it to the native side:
  *
- * <p>{@code // Instantiate FlutterJNI and attach to the native side. FlutterJNI flutterJNI = new
- * FlutterJNI(); flutterJNI.attachToNative();
+ * <pre>{@code
+ * // Instantiate FlutterJNI and attach to the native side.
+ * FlutterJNI flutterJNI = new FlutterJNI();
+ * flutterJNI.attachToNative();
  *
- * <p>// Use FlutterJNI as desired. flutterJNI.dispatchPointerDataPacket(...);
+ * // Use FlutterJNI as desired. flutterJNI.dispatchPointerDataPacket(...);
  *
- * <p>// Destroy the connection to the native side and cleanup.
- * flutterJNI.detachFromNativeAndReleaseResources(); }
+ * // Destroy the connection to the native side and cleanup.
+ * flutterJNI.detachFromNativeAndReleaseResources();
+ * }</pre>
  *
  * <p>To provide a visual, interactive surface for Flutter rendering and touch events, register a
  * {@link RenderSurface} with {@link #setRenderSurface(RenderSurface)}


### PR DESCRIPTION
The formatter didn't understand what was going on here and broke the
text. Changed these to use `<pre>{@code }</pre>` instead.

Tested out `./ci/format.sh` locally first to make sure this wouldn't conflict.