### PR TITLE
Eliminate fx_log_init call

### DIFF
--- a/shell/platform/fuchsia/dart_runner/main.cc
+++ b/shell/platform/fuchsia/dart_runner/main.cc
@@ -31,7 +31,6 @@ static void RegisterProfilerSymbols(const char* symbols_path,
 #endif  // !defined(DART_PRODUCT)
 
 int main(int argc, const char** argv) {
-  fx_log_init();
   async::Loop loop(&kAsyncLoopConfigAttachToCurrentThread);
 
   std::unique_ptr<trace::TraceProviderWithFdio> provider;


### PR DESCRIPTION
fx_log_init was already a no-op, and was eliminated in the latest
Fuchsia SDK.

See: https://fuchsia.googlesource.com/fuchsia/+/47e568475f535c00f53c86e19ff4d8736a7b261f