### PR TITLE
Fix FlutterPlugin doc param reference

### DIFF
--- a/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterPlugin.h
@@ -311,7 +311,7 @@ typedef enum {
  * @param factory The view factory that will be registered.
  * @param factoryId A unique identifier for the factory, the Dart code of the Flutter app can use
  *   this identifier to request creation of a `UIView` by the registered factory.
- * @param gestureBlockingPolicy How UIGestureRecognizers on the platform views are
+ * @param gestureRecognizersBlockingPolicy How UIGestureRecognizers on the platform views are
  * blocked.
  *
  */


### PR DESCRIPTION
Caught in g3 roll static analysis