### PR TITLE
Add libfreetype6-dev to desktop Linux dependencies

### DIFF
--- a/build/install-build-deps-linux-desktop.sh
+++ b/build/install-build-deps-linux-desktop.sh
@@ -8,9 +8,10 @@
 
 set -e
 
-sudo apt -y install libgl-dev       \
-                    libx11-dev      \
-                    libxcursor-dev  \
-                    libxinerama-dev \
-                    libxrandr-dev   \
+sudo apt -y install libfreetype6-dev \
+                    libgl-dev        \
+                    libx11-dev       \
+                    libxcursor-dev   \
+                    libxinerama-dev  \
+                    libxrandr-dev    \
                     libxxf86vm-dev


### PR DESCRIPTION
Required for Freetype 2.