### PR TITLE
Fixed renderSurface assignment when used FlutterTextureView

### DIFF
--- a/shell/platform/android/io/flutter/embedding/android/FlutterView.java
+++ b/shell/platform/android/io/flutter/embedding/android/FlutterView.java
@@ -264,7 +264,7 @@ public class FlutterView extends FrameLayout {
     super(context, attrs);
 
     this.flutterTextureView = flutterTextureView;
-    this.renderSurface = flutterSurfaceView;
+    this.renderSurface = flutterTextureView;
 
     init();
   }


### PR DESCRIPTION
Previously it was assigned to flutterSurfaceView which is null. And it led to the NullPointerException when FlutterFragmentAcitivity started with BackgroundMode.tranparent.