### PR TITLE
ios_debug_unopt build fix - missing new enum in switches

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -704,13 +704,16 @@ static void sendFakeTouchEvent(FlutterEngine* engine,
 static flutter::PointerData::Change PointerDataChangeFromUITouchPhase(UITouchPhase phase) {
   switch (phase) {
     case UITouchPhaseBegan:
+    case UITouchPhaseRegionEntered:
       return flutter::PointerData::Change::kDown;
     case UITouchPhaseMoved:
     case UITouchPhaseStationary:
+    case UITouchPhaseRegionMoved:
       // There is no EVENT_TYPE_POINTER_STATIONARY. So we just pass a move type
       // with the same coordinates
       return flutter::PointerData::Change::kMove;
     case UITouchPhaseEnded:
+    case UITouchPhaseRegionExited:
       return flutter::PointerData::Change::kUp;
     case UITouchPhaseCancelled:
       return flutter::PointerData::Change::kCancel;
@@ -724,6 +727,7 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
     switch (touch.type) {
       case UITouchTypeDirect:
       case UITouchTypeIndirect:
+      case UITouchTypeIndirectPointer:
         return flutter::PointerData::DeviceKind::kTouch;
       case UITouchTypeStylus:
         return flutter::PointerData::DeviceKind::kStylus;


### PR DESCRIPTION
I followed the build instructions for iOS, the command "ninja -C out/ios_debug_unopt && ninja -C out/host_debug_unopt" gave me the following errors:

../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm:705:11: error: enumeration values 'UITouchPhaseRegionEntered', 'UITouchPhaseRegionMoved', and 'UITouchPhaseRegionExited' not handled in switch [-Werror,-Wswitch]

../../flutter/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm:724:13: error: enumeration value 'UITouchTypeIndirectPointer' not handled in switch [-Werror,-Wswitch]

Indeed, the new enum types are not handled, I added them, and this corrects the build