### PR TITLE
Update editing state in InputConnectionAdaptor.setSelection

### DIFF
--- a/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
+++ b/shell/platform/android/io/flutter/plugin/editing/InputConnectionAdaptor.java
@@ -287,6 +287,7 @@ class InputConnectionAdaptor extends BaseInputConnection {
   public boolean setSelection(int start, int end) {
     boolean result = super.setSelection(start, end);
     markDirty();
+    updateEditingState();
     return result;
   }
 


### PR DESCRIPTION
The BaseInputConnection superclass does not call endBatchEdit
in setSelection and therefore does not implicitly cause
InputConnectionAdaptor to send a state update.

Some input modes such as numeric keypads will not function without
these updates.