### PR TITLE
Disconnect from platform views and virtual displays before detaching from the engine

### DIFF
--- a/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
+++ b/shell/platform/android/io/flutter/app/FlutterPluginRegistry.java
@@ -86,7 +86,7 @@ public class FlutterPluginRegistry
 
   public void detach() {
     mPlatformViewsController.detach();
-    mPlatformViewsController.onFlutterViewDestroyed();
+    mPlatformViewsController.onDetachedFromJNI();
     mFlutterView = null;
     mActivity = null;
   }
@@ -239,6 +239,6 @@ public class FlutterPluginRegistry
   }
 
   public void destroy() {
-    mPlatformViewsController.onFlutterViewDestroyed();
+    mPlatformViewsController.onDetachedFromJNI();
   }
 }

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterEngine.java
@@ -225,6 +225,7 @@ public class FlutterEngine {
     textInputChannel = new TextInputChannel(dartExecutor);
 
     this.platformViewsController = platformViewsController;
+    this.platformViewsController.onAttachedToJNI();
 
     this.pluginRegistry =
         new FlutterEnginePluginRegistry(context.getApplicationContext(), this, flutterLoader);
@@ -289,6 +290,7 @@ public class FlutterEngine {
     Log.v(TAG, "Destroying.");
     // The order that these things are destroyed is important.
     pluginRegistry.destroy();
+    platformViewsController.onDetachedFromJNI();
     dartExecutor.onDetachedFromJNI();
     flutterJNI.removeEngineLifecycleListener(engineLifecycleListener);
     flutterJNI.detachFromNativeAndReleaseResources();

--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -404,7 +404,21 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
     return registry;
   }
 
-  public void onFlutterViewDestroyed() {
+  /**
+   * Invoked when the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@link
+   * PlatformViewsController} attaches to JNI.
+   */
+  public void onAttachedToJNI() {
+    // Currently no action needs to be taken after JNI attachment.
+  }
+
+  /**
+   * Invoked when the {@link io.flutter.embedding.engine.FlutterEngine} that owns this {@link
+   * PlatformViewsController} detaches from JNI.
+   */
+  public void onDetachedFromJNI() {
+    // Dispose all virtual displays so that any future updates to textures will not be
+    // propagated to the native peer.
     flushAllViews();
   }
 

--- a/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
+++ b/shell/platform/android/test/io/flutter/embedding/engine/FlutterEngineTest.java
@@ -103,6 +103,28 @@ public class FlutterEngineTest {
   }
 
   @Test
+  public void itNotifiesPlatformViewsControllerAboutJNILifecycle() {
+    FlutterJNI mockFlutterJNI = mock(FlutterJNI.class);
+    when(mockFlutterJNI.isAttached()).thenReturn(true);
+
+    PlatformViewsController platformViewsController = mock(PlatformViewsController.class);
+
+    // Execute behavior under test.
+    FlutterEngine engine =
+        new FlutterEngine(
+            RuntimeEnvironment.application,
+            mock(FlutterLoader.class),
+            mockFlutterJNI,
+            platformViewsController,
+            /*dartVmArgs=*/ new String[] {},
+            /*automaticallyRegisterPlugins=*/ false);
+    verify(platformViewsController, times(1)).onAttachedToJNI();
+
+    engine.destroy();
+    verify(platformViewsController, times(1)).onDetachedFromJNI();
+  }
+
+  @Test
   public void itUsesApplicationContext() {
     Context context = mock(Context.class);
 


### PR DESCRIPTION
Calling PlatformViewsController.onFlutterViewDestroyed will release
any virtual displays and associated textures held on behalf of
platform views.  This must be done before detaching from FlutterJNI
because updates to the textures require an active FlutterJNI.