### PR TITLE
Remove layer integral offset snapping

### DIFF
--- a/flow/layers/image_filter_layer.cc
+++ b/flow/layers/image_filter_layer.cc
@@ -31,9 +31,6 @@ void ImageFilterLayer::Preroll(PrerollContext* context,
   if (!context->has_platform_view && context->raster_cache &&
       SkRect::Intersects(context->cull_rect, paint_bounds())) {
     SkMatrix ctm = matrix;
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    ctm = RasterCache::GetIntegralTransCTM(ctm);
-#endif
     context->raster_cache->Prepare(context, this, ctm);
   }
 }
@@ -41,12 +38,6 @@ void ImageFilterLayer::Preroll(PrerollContext* context,
 void ImageFilterLayer::Paint(PaintContext& context) const {
   TRACE_EVENT0("flutter", "ImageFilterLayer::Paint");
   FML_DCHECK(needs_painting());
-
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  SkAutoCanvasRestore save(context.leaf_nodes_canvas, true);
-  context.leaf_nodes_canvas->setMatrix(RasterCache::GetIntegralTransCTM(
-      context.leaf_nodes_canvas->getTotalMatrix()));
-#endif
 
   if (context.raster_cache) {
     const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -60,14 +60,11 @@ TEST_F(ImageFilterLayerTest, EmptyFilter) {
   layer->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
-                MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkMatrix()}},
                 MockCanvas::DrawCall{
-                    1, MockCanvas::SaveLayerData{child_bounds, filter_paint,
-                                                 nullptr, 2}},
+                    0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
+                                                 nullptr, 1}},
                 MockCanvas::DrawCall{
-                    2, MockCanvas::DrawPathData{child_path, child_paint}},
-                MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+                    1, MockCanvas::DrawPathData{child_path, child_paint}},
                 MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
             }));
 }
@@ -96,14 +93,11 @@ TEST_F(ImageFilterLayerTest, SimpleFilter) {
   layer->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
-                MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkMatrix()}},
                 MockCanvas::DrawCall{
-                    1, MockCanvas::SaveLayerData{child_bounds, filter_paint,
-                                                 nullptr, 2}},
+                    0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
+                                                 nullptr, 1}},
                 MockCanvas::DrawCall{
-                    2, MockCanvas::DrawPathData{child_path, child_paint}},
-                MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+                    1, MockCanvas::DrawPathData{child_path, child_paint}},
                 MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
             }));
 }
@@ -132,14 +126,11 @@ TEST_F(ImageFilterLayerTest, SimpleFilterBounds) {
   layer->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
-                MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkMatrix()}},
                 MockCanvas::DrawCall{
-                    1, MockCanvas::SaveLayerData{child_bounds, filter_paint,
-                                                 nullptr, 2}},
+                    0, MockCanvas::SaveLayerData{child_bounds, filter_paint,
+                                                 nullptr, 1}},
                 MockCanvas::DrawCall{
-                    2, MockCanvas::DrawPathData{child_path, child_paint}},
-                MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+                    1, MockCanvas::DrawPathData{child_path, child_paint}},
                 MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
             }));
 }
