### PR TITLE
[metrics] Record the frame target time on the layer tree

### DIFF
--- a/flow/layers/layer_tree.cc
+++ b/flow/layers/layer_tree.cc
@@ -21,8 +21,10 @@ LayerTree::LayerTree(const SkISize& frame_size,
       checkerboard_raster_cache_images_(false),
       checkerboard_offscreen_layers_(false) {}
 
-void LayerTree::RecordBuildTime(fml::TimePoint start) {
-  build_start_ = start;
+void LayerTree::RecordBuildTime(fml::TimePoint build_start,
+                                fml::TimePoint target_time) {
+  build_start_ = build_start;
+  target_time_ = target_time;
   build_finish_ = fml::TimePoint::Now();
 }
 

--- a/flow/layers/layer_tree.h
+++ b/flow/layers/layer_tree.h
@@ -54,10 +54,11 @@ class LayerTree {
   float frame_physical_depth() const { return frame_physical_depth_; }
   float frame_device_pixel_ratio() const { return frame_device_pixel_ratio_; }
 
-  void RecordBuildTime(fml::TimePoint begin_start);
+  void RecordBuildTime(fml::TimePoint build_start, fml::TimePoint target_time);
   fml::TimePoint build_start() const { return build_start_; }
   fml::TimePoint build_finish() const { return build_finish_; }
   fml::TimeDelta build_time() const { return build_finish_ - build_start_; }
+  fml::TimePoint target_time() const { return target_time_; }
 
   // The number of frame intervals missed after which the compositor must
   // trace the rasterized picture to a trace file. Specify 0 to disable all
@@ -84,6 +85,7 @@ class LayerTree {
   std::shared_ptr<Layer> root_layer_;
   fml::TimePoint build_start_;
   fml::TimePoint build_finish_;
+  fml::TimePoint target_time_;
   SkISize frame_size_ = SkISize::MakeEmpty();  // Physical pixels.
   float frame_physical_depth_;
   float frame_device_pixel_ratio_ = 1.0f;  // Logical / Physical pixels ratio.

--- a/shell/common/animator.cc
+++ b/shell/common/animator.cc
@@ -25,7 +25,8 @@ Animator::Animator(Delegate& delegate,
     : delegate_(delegate),
       task_runners_(std::move(task_runners)),
       waiter_(std::move(waiter)),
-      last_begin_frame_time_(),
+      last_frame_begin_time_(),
+      last_frame_target_time_(),
       dart_frame_deadline_(0),
 #if FLUTTER_SHELL_ENABLE_METAL
       layer_tree_pipeline_(fml::MakeRefCounted<LayerTreePipeline>(2)),
@@ -132,7 +133,8 @@ void Animator::BeginFrame(fml::TimePoint frame_start_time,
   // to service potential frame.
   FML_DCHECK(producer_continuation_);
 
-  last_begin_frame_time_ = frame_start_time;
+  last_frame_begin_time_ = frame_start_time;
+  last_frame_target_time_ = frame_target_time;
   dart_frame_deadline_ = FxlToDartOrEarlier(frame_target_time);
   {
     TRACE_EVENT2("flutter", "Framework Workload", "mode", "basic", "frame",
@@ -178,7 +180,8 @@ void Animator::Render(std::unique_ptr<flutter::LayerTree> layer_tree) {
 
   if (layer_tree) {
     // Note the frame time for instrumentation.
-    layer_tree->RecordBuildTime(last_begin_frame_time_);
+    layer_tree->RecordBuildTime(last_frame_begin_time_,
+                                last_frame_target_time_);
   }
 
   // Commit the pending continuation.

--- a/shell/common/animator.h
+++ b/shell/common/animator.h
@@ -96,7 +96,8 @@ class Animator final {
   TaskRunners task_runners_;
   std::shared_ptr<VsyncWaiter> waiter_;
 
-  fml::TimePoint last_begin_frame_time_;
+  fml::TimePoint last_frame_begin_time_;
+  fml::TimePoint last_frame_target_time_;
   int64_t dart_frame_deadline_;
   fml::RefPtr<LayerTreePipeline> layer_tree_pipeline_;
   fml::Semaphore pending_frame_semaphore_;


### PR DESCRIPTION
This lets us measure stats on when the frame was
scheduled to be rendered vs when it finished rasterizing.

Note: This isn't propagated to the FrameTimings struct yet,
that is to be followed.