### PR TITLE
Increasing memory for web test shards.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,7 +5,7 @@ web_shard_template: &WEB_SHARD_TEMPLATE
   environment:
     # As of October 2019, the Web shards needed more than 6G of RAM.
     CPU: 2
-    MEMORY: 8G
+    MEMORY: 10G
   compile_host_script: |
     cd $ENGINE_PATH/src
     ./flutter/tools/gn --unoptimized --full-dart-sdk


### PR DESCRIPTION
The web tests are flaky, the fail sometime due to a not-found tmp file.

I'll try to increase the memory to see if it helps.