### PR TITLE
Roll Android NDK to r21.0.6113669

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -428,7 +428,7 @@ deps = {
      'packages': [
        {
         'package': 'flutter/android/ndk/${{platform}}',
-        'version': 'version:r19b'
+        'version': 'version:r21.0.6113669'
        }
      ],
      'condition': 'download_android_deps',


### PR DESCRIPTION
While working on the Clang upgrade, noticed the NDK was fairly out of date.  This rolls to the latest stable version.


Process for creating the CIPD package:

- Use `sdkmanager` to get the latest `ndk-bundle`.
- Use `tools/create_ndk_cipd_package.sh` pointed at the `ndk-bundle` folder with an appropriate version tag.