### PR TITLE
Test PR for switching the engine platform file to the NNBD version

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -52,6 +52,7 @@ compiled_action("generate_snapshot_bin") {
   ]
 
   args = [
+    "--enable-experiment=non-nullable",
     "--snapshot_kind=core",
     "--enable_mirrors=false",
     "--vm_snapshot_data=" + rebase_path(vm_snapshot_data),
@@ -233,23 +234,6 @@ source_set("snapshot") {
             get_target_outputs(":platform_strong_dill_linkable")
 }
 
-compile_platform("non_strong_platform") {
-  single_root_scheme = "org-dartlang-sdk"
-  single_root_base = rebase_path("../../../")
-  libraries_specification_uri =
-      "org-dartlang-sdk:///flutter/lib/snapshot/libraries.json"
-
-  outputs = [
-    "$root_out_dir/flutter_patched_sdk/platform.dill",
-    "$root_out_dir/flutter_patched_sdk/vm_outline.dill",
-  ]
-
-  args = [
-    "--target=flutter",
-    "dart:core",
-  ]
-}
-
 compile_platform("strong_platform") {
   single_root_scheme = "org-dartlang-sdk"
   single_root_base = rebase_path("../../../")
@@ -265,6 +249,7 @@ compile_platform("strong_platform") {
       flutter_runtime_mode == "release" || flutter_runtime_mode == "jit_release"
   allow_causal_async_stacks = !is_runtime_mode_release
   args = [
+    "--enable-experiment=non-nullable",
     "--target=flutter",
     "-Ddart.vm.product=$is_runtime_mode_release",
     "-Ddart.developer.causal_async_stacks=$allow_causal_async_stacks",

--- a/lib/snapshot/libraries.json
+++ b/lib/snapshot/libraries.json
@@ -4,154 +4,154 @@
   "flutter": {
     "libraries": {
       "_builtin": {
-        "uri": "../../../third_party/dart/sdk/lib/_internal/vm/bin/builtin.dart"
-      },
-      "core": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/core_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/array.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/array_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/bigint_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/bool_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/date_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/double.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/double_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/errors_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/expando_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/function.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/function_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/growable_array.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/identical_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/immutable_map.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/integers.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/integers_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/invocation_mirror_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/lib_prefix.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/map_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/null_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/object_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/regexp_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/stacktrace.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/stopwatch_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/string_buffer_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/string_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/type_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/uri_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/weak_property.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/core/core.dart"
-      },
-      "async": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/async_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/deferred_load_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/schedule_microtask_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_patch.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/async/async.dart"
-      },
-      "collection": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/collection_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/compact_hash.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/collection/collection.dart"
-      },
-      "ffi": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/ffi/ffi.dart"
-      },
-      "typed_data": {
-        "patches": "../../../third_party/dart/sdk/lib/_internal/vm/lib/typed_data_patch.dart",
-        "uri": "../../../third_party/dart/sdk/lib/typed_data/typed_data.dart"
-      },
-      "nativewrappers": {
-        "uri": "../../../third_party/dart/sdk/lib/html/dartium/nativewrappers.dart"
-      },
-      "mirrors": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_impl.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/mirror_reference.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/mirrors/mirrors.dart"
-      },
-      "developer": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/developer.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/profiler.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/timeline.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/developer/developer.dart"
-      },
-      "isolate": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/isolate_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_impl.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/isolate/isolate.dart"
-      },
-      "_vmservice": {
-        "uri": "../../../third_party/dart/sdk/lib/vmservice/vmservice.dart"
-      },
-      "wasm": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/wasm_patch.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/wasm/wasm.dart"
-      },
-      "io": {
-        "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/common_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/directory_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/eventhandler_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/file_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/file_system_entity_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/filter_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/io_service_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/namespace_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/platform_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/process_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/socket_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/stdio_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/secure_socket_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/bin/sync_socket_patch.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/io/io.dart"
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/builtin.dart"
       },
       "_internal": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/internal/internal.dart",
         "patches": [
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/internal_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/class_id_fasta.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/print_patch.dart",
-          "../../../third_party/dart/sdk/lib/_internal/vm/lib/symbol_patch.dart",
-          "../../../third_party/dart/sdk/lib/internal/patch.dart"
-        ],
-        "uri": "../../../third_party/dart/sdk/lib/internal/internal.dart"
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/internal_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/class_id_fasta.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/print_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/symbol_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/internal/patch.dart"
+        ]
+      },
+      "async": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/async/async.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/async_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/deferred_load_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/schedule_microtask_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/timer_patch.dart"
+        ]
+      },
+      "collection": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/collection/collection.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/collection_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/compact_hash.dart"
+        ]
       },
       "convert": {
-        "patches": "../../../third_party/dart/sdk/lib/_internal/vm/lib/convert_patch.dart",
-        "uri": "../../../third_party/dart/sdk/lib/convert/convert.dart"
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/convert/convert.dart",
+        "patches": "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/convert_patch.dart"
       },
