### PR TITLE
Add comments to build_and_test_linux_unopt_debug

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,6 +74,9 @@ task:
       test_host_script: |
         cd $ENGINE_PATH/src
         ./flutter/testing/run_tests.sh host_release
+
+    # The following test depends on Flutter framework repo. It may fail if the
+    # framework repo is currently broken.
     - name: build_and_test_linux_unopt_debug
       compile_host_script: |
         cd $ENGINE_PATH/src

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -100,6 +100,9 @@ task:
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH
         git clone https://github.com/flutter/flutter.git
+      verify_framework_script:
+        - echo "Checking that the framework Cirrus test is not currently broken..."
+        - curl -s https://api.cirrus-ci.com/github/flutter/flutter.json | grep -q passing
       test_web_script: |
         cd $FRAMEWORK_PATH/flutter/dev/integration_tests/web
         ../../../bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web


### PR DESCRIPTION
Clarify that the test depends on the framework repo. It may fail if the framework repo is broken, so the engine committer don't need to be in panic.

This is inspired by the failure in https://github.com/flutter/engine/pull/17538/checks?check_run_id=565790440 , which was caused by the problem mentioned in https://github.com/flutter/flutter/pull/54176.