### PR TITLE
[web] Guard the remaining calls to window.onPlatformMessage

### DIFF
--- a/lib/web_ui/lib/src/engine/history.dart
+++ b/lib/web_ui/lib/src/engine/history.dart
@@ -94,11 +94,13 @@ class BrowserHistory {
       _setupFlutterEntry(_locationStrategy);
 
       // 2. Send a 'popRoute' platform message so the app can handle it accordingly.
-      ui.window.onPlatformMessage(
-        'flutter/navigation',
-        const JSONMethodCodec().encodeMethodCall(_popRouteMethodCall),
-        (_) {},
-      );
+      if (ui.window.onPlatformMessage != null) {
+        ui.window.onPlatformMessage(
+          'flutter/navigation',
+          const JSONMethodCodec().encodeMethodCall(_popRouteMethodCall),
+          (_) {},
+        );
+      }
     } else if (_isFlutterEntry(event.state)) {
       // We get into this scenario when the user changes the url manually. It
       // causes a new entry to be pushed on top of our "flutter" one. When this
@@ -111,13 +113,15 @@ class BrowserHistory {
       _userProvidedRouteName = null;
 
       // Send a 'pushRoute' platform message so the app handles it accordingly.
-      ui.window.onPlatformMessage(
-        'flutter/navigation',
-        const JSONMethodCodec().encodeMethodCall(
-          MethodCall('pushRoute', newRouteName),
-        ),
-        (_) {},
-      );
+      if (ui.window.onPlatformMessage != null) {
+        ui.window.onPlatformMessage(
+          'flutter/navigation',
+          const JSONMethodCodec().encodeMethodCall(
+            MethodCall('pushRoute', newRouteName),
+          ),
+          (_) {},
+        );
+      }
     } else {
       // The user has pushed a new entry on top of our flutter entry. This could
       // happen when the user modifies the hash part of the url directly, for

--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -68,6 +68,10 @@ class Keyboard {
   static const JSONMessageCodec _messageCodec = JSONMessageCodec();
 
   void _handleHtmlEvent(html.KeyboardEvent event) {
+    if (ui.window.onPlatformMessage == null) {
+      return;
+    }
+
     if (_shouldIgnoreEvent(event)) {
       return;
     }

--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -819,44 +819,50 @@ class TextEditingChannel {
 
   /// Sends the 'TextInputClient.updateEditingState' message to the framework.
   void updateEditingState(int clientId, EditingState editingState) {
-    ui.window.onPlatformMessage(
-      'flutter/textinput',
-      const JSONMethodCodec().encodeMethodCall(
-        MethodCall('TextInputClient.updateEditingState', <dynamic>[
-          clientId,
-          editingState.toFlutter(),
-        ]),
-      ),
-      _emptyCallback,
-    );
+    if (ui.window.onPlatformMessage != null) {
+      ui.window.onPlatformMessage(
+        'flutter/textinput',
+        const JSONMethodCodec().encodeMethodCall(
+          MethodCall('TextInputClient.updateEditingState', <dynamic>[
+            clientId,
+            editingState.toFlutter(),
+          ]),
+        ),
+        _emptyCallback,
+      );
+    }
   }
 
   /// Sends the 'TextInputClient.performAction' message to the framework.
   void performAction(int clientId, String inputAction) {
-    ui.window.onPlatformMessage(
-      'flutter/textinput',
-      const JSONMethodCodec().encodeMethodCall(
-        MethodCall(
-          'TextInputClient.performAction',
-          <dynamic>[clientId, inputAction],
+    if (ui.window.onPlatformMessage != null) {
+      ui.window.onPlatformMessage(
+        'flutter/textinput',
+        const JSONMethodCodec().encodeMethodCall(
+          MethodCall(
+            'TextInputClient.performAction',
+            <dynamic>[clientId, inputAction],
+          ),
         ),
-      ),
-      _emptyCallback,
-    );
+        _emptyCallback,
+      );
+    }
   }
 
   /// Sends the 'TextInputClient.onConnectionClosed' message to the framework.
   void onConnectionClosed(int clientId) {
-    ui.window.onPlatformMessage(
-      'flutter/textinput',
-      const JSONMethodCodec().encodeMethodCall(
-        MethodCall(
-          'TextInputClient.onConnectionClosed',
-          <dynamic>[clientId],
+    if (ui.window.onPlatformMessage != null) {
+      ui.window.onPlatformMessage(
+        'flutter/textinput',
+        const JSONMethodCodec().encodeMethodCall(
+          MethodCall(
+            'TextInputClient.onConnectionClosed',
+            <dynamic>[clientId],
+          ),
         ),
-      ),
-      _emptyCallback,
-    );
+        _emptyCallback,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
From time to time, I see errors in the console caused by `window.onPlatformMessage` being null. Some of these calls are already guarded, and some are not. This PR is guarding all the remaining ones so there's no unguarded calls to `window.onPlatformMessage`.