### PR TITLE
[web] improving felt: running target unit tests, cleaning up used proccesses

### DIFF
--- a/lib/web_ui/dev/felt.dart
+++ b/lib/web_ui/dev/felt.dart
@@ -35,6 +35,7 @@ void main(List<String> args) async {
     final bool result = await runner.run(args);
     if (result == false) {
       print('Sub-command returned false: `${args.join(' ')}`');
+      _cleanup();
       io.exit(1);
     }
   } on UsageException catch (e) {

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -115,13 +115,18 @@ class TestCommand extends Command<bool> {
       case TestTypesRequested.integration:
         return runIntegrationTests();
       case TestTypesRequested.all:
-        bool integrationTestResult = await runIntegrationTests();
-        bool unitTestResult = await runUnitTests();
-        if (integrationTestResult != unitTestResult) {
-          print('Tests run. Integration tests passed: $integrationTestResult '
-              'unit tests passed: $unitTestResult');
+        // TODO(nurhan): https://github.com/flutter/flutter/issues/53322
+        if (runAllTests) {
+          bool integrationTestResult = await runIntegrationTests();
+          bool unitTestResult = await runUnitTests();
+          if (integrationTestResult != unitTestResult) {
+            print('Tests run. Integration tests passed: $integrationTestResult '
+                'unit tests passed: $unitTestResult');
+          }
+          return integrationTestResult && unitTestResult;
+        } else {
+          return await runUnitTests();
         }
-        return integrationTestResult && unitTestResult;
     }
     return false;
   }
@@ -145,13 +150,11 @@ class TestCommand extends Command<bool> {
       await _runPubGet();
     }
 
-    final List<FilePath> targets =
-        this.targets.map((t) => FilePath.fromCwd(t)).toList();
-    await _buildTests(targets: targets);
-    if (targets.isEmpty) {
+    await _buildTests(targets: targetFiles);
+    if (runAllTests) {
       await _runAllTests();
     } else {
-      await _runTargetTests(targets);
+      await _runTargetTests(targetFiles);
     }
     return true;
   }
@@ -164,6 +167,16 @@ class TestCommand extends Command<bool> {
 
   /// Paths to targets to run, e.g. a single test.
   List<String> get targets => argResults.rest;
+
+  /// The target test files to run.
+  ///
+  /// The value can be null if the developer prefers to run all the tests.
+  List<FilePath> get targetFiles => (targets.isEmpty)
+      ? null
+      : targets.map((t) => FilePath.fromCwd(t)).toList();
+
+  /// Whether all tests should run.
+  bool get runAllTests => (targets.isEmpty) ? true : false;
 
   String get browser => argResults['browser'];
 

--- a/lib/web_ui/dev/test_runner.dart
+++ b/lib/web_ui/dev/test_runner.dart
@@ -176,7 +176,7 @@ class TestCommand extends Command<bool> {
       : targets.map((t) => FilePath.fromCwd(t)).toList();
 
   /// Whether all tests should run.
-  bool get runAllTests => (targets.isEmpty) ? true : false;
+  bool get runAllTests => targets.isEmpty;
 
   String get browser => argResults['browser'];
 


### PR DESCRIPTION
Improvements on felt:

- Putting driver files downloaded under .dart_tools
- Running only targets unit tests if targets are provided.
- Cleaning up used processes if tests fails (it used to only cleanup in case of success)
- Some comment and variable fixes.

Fixes: https://github.com/flutter/flutter/issues/53320