### PR TITLE
Release acquired typed data before calling Dart_SetReturnValue.

### DIFF
--- a/third_party/tonic/typed_data/typed_list.cc
+++ b/third_party/tonic/typed_data/typed_list.cc
@@ -69,7 +69,9 @@ template <Dart_TypedData_Type kTypeName, typename ElemType>
 void DartConverter<TypedList<kTypeName, ElemType>>::SetReturnValue(
     Dart_NativeArguments args,
     TypedList<kTypeName, ElemType> val) {
-  Dart_SetReturnValue(args, val.dart_handle());
+  Dart_Handle result = val.dart_handle();
+  val.Release();  // Must release acquired typed data before calling Dart API.
+  Dart_SetReturnValue(args, result);
 }
 
 template <Dart_TypedData_Type kTypeName, typename ElemType>


### PR DESCRIPTION
Otherwise we are going to hit an assertion in debug builds, as
Dart API should not be used between Dart_TypedDataAcquireData and
Dart_TypedDataReleaseData.

Fixes flutter/flutter#54433