### PR TITLE
remove allocation from growLTRB; remove dynamism in vector_math

### DIFF
--- a/lib/web_ui/lib/src/engine/surface/backdrop_filter.dart
+++ b/lib/web_ui/lib/src/engine/surface/backdrop_filter.dart
@@ -65,8 +65,8 @@ class PersistedBackdropFilter extends PersistedContainerSurface
       _invertedTransform = Matrix4.inverted(_transform);
       _previousTransform = _transform;
     }
-    final ui.Rect rect = transformLTRB(_invertedTransform, 0, 0,
-        ui.window.physicalSize.width, ui.window.physicalSize.height);
+    final ui.Rect rect = transformRect(_invertedTransform, ui.Rect.fromLTRB(0, 0,
+        ui.window.physicalSize.width, ui.window.physicalSize.height));
     final html.CssStyleDeclaration filterElementStyle = _filterElement.style;
     filterElementStyle
       ..position = 'absolute'

--- a/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
+++ b/lib/web_ui/lib/src/engine/surface/recording_canvas.dart
@@ -1927,46 +1927,47 @@ class _PaintBounds {
     _currentMatrix.multiply(skewMatrix);
   }
 
-  void clipRect(ui.Rect rect, DrawCommand command) {
+  static final Float64List _tempRectData = Float64List(4);
+
+  void clipRect(final ui.Rect rect, DrawCommand command) {
+    double left = rect.left;
+    double top = rect.top;
+    double right = rect.right;
+    double bottom = rect.bottom;
+
     // If we have an active transform, calculate screen relative clipping
     // rectangle and union with current clipping rectangle.
     if (!_currentMatrixIsIdentity) {
-      final Vector3 leftTop =
-          _currentMatrix.transform3(Vector3(rect.left, rect.top, 0.0));
-      final Vector3 rightTop =
-          _currentMatrix.transform3(Vector3(rect.right, rect.top, 0.0));
-      final Vector3 leftBottom =
-          _currentMatrix.transform3(Vector3(rect.left, rect.bottom, 0.0));
-      final Vector3 rightBottom =
-          _currentMatrix.transform3(Vector3(rect.right, rect.bottom, 0.0));
-      rect = ui.Rect.fromLTRB(
-          math.min(math.min(math.min(leftTop.x, rightTop.x), leftBottom.x),
-              rightBottom.x),
-          math.min(math.min(math.min(leftTop.y, rightTop.y), leftBottom.y),
-              rightBottom.y),
-          math.max(math.max(math.max(leftTop.x, rightTop.x), leftBottom.x),
-              rightBottom.x),
-          math.max(math.max(math.max(leftTop.y, rightTop.y), leftBottom.y),
-              rightBottom.y));
+      _tempRectData[0] = left;
+      _tempRectData[1] = top;
+      _tempRectData[2] = right;
+      _tempRectData[3] = bottom;
+
+      transformLTRB(_currentMatrix, _tempRectData);
+      left = _tempRectData[0];
+      top = _tempRectData[1];
+      right = _tempRectData[2];
+      bottom = _tempRectData[3];
     }
+
     if (!_clipRectInitialized) {
-      _currentClipLeft = rect.left;
-      _currentClipTop = rect.top;
-      _currentClipRight = rect.right;
-      _currentClipBottom = rect.bottom;
+      _currentClipLeft = left;
+      _currentClipTop = top;
+      _currentClipRight = right;
+      _currentClipBottom = bottom;
       _clipRectInitialized = true;
     } else {
-      if (rect.left > _currentClipLeft) {
-        _currentClipLeft = rect.left;
+      if (left > _currentClipLeft) {
+        _currentClipLeft = left;
       }
-      if (rect.top > _currentClipTop) {
-        _currentClipTop = rect.top;
+      if (top > _currentClipTop) {
+        _currentClipTop = top;
       }
-      if (rect.right < _currentClipRight) {
-        _currentClipRight = rect.right;
+      if (right < _currentClipRight) {
+        _currentClipRight = right;
       }
-      if (rect.bottom < _currentClipBottom) {
-        _currentClipBottom = rect.bottom;
+      if (bottom < _currentClipBottom) {
+        _currentClipBottom = bottom;
       }
     }
     if (_currentClipLeft >= _currentClipRight || _currentClipTop >= _currentClipBottom) {
@@ -1997,12 +1998,16 @@ class _PaintBounds {
     double transformedPointBottom = bottom;
 
     if (!_currentMatrixIsIdentity) {
-      final ui.Rect transformedRect =
-          transformLTRB(_currentMatrix, left, top, right, bottom);
-      transformedPointLeft = transformedRect.left;
-      transformedPointTop = transformedRect.top;
-      transformedPointRight = transformedRect.right;
-      transformedPointBottom = transformedRect.bottom;
+      _tempRectData[0] = left;
+      _tempRectData[1] = top;
+      _tempRectData[2] = right;
+      _tempRectData[3] = bottom;
+
+      transformLTRB(_currentMatrix, _tempRectData);
+      transformedPointLeft = _tempRectData[0];
+      transformedPointTop = _tempRectData[1];
+      transformedPointRight = _tempRectData[2];
+      transformedPointBottom = _tempRectData[3];
     }
 
     if (_clipRectInitialized) {

--- a/lib/web_ui/lib/src/engine/util.dart
+++ b/lib/web_ui/lib/src/engine/util.dart
@@ -203,26 +203,39 @@ bool get assertionsEnabled {
   return k;
 }
 
+final Float64List _tempRectData = Float64List(4);
+
 /// Transforms a [ui.Rect] given the effective [transform].
 ///
 /// The resulting rect is aligned to the pixel grid, i.e. two of
 /// its sides are vertical and two are horizontal. In the presence of rotations
 /// the rectangle is inflated such that it fits the rotated rectangle.
 ui.Rect transformRect(Matrix4 transform, ui.Rect rect) {
-  return transformLTRB(transform, rect.left, rect.top, rect.right, rect.bottom);
+  _tempRectData[0] = rect.left;
+  _tempRectData[1] = rect.top;
+  _tempRectData[2] = rect.right;
+  _tempRectData[3] = rect.bottom;
+  transformLTRB(transform, _tempRectData);
+  return ui.Rect.fromLTRB(
+    _tempRectData[0],
+    _tempRectData[1],
+    _tempRectData[2],
+    _tempRectData[3],
+  );
 }
+
+/// Temporary storage for intermediate data used by [transformLTRB].
+///
+/// WARNING: do not use this outside [transformLTRB]. Sharing this variable in
+/// other contexts will lead to bugs.
+final Float64List _tempPointData = Float64List(16);
+final Matrix4 _tempPointMatrix = Matrix4.fromFloat64List(_tempPointData);
 
 /// Transforms a rectangle given the effective [transform].
 ///
 /// This is the same as [transformRect], except that the rect is specified
 /// in terms of left, top, right, and bottom edge offsets.
-ui.Rect transformLTRB(
-    Matrix4 transform, double left, double top, double right, double bottom) {
-  assert(left != null);
-  assert(top != null);
-  assert(right != null);
-  assert(bottom != null);
-
+void transformLTRB(Matrix4 transform, Float64List ltrb) {
   // Construct a matrix where each row represents a vector pointing at
   // one of the four corners of the (left, top, right, bottom) rectangle.
   // Using the row-major order allows us to multiply the matrix in-place
@@ -239,41 +252,37 @@ ui.Rect transformLTRB(
   //
   // `Float64List` initializes the array with zeros, so we do not have to
   // fill in every single element.
-  final Float64List pointData = Float64List(16);
 
   // Row 0: top-left
-  pointData[0] = left;
-  pointData[4] = top;
-  pointData[12] = 1;
+  _tempPointData[0] = ltrb[0];
+  _tempPointData[4] = ltrb[1];
+  _tempPointData[8] = 0;
+  _tempPointData[12] = 1;
 
   // Row 1: top-right
-  pointData[1] = right;
-  pointData[5] = top;
-  pointData[13] = 1;
+  _tempPointData[1] = ltrb[2];
+  _tempPointData[5] = ltrb[1];
+  _tempPointData[9] = 0;
+  _tempPointData[13] = 1;
 
   // Row 2: bottom-left
-  pointData[2] = left;
-  pointData[6] = bottom;
-  pointData[14] = 1;
+  _tempPointData[2] = ltrb[0];
+  _tempPointData[6] = ltrb[3];
+  _tempPointData[10] = 0;
+  _tempPointData[14] = 1;
 
   // Row 3: bottom-right
-  pointData[3] = right;
-  pointData[7] = bottom;
-  pointData[15] = 1;
+  _tempPointData[3] = ltrb[2];
+  _tempPointData[7] = ltrb[3];
+  _tempPointData[11] = 0;
+  _tempPointData[15] = 1;
 
-  final Matrix4 pointMatrix = Matrix4.fromFloat64List(pointData);
-  pointMatrix.multiplyTranspose(transform);
+  _tempPointMatrix.multiplyTranspose(transform);
 
-  return ui.Rect.fromLTRB(
-    math.min(math.min(math.min(pointData[0], pointData[1]), pointData[2]),
-        pointData[3]),
-    math.min(math.min(math.min(pointData[4], pointData[5]), pointData[6]),
-        pointData[7]),
-    math.max(math.max(math.max(pointData[0], pointData[1]), pointData[2]),
-        pointData[3]),
-    math.max(math.max(math.max(pointData[4], pointData[5]), pointData[6]),
-        pointData[7]),
-  );
+  ltrb[0] = math.min(math.min(math.min(_tempPointData[0], _tempPointData[1]), _tempPointData[2]), _tempPointData[3]);
+  ltrb[1] = math.min(math.min(math.min(_tempPointData[4], _tempPointData[5]), _tempPointData[6]), _tempPointData[7]);
+  ltrb[2] = math.max(math.max(math.max(_tempPointData[0], _tempPointData[1]), _tempPointData[2]), _tempPointData[3]);
+  ltrb[3] = math.max(math.max(math.max(_tempPointData[4], _tempPointData[5]), _tempPointData[6]), _tempPointData[7]);
 }
 
 /// Returns true if [rect] contains every point that is also contained by the

--- a/lib/web_ui/lib/src/engine/vector_math.dart
+++ b/lib/web_ui/lib/src/engine/vector_math.dart
@@ -237,36 +237,24 @@ class Matrix4 {
     return arg;
   }
 
-  /// Translate this matrix by a [Vector3], [Vector4], or x,y,z
-  void translate(dynamic x, [double y = 0.0, double z = 0.0]) {
-    double tx;
-    double ty;
-    double tz;
+  /// Translate this matrix by x, y, and z.
+  void translate(double x, [double y = 0.0, double z = 0.0]) {
     const double tw = 1.0;
-    if (x is Vector3) {
-      tx = x.x;
-      ty = x.y;
-      tz = x.z;
-    } else if (x is double) {
-      tx = x;
-      ty = y;
-      tz = z;
-    }
-    final double t1 = _m4storage[0] * tx +
-        _m4storage[4] * ty +
-        _m4storage[8] * tz +
+    final double t1 = _m4storage[0] * x +
+        _m4storage[4] * y +
+        _m4storage[8] * z +
         _m4storage[12] * tw;
-    final double t2 = _m4storage[1] * tx +
-        _m4storage[5] * ty +
-        _m4storage[9] * tz +
+    final double t2 = _m4storage[1] * x +
+        _m4storage[5] * y +
+        _m4storage[9] * z +
         _m4storage[13] * tw;
-    final double t3 = _m4storage[2] * tx +
-        _m4storage[6] * ty +
-        _m4storage[10] * tz +
+    final double t3 = _m4storage[2] * x +
+        _m4storage[6] * y +
+        _m4storage[10] * z +
         _m4storage[14] * tw;
-    final double t4 = _m4storage[3] * tx +
-        _m4storage[7] * ty +
-        _m4storage[11] * tz +
+    final double t4 = _m4storage[3] * x +
+        _m4storage[7] * y +
+        _m4storage[11] * z +
         _m4storage[15] * tw;
     _m4storage[12] = t1;
     _m4storage[13] = t2;
@@ -275,20 +263,11 @@ class Matrix4 {
   }
 
   /// Scale this matrix by a [Vector3], [Vector4], or x,y,z
-  void scale(dynamic x, [double y, double z]) {
-    double sx;
-    double sy;
-    double sz;
+  void scale(double x, [double y, double z]) {
+    final double sx = x;
+    final double sy = y ?? x;
+    final double sz = z ?? x;
     const double sw = 1.0;
-    if (x is Vector3) {
-      sx = x.x;
-      sy = x.y;
-      sz = x.z;
-    } else if (x is double) {
-      sx = x;
-      sy = y ?? x;
-      sz = z ?? x;
-    }
     _m4storage[0] *= sx;
     _m4storage[1] *= sx;
     _m4storage[2] *= sx;
@@ -309,7 +288,7 @@ class Matrix4 {
 
   /// Create a copy of [this] scaled by a [Vector3], [Vector4] or [x],[y], and
   /// [z].
-  Matrix4 scaled(dynamic x, [double y, double z]) => clone()..scale(x, y, z);
+  Matrix4 scaled(double x, [double y, double z]) => clone()..scale(x, y, z);
 
   /// Zeros [this].
   void setZero() {


### PR DESCRIPTION
Optimizes picture recording by speeding up paint bounds estimation:

* Avoid allocating temporary matrices and vectors on the `_PaintBounds` hot paths.
* Remove dynamism in vector math.

Here's the A/B comparison on the `bench_picture_recording` benchmark (see https://github.com/flutter/flutter/pull/54908):

```
Score	Average A (noise)	Average B (noise)	Speed-up
bench_picture_recording.html.recordPaintCommands.average	3393.82 (3.49%)	1755.48 (3.53%)	1.93x	
bench_picture_recording.html.estimatePaintBounds.average	0.00 (0.00%)	3.01 (15.88%)	0.00x
```

(i.e. it speeds it up by ~2x)