### PR TITLE
Set the current GL context to the most recently acquired Surface

### DIFF
--- a/lib/web_ui/lib/src/engine/compositor/surface.dart
+++ b/lib/web_ui/lib/src/engine/compositor/surface.dart
@@ -47,6 +47,7 @@ class Surface {
   /// The given [size] is in physical pixels.
   SurfaceFrame acquireFrame(ui.Size size) {
     final SkSurface surface = acquireRenderSurface(size);
+    canvasKit.callMethod('setCurrentContext', <int>[surface.context]);
 
     if (surface == null) return null;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/49947

Unfortunately, I can't find a way to share resources between GL contexts. But I also found that most errors of textures being bound in one context and used in another are caused by not setting the correct context.