### PR TITLE
remove 10s timeouts from tests

### DIFF
--- a/lib/web_ui/test/golden_tests/engine/canvas_arc_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_arc_golden_test.dart
@@ -45,7 +45,7 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_arc_to_point.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
 }
 

--- a/lib/web_ui/test/golden_tests/engine/canvas_draw_points_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_draw_points_test.dart
@@ -53,5 +53,5 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_draw_points.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_golden_test.dart
@@ -79,7 +79,7 @@ void main() async {
     appendToScene();
 
     await matchGoldenFile('misaligned_pixels_in_canvas_test.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('compensates for misalignment of the canvas', () async {
     // Notice the 0.5 offset in the bounds rectangle. It's what causes the
@@ -94,7 +94,7 @@ void main() async {
     appendToScene();
 
     await matchGoldenFile('misaligned_canvas_test.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('fill the whole canvas with color even when transformed', () async {
     canvas = BitmapCanvas(const Rect.fromLTWH(0, 0, 50, 50));
@@ -105,7 +105,7 @@ void main() async {
     appendToScene();
 
     await matchGoldenFile('bitmap_canvas_fills_color_when_transformed.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('fill the whole canvas with paint even when transformed', () async {
     canvas = BitmapCanvas(const Rect.fromLTWH(0, 0, 50, 50));
@@ -118,7 +118,7 @@ void main() async {
     appendToScene();
 
     await matchGoldenFile('bitmap_canvas_fills_paint_when_transformed.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   // This test reproduces text blurriness when two pieces of text appear inside
   // two nested clips:
@@ -171,7 +171,7 @@ void main() async {
       maxDiffRatePercent: 0.0,
       pixelComparison: PixelComparison.precise,
     );
-  }, timeout: const Timeout(Duration(seconds: 10)), testOn: 'chrome');
+  }, testOn: 'chrome');
 
   // NOTE: Chrome in --headless mode does not reproduce the bug that this test
   //       attempts to reproduce. However, it's still good to have this test

--- a/lib/web_ui/test/golden_tests/engine/canvas_lines_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_lines_golden_test.dart
@@ -30,8 +30,7 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_lines_thickness.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
-
+  });
 }
 
 void paintLines(BitmapCanvas canvas) {

--- a/lib/web_ui/test/golden_tests/engine/canvas_rect_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_rect_golden_test.dart
@@ -30,8 +30,7 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_rect_flipped.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
-
+  });
 }
 
 void paintRects(BitmapCanvas canvas) {

--- a/lib/web_ui/test/golden_tests/engine/canvas_rrect_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_rrect_golden_test.dart
@@ -44,7 +44,7 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_rrect_round_square.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('round rect with big radius scale down smaller radius', () async {
     for (int i = 0; i < 5; i++) {
@@ -60,7 +60,7 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_rrect_overlapping_radius.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('diff round rect with big radius scale down smaller radius', () async {
     for (int i = 0; i < 5; i++) {
@@ -83,5 +83,5 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_drrect_overlapping_radius.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 }

--- a/lib/web_ui/test/golden_tests/engine/canvas_stroke_joins_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_stroke_joins_golden_test.dart
@@ -30,7 +30,7 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_stroke_joins.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
 }
 

--- a/lib/web_ui/test/golden_tests/engine/canvas_stroke_rects_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_stroke_rects_golden_test.dart
@@ -31,7 +31,7 @@ void main() async {
 
     html.document.body.append(canvas.rootElement);
     await matchGoldenFile('canvas_stroke_rects.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
 }
 

--- a/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/compositing_golden_test.dart
@@ -39,7 +39,7 @@ void main() async {
     html.document.body.append(builder.build().webOnlyRootElement);
 
     await matchGoldenFile('compositing_shifted_clip_rect.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('pushClipRect with offset and transform', () async {
     final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
@@ -60,7 +60,7 @@ void main() async {
 
     await matchGoldenFile('compositing_clip_rect_with_offset_and_transform.png',
         region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('pushClipRRect', () async {
     final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
@@ -73,7 +73,7 @@ void main() async {
     html.document.body.append(builder.build().webOnlyRootElement);
 
     await matchGoldenFile('compositing_shifted_clip_rrect.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('pushPhysicalShape', () async {
     final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
@@ -102,7 +102,7 @@ void main() async {
 
     await matchGoldenFile('compositing_shifted_physical_shape_clip.png',
         region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('pushImageFilter', () async {
     final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
@@ -115,7 +115,7 @@ void main() async {
     html.document.body.append(builder.build().webOnlyRootElement);
 
     await matchGoldenFile('compositing_image_filter.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   group('Cull rect computation', () {
     _testCullRectComputation();
@@ -246,7 +246,7 @@ void _testCullRectComputation() {
 
     final PersistedStandardPicture picture = enumeratePictures().single;
     expect(picture.optimalLocalCullRect, const Rect.fromLTRB(40, 40, 70, 70));
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   // Draw a picture inside a layer clip but position the picture such that its
   // paint bounds overflow the layer clip. Verify that the cull rect is the
@@ -276,7 +276,7 @@ void _testCullRectComputation() {
 
     final PersistedStandardPicture picture = enumeratePictures().single;
     expect(picture.optimalLocalCullRect, const Rect.fromLTRB(50, 40, 70, 70));
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   // Draw a picture inside a layer clip that's positioned inside the clip using
   // an offset layer. Verify that the cull rect is the intersection between the
@@ -308,7 +308,7 @@ void _testCullRectComputation() {
     final PersistedStandardPicture picture = enumeratePictures().single;
     expect(picture.optimalLocalCullRect,
         const Rect.fromLTRB(-15.0, -20.0, 15.0, 0.0));
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   // Draw a picture inside a layer clip that's positioned an offset layer such
   // that the picture is push completely outside the clip area. Verify that the
@@ -384,7 +384,7 @@ void _testCullRectComputation() {
       within(
           distance: 0.05, from: const Rect.fromLTRB(-14.1, -14.1, 14.1, 14.1)),
     );
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('pushClipPath', () async {
     final SurfaceSceneBuilder builder = SurfaceSceneBuilder();
@@ -399,7 +399,7 @@ void _testCullRectComputation() {
     html.document.body.append(builder.build().webOnlyRootElement);
 
     await matchGoldenFile('compositing_clip_path.png', region: region);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   // Draw a picture inside a rotated clip. Verify that the cull rect is big
   // enough to fit the rotated clip.
@@ -514,7 +514,7 @@ void _testCullRectComputation() {
     //       from: Rect.fromLTRB(
     //           -140, -140, screenWidth - 360.0, screenHeight + 40.0)),
     // );
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   // This test reproduces text blurriness when two pieces of text appear inside
   // two nested clips:
@@ -597,7 +597,6 @@ void _testCullRectComputation() {
         pixelComparison: PixelComparison.precise,
       );
     },
-    timeout: const Timeout(Duration(seconds: 10)),
     testOn: 'chrome',
   );
 }

--- a/lib/web_ui/test/golden_tests/engine/conic_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/conic_golden_test.dart
@@ -54,7 +54,7 @@ void main() async {
     path.close();
 
     await testPath(path, 'render_conic_1_w10');
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('render conic with control point left of start point', () async {
     const double yStart = 20;
@@ -72,7 +72,7 @@ void main() async {
     path.close();
 
     await testPath(path, 'render_conic_2_w10');
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('render conic with control point above start point', () async {
     const double yStart = 20;
@@ -90,5 +90,5 @@ void main() async {
     path.close();
 
     await testPath(path, 'render_conic_2');
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 }

--- a/lib/web_ui/test/golden_tests/engine/path_to_svg_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/path_to_svg_golden_test.dart
@@ -58,21 +58,21 @@ void main() async {
           ..color = const Color(0xFFFF0000)
           ..strokeWidth = 2.0
           ..style = PaintingStyle.stroke);
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('render quad bezier curve', () async {
     final Path path = Path();
     path.moveTo(50, 60);
     path.quadraticBezierTo(200, 60, 50, 200);
     await testPath(path, 'svg_quad_bezier');
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('render cubic curve', () async {
     final Path path = Path();
     path.moveTo(50, 60);
     path.cubicTo(200, 60, -100, -50, 150, 200);
     await testPath(path, 'svg_cubic_bezier');
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('render arcs', () async {
     final List<ArcSample> arcs = <ArcSample>[
@@ -99,14 +99,14 @@ void main() async {
       final Path path = sample.createPath();
       await testPath(path, 'svg_arc_$sampleIndex');
     }
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('render rect', () async {
     final Path path = Path();
     path.addRect(const Rect.fromLTRB(15, 15, 60, 20));
     path.addRect(const Rect.fromLTRB(35, 160, 15, 100));
     await testPath(path, 'svg_rect');
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 
   test('render notch', () async {
     final Path path = Path();
@@ -123,7 +123,7 @@ void main() async {
     path.lineTo(0, 80);
     path.lineTo(0, 10);
     await testPath(path, 'svg_notch');
-  }, timeout: const Timeout(Duration(seconds: 10)));
+  });
 }
 
 html.Element pathToSvgElement(Path path, Paint paint) {

--- a/lib/web_ui/test/golden_tests/engine/shadow_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/shadow_golden_test.dart
@@ -156,7 +156,6 @@ void main() async {
         pixelComparison: PixelComparison.precise,
       );
     },
-    timeout: const Timeout(Duration(seconds: 10)),
     testOn: 'chrome',
   );
 }


### PR DESCRIPTION
10 seconds is too short. We should use the default 30 seconds.

Fixes https://github.com/flutter/flutter/issues/51811