### PR TITLE
[frontend_server] forward new module name flag

### DIFF
--- a/flutter_frontend_server/lib/server.dart
+++ b/flutter_frontend_server/lib/server.dart
@@ -27,9 +27,11 @@ class _FlutterFrontendCompiler implements frontend.CompilerInterface {
 
   _FlutterFrontendCompiler(StringSink output,
       {bool unsafePackageSerialization,
+      bool useDebuggerModuleNames,
       frontend.ProgramTransformer transformer})
       : _compiler = frontend.FrontendCompiler(output,
             transformer: transformer,
+            useDebuggerModuleNames: useDebuggerModuleNames,
             unsafePackageSerialization: unsafePackageSerialization);
 
   @override
@@ -155,6 +157,7 @@ Future<int> starter(
 
   compiler ??= _FlutterFrontendCompiler(output,
       transformer: transformer,
+      useDebuggerModuleNames: options['debugger-module-names'] as bool,
       unsafePackageSerialization:
           options['unsafe-package-serialization'] as bool);
 


### PR DESCRIPTION
Forward --debugger-module-names to the actual FrontendCompiler

See also: https://github.com/dart-lang/sdk/blob/6b4c4faf28cac9d8b613c6a230eb56e8ce22bb95/pkg/frontend_server/lib/frontend_server.dart#L164