### PR TITLE
Implement getExtractedText in InputConnectionAdaptor

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -21,6 +21,8 @@ import android.view.View;
 import android.view.inputmethod.BaseInputConnection;
 import android.view.inputmethod.CursorAnchorInfo;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.ExtractedText;
+import android.view.inputmethod.ExtractedTextRequest;
 import android.view.inputmethod.InputMethodManager;
 import android.view.inputmethod.InputMethodSubtype;
 import io.flutter.Log;
@@ -159,6 +161,16 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
     updateEditingState();
     return result;
+  }
+
+  // TODO(garyq): Implement a more feature complete version of getExtractedText
+  @Override
+  public ExtractedText getExtractedText(ExtractedTextRequest request, int flags) {
+    ExtractedText extractedText = new ExtractedText();
+    extractedText.selectionStart = Selection.getSelectionStart(mEditable);
+    extractedText.selectionEnd = Selection.getSelectionEnd(mEditable);
+    extractedText.text = mEditable.toString();
+    return extractedText;
   }
 
   // Detect if the keyboard is a Samsung keyboard, where we apply Samsung-specific hacks to

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -19,6 +19,7 @@ import android.text.SpannableStringBuilder;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.ExtractedText;
 import io.flutter.embedding.engine.FlutterJNI;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.systemchannels.TextInputChannel;
@@ -257,16 +258,16 @@ public class InputConnectionAdaptorTest {
   }
 
   @Test
-  public void testMethod_getExtendedText() {
+  public void testMethod_getExtractedText() {
     int selStart = 5;
     Editable editable = sampleEditable(selStart, selStart);
     InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
 
-    ExtendedText extendedText = adaptor.getExtendedText();
+    ExtractedText extractedText = adaptor.getExtractedText();
 
-    assertEquals(extendedText.text, SAMPLE_TEXT);
-    assertEquals(extendedText.selectionStart, selStart);
-    assertEquals(extendedText.selectionEnd, selStart);
+    assertEquals(extractedText.text, SAMPLE_TEXT);
+    assertEquals(extractedText.selectionStart, selStart);
+    assertEquals(extractedText.selectionEnd, selStart);
   }
 
   private static final String SAMPLE_TEXT =

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -263,7 +263,7 @@ public class InputConnectionAdaptorTest {
     Editable editable = sampleEditable(selStart, selStart);
     InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
 
-    ExtractedText extractedText = adaptor.getExtractedText();
+    ExtractedText extractedText = adaptor.getExtractedText(null, 0);
 
     assertEquals(extractedText.text, SAMPLE_TEXT);
     assertEquals(extractedText.selectionStart, selStart);

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -256,6 +256,19 @@ public class InputConnectionAdaptorTest {
     assertTrue(Selection.getSelectionStart(editable) > selStart);
   }
 
+  @Test
+  public void testMethod_getExtendedText() {
+    int selStart = 5;
+    Editable editable = sampleEditable(selStart, selStart);
+    InputConnectionAdaptor adaptor = sampleInputConnectionAdaptor(editable);
+
+    ExtendedText extendedText = adaptor.getExtendedText();
+
+    assertEquals(extendedText.text, SAMPLE_TEXT);
+    assertEquals(extendedText.selectionStart, selStart);
+    assertEquals(extendedText.selectionEnd, selStart);
+  }
+
   private static final String SAMPLE_TEXT =
       "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";
 


### PR DESCRIPTION
Many Asian keyboards uses getExtractedText. Implement the override such that this returns a basic functional version of ExtractedText.

This seems to fix a few Samsung keyboard bugs on some devices (https://github.com/flutter/flutter/issues/51893). Samsung seems to be using the `getExtractedText` API as a getter for the current editing state, which is not what it is meant to be used for. Rather, `getEditable`should be used instead