### PR TITLE
[wip] Revise the raster cache unit test

### DIFF
--- a/flow/raster_cache.cc
+++ b/flow/raster_cache.cc
@@ -26,9 +26,8 @@ void RasterCacheResult::draw(SkCanvas& canvas, const SkPaint* paint) const {
   SkAutoCanvasRestore auto_restore(&canvas, true);
   SkIRect bounds =
       RasterCache::GetDeviceBounds(logical_rect_, canvas.getTotalMatrix());
-  FML_DCHECK(
-      std::abs(bounds.size().width() - image_->dimensions().width()) <= 1 &&
-      std::abs(bounds.size().height() - image_->dimensions().height()) <= 1);
+  FML_DCHECK(bounds.size().width() == image_->dimensions().width() &&
+             bounds.size().height() == image_->dimensions().height());
   canvas.resetMatrix();
   canvas.drawImage(image_, bounds.fLeft, bounds.fTop, paint);
 }

--- a/flow/raster_cache_unittests.cc
+++ b/flow/raster_cache_unittests.cc
@@ -151,7 +151,11 @@ TEST(RasterCache, DeviceRectRoundOut) {
   canvas.setMatrix(ctm);
   canvas.translate(248, 0);
 
-  cache.Get(*picture, ctm).draw(canvas);
+#ifndef SUPPORT_FRACTIONAL_TRANSLATION
+  canvas.setMatrix(RasterCache::GetIntegralTransCTM(canvas.getTotalMatrix()));
+#endif
+
+  cache.Get(*picture, canvas.getTotalMatrix()).draw(canvas);
 }
 
 }  // namespace testing


### PR DESCRIPTION
Previously, it's sending the wrong ctm: the one before the translation.
It's important because canvas.translate is applying the offset to the
matrix using preTranslate, so the fractional scale factor could turn an
integral offset into a final (postTranslate) fractional offset.

After the revision, we no longer fail the assertion that the image rect
should exactly matches the bounds.

I didn't find any case in our code where we used the wrong ctm for
raster cache key. Therefore, we have to find another unit test that
could surface the failed check in the 1st gen Nexus7.