### PR TITLE
Use zx timers and re-arm timer explicitly instead of relying on async::Loop

### DIFF
--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -10,6 +10,7 @@
 #include "flutter/fml/build_config.h"
 #include "flutter/fml/concurrent_message_loop.h"
 #include "flutter/fml/message_loop.h"
+#include "flutter/fml/message_loop_impl.h"
 #include "flutter/fml/synchronization/count_down_latch.h"
 #include "flutter/fml/synchronization/waitable_event.h"
 #include "flutter/fml/task_runner.h"
@@ -314,4 +315,33 @@ TEST(MessageLoop, CanCreateConcurrentMessageLoop) {
   }
   latch.Wait();
   ASSERT_GE(thread_ids.size(), 1u);
+}
+
+TEST(MessageLoop, TIME_SENSITIVE(WakeUpTimersAreSingletons)) {
+  auto loop_impl = fml::MessageLoopImpl::Create();
+
+  const auto t1 = fml::TimeDelta::FromMilliseconds(10);
+  const auto t2 = fml::TimeDelta::FromMilliseconds(20);
+
+  const auto begin = fml::TimePoint::Now();
+
+  // Register a task scheduled for 10ms in the future. This schedules a
+  // WakeUp call on the MessageLoopImpl with that fml::TimePoint
+  loop_impl->PostTask(
+      [&]() {
+        auto delta = fml::TimePoint::Now() - begin;
+        auto ms = delta.ToMillisecondsF();
+        ASSERT_GE(ms, 18);
+        ASSERT_LE(ms, 22);
+
+        loop_impl->Terminate();
+      },
+      fml::TimePoint::Now() + t1);
+
+  // Call WakeUp manually to change the WakeUp time to the future. If the
+  // timer is correctly set up to be rearmed instead of a new timer scheduled,
+  // the above task will be executed at t2 instead of t1 now.
+  loop_impl->WakeUp(fml::TimePoint::Now() + t2);
+
+  loop_impl->Run();
 }

--- a/fml/message_loop_unittests.cc
+++ b/fml/message_loop_unittests.cc
@@ -331,17 +331,17 @@ TEST(MessageLoop, TIME_SENSITIVE(WakeUpTimersAreSingletons)) {
       [&]() {
         auto delta = fml::TimePoint::Now() - begin;
         auto ms = delta.ToMillisecondsF();
-        ASSERT_GE(ms, 18);
-        ASSERT_LE(ms, 22);
+        ASSERT_GE(ms, 20);
+        ASSERT_LE(ms, 24);
 
         loop_impl->Terminate();
       },
-      fml::TimePoint::Now() + t1);
+      begin + t1);
 
   // Call WakeUp manually to change the WakeUp time to the future. If the
   // timer is correctly set up to be rearmed instead of a new timer scheduled,
   // the above task will be executed at t2 instead of t1 now.
-  loop_impl->WakeUp(fml::TimePoint::Now() + t2);
+  loop_impl->WakeUp(begin + t2);
 
   loop_impl->Run();
 }

