### PR TITLE
[web] fix clipboard.getData

### DIFF
--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -396,7 +396,6 @@ class EngineWindow extends ui.Window {
             return;
           case 'Clipboard.getData':
             ClipboardMessageHandler().getDataMethodCall(callback);
-            _replyToPlatformMessage(callback, codec.encodeSuccessEnvelope(true));
             return;
         }
         break;

--- a/lib/web_ui/lib/src/engine/window.dart
+++ b/lib/web_ui/lib/src/engine/window.dart
@@ -392,7 +392,6 @@ class EngineWindow extends ui.Window {
             return;
           case 'Clipboard.setData':
             ClipboardMessageHandler().setDataMethodCall(decoded, callback);
-            _replyToPlatformMessage(callback, codec.encodeSuccessEnvelope(true));
             return;
           case 'Clipboard.getData':
             ClipboardMessageHandler().getDataMethodCall(callback);


### PR DESCRIPTION
remove the fake reply for paste message. the clipboard.dart will reply with the content of the clipboard

Fixes https://github.com/flutter/flutter/issues/53983

Note: This feature is not tested so it breaks with other changes. I'll send an integration tests after merging this PR in to protect the feature towards future changes.

(I'm not sending it now, cause I still need to find a way of giving driver clipboard permission :) or another workaround to test the clipboard.dart code)