### PR TITLE
[shell tests] Integrate Vulkan with Shell Tests

### DIFF
--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/common/shell_test_platform_view_vulkan.h"
-#include "flutter/shell/gpu/gpu_surface_vulkan.h"
 
 namespace flutter {
 namespace testing {
@@ -30,7 +29,7 @@ void ShellTestPlatformViewVulkan::SimulateVSync() {
 
 // |PlatformView|
 std::unique_ptr<Surface> ShellTestPlatformViewVulkan::CreateRenderingSurface() {
-  return std::make_unique<GPUSurfaceVulkan>(this, nullptr, true);
+  return std::make_unique<OffScreenSurface>(proc_table_);
 }
 
 // |PlatformView|
@@ -40,9 +39,128 @@ PointerDataDispatcherMaker ShellTestPlatformViewVulkan::GetDispatcherMaker() {
   };
 }
 
-// |GPUSurfaceVulkanDelegate|
-fml::RefPtr<vulkan::VulkanProcTable> ShellTestPlatformViewVulkan::vk() {
-  return proc_table_;
+ShellTestPlatformViewVulkan::OffScreenSurface::OffScreenSurface(
+    fml::RefPtr<vulkan::VulkanProcTable> vk)
+    : valid_(false), vk_(std::move(vk)) {
+  if (!vk_ || !vk_->HasAcquiredMandatoryProcAddresses()) {
+    FML_DLOG(ERROR) << "Proc table has not acquired mandatory proc addresses.";
+    return;
+  }
+
+  // Create the application instance.
+  std::vector<std::string> extensions = {};
+
+  application_ = std::make_unique<vulkan::VulkanApplication>(
+      *vk_, "FlutterTest", std::move(extensions));
+
+  if (!application_->IsValid() || !vk_->AreInstanceProcsSetup()) {
+    // Make certain the application instance was created and it setup the
+    // instance proc table entries.
+    FML_DLOG(ERROR) << "Instance proc addresses have not been setup.";
+    return;
+  }
+
+  // Create the device.
+
+  logical_device_ = application_->AcquireFirstCompatibleLogicalDevice();
+
+  if (logical_device_ == nullptr || !logical_device_->IsValid() ||
+      !vk_->AreDeviceProcsSetup()) {
+    // Make certain the device was created and it setup the device proc table
+    // entries.
+    FML_DLOG(ERROR) << "Device proc addresses have not been setup.";
+    return;
+  }
+
+  // Create the Skia GrContext.
+  if (!CreateSkiaGrContext()) {
+    FML_DLOG(ERROR) << "Could not create Skia context.";
+    return;
+  }
+
+  valid_ = true;
+}
+
+bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaGrContext() {
+  GrVkBackendContext backend_context;
+
+  if (!CreateSkiaBackendContext(&backend_context)) {
+    FML_DLOG(ERROR) << "Could not create Skia backend context.";
+    return false;
+  }
+
+  sk_sp<GrContext> context = GrContext::MakeVulkan(backend_context);
+
+  if (context == nullptr) {
+    FML_DLOG(ERROR) << "Failed to create GrContext";
+    return false;
+  }
+
+  context->setResourceCacheLimits(vulkan::kGrCacheMaxCount,
+                                  vulkan::kGrCacheMaxByteSize);
+
+  context_ = context;
+
+  return true;
+}
+
+bool ShellTestPlatformViewVulkan::OffScreenSurface::CreateSkiaBackendContext(
+    GrVkBackendContext* context) {
+  auto getProc = vk_->CreateSkiaGetProc();
+
+  if (getProc == nullptr) {
+    FML_DLOG(ERROR) << "GetProcAddress is null";
+    return false;
+  }
+
+  uint32_t skia_features = 0;
+  if (!logical_device_->GetPhysicalDeviceFeaturesSkia(&skia_features)) {
+    FML_DLOG(ERROR) << "Failed to get Physical Device features";
+    return false;
+  }
+
+  context->fInstance = application_->GetInstance();
+  context->fPhysicalDevice = logical_device_->GetPhysicalDeviceHandle();
+  context->fDevice = logical_device_->GetHandle();
+  context->fQueue = logical_device_->GetQueueHandle();
+  context->fGraphicsQueueIndex = logical_device_->GetGraphicsQueueIndex();
+  context->fMinAPIVersion = application_->GetAPIVersion();
+  context->fMaxAPIVersion = application_->GetAPIVersion();
+  context->fFeatures = skia_features;
+  context->fGetProc = std::move(getProc);
+  context->fOwnsInstanceAndDevice = false;
+  return true;
+}
+
+ShellTestPlatformViewVulkan::OffScreenSurface::~OffScreenSurface() {}
+
+bool ShellTestPlatformViewVulkan::OffScreenSurface::IsValid() {
+  return valid_;
+}
+
+std::unique_ptr<SurfaceFrame>
+ShellTestPlatformViewVulkan::OffScreenSurface::AcquireFrame(
+    const SkISize& size) {
+  auto image_info = SkImageInfo::Make(size, SkColorType::kRGBA_8888_SkColorType,
+                                      SkAlphaType::kOpaque_SkAlphaType);
+  auto surface = SkSurface::MakeRenderTarget(context_.get(), SkBudgeted::kNo,
+                                             image_info, 0, nullptr);
+  SurfaceFrame::SubmitCallback callback =
+      [](const SurfaceFrame&, SkCanvas* canvas) -> bool { return true; };
+
+  return std::make_unique<SurfaceFrame>(std::move(surface), true,
+                                        std::move(callback));
+}
+
+GrContext* ShellTestPlatformViewVulkan::OffScreenSurface::GetContext() {
+  return context_.get();
+}
+
+SkMatrix ShellTestPlatformViewVulkan::OffScreenSurface::GetRootTransformation()
+    const {
+  SkMatrix matrix;
+  matrix.reset();
+  return matrix;
 }
 
 }  // namespace testing

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -39,6 +39,9 @@ PointerDataDispatcherMaker ShellTestPlatformViewVulkan::GetDispatcherMaker() {
   };
 }
 
+// TODO(gw280): This code was forked from vulkan_window.cc specifically for shell_test.
+//              We need to merge this functionality back into //vulkan.
+//              https://github.com/flutter/flutter/issues/51132
 ShellTestPlatformViewVulkan::OffScreenSurface::OffScreenSurface(
     fml::RefPtr<vulkan::VulkanProcTable> vk)
     : valid_(false), vk_(std::move(vk)) {

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -39,7 +39,8 @@ PointerDataDispatcherMaker ShellTestPlatformViewVulkan::GetDispatcherMaker() {
   };
 }
 
-// TODO(gw280): This code was forked from vulkan_window.cc specifically for shell_test.
+// TODO(gw280): This code was forked from vulkan_window.cc specifically for
+// shell_test.
 //              We need to merge this functionality back into //vulkan.
 //              https://github.com/flutter/flutter/issues/51132
 ShellTestPlatformViewVulkan::OffScreenSurface::OffScreenSurface(

--- a/testing/fuchsia/meta/fuchsia_test.cmx
+++ b/testing/fuchsia/meta/fuchsia_test.cmx
@@ -9,7 +9,12 @@
     ],
     "services": [
       "fuchsia.accessibility.semantics.SemanticsManager",
-      "fuchsia.process.Launcher"
+      "fuchsia.process.Launcher",
+      "fuchsia.deprecatedtimezone.Timezone",
+      "fuchsia.netstack.Netstack",
+      "fuchsia.vulkan.loader.Loader",
+      "fuchsia.logger.LogSink",
+      "fuchsia.tracing.provider.Registry"
     ]
   }
 }


### PR DESCRIPTION
This change creates a test only implementation of flutter::Surface backed by an
offscreen Vulkan GrContext. Much of the code in this test Surface was lifted
from flutter::VulkanWindow which I was unable to use without extricating it
from the VkSurface/VkSwapchain code which we do not want to use in offscreen
tests. I would recommend refactoring VulkanWindow to separate GrContext
creation and VkSwapchain creation in order to promote greater code reuse
between onscreen and offscreen vulkan paths.

This change is excersised thoroughly by the shell tests and was manually
tested against these tests on Fuchsia on Intel.