### PR TITLE
fuchsia: remove use of replace_as_executable (second try)

### DIFF
--- a/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_component_controller.cc
@@ -201,12 +201,12 @@ bool DartComponentController::SetupFromKernel() {
   }
 
   if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "pkg/data/isolate_core_snapshot_data.bin",
+          nullptr, "/pkg/data/isolate_core_snapshot_data.bin",
           isolate_snapshot_data_)) {
     return false;
   }
   if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "pkg/data/isolate_core_snapshot_instructions.bin",
+          nullptr, "/pkg/data/isolate_core_snapshot_instructions.bin",
           isolate_snapshot_instructions_, true /* executable */)) {
     return false;
   }

--- a/shell/platform/fuchsia/dart_runner/dart_runner.cc
+++ b/shell/platform/fuchsia/dart_runner/dart_runner.cc
@@ -158,11 +158,11 @@ DartRunner::DartRunner() : context_(sys::ComponentContext::Create()) {
   params.vm_snapshot_instructions = ::_kDartVmSnapshotInstructions;
 #else
   if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "pkg/data/vm_snapshot_data.bin", vm_snapshot_data_)) {
+          nullptr, "/pkg/data/vm_snapshot_data.bin", vm_snapshot_data_)) {
     FX_LOG(FATAL, LOG_TAG, "Failed to load vm snapshot data");
   }
   if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "pkg/data/vm_snapshot_instructions.bin",
+          nullptr, "/pkg/data/vm_snapshot_instructions.bin",
           vm_snapshot_instructions_, true /* executable */)) {
     FX_LOG(FATAL, LOG_TAG, "Failed to load vm snapshot instructions");
   }

