### PR TITLE
[WIP] [fuchsia] Add component runner v2 dep

### DIFF
--- a/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
+++ b/shell/platform/fuchsia/flutter/engine_flutter_runner.gni
@@ -111,6 +111,7 @@ template("flutter_runner") {
 
     deps = [
              "$fuchsia_sdk_root/fidl:fuchsia.accessibility.semantics",
+             "$fuchsia_sdk_root/fidl:fuchsia.component.runner",
              "$fuchsia_sdk_root/fidl:fuchsia.fonts",
              "$fuchsia_sdk_root/fidl:fuchsia.images",
              "$fuchsia_sdk_root/fidl:fuchsia.intl",


### PR DESCRIPTION
This is an example to show fidl gen. The generated cpp files will be in the `out` dir after building. Like so: 

`./flutter/tools/fuchsia/build_fuchsia_artifacts.py --archs=x64 --no-lto --runtime-mode=release`

Here are the sample generated filed:

```
./out/fuchsia_release_x64/gen/build/fuchsia/fidl/fuchsia/component/cpp/fidl.h
./out/fuchsia_release_x64/gen/build/fuchsia/fidl/fuchsia/component/runner/cpp/fidl.h
./out/fuchsia_release_x64/gen/build/fuchsia/fidl/fuchsia/component/runner/c/fidl.h
./out/fuchsia_release_x64/gen/build/fuchsia/fidl/fuchsia/component/c/fidl.h
```

