### PR TITLE
Canvas: Remove some unused virtuals, and prepare for signature change

### DIFF
--- a/shell/common/canvas_spy.cc
+++ b/shell/common/canvas_spy.cc
@@ -139,20 +139,6 @@ void DidDrawCanvas::onDrawBitmapRect(const SkBitmap& bitmap,
   did_draw_ = true;
 }
 
-void DidDrawCanvas::onDrawBitmapNine(const SkBitmap& bitmap,
-                                     const SkIRect& center,
-                                     const SkRect& dst,
-                                     const SkPaint* paint) {
-  did_draw_ = true;
-}
-
-void DidDrawCanvas::onDrawBitmapLattice(const SkBitmap& bitmap,
-                                        const Lattice& lattice,
-                                        const SkRect& dst,
-                                        const SkPaint* paint) {
-  did_draw_ = true;
-}
-
 void DidDrawCanvas::onDrawImage(const SkImage* image,
                                 SkScalar left,
                                 SkScalar top,
@@ -201,8 +187,10 @@ void DidDrawCanvas::onDrawDrawable(SkDrawable* drawable,
 }
 
 void DidDrawCanvas::onDrawVerticesObject(const SkVertices* vertices,
-                                         const SkVertices::Bone bones[],
-                                         int boneCount,
+#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
+                                         const SkVertices::Bone[],
+                                         int,
+#endif
                                          SkBlendMode bmode,
                                          const SkPaint& paint) {
   MarkDrawIfNonTransparentPaint(paint);

--- a/shell/common/canvas_spy.cc
+++ b/shell/common/canvas_spy.cc
@@ -187,10 +187,6 @@ void DidDrawCanvas::onDrawDrawable(SkDrawable* drawable,
 }
 
 void DidDrawCanvas::onDrawVerticesObject(const SkVertices* vertices,
-#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
-                                         const SkVertices::Bone[],
-                                         int,
-#endif
                                          SkBlendMode bmode,
                                          const SkPaint& paint) {
   MarkDrawIfNonTransparentPaint(paint);

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -154,12 +154,6 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
                        SrcRectConstraint) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
-  void onDrawBitmapLattice(const SkBitmap&,
-                           const Lattice&,
-                           const SkRect&,
-                           const SkPaint*) override;
-
-  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawImageLattice(const SkImage*,
                           const Lattice&,
                           const SkRect&,
@@ -172,17 +166,13 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
                        const SkPaint*) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
-  void onDrawBitmapNine(const SkBitmap&,
-                        const SkIRect& center,
-                        const SkRect& dst,
-                        const SkPaint*) override;
-
-  // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawVerticesObject(const SkVertices*,
-                            const SkVertices::Bone bones[],
-                            int boneCount,
-                            SkBlendMode,
-                            const SkPaint&) override;
+#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
+                              const SkVertices::Bone[],
+                              int,
+#endif
+                              SkBlendMode,
+                              const SkPaint&) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawAtlas(const SkImage*,

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -167,12 +167,8 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawVerticesObject(const SkVertices*,
-#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
-                              const SkVertices::Bone[],
-                              int,
-#endif
-                              SkBlendMode,
-                              const SkPaint&) override;
+                            SkBlendMode,
+                            const SkPaint&) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void onDrawAtlas(const SkImage*,

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -166,6 +166,13 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
                        const SkPaint*) override;
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
+#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
+  void onDrawVerticesObject(const SkVertices*,
+                            const SkVertices::Bone[],
+                            int,
+                            SkBlendMode,
+                            const SkPaint&) override {}
+#endif
   void onDrawVerticesObject(const SkVertices*,
                             SkBlendMode,
                             const SkPaint&) override;

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -262,13 +262,6 @@ void MockCanvas::onDrawImageNine(const SkImage*,
   FML_DCHECK(false);
 }
 
-void MockCanvas::onDrawBitmapNine(const SkBitmap&,
-                                  const SkIRect&,
-                                  const SkRect&,
-                                  const SkPaint*) {
-  FML_DCHECK(false);
-}
-
 void MockCanvas::onDrawImageLattice(const SkImage*,
                                     const Lattice&,
                                     const SkRect&,
@@ -276,16 +269,11 @@ void MockCanvas::onDrawImageLattice(const SkImage*,
   FML_DCHECK(false);
 }
 
-void MockCanvas::onDrawBitmapLattice(const SkBitmap&,
-                                     const Lattice&,
-                                     const SkRect&,
-                                     const SkPaint*) {
-  FML_DCHECK(false);
-}
-
 void MockCanvas::onDrawVerticesObject(const SkVertices*,
+#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
                                       const SkVertices::Bone[],
                                       int,
+#endif
                                       SkBlendMode,
                                       const SkPaint&) {
   FML_DCHECK(false);

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -270,10 +270,6 @@ void MockCanvas::onDrawImageLattice(const SkImage*,
 }
 
 void MockCanvas::onDrawVerticesObject(const SkVertices*,
-#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
-                                      const SkVertices::Bone[],
-                                      int,
-#endif
                                       SkBlendMode,
                                       const SkPaint&) {
   FML_DCHECK(false);

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -221,6 +221,13 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
                           const Lattice&,
                           const SkRect&,
                           const SkPaint*) override;
+#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
+  void onDrawVerticesObject(const SkVertices*,
+                            const SkVertices::Bone[],
+                            int,
+                            SkBlendMode,
+                            const SkPaint&) override {}
+#endif
   void onDrawVerticesObject(const SkVertices*,
                             SkBlendMode,
                             const SkPaint&) override;

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -222,12 +222,8 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
                           const SkRect&,
                           const SkPaint*) override;
   void onDrawVerticesObject(const SkVertices*,
-#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
-                              const SkVertices::Bone[],
-                              int,
-#endif
-                              SkBlendMode,
-                              const SkPaint&) override;
+                            SkBlendMode,
+                            const SkPaint&) override;
   void onDrawAtlas(const SkImage*,
                    const SkRSXform[],
                    const SkRect[],

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -217,23 +217,17 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
                     SkScalar x,
                     SkScalar y,
                     const SkPaint* paint) override;
-  void onDrawBitmapNine(const SkBitmap&,
-                        const SkIRect&,
-                        const SkRect&,
-                        const SkPaint*) override;
   void onDrawImageLattice(const SkImage*,
                           const Lattice&,
                           const SkRect&,
                           const SkPaint*) override;
-  void onDrawBitmapLattice(const SkBitmap&,
-                           const Lattice&,
-                           const SkRect&,
-                           const SkPaint*) override;
   void onDrawVerticesObject(const SkVertices*,
-                            const SkVertices::Bone[],
-                            int,
-                            SkBlendMode,
-                            const SkPaint&) override;
+#ifdef SK_SUPPORT_LEGACY_DRAWVERTS_VIRTUAL
+                              const SkVertices::Bone[],
+                              int,
+#endif
+                              SkBlendMode,
+                              const SkPaint&) override;
   void onDrawAtlas(const SkImage*,
                    const SkRSXform[],
                    const SkRect[],


### PR DESCRIPTION
The bitmap virtuals are never called (and will be removed soon). The bone parameters to the vertices virtual are being removed.