### PR TITLE
Add name to the XCTAttachments in the scenario test app

### DIFF
--- a/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
+++ b/testing/scenario_app/ios/Scenarios/ScenariosUITests/GoldenPlatformViewTests.m
@@ -49,11 +49,13 @@ static const NSInteger kSecondsToWaitForPlatformView = 30;
 
   XCUIScreenshot* screenshot = [[XCUIScreen mainScreen] screenshot];
   XCTAttachment* attachment = [XCTAttachment attachmentWithScreenshot:screenshot];
+  attachment.name = @"new_golden";
   attachment.lifetime = XCTAttachmentLifetimeKeepAlways;
   [self addAttachment:attachment];
 
   if (golden.image) {
     XCTAttachment* goldenAttachment = [XCTAttachment attachmentWithImage:golden.image];
+    attachment.name = @"current_golden";
     goldenAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
     [self addAttachment:goldenAttachment];
   } else {


### PR DESCRIPTION
This makes it easier to approve new golden images. The current name is randomly generated.