### PR TITLE
Fix AlertDialogs built by platform views

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -9,6 +9,7 @@ import static android.content.Context.WINDOW_SERVICE;
 import static android.view.View.OnFocusChangeListener;
 
 import android.annotation.TargetApi;
+import android.app.AlertDialog;
 import android.app.Presentation;
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -102,6 +103,9 @@ class SingleViewPresentation extends Presentation {
 
   private boolean startFocused = false;
 
+  // The context for the application window that hosts FlutterView.
+  private final Context outerContext;
+
   /**
    * Creates a presentation that will use the view factory to create a new platform view in the
    * presentation's onCreate, and attach it.
@@ -120,6 +124,7 @@ class SingleViewPresentation extends Presentation {
     this.viewId = viewId;
     this.createParams = createParams;
     this.focusChangeListener = focusChangeListener;
+    this.outerContext = outerContext;
     state = new PresentationState();
     getWindow()
         .setFlags(
@@ -147,6 +152,7 @@ class SingleViewPresentation extends Presentation {
     viewFactory = null;
     this.state = state;
     this.focusChangeListener = focusChangeListener;
+    this.outerContext = outerContext;
     getWindow()
         .setFlags(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
@@ -173,7 +179,7 @@ class SingleViewPresentation extends Presentation {
 
     // Our base mContext has already been wrapped with an IMM cache at instantiation time, but
     // we want to wrap it again here to also return state.windowManagerHandler.
-    Context context = new PresentationContext(getContext(), state.windowManagerHandler);
+    Context context = new PresentationContext(getContext(), state.windowManagerHandler, outerContext);
 
     if (state.platformView == null) {
       state.platformView = viewFactory.create(context, viewId, createParams);
@@ -304,15 +310,27 @@ class SingleViewPresentation extends Presentation {
   private static class PresentationContext extends ContextWrapper {
     private @NonNull final WindowManagerHandler windowManagerHandler;
     private @Nullable WindowManager windowManager;
+    private final Context flutterAppWindowContext;
 
-    PresentationContext(Context base, @NonNull WindowManagerHandler windowManagerHandler) {
+    PresentationContext(Context base, @NonNull WindowManagerHandler windowManagerHandler, Context flutterAppWindowContext) {
       super(base);
       this.windowManagerHandler = windowManagerHandler;
+      this.flutterAppWindowContext = flutterAppWindowContext;
     }
 
     @Override
     public Object getSystemService(String name) {
       if (WINDOW_SERVICE.equals(name)) {
+          if (isCalledFromAlertDialog()) {
+            // Alert dialogs are showing on top of the entire application and should not be limited to the virtual
+            // display. If we detect that an android.app.AlertDialog constructor is what's fetching the window manager
+            // we return the one for the application's window.
+            //
+            // Note that if we don't do this AlertDialog will throw a ClassCastException as down the line it tries
+            // to case this instance to a WindowManagerImpl which the object returned by getWindowManager is not
+            // a subclass of.
+            return flutterAppWindowContext.getSystemService(name);
+          }
         return getWindowManager();
       }
       return super.getSystemService(name);
@@ -323,6 +341,17 @@ class SingleViewPresentation extends Presentation {
         windowManager = windowManagerHandler.getWindowManager();
       }
       return windowManager;
+    }
+
+    private boolean isCalledFromAlertDialog() {
+      StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
+      for (int i = 0; i < stackTraceElements.length && i < 11; i++) {
+        if (stackTraceElements[i].getClassName().equals(AlertDialog.class.getCanonicalName())
+                && stackTraceElements[i].getMethodName().equals("<init>") ) {
+          return true;
+        }
+      }
+      return false;
     }
   }
 

--- a/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
+++ b/shell/platform/android/io/flutter/plugin/platform/SingleViewPresentation.java
@@ -179,7 +179,8 @@ class SingleViewPresentation extends Presentation {
 
     // Our base mContext has already been wrapped with an IMM cache at instantiation time, but
     // we want to wrap it again here to also return state.windowManagerHandler.
-    Context context = new PresentationContext(getContext(), state.windowManagerHandler, outerContext);
+    Context context =
+        new PresentationContext(getContext(), state.windowManagerHandler, outerContext);
 
     if (state.platformView == null) {
       state.platformView = viewFactory.create(context, viewId, createParams);
@@ -312,7 +313,10 @@ class SingleViewPresentation extends Presentation {
     private @Nullable WindowManager windowManager;
     private final Context flutterAppWindowContext;
 
-    PresentationContext(Context base, @NonNull WindowManagerHandler windowManagerHandler, Context flutterAppWindowContext) {
+    PresentationContext(
+        Context base,
+        @NonNull WindowManagerHandler windowManagerHandler,
+        Context flutterAppWindowContext) {
       super(base);
       this.windowManagerHandler = windowManagerHandler;
       this.flutterAppWindowContext = flutterAppWindowContext;
@@ -321,16 +325,20 @@ class SingleViewPresentation extends Presentation {
     @Override
     public Object getSystemService(String name) {
       if (WINDOW_SERVICE.equals(name)) {
-          if (isCalledFromAlertDialog()) {
-            // Alert dialogs are showing on top of the entire application and should not be limited to the virtual
-            // display. If we detect that an android.app.AlertDialog constructor is what's fetching the window manager
-            // we return the one for the application's window.
-            //
-            // Note that if we don't do this AlertDialog will throw a ClassCastException as down the line it tries
-            // to case this instance to a WindowManagerImpl which the object returned by getWindowManager is not
-            // a subclass of.
-            return flutterAppWindowContext.getSystemService(name);
-          }
+        if (isCalledFromAlertDialog()) {
+          // Alert dialogs are showing on top of the entire application and should not be limited to
+          // the virtual
+          // display. If we detect that an android.app.AlertDialog constructor is what's fetching
+          // the window manager
+          // we return the one for the application's window.
+          //
+          // Note that if we don't do this AlertDialog will throw a ClassCastException as down the
+          // line it tries
+          // to case this instance to a WindowManagerImpl which the object returned by
+          // getWindowManager is not
+          // a subclass of.
+          return flutterAppWindowContext.getSystemService(name);
+        }
         return getWindowManager();
       }
       return super.getSystemService(name);
@@ -347,7 +355,7 @@ class SingleViewPresentation extends Presentation {
       StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
       for (int i = 0; i < stackTraceElements.length && i < 11; i++) {
         if (stackTraceElements[i].getClassName().equals(AlertDialog.class.getCanonicalName())
-                && stackTraceElements[i].getMethodName().equals("<init>") ) {
+            && stackTraceElements[i].getMethodName().equals("<init>")) {
           return true;
         }
       }


### PR DESCRIPTION
*This is ugly and fragile, I wish I had a better solution, I'll try to follow-up with Android on a better solution for future Android versions.*

This changes the presentation context to check the stack trace of it's callers and if it's an `android.app.AlertDialog` that is asking for a window manger, return the window manager for the window that hosts the Flutter View and not our custom window manager.

### Why we need to do this
When an `AlertDialog` is created with the presentation context, prior to this fix it fails with:

```
W/System.err(18979): java.lang.ClassCastException: $Proxy0 cannot be cast to android.view.WindowManagerImpl
W/System.err(18979):    at android.view.Window.setWindowManager(Window.java:769)
W/System.err(18979):    at android.view.Window.setWindowManager(Window.java:750)
W/System.err(18979):    at android.app.Dialog.<init>(Dialog.java:194)
W/System.err(18979):    at android.app.AlertDialog.<init>(AlertDialog.java:201)
W/System.err(18979):    at android.app.AlertDialog$Builder.create(AlertDialog.java:1088)
```

The presentation context provides a custom window manager that deals with other edge cases of adding windows. Down the line from AlertDialog creation, the Android Framework tries to cast the window manager to a `WindowManagerImpl` which is a `@hide` type that we don't have access to, so as long as we provide our custom window manager this cast is going to fail.

Concretely users ran into this when an html select drop down is opened in a webview, as Android WebVIew implements these as alert dialogs: https://github.com/flutter/flutter/issues/34248

### Why we want to do this
`AlertDialogs` are actually intended to show on top of the entire application (the even overlay a translucent gray on top of everything), even if we could confine them inside the virtual display it wouldn't be the intended behavior (as the overlay will not show on top of the entire screen).

### Test
I added an integration test in: https://github.com/flutter/flutter/pull/53980