### PR TITLE
Enhance image_filter_layer caching to filter a cached child

### DIFF
--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -189,7 +189,6 @@ Layer* MergedContainerLayer::GetCacheableChild() const {
     return child_container->layers()[0].get();
   }
 
-  FML_LOG(INFO) << "Single child layer contains multiple children";
   return child_container;
 }
 

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -163,14 +163,13 @@ void ContainerLayer::UpdateSceneChildren(SceneUpdateContext& context) {
 MergedContainerLayer::MergedContainerLayer() {
   // Ensure the layer has only one direct child.
   //
-  // This intermediary container helps container layers that want or need
-  // to cache the rendering of their children to do so more easily.
-  //
-  // Any children will be actually added as children of this empty
-  // ContainerLayer.
-  //
-  // @see GetChildContainer()
-  // @see GetCacheableChild()
+  // Any children will actually be added as children of this empty
+  // ContainerLayer which can be accessed via ::GetContainerLayer().
+  // If only one child is ever added to this layer then that child
+  // will become the layer returned from ::GetCacheableChild().
+  // If multiple child layers are added, then this implicit container
+  // child becomes the cacheable child, but at the potential cost of
+  // not being as stable in the raster cache from frame to frame.
   ContainerLayer::Add(std::make_shared<ContainerLayer>());
 }
 
@@ -190,6 +189,7 @@ Layer* MergedContainerLayer::GetCacheableChild() const {
     return child_container->layers()[0].get();
   }
 
+  FML_LOG(INFO) << "Single child layer contains multiple children";
   return child_container;
 }
 

--- a/flow/layers/container_layer.cc
+++ b/flow/layers/container_layer.cc
@@ -160,4 +160,37 @@ void ContainerLayer::UpdateSceneChildren(SceneUpdateContext& context) {
 
 #endif  // defined(OS_FUCHSIA)
 
+MergedContainerLayer::MergedContainerLayer() {
+  // Ensure the layer has only one direct child.
+  //
+  // This intermediary container helps container layers that want or need
+  // to cache the rendering of their children to do so more easily.
+  //
+  // Any children will be actually added as children of this empty
+  // ContainerLayer.
+  //
+  // @see GetChildContainer()
+  // @see GetCacheableChild()
+  ContainerLayer::Add(std::make_shared<ContainerLayer>());
+}
+
+void MergedContainerLayer::Add(std::shared_ptr<Layer> layer) {
+  GetChildContainer()->Add(std::move(layer));
+}
+
+ContainerLayer* MergedContainerLayer::GetChildContainer() const {
+  FML_DCHECK(layers().size() == 1);
+
+  return static_cast<ContainerLayer*>(layers()[0].get());
+}
+
+Layer* MergedContainerLayer::GetCacheableChild() const {
+  ContainerLayer* child_container = GetChildContainer();
+  if (child_container->layers().size() == 1) {
+    return child_container->layers()[0].get();
+  }
+
+  return child_container;
+}
+
 }  // namespace flutter

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -35,9 +35,6 @@ class ContainerLayer : public Layer {
   void UpdateSceneChildren(SceneUpdateContext& context);
 #endif  // defined(OS_FUCHSIA)
 
-  // For OpacityLayer to restructure to have a single child.
-  void ClearChildren() { layers_.clear(); }
-
   // Try to prepare the raster cache for a given layer.
   //
   // The raster cache would fail if either of the followings is true:
@@ -56,6 +53,68 @@ class ContainerLayer : public Layer {
   std::vector<std::shared_ptr<Layer>> layers_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);
+};
+
+class MergedContainerLayer : public ContainerLayer {
+ public:
+  MergedContainerLayer();
+
+  void Add(std::shared_ptr<Layer> layer) override;
+
+ protected:
+  /**
+   * @brief Returns the ContainerLayer used to hold all of the children
+   * of the OpacityLayer.
+   *
+   * Often opacity layers will only have a single child since the associated
+   * Flutter widget is specified with only a single child widget pointer.
+   * But depending on the structure of the child tree that single widget at
+   * the framework level can turn into multiple children at the engine
+   * API level since there is no guarantee of a 1:1 correspondence of widgets
+   * to engine layers. This synthetic child container layer is established to
+   * hold all of the children in a single layer so that we can cache their
+   * output, but this synthetic layer will typically not be the best choice
+   * for the layer cache since the synthetic container is created fresh with
+   * each new OpacityLayer, and so may not be stable from frame to frame.
+   *
+   * @see GetCacheableChild()
+   * @return the ContainerLayer child used to hold the children
+   */
+  ContainerLayer* GetChildContainer() const;
+
+  /**
+   * @brief Returns the best choice for a Layer object that can be used
+   * in RasterCache operations to cache the children of the OpacityLayer.
+   *
+   * The returned Layer must represent all children and try to remain stable
+   * if the OpacityLayer is reconstructed in subsequent frames of the scene.
+   *
+   * Note that since the synthetic child container returned from the
+   * GetChildContainer() method is created fresh with each new OpacityLayer,
+   * its return value will not be a good candidate for caching. But if the
+   * standard recommendations for animations are followed and the child widget
+   * is wrapped with a RepaintBoundary widget at the framework level, then
+   * the synthetic child container should contain the same single child layer
+   * on each frame. Under those conditions, that single child of the child
+   * container will be the best candidate for caching in the RasterCache
+   * and this method will return that single child if possible to improve
+   * the performance of caching the children.
+   *
+   * Note that if GetCacheableChild() does not find a single stable child of
+   * the child container it will return the child container as a fallback.
+   * Even though that child is new in each frame of an animation and thus we
+   * cannot reuse the cached layer raster between animation frames, the single
+   * container child will allow us to paint the child onto an offscreen buffer
+   * during Preroll() which reduces one render target switch compared to
+   * painting the child on the fly via an AutoSaveLayer in Paint() and thus
+   * still improves our performance.
+   *
+   * @see GetChildContainer()
+   * @return the best candidate Layer for caching the children
+   */
+  Layer* GetCacheableChild() const;
+
+  FML_DISALLOW_COPY_AND_ASSIGN(MergedContainerLayer);
 };
 
 }  // namespace flutter

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -55,6 +55,37 @@ class ContainerLayer : public Layer {
   FML_DISALLOW_COPY_AND_ASSIGN(ContainerLayer);
 };
 