--- a/shell/platform/fuchsia/dart_runner/examples/goodbye_dart/meta/goodbye_dart_aot.cmx
+++ b/shell/platform/fuchsia/dart_runner/examples/goodbye_dart/meta/goodbye_dart_aot.cmx
@@ -3,9 +3,6 @@
     "data": "data/goodbye_dart_aot"
   },
   "sandbox": {
-    "features": [
-      "deprecated-ambient-replace-as-executable"
-    ],
     "services": [
       "fuchsia.intl.PropertyProvider",
       "fuchsia.sys.Environment"

--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_product_runner.cmx
@@ -5,7 +5,6 @@
   "sandbox": {
     "features": [
       "config-data",
-      "deprecated-ambient-replace-as-executable",
       "root-ssl-certificates"
     ],
     "services": [

--- a/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
+++ b/shell/platform/fuchsia/dart_runner/meta/dart_aot_runner.cmx
@@ -5,7 +5,6 @@
   "sandbox": {
     "features": [
       "config-data",
-      "deprecated-ambient-replace-as-executable",
       "root-ssl-certificates"
     ],
     "services": [

--- a/shell/platform/fuchsia/dart_runner/service_isolate.cc
+++ b/shell/platform/fuchsia/dart_runner/service_isolate.cc
@@ -82,7 +82,7 @@ Dart_Isolate CreateServiceIsolate(const char* uri,
 
 #if defined(AOT_RUNTIME)
   // The VM service was compiled as a separate app.
-  const char* snapshot_path = "pkg/data/vmservice_snapshot.so";
+  const char* snapshot_path = "/pkg/data/vmservice_snapshot.so";
   if (elf_snapshot.Load(nullptr, snapshot_path)) {
     vmservice_data = elf_snapshot.IsolateData();
     vmservice_instructions = elf_snapshot.IsolateInstrs();
@@ -92,14 +92,14 @@ Dart_Isolate CreateServiceIsolate(const char* uri,
   } else {
     // The VM service was compiled as a separate app.
     const char* snapshot_data_path =
-        "pkg/data/vmservice_isolate_snapshot_data.bin";
+        "/pkg/data/vmservice_isolate_snapshot_data.bin";
     const char* snapshot_instructions_path =
-        "pkg/data/vmservice_isolate_snapshot_instructions.bin";
+        "/pkg/data/vmservice_isolate_snapshot_instructions.bin";
 #else
   // The VM service is embedded in the core snapshot.
-  const char* snapshot_data_path = "pkg/data/isolate_core_snapshot_data.bin";
+  const char* snapshot_data_path = "/pkg/data/isolate_core_snapshot_data.bin";
   const char* snapshot_instructions_path =
-      "pkg/data/isolate_core_snapshot_instructions.bin";
+      "/pkg/data/isolate_core_snapshot_instructions.bin";
 #endif
 
     if (!dart_utils::MappedResource::LoadFromNamespace(
@@ -196,7 +196,7 @@ Dart_Isolate CreateServiceIsolate(const char* uri,
 Dart_Handle GetVMServiceAssetsArchiveCallback() {
   dart_utils::MappedResource observatory_tar;
   if (!dart_utils::MappedResource::LoadFromNamespace(
-          nullptr, "pkg/data/observatory.tar", observatory_tar)) {
+          nullptr, "/pkg/data/observatory.tar", observatory_tar)) {
     FX_LOG(ERROR, LOG_TAG, "Failed to load Observatory assets");
     return nullptr;
   }

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_product_runner.cmx
@@ -5,7 +5,6 @@
   "sandbox": {
     "features": [
       "config-data",
-      "deprecated-ambient-replace-as-executable",
       "root-ssl-certificates",
       "vulkan"
     ],

--- a/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
+++ b/shell/platform/fuchsia/flutter/meta/flutter_aot_runner.cmx
@@ -5,7 +5,6 @@
   "sandbox": {
     "features": [
       "config-data",
-      "deprecated-ambient-replace-as-executable",
       "root-ssl-certificates",
       "vulkan"
     ],

--- a/shell/platform/fuchsia/flutter/runner.cc
+++ b/shell/platform/fuchsia/flutter/runner.cc
@@ -87,7 +87,7 @@ bool InitializeICU() {
   const char* data_path = kIcuDataPath;
 
   fuchsia::mem::Buffer icu_data;
-  if (!dart_utils::VmoFromFilename(data_path, &icu_data)) {
+  if (!dart_utils::VmoFromFilename(data_path, false, &icu_data)) {
     return false;
   }
 

--- a/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmo.cc
@@ -7,15 +7,18 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 
+#include <fuchsia/io/cpp/fidl.h>
 #include <fuchsia/mem/cpp/fidl.h>
+#include <lib/fdio/directory.h>
 #include <lib/fdio/io.h>
 #include <lib/syslog/global.h>
+#include <zircon/status.h>
 
 #include "runtime/dart/utils/logging.h"
 
 namespace {
 
-bool VmoFromFd(int fd, fuchsia::mem::Buffer* buffer) {
+bool VmoFromFd(int fd, bool executable, fuchsia::mem::Buffer* buffer) {
   if (!buffer) {
     FX_LOG(FATAL, LOG_TAG, "Invalid buffer pointer");
   }
@@ -27,7 +30,14 @@ bool VmoFromFd(int fd, fuchsia::mem::Buffer* buffer) {
   }
 
   zx_handle_t result = ZX_HANDLE_INVALID;
-  if (fdio_get_vmo_copy(fd, &result) != ZX_OK) {
+  zx_status_t status;
+  if (executable) {
+    status = fdio_get_vmo_exec(fd, &result);
+  } else {
+    status = fdio_get_vmo_copy(fd, &result);
+  }
+
+  if (status != ZX_OK) {
     return false;
   }
 
@@ -42,20 +52,42 @@ bool VmoFromFd(int fd, fuchsia::mem::Buffer* buffer) {
 namespace dart_utils {
 
 bool VmoFromFilename(const std::string& filename,
+                     bool executable,
                      fuchsia::mem::Buffer* buffer) {
-  return VmoFromFilenameAt(AT_FDCWD, filename, buffer);
+  // Note: the implementation here cannot be shared with VmoFromFilenameAt
+  // because fdio_open_fd_at does not aim to provide POSIX compatibility, and
+  // thus does not handle AT_FDCWD as dirfd.
+  uint32_t flags = fuchsia::io::OPEN_RIGHT_READABLE |
+                   (executable ? fuchsia::io::OPEN_RIGHT_EXECUTABLE : 0);
+  zx_status_t status;
+  int fd;
+
+  status = fdio_open_fd(filename.c_str(), flags, &fd);
+  if (status != ZX_OK) {
+    FX_LOGF(ERROR, LOG_TAG, "fdio_open_fd(\"%s\", %08x) failed: %s",
+            filename.c_str(), flags, zx_status_get_string(status));
+    return false;
+  }
+  bool result = VmoFromFd(fd, executable, buffer);
+  close(fd);
+  return result;
 }
 
 bool VmoFromFilenameAt(int dirfd,
                        const std::string& filename,
+                       bool executable,
                        fuchsia::mem::Buffer* buffer) {
-  int fd = openat(dirfd, filename.c_str(), O_RDONLY);
-  if (fd == -1) {
-    FX_LOGF(ERROR, LOG_TAG, "openat(\"%s\") failed: %s", filename.c_str(),
-            strerror(errno));
+  uint32_t flags = fuchsia::io::OPEN_RIGHT_READABLE |
+                   (executable ? fuchsia::io::OPEN_RIGHT_EXECUTABLE : 0);
+  zx_status_t status;
+  int fd;
+  status = fdio_open_fd_at(dirfd, filename.c_str(), flags, &fd);
+  if (status != ZX_OK) {
+    FX_LOGF(ERROR, LOG_TAG, "fdio_open_fd_at(%d, \"%s\", %08x) failed: %s",
+            dirfd, filename.c_str(), flags, zx_status_get_string(status));
     return false;
   }
-  bool result = VmoFromFd(fd, buffer);
+  bool result = VmoFromFd(fd, executable, buffer);
   close(fd);
   return result;
 }

--- a/shell/platform/fuchsia/runtime/dart/utils/vmo.h
+++ b/shell/platform/fuchsia/runtime/dart/utils/vmo.h
@@ -11,10 +11,13 @@
 
 namespace dart_utils {
 
-bool VmoFromFilename(const std::string& filename, fuchsia::mem::Buffer* buffer);
+bool VmoFromFilename(const std::string& filename,
+                     bool executable,
+                     fuchsia::mem::Buffer* buffer);
 
 bool VmoFromFilenameAt(int dirfd,
                        const std::string& filename,
+                       bool executable,
                        fuchsia::mem::Buffer* buffer);
 
 zx_status_t IsSizeValid(const fuchsia::mem::Buffer& buffer, bool* is_valid);


### PR DESCRIPTION
This is a second attempt at #16690, which was reverted because it broke the Dart JIT runner.  The primary differences are that this time around, we correctly handle absolute vs relative paths, depending on whether library loading bottoms out in `fdio_open_fd` or `fdio_open_fd_at`.  I've added additional assertions.

On Fuchsia, we can now get executable VMOs from trusted backing
filesystems.  This allows us to remove the use of replace_as_executable
in favor of opening files with `fdio_open_fd_at` with the
`OPEN_RIGHT_EXECUTABLE` flag and getting VMOs by calling
`fdio_get_vmo_exec`.

By moving the responsibility for executability into the filesystem, we
are able to remove `deprecated-ambient-replace-as-executable` from
component manifests for non-JIT runners (the JIT runners still call
replace_as_executable in Dart's allocator).  It wasn't abundantly clear
whether .cmx files for tests were used purely in AOT runtime
environments or also saw JIT usage, so I left those as-is.

Testing: I verified locally that the flutter product runner works on
Astro, and also successfully ran the Dart JIT example test (which was
the thing blocking the google3 roll with the previous attempt at this
patchset).  If there's any additional pre-flight checks you'd like me to do, let me know!