### PR TITLE
Remove me from auto-assign list

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -20,7 +20,6 @@ reviewers:
   - franciscojma86
   - cbracken
   - flar
-  - stuartmorgan
 
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)


### PR DESCRIPTION
While I think the goal of the bot is good, currently I'm responsible for the entire desktop vertical (three early stage embeddings, tooling, plugin ecosystem, etc.) and don't currently have the bandwidth to also learn random parts of the engine for auto-assigned reviews.