### PR TITLE
[web] remove the web_engine_integration tests from cirrus ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -136,7 +136,7 @@ task:
       script:
         - cd $ENGINE_PATH/src/flutter/lib/web_ui
         - $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/pub get
-        - $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/dartanalyzer --fatal-warnings --fatal-hints dev/ lib/ test/ tool/s
+        - $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/dartanalyzer --fatal-warnings --fatal-hints dev/ lib/ test/ tool/
 
     - name: build_and_test_web_linux_firefox
       compile_host_script: |

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -136,31 +136,7 @@ task:
       script:
         - cd $ENGINE_PATH/src/flutter/lib/web_ui
         - $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/pub get
-        - $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/dartanalyzer --fatal-warnings --fatal-hints dev/ lib/ test/ tool/
-
-    - name: web_engine_integration_test_linux
-      compile_host_script: |
-        cd $ENGINE_PATH/src
-        ./flutter/tools/gn --unoptimized --full-dart-sdk
-        ninja -C out/host_debug_unopt
-      fetch_framework_script: |
-        cd $ENGINE_PATH/src/flutter/tools
-        ./clone_flutter.sh
-        cd $FRAMEWORK_PATH/flutter
-        bin/flutter update-packages --local-engine=host_debug_unopt
-      script:
-        - git clone https://github.com/flutter/web_installers.git
-        - cd web_installers/packages/web_drivers/
-        - $ENGINE_PATH/src/third_party/dart/tools/sdks/dart-sdk/bin/pub get
-        - $ENGINE_PATH/src/third_party/dart/tools/sdks/dart-sdk/bin/dart lib/web_driver_installer.dart chromedriver --install-only
-        - ./chromedriver/chromedriver --port=4444 &
-        - cd $ENGINE_PATH/src/flutter/e2etests/web/regular_integration_tests
-        - $FRAMEWORK_PATH/flutter/bin/flutter config --local-engine=host_debug_unopt --no-analytics --enable-web
-        - $FRAMEWORK_PATH/flutter/bin/flutter pub get --local-engine=host_debug_unopt
-        - $FRAMEWORK_PATH/flutter/bin/flutter drive -v --target=test_driver/text_editing_e2e.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
-        - $FRAMEWORK_PATH/flutter/bin/flutter drive -v --target=test_driver/platform_messages_e2e.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
-        - $FRAMEWORK_PATH/flutter/bin/flutter drive -v --target=test_driver/treeshaking_e2e.dart -d web-server --profile --browser-name=chrome --local-engine=host_debug_unopt
-        - $FRAMEWORK_PATH/flutter/bin/flutter drive -v --target=test_driver/image_loading_e2e.dart -d web-server --release --browser-name=chrome --local-engine=host_debug_unopt
+        - $ENGINE_PATH/src/out/host_debug_unopt/dart-sdk/bin/dartanalyzer --fatal-warnings --fatal-hints dev/ lib/ test/ tool/s
 
     - name: build_and_test_web_linux_firefox
       compile_host_script: |


### PR DESCRIPTION
Remove the web_engine_integration task from cirrus since with the latest changes, `felt test` runs these tests under build_and_test_linux_unopt. Example: https://cirrus-ci.com/task/6360490347593728?command=test_web_engine#L405
```
Starting application: test_driver/image_loading_e2e.dart
Launching test_driver/image_loading_e2e.dart on Web Server in profile mode...
Running "flutter pub get" in flutter_tools...                       1.3s
Compiling test_driver/image_loading_e2e.dart for the Web...        33.6s
test_driver/image_loading_e2e.dart is being served at http://localhost:35341
Application finished.
Waiting for connection from Dart debug extension at http://localhost:35341
All tests passed.
Stopping application instance.
Starting application: test_driver/treeshaking_e2e.dart
Launching test_driver/treeshaking_e2e.dart on Web Server in profile mode...
Compiling test_driver/treeshaking_e2e.dart for the Web...          34.3s
test_driver/treeshaking_e2e.dart is being served at http://localhost:37021
Application finished.
Waiting for connection from Dart debug extension at http://localhost:37021
All tests passed.
Stopping application instance.
Starting application: test_driver/platform_messages_e2e.dart
Launching test_driver/platform_messages_e2e.dart on Web Server in profile mode...
Compiling test_driver/platform_messages_e2e.dart for the Web...        36.8s
test_driver/platform_messages_e2e.dart is being served at http://localhost:41071
Application finished.
Waiting for connection from Dart debug extension at http://localhost:41071
All tests passed.
Stopping application instance.
Starting application: test_driver/text_editing_e2e.dart
Launching test_driver/text_editing_e2e.dart on Web Server in profile mode...
Compiling test_driver/text_editing_e2e.dart for the Web...         37.1s
test_driver/text_editing_e2e.dart is being served at http://localhost:34799
```

related to: https://github.com/flutter/flutter/issues/52983