### PR TITLE
feat(a11y): add magicTap as SemanticsAction

### DIFF
--- a/lib/ui/semantics.dart
+++ b/lib/ui/semantics.dart
@@ -35,6 +35,7 @@ class SemanticsAction {
   static const int _kDismissIndex = 1 << 18;
   static const int _kMoveCursorForwardByWordIndex = 1 << 19;
   static const int _kMoveCursorBackwardByWordIndex = 1 << 20;
+  static const int _kDefaultActionIndex = 1 << 21;
   // READ THIS: if you add an action here, you MUST update the
   // numSemanticsActions value in testing/dart/semantics_test.dart, or tests
   // will fail.
@@ -189,6 +190,15 @@ class SemanticsAction {
   /// movement should extend (or start) a selection.
   static const SemanticsAction moveCursorBackwardByWord = SemanticsAction._(_kMoveCursorBackwardByWordIndex);
 
+  /// A request that the node should perform a default action.
+  ///
+  /// The default action should typically toggle the most important state of the node.
+  /// On iOS (with VoiceOver) users can perform a double two-finger tap (MagicTap)
+  /// to invoke this handler.
+  /// As examples, in the Phone app it answers and ends calls,
+  /// in the Music app it starts and pauses playback.
+  static const SemanticsAction defaultAction = SemanticsAction._(_kDefaultActionIndex);
+
   /// The possible semantics actions.
   ///
   /// The map's key is the [index] of the action and the value is the action
@@ -215,6 +225,7 @@ class SemanticsAction {
     _kDismissIndex: dismiss,
     _kMoveCursorForwardByWordIndex: moveCursorForwardByWord,
     _kMoveCursorBackwardByWordIndex: moveCursorBackwardByWord,
+    _kDefaultActionIndex: defaultAction,
   };
 
   @override
@@ -262,6 +273,8 @@ class SemanticsAction {
         return 'SemanticsAction.moveCursorForwardByWord';
       case _kMoveCursorBackwardByWordIndex:
         return 'SemanticsAction.moveCursorBackwardByWord';
+      case _kDefaultActionIndex:
+        return 'SemanticsAction.defaultAction';
     }
     return null;
   }

--- a/lib/ui/semantics/semantics_node.h
+++ b/lib/ui/semantics/semantics_node.h
@@ -40,6 +40,7 @@ enum class SemanticsAction : int32_t {
   kDismiss = 1 << 18,
   kMoveCursorForwardByWordIndex = 1 << 19,
   kMoveCursorBackwardByWordIndex = 1 << 20,
+  kDefaultAction = 1 << 21,
 };
 
 const int kScrollableSemanticsActions =

--- a/lib/web_ui/lib/src/ui/semantics.dart
+++ b/lib/web_ui/lib/src/ui/semantics.dart
@@ -31,6 +31,7 @@ class SemanticsAction {
   static const int _kDismissIndex = 1 << 18;
   static const int _kMoveCursorForwardByWordIndex = 1 << 19;
   static const int _kMoveCursorBackwardByWordIndex = 1 << 20;
+  static const int _kDefaultActionIndex = 1 << 21;
 
   /// The numerical value for this action.
   ///
@@ -193,6 +194,14 @@ class SemanticsAction {
   static const SemanticsAction moveCursorBackwardByWord =
       SemanticsAction._(_kMoveCursorBackwardByWordIndex);
 
+  /// A request that the node should perform its default action.
+  ///
+  /// Indicates that the app or node should perform a default action.
+  /// The exact action performed by this method depends your app, typically toggling the most important state of the app.
+  /// On iOS (with VoiceOver) users can perform a double two-finger tap to perform the most common action.
+  /// For example, in the Phone app it answers and ends phone calls, in the Music app it plays and pauses playback.
+  static const SemanticsAction defaultAction = SemanticsAction._(_kDefaultActionIndex);
+
   /// The possible semantics actions.
   ///
   /// The map's key is the [index] of the action and the value is the action
@@ -219,6 +228,7 @@ class SemanticsAction {
     _kDismissIndex: dismiss,
     _kMoveCursorForwardByWordIndex: moveCursorForwardByWord,
     _kMoveCursorBackwardByWordIndex: moveCursorBackwardByWord,
+    _kDefaultActionIndex: defaultAction,
   };
 
   @override
@@ -266,6 +276,8 @@ class SemanticsAction {
         return 'SemanticsAction.moveCursorForwardByWord';
       case _kMoveCursorBackwardByWordIndex:
         return 'SemanticsAction.moveCursorBackwardByWord';
+      case _kDefaultActionIndex:
+        return 'SemanticsAction.defaultAction';
     }
     return null;
   }

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -454,6 +454,15 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   return YES;
 }
 
+- (BOOL)accessibilityPerformMagicTap {
+  if (![self isAccessibilityBridgeAlive])
+    return NO;
+  if (![self node].HasAction(flutter::SemanticsAction::kDefaultAction))
+    return NO;
+  [self bridge] -> DispatchSemanticsAction([self uid], flutter::SemanticsAction::kDefaultAction);
+  return YES;
+}
+
 #pragma mark UIAccessibilityFocus overrides
 
 - (void)accessibilityElementDidBecomeFocused {

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -111,6 +111,8 @@ typedef enum {
   kFlutterSemanticsActionMoveCursorForwardByWord = 1 << 19,
   /// Move the cursor backward by one word.
   kFlutterSemanticsActionMoveCursorBackwardByWord = 1 << 20,
+  /// A request that the node should perform the default action.
+  kFlutterSemanticsActionDefaultAction = 1 << 21,
 } FlutterSemanticsAction;
 
 /// The set of properties that may be associated with a semantics node.

--- a/testing/dart/semantics_test.dart
+++ b/testing/dart/semantics_test.dart
@@ -20,7 +20,7 @@ void main() {
   });
 
   // This must match the number of actions in lib/ui/semantics.dart
-  const int numSemanticsActions = 21;
+  const int numSemanticsActions = 22;
   test('SemanticsAction.values refers to all actions.', () async {
     expect(SemanticsAction.values.length, equals(numSemanticsActions));
     for (int index = 0; index < numSemanticsActions; ++index) {


### PR DESCRIPTION
Adds the iOS [accessibilityPerformMagicTap](https://developer.apple.com/documentation/objectivec/nsobject/1615137-accessibilityperformmagictap) (double two-finger tap with VoiceOver enabled) as a SemanticsAction.

I'm not aware that any comparable TalkBack action exists on Android, but for now I have chosen to call the SemanticsAction `defaultAction`, to use a somewhat common term. Other suggestions are welcome.

Some questions for the Flutter team:
- Why does it seem like `SemanticsAction.onDismiss` "bubbles" upwards in the semantics tree, but `onDefaultAction` which I implemented does not. E.g. wrapping the Scaffold in a Semantics node which handles `onDismiss` and `onDefaultAction` only works for `onDismiss`.
- What is the best approach for defining an app-level or route-level magic-tap og dismiss handler? Normally this would be done via the AppDelegate, but in Flutter I guess it would be on the `Scaffold` or `MaterialApp`?
- Why does the Semantics widget become focusable with VoiceOver whenever an action is added to it? Example: Semantics with props `container: false, onDismiss: () {}` is focusable as an outer node.
