### PR TITLE
Make DPAD movement consider grapheme clusters

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
+++ b/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
@@ -203,6 +203,7 @@ class FlutterTextUtils {
     int codePoint = Character.codePointAt(text, offset);
     int nextCharCount = Character.charCount(codePoint);
     int nextOffset = offset + nextCharCount;
+    Log.e("justin", "nextCharCount at " + offset + " is " + nextCharCount + " so nextOffset is " + nextOffset);
 
     if (nextOffset == 0) {
       return 0;
@@ -249,9 +250,11 @@ class FlutterTextUtils {
     }
 
     if (isEmoji(codePoint)) {
+      Log.e("justin", "Is emoji " + offset + ", " + nextOffset);
       boolean isZwj = false;
       int lastSeenVariantSelectorCharCount = 0;
       do {
+        Log.e("justin", "do it " + nextOffset);
         if (isZwj) {
           nextCharCount += Character.charCount(codePoint) + lastSeenVariantSelectorCharCount + 1;
           isZwj = false;
@@ -260,6 +263,7 @@ class FlutterTextUtils {
         if (isEmojiModifier(codePoint)) {
           codePoint = Character.codePointAt(text, nextOffset);
           nextOffset += Character.charCount(codePoint);
+          Log.e("justin", "Is emoji modifier " + offset + ", " + nextOffset);
           if (nextOffset < len && isVariationSelector(codePoint)) {
             codePoint = Character.codePointAt(text, nextOffset);
             if (!isEmoji(codePoint)) {
@@ -275,8 +279,10 @@ class FlutterTextUtils {
         }
 
         if (nextOffset < len) {
+          Log.e("justin", "about to move forward from nextOffset " + nextOffset);
           codePoint = Character.codePointAt(text, nextOffset);
           nextOffset += Character.charCount(codePoint);
+          Log.e("justin", "moved to next, is it an emoji? " + isEmoji(codePoint) + " for " + nextOffset);
           if (codePoint == ZERO_WIDTH_JOINER) {
             isZwj = true;
             codePoint = Character.codePointAt(text, nextOffset);
@@ -295,6 +301,7 @@ class FlutterTextUtils {
       } while (isZwj && isEmoji(codePoint));
     }
 
+    Log.e("justin", "return " + offset + " + " + nextCharCount + " = " + (offset + nextCharCount));
     return offset + nextCharCount;
   }
 }

--- a/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
+++ b/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
@@ -217,15 +217,22 @@ class FlutterTextUtils {
 
     // Flags
     if (isRegionalIndicatorSymbol(codePoint)) {
-      codePoint = Character.codePointAt(text, nextOffset);
-      nextOffset += Character.charCount(codePoint);
+      if (nextOffset >= len - 1
+            || !isRegionalIndicatorSymbol(Character.codePointAt(text, nextOffset))) {
+        return offset + nextCharCount;
+      }
+      // In this case there are at least two regional indicator symbols ahead of
+      // offset. If those two regional indicator symbols are a pair that
+      // represent a region together, the next offset should be after both of
+      // them.
       int regionalIndicatorSymbolCount = 0;
-      while (nextOffset < len && isRegionalIndicatorSymbol(codePoint)) {
-        codePoint = Character.codePointAt(text, nextOffset);
-        nextOffset += Character.charCount(codePoint);
+      int regionOffset = offset;
+      while (regionOffset > 0
+          && isRegionalIndicatorSymbol(Character.codePointBefore(text, offset))) {
+        regionOffset -= Character.charCount(Character.codePointBefore(text, offset));
         regionalIndicatorSymbolCount++;
       }
-      if (regionalIndicatorSymbolCount > 0 && regionalIndicatorSymbolCount % 2 == 0) {
+      if (regionalIndicatorSymbolCount % 2 == 0) {
         nextCharCount += 2;
       }
       return offset + nextCharCount;

--- a/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
+++ b/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
@@ -5,8 +5,8 @@
 package io.flutter.plugin.editing;
 
 import android.graphics.Paint;
-import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.Log;
+import io.flutter.embedding.engine.FlutterJNI;
 
 class FlutterTextUtils {
   public static final int LINE_FEED = 0x0A;
@@ -143,14 +143,12 @@ class FlutterTextUtils {
       boolean isZwj = false;
       int lastSeenVariantSelectorCharCount = 0;
       do {
-        Log.e("justin", "do " + lastOffset);
         if (isZwj) {
           deleteCharCount += Character.charCount(codePoint) + lastSeenVariantSelectorCharCount + 1;
           isZwj = false;
         }
         lastSeenVariantSelectorCharCount = 0;
         if (isEmojiModifier(codePoint)) {
-          Log.e("justin", "Before: isEmojiModifier");
           codePoint = Character.codePointBefore(text, lastOffset);
           lastOffset -= Character.charCount(codePoint);
           if (lastOffset > 0 && isVariationSelector(codePoint)) {
@@ -168,16 +166,13 @@ class FlutterTextUtils {
         }
 
         if (lastOffset > 0) {
-          Log.e("justin", "Before: lastOffset > 0 (" + lastOffset + ")");
           codePoint = Character.codePointBefore(text, lastOffset);
           lastOffset -= Character.charCount(codePoint);
           if (codePoint == ZERO_WIDTH_JOINER) {
-            Log.e("justin", "is ZWJ");
             isZwj = true;
             codePoint = Character.codePointBefore(text, lastOffset);
             lastOffset -= Character.charCount(codePoint);
             if (lastOffset > 0 && isVariationSelector(codePoint)) {
-              Log.e("justin", "is ZWJ and lastOffset > 0 and isVariationSelector");
               codePoint = Character.codePointBefore(text, lastOffset);
               lastSeenVariantSelectorCharCount = Character.charCount(codePoint);
               lastOffset -= Character.charCount(codePoint);
@@ -195,15 +190,13 @@ class FlutterTextUtils {
   }
 
   /**
-   * Gets the offset of the next character following the given offset, with
-   * consideration for multi-byte characters.
+   * Gets the offset of the next character following the given offset, with consideration for
+   * multi-byte characters.
    */
   public int getOffsetAfter(CharSequence text, int offset, Paint paint) {
-    Log.e("justin", "getOffsetAfter " + text + ", " + offset);
     final int len = text.length();
 
     if (offset >= len - 1) {
-      Log.e("justin", "over length " + len);
       return len;
     }
 
@@ -212,13 +205,11 @@ class FlutterTextUtils {
     int nextOffset = offset + nextCharCount;
 
     if (nextOffset == 0) {
-      Log.e("justin", "nextOffset == zero");
       return 0;
     }
 
     // Line Feed
     if (codePoint == LINE_FEED) {
-      Log.e("justin", "line feed");
       codePoint = Character.codePointAt(text, nextOffset);
       if (codePoint == CARRIAGE_RETURN) {
         ++nextCharCount;
@@ -228,7 +219,6 @@ class FlutterTextUtils {
 
     // Flags
     if (isRegionalIndicatorSymbol(codePoint)) {
-      Log.e("justin", "flag");
       codePoint = Character.codePointAt(text, nextOffset);
       nextOffset += Character.charCount(codePoint);
       int regionalIndicatorSymbolCount = 1;
@@ -245,7 +235,6 @@ class FlutterTextUtils {
 
     // Keycaps
     if (codePoint == COMBINING_ENCLOSING_KEYCAP) {
-      Log.e("justin", "keycap");
       codePoint = Character.codePointBefore(text, nextOffset);
       nextOffset += Character.charCount(codePoint);
       if (nextOffset < len && isVariationSelector(codePoint)) {
@@ -260,7 +249,6 @@ class FlutterTextUtils {
     }
 
     if (isEmoji(codePoint)) {
-      Log.e("justin", "emoji at " + nextOffset);
       boolean isZwj = false;
       int lastSeenVariantSelectorCharCount = 0;
       do {
@@ -270,13 +258,11 @@ class FlutterTextUtils {
         }
         lastSeenVariantSelectorCharCount = 0;
         if (isEmojiModifier(codePoint)) {
-          Log.e("justin", "isEmojiModifier");
           codePoint = Character.codePointAt(text, nextOffset);
           nextOffset += Character.charCount(codePoint);
           if (nextOffset < len && isVariationSelector(codePoint)) {
             codePoint = Character.codePointAt(text, nextOffset);
             if (!isEmoji(codePoint)) {
-              Log.e("justin", "emoji not emoji so return " + offset + " + " + nextCharCount);
               return offset + nextCharCount;
             }
             lastSeenVariantSelectorCharCount = Character.charCount(codePoint);
@@ -285,14 +271,12 @@ class FlutterTextUtils {
           if (isEmojiModifierBase(codePoint)) {
             nextCharCount += lastSeenVariantSelectorCharCount + Character.charCount(codePoint);
           }
-          Log.e("justin", "break b/c isEmojiModifier");
           break;
         }
 
         if (nextOffset < len) {
           codePoint = Character.codePointAt(text, nextOffset);
           nextOffset += Character.charCount(codePoint);
-          Log.e("justin", "emoji nextOffset < len so move forward. is this a zwj? " + (codePoint == ZERO_WIDTH_JOINER) + " at " + nextOffset + " after moved forward by " + Character.charCount(codePoint));
           if (codePoint == ZERO_WIDTH_JOINER) {
             isZwj = true;
             codePoint = Character.codePointAt(text, nextOffset);
@@ -306,14 +290,11 @@ class FlutterTextUtils {
         }
 
         if (nextOffset >= len) {
-          Log.e("justin", "emoji nextOffset >= len " + nextOffset + " >= " + len);
           break;
         }
-        Log.e("justin", "emoji while " + isZwj + " and " + isEmoji(codePoint));
       } while (isZwj && isEmoji(codePoint));
     }
 
-    Log.e("justin", "done " + (offset + nextCharCount));
     return offset + nextCharCount;
   }
 }

--- a/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
+++ b/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
@@ -190,6 +190,9 @@ class FlutterTextUtils {
   /**
    * Gets the offset of the next character following the given offset, with consideration for
    * multi-byte characters.
+   *
+   * @see <a target="_new"
+   *     href="https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android10-s3-release/core/java/android/text/method/BaseKeyListener.java#111">https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android10-s3-release/core/java/android/text/method/BaseKeyListener.java#111</a>
    */
   public int getOffsetAfter(CharSequence text, int offset) {
     final int len = text.length();
@@ -218,7 +221,7 @@ class FlutterTextUtils {
     // Flags
     if (isRegionalIndicatorSymbol(codePoint)) {
       if (nextOffset >= len - 1
-            || !isRegionalIndicatorSymbol(Character.codePointAt(text, nextOffset))) {
+          || !isRegionalIndicatorSymbol(Character.codePointAt(text, nextOffset))) {
         return offset + nextCharCount;
       }
       // In this case there are at least two regional indicator symbols ahead of

--- a/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
+++ b/shell/platform/android/io/flutter/plugin/editing/FlutterTextUtils.java
@@ -4,7 +4,9 @@
 
 package io.flutter.plugin.editing;
 
+import android.graphics.Paint;
 import io.flutter.embedding.engine.FlutterJNI;
+import io.flutter.Log;
 
 class FlutterTextUtils {
   public static final int LINE_FEED = 0x0A;
@@ -141,12 +143,14 @@ class FlutterTextUtils {
       boolean isZwj = false;
       int lastSeenVariantSelectorCharCount = 0;
       do {
+        Log.e("justin", "do " + lastOffset);
         if (isZwj) {
           deleteCharCount += Character.charCount(codePoint) + lastSeenVariantSelectorCharCount + 1;
           isZwj = false;
         }
         lastSeenVariantSelectorCharCount = 0;
         if (isEmojiModifier(codePoint)) {
+          Log.e("justin", "Before: isEmojiModifier");
           codePoint = Character.codePointBefore(text, lastOffset);
           lastOffset -= Character.charCount(codePoint);
           if (lastOffset > 0 && isVariationSelector(codePoint)) {
@@ -164,13 +168,16 @@ class FlutterTextUtils {
         }
 
         if (lastOffset > 0) {
+          Log.e("justin", "Before: lastOffset > 0 (" + lastOffset + ")");
           codePoint = Character.codePointBefore(text, lastOffset);
           lastOffset -= Character.charCount(codePoint);
           if (codePoint == ZERO_WIDTH_JOINER) {
+            Log.e("justin", "is ZWJ");
             isZwj = true;
             codePoint = Character.codePointBefore(text, lastOffset);
             lastOffset -= Character.charCount(codePoint);
             if (lastOffset > 0 && isVariationSelector(codePoint)) {
+              Log.e("justin", "is ZWJ and lastOffset > 0 and isVariationSelector");
               codePoint = Character.codePointBefore(text, lastOffset);
               lastSeenVariantSelectorCharCount = Character.charCount(codePoint);
               lastOffset -= Character.charCount(codePoint);
@@ -185,5 +192,128 @@ class FlutterTextUtils {
     }
 
     return offset - deleteCharCount;
+  }
+
+  /**
+   * Gets the offset of the next character following the given offset, with
+   * consideration for multi-byte characters.
+   */
+  public int getOffsetAfter(CharSequence text, int offset, Paint paint) {
+    Log.e("justin", "getOffsetAfter " + text + ", " + offset);
+    final int len = text.length();
+
+    if (offset >= len - 1) {
+      Log.e("justin", "over length " + len);
+      return len;
+    }
+
+    int codePoint = Character.codePointAt(text, offset);
+    int nextCharCount = Character.charCount(codePoint);
+    int nextOffset = offset + nextCharCount;
+
+    if (nextOffset == 0) {
+      Log.e("justin", "nextOffset == zero");
+      return 0;
+    }
+
+    // Line Feed
+    if (codePoint == LINE_FEED) {
+      Log.e("justin", "line feed");
+      codePoint = Character.codePointAt(text, nextOffset);
+      if (codePoint == CARRIAGE_RETURN) {
+        ++nextCharCount;
+      }
+      return offset + nextCharCount;
+    }
+
+    // Flags
+    if (isRegionalIndicatorSymbol(codePoint)) {
+      Log.e("justin", "flag");
+      codePoint = Character.codePointAt(text, nextOffset);
+      nextOffset += Character.charCount(codePoint);
+      int regionalIndicatorSymbolCount = 1;
+      while (nextOffset < len && isRegionalIndicatorSymbol(codePoint)) {
+        codePoint = Character.codePointAt(text, nextOffset);
+        nextOffset += Character.charCount(codePoint);
+        regionalIndicatorSymbolCount++;
+      }
+      if (regionalIndicatorSymbolCount % 2 == 0) {
+        nextCharCount += 2;
+      }
+      return offset + nextCharCount;
+    }
+
+    // Keycaps
+    if (codePoint == COMBINING_ENCLOSING_KEYCAP) {
+      Log.e("justin", "keycap");
+      codePoint = Character.codePointBefore(text, nextOffset);
+      nextOffset += Character.charCount(codePoint);
+      if (nextOffset < len && isVariationSelector(codePoint)) {
+        int tmpCodePoint = Character.codePointAt(text, nextOffset);
+        if (isKeycapBase(tmpCodePoint)) {
+          nextCharCount += Character.charCount(codePoint) + Character.charCount(tmpCodePoint);
+        }
+      } else if (isKeycapBase(codePoint)) {
+        nextCharCount += Character.charCount(codePoint);
+      }
+      return offset + nextCharCount;
+    }
+
+    if (isEmoji(codePoint)) {
+      Log.e("justin", "emoji at " + nextOffset);
+      boolean isZwj = false;
+      int lastSeenVariantSelectorCharCount = 0;
+      do {
+        if (isZwj) {
+          nextCharCount += Character.charCount(codePoint) + lastSeenVariantSelectorCharCount + 1;
+          isZwj = false;
+        }
+        lastSeenVariantSelectorCharCount = 0;
+        if (isEmojiModifier(codePoint)) {
+          Log.e("justin", "isEmojiModifier");
+          codePoint = Character.codePointAt(text, nextOffset);
+          nextOffset += Character.charCount(codePoint);
+          if (nextOffset < len && isVariationSelector(codePoint)) {
+            codePoint = Character.codePointAt(text, nextOffset);
+            if (!isEmoji(codePoint)) {
+              Log.e("justin", "emoji not emoji so return " + offset + " + " + nextCharCount);
+              return offset + nextCharCount;
+            }
+            lastSeenVariantSelectorCharCount = Character.charCount(codePoint);
+            nextOffset += Character.charCount(codePoint);
+          }
+          if (isEmojiModifierBase(codePoint)) {
+            nextCharCount += lastSeenVariantSelectorCharCount + Character.charCount(codePoint);
+          }
+          Log.e("justin", "break b/c isEmojiModifier");
+          break;
+        }
+
+        if (nextOffset < len) {
+          codePoint = Character.codePointAt(text, nextOffset);
+          nextOffset += Character.charCount(codePoint);
+          Log.e("justin", "emoji nextOffset < len so move forward. is this a zwj? " + (codePoint == ZERO_WIDTH_JOINER) + " at " + nextOffset + " after moved forward by " + Character.charCount(codePoint));
+          if (codePoint == ZERO_WIDTH_JOINER) {
+            isZwj = true;
+            codePoint = Character.codePointAt(text, nextOffset);
+            nextOffset += Character.charCount(codePoint);
+            if (nextOffset < len && isVariationSelector(codePoint)) {
+              codePoint = Character.codePointAt(text, nextOffset);
+              lastSeenVariantSelectorCharCount = Character.charCount(codePoint);
+              nextOffset += Character.charCount(codePoint);
+            }
+          }
+        }
+
+        if (nextOffset >= len) {
+          Log.e("justin", "emoji nextOffset >= len " + nextOffset + " >= " + len);
+          break;
+        }
+        Log.e("justin", "emoji while " + isZwj + " and " + isEmoji(codePoint));
+      } while (isZwj && isEmoji(codePoint));
+    }
+
+    Log.e("justin", "done " + (offset + nextCharCount));
+    return offset + nextCharCount;
   }
 }

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -355,15 +355,11 @@ class InputConnectionAdaptor extends BaseInputConnection {
         int selEnd = Selection.getSelectionEnd(mEditable);
         if (selStart == selEnd && !event.isShiftPressed()) {
           int newSel =
-              Math.min(
-                  flutterTextUtils.getOffsetAfter(mEditable, selStart),
-                  mEditable.length());
+              Math.min(flutterTextUtils.getOffsetAfter(mEditable, selStart), mEditable.length());
           setSelection(newSel, newSel);
         } else {
           int newSelEnd =
-              Math.min(
-                  flutterTextUtils.getOffsetAfter(mEditable, selEnd),
-                  mEditable.length());
+              Math.min(flutterTextUtils.getOffsetAfter(mEditable, selEnd), mEditable.length());
           setSelection(selStart, newSelEnd);
         }
         return true;

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -356,13 +356,13 @@ class InputConnectionAdaptor extends BaseInputConnection {
         if (selStart == selEnd && !event.isShiftPressed()) {
           int newSel =
               Math.min(
-                  flutterTextUtils.getOffsetAfter(mEditable, selStart, new TextPaint()),
+                  flutterTextUtils.getOffsetAfter(mEditable, selStart),
                   mEditable.length());
           setSelection(newSel, newSel);
         } else {
           int newSelEnd =
               Math.min(
-                  flutterTextUtils.getOffsetAfter(mEditable, selEnd, new TextPaint()),
+                  flutterTextUtils.getOffsetAfter(mEditable, selEnd),
                   mEditable.length());
           setSelection(selStart, newSelEnd);
         }

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -343,14 +343,11 @@ class InputConnectionAdaptor extends BaseInputConnection {
         int selStart = Selection.getSelectionStart(mEditable);
         int selEnd = Selection.getSelectionEnd(mEditable);
         if (selStart == selEnd && !event.isShiftPressed()) {
-          Selection.moveLeft(mEditable, mLayout);
-          int newSelStart = Selection.getSelectionStart(mEditable);
-          setSelection(newSelStart, newSelStart);
+          int newSel = Math.max(flutterTextUtils.getOffsetBefore(mEditable, selStart), 0);
+          setSelection(newSel, newSel);
         } else {
-          Selection.extendLeft(mEditable, mLayout);
-          int newSelStart = Selection.getSelectionStart(mEditable);
-          int newSelEnd = Selection.getSelectionEnd(mEditable);
-          setSelection(newSelStart, newSelEnd);
+          int newSelEnd = Math.max(flutterTextUtils.getOffsetBefore(mEditable, selEnd), 0);
+          setSelection(selStart, newSelEnd);
         }
         return true;
       } else if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_RIGHT) {

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -354,14 +354,11 @@ class InputConnectionAdaptor extends BaseInputConnection {
         int selStart = Selection.getSelectionStart(mEditable);
         int selEnd = Selection.getSelectionEnd(mEditable);
         if (selStart == selEnd && !event.isShiftPressed()) {
-          Selection.moveRight(mEditable, mLayout);
-          int newSelStart = Selection.getSelectionStart(mEditable);
-          setSelection(newSelStart, newSelStart);
+          int newSel = Math.min(flutterTextUtils.getOffsetAfter(mEditable, selStart, new TextPaint()), mEditable.length());
+          setSelection(newSel, newSel);
         } else {
-          Selection.extendRight(mEditable, mLayout);
-          int newSelStart = Selection.getSelectionStart(mEditable);
-          int newSelEnd = Selection.getSelectionEnd(mEditable);
-          setSelection(newSelStart, newSelEnd);
+          int newSelEnd = Math.min(flutterTextUtils.getOffsetAfter(mEditable, selStart, new TextPaint()), mEditable.length());
+          setSelection(selStart, newSelEnd);
         }
         return true;
       } else if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_UP) {

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -343,22 +343,28 @@ class InputConnectionAdaptor extends BaseInputConnection {
         int selStart = Selection.getSelectionStart(mEditable);
         int selEnd = Selection.getSelectionEnd(mEditable);
         if (selStart == selEnd && !event.isShiftPressed()) {
-          int newSel = Math.max(selStart - 1, 0);
-          setSelection(newSel, newSel);
+          Selection.moveLeft(mEditable, mLayout);
+          int newSelStart = Selection.getSelectionStart(mEditable);
+          setSelection(newSelStart, newSelStart);
         } else {
-          int newSelEnd = Math.max(selEnd - 1, 0);
-          setSelection(selStart, newSelEnd);
+          Selection.extendLeft(mEditable, mLayout);
+          int newSelStart = Selection.getSelectionStart(mEditable);
+          int newSelEnd = Selection.getSelectionEnd(mEditable);
+          setSelection(newSelStart, newSelEnd);
         }
         return true;
       } else if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_RIGHT) {
         int selStart = Selection.getSelectionStart(mEditable);
         int selEnd = Selection.getSelectionEnd(mEditable);
         if (selStart == selEnd && !event.isShiftPressed()) {
-          int newSel = Math.min(selStart + 1, mEditable.length());
-          setSelection(newSel, newSel);
+          Selection.moveRight(mEditable, mLayout);
+          int newSelStart = Selection.getSelectionStart(mEditable);
+          setSelection(newSelStart, newSelStart);
         } else {
-          int newSelEnd = Math.min(selEnd + 1, mEditable.length());
-          setSelection(selStart, newSelEnd);
+          Selection.extendRight(mEditable, mLayout);
+          int newSelStart = Selection.getSelectionStart(mEditable);
+          int newSelEnd = Selection.getSelectionEnd(mEditable);
+          setSelection(newSelStart, newSelEnd);
         }
         return true;
       } else if (event.getKeyCode() == KeyEvent.KEYCODE_DPAD_UP) {

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -354,10 +354,16 @@ class InputConnectionAdaptor extends BaseInputConnection {
         int selStart = Selection.getSelectionStart(mEditable);
         int selEnd = Selection.getSelectionEnd(mEditable);
         if (selStart == selEnd && !event.isShiftPressed()) {
-          int newSel = Math.min(flutterTextUtils.getOffsetAfter(mEditable, selStart, new TextPaint()), mEditable.length());
+          int newSel =
+              Math.min(
+                  flutterTextUtils.getOffsetAfter(mEditable, selStart, new TextPaint()),
+                  mEditable.length());
           setSelection(newSel, newSel);
         } else {
-          int newSelEnd = Math.min(flutterTextUtils.getOffsetAfter(mEditable, selStart, new TextPaint()), mEditable.length());
+          int newSelEnd =
+              Math.min(
+                  flutterTextUtils.getOffsetAfter(mEditable, selEnd, new TextPaint()),
+                  mEditable.length());
           setSelection(selStart, newSelEnd);
         }
         return true;

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.flutter.Log;
 import android.content.ClipboardManager;
 import android.content.res.AssetManager;
 import android.text.Editable;
@@ -352,6 +353,7 @@ public class InputConnectionAdaptorTest {
     KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
     boolean didConsume;
 
+    /*
     // First CodePoint
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
@@ -388,29 +390,32 @@ public class InputConnectionAdaptorTest {
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 13);
+    */
 
 
     // TODO(justinmc): 403 is failing, keep checking failures from here.
 
 
+    Log.e("justin", "This is what's left: |" + SAMPLE_EMOJI_TEXT.substring(13, 13 + 3 + 3) + "| which has length " + SAMPLE_EMOJI_TEXT.substring(13, 13 + 3 + 3).length());
     // Emoji Modifier with invalid base
     //adaptor.setSelection(14, 14);
+    adaptor.setSelection(13, 13);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 14);
-    didConsume = adaptor.sendKeyEvent(downKeyDown);
-    assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 15);
-
-    // Emoji Modifier
+    assertEquals(Selection.getSelectionStart(editable), 17); // actually 14 when no setselection
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 16);
 
-    // Variation Selector
+    // Emoji Modifier
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 19);
+
+    // Variation Selector
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 21);
 
     // Variation Selector with invalid base
     didConsume = adaptor.sendKeyEvent(downKeyDown);

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -353,7 +353,6 @@ public class InputConnectionAdaptorTest {
     KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
     boolean didConsume;
 
-    /*
     // First CodePoint
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
@@ -364,14 +363,12 @@ public class InputConnectionAdaptorTest {
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 3);
 
-    // Regional Indicator Symbol odd
-    // TODO(justinmc): This seems to be wrong. The character is commented below
-    // as even, but the code treats it as odd.
+    // Regional Indicator Symbol even
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 5);
+    assertEquals(Selection.getSelectionStart(editable), 7);
 
-    // Regional Indicator Symbol even
+    // Regional Indicator Symbol odd
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 9);
@@ -390,24 +387,20 @@ public class InputConnectionAdaptorTest {
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 13);
-    */
 
-
-    // TODO(justinmc): 403 is failing, keep checking failures from here.
-
-
-    Log.e("justin", "This is what's left: |" + SAMPLE_EMOJI_TEXT.substring(13, 13 + 3 + 3) + "| which has length " + SAMPLE_EMOJI_TEXT.substring(13, 13 + 3 + 3).length());
-    // Emoji Modifier with invalid base
-    //adaptor.setSelection(14, 14);
-    adaptor.setSelection(13, 13);
-    didConsume = adaptor.sendKeyEvent(downKeyDown);
-    assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 17); // actually 14 when no setselection
+    // Modified Emoji
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 16);
 
     // Emoji Modifier
+    adaptor.setSelection(14, 14);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 16);
+
+    // Emoji Modifier with invalid base
+    adaptor.setSelection(18, 18);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 19);
@@ -418,75 +411,72 @@ public class InputConnectionAdaptorTest {
     assertEquals(Selection.getSelectionStart(editable), 21);
 
     // Variation Selector with invalid base
-    didConsume = adaptor.sendKeyEvent(downKeyDown);
-    assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 20);
-    didConsume = adaptor.sendKeyEvent(downKeyDown);
-    assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 21);
-
-    // Emoji Tag Sequence
+    adaptor.setSelection(22, 22);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 23);
 
-    // ----- Start Emoji Tag Sequence with invalid base testing ----
-    // Pass base tag
-    didConsume = adaptor.sendKeyEvent(downKeyDown);
-    assertTrue(didConsume);
+    // Emoji Tag Sequence
+    for (int i = 0; i < 7; i++) {
+      didConsume = adaptor.sendKeyEvent(downKeyDown);
+      assertTrue(didConsume);
+      assertEquals(Selection.getSelectionStart(editable), 25 + 2 * i);
+    }
     assertEquals(Selection.getSelectionStart(editable), 37);
 
+    // ----- Start Emoji Tag Sequence with invalid base testing ----
     // Pass the sequence
+    adaptor.setSelection(39, 39);
     for (int i = 0; i < 6; i++) {
       didConsume = adaptor.sendKeyEvent(downKeyDown);
       assertTrue(didConsume);
+      assertEquals(Selection.getSelectionStart(editable), 41 + 2 * i);
     }
-    assertEquals(Selection.getSelectionStart(editable), 49);
+    assertEquals(Selection.getSelectionStart(editable), 51);
     // ----- End Emoji Tag Sequence with invalid base testing ----
 
     // Zero Width Joiner with invalid base
-    didConsume = adaptor.sendKeyEvent(downKeyDown);
-    assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 51);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 52);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 53);
-
-    // Zero Width Joiner
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 55);
 
+    // Zero Width Joiner
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 66);
+
     // Keycap with invalid base
+    adaptor.setSelection(67, 67);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 56);
+    assertEquals(Selection.getSelectionStart(editable), 68);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 58);
+    assertEquals(Selection.getSelectionStart(editable), 69);
 
     // Keycap
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 59);
+    assertEquals(Selection.getSelectionStart(editable), 72);
 
     // Non-Spacing Mark
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 60);
+    assertEquals(Selection.getSelectionStart(editable), 73);
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 61);
+    assertEquals(Selection.getSelectionStart(editable), 74);
 
     // Normal Character
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
-    assertEquals(Selection.getSelectionStart(editable), 62);
-    
-    // TODO(justinmc): I'm definiteely missing a bunch, should end like 74.
+    assertEquals(Selection.getSelectionStart(editable), 75);
   }
 
   /*

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.flutter.Log;
 import android.content.ClipboardManager;
 import android.content.res.AssetManager;
 import android.text.Editable;

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -37,6 +37,7 @@ import org.robolectric.shadows.ShadowClipboardManager;
 @Config(manifest = Config.NONE, shadows = ShadowClipboardManager.class)
 @RunWith(RobolectricTestRunner.class)
 public class InputConnectionAdaptorTest {
+  /*
   @Test
   public void inputConnectionAdaptor_ReceivesEnter() throws NullPointerException {
     View testView = new View(RuntimeEnvironment.application);
@@ -156,7 +157,6 @@ public class InputConnectionAdaptorTest {
 
   @Test
   public void testSendKeyEvent_leftKeyMovesCaretLeftComplexEmoji() {
-    SAMPLE_EMOJI_TEXT
     int selStart = 75;
     Editable editable = sampleEditable(selStart, selStart, SAMPLE_EMOJI_TEXT);
     InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
@@ -341,7 +341,150 @@ public class InputConnectionAdaptorTest {
     assertEquals(selStart + 1, Selection.getSelectionStart(editable));
     assertEquals(selStart + 1, Selection.getSelectionEnd(editable));
   }
+  */
 
+  @Test
+  public void testSendKeyEvent_rightKeyMovesCaretRightComplexEmoji() {
+    int selStart = 0;
+    Editable editable = sampleEditable(selStart, selStart, SAMPLE_EMOJI_TEXT);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
+    boolean didConsume;
+
+    // First CodePoint
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 1);
+
+    // Simple Emoji
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 3);
+
+    // Regional Indicator Symbol odd
+    // TODO(justinmc): This seems to be wrong. The character is commented below
+    // as even, but the code treats it as odd.
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 5);
+
+    // Regional Indicator Symbol even
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 9);
+
+    // Carriage Return
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 10);
+
+    // Line Feed and Carriage Return
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 12);
+
+    // Line Feed
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 13);
+
+
+    // TODO(justinmc): 403 is failing, keep checking failures from here.
+
+
+    // Emoji Modifier with invalid base
+    //adaptor.setSelection(14, 14);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 14);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 15);
+
+    // Emoji Modifier
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 16);
+
+    // Variation Selector
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 19);
+
+    // Variation Selector with invalid base
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 20);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 21);
+
+    // Emoji Tag Sequence
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 23);
+
+    // ----- Start Emoji Tag Sequence with invalid base testing ----
+    // Pass base tag
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 37);
+
+    // Pass the sequence
+    for (int i = 0; i < 6; i++) {
+      didConsume = adaptor.sendKeyEvent(downKeyDown);
+      assertTrue(didConsume);
+    }
+    assertEquals(Selection.getSelectionStart(editable), 49);
+    // ----- End Emoji Tag Sequence with invalid base testing ----
+
+    // Zero Width Joiner with invalid base
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 51);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 52);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 53);
+
+    // Zero Width Joiner
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 55);
+
+    // Keycap with invalid base
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 56);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 58);
+
+    // Keycap
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 59);
+
+    // Non-Spacing Mark
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 60);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 61);
+
+    // Normal Character
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 62);
+    
+    // TODO(justinmc): I'm definiteely missing a bunch, should end like 74.
+  }
+
+  /*
   @Test
   public void testSendKeyEvent_rightKeyExtendsSelectionRight() {
     int selStart = 5;
@@ -621,6 +764,7 @@ public class InputConnectionAdaptorTest {
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 0);
   }
+  */
 
   private static final String SAMPLE_TEXT =
       "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -38,7 +38,6 @@ import org.robolectric.shadows.ShadowClipboardManager;
 @Config(manifest = Config.NONE, shadows = ShadowClipboardManager.class)
 @RunWith(RobolectricTestRunner.class)
 public class InputConnectionAdaptorTest {
-  /*
   @Test
   public void inputConnectionAdaptor_ReceivesEnter() throws NullPointerException {
     View testView = new View(RuntimeEnvironment.application);
@@ -342,7 +341,6 @@ public class InputConnectionAdaptorTest {
     assertEquals(selStart + 1, Selection.getSelectionStart(editable));
     assertEquals(selStart + 1, Selection.getSelectionEnd(editable));
   }
-  */
 
   @Test
   public void testSendKeyEvent_rightKeyMovesCaretRightComplexEmoji() {
@@ -479,7 +477,6 @@ public class InputConnectionAdaptorTest {
     assertEquals(Selection.getSelectionStart(editable), 75);
   }
 
-  /*
   @Test
   public void testSendKeyEvent_rightKeyExtendsSelectionRight() {
     int selStart = 5;
@@ -759,7 +756,6 @@ public class InputConnectionAdaptorTest {
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 0);
   }
-  */
 
   private static final String SAMPLE_TEXT =
       "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -155,6 +155,149 @@ public class InputConnectionAdaptorTest {
   }
 
   @Test
+  public void testSendKeyEvent_leftKeyMovesCaretLeftComplexEmoji() {
+    SAMPLE_EMOJI_TEXT
+    int selStart = 75;
+    Editable editable = sampleEditable(selStart, selStart, SAMPLE_EMOJI_TEXT);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_LEFT);
+    boolean didConsume;
+
+    // Normal Character
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 74);
+
+    // Non-Spacing Mark
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 73);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 72);
+
+    // Keycap
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 69);
+
+    // Keycap with invalid base
+    adaptor.setSelection(68, 68);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 66);
+    adaptor.setSelection(67, 67);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 66);
+
+    // Zero Width Joiner
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 55);
+
+    // Zero Width Joiner with invalid base
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 53);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 52);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 51);
+
+    // ----- Start Emoji Tag Sequence with invalid base testing ----
+    // Delete base tag
+    adaptor.setSelection(39, 39);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 37);
+
+    // Delete the sequence
+    adaptor.setSelection(49, 49);
+    for (int i = 0; i < 6; i++) {
+      didConsume = adaptor.sendKeyEvent(downKeyDown);
+      assertTrue(didConsume);
+    }
+    assertEquals(Selection.getSelectionStart(editable), 37);
+    // ----- End Emoji Tag Sequence with invalid base testing ----
+
+    // Emoji Tag Sequence
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 23);
+
+    // Variation Selector with invalid base
+    adaptor.setSelection(22, 22);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 21);
+    adaptor.setSelection(22, 22);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 21);
+
+    // Variation Selector
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 19);
+
+    // Emoji Modifier
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 16);
+
+    // Emoji Modifier with invalid base
+    adaptor.setSelection(14, 14);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 13);
+    adaptor.setSelection(14, 14);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 13);
+
+    // Line Feed
+    adaptor.setSelection(12, 12);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 11);
+
+    // Carriage Return
+    adaptor.setSelection(12, 12);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 11);
+
+    // Carriage Return and Line Feed
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 9);
+
+    // Regional Indicator Symbol odd
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 7);
+
+    // Regional Indicator Symbol even
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 3);
+
+    // Simple Emoji
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 1);
+
+    // First CodePoint
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 0);
+  }
+
+  @Test
   public void testSendKeyEvent_leftKeyExtendsSelectionLeft() {
     int selStart = 5;
     int selEnd = 40;

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -342,6 +342,33 @@ public class InputConnectionAdaptorTest {
   }
 
   @Test
+  public void testSendKeyEvent_rightKeyMovesCaretRightComplexRegion() {
+    int selStart = 0;
+    // Seven region indicator characters. The first six should be considered as
+    // three region indicators, and the final seventh character should be
+    // considered to be on its own because it has no partner.
+    String SAMPLE_REGION_TEXT = "🇷🇷🇷🇷🇷🇷🇷";
+    Editable editable = sampleEditable(selStart, selStart, SAMPLE_REGION_TEXT);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
+    boolean didConsume;
+
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 4);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 8);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 12);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 14);
+  }
+
+  @Test
   public void testSendKeyEvent_rightKeyMovesCaretRightComplexEmoji() {
     int selStart = 0;
     Editable editable = sampleEditable(selStart, selStart, SAMPLE_EMOJI_TEXT);

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -354,6 +354,7 @@ public class InputConnectionAdaptorTest {
     KeyEvent downKeyDown = new KeyEvent(KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_RIGHT);
     boolean didConsume;
 
+    // The cursor moves over two region indicators at a time.
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 4);
@@ -363,9 +364,19 @@ public class InputConnectionAdaptorTest {
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 12);
+
+    // When there is only one region indicator left with no pair, the cursor
+    // moves over that single region indicator.
     didConsume = adaptor.sendKeyEvent(downKeyDown);
     assertTrue(didConsume);
     assertEquals(Selection.getSelectionStart(editable), 14);
+
+    // If the cursor is placed in the middle of a region indicator pair, it
+    // moves over only the second half of the pair.
+    adaptor.setSelection(6, 6);
+    didConsume = adaptor.sendKeyEvent(downKeyDown);
+    assertTrue(didConsume);
+    assertEquals(Selection.getSelectionStart(editable), 8);
   }
 
   @Test


### PR DESCRIPTION
I noticed a similar PR (https://github.com/flutter/engine/pull/8956) that got backspace to work with grapheme clusters, and I thought we could take the same approach to fix dpad movement through grapheme clusters.
| Before | After |
| ------ | ------ |
| <img width="250" src="https://user-images.githubusercontent.com/389558/78049540-0d7ad680-7330-11ea-95d8-006b894b5824.gif" /> | <img width="250" src="https://user-images.githubusercontent.com/389558/78049563-11a6f400-7330-11ea-83c4-b9461e46bed8.gif" /> |

Probably just a partial solution for: https://github.com/flutter/flutter/issues/13404
Potentially solves: https://github.com/flutter/flutter/issues/52167
