### PR TITLE
clone_flutter.sh: use commit date instead of author date

### DIFF
--- a/tools/clone_flutter.sh
+++ b/tools/clone_flutter.sh
@@ -30,7 +30,7 @@ fi
 
 # Get latest commit's time for the engine repo.
 # Use date based on local time otherwise timezones might get mixed.
-LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%ad"`
+LATEST_COMMIT_TIME_ENGINE=`git log -1 --date=local --format="%cd"`
 echo "Latest commit time on engine found as $LATEST_COMMIT_TIME_ENGINE"
 
 # Do rest of the task in the root directory


### PR DESCRIPTION
This fixes an issue I found while working on https://github.com/flutter/engine/pull/16689. That's an old PR from February. I recently rebased it so I can finally submit it. However, the `clone_flutter.sh` script continues cloning a February version of Flutter and fails the PR. This change switches from `ad` (author date) to `cd` (commit date) when considering the latest engine commit date. Author date does not change when rebasing, but the commit date does.