### PR TITLE
[web] increasing user limits for macos

### DIFF
--- a/lib/web_ui/dev/felt
+++ b/lib/web_ui/dev/felt
@@ -57,8 +57,8 @@ KERNEL_NAME=`uname`
 if [[ $KERNEL_NAME == *"Darwin"* ]]
 then
      echo "Running on MacOS. Increase the user limits"
-     ulimit -n 10000
-     ulimit -u 2048
+     ulimit -n 50000
+     ulimit -u 4096
 fi
 
 if [[ "$FELT_USE_SNAPSHOT" == "false" || "$FELT_USE_SNAPSHOT" == "0" ]]; then


### PR DESCRIPTION
Increasing the user limit for Mac. First time when we did this the timeouts dropped by half. Since we are still receiving timeout errors let's try a higher limit.