### PR TITLE
Adjust the GLFW build options

### DIFF
--- a/shell/platform/glfw/config.gni
+++ b/shell/platform/glfw/config.gni
@@ -9,5 +9,5 @@ declare_args() {
   # but it can be enabled for supported platforms (Windows, macOS, and Linux)
   # as an extra build artifact with this flag. The native toolkit shell will
   # still be built as well.
-  build_glfw_shell = (is_linux || is_win) && current_toolchain == host_toolchain
+  build_glfw_shell = is_linux && current_toolchain == host_toolchain
 }

--- a/shell/platform/linux/config/BUILD.gn
+++ b/shell/platform/linux/config/BUILD.gn
@@ -3,9 +3,12 @@
 # found in the LICENSE file.
 
 import("//build/config/linux/pkg_config.gni")
+import("//flutter/shell/platform/glfw/config.gni")
 
-pkg_config("x11") {
-  packages = [ "x11" ]
+if (build_glfw_shell) {
+  pkg_config("x11") {
+    packages = [ "x11" ]
+  }
 }
 
 pkg_config("gtk") {

--- a/tools/gn
+++ b/tools/gn
@@ -250,9 +250,8 @@ def to_gn_args(args):
       gn_args['dart_platform_sdk'] = not args.full_dart_sdk
     gn_args['full_dart_sdk'] = args.full_dart_sdk
 
-    if sys.platform == 'darwin':
-      if args.build_glfw_shell:
-        gn_args['build_glfw_shell'] = True
+    if args.build_glfw_shell is not None:
+      gn_args['build_glfw_shell'] = args.build_glfw_shell
 
     gn_args['stripped_symbols'] = args.stripped
 
@@ -340,8 +339,10 @@ def parse_args(args):
                       help='The IDE files to generate using GN. Use `gn gen help` and look for the --ide flag to' +
                       ' see supported IDEs. If this flag is not specified, a platform specific default is selected.')
 
-  parser.add_argument('--build-glfw-shell', dest='build_glfw_shell', default=False, action='store_true',
-                      help='Force building the GLFW shell on desktop platforms where it is not built by default.')
+  parser.add_argument('--build-glfw-shell', action='store_const', const=True,
+                      help='Build the GLFW shell on supported platforms where it is not built by default.')
+  parser.add_argument('--no-build-glfw-shell', dest='build_glfw_shell', action='store_const', const=False,
+                      help='Do not build the GLFW shell on platforms where it is built by default.')
 
   parser.add_argument('--bitcode', default=False, action='store_true',
                       help='Enable bitcode for iOS targets. On debug runtime modes, this will be a marker only.')


### PR DESCRIPTION
- Adds an explicit option for not building the GLFW embedding.
- Disables GLFW by default on Windows, where it's no longer the
  uploaded embedding.
- Move the X11 pkg-config, which is only used by the GLFW embedding,
  behind the GLFW build flag.