### PR TITLE
Allow drawing raster cache results whose device rect is one pixel larger than the cached image

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -26,7 +26,9 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   SkAutoCanvasRestore auto_restore(&canvas, true);
   SkIRect bounds =
       RasterCache::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
-  FML_DCHECK(bounds.size() == image_->dimensions());
+  FML_DCHECK(
+      std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
+      std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
   canvas.resetMatrix();
   canvas.drawImage(image_, bounds.fLeft, bounds.fTop, paint);
 }


### PR DESCRIPTION
RasterCacheResult::draw constructs the device target rectangle by
calling SkRect::roundOut, which rounds down the left/top coordinates
and rounds up the right/bottom coordinates.  The rounding can produce
a device rect whose width and/or height differs from the cache result
image's width/height by one pixel.