### PR TITLE
Disable the use of the API_AVAILABLE macro in Skia in iOS release builds.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -222,7 +222,10 @@ def to_gn_args(args):
     if args.enable_metal:
       gn_args['skia_use_metal'] = True
       gn_args['shell_enable_metal'] = True
-      gn_args['allow_deprecated_api_calls'] = True
+      # Bitcode enabled builds using the current version of the toolchain leak
+      # C++ symbols decorated with the availability attribute. Disable these
+      # attributess in release modes till the toolchain is updated.
+      gn_args['skia_enable_api_available_macro'] = args.runtime_mode != "release"
 
     if args.enable_vulkan:
       # Enable vulkan in the Flutter shell.

--- a/tools/gn
+++ b/tools/gn
@@ -224,7 +224,7 @@ def to_gn_args(args):
       gn_args['shell_enable_metal'] = True
       # Bitcode enabled builds using the current version of the toolchain leak
       # C++ symbols decorated with the availability attribute. Disable these
-      # attributess in release modes till the toolchain is updated.
+      # attributes in release modes till the toolchain is updated.
       gn_args['skia_enable_api_available_macro'] = args.runtime_mode != "release"
 
     if args.enable_vulkan:


### PR DESCRIPTION
The use of this macro in C++ translation units leads to the symbol visibility
being switched to default instead of hidden. This only happens in bitcode
enabled builds. A toolchain upgrade will be necessary to undo this workaround.