### PR TITLE
[web] use web drivers as a library only. do not fetch/clone web_installers

### DIFF
--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -231,16 +231,16 @@ Future<String> fetchLatestChromeVersion() async {
 /// Get the Chrome Driver version for the system Chrome.
 // TODO(nurhan): https://github.com/flutter/flutter/issues/53179
 Future<String> queryChromeDriverVersion() async {
-  final int chromeVersion = await _querySystemChromeVersion();
+  final int chromeVersion = await _querySystemChromeMajorVersion();
   final io.File lockFile = io.File(
-        path.join(environment.webUiRootDir.path, 'dev', 'driver_version.yaml'));
+      path.join(environment.webUiRootDir.path, 'dev', 'driver_version.yaml'));
   YamlMap _configuration = loadYaml(lockFile.readAsStringSync()) as YamlMap;
   final String chromeDriverVersion =
       _configuration['chrome'][chromeVersion] as String;
   return chromeDriverVersion;
 }
 
-Future<int> _querySystemChromeVersion() async {
+Future<int> _querySystemChromeMajorVersion() async {
   String chromeExecutable = '';
   if (io.Platform.isLinux) {
     chromeExecutable = 'google-chrome';
@@ -262,11 +262,15 @@ Future<int> _querySystemChromeVersion() async {
   print('INFO: chrome version in use $output');
 
   // Version number such as 79.0.3945.36.
-  final String versionAsString = output.split(' ')[2];
-
-  final String versionNo = versionAsString.split('.')[0];
-
-  return int.parse(versionNo);
+  try {
+    final String versionAsString = output.split(' ').last;
+    final String majorVersion = versionAsString.split('.')[0];
+    return int.parse(majorVersion);
+  } catch (e) {
+    throw Exception(
+        'Was expecting a version of the form Google Chrome 79.0.3945.36., '
+        'received $output');
+  }
 }
 
 /// Find Google Chrome App on Mac.

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -229,10 +229,7 @@ Future<String> fetchLatestChromeVersion() async {
 }
 
 /// Get the Chrome Driver version for the system Chrome.
-///
-/// It is only used by integration tests for now.
-/// TODO(nurhan): Merge the chrome download code in the unit tests with this
-/// one. Have both of them relying to the same chrome version.
+// TODO(nurhan): https://github.com/flutter/flutter/issues/53179
 Future<String> queryChromeDriverVersion() async {
   final int chromeVersion = await _querySystemChromeVersion();
   final io.File lockFile = io.File(

--- a/lib/web_ui/dev/chrome_installer.dart
+++ b/lib/web_ui/dev/chrome_installer.dart
@@ -263,7 +263,7 @@ Future<int> _querySystemChromeMajorVersion() async {
 
   // Version number such as 79.0.3945.36.
   try {
-    final String versionAsString = output.split(' ').last;
+    final String versionAsString = output.trim().split(' ').last;
     final String majorVersion = versionAsString.split('.')[0];
     return int.parse(majorVersion);
   } catch (e) {

--- a/lib/web_ui/dev/driver_version.yaml
+++ b/lib/web_ui/dev/driver_version.yaml
@@ -1,0 +1,12 @@
+
+## Map for driver versions to use for each browser version.
+## See: https://chromedriver.chromium.org/downloads
+chrome:
+  81: '81.0.4044.69'
+  80: '80.0.3987.106'
+  79: '79.0.3945.36'
+  78: '78.0.3904.105'
+  77: '77.0.3865.40'
+  76: '76.0.3809.126'
+  75: '75.0.3770.140'
+  74: '74.0.3729.6'

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -89,10 +89,11 @@ class IntegrationTestsManager {
     _browserDriverDir.createSync(recursive: true);
     temporaryDirectories.add(_drivers);
 
+    // TODO(nurhan): https://github.com/flutter/flutter/issues/53179
     final String chromeDriverVersion = await queryChromeDriverVersion();
     ChromeDriverInstaller chromeDriverInstaller =
         ChromeDriverInstaller.withVersion(chromeDriverVersion);
-    await chromeDriverInstaller.install();
+    await chromeDriverInstaller.install(alwaysInstall: true);
     await _runDriver();
   }
 

--- a/lib/web_ui/dev/integration_tests_manager.dart
+++ b/lib/web_ui/dev/integration_tests_manager.dart
@@ -5,7 +5,9 @@
 import 'dart:io' as io;
 import 'package:path/path.dart' as pathlib;
 import 'package:web_driver_installer/chrome_driver_installer.dart';
+import 'package:yaml/yaml.dart';
 
+import 'chrome_installer.dart';
 import 'common.dart';
 import 'environment.dart';
 import 'utils.dart';
@@ -46,24 +48,6 @@ class IntegrationTestsManager {
     }
   }
 
-  void _cloneWebInstallers() async {
-    final int exitCode = await runProcess(
-      'git',
-      <String>[
-        'clone',
-        'https://github.com/flutter/web_installers.git',
-      ],
-      workingDirectory: _browserDriverDir.path,
-    );
-
-    if (exitCode != 0) {
-      io.stderr.writeln('ERROR: '
-          'Failed to clone web installers. Exited with exit code $exitCode');
-      throw DriverException('ERROR: '
-          'Failed to clone web installers. Exited with exit code $exitCode');
-    }
-  }
-
   Future<bool> _runPubGet(String workingDirectory) async {
     final String executable = isCirrus ? environment.pubExecutable : 'flutter';
     final List<String> arguments = isCirrus
@@ -90,34 +74,14 @@ class IntegrationTestsManager {
   }
 
   void _runDriver() async {
-    final int exitCode = await runProcess(
-      environment.dartExecutable,
-      <String>[
-        'lib/web_driver_installer.dart',
-        '${_browser}driver',
-        '--install-only',
-      ],
-      workingDirectory: pathlib.join(
-          _browserDriverDir.path, 'web_installers', 'packages', 'web_drivers'),
-    );
-
-    if (exitCode != 0) {
-      io.stderr.writeln(
-          'ERROR: Failed to run driver. Exited with exit code $exitCode');
-      throw DriverException(
-          'ERROR: Failed to run driver. Exited with exit code $exitCode');
-    }
     startProcess(
       './chromedriver/chromedriver',
       ['--port=4444'],
-      workingDirectory: pathlib.join(
-          _browserDriverDir.path, 'web_installers', 'packages', 'web_drivers'),
     );
     print('INFO: Driver started');
   }
 
   void prepareDriver() async {
-    final io.Directory priorCurrentDirectory = io.Directory.current;
     if (_browserDriverDir.existsSync()) {
       _browserDriverDir.deleteSync(recursive: true);
     }
@@ -125,22 +89,11 @@ class IntegrationTestsManager {
     _browserDriverDir.createSync(recursive: true);
     temporaryDirectories.add(_drivers);
 
-    // TODO(nurhan): We currently need git clone for getting the driver lock
-    // file. Remove this after making changes in web_installers.
-    await _cloneWebInstallers();
-    // Change the directory to the driver_lock.yaml file's directory.
-    io.Directory.current = pathlib.join(
-        _browserDriverDir.path, 'web_installers', 'packages', 'web_drivers');
-    // Chrome is the only browser supporting integration tests for now.
-    ChromeDriverInstaller chromeDriverInstaller = ChromeDriverInstaller();
-    bool installation = await chromeDriverInstaller.install();
-
-    if (installation) {
-      io.Directory.current = priorCurrentDirectory;
-      await _runDriver();
-    } else {
-      throw DriverException('ERROR: Installing driver failed');
-    }
+    final String chromeDriverVersion = await queryChromeDriverVersion();
+    ChromeDriverInstaller chromeDriverInstaller =
+        ChromeDriverInstaller.withVersion(chromeDriverVersion);
+    await chromeDriverInstaller.install();
+    await _runDriver();
   }
 
   /// Runs all the web tests under e2e_tests/web.

--- a/lib/web_ui/pubspec.yaml
+++ b/lib/web_ui/pubspec.yaml
@@ -25,4 +25,4 @@ dev_dependencies:
     git:
       url: git://github.com/flutter/web_installers.git
       path: packages/web_drivers/
-      ref: dae38d8839cc39f997fb4229f1382680b8758b4f
+      ref: 90c69a79b2764c93875dc8ed4f4932c27a6f3a86


### PR DESCRIPTION
Felt is locally broken since it was still fetching the web_installers repository.

This PR removes all those usages and only uses web_drivers as a library.

Fixes: https://github.com/flutter/flutter/issues/53179