### PR TITLE
Locale: empty string equates to null

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -475,14 +475,14 @@ class Locale {
       return true;
     return other is Locale
         && other.languageCode == languageCode
-        && (other.scriptCode == scriptCode
-            || other.scriptCode != null && other.scriptCode.isEmpty && scriptCode == null
-            || scriptCode != null && scriptCode.isEmpty && other.scriptCode == null)
-        && other.countryCode == countryCode;
+        && other.scriptCode == scriptCode // scriptCode cannot be ''
+        && (other.countryCode == countryCode // Treat '' as equal to null.
+            || other.countryCode != null && other.countryCode.isEmpty && countryCode == null
+            || countryCode != null && countryCode.isEmpty && other.countryCode == null);
   }
 
   @override
-  int get hashCode => hashValues(languageCode, scriptCode, countryCode);
+  int get hashCode => hashValues(languageCode, scriptCode, countryCode == '' ? null : countryCode);
 
   static Locale _cachedLocale;
   static String _cachedLocaleString;

--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -475,7 +475,9 @@ class Locale {
       return true;
     return other is Locale
         && other.languageCode == languageCode
-        && other.scriptCode == scriptCode
+        && (other.scriptCode == scriptCode
+            || other.scriptCode != null && other.scriptCode.isEmpty && scriptCode == null
+            || scriptCode != null && scriptCode.isEmpty && other.scriptCode == null)
         && other.countryCode == countryCode;
   }
 

--- a/testing/dart/locale_test.dart
+++ b/testing/dart/locale_test.dart
@@ -13,8 +13,6 @@ void main() {
     expect(const Locale('en').toLanguageTag(), 'en');
     expect(const Locale('en'), const Locale('en', $null));
     expect(const Locale('en').hashCode, const Locale('en', $null).hashCode);
-    expect(const Locale('en'), isNot(const Locale('en', '')));
-    expect(const Locale('en').hashCode, isNot(const Locale('en', '').hashCode));
     expect(const Locale('en', 'US').toLanguageTag(), 'en-US');
     expect(const Locale('en', 'US').toString(), 'en_US');
     expect(const Locale('iw').toLanguageTag(), 'he');

--- a/testing/dart/locale_test.dart
+++ b/testing/dart/locale_test.dart
@@ -50,7 +50,7 @@ void main() {
            isNot(const Locale.fromSubtags(languageCode: 'en', scriptCode: 'Latn')));
     expect(const Locale.fromSubtags(languageCode: 'en').hashCode,
            isNot(const Locale.fromSubtags(languageCode: 'en', scriptCode: 'Latn').hashCode));
-    
+
     expect(const Locale('en', ''), const Locale('en'));
     expect(const Locale('en'), const Locale('en', ''));
     expect(const Locale('en'), const Locale('en'));

--- a/testing/dart/locale_test.dart
+++ b/testing/dart/locale_test.dart
@@ -52,6 +52,10 @@ void main() {
            isNot(const Locale.fromSubtags(languageCode: 'en', scriptCode: 'Latn')));
     expect(const Locale.fromSubtags(languageCode: 'en').hashCode,
            isNot(const Locale.fromSubtags(languageCode: 'en', scriptCode: 'Latn').hashCode));
+    expect(const Locale('en', ''), const Locale('en'));
+    expect(const Locale('en'), const Locale('en', ''));
+    expect(const Locale('en'), const Locale('en'));
+    expect(const Locale('en', ''), const Locale('en', ''));
   });
 
   test('Locale toString does not include separator for \'\'', () {

--- a/testing/dart/locale_test.dart
+++ b/testing/dart/locale_test.dart
@@ -52,10 +52,16 @@ void main() {
            isNot(const Locale.fromSubtags(languageCode: 'en', scriptCode: 'Latn')));
     expect(const Locale.fromSubtags(languageCode: 'en').hashCode,
            isNot(const Locale.fromSubtags(languageCode: 'en', scriptCode: 'Latn').hashCode));
+    
     expect(const Locale('en', ''), const Locale('en'));
     expect(const Locale('en'), const Locale('en', ''));
     expect(const Locale('en'), const Locale('en'));
     expect(const Locale('en', ''), const Locale('en', ''));
+
+    expect(const Locale('en', ''), isNot(const Locale('en', 'GB')));
+    expect(const Locale('en'), isNot(const Locale('en', 'GB')));
+    expect(const Locale('en', 'GB'), isNot(const Locale('en', '')));
+    expect(const Locale('en', 'GB'), isNot(const Locale('en')));
   });
 
   test('Locale toString does not include separator for \'\'', () {


### PR DESCRIPTION
Due to legacy support, we allow empty string as countryCode via the original constructor.

We have since added the `fromSubtags` constructor that added scriptCode and we no longer recommend emptyString as countryCode.

This changes it such that empty string is treated the same as null in terms of equality. This allows improved backwards compatibility and makes two functionally identical locales also compare as equal.