### PR TITLE
[fuchsia] Enable raster cache on Fuchsia

### DIFF
--- a/shell/platform/fuchsia/flutter/compositor_context.cc
+++ b/shell/platform/fuchsia/flutter/compositor_context.cc
@@ -14,14 +14,15 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
               const SkMatrix& root_surface_transformation,
               bool instrumentation_enabled,
               SessionConnection& session_connection)
-      : flutter::CompositorContext::ScopedFrame(context,
-                                                nullptr,
-                                                nullptr,
-                                                nullptr,
-                                                root_surface_transformation,
-                                                instrumentation_enabled,
-                                                true,
-                                                nullptr),
+      : flutter::CompositorContext::ScopedFrame(
+            context,
+            session_connection.vulkan_surface_producer()->gr_context(),
+            nullptr,
+            nullptr,
+            root_surface_transformation,
+            instrumentation_enabled,
+            true,
+            nullptr),
         session_connection_(session_connection) {}
 
  private:
@@ -37,7 +38,7 @@ class ScopedFrame final : public flutter::CompositorContext::ScopedFrame {
       // Preroll the Flutter layer tree. This allows Flutter to perform
       // pre-paint optimizations.
       TRACE_EVENT0("flutter", "Preroll");
-      layer_tree.Preroll(*this, true /* ignore raster cache */);
+      layer_tree.Preroll(*this, ignore_raster_cache);
     }
 
     {

--- a/shell/platform/fuchsia/flutter/session_connection.h
+++ b/shell/platform/fuchsia/flutter/session_connection.h
@@ -68,6 +68,10 @@ class SessionConnection final {
   void OnSessionSizeChangeHint(float width_change_factor,
                                float height_change_factor);
 
+  VulkanSurfaceProducer* vulkan_surface_producer() {
+    return surface_producer_.get();
+  }
+
  private:
   const std::string debug_label_;
   scenic::Session session_wrapper_;

--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.h
@@ -66,6 +66,8 @@ class VulkanSurfaceProducer final
             width_change_factor, height_change_factor);
   }
 
+  GrContext* gr_context() { return context_.get(); }
+
  private:
   // VulkanProvider
   const vulkan::VulkanProcTable& vk() override { return *vk_.get(); }


### PR DESCRIPTION
The raster cache is critical for good performance. This
enables the cache and provides a GrContext to ScopedFrame
instances so the cache can be efficiently populated.

Small increase in peak GPU memory usage is expected from
this change. Otherwise, no change in behavior expected.

Fixes https://github.com/flutter/flutter/issues/54950