### PR TITLE
Rename GPU thread to raster thread in code comments

### DIFF
--- a/flow/README.md
+++ b/flow/README.md
@@ -3,4 +3,4 @@ Flow
 
 Flow is a simple compositor based on Skia that the Flutter engine uses to cache
 recoded paint commands and pixels generated from those recordings. Flow runs on
-the GPU thread and uploads information to the GPU.
+the raster thread and uploads information to Skia.

--- a/flow/testing/mock_texture.h
+++ b/flow/testing/mock_texture.h
@@ -25,7 +25,7 @@ class MockTexture : public Texture {
 
   explicit MockTexture(int64_t textureId);
 
-  // Called from GPU thread.
+  // Called from raster thread.
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,

--- a/flow/texture.h
+++ b/flow/texture.h
@@ -15,25 +15,25 @@ namespace flutter {
 
 class Texture {
  public:
-  Texture(int64_t id);  // Called from UI or GPU thread.
-  virtual ~Texture();   // Called from GPU thread.
+  Texture(int64_t id);  // Called from UI or raster thread.
+  virtual ~Texture();   // Called from raster thread.
 
-  // Called from GPU thread.
+  // Called from raster thread.
   virtual void Paint(SkCanvas& canvas,
                      const SkRect& bounds,
                      bool freeze,
                      GrContext* context) = 0;
 
-  // Called from GPU thread.
+  // Called from raster thread.
   virtual void OnGrContextCreated() = 0;
 
-  // Called from GPU thread.
+  // Called from raster thread.
   virtual void OnGrContextDestroyed() = 0;
 
-  // Called on GPU thread.
+  // Called on raster thread.
   virtual void MarkNewFrameAvailable() = 0;
 
-  // Called on GPU thread.
+  // Called on raster thread.
   virtual void OnTextureUnregistered() = 0;
 
   int64_t Id() { return id_; }
@@ -48,19 +48,19 @@ class TextureRegistry {
  public:
   TextureRegistry();
 
-  // Called from GPU thread.
+  // Called from raster thread.
   void RegisterTexture(std::shared_ptr<Texture> texture);
 
-  // Called from GPU thread.
+  // Called from raster thread.
   void UnregisterTexture(int64_t id);
 
-  // Called from GPU thread.
+  // Called from raster thread.
   std::shared_ptr<Texture> GetTexture(int64_t id);
 
-  // Called from GPU thread.
+  // Called from raster thread.
   void OnGrContextCreated();
 
-  // Called from GPU thread.
+  // Called from raster thread.
   void OnGrContextDestroyed();
 
  private:

--- a/flow/view_holder.cc
+++ b/flow/view_holder.cc
@@ -52,7 +52,7 @@ void ViewHolder::Create(zx_koid_t id,
                         fml::RefPtr<fml::TaskRunner> ui_task_runner,
                         fuchsia::ui::views::ViewHolderToken view_holder_token,
                         const BindCallback& on_bind_callback) {
-  // This GPU thread contains at least 1 ViewHolder.  Initialize the per-thread
+  // This raster thread contains at least 1 ViewHolder.  Initialize the per-thread
   // bindings.
   if (tls_view_holder_bindings.get() == nullptr) {
     tls_view_holder_bindings.reset(new ViewHolderBindings());

--- a/flow/view_holder.cc
+++ b/flow/view_holder.cc
@@ -52,8 +52,8 @@ void ViewHolder::Create(zx_koid_t id,
                         fml::RefPtr<fml::TaskRunner> ui_task_runner,
                         fuchsia::ui::views::ViewHolderToken view_holder_token,
                         const BindCallback& on_bind_callback) {
-  // This raster thread contains at least 1 ViewHolder.  Initialize the per-thread
-  // bindings.
+  // This raster thread contains at least 1 ViewHolder.  Initialize the
+  // per-thread bindings.
   if (tls_view_holder_bindings.get() == nullptr) {
     tls_view_holder_bindings.reset(new ViewHolderBindings());
   }

--- a/fml/gpu_thread_merger.h
+++ b/fml/gpu_thread_merger.h
@@ -17,7 +17,7 @@ enum class GpuThreadStatus { kRemainsMerged, kRemainsUnmerged, kUnmergedNow };
 
 class GpuThreadMerger : public fml::RefCountedThreadSafe<GpuThreadMerger> {
  public:
-  // Merges the GPU thread into platform thread for the duration of
+  // Merges the raster thread into platform thread for the duration of
   // the lease term. Lease is managed by the caller by either calling
   // |ExtendLeaseTo| or |DecrementLease|.
   // When the caller merges with a lease term of say 2. The threads
@@ -38,7 +38,7 @@ class GpuThreadMerger : public fml::RefCountedThreadSafe<GpuThreadMerger> {
 
   // Returns true if the current thread owns rasterizing.
   // When the threads are merged, platform thread owns rasterizing.
-  // When un-merged, gpu thread owns rasterizing.
+  // When un-merged, raster thread owns rasterizing.
   bool IsOnRasterizingThread();
 
  private:

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -645,8 +645,8 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// controls where the statistics are displayed.
   ///
   /// enabledOptions is a bit field with the following bits defined:
-  ///  - 0x01: displayRasterizerStatistics - show GPU thread frame time
-  ///  - 0x02: visualizeRasterizerStatistics - graph GPU thread frame times
+  ///  - 0x01: displayRasterizerStatistics - show raster thread frame time
+  ///  - 0x02: visualizeRasterizerStatistics - graph raster thread frame times
   ///  - 0x04: displayEngineStatistics - show UI thread frame time
   ///  - 0x08: visualizeEngineStatistics - graph UI thread frame times
   /// Set enabledOptions to 0x0F to enable all the currently defined features.

--- a/lib/ui/compositing.dart
+++ b/lib/ui/compositing.dart
@@ -654,7 +654,7 @@ class SceneBuilder extends NativeFieldWrapperClass2 {
   /// The "UI thread" is the thread that includes all the execution of
   /// the main Dart isolate (the isolate that can call
   /// [Window.render]). The UI thread frame time is the total time
-  /// spent executing the [Window.onBeginFrame] callback. The "GPU
+  /// spent executing the [Window.onBeginFrame] callback. The "raster
   /// thread" is the thread (running on the CPU) that subsequently
   /// processes the [Scene] provided by the Dart code to turn it into
   /// GPU commands and send it to the GPU.

--- a/lib/ui/compositing/scene_host.cc
+++ b/lib/ui/compositing/scene_host.cc
@@ -180,7 +180,7 @@ SceneHost::SceneHost(fml::RefPtr<zircon::dart::Handle> viewHolderToken,
   }
 
   // This callback will be posted as a task  when the |scenic::ViewHolder|
-  // resource is created and given an id by the GPU thread.
+  // resource is created and given an id by the raster thread.
   auto bind_callback = [scene_host = this,
                         isolate_service_id =
                             isolate_service_id_](scenic::ResourceId id) {

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -176,7 +176,7 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // raster
+                      CreateNewThread("raster"),    // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -223,7 +223,7 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // raster
+                      CreateNewThread("raster"),    // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -275,7 +275,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // raster
+                      CreateNewThread("raster"),    // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -331,7 +331,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // raster
+                      CreateNewThread("raster"),    // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -430,7 +430,7 @@ TEST_F(ImageDecoderFixtureTest, CanResizeWithoutDecode) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // raster
+                      CreateNewThread("raster"),    // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -590,7 +590,7 @@ TEST_F(ImageDecoderFixtureTest,
 
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // raster
+                      CreateNewThread("raster"),    // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );

--- a/lib/ui/painting/image_decoder_unittests.cc
+++ b/lib/ui/painting/image_decoder_unittests.cc
@@ -125,7 +125,7 @@ TEST_F(ImageDecoderFixtureTest, CanCreateImageDecoder) {
   auto thread_task_runner = CreateNewThread();
   TaskRunners runners(GetCurrentTestName(),  // label
                       thread_task_runner,    // platform
-                      thread_task_runner,    // gpu
+                      thread_task_runner,    // raster
                       thread_task_runner,    // ui
                       thread_task_runner     // io
 
@@ -146,7 +146,7 @@ TEST_F(ImageDecoderFixtureTest, InvalidImageResultsError) {
   auto thread_task_runner = CreateNewThread();
   TaskRunners runners(GetCurrentTestName(),  // label
                       thread_task_runner,    // platform
-                      thread_task_runner,    // gpu
+                      thread_task_runner,    // raster
                       thread_task_runner,    // ui
                       thread_task_runner     // io
   );
@@ -176,7 +176,7 @@ TEST_F(ImageDecoderFixtureTest, ValidImageResultsInSuccess) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("gpu"),       // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -223,7 +223,7 @@ TEST_F(ImageDecoderFixtureTest, ExifDataIsRespectedOnDecode) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("gpu"),       // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -275,7 +275,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithoutAGPUContext) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("gpu"),       // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -331,7 +331,7 @@ TEST_F(ImageDecoderFixtureTest, CanDecodeWithResizes) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("gpu"),       // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -430,7 +430,7 @@ TEST_F(ImageDecoderFixtureTest, CanResizeWithoutDecode) {
   auto loop = fml::ConcurrentMessageLoop::Create();
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("gpu"),       // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );
@@ -590,7 +590,7 @@ TEST_F(ImageDecoderFixtureTest,
 
   TaskRunners runners(GetCurrentTestName(),         // label
                       CreateNewThread("platform"),  // platform
-                      CreateNewThread("gpu"),       // gpu
+                      CreateNewThread("gpu"),       // raster
                       CreateNewThread("ui"),        // ui
                       CreateNewThread("io")         // io
   );

--- a/lib/ui/painting/image_encoding.cc
+++ b/lib/ui/painting/image_encoding.cc
@@ -116,8 +116,8 @@ void ConvertImageToRaster(sk_sp<SkImage> image,
   }
 
   // Cross-context images do not support makeRasterImage. Convert these images
-  // by drawing them into a surface.  This must be done on the GPU thread
-  // to prevent concurrent usage of the image on both the IO and GPU threads.
+  // by drawing them into a surface.  This must be done on the raster thread
+  // to prevent concurrent usage of the image on both the IO and raster threads.
   gpu_task_runner->PostTask([image, encode_task = std::move(encode_task),
                              resource_context, snapshot_delegate,
                              io_task_runner]() {

--- a/lib/ui/painting/multi_frame_codec.cc
+++ b/lib/ui/painting/multi_frame_codec.cc
@@ -124,7 +124,7 @@ sk_sp<SkImage> MultiFrameCodec::State::GetNextFrameImage(
     return SkImage::MakeCrossContextFromPixmap(resourceContext.get(), pixmap,
                                                true);
   } else {
-    // Defer decoding until time of draw later on the GPU thread. Can happen
+    // Defer decoding until time of draw later on the raster thread. Can happen
     // when GL operations are currently forbidden such as in the background
     // on iOS.
     return SkImage::MakeFromBitmap(bitmap);

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -57,12 +57,12 @@ enum FramePhase {
   /// See also [FrameTiming.buildDuration].
   buildFinish,
 
-  /// When the GPU thread starts rasterizing a frame.
+  /// When the raster thread starts rasterizing a frame.
   ///
   /// See also [FrameTiming.rasterDuration].
   rasterStart,
 
-  /// When the GPU thread finishes rasterizing a frame.
+  /// When the raster thread finishes rasterizing a frame.
   ///
   /// See also [FrameTiming.rasterDuration].
   rasterFinish,
@@ -115,7 +115,7 @@ class FrameTiming {
   /// {@endtemplate}
   Duration get buildDuration => _rawDuration(FramePhase.buildFinish) - _rawDuration(FramePhase.buildStart);
 
-  /// The duration to rasterize the frame on the GPU thread.
+  /// The duration to rasterize the frame on the raster thread.
   ///
   /// {@macro dart.ui.FrameTiming.fps_smoothness_milliseconds}
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -310,7 +310,7 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// The "UI thread" is the thread that includes all the execution of
   /// the main Dart isolate (the isolate that can call
   /// [Window.render]). The UI thread frame time is the total time
-  /// spent executing the [Window.onBeginFrame] callback. The "GPU
+  /// spent executing the [Window.onBeginFrame] callback. The "raster
   /// thread" is the thread (running on the CPU) that subsequently
   /// processes the [Scene] provided by the Dart code to turn it into
   /// GPU commands and send it to the GPU.

--- a/lib/web_ui/lib/src/engine/surface/scene_builder.dart
+++ b/lib/web_ui/lib/src/engine/surface/scene_builder.dart
@@ -301,8 +301,8 @@ class SurfaceSceneBuilder implements ui.SceneBuilder {
   /// controls where the statistics are displayed.
   ///
   /// enabledOptions is a bit field with the following bits defined:
-  ///  - 0x01: displayRasterizerStatistics - show GPU thread frame time
-  ///  - 0x02: visualizeRasterizerStatistics - graph GPU thread frame times
+  ///  - 0x01: displayRasterizerStatistics - show raster thread frame time
+  ///  - 0x02: visualizeRasterizerStatistics - graph raster thread frame times
   ///  - 0x04: displayEngineStatistics - show UI thread frame time
   ///  - 0x08: visualizeEngineStatistics - graph UI thread frame times
   /// Set enabledOptions to 0x0F to enable all the currently defined features.

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -298,7 +298,7 @@ abstract class SceneBuilder {
   /// The "UI thread" is the thread that includes all the execution of
   /// the main Dart isolate (the isolate that can call
   /// [Window.render]). The UI thread frame time is the total time
-  /// spent executing the [Window.onBeginFrame] callback. The "GPU
+  /// spent executing the [Window.onBeginFrame] callback. The "raster
   /// thread" is the thread (running on the CPU) that subsequently
   /// processes the [Scene] provided by the Dart code to turn it into
   /// GPU commands and send it to the GPU.

--- a/lib/web_ui/lib/src/ui/compositing.dart
+++ b/lib/web_ui/lib/src/ui/compositing.dart
@@ -289,8 +289,8 @@ abstract class SceneBuilder {
   /// controls where the statistics are displayed.
   ///
   /// enabledOptions is a bit field with the following bits defined:
-  ///  - 0x01: displayRasterizerStatistics - show GPU thread frame time
-  ///  - 0x02: visualizeRasterizerStatistics - graph GPU thread frame times
+  ///  - 0x01: displayRasterizerStatistics - show raster thread frame time
+  ///  - 0x02: visualizeRasterizerStatistics - graph raster thread frame times
   ///  - 0x04: displayEngineStatistics - show UI thread frame time
   ///  - 0x08: visualizeEngineStatistics - graph UI thread frame times
   /// Set enabledOptions to 0x0F to enable all the currently defined features.

--- a/lib/web_ui/lib/src/ui/window.dart
+++ b/lib/web_ui/lib/src/ui/window.dart
@@ -1144,12 +1144,12 @@ enum FramePhase {
   /// See also [FrameTiming.buildDuration].
   buildFinish,
 
-  /// When the GPU thread starts rasterizing a frame.
+  /// When the raster thread starts rasterizing a frame.
   ///
   /// See also [FrameTiming.rasterDuration].
   rasterStart,
 
-  /// When the GPU thread finishes rasterizing a frame.
+  /// When the raster thread finishes rasterizing a frame.
   ///
   /// See also [FrameTiming.rasterDuration].
   rasterFinish,
@@ -1201,7 +1201,7 @@ class FrameTiming {
       _rawDuration(FramePhase.buildFinish) -
       _rawDuration(FramePhase.buildStart);
 
-  /// The duration to rasterize the frame on the GPU thread.
+  /// The duration to rasterize the frame on the raster thread.
   ///
   /// {@macro dart.ui.FrameTiming.fps_smoothness_milliseconds}
   /// {@macro dart.ui.FrameTiming.fps_milliseconds}

--- a/shell/common/engine.h
+++ b/shell/common/engine.h
@@ -210,7 +210,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
     ///             is not possible for the application to determine the total
     ///             time it took to render a specific frame. While the
     ///             layer-tree is constructed on the UI thread, it needs to be
-    ///             rendering on the GPU thread. Dart code cannot execute on
+    ///             rendering on the raster thread. Dart code cannot execute on
     ///             this thread. So any instrumentation about the frame times
     ///             gathered on this thread needs to be aggregated and sent back
     ///             to the UI thread for processing in Dart.
@@ -412,7 +412,7 @@ class Engine final : public RuntimeDelegate, PointerDataDispatcher::Delegate {
   ///               by layer tree in the engine is 2. If both the UI and GPU
   ///               task runner tasks finish within one frame interval, the
   ///               pipeline depth is one. If the UI thread happens to be
-  ///               working on a frame when the GPU thread is still not done
+  ///               working on a frame when the raster thread is still not done
   ///               with the previous frame, the pipeline depth is 2. When the
   ///               pipeline depth changes from 1 to 2, animations and UI
   ///               interactions that cause the generation of the new layer tree

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -172,7 +172,7 @@ class PlatformView {
     ///             Flutter layer tree. All textures must have a unique
     ///             identifier. When the rasterizer encounters an external
     ///             texture within its hierarchy, it gives the embedder a chance
-    ///             to update that texture on the GPU thread before it
+    ///             to update that texture on the raster thread before it
     ///             composites the same on-screen.
     ///
     /// @param[in]  texture  The texture that is being updated by the embedder
@@ -352,7 +352,7 @@ class PlatformView {
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to specify the updated viewport metrics. In
-  ///             response to this call, on the GPU thread, the rasterizer may
+  ///             response to this call, on the raster thread, the rasterizer may
   ///             need to be reconfigured to the updated viewport dimensions. On
   ///             the UI thread, the framework may need to start generating a
   ///             new frame for the updated viewport metrics as well.
@@ -488,7 +488,7 @@ class PlatformView {
   ///             textures must have a unique identifier. When the
   ///             rasterizer encounters an external texture within its
   ///             hierarchy, it gives the embedder a chance to update that
-  ///             texture on the GPU thread before it composites the same
+  ///             texture on the raster thread before it composites the same
   ///             on-screen.
   ///
   /// @attention  This method must only be called once per texture. When the

--- a/shell/common/platform_view.h
+++ b/shell/common/platform_view.h
@@ -352,10 +352,11 @@ class PlatformView {
 
   //----------------------------------------------------------------------------
   /// @brief      Used by embedders to specify the updated viewport metrics. In
-  ///             response to this call, on the raster thread, the rasterizer may
-  ///             need to be reconfigured to the updated viewport dimensions. On
-  ///             the UI thread, the framework may need to start generating a
-  ///             new frame for the updated viewport metrics as well.
+  ///             response to this call, on the raster thread, the rasterizer
+  ///             may need to be reconfigured to the updated viewport
+  ///             dimensions. On the UI thread, the framework may need to start
+  ///             generating a new frame for the updated viewport metrics as
+  ///             well.
   ///
   /// @param[in]  metrics  The updated viewport metrics.
   ///

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -220,8 +220,8 @@ class Rasterizer final : public SnapshotDelegate {
 
   //----------------------------------------------------------------------------
   /// @brief      Takes the next item from the layer tree pipeline and executes
-  ///             the raster thread frame workload for that pipeline item to render
-  ///             a frame on the on-screen surface.
+  ///             the raster thread frame workload for that pipeline item to
+  ///             render a frame on the on-screen surface.
   ///
   ///             Why does the draw call take a layer tree pipeline and not the
   ///             layer tree directly?

--- a/shell/common/rasterizer.h
+++ b/shell/common/rasterizer.h
@@ -220,7 +220,7 @@ class Rasterizer final : public SnapshotDelegate {
 
   //----------------------------------------------------------------------------
   /// @brief      Takes the next item from the layer tree pipeline and executes
-  ///             the GPU thread frame workload for that pipeline item to render
+  ///             the raster thread frame workload for that pipeline item to render
   ///             a frame on the on-screen surface.
   ///
   ///             Why does the draw call take a layer tree pipeline and not the

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -335,9 +335,9 @@ Shell::Shell(DartVMRef vm, TaskRunners task_runners, Settings settings)
   FML_DCHECK(task_runners_.IsValid());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
-  // Generate a WeakPtrFactory for use with the raster thread. This does not need
-  // to wait on a latch because it can only ever be used from the raster thread
-  // from this class, so we have ordering guarantees.
+  // Generate a WeakPtrFactory for use with the raster thread. This does not
+  // need to wait on a latch because it can only ever be used from the raster
+  // thread from this class, so we have ordering guarantees.
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetGPUTaskRunner(), fml::MakeCopyable([this]() mutable {
         this->weak_factory_gpu_ =
@@ -620,11 +620,11 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   // starting the sequence and waiting on the latch. Later the UI thread posts
   // gpu_task to the raster thread which signals the latch. If the GPU the and
   // platform threads are the same this results in a deadlock as the gpu_task
-  // will never be posted to the plaform/raster thread that is blocked on a latch.
-  // To avoid the described deadlock, if the gpu and the platform threads are
-  // the same, should_post_gpu_task will be false, and then instead of posting a
-  // task to the raster thread, the ui thread just signals the latch and the
-  // platform/raster thread follows with executing gpu_task.
+  // will never be posted to the plaform/raster thread that is blocked on a
+  // latch. To avoid the described deadlock, if the gpu and the platform threads
+  // are the same, should_post_gpu_task will be false, and then instead of
+  // posting a task to the raster thread, the ui thread just signals the latch
+  // and the platform/raster thread follows with executing gpu_task.
   bool should_post_gpu_task =
       task_runners_.GetGPUTaskRunner() != task_runners_.GetPlatformTaskRunner();
 
@@ -636,8 +636,8 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     if (engine) {
       engine->OnOutputSurfaceCreated();
     }
-    // Step 2: Next, tell the raster thread that it should create a surface for its
-    // rasterizer.
+    // Step 2: Next, tell the raster thread that it should create a surface for
+    // its rasterizer.
     if (should_post_gpu_task) {
       fml::TaskRunner::RunNowOrPostTask(gpu_task_runner, gpu_task);
     } else {
@@ -713,13 +713,14 @@ void Shell::OnPlatformViewDestroyed() {
 
   // The normal flow executed by this method is that the platform thread is
   // starting the sequence and waiting on the latch. Later the UI thread posts
-  // gpu_task to the raster thread triggers signaling the latch(on the IO thread).
-  // If the GPU the and platform threads are the same this results in a deadlock
-  // as the gpu_task will never be posted to the plaform/raster thread that is
-  // blocked on a latch.  To avoid the described deadlock, if the gpu and the
-  // platform threads are the same, should_post_gpu_task will be false, and then
-  // instead of posting a task to the raster thread, the ui thread just signals the
-  // latch and the platform/raster thread follows with executing gpu_task.
+  // gpu_task to the raster thread triggers signaling the latch(on the IO
+  // thread). If the GPU the and platform threads are the same this results in a
+  // deadlock as the gpu_task will never be posted to the plaform/raster thread
+  // that is blocked on a latch.  To avoid the described deadlock, if the gpu
+  // and the platform threads are the same, should_post_gpu_task will be false,
+  // and then instead of posting a task to the raster thread, the ui thread just
+  // signals the latch and the platform/raster thread follows with executing
+  // gpu_task.
   bool should_post_gpu_task =
       task_runners_.GetGPUTaskRunner() != task_runners_.GetPlatformTaskRunner();
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -55,7 +55,7 @@ std::unique_ptr<Shell> Shell::CreateShellOnPlatformThread(
   auto shell =
       std::unique_ptr<Shell>(new Shell(std::move(vm), task_runners, settings));
 
-  // Create the rasterizer on the GPU thread.
+  // Create the rasterizer on the raster thread.
   std::promise<std::unique_ptr<Rasterizer>> rasterizer_promise;
   auto rasterizer_future = rasterizer_promise.get_future();
   std::promise<fml::WeakPtr<SnapshotDelegate>> snapshot_delegate_promise;
@@ -335,8 +335,8 @@ Shell::Shell(DartVMRef vm, TaskRunners task_runners, Settings settings)
   FML_DCHECK(task_runners_.IsValid());
   FML_DCHECK(task_runners_.GetPlatformTaskRunner()->RunsTasksOnCurrentThread());
 
-  // Generate a WeakPtrFactory for use with the GPU thread. This does not need
-  // to wait on a latch because it can only ever be used from the GPU thread
+  // Generate a WeakPtrFactory for use with the raster thread. This does not need
+  // to wait on a latch because it can only ever be used from the raster thread
   // from this class, so we have ordering guarantees.
   fml::TaskRunner::RunNowOrPostTask(
       task_runners_.GetGPUTaskRunner(), fml::MakeCopyable([this]() mutable {
@@ -618,13 +618,13 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
 
   // The normal flow executed by this method is that the platform thread is
   // starting the sequence and waiting on the latch. Later the UI thread posts
-  // gpu_task to the GPU thread which signals the latch. If the GPU the and
+  // gpu_task to the raster thread which signals the latch. If the GPU the and
   // platform threads are the same this results in a deadlock as the gpu_task
-  // will never be posted to the plaform/gpu thread that is blocked on a latch.
+  // will never be posted to the plaform/raster thread that is blocked on a latch.
   // To avoid the described deadlock, if the gpu and the platform threads are
   // the same, should_post_gpu_task will be false, and then instead of posting a
-  // task to the gpu thread, the ui thread just signals the latch and the
-  // platform/gpu thread follows with executing gpu_task.
+  // task to the raster thread, the ui thread just signals the latch and the
+  // platform/raster thread follows with executing gpu_task.
   bool should_post_gpu_task =
       task_runners_.GetGPUTaskRunner() != task_runners_.GetPlatformTaskRunner();
 
@@ -636,7 +636,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
     if (engine) {
       engine->OnOutputSurfaceCreated();
     }
-    // Step 2: Next, tell the GPU thread that it should create a surface for its
+    // Step 2: Next, tell the raster thread that it should create a surface for its
     // rasterizer.
     if (should_post_gpu_task) {
       fml::TaskRunner::RunNowOrPostTask(gpu_task_runner, gpu_task);
@@ -672,7 +672,7 @@ void Shell::OnPlatformViewCreated(std::unique_ptr<Surface> surface) {
   if (!should_post_gpu_task) {
     // See comment on should_post_gpu_task, in this case the gpu_task
     // wasn't executed, and we just run it here as the platform thread
-    // is the GPU thread.
+    // is the raster thread.
     gpu_task();
   }
 }
@@ -713,13 +713,13 @@ void Shell::OnPlatformViewDestroyed() {
 
   // The normal flow executed by this method is that the platform thread is
   // starting the sequence and waiting on the latch. Later the UI thread posts
-  // gpu_task to the GPU thread triggers signaling the latch(on the IO thread).
+  // gpu_task to the raster thread triggers signaling the latch(on the IO thread).
   // If the GPU the and platform threads are the same this results in a deadlock
-  // as the gpu_task will never be posted to the plaform/gpu thread that is
+  // as the gpu_task will never be posted to the plaform/raster thread that is
   // blocked on a latch.  To avoid the described deadlock, if the gpu and the
   // platform threads are the same, should_post_gpu_task will be false, and then
-  // instead of posting a task to the gpu thread, the ui thread just signals the
-  // latch and the platform/gpu thread follows with executing gpu_task.
+  // instead of posting a task to the raster thread, the ui thread just signals the
+  // latch and the platform/raster thread follows with executing gpu_task.
   bool should_post_gpu_task =
       task_runners_.GetGPUTaskRunner() != task_runners_.GetPlatformTaskRunner();
 
@@ -729,7 +729,7 @@ void Shell::OnPlatformViewDestroyed() {
     if (engine) {
       engine->OnOutputSurfaceDestroyed();
     }
-    // Step 1: Next, tell the GPU thread that its rasterizer should suspend
+    // Step 1: Next, tell the raster thread that its rasterizer should suspend
     // access to the underlying surface.
     if (should_post_gpu_task) {
       fml::TaskRunner::RunNowOrPostTask(gpu_task_runner, gpu_task);
@@ -747,7 +747,7 @@ void Shell::OnPlatformViewDestroyed() {
   if (!should_post_gpu_task) {
     // See comment on should_post_gpu_task, in this case the gpu_task
     // wasn't executed, and we just run it here as the platform thread
-    // is the GPU thread.
+    // is the raster thread.
     gpu_task();
     latch.Wait();
   }
@@ -1085,7 +1085,7 @@ void Shell::ReportTimings() {
 }
 
 size_t Shell::UnreportedFramesCount() const {
-  // Check that this is running on the GPU thread to avoid race conditions.
+  // Check that this is running on the raster thread to avoid race conditions.
   FML_DCHECK(task_runners_.GetGPUTaskRunner()->RunsTasksOnCurrentThread());
   FML_DCHECK(unreported_timings_.size() % FrameTiming::kCount == 0);
   return unreported_timings_.size() / FrameTiming::kCount;

--- a/shell/common/shell.h
+++ b/shell/common/shell.h
@@ -275,7 +275,7 @@ class Shell final : public PlatformView::Delegate,
   // Embedders should call this under low memory conditions to free up
   // internal caches used.
   //
-  // This method posts a task to the GPU threads to signal the Rasterizer to
+  // This method posts a task to the raster threads to signal the Rasterizer to
   // free resources.
 
   //----------------------------------------------------------------------------
@@ -393,7 +393,7 @@ class Shell final : public PlatformView::Delegate,
   std::mutex waiting_for_first_frame_mutex_;
   std::condition_variable waiting_for_first_frame_condition_;
 
-  // Written in the UI thread and read from the GPU thread. Hence make it
+  // Written in the UI thread and read from the raster thread. Hence make it
   // atomic.
   std::atomic<bool> needs_report_timings_{false};
 
@@ -407,10 +407,10 @@ class Shell final : public PlatformView::Delegate,
   std::vector<int64_t> unreported_timings_;
 
   // A cache of `Engine::GetDisplayRefreshRate` (only callable in the UI thread)
-  // so we can access it from `Rasterizer` (in the GPU thread).
+  // so we can access it from `Rasterizer` (in the raster thread).
   //
   // The atomic is for extra thread safety as this is written in the UI thread
-  // and read from the GPU thread.
+  // and read from the raster thread.
   std::atomic<float> display_refresh_rate_ = 0.0f;
 
   // How many frames have been timed since last report.
@@ -563,7 +563,7 @@ class Shell final : public PlatformView::Delegate,
 
   fml::WeakPtrFactory<Shell> weak_factory_;
 
-  // For accessing the Shell via the GPU thread, necessary for various
+  // For accessing the Shell via the raster thread, necessary for various
   // rasterizer callbacks.
   std::unique_ptr<fml::WeakPtrFactory<Shell>> weak_factory_gpu_;
 

--- a/shell/common/shell_test.cc
+++ b/shell/common/shell_test.cc
@@ -230,7 +230,7 @@ TaskRunners ShellTest::GetTaskRunnersForFixture() {
   return {
       "test",
       thread_host_.platform_thread->GetTaskRunner(),  // platform
-      thread_host_.gpu_thread->GetTaskRunner(),       // gpu
+      thread_host_.gpu_thread->GetTaskRunner(),       // raster
       thread_host_.ui_thread->GetTaskRunner(),        // ui
       thread_host_.io_thread->GetTaskRunner()         // io
   };

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -885,7 +885,7 @@ class MockTexture : public Texture {
 
   ~MockTexture() override = default;
 
-  // Called from GPU thread.
+  // Called from raster thread.
   void Paint(SkCanvas& canvas,
              const SkRect& bounds,
              bool freeze,

--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -156,7 +156,7 @@ TEST_F(ShellTest, InitializeWithGPUAndPlatformThreadsTheSame) {
   TaskRunners task_runners(
       "test",
       thread_host.platform_thread->GetTaskRunner(),  // platform
-      thread_host.platform_thread->GetTaskRunner(),  // gpu
+      thread_host.platform_thread->GetTaskRunner(),  // raster
       thread_host.ui_thread->GetTaskRunner(),        // ui
       thread_host.io_thread->GetTaskRunner()         // io
   );
@@ -960,7 +960,7 @@ TEST_F(ShellTest, IsolateCanAccessPersistentIsolateData) {
       std::make_shared<fml::DataMapping>(message);
   TaskRunners task_runners("test",                  // label
                            GetCurrentTaskRunner(),  // platform
-                           CreateNewThread(),       // gpu
+                           CreateNewThread(),       // raster
                            CreateNewThread(),       // ui
                            CreateNewThread()        // io
   );

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -42,7 +42,7 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkan::AcquireFrame(
   SurfaceFrame::SubmitCallback callback =
       [weak_this = weak_factory_.GetWeakPtr()](const SurfaceFrame&,
                                                SkCanvas* canvas) -> bool {
-    // Frames are only ever acquired on the GPU thread. This is also the thread
+    // Frames are only ever acquired on the raster thread. This is also the thread
     // on which the weak pointer factory is collected (as this instance is owned
     // by the rasterizer). So this use of weak pointers is safe.
     if (canvas == nullptr || !weak_this) {

--- a/shell/gpu/gpu_surface_vulkan.cc
+++ b/shell/gpu/gpu_surface_vulkan.cc
@@ -42,9 +42,9 @@ std::unique_ptr<SurfaceFrame> GPUSurfaceVulkan::AcquireFrame(
   SurfaceFrame::SubmitCallback callback =
       [weak_this = weak_factory_.GetWeakPtr()](const SurfaceFrame&,
                                                SkCanvas* canvas) -> bool {
-    // Frames are only ever acquired on the raster thread. This is also the thread
-    // on which the weak pointer factory is collected (as this instance is owned
-    // by the rasterizer). So this use of weak pointers is safe.
+    // Frames are only ever acquired on the raster thread. This is also the
+    // thread on which the weak pointer factory is collected (as this instance
+    // is owned by the rasterizer). So this use of weak pointers is safe.
     if (canvas == nullptr || !weak_this) {
       return false;
     }

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -102,7 +102,7 @@ AndroidShellHolder::AndroidShellHolder(
   }
   flutter::TaskRunners task_runners(thread_label,     // label
                                     platform_runner,  // platform
-                                    gpu_runner,       // gpu
+                                    gpu_runner,       // raster
                                     ui_runner,        // ui
                                     io_runner         // io
   );

--- a/shell/platform/android/android_shell_holder.cc
+++ b/shell/platform/android/android_shell_holder.cc
@@ -45,7 +45,7 @@ AndroidShellHolder::AndroidShellHolder(
                                       ThreadHost::Type::IO};
   }
 
-  // Detach from JNI when the UI and GPU threads exit.
+  // Detach from JNI when the UI and raster threads exit.
   auto jni_exit_task([key = thread_destruct_key_]() {
     FML_CHECK(pthread_setspecific(key, reinterpret_cast<void*>(1)) == 0);
   });
@@ -124,7 +124,7 @@ AndroidShellHolder::AndroidShellHolder(
     task_runners.GetGPUTaskRunner()->PostTask([]() {
       // Android describes -8 as "most important display threads, for
       // compositing the screen and retrieving input events". Conservatively
-      // set the GPU thread to slightly lower priority than it.
+      // set the raster thread to slightly lower priority than it.
       if (::setpriority(PRIO_PROCESS, gettid(), -5) != 0) {
         // Defensive fallback. Depending on the OEM, it may not be possible
         // to set priority to -5.

--- a/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
+++ b/shell/platform/darwin/common/framework/Headers/FlutterTexture.h
@@ -25,7 +25,7 @@ FLUTTER_EXPORT
 /**
  * Called when the texture is unregistered.
  *
- * Called on the GPU thread.
+ * Called on the raster thread.
  */
 @optional
 - (void)onTextureUnregistered:(NSObject<FlutterTexture>*)texture;
@@ -45,7 +45,7 @@ FLUTTER_EXPORT
 /**
  * Notifies Flutter that the content of the previously registered texture has been updated.
  *
- * This will trigger a call to `-[FlutterTexture copyPixelBuffer]` on the GPU thread.
+ * This will trigger a call to `-[FlutterTexture copyPixelBuffer]` on the raster thread.
  */
 - (void)textureFrameAvailable:(int64_t)textureId;
 /**

--- a/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterEngine.mm
@@ -462,7 +462,7 @@ NSString* const FlutterDefaultDartEntrypoint = nil;
 
     flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
                                       fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // gpu
+                                      fml::MessageLoop::GetCurrent().GetTaskRunner(),  // raster
                                       _threadHost.ui_thread->GetTaskRunner(),          // ui
                                       _threadHost.io_thread->GetTaskRunner()           // io
     );
@@ -476,7 +476,7 @@ NSString* const FlutterDefaultDartEntrypoint = nil;
   } else {
     flutter::TaskRunners task_runners(threadLabel.UTF8String,                          // label
                                       fml::MessageLoop::GetCurrent().GetTaskRunner(),  // platform
-                                      _threadHost.gpu_thread->GetTaskRunner(),         // gpu
+                                      _threadHost.gpu_thread->GetTaskRunner(),         // raster
                                       _threadHost.ui_thread->GetTaskRunner(),          // ui
                                       _threadHost.io_thread->GetTaskRunner()           // io
     );

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -445,7 +445,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
                                           platformTaskRunner = [_engine.get() platformTaskRunner],
                                           gpuTaskRunner = [_engine.get() GPUTaskRunner]]() {
     FML_DCHECK(gpuTaskRunner->RunsTasksOnCurrentThread());
-    // Get callback on GPU thread and jump back to platform thread.
+    // Get callback on raster thread and jump back to platform thread.
     platformTaskRunner->PostTask([weakSelf]() {
       fml::scoped_nsobject<FlutterViewController> flutterViewController(
           [(FlutterViewController*)weakSelf.get() retain]);
@@ -536,7 +536,7 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 #pragma mark - Surface creation and teardown updates
 
 - (void)surfaceUpdated:(BOOL)appeared {
-  // NotifyCreated/NotifyDestroyed are synchronous and require hops between the UI and GPU thread.
+  // NotifyCreated/NotifyDestroyed are synchronous and require hops between the UI and raster thread.
   if (appeared) {
     [self installFirstFrameCallback];
     [_engine.get() platformViewsController] -> SetFlutterView(_flutterView.get());

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -536,7 +536,8 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 #pragma mark - Surface creation and teardown updates
 
 - (void)surfaceUpdated:(BOOL)appeared {
-  // NotifyCreated/NotifyDestroyed are synchronous and require hops between the UI and raster thread.
+  // NotifyCreated/NotifyDestroyed are synchronous and require hops between the UI and raster
+  // thread.
   if (appeared) {
     [self installFirstFrameCallback];
     [_engine.get() platformViewsController] -> SetFlutterView(_flutterView.get());

--- a/shell/platform/darwin/ios/platform_view_ios.h
+++ b/shell/platform/darwin/ios/platform_view_ios.h
@@ -68,7 +68,7 @@ class PlatformViewIOS final : public PlatformView {
 
   fml::WeakPtr<FlutterViewController> owner_controller_;
   // Since the `ios_surface_` is created on the platform thread but
-  // used on the GPU thread we need to protect it with a mutex.
+  // used on the raster thread we need to protect it with a mutex.
   std::mutex ios_surface_mutex_;
   std::unique_ptr<IOSSurface> ios_surface_;
   std::shared_ptr<IOSContext> ios_context_;

--- a/shell/platform/embedder/embedder_thread_host.cc
+++ b/shell/platform/embedder/embedder_thread_host.cc
@@ -173,7 +173,7 @@ EmbedderThreadHost::CreateEmbedderManagedThreadHost(
   flutter::TaskRunners task_runners(
       kFlutterThreadName,
       platform_task_runner,                    // platform
-      render_task_runner,                      // gpu
+      render_task_runner,                      // raster
       thread_host.ui_thread->GetTaskRunner(),  // ui (always engine managed)
       thread_host.io_thread->GetTaskRunner()   // io (always engine managed)
   );
@@ -220,7 +220,7 @@ EmbedderThreadHost::CreateEngineManagedThreadHost() {
   flutter::TaskRunners task_runners(
       kFlutterThreadName,
       platform_task_runner,                     // platform
-      thread_host.gpu_thread->GetTaskRunner(),  // gpu
+      thread_host.gpu_thread->GetTaskRunner(),  // raster
       thread_host.ui_thread->GetTaskRunner(),   // ui
       thread_host.io_thread->GetTaskRunner()    // io
   );

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1494,8 +1494,8 @@ TEST_F(EmbedderTest,
 }
 
 //------------------------------------------------------------------------------
-/// Custom compositor must play nicely with a custom task runner. The raster thread
-/// merging mechanism must not interfere with the custom compositor.
+/// Custom compositor must play nicely with a custom task runner. The raster
+/// thread merging mechanism must not interfere with the custom compositor.
 ///
 TEST_F(EmbedderTest, CustomCompositorMustWorkWithCustomTaskRunner) {
   auto& context = GetEmbedderContext();

--- a/shell/platform/embedder/tests/embedder_unittests.cc
+++ b/shell/platform/embedder/tests/embedder_unittests.cc
@@ -1494,7 +1494,7 @@ TEST_F(EmbedderTest,
 }
 
 //------------------------------------------------------------------------------
-/// Custom compositor must play nicely with a custom task runner. The GPU thread
+/// Custom compositor must play nicely with a custom task runner. The raster thread
 /// merging mechanism must not interfere with the custom compositor.
 ///
 TEST_F(EmbedderTest, CustomCompositorMustWorkWithCustomTaskRunner) {

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -175,7 +175,7 @@ Engine::Engine(Delegate& delegate,
   const flutter::TaskRunners task_runners(
       thread_label_,  // Dart thread labels
       CreateFMLTaskRunner(async_get_default_dispatcher()),  // platform
-      CreateFMLTaskRunner(threads_[0]->dispatcher()),       // gpu
+      CreateFMLTaskRunner(threads_[0]->dispatcher()),       // raster
       CreateFMLTaskRunner(threads_[1]->dispatcher()),       // ui
       CreateFMLTaskRunner(threads_[2]->dispatcher())        // io
   );

--- a/shell/platform/fuchsia/flutter/engine.cc
+++ b/shell/platform/fuchsia/flutter/engine.cc
@@ -154,7 +154,7 @@ Engine::Engine(Delegate& delegate,
             );
           });
 
-  // Session can be terminated on the GPU thread, but we must terminate
+  // Session can be terminated on the raster thread, but we must terminate
   // ourselves on the platform thread.
   //
   // This handles the fidl error callback when the Session connection is

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -27,7 +27,7 @@ namespace flutter_runner {
 using on_frame_presented_event =
     std::function<void(fuchsia::scenic::scheduling::FramePresentedInfo)>;
 
-// The component residing on the GPU thread that is responsible for
+// The component residing on the raster thread that is responsible for
 // maintaining the Scenic session connection and presenting node updates.
 class SessionConnection final {
  public:

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -12,7 +12,7 @@
 namespace flutter_runner {
 
 // The interface between the Flutter rasterizer and the underlying platform. May
-// be constructed on any thread but will be used by the engine only on the GPU
+// be constructed on any thread but will be used by the engine only on the raster
 // thread.
 class Surface final : public flutter::Surface {
  public:

--- a/shell/platform/fuchsia/flutter/surface.h
+++ b/shell/platform/fuchsia/flutter/surface.h
@@ -12,8 +12,8 @@
 namespace flutter_runner {
 
 // The interface between the Flutter rasterizer and the underlying platform. May
-// be constructed on any thread but will be used by the engine only on the raster
-// thread.
+// be constructed on any thread but will be used by the engine only on the
+// raster thread.
 class Surface final : public flutter::Surface {
  public:
   Surface(std::string debug_label);

--- a/shell/platform/fuchsia/flutter/vsync_waiter_unittests.cc
+++ b/shell/platform/fuchsia/flutter/vsync_waiter_unittests.cc
@@ -62,7 +62,7 @@ TEST_F(VsyncWaiterTest, AwaitVsync) {
       "VsyncWaiterTests",  // Dart thread labels
       flutter_runner::CreateFMLTaskRunner(
           async_get_default_dispatcher()),  // platform
-      flutter_runner::CreateFMLTaskRunner(threads[0]->dispatcher()),  // gpu
+      flutter_runner::CreateFMLTaskRunner(threads[0]->dispatcher()),  // raster
       flutter_runner::CreateFMLTaskRunner(threads[1]->dispatcher()),  // ui
       flutter_runner::CreateFMLTaskRunner(threads[2]->dispatcher())   // io
   );

--- a/shell/testing/tester_main.cc
+++ b/shell/testing/tester_main.cc
@@ -128,7 +128,7 @@ int RunTester(const flutter::Settings& settings,
 
   const flutter::TaskRunners task_runners(thread_label,  // dart thread label
                                           platform_task_runner,  // platform
-                                          gpu_task_runner,       // gpu
+                                          gpu_task_runner,       // raster
                                           ui_task_runner,        // ui
                                           io_task_runner         // io
   );


### PR DESCRIPTION
This pull request should be fairly safe because it only changes comments. I've split the change into several commits for easier checks. We'll rename the actual code variable name, class name, and filename later as those are risky changes.