### PR TITLE
Revert "Try rasterizing images and layers only once , even when their…

### DIFF
--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -84,7 +84,7 @@ class RasterCache {
                bool is_complex,
                bool will_change);
 
-  bool Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
+  void Prepare(PrerollContext* context, Layer* layer, const SkMatrix& ctm);
 
   RasterCacheResult Get(const SkPicture& picture, const SkMatrix& ctm) const;
 
@@ -101,7 +101,6 @@ class RasterCache {
  private:
   struct Entry {
     bool used_this_frame = false;
-    bool did_rasterize = false;
     size_t access_count = 0;
     RasterCacheResult image;
   };


### PR DESCRIPTION
… rasterization fails. Further enforce the same access threshold on layers as on Pictures. Previously layers would always be cached. The latter is a semantic change. (#16545)"

This caused regression in several benchmarks, including:
animated_placeholder_perf. Regression tracked in
https://github.com/flutter/flutter/issues/51776.

This reverts commit 01a52b9947054f57398f2aaa2b59e7d501506580.