### PR TITLE
Add more child lifecycle tests

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -50,6 +50,15 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
     return surface;
   }
 
+  /// Adds [surface] to the surface tree.
+  ///
+  /// This is used by tests.
+  void debugAddSurface(PersistedSurface surface) {
+    if (assertionsEnabled) {
+      _addSurface(surface);
+    }
+  }
+
   void _addSurface(PersistedSurface surface) {
     _adoptSurface(surface);
   }


### PR DESCRIPTION
Add tests that check what happens to a child when its parent is moved around the tree or is retained. For example, we check that the child is not accidentally discarded during the move.

This is not fixing any bugs. I just realized, while trying to reproduce an unrelated bug, that our tests were not covering this scenario.