### PR TITLE
Revert "Added errors to match g3 builds and simple errors (#17536)"

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -68,11 +68,3 @@ if (is_fuchsia) {
 if ((is_ios || is_mac) && defined(enable_bitcode)) {
   flutter_enable_bitcode = enable_bitcode
 }
-
-if (is_ios || is_mac) {
-  flutter_cflags_objc = [
-    "-Werror=overriding-method-mismatch",
-    "-Werror=undeclared-selector",
-  ]
-  flutter_cflags_objcc = flutter_cflags_objc
-}

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -120,9 +120,6 @@ source_set("fml") {
   }
 
   if (is_ios || is_mac) {
-    cflags_objc = flutter_cflags_objc
-    cflags_objcc = flutter_cflags_objcc
-
     sources += [
       "platform/darwin/cf_utils.cc",
       "platform/darwin/cf_utils.h",

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -20,9 +20,6 @@ group("darwin") {
 }
 
 source_set("flutter_channels") {
-  cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc
-
   sources = [
     "common/buffer_conversions.h",
     "common/buffer_conversions.mm",

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -2,13 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-import("//flutter/common/config.gni")
 import("framework_shared.gni")
 
 source_set("common") {
-  cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc
-
   sources = [
     "buffer_conversions.h",
     "buffer_conversions.mm",
@@ -38,9 +34,6 @@ config("framework_relative_headers") {
 
 # Framework code shared between iOS and macOS.
 source_set("framework_shared") {
-  cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc
-
   sources = [
     "framework/Source/FlutterChannels.mm",
     "framework/Source/FlutterCodecs.mm",

--- a/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -13,8 +13,7 @@
   return _sharedInstance;
 }
 
-- (NSData*)encode:(id)message {
-  NSAssert([message isKindOfClass:[NSData class]], @"");
+- (NSData*)encode:(NSData*)message {
   return message;
 }
 
@@ -32,12 +31,10 @@
   return _sharedInstance;
 }
 
-- (NSData*)encode:(id)message {
-  NSAssert([message isKindOfClass:[NSString class]], @"");
-  NSString* stringMessage = message;
+- (NSData*)encode:(NSString*)message {
   if (message == nil)
     return nil;
-  const char* utf8 = stringMessage.UTF8String;
+  const char* utf8 = message.UTF8String;
   return [NSData dataWithBytes:utf8 length:strlen(utf8)];
 }
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -46,9 +46,6 @@ shared_library("create_flutter_framework_dylib") {
 
   public = _flutter_framework_headers
 
-  cflags_objc = flutter_cflags_objc
-  cflags_objcc = flutter_cflags_objcc
-
   sources = [
     "framework/Source/FlutterAppDelegate.mm",
     "framework/Source/FlutterBinaryMessengerRelay.mm",

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -8,6 +8,8 @@
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate_internal.h"
 
+#pragma GCC diagnostic error "-Woverriding-method-mismatch"
+
 static NSString* kUIBackgroundMode = @"UIBackgroundModes";
 static NSString* kRemoteNotificationCapabitiliy = @"remote-notification";
 static NSString* kBackgroundFetchCapatibility = @"fetch";


### PR DESCRIPTION
Test failure:

    [ RUN      ] FlutterStringCodec.CanEncodeAndDecodeNil
    2020-04-07 10:21:25.091 flutter_channels_unittests[26965:163315] *** Assertion failure in -[FlutterStringCodec encode:], ../../flutter/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm:36
    2020-04-07 10:21:25.118 flutter_channels_unittests[26965:163315] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: ''
    *** First throw call stack:
    (
    	0   CoreFoundation                      0x00007fff2ccabcf9 __exceptionPreprocess + 256
    	1   libobjc.A.dylib                     0x00007fff5785ea17 objc_exception_throw + 48
    	2   CoreFoundation                      0x00007fff2ccc6a16 +[NSException raise:format:arguments:] + 98
    	3   Foundation                          0x00007fff2ef58e11 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:] + 194
    	4   flutter_channels_unittests          0x0000000105f1cce2 -[FlutterStringCodec encode:] + 290
    	5   flutter_channels_unittests          0x0000000105f01bbb _ZN45FlutterStringCodec_CanEncodeAndDecodeNil_Test8TestBodyEv + 107
    	6   flutter_channels_unittests          0x00000001081d1732 _ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc + 146
    	7   flutter_channels_unittests          0x00000001081a76b0 _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc + 128
    	8   flutter_channels_unittests          0x00000001081a75c1 _ZN7testing4Test3RunEv + 209
    	9   flutter_channels_unittests          0x00000001081a8415 _ZN7testing8TestInfo3RunEv + 229
    	10  flutter_channels_unittests          0x00000001081a95aa _ZN7testing9TestSuite3RunEv + 266
    	11  flutter_channels_unittests          0x00000001081b4e43 _ZN7testing8internal12UnitTestImpl11RunAllTestsEv + 995
    	12  flutter_channels_unittests          0x00000001081d8572 _ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc + 146
    	13  flutter_channels_unittests          0x00000001081b49b3 _ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc + 131
    	14  flutter_channels_unittests          0x00000001081b4835 _ZN7testing8UnitTest3RunEv + 197
    	15  flutter_channels_unittests          0x0000000105f22e73 _Z13RUN_ALL_TESTSv + 35
    	16  flutter_channels_unittests          0x0000000105f22d79 main + 553
    	17  libdyld.dylib                       0x00007fff5908c3d5 start + 1
    )
    libc++abi.dylib: terminating with uncaught exception of type NSException
    [ERROR:flutter/fml/backtrace.cc(110)] Caught signal SIGABRT during program execution.
    Frame 0: 0x7fff591316a6 abort
    Frame 1: 0x7fff560ea641 __cxa_bad_cast
    Frame 2: 0x7fff560ea7df default_unexpected_handler()�
    Frame 3: 0x7fff57860ee3 _objc_terminate()�
    Frame 4: 0x7fff560f619e std::__terminate(void (*)())�
    Frame 5: 0x7fff560f5f86 __cxa_get_exception_ptr
    Frame 6: 0x7fff560e8f99 __cxa_get_globals
    Frame 7: 0x7fff5785eb51 objc_exception_throw
    Frame 8: 0x7fff2ccc6a16 +[NSException raise:format:arguments:]
    Frame 9: 0x7fff2ef58e11 -[NSAssertionHandler handleFailureInMethod:object:file:lineNumber:description:]
    Frame 10: 0x105f1cce2 -[FlutterStringCodec encode:]
    Frame 11: 0x105f01bbb FlutterStringCodec_CanEncodeAndDecodeNil_Test::TestBody()�
    Frame 12: 0x1081d1732 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)�
    Frame 13: 0x1081a76b0 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)�
    Frame 14: 0x1081a75c1 testing::Test::Run()�
    Frame 15: 0x1081a8415 testing::TestInfo::Run()�
    Frame 16: 0x1081a95aa testing::TestSuite::Run()�
    Frame 17: 0x1081b4e43 testing::internal::UnitTestImpl::RunAllTests()�
    Frame 18: 0x1081d8572 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)�
    Frame 19: 0x1081b49b3 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)�
    Frame 20: 0x1081b4835 testing::UnitTest::Run()�
    Frame 21: 0x105f22e73 RUN_ALL_TESTS()�
    Frame 22: 0x105f22d79 main
    Frame 23: 0x7fff5908c3d5 start

This reverts commit d1c90b4284282f9745ecd7c65aa72c612df671c1.