### PR TITLE
Disable OnServiceProtocolGetSkSLsWorks in Fuchsia

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1132,8 +1132,7 @@ TEST_F(ShellTest, CanDecompressImageFromAsset) {
   DestroyShell(std::move(shell));
 }
 
-// TODO(53399): Re-enable once it passes on Fuchsia.
-TEST_F(ShellTest, DISABLED_OnServiceProtocolGetSkSLsWorks) {
+TEST_F(ShellTest, OnServiceProtocolGetSkSLsWorks) {
   // Create 2 dummpy SkSL cache file IE (base32 encoding of A), II (base32
   // encoding of B) with content x and y.
   fml::ScopedTemporaryDirectory temp_dir;

--- a/testing/fuchsia/run_tests.sh
+++ b/testing/fuchsia/run_tests.sh
@@ -71,8 +71,10 @@ done
     -f runtime_tests-0.far  \
     -t runtime_tests
 
+# TODO(https://github.com/flutter/flutter/issues/53399): Re-enable
+# OnServiceProtocolGetSkSLsWorks once it passes on Fuchsia.
 ./fuchsia_ctl -d $device_name test \
     -f shell_tests-0.far  \
     -t shell_tests \
-    -a "--gtest_filter=-ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*"
+    -a "--gtest_filter=-ShellTest.CacheSkSLWorks:ShellTest.SetResourceCacheSize*:ShellTest.OnServiceProtocolGetSkSLsWorks"
 


### PR DESCRIPTION
That unit test depends on `fml::WriteAtomically`. Such file operations
does not seem to be well supported as FileTest is also disabled in
Fuchsia.