### PR TITLE
Guard canvas virtuals so we can remove legacy didConcat44

### DIFF
--- a/shell/common/canvas_spy.cc
+++ b/shell/common/canvas_spy.cc
@@ -53,7 +53,11 @@ void DidDrawCanvas::willRestore() {}
 
 void DidDrawCanvas::didConcat(const SkMatrix& matrix) {}
 
+#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
 void DidDrawCanvas::didConcat44(const SkScalar[]) {}
+#else
+void DidDrawCanvas::didConcat44(const SkM44&) {}
+#endif
 
 void DidDrawCanvas::didScale(SkScalar, SkScalar) {}
 

--- a/shell/common/canvas_spy.h
+++ b/shell/common/canvas_spy.h
@@ -71,7 +71,11 @@ class DidDrawCanvas final : public SkCanvasVirtualEnforcer<SkNoDrawCanvas> {
 
   // |SkCanvasVirtualEnforcer<SkNoDrawCanvas>|
   void didConcat(const SkMatrix&) override;
+#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
   void didConcat44(const SkScalar[]) override;
+#else
+  void didConcat44(const SkM44&) override;
+#endif
   void didScale(SkScalar, SkScalar) override;
   void didTranslate(SkScalar, SkScalar) override;
 

--- a/testing/assertions_skia.cc
+++ b/testing/assertions_skia.cc
@@ -61,15 +61,15 @@ std::ostream& operator<<(std::ostream& os, const SkMatrix& m) {
   return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const SkMatrix44& m) {
-  os << m.get(0, 0) << ", " << m.get(0, 1) << ", " << m.get(0, 2) << ", "
-     << m.get(0, 3) << std::endl;
-  os << m.get(1, 0) << ", " << m.get(1, 1) << ", " << m.get(1, 2) << ", "
-     << m.get(1, 3) << std::endl;
-  os << m.get(2, 0) << ", " << m.get(2, 1) << ", " << m.get(2, 2) << ", "
-     << m.get(2, 3) << std::endl;
-  os << m.get(3, 0) << ", " << m.get(3, 1) << ", " << m.get(3, 2) << ", "
-     << m.get(3, 3);
+std::ostream& operator<<(std::ostream& os, const SkM44& m) {
+  os << m.rc(0, 0) << ", " << m.rc(0, 1) << ", " << m.rc(0, 2) << ", "
+     << m.rc(0, 3) << std::endl;
+  os << m.rc(1, 0) << ", " << m.rc(1, 1) << ", " << m.rc(1, 2) << ", "
+     << m.rc(1, 3) << std::endl;
+  os << m.rc(2, 0) << ", " << m.rc(2, 1) << ", " << m.rc(2, 2) << ", "
+     << m.rc(2, 3) << std::endl;
+  os << m.rc(3, 0) << ", " << m.rc(3, 1) << ", " << m.rc(3, 2) << ", "
+     << m.rc(3, 3);
   return os;
 }
 

--- a/testing/assertions_skia.h
+++ b/testing/assertions_skia.h
@@ -9,6 +9,7 @@
 
 #include "third_party/skia/include/core/SkClipOp.h"
 #include "third_party/skia/include/core/SkMatrix.h"
+#include "third_party/skia/include/core/SkM44.h"
 #include "third_party/skia/include/core/SkMatrix44.h"
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkPath.h"
@@ -20,7 +21,7 @@ namespace testing {
 
 extern std::ostream& operator<<(std::ostream& os, const SkClipOp& o);
 extern std::ostream& operator<<(std::ostream& os, const SkMatrix& m);
-extern std::ostream& operator<<(std::ostream& os, const SkMatrix44& m);
+extern std::ostream& operator<<(std::ostream& os, const SkM44& m);
 extern std::ostream& operator<<(std::ostream& os, const SkVector3& v);
 extern std::ostream& operator<<(std::ostream& os, const SkVector4& v);
 extern std::ostream& operator<<(std::ostream& os, const SkRect& r);

--- a/testing/assertions_skia.h
+++ b/testing/assertions_skia.h
@@ -8,8 +8,8 @@
 #include <ostream>
 
 #include "third_party/skia/include/core/SkClipOp.h"
-#include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/core/SkM44.h"
+#include "third_party/skia/include/core/SkMatrix.h"
 #include "third_party/skia/include/core/SkMatrix44.h"
 #include "third_party/skia/include/core/SkPaint.h"
 #include "third_party/skia/include/core/SkPath.h"

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -60,11 +60,17 @@ void MockCanvas::didConcat(const SkMatrix& matrix) {
   draw_calls_.emplace_back(DrawCall{current_layer_, ConcatMatrixData{matrix}});
 }
 
+#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
 void MockCanvas::didConcat44(const SkScalar matrix[]) {
-  SkMatrix44 m44;
-  m44.setColMajor(matrix);
+  SkM44 m44 = SkM44::ColMajor(matrix);
   draw_calls_.emplace_back(DrawCall{current_layer_, ConcatMatrix44Data{m44}});
 }
+#else
+void MockCanvas::didConcat44(const SkM44& matrix) {
+  draw_calls_.emplace_back(DrawCall{current_layer_,
+                                    ConcatMatrix44Data{matrix}});
+}
+#endif
 
 void MockCanvas::didScale(SkScalar x, SkScalar y) {
   SkMatrix m;

--- a/testing/mock_canvas.cc
+++ b/testing/mock_canvas.cc
@@ -67,8 +67,8 @@ void MockCanvas::didConcat44(const SkScalar matrix[]) {
 }
 #else
 void MockCanvas::didConcat44(const SkM44& matrix) {
-  draw_calls_.emplace_back(DrawCall{current_layer_,
-                                    ConcatMatrix44Data{matrix}});
+  draw_calls_.emplace_back(
+      DrawCall{current_layer_, ConcatMatrix44Data{matrix}});
 }
 #endif
 

--- a/testing/mock_canvas.h
+++ b/testing/mock_canvas.h
@@ -16,7 +16,7 @@
 #include "third_party/skia/include/core/SkClipOp.h"
 #include "third_party/skia/include/core/SkData.h"
 #include "third_party/skia/include/core/SkImageFilter.h"
-#include "third_party/skia/include/core/SkMatrix44.h"
+#include "third_party/skia/include/core/SkM44.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "third_party/skia/include/core/SkRRect.h"
 #include "third_party/skia/include/core/SkRect.h"
@@ -57,7 +57,7 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
   };
 
   struct ConcatMatrix44Data {
-    SkMatrix44 matrix;
+    SkM44 matrix;
   };
 
   struct SetMatrixData {
@@ -145,7 +145,11 @@ class MockCanvas : public SkCanvasVirtualEnforcer<SkCanvas> {
   void willRestore() override;
   void didRestore() override {}
   void didConcat(const SkMatrix& matrix) override;
+#ifdef SK_SUPPORT_LEGACY_DIDCONCAT44
   void didConcat44(const SkScalar matrix[]) override;
+#else
+  void didConcat44(const SkM44&) override;
+#endif
   void didScale(SkScalar x, SkScalar y) override;
   void didTranslate(SkScalar x, SkScalar y) override;
   void didSetMatrix(const SkMatrix& matrix) override;


### PR DESCRIPTION
SkMatrix44 is also deprecated, so start transitioning to SkM44.