### PR TITLE
Fix problem that using multi-engines, sometimes OpenGL would crash be…

### DIFF
--- a/shell/platform/darwin/ios/ios_render_target_gl.mm
+++ b/shell/platform/darwin/ios/ios_render_target_gl.mm
@@ -72,8 +72,7 @@ IOSRenderTargetGL::~IOSRenderTargetGL() {
   FML_DCHECK(glGetError() == GL_NO_ERROR);
   if (context == context_.get()) {
     [EAGLContext setCurrentContext:nil];
-  }
-  else {
+  } else {
     [EAGLContext setCurrentContext:context];
   }
 }

--- a/shell/platform/darwin/ios/ios_render_target_gl.mm
+++ b/shell/platform/darwin/ios/ios_render_target_gl.mm
@@ -70,7 +70,12 @@ IOSRenderTargetGL::~IOSRenderTargetGL() {
   glDeleteRenderbuffers(1, &colorbuffer_);
 
   FML_DCHECK(glGetError() == GL_NO_ERROR);
-  [EAGLContext setCurrentContext:context];
+  if (context == context_.get()) {
+    [EAGLContext setCurrentContext:nil];
+  }
+  else {
+    [EAGLContext setCurrentContext:context];
+  }
 }
 
 // |IOSRenderTarget|


### PR DESCRIPTION
…cause of invalid EAGLContext.

We are using multi-engines in our app. So there are chances that an iOS render target would be deallocated.

We found random crash and finally found that when ios_render_target_gl is being destructed. 
The first line of this function "EAGLContext* context = EAGLContext.currentContext;". The context is actually equal to "context_.get()". So an invalid opengl context is set to current.