### PR TITLE
[web] new text editing method.

### DIFF
--- a/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
+++ b/lib/web_ui/lib/src/engine/text_editing/text_editing.dart
@@ -815,6 +815,11 @@ class TextEditingChannel {
         implementation.hide();
         break;
 
+      case 'TextInput.requestAutofill':
+        // No-op:  This message is sent by the framework to requests the platform autofill UI to appear.
+        // Since autofill UI is a part of the browser, web engine does not need to utilize this method.
+        break;
+
       default:
         throw StateError('Unsupported method call on the flutter/textinput channel: ${call.method}');
     }


### PR DESCRIPTION
web engine should not give an error for the  new text editing method. This PR is good to have before PR: https://github.com/flutter/flutter/pull/52126/ 

Since the web engine starts returning Bad State Error for every autofill field, filling the log with red warnings:

```
Error: Bad state: Unsupported method call on the flutter/textinput channel: TextInput.requestAutofill
    at Object.throw_ [as throw] (http://localhost:8080/dart_sdk.js:4040:11)
    at _engine.TextEditingChannel.new.handleTextInput (http://localhost:8080/dart_sdk.js:160283:21)
    at _engine.EngineWindow.new.[_sendPlatformMessage] (http://localhost:8080/dart_sdk.js:162238:39)
    at _engine.EngineWindow.new.sendPlatformMessage (http://localhost:8080/dart_sdk.js:162158:33)
    at _DefaultBinaryMessenger.[_sendPlatformMessage] (http://localhost:8080/packages/flutter/src/services/platform_channel.dart.lib.js:1357:17)
    at _DefaultBinaryMessenger.send (http://localhost:8080/packages/flutter/src/services/platform_channel.dart.lib.js:1393:40)
    at OptionalMethodChannel._invokeMethod (http://localhost:8080/packages/flutter/src/services/platform_channel.dart.lib.js:367:50)
    at _invokeMethod.next (<anonymous>)
```