@@ -179,16 +170,13 @@ TEST_F(ImageFilterLayerTest, MultipleChildren) {
   layer->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector(
-                {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-                 MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkMatrix()}},
+                 {MockCanvas::DrawCall{
+                     0, MockCanvas::SaveLayerData{children_bounds, filter_paint,
+                                                  nullptr, 1}},
                  MockCanvas::DrawCall{
-                     1, MockCanvas::SaveLayerData{children_bounds, filter_paint,
-                                                  nullptr, 2}},
+                     1, MockCanvas::DrawPathData{child_path1, child_paint1}},
                  MockCanvas::DrawCall{
-                     2, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                 MockCanvas::DrawCall{
-                     2, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                 MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
+                     1, MockCanvas::DrawPathData{child_path2, child_paint2}},
                  MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
@@ -237,22 +225,16 @@ TEST_F(ImageFilterLayerTest, Nested) {
   layer1->Paint(paint_context());
   EXPECT_EQ(mock_canvas().draw_calls(),
             std::vector({
-                MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-                MockCanvas::DrawCall{1, MockCanvas::SetMatrixData{SkMatrix()}},
                 MockCanvas::DrawCall{
-                    1, MockCanvas::SaveLayerData{children_bounds, filter_paint1,
-                                                 nullptr, 2}},
+                    0, MockCanvas::SaveLayerData{children_bounds, filter_paint1,
+                                                 nullptr, 1}},
                 MockCanvas::DrawCall{
-                    2, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                MockCanvas::DrawCall{2, MockCanvas::SaveData{3}},
-                MockCanvas::DrawCall{3, MockCanvas::SetMatrixData{SkMatrix()}},
+                    1, MockCanvas::DrawPathData{child_path1, child_paint1}},
                 MockCanvas::DrawCall{
-                    3, MockCanvas::SaveLayerData{child_path2.getBounds(),
-                                                 filter_paint2, nullptr, 4}},
+                    1, MockCanvas::SaveLayerData{child_path2.getBounds(),
+                                                 filter_paint2, nullptr, 2}},
                 MockCanvas::DrawCall{
-                    4, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                MockCanvas::DrawCall{4, MockCanvas::RestoreData{3}},
-                MockCanvas::DrawCall{3, MockCanvas::RestoreData{2}},
+                    2, MockCanvas::DrawPathData{child_path2, child_paint2}},
                 MockCanvas::DrawCall{2, MockCanvas::RestoreData{1}},
                 MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}},
             }));

