### PR TITLE
fix bug: https://github.com/flutter/flutter/issues/52455

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -589,7 +589,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
                          rasterizer = rasterizer_->GetWeakPtr(),  //
                          surface = std::move(surface),            //
                          &latch]() mutable {
-        if (rasterizer) {
+        if (rasterizer && surface) {
           rasterizer->Setup(std::move(surface));
         }
 


### PR DESCRIPTION
We need to check if surface is nullptr before invoke the setup as well.
For the detail of bug, please refer https://github.com/flutter/flutter/issues/52455