### PR TITLE
Enable Vulkan validation layers for shell_test

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -7,7 +7,6 @@ import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/testing/testing.gni")
 import("//flutter/vulkan/config.gni")
 
-
 if (is_fuchsia) {
   import("//build/fuchsia/sdk.gni")
   import("//flutter/tools/fuchsia/fuchsia_archive.gni")

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -5,6 +5,8 @@
 import("//flutter/common/config.gni")
 import("//flutter/shell/gpu/gpu.gni")
 import("//flutter/testing/testing.gni")
+import("//flutter/vulkan/config.gni")
+
 
 if (is_fuchsia) {
   import("//build/fuchsia/sdk.gni")
@@ -267,6 +269,11 @@ if (enable_unittests) {
           dest = "assets/shelltest_screenshot.png"
         },
       ]
+
+      if (test_enable_vulkan) {
+        libraries = vulkan_validation_libs
+        resources += vulkan_icds
+      }
     }
   }
 

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "flutter/shell/common/shell_test_platform_view_vulkan.h"
+#include "flutter/vulkan/vulkan_utilities.h"
 
 namespace flutter {
 namespace testing {
@@ -18,7 +19,9 @@ ShellTestPlatformViewVulkan::ShellTestPlatformViewVulkan(
       create_vsync_waiter_(std::move(create_vsync_waiter)),
       vsync_clock_(vsync_clock),
       proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()),
-      shell_test_external_view_embedder_(shell_test_external_view_embedder) {}
+      shell_test_external_view_embedder_(shell_test_external_view_embedder) {
+        vulkan::SetValidationLayersEnabled(true);
+      }
 
 ShellTestPlatformViewVulkan::~ShellTestPlatformViewVulkan() = default;
 

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -19,7 +19,7 @@ ShellTestPlatformViewVulkan::ShellTestPlatformViewVulkan(
       create_vsync_waiter_(std::move(create_vsync_waiter)),
       vsync_clock_(vsync_clock),
       proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()),
-      shell_test_external_view_embedder_(shell_test_external_view_embedder) { }
+      shell_test_external_view_embedder_(shell_test_external_view_embedder) {}
 
 ShellTestPlatformViewVulkan::~ShellTestPlatformViewVulkan() = default;
 

--- a/shell/common/shell_test_platform_view_vulkan.cc
+++ b/shell/common/shell_test_platform_view_vulkan.cc
@@ -19,9 +19,7 @@ ShellTestPlatformViewVulkan::ShellTestPlatformViewVulkan(
       create_vsync_waiter_(std::move(create_vsync_waiter)),
       vsync_clock_(vsync_clock),
       proc_table_(fml::MakeRefCounted<vulkan::VulkanProcTable>()),
-      shell_test_external_view_embedder_(shell_test_external_view_embedder) {
-        vulkan::SetValidationLayersEnabled(true);
-      }
+      shell_test_external_view_embedder_(shell_test_external_view_embedder) { }
 
 ShellTestPlatformViewVulkan::~ShellTestPlatformViewVulkan() = default;
 
@@ -68,7 +66,8 @@ ShellTestPlatformViewVulkan::OffScreenSurface::OffScreenSurface(
   };
 
   application_ = std::make_unique<vulkan::VulkanApplication>(
-      *vk_, "FlutterTest", std::move(extensions));
+      *vk_, "FlutterTest", std::move(extensions), VK_MAKE_VERSION(1, 0, 0),
+      VK_MAKE_VERSION(1, 1, 0), true);
 
   if (!application_->IsValid() || !vk_->AreInstanceProcsSetup()) {
     // Make certain the application instance was created and it setup the

--- a/shell/platform/fuchsia/flutter/BUILD.gn
+++ b/shell/platform/fuchsia/flutter/BUILD.gn
@@ -34,10 +34,6 @@ flutter_runner("jit") {
     extra_defines += [ "FLUTTER_PROFILE" ]
   }
 
-  if (enable_vulkan_validation_layers) {
-    extra_defines += [ "VULKAN_VALIDATION_LAYERS_ENABLED" ]
-  }
-
   extra_deps = [
     "//third_party/dart/runtime:libdart_jit",
     "//third_party/dart/runtime/platform:libdart_platform_jit",
@@ -49,10 +45,6 @@ flutter_runner("jit_product") {
   product = true
 
   extra_defines = [ "DART_PRODUCT" ]
-
-  if (enable_vulkan_validation_layers) {
-    extra_defines += [ "VULKAN_VALIDATION_LAYERS_ENABLED" ]
-  }
 
   extra_deps = [
     "//third_party/dart/runtime:libdart_jit_product",
@@ -69,10 +61,6 @@ flutter_runner("aot") {
     extra_defines += [ "FLUTTER_PROFILE" ]
   }
 
-  if (enable_vulkan_validation_layers) {
-    extra_defines += [ "VULKAN_VALIDATION_LAYERS_ENABLED" ]
-  }
-
   extra_deps = [
     "//third_party/dart/runtime:libdart_precompiled_runtime",
     "//third_party/dart/runtime/platform:libdart_platform_precompiled_runtime",
@@ -84,10 +72,6 @@ flutter_runner("aot_product") {
   product = true
 
   extra_defines = [ "DART_PRODUCT" ]
-
-  if (enable_vulkan_validation_layers) {
-    extra_defines += [ "VULKAN_VALIDATION_LAYERS_ENABLED" ]
-  }
 
   extra_deps = [
     "//third_party/dart/runtime:libdart_precompiled_runtime_product",

--- a/tools/fuchsia/fuchsia_archive.gni
+++ b/tools/fuchsia/fuchsia_archive.gni
@@ -143,6 +143,10 @@ template("fuchsia_test_archive") {
       resources = invoker.resources
     }
 
+    if (defined(invoker.libraries)) {
+      libraries += invoker.libraries
+    }
+
     meta_dir = "//flutter/testing/fuchsia/meta"
     cmx_file = "$meta_dir/fuchsia_test.cmx"
   }

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -25,7 +25,7 @@ VulkanApplication::VulkanApplication(
   std::vector<VkExtensionProperties> supported_extensions =
       GetSupportedInstanceExtensions(vk);
   bool enable_instance_debugging =
-      (enable_validation_layers_ || IsDebuggingEnabled()) &&
+      enable_validation_layers_ &&
       ExtensionSupported(supported_extensions,
                          VulkanDebugReport::DebugExtensionName());
 

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -20,7 +20,10 @@ VulkanApplication::VulkanApplication(
     uint32_t application_version,
     uint32_t api_version,
     bool enable_validation_layers)
-    : vk(p_vk), api_version_(api_version), valid_(false), enable_validation_layers_(enable_validation_layers) {
+    : vk(p_vk),
+      api_version_(api_version),
+      valid_(false),
+      enable_validation_layers_(enable_validation_layers) {
   // Check if we want to enable debugging.
   std::vector<VkExtensionProperties> supported_extensions =
       GetSupportedInstanceExtensions(vk);
@@ -55,7 +58,8 @@ VulkanApplication::VulkanApplication(
 
   // Configure layers.
 
-  const std::vector<std::string> enabled_layers = InstanceLayersToEnable(vk, enable_validation_layers_);
+  const std::vector<std::string> enabled_layers =
+      InstanceLayersToEnable(vk, enable_validation_layers_);
 
   const char* layers[enabled_layers.size()];
 
@@ -173,7 +177,8 @@ std::vector<VkPhysicalDevice> VulkanApplication::GetPhysicalDevices() const {
 std::unique_ptr<VulkanDevice>
 VulkanApplication::AcquireFirstCompatibleLogicalDevice() const {
   for (auto device_handle : GetPhysicalDevices()) {
-    auto logical_device = std::make_unique<VulkanDevice>(vk, device_handle, enable_validation_layers_);
+    auto logical_device = std::make_unique<VulkanDevice>(
+        vk, device_handle, enable_validation_layers_);
     if (logical_device->IsValid()) {
       return logical_device;
     }

--- a/vulkan/vulkan_application.cc
+++ b/vulkan/vulkan_application.cc
@@ -18,13 +18,14 @@ VulkanApplication::VulkanApplication(
     const std::string& application_name,
     std::vector<std::string> enabled_extensions,
     uint32_t application_version,
-    uint32_t api_version)
-    : vk(p_vk), api_version_(api_version), valid_(false) {
+    uint32_t api_version,
+    bool enable_validation_layers)
+    : vk(p_vk), api_version_(api_version), valid_(false), enable_validation_layers_(enable_validation_layers) {
   // Check if we want to enable debugging.
   std::vector<VkExtensionProperties> supported_extensions =
       GetSupportedInstanceExtensions(vk);
   bool enable_instance_debugging =
-      IsDebuggingEnabled() &&
+      (enable_validation_layers_ || IsDebuggingEnabled()) &&
       ExtensionSupported(supported_extensions,
                          VulkanDebugReport::DebugExtensionName());
 
@@ -54,7 +55,7 @@ VulkanApplication::VulkanApplication(
 
   // Configure layers.
 
-  const std::vector<std::string> enabled_layers = InstanceLayersToEnable(vk);
+  const std::vector<std::string> enabled_layers = InstanceLayersToEnable(vk, enable_validation_layers_);
 
   const char* layers[enabled_layers.size()];
 
@@ -172,7 +173,7 @@ std::vector<VkPhysicalDevice> VulkanApplication::GetPhysicalDevices() const {
 std::unique_ptr<VulkanDevice>
 VulkanApplication::AcquireFirstCompatibleLogicalDevice() const {
   for (auto device_handle : GetPhysicalDevices()) {
-    auto logical_device = std::make_unique<VulkanDevice>(vk, device_handle);
+    auto logical_device = std::make_unique<VulkanDevice>(vk, device_handle, enable_validation_layers_);
     if (logical_device->IsValid()) {
       return logical_device;
     }

--- a/vulkan/vulkan_application.h
+++ b/vulkan/vulkan_application.h
@@ -28,7 +28,8 @@ class VulkanApplication {
                     const std::string& application_name,
                     std::vector<std::string> enabled_extensions,
                     uint32_t application_version = VK_MAKE_VERSION(1, 0, 0),
-                    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0));
+                    uint32_t api_version = VK_MAKE_VERSION(1, 0, 0),
+                    bool enable_validation_layers = false);
 
   ~VulkanApplication();
 
@@ -48,6 +49,7 @@ class VulkanApplication {
   uint32_t api_version_;
   std::unique_ptr<VulkanDebugReport> debug_report_;
   bool valid_;
+  bool enable_validation_layers_;
 
   std::vector<VkPhysicalDevice> GetPhysicalDevices() const;
   std::vector<VkExtensionProperties> GetSupportedInstanceExtensions(

--- a/vulkan/vulkan_debug_report.cc
+++ b/vulkan/vulkan_debug_report.cc
@@ -182,7 +182,7 @@ VulkanDebugReport::VulkanDebugReport(
     const VulkanProcTable& p_vk,
     const VulkanHandle<VkInstance>& application)
     : vk(p_vk), application_(application), valid_(false) {
-  if (!IsDebuggingEnabled() || !vk.CreateDebugReportCallbackEXT ||
+  if (!vk.CreateDebugReportCallbackEXT ||
       !vk.DestroyDebugReportCallbackEXT) {
     return;
   }

--- a/vulkan/vulkan_debug_report.cc
+++ b/vulkan/vulkan_debug_report.cc
@@ -182,8 +182,7 @@ VulkanDebugReport::VulkanDebugReport(
     const VulkanProcTable& p_vk,
     const VulkanHandle<VkInstance>& application)
     : vk(p_vk), application_(application), valid_(false) {
-  if (!vk.CreateDebugReportCallbackEXT ||
-      !vk.DestroyDebugReportCallbackEXT) {
+  if (!vk.CreateDebugReportCallbackEXT || !vk.DestroyDebugReportCallbackEXT) {
     return;
   }
 

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -71,7 +71,8 @@ VulkanDevice::VulkanDevice(VulkanProcTable& p_vk,
 #endif
   };
 
-  auto enabled_layers = DeviceLayersToEnable(vk, physical_device_, enable_validation_layers_);
+  auto enabled_layers =
+      DeviceLayersToEnable(vk, physical_device_, enable_validation_layers_);
 
   const char* layers[enabled_layers.size()];
 

--- a/vulkan/vulkan_device.cc
+++ b/vulkan/vulkan_device.cc
@@ -30,11 +30,13 @@ static uint32_t FindGraphicsQueueIndex(
 }
 
 VulkanDevice::VulkanDevice(VulkanProcTable& p_vk,
-                           VulkanHandle<VkPhysicalDevice> physical_device)
+                           VulkanHandle<VkPhysicalDevice> physical_device,
+                           bool enable_validation_layers)
     : vk(p_vk),
       physical_device_(std::move(physical_device)),
       graphics_queue_index_(std::numeric_limits<uint32_t>::max()),
-      valid_(false) {
+      valid_(false),
+      enable_validation_layers_(enable_validation_layers) {
   if (!physical_device_ || !vk.AreInstanceProcsSetup()) {
     return;
   }
@@ -69,7 +71,7 @@ VulkanDevice::VulkanDevice(VulkanProcTable& p_vk,
 #endif
   };
 
-  auto enabled_layers = DeviceLayersToEnable(vk, physical_device_);
+  auto enabled_layers = DeviceLayersToEnable(vk, physical_device_, enable_validation_layers_);
 
   const char* layers[enabled_layers.size()];
 

--- a/vulkan/vulkan_device.h
+++ b/vulkan/vulkan_device.h
@@ -19,7 +19,8 @@ class VulkanSurface;
 class VulkanDevice {
  public:
   VulkanDevice(VulkanProcTable& vk,
-               VulkanHandle<VkPhysicalDevice> physical_device);
+               VulkanHandle<VkPhysicalDevice> physical_device,
+               bool enable_validation_layers);
 
   ~VulkanDevice();
 
@@ -71,6 +72,7 @@ class VulkanDevice {
   VulkanHandle<VkCommandPool> command_pool_;
   uint32_t graphics_queue_index_;
   bool valid_;
+  bool enable_validation_layers_;
 
   std::vector<VkQueueFamilyProperties> GetQueueFamilyProperties() const;
 

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -93,8 +93,10 @@ static std::vector<std::string> InstanceOrDeviceLayersToEnable(
   return available_candidates;
 }
 
-std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk, bool enable_validation_layers) {
-  return InstanceOrDeviceLayersToEnable(vk, VK_NULL_HANDLE, enable_validation_layers);
+std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk,
+                                                bool enable_validation_layers) {
+  return InstanceOrDeviceLayersToEnable(vk, VK_NULL_HANDLE,
+                                        enable_validation_layers);
 }
 
 std::vector<std::string> DeviceLayersToEnable(
@@ -105,7 +107,8 @@ std::vector<std::string> DeviceLayersToEnable(
     return {};
   }
 
-  return InstanceOrDeviceLayersToEnable(vk, physical_device, enable_validation_layers);
+  return InstanceOrDeviceLayersToEnable(vk, physical_device,
+                                        enable_validation_layers);
 }
 
 }  // namespace vulkan

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -10,22 +10,12 @@
 
 namespace vulkan {
 
-static bool sValidationLayersEnabled = false;
-
 bool IsDebuggingEnabled() {
 #ifndef NDEBUG
   return true;
 #else
-  return ValidationLayersEnabled();
+  return false;
 #endif
-}
-
-void SetValidationLayersEnabled(bool enabled) {
-  sValidationLayersEnabled = enabled;
-}
-
-bool ValidationLayersEnabled() {
-  return sValidationLayersEnabled;
 }
 
 // Whether to show Vulkan validation layer info messages in addition
@@ -43,8 +33,9 @@ bool ValidationErrorsFatal() {
 
 static std::vector<std::string> InstanceOrDeviceLayersToEnable(
     const VulkanProcTable& vk,
-    VkPhysicalDevice physical_device) {
-  if (!ValidationLayersEnabled()) {
+    VkPhysicalDevice physical_device,
+    bool enable_validation_layers) {
+  if (!enable_validation_layers) {
     return {};
   }
 
@@ -110,18 +101,19 @@ static std::vector<std::string> InstanceOrDeviceLayersToEnable(
   return available_candidates;
 }
 
-std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk) {
-  return InstanceOrDeviceLayersToEnable(vk, VK_NULL_HANDLE);
+std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk, bool enable_validation_layers) {
+  return InstanceOrDeviceLayersToEnable(vk, VK_NULL_HANDLE, enable_validation_layers);
 }
 
 std::vector<std::string> DeviceLayersToEnable(
     const VulkanProcTable& vk,
-    const VulkanHandle<VkPhysicalDevice>& physical_device) {
+    const VulkanHandle<VkPhysicalDevice>& physical_device,
+    bool enable_validation_layers) {
   if (!physical_device) {
     return {};
   }
 
-  return InstanceOrDeviceLayersToEnable(vk, physical_device);
+  return InstanceOrDeviceLayersToEnable(vk, physical_device, enable_validation_layers);
 }
 
 }  // namespace vulkan

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -10,14 +10,6 @@
 
 namespace vulkan {
 
-bool IsDebuggingEnabled() {
-#ifndef NDEBUG
-  return true;
-#else
-  return false;
-#endif
-}
-
 // Whether to show Vulkan validation layer info messages in addition
 // to the error messages.
 bool ValidationLayerInfoMessagesEnabled() {

--- a/vulkan/vulkan_utilities.cc
+++ b/vulkan/vulkan_utilities.cc
@@ -10,14 +10,22 @@
 
 namespace vulkan {
 
+static bool sValidationLayersEnabled = false;
+
 bool IsDebuggingEnabled() {
 #ifndef NDEBUG
   return true;
-#elif defined(VULKAN_VALIDATION_LAYERS_ENABLED)
-  return true;
 #else
-  return false;
+  return ValidationLayersEnabled();
 #endif
+}
+
+void SetValidationLayersEnabled(bool enabled) {
+  sValidationLayersEnabled = enabled;
+}
+
+bool ValidationLayersEnabled() {
+  return sValidationLayersEnabled;
 }
 
 // Whether to show Vulkan validation layer info messages in addition
@@ -36,7 +44,7 @@ bool ValidationErrorsFatal() {
 static std::vector<std::string> InstanceOrDeviceLayersToEnable(
     const VulkanProcTable& vk,
     VkPhysicalDevice physical_device) {
-  if (!IsDebuggingEnabled()) {
+  if (!ValidationLayersEnabled()) {
     return {};
   }
 

--- a/vulkan/vulkan_utilities.h
+++ b/vulkan/vulkan_utilities.h
@@ -15,16 +15,15 @@
 namespace vulkan {
 
 bool IsDebuggingEnabled();
-void SetValidationLayersEnabled(bool enabled);
-bool ValidationLayersEnabled();
 bool ValidationLayerInfoMessagesEnabled();
 bool ValidationErrorsFatal();
 
-std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk);
+std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk, bool enable_validation_layers);
 
 std::vector<std::string> DeviceLayersToEnable(
     const VulkanProcTable& vk,
-    const VulkanHandle<VkPhysicalDevice>& physical_device);
+    const VulkanHandle<VkPhysicalDevice>& physical_device,
+    bool enable_validation_layers);
 
 }  // namespace vulkan
 

--- a/vulkan/vulkan_utilities.h
+++ b/vulkan/vulkan_utilities.h
@@ -14,7 +14,6 @@
 
 namespace vulkan {
 
-bool IsDebuggingEnabled();
 bool ValidationLayerInfoMessagesEnabled();
 bool ValidationErrorsFatal();
 

--- a/vulkan/vulkan_utilities.h
+++ b/vulkan/vulkan_utilities.h
@@ -17,7 +17,8 @@ namespace vulkan {
 bool ValidationLayerInfoMessagesEnabled();
 bool ValidationErrorsFatal();
 
-std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk, bool enable_validation_layers);
+std::vector<std::string> InstanceLayersToEnable(const VulkanProcTable& vk,
+                                                bool enable_validation_layers);
 
 std::vector<std::string> DeviceLayersToEnable(
     const VulkanProcTable& vk,

--- a/vulkan/vulkan_utilities.h
+++ b/vulkan/vulkan_utilities.h
@@ -15,6 +15,8 @@
 namespace vulkan {
 
 bool IsDebuggingEnabled();
+void SetValidationLayersEnabled(bool enabled);
+bool ValidationLayersEnabled();
 bool ValidationLayerInfoMessagesEnabled();
 bool ValidationErrorsFatal();
 


### PR DESCRIPTION
I'm not 100% clear on what the implied relationship between IsDebuggingEnabled() and ValidationLayersEnabled() should be here, but I've made validation layers strictly imply that debugging is enabled.