### PR TITLE
fix typos in switch descriptions caused by missing spaces

### DIFF
--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -95,13 +95,13 @@ DEF_SWITCH(EndlessTraceBuffer,
            "indefinitely however.")
 DEF_SWITCH(EnableSoftwareRendering,
            "enable-software-rendering",
-           "Enable rendering using the Skia software backend. This is useful"
-           "when testing Flutter on emulators. By default, Flutter will"
+           "Enable rendering using the Skia software backend. This is useful "
+           "when testing Flutter on emulators. By default, Flutter will "
            "attempt to either use OpenGL or Vulkan.")
 DEF_SWITCH(SkiaDeterministicRendering,
            "skia-deterministic-rendering",
-           "Skips the call to SkGraphics::Init(), thus avoiding swapping out"
-           "some Skia function pointers based on available CPU features. This"
+           "Skips the call to SkGraphics::Init(), thus avoiding swapping out "
+           "some Skia function pointers based on available CPU features. This "
            "is used to obtain 100% deterministic behavior in Skia rendering.")
 DEF_SWITCH(FlutterAssetsDir,
            "flutter-assets-dir",


### PR DESCRIPTION
The current output is missing some spaces:

```
     --enable-software-rendering : Enable rendering using the Skia software 
                                   backend. This is usefulwhen testing Flutter on 
                                   emulators. By default, Flutter willattempt to either 
                                   use OpenGL or Vulkan. 
  --skia-deterministic-rendering : Skips the call to SkGraphics::Init(), thus 
                                   avoiding swapping outsome Skia function pointers 
                                   based on available CPU features. Thisis used to 
                                   obtain 100% deterministic behavior in Skia 
                                   rendering. 
```