### PR TITLE
Ban HTTP by default on iOS and Android

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
+++ b/shell/platform/android/io/flutter/embedding/engine/loader/FlutterLoader.java
@@ -199,6 +199,8 @@ public class FlutterLoader {
       if (settings.getLogTag() != null) {
         shellArgs.add("--log-tag=" + settings.getLogTag());
       }
+      // On Android, we ban HTTP connections by default.
+      shellArgs.add("--disable-http");
 
       String appStoragePath = PathUtils.getFilesDir(applicationContext);
       String engineCachesPath = PathUtils.getCacheDirectory(applicationContext);

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -132,6 +132,9 @@ static flutter::Settings DefaultSettingsForProcess(NSBundle* bundle = nil) {
     }
   }
 
+  // On iOS, we ban HTTP by default.
+  settings.disable_http = true;
+
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
   // There are no ownership concerns here as all mappings are owned by the
   // embedder and not the engine.


### PR DESCRIPTION
Prerequisites for merging this PR:

- https://github.com/flutter/flutter/pull/54522 needs to land.
- https://github.com/flutter/engine/pull/17653 needs to land.
- Announcement needs to go out to flutter-announce@ since this is a breaking change.