### PR TITLE
[web] Rename LineMetrics.text to LineMetrics.displayText

### DIFF
--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -447,7 +447,7 @@ class BitmapCanvas extends EngineCanvas {
     x += line.left;
     final double letterSpacing = style.letterSpacing;
     if (letterSpacing == null || letterSpacing == 0.0) {
-      ctx.fillText(line.text, x, y);
+      ctx.fillText(line.displayText, x, y);
     } else {
       // When letter-spacing is set, we go through a more expensive code path
       // that renders each character separately with the correct spacing
@@ -459,9 +459,9 @@ class BitmapCanvas extends EngineCanvas {
       // would put 5px before each letter and 5px after it, but on the web, we
       // put no spacing before the letter and 10px after it. This is how the DOM
       // does it.
-      final int len = line.text.length;
+      final int len = line.displayText.length;
       for (int i = 0; i < len; i++) {
-        final String char = line.text[i];
+        final String char = line.displayText[i];
         ctx.fillText(char, x, y);
         x += letterSpacing + ctx.measureText(char).width;
       }

--- a/lib/web_ui/lib/src/engine/text/paragraph.dart
+++ b/lib/web_ui/lib/src/engine/text/paragraph.dart
@@ -16,13 +16,13 @@ class EngineLineMetrics implements ui.LineMetrics {
     this.left,
     this.baseline,
     this.lineNumber,
-  })  : text = null,
+  })  : displayText = null,
         startIndex = -1,
         endIndex = -1,
         endIndexWithoutNewlines = -1;
 
   EngineLineMetrics.withText(
-    this.text, {
+    this.displayText, {
     @required this.startIndex,
     @required this.endIndex,
     @required this.endIndexWithoutNewlines,
@@ -35,7 +35,7 @@ class EngineLineMetrics implements ui.LineMetrics {
     @required this.left,
     this.baseline,
     @required this.lineNumber,
-  })  : assert(text != null),
+  })  : assert(displayText != null),
         assert(startIndex != null),
         assert(endIndex != null),
         assert(endIndexWithoutNewlines != null),
@@ -44,8 +44,8 @@ class EngineLineMetrics implements ui.LineMetrics {
         assert(left != null),
         assert(lineNumber != null && lineNumber >= 0);
 
-  /// The textual content representing this line.
-  final String text;
+  /// The text to be rendered on the screen representing this line.
+  final String displayText;
 
   /// The index (inclusive) in the text where this line begins.
   final int startIndex;
@@ -89,7 +89,7 @@ class EngineLineMetrics implements ui.LineMetrics {
 
   @override
   int get hashCode => ui.hashValues(
-        text,
+        displayText,
         startIndex,
         endIndex,
         hardBreak,
@@ -113,7 +113,7 @@ class EngineLineMetrics implements ui.LineMetrics {
       return false;
     }
     final EngineLineMetrics typedOther = other;
-    return text == typedOther.text &&
+    return displayText == typedOther.displayText &&
         startIndex == typedOther.startIndex &&
         endIndex == typedOther.endIndex &&
         hardBreak == typedOther.hardBreak &&

--- a/lib/web_ui/test/text/measurement_test.dart
+++ b/lib/web_ui/test/text/measurement_test.dart
@@ -1138,7 +1138,7 @@ void main() async {
 
 /// Shortcut to avoid many line wraps in the tests above.
 EngineLineMetrics line(
-  String text,
+  String displayText,
   int startIndex,
   int endIndex, {
   double width,
@@ -1147,7 +1147,7 @@ EngineLineMetrics line(
   double left,
 }) {
   return EngineLineMetrics.withText(
-    text,
+    displayText,
     startIndex: startIndex,
     endIndex: endIndex,
     hardBreak: hardBreak,


### PR DESCRIPTION
Calling it `text` was a little confusing since it doesn't always contain the exact substring from the paragraph. It's really just the text that will be rendered, so it includes ellipsis, for example when the line overflows.