### PR TITLE
build a precompiled SDK with canvas kit enabled

### DIFF
--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -30,6 +30,7 @@ group("web_sdk") {
   deps = [
     ":flutter_dartdevc_kernel_sdk",
     ":flutter_dartdevc_kernel_sdk_outline",
+    ":flutter_dartdevc_canvaskit_kernel_sdk",
     ":web_engine_sources",
     ":web_ui_library",
     ":web_ui_sources",
@@ -184,5 +185,57 @@ prebuilt_dart_action("flutter_dartdevc_kernel_sdk") {
     "legacy",
     "-o",
     rebase_path("$root_out_dir/flutter_web_sdk/kernel/legacy/dart_sdk.js"),
+  ]
+}
+
+# Compiles the DDC CanvasKit SDK's JS code.
+prebuilt_dart_action("flutter_dartdevc_canvaskit_kernel_sdk") {
+  deps = [
+    "//third_party/dart:create_sdk",
+    "//third_party/dart/pkg:pkg_files_stamp",
+    "//third_party/dart/utils/dartdevc:dartdevc_files_stamp",
+    "//third_party/dart/utils/dartdevc:dartdevc_sdk_patch_stamp",
+  ]
+
+  inputs = [ "sdk_rewriter.dart" ] + web_ui_sources + web_engine_sources
+
+  packages = "//third_party/dart/.packages"
+
+  script = "//third_party/dart/pkg/dev_compiler/bin/dartdevc.dart"
+
+  outputs = [
+    "$root_out_dir/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js",
+    "$root_out_dir/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js.map",
+  ]
+
+  args = [
+    "-k",
+    "--compile-sdk",
+    "dart:core",
+
+    # Additional Flutter web dart libraries
+    "dart:ui",
+    "dart:_engine",
+    "--no-summarize",
+    "--packages",
+    "file:///" + rebase_path("//third_party/dart/.packages"),
+    "--multi-root-scheme",
+    "org-dartlang-sdk",
+    "--multi-root",
+    "file:///" + rebase_path("$root_out_dir"),
+    "--multi-root-output-path",
+    rebase_path("$root_out_dir/"),
+    "--libraries-file",
+    "org-dartlang-sdk:///flutter_web_sdk/libraries.json",
+    "--inline-source-map",
+    "-DFLUTTER_WEB_USE_SKIA=true",
+    "--modules",
+    "amd",
+    "-o",
+    rebase_path("$root_out_dir/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js"),
+    "--modules",
+    "legacy",
+    "-o",
+    rebase_path("$root_out_dir/flutter_web_sdk/kernel/legacy-canvaskit/dart_sdk.js"),
   ]
 }

--- a/web_sdk/BUILD.gn
+++ b/web_sdk/BUILD.gn
@@ -28,9 +28,9 @@ web_engine_sources += [ "//flutter/lib/web_ui/lib/src/engine.dart" ]
 
 group("web_sdk") {
   deps = [
+    ":flutter_dartdevc_canvaskit_kernel_sdk",
     ":flutter_dartdevc_kernel_sdk",
     ":flutter_dartdevc_kernel_sdk_outline",
-    ":flutter_dartdevc_canvaskit_kernel_sdk",
     ":web_engine_sources",
     ":web_ui_library",
     ":web_ui_sources",
@@ -232,10 +232,12 @@ prebuilt_dart_action("flutter_dartdevc_canvaskit_kernel_sdk") {
     "--modules",
     "amd",
     "-o",
-    rebase_path("$root_out_dir/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js"),
+    rebase_path(
+        "$root_out_dir/flutter_web_sdk/kernel/amd-canvaskit/dart_sdk.js"),
     "--modules",
     "legacy",
     "-o",
-    rebase_path("$root_out_dir/flutter_web_sdk/kernel/legacy-canvaskit/dart_sdk.js"),
+    rebase_path(
+        "$root_out_dir/flutter_web_sdk/kernel/legacy-canvaskit/dart_sdk.js"),
   ]
 }


### PR DESCRIPTION
This will allow enabling canvaskit in debug mode, by switching the sdk sources. This could also enable a "toggle canvaskit rendering" mode.