### PR TITLE
always forward move event

### DIFF
--- a/lib/ui/window/pointer_data_packet_converter.cc
+++ b/lib/ui/window/pointer_data_packet_converter.cc
@@ -169,11 +169,9 @@ void PointerDataPacketConverter::ConvertPointerData(
         PointerState state = iter->second;
         FML_DCHECK(state.isDown);
 
-        if (LocationNeedsUpdate(pointer_data, state)) {
-          UpdatePointerIdentifier(pointer_data, state, false);
-          UpdateDeltaAndState(pointer_data, state);
-          converted_pointers.push_back(pointer_data);
-        }
+        UpdatePointerIdentifier(pointer_data, state, false);
+        UpdateDeltaAndState(pointer_data, state);
+        converted_pointers.push_back(pointer_data);
         break;
       }
       case PointerData::Change::kUp: {

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -244,6 +244,43 @@ TEST(PointerDataPacketConverterTest, CanUpdatePointerIdentifier) {
   ASSERT_EQ(result[6].synthesized, 0);
 }
 
+TEST(PointerDataPacketConverterTest, AlwaysForwardMoveEvent) {
+  PointerDataPacketConverter converter;
+  auto packet = std::make_unique<PointerDataPacket>(7);
+  PointerData data;
+  CreateSimulatedPointerData(data, PointerData::Change::kAdd, 0, 0.0, 0.0);
+  packet->SetPointerData(0, data);
+  CreateSimulatedPointerData(data, PointerData::Change::kDown, 0, 0.0, 0.0);
+  packet->SetPointerData(1, data);
+  // Creates a move event without location change.
+  CreateSimulatedPointerData(data, PointerData::Change::kMove, 0, 0.0, 0.0);
+  packet->SetPointerData(2, data);
+  CreateSimulatedPointerData(data, PointerData::Change::kUp, 0, 0.0, 0.0);
+  packet->SetPointerData(3, data);
+
+  auto converted_packet = converter.Convert(std::move(packet));
+
+  std::vector<PointerData> result;
+  UnpackPointerPacket(result, std::move(converted_packet));
+
+  ASSERT_EQ(result.size(), (size_t)4);
+  ASSERT_EQ(result[0].change, PointerData::Change::kAdd);
+  ASSERT_EQ(result[0].synthesized, 0);
+
+  ASSERT_EQ(result[1].change, PointerData::Change::kDown);
+  ASSERT_EQ(result[1].pointer_identifier, 1);
+  ASSERT_EQ(result[1].synthesized, 0);
+
+  // Does not filter out move event
+  ASSERT_EQ(result[2].change, PointerData::Change::kMove);
+  ASSERT_EQ(result[2].pointer_identifier, 1);
+  ASSERT_EQ(result[2].synthesized, 0);
+
+  ASSERT_EQ(result[3].change, PointerData::Change::kUp);
+  ASSERT_EQ(result[3].pointer_identifier, 1);
+  ASSERT_EQ(result[3].synthesized, 0);
+}
+
 TEST(PointerDataPacketConverterTest, CanWorkWithDifferentDevices) {
   PointerDataPacketConverter converter;
   auto packet = std::make_unique<PointerDataPacket>(12);

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -246,7 +246,7 @@ TEST(PointerDataPacketConverterTest, CanUpdatePointerIdentifier) {
 
 TEST(PointerDataPacketConverterTest, AlwaysForwardMoveEvent) {
   PointerDataPacketConverter converter;
-  auto packet = std::make_unique<PointerDataPacket>(7);
+  auto packet = std::make_unique<PointerDataPacket>(4);
   PointerData data;
   CreateSimulatedPointerData(data, PointerData::Change::kAdd, 0, 0.0, 0.0);
   packet->SetPointerData(0, data);

--- a/lib/ui/window/pointer_data_packet_converter_unittests.cc
+++ b/lib/ui/window/pointer_data_packet_converter_unittests.cc
@@ -252,7 +252,7 @@ TEST(PointerDataPacketConverterTest, AlwaysForwardMoveEvent) {
   packet->SetPointerData(0, data);
   CreateSimulatedPointerData(data, PointerData::Change::kDown, 0, 0.0, 0.0);
   packet->SetPointerData(1, data);
-  // Creates a move event without location change.
+  // Creates a move event without a location change.
   CreateSimulatedPointerData(data, PointerData::Change::kMove, 0, 0.0, 0.0);
   packet->SetPointerData(2, data);
   CreateSimulatedPointerData(data, PointerData::Change::kUp, 0, 0.0, 0.0);
@@ -271,7 +271,7 @@ TEST(PointerDataPacketConverterTest, AlwaysForwardMoveEvent) {
   ASSERT_EQ(result[1].pointer_identifier, 1);
   ASSERT_EQ(result[1].synthesized, 0);
 
-  // Does not filter out move event
+  // Does not filter out the move event.
   ASSERT_EQ(result[2].change, PointerData::Change::kMove);
   ASSERT_EQ(result[2].pointer_identifier, 1);
   ASSERT_EQ(result[2].synthesized, 0);


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/54022

The original issue is the _MotionEventsDispatcher depends on all down pointers to send out their own move events. If the third pointer has the movement of zero, it will get filter out by the PointerDataPacketConverter. This result with only two pointer move events been sent to RenderAndroidView, and they both get ignored because it is waiting for the third one.

This pr fixes it by always forward the move event