### PR TITLE
Add support for setting allow http flag in Dart VM

### DIFF
--- a/common/settings.h
+++ b/common/settings.h
@@ -99,6 +99,10 @@ struct Settings {
   bool endless_trace_buffer = false;
   bool enable_dart_profiling = false;
   bool disable_dart_asserts = false;
+
+  // Used to signal the embedder whether HTTP connections are disabled.
+  bool disable_http = false;
+
   // Used as the script URI in debug messages. Does not affect how the Dart code
   // is executed.
   std::string advisory_script_uri = "main.dart";

--- a/lib/io/BUILD.gn
+++ b/lib/io/BUILD.gn
@@ -9,6 +9,7 @@ source_set("io") {
   ]
 
   deps = [
+    "//flutter/fml",
     "//flutter/third_party/tonic",
     "//third_party/dart/runtime:dart_api",
     "//third_party/dart/runtime/bin:dart_io_api",

--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -4,11 +4,15 @@
 
 #include "flutter/lib/io/dart_io.h"
 
+#include "flutter/fml/logging.h"
+
 #include "third_party/dart/runtime/include/bin/dart_io_api.h"
 #include "third_party/dart/runtime/include/dart_api.h"
 #include "third_party/tonic/converter/dart_converter.h"
+#include "third_party/tonic/logging/dart_error.h"
 
 using tonic::ToDart;
+using tonic::LogIfError;
 
 namespace flutter {
 
@@ -16,7 +20,7 @@ void DartIO::InitForIsolate(bool disable_http) {
   Dart_Handle result = Dart_SetNativeResolver(
       Dart_LookupLibrary(ToDart("dart:io")), dart::bin::LookupIONative,
       dart::bin::LookupIONativeSymbol);
-  FML_CHECK(!tonic::LogIfError(result));
+  FML_CHECK(!LogIfError(result));
 
   // The SDK expects this field to represent "allow http" so we switch the
   // value.
@@ -24,7 +28,7 @@ void DartIO::InitForIsolate(bool disable_http) {
   Dart_Handle set_field_result =
       Dart_SetField(Dart_LookupLibrary(ToDart("dart:_http")),
                     ToDart("_embedderAllowsHttp"), allow_http_value);
-  FML_CHECK(!tonic::LogIfError(set_field_result));
+  FML_CHECK(!LogIfError(set_field_result));
 }
 
 }  // namespace flutter

--- a/lib/io/dart_io.cc
+++ b/lib/io/dart_io.cc
@@ -11,8 +11,8 @@
 #include "third_party/tonic/converter/dart_converter.h"
 #include "third_party/tonic/logging/dart_error.h"
 
-using tonic::ToDart;
 using tonic::LogIfError;
+using tonic::ToDart;
 
 namespace flutter {
 

--- a/lib/io/dart_io.h
+++ b/lib/io/dart_io.h
@@ -13,7 +13,7 @@ namespace flutter {
 
 class DartIO {
  public:
-  static void InitForIsolate();
+  static void InitForIsolate(bool disable_http);
 
  private:
   FML_DISALLOW_IMPLICIT_CONSTRUCTORS(DartIO);

--- a/runtime/dart_isolate.cc
+++ b/runtime/dart_isolate.cc
@@ -137,7 +137,8 @@ DartIsolate::DartIsolate(const Settings& settings,
                   settings.log_tag,
                   settings.unhandled_exception_callback,
                   DartVMRef::GetIsolateNameServer()),
-      is_root_isolate_(is_root_isolate) {
+      is_root_isolate_(is_root_isolate),
+      disable_http_(settings.disable_http) {
   phase_ = Phase::Uninitialized;
 }
 
@@ -261,7 +262,7 @@ bool DartIsolate::LoadLibraries() {
 
   tonic::DartState::Scope scope(this);
 
-  DartIO::InitForIsolate();
+  DartIO::InitForIsolate(disable_http_);
 
   DartUI::InitForIsolate(IsRootIsolate());
 

--- a/runtime/dart_isolate.h
+++ b/runtime/dart_isolate.h
@@ -402,6 +402,7 @@ class DartIsolate : public UIDartState {
   std::vector<std::unique_ptr<AutoFireClosure>> shutdown_callbacks_;
   fml::RefPtr<fml::TaskRunner> message_handling_task_runner_;
   const bool is_root_isolate_;
+  const bool disable_http_;
 
   DartIsolate(const Settings& settings,
               TaskRunners task_runners,

--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -237,6 +237,9 @@ Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
     }
   }
 
+  settings.disable_http =
+      command_line.HasOption(FlagForSwitch(Switch::DisableHttp));
+
   // Disable need for authentication codes for VM service communication, if
   // specified.
   settings.disable_service_auth_codes =

--- a/shell/common/switches.h
+++ b/shell/common/switches.h
@@ -174,6 +174,12 @@ DEF_SWITCH(DisableDartAsserts,
            "disabled. This flag may be specified if the user wishes to run "
            "with assertions disabled in the debug product mode (i.e. with JIT "
            "or DBC).")
+DEF_SWITCH(DisableHttp,
+           "disable-http",
+           "Dart VM has a master switch that can be set to disable insecure "
+           "HTTP and WebSocket protocols. Localhost or loopback addresses are "
+           "exempted. This flag can be specified if the embedder wants this "
+           "for a particular platform.")
 DEF_SWITCH(
     ForceMultithreading,
     "force-multithreading",


### PR DESCRIPTION
This is not a breaking change. It simply allows embedding code to set `disable_http` setting. Related to https://github.com/flutter/flutter/issues/54448.