### PR TITLE
Enable unified OpenGL/Metal builds.

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -44,9 +44,6 @@ def get_out_dir(args):
     if args.enable_vulkan:
         target_dir.append('vulkan')
 
-    if args.enable_metal and args.target_os == 'ios':
-      target_dir.append('metal')
-
     return os.path.join(args.out_dir, 'out', '_'.join(target_dir))
 
 def to_command_line(gn_args):
@@ -219,7 +216,8 @@ def to_gn_args(args):
       gn_args['use_goma'] = False
       gn_args['goma_dir'] = None
 
-    if args.enable_metal:
+    # Enable Metal on non-simulator iOS builds.
+    if args.target_os == 'ios' and not args.simulator:
       gn_args['skia_use_metal'] = True
       gn_args['shell_enable_metal'] = True
       # Bitcode enabled builds using the current version of the toolchain leak
@@ -323,7 +321,6 @@ def parse_args(args):
   parser.add_argument('--operator-new-alignment', dest='operator_new_alignment', type=str, default=None)
 
   parser.add_argument('--enable-vulkan', action='store_true', default=False)
-  parser.add_argument('--enable-metal', action='store_true', default=False)
 
   parser.add_argument('--enable-fontconfig', action='store_true', default=False)
   parser.add_argument('--enable-skshaper', action='store_true', default=False)


### PR DESCRIPTION
This was attempted and reverted twice due do various issues. The last issue
was one where [symbols in C++ TUs decorated with availability macros](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8886159363875395744/+/steps/Verify_exported_symbols_on_release_binaries/0/stdout) were
marked as visible. This has been patched [via a workaround in Skia](https://github.com/google/skia/commit/f832c0ae493d3d8b94a446b1ea5a4e1123d42bb2) that
has [rolled into the tree](https://github.com/flutter/engine/pull/17214).

Fixes https://github.com/flutter/flutter/issues/52638