+//------------------------------------------------------------------------------
+/// Some ContainerLayer objects need to cache their children. The existing
+/// layer caching mechanism only supports caching an individual layer as it
+/// uses the unique_id() of that layer as the cache key. If a ContainerLayer
+/// has multiple children and needs to cache them then it will need to first
+/// collect them into a single layer object to satisfy the caching mechanism.
+/// This utility class will silently collect all of the children of a
+/// ContainerLayer into a single merged ContainerLayer automatically.
+///
+/// The Flutter Widget objects that produce these layers tend to enforce
+/// having only a single child Widget object which means that there is really
+/// only a single child being added to this engine layer anyway, but due to
+/// the complicated mechanism that turns trees of Widgets eventually into a
+/// tree of engine layers, the associated layer may end up with multiple
+/// direct child layers. This class implements a protection against the
+/// incidental creation of "extra" children.
+///
+/// When the layer needs to recurse to perform some opertion on its children,
+/// it can call GetChildContainer() to return the hidden container containing
+/// all of the real children.
+///
+/// When the layer wants to cache the rendered contents of its children, it
+/// should call GetCacheableChild() for best performance.
+///
+/// Note that since the implicit child container is created new every time
+/// this layer is recreated, the child container will be different for each
+/// frame of an animation that modifies the properties of this layer.
+/// The GetCacheableChild() method will attempt to find the single actual
+/// child of this layer and return that instead since that child will more
+/// likely remain stable across the frames of an animation.
+///
 class MergedContainerLayer : public ContainerLayer {
  public:
   MergedContainerLayer();

--- a/flow/layers/container_layer.h
+++ b/flow/layers/container_layer.h
@@ -114,6 +114,7 @@ class MergedContainerLayer : public ContainerLayer {
    */
   Layer* GetCacheableChild() const;
 
+ private:
   FML_DISALLOW_COPY_AND_ASSIGN(MergedContainerLayer);
 };
 

--- a/flow/layers/container_layer_unittests.cc
+++ b/flow/layers/container_layer_unittests.cc
@@ -198,5 +198,75 @@ TEST_F(ContainerLayerTest, NeedsSystemComposite) {
                                                child_path2, child_paint2}}}));
 }
 
