### PR TITLE
[fuchsia] Fix bug when applying scale.

### DIFF
--- a/flow/scene_update_context.cc
+++ b/flow/scene_update_context.cc
@@ -257,7 +257,7 @@ SceneUpdateContext::Transform::Transform(SceneUpdateContext& context,
 
       entity_node().SetScale(decomposition.scale().x(),  //
                              decomposition.scale().y(),  //
-                             0.f                         //
+                             1.f                         //
       );
       context.top_scale_x_ *= decomposition.scale().x();
       context.top_scale_y_ *= decomposition.scale().y();


### PR DESCRIPTION
We were always scaling z by 0, instead of 1. This
caused the z elevation of some layers to be 0,
which was incorrect.