### PR TITLE
Peformance improvement : reduce engine init time  50%off at least

### DIFF
--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -95,6 +95,8 @@ class Shell final : public PlatformView::Delegate,
  public:
   template <class T>
   using CreateCallback = std::function<std::unique_ptr<T>(Shell&)>;
+  using ShellCreateCallback =
+      std::function<void(bool success, std::unique_ptr<Shell> shell)>;
 
   //----------------------------------------------------------------------------
   /// @brief      Creates a shell instance using the provided settings. The
@@ -165,6 +167,13 @@ class Shell final : public PlatformView::Delegate,
       Settings settings,
       CreateCallback<PlatformView> on_create_platform_view,
       CreateCallback<Rasterizer> on_create_rasterizer);
+
+  static void CreateAsync(ShellCreateCallback callBack,
+                          TaskRunners task_runners,
+                          WindowData window_data,
+                          Settings settings,
+                          CreateCallback<PlatformView> on_create_platform_view,
+                          CreateCallback<Rasterizer> on_create_rasterizer);
 
   //----------------------------------------------------------------------------
   /// @brief      Creates a shell instance using the provided settings. The
@@ -430,6 +439,16 @@ class Shell final : public PlatformView::Delegate,
       fml::RefPtr<const DartSnapshot> isolate_snapshot,
       const Shell::CreateCallback<PlatformView>& on_create_platform_view,
       const Shell::CreateCallback<Rasterizer>& on_create_rasterizer);
