### PR TITLE
Update SystemNavigator.pop for iOS shell

### DIFF
--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -204,16 +204,17 @@ using namespace flutter;
 
 - (void)popSystemNavigator:(BOOL)isAnimated {
   // Apple's human user guidelines say not to terminate iOS applications. However, if the
-  // root view of the app is a navigation controller, it is instructed to back up a level
-  // in the navigation hierarchy.
+  // FlutterViewController or one of its ancestors is a child of a navigation controller,
+  // it is instructed to back up a level in the navigation hierarchy.
   // It's also possible in an Add2App scenario that the FlutterViewController was presented
   // outside the context of a UINavigationController, and still wants to be popped.
-  UIViewController* viewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-  if ([viewController isKindOfClass:[UINavigationController class]]) {
-    [((UINavigationController*)viewController) popViewControllerAnimated:isAnimated];
+  auto engineViewController = static_cast<UIViewController*>([_engine.get() viewController]);
+  if ([engineViewController navigationController] != nil) {
+    [[engineViewController navigationController] popViewControllerAnimated:isAnimated];
   } else {
-    auto engineViewController = static_cast<UIViewController*>([_engine.get() viewController]);
-    if (engineViewController != viewController) {
+    UIViewController* rootViewController =
+        [UIApplication sharedApplication].keyWindow.rootViewController;
+    if (engineViewController != rootViewController) {
       [engineViewController dismissViewControllerAnimated:isAnimated completion:nil];
     }
   }

--- a/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterPlatformPlugin.mm
@@ -209,8 +209,8 @@ using namespace flutter;
   // It's also possible in an Add2App scenario that the FlutterViewController was presented
   // outside the context of a UINavigationController, and still wants to be popped.
   auto engineViewController = static_cast<UIViewController*>([_engine.get() viewController]);
-  if ([engineViewController navigationController] != nil) {
-    [[engineViewController navigationController] popViewControllerAnimated:isAnimated];
+  if (auto navitationController = engineViewController.navigationController) {
+    [navitationController popViewControllerAnimated:isAnimated];
   } else {
     UIViewController* rootViewController =
         [UIApplication sharedApplication].keyWindow.rootViewController;


### PR DESCRIPTION
Checking if the root view of the app is a navigation controller to back up a level does not work for all scenarios. For example, when the root view is a navigation controller but FlutterViewController was presented as a modal.

The best way to know that the FlutterViewController was opened from a navigation controller context is check its `navigationController` property.

According to Apple documentation:
> The navigationController property is the nearest ancestor in the view controller hierarchy that is a navigation controller.
>
> If the view controller or one of its ancestors is a child of a navigation controller, this property contains the owning navigation controller. This property is nil if the view controller is not embedded inside a navigation controller.