### PR TITLE
Remove fuchsia build from cirrus.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -196,8 +196,3 @@ task:
       build_script: |
         cd $ENGINE_PATH/src/flutter
         ./ci/build.sh
-    - name: build_fuchsia_artifacts
-      compile_fuchsia_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/fuchsia/build_fuchsia_artifacts.py --engine-version HEAD --runtime-mode debug --no-lto --archs x64
-        cd $ENGINE_PATH/src/flutter


### PR DESCRIPTION
Building fuchsia is covered already by LUCI.

Link to luci execution:
  https://ci.chromium.org/p/flutter/builders/try/Linux%20Fuchsia

Bug:
  https://github.com/flutter/flutter/issues/54412