### PR TITLE
Dispatch platform view touch events to the presentation

### DIFF
--- a/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/PlatformViewsController.java
@@ -216,7 +216,6 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
             throw new IllegalStateException(
                 "Sending touch to an unknown view with id: " + touch.viewId);
           }
-          View view = vdControllers.get(touch.viewId).getView();
 
           MotionEvent event =
               MotionEvent.obtain(
@@ -235,7 +234,7 @@ public class PlatformViewsController implements PlatformViewsAccessibilityDelega
                   touch.source,
                   touch.flags);
 
-          view.dispatchTouchEvent(event);
+          vdControllers.get(touch.viewId).dispatchTouchEvent(event);
         }
 
         @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -202,9 +202,7 @@ class VirtualDisplayController {
     return platformView.getView();
   }
 
-  /***
-   * Dispatches a motion event to the presentation for this controller.
-   */
+  /** Dispatches a motion event to the presentation for this controller. */
   public void dispatchTouchEvent(MotionEvent event) {
     if (presentation == null) return;
     presentation.dispatchTouchEvent(event);

--- a/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
+++ b/shell/platform/android/io/flutter/plugin/platform/VirtualDisplayController.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.hardware.display.DisplayManager;
 import android.hardware.display.VirtualDisplay;
 import android.os.Build;
+import android.view.MotionEvent;
 import android.view.Surface;
 import android.view.View;
 import android.view.ViewTreeObserver;
@@ -199,6 +200,14 @@ class VirtualDisplayController {
     if (presentation == null) return null;
     PlatformView platformView = presentation.getView();
     return platformView.getView();
+  }
+
+  /***
+   * Dispatches a motion event to the presentation for this controller.
+   */
+  public void dispatchTouchEvent(MotionEvent event) {
+    if (presentation == null) return;
+    presentation.dispatchTouchEvent(event);
   }
 
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN)


### PR DESCRIPTION
On Android, platform view touch events were previously dispatched directly to the platform view, which prevented views added to the VD hierarchy above the platform view (e.g new windows) from processing events.

Fixes: https://github.com/flutter/flutter/issues/55066

Test is added in: https://github.com/flutter/flutter/pull/55068

