### PR TITLE
Revert "Enable unified OpenGL/Metal builds."

### DIFF
--- a/tools/gn
+++ b/tools/gn
@@ -44,6 +44,9 @@ def get_out_dir(args):
     if args.enable_vulkan:
         target_dir.append('vulkan')
 
+    if args.enable_metal and args.target_os == 'ios':
+      target_dir.append('metal')
+
     return os.path.join(args.out_dir, 'out', '_'.join(target_dir))
 
 def to_command_line(gn_args):
@@ -216,8 +219,7 @@ def to_gn_args(args):
       gn_args['use_goma'] = False
       gn_args['goma_dir'] = None
 
-    # Enable Metal on non-simulator iOS builds.
-    if args.target_os == 'ios' and not args.simulator:
+    if args.enable_metal:
       gn_args['skia_use_metal'] = True
       gn_args['shell_enable_metal'] = True
       # Bitcode enabled builds using the current version of the toolchain leak
@@ -321,6 +323,7 @@ def parse_args(args):
   parser.add_argument('--operator-new-alignment', dest='operator_new_alignment', type=str, default=None)
 
   parser.add_argument('--enable-vulkan', action='store_true', default=False)
+  parser.add_argument('--enable-metal', action='store_true', default=False)
 
   parser.add_argument('--enable-fontconfig', action='store_true', default=False)
   parser.add_argument('--enable-skshaper', action='store_true', default=False)


### PR DESCRIPTION
Reverts flutter/engine#17217

Between the short window in which the metal only builds were disabled and the unified builds enabled, https://github.com/google/skia/commit/d29d885c882c5ff67b117aaa4e5009365ec8d1bd landed which used an iOS 9 API without guards. This [broke LUCI builds](https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8885343949344263136/+/steps/build_ios_debug/0/stdout). I am patching Skia now. In the meantime, reverting this to unblock LUCI.