### PR TITLE
[web] Skipping failing edge tests

### DIFF
--- a/lib/web_ui/dev/felt_test.bat
+++ b/lib/web_ui/dev/felt_test.bat
@@ -1,0 +1,8 @@
+:: felt_windows: a command-line utility for Windows for building and testing
+:: Flutter web engine.
+:: FELT stands for Flutter Engine Local Tester.
+
+@ECHO OFF
+SETLOCAL
+ECHO %1
+IF %1==test (ECHO "TEST")

--- a/lib/web_ui/dev/felt_test.bat
+++ b/lib/web_ui/dev/felt_test.bat
@@ -1,8 +1,0 @@
-:: felt_windows: a command-line utility for Windows for building and testing
-:: Flutter web engine.
-:: FELT stands for Flutter Engine Local Tester.
-
-@ECHO OFF
-SETLOCAL
-ECHO %1
-IF %1==test (ECHO "TEST")

--- a/lib/web_ui/dev/felt_windows.bat
+++ b/lib/web_ui/dev/felt_windows.bat
@@ -57,8 +57,7 @@ IF %orTempValue%==0 (
 :: TODO(nurhan): The batch script does not support snanphot option.
 :: Support snapshot option.
 CALL :installdeps
-IF %1==test (%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %* --browser=edge)
-ELSE (%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %*)
+IF %1==test (%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %* --browser=edge) ELSE ( %DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %* )
 
 EXIT /B 0
 

--- a/lib/web_ui/dev/felt_windows.bat
+++ b/lib/web_ui/dev/felt_windows.bat
@@ -57,7 +57,8 @@ IF %orTempValue%==0 (
 :: TODO(nurhan): The batch script does not support snanphot option.
 :: Support snapshot option.
 CALL :installdeps
-%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %* --browser=edge
+IF %1==test (%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %* --browser=edge)
+ELSE (%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %*)
 
 EXIT /B 0
 

--- a/lib/web_ui/dev/felt_windows.bat
+++ b/lib/web_ui/dev/felt_windows.bat
@@ -57,7 +57,7 @@ IF %orTempValue%==0 (
 :: TODO(nurhan): The batch script does not support snanphot option.
 :: Support snapshot option.
 CALL :installdeps
-%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %*
+%DART_SDK_DIR%\bin\dart "%DEV_DIR%\felt.dart" %* --browser=edge
 
 EXIT /B 0
 

--- a/lib/web_ui/test/dom_renderer_test.dart
+++ b/lib/web_ui/test/dom_renderer_test.dart
@@ -99,7 +99,7 @@ void main() {
     expect(parent.innerHtml, '<a></a><b></b><c></c><d></d>');
   });
 
-  test('inneheight/innerWidth are equal to visualViewport height and width',
+  test('innerHeight/innerWidth are equal to visualViewport height and width',
       () {
     if (html.window.visualViewport != null) {
       expect(html.window.visualViewport.width, html.window.innerWidth);

--- a/lib/web_ui/test/dom_renderer_test.dart
+++ b/lib/web_ui/test/dom_renderer_test.dart
@@ -99,7 +99,8 @@ void main() {
     expect(parent.innerHtml, '<a></a><b></b><c></c><d></d>');
   });
 
-  test('inneheight/innerWidth are equal to visualViewport height and width', () {
+  test('inneheight/innerWidth are equal to visualViewport height and width',
+      () {
     if (html.window.visualViewport != null) {
       expect(html.window.visualViewport.width, html.window.innerWidth);
       expect(html.window.visualViewport.height, html.window.innerHeight);
@@ -115,13 +116,16 @@ void main() {
 
     final DomRenderer renderer = DomRenderer();
     renderer.reset();
-  }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
-      skip: (browserEngine == BrowserEngine.firefox));
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50828
+      skip: (browserEngine == BrowserEngine.firefox ||
+          browserEngine == BrowserEngine.edge));
 
   test('accesibility placeholder is attached after creation', () {
     DomRenderer();
 
     expect(html.document.getElementsByTagName('flt-semantics-placeholder'),
-          isNotEmpty);
+        isNotEmpty);
   });
 }

--- a/lib/web_ui/test/engine/history_test.dart
+++ b/lib/web_ui/test/engine/history_test.dart
@@ -56,7 +56,9 @@ void main() {
 
       // The flutter entry is the current entry.
       expect(strategy.currentEntry, flutterEntry);
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50836
+        skip: browserEngine == BrowserEngine.edge);
 
     test('browser back button pops routes correctly', () async {
       strategy =
@@ -90,7 +92,9 @@ void main() {
       // The url of the current entry (flutter entry) should go back to /home.
       expect(strategy.currentEntry.state, flutterState);
       expect(strategy.currentEntry.url, '/home');
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50836
+        skip: browserEngine == BrowserEngine.edge);
 
     test('multiple browser back clicks', () async {
       strategy =
@@ -151,7 +155,9 @@ void main() {
       // 3. The active entry doesn't belong to our history anymore because we
       // navigated past it.
       expect(strategy.currentEntryIndex, -1);
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50836
+        skip: browserEngine == BrowserEngine.edge);
 
     test('handle user-provided url', () async {
       strategy =
@@ -190,7 +196,9 @@ void main() {
       expect(strategy.currentEntryIndex, 1);
       expect(strategy.currentEntry.state, flutterState);
       expect(strategy.currentEntry.url, '/home');
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50836
+        skip: browserEngine == BrowserEngine.edge);
 
     test('user types unknown url', () async {
       strategy =
@@ -212,7 +220,9 @@ void main() {
       expect(strategy.currentEntryIndex, 1);
       expect(strategy.currentEntry.state, flutterState);
       expect(strategy.currentEntry.url, '/home');
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50836
+        skip: browserEngine == BrowserEngine.edge);
   });
 }
 

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -63,7 +63,9 @@ void main() {
           desktopSemanticsEnabler.tryEnableSemantics(event);
 
       expect(shouldForwardToFramework, true);
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+        skip: browserEngine == BrowserEngine.edge);
 
     test(
         'Relevants events targeting placeholder should not be forwarded to the framework',

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -151,7 +151,7 @@ void main() {
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
         // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
-        skip: (browserEngine == BrowserEngine.firefox ||
-            browserEngine == BrowserEngine.webkit));
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+        skip: browserEngine != BrowserEngine.blink);
   });
 }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -159,7 +159,9 @@ void _testEngineSemanticsOwner() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('clears semantics tree when disabled', () {
     expect(semantics().debugSemanticsTree, isEmpty);
@@ -576,7 +578,9 @@ void _testHorizontalScrolling() {
     expect(scrollable.scrollLeft, 0);
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('scrollable node dispatches scroll events', () async {
     final SemanticsActionLogger logger = SemanticsActionLogger();

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -239,7 +239,9 @@ void _testHeader() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 }
 
 void _testLongestIncreasingSubsequence() {
@@ -325,7 +327,9 @@ void _testContainer() {
     expect(container.style.transformOrigin, '');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('container node compensates for rect offset', () async {
     semantics()
@@ -362,7 +366,9 @@ void _testContainer() {
     expect(container.style.transformOrigin, '0px 0px 0px');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 }
 
 void _testVerticalScrolling() {
@@ -386,7 +392,9 @@ void _testVerticalScrolling() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('scrollable node with children has a container node', () async {
     semantics()
@@ -420,7 +428,9 @@ void _testVerticalScrolling() {
     expect(scrollable.scrollTop, 0);
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('scrollable node dispatches scroll events', () async {
     final StreamController<int> idLogController = StreamController<int>();
@@ -503,8 +513,10 @@ void _testVerticalScrolling() {
 
     semantics().semanticsEnabled = false;
   },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-      skip: browserEngine == BrowserEngine.webkit);
+      skip: browserEngine == BrowserEngine.webkit ||
+          browserEngine == BrowserEngine.edge);
 }
 
 void _testHorizontalScrolling() {
@@ -528,7 +540,9 @@ void _testHorizontalScrolling() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('scrollable node with children has a container node', () async {
     semantics()
@@ -627,7 +641,9 @@ void _testHorizontalScrolling() {
     semantics().semanticsEnabled = false;
   },
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-      skip: browserEngine == BrowserEngine.webkit);
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.webkit ||
+          browserEngine == BrowserEngine.edge);
 }
 
 void _testIncrementables() {
@@ -653,7 +669,9 @@ void _testIncrementables() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('increments', () async {
     final SemanticsActionLogger logger = SemanticsActionLogger();
@@ -687,7 +705,9 @@ void _testIncrementables() {
     expect(await logger.actionLog.first, ui.SemanticsAction.increase);
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('decrements', () async {
     final SemanticsActionLogger logger = SemanticsActionLogger();
@@ -721,7 +741,9 @@ void _testIncrementables() {
     expect(await logger.actionLog.first, ui.SemanticsAction.decrease);
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders a node that can both increment and decrement', () async {
     semantics()
@@ -749,7 +771,9 @@ void _testIncrementables() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 }
 
 void _testTextField() {
@@ -775,7 +799,9 @@ void _testTextField() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   // TODO(yjbanov): this test will need to be adjusted for Safari when we add
   //                Safari testing.
@@ -812,8 +838,8 @@ void _testTextField() {
     semantics().semanticsEnabled = false;
   }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-      skip: (browserEngine == BrowserEngine.firefox ||
-          browserEngine == BrowserEngine.webkit));
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: (browserEngine != BrowserEngine.blink));
 }
 
 void _testCheckables() {
@@ -840,7 +866,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders a switched on disabled switch element', () async {
     semantics()
@@ -864,7 +892,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders a switched off switch element', () async {
     semantics()
@@ -888,7 +918,10 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
+
   test('renders a checked checkbox', () async {
     semantics()
       ..debugOverrideTimestampFunction(() => _testTime)
@@ -912,7 +945,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders a checked disabled checkbox', () async {
     semantics()
@@ -936,7 +971,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders an unchecked checkbox', () async {
     semantics()
@@ -960,7 +997,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders a checked radio button', () async {
     semantics()
@@ -986,7 +1025,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders a checked disabled radio button', () async {
     semantics()
@@ -1011,7 +1052,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders an unchecked checkbox', () async {
     semantics()
@@ -1036,7 +1079,9 @@ void _testCheckables() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 }
 
 void _testTappable() {
@@ -1063,7 +1108,9 @@ void _testTappable() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders a disabled tappable widget', () async {
     semantics()
@@ -1087,7 +1134,9 @@ void _testTappable() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 }
 
 void _testImage() {
@@ -1112,7 +1161,9 @@ void _testImage() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders an image with a child node and with a label', () async {
     semantics()
@@ -1142,7 +1193,9 @@ void _testImage() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders an image with no child nodes without a label', () async {
     semantics()
@@ -1163,7 +1216,9 @@ void _testImage() {
         '''<sem role="img" style="filter: opacity(0%); color: rgba(0, 0, 0, 0)"></sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('renders an image with a child node and without a label', () async {
     semantics()
@@ -1192,7 +1247,9 @@ void _testImage() {
 </sem>''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 }
 
 void _testLiveRegion() {
@@ -1217,7 +1274,9 @@ void _testLiveRegion() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 
   test('does not render a live region if there is no label', () async {
     semantics()
@@ -1239,7 +1298,9 @@ void _testLiveRegion() {
 ''');
 
     semantics().semanticsEnabled = false;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
+      skip: browserEngine == BrowserEngine.edge);
 }
 
 void expectSemanticsTree(String semanticsHtml) {

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -58,7 +58,9 @@ void main() {
       });
 
       Keyboard.instance.dispose();
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50815
+        skip: browserEngine == BrowserEngine.edge);
 
     test('dispatches keydown to flutter/keyevent channel', () {
       Keyboard.initialize();
@@ -87,7 +89,9 @@ void main() {
       expect(event.defaultPrevented, isFalse);
 
       Keyboard.instance.dispose();
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50815
+        skip: browserEngine == BrowserEngine.edge);
 
     test('dispatches correct meta state', () {
       Keyboard.initialize();
@@ -135,7 +139,9 @@ void main() {
       });
 
       Keyboard.instance.dispose();
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50815
+        skip: browserEngine == BrowserEngine.edge);
 
     test('dispatches repeat events', () {
       Keyboard.initialize();
@@ -186,7 +192,9 @@ void main() {
       ]);
 
       Keyboard.instance.dispose();
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50815
+        skip: browserEngine == BrowserEngine.edge);
 
     test('stops dispatching events after dispose', () {
       Keyboard.initialize();

--- a/lib/web_ui/test/paragraph_test.dart
+++ b/lib/web_ui/test/paragraph_test.dart
@@ -104,10 +104,11 @@ void main() async {
       expect(paragraph.minIntrinsicWidth, fontSize * 10.0);
       expect(paragraph.maxIntrinsicWidth, fontSize * 10.0);
     }
-  }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50771
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-      skip: (browserEngine == BrowserEngine.firefox ||
-          browserEngine == BrowserEngine.webkit));
+      skip: (browserEngine != BrowserEngine.blink));
 
   testEachMeasurement('predictably lays out a multi-line rich paragraph', () {
     for (double fontSize in <double>[10.0, 20.0, 30.0, 40.0]) {
@@ -129,10 +130,11 @@ void main() async {
       expect(paragraph.minIntrinsicWidth, fontSize * 5.0);
       expect(paragraph.maxIntrinsicWidth, fontSize * 16.0);
     }
-  }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-      skip: (browserEngine == BrowserEngine.firefox ||
-          browserEngine == BrowserEngine.webkit));
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50771
+      skip: (browserEngine != BrowserEngine.blink));
 
   testEachMeasurement('getPositionForOffset single-line', () {
     final ParagraphBuilder builder = ParagraphBuilder(ParagraphStyle(
@@ -328,7 +330,6 @@ void main() async {
       TextPosition(offset: 2, affinity: TextAffinity.upstream),
     );
 
-
     // Second line: "abcdefg\n"
 
     // At the beginning of the second line.
@@ -353,7 +354,6 @@ void main() async {
       paragraph.getPositionForOffset(Offset(15.0 + 46, 15)),
       TextPosition(offset: 10, affinity: TextAffinity.upstream),
     );
-
 
     // Last (third) line: "ab"
 

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -36,7 +36,9 @@ void main() {
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'Ahem');
-      });
+      },
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+          skip: browserEngine == BrowserEngine.edge);
 
       test('Register Asset with white space in the family name', () async {
         final String _testFontFamily = "Ahem ahem ahem";
@@ -52,7 +54,9 @@ void main() {
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'Ahem ahem ahem');
-      });
+      },
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+          skip: browserEngine == BrowserEngine.edge);
 
       test('Register Asset with capital case letters', () async {
         final String _testFontFamily = "AhEm";
@@ -68,7 +72,9 @@ void main() {
 
         expect(fontFamilyList.length, equals(1));
         expect(fontFamilyList.first, 'AhEm');
-      });
+      },
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+          skip: browserEngine == BrowserEngine.edge);
     });
 
     group('fonts with special characters', () {
@@ -92,7 +98,9 @@ void main() {
           expect(fontFamilyList.length, equals(1));
           expect(fontFamilyList.first, '\"/Ahem\"');
         }
-      });
+      },
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+          skip: browserEngine == BrowserEngine.edge);
 
       test('Register Asset twice with exclamation mark', () async {
         final String _testFontFamily = 'Ahem!!ahem';
@@ -114,7 +122,9 @@ void main() {
           expect(fontFamilyList.length, equals(1));
           expect(fontFamilyList.first, '\"Ahem!!ahem\"');
         }
-      });
+      },
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+          skip: browserEngine == BrowserEngine.edge);
 
       test('Register Asset twice with comma', () async {
         final String _testFontFamily = 'Ahem ,ahem';
@@ -136,7 +146,9 @@ void main() {
           expect(fontFamilyList.length, equals(1));
           expect(fontFamilyList.first, '\"Ahem ,ahem\"');
         }
-      });
+      },
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+          skip: browserEngine == BrowserEngine.edge);
 
       test('Register Asset twice with a digit at the start of a token',
           () async {
@@ -159,7 +171,9 @@ void main() {
           expect(fontFamilyList.length, equals(1));
           expect(fontFamilyList.first, '\"Ahem 1998\"');
         }
-      });
+      },
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+          skip: browserEngine == BrowserEngine.edge);
     });
   });
 }

--- a/lib/web_ui/test/text/font_loading_test.dart
+++ b/lib/web_ui/test/text/font_loading_test.dart
@@ -23,7 +23,9 @@ Future<void> main() async {
       await expectLater(
           ui.loadFontFromList(Uint8List(0), fontFamily: 'test-font'),
           throwsA(TypeMatcher<Exception>()));
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+        skip: browserEngine == BrowserEngine.edge);
 
     test('loads Blehm font from buffer', () async {
       expect(_containsFontFamily('Blehm'), false);
@@ -35,12 +37,15 @@ Future<void> main() async {
           fontFamily: 'Blehm');
 
       expect(_containsFontFamily('Blehm'), true);
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+        skip: browserEngine == BrowserEngine.edge);
 
     test('loading font should clear measurement caches', () async {
       final ui.ParagraphStyle style = ui.ParagraphStyle();
       final ui.ParagraphBuilder builder = ui.ParagraphBuilder(style);
-      final ui.ParagraphConstraints constraints = ui.ParagraphConstraints(width: 30.0);
+      final ui.ParagraphConstraints constraints =
+          ui.ParagraphConstraints(width: 30.0);
       builder.addText('test');
       final ui.Paragraph paragraph = builder.build();
       // Triggers the measuring and verifies the result has been cached.
@@ -50,35 +55,41 @@ Future<void> main() async {
       // Now, loads a new font using loadFontFromList. This should clear the
       // cache
       final html.HttpRequest response = await html.HttpRequest.request(
-        _testFontUrl,
-        responseType: 'arraybuffer');
+          _testFontUrl,
+          responseType: 'arraybuffer');
       await ui.loadFontFromList(Uint8List.view(response.response),
-        fontFamily: 'Blehm');
+          fontFamily: 'Blehm');
 
       // Verifies the font is loaded, and the cache is cleaned.
       expect(_containsFontFamily('Blehm'), true);
       expect(TextMeasurementService.rulerManager.rulers.length, 0);
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+        skip: browserEngine == BrowserEngine.edge);
 
     test('loading font should send font change message', () async {
       final ui.PlatformMessageCallback oldHandler = ui.window.onPlatformMessage;
       String actualName;
       String message;
-      window.onPlatformMessage = (String name, ByteData data, ui.PlatformMessageResponseCallback callback) {
+      window.onPlatformMessage = (String name, ByteData data,
+          ui.PlatformMessageResponseCallback callback) {
         actualName = name;
         final buffer = data.buffer;
-        final Uint8List list = buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
+        final Uint8List list =
+            buffer.asUint8List(data.offsetInBytes, data.lengthInBytes);
         message = utf8.decode(list);
       };
       final html.HttpRequest response = await html.HttpRequest.request(
-        _testFontUrl,
-        responseType: 'arraybuffer');
+          _testFontUrl,
+          responseType: 'arraybuffer');
       await ui.loadFontFromList(Uint8List.view(response.response),
-        fontFamily: 'Blehm');
+          fontFamily: 'Blehm');
       window.onPlatformMessage = oldHandler;
       expect(actualName, 'flutter/system');
       expect(message, '{"type":"fontsChange"}');
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
+        skip: browserEngine == BrowserEngine.edge);
   });
 }
 

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -409,7 +409,9 @@ void main() {
       editingElement.disable();
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: (browserEngine == BrowserEngine.webkit ||
+            browserEngine == BrowserEngine.edge));
 
     test('Does not dispose and recreate dom elements in persistent mode', () {
       editingElement =
@@ -448,7 +450,9 @@ void main() {
       expect(document.activeElement, document.body);
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: (browserEngine == BrowserEngine.webkit ||
+            browserEngine == BrowserEngine.edge));
 
     test('Refocuses when setting editing state', () {
       editingElement =
@@ -472,7 +476,9 @@ void main() {
       editingElement.disable();
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: (browserEngine == BrowserEngine.webkit ||
+            browserEngine == BrowserEngine.edge));
 
     test('Works in multi-line mode', () {
       final TextAreaElement textarea = TextAreaElement();
@@ -517,7 +523,9 @@ void main() {
       expect(document.activeElement, document.body);
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: (browserEngine == BrowserEngine.webkit ||
+            browserEngine == BrowserEngine.edge));
 
     test('Does not position or size its DOM element', () {
       editingElement.enable(
@@ -703,7 +711,9 @@ void main() {
       expect(document.getElementsByTagName('input'), hasLength(0));
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
-        skip: browserEngine == BrowserEngine.webkit);
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: (browserEngine == BrowserEngine.webkit ||
+            browserEngine == BrowserEngine.edge));
 
     test('setClient, setEditingState, show, setClient', () {
       final MethodCall setClient = MethodCall(

--- a/lib/web_ui/test/text_editing_test.dart
+++ b/lib/web_ui/test/text_editing_test.dart
@@ -306,7 +306,9 @@ void main() {
         keyCode: _kReturnKeyCode,
       );
       expect(lastInputAction, 'TextInputAction.done');
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: browserEngine == BrowserEngine.edge);
 
     test('Does not trigger input action in multi-line mode', () {
       final InputConfiguration config = InputConfiguration(
@@ -356,7 +358,8 @@ void main() {
       ));
 
       // setEditableSizeAndTransform calls placeElement, so expecting geometry to be applied.
-      expect(editingElement.domElement.style.transform, 'matrix(1, 0, 0, 1, 14, 15)');
+      expect(editingElement.domElement.style.transform,
+          'matrix(1, 0, 0, 1, 14, 15)');
       expect(editingElement.domElement.style.width, '13px');
       expect(editingElement.domElement.style.height, '12px');
     });
@@ -1163,7 +1166,9 @@ void main() {
         call.arguments,
         <dynamic>[clientId, 'TextInputAction.next'],
       );
-    });
+    },
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+        skip: browserEngine == BrowserEngine.edge);
 
     test('does not send input action in multi-line mode', () {
       showKeyboard(

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -364,7 +364,7 @@ void main() async {
     // The nested span here should not set it's family to default sans-serif.
     expect(spans[1].style.fontFamily, 'Ahem, Arial, sans-serif');
   },
-      // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50771
       // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
       skip: (browserEngine == BrowserEngine.firefox ||
           browserEngine == BrowserEngine.edge));
@@ -386,7 +386,7 @@ void main() async {
 
     debugEmulateFlutterTesterEnvironment = true;
   },
-      // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50771
       // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
       skip: (browserEngine == BrowserEngine.firefox ||
           browserEngine == BrowserEngine.edge));

--- a/lib/web_ui/test/text_test.dart
+++ b/lib/web_ui/test/text_test.dart
@@ -363,8 +363,11 @@ void main() async {
     expect(spans[0].style.fontFamily, 'Ahem, Arial, sans-serif');
     // The nested span here should not set it's family to default sans-serif.
     expect(spans[1].style.fontFamily, 'Ahem, Arial, sans-serif');
-  }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
-      skip: (browserEngine == BrowserEngine.firefox));
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
+      skip: (browserEngine == BrowserEngine.firefox ||
+          browserEngine == BrowserEngine.edge));
 
   test('adds Arial and sans-serif as fallback fonts', () {
     // Set this to false so it doesn't default to 'Ahem' font.
@@ -382,8 +385,11 @@ void main() async {
         'SomeFont, Arial, sans-serif');
 
     debugEmulateFlutterTesterEnvironment = true;
-  }, // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
-      skip: (browserEngine == BrowserEngine.firefox));
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50769
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/46638
+      skip: (browserEngine == BrowserEngine.firefox ||
+          browserEngine == BrowserEngine.edge));
 
   test('does not add fallback fonts to generic families', () {
     // Set this to false so it doesn't default to 'Ahem' font.
@@ -418,7 +424,9 @@ void main() async {
         '"MyFont 2000", Arial, sans-serif');
 
     debugEmulateFlutterTesterEnvironment = true;
-  });
+  },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50771
+      skip: browserEngine == BrowserEngine.edge);
 
   group('TextRange', () {
     test('empty ranges are correct', () {


### PR DESCRIPTION
skip failing test methods on Edge. make Egde default for testing on windows. (I only changed the windows bat file so this won't effect other cirrus/LUCI tests in anyway)

the skipped tests are added to this project: https://github.com/flutter/flutter/projects/114

The Edge tests will start running on LUCI, the results can be seen under: Windows Web Engine 

