### PR TITLE
Update linux desktop deps installation script

### DIFF
--- a/build/install-build-deps-linux-desktop.sh
+++ b/build/install-build-deps-linux-desktop.sh
@@ -8,4 +8,9 @@
 
 set -e
 
-sudo apt-get -y install libx11-dev
+sudo apt -y install libgl-dev       \
+                    libx11-dev      \
+                    libxcursor-dev  \
+                    libxinerama-dev \
+                    libxrandr-dev   \
+                    libxxf86vm-dev


### PR DESCRIPTION
On a stock Ubuntu 19.10 system, the following deps are required, at
minimum:
  * libgl-dev
  * libx11-dev
  * libxcursor-dev
  * libxinerama-dev
  * libxrandr-dev
  * libxxf86vm-dev