### PR TITLE
Eliminate verify_framework presubmit step

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -100,9 +100,6 @@ task:
         mkdir -p $FRAMEWORK_PATH
         cd $FRAMEWORK_PATH
         git clone https://github.com/flutter/flutter.git
-      verify_framework_script:
-        - echo "Checking that the framework Cirrus test is not currently broken..."
-        - curl -s https://api.cirrus-ci.com/github/flutter/flutter.json | grep -q passing
       test_web_script: |
         cd $FRAMEWORK_PATH/flutter/dev/integration_tests/web
         ../../../bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web


### PR DESCRIPTION
This was originally added in 3c1c3e26d4e96d8f6f7a313b5e609da3c164378d as
a means of avoiding running framework tests if they're known to be
failing, but given how flaky Cirrus infrastructure has historically
been, the number of false positives is too high.