### PR TITLE
set -e on assemble_apk.sh

### DIFF
--- a/testing/scenario_app/assemble_apk.sh
+++ b/testing/scenario_app/assemble_apk.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 pushd "${BASH_SOURCE%/*}"
   ./compile_android_aot.sh "$1" "$2"
 popd

--- a/testing/scenario_app/assemble_apk.sh
+++ b/testing/scenario_app/assemble_apk.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+pushd "${BASH_SOURCE%/*}/../../.."
+  ./flutter/tools/gn --unopt
+  ninja -C out/host_debug_unopt sky_engine sky_services
+popd
+
 pushd "${BASH_SOURCE%/*}"
   ./compile_android_aot.sh "$1" "$2"
 popd


### PR DESCRIPTION
Without this, CI will incorrectly think that the script has succeeded even if a sub-invocation failed.

Additional context at #17583