### PR TITLE
Add a gn flag to disable desktop embeddings

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//flutter/common/config.gni")
+import("//flutter/shell/platform/config.gni")
 
 if (is_fuchsia) {
   import("//build/fuchsia/sdk.gni")
@@ -63,10 +64,8 @@ group("flutter") {
   # If on the host, compile all unittests targets.
   if (current_toolchain == host_toolchain) {
     if (is_mac) {
-      public_deps += [
-        "//flutter/shell/platform/darwin:flutter_channels_unittests",
-        "//flutter/shell/platform/darwin/macos:flutter_desktop_darwin_unittests",
-      ]
+      public_deps +=
+          [ "//flutter/shell/platform/darwin:flutter_channels_unittests" ]
     }
 
     public_deps += [
@@ -75,21 +74,10 @@ group("flutter") {
       "//flutter/lib/ui:ui_unittests",
       "//flutter/runtime:runtime_unittests",
       "//flutter/shell/common:shell_unittests",
-      "//flutter/shell/platform/common/cpp:common_cpp_core_unittests",
-      "//flutter/shell/platform/common/cpp:common_cpp_unittests",
-      "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper_unittests",
       "//flutter/shell/platform/embedder:embedder_unittests",
-      "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw_unittests",
       "//flutter/testing:testing_unittests",
       "//flutter/third_party/txt:txt_unittests",
     ]
-
-    if (is_win) {
-      public_deps += [
-        "//flutter/shell/platform/windows:flutter_windows_unittests",
-        "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows_unittests",
-      ]
-    }
 
     if (!is_win) {
       public_deps += [
@@ -97,6 +85,26 @@ group("flutter") {
         "//flutter/shell/common:shell_benchmarks",
         "//flutter/third_party/txt:txt_benchmarks",
       ]
+    }
+
+    # Unit tests for desktop embeddings should only be built if the desktop
+    # embeddings are being built.
+    if (enable_desktop_embeddings) {
+      public_deps += [
+        "//flutter/shell/platform/common/cpp:common_cpp_core_unittests",
+        "//flutter/shell/platform/common/cpp:common_cpp_unittests",
+        "//flutter/shell/platform/common/cpp/client_wrapper:client_wrapper_unittests",
+        "//flutter/shell/platform/glfw/client_wrapper:client_wrapper_glfw_unittests",
+      ]
+      if (is_mac) {
+        public_deps += [ "//flutter/shell/platform/darwin/macos:flutter_desktop_darwin_unittests" ]
+      }
+      if (is_win) {
+        public_deps += [
+          "//flutter/shell/platform/windows:flutter_windows_unittests",
+          "//flutter/shell/platform/windows/client_wrapper:client_wrapper_windows_unittests",
+        ]
+      }
     }
   }
 }

--- a/shell/platform/BUILD.gn
+++ b/shell/platform/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/fuchsia/sdk.gni")
+import("//flutter/shell/platform/config.gni")
 
 group("platform") {
   if (is_mac || is_ios) {
@@ -14,18 +15,15 @@ group("platform") {
       "android",
     ]
   } else if (is_linux) {
-    if (is_fuchsia_host) {
-      # The linux build is not supported as part of the Fuchsia host build.
-      deps = []
-    } else {
-      deps = [
-        "linux",
-      ]
+    deps = []
+    if (enable_desktop_embeddings) {
+      deps += [ "linux" ]
     }
   } else if (is_win) {
-    deps = [
-      "windows",
-    ]
+    deps = []
+    if (enable_desktop_embeddings) {
+      deps += [ "windows" ]
+    }
   } else if (is_fuchsia) {
     deps = [
       "fuchsia",

--- a/shell/platform/config.gni
+++ b/shell/platform/config.gni
@@ -1,0 +1,8 @@
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+declare_args() {
+  # Whether or not to include desktop embedding targets in the build.
+  enable_desktop_embeddings = !is_fuchsia_host
+}

--- a/shell/platform/darwin/BUILD.gn
+++ b/shell/platform/darwin/BUILD.gn
@@ -4,6 +4,7 @@
 
 assert(is_mac || is_ios)
 
+import("//flutter/shell/platform/config.gni")
 import("//flutter/testing/testing.gni")
 
 group("darwin") {
@@ -13,9 +14,10 @@ group("darwin") {
     ]
   }
   if (is_mac) {
-    deps = [
-      "macos",
-    ]
+    deps = []
+    if (enable_desktop_embeddings) {
+      deps += [ "macos" ]
+    }
   }
 }
 

--- a/tools/gn
+++ b/tools/gn
@@ -250,6 +250,12 @@ def to_gn_args(args):
       gn_args['dart_platform_sdk'] = not args.full_dart_sdk
     gn_args['full_dart_sdk'] = args.full_dart_sdk
 
+    # Desktop embeddings can have more dependencies than the engine library,
+    # which can be problematic in some build environments (e.g., building on
+    # Linux will bring in pkg-config dependencies at generation time). These
+    # flags allow preventing those those targets from being part of the build
+    # tree.
+    gn_args['enable_desktop_embeddings'] = not args.disable_desktop_embeddings
     if args.build_glfw_shell is not None:
       gn_args['build_glfw_shell'] = args.build_glfw_shell
 
@@ -339,6 +345,8 @@ def parse_args(args):
                       help='The IDE files to generate using GN. Use `gn gen help` and look for the --ide flag to' +
                       ' see supported IDEs. If this flag is not specified, a platform specific default is selected.')
 
+  parser.add_argument('--disable-desktop-embeddings', default=False, action='store_true',
+                      help='Do not include desktop embeddings in the build.')
   parser.add_argument('--build-glfw-shell', action='store_const', const=True,
                       help='Build the GLFW shell on supported platforms where it is not built by default.')
   parser.add_argument('--no-build-glfw-shell', dest='build_glfw_shell', action='store_const', const=False,


### PR DESCRIPTION
Desktop embedding dependencies can trigger gn-generation-time
requiremenets; e.g., the Linux embeddings have pkg-config dependencies.
This can be problematic in some build environments, such as building
flutter_engine.so with a custom sysroot where those higher-level
dependencies aren't available.

This flag allows generating build files that don't have those
dependencies.