### PR TITLE
Remove checks for the always true using_fuchsia_sdk flag in all GN files.

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -19,7 +19,7 @@ group("flutter") {
 
   public_deps = []
 
-  if (!(is_fuchsia && using_fuchsia_sdk)) {
+  if (!is_fuchsia) {
     public_deps += [
       "//flutter/lib/snapshot:generate_snapshot_bin",
       "//flutter/lib/snapshot:kernel_platform_files",
@@ -40,14 +40,14 @@ group("flutter") {
     public_deps += [ "//flutter/tools/const_finder" ]
   }
 
-  if (is_fuchsia && using_fuchsia_sdk) {
+  if (is_fuchsia) {
     public_deps += [
       "//flutter/shell/platform/fuchsia",
       "//flutter/shell/testing($host_toolchain)",
     ]
   }
 
-  if (!is_fuchsia && !is_fuchsia_host) {
+  if (!is_fuchsia) {
     if (current_toolchain == host_toolchain) {
       public_deps += [
         "//flutter/flutter_frontend_server:frontend_server",

--- a/common/config.gni
+++ b/common/config.gni
@@ -12,12 +12,8 @@ if (target_cpu == "arm" || target_cpu == "arm64") {
   import("//build/config/arm.gni")
 }
 
-if (is_ios || is_mac) {
-  if (using_fuchsia_sdk) {
-    import("//build/toolchain/clang.gni")
-  } else {
-    import("//build/toolchain/clang_toolchain.gni")
-  }
+if (is_fuchsia) {
+  import("//build/toolchain/clang.gni")
 }
 
 declare_args() {
@@ -64,7 +60,8 @@ if (flutter_runtime_mode == "debug") {
   feature_defines_list += [ "FLUTTER_RUNTIME_MODE=0" ]
 }
 
-if (is_fuchsia && using_fuchsia_sdk) {
+if (is_fuchsia) {
+  # TODO(chinmaygarde): This is always set. The macro may now be removed.
   feature_defines_list += [ "FUCHSIA_SDK=1" ]
 }
 

--- a/common/fuchsia_config.gni
+++ b/common/fuchsia_config.gni
@@ -4,7 +4,7 @@
 
 import("config.gni")
 
-if (is_fuchsia && using_fuchsia_sdk) {
+if (is_fuchsia) {
   dart_tools_root = "//flutter/tools/fuchsia/dart"
   fuchsia_base = "//flutter/shell/platform/fuchsia"
   flutter_runner_base = "$fuchsia_base/flutter/"

--- a/flow/BUILD.gn
+++ b/flow/BUILD.gn
@@ -86,20 +86,11 @@ source_set("flow") {
       "view_holder.h",
     ]
 
-    if (using_fuchsia_sdk) {
-      public_deps += [
-        "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
-        "$fuchsia_sdk_root/fidl:fuchsia.ui.gfx",
-        "$fuchsia_sdk_root/pkg:scenic_cpp",
-      ]
-    } else {
-      public_deps += [
-        "//garnet/public/lib/ui/scenic/cpp",
-        "//sdk/fidl/fuchsia.ui.scenic",
-        "//topaz/public/dart-pkg/zircon",
-        "//zircon/public/lib/zx",
-      ]
-    }
+    public_deps += [
+      "$fuchsia_sdk_root/fidl:fuchsia.ui.app",
+      "$fuchsia_sdk_root/fidl:fuchsia.ui.gfx",
+      "$fuchsia_sdk_root/pkg:scenic_cpp",
+    ]
   }
 }
 

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -180,25 +180,14 @@ source_set("fml") {
       "platform/fuchsia/paths_fuchsia.cc",
     ]
 
-    if (using_fuchsia_sdk) {
-      public_deps += [
-        "$fuchsia_sdk_root/pkg:async-cpp",
-        "$fuchsia_sdk_root/pkg:async-loop-cpp",
-        "$fuchsia_sdk_root/pkg:async-loop-default",
-        "$fuchsia_sdk_root/pkg:trace",
-        "$fuchsia_sdk_root/pkg:trace-engine",
-        "$fuchsia_sdk_root/pkg:zx",
-      ]
-    } else {
-      public_deps += [
-        "//zircon/public/lib/async-cpp",
-        "//zircon/public/lib/async-loop-cpp",
-        "//zircon/public/lib/async-loop-default",
-        "//zircon/public/lib/trace",
-        "//zircon/public/lib/trace-engine",
-        "//zircon/public/lib/zx",
-      ]
-    }
+    public_deps += [
+      "$fuchsia_sdk_root/pkg:async-cpp",
+      "$fuchsia_sdk_root/pkg:async-loop-cpp",
+      "$fuchsia_sdk_root/pkg:async-loop-default",
+      "$fuchsia_sdk_root/pkg:trace",
+      "$fuchsia_sdk_root/pkg:trace-engine",
+      "$fuchsia_sdk_root/pkg:zx",
+    ]
   }
 
   if (is_win) {
@@ -278,7 +267,7 @@ executable("fml_unittests") {
     "//flutter/testing",
   ]
 
-  if (is_fuchsia && using_fuchsia_sdk) {
+  if (is_fuchsia) {
     libs = [ "${fuchsia_sdk_path}/arch/${target_cpu}/sysroot/lib/libzircon.so" ]
   }
 }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -30,12 +30,7 @@ compiled_action("generate_snapshot_bin") {
     tool = "//third_party/dart/runtime/bin:gen_snapshot"
   }
 
-  if ((is_fuchsia || is_fuchsia_host) && !using_fuchsia_sdk) {
-    platform_kernel =
-        "$root_out_dir/flutter_runner_patched_sdk/platform_strong.dill"
-  } else {
-    platform_kernel = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
-  }
+  platform_kernel = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
 
   inputs = [
     platform_kernel,
@@ -217,11 +212,7 @@ bin_to_linkable("platform_strong_dill_linkable") {
   deps = [
     ":kernel_platform_files",
   ]
-  if ((is_fuchsia || is_fuchsia_host) && !using_fuchsia_sdk) {
-    input = "$root_out_dir/flutter_runner_patched_sdk/platform_strong.dill"
-  } else {
-    input = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
-  }
+  input = "$root_out_dir/flutter_patched_sdk/platform_strong.dill"
   symbol = "kPlatformStrongDill"
   size_symbol = "kPlatformStrongDillSize"
   executable = false
@@ -283,16 +274,8 @@ compile_platform("strong_platform") {
 }
 
 # Fuchsia's snapshot requires a different platform with extra dart: libraries.
-if ((is_fuchsia || is_fuchsia_host) && !using_fuchsia_sdk) {
-  group("kernel_platform_files") {
-    public_deps = [
-      "//topaz/runtime/flutter_runner/kernel:kernel_platform_files",
-    ]
-  }
-} else {
-  group("kernel_platform_files") {
-    public_deps = [
-      ":strong_platform",
-    ]
-  }
+group("kernel_platform_files") {
+  public_deps = [
+    ":strong_platform",
+  ]
 }

--- a/lib/ui/BUILD.gn
+++ b/lib/ui/BUILD.gn
@@ -135,15 +135,11 @@ source_set("ui") {
       "compositing/scene_host.h",
     ]
 
-    if (using_fuchsia_sdk) {
-      deps += [
-        "$fuchsia_sdk_root/pkg:async-cpp",
-        "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
-        "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
-      ]
-    } else {
-      deps += [ "//topaz/public/dart-pkg/zircon" ]
-    }
+    deps += [
+      "$fuchsia_sdk_root/pkg:async-cpp",
+      "//flutter/shell/platform/fuchsia/dart-pkg/fuchsia",
+      "//flutter/shell/platform/fuchsia/dart-pkg/zircon",
+    ]
   }
 }
 

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -12,11 +12,8 @@ if (is_fuchsia) {
 }
 
 config("vulkan_config") {
-  if (using_fuchsia_sdk) {
+  if (is_fuchsia) {
     include_dirs = [ "$fuchsia_sdk_root/vulkan/include" ]
-  } else if (is_fuchsia) {
-    include_dirs =
-        [ "//third_party/vulkan_loader_and_validation_layers/include" ]
   } else {
     include_dirs = [ "//third_party/vulkan/src" ]
   }

--- a/shell/platform/BUILD.gn
+++ b/shell/platform/BUILD.gn
@@ -27,11 +27,9 @@ group("platform") {
       "windows",
     ]
   } else if (is_fuchsia) {
-    if (using_fuchsia_sdk) {
-      deps = [
-        "fuchsia",
-      ]
-    }
+    deps = [
+      "fuchsia",
+    ]
   } else {
     assert(false, "Unknown/Unsupported platform.")
   }

--- a/shell/platform/fuchsia/BUILD.gn
+++ b/shell/platform/fuchsia/BUILD.gn
@@ -7,7 +7,7 @@ import("//flutter/common/config.gni")
 import("//flutter/tools/fuchsia/dart.gni")
 import("//flutter/tools/fuchsia/fuchsia_host_bundle.gni")
 
-if (using_fuchsia_sdk) {
+if (is_fuchsia) {
   product_suffix = ""
   is_product = false
 

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -25,17 +25,6 @@ shell_gpu_configuration("fuchsia_gpu_configuration") {
 # 1. Kernel snapshot framework mode.
 # 2. Profiler symbols.
 
-# Dependencies for flutter tooling
-#
-# While not required to run a flutter mod, these allow interacting
-# with flutter via the fx tool and need to be built.
-#
-# This is only for builds in topaz tree.
-flutter_tool_deps = []
-if (!using_fuchsia_sdk) {
-  flutter_tool_deps += [ "//third_party/dart-pkg/git/flutter/packages/flutter_tools:fuchsia_attach($host_toolchain)" ]
-}
-
 flutter_runner("jit") {
   output_name = "flutter_jit_runner"
   product = false
@@ -50,9 +39,9 @@ flutter_runner("jit") {
   }
 
   extra_deps = [
-                 "//third_party/dart/runtime:libdart_jit",
-                 "//third_party/dart/runtime/platform:libdart_platform_jit",
-               ] + flutter_tool_deps
+    "//third_party/dart/runtime:libdart_jit",
+    "//third_party/dart/runtime/platform:libdart_platform_jit",
+  ]
 }
 
 flutter_runner("jit_product") {

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -29,10 +29,6 @@ executable("testing") {
   ]
 
   if (is_fuchsia) {
-    if (!using_fuchsia_sdk) {
-      deps += [ "//garnet/public/lib/ui/scenic:client" ]
-    } else {
-      deps += [ "$fuchsia_sdk_root/pkg:scenic_cpp" ]
-    }
+    deps += [ "$fuchsia_sdk_root/pkg:scenic_cpp" ]
   }
 }

--- a/sky/packages/sky_engine/BUILD.gn
+++ b/sky/packages/sky_engine/BUILD.gn
@@ -229,23 +229,3 @@ dart_pkg("sky_engine") {
     "$service_isolate_dir/vmservice_server.dart",
   ]
 }
-
-if (is_fuchsia && !using_fuchsia_sdk) {
-  import("//build/dart/dart_library.gni")
-
-  dart_library("sky_engine_dart") {
-    package_name = "sky_engine"
-
-    package_root = "$root_gen_dir/dart-pkg/sky_engine"
-
-    sources = []
-
-    disable_analysis = true
-
-    non_dart_deps = [
-      # This will ensure all the source files needed for this package are
-      # copied to the right location.
-      ":sky_engine",
-    ]
-  }
-}

--- a/vulkan/BUILD.gn
+++ b/vulkan/BUILD.gn
@@ -5,17 +5,13 @@
 import("//build/fuchsia/sdk.gni")
 
 config("vulkan_config") {
-  if (using_fuchsia_sdk) {
-    include_dirs = [ "$fuchsia_sdk_root/vulkan/include" ]
-  } else if (is_fuchsia) {
-    include_dirs =
-        [ "//third_party/vulkan_loader_and_validation_layers/include" ]
-  } else {
-    include_dirs = [ "//third_party/vulkan/src" ]
-  }
-
+  include_dirs = []
+  defines = []
   if (is_fuchsia) {
-    defines = [ "VK_USE_PLATFORM_FUCHSIA=1" ]
+    include_dirs += [ "$fuchsia_sdk_root/vulkan/include" ]
+    defines += [ "VK_USE_PLATFORM_FUCHSIA=1" ]
+  } else {
+    include_dirs += [ "//third_party/vulkan/src" ]
   }
 }
 


### PR DESCRIPTION
This flag was used as a temporary measure to make engine targets buildable in
both the Fuchsia and Flutter buildroots. `using_fuchsia_sdk` would be set to
true in Flutter because Flutter would be using the Fuchsia SDK to build Fuchsia
artifacts. The Fuchsia buildroot would set the flag to false because it had its
buildroot to build artifacts directly and didn’t need (or indeed have) and SDK.

No functional change. Just a cleanup of dead build rules.