### PR TITLE
[web] Running safari tests on LUCI

### DIFF
--- a/lib/web_ui/test/engine/history_test.dart
+++ b/lib/web_ui/test/engine/history_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 // @dart = 2.6
+@TestOn('vm && linux')
+
 import 'dart:async';
 import 'dart:typed_data';
 
@@ -158,7 +160,8 @@ void main() {
       expect(strategy.currentEntryIndex, -1);
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50836
-        skip: browserEngine == BrowserEngine.edge);
+        skip: browserEngine == BrowserEngine.edge ||
+            browserEngine == BrowserEngine.webkit);
 
     test('handle user-provided url', () async {
       strategy =

--- a/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_helper_test.dart
@@ -59,11 +59,14 @@ void main() {
 
       expect(shouldForwardToFramework, true);
 
-      event = html.PointerEvent('pointermove');
-      shouldForwardToFramework =
-          desktopSemanticsEnabler.tryEnableSemantics(event);
+      // Pointer events are not defined in webkit.
+      if (browserEngine != BrowserEngine.webkit) {
+        event = html.PointerEvent('pointermove');
+        shouldForwardToFramework =
+            desktopSemanticsEnabler.tryEnableSemantics(event);
 
-      expect(shouldForwardToFramework, true);
+        expect(shouldForwardToFramework, true);
+      }
     },
         // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
         skip: browserEngine == BrowserEngine.edge);

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -25,10 +25,6 @@ void main() {
     EngineSemanticsOwner.debugResetSemantics();
   });
 
-  tearDown(() {
-    clearSemanticsDomElementIfExists();
-  });
-
   group(EngineSemanticsOwner, () {
     _testEngineSemanticsOwner();
   });
@@ -400,8 +396,10 @@ void _testVerticalScrolling() {
 
     semantics().semanticsEnabled = false;
   },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.webkit ||
+          browserEngine == BrowserEngine.edge);
 
   test('scrollable node with children has a container node', () async {
     semantics()
@@ -436,8 +434,10 @@ void _testVerticalScrolling() {
 
     semantics().semanticsEnabled = false;
   },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.webkit ||
+          browserEngine == BrowserEngine.edge);
 
   test('scrollable node dispatches scroll events', () async {
     final StreamController<int> idLogController = StreamController<int>();
@@ -548,8 +548,10 @@ void _testHorizontalScrolling() {
 
     semantics().semanticsEnabled = false;
   },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.webkit ||
+          browserEngine == BrowserEngine.edge);
 
   test('scrollable node with children has a container node', () async {
     semantics()
@@ -584,8 +586,10 @@ void _testHorizontalScrolling() {
 
     semantics().semanticsEnabled = false;
   },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.webkit ||
+          browserEngine == BrowserEngine.edge);
 
   test('scrollable node dispatches scroll events', () async {
     final SemanticsActionLogger logger = SemanticsActionLogger();
@@ -1355,14 +1359,4 @@ class SemanticsActionLogger {
       });
     };
   }
-}
-
-/// In case of an exception semantics DOM element(s) can still stay on the DOM.
-void clearSemanticsDomElementIfExists() {
-  List<html.Node> domElementsToRemove = List<html.Node>();
-  if (html.document.getElementsByTagName('flt-semantics').length > 0) {
-    domElementsToRemove
-      ..addAll(html.document.getElementsByTagName('flt-semantics'));
-  }
-  domElementsToRemove.forEach((html.Node n) => n.remove());
 }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -25,6 +25,10 @@ void main() {
     EngineSemanticsOwner.debugResetSemantics();
   });
 
+  tearDown(() {
+    clearSemanticsDomElementIfExists();
+  });
+
   group(EngineSemanticsOwner, () {
     _testEngineSemanticsOwner();
   });
@@ -1351,4 +1355,14 @@ class SemanticsActionLogger {
       });
     };
   }
+}
+
+/// In case of an exception semantics DOM element(s) can still stay on the DOM.
+void clearSemanticsDomElementIfExists() {
+  List<html.Node> domElementsToRemove = List<html.Node>();
+  if (html.document.getElementsByTagName('flt-semantics').length > 0) {
+    domElementsToRemove
+      ..addAll(html.document.getElementsByTagName('flt-semantics'));
+  }
+  domElementsToRemove.forEach((html.Node n) => n.remove());
 }

--- a/lib/web_ui/test/engine/semantics/semantics_test.dart
+++ b/lib/web_ui/test/engine/semantics/semantics_test.dart
@@ -1148,8 +1148,10 @@ void _testTappable() {
 
     semantics().semanticsEnabled = false;
   },
+      // TODO(nurhan): https://github.com/flutter/flutter/issues/50590
       // TODO(nurhan): https://github.com/flutter/flutter/issues/50754
-      skip: browserEngine == BrowserEngine.edge);
+      skip: browserEngine == BrowserEngine.webkit ||
+          browserEngine == BrowserEngine.edge);
 }
 
 void _testImage() {

--- a/lib/web_ui/test/text/font_collection_test.dart
+++ b/lib/web_ui/test/text/font_collection_test.dart
@@ -57,7 +57,9 @@ void main() {
         expect(fontFamilyList.first, 'Ahem ahem ahem');
       },
           // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
-          skip: browserEngine == BrowserEngine.edge);
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/51142
+          skip: browserEngine == BrowserEngine.edge ||
+              browserEngine == BrowserEngine.webkit);
 
       test('Register Asset with capital case letters', () async {
         final String _testFontFamily = "AhEm";
@@ -101,7 +103,9 @@ void main() {
         }
       },
           // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
-          skip: browserEngine == BrowserEngine.edge);
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/51142
+          skip: browserEngine == BrowserEngine.edge ||
+              browserEngine == BrowserEngine.webkit);
 
       test('Register Asset twice with exclamation mark', () async {
         final String _testFontFamily = 'Ahem!!ahem';
@@ -125,7 +129,9 @@ void main() {
         }
       },
           // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
-          skip: browserEngine == BrowserEngine.edge);
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/51142
+          skip: browserEngine == BrowserEngine.edge ||
+              browserEngine == BrowserEngine.webkit);
 
       test('Register Asset twice with comma', () async {
         final String _testFontFamily = 'Ahem ,ahem';
@@ -149,7 +155,9 @@ void main() {
         }
       },
           // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
-          skip: browserEngine == BrowserEngine.edge);
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/51142
+          skip: browserEngine == BrowserEngine.edge ||
+              browserEngine == BrowserEngine.webkit);
 
       test('Register Asset twice with a digit at the start of a token',
           () async {
@@ -174,7 +182,9 @@ void main() {
         }
       },
           // TODO(nurhan): https://github.com/flutter/flutter/issues/50770
-          skip: browserEngine == BrowserEngine.edge);
+          // TODO(nurhan): https://github.com/flutter/flutter/issues/51142
+          skip: browserEngine == BrowserEngine.edge ||
+              browserEngine == BrowserEngine.webkit);
     });
   });
 }


### PR DESCRIPTION
- Safari font collection tests skip failing methods
- Semantics_test skip failing method.
- Semantics_helper test fix the failing method (no pointer events in Safari)
- disable history_test.dart (it took 8-9 minutes to run we should investigate more).

Tests can run on LUCI now. Successful run: https://chromium-swarm.appspot.com/task?id=4a7efb301d71cb10