### PR TITLE
Fix flutter_windows_unittests runtime dependency

### DIFF
--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -123,11 +123,6 @@ executable("flutter_windows_unittests") {
     ":flutter_windows_headers",
     ":flutter_windows_source",
     "//flutter/testing",
-
-    # TODO(chunhtai): Consider refactoring flutter_root/testing so that there's a testing
-    # target that doesn't require a Dart runtime to be linked in.
-    # https://github.com/flutter/flutter/issues/41414.
-    "//third_party/dart/runtime:libdart_jit",
     "//third_party/rapidjson",
   ]
 }


### PR DESCRIPTION
The transitive dependency on the embedder library brings in the right
runtime for the build mode, so directly depending on the JIT version
isn't necessary, and causes duplicate symbol issues in release builds.