--- a/fml/platform/fuchsia/message_loop_fuchsia.cc
+++ b/fml/platform/fuchsia/message_loop_fuchsia.cc
@@ -58,7 +58,9 @@ void MessageLoopFuchsia::Terminate() {
 
 void MessageLoopFuchsia::WakeUp(fml::TimePoint time_point) {
   zx::time due_time(time_point.ToEpochDelta().ToNanoseconds());
-  auto status = timer_.set(due_time, zx::duration(1));
+  auto status = timer_.set(due_time,        // due time
+                           zx::duration(0)  // slack
+  );
   FML_CHECK(status == ZX_OK);
 }
 

--- a/fml/platform/fuchsia/message_loop_fuchsia.cc
+++ b/fml/platform/fuchsia/message_loop_fuchsia.cc
@@ -24,7 +24,7 @@ void MessageLoopFuchsia::Run() {
   while (running_) {
     auto status = zx_object_wait_one(timer_, ZX_TIMER_SIGNALED,
                                      ZX_TIME_INFINITE, &observed);
-    FML_CHECK(observed == ZX_TIMER_SCHEDULED ||
+    FML_CHECK(observed == ZX_TIMER_SIGNALED ||
               observed == ZX_SIGNAL_HANDLE_CLOSED);
 
     RunExpiredTasksNow();

--- a/fml/platform/fuchsia/message_loop_fuchsia.cc
+++ b/fml/platform/fuchsia/message_loop_fuchsia.cc
@@ -11,27 +11,38 @@
 namespace fml {
 
 MessageLoopFuchsia::MessageLoopFuchsia()
-    : loop_(&kAsyncLoopConfigAttachToCurrentThread) {}
+  : running_(false) {
+  auto status = zx_timer_create(0, ZX_CLOCK_MONOTONIC, &timer_);
+  FML_DCHECK(status == ZX_OK);
+}
 
 MessageLoopFuchsia::~MessageLoopFuchsia() = default;
 
 void MessageLoopFuchsia::Run() {
-  loop_.Run();
+  zx_signals_t observed;
+  running_ = true;
+  while (running_) {
+    auto status = zx_object_wait_one(timer_, ZX_TIMER_SIGNALED, ZX_TIME_INFINITE, &observed);
+
+    if (status == ZX_OK) {
+      RunExpiredTasksNow();
+    }
+  }
 }
 
 void MessageLoopFuchsia::Terminate() {
-  loop_.Quit();
+  running_ = false;
 }
 
 void MessageLoopFuchsia::WakeUp(fml::TimePoint time_point) {
-  fml::TimePoint now = fml::TimePoint::Now();
-  zx::duration due_time{0};
-  if (time_point > now) {
-    due_time = zx::nsec((time_point - now).ToNanoseconds());
-  }
 
-  auto status = async::PostDelayedTask(
-      loop_.dispatcher(), [this]() { RunExpiredTasksNow(); }, due_time);
+  fml::TimePoint now = fml::TimePoint::Now();
+  zx_duration_t delay = 0;
+  if (time_point > now) {
+    delay = (time_point - now).ToNanoseconds();
+  }
+  auto due_time = zx_deadline_after(delay);
+  auto status = zx_timer_set(timer_, due_time, ZX_TIMER_SLACK_CENTER);
   FML_DCHECK(status == ZX_OK);
 }
 

--- a/fml/platform/fuchsia/message_loop_fuchsia.cc
+++ b/fml/platform/fuchsia/message_loop_fuchsia.cc
@@ -19,10 +19,10 @@ MessageLoopFuchsia::MessageLoopFuchsia()
   auto wait_handler = [this](async_dispatcher_t* dispatcher, async::Wait* wait,
                              zx_status_t status,
                              const zx_packet_signal_t* signal) {
-    FML_CHECK(signal->observed & ZX_TIMER_SIGNALED);
     timer_.cancel();
     RunExpiredTasksNow();
-    if (running_) {
+    if (status != ZX_ERR_CANCELED) {
+      FML_CHECK(signal->observed & ZX_TIMER_SIGNALED);
       auto result = wait->Begin(loop_.dispatcher());
       FML_CHECK(result == ZX_OK);
     }

--- a/fml/platform/fuchsia/message_loop_fuchsia.h
+++ b/fml/platform/fuchsia/message_loop_fuchsia.h
@@ -9,6 +9,8 @@
 #include "flutter/fml/message_loop_impl.h"
 
 #include <zircon/syscalls.h>
+#include <lib/async/cpp/wait.h>
+#include <lib/async-loop/cpp/loop.h>
 
 namespace fml {
 
@@ -25,6 +27,10 @@ class MessageLoopFuchsia : public MessageLoopImpl {
   void WakeUp(fml::TimePoint time_point) override;
 
   zx_handle_t timer_;
+
+  async::Wait* timer_wait_;
+  async::Loop loop_;
+
   bool running_;
 
   FML_FRIEND_MAKE_REF_COUNTED(MessageLoopFuchsia);

--- a/fml/platform/fuchsia/message_loop_fuchsia.h
+++ b/fml/platform/fuchsia/message_loop_fuchsia.h
@@ -5,10 +5,10 @@
 #ifndef FLUTTER_FML_PLATFORM_FUCHSIA_MESSAGE_LOOP_FUCHSIA_H_
 #define FLUTTER_FML_PLATFORM_FUCHSIA_MESSAGE_LOOP_FUCHSIA_H_
 
-#include <lib/async-loop/cpp/loop.h>
-
 #include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
+
+#include <zircon/syscalls.h>
 
 namespace fml {
 
@@ -24,7 +24,8 @@ class MessageLoopFuchsia : public MessageLoopImpl {
 
   void WakeUp(fml::TimePoint time_point) override;
 
-  async::Loop loop_;
+  zx_handle_t timer_;
+  bool running_;
 
   FML_FRIEND_MAKE_REF_COUNTED(MessageLoopFuchsia);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopFuchsia);

--- a/fml/platform/fuchsia/message_loop_fuchsia.h
+++ b/fml/platform/fuchsia/message_loop_fuchsia.h
@@ -8,9 +8,10 @@
 #include "flutter/fml/macros.h"
 #include "flutter/fml/message_loop_impl.h"
 
-#include <zircon/syscalls.h>
-#include <lib/async/cpp/wait.h>
 #include <lib/async-loop/cpp/loop.h>
+#include <lib/async/cpp/wait.h>
+#include <lib/zx/timer.h>
+#include <zircon/syscalls.h>
 
 namespace fml {
 
@@ -26,12 +27,11 @@ class MessageLoopFuchsia : public MessageLoopImpl {
 
   void WakeUp(fml::TimePoint time_point) override;
 
-  zx_handle_t timer_;
-
-  async::Wait* timer_wait_;
+  zx::timer timer_;
+  std::unique_ptr<async::Wait> timer_wait_;
   async::Loop loop_;
 
-  bool running_;
+  std::atomic_bool running_;
 
   FML_FRIEND_MAKE_REF_COUNTED(MessageLoopFuchsia);
   FML_FRIEND_REF_COUNTED_THREAD_SAFE(MessageLoopFuchsia);

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -59,7 +59,7 @@ done
 ./fuchsia_ctl -d $device_name test \
     -f fml_tests-0.far  \
     -t fml_tests \
-    -a "--gtest_filter=-MessageLoop*:Message*:FileTest*"
+    -a "--gtest_filter=-FileTest*"
 
 ./fuchsia_ctl -d $device_name test \
     -f flow_tests-0.far  \
@@ -72,5 +72,5 @@ done
 ./fuchsia_ctl -d $device_name test \
     -f shell_tests-0.far  \
     -t shell_tests \
-    -a "--gtest_filter=-ShellTest.HandlesActualIphoneXsInputEvents:ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*:ShellTest.Screenshot:ShellTest.WaitForFirstFrameTimeout"
+    -a "--gtest_filter=-ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*:ShellTest.Screenshot"
 


### PR DESCRIPTION
I want to add more checking and logging around this but this is I think the general direction we should head in.

This basically brings MessaageLoopFuchsia in line with Linux and Android in terms of the implementation details.