### PR TITLE
Change the directory to the scenario app

### DIFF
--- a/testing/scenario_app/assemble_apk.sh
+++ b/testing/scenario_app/assemble_apk.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-"${BASH_SOURCE%/*}/compile_android_aot.sh" $1 $2
+pushd "${BASH_SOURCE%/*}"
+  ./compile_android_aot.sh "$1" "$2"
+popd
 
 pushd "${BASH_SOURCE%/*}/android"
 ./gradlew assembleDebug --no-daemon


### PR DESCRIPTION
This change might fix the issue in the log: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8883634725340095856/+/steps/Build_scenario_app/0/stdout?format=raw.

See: `Could not find a file named "pubspec.yaml" in "/b/s/w/ir/cache/builder/src".`