### PR TITLE
[web] changing the integration tests to show errors

### DIFF
--- a/e2etests/web/regular_integration_tests/README.md
+++ b/e2etests/web/regular_integration_tests/README.md
@@ -6,15 +6,17 @@ directory under e2etests/web. Otherwise tests such as text_editing, history,
 scrolling, pointer events... should all go under this package.
 
 Tests can be run on both 'release' and 'profile' modes. However 'release' mode
-will swallow the stack trace and only fails the test. Use 'profile' mode for
-trouble-shooting purposes.
+will shorten the error. Use 'profile' mode for trouble-shooting purposes where
+you can also see the full stack trace.
 
-# To run the application under test for traouble shooting purposes.
+# To run the application under test for trouble shooting purposes.
 flutter run -d web-server lib/text_editing_main.dart --local-engine=host_debug_unopt
 
 # To run the Text Editing test and use the developer tools in the browser.
 flutter run --target=test_driver/text_editing_e2e.dart -d web-server --web-port=8080 --profile --local-engine=host_debug_unopt
 
-# To test the Text Editing test with driver:
+# To test the Text Editing test with driver you either of the following:
 flutter drive -v --target=test_driver/text_editing_e2e.dart -d web-server --profile --browser-name=chrome --local-engine=host_debug_unopt
+
+flutter drive -v --target=test_driver/text_editing_e2e.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
 ```

--- a/e2etests/web/regular_integration_tests/README.md
+++ b/e2etests/web/regular_integration_tests/README.md
@@ -9,8 +9,8 @@ scrolling, pointer events... should all go under this package.
 flutter run -d web-server lib/text_editing_main.dart --local-engine=host_debug_unopt
 
 # To run the Text Editing test and use the developer tools in the browser.
-flutter run --target=test_driver/text_editing_e2e.dart -d web-server --web-port=8080 --release --local-engine=host_debug_unopt
+flutter run --target=test_driver/text_editing_e2e.dart -d web-server --web-port=8080 --profile --local-engine=host_debug_unopt
 
 # To test the Text Editing test with driver:
-flutter drive -v --target=test_driver/text_editing_e2e.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
+flutter drive -v --target=test_driver/text_editing_e2e.dart -d web-server --profile --browser-name=chrome --local-engine=host_debug_unopt
 ```

--- a/e2etests/web/regular_integration_tests/README.md
+++ b/e2etests/web/regular_integration_tests/README.md
@@ -5,6 +5,10 @@ configuration (e.g. PWA vs non-PWA packaging), please create another
 directory under e2etests/web. Otherwise tests such as text_editing, history,
 scrolling, pointer events... should all go under this package.
 
+Tests can be run on both 'release' and 'profile' modes. However 'release' mode
+will swallow the stack trace and only fails the test. Use 'profile' mode for
+trouble-shooting purposes.
+
 # To run the application under test for traouble shooting purposes.
 flutter run -d web-server lib/text_editing_main.dart --local-engine=host_debug_unopt
 

--- a/e2etests/web/regular_integration_tests/pubspec.yaml
+++ b/e2etests/web/regular_integration_tests/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  e2e: 0.2.4+4
+  e2e: 0.4.0
   http: 0.12.0+2
   test: any
 

--- a/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:html' as html;
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:regular_integration_tests/image_loading_main.dart' as app;
 

--- a/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/image_loading_e2e_test.dart
@@ -2,16 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'package:e2e/e2e_driver.dart' as e2e;
 
-import 'package:flutter_driver/flutter_driver.dart';
-
-Future<void> main() async {
-  final FlutterDriver driver = await FlutterDriver.connect();
-
-  final String dataRequest =
-      await driver.requestData(null, timeout: const Duration(seconds: 1));
-  await driver.close();
-
-  exit(dataRequest == 'pass' ? 0 : 1);
-}
+Future<void> main() async => e2e.main();

--- a/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e_test.dart
+++ b/e2etests/web/regular_integration_tests/test_driver/text_editing_e2e_test.dart
@@ -2,18 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
+import 'package:e2e/e2e_driver.dart' as e2e;
 
-import 'package:flutter_driver/flutter_driver.dart';
-
-Future<void> main() async {
-  final FlutterDriver driver = await FlutterDriver.connect();
-
-  // TODO(nurhan): https://github.com/flutter/flutter/issues/51940
-  final String dataRequest =
-      await driver.requestData(null, timeout: const Duration(seconds: 1));
-  print('result $dataRequest');
-  await driver.close();
-
-  exit(dataRequest == 'pass' ? 0 : 1);
-}
+Future<void> main() async => e2e.main();


### PR DESCRIPTION
changing the integration tests to show errors instead of only showing 'pass' 'fail'.
Example stack trace
```
[+2643 ms] Failure Details:
[        ] Failure in method: Focused text field creates a native input element
[        ] ══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞═════════════════
[        ] The following TestFailure object was thrown running a test:
[        ]   Expected: 'New Value'
[        ]   Actual: 'New Valu'
[        ]    Which: is different. Both strings start the same, but the
[        ] actual value is missing the following trailing characters: e
[        ] When the exception was thrown, this was the stack:
[        ]     at Object.wrapException (http://localhost:51152/main.dart.js:3797:17)
[        ]     at Object.throwExpression (http://localhost:51152/main.dart.js:3810:15)
[        ]     at Object.fail (http://localhost:51152/main.dart.js:17257:16)
[        ]     at Object._expect (http://localhost:51152/main.dart.js:17254:9)
[        ]     at Object.expect0 (http://localhost:51152/main.dart.js:17230:9)
[        ]     at Object.expect (http://localhost:51152/main.dart.js:20901:9)
[        ]     at http://localhost:51152/main.dart.js:94294:17
[        ]     at _wrapJsFunctionForAsync_closure.$protected (http://localhost:51152/main.dart.js:6725:15)
[        ]     at _wrapJsFunctionForAsync_closure.call$2 (http://localhost:51152/main.dart.js:39680:12)
[        ]     at StackZoneSpecification__registerBinaryCallback__closure.call$0 (http://localhost:51152/main.dart.js:92295:21)
[        ] The test description was:
[        ]   Focused text field creates a native input element
[        ] ═════════════════════════════════════════════════════════════════
[        ] end of failure 1

```
The drive file is reduced to nothing now :)
```
import 'package:e2e/e2e_driver.dart' as e2e;

Future<void> main() async => e2e.main();
```