### PR TITLE
Fix ViewRootImpl crash when using AndroidView on some brand devices

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -96,6 +96,9 @@ class VirtualDisplayController {
   public void resize(final int width, final int height, final Runnable onNewSizeFrameAvailable) {
     boolean isFocused = getView().isFocused();
     final SingleViewPresentation.PresentationState presentationState = presentation.detachState();
+    // Fix ViewRootImpl crash when using AndroidView on some brand devices
+    // described in: https://github.com/flutter/flutter/issues/47154
+    presentation.cancel();
     // We detach the surface to prevent it being destroyed when releasing the vd.
     //
     // setSurface is only available starting API 20. We could support API 19 by re-creating a new


### PR DESCRIPTION
Fix flutter/flutter/issues/47154, flutter/flutter/issues/26345

Tested on
- Redmi Note 7 Pro, reproduced by showing soft keyboard while playing video in WebView(`webview_flutter` plugin).


When soft keyboard shows/hides, `VirtualDisplayController.resize()` is called, and `SingleViewPresentation` would be **recreated**,
then the deprecated `presentation` **SHOULD** be `cancel`ed, which would call `ViewRootImpl.unscheduleTraversals()`, before **at most 1** `ViewRootImpl.performTraversals()` calls, which are triggered by `scheduleTraversals()`.
Actually, after resize, the first `performTraversals()` would make `mDisplay` field null, and the second would crash with `NullPointerException `.