### PR TITLE
Disable Embedder11yTest::A11yTreeIsConsistent to unblock LUCI.

### DIFF
--- a/shell/platform/embedder/tests/embedder_a11y_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_a11y_unittests.cc
@@ -21,7 +21,8 @@ namespace testing {
 
 using Embedder11yTest = testing::EmbedderTest;
 
-TEST_F(Embedder11yTest, A11yTreeIsConsistent) {
+// TODO(52372): De-flake and re-enable.
+TEST_F(Embedder11yTest, DISABLED_A11yTreeIsConsistent) {
   auto& context = GetEmbedderContext();
 
   fml::AutoResetWaitableEvent latch;


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/52372