+TEST_F(ContainerLayerTest, MergedOneChild) {
+  SkPath child_path;
+  child_path.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  SkPaint child_paint(SkColors::kGreen);
+  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+
+  auto mock_layer = std::make_shared<MockLayer>(child_path, child_paint);
+  auto layer = std::make_shared<MergedContainerLayer>();
+  layer->Add(mock_layer);
+
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->has_platform_view);
+  EXPECT_EQ(mock_layer->paint_bounds(), child_path.getBounds());
+  EXPECT_EQ(layer->paint_bounds(), child_path.getBounds());
+  EXPECT_TRUE(mock_layer->needs_painting());
+  EXPECT_TRUE(layer->needs_painting());
+  EXPECT_FALSE(mock_layer->needs_system_composite());
+  EXPECT_FALSE(layer->needs_system_composite());
+  EXPECT_EQ(mock_layer->parent_matrix(), initial_transform);
+  EXPECT_EQ(mock_layer->parent_cull_rect(), kGiantRect);
+
+  layer->Paint(paint_context());
+  EXPECT_EQ(mock_canvas().draw_calls(),
+            std::vector({MockCanvas::DrawCall{
+                0, MockCanvas::DrawPathData{child_path, child_paint}}}));
+}
+
+TEST_F(ContainerLayerTest, MergedMultipleChildren) {
+  SkPath child_path1;
+  child_path1.addRect(5.0f, 6.0f, 20.5f, 21.5f);
+  SkPath child_path2;
+  child_path2.addRect(58.0f, 2.0f, 16.5f, 14.5f);
+  SkPaint child_paint1(SkColors::kGray);
+  SkPaint child_paint2(SkColors::kGreen);
+  SkMatrix initial_transform = SkMatrix::Translate(-0.5f, -0.5f);
+
+  auto mock_layer1 = std::make_shared<MockLayer>(child_path1, child_paint1);
+  auto mock_layer2 = std::make_shared<MockLayer>(child_path2, child_paint2);
+  auto layer = std::make_shared<MergedContainerLayer>();
+  layer->Add(mock_layer1);
+  layer->Add(mock_layer2);
+
+  SkRect expected_total_bounds = child_path1.getBounds();
+  expected_total_bounds.join(child_path2.getBounds());
+  layer->Preroll(preroll_context(), initial_transform);
+  EXPECT_FALSE(preroll_context()->has_platform_view);
+  EXPECT_EQ(mock_layer1->paint_bounds(), child_path1.getBounds());
+  EXPECT_EQ(mock_layer2->paint_bounds(), child_path2.getBounds());
+  EXPECT_EQ(layer->paint_bounds(), expected_total_bounds);
+  EXPECT_TRUE(mock_layer1->needs_painting());
+  EXPECT_TRUE(mock_layer2->needs_painting());
+  EXPECT_TRUE(layer->needs_painting());
+  EXPECT_FALSE(mock_layer1->needs_system_composite());
+  EXPECT_FALSE(mock_layer2->needs_system_composite());
+  EXPECT_FALSE(layer->needs_system_composite());
+  EXPECT_EQ(mock_layer1->parent_matrix(), initial_transform);
+  EXPECT_EQ(mock_layer2->parent_matrix(), initial_transform);
+  EXPECT_EQ(mock_layer1->parent_cull_rect(), kGiantRect);
+  EXPECT_EQ(mock_layer2->parent_cull_rect(),
+            kGiantRect);  // Siblings are independent
+
+  layer->Paint(paint_context());
+  EXPECT_EQ(
+      mock_canvas().draw_calls(),
+      std::vector({MockCanvas::DrawCall{
+                       0, MockCanvas::DrawPathData{child_path1, child_paint1}},
+                   MockCanvas::DrawCall{0, MockCanvas::DrawPathData{
+                                               child_path2, child_paint2}}}));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -31,7 +31,7 @@ void ImageFilterLayer::Preroll(PrerollContext* context,
     TryToPrepareRasterCache(context, this, matrix);
   } else {
     render_count_++;
-    context->raster_cache->Prepare(context, GetCacheableChild(), matrix);
+    TryToPrepareRasterCache(context, GetCacheableChild(), matrix);
   }
 }
 