+
+  static bool CreateShellAsyncOnPlatformThread(
+      ShellCreateCallback async_init_callback,
+      DartVMRef vm,
+      TaskRunners task_runners,
+      WindowData window_data,
+      Settings settings,
+      fml::RefPtr<const DartSnapshot> isolate_snapshot,
+      Shell::CreateCallback<PlatformView> on_create_platform_view,
+      Shell::CreateCallback<Rasterizer> on_create_rasterizer);
 
   bool Setup(std::unique_ptr<PlatformView> platform_view,
              std::unique_ptr<Engine> engine,

--- a/shell/common/shell_benchmarks.cc
+++ b/shell/common/shell_benchmarks.cc
@@ -81,6 +81,79 @@ static void StartupAndShutdownShell(benchmark::State& state,
   FML_CHECK(!shell);
 }
 
+static void StartupAsync(benchmark::State& state, bool mesure_async_total) {
+  auto assets_dir = fml::OpenDirectory(testing::GetFixturesPath(), false,
+                                       fml::FilePermission::kRead);
+  std::unique_ptr<Shell> shell_res;
+  std::unique_ptr<ThreadHost> thread_host;
+  testing::ELFAOTSymbols aot_symbols;
+  {
+    Settings settings = {};
+    settings.task_observer_add = [](intptr_t, fml::closure) {};
+    settings.task_observer_remove = [](intptr_t) {};
+
+    if (DartVM::IsRunningPrecompiledCode()) {
+      aot_symbols = testing::LoadELFSymbolFromFixturesIfNeccessary();
+      FML_CHECK(
+          testing::PrepareSettingsForAOTWithSymbols(settings, aot_symbols))
+          << "Could not setup settings with AOT symbols.";
+    } else {
+      settings.application_kernels = [&]() {
+        std::vector<std::unique_ptr<const fml::Mapping>> kernel_mappings;
+        kernel_mappings.emplace_back(
+            fml::FileMapping::CreateReadOnly(assets_dir, "kernel_blob.bin"));
+        return kernel_mappings;
+      };
+    }
+
+    thread_host = std::make_unique<ThreadHost>(
+        "io.flutter.bench.", ThreadHost::Type::Platform |
+                                 ThreadHost::Type::GPU | ThreadHost::Type::IO |
+                                 ThreadHost::Type::UI);
+
+    TaskRunners task_runners("test",
+                             thread_host->platform_thread->GetTaskRunner(),
+                             thread_host->raster_thread->GetTaskRunner(),
+                             thread_host->ui_thread->GetTaskRunner(),
+                             thread_host->io_thread->GetTaskRunner());
+
+    fml::AutoResetWaitableEvent latch;
+    Shell::CreateAsync(
+        [&latch, &shell_res](bool success, std::unique_ptr<Shell> shell) {
+          if (success) {
+            shell_res = std::move(shell);
+          }
+          latch.Signal();
+        },
+        std::move(task_runners), WindowData{/* default window data */},
+        settings,
+        [](Shell& shell) {
+          return std::make_unique<PlatformView>(shell, shell.GetTaskRunners());
+        },
+        [](Shell& shell) {
+          return std::make_unique<Rasterizer>(shell, shell.GetTaskRunners());
+        });
+    benchmarking::ScopedPauseTiming pause(state, !mesure_async_total);
+    latch.Wait();
+    FML_CHECK(shell_res);
+  }
+  {
+    // dont' care shutdown time here
+    benchmarking::ScopedPauseTiming pause(state, true);
+    // Shutdown must occur synchronously on the platform thread.
+    fml::AutoResetWaitableEvent latch;
+    fml::TaskRunner::RunNowOrPostTask(
+        thread_host->platform_thread->GetTaskRunner(),
+        [&shell_res, &latch]() mutable {
+          shell_res.reset();
+          latch.Signal();
+        });
+    latch.Wait();
+    thread_host.reset();
+  }
+  FML_CHECK(!shell_res);
+}
+
 static void BM_ShellInitialization(benchmark::State& state) {
   while (state.KeepRunning()) {
     StartupAndShutdownShell(state, true, false);
@@ -104,5 +177,19 @@ static void BM_ShellInitializationAndShutdown(benchmark::State& state) {
 }
 
 BENCHMARK(BM_ShellInitializationAndShutdown);
+
+static void BM_ShellInitializationAsyncLockTime(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    StartupAsync(state, false);
+  }
+}
+BENCHMARK(BM_ShellInitializationAsyncLockTime);
+
+static void BM_ShellInitializationAsyncTotalTime(benchmark::State& state) {
+  while (state.KeepRunning()) {
+    StartupAsync(state, true);
+  }
+}
+BENCHMARK(BM_ShellInitializationAsyncTotalTime);
 
 }  // namespace flutter

--- a/shell/platform/android/android_shell_holder.h
+++ b/shell/platform/android/android_shell_holder.h
@@ -21,11 +21,20 @@ namespace flutter {
 
 class AndroidShellHolder {
  public:
+  using AsyncInitCallback = std::function<void(bool)>;
+
   AndroidShellHolder(flutter::Settings settings,
                      fml::jni::JavaObjectWeakGlobalRef java_object,
                      bool is_background_view);
 
+  AndroidShellHolder(flutter::Settings settings,
+                     fml::jni::JavaObjectWeakGlobalRef java_object,
+                     bool is_background_view,
+                     bool initAsync);
+
   ~AndroidShellHolder();
+
+  void init(AsyncInitCallback asyncCallBack);
 
   bool IsValid() const;
 
@@ -47,10 +56,12 @@ class AndroidShellHolder {
   ThreadHost thread_host_;
   std::unique_ptr<Shell> shell_;
   bool is_valid_ = false;
+  bool is_background_view_ = false;
   pthread_key_t thread_destruct_key_;
   uint64_t next_pointer_flow_id_ = 0;
-
   static void ThreadDestructCallback(void* value);
+
+  void setThreadPriority();
 
   FML_DISALLOW_COPY_AND_ASSIGN(AndroidShellHolder);
 };

--- a/shell/platform/android/io/flutter/view/FlutterNativeView.java
+++ b/shell/platform/android/io/flutter/view/FlutterNativeView.java
@@ -144,7 +144,7 @@ public class FlutterNativeView implements BinaryMessenger {
   }
 
   private void attach(FlutterNativeView view, boolean isBackgroundView) {
-    mFlutterJNI.attachToNative(isBackgroundView);
+    mFlutterJNI.attachToNative(isBackgroundView, false);
     dartExecutor.onAttachedToJNI();
   }
 
@@ -160,5 +160,11 @@ public class FlutterNativeView implements BinaryMessenger {
       }
       mPluginRegistry.onPreEngineRestart();
     }
+
+    @Override
+    public void onAsyncAttachEnd(boolean success) {}
+
+    @Override
+    public void onAsyncCreateEngineEnd(boolean success) {}
   }
 }

