### PR TITLE
Disable ShellTest.OnServiceProtocolGetSkSLsWorks.

### DIFF
--- a/shell/common/shell_unittests.cc
+++ b/shell/common/shell_unittests.cc
@@ -1132,7 +1132,8 @@ TEST_F(ShellTest, CanDecompressImageFromAsset) {
   DestroyShell(std::move(shell));
 }
 
-TEST_F(ShellTest, OnServiceProtocolGetSkSLsWorks) {
+// TODO(53399): Re-enable once it passes on Fuchsia.
+TEST_F(ShellTest, DISABLED_OnServiceProtocolGetSkSLsWorks) {
   // Create 2 dummpy SkSL cache file IE (base32 encoding of A), II (base32
   // encoding of B) with content x and y.
   fml::ScopedTemporaryDirectory temp_dir;


### PR DESCRIPTION
Re-enabling tracked in https://github.com/flutter/flutter/issues/53399.