--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -41,7 +41,6 @@ void ImageFilterLayer::Paint(PaintContext& context) const {
 
   if (context.raster_cache) {
     if (context.raster_cache->Draw(this, *context.leaf_nodes_canvas)) {
-      FML_LOG(ERROR) << "Rendered filtered output from cache";
       return;
     }
     const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();
@@ -52,7 +51,6 @@ void ImageFilterLayer::Paint(PaintContext& context) const {
 
       if (context.raster_cache->Draw(GetCacheableChild(),
                                      *context.leaf_nodes_canvas, &paint)) {
-        FML_LOG(ERROR) << "Filtered from cached child";
         return;
       }
     }

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -11,7 +11,7 @@
 
 namespace flutter {
 
-class ImageFilterLayer : public ContainerLayer {
+class ImageFilterLayer : public MergedContainerLayer {
  public:
   ImageFilterLayer(sk_sp<SkImageFilter> filter);
 
@@ -20,8 +20,14 @@ class ImageFilterLayer : public ContainerLayer {
   void Paint(PaintContext& context) const override;
 
  private:
+  // The default minimum number of times to render a filtered layer before
+  // we cache the output of the filter. Note that until this limit is
+  // reached we may continue to cache the children anyway.
+  static constexpr int kMinimumRendersBeforeCachingFilterLayer = 3;
+
   sk_sp<SkImageFilter> filter_;
   SkRect child_paint_bounds_;
+  int render_count_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ImageFilterLayer);
 };

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -26,7 +26,6 @@ class ImageFilterLayer : public MergedContainerLayer {
   static constexpr int kMinimumRendersBeforeCachingFilterLayer = 3;
 
   sk_sp<SkImageFilter> filter_;
-  SkRect child_paint_bounds_;
   int render_count_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ImageFilterLayer);

--- a/flow/layers/image_filter_layer.h
+++ b/flow/layers/image_filter_layer.h
@@ -20,12 +20,24 @@ class ImageFilterLayer : public MergedContainerLayer {
   void Paint(PaintContext& context) const override;
 
  private:
-  // The default minimum number of times to render a filtered layer before
-  // we cache the output of the filter. Note that until this limit is
-  // reached we may continue to cache the children anyway.
+  // The ImageFilterLayer might cache the filtered output of this layer
+  // if the layer remains stable (if it is not animating for instance).
+  // If the ImageFilterLayer is not the same between rendered frames,
+  // though, it will cache its children instead and filter their cached
+  // output on the fly.
+  // Caching just the children saves the time to render them and also
+  // avoids a rendering surface switch to draw them.
+  // Caching the layer itself avoids all of that and additionally avoids
+  // the cost of applying the filter, but can be worse than caching the
+  // children if the filter itself is not stable from frame to frame.
+  // This constant controls how many times we will Preroll and Paint this
+  // same ImageFilterLayer before we consider the layer and filter to be
+  // stable enough to switch from caching the children to caching the
+  // filtered output of this layer.
   static constexpr int kMinimumRendersBeforeCachingFilterLayer = 3;
 
   sk_sp<SkImageFilter> filter_;
+  sk_sp<SkImageFilter> transformed_filter_;
   int render_count_;
 
   FML_DISALLOW_COPY_AND_ASSIGN(ImageFilterLayer);

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -267,8 +267,7 @@ TEST_F(ImageFilterLayerTest, ChildIsCached) {
   auto other_transform = SkMatrix::Scale(1.0, 2.0);
   const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
   auto mock_layer = std::make_shared<MockLayer>(child_path);
-  auto layer =
-      std::make_shared<ImageFilterLayer>(layer_filter);
+  auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
   layer->Add(mock_layer);
 
   SkMatrix cache_ctm = initial_transform;
@@ -299,8 +298,7 @@ TEST_F(ImageFilterLayerTest, ChildrenNotCached) {
   const SkPath child_path2 = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
   auto mock_layer1 = std::make_shared<MockLayer>(child_path1);
   auto mock_layer2 = std::make_shared<MockLayer>(child_path2);
-  auto layer =
-      std::make_shared<ImageFilterLayer>(layer_filter);
+  auto layer = std::make_shared<ImageFilterLayer>(layer_filter);
   layer->Add(mock_layer1);
   layer->Add(mock_layer2);
 

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -260,5 +260,72 @@ TEST_F(ImageFilterLayerTest, Readback) {
   EXPECT_FALSE(preroll_context()->surface_needs_readback);
 }
 
+TEST_F(ImageFilterLayerTest, ChildIsCached) {
+  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+  auto initial_transform = SkMatrix::Translate(50.0, 25.5);
+  auto other_transform = SkMatrix::Scale(1.0, 2.0);
+  const SkPath child_path = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
+  auto mock_layer = std::make_shared<MockLayer>(child_path);
+  auto layer =
+      std::make_shared<ImageFilterLayer>(layer_filter);
+  layer->Add(mock_layer);
+
+  SkMatrix cache_ctm = initial_transform;
+  SkCanvas cache_canvas;
+  cache_canvas.setMatrix(cache_ctm);
+  SkCanvas other_canvas;
+  other_canvas.setMatrix(other_transform);
+
+  use_mock_raster_cache();
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
+
+  layer->Preroll(preroll_context(), initial_transform);
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer.get(), other_canvas));
+  EXPECT_TRUE(raster_cache()->Draw(mock_layer.get(), cache_canvas));
+}
+
+TEST_F(ImageFilterLayerTest, ChildrenNotCached) {
+  auto layer_filter = SkImageFilter::MakeMatrixFilter(
+      SkMatrix(), SkFilterQuality::kMedium_SkFilterQuality, nullptr);
+  auto initial_transform = SkMatrix::Translate(50.0, 25.5);
+  auto other_transform = SkMatrix::Scale(1.0, 2.0);
+  const SkPath child_path1 = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
+  const SkPath child_path2 = SkPath().addRect(SkRect::MakeWH(5.0f, 5.0f));
+  auto mock_layer1 = std::make_shared<MockLayer>(child_path1);
+  auto mock_layer2 = std::make_shared<MockLayer>(child_path2);
+  auto layer =
+      std::make_shared<ImageFilterLayer>(layer_filter);
+  layer->Add(mock_layer1);
+  layer->Add(mock_layer2);
+
+  SkMatrix cache_ctm = initial_transform;
+  SkCanvas cache_canvas;
+  cache_canvas.setMatrix(cache_ctm);
+  SkCanvas other_canvas;
+  other_canvas.setMatrix(other_transform);
+
+  use_mock_raster_cache();
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)0);
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), cache_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), cache_canvas));
+
+  layer->Preroll(preroll_context(), initial_transform);
+
+  EXPECT_EQ(raster_cache()->GetLayerCachedEntriesCount(), (size_t)1);
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer1.get(), cache_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), other_canvas));
+  EXPECT_FALSE(raster_cache()->Draw(mock_layer2.get(), cache_canvas));
+}
+
 }  // namespace testing
 }  // namespace flutter