-      "profiler": {
-        "uri": "../../../third_party/dart/sdk/lib/profiler/profiler.dart"
+      "core": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/core/core.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/core_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/array.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/array_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/bigint_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/bool_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/date_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/double.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/double_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/errors_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/expando_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/function.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/function_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/growable_array.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/identical_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/immutable_map.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/integers.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/integers_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/invocation_mirror_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/lib_prefix.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/map_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/null_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/object_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/regexp_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/stacktrace.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/stopwatch_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/string_buffer_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/string_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/type_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/uri_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/weak_property.dart"
+        ]
       },
-      "math": {
-        "patches": "../../../third_party/dart/sdk/lib/_internal/vm/lib/math_patch.dart",
-        "uri": "../../../third_party/dart/sdk/lib/math/math.dart"
+      "developer": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/developer/developer.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/developer.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/profiler.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/timeline.dart"
+        ]
+      },
+      "ffi": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/ffi/ffi.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/ffi_native_type_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/ffi_patch.dart"
+        ]
+      },
+      "wasm": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/wasm/wasm.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/wasm_patch.dart"
+        ]
       },
       "_http": {
-        "uri": "../../../third_party/dart/sdk/lib/_http/http.dart"
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/_http/http.dart"
+      },
+      "io": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/io/io.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/common_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/directory_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/eventhandler_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/file_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/file_system_entity_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/filter_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/io_service_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/namespace_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/platform_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/process_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/socket_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/stdio_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/secure_socket_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/sync_socket_patch.dart"
+        ]
+      },
+      "isolate": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/isolate/isolate.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/isolate_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/timer_impl.dart"
+        ]
+      },
+      "math": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/math/math.dart",
+        "patches": "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/math_patch.dart"
+      },
+      "mirrors": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/mirrors/mirrors.dart",
+        "patches": [
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/mirrors_patch.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/mirrors_impl.dart",
+          "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/mirror_reference.dart"
+        ]
+      },
+      "nativewrappers": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/html/dartium/nativewrappers.dart"
+      },
+      "profiler": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/profiler/profiler.dart"
+      },
+      "typed_data": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/typed_data/typed_data.dart",
+        "patches": "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/typed_data_patch.dart"
       },
       "ui": {
         "uri": "../../lib/ui/ui.dart"
       },
+      "_vmservice": {
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/vmservice/vmservice.dart"
+      },
       "vmservice_io": {
-        "uri": "../../../third_party/dart/sdk/lib/_internal/vm/bin/vmservice_io.dart"
+        "uri": "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/vmservice_io.dart"
       }
     }
   }

--- a/lib/snapshot/libraries.yaml
+++ b/lib/snapshot/libraries.yaml
@@ -14,141 +14,141 @@
 flutter:
   libraries:
     _builtin:
-      uri: "../../../third_party/dart/sdk/lib/_internal/vm/bin/builtin.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/builtin.dart"
 
     _internal:
-      uri: "../../../third_party/dart/sdk/lib/internal/internal.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/internal/internal.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/internal_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/class_id_fasta.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/print_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/symbol_patch.dart"
-        - "../../../third_party/dart/sdk/lib/internal/patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/internal_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/class_id_fasta.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/print_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/symbol_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/internal/patch.dart"
 
     async:
-      uri: "../../../third_party/dart/sdk/lib/async/async.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/async/async.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/async_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/deferred_load_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/schedule_microtask_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/async_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/deferred_load_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/schedule_microtask_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/timer_patch.dart"
 
     collection:
-      uri: "../../../third_party/dart/sdk/lib/collection/collection.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/collection/collection.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/collection_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/compact_hash.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/collection_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/compact_hash.dart"
 
     convert:
-      uri: "../../../third_party/dart/sdk/lib/convert/convert.dart"
-      patches: "../../../third_party/dart/sdk/lib/_internal/vm/lib/convert_patch.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/convert/convert.dart"
+      patches: "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/convert_patch.dart"
 
     core:
