### PR TITLE
If the application says there is a new texture but does not provide one, reuse the last texture.

### DIFF
--- a/shell/platform/darwin/ios/ios_external_texture_metal.h
+++ b/shell/platform/darwin/ios/ios_external_texture_metal.h
@@ -48,7 +48,7 @@ class IOSExternalTextureMetal final : public Texture {
   // |Texture|
   void OnTextureUnregistered() override;
 
-  sk_sp<SkImage> WrapExternalPixelBuffer(GrContext* context);
+  sk_sp<SkImage> WrapExternalPixelBuffer(GrContext* context) const;
 
   FML_DISALLOW_COPY_AND_ASSIGN(IOSExternalTextureMetal);
 };


### PR DESCRIPTION
This matches the behavior of the OpenGL backend.