### PR TITLE
Partially revert Samsung keyboard force-update workaround

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -155,25 +155,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
         CursorAnchorInfo anchorInfo = builder.build();
         mImm.updateCursorAnchorInfo(mFlutterView, anchorInfo);
       }
-      // TODO(garyq): There is still a duplication case that comes from hiding+showing the keyboard.
-      // The exact behavior to cause it has so far been hard to pinpoint and it happens far more
-      // rarely than the original bug.
-
-      // Temporarily indicate to the IME that the composing region selection should be reset.
-      // The correct selection is then immediately set properly in the updateEditingState() call
-      // in this method. This is a hack to trigger Samsung keyboard's internal cache to clear.
-      // This prevents duplication on keyboard hide+show. See
-      // https://github.com/flutter/flutter/issues/31512
-      //
-      // We only do this if the proper selection will be restored later, eg, when mBatchCount is 0.
-      if (mBatchCount == 0) {
-        mImm.updateSelection(
-            mFlutterView,
-            -1, /*selStart*/
-            -1, /*selEnd*/
-            -1, /*candidatesStart*/
-            -1 /*candidatesEnd*/);
-      }
     }
 
     updateEditingState();

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -29,8 +29,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.platform.PlatformViewsController;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.junit.Test;

--- a/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/TextInputPluginTest.java
@@ -349,48 +349,6 @@ public class TextInputPluginTest {
     }
   }
 
-  @Test
-  public void inputConnection_samsungFinishComposingTextSetsSelection() throws JSONException {
-    ShadowBuild.setManufacturer("samsung");
-    InputMethodSubtype inputMethodSubtype =
-        new InputMethodSubtype(0, 0, /*locale=*/ "en", "", "", false, false);
-    Settings.Secure.putString(
-        RuntimeEnvironment.application.getContentResolver(),
-        Settings.Secure.DEFAULT_INPUT_METHOD,
-        "com.sec.android.inputmethod/.SamsungKeypad");
-    TestImm testImm =
-        Shadow.extract(
-            RuntimeEnvironment.application.getSystemService(Context.INPUT_METHOD_SERVICE));
-    testImm.setCurrentInputMethodSubtype(inputMethodSubtype);
-    FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
-    View testView = new View(RuntimeEnvironment.application);
-    DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
-    TextInputPlugin textInputPlugin =
-        new TextInputPlugin(testView, dartExecutor, mock(PlatformViewsController.class));
-    textInputPlugin.setTextInputClient(
-        0,
-        new TextInputChannel.Configuration(
-            false,
-            false,
-            true,
-            TextInputChannel.TextCapitalization.NONE,
-            new TextInputChannel.InputType(TextInputChannel.TextInputType.TEXT, false, false),
-            null,
-            null));
-    // There's a pending restart since we initialized the text input client. Flush that now.
-    textInputPlugin.setTextInputEditingState(
-        testView, new TextInputChannel.TextEditState("", 0, 0));
-    InputConnection connection = textInputPlugin.createInputConnection(testView, new EditorInfo());
-
-    testImm.setTrackSelection(true);
-    connection.finishComposingText();
-    testImm.setTrackSelection(false);
-
-    List<Integer> expectedSelectionValues =
-        Arrays.asList(0, 0, -1, -1, -1, -1, -1, -1, 0, 0, -1, -1);
-    assertEquals(testImm.getSelectionUpdateValues(), expectedSelectionValues);
-  }
-
   @Implements(InputMethodManager.class)
   public static class TestImm extends ShadowInputMethodManager {
     private InputMethodSubtype currentInputMethodSubtype;


### PR DESCRIPTION
Reverts the functional part of https://github.com/flutter/engine/pull/16547

Leaves the testing improvements and samsung keyboard filtering portion of the original PR intact.