### PR TITLE
Revert "Reland "Add support for the Metal backend on all iOS builds.""

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -44,6 +44,9 @@ def get_out_dir(args):
     if args.enable_vulkan:
         target_dir.append('vulkan')
 
+    if args.enable_metal and args.target_os == 'ios':
+      target_dir.append('metal')
+
     return os.path.join(args.out_dir, 'out', '_'.join(target_dir))
 
 def to_command_line(gn_args):
@@ -216,16 +219,16 @@ def to_gn_args(args):
       gn_args['use_goma'] = False
       gn_args['goma_dir'] = None
 
+    if args.enable_metal:
+      gn_args['skia_use_metal'] = True
+      gn_args['shell_enable_metal'] = True
+      gn_args['allow_deprecated_api_calls'] = True
+
     if args.enable_vulkan:
       # Enable vulkan in the Flutter shell.
       gn_args['shell_enable_vulkan'] = True
       # Configure Skia for Vulkan support.
       gn_args['skia_use_vulkan'] = True
-
-    # Enable Metal on non-simulator iOS builds.
-    if args.target_os == 'ios':
-      gn_args['skia_use_metal'] = not args.simulator
-      gn_args['shell_enable_metal'] = not args.simulator
 
     # The buildroot currently isn't set up to support Vulkan in the
     # Windows ANGLE build, so disable it regardless of enable_vulkan's value.


### PR DESCRIPTION
Reverts flutter/engine#17191

This broke LUCI again. This is bizzare because the [artifacts just uploaded to the buckets](https://storage.cloud.google.com/flutter_infra/flutter/4196207ee70e1f35557441ba65fa11d14e3a47f0/ios-release/artifacts.zip) before the check do not list these symbols are being exported. I have verified this with the same version of the toolchain and Xcode. The only thing different is `nm` maybe but that seems unlikely to show different results. Downloading the artifacts that failed the run and running the checks locally seems to be fine as well.