### PR TITLE
[fuchsia] Adjust Skia GPU resource cache size

### DIFF
--- a/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
+++ b/shell/platform/fuchsia/flutter/vulkan_surface_producer.cc
@@ -32,7 +32,7 @@ constexpr int kGrCacheMaxCount = 8192;
 //     "SkiaCacheBytes" field in the ("flutter", "SurfacePool") trace counter
 //     (compare it to the bytes value here)
 // then you should consider increasing the size of the GPU resource cache.
-constexpr size_t kGrCacheMaxByteSize = 16 * (1 << 20);
+constexpr size_t kGrCacheMaxByteSize = 1024 * 600 * 12 * 4;
 
 }  // namespace
 


### PR DESCRIPTION
16 MiB -> 28 MiB

Same size as what would be used on a 1024x600 display if we
allowed the common engine code to adjust this.