--- a/flow/layers/image_filter_layer_unittests.cc
+++ b/flow/layers/image_filter_layer_unittests.cc
@@ -168,16 +168,16 @@ TEST_F(ImageFilterLayerTest, MultipleChildren) {
   SkPaint filter_paint;
   filter_paint.setImageFilter(layer_filter);
   layer->Paint(paint_context());
-  EXPECT_EQ(mock_canvas().draw_calls(),
-            std::vector(
-                 {MockCanvas::DrawCall{
-                     0, MockCanvas::SaveLayerData{children_bounds, filter_paint,
-                                                  nullptr, 1}},
-                 MockCanvas::DrawCall{
-                     1, MockCanvas::DrawPathData{child_path1, child_paint1}},
-                 MockCanvas::DrawCall{
-                     1, MockCanvas::DrawPathData{child_path2, child_paint2}},
-                 MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
+  EXPECT_EQ(
+      mock_canvas().draw_calls(),
+      std::vector({MockCanvas::DrawCall{
+                       0, MockCanvas::SaveLayerData{children_bounds,
+                                                    filter_paint, nullptr, 1}},
+                   MockCanvas::DrawCall{
+                       1, MockCanvas::DrawPathData{child_path1, child_paint1}},
+                   MockCanvas::DrawCall{
+                       1, MockCanvas::DrawPathData{child_path2, child_paint2}},
+                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}}));
 }
 
 TEST_F(ImageFilterLayerTest, Nested) {

--- a/flow/layers/opacity_layer_unittests.cc
+++ b/flow/layers/opacity_layer_unittests.cc
@@ -58,10 +58,6 @@ TEST_F(OpacityLayerTest, FullyOpaque) {
   const SkMatrix initial_transform = SkMatrix::MakeTrans(0.5f, 0.5f);
   const SkMatrix layer_transform =
       SkMatrix::MakeTrans(layer_offset.fX, layer_offset.fY);
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  const SkMatrix integral_layer_transform = RasterCache::GetIntegralTransCTM(
-      SkMatrix::Concat(initial_transform, layer_transform));
-#endif
   const SkPaint child_paint = SkPaint(SkColors::kGreen);
   const SkRect expected_layer_bounds =
       layer_transform.mapRect(child_path.getBounds());
@@ -86,10 +82,6 @@ TEST_F(OpacityLayerTest, FullyOpaque) {
   auto expected_draw_calls = std::vector(
       {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
        MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{layer_transform}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-       MockCanvas::DrawCall{
-           1, MockCanvas::SetMatrixData{integral_layer_transform}},
-#endif
        MockCanvas::DrawCall{
            1, MockCanvas::SaveLayerData{opacity_bounds, opacity_paint, nullptr,
                                         2}},
@@ -107,10 +99,6 @@ TEST_F(OpacityLayerTest, FullyTransparent) {
   const SkMatrix initial_transform = SkMatrix::MakeTrans(0.5f, 0.5f);
   const SkMatrix layer_transform =
       SkMatrix::MakeTrans(layer_offset.fX, layer_offset.fY);
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  const SkMatrix integral_layer_transform = RasterCache::GetIntegralTransCTM(
-      SkMatrix::Concat(initial_transform, layer_transform));
-#endif
   const SkPaint child_paint = SkPaint(SkColors::kGreen);
   const SkRect expected_layer_bounds =
       layer_transform.mapRect(child_path.getBounds());
@@ -133,10 +121,6 @@ TEST_F(OpacityLayerTest, FullyTransparent) {
   auto expected_draw_calls = std::vector(
       {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
        MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{layer_transform}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-       MockCanvas::DrawCall{
-           1, MockCanvas::SetMatrixData{integral_layer_transform}},
-#endif
        MockCanvas::DrawCall{1, MockCanvas::SaveData{2}},
        MockCanvas::DrawCall{
            2, MockCanvas::ClipRectData{kEmptyRect, SkClipOp::kIntersect,
@@ -155,10 +139,6 @@ TEST_F(OpacityLayerTest, HalfTransparent) {
   const SkMatrix initial_transform = SkMatrix::MakeTrans(0.5f, 0.5f);
   const SkMatrix layer_transform =
       SkMatrix::MakeTrans(layer_offset.fX, layer_offset.fY);
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  const SkMatrix integral_layer_transform = RasterCache::GetIntegralTransCTM(
-      SkMatrix::Concat(initial_transform, layer_transform));
-#endif
   const SkPaint child_paint = SkPaint(SkColors::kGreen);
   const SkRect expected_layer_bounds =
       layer_transform.mapRect(child_path.getBounds());
@@ -185,10 +165,6 @@ TEST_F(OpacityLayerTest, HalfTransparent) {
   auto expected_draw_calls = std::vector(
       {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
        MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{layer_transform}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-       MockCanvas::DrawCall{
-           1, MockCanvas::SetMatrixData{integral_layer_transform}},
-#endif
        MockCanvas::DrawCall{
            1, MockCanvas::SaveLayerData{opacity_bounds, opacity_paint, nullptr,
                                         2}},
@@ -211,13 +187,6 @@ TEST_F(OpacityLayerTest, Nested) {
       SkMatrix::MakeTrans(layer1_offset.fX, layer1_offset.fY);
   const SkMatrix layer2_transform =
       SkMatrix::MakeTrans(layer2_offset.fX, layer2_offset.fY);
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  const SkMatrix integral_layer1_transform = RasterCache::GetIntegralTransCTM(
-      SkMatrix::Concat(initial_transform, layer1_transform));
-  const SkMatrix integral_layer2_transform = RasterCache::GetIntegralTransCTM(
-      SkMatrix::Concat(SkMatrix::Concat(initial_transform, layer1_transform),
-                       layer2_transform));
-#endif
   const SkPaint child1_paint = SkPaint(SkColors::kRed);
   const SkPaint child2_paint = SkPaint(SkColors::kBlue);
   const SkPaint child3_paint = SkPaint(SkColors::kGreen);
@@ -278,10 +247,6 @@ TEST_F(OpacityLayerTest, Nested) {
   auto expected_draw_calls = std::vector(
       {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
        MockCanvas::DrawCall{1, MockCanvas::ConcatMatrixData{layer1_transform}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-       MockCanvas::DrawCall{
-           1, MockCanvas::SetMatrixData{integral_layer1_transform}},
-#endif
        MockCanvas::DrawCall{
            1, MockCanvas::SaveLayerData{opacity1_bounds, opacity1_paint,
                                         nullptr, 2}},
@@ -289,10 +254,6 @@ TEST_F(OpacityLayerTest, Nested) {
            2, MockCanvas::DrawPathData{child1_path, child1_paint}},
        MockCanvas::DrawCall{2, MockCanvas::SaveData{3}},
        MockCanvas::DrawCall{3, MockCanvas::ConcatMatrixData{layer2_transform}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-       MockCanvas::DrawCall{
-           3, MockCanvas::SetMatrixData{integral_layer2_transform}},
-#endif
        MockCanvas::DrawCall{
            3, MockCanvas::SaveLayerData{opacity2_bounds, opacity2_paint,
                                         nullptr, 4}},

--- a/flow/layers/picture_layer.cc
+++ b/flow/layers/picture_layer.cc
@@ -26,9 +26,6 @@ void PictureLayer::Preroll(PrerollContext* context, const SkMatrix& matrix) {
 
     SkMatrix ctm = matrix;
     ctm.postTranslate(offset_.x(), offset_.y());
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    ctm = RasterCache::GetIntegralTransCTM(ctm);
-#endif
     cache->Prepare(context->gr_context, sk_picture, ctm,
                    context->dst_color_space, is_complex_, will_change_);
   }
@@ -44,10 +41,6 @@ void PictureLayer::Paint(PaintContext& context) const {
 
   SkAutoCanvasRestore save(context.leaf_nodes_canvas, true);
   context.leaf_nodes_canvas->translate(offset_.x(), offset_.y());
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-  context.leaf_nodes_canvas->setMatrix(RasterCache::GetIntegralTransCTM(
-      context.leaf_nodes_canvas->getTotalMatrix()));
-#endif
 
   if (context.raster_cache) {
     const SkMatrix& ctm = context.leaf_nodes_canvas->getTotalMatrix();

--- a/flow/layers/picture_layer_unittests.cc
+++ b/flow/layers/picture_layer_unittests.cc
@@ -11,10 +11,6 @@
 #include "flutter/testing/mock_canvas.h"
 #include "third_party/skia/include/core/SkPicture.h"
 
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-#include "flutter/flow/raster_cache.h"
-#endif
-
 namespace flutter {
 namespace testing {
 
@@ -89,11 +85,6 @@ TEST_F(PictureLayerTest, SimplePicture) {
       {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
        MockCanvas::DrawCall{1,
                             MockCanvas::ConcatMatrixData{layer_offset_matrix}},
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-       MockCanvas::DrawCall{
-           1, MockCanvas::SetMatrixData{RasterCache::GetIntegralTransCTM(
-                  layer_offset_matrix)}},
-#endif
        MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}});
   EXPECT_EQ(mock_canvas().draw_calls(), expected_draw_calls);
 }

--- a/flow/layers/picture_layer_unittests.cc
+++ b/flow/layers/picture_layer_unittests.cc
@@ -81,11 +81,11 @@ TEST_F(PictureLayerTest, SimplePicture) {
   EXPECT_FALSE(layer->needs_system_composite());
 
   layer->Paint(paint_context());
-  auto expected_draw_calls = std::vector(
-      {MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
-       MockCanvas::DrawCall{1,
-                            MockCanvas::ConcatMatrixData{layer_offset_matrix}},
-       MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}});
+  auto expected_draw_calls =
+      std::vector({MockCanvas::DrawCall{0, MockCanvas::SaveData{1}},
+                   MockCanvas::DrawCall{
+                       1, MockCanvas::ConcatMatrixData{layer_offset_matrix}},
+                   MockCanvas::DrawCall{1, MockCanvas::RestoreData{0}}});
   EXPECT_EQ(mock_canvas().draw_calls(), expected_draw_calls);
 }
 

--- a/flow/raster_cache.h
+++ b/flow/raster_cache.h
@@ -62,13 +62,6 @@ class RasterCache {
     return bounds;
   }
 
-  static SkMatrix GetIntegralTransCTM(const SkMatrix& ctm) {
-    SkMatrix result = ctm;
-    result[SkMatrix::kMTransX] = SkScalarRoundToScalar(ctm.getTranslateX());
-    result[SkMatrix::kMTransY] = SkScalarRoundToScalar(ctm.getTranslateY());
-    return result;
-  }
-
   // Return true if the cache is generated.
   //
   // We may return false and not generate the cache if

--- a/flow/raster_cache_key.h
+++ b/flow/raster_cache_key.h
@@ -15,11 +15,8 @@ template <typename ID>
 class RasterCacheKey {
  public:
   RasterCacheKey(ID id, const SkMatrix& ctm) : id_(id), matrix_(ctm) {
-    matrix_[SkMatrix::kMTransX] = SkScalarFraction(ctm.getTranslateX());
-    matrix_[SkMatrix::kMTransY] = SkScalarFraction(ctm.getTranslateY());
-#ifndef SUPPORT_FRACTIONAL_TRANSLATION
-    FML_DCHECK(matrix_.getTranslateX() == 0 && matrix_.getTranslateY() == 0);
-#endif
+    matrix_[SkMatrix::kMTransX] = 0;
+    matrix_[SkMatrix::kMTransY] = 0;
   }
 
   ID id() const { return id_; }


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/53288 and https://github.com/flutter/flutter/issues/41654. It removes the problematic `GetIntegralTransCTM`, but preserves the rect round-out in `RasterCacheResult::draw` for performance considerations: the average frame raster time doesn't change much but the worst frame raster time significantly regressed if rect round-out is removed. That's probably because a new shader needs to be compiled to draw raster cache with fractional offsets.

## Correctness test
The fixing of https://github.com/flutter/flutter/issues/41654 is verified by running the unit test in https://github.com/flutter/flutter/issues/41654#issuecomment-558416745 against the locally built engine. That unit test will be added to the framework repo once this PR is rolled into the framework.

This PR may change golden images so manual engine and google rolls may be required.

## Performance test
The performance impact of this PR is measured by A/B testing the following framework devicelab test:
```
../../bin/cache/dart-sdk/bin/dart bin/run.dart --ab=10 --local-engine=android_profile -t complex_layout_scroll_perf__timeline_summary
```

We tested 3 variants: (1) an engine without any change (2) an engine with this PR that removes integral snapping (3) an engine with both this PR, and additionally removes the rect round-out in `RasterCacheResult::draw`.

The `average_frame_rasterizer_time_millis` of those 3 variants are as follows:
1. 4.98 (1.07%)	5.06 (1.60%)	0.98x
2. 5.02 (1.30%)	5.14 (1.24%)	0.98x
3. 4.99 (1.78%)	5.15 (0.98%)	0.97x	

The `worst_frame_rasterizer_time_millis` of those 3 variants are as follows:
1. 21.59 (27.66%)	20.12 (6.18%)	1.07x	
2. 20.47 (7.70%)	21.88 (11.62%)	0.94x	
3. 19.81 (10.79%)	29.56 (12.06%)	0.67x

Here are full A/B test results:
1. an engine without any change
```
═════════════════════════╡ ••• Final A/B results ••• ╞══════════════════════════

Score	Average A (noise)	Average B (noise)	Speed-up
average_frame_build_time_millis	2.44 (4.12%)	2.64 (3.44%)	0.93x	
worst_frame_build_time_millis	23.65 (5.20%)	25.50 (9.14%)	0.93x	
90th_percentile_frame_build_time_millis	4.14 (10.95%)	4.41 (8.15%)	0.94x	
99th_percentile_frame_build_time_millis	22.01 (3.96%)	23.25 (4.40%)	0.95x	
average_frame_rasterizer_time_millis	4.98 (1.07%)	5.06 (1.60%)	0.98x	
worst_frame_rasterizer_time_millis	21.59 (27.66%)	20.12 (6.18%)	1.07x	
90th_percentile_frame_rasterizer_time_millis	6.92 (5.69%)	7.01 (4.53%)	0.99x	
99th_percentile_frame_rasterizer_time_millis	12.85 (18.10%)	11.64 (5.30%)	1.10x	
average_vsync_transitions_missed	1.01 (4.23%)	1.04 (7.90%)	0.98x	
90th_percentile_vsync_transitions_missed	1.10 (27.27%)	1.20 (33.33%)	0.92x	
99th_percentile_vsync_transitions_missed	1.10 (27.27%)	1.20 (33.33%)	0.92x	
```

2. an engine with this PR that removes integral snapping
```
═════════════════════════╡ ••• Final A/B results ••• ╞══════════════════════════

Score	Average A (noise)	Average B (noise)	Speed-up
average_frame_build_time_millis	2.54 (3.23%)	2.69 (4.24%)	0.94x
worst_frame_build_time_millis	24.00 (8.37%)	26.29 (10.64%)	0.91x
90th_percentile_frame_build_time_millis	4.64 (10.39%)	4.68 (11.77%)	0.99x
99th_percentile_frame_build_time_millis	21.53 (2.73%)	23.02 (5.77%)	0.94x
average_frame_rasterizer_time_millis	5.02 (1.30%)	5.14 (1.24%)	0.98x
worst_frame_rasterizer_time_millis	20.47 (7.70%)	21.88 (11.62%)	0.94x
90th_percentile_frame_rasterizer_time_millis	6.92 (4.96%)	7.03 (5.31%)	0.98x
99th_percentile_frame_rasterizer_time_millis	13.52 (7.95%)	13.86 (8.76%)	0.98x
average_vsync_transitions_missed	1.04 (5.44%)	1.07 (5.08%)	0.97x
90th_percentile_vsync_transitions_missed	1.10 (27.27%)	1.10 (27.27%)	1.00x
99th_percentile_vsync_transitions_missed	1.30 (35.25%)	1.60 (30.62%)	0.81x
```

3. an engine with both this PR, and additionally removes the rect round-out in `RasterCacheResult::draw`
```
═════════════════════════╡ ••• Final A/B results ••• ╞══════════════════════════

Score	Average A (noise)	Average B (noise)	Speed-up
average_frame_build_time_millis	2.48 (2.54%)	2.72 (3.41%)	0.91x	
worst_frame_build_time_millis	23.87 (7.15%)	26.75 (6.55%)	0.89x	
90th_percentile_frame_build_time_millis	4.33 (10.48%)	4.60 (9.75%)	0.94x	
99th_percentile_frame_build_time_millis	21.71 (2.27%)	23.53 (4.65%)	0.92x	
average_frame_rasterizer_time_millis	4.99 (1.78%)	5.15 (0.98%)	0.97x	
worst_frame_rasterizer_time_millis	19.81 (10.79%)	29.56 (12.06%)	0.67x	
90th_percentile_frame_rasterizer_time_millis	6.97 (4.12%)	6.77 (4.08%)	1.03x	
99th_percentile_frame_rasterizer_time_millis	13.18 (9.38%)	13.96 (9.41%)	0.94x	
average_vsync_transitions_missed	1.00 (0.00%)	1.12 (9.21%)	0.90x	
90th_percentile_vsync_transitions_missed	1.00 (0.00%)	1.40 (34.99%)	0.71x	
99th_percentile_vsync_transitions_missed	1.00 (0.00%)	1.70 (26.96%)	0.59x	
```