### PR TITLE
Fix FlutterEngine destroy and accessibility disable race

### DIFF
--- a/shell/platform/android/io/flutter/view/AccessibilityBridge.java
+++ b/shell/platform/android/io/flutter/view/AccessibilityBridge.java
@@ -273,17 +273,21 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           new AccessibilityManager.AccessibilityStateChangeListener() {
             @Override
             public void onAccessibilityStateChanged(boolean accessibilityEnabled) {
-              if (accessibilityEnabled) {
-                accessibilityChannel.setAccessibilityMessageHandler(accessibilityMessageHandler);
-                accessibilityChannel.onAndroidAccessibilityEnabled();
-              } else {
-                accessibilityChannel.setAccessibilityMessageHandler(null);
-                accessibilityChannel.onAndroidAccessibilityDisabled();
-              }
+              if (accessibilityChannel.flutterJNI.isAttached()) {
+                if (accessibilityEnabled) {
+                  accessibilityChannel.setAccessibilityMessageHandler(accessibilityMessageHandler);
+                  accessibilityChannel.onAndroidAccessibilityEnabled();
+                } else {
+                  accessibilityChannel.setAccessibilityMessageHandler(null);
+                  accessibilityChannel.onAndroidAccessibilityDisabled();
+                }
 
-              if (onAccessibilityChangeListener != null) {
-                onAccessibilityChangeListener.onAccessibilityChanged(
-                    accessibilityEnabled, accessibilityManager.isTouchExplorationEnabled());
+                if (onAccessibilityChangeListener != null) {
+                  onAccessibilityChangeListener.onAccessibilityChanged(
+                      accessibilityEnabled, accessibilityManager.isTouchExplorationEnabled());
+                }
+              } else {
+                Log.w(TAG, "flutterJNI not attached,ignore accessibilityStateChanged");
               }
             }
           };
@@ -351,17 +355,21 @@ public class AccessibilityBridge extends AccessibilityNodeProvider {
           new AccessibilityManager.TouchExplorationStateChangeListener() {
             @Override
             public void onTouchExplorationStateChanged(boolean isTouchExplorationEnabled) {
-              if (isTouchExplorationEnabled) {
-                accessibilityFeatureFlags |= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
-              } else {
-                onTouchExplorationExit();
-                accessibilityFeatureFlags &= ~AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
-              }
-              sendLatestAccessibilityFlagsToFlutter();
+              if (accessibilityChannel.flutterJNI.isAttached()) {
+                if (isTouchExplorationEnabled) {
+                  accessibilityFeatureFlags |= AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
+                } else {
+                  onTouchExplorationExit();
+                  accessibilityFeatureFlags &= ~AccessibilityFeature.ACCESSIBLE_NAVIGATION.value;
+                }
+                sendLatestAccessibilityFlagsToFlutter();
 
-              if (onAccessibilityChangeListener != null) {
-                onAccessibilityChangeListener.onAccessibilityChanged(
-                    accessibilityManager.isEnabled(), isTouchExplorationEnabled);
+                if (onAccessibilityChangeListener != null) {
+                  onAccessibilityChangeListener.onAccessibilityChanged(
+                      accessibilityManager.isEnabled(), isTouchExplorationEnabled);
+                }
+              } else {
+                Log.w(TAG, "flutterJNI not attached,ignore touchExplorationStateChanged");
               }
             }
           };


### PR DESCRIPTION
AccessibilityManager.notifyAccessibilityStateChanged() use post to call listener.onAccessibilityStateChanged(),if post and FlutterEngine.destroy() occur at the same time,it may be post->FlutterEngine.destroy->FlutterJNI.nativePlatformViewId=null->listener.onAccessibilityStateChanged(),and app will crash with FlutterJNI.ensureAttachedToNative as #33511
For safety reasons,Huawei will close Accessibility when app quit completely.If phone low memory and try to kill some background app,onAccessibilityStateChanged and FlutterEngine.destroy will occur at the same time ,this will greatly increase the probability of crash.

Issue https://github.com/flutter/flutter/issues/33511