-      uri: "../../../third_party/dart/sdk/lib/core/core.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/core/core.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/core_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/array.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/array_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/bigint_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/bool_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/date_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/double.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/double_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/errors_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/expando_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/function.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/function_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/growable_array.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/identical_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/immutable_map.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/integers.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/integers_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/invocation_mirror_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/lib_prefix.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/map_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/null_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/object_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/regexp_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/stacktrace.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/stopwatch_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/string_buffer_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/string_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/type_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/uri_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/weak_property.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/core_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/array.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/array_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/bigint_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/bool_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/date_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/double.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/double_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/errors_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/expando_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/function.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/function_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/growable_array.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/identical_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/immutable_map.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/integers.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/integers_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/invocation_mirror_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/lib_prefix.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/map_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/null_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/object_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/regexp_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/stacktrace.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/stopwatch_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/string_buffer_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/string_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/type_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/uri_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/weak_property.dart"
 
     developer:
-      uri: "../../../third_party/dart/sdk/lib/developer/developer.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/developer/developer.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/developer.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/profiler.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/timeline.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/developer.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/profiler.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/timeline.dart"
 
     ffi:
-      uri: "../../../third_party/dart/sdk/lib/ffi/ffi.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/ffi/ffi.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_native_type_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/ffi_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/ffi_dynamic_library_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/ffi_native_type_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/ffi_patch.dart"
 
     wasm:
-      uri: "../../../third_party/dart/sdk/lib/wasm/wasm.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/wasm/wasm.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/wasm_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/wasm_patch.dart"
 
     _http:
-      uri: "../../../third_party/dart/sdk/lib/_http/http.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/_http/http.dart"
 
     io:
-      uri: "../../../third_party/dart/sdk/lib/io/io.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/io/io.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/common_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/directory_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/eventhandler_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/file_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/file_system_entity_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/filter_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/io_service_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/namespace_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/platform_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/process_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/socket_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/stdio_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/secure_socket_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/bin/sync_socket_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/common_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/directory_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/eventhandler_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/file_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/file_system_entity_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/filter_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/io_service_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/namespace_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/platform_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/process_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/socket_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/stdio_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/secure_socket_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/sync_socket_patch.dart"
 
     isolate:
-      uri: "../../../third_party/dart/sdk/lib/isolate/isolate.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/isolate/isolate.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/isolate_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/timer_impl.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/isolate_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/timer_impl.dart"
 
     math:
-      uri: "../../../third_party/dart/sdk/lib/math/math.dart"
-      patches: "../../../third_party/dart/sdk/lib/_internal/vm/lib/math_patch.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/math/math.dart"
+      patches: "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/math_patch.dart"
 
     mirrors:
-      uri: "../../../third_party/dart/sdk/lib/mirrors/mirrors.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/mirrors/mirrors.dart"
       patches:
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_patch.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/mirrors_impl.dart"
-        - "../../../third_party/dart/sdk/lib/_internal/vm/lib/mirror_reference.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/mirrors_patch.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/mirrors_impl.dart"
+        - "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/mirror_reference.dart"
 
     nativewrappers:
-      uri: "../../../third_party/dart/sdk/lib/html/dartium/nativewrappers.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/html/dartium/nativewrappers.dart"
 
     profiler:
-      uri: "../../../third_party/dart/sdk/lib/profiler/profiler.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/profiler/profiler.dart"
 
     typed_data:
-      uri: "../../../third_party/dart/sdk/lib/typed_data/typed_data.dart"
-      patches: "../../../third_party/dart/sdk/lib/_internal/vm/lib/typed_data_patch.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/typed_data/typed_data.dart"
+      patches: "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/lib/typed_data_patch.dart"
 
     ui:
       uri: "../../lib/ui/ui.dart"
 
     _vmservice:
-      uri: "../../../third_party/dart/sdk/lib/vmservice/vmservice.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/vmservice/vmservice.dart"
 
     vmservice_io:
-      uri: "../../../third_party/dart/sdk/lib/_internal/vm/bin/vmservice_io.dart"
+      uri: "../../../third_party/dart/sdk_nnbd/lib/_internal/vm/bin/vmservice_io.dart"


### PR DESCRIPTION
Switch libraries.yaml file to use the NNBD version of the dart:* libraries
Flip the build rules to use the non-nullable option when building the platform file.

In this version the dart:ui library is not opted in and hence the platform file is built in weak mode.

(This PR is not intended to land)