### PR TITLE
[web] Fixing launching Safari. This should solve the LUCI issue

### DIFF
--- a/lib/web_ui/dev/common.dart
+++ b/lib/web_ui/dev/common.dart
@@ -50,7 +50,7 @@ abstract class PlatformBinding {
   String getChromeExecutablePath(io.Directory versionDir);
   String getFirefoxExecutablePath(io.Directory versionDir);
   String getFirefoxLatestVersionUrl();
-  String getSafariSystemExecutablePath();
+  String getMacApplicationLauncher();
   String getCommandToRunEdge();
 }
 
@@ -85,7 +85,7 @@ class _WindowsBinding implements PlatformBinding {
       'https://download.mozilla.org/?product=firefox-latest&os=win&lang=en-US';
 
   @override
-  String getSafariSystemExecutablePath() =>
+  String getMacApplicationLauncher() =>
       throw UnsupportedError('Safari is not supported on Windows');
 
   @override
@@ -120,7 +120,7 @@ class _LinuxBinding implements PlatformBinding {
       'https://download.mozilla.org/?product=firefox-latest&os=linux64&lang=en-US';
 
   @override
-  String getSafariSystemExecutablePath() =>
+  String getMacApplicationLauncher() =>
       throw UnsupportedError('Safari is not supported on Linux');
 
   @override
@@ -161,8 +161,7 @@ class _MacBinding implements PlatformBinding {
       'https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US';
 
   @override
-  String getSafariSystemExecutablePath() =>
-      '/Applications/Safari.app/Contents/MacOS/Safari';
+  String getMacApplicationLauncher() => 'open';
 
   @override
   String getCommandToRunEdge() =>

--- a/lib/web_ui/dev/safari.dart
+++ b/lib/web_ui/dev/safari.dart
@@ -41,18 +41,16 @@ class Safari extends Browser {
       // to open Safari for a given URL. In summary they provide a new instance
       // to open, that instance to wait for opening the url until Safari launches,
       // provide Safari bundles identifier.
-      // For more details run `man open` on MacOS.
-      // TODO(nurhan): explore implementing this part using Apple Script or
-      // MacOS native APIs such as LSLaunchURLSpec. In the current solution there is
-      // no way of closing Safari after opening with open command.
+      // The details copied from `man open` on MacOS.
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50809
       var process = await Process.start(installation.executable, [
-        '-F',
-        '-W',
-        '-n',
-        '-b',
-        'com.apple.Safari',
+        '-F', // Open a fresh application with no persistant state.
+        '-W', // Open to wait until the applications it opens.
+        '-n', // Open a new instance of the application.
+        '-b', // Specifies the bundle identifier for the application to use.
+        'com.apple.Safari', // Bundle identifier for Safari.
         '${url.toString()}'
-      ] /* args */);
+      ]);
 
       return process;
     });

--- a/lib/web_ui/dev/safari_installation.dart
+++ b/lib/web_ui/dev/safari_installation.dart
@@ -70,7 +70,7 @@ Future<BrowserInstallation> getOrInstallSafari(
     infoLog.writeln('Using the system version that is already installed.');
     return BrowserInstallation(
       version: 'system',
-      executable: PlatformBinding.instance.getSafariSystemExecutablePath(),
+      executable: PlatformBinding.instance.getMacApplicationLauncher(),
     );
   } else {
     infoLog.writeln('Unsupported version $requestedVersion.');


### PR DESCRIPTION
Changing the way we are launching Safari for tests.

So far we were using the method from dart-sdk/test to open safari browser, on the other hand it looks like this method become obsolete with the new MacOs version with the increasing file security. It became an issue in other projects as well. We applied one of the solutions proposed here: https://github.com/karma-runner/karma-safari-launcher/issues/29#issuecomment-501101074