--- a/shell/platform/android/platform_view_android_jni.h
+++ b/shell/platform/android/platform_view_android_jni.h
@@ -46,6 +46,11 @@ void SurfaceTextureGetTransformMatrix(JNIEnv* env,
 
 void SurfaceTextureDetachFromGLContext(JNIEnv* env, jobject obj);
 
+void FlutterViewHandleEngineInit(JNIEnv* env,
+                                 jobject obj,
+                                 jboolean success,
+                                 jlong holder_id);
+
 }  // namespace flutter
 
 #endif  // FLUTTER_SHELL_PLATFORM_ANDROID_PLATFORM_VIEW_ANDROID_JNI_H_

--- a/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
+++ b/shell/platform/darwin/ios/framework/Headers/FlutterEngine.h
@@ -25,6 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString* const FlutterDefaultDartEntrypoint;
 
 /**
+ * the callback of engine async init mode
+ */
+typedef void (^InitCallBackBlock)(bool);
+
+/**
  * The FlutterEngine class coordinates a single instance of execution for a
  * `FlutterDartProject`.  It may have zero or one `FlutterViewController` at a
  * time, which can be specified via `-setViewController:`.
@@ -128,6 +133,10 @@ FLUTTER_EXPORT
  */
 - (BOOL)run;
 
+/** like run() method, but this method not block mainThread when init
+ * @param block callbackBlock, called when async init end. must not be nil!
+ */
+- (void)asyncRun:(InitCallBackBlock)block;
 /**
  * Runs a Dart program on an Isolate from the main Dart library (i.e. the library that
  * contains `main()`).

--- a/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosTests/FlutterEngineTest.m
@@ -47,4 +47,14 @@
   XCTAssertNil(engine.lifecycleChannel);
 }
 
+- (void)testAsyncInitEngine {
+  FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"my flutter engine"];
+  [flutterEngine asyncRun:^(boolean success) {
+    // on app
+    if (success) {
+      //[GeneratedPluginRegistrant registerWithRegistry:self];
+    }
+  }];
+}
+
 @end


### PR DESCRIPTION
Hi, this pr try to reduce engine init time. In our data, init engine cost too much time: Android 300ms, iOS 380ms(most are mid-end and low-end machine)。

 In our local test. **Android reduce about 66.3% time，and iOS reduce about 46.6% time.**

update:
##  Introduction change
Cause there are 15 files change, so Introduction to changes.

In fact , __core modification all in `shell.cc`__ ,new method `CreateAsync` and `CreateShellAsyncOnPlatformThread`, other modification most are adapter code(android、iOS） and  test。
- engine (__Core modification__ , also can work on other platform,  just adapter Android/iOS now）
  - runtime
      - shell.h 
      - shell.cc
  - test
     - shell_benchmarks.cc
     - shell_unittests.cc
- adapter iOS
    - runtime:
        - FlutterEngine.mm
        - FlutterEngine.h
    - test:
        - FlutterEngineTest.mm
- adapter android
    - runtime:
        - FlutterEngine.java
        - FlutterJNI.java
        - platform_view_android_jni.h/.cc
        - android_shell_holder.h /.cc
        - FlutterNativeView.java
    - test: 
        - EngineLaunchE2ETest.java

![](https://s1.ax1x.com/2020/04/03/GUjNVJ.png)


## ApiUsage

- Android
```
final FlutterEngine engine = new FlutterEngine();
engine.initAsync( this,new EngineLifecycleListener() {
    public void onAsyncCreateEngineEnd(boolean success) {
        if (success) {
            engine.getDartExecutor().executeDartEntrypoint(DartEntrypoint.createDefault());
         } else {
            //balaba
        }
}});
```
- iOS
```
 FlutterEngine* engine = [[FlutterEngine alloc] initWithName:@"my flutter engine"];
  [flutterEngine asyncRun:^(boolean success) {
    if (success) {
       [GeneratedPluginRegistrant registerWithRegistry:self];
    }else{
       //balaba
    }
  }];
```
