### PR TITLE
Document texture registry threading requirements.

### DIFF
--- a/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
@@ -38,7 +38,8 @@ FLUTTER_EXPORT
 @protocol FlutterTextureRegistry <NSObject>
 /**
  * Registers a `FlutterTexture` for usage in Flutter and returns an id that can be used to reference
- * that texture when calling into Flutter with channels.
+ * that texture when calling into Flutter with channels. Textures must be registered on the
+ * platform thread.
  */
 - (int64_t)registerTexture:(NSObject<FlutterTexture>*)texture;
 /**
@@ -48,7 +49,8 @@ FLUTTER_EXPORT
  */
 - (void)textureFrameAvailable:(int64_t)textureId;
 /**
- * Unregisters a `FlutterTexture` that has previously regeistered with `registerTexture:`.
+ * Unregisters a `FlutterTexture` that has previously regeistered with `registerTexture:`. Textures
+ * must be unregistered on the the platform thread.
  *
  * @param textureId The result that was previously returned from `registerTexture:`.
  */


### PR DESCRIPTION
The [camera plugin](https://github.com/flutter/flutter/issues/52578) seems to be violating these rules.