--- a/flow/layers/opacity_layer.cc
+++ b/flow/layers/opacity_layer.cc
@@ -10,20 +10,7 @@
 namespace flutter {
 
 OpacityLayer::OpacityLayer(SkAlpha alpha, const SkPoint& offset)
-    : alpha_(alpha), offset_(offset) {
-  // Ensure OpacityLayer has only one direct child.
-  //
-  // This is needed to ensure that retained rendering can always be applied to
-  // save the costly saveLayer.
-  //
-  // Any children will be actually added as children of this empty
-  // ContainerLayer.
-  ContainerLayer::Add(std::make_shared<ContainerLayer>());
-}
-
-void OpacityLayer::Add(std::shared_ptr<Layer> layer) {
-  GetChildContainer()->Add(std::move(layer));
-}
+    : alpha_(alpha), offset_(offset) {}
 
 void OpacityLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
   TRACE_EVENT0("flutter", "OpacityLayer::Preroll");
@@ -111,20 +98,5 @@ void OpacityLayer::UpdateScene(SceneUpdateContext& context) {
 }
 
 #endif  // defined(OS_FUCHSIA)
-
-ContainerLayer* OpacityLayer::GetChildContainer() const {
-  FML_DCHECK(layers().size() == 1);
-
-  return static_cast<ContainerLayer*>(layers()[0].get());
-}
-
-Layer* OpacityLayer::GetCacheableChild() const {
-  ContainerLayer* child_container = GetChildContainer();
-  if (child_container->layers().size() == 1) {
-    return child_container->layers()[0].get();
-  }
-
-  return child_container;
-}
 
 }  // namespace flutter

