### PR TITLE
fix underline lineThrough and overline display exception, in the case…

### DIFF
--- a/third_party/txt/src/txt/paragraph_txt.h
+++ b/third_party/txt/src/txt/paragraph_txt.h
@@ -192,6 +192,14 @@ class ParagraphTxt : public Paragraph {
   // Stores the result of Layout().
   std::vector<PaintRecord> records_;
 
+  // Values for adjust the underline lineThrough and overline, in the case of
+  // multiple fonts.
+  SkScalar underline_y_offset_;
+  SkScalar line_through_y_offset_;
+  SkScalar overline_y_offset_;
+  SkScalar underline_thickness_;
+  SkScalar strikeout_thickness_;
+
   bool did_exceed_max_lines_;
 
   // Strut metrics of zero will have no effect on the layout.
@@ -383,6 +391,9 @@ class ParagraphTxt : public Paragraph {
   void PaintDecorations(SkCanvas* canvas,
                         const PaintRecord& record,
                         SkPoint base_offset);
+  // adjust values for the underline lineThrough and overline, in the case of
+  // multiple fonts.
+  void AdjustDecorationValues();
 
   // Computes the beziers for a wavy decoration. The results will be
   // applied to path.


### PR DESCRIPTION
Fix underline lineThrough and overline display exception, in the case of multiple fonts

https://github.com/flutter/flutter/issues/42833

before fix:
![image](https://user-images.githubusercontent.com/3382181/74958909-a7538780-5444-11ea-8f51-504262393ae1.png)

In image before， the text contain of Chinese and english, and them use different fonts.

alfter fix:
![image](https://user-images.githubusercontent.com/3382181/74958939-b803fd80-5444-11ea-8c07-f8f4f3d63904.png)


Test code as fellow:

```
child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            Padding(
              padding: const EdgeInsets.all(8.0),
              child: Text(
                '你好？。@english 英语', style: TextStyle(decoration: TextDecoration.underline, fontSize: 20),
              ),
            ),
            Padding(
              padding: const EdgeInsets.all(8.0),
              child: Text(
                '你好？。@english 英语', style: TextStyle(decoration: TextDecoration.lineThrough, fontSize: 20),
              ),
            ),
            Padding(
              padding: const EdgeInsets.all(8.0),
              child: Text(
                '你好？。@english 英语', style: TextStyle(decoration: TextDecoration.overline, fontSize: 20),
              ),
            ),
            Padding(
              padding: const EdgeInsets.all(8.0),
              child: Text(
                '你好？。@english 英语', style: TextStyle(decoration: TextDecoration.underline, fontSize: 20, decorationStyle: TextDecorationStyle.double),
              ),
            ),
            Padding(
              padding: const EdgeInsets.all(8.0),
              child: Text(
                '你好？。@english 英语', style: TextStyle(decoration: TextDecoration.lineThrough, fontSize: 20, decorationStyle: TextDecorationStyle.double),
              ),
            ),
            Padding(
              padding: const EdgeInsets.all(8.0),
              child: Text(
                '你好？。@english 英语', style: TextStyle(decoration: TextDecoration.overline, fontSize: 20, decorationStyle: TextDecorationStyle.double),
              ),
            ),

          ],
        ),
```
