### PR TITLE
Implement Hashcode for TextEditingValue in InputConnectionAdaptor

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -75,6 +75,11 @@ class InputConnectionAdaptor extends BaseInputConnection {
           && composingEnd == value.composingEnd
           && text.equals(value.text);
     }
+
+    @Override
+    public int hashCode() {
+        return selectionStart + (selectionEnd << 8) + (composingStart << 16) + (composingEnd << 24) + text.hashCode();
+    }
   }
 
   @SuppressWarnings("deprecation")

--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -78,7 +78,14 @@ class InputConnectionAdaptor extends BaseInputConnection {
 
     @Override
     public int hashCode() {
-        return selectionStart + (selectionEnd << 8) + (composingStart << 16) + (composingEnd << 24) + text.hashCode();
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + selectionStart;
+      result = prime * result + selectionEnd;
+      result = prime * result + composingStart;
+      result = prime * result + composingEnd;
+      result = prime * result + text.hashCode();
+      return result;
     }
   }
 


### PR DESCRIPTION
The equals override requires hashcode override as well. This class is private and the hashcode is (currently) unused.