### PR TITLE
Use const refs in for loops where reasonable

### DIFF
--- a/runtime/dart_service_isolate.cc
+++ b/runtime/dart_service_isolate.cc
@@ -76,7 +76,7 @@ void DartServiceIsolate::NotifyServerState(Dart_NativeArguments args) {
     }
   }
 
-  for (auto callback_to_fire : callbacks_to_fire) {
+  for (const auto& callback_to_fire : callbacks_to_fire) {
     callback_to_fire(uri);
   }
 }

--- a/third_party/txt/src/txt/font_collection.cc
+++ b/third_party/txt/src/txt/font_collection.cc
@@ -151,7 +151,7 @@ FontCollection::GetMinikinFontCollectionForFamilies(
   // Search for default font family if no user font families were found.
   if (minikin_families.empty()) {
     const auto default_font_families = GetDefaultFontFamilies();
-    for (auto family : default_font_families) {
+    for (const auto& family : default_font_families) {
       std::shared_ptr<minikin::FontFamily> minikin_family =
           FindFontFamilyInManagers(family);
       if (minikin_family != nullptr) {
@@ -166,7 +166,8 @@ FontCollection::GetMinikinFontCollectionForFamilies(
     return nullptr;
   }
   if (enable_font_fallback_) {
-    for (std::string fallback_family : fallback_fonts_for_locale_[locale]) {
+    for (const std::string& fallback_family :
+         fallback_fonts_for_locale_[locale]) {
       auto it = fallback_fonts_.find(fallback_family);
       if (it != fallback_fonts_.end()) {
         minikin_families.push_back(it->second);

--- a/third_party/txt/src/txt/font_features.cc
+++ b/third_party/txt/src/txt/font_features.cc
@@ -30,7 +30,7 @@ std::string FontFeatures::GetFeatureSettings() const {
 
   std::ostringstream stream;
 
-  for (auto kv : feature_map_) {
+  for (const auto& kv : feature_map_) {
     if (stream.tellp()) {
       stream << ',';
     }


### PR DESCRIPTION
This patch optimizes C++11 range-based for loops where the variable is
copied in each iteration but it would suffice to obtain it by const
reference. This is only applied to loop variables of types that are
expensive to copy which means they are not trivially copyable or have a
non-trivial copy constructor or destructor.

To ensure that it is safe to replace the copy with a const reference
only the following cases are modified:
  * The loop variable is const qualified.
  * The loop variable is not const, but only const methods or operators
    are invoked on it, or it is used as const reference or value argument
    in constructors or function calls.

This is an application of the internal performance-for-range-copy
clang-tidy analysis.