### PR TITLE
Fix iOS builds on Xcode 11.4 for new enum values added in iOS 13.4.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -714,6 +714,10 @@ static flutter::PointerData::Change PointerDataChangeFromUITouchPhase(UITouchPha
       return flutter::PointerData::Change::kUp;
     case UITouchPhaseCancelled:
       return flutter::PointerData::Change::kCancel;
+    default:
+      // TODO(53695): Handle the `UITouchPhaseRegion`... enum values.
+      FML_DLOG(INFO) << "Unhandled touch phase: " << phase;
+      break;
   }
 
   return flutter::PointerData::Change::kCancel;
@@ -727,9 +731,11 @@ static flutter::PointerData::DeviceKind DeviceKindFromTouchType(UITouch* touch) 
         return flutter::PointerData::DeviceKind::kTouch;
       case UITouchTypeStylus:
         return flutter::PointerData::DeviceKind::kStylus;
+      default:
+        // TODO(53696): Handle the UITouchTypeIndirectPointer enum value.
+        FML_DLOG(INFO) << "Unhandled touch type: " << touch.type;
+        break;
     }
-  } else {
-    return flutter::PointerData::DeviceKind::kTouch;
   }
 
   return flutter::PointerData::DeviceKind::kTouch;


### PR DESCRIPTION
The following issues have been filed to track the handling of these enum values:

* Handle the `UITouchTypeIndirectPointer` enum value. https://github.com/flutter/flutter/issues/53696
* Handle the `UITouchPhaseRegion` enum values. https://github.com/flutter/flutter/issues/53695

No change in functionality. Only makes the iOS engine build on the latest
versions of Xcode and iOS SDK. The enum values cannot be used with the
`API_AVAILABLE` macro because the buildbots have not been updated yet.