### PR TITLE
Update SystemNavigator.pop for iOS shell

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -204,15 +204,17 @@ using namespace flutter;
 
 - (void)popSystemNavigator:(BOOL)isAnimated {
   // Apple's human user guidelines say not to terminate iOS applications. However, if the
-  // root view of the app is a navigation controller, it is instructed to back up a level
-  // in the navigation hierarchy.
+  // root view of the app is a navigation controller and contains the FlutterViewController,
+  // it is instructed to back up a level in the navigation hierarchy.
   // It's also possible in an Add2App scenario that the FlutterViewController was presented
-  // outside the context of a UINavigationController, and still wants to be popped.
+  // outside the context of a UINavigationController, even if the root view of the app is a
+  // navigation controller, and still wants to be popped.
+  auto engineViewController = static_cast<UIViewController*>([_engine.get() viewController]);
   UIViewController* viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-  if ([viewController isKindOfClass:[UINavigationController class]]) {
+  if ([viewController isKindOfClass:[UINavigationController class]]
+      && [[((UINavigationController*)viewController) viewControllers] containsObject:engineViewController]) {
     [((UINavigationController*)viewController) popViewControllerAnimated:isAnimated];
   } else {
-    auto engineViewController = static_cast<UIViewController*>([_engine.get() viewController]);
     if (engineViewController != viewController) {
       [engineViewController dismissViewControllerAnimated:isAnimated completion:nil];
     }


### PR DESCRIPTION
Check that UINavigationController contains the FlutterViewController to back up a level.

It's also possible in an Add2App scenario that the FlutterViewController was presented
outside the context of a UINavigationController, even if the root view of the app is a
navigation controller, and still wants to be popped.