--- a/flow/layers/opacity_layer.h
+++ b/flow/layers/opacity_layer.h
@@ -13,7 +13,7 @@ namespace flutter {
 // OpacityLayer is very costly due to the saveLayer call. If there's no child,
 // having the OpacityLayer or not has the same effect. In debug_unopt build,
 // |Preroll| will assert if there are no children.
-class OpacityLayer : public ContainerLayer {
+class OpacityLayer : public MergedContainerLayer {
  public:
   // An offset is provided here because OpacityLayer.addToScene method in the
   // Flutter framework can take an optional offset argument.
@@ -27,8 +27,6 @@ class OpacityLayer : public ContainerLayer {
   // the propagation as repainting the OpacityLayer is expensive.
   OpacityLayer(SkAlpha alpha, const SkPoint& offset);
 
-  void Add(std::shared_ptr<Layer> layer) override;
-
   void Preroll(PrerollContext* context, const SkMatrix& matrix) override;
 
   void Paint(PaintContext& context) const override;
@@ -38,58 +36,6 @@ class OpacityLayer : public ContainerLayer {
 #endif  // defined(OS_FUCHSIA)
 
  private:
-  /**
-   * @brief Returns the ContainerLayer used to hold all of the children
-   * of the OpacityLayer.
-   *
-   * Often opacity layers will only have a single child since the associated
-   * Flutter widget is specified with only a single child widget pointer.
-   * But depending on the structure of the child tree that single widget at
-   * the framework level can turn into multiple children at the engine
-   * API level since there is no guarantee of a 1:1 correspondence of widgets
-   * to engine layers. This synthetic child container layer is established to
-   * hold all of the children in a single layer so that we can cache their
-   * output, but this synthetic layer will typically not be the best choice
-   * for the layer cache since the synthetic container is created fresh with
-   * each new OpacityLayer, and so may not be stable from frame to frame.
-   *
-   * @see GetCacheableChild()
-   * @return the ContainerLayer child used to hold the children
-   */
-  ContainerLayer* GetChildContainer() const;
-
-  /**
-   * @brief Returns the best choice for a Layer object that can be used
-   * in RasterCache operations to cache the children of the OpacityLayer.
-   *
-   * The returned Layer must represent all children and try to remain stable
-   * if the OpacityLayer is reconstructed in subsequent frames of the scene.
-   *
-   * Note that since the synthetic child container returned from the
-   * GetChildContainer() method is created fresh with each new OpacityLayer,
-   * its return value will not be a good candidate for caching. But if the
-   * standard recommendations for animations are followed and the child widget
-   * is wrapped with a RepaintBoundary widget at the framework level, then
-   * the synthetic child container should contain the same single child layer
-   * on each frame. Under those conditions, that single child of the child
-   * container will be the best candidate for caching in the RasterCache
-   * and this method will return that single child if possible to improve
-   * the performance of caching the children.
-   *
-   * Note that if GetCacheableChild() does not find a single stable child of
-   * the child container it will return the child container as a fallback.
-   * Even though that child is new in each frame of an animation and thus we
-   * cannot reuse the cached layer raster between animation frames, the single
-   * container child will allow us to paint the child onto an offscreen buffer
-   * during Preroll() which reduces one render target switch compared to
-   * painting the child on the fly via an AutoSaveLayer in Paint() and thus
-   * still improves our performance.
-   *
-   * @see GetChildContainer()
-   * @return the best candidate Layer for caching the children
-   */
-  Layer* GetCacheableChild() const;
-
   SkAlpha alpha_;
   SkPoint offset_;
   SkRRect frameRRect_;

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -141,6 +141,7 @@ void RasterCache::Prepare(PrerollContext* context,
   entry.access_count++;
   entry.used_this_frame = true;
   if (!entry.image) {
+    FML_LOG(ERROR) << "Rasterizing " << layer->unique_id();
     entry.image = RasterizeLayer(context, layer, ctm, checkerboard_images_);
   }
 }

--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -141,7 +141,6 @@ void RasterCache::Prepare(PrerollContext* context,
   entry.access_count++;
   entry.used_this_frame = true;
   if (!entry.image) {
-    FML_LOG(ERROR) << "Rasterizing " << layer->unique_id();
     entry.image = RasterizeLayer(context, layer, ctm, checkerboard_images_);
   }
 }


### PR DESCRIPTION
This is a nearly complete prototype to enhance the optimization of `ImageFilterLayer` in a manner similar to `OpacityLayer`. While implementing this prototype I discovered (and fixed) a bug in the way that `OpacityLayer` manages the caching of its child(ren).  This prototype:

- breaks out the "single child" code from `OpacityLayer` into a shareable utility layer called `MergedContainerLayer`
- enhances that implementation to better extract a single `Layer` to be used for caching that avoids the problem where every new merged layer contains a brand new unique `ContainerLayer` child.
- reworks `ImageFilterLayer` to use the new mechanism
- minor changes to `OpacityLayer` logic to use a better child for caching

- also includes a number of debug log strings to track the work done by `ImageFilterLayer` and the layer cache
- includes an `INFO` log string when the caching assumptions in the new `MergedContainerLayer::GetCacheableChild` method fail

The new caching mechanism can speed up opacity layers on cached children by 40% or so, possibly more if the child is more than just a single `Picture`. Similar effects are seen on the image filter layers, especially when animating the filter on a static child.

Actual test results will be compiled when I settle on a test that best represents what app developers might encounter in the wild.