### PR TITLE
shake out Paint.toString

### DIFF
--- a/lib/ui/painting.dart
+++ b/lib/ui/painting.dart
@@ -1454,6 +1454,9 @@ class Paint {
 
   @override
   String toString() {
+    if (const bool.fromEnvironment('dart.vm.product', defaultValue: false)) {
+      return super.toString();
+    }
     final StringBuffer result = StringBuffer();
     String semicolon = '';
     result.write('Paint(');


### PR DESCRIPTION
This method takes up about 6kb uncompressed.  It's also probably slower than people would care for in release mode.

Ideally we'd have a general solution for `toString` in dart:ui and the framework, but this is the only case I'm seeing in dart:ui that is this troublesome for binary size/performance reasons currently.