### PR TITLE
Fix stale physicalSize on resize event

### DIFF
--- a/lib/web_ui/lib/src/engine/dom_renderer.dart
+++ b/lib/web_ui/lib/src/engine/dom_renderer.dart
@@ -472,6 +472,7 @@ flt-glass-pane * {
 
   /// Called immediately after browser window metrics change.
   void _metricsDidChange(html.Event event) {
+    window._computePhysicalSize();
     if (ui.window.onMetricsChanged != null) {
       ui.window.onMetricsChanged();
     }

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -48,12 +48,11 @@ class EngineWindow extends ui.Window {
 
   @override
   ui.Size get physicalSize {
-    if (_physicalSize?.value == null) {
+    if (_physicalSize == null) {
       _computePhysicalSize();
     }
     assert(_physicalSize != null);
-    assert(_physicalSize.value != null);
-    return _physicalSize.value;
+    return _physicalSize;
   }
 
   /// Computes the physical size of the screen from [html.window].
@@ -65,7 +64,7 @@ class EngineWindow extends ui.Window {
 
     assert(() {
       if (webOnlyDebugPhysicalSizeOverride != null) {
-        _physicalSize = FrameReference<ui.Size>(webOnlyDebugPhysicalSizeOverride);
+        _physicalSize = webOnlyDebugPhysicalSizeOverride;
         override = true;
       }
       return true;
@@ -82,15 +81,15 @@ class EngineWindow extends ui.Window {
         windowInnerWidth = html.window.innerWidth * devicePixelRatio;
         windowInnerHeight = html.window.innerHeight * devicePixelRatio;
       }
-      _physicalSize = FrameReference<ui.Size>(ui.Size(
+      _physicalSize = ui.Size(
         windowInnerWidth,
         windowInnerHeight,
-      ));
+      );
     }
   }
 
   /// Lazily populated and cleared at the end of the frame.
-  FrameReference<ui.Size> _physicalSize;
+  ui.Size _physicalSize;
 
   /// Overrides the value of [physicalSize] in tests.
   ui.Size webOnlyDebugPhysicalSizeOverride;


### PR DESCRIPTION
FrameReference outside frame loop causes physicalSize read on onMetricsChanged to read stale value. This change stops using FrameReference instead caches locally and forces cache update when resize event is handled.
Issue: https://github.com/flutter/flutter/issues/50797