### PR TITLE
Fix C++ MethodChannel reply type

### DIFF
--- a/ci/licenses_golden/licenses_flutter
+++ b/ci/licenses_golden/licenses_flutter
@@ -783,12 +783,14 @@ FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_codec.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result.h
+FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registrar.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/plugin_registry.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_message_codec.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/method_call_unittests.cc
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/method_channel_unittests.cc
+FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/method_result_functions_unittests.cc
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/plugin_registrar.cc
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/plugin_registrar_unittests.cc
 FILE: ../../../flutter/shell/platform/common/cpp/client_wrapper/standard_codec.cc

--- a/shell/platform/common/cpp/BUILD.gn
+++ b/shell/platform/common/cpp/BUILD.gn
@@ -116,6 +116,7 @@ executable("common_cpp_unittests") {
   deps = [
     ":common_cpp",
     ":common_cpp_fixtures",
+    "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper",
     "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper_library_stubs",
     "//flutter/testing",
   ]

--- a/shell/platform/common/cpp/client_wrapper/BUILD.gn
+++ b/shell/platform/common/cpp/client_wrapper/BUILD.gn
@@ -41,12 +41,12 @@ test_fixtures("client_wrapper_fixtures") {
 executable("client_wrapper_unittests") {
   testonly = true
 
-  # TODO: Add more unit tests.
   sources = [
     "basic_message_channel_unittests.cc",
     "encodable_value_unittests.cc",
     "method_call_unittests.cc",
     "method_channel_unittests.cc",
+    "method_result_functions_unittests.cc",
     "plugin_registrar_unittests.cc",
     "standard_message_codec_unittests.cc",
     "standard_method_codec_unittests.cc",

--- a/shell/platform/common/cpp/client_wrapper/basic_message_channel_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/basic_message_channel_unittests.cc
@@ -19,10 +19,6 @@ class TestBinaryMessenger : public BinaryMessenger {
  public:
   void Send(const std::string& channel,
             const uint8_t* message,
-            const size_t message_size) const override {}
-
-  void Send(const std::string& channel,
-            const uint8_t* message,
             const size_t message_size,
             BinaryReply reply) const override {}
 

--- a/shell/platform/common/cpp/client_wrapper/core_wrapper_files.gni
+++ b/shell/platform/common/cpp/client_wrapper/core_wrapper_files.gni
@@ -12,6 +12,7 @@ core_cpp_client_wrapper_includes =
                     "include/flutter/method_call.h",
                     "include/flutter/method_channel.h",
                     "include/flutter/method_codec.h",
+                    "include/flutter/method_result_functions.h",
                     "include/flutter/method_result.h",
                     "include/flutter/plugin_registrar.h",
                     "include/flutter/plugin_registry.h",

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/binary_messenger.h
@@ -8,21 +8,19 @@
 #include <functional>
 #include <string>
 
-// TODO: Consider adding absl as a dependency and using absl::Span for all of
-// the message/message_size pairs.
 namespace flutter {
 
 // A binary message reply callback.
 //
 // Used for submitting a binary reply back to a Flutter message sender.
-typedef std::function<void(const uint8_t* reply, const size_t reply_size)>
+typedef std::function<void(const uint8_t* reply, size_t reply_size)>
     BinaryReply;
 
 // A message handler callback.
 //
 // Used for receiving messages from Flutter and providing an asynchronous reply.
 typedef std::function<
-    void(const uint8_t* message, const size_t message_size, BinaryReply reply)>
+    void(const uint8_t* message, size_t message_size, BinaryReply reply)>
     BinaryMessageHandler;
 
 // A protocol for a class that handles communication of binary data on named
@@ -31,18 +29,14 @@ class BinaryMessenger {
  public:
   virtual ~BinaryMessenger() = default;
 
-  // Sends a binary message to the Flutter side on the specified channel,
-  // expecting no reply.
+  // Sends a binary message to the Flutter engine on the specified channel.
+  //
+  // If |reply| is provided, it will be called back with the response from the
+  // engine.
   virtual void Send(const std::string& channel,
                     const uint8_t* message,
-                    const size_t message_size) const = 0;
-
-  // Sends a binary message to the Flutter side on the specified channel,
-  // expecting a reply.
-  virtual void Send(const std::string& channel,
-                    const uint8_t* message,
-                    const size_t message_size,
-                    BinaryReply reply) const = 0;
+                    size_t message_size,
+                    BinaryReply reply = nullptr) const = 0;
 
   // Registers a message handler for incoming binary messages from the Flutter
   // side on the specified channel.

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/method_channel.h
@@ -44,21 +44,46 @@ class MethodChannel {
   MethodChannel& operator=(MethodChannel const&) = delete;
 
   // Sends a message to the Flutter engine on this channel.
-  void InvokeMethod(const std::string& method, std::unique_ptr<T> arguments) {
-    MethodCall<T> method_call(method, std::move(arguments));
-    std::unique_ptr<std::vector<uint8_t>> message =
-        codec_->EncodeMethodCall(method_call);
-    messenger_->Send(name_, message->data(), message->size(), nullptr);
-  }
-
-  // Sends a message to the Flutter engine on this channel expecting a reply.
+  //
+  // If |result| is provided, one of its methods will be invoked with the
+  // response from the engine.
   void InvokeMethod(const std::string& method,
                     std::unique_ptr<T> arguments,
-                    flutter::BinaryReply reply) {
+                    std::unique_ptr<MethodResult<T>> result = nullptr) {
     MethodCall<T> method_call(method, std::move(arguments));
     std::unique_ptr<std::vector<uint8_t>> message =
         codec_->EncodeMethodCall(method_call);
-    messenger_->Send(name_, message->data(), message->size(), reply);
+    if (!result) {
+      messenger_->Send(name_, message->data(), message->size(), nullptr);
+      return;
+    }
+
+    // std::function requires a copyable lambda, so convert to a shared pointer.
+    // This is safe since only one copy of the shared_pointer will ever be
+    // accessed.
+    std::shared_ptr<MethodResult<T>> shared_result(result.release());
+    const auto* codec = codec_;
+    std::string channel_name = name_;
+    BinaryReply reply_handler = [shared_result, codec, channel_name](
+                                    const uint8_t* reply, size_t reply_size) {
+      if (reply_size == 0) {
+        shared_result->NotImplemented();
+        return;
+      }
+      // Use this channel's codec to decode and handle the
+      // reply.
+      bool decoded = codec->DecodeAndProcessResponseEnvelope(
+          reply, reply_size, shared_result.get());
+      if (!decoded) {
+        std::cerr << "Unable to decode reply to method "
+                     "invocation on channel "
+                  << channel_name << std::endl;
+        shared_result->NotImplemented();
+      }
+    };
+
+    messenger_->Send(name_, message->data(), message->size(),
+                     std::move(reply_handler));
   }
 
   // Registers a handler that should be called any time a method call is
@@ -76,7 +101,7 @@ class MethodChannel {
     std::string channel_name = name_;
     BinaryMessageHandler binary_handler = [handler, codec, channel_name](
                                               const uint8_t* message,
-                                              const size_t message_size,
+                                              size_t message_size,
                                               BinaryReply reply) {
       // Use this channel's codec to decode the call and build a result handler.
       auto result =

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/method_codec.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/method_codec.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "method_call.h"
+#include "method_result.h"
 
 namespace flutter {
 
@@ -28,9 +29,8 @@ class MethodCodec {
 
   // Returns the MethodCall encoded in |message|, or nullptr if it cannot be
   // decoded.
-  std::unique_ptr<MethodCall<T>> DecodeMethodCall(
-      const uint8_t* message,
-      const size_t message_size) const {
+  std::unique_ptr<MethodCall<T>> DecodeMethodCall(const uint8_t* message,
+                                                  size_t message_size) const {
     return std::move(DecodeMethodCallInternal(message, message_size));
   }
 
@@ -67,11 +67,23 @@ class MethodCodec {
         EncodeErrorEnvelopeInternal(error_code, error_message, error_details));
   }
 
+  // Decodes the response envelope encoded in |response|, calling the
+  // appropriate method on |result|.
+  //
+  // Returns false if |response| cannot be decoded. In that case the caller is
+  // responsible for calling a |result| method.
+  bool DecodeAndProcessResponseEnvelope(const uint8_t* response,
+                                        size_t response_size,
+                                        MethodResult<T>* result) const {
+    return DecodeAndProcessResponseEnvelopeInternal(response, response_size,
+                                                    result);
+  }
+
  protected:
   // Implementation of the public interface, to be provided by subclasses.
   virtual std::unique_ptr<MethodCall<T>> DecodeMethodCallInternal(
       const uint8_t* message,
-      const size_t message_size) const = 0;
+      size_t message_size) const = 0;
 
   // Implementation of the public interface, to be provided by subclasses.
   virtual std::unique_ptr<std::vector<uint8_t>> EncodeMethodCallInternal(
@@ -86,6 +98,12 @@ class MethodCodec {
       const std::string& error_code,
       const std::string& error_message,
       const T* error_details) const = 0;
+
+  // Implementation of the public interface, to be provided by subclasses.
+  virtual bool DecodeAndProcessResponseEnvelopeInternal(
+      const uint8_t* response,
+      size_t response_size,
+      MethodResult<T>* result) const = 0;
 };
 
 }  // namespace flutter

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/method_result.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/method_result.h
@@ -9,8 +9,8 @@
 
 namespace flutter {
 
-// Encapsulates a result sent back to the Flutter engine in response to a
-// MethodCall. Only one method should be called on any given instance.
+// Encapsulates a result returned from a MethodCall. Only one method should be
+// called on any given instance.
 template <typename T>
 class MethodResult {
  public:

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h
@@ -22,7 +22,7 @@ using ResultHandlerError = std::function<void(const std::string& error_code,
 template <typename T>
 using ResultHandlerNotImplemented = std::function<void()>;
 
-// An implementatino of MethodResult that pass calls through to provided
+// An implementation of MethodResult that pass calls through to provided
 // function objects, for ease of constructing one-off result handlers.
 template <typename T>
 class MethodResultFunctions : public MethodResult<T> {

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h
@@ -1,0 +1,77 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef FLUTTER_SHELL_PLATFORM_COMMON_CPP_CLIENT_WRAPPER_INCLUDE_FLUTTER_METHOD_RESULT_FUNCTIONS_H_
+#define FLUTTER_SHELL_PLATFORM_COMMON_CPP_CLIENT_WRAPPER_INCLUDE_FLUTTER_METHOD_RESULT_FUNCTIONS_H_
+
+#include <functional>
+#include <string>
+
+#include "method_result.h"
+
+namespace flutter {
+
+// Handler types for each of the MethodResult outcomes.
+template <typename T>
+using ResultHandlerSuccess = std::function<void(const T* result)>;
+template <typename T>
+using ResultHandlerError = std::function<void(const std::string& error_code,
+                                              const std::string& error_message,
+                                              const T* error_details)>;
+template <typename T>
+using ResultHandlerNotImplemented = std::function<void()>;
+
+// An implementatino of MethodResult that pass calls through to provided
+// function objects, for ease of constructing one-off result handlers.
+template <typename T>
+class MethodResultFunctions : public MethodResult<T> {
+ public:
+  // Creates a result object that calls the provided functions for the
+  // corresponding MethodResult outcomes.
+  MethodResultFunctions(ResultHandlerSuccess<T> on_success,
+                        ResultHandlerError<T> on_error,
+                        ResultHandlerNotImplemented<T> on_not_implemented)
+      : on_success_(on_success),
+        on_error_(on_error),
+        on_not_implemented_(on_not_implemented) {}
+
+  virtual ~MethodResultFunctions() = default;
+
+  // Prevent copying.
+  MethodResultFunctions(MethodResultFunctions const&) = delete;
+  MethodResultFunctions& operator=(MethodResultFunctions const&) = delete;
+
+ protected:
+  // |flutter::MethodResult|
+  void SuccessInternal(const T* result) override {
+    if (on_success_) {
+      on_success_(result);
+    }
+  }
+
+  // |flutter::MethodResult|
+  void ErrorInternal(const std::string& error_code,
+                     const std::string& error_message,
+                     const T* error_details) override {
+    if (on_error_) {
+      on_error_(error_code, error_message, error_details);
+    }
+  }
+
+  // |flutter::MethodResult|
+  void NotImplementedInternal() override {
+    if (on_not_implemented_) {
+      on_not_implemented_();
+    }
+  }
+
+ private:
+  ResultHandlerSuccess<T> on_success_;
+  ResultHandlerError<T> on_error_;
+  ResultHandlerNotImplemented<T> on_not_implemented_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_PLATFORM_COMMON_CPP_CLIENT_WRAPPER_INCLUDE_FLUTTER_METHOD_RESULT_FUNCTIONS_H_

--- a/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h
+++ b/shell/platform/common/cpp/client_wrapper/include/flutter/standard_method_codec.h
@@ -30,7 +30,7 @@ class StandardMethodCodec : public MethodCodec<EncodableValue> {
   // |flutter::MethodCodec|
   std::unique_ptr<MethodCall<EncodableValue>> DecodeMethodCallInternal(
       const uint8_t* message,
-      const size_t message_size) const override;
+      size_t message_size) const override;
 
   // |flutter::MethodCodec|
   std::unique_ptr<std::vector<uint8_t>> EncodeMethodCallInternal(
@@ -45,6 +45,12 @@ class StandardMethodCodec : public MethodCodec<EncodableValue> {
       const std::string& error_code,
       const std::string& error_message,
       const EncodableValue* error_details) const override;
+
+  // |flutter::MethodCodec|
+  bool DecodeAndProcessResponseEnvelopeInternal(
+      const uint8_t* response,
+      size_t response_size,
+      MethodResult<EncodableValue>* result) const override;
 };
 
 }  // namespace flutter

--- a/shell/platform/common/cpp/client_wrapper/method_result_functions_unittests.cc
+++ b/shell/platform/common/cpp/client_wrapper/method_result_functions_unittests.cc
@@ -1,0 +1,66 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "flutter/shell/platform/common/cpp/client_wrapper/include/flutter/method_result_functions.h"
+
+#include <functional>
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace flutter {
+
+// Tests that unset handlers don't cause crashes.
+TEST(MethodChannelTest, NoHandlers) {
+  MethodResultFunctions<int> result(nullptr, nullptr, nullptr);
+  result.Success();
+  result.Error("error");
+  result.NotImplemented();
+}
+
+// Tests that Success calls through to handler.
+TEST(MethodChannelTest, Success) {
+  bool called = false;
+  int value = 1;
+  MethodResultFunctions<int> result(
+      [&called, value](const int* i) {
+        called = true;
+        EXPECT_EQ(*i, value);
+      },
+      nullptr, nullptr);
+  result.Success(&value);
+  EXPECT_TRUE(called);
+}
+
+// Tests that Error calls through to handler.
+TEST(MethodChannelTest, Error) {
+  bool called = false;
+  std::string error_code = "a";
+  std::string error_message = "b";
+  int error_details = 1;
+  MethodResultFunctions<int> result(
+      nullptr,
+      [&called, error_code, error_message, error_details](
+          const std::string& code, const std::string& message,
+          const int* details) {
+        called = true;
+        EXPECT_EQ(code, error_code);
+        EXPECT_EQ(message, error_message);
+        EXPECT_EQ(*details, error_details);
+      },
+      nullptr);
+  result.Error(error_code, error_message, &error_details);
+  EXPECT_TRUE(called);
+}
+
+// Tests that NotImplemented calls through to handler.
+TEST(MethodChannelTest, NotImplemented) {
+  bool called = false;
+  MethodResultFunctions<int> result(nullptr, nullptr,
+                                    [&called]() { called = true; });
+  result.NotImplemented();
+  EXPECT_TRUE(called);
+}
+
+}  // namespace flutter

--- a/shell/platform/common/cpp/client_wrapper/plugin_registrar.cc
+++ b/shell/platform/common/cpp/client_wrapper/plugin_registrar.cc
@@ -26,7 +26,7 @@ void ForwardToHandler(FlutterDesktopMessengerRef messenger,
   auto* response_handle = message->response_handle;
   BinaryReply reply_handler = [messenger, response_handle](
                                   const uint8_t* reply,
-                                  const size_t reply_size) mutable {
+                                  size_t reply_size) mutable {
     if (!response_handle) {
       std::cerr << "Error: Response can be set only once. Ignoring "
                    "duplicate response."
@@ -65,12 +65,7 @@ class BinaryMessengerImpl : public BinaryMessenger {
   // |flutter::BinaryMessenger|
   void Send(const std::string& channel,
             const uint8_t* message,
-            const size_t message_size) const override;
-
-  // |flutter::BinaryMessenger|
-  void Send(const std::string& channel,
-            const uint8_t* message,
-            const size_t message_size,
+            size_t message_size,
             BinaryReply reply) const override;
 
   // |flutter::BinaryMessenger|
@@ -88,14 +83,7 @@ class BinaryMessengerImpl : public BinaryMessenger {
 
 void BinaryMessengerImpl::Send(const std::string& channel,
                                const uint8_t* message,
-                               const size_t message_size) const {
-  FlutterDesktopMessengerSend(messenger_, channel.c_str(), message,
-                              message_size);
-}
-
-void BinaryMessengerImpl::Send(const std::string& channel,
-                               const uint8_t* message,
-                               const size_t message_size,
+                               size_t message_size,
                                BinaryReply reply) const {
   if (reply == nullptr) {
     FlutterDesktopMessengerSend(messenger_, channel.c_str(), message,

--- a/shell/platform/common/cpp/client_wrapper/standard_codec.cc
+++ b/shell/platform/common/cpp/client_wrapper/standard_codec.cc
@@ -286,7 +286,7 @@ StandardMessageCodec::~StandardMessageCodec() = default;
 
 std::unique_ptr<EncodableValue> StandardMessageCodec::DecodeMessageInternal(
     const uint8_t* binary_message,
-    const size_t message_size) const {
+    size_t message_size) const {
   StandardCodecSerializer serializer;
   ByteBufferStreamReader stream(binary_message, message_size);
   return std::make_unique<EncodableValue>(serializer.ReadValue(&stream));
@@ -312,7 +312,7 @@ const StandardMethodCodec& StandardMethodCodec::GetInstance() {
 
 std::unique_ptr<MethodCall<EncodableValue>>
 StandardMethodCodec::DecodeMethodCallInternal(const uint8_t* message,
-                                              const size_t message_size) const {
+                                              size_t message_size) const {
   StandardCodecSerializer serializer;
   ByteBufferStreamReader stream(message, message_size);
   EncodableValue method_name = serializer.ReadValue(&stream);
@@ -378,6 +378,33 @@ StandardMethodCodec::EncodeErrorEnvelopeInternal(
     serializer.WriteValue(EncodableValue(), &stream);
   }
   return encoded;
+}
+
+bool StandardMethodCodec::DecodeAndProcessResponseEnvelopeInternal(
+    const uint8_t* response,
+    size_t response_size,
+    MethodResult<EncodableValue>* result) const {
+  StandardCodecSerializer serializer;
+  ByteBufferStreamReader stream(response, response_size);
+  uint8_t flag = stream.ReadByte();
+  switch (flag) {
+    case 0: {
+      EncodableValue value = serializer.ReadValue(&stream);
+      result->Success(value.IsNull() ? nullptr : &value);
+      return true;
+    }
+    case 1: {
+      EncodableValue code = serializer.ReadValue(&stream);
+      EncodableValue message = serializer.ReadValue(&stream);
+      EncodableValue details = serializer.ReadValue(&stream);
+      result->Error(code.StringValue(),
+                    message.IsNull() ? "" : message.StringValue(),
+                    details.IsNull() ? nullptr : &details);
+      return true;
+    }
+    default:
+      return false;
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/common/cpp/json_method_codec.cc
+++ b/shell/platform/common/cpp/json_method_codec.cc
@@ -25,7 +25,7 @@ std::unique_ptr<rapidjson::Document> ExtractElement(
   document->Swap(*subtree);
   // Swap the entire document into |extracted|. Unlike the swap above this moves
   // the allocator ownership, so the data won't be deleted when |document| is
-  // destroyed goes out of scope.
+  // destroyed.
   extracted->Swap(*document);
   return extracted;
 }

--- a/shell/platform/common/cpp/json_method_codec.cc
+++ b/shell/platform/common/cpp/json_method_codec.cc
@@ -9,9 +9,27 @@
 namespace flutter {
 
 namespace {
+
 // Keys used in MethodCall encoding.
 constexpr char kMessageMethodKey[] = "method";
 constexpr char kMessageArgumentsKey[] = "args";
+
+// Returns a new document containing only |element|, which must be an element
+// in |document|. This is a move rather than a copy, so it is efficient but
+// destructive to the data in |document|.
+std::unique_ptr<rapidjson::Document> ExtractElement(
+    rapidjson::Document* document,
+    rapidjson::Value* subtree) {
+  auto extracted = std::make_unique<rapidjson::Document>();
+  // Pull the subtree up to the root of the document.
+  document->Swap(*subtree);
+  // Swap the entire document into |extracted|. Unlike the swap above this moves
+  // the allocator ownership, so the data won't be deleted when |document| is
+  // destroyed goes out of scope.
+  extracted->Swap(*document);
+  return extracted;
+}
+
 }  // namespace
 
 // static
@@ -22,7 +40,7 @@ const JsonMethodCodec& JsonMethodCodec::GetInstance() {
 
 std::unique_ptr<MethodCall<rapidjson::Document>>
 JsonMethodCodec::DecodeMethodCallInternal(const uint8_t* message,
-                                          const size_t message_size) const {
+                                          size_t message_size) const {
   std::unique_ptr<rapidjson::Document> json_message =
       JsonMessageCodec::GetInstance().DecodeMessage(message, message_size);
   if (!json_message) {
@@ -40,19 +58,7 @@ JsonMethodCodec::DecodeMethodCallInternal(const uint8_t* message,
   auto arguments_iter = json_message->FindMember(kMessageArgumentsKey);
   std::unique_ptr<rapidjson::Document> arguments;
   if (arguments_iter != json_message->MemberEnd()) {
-    // Pull the arguments subtree up to the root of json_message. This is
-    // destructive to json_message, but the full value is no longer needed, and
-    // this avoids a subtree copy.
-    // Note: The static_cast is for compatibility with RapidJSON 1.1; master
-    // already allows swapping a Document with a Value directly. Once there is
-    // a new RapidJSON release (at which point clients can be expected to have
-    // that change in the version they depend on) remove the cast.
-    static_cast<rapidjson::Value*>(json_message.get())
-        ->Swap(arguments_iter->value);
-    // Swap it into |arguments|. This moves the allocator ownership, so that
-    // the data won't be deleted when json_message goes out of scope.
-    arguments = std::make_unique<rapidjson::Document>();
-    arguments->Swap(*json_message);
+    arguments = ExtractElement(json_message.get(), &(arguments_iter->value));
   }
   return std::make_unique<MethodCall<rapidjson::Document>>(
       method_name, std::move(arguments));
@@ -106,6 +112,38 @@ JsonMethodCodec::EncodeErrorEnvelopeInternal(
   envelope.PushBack(details_value, allocator);
 
   return JsonMessageCodec::GetInstance().EncodeMessage(envelope);
+}
+
+bool JsonMethodCodec::DecodeAndProcessResponseEnvelopeInternal(
+    const uint8_t* response,
+    size_t response_size,
+    MethodResult<rapidjson::Document>* result) const {
+  std::unique_ptr<rapidjson::Document> json_response =
+      JsonMessageCodec::GetInstance().DecodeMessage(response, response_size);
+  if (!json_response) {
+    return false;
+  }
+  if (!json_response->IsArray()) {
+    return false;
+  }
+  switch (json_response->Size()) {
+    case 1: {
+      std::unique_ptr<rapidjson::Document> value =
+          ExtractElement(json_response.get(), &((*json_response)[0]));
+      result->Success(value->IsNull() ? nullptr : value.get());
+      return true;
+    }
+    case 3: {
+      std::string code = (*json_response)[0].GetString();
+      std::string message = (*json_response)[1].GetString();
+      std::unique_ptr<rapidjson::Document> details =
+          ExtractElement(json_response.get(), &((*json_response)[2]));
+      result->Error(code, message, details->IsNull() ? nullptr : details.get());
+      return true;
+    }
+    default:
+      return false;
+  }
 }
 
 }  // namespace flutter

--- a/shell/platform/common/cpp/json_method_codec.h
+++ b/shell/platform/common/cpp/json_method_codec.h
@@ -46,6 +46,12 @@ class JsonMethodCodec : public MethodCodec<rapidjson::Document> {
       const std::string& error_code,
       const std::string& error_message,
       const rapidjson::Document* error_details) const override;
+
+  // |flutter::MethodCodec|
+  bool DecodeAndProcessResponseEnvelopeInternal(
+      const uint8_t* response,
+      const size_t response_size,
+      MethodResult<rapidjson::Document>* result) const override;
 };
 
 }  // namespace flutter


### PR DESCRIPTION
Makes InvokeMethod's reply a high-level response object, rather than
binary data, matching the abstraction level of the class (and the other
languages' implementations).

In support of that:
- Adds the logic to the codecs to decode response envelopes, which had
  never been implemented.
- Adds a convience implementation of MethodResult that forwards to
  lambdas, so that one-off invocation handlers are easier to write.

Also simplified BinaryMessenger's API so that subclasses only need to
implement one version of Send, rather than two almost-identical versions.

Fixes https://github.com/flutter/flutter/issues/53223