### PR TITLE
Fix bug in handling delete key event for android

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -17,7 +17,6 @@ import android.text.Layout;
 import android.text.Selection;
 import android.text.TextPaint;
 import android.text.method.TextKeyListener;
-import android.text.method.TextKeyListener.Capitalize;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.BaseInputConnection;
@@ -323,8 +322,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
           updateEditingState();
           return true;
         } else if (selStart > 0) {
-          TextKeyListener textKeyListener = new TextKeyListener(Capitalize.NONE, false);
-          if (textKeyListener.onKeyDown(null, mEditable, event.getKeyCode(), event)) {
+          if (TextKeyListener.getInstance().onKeyDown(null, mEditable, event.getKeyCode(), event)) {
             updateEditingState();
             return true;
           }

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -16,7 +16,7 @@ import android.text.InputType;
 import android.text.Layout;
 import android.text.Selection;
 import android.text.TextPaint;
-import android.text.method.QwertyKeyListener;
+import android.text.method.TextKeyListener;
 import android.text.method.TextKeyListener.Capitalize;
 import android.view.KeyEvent;
 import android.view.View;
@@ -323,8 +323,8 @@ class InputConnectionAdaptor extends BaseInputConnection {
           updateEditingState();
           return true;
         } else if (selStart > 0) {
-          QwertyKeyListener qwertyKeyListener = new QwertyKeyListener(Capitalize.NONE, false);
-          if (qwertyKeyListener.onKeyDown(null, mEditable, event.getKeyCode(), event)) {
+          TextKeyListener textKeyListener = new TextKeyListener(Capitalize.NONE, false);
+          if (textKeyListener.onKeyDown(null, mEditable, event.getKeyCode(), event)) {
             updateEditingState();
             return true;
           }

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -325,21 +325,39 @@ class InputConnectionAdaptor extends BaseInputConnection {
           // TODO(garyq): Explore how to obtain per-character direction. The
           // isRTLCharAt() call below is returning blanket direction assumption
           // based on the first character in the line.
-          boolean isRtl = mLayout.isRtlCharAt(mLayout.getLineForOffset(selStart));
-          try {
-            if (isRtl) {
-              Selection.extendRight(mEditable, mLayout);
-            } else {
-              Selection.extendLeft(mEditable, mLayout);
+
+          Boolean selectedCharIsEmoji = false;
+          if (selStart > 1) {
+            final String emo_regex =
+                "([\\u20a0-\\u32ff\\ud83c\\udc00-\\ud83d\\udeff\\udbb9\\udce5-\\udbb9\\udcee])";
+            String lastChars = mLayout.getText().subSequence(selStart - 2, selStart).toString();
+            selectedCharIsEmoji = lastChars.matches(emo_regex);
+          }
+
+          // The Selection.extendLeft and extendRight calls have some problems
+          // when mixing RTL and LTR text so if selected character is not emoji
+          // simply select that character
+          if (selectedCharIsEmoji) {
+            boolean isRtl =
+                mLayout.isRtlCharAt(mLayout.getLineStart(mLayout.getLineForOffset(selStart)));
+            Log.i("isRtl", Boolean.toString(isRtl));
+            try {
+              if (isRtl) {
+                Selection.extendRight(mEditable, mLayout);
+              } else {
+                Selection.extendLeft(mEditable, mLayout);
+              }
+            } catch (IndexOutOfBoundsException e) {
+              // On some Chinese devices (primarily Huawei, some Xiaomi),
+              // on initial app startup before focus is lost, the
+              // Selection.extendLeft and extendRight calls always extend
+              // from the index of the initial contents of mEditable. This
+              // try-catch will prevent crashing on Huawei devices by falling
+              // back to a simple way of deletion, although this a hack and
+              // will not handle emojis.
+              Selection.setSelection(mEditable, selStart, selStart - 1);
             }
-          } catch (IndexOutOfBoundsException e) {
-            // On some Chinese devices (primarily Huawei, some Xiaomi),
-            // on initial app startup before focus is lost, the
-            // Selection.extendLeft and extendRight calls always extend
-            // from the index of the initial contents of mEditable. This
-            // try-catch will prevent crashing on Huawei devices by falling
-            // back to a simple way of deletion, although this a hack and
-            // will not handle emojis.
+          } else {
             Selection.setSelection(mEditable, selStart, selStart - 1);
           }
           int newStart = clampIndexToEditable(Selection.getSelectionStart(mEditable), mEditable);

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -313,11 +313,40 @@ public class InputConnectionAdaptorTest {
     assertEquals(textInputChannel.selectionEnd, 4);
   }
 
+  @Test
+  public void testSendKeyEvent_delKeyDeletesBackward() {
+    int selStart = 29;
+    Editable editable = sampleRtlEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DEL);
+
+    for (int i = 0; i < 9; i++) {
+      boolean didConsume = adaptor.sendKeyEvent(downKeyDown);
+      assertTrue(didConsume);
+    }
+    assertEquals(Selection.getSelectionStart(editable), 19);
+
+    for (int i = 0; i < 9; i++) {
+      boolean didConsume = adaptor.sendKeyEvent(downKeyDown);
+      assertTrue(didConsume);
+    }
+    assertEquals(Selection.getSelectionStart(editable), 10);
+  }
+
   private static final String SAMPLE_TEXT =
       "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";
 
+  private static final String SAMPLE_RTL_TEXT = "متن ساختگی" + "\nبرای تستfor test😊";
+
   private static Editable sampleEditable(int selStart, int selEnd) {
     SpannableStringBuilder sample = new SpannableStringBuilder(SAMPLE_TEXT);
+    Selection.setSelection(sample, selStart, selEnd);
+    return sample;
+  }
+
+  private static Editable sampleRtlEditable(int selStart, int selEnd) {
+    SpannableStringBuilder sample = new SpannableStringBuilder(SAMPLE_RTL_TEXT);
     Selection.setSelection(sample, selStart, selEnd);
     return sample;
   }


### PR DESCRIPTION
When typing RTL and LTR characters together in TextField, deleting a single character might cause it's previous characters from the same direction to be deleted.
Also, you can't delete a new line when typing RTL text.

This PR is for fixing these problems.