### PR TITLE
Revert "Re-arm timer as necessary in MessageLoopFuchsia"

### DIFF
--- a/fml/platform/fuchsia/message_loop_fuchsia.cc
+++ b/fml/platform/fuchsia/message_loop_fuchsia.cc
@@ -5,16 +5,13 @@
 #include "flutter/fml/platform/fuchsia/message_loop_fuchsia.h"
 
 #include <lib/async-loop/default.h>
+#include <lib/async/cpp/task.h>
 #include <lib/zx/time.h>
 
 namespace fml {
 
 MessageLoopFuchsia::MessageLoopFuchsia()
-    : loop_(&kAsyncLoopConfigAttachToCurrentThread) {
-  auto handler = [this](async_dispatcher_t* dispatcher, async::Task* task,
-                        zx_status_t status) { RunExpiredTasksNow(); };
-  task_.set_handler(handler);
-}
+    : loop_(&kAsyncLoopConfigAttachToCurrentThread) {}
 
 MessageLoopFuchsia::~MessageLoopFuchsia() = default;
 
@@ -33,12 +30,8 @@ void MessageLoopFuchsia::WakeUp(fml::TimePoint time_point) {
     due_time = zx::nsec((time_point - now).ToNanoseconds());
   }
 
-  std::scoped_lock lock(task_mutex_);
-
-  auto status = task_.Cancel();
-  FML_DCHECK(status == ZX_OK || status == ZX_ERR_NOT_FOUND);
-
-  status = task_.PostDelayed(loop_.dispatcher(), due_time);
+  auto status = async::PostDelayedTask(
+      loop_.dispatcher(), [this]() { RunExpiredTasksNow(); }, due_time);
   FML_DCHECK(status == ZX_OK);
 }
 

--- a/fml/platform/fuchsia/message_loop_fuchsia.h
+++ b/fml/platform/fuchsia/message_loop_fuchsia.h
@@ -6,7 +6,6 @@
 #define FLUTTER_FML_PLATFORM_FUCHSIA_MESSAGE_LOOP_FUCHSIA_H_
 
 #include <lib/async-loop/cpp/loop.h>
-#include <lib/async/cpp/task.h>
 
 #include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
@@ -26,8 +25,6 @@ class MessageLoopFuchsia : public MessageLoopImpl {
   void WakeUp(fml::TimePoint time_point) override;
 
   async::Loop loop_;
-  std::mutex task_mutex_;
-  async::Task task_;
 
   FML_FRIEND_MAKE_REF_COUNTED(MessageLoopFuchsia);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopFuchsia);


### PR DESCRIPTION
It turns out that async::Task::Cancel() isn't threadsafe, and it was the root cause of our crashes on Fuchsia.

This reverts this patch. It exposes a performance issue but that's better than crashing. It should also make our Fuchsia infra testing more reliable (I think this is the cause of the `Linux Fuchsia` failures we've been seeing).

I've verified this resolves the crash locally as `ShellTest.HandlesActualIphoneXsInputEvents` was a fairly reliable reproducer of it.