### PR TITLE
Revert "Enable lazy-async-stacks by-default in all modes"

### DIFF
--- a/runtime/dart_vm.cc
+++ b/runtime/dart_vm.cc
@@ -60,8 +60,7 @@ static const char* kDartLanguageArgs[] = {
     // clang-format off
     "--enable_mirrors=false",
     "--background_compilation",
-    "--no-causal_async_stacks",
-    "--lazy_async_stacks",
+    "--causal_async_stacks",
     // clang-format on
 };
 

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -281,20 +281,16 @@ TEST_F(ShellTest, BlacklistedDartVMFlag) {
 TEST_F(ShellTest, WhitelistedDartVMFlag) {
   const std::vector<fml::CommandLine::Option> options = {
       fml::CommandLine::Option("dart-flags",
-                               "--lazy_async_stacks,--no-causal_async_stacks,"
                                "--max_profile_depth 1,--random_seed 42")};
   fml::CommandLine command_line("", options, std::vector<std::string>());
   flutter::Settings settings = flutter::SettingsFromCommandLine(command_line);
 
-  EXPECT_GE(settings.dart_flags.size(), 2u);
-  EXPECT_EQ(settings.dart_flags[0], "--lazy_async_stacks");
-  EXPECT_EQ(settings.dart_flags[1], "--no-causal_async_stacks");
 #if !FLUTTER_RELEASE
-  EXPECT_EQ(settings.dart_flags.size(), 4u);
-  EXPECT_EQ(settings.dart_flags[2], "--max_profile_depth 1");
-  EXPECT_EQ(settings.dart_flags[3], "--random_seed 42");
-#else
   EXPECT_EQ(settings.dart_flags.size(), 2u);
+  EXPECT_EQ(settings.dart_flags[0], "--max_profile_depth 1");
+  EXPECT_EQ(settings.dart_flags[1], "--random_seed 42");
+#else
+  EXPECT_EQ(settings.dart_flags.size(), 0u);
 #endif
 }
 

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -41,8 +41,8 @@ struct SwitchDesc {
 
 // clang-format off
 static const std::string gDartFlagsWhitelist[] = {
-    "--lazy_async_stacks",
     "--no-causal_async_stacks",
+    "--lazy_async_stacks",
 };
 // clang-format on
 

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -35,7 +35,8 @@ namespace {
 
 const char* kDartVMArgs[] = {
     // clang-format off
-    "--lazy_async_stacks",
+    // TODO(FL-117): Re-enable causal async stack traces when this issue is
+    // addressed.
     "--no_causal_async_stacks",
 
 #if !defined(FLUTTER_PROFILE)

--- a/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/embedder/BUILD.gn
@@ -53,7 +53,6 @@ template("create_aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=vm-aot-assembly",
       "--assembly=" + rebase_path(snapshot_assembly),

--- a/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/kernel/BUILD.gn
@@ -71,8 +71,9 @@ template("create_kernel_core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
+      # TODO(FL-117): Re-enable causal async stack traces when this issue is
+      # addressed.
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",

--- a/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
+++ b/shell/platform/fuchsia/dart_runner/vmservice/BUILD.gn
@@ -64,7 +64,6 @@ template("aot_snapshot") {
 
     args = [
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(snapshot_path),

--- a/shell/platform/fuchsia/flutter/component.cc
+++ b/shell/platform/fuchsia/flutter/component.cc
@@ -353,6 +353,10 @@ Application::Application(
   settings_.task_observer_remove = std::bind(
       &CurrentMessageLoopRemoveAfterTaskObserver, std::placeholders::_1);
 
+  // TODO(FL-117): Re-enable causal async stack traces when this issue is
+  // addressed.
+  settings_.dart_flags = {"--no_causal_async_stacks"};
+
   // Disable code collection as it interferes with JIT code warmup
   // by decreasing usage counters and flushing code which is still useful.
   settings_.dart_flags.push_back("--no-collect_code");

--- a/shell/platform/fuchsia/flutter/kernel/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/kernel/BUILD.gn
@@ -75,8 +75,9 @@ template("core_snapshot") {
     tool = gen_snapshot_to_use
 
     args = [
+      # TODO(FL-117): Re-enable causal async stack traces when this issue is
+      # addressed.
       "--no_causal_async_stacks",
-      "--lazy_async_stacks",
       "--use_bytecode_compiler",
       "--enable_mirrors=false",
       "--deterministic",

--- a/testing/scenario_app/compile_ios_jit.sh
+++ b/testing/scenario_app/compile_ios_jit.sh
@@ -48,8 +48,7 @@ echo "Compiling JIT Snapshot..."
 
 "$DEVICE_TOOLS/gen_snapshot" --deterministic \
   --enable-asserts \
-  --no-causal_async_stacks \
-  --lazy_async_stacks \
+  --causal_async_stacks \
   --isolate_snapshot_instructions="$OUTDIR/isolate_snapshot_instr" \
   --snapshot_kind=app-jit \
   --load_vm_snapshot_data="$DEVICE_TOOLS/../gen/flutter/lib/snapshot/vm_isolate_snapshot.bin" \

--- a/testing/testing.gni
+++ b/testing/testing.gni
@@ -138,8 +138,7 @@ template("dart_snapshot_aot") {
     ]
 
     args = [
-      "--no-causal_async_stacks",
-      "--lazy_async_stacks",
+      "--causal_async_stacks",
       "--deterministic",
       "--snapshot_kind=app-aot-elf",
       "--elf=" + rebase_path(elf_object),


### PR DESCRIPTION
Reverts flutter/engine#16556

This is believed to be the cause of the failures seen in the engine roll in expression_evaluation_test.dart

@jason-simmons @mkustermann @jonahwilliams 