### PR TITLE
Add keep annotation to Locale.toString

### DIFF
--- a/lib/ui/window.dart
+++ b/lib/ui/window.dart
@@ -492,6 +492,7 @@ class Locale {
   /// This identifier happens to be a valid Unicode Locale Identifier using
   /// underscores as separator, however it is intended to be used for debugging
   /// purposes only. For parseable results, use [toLanguageTag] instead.
+  @keepToString
   @override
   String toString() {
     if (!identical(_cachedLocale, this)) {

--- a/testing/dart/window_hooks_integration_test.dart
+++ b/testing/dart/window_hooks_integration_test.dart
@@ -19,6 +19,7 @@ import 'dart:typed_data';
 import 'package:test/test.dart';
 
 // HACK: these parts are to get access to private functions tested here.
+part '../../lib/ui/annotations.dart';
 part '../../lib/ui/channel_buffers.dart';
 part '../../lib/ui/compositing.dart';
 part '../../lib/ui/geometry.dart';


### PR DESCRIPTION
Locale.toString is used meaningfully even in release builds.  We should keep it.

/cc @zanderso @chingjun @jonahwilliams @jason-simmons 