### PR TITLE
[i18n] Deprecates fuchsia.timezone.Timezone

### DIFF
--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
@@ -9,13 +9,13 @@
       "root-ssl-certificates"
     ],
     "services": [
+      "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",
-      "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
@@ -9,13 +9,13 @@
       "root-ssl-certificates"
     ],
     "services": [
+      "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
       "fuchsia.net.NameLookup",
       "fuchsia.netstack.Netstack",
       "fuchsia.posix.socket.Provider",
-      "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_product_runner.cmx
@@ -9,6 +9,7 @@
       "root-ssl-certificates"
     ],
     "services": [
+      "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
@@ -17,7 +18,6 @@
       "fuchsia.posix.socket.Provider",
       "fuchsia.process.Launcher",
       "fuchsia.process.Resolver",
-      "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry"
     ]
   }

--- a/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_jit_runner.cmx
@@ -9,6 +9,7 @@
       "root-ssl-certificates"
     ],
     "services": [
+      "fuchsia.deprecatedtimezone.Timezone",
       "fuchsia.feedback.CrashReporter",
       "fuchsia.intl.PropertyProvider",
       "fuchsia.logger.LogSink",
@@ -17,7 +18,6 @@
       "fuchsia.posix.socket.Provider",
       "fuchsia.process.Launcher",
       "fuchsia.process.Resolver",
-      "fuchsia.timezone.Timezone",
       "fuchsia.tracing.provider.Registry"
     ]
   }


### PR DESCRIPTION
The FIDL interface `fuchsia.timezone.Timezone` does not exist for quite
a while now.  Instead, a transitional `fuchsia.timezone.Timezone` should
be used.

Fixes flutter/flutter#51087