### PR TITLE
Do not drop toString for enums

### DIFF
--- a/flutter_frontend_server/lib/server.dart
+++ b/flutter_frontend_server/lib/server.dart
@@ -224,6 +224,7 @@ class ToStringVisitor extends RecursiveVisitor<void> {
       node.enclosingLibrary != null       &&
       !node.isStatic                      &&
       !node.isAbstract                    &&
+      !node.enclosingClass.isEnum         &&
       _isInTargetPackage(node)            &&
       !_hasKeepAnnotation(node)
     ) {

--- a/flutter_frontend_server/test/fixtures/lib/main.dart
+++ b/flutter_frontend_server/test/fixtures/lib/main.dart
@@ -9,6 +9,7 @@ void main() {
   final Paint paint = Paint()..color = Color(0xFFFFFFFF);
   print(jsonEncode(<String, String>{
     'Paint.toString': paint.toString(),
+    'Brightness.toString': Brightness.dark.toString(),
     'Foo.toString': Foo().toString(),
     'Keep.toString': Keep().toString(),
   }));

--- a/flutter_frontend_server/test/to_string_test.dart
+++ b/flutter_frontend_server/test/to_string_test.dart
@@ -121,6 +121,25 @@ void main(List<String> args) async {
     verifyNever(statement.replaceWith(any));
   });
 
+  test('ToStringVisitor ignores enum toString', () {
+    final ToStringVisitor visitor = ToStringVisitor(uiAndFlutter);
+    final MockProcedure procedure = MockProcedure();
+    final MockFunctionNode function = MockFunctionNode();
+    final MockStatement statement = MockStatement();
+    final Library library = Library(Uri.parse('package:some_package/src/blah.dart'));
+    when(procedure.function).thenReturn(function);
+    when(procedure.name).thenReturn(Name('toString'));
+    when(procedure.annotations).thenReturn(const <Expression>[]);
+    when(procedure.enclosingLibrary).thenReturn(library);
+    when(procedure.enclosingClass).thenReturn(Class()..isEnum = true);
+    when(procedure.isAbstract).thenReturn(false);
+    when(procedure.isStatic).thenReturn(false);
+    when(function.body).thenReturn(statement);
+
+    visitor.visitProcedure(procedure);
+    verifyNever(statement.replaceWith(any));
+  });
+
   test('ToStringVisitor ignores non-specified libraries', () {
     final ToStringVisitor visitor = ToStringVisitor(uiAndFlutter);
     final MockProcedure procedure = MockProcedure();
@@ -254,6 +273,7 @@ void main(List<String> args) async {
       expect(
         runResult.stdout.trim(),
         '{"Paint.toString":"Paint(Color(0xffffffff))",'
+         '"Brightness.toString":"Brightness.dark",'
          '"Foo.toString":"I am a Foo",'
          '"Keep.toString":"I am a Keep"}',
       );
@@ -275,6 +295,7 @@ void main(List<String> args) async {
       expect(
         runResult.stdout.trim(),
         '{"Paint.toString":"Instance of \'Paint\'",'
+         '"Brightness.toString":"Brightness.dark",'
          '"Foo.toString":"Instance of \'Foo\'",'
          '"Keep.toString":"I am a Keep"}',
       );


### PR DESCRIPTION
Discovered when attempting to use this in google3.  A number of method channels/platform channels call `toString` on an enum (e.g. `Brightness.dark`) to pass platform data back and forth.  

It would be better if these just used indices (encoding a single int instead of encoding a string), we can't really stop customers from doing it and it can cause unexpected failures in release mode.