### PR TITLE
Look for host_profile_unopt instead host_debug_unopt

### DIFF
--- a/testing/scenario_app/pubspec.yaml
+++ b/testing/scenario_app/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 # impact the build.
 dependencies:
  sky_engine:
-   path: ../../../out/host_debug_unopt/gen/dart-pkg/sky_engine
+   path: ../../../out/host_profile_unopt/gen/dart-pkg/sky_engine
  sky_services:
-   path: ../../../out/host_debug_unopt/gen/dart-pkg/sky_services
+   path: ../../../out/host_profile_unopt/gen/dart-pkg/sky_services
  vector_math: ^2.0.8


### PR DESCRIPTION
The script is building profile, but then reading this dependency from debug.

Log: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket.appspot.com/8883573340205488752/+/steps/Build_scenario_app/0/stdout?format=raw