### PR TITLE
Added "unrecognized-selector" errors to match g3 builds

### DIFF
--- a/common/config.gni
+++ b/common/config.gni
@@ -68,3 +68,11 @@ if (is_fuchsia) {
 if ((is_ios || is_mac) && defined(enable_bitcode)) {
   flutter_enable_bitcode = enable_bitcode
 }
+
+if (is_ios || is_mac) {
+  flutter_cflags_objc = [
+    "-Werror=overriding-method-mismatch",
+    "-Werror=undeclared-selector",
+  ]
+  flutter_cflags_objcc = flutter_cflags_objc
+}

--- a/fml/BUILD.gn
+++ b/fml/BUILD.gn
@@ -120,6 +120,9 @@ source_set("fml") {
   }
 
   if (is_ios || is_mac) {
+    cflags_objc = flutter_cflags_objc
+    cflags_objcc = flutter_cflags_objcc
+
     sources += [
       "platform/darwin/cf_utils.cc",
       "platform/darwin/cf_utils.h",

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -20,6 +20,9 @@ group("darwin") {
 }
 
 source_set("flutter_channels") {
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
+
   sources = [
     "common/buffer_conversions.h",
     "common/buffer_conversions.mm",

--- a/shell/platform/darwin/common/BUILD.gn
+++ b/shell/platform/darwin/common/BUILD.gn
@@ -2,9 +2,13 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//flutter/common/config.gni")
 import("framework_shared.gni")
 
 source_set("common") {
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
+
   sources = [
     "buffer_conversions.h",
     "buffer_conversions.mm",
@@ -34,6 +38,9 @@ config("framework_relative_headers") {
 
 # Framework code shared between iOS and macOS.
 source_set("framework_shared") {
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
+
   sources = [
     "framework/Source/FlutterChannels.mm",
     "framework/Source/FlutterCodecs.mm",

--- a/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -13,7 +13,8 @@
   return _sharedInstance;
 }
 
-- (NSData*)encode:(NSData*)message {
+- (NSData*)encode:(id)message {
+  NSAssert(!message || [message isKindOfClass:[NSData class]], @"");
   return message;
 }
 
@@ -31,10 +32,12 @@
   return _sharedInstance;
 }
 
-- (NSData*)encode:(NSString*)message {
+- (NSData*)encode:(id)message {
+  NSAssert(!message || [message isKindOfClass:[NSString class]], @"");
+  NSString* stringMessage = message;
   if (message == nil)
     return nil;
-  const char* utf8 = message.UTF8String;
+  const char* utf8 = stringMessage.UTF8String;
   return [NSData dataWithBytes:utf8 length:strlen(utf8)];
 }
 

--- a/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
+++ b/shell/platform/darwin/common/framework/Source/FlutterCodecs.mm
@@ -33,10 +33,10 @@
 }
 
 - (NSData*)encode:(id)message {
-  NSAssert(!message || [message isKindOfClass:[NSString class]], @"");
-  NSString* stringMessage = message;
   if (message == nil)
     return nil;
+  NSAssert([message isKindOfClass:[NSString class]], @"");
+  NSString* stringMessage = message;
   const char* utf8 = stringMessage.UTF8String;
   return [NSData dataWithBytes:utf8 length:strlen(utf8)];
 }

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -46,6 +46,9 @@ shared_library("create_flutter_framework_dylib") {
 
   public = _flutter_framework_headers
 
+  cflags_objc = flutter_cflags_objc
+  cflags_objcc = flutter_cflags_objcc
+
   sources = [
     "framework/Source/FlutterAppDelegate.mm",
     "framework/Source/FlutterBinaryMessengerRelay.mm",

--- a/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterAppDelegate.mm
@@ -8,8 +8,6 @@
 #include "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
 #include "flutter/shell/platform/darwin/ios/framework/Source/FlutterPluginAppLifeCycleDelegate_internal.h"
 
-#pragma GCC diagnostic error "-Woverriding-method-mismatch"
-
 static NSString* kUIBackgroundMode = @"UIBackgroundModes";
 static NSString* kRemoteNotificationCapabitiliy = @"remote-notification";
 static NSString* kBackgroundFetchCapatibility = @"fetch";


### PR DESCRIPTION
Also added"overriding-method-mismatch" to catch a common error.

reland of https://github.com/flutter/engine/pull/17536