### PR TITLE
Remove code which skips keyEvent from input element on web

### DIFF
--- a/lib/web_ui/lib/src/engine/keyboard.dart
+++ b/lib/web_ui/lib/src/engine/keyboard.dart
@@ -5,22 +5,6 @@
 // @dart = 2.6
 part of engine;
 
-/// Contains a whitelist of keys that must be sent to Flutter under all
-/// circumstances.
-///
-/// When keys are pressed in a text field, we generally don't want to send them
-/// to Flutter. This list of keys is the exception to that rule. Keys in this
-/// list will be sent to Flutter even if pressed in a text field.
-///
-/// A good example is the "Tab" and "Shift" keys which are used by the framework
-/// to move focus between text fields.
-const List<String> _alwaysSentKeys = <String>[
-  'Alt',
-  'Control',
-  'Meta',
-  'Shift',
-  'Tab',
-];
 
 /// Provides keyboard bindings, such as the `flutter/keyevent` channel.
 class Keyboard {
@@ -72,10 +56,6 @@ class Keyboard {
       return;
     }
 
-    if (_shouldIgnoreEvent(event)) {
-      return;
-    }
-
     if (_shouldPreventDefault(event)) {
       event.preventDefault();
     }
@@ -90,20 +70,6 @@ class Keyboard {
 
     ui.window.onPlatformMessage('flutter/keyevent',
         _messageCodec.encodeMessage(eventData), _noopCallback);
-  }
-
-  /// Whether the [Keyboard] class should ignore the given [html.KeyboardEvent].
-  ///
-  /// When this method returns true, it prevents the keyboard event from being
-  /// sent to Flutter.
-  bool _shouldIgnoreEvent(html.KeyboardEvent event) {
-    // Keys in the [_alwaysSentKeys] list should never be ignored.
-    if (_alwaysSentKeys.contains(event.key)) {
-      return false;
-    }
-    // Other keys should be ignored if triggered on a text field.
-    return event.target is html.Element &&
-        HybridTextEditing.isEditingElement(event.target);
   }
 
   bool _shouldPreventDefault(html.KeyboardEvent event) {

--- a/lib/web_ui/test/keyboard_test.dart
+++ b/lib/web_ui/test/keyboard_test.dart
@@ -242,7 +242,7 @@ void main() {
       Keyboard.instance.dispose();
     });
 
-    test('ignores keyboard events triggered on text fields', () {
+    test('keyboard events should be triggered on text fields', () {
       Keyboard.initialize();
 
       int count = 0;
@@ -260,7 +260,7 @@ void main() {
         );
 
         expect(event.defaultPrevented, isFalse);
-        expect(count, 0);
+        expect(count, 1);
       });
 
       Keyboard.instance.dispose();


### PR DESCRIPTION
I remove the code which skips keyEvent from input element on web.
Instead, we block keyEvent in _handleKeyEvent in editable.dart in flutter platform on [another flutter pull-request](https://github.com/flutter/flutter/pull/52661). if so, we can use RawKeyListener with EditableText on web platform.

I didn't revert [original pull-request](https://github.com/flutter/engine/pull/13699) because this pull-request has extra useful features(identifiable domElement text class, test code helper code for keyboard on inputElement)

[Relevant flutter issue](https://github.com/flutter/flutter/issues/52656)
