### PR TITLE
Use VK_LAYER_KHRONOS_validation only on Fuchsia

### DIFF
--- a/tools/fuchsia/fuchsia_libs.gni
+++ b/tools/fuchsia/fuchsia_libs.gni
@@ -72,29 +72,12 @@ common_libs = [
 
 vulkan_dist = "$fuchsia_sdk_base/dist"
 
+# Note that the other validation libraries in the Fuchsia SDK seem to have a bug right
+# now causing crashes, so it is only recommended that we use
+# VkLayer_khronos_validation.so until we have a confirmation that they are fixed.
 vulkan_validation_libs = [
   {
-    name = "VkLayer_core_validation.so"
-    path = rebase_path("$vulkan_dist")
-  },
-  {
     name = "VkLayer_khronos_validation.so"
-    path = rebase_path("$vulkan_dist")
-  },
-  {
-    name = "VkLayer_object_lifetimes.so"
-    path = rebase_path("$vulkan_dist")
-  },
-  {
-    name = "VkLayer_stateless_validation.so"
-    path = rebase_path("$vulkan_dist")
-  },
-  {
-    name = "VkLayer_thread_safety.so"
-    path = rebase_path("$vulkan_dist")
-  },
-  {
-    name = "VkLayer_unique_objects.so"
     path = rebase_path("$vulkan_dist")
   },
 ]
@@ -104,31 +87,7 @@ vulkan_data_dir =
 
 vulkan_icds = [
   {
-    path = rebase_path("$vulkan_data_dir/VkLayer_core_validation.json")
-    dest = "vulkan/explicit_layer.d/VkLayer_core_validation.json"
-  },
-  {
-    path = rebase_path("$vulkan_data_dir/VkLayer_object_lifetimes.json")
-    dest = "vulkan/explicit_layer.d/VkLayer_object_lifetimes.json"
-  },
-  {
-    path = rebase_path("$vulkan_data_dir/VkLayer_thread_safety.json")
-    dest = "vulkan/explicit_layer.d/VkLayer_thread_safety.json"
-  },
-  {
-    path = rebase_path("$vulkan_data_dir/VkLayer_stateless_validation.json")
-    dest = "vulkan/explicit_layer.d/VkLayer_stateless_validation.json"
-  },
-  {
-    path = rebase_path("$vulkan_data_dir/VkLayer_unique_objects.json")
-    dest = "vulkan/explicit_layer.d/VkLayer_unique_objects.json"
-  },
-  {
     path = rebase_path("$vulkan_data_dir/VkLayer_khronos_validation.json")
     dest = "vulkan/explicit_layer.d/VkLayer_khronos_validation.json"
-  },
-  {
-    path = rebase_path("$vulkan_data_dir/VkLayer_standard_validation.json")
-    dest = "vulkan/explicit_layer.d/VkLayer_standard_validation.json"
   },
 ]

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -43,13 +43,10 @@ static std::vector<std::string> InstanceOrDeviceLayersToEnable(
   // NOTE: The loader is sensitive to the ordering here. Please do not rearrange
   // this list.
 #if OS_FUCHSIA
-  // Fuchsia uses the updated Vulkan loader and validation layers which no
-  // longer includes the image validation layer.
-  const std::vector<std::string> candidates = {
-      "VK_LAYER_GOOGLE_threading",      "VK_LAYER_LUNARG_parameter_validation",
-      "VK_LAYER_LUNARG_object_tracker", "VK_LAYER_LUNARG_core_validation",
-      "VK_LAYER_LUNARG_device_limits",  "VK_LAYER_LUNARG_swapchain",
-      "VK_LAYER_GOOGLE_unique_objects"};
+  // The other layers in the Fuchsia SDK seem to have a bug right now causing
+  // crashes, so it is only recommended that we use VK_LAYER_KHRONOS_validation
+  // until we have a confirmation that they are fixed.
+  const std::vector<std::string> candidates = {"VK_LAYER_KHRONOS_validation"};
 #else
   const std::vector<std::string> candidates = {
       "VK_LAYER_GOOGLE_threading",      "VK_LAYER_LUNARG_parameter_validation",


### PR DESCRIPTION
There's an issue with the way Vulkan validation layers are packaged and/or built in the Fuchsia SDK, which means that using the layers individually results in bizarre crashes. If we use the monolithic `VK_LAYER_KHRONOS_validation` layer, it seems to work fine.

This workaround was suggested by the Fuchsia maintainer of the validation layers and he is aware of the crash issues.