### PR TITLE
Use the right constant for macOS event timestamps

### DIFF
--- a/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterViewController.mm
@@ -405,7 +405,7 @@ static void CommonInit(FlutterViewController* controller) {
   FlutterPointerEvent flutterEvent = {
       .struct_size = sizeof(flutterEvent),
       .phase = phase,
-      .timestamp = static_cast<size_t>(event.timestamp * NSEC_PER_MSEC),
+      .timestamp = static_cast<size_t>(event.timestamp * USEC_PER_SEC),
       .x = locationInBackingCoordinates.x,
       .y = -locationInBackingCoordinates.y,  // convertPointToBacking makes this negative.
       .device_kind = kFlutterPointerDeviceKindMouse,


### PR DESCRIPTION
The NSEvent->Flutter event conversion code for pointer events was
multiplying seconds by nanoseconds per milliseconds. While this does end
up giving the right number of microseconds, it's a very confusing way to
write it.