### PR TITLE
[fuchsia] Remove "CreateTraceProvider" trace event

### DIFF
--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -36,7 +36,6 @@ int main(int argc, const char** argv) {
 
   std::unique_ptr<trace::TraceProviderWithFdio> provider;
   {
-    TRACE_DURATION("dart", "CreateTraceProvider");
     bool already_started;
     // Use CreateSynchronously to prevent loss of early events.
     trace::TraceProviderWithFdio::CreateSynchronously(

--- a/shell/platform/fuchsia/flutter/main.cc
+++ b/shell/platform/fuchsia/flutter/main.cc
@@ -17,7 +17,6 @@ int main(int argc, char const* argv[]) {
 
   std::unique_ptr<trace::TraceProviderWithFdio> provider;
   {
-    TRACE_DURATION("flutter", "CreateTraceProvider");
     bool already_started;
     // Use CreateSynchronously to prevent loss of early events.
     trace::TraceProviderWithFdio::CreateSynchronously(


### PR DESCRIPTION
Since the trace provider hasn't been created yet, it is not possible to
trace the creation of a trace provider using a TRACE_DURATION event (the
trace enabled and category check will always fail).  While this isn't
causing any urgent problems, remove it to set a good example for other
clients of tracing that might happen to reference this code.