### PR TITLE
Started clearing out the parent of orphaned semantic objects.

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -85,12 +85,14 @@ class AccessibilityBridge;
  * Direct children of this semantics object. Each child's `parent` property must
  * be equal to this object.
  */
-@property(nonatomic, strong) NSMutableArray<SemanticsObject*>* children;
+@property(nonatomic, strong) NSArray<SemanticsObject*>* children;
 
 /**
  * Used if this SemanticsObject is for a platform view.
  */
 @property(strong, nonatomic) FlutterPlatformViewSemanticsContainer* platformViewSemanticsContainer;
+
+- (void)replaceChildAtIndex:(NSInteger)index withChild:(SemanticsObject*)child;
 
 - (BOOL)nodeWillCauseLayoutChange:(const flutter::SemanticsNode*)node;
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.h
@@ -43,7 +43,7 @@ class AccessibilityBridge;
  * The parent of this node in the node tree. Will be nil for the root node and
  * during transient state changes.
  */
-@property(nonatomic, assign) SemanticsObject* parent;
+@property(nonatomic, readonly) SemanticsObject* parent;
 
 /**
  * The accessibility bridge that this semantics object is attached to. This

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -166,6 +166,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 
 @implementation SemanticsObject {
   fml::scoped_nsobject<SemanticsObjectContainer> _container;
+  NSMutableArray<SemanticsObject*>* _children;
 }
 
 #pragma mark - Override base class designated initializers
@@ -249,6 +250,13 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   for (SemanticsObject* child in _children) {
     child.parent = self;
   }
+}
+
+- (void)replaceChildAtIndex:(NSInteger)index withChild:(SemanticsObject*)child {
+  SemanticsObject* oldChild = _children[index];
+  [_children replaceObjectAtIndex:index withObject:child];
+  oldChild.parent = nil;
+  child.parent = self;
 }
 
 #pragma mark - UIAccessibility overrides
@@ -859,11 +867,8 @@ static void ReplaceSemanticsObject(SemanticsObject* oldObject,
   assert(oldObject.node.id == newObject.node.id);
   NSNumber* nodeId = @(oldObject.node.id);
   NSUInteger positionInChildlist = [oldObject.parent.children indexOfObject:oldObject];
-  SemanticsObject* parent = oldObject.parent;
   [objects removeObjectForKey:nodeId];
-  newObject.parent = parent;
-  oldObject.parent = nil;
-  [newObject.parent.children replaceObjectAtIndex:positionInChildlist withObject:newObject];
+  [oldObject.parent replaceChildAtIndex:positionInChildlist withChild:newObject];
   objects[nodeId] = newObject;
 }
 

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -207,6 +207,7 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   for (SemanticsObject* child in _children) {
     [child privateSetParent:nil];
   }
+  [_children removeAllObjects];
   [_children release];
   _parent = nil;
   _container.get().semanticsObject = nil;
@@ -263,9 +264,9 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
 
 - (void)replaceChildAtIndex:(NSInteger)index withChild:(SemanticsObject*)child {
   SemanticsObject* oldChild = _children[index];
-  [_children replaceObjectAtIndex:index withObject:child];
   [oldChild privateSetParent:nil];
   [child privateSetParent:self];
+  [_children replaceObjectAtIndex:index withObject:child];
 }
 
 #pragma mark - UIAccessibility overrides

--- a/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
+++ b/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm
@@ -250,12 +250,12 @@ flutter::SemanticsAction GetSemanticsActionForScrollDirection(
   _parent = parent;
 }
 
-- (void)setChildren:(NSMutableArray<SemanticsObject*>*)children {
+- (void)setChildren:(NSArray<SemanticsObject*>*)children {
   for (SemanticsObject* child in _children) {
     [child privateSetParent:nil];
   }
   [_children release];
-  _children = [children retain];
+  _children = [[NSMutableArray alloc] initWithArray:children];
   for (SemanticsObject* child in _children) {
     [child privateSetParent:self];
   }


### PR DESCRIPTION
Relevant issue: https://github.com/flutter/flutter/issues/53827

The actual bug was here: https://github.com/gaaclarke/engine/blob/3185a9fca1386f5ba062f7adafa4d102f2d7e036/shell/platform/darwin/ios/framework/Source/accessibility_bridge.mm#L759:L759.
We weren't clearing out the parent.

The following changes have been made to make the code more robust:
1) `SemanticsObject.parent` is no longer settable publicly.  Editing of that field now happens only in SemanticsObject in reaction to editing its children.
2) `SemanticsObject.children` no longer returns a mutable collection.  All edits must go through `-[SemanticsObject setChildren:]` or `-[SemanticsObject replaceChildAtIndex:withChild:]`.