### PR TITLE
Implement repeat filtering logic in Android Embedder

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -135,7 +135,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
   @Override
   public boolean beginBatchEdit() {
     mBatchCount++;
-    Log.e("flutter", "    # beg " + mBatchCount);
     return super.beginBatchEdit();
   }
 
@@ -143,14 +142,12 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean endBatchEdit() {
     boolean result = super.endBatchEdit();
     mBatchCount--;
-    Log.e("flutter", "    # end " + mBatchCount);
     updateEditingState();
     return result;
   }
 
   @Override
   public boolean commitText(CharSequence text, int newCursorPosition) {
-    Log.e("flutter", "commitText");
     boolean result = super.commitText(text, newCursorPosition);
     markDirty();
     updateEditingState();
@@ -159,7 +156,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean deleteSurroundingText(int beforeLength, int afterLength) {
-    Log.e("flutter", "deleteSurroundingText");
     if (Selection.getSelectionStart(mEditable) == -1) return true;
 
     boolean result = super.deleteSurroundingText(beforeLength, afterLength);
@@ -170,7 +166,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingRegion(int start, int end) {
-    Log.e("flutter", "setComposingRegion(" + start + "," + end + ")");
     boolean result = super.setComposingRegion(start, end);
     markDirty();
     updateEditingState();
@@ -179,7 +174,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingText(CharSequence text, int newCursorPosition) {
-    Log.e("flutter", "setComposingText(" + text + "," + newCursorPosition + ")");
     boolean result;
     if (text.length() == 0) {
       result = super.commitText(text, newCursorPosition);
@@ -193,13 +187,11 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean finishComposingText() {
-    Log.e("flutter", "finishComposingText");
     boolean result = super.finishComposingText();
 
     // Apply Samsung hacks. Samsung caches composing region data strangely, causing text
     // duplication.
     if (isSamsung) {
-      Log.e("flutter", "finishComposingText: Samsung hacks");
       if (Build.VERSION.SDK_INT >= 21) {
         // Samsung keyboards don't clear the composing region on finishComposingText.
         // Update the keyboard with a reset/empty composing region. Critical on
@@ -249,7 +241,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setSelection(int start, int end) {
-    Log.e("flutter", "setSelection");
     boolean result = super.setSelection(start, end);
     markDirty();
     updateEditingState();
@@ -274,7 +265,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean sendKeyEvent(KeyEvent event) {
-    Log.e("flutter", "sendKeyEvent(" + event + ")");
     markDirty();
     if (event.getAction() == KeyEvent.ACTION_DOWN) {
       if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
@@ -401,7 +391,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean performContextMenuAction(int id) {
-    Log.e("flutter", "performContextMenuAction(" + id + ")");
     markDirty();
     if (id == android.R.id.selectAll) {
       setSelection(0, mEditable.length());

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -46,7 +46,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
   private int mPreviousComposingStart;
   private int mPreviousComposingEnd;
   private String mPreviousText;
-  private boolean repeatCheckNeeded = false;
+  private boolean mRepeatCheckNeeded = false;
 
   // Used to determine if Samsung-specific hacks should be applied.
   private final boolean isSamsung;
@@ -96,7 +96,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     // occurred to mark this as dirty. This prevents duplicate remote updates of
     // the same data, which can break formatters that change the length of the
     // contents.
-    if (repeatCheckNeeded
+    if (mRepeatCheckNeeded
         && selectionStart == mPreviousSelectionStart
         && selectionEnd == mPreviousSelectionEnd
         && composingStart == mPreviousComposingStart
@@ -110,7 +110,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     textInputChannel.updateEditingState(
         mClient, text, selectionStart, selectionEnd, composingStart, composingEnd);
 
-    repeatCheckNeeded = true;
+    mRepeatCheckNeeded = true;
     mPreviousSelectionStart = selectionStart;
     mPreviousSelectionEnd = selectionEnd;
     mPreviousComposingStart = composingStart;
@@ -124,7 +124,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
   // to the framework.
   public void markDirty() {
     // Disable updateEditngState's repeat-update check
-    repeatCheckNeeded = false;
+    mRepeatCheckNeeded = false;
   }
 
   @Override

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -80,6 +80,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
     int selectionEnd = Selection.getSelectionEnd(mEditable);
     int composingStart = BaseInputConnection.getComposingSpanStart(mEditable);
     int composingEnd = BaseInputConnection.getComposingSpanEnd(mEditable);
+    Log.e("flutter", "    ## updateEditingState(" +selectionStart + "," +selectionEnd + "," +composingStart + "," +composingEnd + ")");
 
     mImm.updateSelection(mFlutterView, selectionStart, selectionEnd, composingStart, composingEnd);
 
@@ -95,6 +96,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
   @Override
   public boolean beginBatchEdit() {
     mBatchCount++;
+    Log.e("flutter", "    # beg " + mBatchCount);
     return super.beginBatchEdit();
   }
 
@@ -102,12 +104,14 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean endBatchEdit() {
     boolean result = super.endBatchEdit();
     mBatchCount--;
+    Log.e("flutter", "    # end " + mBatchCount);
     updateEditingState();
     return result;
   }
 
   @Override
   public boolean commitText(CharSequence text, int newCursorPosition) {
+    Log.e("flutter", "commitText");
     boolean result = super.commitText(text, newCursorPosition);
     updateEditingState();
     return result;
@@ -115,6 +119,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+    Log.e("flutter", "deleteSurroundingText");
     if (Selection.getSelectionStart(mEditable) == -1) return true;
 
     boolean result = super.deleteSurroundingText(beforeLength, afterLength);
@@ -124,6 +129,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingRegion(int start, int end) {
+    Log.e("flutter", "setComposingRegion(" + start + "," + end + ")");
     boolean result = super.setComposingRegion(start, end);
     updateEditingState();
     return result;
@@ -131,6 +137,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingText(CharSequence text, int newCursorPosition) {
+    Log.e("flutter", "setComposingText(" + text + "," + newCursorPosition + ")");
     boolean result;
     if (text.length() == 0) {
       result = super.commitText(text, newCursorPosition);
@@ -143,11 +150,13 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean finishComposingText() {
+    Log.e("flutter", "finishComposingText");
     boolean result = super.finishComposingText();
 
     // Apply Samsung hacks. Samsung caches composing region data strangely, causing text
     // duplication.
     if (isSamsung) {
+      Log.e("flutter", "finishComposingText: Samsung hacks");
       if (Build.VERSION.SDK_INT >= 21) {
         // Samsung keyboards don't clear the composing region on finishComposingText.
         // Update the keyboard with a reset/empty composing region. Critical on
@@ -196,6 +205,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setSelection(int start, int end) {
+    Log.e("flutter", "setSelection");
     boolean result = super.setSelection(start, end);
     updateEditingState();
     return result;
@@ -219,6 +229,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean sendKeyEvent(KeyEvent event) {
+    Log.e("flutter", "sendKeyEvent(" + event + ")");
     if (event.getAction() == KeyEvent.ACTION_DOWN) {
       if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
         int selStart = clampIndexToEditable(Selection.getSelectionStart(mEditable), mEditable);

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -70,13 +70,12 @@ class InputConnectionAdaptor extends BaseInputConnection {
       }
       TextEditingValue value = (TextEditingValue) o;
       return selectionStart == value.selectionStart
-        && selectionEnd == value.selectionEnd
-        && composingStart == value.composingStart
-        && composingEnd == value.composingEnd
-        && text.equals(value.text);
+          && selectionEnd == value.selectionEnd
+          && composingStart == value.composingStart
+          && composingEnd == value.composingEnd
+          && text.equals(value.text);
     }
   }
-
 
   @SuppressWarnings("deprecation")
   public InputConnectionAdaptor(

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -135,6 +135,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
   @Override
   public boolean beginBatchEdit() {
     mBatchCount++;
+    Log.e("flutter", "    # beg " + mBatchCount);
     return super.beginBatchEdit();
   }
 
@@ -142,12 +143,14 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean endBatchEdit() {
     boolean result = super.endBatchEdit();
     mBatchCount--;
+    Log.e("flutter", "    # end " + mBatchCount);
     updateEditingState();
     return result;
   }
 
   @Override
   public boolean commitText(CharSequence text, int newCursorPosition) {
+    Log.e("flutter", "commitText");
     boolean result = super.commitText(text, newCursorPosition);
     markDirty();
     updateEditingState();
@@ -156,6 +159,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean deleteSurroundingText(int beforeLength, int afterLength) {
+    Log.e("flutter", "deleteSurroundingText");
     if (Selection.getSelectionStart(mEditable) == -1) return true;
 
     boolean result = super.deleteSurroundingText(beforeLength, afterLength);
@@ -174,6 +178,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingRegion(int start, int end) {
+    Log.e("flutter", "setComposingRegion(" + start + "," + end + ")");
     boolean result = super.setComposingRegion(start, end);
     markDirty();
     updateEditingState();
@@ -182,6 +187,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingText(CharSequence text, int newCursorPosition) {
+    Log.e("flutter", "setComposingText(" + text + "," + newCursorPosition + ")");
     boolean result;
     if (text.length() == 0) {
       result = super.commitText(text, newCursorPosition);
@@ -195,11 +201,13 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean finishComposingText() {
+    Log.e("flutter", "finishComposingText");
     boolean result = super.finishComposingText();
 
     // Apply Samsung hacks. Samsung caches composing region data strangely, causing text
     // duplication.
     if (isSamsung) {
+      Log.e("flutter", "finishComposingText: Samsung hacks");
       if (Build.VERSION.SDK_INT >= 21) {
         // Samsung keyboards don't clear the composing region on finishComposingText.
         // Update the keyboard with a reset/empty composing region. Critical on
@@ -256,6 +264,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setSelection(int start, int end) {
+    Log.e("flutter", "setSelection");
     boolean result = super.setSelection(start, end);
     markDirty();
     updateEditingState();
@@ -280,6 +289,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean sendKeyEvent(KeyEvent event) {
+    Log.e("flutter", "sendKeyEvent(" + event + ")");
     markDirty();
     if (event.getAction() == KeyEvent.ACTION_DOWN) {
       if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
@@ -406,6 +416,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean performContextMenuAction(int id) {
+    Log.e("flutter", "performContextMenuAction(" + id + ")");
     markDirty();
     if (id == android.R.id.selectAll) {
       setSelection(0, mEditable.length());

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -135,7 +135,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
   @Override
   public boolean beginBatchEdit() {
     mBatchCount++;
-    Log.e("flutter", "    # beg " + mBatchCount);
     return super.beginBatchEdit();
   }
 
@@ -143,14 +142,12 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean endBatchEdit() {
     boolean result = super.endBatchEdit();
     mBatchCount--;
-    Log.e("flutter", "    # end " + mBatchCount);
     updateEditingState();
     return result;
   }
 
   @Override
   public boolean commitText(CharSequence text, int newCursorPosition) {
-    Log.e("flutter", "commitText");
     boolean result = super.commitText(text, newCursorPosition);
     markDirty();
     updateEditingState();
@@ -159,7 +156,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean deleteSurroundingText(int beforeLength, int afterLength) {
-    Log.e("flutter", "deleteSurroundingText");
     if (Selection.getSelectionStart(mEditable) == -1) return true;
 
     boolean result = super.deleteSurroundingText(beforeLength, afterLength);
@@ -178,7 +174,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingRegion(int start, int end) {
-    Log.e("flutter", "setComposingRegion(" + start + "," + end + ")");
     boolean result = super.setComposingRegion(start, end);
     markDirty();
     updateEditingState();
@@ -187,7 +182,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setComposingText(CharSequence text, int newCursorPosition) {
-    Log.e("flutter", "setComposingText(" + text + "," + newCursorPosition + ")");
     boolean result;
     if (text.length() == 0) {
       result = super.commitText(text, newCursorPosition);
@@ -201,13 +195,11 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean finishComposingText() {
-    Log.e("flutter", "finishComposingText");
     boolean result = super.finishComposingText();
 
     // Apply Samsung hacks. Samsung caches composing region data strangely, causing text
     // duplication.
     if (isSamsung) {
-      Log.e("flutter", "finishComposingText: Samsung hacks");
       if (Build.VERSION.SDK_INT >= 21) {
         // Samsung keyboards don't clear the composing region on finishComposingText.
         // Update the keyboard with a reset/empty composing region. Critical on
@@ -264,7 +256,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean setSelection(int start, int end) {
-    Log.e("flutter", "setSelection");
     boolean result = super.setSelection(start, end);
     markDirty();
     updateEditingState();
@@ -289,7 +280,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean sendKeyEvent(KeyEvent event) {
-    Log.e("flutter", "sendKeyEvent(" + event + ")");
     markDirty();
     if (event.getAction() == KeyEvent.ACTION_DOWN) {
       if (event.getKeyCode() == KeyEvent.KEYCODE_DEL) {
@@ -416,7 +406,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
   @Override
   public boolean performContextMenuAction(int id) {
-    Log.e("flutter", "performContextMenuAction(" + id + ")");
     markDirty();
     if (id == android.R.id.selectAll) {
       setSelection(0, mEditable.length());

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -150,7 +150,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean commitText(CharSequence text, int newCursorPosition) {
     boolean result = super.commitText(text, newCursorPosition);
     markDirty();
-    updateEditingState();
     return result;
   }
 
@@ -160,7 +159,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
     boolean result = super.deleteSurroundingText(beforeLength, afterLength);
     markDirty();
-    updateEditingState();
     return result;
   }
 
@@ -168,7 +166,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean deleteSurroundingTextInCodePoints(int beforeLength, int afterLength) {
     boolean result = super.deleteSurroundingTextInCodePoints(beforeLength, afterLength);
     markDirty();
-    updateEditingState();
     return result;
   }
 
@@ -176,7 +173,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean setComposingRegion(int start, int end) {
     boolean result = super.setComposingRegion(start, end);
     markDirty();
-    updateEditingState();
     return result;
   }
 
@@ -189,7 +185,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
       result = super.setComposingText(text, newCursorPosition);
     }
     markDirty();
-    updateEditingState();
     return result;
   }
 
@@ -212,7 +207,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
     }
 
     markDirty();
-    updateEditingState();
     return result;
   }
 
@@ -258,7 +252,6 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean setSelection(int start, int end) {
     boolean result = super.setSelection(start, end);
     markDirty();
-    updateEditingState();
     return result;
   }
 

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -165,6 +165,14 @@ class InputConnectionAdaptor extends BaseInputConnection {
   }
 
   @Override
+  public boolean deleteSurroundingTextInCodePoints(int beforeLength, int afterLength) {
+    boolean result = super.deleteSurroundingTextInCodePoints(beforeLength, afterLength);
+    markDirty();
+    updateEditingState();
+    return result;
+  }
+
+  @Override
   public boolean setComposingRegion(int start, int end) {
     boolean result = super.setComposingRegion(start, end);
     markDirty();
@@ -217,6 +225,13 @@ class InputConnectionAdaptor extends BaseInputConnection {
     extractedText.text = mEditable.toString();
     return extractedText;
   }
+
+ @Override
+ public boolean clearMetaKeyStates(int states) {
+    boolean result = super.clearMetaKeyStates(states);
+    markDirty();
+    return result;
+ }
 
   // Detect if the keyboard is a Samsung keyboard, where we apply Samsung-specific hacks to
   // fix critical bugs that make the keyboard otherwise unusable. See finishComposingText() for

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -96,12 +96,12 @@ class InputConnectionAdaptor extends BaseInputConnection {
     // occurred to mark this as dirty. This prevents duplicate remote updates of
     // the same data, which can break formatters that change the length of the
     // contents.
-    if (repeatCheckNeeded &&
-        selectionStart == mPreviousSelectionStart &&
-        selectionEnd == mPreviousSelectionEnd &&
-        composingStart == mPreviousComposingStart &&
-        composingEnd == mPreviousComposingEnd &&
-        text.equals(mPreviousText)) {
+    if (repeatCheckNeeded
+        && selectionStart == mPreviousSelectionStart
+        && selectionEnd == mPreviousSelectionEnd
+        && composingStart == mPreviousComposingStart
+        && composingEnd == mPreviousComposingEnd
+        && text.equals(mPreviousText)) {
       return;
     }
 

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -226,12 +226,12 @@ class InputConnectionAdaptor extends BaseInputConnection {
     return extractedText;
   }
 
- @Override
- public boolean clearMetaKeyStates(int states) {
+  @Override
+  public boolean clearMetaKeyStates(int states) {
     boolean result = super.clearMetaKeyStates(states);
     markDirty();
     return result;
- }
+  }
 
   // Detect if the keyboard is a Samsung keyboard, where we apply Samsung-specific hacks to
   // fix critical bugs that make the keyboard otherwise unusable. See finishComposingText() for

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -322,6 +322,10 @@ public class TextInputPlugin {
     }
     // Always apply state to selection which handles updating the selection if needed.
     applyStateToSelection(state);
+    InputConnection connection = getLastInputConnection();
+    if (connection != null && connection instanceof InputConnectionAdaptor) {
+      ((InputConnectionAdaptor)connection).markDirty();
+    }
     // Use updateSelection to update imm on selection if it is not neccessary to restart.
     if (!restartAlwaysRequired && !mRestartInputPending) {
       mImm.updateSelection(

--- a/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
+++ b/shell/platform/android/io/flutter/plugin/editing/TextInputPlugin.java
@@ -324,7 +324,7 @@ public class TextInputPlugin {
     applyStateToSelection(state);
     InputConnection connection = getLastInputConnection();
     if (connection != null && connection instanceof InputConnectionAdaptor) {
-      ((InputConnectionAdaptor)connection).markDirty();
+      ((InputConnectionAdaptor) connection).markDirty();
     }
     // Use updateSelection to update imm on selection if it is not neccessary to restart.
     if (!restartAlwaysRequired && !mRestartInputPending) {

--- a/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
+++ b/shell/platform/android/test/io/flutter/plugin/editing/InputConnectionAdaptorTest.java
@@ -270,6 +270,49 @@ public class InputConnectionAdaptorTest {
     assertEquals(extractedText.selectionEnd, selStart);
   }
 
+  @Test
+  public void inputConnectionAdaptor_RepeatFilter() throws NullPointerException {
+    View testView = new View(RuntimeEnvironment.application);
+    FlutterJNI mockFlutterJni = mock(FlutterJNI.class);
+    DartExecutor dartExecutor = spy(new DartExecutor(mockFlutterJni, mock(AssetManager.class)));
+    int inputTargetId = 0;
+    TestTextInputChannel textInputChannel = new TestTextInputChannel(dartExecutor);
+    Editable mEditable = Editable.Factory.getInstance().newEditable("");
+    Editable spyEditable = spy(mEditable);
+    EditorInfo outAttrs = new EditorInfo();
+    outAttrs.inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
+
+    InputConnectionAdaptor inputConnectionAdaptor =
+        new InputConnectionAdaptor(
+            testView, inputTargetId, textInputChannel, spyEditable, outAttrs);
+
+    inputConnectionAdaptor.beginBatchEdit();
+    assertEquals(textInputChannel.updateEditingStateInvocations, 0);
+    inputConnectionAdaptor.setComposingText("I do not fear computers. I fear the lack of them.", 1);
+    assertEquals(textInputChannel.text, null);
+    assertEquals(textInputChannel.updateEditingStateInvocations, 0);
+    inputConnectionAdaptor.endBatchEdit();
+    assertEquals(textInputChannel.updateEditingStateInvocations, 1);
+    assertEquals(textInputChannel.text, "I do not fear computers. I fear the lack of them.");
+
+    inputConnectionAdaptor.beginBatchEdit();
+    assertEquals(textInputChannel.updateEditingStateInvocations, 1);
+    inputConnectionAdaptor.endBatchEdit();
+    assertEquals(textInputChannel.updateEditingStateInvocations, 1);
+
+    inputConnectionAdaptor.beginBatchEdit();
+    assertEquals(textInputChannel.text, "I do not fear computers. I fear the lack of them.");
+    assertEquals(textInputChannel.updateEditingStateInvocations, 1);
+    inputConnectionAdaptor.setSelection(3, 4);
+    assertEquals(textInputChannel.updateEditingStateInvocations, 1);
+    assertEquals(textInputChannel.selectionStart, 49);
+    assertEquals(textInputChannel.selectionEnd, 49);
+    inputConnectionAdaptor.endBatchEdit();
+    assertEquals(textInputChannel.updateEditingStateInvocations, 2);
+    assertEquals(textInputChannel.selectionStart, 3);
+    assertEquals(textInputChannel.selectionEnd, 4);
+  }
+
   private static final String SAMPLE_TEXT =
       "Lorem ipsum dolor sit amet," + "\nconsectetur adipiscing elit.";
 
@@ -284,5 +327,36 @@ public class InputConnectionAdaptorTest {
     int client = 0;
     TextInputChannel textInputChannel = mock(TextInputChannel.class);
     return new InputConnectionAdaptor(testView, client, textInputChannel, editable, null);
+  }
+
+  private class TestTextInputChannel extends TextInputChannel {
+    public TestTextInputChannel(DartExecutor dartExecutor) {
+      super(dartExecutor);
+    }
+
+    public int inputClientId;
+    public String text;
+    public int selectionStart;
+    public int selectionEnd;
+    public int composingStart;
+    public int composingEnd;
+    public int updateEditingStateInvocations = 0;
+
+    @Override
+    public void updateEditingState(
+        int inputClientId,
+        String text,
+        int selectionStart,
+        int selectionEnd,
+        int composingStart,
+        int composingEnd) {
+      this.inputClientId = inputClientId;
+      this.text = text;
+      this.selectionStart = selectionStart;
+      this.selectionEnd = selectionEnd;
+      this.composingStart = composingStart;
+      this.composingEnd = composingEnd;
+      updateEditingStateInvocations++;
+    }
   }
 }


### PR DESCRIPTION
There is a longstanding problem where some keyboards, via calls to endBatchEdit(), inadvertently send multiple copies of the same editing state to the framework. This has caused many issues that stem from the framework treating these repeat invocations as new instances of data or new keypresses.

In this PR, I add filtering to prevent the embedder from sending any state more than once unless it is marked as dirty via making any change to the state. This ensures that only valid changes to the state are sent to the framework.

The extra calls to `updateEdtingState()` may be removed for any override that calls the super version of itself since the default android implementation all include calls to `endBatchEdit()` which includes a gated call to `updateEditingState` as needed.

Paired with https://github.com/flutter/flutter/pull/53974 to resolve b/152733348