### PR TITLE
Enable required extension VK_KHR_external_semaphore_capabilities in shell_test

### DIFF
--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -60,7 +60,9 @@ ShellTestPlatformViewVulkan::OffScreenSurface::OffScreenSurface(
   }
 
   // Create the application instance.
-  std::vector<std::string> extensions = {};
+  std::vector<std::string> extensions = {
+      VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME,
+  };
 
   application_ = std::make_unique<vulkan::VulkanApplication>(
       *vk_, "FlutterTest", std::move(extensions));


### PR DESCRIPTION
This is a test-only issue. Found using validation layers:

`|        Message:  [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ] Object: VK_NULL_HANDLE (Type = 1) | Missing extension required by the device extension VK_KHR_external_semaphore: VK_KHR_external_semaphore_capabilities. The Vulkan spec states: All required extensions for each extension in the VkDeviceCreateInfo::ppEnabledExtensionNames list must also be present in that list. (https://www.khronos.org/registry/vulkan/specs/1.1-extensions/html/vkspec.html#VUID-vkCreateDevice-ppEnabledExtensionNames-01387)`