### PR TITLE
Define embedding dependencies in Gradle

### DIFF
--- a/shell/platform/android/embedding_bundle/README.md
+++ b/shell/platform/android/embedding_bundle/README.md
@@ -1,0 +1,54 @@
+# Updating the Embedding Dependencies
+
+## Requirements
+
+1. Gradle. If you don't have Gradle installed, you can get it on [https://gradle.org/install/#manually](https://gradle.org/install/#manually).
+2. [Depot tools](http://commondatastorage.googleapis.com/chrome-infra-docs/flat/depot_tools/docs/html/depot_tools_tutorial.html#_setting_up).
+
+## Steps
+
+To update the embedding dependencies, just `cd` into this directory,
+modify the dependencies in `build.gradle` and run `gradle updateDependencies`.
+
+Once you have updated the dependencies, you can upload a new version by running
+`cipd create --pkg-def cipd.yaml`. For more, see the Chromium instructions on ["Updating a CIPD
+dependency"](https://chromium.googlesource.com/chromium/src/+/master/docs/cipd.md#Updating-a-CIPD-dependency) for how to upload a package update to CIPD.
+
+Once you've uploaded the new version, also make sure to tag it with the updated
+timestamp and robolectric version (most likely still 3.8, unless you've migrated
+all the packages to 4+).
+
+    $ cipd set-tag flutter/android/embedding_bundle --version=<new_version_hash> -tag=last_updated:<timestamp>
+
+Example of a last-updated timestamp: 2019-07-29T15:27:42-0700
+
+You can generate the same date format with `date +%Y-%m-%dT%T%z`.
+
+You can run `cipd describe flutter/android/embedding_bundle
+--version=<new_version_hash>` to verify. You should see:
+
+```
+Package:       flutter/android/embedding_bundle
+Instance ID:   <new_version_hash>
+...
+Tags:
+ last_updated:<timestamp>
+```
+
+Then update the `DEPS` file (located at /src/flutter/DEPS) to use the new version by pointing to
+your new `last_updated_at` tag.
+
+```
+  'src/third_party/android_embedding_dependencies': {
+     'packages': [
+       {
+        'package': 'flutter/android/embedding_bundle',
+        'version': 'last_updated:<timestamp>'
+       }
+     ],
+     'condition': 'download_android_deps',
+     'dep_type': 'cipd',
+   },
+```
+
+You can now re-run `gclient sync` to fetch the latest package version.

--- a/shell/platform/android/embedding_bundle/build.gradle
+++ b/shell/platform/android/embedding_bundle/build.gradle
@@ -1,0 +1,104 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// To use, run:
+//  $  gradle updateDependencies
+//
+// This script downloads the embedding dependencies into a lib/ directory,
+// extract jar files from AARs, so they can be used in gn.
+def destinationDir = "lib"
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+    dependencies {
+        classpath "com.android.tools.build:gradle:3.5.0"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+apply plugin: "com.android.application"
+
+configurations {
+  // Use this configuration for dependencies required by the embedding.
+  embedding
+  // Use any of these configurations for dependencies required for testing the embedding.
+  embeddingTesting
+  embeddingTesting_duplicated
+}
+
+android {
+  compileSdkVersion 28
+
+  dependencies {
+    embedding "androidx.annotation:annotation:1.1.0"
+    embedding "androidx.fragment:fragment:1.1.0"
+
+    def lifecycle_version = "2.2.0"
+    embedding "androidx.lifecycle:lifecycle-viewmodel:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-livedata:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-runtime:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-compiler:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-common-java8:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-service:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-process:$lifecycle_version"
+    embedding "androidx.lifecycle:lifecycle-reactivestreams:$lifecycle_version"
+
+    // Testing
+    embeddingTesting "androidx.arch.core:core-testing:2.1.0"
+    embeddingTesting "org.robolectric:android-all:8.1.0-robolectric-4611349"
+    // This is required by the robolectric test.
+    embeddingTesting_duplicated "org.robolectric:android-all:4.1.2_r1-robolectric-r1"
+    embeddingTesting "org.robolectric:robolectric:3.8"
+    embeddingTesting "org.robolectric:junit:3.8"
+    embeddingTesting "org.robolectric:shadows-framework:3.8"
+    embeddingTesting "org.robolectric:resources:3.8"
+    embeddingTesting "org.mockito:mockito-all:1.10.19"
+    embeddingTesting "junit:junit:4.13-beta-3"
+  }
+}
+
+task updateDependencies() {
+  delete destinationDir
+  // Copy the dependencies from the compileOnly configuration into
+  // the destination directory.
+  copy {
+    from configurations.embedding
+    from configurations.embeddingTesting
+    from configurations.embeddingTesting_duplicated
+    into destinationDir
+  }
+  doLast {
+    // Extract classes.jar from aar and rename it as the dependency name .jar
+    // since javac doesn't support AARs.
+    fileTree(destinationDir)
+      .filter { it.name.endsWith(".aar") }
+      .collect { aarDependency ->
+        def dependencyName = "${aarDependency.name.take(aarDependency.name.lastIndexOf('.'))}";
+        copy {
+          into destinationDir
+          from(zipTree(aarDependency)) {
+            include "classes.jar"
+          }
+          rename "classes.jar", "${dependencyName}.jar"
+        }
+        delete aarDependency
+      }
+  }
+  doLast {
+    fileTree(destinationDir)
+      .collect { dependency ->
+        println "\"//third_party/robolectric/lib/${dependency.name}\","
+      }
+  }
+}

--- a/shell/platform/android/embedding_bundle/cipd.yaml
+++ b/shell/platform/android/embedding_bundle/cipd.yaml
@@ -1,0 +1,4 @@
+package: flutter/android/embedding_bundle
+description: Dependencies used by the Android embedding.
+data:
+  - dir: lib

--- a/shell/platform/android/test/README.md
+++ b/shell/platform/android/test/README.md
@@ -32,72 +32,8 @@ the tests, but it would add an extra point of failure.
 
 ### My new test won't run. There's a "ClassNotFoundException".
 
-Your test is probably using a dependency that we haven't needed yet. You
-probably need to find the dependency you need, add it to the
-`flutter/android/robolectric_bundle` CIPD package, and then re-run `gclient
-sync`. See ["Updating a CIPD dependency"](#Updating-a-CIPD-dependency) below.
+See [shell/platform/android/embedding_bundle](Updating Embedding Dependencies).
 
 ### My new test won't compile. It can't find one of my imports.
 
-You could be using a brand new dependency. If so, you'll need to add it to the
-CIPD package for the robolectric tests. See ["Updating a CIPD
-dependency"](#Updating-a-CIPD-dependency) below.
-
-Then you'll also need to add the jar to the `robolectric_tests` build target.
-Add `//third_party/robolectric/lib/<dependency.jar>` to
-`robolectric_tests._jar_dependencies` in `/shell/platform/android/BUILD.gn`.
-
-There's also a chance that you're using a dependency that we're relying on at
-runtime, but not compile time. If so you'll just need to update
-`_jar_dependencies` in `BUILD.gn`.
-
-### Updating a CIPD dependency
-
-See the Chromium instructions on ["Updating a CIPD
-dependency"](https://chromium.googlesource.com/chromium/src/+/master/docs/cipd.md#Updating-a-CIPD-dependency)
-for how to upload a package update to CIPD. Download and extract the latest
-package from CIPD and then copy
-[shell/platform/android/test/cipd.yaml](cipd.yaml) into the extracted directory
-to use as the base for the pre-existing package. Add new dependencies to `lib/`.
-
-Once you've uploaded the new version, also make sure to tag it with the updated
-timestamp and robolectric version (most likely still 3.8, unless you've migrated
-all the packages to 4+).
-
-    $ cipd set-tag flutter/android/robolectric_bundle --version=<new_version_hash> -tag=last_updated:<timestamp>
-
-Example of a last-updated timestamp: 2019-07-29T15:27:42-0700
-
-You can generate the same date format with `date +%Y-%m-%dT%T%z`.
-
-    $ cipd set-tag flutter/android/robolectric_bundle --version=<new_version_hash> -tag=robolectric_version:<robolectric_version>
-
-You can run `cipd describe flutter/android/robolectric_bundle
---version=<new_version_hash>` to verify. You should see:
-
-```
-Package:       flutter/android/robolectric_bundle
-Instance ID:   <new_version_hash>
-...
-Tags:
- last_updated:<timestamp>
- robolectric_version:<robolectric_version>
-```
-
-Then update the `DEPS` file (located at /src/flutter/DEPS) to use the new version by pointing to
-your new `last_updated_at` tag.
-
-```
-  'src/third_party/robolectric': {
-     'packages': [
-       {
-        'package': 'flutter/android/robolectric_bundle',
-        'version': 'last_updated:<timestamp>'
-       }
-     ],
-     'condition': 'download_android_deps',
-     'dep_type': 'cipd',
-   },
-```
-
-You can now re-run `gclient sync` to fetch the latest package version.
+See [shell/platform/android/embedding_bundle](Updating Embedding Dependencies).

--- a/shell/platform/android/test/cipd.yaml
+++ b/shell/platform/android/test/cipd.yaml
@@ -1,4 +1,0 @@
-package: flutter/android/robolectric_bundle
-description: Robolectric 3.8 and associated runtime dependencies.
-data:
-  - dir: lib


### PR DESCRIPTION
I found that it's very hard to update the embedding dependencies. The current approach requires to manually find the transitive dependencies as well as extracting jar from AARs since gn/javac doesn't support AARs like Gradle. 

I'm proposing to change that approach to defining the dependencies in Gradle itself, then configure a Gradle task that downloads each of the artifacts (including transitive ones) and finally extracts jars from AARs so they can be used in gn.

We currently have a cipd package used exclusively for testing. Instead, we will have a single package that has all the JARs required to compile and test the embedding.

I'm also looking into generating the embedding POM file from these dependencies as well.