### PR TITLE
use a fixed version of flutter in the tests running on the engine

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -84,9 +84,8 @@ task:
         web_engine_test_artifacts:
           path: test_results/*
       fetch_framework_script: |
-        mkdir -p $FRAMEWORK_PATH
-        cd $FRAMEWORK_PATH
-        git clone https://github.com/flutter/flutter.git
+        cd $ENGINE_PATH/src/flutter/tools
+        ./clone_flutter.sh
       test_web_script: |
         cd $FRAMEWORK_PATH/flutter/dev/integration_tests/web
         ../../../bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web


### PR DESCRIPTION
We should fetch the correct version of the flutter framework into engine. As we decided earlier in [PR](https://github.com/flutter/engine/pull/16818) we aim to use "the youngest commit of the framework which is older than engine commit" in order to prevent issues which will be caused by cyclic dependency.

This test was added almost a year ago, we want to change it as we changed the web integration tests.
