### PR TITLE
Optimize static content scrolling

### DIFF
--- a/lib/web_ui/lib/src/engine/bitmap_canvas.dart
+++ b/lib/web_ui/lib/src/engine/bitmap_canvas.dart
@@ -545,7 +545,7 @@ class BitmapCanvas extends EngineCanvas {
   /// Paints the [picture] into this canvas.
   void drawPicture(ui.Picture picture) {
     final EnginePicture enginePicture = picture;
-    enginePicture.recordingCanvas.apply(this);
+    enginePicture.recordingCanvas.apply(this, bounds);
   }
 
   /// Draws vertices on a gl context.

--- a/lib/web_ui/lib/src/engine/picture.dart
+++ b/lib/web_ui/lib/src/engine/picture.dart
@@ -32,6 +32,7 @@ class EnginePictureRecorder implements ui.PictureRecorder {
       return null;
     }
     _isRecording = false;
+    _canvas.endRecording();
     return EnginePicture(_canvas, cullRect);
   }
 }

--- a/lib/web_ui/lib/src/engine/picture.dart
+++ b/lib/web_ui/lib/src/engine/picture.dart
@@ -46,8 +46,9 @@ class EnginePicture implements ui.Picture {
 
   @override
   Future<ui.Image> toImage(int width, int height) async {
-    final BitmapCanvas canvas = BitmapCanvas(ui.Rect.fromLTRB(0, 0, width.toDouble(), height.toDouble()));
-    recordingCanvas.apply(canvas);
+    final ui.Rect imageRect = ui.Rect.fromLTRB(0, 0, width.toDouble(), height.toDouble());
+    final BitmapCanvas canvas = BitmapCanvas(imageRect);
+    recordingCanvas.apply(canvas, imageRect);
     final String imageDataUrl = canvas.toDataUrl();
     final html.ImageElement imageElement = html.ImageElement()
       ..src = imageDataUrl

--- a/lib/web_ui/lib/src/engine/surface/picture.dart
+++ b/lib/web_ui/lib/src/engine/surface/picture.dart
@@ -352,7 +352,7 @@ class PersistedStandardPicture extends PersistedPicture {
 /// to draw shapes and text.
 abstract class PersistedPicture extends PersistedLeafSurface {
   PersistedPicture(this.dx, this.dy, this.picture, this.hints)
-      : localPaintBounds = picture.recordingCanvas.computePaintBounds();
+      : localPaintBounds = picture.recordingCanvas.pictureBounds;
 
   EngineCanvas _canvas;
 

--- a/lib/web_ui/lib/src/engine/surface/picture.dart
+++ b/lib/web_ui/lib/src/engine/surface/picture.dart
@@ -532,8 +532,8 @@ abstract class PersistedPicture extends PersistedLeafSurface {
       // 50% of the extent (protect from extremely slow growth trend such as
       // slow scrolling). Give no more than the full extent (protects from
       // fast scrolling that could lead to overallocation).
-      return math.max(
-        math.min(extent * 0.5, delta * 10.0),
+      return math.min(
+        math.max(extent * 0.5, delta * 10.0),
         extent,
       );
     }

--- a/lib/web_ui/lib/src/engine/surface/picture.dart
+++ b/lib/web_ui/lib/src/engine/surface/picture.dart
@@ -523,7 +523,6 @@ abstract class PersistedPicture extends PersistedLeafSurface {
       // Shrinking. Give it 10% of the extent in case the trend is reversed.
       return extent * 0.1;
     } else {
-      print('>>> _predictTrend(extent = $extent, delta = $delta)');
       // Growing. Predict 10 more frames of similar deltas. Give it at least
       // 50% of the extent (protect from extremely slow growth trend such as
       // slow scrolling). Give no more than the full extent (protects from

--- a/lib/web_ui/lib/src/engine/surface/picture.dart
+++ b/lib/web_ui/lib/src/engine/surface/picture.dart
@@ -145,7 +145,7 @@ class PersistedHoudiniPicture extends PersistedPicture {
     _canvas = canvas;
     domRenderer.clearDom(rootElement);
     rootElement.append(_canvas.rootElement);
-    picture.recordingCanvas.apply(_canvas);
+    picture.recordingCanvas.apply(_canvas, _optimalLocalCullRect);
     canvas.commit();
   }
 }
@@ -231,7 +231,7 @@ class PersistedStandardPicture extends PersistedPicture {
     _canvas = DomCanvas();
     domRenderer.clearDom(rootElement);
     rootElement.append(_canvas.rootElement);
-    picture.recordingCanvas.apply(_canvas);
+    picture.recordingCanvas.apply(_canvas, _optimalLocalCullRect);
   }
 
   void _applyBitmapPaint(EngineCanvas oldCanvas) {
@@ -244,7 +244,7 @@ class PersistedStandardPicture extends PersistedPicture {
       oldCanvas.bounds = _optimalLocalCullRect;
       _canvas = oldCanvas;
       _canvas.clear();
-      picture.recordingCanvas.apply(_canvas);
+      picture.recordingCanvas.apply(_canvas, _optimalLocalCullRect);
     } else {
       // We can't use the old canvas because the size has changed, so we put
       // it in a cache for later reuse.
@@ -265,7 +265,7 @@ class PersistedStandardPicture extends PersistedPicture {
           domRenderer.clearDom(rootElement);
           rootElement.append(_canvas.rootElement);
           _canvas.clear();
-          picture.recordingCanvas.apply(_canvas);
+          picture.recordingCanvas.apply(_canvas, _optimalLocalCullRect);
         },
       ));
     }

--- a/lib/web_ui/lib/src/engine/surface/picture.dart
+++ b/lib/web_ui/lib/src/engine/surface/picture.dart
@@ -491,7 +491,7 @@ abstract class PersistedPicture extends PersistedLeafSurface {
 
     // The new cull rect contains area not covered by a previous rect. Perhaps
     // the clip is growing, moving around the picture, or both. In this case
-    // a part of the picture may not been painted. We will need to
+    // a part of the picture may not have been painted. We will need to
     // request a new canvas and paint the picture on it. However, this is also
     // a strong signal that the clip will continue growing as typically
     // Flutter uses animated transitions. So instead of allocating the canvas
@@ -500,12 +500,14 @@ abstract class PersistedPicture extends PersistedLeafSurface {
     // will hit the above case where the new cull rect is fully contained
     // within the cull rect we compute now.
 
-    // If any of the borders moved.
+    // Compute the delta, by which each of the side of the clip rect has "moved"
+    // since the last time we updated the cull rect.
     final double leftwardDelta = oldOptimalLocalCullRect.left - _exactLocalCullRect.left;
     final double upwardDelta = oldOptimalLocalCullRect.top - _exactLocalCullRect.top;
     final double rightwardDelta = _exactLocalCullRect.right - oldOptimalLocalCullRect.right;
     final double bottomwardDelta = _exactLocalCullRect.bottom - oldOptimalLocalCullRect.bottom;
 
+    // Compute the new optimal rect to paint into.
     final ui.Rect newLocalCullRect = ui.Rect.fromLTRB(
       _exactLocalCullRect.left - _predictTrend(leftwardDelta, _exactLocalCullRect.width),
       _exactLocalCullRect.top - _predictTrend(upwardDelta, _exactLocalCullRect.height),
@@ -518,6 +520,9 @@ abstract class PersistedPicture extends PersistedLeafSurface {
     return localCullRectChanged;
   }
 
+  /// Predicts the delta a particular side of a clip rect will move given the
+  /// [delta] it moved by last, and the respective [extent] (width or height)
+  /// of the clip.
   static double _predictTrend(double delta, double extent) {
     if (delta <= 0.0) {
       // Shrinking. Give it 10% of the extent in case the trend is reversed.

--- a/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
@@ -82,6 +82,7 @@ class RecordingCanvas {
   ///
   /// The [clipRect] specifies the clip applied to the picture (screen clip at a minimum).
   void apply(EngineCanvas engineCanvas, ui.Rect clipRect) {
+    assert(_debugRecordingEnded);
     if (_debugDumpPaintCommands) {
       final StringBuffer debugBuf = StringBuffer();
       int skips = 0;

--- a/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
@@ -64,20 +64,25 @@ class RecordingCanvas {
   void apply(EngineCanvas engineCanvas, ui.Rect clipRect) {
     if (_debugDumpPaintCommands) {
       final StringBuffer debugBuf = StringBuffer();
+      int skips = 0;
       debugBuf.writeln(
           '--- Applying RecordingCanvas to ${engineCanvas.runtimeType} '
-          'with bounds $_paintBounds');
+          'with bounds $_paintBounds and clip $clipRect (w = ${clipRect.width}, h = ${clipRect.height})');
       for (int i = 0; i < _commands.length; i++) {
         final PaintCommand command = _commands[i];
         if (command is DrawCommand) {
           if (_isOutsideClipRegion(command, clipRect)) {
             // The drawing command is outside the clip region. No need to apply.
             debugBuf.writeln('SKIPPED: ctx.$command;');
+            skips += 1;
             continue;
           }
         }
         debugBuf.writeln('ctx.$command;');
         command.apply(engineCanvas);
+      }
+      if (skips > 0) {
+        debugBuf.writeln('Total commands skipped: $skips');
       }
       debugBuf.writeln('--- End of command stream');
       print(debugBuf);

--- a/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
@@ -29,7 +29,7 @@ class RecordingCanvas {
   /// Maximum paintable bounds for this canvas.
   ui.Rect get pictureBounds {
     assert(
-      !_debugRecordingEnded,
+      _debugRecordingEnded,
       'Picture bounds not available yet. Call [endRecording] before accessing picture bounds.',
     );
     return _pictureBounds;

--- a/lib/web_ui/test/canvas_test.dart
+++ b/lib/web_ui/test/canvas_test.dart
@@ -36,16 +36,17 @@ void main() {
     }
 
     testCanvas('draws laid out paragraph', (EngineCanvas canvas) {
-      final RecordingCanvas recordingCanvas =
-          RecordingCanvas(const ui.Rect.fromLTWH(0, 0, 100, 100));
+      final ui.Rect screenRect = const ui.Rect.fromLTWH(0, 0, 100, 100);
+      final RecordingCanvas recordingCanvas = RecordingCanvas(screenRect);
       final ui.ParagraphBuilder builder =
           ui.ParagraphBuilder(ui.ParagraphStyle());
       builder.addText('sample');
       paragraph = builder.build();
       paragraph.layout(const ui.ParagraphConstraints(width: 100));
       recordingCanvas.drawParagraph(paragraph, const ui.Offset(10, 10));
+      recordingCanvas.endRecording();
       canvas.clear();
-      recordingCanvas.apply(canvas);
+      recordingCanvas.apply(canvas, screenRect);
     }, whenDone: () {
       expect(mockCanvas.methodCallLog, hasLength(3));
 
@@ -60,15 +61,16 @@ void main() {
 
     testCanvas('ignores paragraphs that were not laid out',
         (EngineCanvas canvas) {
-      final RecordingCanvas recordingCanvas =
-          RecordingCanvas(const ui.Rect.fromLTWH(0, 0, 100, 100));
+      final ui.Rect screenRect = const ui.Rect.fromLTWH(0, 0, 100, 100);
+      final RecordingCanvas recordingCanvas = RecordingCanvas(screenRect);
       final ui.ParagraphBuilder builder =
           ui.ParagraphBuilder(ui.ParagraphStyle());
       builder.addText('sample');
       final ui.Paragraph paragraph = builder.build();
       recordingCanvas.drawParagraph(paragraph, const ui.Offset(10, 10));
+      recordingCanvas.endRecording();
       canvas.clear();
-      recordingCanvas.apply(canvas);
+      recordingCanvas.apply(canvas, screenRect);
     }, whenDone: () {
       expect(mockCanvas.methodCallLog, hasLength(2));
       expect(mockCanvas.methodCallLog[0].methodName, 'clear');

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -12,9 +12,10 @@ import '../mock_engine_canvas.dart';
 void main() {
   RecordingCanvas underTest;
   MockEngineCanvas mockCanvas;
+  final Rect screenRect = Rect.largest;
 
   setUp(() {
-    underTest = RecordingCanvas(Rect.largest);
+    underTest = RecordingCanvas(screenRect);
     mockCanvas = MockEngineCanvas();
   });
 
@@ -25,7 +26,8 @@ void main() {
 
     test('Happy case', () {
       underTest.drawDRRect(rrect, rrect.deflate(1), somePaint);
-      underTest.apply(mockCanvas);
+      underTest.endRecording();
+      underTest.apply(mockCanvas, screenRect);
 
       _expectDrawCall(mockCanvas, <String, dynamic>{
         'outer': rrect,
@@ -36,7 +38,8 @@ void main() {
 
     test('Inner RRect > Outer RRect', () {
       underTest.drawDRRect(rrect, rrect.inflate(1), somePaint);
-      underTest.apply(mockCanvas);
+      underTest.endRecording();
+      underTest.apply(mockCanvas, screenRect);
       // Expect nothing to be called
       expect(mockCanvas.methodCallLog.length, equals(1));
       expect(mockCanvas.methodCallLog.single.methodName, 'endOfPaint');
@@ -45,7 +48,8 @@ void main() {
     test('Inner RRect not completely inside Outer RRect', () {
       underTest.drawDRRect(
           rrect, rrect.deflate(1).shift(const Offset(0.0, 10)), somePaint);
-      underTest.apply(mockCanvas);
+      underTest.endRecording();
+      underTest.apply(mockCanvas, screenRect);
       // Expect nothing to be called
       expect(mockCanvas.methodCallLog.length, equals(1));
       expect(mockCanvas.methodCallLog.single.methodName, 'endOfPaint');
@@ -53,7 +57,8 @@ void main() {
 
     test('Inner RRect same as Outer RRect', () {
       underTest.drawDRRect(rrect, rrect, somePaint);
-      underTest.apply(mockCanvas);
+      underTest.endRecording();
+      underTest.apply(mockCanvas, screenRect);
       // Expect nothing to be called
       expect(mockCanvas.methodCallLog.length, equals(1));
       expect(mockCanvas.methodCallLog.single.methodName, 'endOfPaint');
@@ -72,7 +77,8 @@ void main() {
       expect(inner.trRadius, equals(Radius.circular(-1)));
 
       underTest.drawDRRect(outer, inner, somePaint);
-      underTest.apply(mockCanvas);
+      underTest.endRecording();
+      underTest.apply(mockCanvas, screenRect);
 
       // Expect to draw, even when inner has negative radii (which get ignored by canvas)
       _expectDrawCall(mockCanvas, <String, dynamic>{
@@ -89,7 +95,8 @@ void main() {
           RRect.fromRectAndCorners(const Rect.fromLTRB(12, 22, 28, 38));
 
       underTest.drawDRRect(outer, inner, somePaint);
-      underTest.apply(mockCanvas);
+      underTest.endRecording();
+      underTest.apply(mockCanvas, screenRect);
 
       _expectDrawCall(mockCanvas, <String, dynamic>{
         'outer': outer,

--- a/lib/web_ui/test/engine/recording_canvas_test.dart
+++ b/lib/web_ui/test/engine/recording_canvas_test.dart
@@ -29,7 +29,7 @@ void main() {
       underTest.endRecording();
       underTest.apply(mockCanvas, screenRect);
 
-      _expectDrawCall(mockCanvas, <String, dynamic>{
+      _expectDrawDRRectCall(mockCanvas, <String, dynamic>{
         'outer': rrect,
         'inner': rrect.deflate(1),
         'paint': somePaint.paintData,
@@ -81,7 +81,7 @@ void main() {
       underTest.apply(mockCanvas, screenRect);
 
       // Expect to draw, even when inner has negative radii (which get ignored by canvas)
-      _expectDrawCall(mockCanvas, <String, dynamic>{
+      _expectDrawDRRectCall(mockCanvas, <String, dynamic>{
         'outer': outer,
         'inner': inner,
         'paint': somePaint.paintData,
@@ -98,17 +98,102 @@ void main() {
       underTest.endRecording();
       underTest.apply(mockCanvas, screenRect);
 
-      _expectDrawCall(mockCanvas, <String, dynamic>{
+      _expectDrawDRRectCall(mockCanvas, <String, dynamic>{
         'outer': outer,
         'inner': inner,
         'paint': somePaint.paintData,
       });
     });
   });
+
+  test('Filters out paint commands outside the clip rect', () {
+    // Outside to the left
+    underTest.drawRect(Rect.fromLTWH(0.0, 20.0, 10.0, 10.0), Paint());
+
+    // Outside above
+    underTest.drawRect(Rect.fromLTWH(20.0, 0.0, 10.0, 10.0), Paint());
+
+    // Visible
+    underTest.drawRect(Rect.fromLTWH(20.0, 20.0, 10.0, 10.0), Paint());
+
+    // Inside the layer clip rect but zero-size
+    underTest.drawRect(Rect.fromLTRB(20.0, 20.0, 30.0, 20.0), Paint());
+
+    // Inside the layer clip but clipped out by a canvas clip
+    underTest.save();
+    underTest.clipRect(Rect.fromLTWH(0, 0, 10, 10));
+    underTest.drawRect(Rect.fromLTWH(20.0, 20.0, 10.0, 10.0), Paint());
+    underTest.restore();
+
+    // Outside to the right
+    underTest.drawRect(Rect.fromLTWH(40.0, 20.0, 10.0, 10.0), Paint());
+
+    // Outside below
+    underTest.drawRect(Rect.fromLTWH(20.0, 40.0, 10.0, 10.0), Paint());
+
+    underTest.endRecording();
+
+    expect(underTest.debugPaintCommands, hasLength(10));
+    final PaintDrawRect outsideLeft = underTest.debugPaintCommands[0];
+    expect(outsideLeft.isClippedOut, false);
+    expect(outsideLeft.leftBound, 0);
+    expect(outsideLeft.topBound, 20);
+    expect(outsideLeft.rightBound, 10);
+    expect(outsideLeft.bottomBound, 30);
+
+    final PaintDrawRect outsideAbove = underTest.debugPaintCommands[1];
+    expect(outsideAbove.isClippedOut, false);
+
+    final PaintDrawRect visible = underTest.debugPaintCommands[2];
+    expect(visible.isClippedOut, false);
+
+    final PaintDrawRect zeroSize = underTest.debugPaintCommands[3];
+    expect(zeroSize.isClippedOut, true);
+
+    expect(underTest.debugPaintCommands[4], isA<PaintSave>());
+
+    final PaintClipRect clip = underTest.debugPaintCommands[5];
+    expect(clip.isClippedOut, false);
+
+    final PaintDrawRect clippedOut = underTest.debugPaintCommands[6];
+    expect(clippedOut.isClippedOut, true);
+
+    expect(underTest.debugPaintCommands[7], isA<PaintRestore>());
+
+    final PaintDrawRect outsideRight = underTest.debugPaintCommands[8];
+    expect(outsideRight.isClippedOut, false);
+
+    final PaintDrawRect outsideBelow = underTest.debugPaintCommands[9];
+    expect(outsideBelow.isClippedOut, false);
+
+    // Give it the entire screen so everything paints.
+    underTest.apply(mockCanvas, screenRect);
+    expect(mockCanvas.methodCallLog, hasLength(11));
+    expect(mockCanvas.methodCallLog[0].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[1].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[2].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[3].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[4].methodName, 'save');
+    expect(mockCanvas.methodCallLog[5].methodName, 'clipRect');
+    expect(mockCanvas.methodCallLog[6].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[7].methodName, 'restore');
+    expect(mockCanvas.methodCallLog[8].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[9].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[10].methodName, 'endOfPaint');
+
+    // Clip out a middle region that only contains 'drawRect'
+    mockCanvas.methodCallLog.clear();
+    underTest.apply(mockCanvas, Rect.fromLTRB(15, 15, 35, 35));
+    expect(mockCanvas.methodCallLog, hasLength(4));
+    expect(mockCanvas.methodCallLog[0].methodName, 'drawRect');
+    expect(mockCanvas.methodCallLog[1].methodName, 'save');
+    expect(mockCanvas.methodCallLog[2].methodName, 'restore');
+    expect(mockCanvas.methodCallLog[3].methodName, 'endOfPaint');
+  });
 }
 
 // Expect a drawDRRect call to be registered in the mock call log, with the expectedArguments
-void _expectDrawCall(
+void _expectDrawDRRectCall(
     MockEngineCanvas mock, Map<String, dynamic> expectedArguments) {
   expect(mock.methodCallLog.length, equals(2));
   MockCanvasCall mockCall = mock.methodCallLog[0];

--- a/lib/web_ui/test/golden_tests/engine/canvas_blend_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_blend_golden_test.dart
@@ -23,7 +23,8 @@ void main() async {
        double maxDiffRatePercent = 0.0}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
 
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/canvas_clip_path_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_clip_path_test.dart
@@ -22,7 +22,8 @@ void main() async {
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
     final engine.EngineCanvas engineCanvas = engine.BitmapCanvas(screenRect);
 
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/canvas_context_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_context_test.dart
@@ -22,7 +22,8 @@ void main() async {
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500)}) async {
     final engine.EngineCanvas engineCanvas = engine.BitmapCanvas(screenRect);
 
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
@@ -26,6 +26,7 @@ void main() async {
         double maxDiffRatePercent = 0.0}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
 
+    rc.endRecording();
     rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.

--- a/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_draw_image_golden_test.dart
@@ -26,7 +26,7 @@ void main() async {
         double maxDiffRatePercent = 0.0}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
 
-    rc.apply(engineCanvas);
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/canvas_reuse_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/canvas_reuse_test.dart
@@ -39,7 +39,8 @@ void main() async {
       ..moveTo(3, 0)
       ..lineTo(100, 97);
     rc.drawPath(path, testPaint);
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
     engineCanvas.endOfPaint();
 
     html.Element sceneElement = html.Element.tag('flt-scene');
@@ -69,7 +70,8 @@ void main() async {
       ..quadraticBezierTo(100, 0, 100, 100);
     rc2.drawImage(_createRealTestImage(), Offset(0, 0), Paint());
     rc2.drawPath(path2, testPaint);
-    rc2.apply(engineCanvas);
+    rc2.endRecording();
+    rc2.apply(engineCanvas, screenRect);
 
     sceneElement = html.Element.tag('flt-scene');
     sceneElement.append(engineCanvas.rootElement);

--- a/lib/web_ui/test/golden_tests/engine/conic_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/conic_golden_test.dart
@@ -31,9 +31,10 @@ void main() async {
       ..style = PaintingStyle.stroke;
 
     canvas.drawPath(path, paint);
+    canvas.endRecording();
 
     html.document.body.append(bitmapCanvas.rootElement);
-    canvas.apply(bitmapCanvas);
+    canvas.apply(bitmapCanvas, canvasBounds);
     await matchGoldenFile('$scubaFileName.png', region: region);
     bitmapCanvas.rootElement.remove();
   }

--- a/lib/web_ui/test/golden_tests/engine/draw_vertices_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/draw_vertices_golden_test.dart
@@ -22,7 +22,8 @@ void main() async {
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
         bool write = false}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/linear_gradient_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/linear_gradient_golden_test.dart
@@ -21,7 +21,8 @@ void main() async {
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
         bool write = false}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/multiline_text_clipping_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/multiline_text_clipping_golden_test.dart
@@ -21,10 +21,11 @@ void main() async {
   setUpStableTestFonts();
 
   void paintTest(EngineCanvas canvas, PaintTest painter) {
-    final RecordingCanvas recordingCanvas =
-        RecordingCanvas(const Rect.fromLTWH(0, 0, 600, 600));
+    final Rect screenRect = const Rect.fromLTWH(0, 0, 600, 600);
+    final RecordingCanvas recordingCanvas = RecordingCanvas(screenRect);
     painter(recordingCanvas);
-    recordingCanvas.apply(canvas);
+    recordingCanvas.endRecording();
+    recordingCanvas.apply(canvas, screenRect);
   }
 
   testEachCanvas(

--- a/lib/web_ui/test/golden_tests/engine/path_metrics_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/path_metrics_test.dart
@@ -25,7 +25,8 @@ void main() async {
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
       bool write = false}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/path_to_svg_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/path_to_svg_golden_test.dart
@@ -37,7 +37,8 @@ void main() async {
     html.document.body.append(bitmapCanvas.rootElement);
     html.document.body.append(svgElement);
 
-    canvas.apply(bitmapCanvas);
+    canvas.endRecording();
+    canvas.apply(bitmapCanvas, canvasBounds);
 
     await matchGoldenFile('$scubaFileName.png', region: region);
 

--- a/lib/web_ui/test/golden_tests/engine/path_transform_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/path_transform_test.dart
@@ -22,7 +22,8 @@ void main() async {
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
       bool write = false}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/radial_gradient_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/radial_gradient_golden_test.dart
@@ -21,7 +21,8 @@ void main() async {
       {Rect region = const Rect.fromLTWH(0, 0, 500, 500),
       bool write = false}) async {
     final EngineCanvas engineCanvas = BitmapCanvas(screenRect);
-    rc.apply(engineCanvas);
+    rc.endRecording();
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');

--- a/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
+++ b/lib/web_ui/test/golden_tests/engine/recording_canvas_golden_test.dart
@@ -30,7 +30,7 @@ void main() async {
     engineCanvas
       ..save()
       ..drawRect(
-        rc.computePaintBounds(),
+        rc.pictureBounds,
         SurfacePaintData()
           ..color = const Color.fromRGBO(0, 0, 255, 1.0)
           ..style = PaintingStyle.stroke
@@ -38,7 +38,7 @@ void main() async {
       )
       ..restore();
 
-    rc.apply(engineCanvas);
+    rc.apply(engineCanvas, screenRect);
 
     // Wrap in <flt-scene> so that our CSS selectors kick in.
     final html.Element sceneElement = html.Element.tag('flt-scene');
@@ -63,15 +63,17 @@ void main() async {
   test('Empty canvas reports correct paint bounds', () async {
     final RecordingCanvas rc =
         RecordingCanvas(const Rect.fromLTWH(1, 2, 300, 400));
-    expect(rc.computePaintBounds(), Rect.zero);
+    rc.endRecording();
+    expect(rc.pictureBounds, Rect.zero);
     await _checkScreenshot(rc, 'empty_canvas');
   });
 
   test('Computes paint bounds for draw line', () async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawLine(const Offset(50, 100), const Offset(120, 140), testPaint);
+    rc.endRecording();
     // The off by one is due to the minimum stroke width of 1.
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(49, 99, 121, 141));
+    expect(rc.pictureBounds, const Rect.fromLTRB(49, 99, 121, 141));
     await _checkScreenshot(rc, 'draw_line');
   });
 
@@ -81,8 +83,9 @@ void main() async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawLine(const Offset(50, 100), const Offset(screenWidth + 100.0, 140),
         testPaint);
+    rc.endRecording();
     // The off by one is due to the minimum stroke width of 1.
-    expect(rc.computePaintBounds(),
+    expect(rc.pictureBounds,
         const Rect.fromLTRB(49.0, 99.0, screenWidth, 141.0));
     await _checkScreenshot(rc, 'draw_line_exceeding_limits');
   });
@@ -90,7 +93,8 @@ void main() async {
   test('Computes paint bounds for draw rect', () async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawRect(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(10, 20, 30, 40));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(10, 20, 30, 40));
     await _checkScreenshot(rc, 'draw_rect');
   });
 
@@ -100,12 +104,14 @@ void main() async {
     rc.drawRect(
         const Rect.fromLTRB(10, 20, 30 + screenWidth, 40 + screenHeight),
         testPaint);
-    expect(rc.computePaintBounds(),
+    rc.endRecording();
+    expect(rc.pictureBounds,
         const Rect.fromLTRB(10, 20, screenWidth, screenHeight));
 
     rc = RecordingCanvas(screenRect);
     rc.drawRect(const Rect.fromLTRB(-200, -100, 30, 40), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(0, 0, 30, 40));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(0, 0, 30, 40));
     await _checkScreenshot(rc, 'draw_rect_exceeding_limits');
   });
 
@@ -113,7 +119,8 @@ void main() async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.translate(5, 7);
     rc.drawRect(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(15, 27, 35, 47));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(15, 27, 35, 47));
     await _checkScreenshot(rc, 'translate');
   });
 
@@ -121,7 +128,8 @@ void main() async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.scale(2, 2);
     rc.drawRect(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(20, 40, 60, 80));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(20, 40, 60, 80));
     await _checkScreenshot(rc, 'scale');
   });
 
@@ -130,8 +138,9 @@ void main() async {
     rc.rotate(math.pi / 4.0);
     rc.drawLine(
         const Offset(1, 0), Offset(50 * math.sqrt(2) - 1, 0), testPaint);
+    rc.endRecording();
     // The extra 0.7 is due to stroke width of 1 rotated by 45 degrees.
-    expect(rc.computePaintBounds(),
+    expect(rc.pictureBounds,
         within(distance: 0.1, from: const Rect.fromLTRB(0, 0, 50.7, 50.7)));
     await _checkScreenshot(rc, 'rotate');
   });
@@ -140,8 +149,9 @@ void main() async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.skew(1.0, 0.0);
     rc.drawRect(const Rect.fromLTRB(20, 20, 40, 40), testPaint);
+    rc.endRecording();
     expect(
-        rc.computePaintBounds(),
+        rc.pictureBounds,
         within(
             distance: 0.1, from: const Rect.fromLTRB(40.0, 20.0, 80.0, 40.0)));
     await _checkScreenshot(rc, 'skew_horizontally');
@@ -151,8 +161,9 @@ void main() async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.skew(0.0, 1.0);
     rc.drawRect(const Rect.fromLTRB(20, 20, 40, 40), testPaint);
+    rc.endRecording();
     expect(
-        rc.computePaintBounds(),
+        rc.pictureBounds,
         within(
             distance: 0.1, from: const Rect.fromLTRB(20.0, 40.0, 40.0, 80.0)));
     await _checkScreenshot(rc, 'skew_vertically');
@@ -180,7 +191,8 @@ void main() async {
     matrix[15] = 1.0;
     rc.transform(matrix);
     rc.drawRect(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
-    expect(rc.computePaintBounds(),
+    rc.endRecording();
+    expect(rc.pictureBounds,
         const Rect.fromLTRB(168.0, 283.6, 224.0, 368.4));
     await _checkScreenshot(rc, 'complex_transform');
   });
@@ -189,7 +201,8 @@ void main() async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawPaint(testPaint);
     rc.drawRect(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
-    expect(rc.computePaintBounds(), screenRect);
+    rc.endRecording();
+    expect(rc.pictureBounds, screenRect);
     await _checkScreenshot(rc, 'draw_paint');
   });
 
@@ -199,14 +212,16 @@ void main() async {
     rc.drawRect(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
     rc.drawColor(const Color(0xFFFF0000), BlendMode.multiply);
     rc.drawRect(const Rect.fromLTRB(10, 60, 30, 80), testPaint);
-    expect(rc.computePaintBounds(), screenRect);
+    rc.endRecording();
+    expect(rc.pictureBounds, screenRect);
     await _checkScreenshot(rc, 'draw_color');
   });
 
   test('Computes paint bounds for draw oval', () async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawOval(const Rect.fromLTRB(10, 20, 30, 40), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(10, 20, 30, 40));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(10, 20, 30, 40));
     await _checkScreenshot(rc, 'draw_oval');
   });
 
@@ -216,7 +231,8 @@ void main() async {
         RRect.fromRectAndRadius(
             const Rect.fromLTRB(10, 20, 30, 40), const Radius.circular(5.0)),
         testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(10, 20, 30, 40));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(10, 20, 30, 40));
     await _checkScreenshot(rc, 'draw_round_rect');
   });
 
@@ -226,7 +242,8 @@ void main() async {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawDRRect(RRect.fromRectAndCorners(const Rect.fromLTRB(10, 20, 30, 40)),
         RRect.fromRectAndCorners(const Rect.fromLTRB(1, 2, 3, 4)), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(0, 0, 0, 0));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(0, 0, 0, 0));
     await _checkScreenshot(rc, 'draw_drrect_empty');
   });
 
@@ -236,34 +253,44 @@ void main() async {
         RRect.fromRectAndCorners(const Rect.fromLTRB(10, 20, 30, 40)),
         RRect.fromRectAndCorners(const Rect.fromLTRB(12, 22, 28, 38)),
         testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(10, 20, 30, 40));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(10, 20, 30, 40));
     await _checkScreenshot(rc, 'draw_drrect');
   });
 
   test('Computes paint bounds for draw circle', () async {
-    final RecordingCanvas rc = RecordingCanvas(screenRect);
+    // Paint bounds of one circle.
+    RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawCircle(const Offset(20, 20), 10.0, testPaint);
+    rc.endRecording();
     expect(
-        rc.computePaintBounds(), const Rect.fromLTRB(10.0, 10.0, 30.0, 30.0));
+        rc.pictureBounds, const Rect.fromLTRB(10.0, 10.0, 30.0, 30.0));
+
+    // Paint bounds of a union of two circles.
+    rc = RecordingCanvas(screenRect);
+    rc.drawCircle(const Offset(20, 20), 10.0, testPaint);
     rc.drawCircle(const Offset(200, 300), 100.0, testPaint);
+    rc.endRecording();
     expect(
-        rc.computePaintBounds(), const Rect.fromLTRB(10.0, 10.0, 300.0, 400.0));
+        rc.pictureBounds, const Rect.fromLTRB(10.0, 10.0, 300.0, 400.0));
     await _checkScreenshot(rc, 'draw_circle');
   });
 
   test('Computes paint bounds for draw image', () {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawImage(TestImage(), const Offset(50, 100), Paint());
+    rc.endRecording();
     expect(
-        rc.computePaintBounds(), const Rect.fromLTRB(50.0, 100.0, 70.0, 110.0));
+        rc.pictureBounds, const Rect.fromLTRB(50.0, 100.0, 70.0, 110.0));
   });
 
   test('Computes paint bounds for draw image rect', () {
     final RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.drawImageRect(TestImage(), const Rect.fromLTRB(1, 1, 20, 10),
         const Rect.fromLTRB(5, 6, 400, 500), Paint());
+    rc.endRecording();
     expect(
-        rc.computePaintBounds(), const Rect.fromLTRB(5.0, 6.0, 400.0, 500.0));
+        rc.pictureBounds, const Rect.fromLTRB(5.0, 6.0, 400.0, 500.0));
   });
 
   test('Computes paint bounds for single-line draw paragraph', () async {
@@ -274,8 +301,9 @@ void main() async {
     const double widthConstraint = 300.0;
     paragraph.layout(const ParagraphConstraints(width: widthConstraint));
     rc.drawParagraph(paragraph, const Offset(textLeft, textTop));
+    rc.endRecording();
     expect(
-      rc.computePaintBounds(),
+      rc.pictureBounds,
       const Rect.fromLTRB(textLeft, textTop, textLeft + widthConstraint, 21.0),
     );
     await _checkScreenshot(rc, 'draw_paragraph');
@@ -286,27 +314,35 @@ void main() async {
     final Paragraph paragraph = createTestParagraph();
     const double textLeft = 5.0;
     const double textTop = 7.0;
-    const double widthConstraint =
-        130.0; // do not go lower than the shortest word.
+    // Do not go lower than the shortest word.
+    const double widthConstraint = 130.0;
     paragraph.layout(const ParagraphConstraints(width: widthConstraint));
     rc.drawParagraph(paragraph, const Offset(textLeft, textTop));
+    rc.endRecording();
     expect(
-      rc.computePaintBounds(),
+      rc.pictureBounds,
       const Rect.fromLTRB(textLeft, textTop, textLeft + widthConstraint, 35.0),
     );
     await _checkScreenshot(rc, 'draw_paragraph_multi_line');
   });
 
   test('Should exclude painting outside simple clipRect', () async {
-    final RecordingCanvas rc = RecordingCanvas(screenRect);
+    // One clipped line.
+    RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.clipRect(const Rect.fromLTRB(50, 50, 100, 100));
     rc.drawLine(const Offset(10, 11), const Offset(20, 21), testPaint);
+    rc.endRecording();
+    expect(rc.pictureBounds, Rect.zero);
 
-    expect(rc.computePaintBounds(), Rect.zero);
+    // Two clipped lines.
+    rc = RecordingCanvas(screenRect);
+    rc.clipRect(const Rect.fromLTRB(50, 50, 100, 100));
+    rc.drawLine(const Offset(10, 11), const Offset(20, 21), testPaint);
     rc.drawLine(const Offset(52, 53), const Offset(55, 56), testPaint);
+    rc.endRecording();
 
     // Extra pixel due to default line length
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(51, 52, 56, 57));
+    expect(rc.pictureBounds, const Rect.fromLTRB(51, 52, 56, 57));
     await _checkScreenshot(rc, 'clip_rect_simple');
   });
 
@@ -314,13 +350,15 @@ void main() async {
     RecordingCanvas rc = RecordingCanvas(screenRect);
     rc.clipRect(const Rect.fromLTRB(50, 50, 100, 100));
     rc.drawRect(const Rect.fromLTRB(20, 60, 120, 70), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(50, 60, 100, 70));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(50, 60, 100, 70));
     await _checkScreenshot(rc, 'clip_rect_intersects_paint_left_to_right');
 
     rc = RecordingCanvas(screenRect);
     rc.clipRect(const Rect.fromLTRB(50, 50, 100, 100));
     rc.drawRect(const Rect.fromLTRB(60, 20, 70, 200), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(60, 50, 70, 100));
+    rc.endRecording();
+    expect(rc.pictureBounds, const Rect.fromLTRB(60, 50, 70, 100));
     await _checkScreenshot(rc, 'clip_rect_intersects_paint_top_to_bottom');
   });
 
@@ -330,7 +368,9 @@ void main() async {
     rc.scale(2.0, 2.0);
     rc.clipRect(const Rect.fromLTRB(30, 30, 45, 45));
     rc.drawRect(const Rect.fromLTRB(10, 30, 60, 35), testPaint);
-    expect(rc.computePaintBounds(), const Rect.fromLTRB(60, 60, 90, 70));
+    rc.endRecording();
+
+    expect(rc.pictureBounds, const Rect.fromLTRB(60, 60, 90, 70));
     await _checkScreenshot(rc, 'clip_rects_intersect');
   });
 
@@ -340,8 +380,10 @@ void main() async {
     final Path path = Path();
     path.addRect(const Rect.fromLTRB(20, 30, 100, 110));
     rc.drawShadow(path, const Color(0xFFFF0000), 2.0, true);
+    rc.endRecording();
+
     expect(
-      rc.computePaintBounds(),
+      rc.pictureBounds,
       within(distance: 0.05, from: const Rect.fromLTRB(17.9, 28.5, 103.5, 114.1)),
     );
     await _checkScreenshot(rc, 'path_with_shadow');
@@ -361,8 +403,10 @@ void main() async {
       ..scale(1, -1)
       ..clipRect(const Rect.fromLTRB(0, 0, 100, 50))
       ..drawRect(const Rect.fromLTRB(0, 0, 100, 100), Paint());
+    rc.endRecording();
+
     expect(
-        rc.computePaintBounds(), const Rect.fromLTRB(0.0, 50.0, 100.0, 100.0));
+        rc.pictureBounds, const Rect.fromLTRB(0.0, 50.0, 100.0, 100.0));
     await _checkScreenshot(rc, 'scale_negative');
   });
 
@@ -374,8 +418,10 @@ void main() async {
       ..rotate(math.pi / 4.0)
       ..clipRect(const Rect.fromLTWH(-20, -20, 40, 40))
       ..drawRect(const Rect.fromLTWH(-80, -80, 160, 160), Paint());
+    rc.endRecording();
+
     expect(
-      rc.computePaintBounds(),
+      rc.pictureBounds,
       Rect.fromCircle(center: const Offset(50, 50), radius: 20 * math.sqrt(2)),
     );
     await _checkScreenshot(rc, 'clip_rect_rotated');
@@ -388,8 +434,10 @@ void main() async {
       ..translate(50, 50)
       ..rotate(math.pi / 4.0)
       ..drawLine(const Offset(0, 0), const Offset(20, 20), Paint());
+    rc.endRecording();
+
     expect(
-      rc.computePaintBounds(),
+      rc.pictureBounds,
       within(distance: 0.1, from: const Rect.fromLTRB(34.4, 48.6, 65.6, 79.7)),
     );
     await _checkScreenshot(rc, 'line_rotated');
@@ -418,6 +466,7 @@ void main() async {
           ..style = PaintingStyle.stroke
           ..strokeWidth = 2.0
           ..color = const Color(0xFF00FF00));
+    rc.endRecording();
     await _checkScreenshot(rc, 'reuse_path');
   });
 
@@ -440,6 +489,7 @@ void main() async {
           ..strokeWidth = 2.0
           ..color = const Color(0xFF404000));
     rc.restore();
+    rc.endRecording();
     await _checkScreenshot(rc, 'path_with_line_and_roundrect');
   });
 
@@ -536,7 +586,7 @@ void main() async {
         final SurfacePaint zeroSpreadPaint = SurfacePaint();
         painter(canvas, zeroSpreadPaint);
         sb.addPicture(Offset.zero, recorder.endRecording());
-        sb.addPicture(Offset.zero, drawBounds(canvas.computePaintBounds()));
+        sb.addPicture(Offset.zero, drawBounds(canvas.pictureBounds));
         sb.pop();
       }
 
@@ -550,7 +600,7 @@ void main() async {
           ..strokeWidth = 5.0;
         painter(canvas, thickStrokePaint);
         sb.addPicture(Offset.zero, recorder.endRecording());
-        sb.addPicture(Offset.zero, drawBounds(canvas.computePaintBounds()));
+        sb.addPicture(Offset.zero, drawBounds(canvas.pictureBounds));
         sb.pop();
       }
 
@@ -563,7 +613,7 @@ void main() async {
           ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 5.0);
         painter(canvas, maskFilterBlurPaint);
         sb.addPicture(Offset.zero, recorder.endRecording());
-        sb.addPicture(Offset.zero, drawBounds(canvas.computePaintBounds()));
+        sb.addPicture(Offset.zero, drawBounds(canvas.pictureBounds));
         sb.pop();
       }
 
@@ -578,7 +628,7 @@ void main() async {
           ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 5.0);
         painter(canvas, thickStrokeAndBlurPaint);
         sb.addPicture(Offset.zero, recorder.endRecording());
-        sb.addPicture(Offset.zero, drawBounds(canvas.computePaintBounds()));
+        sb.addPicture(Offset.zero, drawBounds(canvas.pictureBounds));
         sb.pop();
       }
 

--- a/lib/web_ui/test/mock_engine_canvas.dart
+++ b/lib/web_ui/test/mock_engine_canvas.dart
@@ -137,7 +137,10 @@ class MockEngineCanvas implements EngineCanvas {
 
   @override
   void drawRect(Rect rect, SurfacePaintData paint) {
-    _called('drawRect', arguments: paint);
+    _called('drawRect', arguments: <String, dynamic>{
+      'rect': rect,
+      'paint': paint,
+    });
   }
 
   @override


### PR DESCRIPTION
Optimize static content scrolling by pruning paint operations that are clipped out either by one of `Canvas.clip*` methods, or more commonly, by a clipping ancestor layer. This also adjusts the `_optimalCullRect` calculation. Previously we allowed the cull rect to grow indefinitely. With this change we also allow it to shrink.

Fixes https://github.com/flutter/flutter/issues/42987
Fixes https://github.com/flutter/flutter/issues/48516
Fixes partially https://github.com/flutter/flutter/issues/32338 (the provided sample can use a `SingleChildScrollView` with a `Column` of thousands of `Text` widgets with reasonable scrolling performance, but this PR does not fix the sample app as is)
Fixes partially https://github.com/flutter/flutter/issues/54584 (but we should also look at the canvas sandwich problem)

## How does this affect static content scrolling?

When scrolling we typically shift a picture inside a static clip. However, when viewed from the picture's coordinate system, the clip is moving around a static picture. This will occasionally cause repaints because `PersistedPicture` will conclude that the clip has moved to a location that was not previously painted and ask the canvas to paint at the new clip region. This logic existed there for the sake of painting on `<canvas>` where we did not want to allocate a canvas that's too big. However, when painting using DOM nodes we never took clipping into account and always created all the DOM nodes no matter whether they are visible or not.

This change eliminates a lot of nodes that are outside the visible range. We still need the optimization that predicts the next several clips, otherwise we'd be repainting on every frame. However, we can no longer allow the predicted clip to grow indefinitely because there are situations when the picture contains enormous amounts of paint operations, so if there's no upper bound for the clip region, we'll eventually jank again.

## How does this affect lazy-rendered scrolling?

Lazy-rendered scrolling already prunes paint operations at the framework level (e.g. via slivers), and so it doesn't need pruning at the engine level. So when we see that the picture fully fits in the clip (as is commonly the case for lazy-rendered content) we do not filter the paint ops. However, we have to track the paint bounds for every paint operation. We already compute these bounds but we "forget" them as soon as we compute them. With this change we store these bounds on every paint operation. Unfortunately this causes a 2-5% regression for lazy-rendered content. In subsequent PRs I will optimize these away, but I decided to not include them as part of this PR to minimize the risk of correctness regressions (it's harder to roll back a mega PR than small PRs).

## Benchmarks

The benchmark results can be found [here](https://docs.google.com/spreadsheets/d/10AXb-4ulJipM6ZtiieFEBXhmybB6-_gTV6HDQlgcQdA).