### PR TITLE
Add support for the Metal backend on all iOS builds.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -44,9 +44,6 @@ def get_out_dir(args):
     if args.enable_vulkan:
         target_dir.append('vulkan')
 
-    if args.enable_metal and args.target_os == 'ios':
-      target_dir.append('metal')
-
     return os.path.join(args.out_dir, 'out', '_'.join(target_dir))
 
 def to_command_line(gn_args):
@@ -219,16 +216,17 @@ def to_gn_args(args):
       gn_args['use_goma'] = False
       gn_args['goma_dir'] = None
 
-    if args.enable_metal:
-      gn_args['skia_use_metal'] = True
-      gn_args['shell_enable_metal'] = True
-      gn_args['allow_deprecated_api_calls'] = True
-
     if args.enable_vulkan:
       # Enable vulkan in the Flutter shell.
       gn_args['shell_enable_vulkan'] = True
       # Configure Skia for Vulkan support.
       gn_args['skia_use_vulkan'] = True
+
+    # Enable Metal on non-simulator iOS builds.
+    if args.target_os == 'ios':
+      gn_args['skia_use_metal'] = not args.simulator
+      gn_args['shell_enable_metal'] = not args.simulator
+      gn_args['allow_deprecated_api_calls'] = not args.simulator
 
     # The buildroot currently isn't set up to support Vulkan in the
     # Windows ANGLE build, so disable it regardless of enable_vulkan's value.


### PR DESCRIPTION
Metal is not enabled by default yet. This commit will increase the size of the
iOS engine binary. A breakdown of the increase is as follows:

Both binaries are Mach-O 64-bit dynamically linked shared library of type arm64.
For reproduction, these numbers were gathered at Engine hash
01a52b9947054f57398f2aaa2b59e7d501506580.

* Uncompressed Metal iOS Engine Version: 11380 KB
* Uncompressed Non-Metal iOS: 11128 KB

Detailed breakdown of size differences:
```
     VM SIZE                                FILE SIZE
 --------------                          --------------
  +2.0%  +106Ki __TEXT,__text             +106Ki  +2.0%
  +2.6% +70.9Ki String Table             +70.9Ki  +2.6%
  +2.3% +35.5Ki Symbol Table             +35.5Ki  +2.3%
  +171% +8.32Ki [__DATA]                 +8.32Ki +13e3%
  +2.3% +6.48Ki __TEXT,__cstring         +6.48Ki  +2.3%
  +2.3% +6.12Ki __DATA,__const           +6.12Ki  +2.3%
   +23% +4.67Ki [__TEXT]                 +4.67Ki   +23%
  +109% +4.06Ki __TEXT,__gcc_except_tab  +4.06Ki  +109%
   +38% +3.98Ki [__LINKEDIT]                   0  [ = ]
   +18% +3.40Ki __TEXT,__objc_methname   +3.40Ki   +18%
  +3.5% +1.64Ki __TEXT,__unwind_info     +1.64Ki  +3.5%
   +23% +1.12Ki __DATA,__objc_selrefs    +1.12Ki   +23%
  +0.1%    +656 __TEXT,__const              +656  +0.1%
  +2.1%    +568 Function Start Addresses    +568  +2.1%
  +6.0%    +528 Binding Info                +528  +6.0%
  +2.1%    +320 Lazy Binding Info           +320  +2.1%
  +1.3%    +292 [5 Others]                  +292  +1.3%
  +4.5%    +288 __DATA,__cfstring           +288  +4.5%
  +3.8%    +160 [Mach-O Headers]            +160  +3.8%
  +1.2%    +136 Rebase Info                 +136  +1.2%
   +12%     +88 __DATA,__objc_classrefs      +88   +12%
  +2.3%  +256Ki TOTAL                     +252Ki  +2.3%
```

Fixes https://github.com/flutter/flutter/issues/52369