### PR TITLE
[runner] Corrects logging of close() status

### DIFF
--- a/shell/platform/fuchsia/flutter/runner.cc
+++ b/shell/platform/fuchsia/flutter/runner.cc
@@ -75,7 +75,7 @@ bool InitializeTZData() {
                   << strerror(errno);
     return false;
   }
-  if (!close(fd)) {
+  if (close(fd)) {
     FML_LOG(WARNING) << "Could not close: " << tzdata_dir << ": "
                      << strerror(errno);
   }


### PR DESCRIPTION
close() returns a nonzero in case of an error.  Old code had it log
only when *no* error happens on close, which is exactly the opposite
of what we want.