### PR TITLE
Remove unused or unnecessary compiler specific marcos in FML.

### DIFF
--- a/fml/compiler_specific.h
+++ b/fml/compiler_specific.h
@@ -26,44 +26,4 @@
 #define FML_ALLOW_UNUSED_TYPE
 #endif
 
-// Annotate a function indicating it should not be inlined.
-// Use like:
-//   NOINLINE void DoStuff() { ... }
-#if defined(__GNUC__) || defined(__clang__)
-#define FML_NOINLINE __attribute__((noinline))
-#elif defined(_MSC_VER)
-#define FML_NOINLINE __declspec(noinline)
-#endif
-
-// Specify memory alignment for structs, classes, etc.
-// Use like:
-//   class FML_ALIGNAS(16) MyClass { ... }
-//   FML_ALIGNAS(16) int array[4];
-#if defined(__GNUC__) || defined(__clang__)
-#define FML_ALIGNAS(byte_alignment) __attribute__((aligned(byte_alignment)))
-#elif defined(_MSC_VER)
-#define FML_ALIGNAS(byte_alignment) __declspec(align(byte_alignment))
-#endif
-
-// Return the byte alignment of the given type (available at compile time).
-// Use like:
-//   FML_ALIGNOF(int32)  // this would be 4
-#if defined(__GNUC__) || defined(__clang__)
-#define FML_ALIGNOF(type) __alignof__(type)
-#elif defined(_MSC_VER)
-#define FML_ALIGNOF(type) __alignof(type)
-#endif
-
-// Tell the compiler a function is using a printf-style format string.
-// |format_param| is the one-based index of the format string parameter;
-// |dots_param| is the one-based index of the "..." parameter.
-// For v*printf functions (which take a va_list), pass 0 for dots_param.
-// (This is undocumented but matches what the system C headers do.)
-#if defined(__GNUC__) || defined(__clang__)
-#define FML_PRINTF_FORMAT(format_param, dots_param) \
-  __attribute__((format(printf, format_param, dots_param)))
-#else
-#define FML_PRINTF_FORMAT(format_param, dots_param)
-#endif
-
 #endif  // FLUTTER_FML_COMPILER_SPECIFIC_H_


### PR DESCRIPTION
Macros to control inlining are not used and we explicitly recommending against
playing with compiler inlining. The macros for alignment became part of the
standard in C++11 and we already use the standard variants over these macros
(see `PointerData`). The formatters are unused as well and we use the stream
based variants for formatting.